### PR TITLE
feat(experimental): add flashinfer.experimental.sm12x

### DIFF
--- a/.github/workflows/experimental-sm12x.yml
+++ b/.github/workflows/experimental-sm12x.yml
@@ -1,0 +1,64 @@
+# CI lane for flashinfer/experimental (proposal rule §5: lightweight,
+# separate, non-blocking for kernel tests; the cheap structural lints are
+# blocking because they are what "minimal mechanical review" leans on).
+name: experimental-sm12x
+
+on:
+  pull_request:
+    paths:
+      - "flashinfer/experimental/**"
+      - "tests/experimental/**"
+      - ".github/workflows/experimental-sm12x.yml"
+
+jobs:
+  # Blocking: stdlib-only structural lints (~30s). Proves the isolation and
+  # arch rules hold without installing torch.
+  lints:
+    name: isolation + arch lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pytest
+      # --confcutdir skips the repo-root tests/conftest.py (which imports
+      # flashinfer and therefore torch); the lint tests are stdlib-only.
+      - run: pytest --confcutdir=tests/experimental tests/experimental/lint -q
+
+  # Non-blocking: CPU import hygiene (FutureWarning-once, lazy-import purity,
+  # registry contract). Needs a working `import flashinfer` on CPU torch.
+  import-hygiene:
+    name: cpu import hygiene (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - run: pip install -r requirements.txt
+      - run: BUILD_NVEP=0 pip install --no-build-isolation --no-deps -e .
+      - run: pip install pytest
+      - run: >
+          pytest tests/experimental/test_import_hygiene.py
+          tests/experimental/test_registry.py
+          tests/experimental/_lib -q
+
+  # GPU kernel tests require an SM12x (SM120/SM121) runner, which the fleet
+  # does not have yet. Until one exists the GPU lane is the local runbook in
+  # flashinfer/experimental/README.md. Template for when a labeled runner
+  # lands:
+  #
+  # gpu-tests:
+  #   name: sm12x kernel tests (non-blocking)
+  #   runs-on: [self-hosted, sm120]
+  #   continue-on-error: true
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with: { submodules: recursive }
+  #     - run: pip install -e . && pip install pytest
+  #     - run: pytest tests/experimental -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,15 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
+        # flashinfer/experimental/ .cu sources are a mechanical port kept
+        # byte-faithful to their upstream; exempt from formatting like the
+        # subtree's mypy/ruff style exemptions.
         exclude: |
-          (?x)^(3rdparty/.* flashinfer/jit/aot_config.py)$
+          (?x)^(
+            3rdparty/.*|
+            flashinfer/experimental/.*|
+            flashinfer/jit/aot_config.py
+          )$
 
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: 'v1.17.1'  # Use the sha / tag you want to point at
@@ -49,7 +56,7 @@ repos:
       -   id: mypy
           args: ["--config-file", "pyproject.toml", "--exclude", "flashinfer-cubin/"]
           files: ^flashinfer/
-          exclude: ^(flashinfer-cubin/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/(fmha\.py|fmha_blockscaled\.py|helpers/))
+          exclude: ^(flashinfer-cubin/|3rdparty/|build/|flashinfer/experimental/|flashinfer/cute_dsl/attention/fmha/(fmha\.py|fmha_blockscaled\.py|helpers/))
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/flashinfer/experimental/README.md
+++ b/flashinfer/experimental/README.md
@@ -1,0 +1,166 @@
+# flashinfer.experimental
+
+Fast-moving, arch-scoped kernels, exempt from FlashInfer's stability and
+support guarantees. APIs here may change or disappear in any release. The
+expected consumers are community containers and local framework forks — not
+framework main branches; a kernel needed on a framework release path should
+be promoted to core first.
+
+Currently one arch namespace: **`sm12x`** (consumer Blackwell, SM120/SM121),
+a curated one-time port of the [b12x](https://github.com/lukealonso/b12x)
+CuTe-DSL kernel corpus (`@ 7f7e4f84`). Upstream b12x is now a research
+sandbox; this tree is the canonical home.
+
+## Rules (enforced by `tests/experimental/lint/`, blocking in CI)
+
+- **Isolation.** Nothing under `flashinfer/experimental/` imports core
+  flashinfer (zero outbound imports — capability gating is vendored in
+  `sm12x/_lib/gating.py`), and core never imports experimental. `aot.py`,
+  the jit-cache wheel, and the cubin wheel structurally cannot pick up
+  experimental code. Tests may import both worlds.
+- **Arch restriction.** No SM90/SM100/SM103/SM110 targets anywhere in the
+  tree (arch lint).
+- **Import topology.** `_lib/` (universal base) ← `<group>/_shared/`
+  (intra-group lowering) ← `<group>/<op>/` (one public op). Ops never import
+  sibling ops or other groups; anything two groups need moves to `_lib`.
+- **Side-effect-free namespace.** `import flashinfer.experimental.sm12x` is
+  cheap: no cutlass/triton import, no torch custom-op registration, exactly
+  one `FutureWarning` per process (silence with `FLASHINFER_EXP_QUIET=1`).
+  Kernels load on first op use.
+- **JIT only.** Pure Python + JIT-compiled sources (CuTe DSL, plus raw `.cu`
+  via torch cpp_extension inside `comm/pcie/` only). Never AOT.
+
+## One grammar
+
+Every op lives at `sm12x.<group>.<op>` and declares itself via `META`
+(an `OpMeta`: entry points, dtypes/recipes, requirements, provenance, test
+path). `sm12x.list_ops()` / `sm12x.find_op("moe.fused_moe")` enumerate them;
+a registry test keeps `sm12x._OPS` and the op directories in bijection.
+
+Planned (`api_style="planned"`) ops all share the **same shape** — `plan` the
+work, size scratch from the plan, `bind` your tensors as views, `run`. Across
+three different kernel families, only the module path and the arguments move:
+
+```python
+# norm — fused RMSNorm + hyper-connection residual mixing
+from flashinfer.experimental.sm12x.norm import mhc
+
+plan    = mhc.plan(mhc.Caps(...))
+spec    = plan.scratch_specs()[0]
+scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+binding = mhc.bind(plan, scratch=scratch, ...)
+residual, post, comb, y = mhc.run_post_pre(..., binding=binding)
+```
+
+```python
+# moe — fused tensor-parallel routed-expert FFN (weights prepped once per model)
+from flashinfer.experimental.sm12x.moe import fused_moe
+
+wplan   = fused_moe.plan_weights(quant_modes="nvfp4",
+                                 source_format="modelopt_nvfp4", ...)
+experts = fused_moe.prepare_weights(plan=wplan, ...)
+plan    = fused_moe.plan(fused_moe.Caps(...))
+spec    = plan.scratch_specs()[0]
+scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+binding = fused_moe.bind(plan, scratch=scratch, a=x, experts=experts,
+                         topk_weights=tw, topk_ids=ti)
+out     = fused_moe.run(binding=binding)
+```
+
+```python
+# attention — MLA decode from compressed KV pages (DeepSeek-V3.2)
+from flashinfer.experimental.sm12x.attention import compressed_mla
+
+plan    = compressed_mla.plan(compressed_mla.Caps(...))
+spec    = plan.scratch_specs()[0]
+scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+binding = compressed_mla.bind(plan, scratch=scratch, q=q,
+                              swa_indices=idx, swa_lengths=lens, ...)
+out     = compressed_mla.run(swa_k_cache=swa, binding=binding, sm_scale=scale, ...)
+```
+
+`plan` is host-side and may allocate; `bind` only narrows/views (never
+allocates), which is what makes captured graphs safe; `run*` executes and is
+CUDA-graph-capture safe. The family-specific bits vary — a multi-value return
+(`mhc`), one-time weight prep (`moe`), cache arguments (`attention`) — while
+the plan/scratch/bind/run skeleton does not. One-shot ops
+(`gemm.blockscaled.mm`, `quantization.mxfp8.quantize_rows`) are plain
+functions; `comm.pcie` collectives are stateful classes (they own IPC
+handles). Every op exports `is_supported()`.
+
+Serving controls live at the arch root: warm every kernel shape, then
+`sm12x.freeze_kernel_resolution()` so a cache miss raises instead of
+compiling inside a live request or graph capture. `sm12x.clear_all_caches()`
+clears whatever is already imported.
+
+## Ops
+
+| Op | What it is |
+|---|---|
+| `attention.paged` | Paged-KV decode/extend (FP8 KV, MSA block-sparse); planner owns tile/split/chunk policy |
+| `attention.sparse_mla` | Top-k-selected MLA decode/extend (DeepSeek-V3.2, GLM NSA) |
+| `attention.compressed_mla` | MLA decode from compressed KV pages (DSV4), fused merge |
+| `attention.nsa_indexer` | NSA index stage: quantize → score → select (+ persistent top-k-2048) |
+| `attention.varlen` | Contiguous batched/varlen attention (reduced-assurance tier) |
+| `gemm.blockscaled` | One-shot NVFP4/MXFP4/MXFP8 dense block-scaled GEMM |
+| `gemm.block_fp8_linear` | DeepSeek-style serialized block-FP8 linear via MXFP8 |
+| `gemm.mxfp8_linear` | ModelOpt MXFP8 linear (one-shot) |
+| `gemm.wo_projection` | Fused MLA WO-A/WO-B projections (+ inverse-RoPE variant) |
+| `moe.fused_moe` | Fused TP routed-expert FFN; recipes nvfp4/mxfp4/w4a8_mx/w4a8_nvfp4/w4a16 |
+| `moe.ep_moe` | Expert-parallel W4A16 MoE (cross-rank reduce is the caller's job) |
+| `norm.mhc` | Fused RMSNorm + hyper-connection residual mixing + projection |
+| `quantization.mxfp8` | BF16/FP16 rows → dense-GEMM MXFP8 layout |
+| `comm.pcie` | PCIe collectives: oneshot/DMA all-reduce, FP8 two-shot, DCP A2A (needs nvcc) |
+
+## Environment & caches
+
+All sm12x knobs use the `FLASHINFER_EXP_SM12X_` prefix. Legacy `B12X_*`
+variables are read through (copied onto the new names at first use, with a
+one-time `DeprecationWarning`). Compile cache:
+`FLASHINFER_EXP_SM12X_COMPILE_CACHE_DIR` →
+`$FLASHINFER_CACHE_DIR/experimental/sm12x/compile` →
+`~/.cache/flashinfer/experimental/sm12x/compile`; disk keys fingerprint the
+whole `sm12x/` subtree, so any source edit invalidates exactly.
+
+Known process-global side effect: on first op use, small CUTLASS-DSL runtime
+patches apply (compile-only-cache warning suppression, memory-debug no-op,
+a `getframeinfo` fast path for 40k-op kernels). Disable with
+`FLASHINFER_EXP_SM12X_DISABLE_CUTLASS_RUNTIME_PATCHES=1`; safe alongside a
+co-installed b12x. The `torch.ops.flashinfer_sm12x.*` custom-op namespace is
+private (torch.compile/graph integration only) — use the Python API.
+
+## Migrating from b12x
+
+Module paths carry the context b12x encoded in names; the verbs are the
+closed set `plan / bind / run[_variant] / prepare_* / pack_* / quantize_* /
+clear_caches / is_supported` with role classes `Caps / Plan / Binding /
+Scratch / Weights`. Representative renames
+(`plan.bind(**kw)` ≡ module-level `bind(plan, **kw)`):
+
+| b12x | experimental |
+|---|---|
+| `b12x_moe_fp4(binding=b)` | `moe.fused_moe.run(binding=b)` |
+| `plan_tp_moe_scratch` / `build_tp_moe_fp4_binding` | `moe.fused_moe.plan` / `.bind` |
+| `prepare_b12x_fp4_moe_weights` | `moe.fused_moe.prepare_weights` |
+| `paged_attention_forward` / `plan_paged_attention_scratch` | `attention.paged.run` / `.plan` |
+| `sparse_mla_decode_forward` | `attention.sparse_mla.run_decode` |
+| `dense_gemm` | `gemm.blockscaled.mm` |
+| `b12x_mhc_post_pre` | `norm.mhc.run_post_pre` |
+| `PCIeOneshotAllReduce` | `comm.pcie.OneshotAllReduce` |
+| `b12x.freeze_kernel_resolution` | `sm12x.freeze_kernel_resolution` |
+
+Not ported: `attention/mla/legacy/` (retired upstream), the standalone
+BF16→NVFP4 TMA quantizer (dead dev harness upstream), b12x's benchmark
+harness and exhaustive policy/tuning test sweeps (they remain in b12x).
+
+## Tests
+
+`tests/experimental/` — curated, small-shape, pure-torch-reference tests
+(seconds each), per the lightweight-tests rule. The structural lints and
+CPU import-hygiene checks run in the `experimental-sm12x` CI workflow; GPU
+kernel tests need an SM12x machine:
+
+```bash
+pytest tests/experimental/lint -q                  # blocking, stdlib-only
+pytest tests/experimental -q                       # full suite (SM120/SM121 GPU)
+```

--- a/flashinfer/experimental/__init__.py
+++ b/flashinfer/experimental/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""flashinfer.experimental — fast-moving, arch-scoped kernels.
+
+Everything under this namespace is exempt from FlashInfer's stability and
+support guarantees: APIs may change or disappear in any release, ops target
+non-flagship architectures only (currently SM12x consumer Blackwell), nothing
+here is ever compiled ahead-of-time or shipped in the jit-cache/cubin wheels,
+and core FlashInfer never imports it.  See flashinfer/experimental/README.md
+for the governing rules.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import warnings
+from typing import Any
+
+if os.environ.get("FLASHINFER_EXP_QUIET", "").strip().lower() not in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}:
+    warnings.warn(
+        "flashinfer.experimental APIs are experimental: no API stability and "
+        "no support guarantees; interfaces may change or be removed in any "
+        "release. Set FLASHINFER_EXP_QUIET=1 to silence this warning.",
+        FutureWarning,
+        stacklevel=2,
+    )
+
+_ARCH_NAMESPACES = ("sm12x",)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _ARCH_NAMESPACES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(_ARCH_NAMESPACES)
+
+
+__all__ = list(_ARCH_NAMESPACES)

--- a/flashinfer/experimental/sm12x/__init__.py
+++ b/flashinfer/experimental/sm12x/__init__.py
@@ -46,6 +46,7 @@ _OPS: tuple[str, ...] = (
     "attention.compressed_mla",
     "attention.nsa_indexer",
     "attention.varlen",
+    "comm.pcie",
     "gemm.blockscaled",
     "gemm.block_fp8_linear",
     "gemm.mxfp8_linear",

--- a/flashinfer/experimental/sm12x/__init__.py
+++ b/flashinfer/experimental/sm12x/__init__.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""flashinfer.experimental.sm12x — consumer-Blackwell (SM120/SM121) kernels.
+
+CuTe-DSL kernels for NVFP4/MXFP4/MXFP8 GEMM, fused MoE, attention (paged,
+sparse/compressed MLA, NSA indexing), quantization, mHC residual, and PCIe
+collectives, ported from the b12x project.  One grammar everywhere:
+
+- ops live at ``sm12x.<group>.<op>`` and declare themselves via ``META``;
+- planned ops share the lifecycle ``Caps -> plan() -> bind() ->
+  run*()`` (``plan`` may allocate; ``bind`` builds views only and never
+  allocates; ``run*`` is CUDA-graph-capture safe);
+- one-shot ops are plain functions; comm collectives are classes.
+
+Serving controls (`freeze_kernel_resolution` & friends) live here at the
+arch root because they guard the shared compiler: warm every kernel shape,
+then freeze so a cache miss raises instead of compiling inside a live
+request or graph capture.
+
+Importing this module is cheap and side-effect free; kernels, cutlass, and
+torch custom ops load on first op use.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+from ._lib.meta import OpMeta
+from ._lib.runtime_control import (
+    KernelResolutionFrozenError,
+    compilation_frozen,
+    freeze_compilation,
+    freeze_kernel_resolution,
+    kernel_resolution_frozen,
+    unfreeze_compilation,
+    unfreeze_kernel_resolution,
+)
+
+# Static op registry: one entry per op directory, kept in lockstep by
+# tests/experimental/test_registry.py.  Grows as port phases land.
+_OPS: tuple[str, ...] = ()
+
+_GROUPS = ("attention", "comm", "gemm", "moe", "norm", "quantization")
+_LAZY_ROOT_ATTRS: dict[str, tuple[str, str]] = {
+    # public name -> (module, attribute)
+    "ScratchBufferSpec": ("._lib.scratch", "ScratchBufferSpec"),
+}
+
+
+def list_ops() -> tuple[OpMeta, ...]:
+    """Import every op's (cheap) ``__init__`` and return their ``META``s."""
+    return tuple(
+        importlib.import_module(f".{op_path}", __name__).META for op_path in _OPS
+    )
+
+
+def find_op(qualname: str) -> OpMeta:
+    """Look up one op's ``META`` by ``"<group>.<op>"`` qualname."""
+    if qualname not in _OPS:
+        raise KeyError(
+            f"unknown experimental sm12x op {qualname!r}; known ops: {sorted(_OPS)}"
+        )
+    return importlib.import_module(f".{qualname}", __name__).META
+
+
+def clear_all_caches() -> None:
+    """Clear caches of every op already imported; never forces imports."""
+    for op_path in _OPS:
+        api = sys.modules.get(f"{__name__}.{op_path}.api")
+        clear = getattr(api, "clear_caches", None) if api is not None else None
+        if clear is not None:
+            clear()
+    compiler = sys.modules.get(f"{__name__}._lib.compiler")
+    if compiler is not None:
+        compiler.clear_compile_cache()
+
+
+def __getattr__(name: str) -> Any:
+    if name in _GROUPS:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    if name in _LAZY_ROOT_ATTRS:
+        module_name, attr = _LAZY_ROOT_ATTRS[name]
+        value = getattr(importlib.import_module(module_name, __name__), attr)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted([*__all__, *_GROUPS])
+
+
+__all__ = [
+    "KernelResolutionFrozenError",
+    "OpMeta",
+    "ScratchBufferSpec",
+    "clear_all_caches",
+    "compilation_frozen",
+    "find_op",
+    "freeze_compilation",
+    "freeze_kernel_resolution",
+    "kernel_resolution_frozen",
+    "list_ops",
+    "unfreeze_compilation",
+    "unfreeze_kernel_resolution",
+]

--- a/flashinfer/experimental/sm12x/__init__.py
+++ b/flashinfer/experimental/sm12x/__init__.py
@@ -52,6 +52,7 @@ _OPS: tuple[str, ...] = (
     "gemm.wo_projection",
     "moe.fused_moe",
     "moe.ep_moe",
+    "norm.mhc",
     "quantization.mxfp8",
     "quantization.nvfp4",
 )

--- a/flashinfer/experimental/sm12x/__init__.py
+++ b/flashinfer/experimental/sm12x/__init__.py
@@ -41,6 +41,11 @@ from ._lib.runtime_control import (
 # Static op registry: one entry per op directory, kept in lockstep by
 # tests/experimental/test_registry.py.  Grows as port phases land.
 _OPS: tuple[str, ...] = (
+    "attention.paged",
+    "attention.sparse_mla",
+    "attention.compressed_mla",
+    "attention.nsa_indexer",
+    "attention.varlen",
     "gemm.blockscaled",
     "gemm.block_fp8_linear",
     "gemm.mxfp8_linear",

--- a/flashinfer/experimental/sm12x/__init__.py
+++ b/flashinfer/experimental/sm12x/__init__.py
@@ -45,6 +45,8 @@ _OPS: tuple[str, ...] = (
     "gemm.block_fp8_linear",
     "gemm.mxfp8_linear",
     "gemm.wo_projection",
+    "moe.fused_moe",
+    "moe.ep_moe",
     "quantization.mxfp8",
     "quantization.nvfp4",
 )

--- a/flashinfer/experimental/sm12x/__init__.py
+++ b/flashinfer/experimental/sm12x/__init__.py
@@ -40,7 +40,14 @@ from ._lib.runtime_control import (
 
 # Static op registry: one entry per op directory, kept in lockstep by
 # tests/experimental/test_registry.py.  Grows as port phases land.
-_OPS: tuple[str, ...] = ()
+_OPS: tuple[str, ...] = (
+    "gemm.blockscaled",
+    "gemm.block_fp8_linear",
+    "gemm.mxfp8_linear",
+    "gemm.wo_projection",
+    "quantization.mxfp8",
+    "quantization.nvfp4",
+)
 
 _GROUPS = ("attention", "comm", "gemm", "moe", "norm", "quantization")
 _LAZY_ROOT_ATTRS: dict[str, tuple[str, str]] = {

--- a/flashinfer/experimental/sm12x/_lib/__init__.py
+++ b/flashinfer/experimental/sm12x/_lib/__init__.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Shared runtime for flashinfer.experimental.sm12x (vendored from b12x).
+
+One infrastructure spine for every op: the CuTe-DSL compile/cache wrapper
+(``compiler``), device PTX intrinsics and host quant helpers (``intrinsics``),
+dtype/stream/arch utilities (``utils``), the caller-owned scratch contract
+(``scratch``/``scratch_layout``), serving freeze guards (``runtime_control``),
+CUTLASS DSL runtime patches (``runtime_patches``), plus the hand-written
+``env``/``meta``/``gating`` conventions.
+
+Importing this package is side-effect free and light (no cutlass, no torch
+ops).  Attribute access hydrates the aggregation surface once — mirroring
+b12x's ``from b12x.cute import compile, launch, ...`` idiom — which is when
+the CUTLASS runtime patches apply (via ``compiler`` import).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+# Order matters: compiler first (applies runtime patches + legacy-env sync
+# before intrinsics/utils import cutlass); later modules win name collisions to
+# match b12x's `from .intrinsics import *; from .utils import *` aggregation.
+_AGG_MODULES = ("compiler", "runtime_control", "scratch", "intrinsics", "utils")
+_hydrated = False
+
+
+def _hydrate() -> None:
+    global _hydrated
+    if _hydrated:
+        return
+    _hydrated = True
+    for module_name in _AGG_MODULES:
+        module = importlib.import_module(f".{module_name}", __name__)
+        public = getattr(module, "__all__", None)
+        if public is None:
+            public = [name for name in vars(module) if not name.startswith("_")]
+        for symbol in public:
+            globals()[symbol] = getattr(module, symbol)
+
+
+def __getattr__(name: str) -> Any:
+    if name.startswith("__"):
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    _hydrate()
+    try:
+        return globals()[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None

--- a/flashinfer/experimental/sm12x/_lib/compiler.py
+++ b/flashinfer/experimental/sm12x/_lib/compiler.py
@@ -1,0 +1,2750 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/cute/compiler.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import inspect
+import json
+import math
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+import traceback
+from collections import OrderedDict
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, fields, is_dataclass
+from functools import lru_cache
+from pathlib import Path
+from threading import RLock
+from types import SimpleNamespace
+from typing import Any
+
+from .env import sync_legacy_env
+from .runtime_patches import apply_cutlass_runtime_patches
+
+sync_legacy_env()
+apply_cutlass_runtime_patches()
+
+# The package fingerprint hashes every source file under this root; it is
+# part of every disk-cache key.  Must resolve to flashinfer/experimental/sm12x.
+_PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+_MEMORY_CACHE: OrderedDict[object, Any] = OrderedDict()
+_MEMORY_CACHE_LOCK = RLock()
+_SPEC_MEMO: OrderedDict[tuple[object, ...], Any] = OrderedDict()
+_SPEC_MEMO_LOCK = RLock()
+_SPEC_MEMO_MAX = 8192
+_SPEC_MEMO_HITS = 0
+_SPEC_MEMO_MISSES = 0
+_MEMORY_CACHE_HITS = 0
+_MEMORY_CACHE_MISSES = 0
+_DISK_CACHE_HITS = 0
+_COMPILE_MISSES = 0
+_COMPILE_PROGRESS_LOCK = RLock()
+_COMPILE_PROGRESS_COUNT = 0
+_COMPILE_PROGRESS_TOTAL_SECONDS = 0.0
+_EXECUTOR_CACHE_LOCK = RLock()
+_EXECUTOR_CACHE_ATTR = "_sm12x_cached_default_executor"
+_VLLM_ENGINE_STARTED_ENV = "FLASHINFER_EXP_SM12X_ENGINE_STARTED"
+_POST_ENGINE_START_LOG_ENV = "FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILES_AFTER_ENGINE_START"
+_PRINT_COMPILE_PROGRESS_ENV = "FLASHINFER_EXP_SM12X_PRINT_COMPILE_PROGRESS"
+
+
+@dataclass(frozen=True)
+class DimKey:
+    kind: str
+    value: object = None
+
+    @staticmethod
+    def exact(value: object) -> "DimKey":
+        return DimKey("exact", value)
+
+    @staticmethod
+    def capacity(value: object) -> "DimKey":
+        return DimKey("capacity", value)
+
+    @staticmethod
+    def bucket(value: object) -> "DimKey":
+        return DimKey("bucket", value)
+
+    @staticmethod
+    def dynamic() -> "DimKey":
+        return DimKey("dynamic")
+
+    @staticmethod
+    def ignored() -> "DimKey":
+        return DimKey("ignored")
+
+
+@dataclass(frozen=True)
+class TensorKey:
+    name: str
+    dtype: str
+    rank: int
+    dims: tuple[DimKey, ...]
+    stride: tuple[int, ...]
+    device: tuple[str, int | None]
+    align: int | None = None
+    layout: object = None
+
+    @staticmethod
+    def from_tensor(
+        name: str,
+        tensor: Any,
+        *,
+        dims: tuple[DimKey, ...] | None = None,
+        align: int | None = None,
+        layout: object = None,
+    ) -> "TensorKey":
+        shape = tuple(int(dim) for dim in tensor.shape)
+        if dims is None:
+            dims = tuple(DimKey.exact(dim) for dim in shape)
+        if len(dims) != len(shape):
+            raise ValueError(
+                f"tensor key {name!r} dim policy rank {len(dims)} "
+                f"does not match tensor rank {len(shape)}"
+            )
+        device = tensor.device
+        return TensorKey(
+            name=name,
+            dtype=str(tensor.dtype),
+            rank=len(shape),
+            dims=dims,
+            stride=tuple(int(stride) for stride in tensor.stride()),
+            device=(device.type, device.index),
+            align=align,
+            layout=layout,
+        )
+
+
+def _spec_memo_enabled() -> bool:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_COMPILE_SPEC_MEMO", "1")
+    return raw.lower() not in {"0", "false", "no", ""}
+
+
+def _spec_memo_key(
+    kind: str,
+    kernel_id: str,
+    version: int,
+    payload: object,
+    extra: object = None,
+) -> tuple[object, ...] | None:
+    # repr() of a JSON-POD payload is content-deterministic and preserves
+    # type distinctions (True vs 1, tuple vs list), so it is a safe memo key.
+    # Non-POD payloads never get stored (see _spec_memo_put callers), which
+    # keeps id-based reprs out of the cache.
+    if not _spec_memo_enabled():
+        return None
+    try:
+        memo_key = (kind, str(kernel_id), int(version), repr(payload), extra)
+        hash(memo_key)
+    except Exception:
+        return None
+    return memo_key
+
+
+def _spec_memo_get(memo_key: tuple[object, ...] | None) -> Any | None:
+    global _SPEC_MEMO_HITS
+    global _SPEC_MEMO_MISSES
+    if memo_key is None:
+        return None
+    with _SPEC_MEMO_LOCK:
+        spec = _SPEC_MEMO.get(memo_key)
+        if spec is None:
+            _SPEC_MEMO_MISSES += 1
+            return None
+        _SPEC_MEMO_HITS += 1
+        _SPEC_MEMO.move_to_end(memo_key)
+        return spec
+
+
+def _spec_memo_put(memo_key: tuple[object, ...] | None, spec: Any) -> None:
+    if memo_key is None:
+        return
+    with _SPEC_MEMO_LOCK:
+        _SPEC_MEMO[memo_key] = spec
+        _SPEC_MEMO.move_to_end(memo_key)
+        while len(_SPEC_MEMO) > _SPEC_MEMO_MAX:
+            _SPEC_MEMO.popitem(last=False)
+
+
+@dataclass(frozen=True)
+class KeyField:
+    name: str
+    value: object
+
+
+@dataclass(frozen=True)
+class KernelCompileSpec:
+    kernel_id: str
+    version: int
+    fields: tuple[KeyField, ...] = ()
+    json_key: str = ""
+    hash_key: str = ""
+    legacy: bool = False
+
+    def __post_init__(self) -> None:
+        if self.json_key and self.hash_key:
+            return
+        json_key = _compile_spec_json(
+            self.kernel_id,
+            self.version,
+            _legacy_compile_spec_facts(self.kernel_id, self.version, self.fields),
+        )
+        object.__setattr__(self, "json_key", json_key)
+        object.__setattr__(self, "hash_key", _hash_json_key(json_key))
+        object.__setattr__(self, "legacy", True)
+
+    @staticmethod
+    def from_facts(
+        kernel_id: str,
+        version: int,
+        *facts: object,
+    ) -> "KernelCompileSpec":
+        memo_key = _spec_memo_key("facts", kernel_id, version, facts)
+        spec = _spec_memo_get(memo_key)
+        if spec is not None:
+            return spec
+        json_key = _compile_spec_json(kernel_id, version, facts)
+        spec = KernelCompileSpec(
+            kernel_id=str(kernel_id),
+            version=int(version),
+            fields=(),
+            json_key=json_key,
+            hash_key=_hash_json_key(json_key),
+            legacy=False,
+        )
+        # _compile_spec_json raises for non-POD facts, so only POD-validated
+        # specs reach the memo.
+        _spec_memo_put(memo_key, spec)
+        return spec
+
+    @staticmethod
+    def from_fields(
+        kernel_id: str,
+        version: int,
+        *fields: KeyField | tuple[str, object],
+    ) -> "KernelCompileSpec":
+        memo_key = _spec_memo_key("fields", kernel_id, version, fields)
+        spec = _spec_memo_get(memo_key)
+        if spec is not None:
+            return spec
+        coerced_fields = tuple(_coerce_key_field(field) for field in fields)
+        if all(_is_json_pod(field.value) for field in coerced_fields):
+            spec = KernelCompileSpec.from_facts(
+                kernel_id,
+                version,
+                *((field.name, field.value) for field in coerced_fields),
+            )
+            _spec_memo_put(memo_key, spec)
+            return spec
+        return KernelCompileSpec(
+            kernel_id=kernel_id,
+            version=int(version),
+            fields=coerced_fields,
+            legacy=True,
+        )
+
+    @staticmethod
+    def from_legacy_fields(
+        kernel_id: str,
+        version: int,
+        *fields: KeyField | tuple[str, object],
+    ) -> "KernelCompileSpec":
+        return KernelCompileSpec(
+            kernel_id=kernel_id,
+            version=int(version),
+            fields=tuple(_coerce_key_field(field) for field in fields),
+            legacy=True,
+        )
+
+    @staticmethod
+    def from_key(
+        kernel_id: str,
+        version: int,
+        key: tuple[object, ...],
+        *,
+        labels: tuple[str, ...] | None = None,
+    ) -> "KernelCompileSpec":
+        if labels is not None and len(labels) != len(key):
+            raise ValueError(
+                f"compile spec labels length {len(labels)} does not match "
+                f"key length {len(key)}"
+            )
+        memo_key = _spec_memo_key("key", kernel_id, version, key, extra=labels)
+        spec = _spec_memo_get(memo_key)
+        if spec is not None:
+            return spec
+        if _is_json_pod(key):
+            facts = (
+                tuple((str(labels[idx]), value) for idx, value in enumerate(key))
+                if labels is not None
+                else key
+            )
+            spec = KernelCompileSpec.from_facts(kernel_id, version, *facts)
+            _spec_memo_put(memo_key, spec)
+            return spec
+        return KernelCompileSpec(
+            kernel_id=kernel_id,
+            version=int(version),
+            fields=tuple(
+                KeyField(labels[idx] if labels is not None else f"arg{idx}", value)
+                for idx, value in enumerate(key)
+            ),
+            legacy=True,
+        )
+
+    @staticmethod
+    def from_legacy_key(
+        kernel_id: str,
+        version: int,
+        key: tuple[object, ...],
+        *,
+        labels: tuple[str, ...] | None = None,
+    ) -> "KernelCompileSpec":
+        if labels is not None and len(labels) != len(key):
+            raise ValueError(
+                f"compile spec labels length {len(labels)} does not match "
+                f"key length {len(key)}"
+            )
+        return KernelCompileSpec(
+            kernel_id=kernel_id,
+            version=int(version),
+            fields=tuple(
+                KeyField(labels[idx] if labels is not None else f"arg{idx}", value)
+                for idx, value in enumerate(key)
+            ),
+            legacy=True,
+        )
+
+
+def _coerce_key_field(field: KeyField | tuple[str, object]) -> KeyField:
+    if isinstance(field, KeyField):
+        return field
+    name, value = field
+    return KeyField(str(name), value)
+
+
+def key_field(name: str, value: object) -> KeyField:
+    return KeyField(name, value)
+
+
+def tensor_key(
+    name: str,
+    tensor: Any | None,
+    *,
+    dims: tuple[DimKey, ...] | None = None,
+    align: int | None = None,
+    layout: object = None,
+) -> KeyField:
+    if tensor is None:
+        value = None
+    else:
+        try:
+            value = tensor_compile_fact(
+                name,
+                tensor,
+                dims=dims,
+                align=align,
+                layout=layout,
+            )
+        except TypeError:
+            value = TensorKey.from_tensor(
+                name,
+                tensor,
+                dims=dims,
+                align=align,
+                layout=layout,
+            )
+    return KeyField(name, value)
+
+
+def dim_compile_fact(dim: DimKey | object) -> tuple[str, object]:
+    return _dim_policy_fact(dim)
+
+
+def _dim_policy_fact(dim: DimKey | object) -> tuple[str, object]:
+    if isinstance(dim, DimKey):
+        return ("dim", str(dim.kind), _json_pod(dim.value, path="dim.value"))
+    return ("dim", "exact", _json_pod(dim, path="dim.value"))
+
+
+def tensor_compile_fact(
+    name: str,
+    tensor: Any,
+    *,
+    dims: tuple[DimKey | object, ...] | None = None,
+    dynamic_dims: tuple[int, ...] = (),
+    strides: tuple[DimKey | object, ...] | None = None,
+    dynamic_strides: tuple[int, ...] = (),
+    align: int | None = None,
+    layout: object = None,
+) -> tuple[object, ...]:
+    shape = tuple(int(dim) for dim in tensor.shape)
+    if dims is None:
+        dynamic_dim_set = set(dynamic_dims)
+        dims = tuple(
+            DimKey.dynamic() if idx in dynamic_dim_set else DimKey.exact(dim)
+            for idx, dim in enumerate(shape)
+        )
+    if len(dims) != len(shape):
+        raise ValueError(
+            f"tensor key {name!r} dim policy rank {len(dims)} "
+            f"does not match tensor rank {len(shape)}"
+        )
+
+    raw_strides = tuple(int(stride) for stride in tensor.stride())
+    if strides is None:
+        dynamic_stride_set = set(dynamic_strides)
+        strides = tuple(
+            DimKey.dynamic() if idx in dynamic_stride_set else DimKey.exact(stride)
+            for idx, stride in enumerate(raw_strides)
+        )
+    if len(strides) != len(raw_strides):
+        raise ValueError(
+            f"tensor key {name!r} stride policy rank {len(strides)} "
+            f"does not match tensor rank {len(raw_strides)}"
+        )
+
+    device = tensor.device
+    layout_fact = None if layout is None else _json_pod(layout, path="layout")
+    return (
+        "tensor",
+        str(name),
+        str(tensor.dtype),
+        len(shape),
+        tuple(_dim_policy_fact(dim) for dim in dims),
+        tuple(_dim_policy_fact(stride) for stride in strides),
+        (str(device.type), device.index),
+        None if align is None else int(align),
+        layout_fact,
+    )
+
+
+def _is_json_scalar(value: Any) -> bool:
+    if value is None or isinstance(value, (bool, int, str)):
+        return True
+    return isinstance(value, float) and math.isfinite(value)
+
+
+def _is_json_pod(value: Any) -> bool:
+    if _is_json_scalar(value):
+        return True
+    if isinstance(value, DimKey):
+        return _is_json_pod(value.value)
+    if isinstance(value, KeyField):
+        return _is_json_pod(value.value)
+    if isinstance(value, (TensorKey, KernelCompileSpec)):
+        return False
+    if isinstance(value, (tuple, list)):
+        return all(_is_json_pod(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_json_pod(item) for key, item in value.items()
+        )
+    return False
+
+
+def _json_pod(value: Any, *, path: str = "value") -> Any:
+    if _is_json_scalar(value):
+        return value
+    if isinstance(value, float):
+        raise TypeError(f"{path} must be finite for JSON compile specs")
+    if isinstance(value, DimKey):
+        return [
+            "dim",
+            str(value.kind),
+            _json_pod(value.value, path=f"{path}.value"),
+        ]
+    if isinstance(value, KeyField):
+        return [
+            "field",
+            str(value.name),
+            _json_pod(value.value, path=f"{path}.{value.name}"),
+        ]
+    if isinstance(value, (TensorKey, KernelCompileSpec)):
+        raise TypeError(
+            f"{path} contains legacy compile-key object {type(value).__name__}; "
+            "use explicit POD facts instead"
+        )
+    if isinstance(value, tuple):
+        return [
+            _json_pod(item, path=f"{path}[{idx}]") for idx, item in enumerate(value)
+        ]
+    if isinstance(value, list):
+        return [
+            _json_pod(item, path=f"{path}[{idx}]") for idx, item in enumerate(value)
+        ]
+    if isinstance(value, dict):
+        out = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} dict key {key!r} is not a string")
+            out[key] = _json_pod(item, path=f"{path}.{key}")
+        return out
+    raise TypeError(
+        f"{path} contains non-POD compile fact "
+        f"{type(value).__module__}.{type(value).__qualname__}"
+    )
+
+
+def _json_dumps_pod(value: Any) -> str:
+    return json.dumps(
+        _json_pod(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _hash_json_key(json_key: str) -> str:
+    return hashlib.sha256(json_key.encode("utf-8")).hexdigest()
+
+
+def _compile_spec_json(
+    kernel_id: str,
+    version: int,
+    facts: object,
+) -> str:
+    return _json_dumps_pod(
+        {
+            "facts": facts,
+            "kernel": str(kernel_id),
+            "version": int(version),
+        }
+    )
+
+
+def _legacy_compile_spec_facts(
+    kernel_id: str,
+    version: int,
+    fields: tuple[KeyField, ...],
+) -> tuple[object, ...]:
+    return (
+        "legacy",
+        str(kernel_id),
+        int(version),
+        tuple(_compile_spec_shape_key(field) for field in fields),
+    )
+
+
+def _compile_kwargs_json_key(kwargs: dict[str, Any]) -> tuple[str, str]:
+    if not kwargs:
+        return "", ""
+    try:
+        json_key = _json_dumps_pod(kwargs)
+    except TypeError:
+        json_key = _json_dumps_pod(_compile_spec_shape_key(kwargs))
+    return json_key, _hash_json_key(json_key)
+
+
+def _compile_spec_shape_key(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, bytes):
+        return ("bytes", value)
+    if isinstance(value, Path):
+        return ("path", str(value))
+    if isinstance(value, DimKey):
+        return ("dim", value.kind, _compile_spec_shape_key(value.value))
+    if isinstance(value, TensorKey):
+        return (
+            "tensor",
+            value.name,
+            value.dtype,
+            value.rank,
+            tuple(_compile_spec_shape_key(dim) for dim in value.dims),
+            value.stride,
+            value.device,
+            value.align,
+            _compile_spec_shape_key(value.layout),
+        )
+    if isinstance(value, KeyField):
+        return ("field", value.name, _compile_spec_shape_key(value.value))
+    if isinstance(value, KernelCompileSpec):
+        return (
+            "kernel_spec_json" if not value.legacy else "kernel_spec_legacy_json",
+            value.kernel_id,
+            value.version,
+            value.hash_key,
+            value.json_key,
+        )
+    if isinstance(value, (tuple, list)):
+        return tuple(_compile_spec_shape_key(item) for item in value)
+    if isinstance(value, dict):
+        return (
+            "dict",
+            tuple(
+                (
+                    _compile_spec_shape_key(key),
+                    _compile_spec_shape_key(item_value),
+                )
+                for key, item_value in value.items()
+            ),
+        )
+    if isinstance(value, type):
+        return ("type", value.__module__, value.__qualname__)
+    cache_key_attr = getattr(value, "__cache_key__", None)
+    if cache_key_attr is not None:
+        return (
+            "cache_key",
+            type(value).__module__,
+            type(value).__qualname__,
+            _compile_spec_shape_key(cache_key_attr),
+        )
+    if is_dataclass(value):
+        return (
+            "dataclass",
+            type(value).__module__,
+            type(value).__qualname__,
+            tuple(
+                (
+                    field.name,
+                    _compile_spec_shape_key(getattr(value, field.name)),
+                )
+                for field in fields(value)
+            ),
+        )
+    return (
+        "repr",
+        type(value).__module__,
+        type(value).__qualname__,
+        repr(value),
+    )
+
+
+def _compile_memory_cache_key(
+    compile_callable: Any,
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    compile_spec: KernelCompileSpec | None,
+) -> object:
+    if compile_spec is not None:
+        kwargs_json_key, kwargs_hash_key = _compile_kwargs_json_key(kwargs)
+        key: tuple[object, ...] = (
+            "sm12x_cute_memory_cache_v2_explicit_spec",
+            compile_spec.hash_key,
+        )
+        if kwargs_hash_key:
+            key += (kwargs_hash_key, kwargs_json_key)
+        return key
+
+    return hashlib.sha256(
+        repr(_compile_disk_cache_payload(compile_callable, func, args, kwargs)).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+
+
+def _cute_compile_memory_cache_enabled() -> bool:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_COMPILE_MEMORY_CACHE", "1")
+    return raw.lower() not in {"0", "false", "no", ""}
+
+
+def _cute_compile_memory_cache_size() -> int:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_COMPILE_MEMORY_CACHE_SIZE", "1024")
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1024
+
+
+def _cute_compile_disk_cache_enabled() -> bool:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_COMPILE_DISK_CACHE", "1")
+    return raw.lower() not in {"0", "false", "no", ""}
+
+
+def _cute_compile_cache_dir() -> Path:
+    root = os.environ.get("FLASHINFER_EXP_SM12X_COMPILE_CACHE_DIR")
+    if root:
+        return Path(root)
+    flashinfer_cache_dir = os.environ.get("FLASHINFER_CACHE_DIR")
+    if flashinfer_cache_dir:
+        return Path(flashinfer_cache_dir) / "experimental" / "sm12x" / "compile"
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return (
+            Path(xdg_cache_home) / "flashinfer" / "experimental" / "sm12x" / "compile"
+        )
+    return Path.home() / ".cache" / "flashinfer" / "experimental" / "sm12x" / "compile"
+
+
+def _cute_compile_log_enabled() -> bool:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILES", "")
+    return raw.lower() not in {"", "0", "false", "no", "off"}
+
+
+def _cute_compile_progress_enabled() -> bool:
+    raw = os.environ.get(_PRINT_COMPILE_PROGRESS_ENV, "")
+    return raw.lower() not in {"", "0", "false", "no", "off"}
+
+
+def _cute_compile_post_engine_start_log_enabled() -> bool:
+    marker = os.environ.get(_VLLM_ENGINE_STARTED_ENV, "")
+    if marker.lower() in {"", "0", "false", "no", "off"}:
+        return False
+    raw = os.environ.get(_POST_ENGINE_START_LOG_ENV)
+    if raw is None:
+        return True
+    return raw.lower() not in {"", "0", "false", "no", "off"}
+
+
+def _cute_compile_stack_log_enabled() -> bool:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILE_STACK", "")
+    if raw:
+        return raw.lower() not in {"0", "false", "no", "off"}
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILES", "")
+    if raw.lower() in {"stack", "trace", "traceback", "full"}:
+        return True
+    raw = os.environ.get(_POST_ENGINE_START_LOG_ENV, "")
+    return raw.lower() in {"stack", "trace", "traceback", "full"}
+
+
+def _cute_compile_stack_log_depth() -> int:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILE_STACK_DEPTH", "")
+    if not raw:
+        return 48
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 48
+
+
+def _short_repr(value: Any, *, max_len: int = 160) -> str:
+    try:
+        if isinstance(value, type):
+            text = f"{value.__module__}.{value.__qualname__}"
+        else:
+            text = repr(value)
+    except Exception:
+        text = f"<{type(value).__module__}.{type(value).__qualname__}>"
+    if len(text) > max_len:
+        return text[: max_len - 3] + "..."
+    return text
+
+
+def _compile_target_name(func: Any) -> str:
+    unwrapped = inspect.unwrap(func)
+    if inspect.ismethod(unwrapped):
+        module = getattr(unwrapped.__func__, "__module__", "")
+        qualname = getattr(
+            unwrapped.__func__,
+            "__qualname__",
+            getattr(unwrapped.__func__, "__name__", ""),
+        )
+        return f"{module}.{qualname}" if module else qualname
+    if inspect.isfunction(unwrapped):
+        module = getattr(unwrapped, "__module__", "")
+        qualname = getattr(
+            unwrapped, "__qualname__", getattr(unwrapped, "__name__", "")
+        )
+        return f"{module}.{qualname}" if module else qualname
+    target_type = type(func)
+    module = getattr(target_type, "__module__", "")
+    qualname = getattr(target_type, "__qualname__", target_type.__name__)
+    return f"{module}.{qualname}" if module else qualname
+
+
+def _simple_log_value(value: Any) -> Any | None:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, type):
+        return f"{value.__module__}.{value.__qualname__}"
+    if isinstance(value, (tuple, list)) and len(value) <= 8:
+        items = []
+        for item in value:
+            simple = _simple_log_value(item)
+            if simple is None:
+                return None
+            items.append(simple)
+        return tuple(items) if isinstance(value, tuple) else items
+    return None
+
+
+def _compile_target_attrs(func: Any) -> dict[str, Any]:
+    if not hasattr(func, "__dict__"):
+        return {}
+    attrs = {}
+    for name, value in sorted(vars(func).items()):
+        if name.startswith("_"):
+            continue
+        simple = _simple_log_value(value)
+        if simple is None:
+            continue
+        attrs[name] = simple
+        if len(attrs) >= 48:
+            attrs["..."] = "truncated"
+            break
+    return attrs
+
+
+def _compile_arg_shape_summary(value: Any) -> dict[str, Any] | None:
+    shape = _first_present_attr(value, "_shape", "shape")
+    if shape is None:
+        return None
+    try:
+        shape_value = tuple(shape)
+    except TypeError:
+        shape_value = shape
+    summary: dict[str, Any] = {
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "shape": _short_repr(shape_value, max_len=96),
+    }
+    stride = _first_present_attr(value, "_stride", "stride")
+    if stride is not None:
+        try:
+            stride_value = tuple(stride)
+        except TypeError:
+            stride_value = stride
+        summary["stride"] = _short_repr(stride_value, max_len=96)
+    stride_order = _first_present_attr(value, "_stride_order", "stride_order")
+    if stride_order is not None:
+        try:
+            stride_order_value = tuple(stride_order)
+        except TypeError:
+            stride_order_value = stride_order
+        summary["stride_order"] = _short_repr(stride_order_value, max_len=96)
+    dtype = _first_present_attr(value, "_dtype", "dtype", "element_type")
+    if dtype is not None:
+        summary["dtype"] = _short_repr(dtype, max_len=80)
+    memspace = _first_present_attr(value, "_memspace", "memspace")
+    if memspace is not None:
+        summary["memspace"] = _short_repr(memspace, max_len=80)
+    assumed_align = _first_present_attr(value, "_assumed_align", "assumed_align")
+    if assumed_align is not None:
+        summary["align"] = assumed_align
+    return summary
+
+
+def _compile_args_shape_summary(
+    args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for idx, value in enumerate(args):
+        shaped = _compile_arg_shape_summary(value)
+        if shaped is not None:
+            summary[f"arg{idx}"] = shaped
+        elif value is None or isinstance(value, (bool, int, float, str)):
+            summary[f"arg{idx}"] = value
+        if len(summary) >= 24:
+            summary["..."] = "truncated"
+            return summary
+    for name, value in sorted(kwargs.items()):
+        shaped = _compile_arg_shape_summary(value)
+        if shaped is not None:
+            summary[f"kw:{name}"] = shaped
+        elif value is None or isinstance(value, (bool, int, float, str)):
+            summary[f"kw:{name}"] = value
+        if len(summary) >= 24:
+            summary["..."] = "truncated"
+            return summary
+    return summary
+
+
+def _type_log_name(module: str, qualname: str) -> str:
+    return f"{module}.{qualname}" if module else qualname
+
+
+def _function_fingerprint_log_value(value: Any) -> Any:
+    if isinstance(value, tuple) and len(value) == 3:
+        module, qualname, _fingerprint = value
+        if isinstance(module, str) and isinstance(qualname, str):
+            return _type_log_name(module, qualname)
+    return _cache_key_log_value(value, max_depth=2, max_items=8)
+
+
+def _object_state_log_value(
+    value: Any, *, max_depth: int, max_items: int
+) -> dict[str, Any] | None:
+    if not (isinstance(value, tuple) and len(value) == 4 and value[0] == "object"):
+        return None
+    _tag, module, qualname, attrs = value
+    if not isinstance(attrs, tuple):
+        return None
+
+    state: dict[str, Any] = {}
+    for idx, item in enumerate(attrs):
+        if idx >= max_items:
+            state["..."] = f"{len(attrs) - idx} more"
+            break
+        if not (isinstance(item, tuple) and len(item) == 2):
+            continue
+        name, attr_value = item
+        state[str(name)] = _cache_key_log_value(
+            attr_value, max_depth=max_depth - 1, max_items=max_items
+        )
+    return {"type": _type_log_name(str(module), str(qualname)), "attrs": state}
+
+
+def _tensor_key_log_value(
+    names: tuple[str, ...], values: tuple[Any, ...], *, max_depth: int, max_items: int
+) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name, value in zip(names, values, strict=False):
+        if value is None:
+            continue
+        out[name] = _cache_key_log_value(
+            value, max_depth=max_depth - 1, max_items=max_items
+        )
+    return out
+
+
+def _cache_key_log_value(value: Any, *, max_depth: int = 5, max_items: int = 32) -> Any:
+    if max_depth <= 0:
+        return _short_repr(value, max_len=120)
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, type):
+        return _type_log_name(value.__module__, value.__qualname__)
+
+    object_state = _object_state_log_value(
+        value, max_depth=max_depth, max_items=max_items
+    )
+    if object_state is not None:
+        return object_state
+
+    if (
+        isinstance(value, tuple)
+        and value
+        and all(
+            isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str)
+            for item in value
+        )
+    ):
+        out: dict[str, Any] = {}
+        for idx, (key, item_value) in enumerate(value):
+            if idx >= max_items:
+                out["..."] = f"{len(value) - idx} more"
+                break
+            out[key] = _cache_key_log_value(
+                item_value, max_depth=max_depth - 1, max_items=max_items
+            )
+        return out
+
+    if isinstance(value, tuple) and value:
+        tag = value[0]
+        if tag == "type" and len(value) == 3:
+            return _type_log_name(str(value[1]), str(value[2]))
+        if tag == "function" and len(value) == 2:
+            return _function_fingerprint_log_value(value[1])
+        if tag == "method" and len(value) == 3:
+            return {
+                "kind": "method",
+                "function": _function_fingerprint_log_value(value[1]),
+                "self": _cache_key_log_value(
+                    value[2], max_depth=max_depth - 1, max_items=max_items
+                ),
+            }
+        if tag == "callable_instance" and len(value) == 5:
+            return {
+                "kind": "callable_instance",
+                "type": _type_log_name(str(value[1]), str(value[2])),
+                "call": _function_fingerprint_log_value(value[3]),
+                "state": _cache_key_log_value(
+                    value[4], max_depth=max_depth - 1, max_items=max_items
+                ),
+            }
+        if tag == "callable" and len(value) == 4:
+            return {
+                "kind": "callable",
+                "type": _type_log_name(str(value[1]), str(value[2])),
+                "repr": _short_repr(value[3], max_len=160),
+            }
+        if tag == "cache_key" and len(value) == 4:
+            return {
+                "type": _type_log_name(str(value[1]), str(value[2])),
+                "cache_key": _cache_key_log_value(
+                    value[3], max_depth=max_depth - 1, max_items=max_items
+                ),
+            }
+        if tag == "fake_tensor" and len(value) == 12:
+            return _tensor_key_log_value(
+                (
+                    "kind",
+                    "type",
+                    "dtype",
+                    "shape",
+                    "stride",
+                    "stride_order",
+                    "device",
+                    "layout",
+                    "memspace",
+                    "align",
+                    "use_32bit_stride",
+                ),
+                (
+                    "fake_tensor",
+                    _type_log_name(str(value[1]), str(value[2])),
+                    *value[3:],
+                ),
+                max_depth=max_depth,
+                max_items=max_items,
+            )
+        if tag == "runtime_tensor" and len(value) == 8:
+            return _tensor_key_log_value(
+                (
+                    "kind",
+                    "dtype",
+                    "shape",
+                    "stride",
+                    "memspace",
+                    "align",
+                    "is_dynamic",
+                    "use_32bit_stride",
+                ),
+                value,
+                max_depth=max_depth,
+                max_items=max_items,
+            )
+        if tag == "fake_compact_tensor" and len(value) == 7:
+            return _tensor_key_log_value(
+                (
+                    "kind",
+                    "dtype",
+                    "shape",
+                    "stride_order",
+                    "memspace",
+                    "align",
+                    "use_32bit_stride",
+                ),
+                value,
+                max_depth=max_depth,
+                max_items=max_items,
+            )
+        if tag == "cuda_stream":
+            return "cuda_stream"
+        if tag == "symbolic_dim" and len(value) == 4:
+            return value[3]
+        if tag == "bytes" and len(value) == 2 and isinstance(value[1], str):
+            return f"bytes[{len(value[1]) // 2}]"
+        if tag == "path" and len(value) == 2:
+            return value[1]
+        if tag == "repr" and len(value) == 4:
+            return {
+                "type": _type_log_name(str(value[1]), str(value[2])),
+                "repr": _short_repr(value[3], max_len=160),
+            }
+        if tag == "cycle" and len(value) == 3:
+            return {"cycle": _type_log_name(str(value[1]), str(value[2]))}
+
+    if isinstance(value, dict):
+        out = {}
+        for idx, (key, item_value) in enumerate(
+            sorted(value.items(), key=lambda kv: str(kv[0]))
+        ):
+            if idx >= max_items:
+                out["..."] = f"{len(value) - idx} more"
+                break
+            out[str(key)] = _cache_key_log_value(
+                item_value, max_depth=max_depth - 1, max_items=max_items
+            )
+        return out
+
+    if isinstance(value, (tuple, list)):
+        items = [
+            _cache_key_log_value(item, max_depth=max_depth - 1, max_items=max_items)
+            for item in value[:max_items]
+        ]
+        if len(value) > max_items:
+            items.append(f"... {len(value) - max_items} more")
+        return tuple(items) if isinstance(value, tuple) else items
+
+    return _short_repr(value, max_len=160)
+
+
+def _toolchain_log_value(toolchain: tuple[object, ...]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for entry in toolchain:
+        if not (isinstance(entry, tuple) and entry):
+            continue
+        name = entry[0]
+        if name == "python" and len(entry) >= 3:
+            summary[str(name)] = f"{entry[1]} {'.'.join(str(v) for v in entry[2])}"
+        elif len(entry) >= 2 and entry[1]:
+            summary[str(name)] = entry[1]
+    return summary
+
+
+def _environment_log_value(env: tuple[tuple[str, str], ...]) -> dict[str, str]:
+    return {name: value for name, value in env if value}
+
+
+def _compile_cache_payload_log_value(
+    payload: tuple[object, ...] | None,
+) -> dict[str, Any]:
+    if payload is None:
+        return {}
+    if len(payload) == 10 and payload[0] == "sm12x_cute_compile_cache_v5_explicit_spec":
+        (
+            _version,
+            target_key,
+            _sm12x_fingerprint,
+            toolchain_key,
+            spec_hash,
+            spec_json,
+            kwargs_hash,
+            kwargs_json,
+            options_key,
+            env_key,
+        ) = payload
+
+        summary: dict[str, Any] = {
+            "target": _cache_key_log_value(target_key, max_depth=7, max_items=80),
+            "spec_hash": spec_hash,
+            "spec": spec_json,
+        }
+        if kwargs_hash:
+            summary["kwargs_hash"] = kwargs_hash
+            summary["kwargs"] = kwargs_json
+        if options_key:
+            summary["options"] = _cache_key_log_value(
+                options_key, max_depth=4, max_items=32
+            )
+        env_summary = (
+            _environment_log_value(env_key) if isinstance(env_key, tuple) else {}
+        )
+        if env_summary:
+            summary["env"] = env_summary
+        if isinstance(toolchain_key, tuple):
+            toolchain_summary = _toolchain_log_value(toolchain_key)
+            if toolchain_summary:
+                summary["toolchain"] = toolchain_summary
+        return summary
+
+    if len(payload) == 8 and payload[0] in {
+        "sm12x_cute_compile_cache_v3_explicit_spec",
+        "sm12x_cute_compile_cache_v4_explicit_spec",
+    }:
+        (
+            _version,
+            target_key,
+            _sm12x_fingerprint,
+            toolchain_key,
+            spec_key,
+            kwargs_key,
+            options_key,
+            env_key,
+        ) = payload
+
+        summary: dict[str, Any] = {
+            "target": _cache_key_log_value(target_key, max_depth=7, max_items=80),
+            "spec": _cache_key_log_value(spec_key, max_depth=7, max_items=80),
+        }
+        if options_key:
+            summary["options"] = _cache_key_log_value(
+                options_key, max_depth=4, max_items=32
+            )
+        kwargs_summary = _cache_key_log_value(kwargs_key, max_depth=5, max_items=32)
+        if kwargs_summary:
+            summary["kwargs"] = kwargs_summary
+        env_summary = (
+            _environment_log_value(env_key) if isinstance(env_key, tuple) else {}
+        )
+        if env_summary:
+            summary["env"] = env_summary
+        if isinstance(toolchain_key, tuple):
+            toolchain_summary = _toolchain_log_value(toolchain_key)
+            if toolchain_summary:
+                summary["toolchain"] = toolchain_summary
+        return summary
+
+    if len(payload) != 8:
+        return {}
+    (
+        _version,
+        target_key,
+        _sm12x_fingerprint,
+        toolchain_key,
+        args_key,
+        kwargs_key,
+        options_key,
+        env_key,
+    ) = payload
+
+    summary: dict[str, Any] = {
+        "target": _cache_key_log_value(target_key, max_depth=7, max_items=80),
+        "args": _cache_key_log_value(args_key, max_depth=5, max_items=32),
+    }
+    kwargs_summary = _cache_key_log_value(kwargs_key, max_depth=5, max_items=32)
+    if kwargs_summary:
+        summary["kwargs"] = kwargs_summary
+    if options_key:
+        summary["options"] = _cache_key_log_value(
+            options_key, max_depth=4, max_items=32
+        )
+    env_summary = _environment_log_value(env_key) if isinstance(env_key, tuple) else {}
+    if env_summary:
+        summary["env"] = env_summary
+    if isinstance(toolchain_key, tuple):
+        toolchain_summary = _toolchain_log_value(toolchain_key)
+        if toolchain_summary:
+            summary["toolchain"] = toolchain_summary
+    return summary
+
+
+def _is_explicit_spec_payload(payload: tuple[object, ...] | None) -> bool:
+    return (
+        payload is not None
+        and len(payload) == 10
+        and payload[0] == "sm12x_cute_compile_cache_v5_explicit_spec"
+    )
+
+
+def _cute_compile_arg_log_enabled() -> bool:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILE_ARGS", "")
+    return raw.lower() not in {"", "0", "false", "no", "off"}
+
+
+def _format_explicit_spec_log_details(summary: dict[str, Any]) -> str:
+    parts = []
+    if "spec_hash" in summary:
+        parts.append(f"spec_hash={summary['spec_hash']}")
+    if "spec" in summary:
+        parts.append(f"spec={summary['spec']}")
+    if "kwargs_hash" in summary:
+        parts.append(f"kwargs_hash={summary['kwargs_hash']}")
+    if "kwargs" in summary:
+        parts.append(f"kwargs={summary['kwargs']}")
+    if "options" in summary:
+        parts.append(f"options={_short_repr(summary['options'], max_len=1200)}")
+    if "env" in summary:
+        parts.append(f"env={_short_repr(summary['env'], max_len=1200)}")
+    if "toolchain" in summary:
+        parts.append(f"toolchain={_short_repr(summary['toolchain'], max_len=1200)}")
+    return " ".join(parts)
+
+
+def _format_cute_compile_stack() -> str:
+    depth = _cute_compile_stack_log_depth()
+    frames = traceback.extract_stack()[:-2]
+    runtime_patch_path = str(Path(__file__).resolve())
+    visible_frames = [
+        frame
+        for frame in frames
+        if str(Path(frame.filename).resolve()) != runtime_patch_path
+    ]
+    if depth:
+        visible_frames = visible_frames[-depth:]
+
+    lines = ["[sm12x cute.compile] python_stack (most recent call last):"]
+    for frame in visible_frames:
+        lines.append(f'  File "{frame.filename}", line {frame.lineno}, in {frame.name}')
+        if frame.line:
+            lines.append(f"    {frame.line.strip()}")
+    return "\n".join(lines)
+
+
+def _log_cute_compile_event(
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    event: str,
+    cache_status: str,
+    cache_payload: tuple[object, ...] | None = None,
+    reason: str | None = None,
+    cache_key: str | None = None,
+) -> None:
+    key_inputs = _compile_cache_payload_log_value(cache_payload)
+    reason_text = "" if reason is None else f"reason={reason} "
+    cache_key_text = "" if cache_key is None else f"cache_key={cache_key[:16]} "
+    if _is_explicit_spec_payload(cache_payload):
+        attrs_text = _short_repr(_compile_target_attrs(func), max_len=1200)
+        args_text = ""
+        if _cute_compile_arg_log_enabled():
+            args_text = f"args={_short_repr(_compile_args_shape_summary(args, kwargs), max_len=1600)} "
+        details = _format_explicit_spec_log_details(key_inputs)
+        print(
+            f"[sm12x cute.compile] {event} "
+            f"{reason_text}"
+            f"target={_compile_target_name(func)} "
+            f"status={cache_status} "
+            f"{cache_key_text}"
+            f"attrs={attrs_text} "
+            f"{args_text}"
+            f"{details}",
+            flush=True,
+        )
+        if _cute_compile_stack_log_enabled():
+            print(_format_cute_compile_stack(), flush=True)
+        return
+
+    print(
+        f"[sm12x cute.compile] {event} "
+        f"{reason_text}"
+        f"target={_compile_target_name(func)} "
+        f"status={cache_status} "
+        f"{cache_key_text}"
+        f"attrs={_short_repr(_compile_target_attrs(func), max_len=1200)} "
+        f"args={_short_repr(_compile_args_shape_summary(args, kwargs), max_len=1600)} "
+        f"key_inputs={_short_repr(key_inputs, max_len=4000)}",
+        flush=True,
+    )
+    if _cute_compile_stack_log_enabled():
+        print(_format_cute_compile_stack(), flush=True)
+
+
+def _log_cute_compile_miss(
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    cache_status: str,
+    cache_payload: tuple[object, ...] | None = None,
+    reason: str | None = None,
+    cache_key: str | None = None,
+) -> None:
+    _log_cute_compile_event(
+        func,
+        args,
+        kwargs,
+        event="miss",
+        cache_status=cache_status,
+        cache_payload=cache_payload,
+        reason=reason,
+        cache_key=cache_key,
+    )
+
+
+def _compile_progress_details(
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    compile_spec: KernelCompileSpec | None,
+    cache_key: str,
+) -> str:
+    parts = [
+        f"target={_compile_target_name(func)}",
+        f"cache_key={cache_key[:16]}",
+    ]
+    if compile_spec is not None:
+        try:
+            params = json.loads(compile_spec.json_key)["facts"]
+        except Exception:
+            params = compile_spec.json_key
+        parts.extend(
+            (
+                f"kernel={compile_spec.kernel_id}",
+                f"version={compile_spec.version}",
+                f"params={_short_repr(params, max_len=2400)}",
+            )
+        )
+    else:
+        attrs = _compile_target_attrs(func)
+        if attrs:
+            parts.append(f"attrs={_short_repr(attrs, max_len=1200)}")
+        parts.append(
+            f"args={_short_repr(_compile_args_shape_summary(args, kwargs), max_len=2000)}"
+        )
+    return " ".join(parts)
+
+
+def _call_cute_compile(
+    compile_callable: Any,
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    compile_spec: KernelCompileSpec | None,
+    cache_key: str,
+) -> Any:
+    if not _cute_compile_progress_enabled():
+        return compile_callable(func, *args, **kwargs)
+
+    global _COMPILE_PROGRESS_COUNT
+    global _COMPILE_PROGRESS_TOTAL_SECONDS
+    with _COMPILE_PROGRESS_LOCK:
+        _COMPILE_PROGRESS_COUNT += 1
+        compile_number = _COMPILE_PROGRESS_COUNT
+
+    try:
+        details = _compile_progress_details(
+            func,
+            args,
+            kwargs,
+            compile_spec=compile_spec,
+            cache_key=cache_key,
+        )
+    except Exception as exc:
+        details = (
+            f"target={_short_repr(func)} cache_key={cache_key[:16]} "
+            f"details_error={type(exc).__name__}"
+        )
+    print(
+        f"[sm12x cute.compile] compile-start number={compile_number} {details}",
+        flush=True,
+    )
+    started = time.perf_counter()
+    try:
+        compiled = compile_callable(func, *args, **kwargs)
+    except BaseException as exc:
+        elapsed = time.perf_counter() - started
+        with _COMPILE_PROGRESS_LOCK:
+            _COMPILE_PROGRESS_TOTAL_SECONDS += elapsed
+            total = _COMPILE_PROGRESS_TOTAL_SECONDS
+        print(
+            f"[sm12x cute.compile] compile-failed number={compile_number} "
+            f"duration_s={elapsed:.3f} total_compile_s={total:.3f} {details} "
+            f"error={type(exc).__name__}: {_short_repr(exc, max_len=500)}",
+            flush=True,
+        )
+        raise
+
+    elapsed = time.perf_counter() - started
+    with _COMPILE_PROGRESS_LOCK:
+        _COMPILE_PROGRESS_TOTAL_SECONDS += elapsed
+        total = _COMPILE_PROGRESS_TOTAL_SECONDS
+    print(
+        f"[sm12x cute.compile] compile-done number={compile_number} "
+        f"duration_s={elapsed:.3f} total_compile_s={total:.3f} {details}",
+        flush=True,
+    )
+    return compiled
+
+
+def _iter_fingerprint_files(root: Path) -> list[Path]:
+    files = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if "__pycache__" in path.parts:
+            continue
+        if path.suffix in {".pyc", ".pyo"}:
+            continue
+        files.append(path)
+    files.sort()
+    return files
+
+
+def _compute_sm12x_package_fingerprint() -> str:
+    digest = hashlib.sha256()
+    for path in _iter_fingerprint_files(_PACKAGE_ROOT):
+        rel_path = str(path.relative_to(_PACKAGE_ROOT))
+        digest.update(rel_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+@lru_cache(maxsize=1)
+def _sm12x_package_fingerprint() -> str:
+    return _compute_sm12x_package_fingerprint()
+
+
+def sm12x_package_fingerprint() -> str:
+    """Return the exact content fingerprint used by the CuTe object cache."""
+    return _sm12x_package_fingerprint()
+
+
+def _distribution_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return ""
+
+
+@lru_cache(maxsize=1)
+def _runtime_toolchain_key() -> tuple[object, ...]:
+    from .runtime_patches import cutlass_runtime_patch_status
+
+    torch_version = _distribution_version("torch")
+    torch_cuda_version = ""
+    try:
+        import torch
+
+        if not torch_version:
+            torch_version = getattr(torch, "__version__", "")
+        torch_cuda_version = getattr(torch.version, "cuda", "") or ""
+    except Exception:
+        pass
+
+    cutlass_version = _distribution_version("nvidia-cutlass-dsl")
+    if not cutlass_version:
+        cutlass_version = _distribution_version("cutlass")
+    if not cutlass_version:
+        try:
+            import cutlass
+
+            cutlass_version = getattr(cutlass, "__version__", "")
+        except Exception:
+            cutlass_version = ""
+    cutlass_version = cutlass_version or "missing"
+
+    return (
+        ("python", sys.implementation.name, sys.version_info[:3]),
+        ("torch", torch_version),
+        ("torch_cuda", torch_cuda_version),
+        ("cutlass_dsl", cutlass_version),
+        (
+            "cutlass_dsl_libs_base",
+            _distribution_version("nvidia-cutlass-dsl-libs-base") or "missing",
+        ),
+        (
+            "cutlass_dsl_libs_core",
+            _distribution_version("nvidia-cutlass-dsl-libs-core") or "missing",
+        ),
+        (
+            "cutlass_dsl_libs_cu12",
+            _distribution_version("nvidia-cutlass-dsl-libs-cu12") or "missing",
+        ),
+        (
+            "cutlass_dsl_libs_cu13",
+            _distribution_version("nvidia-cutlass-dsl-libs-cu13") or "missing",
+        ),
+        ("cuda_python", _distribution_version("cuda-python")),
+        ("cuda_bindings", _distribution_version("cuda-bindings")),
+        ("sm12x_runtime_patches", cutlass_runtime_patch_status()),
+    )
+
+
+@lru_cache(maxsize=1)
+def _compile_environment_key() -> tuple[tuple[str, str], ...]:
+    compile_env_vars = {
+        "CC",
+        "CXX",
+        "CUDA_HOME",
+        "CUDA_PATH",
+        "CUDA_TOOLKIT_PATH",
+        "CUDACXX",
+        "CUTE_DSL_ARCH",
+        "NVCC_APPEND_FLAGS",
+        "NVCC_PREPEND_FLAGS",
+    }
+    operational_env_vars = {
+        "FLASHINFER_EXP_SM12X_COMPILE_CACHE_DIR",
+        "FLASHINFER_EXP_SM12X_COMPILE_DISK_CACHE",
+        "FLASHINFER_EXP_SM12X_COMPILE_MEMORY_CACHE",
+        "FLASHINFER_EXP_SM12X_COMPILE_MEMORY_CACHE_SIZE",
+        "FLASHINFER_EXP_SM12X_COMPILE_SPEC_MEMO",
+        "FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILES",
+        "FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILES_AFTER_ENGINE_START",
+        "FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILE_ARGS",
+        "FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILE_STACK",
+        "FLASHINFER_EXP_SM12X_LOG_CUTE_COMPILE_STACK_DEPTH",
+        "FLASHINFER_EXP_SM12X_PRINT_COMPILE_PROGRESS",
+        "FLASHINFER_EXP_SM12X_TIMING",
+        "FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS",
+        "CUTE_DSL_CACHE_DIR",
+    }
+    for name in os.environ:
+        if name.startswith(("FLASHINFER_EXP_SM12X_", "CUTE_", "CUTLASS_")):
+            if name not in operational_env_vars:
+                compile_env_vars.add(name)
+    return tuple((name, os.environ.get(name, "")) for name in sorted(compile_env_vars))
+
+
+@lru_cache(maxsize=16)
+def _static_compile_cache_context(compile_callable: Any) -> tuple[object, ...]:
+    return (
+        _sm12x_package_fingerprint(),
+        _runtime_toolchain_key(),
+        _compile_options_cache_key(compile_callable),
+        _compile_environment_key(),
+    )
+
+
+def _function_fingerprint(func: Any) -> tuple[str, str, str]:
+    func = inspect.unwrap(func)
+    module = getattr(func, "__module__", "")
+    qualname = getattr(
+        func, "__qualname__", getattr(func, "__name__", type(func).__qualname__)
+    )
+    if module.startswith("flashinfer.experimental.sm12x"):
+        return module, qualname, f"sm12x:{_sm12x_package_fingerprint()}"
+    try:
+        source = inspect.getsource(func)
+        payload = source.encode("utf-8")
+    except (OSError, TypeError):
+        code = getattr(func, "__code__", None)
+        if code is None:
+            payload = repr(func).encode("utf-8")
+        else:
+            payload = repr(
+                (
+                    code.co_code,
+                    code.co_consts,
+                    code.co_names,
+                    code.co_varnames,
+                    code.co_argcount,
+                    code.co_kwonlyargcount,
+                )
+            ).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    return module, qualname, digest
+
+
+def _normalize_compile_target(func: Any, visited: set[int]) -> Any:
+    if inspect.ismethod(func):
+        return (
+            "method",
+            _function_fingerprint(func.__func__),
+            _structural_cache_key(func.__self__, visited),
+        )
+    if inspect.isfunction(func):
+        return ("function", _function_fingerprint(func))
+    if callable(func) and hasattr(func.__call__, "__func__"):
+        state = vars(func) if hasattr(func, "__dict__") else None
+        return (
+            "callable_instance",
+            type(func).__module__,
+            type(func).__qualname__,
+            _function_fingerprint(func.__call__.__func__),
+            _structural_cache_key(state, visited),
+        )
+    return ("callable", type(func).__module__, type(func).__qualname__, repr(func))
+
+
+def _explicit_spec_compile_target(func: Any) -> Any:
+    if inspect.ismethod(func):
+        return ("method", _function_fingerprint(func.__func__))
+    if inspect.isfunction(func):
+        return ("function", _function_fingerprint(func))
+    if callable(func) and hasattr(func.__call__, "__func__"):
+        return (
+            "callable_instance",
+            type(func).__module__,
+            type(func).__qualname__,
+            _function_fingerprint(func.__call__.__func__),
+        )
+    return ("callable", type(func).__module__, type(func).__qualname__)
+
+
+def _structural_dim_key(dim: Any, visited: set[int]) -> Any:
+    if dim is None or isinstance(dim, (bool, int, float, str)):
+        return dim
+    try:
+        return int(dim)
+    except (TypeError, ValueError):
+        pass
+    label = None
+    for attr in ("symbol", "_symbol", "name", "_name"):
+        value = getattr(dim, attr, None)
+        if isinstance(value, str) and value:
+            label = value
+            break
+    if label is None:
+        node = getattr(dim, "node", None)
+        expr = getattr(node, "expr", getattr(node, "_expr", None))
+        if expr is not None:
+            label = str(expr)
+    if label is None:
+        text = str(dim)
+        if text and not text.startswith("?{"):
+            label = text
+    if label is not None:
+        return (
+            "symbolic_dim",
+            type(dim).__module__,
+            type(dim).__qualname__,
+            label,
+        )
+    return (
+        "symbolic_dim",
+        type(dim).__module__,
+        type(dim).__qualname__,
+        id(getattr(dim, "node", dim)),
+    )
+
+
+def _maybe_call_zero_arg(value: Any) -> Any:
+    if callable(value):
+        try:
+            return value()
+        except TypeError:
+            return None
+    return value
+
+
+def _first_present_attr(value: Any, *names: str) -> Any:
+    for name in names:
+        try:
+            attr = getattr(value, name)
+        except Exception:
+            continue
+        attr = _maybe_call_zero_arg(attr)
+        if attr is not None:
+            return attr
+    return None
+
+
+def _tensor_like_cache_key(value: Any, visited: set[int]) -> Any | None:
+    shape = _first_present_attr(value, "_shape", "shape")
+    if shape is None:
+        return None
+    stride = _first_present_attr(value, "_stride", "stride")
+    stride_order = _first_present_attr(value, "_stride_order", "stride_order")
+    dtype = _first_present_attr(value, "_dtype", "dtype", "element_type")
+    device = _first_present_attr(value, "fake_device", "device")
+    layout = _first_present_attr(value, "layout")
+    memspace = _first_present_attr(value, "memspace", "_memspace")
+    assumed_align = _first_present_attr(value, "_assumed_align")
+    use_32bit_stride = _first_present_attr(value, "_use_32bit_stride")
+    shape_key = tuple(_structural_dim_key(dim, visited) for dim in shape)
+    stride_key = (
+        None
+        if stride is None
+        else tuple(_structural_dim_key(dim, visited) for dim in stride)
+    )
+    stride_order_key = (
+        None
+        if stride_order is None
+        else tuple(_structural_dim_key(dim, visited) for dim in stride_order)
+    )
+    return (
+        "fake_tensor",
+        type(value).__module__,
+        type(value).__qualname__,
+        _structural_cache_key(dtype, visited),
+        shape_key,
+        stride_key,
+        stride_order_key,
+        _structural_cache_key(device, visited),
+        _structural_cache_key(layout, visited),
+        _structural_cache_key(memspace, visited),
+        assumed_align,
+        use_32bit_stride,
+    )
+
+
+def _structural_cache_key(value: Any, visited: set[int] | None = None) -> Any:
+    if visited is None:
+        visited = set()
+
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, bytes):
+        return ("bytes", value.hex())
+    if isinstance(value, Path):
+        return ("path", str(value))
+    if inspect.isfunction(value) or inspect.ismethod(value):
+        return _normalize_compile_target(value, visited)
+    if isinstance(value, type):
+        return ("type", value.__module__, value.__qualname__)
+    if isinstance(value, SimpleNamespace):
+        return (
+            "namespace",
+            tuple(
+                sorted(
+                    (k, _structural_cache_key(v, visited))
+                    for k, v in vars(value).items()
+                )
+            ),
+        )
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (_structural_cache_key(k, visited), _structural_cache_key(v, visited))
+                for k, v in value.items()
+            )
+        )
+    if isinstance(value, (tuple, list)):
+        return tuple(_structural_cache_key(v, visited) for v in value)
+    if isinstance(value, set):
+        return tuple(sorted(_structural_cache_key(v, visited) for v in value))
+
+    type_name = type(value).__name__
+    type_module = type(value).__module__
+    if type_name == "CUstream" and type_module.startswith("cuda.bindings"):
+        return ("cuda_stream",)
+    if type_module == "cutlass.cute.runtime" and type_name == "_Tensor":
+        dtype = getattr(value, "_dtype", getattr(value, "element_type", None))
+        shape = tuple(_structural_dim_key(dim, visited) for dim in value.shape)
+        stride = tuple(_structural_dim_key(dim, visited) for dim in value.stride)
+        memspace = getattr(value, "memspace", getattr(value, "_memspace", None))
+        assumed_align = getattr(value, "_assumed_align", None)
+        is_dynamic = getattr(value, "_is_dynamic", None)
+        use_32bit_stride = getattr(value, "_use_32bit_stride", None)
+        return (
+            "runtime_tensor",
+            dtype,
+            shape,
+            stride,
+            memspace,
+            assumed_align,
+            is_dynamic,
+            use_32bit_stride,
+        )
+    if type_module == "cutlass.cute.runtime" and type_name == "_FakeCompactTensor":
+        dtype = getattr(value, "_dtype", None)
+        shape = tuple(
+            _structural_dim_key(dim, visited) for dim in getattr(value, "_shape", ())
+        )
+        stride_order = tuple(
+            _structural_dim_key(dim, visited)
+            for dim in getattr(value, "_stride_order", ())
+        )
+        memspace = getattr(value, "_memspace", None)
+        assumed_align = getattr(value, "_assumed_align", None)
+        use_32bit_stride = getattr(value, "_use_32bit_stride", None)
+        return (
+            "fake_compact_tensor",
+            dtype,
+            shape,
+            stride_order,
+            memspace,
+            assumed_align,
+            use_32bit_stride,
+        )
+    if "FakeTensor" in type_name:
+        fake_tensor_key = _tensor_like_cache_key(value, visited)
+        if fake_tensor_key is not None:
+            return fake_tensor_key
+
+    cache_key_attr = getattr(value, "__cache_key__", None)
+    if cache_key_attr is not None:
+        return (
+            "cache_key",
+            type_module,
+            type_name,
+            _structural_cache_key(cache_key_attr, visited),
+        )
+
+    object_id = id(value)
+    if object_id in visited:
+        return ("cycle", type_module, type_name)
+
+    if hasattr(value, "__dict__"):
+        visited.add(object_id)
+        try:
+            return (
+                "object",
+                type_module,
+                type_name,
+                tuple(
+                    sorted(
+                        (
+                            k,
+                            _structural_cache_key(v, visited),
+                        )
+                        for k, v in vars(value).items()
+                    )
+                ),
+            )
+        finally:
+            visited.remove(object_id)
+
+    return ("repr", type_module, type_name, repr(value))
+
+
+def _compile_options_cache_key(compile_callable: Any) -> tuple[str, ...]:
+    compile_options = getattr(compile_callable, "_compile_options", None)
+    if compile_options is None:
+        return ()
+    options = getattr(compile_options, "options", {})
+    serialized = []
+    for option in options.values():
+        value = option.serialize()
+        if value:
+            serialized.append(value)
+    return tuple(serialized)
+
+
+def _compile_disk_cache_payload(
+    compile_callable: Any,
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    compile_spec: KernelCompileSpec | None = None,
+) -> tuple[object, ...]:
+    (
+        package_fingerprint,
+        runtime_toolchain,
+        compile_options,
+        compile_environment,
+    ) = _static_compile_cache_context(compile_callable)
+    if compile_spec is not None:
+        kwargs_json_key, kwargs_hash_key = _compile_kwargs_json_key(kwargs)
+        return (
+            "sm12x_cute_compile_cache_v5_explicit_spec",
+            _explicit_spec_compile_target(func),
+            package_fingerprint,
+            runtime_toolchain,
+            compile_spec.hash_key,
+            compile_spec.json_key,
+            kwargs_hash_key,
+            kwargs_json_key,
+            compile_options,
+            compile_environment,
+        )
+    return (
+        "sm12x_cute_compile_cache_v2",
+        _normalize_compile_target(func, set()),
+        package_fingerprint,
+        runtime_toolchain,
+        _structural_cache_key(args),
+        _structural_cache_key(kwargs),
+        compile_options,
+        compile_environment,
+    )
+
+
+def _build_compile_disk_cache_key(
+    compile_callable: Any,
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    compile_spec: KernelCompileSpec | None = None,
+) -> str:
+    payload = _compile_disk_cache_payload(
+        compile_callable, func, args, kwargs, compile_spec
+    )
+    return hashlib.sha256(repr(payload).encode("utf-8")).hexdigest()
+
+
+def _cache_prefix(cache_key: str) -> str:
+    return f"sm12x_cute_{cache_key}"
+
+
+def _cache_object_path(cache_key: str) -> Path:
+    return _cute_compile_cache_dir() / cache_key[:2] / f"{cache_key}.o"
+
+
+def _cache_manifest_path(cache_key: str) -> Path:
+    return _cache_object_path(cache_key).with_suffix(".json")
+
+
+def _cache_lock_path(cache_key: str) -> Path:
+    return _cache_object_path(cache_key).with_suffix(".lock")
+
+
+def _manifest_json_value(value: Any) -> Any:
+    """Return a lossless-enough JSON view of an already-normalized cache value.
+
+    Compile-cache payloads consist almost entirely of tuples and JSON scalar
+    values.  Keep an explicit representation for uncommon values instead of
+    allowing a sidecar write failure to discard the useful semantic fields.
+    The exact payload used to form ``cache_key`` is also stored as ``repr`` in
+    the manifest.
+    """
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else {"kind": "float", "repr": repr(value)}
+    if isinstance(value, bytes):
+        return {"kind": "bytes", "hex": value.hex()}
+    if isinstance(value, Path):
+        return {"kind": "path", "value": str(value)}
+    if isinstance(value, (tuple, list)):
+        return [_manifest_json_value(item) for item in value]
+    if isinstance(value, dict):
+        if all(isinstance(key, str) for key in value):
+            return {
+                key: _manifest_json_value(item) for key, item in sorted(value.items())
+            }
+        return {
+            "kind": "mapping",
+            "items": [
+                [_manifest_json_value(key), _manifest_json_value(item)]
+                for key, item in sorted(value.items(), key=lambda pair: repr(pair[0]))
+            ],
+        }
+    return {
+        "kind": "repr",
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "value": repr(value),
+    }
+
+
+def _semantic_target_key(target_key: Any) -> Any:
+    """Remove source fingerprints while retaining callable semantic state."""
+
+    if not isinstance(target_key, tuple) or not target_key:
+        return _manifest_json_value(target_key)
+
+    tag = target_key[0]
+    if tag in {"method", "function"} and len(target_key) >= 2:
+        fingerprint = target_key[1]
+        if isinstance(fingerprint, tuple) and len(fingerprint) >= 2:
+            result: dict[str, Any] = {
+                "kind": tag,
+                "module": str(fingerprint[0]),
+                "qualname": str(fingerprint[1]),
+            }
+            if len(target_key) >= 3:
+                result["state"] = _semantic_structural_key(target_key[2])
+            return result
+    if tag == "callable_instance" and len(target_key) >= 4:
+        call_fingerprint = target_key[3]
+        result = {
+            "kind": tag,
+            "type": f"{target_key[1]}.{target_key[2]}",
+        }
+        if isinstance(call_fingerprint, tuple) and len(call_fingerprint) >= 2:
+            result["call"] = f"{call_fingerprint[0]}.{call_fingerprint[1]}"
+        else:
+            result["call"] = _semantic_structural_key(call_fingerprint)
+        if len(target_key) >= 5:
+            result["state"] = _semantic_structural_key(target_key[4])
+        return result
+    if tag == "callable" and len(target_key) >= 3:
+        return {
+            "kind": tag,
+            "type": f"{target_key[1]}.{target_key[2]}",
+        }
+    return _semantic_structural_key(target_key)
+
+
+def _semantic_structural_key(value: Any) -> Any:
+    if isinstance(value, tuple):
+        if value and value[0] in {
+            "method",
+            "function",
+            "callable_instance",
+            "callable",
+        }:
+            return _semantic_target_key(value)
+        return [_semantic_structural_key(item) for item in value]
+    if isinstance(value, list):
+        return [_semantic_structural_key(item) for item in value]
+    return _manifest_json_value(value)
+
+
+def _semantic_compile_manifest_payload(
+    cache_payload: tuple[object, ...],
+) -> dict[str, Any]:
+    cache_format = str(cache_payload[0]) if cache_payload else "unknown"
+    semantic: dict[str, Any] = {
+        "cache_format": cache_format,
+        "target": _semantic_target_key(cache_payload[1]),
+    }
+    if cache_format == "sm12x_cute_compile_cache_v5_explicit_spec":
+        semantic["compile_spec_hash"] = cache_payload[4]
+        try:
+            semantic["compile_spec"] = json.loads(str(cache_payload[5]))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            semantic["compile_spec"] = str(cache_payload[5])
+        if cache_payload[6]:
+            semantic["compile_kwargs_hash"] = cache_payload[6]
+            try:
+                semantic["compile_kwargs"] = json.loads(str(cache_payload[7]))
+            except (TypeError, ValueError, json.JSONDecodeError):
+                semantic["compile_kwargs"] = str(cache_payload[7])
+        semantic["compile_options"] = _manifest_json_value(cache_payload[8])
+        semantic["compile_environment"] = _manifest_json_value(cache_payload[9])
+    else:
+        semantic["args"] = _semantic_structural_key(cache_payload[4])
+        semantic["kwargs"] = _semantic_structural_key(cache_payload[5])
+        semantic["compile_options"] = _manifest_json_value(cache_payload[6])
+        semantic["compile_environment"] = _manifest_json_value(cache_payload[7])
+    return semantic
+
+
+_LLVM_SSA_NAME = r"%[-a-zA-Z$._0-9]+"
+_LLVM_I64_CONSTANT_RE = re.compile(
+    rf"^\s*(?P<result>{_LLVM_SSA_NAME}) = "
+    r"llvm\.mlir\.constant\((?P<value>[0-9]+) : i64\) : i64\s*$"
+)
+_LLVM_GEP_RE = re.compile(
+    rf"^\s*(?P<result>{_LLVM_SSA_NAME}) = llvm\.getelementptr "
+    rf"(?P<base>{_LLVM_SSA_NAME})\[(?P<indices>[^]]+)\]"
+)
+_LLVM_LOAD_RE = re.compile(
+    rf"^\s*(?P<result>{_LLVM_SSA_NAME}) = llvm\.load "
+    rf"(?P<pointer>{_LLVM_SSA_NAME})(?:\s|:)"
+)
+_LLVM_STORE_RE = re.compile(
+    rf"^\s*llvm\.store (?P<value>{_LLVM_SSA_NAME}), "
+    rf"(?P<pointer>{_LLVM_SSA_NAME})(?:\s|:)"
+)
+_LLVM_KERNEL_ADDRESS_RE = re.compile(
+    rf"^\s*(?P<result>{_LLVM_SSA_NAME}) = llvm\.mlir\.addressof "
+    r"@kernels_(?P<kernel>[^\s:]+)\s*:"
+)
+_LLVM_LAUNCH_EX_RE = re.compile(
+    r"llvm\.call @_cudaLaunchKernelEx\((?P<arguments>[^)]*)\)"
+)
+
+
+def _final_llvm_function_bodies(module_text: str) -> list[list[str]]:
+    """Return lowered LLVM function bodies without parsing the embedded cubin.
+
+    CUTLASS' final module contains the cubin as one very large LLVM global.
+    Launch configuration is emitted in host ``llvm.func`` bodies, whose closing
+    brace is at module indentation.  Keeping the scan line-oriented avoids
+    retaining or reparsing a second MLIR module during every compilation.
+    """
+
+    bodies: list[list[str]] = []
+    current: list[str] | None = None
+    for line in module_text.splitlines():
+        if current is None:
+            if line.startswith("  llvm.func @") and line.rstrip().endswith("{"):
+                current = [line]
+            continue
+        current.append(line)
+        if line == "  }":
+            bodies.append(current)
+            current = None
+    return bodies
+
+
+def _parse_launch_dynamic_smem_from_final_llvm(
+    module_text: str, expected_kernels: set[str]
+) -> dict[str, Any]:
+    """Extract exact resolved CUDA launch SMEM from CUTLASS final LLVM IR.
+
+    CUTLASS 4.5 and 4.6 lower ``cute.kernel_smem_size`` to an i64 constant
+    stored in field 2 of the CUDA launch-config struct.  The exported object
+    retains the host launcher but not the MLIR dataflow needed to identify that
+    constant, so this must run while the freshly compiled function still owns
+    ``ir_module``.  Any unrecognised lowering is reported as unknown rather
+    than guessed from the cubin's shared sections.
+    """
+
+    source = "cutlass-final-llvm-launch-config-field-2"
+    if not expected_kernels:
+        return {
+            "status": "unknown",
+            "source": source,
+            "reason": "kernel-info-unavailable",
+            "launch_dynamic_smem_bytes": {},
+        }
+
+    launches: dict[str, list[int]] = {kernel: [] for kernel in expected_kernels}
+    parsed_launches = 0
+    unparsed_launches = 0
+
+    for lines in _final_llvm_function_bodies(module_text):
+        if not any("llvm.call @_cudaLaunchKernelEx" in line for line in lines):
+            continue
+
+        constants: dict[str, int] = {}
+        geps: dict[str, tuple[str, tuple[str, ...]]] = {}
+        loads: dict[str, tuple[str, int]] = {}
+        stores: list[tuple[int, str, str]] = []
+        kernel_addresses: dict[str, str] = {}
+
+        def pointer_key(pointer: str) -> tuple[str, tuple[str, ...]]:
+            return geps.get(pointer, (pointer, ()))
+
+        def stored_value(pointer: str, before: int) -> str | None:
+            key = pointer_key(pointer)
+            for line_number, value, destination in reversed(stores):
+                if line_number < before and pointer_key(destination) == key:
+                    return value
+            return None
+
+        for line_number, line in enumerate(lines):
+            if match := _LLVM_I64_CONSTANT_RE.match(line):
+                constants[match.group("result")] = int(match.group("value"))
+                continue
+            if match := _LLVM_GEP_RE.match(line):
+                indices = tuple(
+                    item.strip() for item in match.group("indices").split(",")
+                )
+                geps[match.group("result")] = (match.group("base"), indices)
+                continue
+            if match := _LLVM_LOAD_RE.match(line):
+                loads[match.group("result")] = (
+                    match.group("pointer"),
+                    line_number,
+                )
+                continue
+            if match := _LLVM_STORE_RE.match(line):
+                stores.append(
+                    (line_number, match.group("value"), match.group("pointer"))
+                )
+                continue
+            if match := _LLVM_KERNEL_ADDRESS_RE.match(line):
+                kernel_addresses[match.group("result")] = match.group("kernel")
+                continue
+            match = _LLVM_LAUNCH_EX_RE.search(line)
+            if match is None:
+                continue
+
+            arguments = [
+                argument.strip() for argument in match.group("arguments").split(",")
+            ]
+            if len(arguments) < 2:
+                unparsed_launches += 1
+                continue
+            config_operand, kernel_operand = arguments[:2]
+
+            kernel_load = loads.get(kernel_operand)
+            kernel = (
+                kernel_addresses.get(kernel_load[0])
+                if kernel_load is not None
+                else kernel_addresses.get(kernel_operand)
+            )
+
+            config = config_operand
+            if config_load := loads.get(config_operand):
+                config = stored_value(config_load[0], config_load[1]) or ""
+
+            smem_values: list[int] = []
+            if config:
+                for pointer, (base, indices) in geps.items():
+                    if base != config or indices != ("0", "2"):
+                        continue
+                    value_name = stored_value(pointer, line_number)
+                    if value_name in constants:
+                        smem_values.append(constants[value_name])
+
+            if (
+                kernel not in expected_kernels
+                or len(smem_values) != 1
+                or smem_values[0] < 0
+            ):
+                unparsed_launches += 1
+                continue
+            launches[kernel].append(smem_values[0])
+            parsed_launches += 1
+
+    missing_kernels = sorted(
+        kernel for kernel, values in launches.items() if not values
+    )
+    if unparsed_launches or missing_kernels or parsed_launches == 0:
+        reason_parts = []
+        if unparsed_launches:
+            reason_parts.append(f"unparsed-launches={unparsed_launches}")
+        if missing_kernels:
+            reason_parts.append("missing-kernels=" + ",".join(missing_kernels))
+        if parsed_launches == 0 and not reason_parts:
+            reason_parts.append("no-launches")
+        return {
+            "status": "unknown",
+            "source": source,
+            "reason": ";".join(reason_parts),
+            "launch_dynamic_smem_bytes": {},
+        }
+    return {
+        "status": "exact",
+        "source": source,
+        "launch_dynamic_smem_bytes": {
+            kernel: values for kernel, values in sorted(launches.items())
+        },
+    }
+
+
+def _extract_launch_dynamic_smem_bytes(compiled: Any) -> dict[str, Any]:
+    module = getattr(compiled, "ir_module", None)
+    kernel_info = getattr(compiled, "kernel_info", None)
+    source = "cutlass-final-llvm-launch-config-field-2"
+    if module is None:
+        return {
+            "status": "unknown",
+            "source": source,
+            "reason": "compiled-ir-unavailable",
+            "launch_dynamic_smem_bytes": {},
+        }
+    expected_kernels = (
+        {str(kernel) for kernel in kernel_info}
+        if isinstance(kernel_info, dict)
+        else set()
+    )
+    try:
+        return _parse_launch_dynamic_smem_from_final_llvm(str(module), expected_kernels)
+    except Exception as exc:
+        return {
+            "status": "unknown",
+            "source": source,
+            "reason": f"extractor-error:{type(exc).__name__}",
+            "launch_dynamic_smem_bytes": {},
+        }
+
+
+def _build_compile_manifest(
+    cache_key: str,
+    cache_payload: tuple[object, ...],
+    func: Any,
+    object_bytes: bytes,
+    compiled: Any = None,
+) -> dict[str, Any]:
+    semantic_payload = _semantic_compile_manifest_payload(cache_payload)
+    semantic_json = json.dumps(
+        semantic_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    cache_format = str(cache_payload[0]) if cache_payload else "unknown"
+    explicit = cache_format == "sm12x_cute_compile_cache_v5_explicit_spec"
+    options_index = 8 if explicit else 6
+    environment_index = 9 if explicit else 7
+    launch_metadata = (
+        _extract_launch_dynamic_smem_bytes(compiled)
+        if compiled is not None
+        else {
+            "status": "unknown",
+            "source": "cutlass-final-llvm-launch-config-field-2",
+            "reason": "compiled-ir-unavailable-on-object-reload",
+            "launch_dynamic_smem_bytes": {},
+        }
+    )
+    object_sha256 = hashlib.sha256(object_bytes).hexdigest()
+    artifact_evidence = {
+        "cache_key": cache_key,
+        "object_sha256": object_sha256,
+        "launch_metadata": launch_metadata,
+    }
+    artifact_evidence_json = json.dumps(
+        artifact_evidence,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    manifest: dict[str, Any] = {
+        "schema": "flashinfer.experimental.sm12x._lib.compile_manifest.v3",
+        "cache_key": cache_key,
+        "cache_format": cache_format,
+        "cache_payload_repr": repr(cache_payload),
+        "cache_payload": _manifest_json_value(cache_payload),
+        "object_sha256": object_sha256,
+        "object_bytes": len(object_bytes),
+        "semantic_key": hashlib.sha256(semantic_json.encode("utf-8")).hexdigest(),
+        "semantic_payload": semantic_payload,
+        "target": _compile_target_name(func),
+        "target_identity": _semantic_target_key(cache_payload[1]),
+        "package_fingerprint": str(cache_payload[2]),
+        "toolchain": _manifest_json_value(cache_payload[3]),
+        "compile_options": _manifest_json_value(cache_payload[options_index]),
+        "compile_environment": _manifest_json_value(cache_payload[environment_index]),
+        "launch_metadata": launch_metadata,
+        "artifact_evidence_sha256": hashlib.sha256(
+            artifact_evidence_json.encode("utf-8")
+        ).hexdigest(),
+    }
+    if explicit:
+        manifest["compile_spec_hash"] = str(cache_payload[4])
+        manifest["compile_spec_json"] = str(cache_payload[5])
+        manifest["compile_kwargs_hash"] = str(cache_payload[6])
+        manifest["compile_kwargs_json"] = str(cache_payload[7])
+        try:
+            spec = json.loads(str(cache_payload[5]))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            spec = None
+        if isinstance(spec, dict):
+            manifest["kernel_id"] = str(spec.get("kernel", ""))
+            manifest["compile_spec_version"] = spec.get("version", "")
+    return manifest
+
+
+def _write_compile_manifest(
+    cache_key: str,
+    cache_payload: tuple[object, ...],
+    func: Any,
+    object_bytes: bytes,
+    compiled: Any = None,
+) -> None:
+    manifest_path = _cache_manifest_path(cache_key)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = _build_compile_manifest(
+        cache_key, cache_payload, func, object_bytes, compiled=compiled
+    )
+    tmp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=manifest_path.parent,
+            prefix=f".{manifest_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp_file:
+            tmp_name = tmp_file.name
+            json.dump(
+                manifest,
+                tmp_file,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+            tmp_file.write("\n")
+        os.replace(tmp_name, manifest_path)
+        tmp_name = None
+    finally:
+        if tmp_name is not None:
+            with suppress(OSError):
+                os.unlink(tmp_name)
+
+
+def _ensure_cute_compile_manifest(
+    cache_key: str,
+    cache_payload: tuple[object, ...],
+    func: Any,
+) -> None:
+    manifest_path = _cache_manifest_path(cache_key)
+    if manifest_path.exists():
+        return
+    object_bytes = _cache_object_path(cache_key).read_bytes()
+    _write_compile_manifest(cache_key, cache_payload, func, object_bytes)
+
+
+@contextmanager
+def _disk_cache_key_lock(cache_key: str):
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+
+    lock_path = _cache_lock_path(cache_key)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _load_cute_compile_from_disk(cache_key: str):
+    from cutlass.base_dsl.export.external_binary_module import ExternalBinaryModule
+
+    object_path = _cache_object_path(cache_key)
+    if not object_path.exists():
+        return None
+    try:
+        # CUTLASS may finalize or patch the ELF while loading it.  The cache
+        # object is content-addressed and its digest is recorded in the compile
+        # manifest, so never expose that canonical object to the loader.
+        with tempfile.TemporaryDirectory(prefix="sm12x-cute-cache-load-") as raw_stage:
+            staged_object = Path(raw_stage) / object_path.name
+            shutil.copy2(object_path, staged_object)
+            module = ExternalBinaryModule(str(staged_object))
+            return getattr(module, _cache_prefix(cache_key))
+    except Exception:
+        return None
+
+
+def _store_cute_compile_to_disk(
+    cache_key: str,
+    compiled: Any,
+    *,
+    cache_payload: tuple[object, ...] | None = None,
+    func: Any = None,
+) -> None:
+    if not hasattr(compiled, "dump_to_object"):
+        return
+
+    object_path = _cache_object_path(cache_key)
+    object_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = object_path.with_suffix(".tmp")
+    object_bytes = compiled.dump_to_object(_cache_prefix(cache_key))
+    with open(tmp_path, "wb") as f:
+        f.write(object_bytes)
+    os.replace(tmp_path, object_path)
+    if cache_payload is not None and func is not None:
+        _write_compile_manifest(
+            cache_key, cache_payload, func, object_bytes, compiled=compiled
+        )
+
+
+def _memory_cache_get(cache_key: object) -> Any | None:
+    global _MEMORY_CACHE_HITS
+    global _MEMORY_CACHE_MISSES
+    if not _cute_compile_memory_cache_enabled():
+        return None
+    with _MEMORY_CACHE_LOCK:
+        compiled = _MEMORY_CACHE.get(cache_key)
+        if compiled is None:
+            _MEMORY_CACHE_MISSES += 1
+            return None
+        _MEMORY_CACHE_HITS += 1
+        _MEMORY_CACHE.move_to_end(cache_key)
+        return compiled
+
+
+def _memory_cache_put(cache_key: object, compiled: Any) -> None:
+    if not _cute_compile_memory_cache_enabled():
+        return
+    with _MEMORY_CACHE_LOCK:
+        _MEMORY_CACHE[cache_key] = compiled
+        _MEMORY_CACHE.move_to_end(cache_key)
+        while len(_MEMORY_CACHE) > _cute_compile_memory_cache_size():
+            _MEMORY_CACHE.popitem(last=False)
+
+
+def clear_compile_cache() -> None:
+    global _MEMORY_CACHE_HITS
+    global _MEMORY_CACHE_MISSES
+    global _DISK_CACHE_HITS
+    global _COMPILE_MISSES
+    global _SPEC_MEMO_HITS
+    global _SPEC_MEMO_MISSES
+    global _COMPILE_PROGRESS_COUNT
+    global _COMPILE_PROGRESS_TOTAL_SECONDS
+    _compile_environment_key.cache_clear()
+    _static_compile_cache_context.cache_clear()
+    with _MEMORY_CACHE_LOCK:
+        _MEMORY_CACHE.clear()
+        _MEMORY_CACHE_HITS = 0
+        _MEMORY_CACHE_MISSES = 0
+        _DISK_CACHE_HITS = 0
+        _COMPILE_MISSES = 0
+    with _SPEC_MEMO_LOCK:
+        _SPEC_MEMO.clear()
+        _SPEC_MEMO_HITS = 0
+        _SPEC_MEMO_MISSES = 0
+    with _COMPILE_PROGRESS_LOCK:
+        _COMPILE_PROGRESS_COUNT = 0
+        _COMPILE_PROGRESS_TOTAL_SECONDS = 0.0
+
+
+def compile_cache_info() -> dict[str, int | bool]:
+    with _MEMORY_CACHE_LOCK:
+        info: dict[str, int | bool] = {
+            "memory_cache_enabled": _cute_compile_memory_cache_enabled(),
+            "memory_cache_size": len(_MEMORY_CACHE),
+            "memory_cache_max_size": _cute_compile_memory_cache_size(),
+            "memory_cache_hits": _MEMORY_CACHE_HITS,
+            "memory_cache_misses": _MEMORY_CACHE_MISSES,
+            "disk_cache_enabled": _cute_compile_disk_cache_enabled(),
+            "disk_cache_hits": _DISK_CACHE_HITS,
+            "compile_misses": _COMPILE_MISSES,
+        }
+    with _SPEC_MEMO_LOCK:
+        info["spec_memo_enabled"] = _spec_memo_enabled()
+        info["spec_memo_size"] = len(_SPEC_MEMO)
+        info["spec_memo_hits"] = _SPEC_MEMO_HITS
+        info["spec_memo_misses"] = _SPEC_MEMO_MISSES
+    return info
+
+
+def compile(
+    func: Any,
+    *args: Any,
+    compile_spec: KernelCompileSpec | None = None,
+    dsl_compile_options: Any = None,
+    **kwargs: Any,
+) -> Any:
+    import cutlass.cute as cute
+
+    global _DISK_CACHE_HITS
+    global _COMPILE_MISSES
+    compile_callable = cute.compile
+    if dsl_compile_options is not None:
+        # Subscript-style DSL compile options (e.g. OptLevel(2): ptxas -O3's
+        # scheduler register-starves some scalar-heavy kernels; see the w4a8
+        # dynamic MoE recipe).
+        if hasattr(compile_callable, "__getitem__"):
+            compile_callable = compile_callable[dsl_compile_options]
+        else:
+            # Some embedded runtimes expose cutlass.cute.compile as a plain
+            # function instead of the CompileCallable instance installed by the
+            # top-level module import.  Recreate the callable explicitly so DSL
+            # options still take effect instead of crashing or silently falling
+            # back to the default compiler options.
+            from cutlass.base_dsl.compiler import CompileCallable
+
+            compile_callable = CompileCallable(dsl_compile_options)
+        kwargs = dict(kwargs)
+        kwargs["__dsl_compile_options_key"] = _structural_cache_key(dsl_compile_options)
+    memory_cache_key = _compile_memory_cache_key(
+        compile_callable, func, args, kwargs, compile_spec
+    )
+    compiled = _memory_cache_get(memory_cache_key)
+    if compiled is not None:
+        return compiled
+
+    post_engine_start_log = _cute_compile_post_engine_start_log_enabled()
+    payload = _compile_disk_cache_payload(
+        compile_callable, func, args, kwargs, compile_spec
+    )
+    cache_key = hashlib.sha256(repr(payload).encode("utf-8")).hexdigest()
+
+    if _cute_compile_disk_cache_enabled():
+        compiled = _load_cute_compile_from_disk(cache_key)
+        if compiled is not None:
+            with suppress(Exception):
+                _ensure_cute_compile_manifest(cache_key, payload, func)
+            with _MEMORY_CACHE_LOCK:
+                _DISK_CACHE_HITS += 1
+            if post_engine_start_log:
+                with suppress(Exception):
+                    _log_cute_compile_event(
+                        func,
+                        args,
+                        kwargs,
+                        event="disk-hit",
+                        cache_status="disk-cache-hit",
+                        cache_payload=payload,
+                        reason="post-engine-start",
+                        cache_key=cache_key,
+                    )
+            _memory_cache_put(memory_cache_key, compiled)
+            return compiled
+
+        with _disk_cache_key_lock(cache_key):
+            compiled = _memory_cache_get(memory_cache_key)
+            if compiled is not None:
+                return compiled
+
+            compiled = _load_cute_compile_from_disk(cache_key)
+            if compiled is not None:
+                with suppress(Exception):
+                    _ensure_cute_compile_manifest(cache_key, payload, func)
+                with _MEMORY_CACHE_LOCK:
+                    _DISK_CACHE_HITS += 1
+                if post_engine_start_log:
+                    with suppress(Exception):
+                        _log_cute_compile_event(
+                            func,
+                            args,
+                            kwargs,
+                            event="disk-hit-after-wait",
+                            cache_status="disk-cache-hit-after-wait",
+                            cache_payload=payload,
+                            reason="post-engine-start",
+                            cache_key=cache_key,
+                        )
+                _memory_cache_put(memory_cache_key, compiled)
+                return compiled
+
+            cache_status = "disk-cache-miss"
+
+            if _cute_compile_log_enabled() or post_engine_start_log:
+                with suppress(Exception):
+                    _log_cute_compile_miss(
+                        func,
+                        args,
+                        kwargs,
+                        cache_status=cache_status,
+                        cache_payload=payload,
+                        reason="post-engine-start" if post_engine_start_log else None,
+                        cache_key=cache_key,
+                    )
+
+            with _MEMORY_CACHE_LOCK:
+                _COMPILE_MISSES += 1
+            from flashinfer.experimental.sm12x._lib.runtime_control import (
+                raise_if_kernel_resolution_frozen,
+            )
+
+            raise_if_kernel_resolution_frozen(
+                "cute.compile",
+                target=func,
+                cache_key=compile_spec if compile_spec is not None else payload,
+            )
+            call_kwargs = {
+                k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"
+            }
+            compiled = _call_cute_compile(
+                compile_callable,
+                func,
+                args,
+                call_kwargs,
+                compile_spec=compile_spec,
+                cache_key=cache_key,
+            )
+            with suppress(Exception):
+                _store_cute_compile_to_disk(
+                    cache_key,
+                    compiled,
+                    cache_payload=payload,
+                    func=func,
+                )
+            _memory_cache_put(memory_cache_key, compiled)
+            return compiled
+    else:
+        cache_status = "disk-cache-disabled"
+
+    if _cute_compile_log_enabled() or post_engine_start_log:
+        with suppress(Exception):
+            _log_cute_compile_miss(
+                func,
+                args,
+                kwargs,
+                cache_status=cache_status,
+                cache_payload=payload,
+                reason="post-engine-start" if post_engine_start_log else None,
+                cache_key=cache_key,
+            )
+
+    with _MEMORY_CACHE_LOCK:
+        _COMPILE_MISSES += 1
+    from flashinfer.experimental.sm12x._lib.runtime_control import (
+        raise_if_kernel_resolution_frozen,
+    )
+
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=func,
+        cache_key=compile_spec if compile_spec is not None else payload,
+    )
+    call_kwargs = {k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"}
+    compiled = _call_cute_compile(
+        compile_callable,
+        func,
+        args,
+        call_kwargs,
+        compile_spec=compile_spec,
+        cache_key=cache_key,
+    )
+    if _cute_compile_disk_cache_enabled():
+        with suppress(Exception):
+            _store_cute_compile_to_disk(
+                cache_key,
+                compiled,
+                cache_payload=payload,
+                func=func,
+            )
+    _memory_cache_put(memory_cache_key, compiled)
+    return compiled
+
+
+def _cached_default_executor(compiled: Any) -> Any | None:
+    if not hasattr(compiled, "_default_executor"):
+        return None
+
+    executor = getattr(compiled, _EXECUTOR_CACHE_ATTR, None)
+    if executor is not None:
+        return executor
+
+    with _EXECUTOR_CACHE_LOCK:
+        executor = getattr(compiled, _EXECUTOR_CACHE_ATTR, None)
+        if executor is not None:
+            return executor
+        executor = getattr(compiled, "_default_executor", None)
+        if executor is None:
+            to_executor = getattr(compiled, "to", None)
+            if to_executor is None:
+                return None
+            executor = to_executor(None)
+            with suppress(Exception):
+                compiled._default_executor = executor
+        with suppress(Exception):
+            setattr(compiled, _EXECUTOR_CACHE_ATTR, executor)
+        return executor
+
+
+def run_compiled(compiled: Any, args: tuple[Any, ...]) -> Any:
+    if hasattr(compiled, "generate_execution_args") and hasattr(
+        compiled, "run_compiled_program"
+    ):
+        execution_args, _ = compiled.generate_execution_args(*args)
+        executor = _cached_default_executor(compiled)
+        if executor is not None and hasattr(executor, "run_compiled_program"):
+            return executor.run_compiled_program(execution_args)
+        return compiled.run_compiled_program(execution_args)
+    return compiled(*args)
+
+
+def launch(
+    func: Any,
+    *,
+    compile_spec: KernelCompileSpec,
+    compile_args: tuple[Any, ...],
+    runtime_args: tuple[Any, ...],
+    compile_kwargs: dict[str, Any] | None = None,
+) -> Any:
+    compiled = compile(
+        func,
+        *compile_args,
+        compile_spec=compile_spec,
+        **(compile_kwargs or {}),
+    )
+    return run_compiled(compiled, runtime_args)

--- a/flashinfer/experimental/sm12x/_lib/dense_gemm.py
+++ b/flashinfer/experimental/sm12x/_lib/dense_gemm.py
@@ -1,0 +1,5967 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/gemm/dense.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is ported from the CUTLASS dense block-scaled GEMM example
+# and adapted for the current Blackwell GeForce target.
+
+from dataclasses import dataclass
+from typing import Callable, List, Literal, Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm120_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+import cutlass.utils.hopper_helpers as sm90_utils
+import functools
+import logging
+import os
+import time
+import torch
+import triton
+import triton.language as tl
+from cutlass import Int32, Int64, Uint64
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.nvgpu.warp.mma import Field as WarpField
+from cutlass.utils.static_persistent_tile_scheduler import WorkTileInfo
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    compile as sm12x_compile,
+)
+from flashinfer.experimental.sm12x._lib.utils import (
+    cuda_stream_from_int_or_current,
+    cuda_stream_to_int,
+    current_cuda_stream,
+    cutlass_to_torch_dtype,
+    get_cutlass_dtype,
+    get_max_active_clusters,
+    get_num_sm,
+    make_ptr,
+    sm120_make_smem_layout_sfa,
+    sm120_make_smem_layout_sfb,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    FLOAT8_E4M3_MAX,
+    bfloat2_to_float2_scaled,
+    cp_async_bulk_g2s_mbar,
+    cvt_f32x4_to_e4m3x4,
+    elem_pointer,
+    fabs_f32,
+    fmax_f32,
+    get_ptr_as_int64,
+    ld_global_b16,
+    ld_global_v4_u32,
+    pow2_ceil_ue8m0,
+    quantize_block_fp8_mx,
+    scatter_add_bf16,
+    scatter_add_bf16x2,
+    shared_ptr_to_u32,
+    st_global_u32,
+    st_global_u64,
+    st_shared_u16,
+    ue8m0_to_output_scale,
+)
+from flashinfer.experimental.sm12x._lib.runtime_control import (
+    raise_if_kernel_resolution_frozen,
+)
+
+logger = logging.getLogger(__name__)
+_WO_SPARK_MAX_SMS = 64
+_DENSE_SPARK_MAX_SMS = 64
+
+
+def _dense_spark_policy_for_sm_count(sm_count: int) -> bool:
+    """Select dense-GEMM tactics measured on the low-SM DGX Spark class."""
+    return int(sm_count) <= _DENSE_SPARK_MAX_SMS
+
+
+_FLASHINFER_EXP_SM12X_TIMING = (
+    os.getenv("FLASHINFER_EXP_SM12X_TIMING", "0") == "1"
+    or os.getenv("VLLM_FLASHINFER_EXP_SM12X_TIMING", "0") == "1"
+)
+_FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS = float(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS",
+        os.getenv("VLLM_FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS", "0"),
+    )
+)
+_FLASHINFER_EXP_SM12X_DENSE_SPLITK_TURBO = (
+    os.getenv("FLASHINFER_EXP_SM12X_DENSE_SPLITK_TURBO", "1") == "1"
+)
+_FLASHINFER_EXP_SM12X_DENSE_ATOM_24 = (
+    os.getenv("FLASHINFER_EXP_SM12X_DENSE_ATOM_24", "0") == "1"
+)
+_DENSE_LOAD_PATHS = ("tma", "cpasync")
+
+
+@dataclass(frozen=True)
+class _DenseGemmPlan:
+    mma_tiler_mn: Tuple[int, int]
+    load_path: Literal["tma", "cpasync"]
+    swap_ab: bool
+
+
+@triton.jit
+def _reduce_split_k2_bf16_kernel(
+    partials, out, total: tl.constexpr, BLOCK: tl.constexpr
+) -> None:
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < total
+    accum = tl.load(partials + offs, mask=mask).to(tl.float32)
+    accum += tl.load(partials + total + offs, mask=mask).to(tl.float32)
+    tl.store(out + offs, accum, mask=mask)
+
+
+def _reduce_split_k2_bf16(
+    partials: torch.Tensor, out: torch.Tensor, *, m: int, n: int
+) -> None:
+    """Fused 2-way split-K FP32-partials reduction (exact); faster than torch.add.
+
+    Falls back to torch.add when the scratch/output layout is not the expected
+    [m, n, 2] / [m, n, 1] contiguous-row form.
+    """
+    total = int(m) * int(n)
+    if (
+        partials.shape == (m, n, 2)
+        and partials.stride() == (n, 1, total)
+        and out.shape == (m, n, 1)
+        and out.stride()[0] == n
+        and out.stride()[1] == 1
+    ):
+        block = 1024
+        grid = (triton.cdiv(total, block),)
+        _reduce_split_k2_bf16_kernel[grid](partials, out, total, BLOCK=block)
+    else:
+        torch.add(partials[:, :, 0], partials[:, :, 1], out=out[:, :, 0])
+
+
+# @dsl_user_op on PersistentTileSchedulerParams.__init__ can rename attributes
+# (e.g. raster_along_m -> _raster_along_m, cluster_shape_major_fdd ->
+# cluster_shape_m_fdd) but __extract_mlir_values__ (used by TVM-FFI)
+# still references the original names.
+_orig_extract = utils.PersistentTileSchedulerParams.__extract_mlir_values__
+
+# Map of source-code attr name -> runtime attr name set by @dsl_user_op
+_ATTR_RENAMES = {
+    "raster_along_m": "_raster_along_m",
+    "cluster_shape_major_fdd": "cluster_shape_m_fdd",
+    "cluster_shape_minor_fdd": "cluster_shape_n_fdd",
+}
+
+
+def _patched_extract(self):
+    for src_name, dst_name in _ATTR_RENAMES.items():
+        if not hasattr(self, src_name) and hasattr(self, dst_name):
+            setattr(self, src_name, getattr(self, dst_name))
+    return _orig_extract(self)
+
+
+utils.PersistentTileSchedulerParams.__extract_mlir_values__ = _patched_extract
+
+
+def _convert_layout_acc_mn(
+    acc_layout: cute.Layout, transpose: bool = False
+) -> cute.Layout:
+    acc_layout_col_major = cute.make_layout(acc_layout.shape)
+    shape = (
+        (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+        (
+            acc_layout_col_major.shape[0][0],
+            *acc_layout_col_major.shape[0][2:],
+            acc_layout_col_major.shape[2],
+        ),
+        *acc_layout_col_major.shape[3:],
+    )
+    stride = (
+        (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+        (
+            acc_layout_col_major.stride[0][0],
+            *acc_layout_col_major.stride[0][2:],
+            acc_layout_col_major.stride[2],
+        ),
+        *acc_layout_col_major.stride[3:],
+    )
+    if cutlass.const_expr(transpose):
+        shape = (shape[1], shape[0], *shape[2:])
+        stride = (stride[1], stride[0], *stride[2:])
+    return cute.composition(acc_layout, cute.make_layout(shape, stride=stride))
+
+
+def _reshape_acc_to_mn(acc: cute.Tensor, transpose: bool = False) -> cute.Tensor:
+    return cute.make_tensor(
+        acc.iterator, _convert_layout_acc_mn(acc.layout, transpose=transpose)
+    )
+
+
+@dataclass(frozen=True)
+class _DenseGemmPolicy:
+    single_work_tile_per_cta: bool
+    direct_one_m_tile_scheduler: bool
+    use_m1_non_tma: bool
+    split_k_slices: int
+    split_k_atomic_bf16: bool
+    large_m_unroll: bool
+
+
+def _max_active_clusters_for(
+    cluster_shape_mn: Tuple[int, int],
+    sm_count: int,
+) -> int:
+    cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
+    # For the default single-cluster launch, occupancy is bounded only by
+    # the SM count. Avoid the CUTLASS hardware-info probe here because it
+    # can fail on some driver/runtime combinations with INVALID_HANDLE
+    # while providing no additional information for cluster_size == 1.
+    return (
+        sm_count
+        if cluster_size == 1
+        else min(get_max_active_clusters(cluster_size), sm_count)
+    )
+
+
+def _use_direct_sfa_live16(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    l: int,
+    sf_vec_size: int,
+    tile_k: int,
+    mma_tiler_mn: Tuple[int, int],
+    load_path: str,
+    swap_ab: bool,
+    b_tile_major: bool,
+    sfb_k_reuse: bool,
+    alpha_is_one: bool,
+    is_mxfp8: bool,
+) -> bool:
+    return (
+        m == 16
+        and is_mxfp8
+        and sf_vec_size == 32
+        and tile_k == 128
+        and mma_tiler_mn == (32, 64)
+        and load_path == "tma"
+        and not swap_ab
+        and b_tile_major
+        and sfb_k_reuse
+        and alpha_is_one
+        and (n, k, l) in ((1024, 4096, 4), (4096, 4096, 1))
+    )
+
+
+def _use_direct_m1_wo_a_inputs(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    l: int,
+    sf_vec_size: int,
+    tile_k: int,
+    mma_tiler_mn: Tuple[int, int],
+    load_path: str,
+    swap_ab: bool,
+    b_tile_major: bool,
+    sfb_k_reuse: bool,
+    is_mxfp8: bool,
+) -> bool:
+    return (
+        m == 1
+        and (n, k, l) == (1024, 4096, 4)
+        and is_mxfp8
+        and sf_vec_size == 32
+        and tile_k == 128
+        and mma_tiler_mn == (16, 64)
+        and load_path == "tma"
+        and not swap_ab
+        and b_tile_major
+        and sfb_k_reuse
+    )
+
+
+def _dense_gemm_policy_for(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    l: int,
+    ab_dtype: Type[cutlass.Numeric],
+    c_dtype: Type[cutlass.Numeric],
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    sm_count: int,
+    expected_m: Optional[int] = None,
+) -> _DenseGemmPolicy:
+    max_active_clusters = _max_active_clusters_for(cluster_shape_mn, sm_count)
+    tile_m, tile_n = mma_tiler_mn
+    one_work_tile_per_cta = ((m + tile_m - 1) // tile_m) * (
+        (n + tile_n - 1) // tile_n
+    ) * l <= max_active_clusters
+    single_work_tile_per_cta = (
+        one_work_tile_per_cta and m < 16 and m <= tile_m and l == 1
+    )
+    direct_one_m_tile_scheduler = (
+        one_work_tile_per_cta and m == 1 and m <= tile_m and l == 1
+    )
+    use_m1_non_tma = ab_dtype == cutlass.Float8E4M3FN and m == 1
+    split_k_candidate = (
+        single_work_tile_per_cta
+        and ab_dtype == cutlass.Float8E4M3FN
+        and c_dtype == cutlass.BFloat16
+        and m <= 8
+        and n >= 4096
+        and k >= 4096
+        and k % 256 == 0
+        and l == 1
+    )
+    split_k_slices = 1
+    if split_k_candidate:
+        split_k_slices = (
+            4 if m == 8 and (n, k) == (4096, 4096) and mma_tiler_mn == (16, 128) else 2
+        )
+    # A declared expected_m owns compile-time tuning for its regime. Without a
+    # hint, keep the unroll choice stable throughout the existing persistent
+    # scheduler regime (m >= 16); otherwise warming a large prefill and serving
+    # a smaller live prefill resolves a second kernel under frozen resolution.
+    # Tiny M already has distinct scheduler/load policies and is warmed
+    # separately by contract. M=4096 unrolling is a Spark win, but the RTX
+    # audit measured regressions on q_b and wo_b, so RTX keeps the M=8192
+    # threshold.
+    large_m_unroll_threshold = (
+        4096 if _dense_spark_policy_for_sm_count(sm_count) else 8192
+    )
+    use_large_m_unroll = (
+        expected_m >= large_m_unroll_threshold
+        if expected_m is not None
+        else not single_work_tile_per_cta
+        and not direct_one_m_tile_scheduler
+        and not use_m1_non_tma
+    )
+    return _DenseGemmPolicy(
+        single_work_tile_per_cta=single_work_tile_per_cta,
+        direct_one_m_tile_scheduler=direct_one_m_tile_scheduler,
+        use_m1_non_tma=use_m1_non_tma,
+        split_k_slices=split_k_slices,
+        split_k_atomic_bf16=_FLASHINFER_EXP_SM12X_DENSE_SPLITK_TURBO,
+        large_m_unroll=(
+            ab_dtype == cutlass.Float8E4M3FN and use_large_m_unroll and l == 1
+        ),
+    )
+
+
+class DenseGemmKernel:
+    """Implements batched matrix multiplication (C = A x SFA x B x SFB) for
+    Blackwell GeForce architecture using warp-level MMA.
+
+    Key architectural differences from the tcgen05 donor path:
+    - No TMEM, no tcgen05, no 2-CTA instructions, no multi-cluster
+    - Warp-level MMA: MmaMXF4NVF4Op atom m16n8k64, atom_layout=(4,2,1)
+    - 256 MMA threads + 32 DMA = 288 total threads
+    - PipelineTmaAsync (not PipelineTmaUmma)
+    - Manual atom unroll workaround for CuTe DSL compiler SF address space bug
+    - Cluster shape always (1,1,1)
+
+    Notes:
+        - Supported combinations:
+            * NVF4: A/B: Float4E2M1FN, SF: Float8E4M3FN, sf_vec_size: 16
+            * MXF4: A/B: Float4E2M1FN, SF: Float8E8M0FNU, sf_vec_size: 32
+        - Tile shape constraints:
+            * tile_m must be divisible by 128
+            * tile_n must be divisible by 128
+            * tile_k must be divisible by 64
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        mma_k: int = 64,
+        tile_k: Optional[int] = None,
+        single_work_tile_per_cta: bool = False,
+        use_prefetch: bool = False,
+        direct_one_m_tile_scheduler: bool = False,
+        split_k_slices: int = 1,
+        split_k_atomic_bf16: bool = False,
+        large_m_unroll: bool = False,
+        use_m1_non_tma_a: bool = False,
+        use_m1_non_tma_c: bool = False,
+        use_m1_non_tma_sfa: bool = False,
+        load_path: Literal["tma", "cpasync"] = "tma",
+        swap_ab: bool = False,
+        sfb_k_reuse: bool = False,
+        fused_quant_a: bool = False,
+        fused_quant_a_inner_span: int = 0,
+        fused_quant_a_row_stride: int = 0,
+        fused_quant_a_l_stride: int = 0,
+        fused_quant_a_inv_rope: bool = False,
+        fused_quant_a_head_dim: int = 0,
+        fused_quant_a_nope_dim: int = 0,
+        fused_quant_a_rope_dim: int = 0,
+        fused_quant_a_wide: bool = False,
+        atom_shape_24: bool = False,
+        b_tile_major: bool = False,
+        quantize_c: bool = False,
+        alpha_is_one: bool = False,
+        direct_sfa_live16: bool = False,
+        direct_m1_wo_a_inputs: bool = False,
+        target_occupancy: int = 1,
+    ):
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.mma_k = mma_k
+        if tile_k is None:
+            tile_k = sf_vec_size * 8
+        self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        self.manual_bk64_sf = sf_vec_size == 32 and tile_k == 64
+        self.mma_tile_shape_mnk = (
+            (mma_tiler_mn[1], mma_tiler_mn[0], tile_k)
+            if swap_ab
+            else self.tile_shape_mnk
+        )
+        self.sfa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
+        self.sfa_tiles_per_block = self.sfa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.sfb_tile_shape_nk = (max(128, mma_tiler_mn[1]), tile_k)
+        self.sfb_tiles_per_block = self.sfb_tile_shape_nk[0] // mma_tiler_mn[1]
+        self.cluster_shape_mnk = (1, 1, 1)  # Always (1,1,1) on the current target
+        self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
+        self.single_work_tile_per_cta = single_work_tile_per_cta
+        self.use_prefetch = use_prefetch
+        self.direct_one_m_tile_scheduler = direct_one_m_tile_scheduler
+        self.split_k_slices = split_k_slices
+        self.split_k_atomic_bf16 = split_k_atomic_bf16
+        self.large_m_unroll = large_m_unroll
+        self.use_m1_non_tma_a = use_m1_non_tma_a
+        self.use_m1_non_tma_c = use_m1_non_tma_c
+        self.use_m1_non_tma_sfa = use_m1_non_tma_sfa
+        self.load_path = load_path
+        self.swap_ab = swap_ab
+        # SFB bytes are k-replicated within a 128-wide k tile (128x128 block
+        # weight scales expanded to per-32): load one byte per stage and feed
+        # every k block from it.
+        self.sfb_k_reuse = sfb_k_reuse
+        self.fused_quant_a = fused_quant_a
+        # When >0, the BF16 A source is stored L-blocked along K (physical
+        # [K/span, M, span], e.g. the WO tmp group-major view over [groups, M,
+        # rank]): flat k = outer * span + inner reads element
+        # outer * (M * span) + row * span + inner. 0 keeps contiguous [M, K].
+        self.fused_quant_a_inner_span = fused_quant_a_inner_span
+        # Grouped (L>1) BF16 A source, e.g. WO-A reading attention output
+        # [M, groups, group_width] flat rows: element offset is
+        # row * row_stride + l * l_stride + k (both strides in elements;
+        # row_stride 0 keeps the contiguous shape[1] row pitch).
+        self.fused_quant_a_row_stride = fused_quant_a_row_stride
+        self.fused_quant_a_l_stride = fused_quant_a_l_stride
+        # Inverse-RoPE applied in the quantizing A load: the trailing rope_dim
+        # of every head_dim block is de-rotated with cos/sin at positions[row]
+        # before MXFP8 quantization (head_dim/nope_dim aligned to 32-value
+        # scale blocks; adjacent-pair rotation stays inside one load).
+        self.fused_quant_a_inv_rope = fused_quant_a_inv_rope
+        self.fused_quant_a_head_dim = fused_quant_a_head_dim
+        self.fused_quant_a_nope_dim = fused_quant_a_nope_dim
+        self.fused_quant_a_rope_dim = fused_quant_a_rope_dim
+        # M=1 layout: 4 lanes per 32-value scale block (16 active lanes per
+        # 128-wide k tile) instead of one, cutting the DMA-warp quantization
+        # latency that serializes deep-K small-N pipelines.
+        self.fused_quant_a_wide = fused_quant_a_wide
+        self.b_tile_major = b_tile_major
+        self.quantize_c = quantize_c
+        self.alpha_is_one = alpha_is_one
+        self.direct_sfb_representative = (
+            sfb_k_reuse
+            and b_tile_major
+            and (
+                (
+                    not fused_quant_a
+                    and self.tile_shape_mnk in ((16, 64, 128), (32, 64, 128))
+                )
+                or (fused_quant_a and self.tile_shape_mnk == (16, 128, 128))
+            )
+        )
+        self.direct_m1_wo_a_inputs = direct_m1_wo_a_inputs
+        # Exact B16 consumes only rows 0-15 of each 128-row SFA atom. Those
+        # rows are the contiguous first 256 bytes in both the packed global
+        # and shared-memory layouts.
+        self.direct_sfa_prefix = direct_sfa_live16 and self.direct_sfb_representative
+        mma_atom_mn = (self.mma_tile_shape_mnk[0], self.mma_tile_shape_mnk[1])
+        if mma_atom_mn in ((16, 64), (16, 128)):
+            self.atom_shape = (1, 2, 1)
+        elif mma_atom_mn in ((32, 64), (32, 128)):
+            self.atom_shape = (2, 2, 1)
+        elif atom_shape_24:
+            self.atom_shape = (2, 4, 1)
+        else:
+            self.atom_shape = (4, 2, 1)
+
+        self.tiled_mma = None
+        self.occupancy = target_occupancy
+        if mma_atom_mn in ((16, 64), (16, 128)):
+            self.num_mma_warps = 2
+        elif mma_atom_mn in ((32, 64), (32, 128)):
+            self.num_mma_warps = 4
+        else:
+            self.num_mma_warps = 8
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        self.threads_per_cta = (
+            self.num_mma_warps + 1  # 1 warp for DMA
+        ) * self.num_threads_per_warp
+
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+
+        self.ab_stage = None
+        self.epi_stage = None
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+
+        self.buffer_align_bytes = 1024
+
+        self.mma_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+
+    def _setup_attributes(self):
+        if cutlass.const_expr(self.a_dtype == cutlass.Float8E4M3FN):
+            mma_op = cute.nvgpu.warp.MmaMXF8Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        atom_shape = self.atom_shape
+        atom_layout = cute.make_layout(atom_shape)
+        permutation_mnk = sm120_utils.get_permutation_mnk(
+            self.mma_tile_shape_mnk,
+            self.sf_vec_size,
+            cutlass.const_expr(self.a_dtype == cutlass.Float8E4M3FN),
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            atom_layout,
+            permutation_mnk=permutation_mnk,
+        )
+        # Bare atom for manual unroll workaround (avoids hasAuxTensor address space bug)
+        self.mma_atom = cute.make_mma_atom(mma_op)
+        # Compute atom loop bounds from tile shape and atom/layout shape
+        # MMA atom: m16n8k64 for FP4, m16n8k32 for MXFP8.
+        mma_m, mma_n, mma_k = 16, 8, self.mma_k
+        self.num_m_tiles = self.mma_tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.mma_tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.mma_tile_shape_mnk[2] // mma_k
+
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+
+        # Compute the smem size of SFA/SFB
+        sfa_smem_layout_per_stage = sm120_make_smem_layout_sfa(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+        sfb_smem_layout_per_stage = sm120_make_smem_layout_sfb(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        # Compute stage before compute smem layout
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.sf_dtype,
+            sfa_smem_layout_per_stage,
+            sfb_smem_layout_per_stage,
+            self.epi_tile,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        assert self.epi_stage > 0, (
+            "epi_stage <= 0, not enough shared memory. This configuration will be skipped."
+        )
+
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+            self.sf_vec_size,
+            self.tiled_mma,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        quant_a_source: cute.Tensor,
+        quant_a_positions: cute.Tensor,
+        quant_a_cos_sin: cute.Tensor,
+        b: cute.Tensor,
+        sfa: cute.Tensor,
+        sfb: cute.Tensor,
+        c: cute.Tensor,
+        quant_c_values: cute.Tensor,
+        quant_c_scale_rows: cute.Tensor,
+        quant_c_scale_mma: cute.Tensor,
+        alpha: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM operation.
+
+        Args:
+            a: Input tensor A
+            b: Input tensor B
+            sfa: Scale factor tensor for A
+            sfb: Scale factor tensor for B
+            c: Output tensor C
+            alpha: Alpha scaling factor tensor, shape (1,), float32
+            max_active_clusters: Max active clusters
+            stream: CUDA stream
+            epilogue_op: Elementwise epilogue function
+        """
+        # Setup static attributes
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.sf_dtype = sfa.element_type
+
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = (
+            utils.LayoutEnum.ROW_MAJOR
+            if self.b_tile_major
+            else utils.LayoutEnum.from_tensor(b)
+        )
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
+
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        self.sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            a.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa.iterator, self.sfa_layout)
+
+        b_logical_shape = (
+            cute.size(b.shape[0]),
+            cute.size(b.shape[1]),
+            cute.size(b.shape[2]),
+        )
+        self.sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_logical_shape, self.sf_vec_size
+        )
+        sfb_tensor = cute.make_tensor(sfb.iterator, self.sfb_layout)
+
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+        )
+        if cutlass.const_expr(self.fused_quant_a or self.direct_m1_wo_a_inputs):
+            # A does not use a TMA descriptor on these paths. Reuse B's as a
+            # type-compatible placeholder for the dead kernel argument.
+            tma_atom_a = tma_atom_b
+            tma_tensor_a = a
+        else:
+            tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+                a,
+                self.a_smem_layout_staged,
+                (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+                1,
+            )
+        if cutlass.const_expr(self.fused_quant_a):
+            tma_atom_sfa = tma_atom_b
+            tma_tensor_sfa = sfa_tensor
+        elif cutlass.const_expr(
+            self.use_m1_non_tma_sfa or self.manual_bk64_sf or self.direct_sfa_prefix
+        ):
+            tma_atom_sfa = tma_atom_b
+            tma_tensor_sfa = sfa_tensor
+        else:
+            tma_atom_sfa, tma_tensor_sfa = self._make_tma_atoms_and_tensors(
+                sfa_tensor,
+                self.sfa_smem_layout_staged,
+                self.sfa_tile_shape_mk,
+                1,
+                internal_type=cutlass.Int16,
+            )
+        if cutlass.const_expr(self.manual_bk64_sf or self.direct_sfb_representative):
+            tma_atom_sfb = tma_atom_b
+            tma_tensor_sfb = sfb_tensor
+        else:
+            tma_atom_sfb, tma_tensor_sfb = self._make_tma_atoms_and_tensors(
+                sfb_tensor,
+                self.sfb_smem_layout_staged,
+                self.sfb_tile_shape_nk,
+                1,
+                internal_type=cutlass.Int16,
+            )
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c,
+            self.epi_smem_layout_staged,
+            self.epi_tile,
+        )
+
+        tile_sched_params, grid = self._compute_grid(
+            c,
+            self.tile_shape_mnk,
+            max_active_clusters,
+            self.direct_one_m_tile_scheduler,
+            self.split_k_slices,
+            self.large_m_unroll,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype, cute.cosize(self.epi_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            a,
+            quant_a_source,
+            quant_a_positions,
+            quant_a_cos_sin,
+            tma_atom_b,
+            tma_tensor_b,
+            b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            sfa if self.manual_bk64_sf else sfa_tensor,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            sfb if self.manual_bk64_sf else sfb_tensor,
+            tma_atom_c,
+            tma_tensor_c,
+            c,
+            quant_c_values,
+            quant_c_scale_rows,
+            quant_c_scale_mma,
+            self.tiled_mma,
+            self.mma_atom,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            tile_sched_params,
+            epilogue_op,
+            alpha,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+        )
+        return
+
+    def _partition_fragment_SFA(
+        self,
+        sfa_tensor: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        tidx: int,
+    ):
+        return sm120_utils.partition_fragment_SFA(sfa_tensor, thr_mma, tidx)
+
+    def _partition_fragment_SFB(
+        self,
+        sfb_tensor: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        tidx: int,
+    ):
+        return sm120_utils.partition_fragment_SFB(sfb_tensor, thr_mma, tidx)
+
+    def _thrfrg_SFA(self, sfa_tensor, tiled_mma: cute.TiledMma):
+        return sm120_utils.thrfrg_SFA(sfa_tensor, tiled_mma)
+
+    def _thrfrg_SFB(self, sfb_tensor, tiled_mma: cute.TiledMma):
+        return sm120_utils.thrfrg_SFB(sfb_tensor, tiled_mma)
+
+    def _get_layoutSFA_TV(self, tiled_mma: cute.TiledMma):
+        return sm120_utils.get_layoutSFA_TV(tiled_mma)
+
+    def _get_layoutSFB_TV(self, tiled_mma: cute.TiledMma):
+        return sm120_utils.get_layoutSFB_TV(tiled_mma)
+
+    @cute.jit
+    def _fill_replicated_sfb_fragment(self, fragment: cute.Tensor, scale) -> None:
+        flat = cute.group_modes(cute.flatten(fragment), 0, cute.rank(fragment))
+        for idx in cutlass.range_constexpr(cute.size(flat)):
+            flat[idx] = scale
+
+    @cute.jit
+    def _make_cpasync_tiled_copy(
+        self,
+        dtype: cutlass.Constexpr,
+        tile_cols: cutlass.Constexpr[int],
+    ) -> cute.TiledCopy:
+        copy_bits = 128
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            dtype,
+            num_bits_per_copy=copy_bits,
+        )
+        async_copy_elems = copy_bits // dtype.width
+        t_shape_dim_1 = tile_cols // async_copy_elems
+        assert self.num_threads_per_warp % t_shape_dim_1 == 0
+        t_layout = cute.make_ordered_layout(
+            (self.num_threads_per_warp // t_shape_dim_1, t_shape_dim_1),
+            order=(1, 0),
+        )
+        v_layout = cute.make_layout((1, async_copy_elems))
+        return cute.make_tiled_copy_tv(atom_async_copy, t_layout, v_layout)
+
+    @cute.jit
+    def _make_scale_tiled_copy(
+        self,
+        dtype: cutlass.Constexpr,
+    ) -> cute.TiledCopy:
+        copy_bits = dtype.width
+        atom_async_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            dtype,
+            num_bits_per_copy=copy_bits,
+        )
+        return cute.make_tiled_copy_tv(
+            atom_async_copy,
+            cute.make_layout((self.num_threads_per_warp,)),
+            cute.make_layout((copy_bits // dtype.width,)),
+        )
+
+    @cute.jit
+    def _predicate_cpasync_rows(
+        self,
+        tCc: cute.Tensor,
+        row_limit: Int32,
+    ) -> cute.Tensor:
+        tPred = cute.make_rmem_tensor(
+            cute.make_layout(
+                (
+                    cute.size(tCc, mode=[0, 1]),
+                    cute.size(tCc, mode=[1]),
+                    cute.size(tCc, mode=[2]),
+                ),
+                stride=(cute.size(tCc, mode=[2]), 0, 1),
+            ),
+            cutlass.Boolean,
+        )
+        for rest_v in cutlass.range_constexpr(tPred.shape[0]):
+            for rest_k in cutlass.range_constexpr(tPred.shape[2]):
+                tPred[rest_v, 0, rest_k] = tCc[(0, rest_v), 0, rest_k][0] < row_limit
+        return tPred
+
+    @cute.jit
+    def _cpasync_copy_2d(
+        self,
+        tiled_copy: cute.TiledCopy,
+        tG: cute.Tensor,
+        tS: cute.Tensor,
+        tC: cute.Tensor,
+        row_limit: Int32,
+        predicate_rows: cutlass.Constexpr[bool],
+    ) -> None:
+        if cutlass.const_expr(predicate_rows):
+            tP = self._predicate_cpasync_rows(tC, row_limit)
+        for rest_m in cutlass.range_constexpr(cute.size(tS.shape[1])):
+            if cutlass.const_expr(predicate_rows):
+                cute.copy(
+                    tiled_copy,
+                    tG[None, rest_m, None],
+                    tS[None, rest_m, None],
+                    pred=tP[None, rest_m, None],
+                )
+            else:
+                cute.copy(
+                    tiled_copy,
+                    tG[None, rest_m, None],
+                    tS[None, rest_m, None],
+                )
+
+    @cute.jit
+    def _scale_copy_2d(
+        self,
+        tiled_copy: cute.TiledCopy,
+        tG: cute.Tensor,
+        tS: cute.Tensor,
+        tC: cute.Tensor,
+        row_limit: Int32,
+    ) -> None:
+        tP = cute.make_rmem_tensor(cute.make_layout(tS.shape), cutlass.Boolean)
+        for i in cutlass.range_constexpr(cute.size(tP)):
+            tP[i] = cute.elem_less(tC[i][0][0][0], row_limit)
+        for rest_m in cutlass.range_constexpr(cute.size(tS.shape[1])):
+            cute.copy(
+                tiled_copy,
+                tG[None, rest_m, None],
+                tS[None, rest_m, None],
+                pred=tP[None, rest_m, None],
+            )
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        directA_mkl: cute.Tensor,
+        quantA_mkl: cute.Tensor,
+        quantA_positions: cute.Tensor,
+        quantA_cos_sin: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        directB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        directSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        directSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        directC_mnl: cute.Tensor,
+        quantC_values: cute.Tensor,
+        quantC_scale_rows: cute.Tensor,
+        quantC_scale_mma: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        mma_atom: cute.MmaAtom,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+        alpha: cute.Tensor,
+    ):
+        # Keep alpha in FP32 for precision
+        alpha_value = alpha[0].to(cutlass.Float32)
+
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        # Prefetch TMA descriptors
+        if warp_idx == 0:
+            if cutlass.const_expr(
+                self.load_path == "tma"
+                and not self.use_m1_non_tma_a
+                and not self.fused_quant_a
+                and not self.direct_m1_wo_a_inputs
+            ):
+                cpasync.prefetch_descriptor(tma_atom_a)
+            if cutlass.const_expr(self.load_path == "tma"):
+                cpasync.prefetch_descriptor(tma_atom_b)
+            if cutlass.const_expr(
+                self.load_path == "tma"
+                and not self.use_m1_non_tma_sfa
+                and not self.fused_quant_a
+                and not self.manual_bk64_sf
+                and not self.direct_sfa_prefix
+            ):
+                cpasync.prefetch_descriptor(tma_atom_sfa)
+            if cutlass.const_expr(
+                self.load_path == "tma"
+                and not self.manual_bk64_sf
+                and not self.direct_sfb_representative
+            ):
+                cpasync.prefetch_descriptor(tma_atom_sfb)
+            if cutlass.const_expr(not self.use_m1_non_tma_c):
+                cpasync.prefetch_descriptor(tma_atom_c)
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, 0))
+        sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, 0))
+        if cutlass.const_expr(self.fused_quant_a):
+            tma_copy_bytes = cute.size_in_bytes(
+                self.b_dtype, b_smem_layout
+            ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        elif cutlass.const_expr(self.manual_bk64_sf):
+            tma_copy_bytes = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+            if cutlass.const_expr(not self.use_m1_non_tma_a):
+                tma_copy_bytes += cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        elif cutlass.const_expr(self.use_m1_non_tma_sfa):
+            tma_copy_bytes = cute.size_in_bytes(
+                self.b_dtype, b_smem_layout
+            ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+            if cutlass.const_expr(not self.use_m1_non_tma_a):
+                tma_copy_bytes += cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        else:
+            tma_copy_bytes = (
+                cute.size_in_bytes(self.b_dtype, b_smem_layout)
+                + cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+                + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+            )
+            if cutlass.const_expr(self.direct_m1_wo_a_inputs):
+                tma_copy_bytes += 128
+            else:
+                tma_copy_bytes += cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        if cutlass.const_expr(self.direct_sfb_representative):
+            tma_copy_bytes -= cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+            tma_copy_bytes += 16
+        if cutlass.const_expr(self.direct_sfa_prefix):
+            tma_copy_bytes -= cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+            tma_copy_bytes += 256
+
+        # Allocate shared memory
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Pipeline setup
+        mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps
+        )
+
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        if cutlass.const_expr(self.load_path == "cpasync"):
+            mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_threads_per_warp,
+            )
+            mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_mma_warps * self.num_threads_per_warp,
+            )
+            mainloop_pipeline = pipeline.PipelineAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=mainloop_pipeline_producer_group,
+                consumer_group=mainloop_pipeline_consumer_group,
+                barrier_storage=mainloop_pipeline_array_ptr,
+            )
+        else:
+            mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=mainloop_pipeline_producer_group,
+                consumer_group=mainloop_pipeline_consumer_group,
+                tx_count=tma_copy_bytes,
+                barrier_storage=mainloop_pipeline_array_ptr,
+                cta_layout_vmnk=cta_layout_vmnk,
+            )
+
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        # Generate smem tensors
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_layout_staged.outer, swizzle=epi_smem_layout_staged.inner
+        )
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        # Local_tile partition global tensors
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        if cutlass.const_expr(not self.use_m1_non_tma_sfa and not self.fused_quant_a):
+            gSFA_mkl = cute.local_tile(
+                mSFA_mkl,
+                self.sfa_tile_shape_mk,
+                (None, None, None),
+            )
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            self.sfb_tile_shape_nk,
+            (None, None, None),
+        )
+        if cutlass.const_expr(self.load_path == "cpasync"):
+            gA_cpasync_mkl = cute.local_tile(
+                directA_mkl,
+                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                (None, None, None),
+            )
+            gB_cpasync_nkl = cute.local_tile(
+                directB_nkl,
+                cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                (None, None, None),
+            )
+            gSFA_cpasync_mkl = cute.local_tile(
+                directSFA_mkl,
+                self.sfa_tile_shape_mk,
+                (None, None, None),
+            )
+            gSFB_cpasync_nkl = cute.local_tile(
+                directSFB_nkl,
+                self.sfb_tile_shape_nk,
+                (None, None, None),
+            )
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.tile_shape_mnk, (None, None, 0)),
+            (None, None, None),
+        )
+
+        # Partition for TiledMMA
+        thr_mma = tiled_mma.get_slice(tidx)
+
+        # TMA partitions for A
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord_mnk[1]
+        if cutlass.const_expr(
+            self.load_path == "tma"
+            and not self.use_m1_non_tma_a
+            and not self.fused_quant_a
+            and not self.direct_m1_wo_a_inputs
+        ):
+            tAsA, tAgA = cpasync.tma_partition(
+                tma_atom_a,
+                a_cta_crd,
+                a_cta_layout,
+                cute.group_modes(sA, 0, 2),
+                cute.group_modes(gA_mkl, 0, 2),
+            )
+
+        # TMA partitions for B
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord_mnk[0]
+        if cutlass.const_expr(self.load_path == "tma"):
+            tBsB, tBgB = cpasync.tma_partition(
+                tma_atom_b,
+                b_cta_crd,
+                b_cta_layout,
+                cute.group_modes(sB, 0, 2),
+                cute.group_modes(gB_nkl, 0, 2),
+            )
+
+        # TMA partitions for SFA
+        if cutlass.const_expr(
+            self.load_path == "tma"
+            and not self.use_m1_non_tma_sfa
+            and not self.fused_quant_a
+            and not self.manual_bk64_sf
+            and not self.direct_sfa_prefix
+        ):
+            tAsSFA, tAgSFA = cpasync.tma_partition(
+                tma_atom_sfa,
+                a_cta_crd,
+                a_cta_layout,
+                cute.group_modes(sSFA, 0, 2),
+                cute.group_modes(gSFA_mkl, 0, 2),
+            )
+            tAsSFA = cute.filter_zeros(tAsSFA)
+            tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # TMA partitions for SFB
+        if cutlass.const_expr(
+            self.load_path == "tma"
+            and not self.manual_bk64_sf
+            and not self.direct_sfb_representative
+        ):
+            tBsSFB, tBgSFB = cpasync.tma_partition(
+                tma_atom_sfb,
+                b_cta_crd,
+                b_cta_layout,
+                cute.group_modes(sSFB, 0, 2),
+                cute.group_modes(gSFB_nkl, 0, 2),
+            )
+            tBsSFB = cute.filter_zeros(tBsSFB)
+            tBgSFB = cute.filter_zeros(tBgSFB)
+
+        if cutlass.const_expr(self.load_path == "cpasync"):
+            cpasync_tiled_copy_A = self._make_cpasync_tiled_copy(
+                self.a_dtype,
+                self.tile_shape_mnk[2],
+            )
+            cpasync_tiled_copy_B = self._make_cpasync_tiled_copy(
+                self.b_dtype,
+                self.tile_shape_mnk[2],
+            )
+            cpasync_tiled_copy_SF = self._make_scale_tiled_copy(self.sf_dtype)
+            cA_mkl = cute.make_identity_tensor(cute.shape(directA_mkl))
+            cA_cpasync_mkl = cute.local_tile(
+                cA_mkl,
+                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                (None, None, None),
+            )
+            cB_nkl = cute.make_identity_tensor(cute.shape(directB_nkl))
+            cB_cpasync_nkl = cute.local_tile(
+                cB_nkl,
+                cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                (None, None, None),
+            )
+            cSFA_mkl = cute.make_identity_tensor(cute.shape(directSFA_mkl))
+            cSFA_cpasync_mkl = cute.local_tile(
+                cSFA_mkl,
+                self.sfa_tile_shape_mk,
+                (None, None, None),
+            )
+            cSFB_nkl = cute.make_identity_tensor(cute.shape(directSFB_nkl))
+            cSFB_cpasync_nkl = cute.local_tile(
+                cSFB_nkl,
+                self.sfb_tile_shape_nk,
+                (None, None, None),
+            )
+
+            cpasync_lane = tidx % self.num_threads_per_warp
+            thr_cpasync_A = cpasync_tiled_copy_A.get_slice(cpasync_lane)
+            thr_cpasync_B = cpasync_tiled_copy_B.get_slice(cpasync_lane)
+            thr_cpasync_SF = cpasync_tiled_copy_SF.get_slice(cpasync_lane)
+            tAgA_cpasync_mkl = thr_cpasync_A.partition_S(gA_cpasync_mkl)
+            tAsA_cpasync = thr_cpasync_A.partition_D(sA)
+            tAcA_cpasync_mkl = thr_cpasync_A.partition_S(cA_cpasync_mkl)
+            tBgB_cpasync_nkl = thr_cpasync_B.partition_S(gB_cpasync_nkl)
+            tBsB_cpasync = thr_cpasync_B.partition_D(sB)
+            tBcB_cpasync_nkl = thr_cpasync_B.partition_S(cB_cpasync_nkl)
+            tAgSFA_cpasync_mkl = thr_cpasync_SF.partition_S(gSFA_cpasync_mkl)
+            tAsSFA_cpasync = thr_cpasync_SF.partition_D(sSFA)
+            tAcSFA_cpasync_mkl = thr_cpasync_SF.partition_S(cSFA_cpasync_mkl)
+            tBgSFB_cpasync_nkl = thr_cpasync_SF.partition_S(gSFB_cpasync_nkl)
+            tBsSFB_cpasync = thr_cpasync_SF.partition_D(sSFB)
+            tBcSFB_cpasync_nkl = thr_cpasync_SF.partition_S(cSFB_cpasync_nkl)
+
+        # Make fragments. swap_ab keeps public C[M,N] unchanged but presents
+        # B as MMA-A and A as MMA-B.
+        if cutlass.const_expr(self.swap_ab):
+            tCsA = thr_mma.partition_A(sB)
+            tCsB = thr_mma.partition_B(sA)
+        else:
+            tCsA = thr_mma.partition_A(sA)
+            tCsB = thr_mma.partition_B(sB)
+
+        tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        if cutlass.const_expr(self.swap_ab):
+            tCrSFA_full = self._partition_fragment_SFA(
+                sSFB[None, None, 0], thr_mma, tidx
+            )
+            tCrSFB_full = self._partition_fragment_SFB(
+                sSFA[None, None, 0], thr_mma, tidx
+            )
+            c_mma = cute.make_identity_tensor(
+                (self.tile_shape_mnk[1], self.tile_shape_mnk[0])
+            )
+            tCgC = thr_mma.partition_C(c_mma)
+        else:
+            tCrSFA_full = self._partition_fragment_SFA(
+                sSFA[None, None, 0], thr_mma, tidx
+            )
+            tCrSFB_full = self._partition_fragment_SFB(
+                sSFB[None, None, 0], thr_mma, tidx
+            )
+            tCgC = thr_mma.partition_C(gC_mnl)
+        acc_shape = tCgC.shape[:3]
+        accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        # Cluster/thread sync
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.sync_threads()
+
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+        block_idx = cute.arch.block_idx()
+        k_tile_start = Int32(0)
+        k_tile_iter_cnt = k_tile_cnt
+        if cutlass.const_expr(self.split_k_slices > 1):
+            k_tiles_per_split = k_tile_cnt // self.split_k_slices
+            k_tile_start = Int32(block_idx[1]) * Int32(k_tiles_per_split)
+            k_tile_iter_cnt = k_tiles_per_split
+
+        # Tile scheduler
+        if cutlass.const_expr(self.direct_one_m_tile_scheduler):
+            direct_tile_valid = Int32(block_idx[2]) < Int32(
+                tile_sched_params.problem_shape_ntile_mnl[1]
+            )
+            work_tile = WorkTileInfo(
+                (Int32(0), Int32(block_idx[2]), Int32(0)),
+                direct_tile_valid,
+            )
+        else:
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, block_idx, cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+        # Pipeline states
+        mainloop_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        mainloop_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        # MMA warp group
+        if warp_idx < self.num_mma_warps:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+
+            num_k_blocks = cute.size(tCrA, mode=[2])
+
+            # Copy atoms for SMEM->RMEM
+            if cutlass.const_expr(self.swap_ab):
+                atom_copy_ldmatrix_A = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                    self.b_dtype,
+                )
+                atom_copy_ldmatrix_B = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                    self.a_dtype,
+                )
+            else:
+                atom_copy_ldmatrix_A = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                    self.a_dtype,
+                )
+                atom_copy_ldmatrix_B = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                    self.b_dtype,
+                )
+            smem_tiled_copy_A = cute.make_tiled_copy_A(atom_copy_ldmatrix_A, tiled_mma)
+            smem_tiled_copy_B = cute.make_tiled_copy_B(atom_copy_ldmatrix_B, tiled_mma)
+
+            atom_copy_ldmatrix_SF = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.sf_dtype,
+            )
+            smem_tiled_copy_SFA = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                self._get_layoutSFA_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[0]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+            smem_tiled_copy_SFB = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                self._get_layoutSFB_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[1]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+
+            thr_copy_ldmatrix_A = smem_tiled_copy_A.get_slice(tidx)
+            thr_copy_ldmatrix_B = smem_tiled_copy_B.get_slice(tidx)
+            tCsA_copy_view = thr_copy_ldmatrix_A.partition_S(
+                sB if cutlass.const_expr(self.swap_ab) else sA
+            )
+            tCrA_copy_view = thr_copy_ldmatrix_A.retile(tCrA)
+            tCsB_copy_view = thr_copy_ldmatrix_B.partition_S(
+                sA if cutlass.const_expr(self.swap_ab) else sB
+            )
+            tCrB_copy_view = thr_copy_ldmatrix_B.retile(tCrB)
+
+            thr_copy_ldmatrix_SFA = smem_tiled_copy_SFA.get_slice(tidx)
+            thr_copy_ldmatrix_SFB = smem_tiled_copy_SFB.get_slice(tidx)
+            tCsSFA_copy_view_full = thr_copy_ldmatrix_SFA.partition_S(
+                sSFB if cutlass.const_expr(self.swap_ab) else sSFA
+            )
+            tCrSFA_copy_view_full = thr_copy_ldmatrix_SFA.retile(tCrSFA_full)
+            tCsSFB_copy_view_full = thr_copy_ldmatrix_SFB.partition_S(
+                sSFA if cutlass.const_expr(self.swap_ab) else sSFB
+            )
+            tCrSFB_copy_view_full = thr_copy_ldmatrix_SFB.retile(tCrSFB_full)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                gC_mnl_slice = gC_mnl[(None, None, *tile_coord_mnl)]
+                sfa_tile_offset = tile_coord_mnl[0] % self.sfa_tiles_per_block
+                sfb_tile_offset = tile_coord_mnl[1] % self.sfb_tiles_per_block
+                if cutlass.const_expr(self.swap_ab):
+                    if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                        sSFB_tile = cute.local_tile(
+                            sSFB,
+                            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                            (sfb_tile_offset, 0, None),
+                        )
+                        tCsSFA_tile_copy_view = thr_copy_ldmatrix_SFA.partition_S(
+                            sSFB_tile
+                        )
+                        tCrSFA_tile = self._partition_fragment_SFA(
+                            sSFB_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFA_tile_copy_view = thr_copy_ldmatrix_SFA.retile(
+                            tCrSFA_tile
+                        )
+                    else:
+                        tCsSFA_tile_copy_view = tCsSFA_copy_view_full
+                        tCrSFA_tile = tCrSFA_full
+                        tCrSFA_tile_copy_view = tCrSFA_copy_view_full
+                    if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                        sSFA_tile = cute.local_tile(
+                            sSFA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (sfa_tile_offset, 0, None),
+                        )
+                        tCsSFB_tile_copy_view = thr_copy_ldmatrix_SFB.partition_S(
+                            sSFA_tile
+                        )
+                        tCrSFB_tile = self._partition_fragment_SFB(
+                            sSFA_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFB_tile_copy_view = thr_copy_ldmatrix_SFB.retile(
+                            tCrSFB_tile
+                        )
+                    else:
+                        tCsSFB_tile_copy_view = tCsSFB_copy_view_full
+                        tCrSFB_tile = tCrSFB_full
+                        tCrSFB_tile_copy_view = tCrSFB_copy_view_full
+                else:
+                    if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                        sSFA_tile = cute.local_tile(
+                            sSFA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (sfa_tile_offset, 0, None),
+                        )
+                        tCsSFA_tile_copy_view = thr_copy_ldmatrix_SFA.partition_S(
+                            sSFA_tile
+                        )
+                        tCrSFA_tile = self._partition_fragment_SFA(
+                            sSFA_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFA_tile_copy_view = thr_copy_ldmatrix_SFA.retile(
+                            tCrSFA_tile
+                        )
+                    else:
+                        tCsSFA_tile_copy_view = tCsSFA_copy_view_full
+                        tCrSFA_tile = tCrSFA_full
+                        tCrSFA_tile_copy_view = tCrSFA_copy_view_full
+                    if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                        sSFB_tile = cute.local_tile(
+                            sSFB,
+                            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                            (sfb_tile_offset, 0, None),
+                        )
+                        tCsSFB_tile_copy_view = thr_copy_ldmatrix_SFB.partition_S(
+                            sSFB_tile
+                        )
+                        tCrSFB_tile = self._partition_fragment_SFB(
+                            sSFB_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFB_tile_copy_view = thr_copy_ldmatrix_SFB.retile(
+                            tCrSFB_tile
+                        )
+                    else:
+                        tCsSFB_tile_copy_view = tCsSFB_copy_view_full
+                        tCrSFB_tile = tCrSFB_full
+                        tCrSFB_tile_copy_view = tCrSFB_copy_view_full
+                accumulators.fill(0.0)
+
+                # Pipelined MAINLOOP
+                mainloop_consumer_state.reset_count()
+
+                peek_ab_full_status = cutlass.Boolean(1)
+                if mainloop_consumer_state.count < k_tile_iter_cnt:
+                    peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                        mainloop_consumer_state
+                    )
+
+                mainloop_pipeline.consumer_wait(
+                    mainloop_consumer_state, peek_ab_full_status
+                )
+                tCsA_p = tCsA_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsB_p = tCsB_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsSFA_p = tCsSFA_tile_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                tCsSFB_p = tCsSFB_tile_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                cute.copy(
+                    smem_tiled_copy_A,
+                    tCsA_p[None, None, 0],
+                    tCrA_copy_view[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_B,
+                    tCsB_p[None, None, 0],
+                    tCrB_copy_view[None, None, 0],
+                )
+
+                tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
+                tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
+
+                # Whole-stage SF copy: scale bytes for all k blocks of the
+                # acquired stage load in one bulk copy (per-k_block SF reloads
+                # dominated the LDS/issue budget at prefill M).
+                cute.copy(
+                    smem_tiled_copy_SFA,
+                    tCsSFA_p_filtered,
+                    tCrSFA_copy_view_filtered,
+                )
+                if cutlass.const_expr(self.direct_sfb_representative):
+                    self._fill_replicated_sfb_fragment(
+                        tCrSFB_tile[None, None, 0],
+                        sSFB[
+                            (
+                                Int32(0),
+                                Int32(0),
+                                mainloop_consumer_state.index,
+                            )
+                        ],
+                    )
+                elif cutlass.const_expr(self.sfb_k_reuse):
+                    cute.copy(
+                        smem_tiled_copy_SFB,
+                        tCsSFB_p_filtered[None, None, 0],
+                        tCrSFB_copy_view_filtered[None, None, 0],
+                    )
+                else:
+                    cute.copy(
+                        smem_tiled_copy_SFB,
+                        tCsSFB_p_filtered,
+                        tCrSFB_copy_view_filtered,
+                    )
+
+                for k_tile in range(
+                    0,
+                    k_tile_iter_cnt - 1,
+                    1,
+                    unroll=4 if self.large_m_unroll else 2,
+                ):
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+
+                        if k_block_idx == num_k_blocks - 1:
+                            mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                            mainloop_consumer_state.advance()
+
+                            peek_ab_full_status = cutlass.Boolean(1)
+                            peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                                mainloop_consumer_state
+                            )
+
+                            tCsA_p = tCsA_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsB_p = tCsB_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFA_p = tCsSFA_tile_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFB_p = tCsSFB_tile_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            mainloop_pipeline.consumer_wait(
+                                mainloop_consumer_state, peek_ab_full_status
+                            )
+
+                        # Manual atom unroll: avoids hasAuxTensor address space bug
+                        for _mt in range(self.num_m_tiles):
+                            for _nt in range(self.num_n_tiles):
+                                mma_atom.set(
+                                    WarpField.SFA,
+                                    tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                )
+                                if cutlass.const_expr(self.sfb_k_reuse):
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_tile[None, _nt, 0].iterator,
+                                    )
+                                else:
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                    )
+                                cute.gemm(
+                                    mma_atom,
+                                    accumulators[None, _mt, _nt],
+                                    tCrA[None, _mt, k_block_idx],
+                                    tCrB[None, _nt, k_block_idx],
+                                    accumulators[None, _mt, _nt],
+                                )
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+
+                        if k_block_idx == num_k_blocks - 1:
+                            # New stage acquired above: bulk-load its whole SF
+                            # tile once. The current tile's k_block MMAs have
+                            # all consumed their SF registers by this point.
+                            tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                            tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                            tCrSFA_copy_view_filtered = cute.filter_zeros(
+                                tCrSFA_tile_copy_view
+                            )
+                            tCrSFB_copy_view_filtered = cute.filter_zeros(
+                                tCrSFB_tile_copy_view
+                            )
+                            cute.copy(
+                                smem_tiled_copy_SFA,
+                                tCsSFA_p_filtered,
+                                tCrSFA_copy_view_filtered,
+                            )
+                            if cutlass.const_expr(self.direct_sfb_representative):
+                                self._fill_replicated_sfb_fragment(
+                                    tCrSFB_tile[None, None, 0],
+                                    sSFB[
+                                        (
+                                            Int32(0),
+                                            Int32(0),
+                                            mainloop_consumer_state.index,
+                                        )
+                                    ],
+                                )
+                            elif cutlass.const_expr(self.sfb_k_reuse):
+                                cute.copy(
+                                    smem_tiled_copy_SFB,
+                                    tCsSFB_p_filtered[None, None, 0],
+                                    tCrSFB_copy_view_filtered[None, None, 0],
+                                )
+                            else:
+                                cute.copy(
+                                    smem_tiled_copy_SFB,
+                                    tCsSFB_p_filtered,
+                                    tCrSFB_copy_view_filtered,
+                                )
+
+                # Hoist out last k_tile
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_block_next = (
+                        0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                    )
+
+                    if k_block_idx == num_k_blocks - 1:
+                        mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                        mainloop_consumer_state.advance()
+
+                    if k_block_next > 0:
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+                        # SF registers for the whole stage were bulk-loaded at
+                        # stage acquisition; nothing to reload per k block.
+                    # Manual atom unroll: avoids hasAuxTensor address space bug
+                    for _mt in range(self.num_m_tiles):
+                        for _nt in range(self.num_n_tiles):
+                            mma_atom.set(
+                                WarpField.SFA,
+                                tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                            )
+                            if cutlass.const_expr(self.sfb_k_reuse):
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_tile[None, _nt, 0].iterator,
+                                )
+                            else:
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                )
+                            cute.gemm(
+                                mma_atom,
+                                accumulators[None, _mt, _nt],
+                                tCrA[None, _mt, k_block_idx],
+                                tCrB[None, _nt, k_block_idx],
+                                accumulators[None, _mt, _nt],
+                            )
+
+                if cutlass.const_expr(self.swap_ab):
+                    acc_mn = _reshape_acc_to_mn(accumulators, transpose=True)
+                    c_identity = cute.make_identity_tensor(
+                        (self.tile_shape_mnk[1], self.tile_shape_mnk[0])
+                    )
+                    coord_mn = _reshape_acc_to_mn(
+                        thr_mma.partition_C(c_identity),
+                        transpose=True,
+                    )
+                    for acc_m in cutlass.range_constexpr(cute.size(acc_mn.shape[0])):
+                        for acc_n in cutlass.range_constexpr(
+                            cute.size(acc_mn.shape[1])
+                        ):
+                            coord = coord_mn[acc_m, acc_n]
+                            m_coord = (
+                                tile_coord_mnl[0] * Int32(self.tile_shape_mnk[0])
+                                + coord[1]
+                            )
+                            n_coord = (
+                                tile_coord_mnl[1] * Int32(self.tile_shape_mnk[1])
+                                + coord[0]
+                            )
+                            if m_coord < Int32(
+                                directC_mnl.shape[0]
+                            ) and n_coord < Int32(directC_mnl.shape[1]):
+                                directC_mnl[
+                                    (
+                                        m_coord,
+                                        n_coord,
+                                        tile_coord_mnl[2],
+                                    )
+                                ] = epilogue_op(
+                                    (alpha_value * acc_mn[acc_m, acc_n]).to(
+                                        self.c_dtype
+                                    )
+                                )
+                    if cutlass.const_expr(self.single_work_tile_per_cta):
+                        work_tile = WorkTileInfo(
+                            work_tile.tile_idx,
+                            cutlass.Boolean(0),
+                        )
+                    else:
+                        tile_sched.advance_to_next_work()
+                        work_tile = tile_sched.get_current_work()
+
+                if cutlass.const_expr(not self.swap_ab):
+                    # EPILOGUE
+                    _is_m_major = self.c_layout.is_m_major_c()
+                    if cutlass.const_expr(self.c_dtype.width == 16):
+                        copy_atom_r2s = cute.make_copy_atom(
+                            cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
+                            self.c_dtype,
+                        )
+                    else:
+                        copy_atom_r2s = cute.make_copy_atom(
+                            cute.nvgpu.CopyUniversalOp(),
+                            self.c_dtype,
+                        )
+
+                    if cutlass.const_expr(self.c_dtype.width == 16):
+                        copy_atom_C = cute.make_copy_atom(
+                            cute.nvgpu.warp.StMatrix8x8x16bOp(
+                                self.c_layout.is_m_major_c(),
+                                2,
+                            ),
+                            self.c_dtype,
+                        )
+                    else:
+                        copy_atom_C = cute.make_copy_atom(
+                            cute.nvgpu.CopyUniversalOp(), self.c_dtype
+                        )
+
+                    tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(
+                        copy_atom_C, tiled_mma
+                    )
+
+                    tiled_copy_r2s = cute.make_tiled_copy_S(
+                        copy_atom_r2s,
+                        tiled_copy_C_Atom,
+                    )
+
+                    thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                    tRS_sD = thr_copy_r2s.partition_D(sC)
+                    tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+                    rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                    tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                    tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+
+                    sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
+                    tcgc_for_tma_partition = cute.zipped_divide(
+                        gC_mnl_slice, self.epi_tile
+                    )
+
+                    bSG_sD, bSG_gD = cpasync.tma_partition(
+                        tma_atom_c,
+                        0,
+                        cute.make_layout(1),
+                        sepi_for_tma_partition,
+                        tcgc_for_tma_partition,
+                    )
+
+                    epi_rest_m = bSG_gD.shape[1][0]
+                    epi_rest_n = bSG_gD.shape[1][1]
+                    epi_tile_m = self.epi_tile[0]
+                    epi_tile_n = self.epi_tile[1]
+                    mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
+                    mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
+                    has_multi_epi_store = cutlass.const_expr(
+                        not (
+                            self.epi_stage == 1 and epi_rest_m == 1 and epi_rest_n == 1
+                        )
+                    )
+                    tma_store_producer_group = pipeline.CooperativeGroup(
+                        pipeline.Agent.Thread,
+                        self.num_mma_warps * self.num_threads_per_warp,
+                    )
+                    tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                        num_stages=self.epi_stage,
+                        producer_group=tma_store_producer_group,
+                    )
+
+                    for epi_m in cutlass.range_constexpr(epi_rest_m):
+                        for epi_n in cutlass.range_constexpr(epi_rest_n):
+                            MmaMPerEpiM = epi_tile_m // mma_tile_m
+                            MmaNPerEpiN = epi_tile_n // mma_tile_n
+                            for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                                for mma_m_in_epi in cutlass.range_constexpr(
+                                    MmaMPerEpiM
+                                ):
+                                    mma_n = (epi_n * MmaNPerEpiN) + mma_n_in_epi
+                                    mma_m = (epi_m * MmaMPerEpiM) + mma_m_in_epi
+                                    tRS_rD_slice = tRS_rD[
+                                        (None, mma_m_in_epi, mma_n_in_epi)
+                                    ]
+                                    tRS_rAcc_slice = tRS_rAcc[(None, mma_m, mma_n)]
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        tRS_rD_slice[elem_idx] = tRS_rAcc_slice[
+                                            elem_idx
+                                        ]
+
+                            gmem_coord = (epi_m, epi_n)
+                            if cutlass.const_expr(self.split_k_slices > 1):
+                                acc_mn = _reshape_acc_to_mn(accumulators)
+                                c_identity = cute.make_identity_tensor(
+                                    cute.slice_(self.tile_shape_mnk, (None, None, 0))
+                                )
+                                coord_mn = _reshape_acc_to_mn(
+                                    thr_mma.partition_C(c_identity)
+                                )
+                                if cutlass.const_expr(self.split_k_atomic_bf16):
+                                    for acc_m in cutlass.range_constexpr(
+                                        cute.size(acc_mn.shape[0])
+                                    ):
+                                        for acc_n_pair in cutlass.range_constexpr(
+                                            cute.size(acc_mn.shape[1]) // 2
+                                        ):
+                                            acc_n0 = acc_n_pair * 2
+                                            acc_n1 = acc_n0 + 1
+                                            coord0 = coord_mn[acc_m, acc_n0]
+                                            coord1 = coord_mn[acc_m, acc_n1]
+                                            m_coord0 = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord0[0]
+                                            )
+                                            n_coord0 = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord0[1]
+                                            )
+                                            m_coord1 = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord1[0]
+                                            )
+                                            n_coord1 = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord1[1]
+                                            )
+                                            if (
+                                                m_coord0 < Int32(directC_mnl.shape[0])
+                                                and m_coord1
+                                                < Int32(directC_mnl.shape[0])
+                                                and n_coord0
+                                                < Int32(directC_mnl.shape[1])
+                                                and n_coord1
+                                                < Int32(directC_mnl.shape[1])
+                                            ):
+                                                c_offset = cute.crd2idx(
+                                                    (
+                                                        m_coord0,
+                                                        n_coord0,
+                                                        Int32(0),
+                                                    ),
+                                                    directC_mnl.layout,
+                                                )
+                                                scatter_add_bf16x2(
+                                                    get_ptr_as_int64(
+                                                        directC_mnl,
+                                                        c_offset,
+                                                    ),
+                                                    alpha_value * acc_mn[acc_m, acc_n0],
+                                                    alpha_value * acc_mn[acc_m, acc_n1],
+                                                )
+                                        if cutlass.const_expr(
+                                            cute.size(acc_mn.shape[1]) % 2 == 1
+                                        ):
+                                            acc_n = cute.size(acc_mn.shape[1]) - 1
+                                            coord = coord_mn[acc_m, acc_n]
+                                            m_coord = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord[0]
+                                            )
+                                            n_coord = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord[1]
+                                            )
+                                            if m_coord < Int32(
+                                                directC_mnl.shape[0]
+                                            ) and n_coord < Int32(directC_mnl.shape[1]):
+                                                c_offset = cute.crd2idx(
+                                                    (
+                                                        m_coord,
+                                                        n_coord,
+                                                        Int32(0),
+                                                    ),
+                                                    directC_mnl.layout,
+                                                )
+                                                scatter_add_bf16(
+                                                    get_ptr_as_int64(
+                                                        directC_mnl,
+                                                        c_offset,
+                                                    ),
+                                                    alpha_value * acc_mn[acc_m, acc_n],
+                                                )
+                                else:
+                                    split_idx = Int32(block_idx[1])
+                                    for acc_m in cutlass.range_constexpr(
+                                        cute.size(acc_mn.shape[0])
+                                    ):
+                                        for acc_n in cutlass.range_constexpr(
+                                            cute.size(acc_mn.shape[1])
+                                        ):
+                                            coord = coord_mn[acc_m, acc_n]
+                                            m_coord = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord[0]
+                                            )
+                                            n_coord = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord[1]
+                                            )
+                                            if m_coord < Int32(
+                                                directC_mnl.shape[0]
+                                            ) and n_coord < Int32(directC_mnl.shape[1]):
+                                                directC_mnl[
+                                                    (m_coord, n_coord, split_idx)
+                                                ] = alpha_value * acc_mn[acc_m, acc_n]
+                            else:
+                                # Type conversion with alpha scaling
+                                tRS_rD_out = cute.make_rmem_tensor(
+                                    tRS_rD_layout.shape, self.c_dtype
+                                )
+                                acc_vec = tRS_rD.load()
+                                # Multiply alpha in FP32 before converting to c_dtype
+                                # to avoid overflow when c_dtype is FP16
+                                if cutlass.const_expr(self.alpha_is_one):
+                                    acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                                else:
+                                    acc_vec = epilogue_op(
+                                        (alpha_value * acc_vec).to(self.c_dtype)
+                                    )
+                                tRS_rD_out.store(acc_vec)
+
+                                # Register to shared memory
+                                epi_buffer = (epi_m * epi_rest_n + epi_n) % cute.size(
+                                    tRS_sD, mode=[3]
+                                )
+                                if has_multi_epi_store:
+                                    self.epilog_sync_barrier.arrive_and_wait()
+                                cute.copy(
+                                    tiled_copy_r2s,
+                                    tRS_rD_out,
+                                    tRS_sD[(None, None, None, epi_buffer)],
+                                )
+                                cute.arch.fence_proxy(
+                                    "async.shared",
+                                    space="cta",
+                                )
+                                self.epilog_sync_barrier.arrive_and_wait()
+
+                                if cutlass.const_expr(self.quantize_c):
+                                    quant_chunks_per_epi = self.epi_tile[1] // 32
+                                    quant_active_warps = min(self.num_mma_warps, 4)
+                                    quant_subgroups = quant_active_warps * 8
+                                    quant_lane = Int32(tidx % 4)
+                                    quant_subgroup = Int32(tidx // 4)
+                                    quant_iters = (
+                                        16 * quant_chunks_per_epi + quant_subgroups - 1
+                                    ) // quant_subgroups
+                                    if warp_idx < Int32(quant_active_warps):
+                                        for quant_iter in cutlass.range(
+                                            quant_iters,
+                                            unroll=1,
+                                            at_least_once=True,
+                                        ):
+                                            quant_task = quant_subgroup + Int32(
+                                                quant_iter * quant_subgroups
+                                            )
+                                            quant_row = quant_task // Int32(
+                                                quant_chunks_per_epi
+                                            )
+                                            quant_chunk = (
+                                                quant_task
+                                                - quant_row
+                                                * Int32(quant_chunks_per_epi)
+                                            )
+                                            quant_row_valid = quant_row < Int32(
+                                                quantC_values.shape[0]
+                                            )
+                                            quant_row_safe = quant_row
+                                            if quant_row_safe >= Int32(
+                                                quantC_values.shape[0]
+                                            ):
+                                                quant_row_safe = Int32(0)
+                                            if quant_row_safe < Int32(
+                                                quantC_values.shape[0]
+                                            ):
+                                                quant_elem0 = quant_chunk * Int32(
+                                                    32
+                                                ) + quant_lane * Int32(8)
+                                                quant_v0 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0,
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_v1 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0 + Int32(1),
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_v2 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0 + Int32(2),
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_v3 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0 + Int32(3),
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_v4 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0 + Int32(4),
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_v5 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0 + Int32(5),
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_v6 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0 + Int32(6),
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_v7 = cutlass.Float32(
+                                                    sC[
+                                                        (
+                                                            quant_row_safe,
+                                                            quant_elem0 + Int32(7),
+                                                            epi_buffer,
+                                                        )
+                                                    ]
+                                                )
+                                                quant_max = fmax_f32(
+                                                    fmax_f32(
+                                                        fmax_f32(
+                                                            fabs_f32(quant_v0),
+                                                            fabs_f32(quant_v1),
+                                                        ),
+                                                        fmax_f32(
+                                                            fabs_f32(quant_v2),
+                                                            fabs_f32(quant_v3),
+                                                        ),
+                                                    ),
+                                                    fmax_f32(
+                                                        fmax_f32(
+                                                            fabs_f32(quant_v4),
+                                                            fabs_f32(quant_v5),
+                                                        ),
+                                                        fmax_f32(
+                                                            fabs_f32(quant_v6),
+                                                            fabs_f32(quant_v7),
+                                                        ),
+                                                    ),
+                                                )
+                                                for (
+                                                    quant_shift
+                                                ) in cutlass.range_constexpr(2):
+                                                    quant_max = fmax_f32(
+                                                        quant_max,
+                                                        cute.arch.shuffle_sync_bfly(
+                                                            quant_max,
+                                                            offset=1 << quant_shift,
+                                                        ),
+                                                    )
+                                                _, quant_scale_byte = pow2_ceil_ue8m0(
+                                                    quant_max
+                                                    * cutlass.Float32(
+                                                        1.0 / FLOAT8_E4M3_MAX
+                                                    )
+                                                )
+                                                if quant_max == cutlass.Float32(0.0):
+                                                    quant_scale_byte = cutlass.Uint32(
+                                                        127
+                                                    )
+                                                quant_inv_scale = ue8m0_to_output_scale(
+                                                    quant_scale_byte
+                                                )
+                                                quant_payload_lo = cvt_f32x4_to_e4m3x4(
+                                                    quant_v0 * quant_inv_scale,
+                                                    quant_v1 * quant_inv_scale,
+                                                    quant_v2 * quant_inv_scale,
+                                                    quant_v3 * quant_inv_scale,
+                                                )
+                                                quant_payload_hi = cvt_f32x4_to_e4m3x4(
+                                                    quant_v4 * quant_inv_scale,
+                                                    quant_v5 * quant_inv_scale,
+                                                    quant_v6 * quant_inv_scale,
+                                                    quant_v7 * quant_inv_scale,
+                                                )
+                                                quant_payload = (
+                                                    Uint64(quant_payload_hi)
+                                                    << Uint64(32)
+                                                ) | Uint64(quant_payload_lo)
+                                                quant_global_chunk = (
+                                                    tile_coord_mnl[2]
+                                                    * Int32(directC_mnl.shape[1] // 32)
+                                                    + tile_coord_mnl[1]
+                                                    * Int32(
+                                                        self.tile_shape_mnk[1] // 32
+                                                    )
+                                                    + Int32(
+                                                        epi_n * quant_chunks_per_epi
+                                                    )
+                                                    + quant_chunk
+                                                )
+                                                quant_global_col = (
+                                                    quant_global_chunk * Int32(32)
+                                                    + quant_lane * Int32(8)
+                                                )
+                                                if quant_row_valid:
+                                                    st_global_u64(
+                                                        get_ptr_as_int64(
+                                                            quantC_values,
+                                                            quant_row
+                                                            * Int32(
+                                                                quantC_values.shape[1]
+                                                            )
+                                                            + quant_global_col,
+                                                        ),
+                                                        quant_payload,
+                                                    )
+                                                    if quant_lane == Int32(0):
+                                                        quant_scale = cutlass.Uint8(
+                                                            quant_scale_byte
+                                                        ).bitcast(cutlass.Float8E8M0FNU)
+                                                        quantC_scale_rows[
+                                                            (
+                                                                quant_row,
+                                                                quant_global_chunk,
+                                                            )
+                                                        ] = quant_scale
+                                                        quantC_scale_mma[
+                                                            (
+                                                                quant_row,
+                                                                Int32(0),
+                                                                Int32(0),
+                                                                quant_global_chunk
+                                                                % Int32(4),
+                                                                quant_global_chunk
+                                                                // Int32(4),
+                                                                Int32(0),
+                                                            )
+                                                        ] = quant_scale
+
+                                    # Only synchronize before a persistent CTA
+                                    # reuses sC for another work tile. Kernel
+                                    # completion orders terminal-tile stores.
+                                    if cutlass.const_expr(
+                                        self.single_work_tile_per_cta
+                                    ):
+                                        work_tile = WorkTileInfo(
+                                            work_tile.tile_idx,
+                                            cutlass.Boolean(0),
+                                        )
+                                    else:
+                                        tile_sched.advance_to_next_work()
+                                        work_tile = tile_sched.get_current_work()
+                                    if work_tile.is_valid_tile:
+                                        self.epilog_sync_barrier.arrive_and_wait()
+
+                                # Copy from shared memory to global memory
+                                if cutlass.const_expr(
+                                    self.use_m1_non_tma_c and not self.quantize_c
+                                ):
+                                    for n_iter in cutlass.range_constexpr(
+                                        (
+                                            self.epi_tile[1]
+                                            + self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                            - 1
+                                        )
+                                        // (
+                                            self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                        )
+                                    ):
+                                        n_local = Int32(tidx) + Int32(
+                                            n_iter
+                                            * self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                        )
+                                        n_coord = (
+                                            tile_coord_mnl[1]
+                                            * Int32(self.tile_shape_mnk[1])
+                                            + Int32(epi_n * self.epi_tile[1])
+                                            + n_local
+                                        )
+                                        if n_local < Int32(
+                                            self.epi_tile[1]
+                                        ) and n_coord < Int32(directC_mnl.shape[1]):
+                                            directC_mnl[
+                                                (
+                                                    Int32(0),
+                                                    n_coord,
+                                                    tile_coord_mnl[2],
+                                                )
+                                            ] = sC[(Int32(0), n_local, epi_buffer)]
+                                elif cutlass.const_expr(not self.quantize_c):
+                                    if warp_idx == 0:
+                                        cute.copy(
+                                            tma_atom_c,
+                                            bSG_sD[(None, epi_buffer)],
+                                            bSG_gD[(None, gmem_coord)],
+                                        )
+                                        if has_multi_epi_store:
+                                            tma_store_pipeline.producer_commit()
+                                            tma_store_pipeline.producer_acquire()
+
+                    # Advance to the next work tile
+                    if cutlass.const_expr(not self.quantize_c):
+                        if cutlass.const_expr(self.single_work_tile_per_cta):
+                            work_tile = WorkTileInfo(
+                                work_tile.tile_idx,
+                                cutlass.Boolean(0),
+                            )
+                        else:
+                            tile_sched.advance_to_next_work()
+                            work_tile = tile_sched.get_current_work()
+                    if has_multi_epi_store and cutlass.const_expr(
+                        self.split_k_slices == 1
+                    ):
+                        tma_store_pipeline.producer_tail()
+
+        elif warp_idx == self.tma_load_warp_id:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                if cutlass.const_expr(
+                    self.load_path == "tma"
+                    and not self.use_m1_non_tma_a
+                    and not self.fused_quant_a
+                    and not self.direct_m1_wo_a_inputs
+                ):
+                    tAgA_mkl = tAgA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
+                if cutlass.const_expr(self.load_path == "tma"):
+                    tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
+                if cutlass.const_expr(
+                    self.load_path == "tma"
+                    and not self.use_m1_non_tma_sfa
+                    and not self.fused_quant_a
+                    and not self.manual_bk64_sf
+                    and not self.direct_sfa_prefix
+                ):
+                    sfa_tile_coord_m = tile_coord_mnl[0] // self.sfa_tiles_per_block
+                    tAgSFA_mkl = tAgSFA[
+                        (None, sfa_tile_coord_m, None, tile_coord_mnl[2])
+                    ]
+                if cutlass.const_expr(
+                    self.load_path == "tma"
+                    and not self.manual_bk64_sf
+                    and not self.direct_sfb_representative
+                ):
+                    sfb_tile_coord_n = tile_coord_mnl[1] // self.sfb_tiles_per_block
+                    tBgSFB_nkl = tBgSFB[
+                        (None, sfb_tile_coord_n, None, tile_coord_mnl[2])
+                    ]
+                if cutlass.const_expr(self.load_path == "cpasync"):
+                    cpasync_sfa_tile_coord_m = (
+                        tile_coord_mnl[0] // self.sfa_tiles_per_block
+                    )
+                    cpasync_sfb_tile_coord_n = (
+                        tile_coord_mnl[1] // self.sfb_tiles_per_block
+                    )
+
+                mainloop_producer_state.reset_count()
+
+                for k_tile in range(0, k_tile_iter_cnt, 1, unroll=2):
+                    mainloop_pipeline.producer_acquire(mainloop_producer_state)
+
+                    k_tile_global = k_tile_start + mainloop_producer_state.count
+                    if cutlass.const_expr(self.load_path == "tma"):
+                        tBgB_k = tBgB_nkl[(None, k_tile_global)]
+                        tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+                        if cutlass.const_expr(
+                            not self.use_m1_non_tma_a
+                            and not self.fused_quant_a
+                            and not self.direct_m1_wo_a_inputs
+                        ):
+                            tAgA_k = tAgA_mkl[(None, k_tile_global)]
+                            tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+
+                        if cutlass.const_expr(
+                            not self.use_m1_non_tma_sfa
+                            and not self.fused_quant_a
+                            and not self.manual_bk64_sf
+                            and not self.direct_sfa_prefix
+                        ):
+                            tAgSFA_k = tAgSFA_mkl[(None, k_tile_global)]
+                            tAsSFA_pipe = tAsSFA[(None, mainloop_producer_state.index)]
+
+                        if cutlass.const_expr(
+                            not self.manual_bk64_sf
+                            and not self.direct_sfb_representative
+                        ):
+                            tBgSFB_k = tBgSFB_nkl[(None, k_tile_global)]
+                            tBsSFB_pipe = tBsSFB[(None, mainloop_producer_state.index)]
+
+                        if cutlass.const_expr(self.fused_quant_a and self.b_tile_major):
+                            # Start the large weight transfer before synchronous
+                            # A quantization. SFB stays below as a post-fence
+                            # doorbell because TMA producer_commit is a no-op.
+                            cute.copy(
+                                tma_atom_b,
+                                tBgB_k,
+                                tBsB_pipe,
+                                tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                    mainloop_producer_state
+                                ),
+                                cache_policy=Int64(0x12F0000000000000),
+                            )
+
+                    if cutlass.const_expr(self.load_path == "cpasync"):
+                        tAgA_cpasync_k = tAgA_cpasync_mkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[0],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            )
+                        ]
+                        tAsA_cpasync_pipe = tAsA_cpasync[
+                            (None, None, None, mainloop_producer_state.index)
+                        ]
+                        tAcA_cpasync_k = cute.slice_(
+                            tAcA_cpasync_mkl,
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[0],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            ),
+                        )
+                        tBgB_cpasync_k = tBgB_cpasync_nkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[1],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            )
+                        ]
+                        tBsB_cpasync_pipe = tBsB_cpasync[
+                            (None, None, None, mainloop_producer_state.index)
+                        ]
+                        tBcB_cpasync_k = cute.slice_(
+                            tBcB_cpasync_nkl,
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[1],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            ),
+                        )
+                        tAgSFA_cpasync_k = cute.filter_zeros(
+                            tAgSFA_cpasync_mkl[
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfa_tile_coord_m,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                )
+                            ]
+                        )
+                        tAsSFA_cpasync_pipe = cute.filter_zeros(
+                            tAsSFA_cpasync[
+                                (None, None, None, mainloop_producer_state.index)
+                            ]
+                        )
+                        tAcSFA_cpasync_k = cute.filter_zeros(
+                            cute.slice_(
+                                tAcSFA_cpasync_mkl,
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfa_tile_coord_m,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                ),
+                            )
+                        )
+                        tBgSFB_cpasync_k = cute.filter_zeros(
+                            tBgSFB_cpasync_nkl[
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfb_tile_coord_n,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                )
+                            ]
+                        )
+                        tBsSFB_cpasync_pipe = cute.filter_zeros(
+                            tBsSFB_cpasync[
+                                (None, None, None, mainloop_producer_state.index)
+                            ]
+                        )
+                        tBcSFB_cpasync_k = cute.filter_zeros(
+                            cute.slice_(
+                                tBcSFB_cpasync_nkl,
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfb_tile_coord_n,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                ),
+                            )
+                        )
+                        self._cpasync_copy_2d(
+                            cpasync_tiled_copy_A,
+                            tAgA_cpasync_k,
+                            tAsA_cpasync_pipe,
+                            tAcA_cpasync_k,
+                            Int32(directA_mkl.shape[0]),
+                            True,
+                        )
+                        self._cpasync_copy_2d(
+                            cpasync_tiled_copy_B,
+                            tBgB_cpasync_k,
+                            tBsB_cpasync_pipe,
+                            tBcB_cpasync_k,
+                            Int32(directC_mnl.shape[1]),
+                            True,
+                        )
+                        self._scale_copy_2d(
+                            cpasync_tiled_copy_SF,
+                            tAgSFA_cpasync_k,
+                            tAsSFA_cpasync_pipe,
+                            tAcSFA_cpasync_k,
+                            Int32(directA_mkl.shape[0]),
+                        )
+                        self._scale_copy_2d(
+                            cpasync_tiled_copy_SF,
+                            tBgSFB_cpasync_k,
+                            tBsSFB_cpasync_pipe,
+                            tBcSFB_cpasync_k,
+                            Int32(directC_mnl.shape[1]),
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    elif cutlass.const_expr(
+                        self.fused_quant_a and self.fused_quant_a_wide
+                    ):
+                        # M=1 wide layout: 4 lanes cooperate on each 32-value
+                        # scale block (16B load per lane, butterfly max), so a
+                        # k-tile quantizes with 16 lanes instead of 4 and stops
+                        # throttling deep-K producer pipelines. Lanes 16..31
+                        # mirror blocks 0..3 (clamped index, stores predicated
+                        # off) so the warp stays converged at the shuffles.
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        scale_group_raw = lane // Int32(4)
+                        scale_group = scale_group_raw % Int32(4)
+                        lane4 = lane % Int32(4)
+                        row_global = tile_coord_mnl[0] * Int32(self.tile_shape_mnk[0])
+                        # Uniform across the warp: at M=1 there is a single
+                        # m tile, so this only guards the degenerate case.
+                        if row_global < Int32(quantA_mkl.shape[0]):
+                            values = cute.make_rmem_tensor((8,), cutlass.Float32)
+                            k_local0 = scale_group * Int32(32)
+                            k_global0 = (
+                                k_tile_global * Int32(self.tile_shape_mnk[2]) + k_local0
+                            )
+                            if cutlass.const_expr(self.fused_quant_a_inner_span > 0):
+                                span = Int32(self.fused_quant_a_inner_span)
+                                outer = k_global0 // span
+                                linear_offset = (
+                                    outer * (Int32(quantA_mkl.shape[0]) * span)
+                                    + row_global * span
+                                    + (k_global0 - outer * span)
+                                )
+                            else:
+                                if cutlass.const_expr(
+                                    self.fused_quant_a_row_stride > 0
+                                ):
+                                    linear_offset = (
+                                        row_global
+                                        * Int32(self.fused_quant_a_row_stride)
+                                        + k_global0
+                                    )
+                                else:
+                                    linear_offset = (
+                                        row_global * Int32(quantA_mkl.shape[1])
+                                        + k_global0
+                                    )
+                                if cutlass.const_expr(self.fused_quant_a_l_stride > 0):
+                                    linear_offset = linear_offset + tile_coord_mnl[
+                                        2
+                                    ] * Int32(self.fused_quant_a_l_stride)
+                            elem0 = lane4 * Int32(8)
+                            source_base = get_ptr_as_int64(
+                                quantA_mkl, linear_offset + elem0
+                            )
+                            max_abs = cutlass.Float32(0.0)
+                            w0, w1, w2, w3 = ld_global_v4_u32(source_base)
+                            v0, v1 = bfloat2_to_float2_scaled(w0, cutlass.Float32(1.0))
+                            v2, v3 = bfloat2_to_float2_scaled(w1, cutlass.Float32(1.0))
+                            v4, v5 = bfloat2_to_float2_scaled(w2, cutlass.Float32(1.0))
+                            v6, v7 = bfloat2_to_float2_scaled(w3, cutlass.Float32(1.0))
+                            values[0] = v0
+                            values[1] = v1
+                            values[2] = v2
+                            values[3] = v3
+                            values[4] = v4
+                            values[5] = v5
+                            values[6] = v6
+                            values[7] = v7
+                            if cutlass.const_expr(self.fused_quant_a_inv_rope):
+                                head_d0 = k_global0 % Int32(self.fused_quant_a_head_dim)
+                                if head_d0 >= Int32(self.fused_quant_a_nope_dim):
+                                    pos = Int32(quantA_positions[row_global])
+                                    half_rope = Int32(self.fused_quant_a_rope_dim // 2)
+                                    cs_base = pos * Int32(self.fused_quant_a_rope_dim)
+                                    rl_half0 = (
+                                        head_d0
+                                        - Int32(self.fused_quant_a_nope_dim)
+                                        + elem0
+                                    ) // Int32(2)
+                                    for pair in cutlass.range_constexpr(4):
+                                        cs_idx = cs_base + rl_half0 + Int32(pair)
+                                        cos_v = cutlass.Float32(quantA_cos_sin[cs_idx])
+                                        sin_v = cutlass.Float32(
+                                            quantA_cos_sin[cs_idx + half_rope]
+                                        )
+                                        v_even = values[pair * 2]
+                                        v_odd = values[pair * 2 + 1]
+                                        values[pair * 2] = (
+                                            v_even * cos_v + v_odd * sin_v
+                                        )
+                                        values[pair * 2 + 1] = (
+                                            v_odd * cos_v - v_even * sin_v
+                                        )
+                            for elem in cutlass.range_constexpr(8):
+                                max_abs = fmax_f32(max_abs, fabs_f32(values[elem]))
+                            for shift in cutlass.range_constexpr(2):
+                                max_abs = fmax_f32(
+                                    max_abs,
+                                    cute.arch.shuffle_sync_bfly(
+                                        max_abs, offset=1 << shift
+                                    ),
+                                )
+                            _, scale_byte = pow2_ceil_ue8m0(
+                                max_abs * cutlass.Float32(1.0 / FLOAT8_E4M3_MAX)
+                            )
+                            if max_abs == cutlass.Float32(0.0):
+                                scale_byte = cutlass.Uint32(127)
+                            inv_scale = ue8m0_to_output_scale(scale_byte)
+                            payload0 = cvt_f32x4_to_e4m3x4(
+                                values[0] * inv_scale,
+                                values[1] * inv_scale,
+                                values[2] * inv_scale,
+                                values[3] * inv_scale,
+                            )
+                            payload1 = cvt_f32x4_to_e4m3x4(
+                                values[4] * inv_scale,
+                                values[5] * inv_scale,
+                                values[6] * inv_scale,
+                                values[7] * inv_scale,
+                            )
+                            if scale_group_raw < Int32(4):
+                                for byte in cutlass.range_constexpr(4):
+                                    raw0 = cutlass.Uint8(
+                                        payload0 >> cutlass.Uint32(byte * 8)
+                                    )
+                                    raw1 = cutlass.Uint8(
+                                        payload1 >> cutlass.Uint32(byte * 8)
+                                    )
+                                    sA[
+                                        (
+                                            Int32(0),
+                                            k_local0 + elem0 + Int32(byte),
+                                            mainloop_producer_state.index,
+                                        )
+                                    ] = raw0.bitcast(cutlass.Float8E4M3FN)
+                                    sA[
+                                        (
+                                            Int32(0),
+                                            k_local0 + elem0 + Int32(4 + byte),
+                                            mainloop_producer_state.index,
+                                        )
+                                    ] = raw1.bitcast(cutlass.Float8E4M3FN)
+                                if lane4 == Int32(0):
+                                    sSFA[
+                                        (
+                                            Int32(0),
+                                            k_local0,
+                                            mainloop_producer_state.index,
+                                        )
+                                    ] = cutlass.Uint8(scale_byte).bitcast(
+                                        cutlass.Float8E8M0FNU
+                                    )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    elif cutlass.const_expr(self.fused_quant_a):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        row_local = lane // Int32(4)
+                        scale_group = lane % Int32(4)
+                        row_global = (
+                            tile_coord_mnl[0] * Int32(self.tile_shape_mnk[0])
+                            + row_local
+                        )
+                        if row_global < Int32(quantA_mkl.shape[0]):
+                            values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                            k_local0 = scale_group * Int32(32)
+                            k_global0 = (
+                                k_tile_global * Int32(self.tile_shape_mnk[2]) + k_local0
+                            )
+                            if cutlass.const_expr(self.fused_quant_a_inner_span > 0):
+                                # L-blocked source: each 32-value scale block
+                                # lies within one span (span % 32 == 0).
+                                span = Int32(self.fused_quant_a_inner_span)
+                                outer = k_global0 // span
+                                linear_offset = (
+                                    outer * (Int32(quantA_mkl.shape[0]) * span)
+                                    + row_global * span
+                                    + (k_global0 - outer * span)
+                                )
+                            else:
+                                if cutlass.const_expr(
+                                    self.fused_quant_a_row_stride > 0
+                                ):
+                                    linear_offset = (
+                                        row_global
+                                        * Int32(self.fused_quant_a_row_stride)
+                                        + k_global0
+                                    )
+                                else:
+                                    linear_offset = (
+                                        row_global * Int32(quantA_mkl.shape[1])
+                                        + k_global0
+                                    )
+                                if cutlass.const_expr(self.fused_quant_a_l_stride > 0):
+                                    linear_offset = linear_offset + tile_coord_mnl[
+                                        2
+                                    ] * Int32(self.fused_quant_a_l_stride)
+                            source_base = get_ptr_as_int64(quantA_mkl, linear_offset)
+                            max_abs = cutlass.Float32(0.0)
+                            for vec in cutlass.range_constexpr(4):
+                                w0, w1, w2, w3 = ld_global_v4_u32(
+                                    source_base + Int64(vec * 16)
+                                )
+                                v0, v1 = bfloat2_to_float2_scaled(
+                                    w0, cutlass.Float32(1.0)
+                                )
+                                v2, v3 = bfloat2_to_float2_scaled(
+                                    w1, cutlass.Float32(1.0)
+                                )
+                                v4, v5 = bfloat2_to_float2_scaled(
+                                    w2, cutlass.Float32(1.0)
+                                )
+                                v6, v7 = bfloat2_to_float2_scaled(
+                                    w3, cutlass.Float32(1.0)
+                                )
+                                values[vec * 8 + 0] = v0
+                                values[vec * 8 + 1] = v1
+                                values[vec * 8 + 2] = v2
+                                values[vec * 8 + 3] = v3
+                                values[vec * 8 + 4] = v4
+                                values[vec * 8 + 5] = v5
+                                values[vec * 8 + 6] = v6
+                                values[vec * 8 + 7] = v7
+                                max_abs = fmax_f32(max_abs, fabs_f32(v0))
+                                max_abs = fmax_f32(max_abs, fabs_f32(v1))
+                                max_abs = fmax_f32(max_abs, fabs_f32(v2))
+                                max_abs = fmax_f32(max_abs, fabs_f32(v3))
+                                max_abs = fmax_f32(max_abs, fabs_f32(v4))
+                                max_abs = fmax_f32(max_abs, fabs_f32(v5))
+                                max_abs = fmax_f32(max_abs, fabs_f32(v6))
+                                max_abs = fmax_f32(max_abs, fabs_f32(v7))
+                            if cutlass.const_expr(self.fused_quant_a_inv_rope):
+                                # nope_dim % 32 == 0, so a scale block is
+                                # entirely nope (left as loaded) or entirely
+                                # rope: de-rotate adjacent pairs with cos/sin
+                                # at positions[row] and recompute the block
+                                # max over the rotated values.
+                                head_d0 = k_global0 % Int32(self.fused_quant_a_head_dim)
+                                if head_d0 >= Int32(self.fused_quant_a_nope_dim):
+                                    pos = Int32(quantA_positions[row_global])
+                                    half_rope = Int32(self.fused_quant_a_rope_dim // 2)
+                                    cs_base = pos * Int32(self.fused_quant_a_rope_dim)
+                                    rl_half0 = (
+                                        head_d0 - Int32(self.fused_quant_a_nope_dim)
+                                    ) // Int32(2)
+                                    max_abs = cutlass.Float32(0.0)
+                                    for pair in cutlass.range_constexpr(16):
+                                        cs_idx = cs_base + rl_half0 + Int32(pair)
+                                        cos_v = cutlass.Float32(quantA_cos_sin[cs_idx])
+                                        sin_v = cutlass.Float32(
+                                            quantA_cos_sin[cs_idx + half_rope]
+                                        )
+                                        v_even = values[pair * 2]
+                                        v_odd = values[pair * 2 + 1]
+                                        values[pair * 2] = (
+                                            v_even * cos_v + v_odd * sin_v
+                                        )
+                                        values[pair * 2 + 1] = (
+                                            v_odd * cos_v - v_even * sin_v
+                                        )
+                                        max_abs = fmax_f32(
+                                            max_abs,
+                                            fabs_f32(values[pair * 2]),
+                                        )
+                                        max_abs = fmax_f32(
+                                            max_abs,
+                                            fabs_f32(values[pair * 2 + 1]),
+                                        )
+                            payload, scale_byte = quantize_block_fp8_mx(values, max_abs)
+                            if max_abs == cutlass.Float32(0.0):
+                                scale_byte = cutlass.Uint32(127)
+                            for word in cutlass.range_constexpr(8):
+                                for byte in cutlass.range_constexpr(4):
+                                    raw_byte = cutlass.Uint8(
+                                        payload[word] >> cutlass.Uint32(byte * 8)
+                                    )
+                                    sA[
+                                        (
+                                            row_local,
+                                            k_local0 + Int32(word * 4 + byte),
+                                            mainloop_producer_state.index,
+                                        )
+                                    ] = raw_byte.bitcast(cutlass.Float8E4M3FN)
+                            sSFA[
+                                (
+                                    row_local,
+                                    k_local0,
+                                    mainloop_producer_state.index,
+                                )
+                            ] = cutlass.Uint8(scale_byte).bitcast(cutlass.Float8E8M0FNU)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    elif cutlass.const_expr(self.use_m1_non_tma_a):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        for a_iter in cutlass.range_constexpr(
+                            (self.tile_shape_mnk[2] + self.num_threads_per_warp - 1)
+                            // self.num_threads_per_warp
+                        ):
+                            k_local = lane + Int32(a_iter * self.num_threads_per_warp)
+                            if k_local < Int32(self.tile_shape_mnk[2]):
+                                k_coord = (
+                                    k_tile_global * Int32(self.tile_shape_mnk[2])
+                                    + k_local
+                                )
+                                sA[
+                                    (
+                                        Int32(0),
+                                        k_local,
+                                        mainloop_producer_state.index,
+                                    )
+                                ] = directA_mkl[
+                                    (
+                                        Int32(0),
+                                        k_coord,
+                                        tile_coord_mnl[2],
+                                    )
+                                ]
+                    elif cutlass.const_expr(self.direct_m1_wo_a_inputs):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        if lane == Int32(0):
+                            a_offset = tile_coord_mnl[2] * Int32(
+                                directA_mkl.shape[0]
+                            ) * Int32(directA_mkl.shape[1]) + k_tile_global * Int32(
+                                self.tile_shape_mnk[2]
+                            )
+                            cp_async_bulk_g2s_mbar(
+                                shared_ptr_to_u32(
+                                    elem_pointer(
+                                        sA,
+                                        (
+                                            Int32(0),
+                                            Int32(0),
+                                            mainloop_producer_state.index,
+                                        ),
+                                    )
+                                ),
+                                get_ptr_as_int64(directA_mkl, a_offset),
+                                Int32(128),
+                                shared_ptr_to_u32(
+                                    mainloop_pipeline.producer_get_barrier(
+                                        mainloop_producer_state
+                                    )
+                                ),
+                            )
+                    else:
+                        cute.copy(
+                            tma_atom_a,
+                            tAgA_k,
+                            tAsA_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
+
+                    if cutlass.const_expr(self.load_path == "cpasync"):
+                        pass
+                    elif cutlass.const_expr(self.fused_quant_a):
+                        pass
+                    elif cutlass.const_expr(self.manual_bk64_sf):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        sf_k_tiles = Int32(k_tile_cnt // 2)
+                        sf_k_tile = k_tile_global // Int32(2)
+                        sf_k_half = k_tile_global - sf_k_tile * Int32(2)
+                        sfa_tile = tile_coord_mnl[0]
+                        sfb_tile = tile_coord_mnl[1] // Int32(self.sfb_tiles_per_block)
+                        # directSFA/directSFB retain the physical packed-scale
+                        # storage order [L, MN-tile, K128-tile, 32, 4, 4].
+                        # The original BK64 address arithmetic covered only
+                        # L=1; without these strides every later grouped GEMM
+                        # batch silently consumed batch 0's scales.
+                        sfa_l_stride = (
+                            Int32(tile_sched_params.problem_shape_ntile_mnl[0])
+                            * sf_k_tiles
+                            * Int32(512)
+                        )
+                        problem_n_tiles = Int32(
+                            tile_sched_params.problem_shape_ntile_mnl[1]
+                        )
+                        sfb_scale_n_tiles = (
+                            problem_n_tiles + Int32(self.sfb_tiles_per_block - 1)
+                        ) // Int32(self.sfb_tiles_per_block)
+                        sfb_l_stride = sfb_scale_n_tiles * sf_k_tiles * Int32(512)
+                        l_coord = tile_coord_mnl[2]
+                        for sf_iter in cutlass.range_constexpr(4):
+                            mn_local = lane + Int32(sf_iter * self.num_threads_per_warp)
+                            mn_outer = mn_local // Int32(32)
+                            mn_inner = mn_local - mn_outer * Int32(32)
+                            atom_offset = (
+                                mn_inner * Int32(16)
+                                + mn_outer * Int32(4)
+                                + sf_k_half * Int32(2)
+                            )
+                            sfa_offset = (
+                                l_coord * sfa_l_stride
+                                + (sfa_tile * sf_k_tiles + sf_k_tile) * Int32(512)
+                                + atom_offset
+                            )
+                            sfb_offset = (
+                                l_coord * sfb_l_stride
+                                + (sfb_tile * sf_k_tiles + sf_k_tile) * Int32(512)
+                                + atom_offset
+                            )
+                            sfa_pair = ld_global_b16(
+                                get_ptr_as_int64(directSFA_mkl, sfa_offset)
+                            )
+                            sfb_pair = ld_global_b16(
+                                get_ptr_as_int64(directSFB_nkl, sfb_offset)
+                            )
+                            sfa_smem_addr = shared_ptr_to_u32(
+                                elem_pointer(
+                                    sSFA,
+                                    (
+                                        mn_local,
+                                        Int32(0),
+                                        mainloop_producer_state.index,
+                                    ),
+                                )
+                            )
+                            sfb_smem_addr = shared_ptr_to_u32(
+                                elem_pointer(
+                                    sSFB,
+                                    (
+                                        mn_local,
+                                        Int32(0),
+                                        mainloop_producer_state.index,
+                                    ),
+                                )
+                            )
+                            st_shared_u16(sfa_smem_addr, sfa_pair)
+                            st_shared_u16(sfb_smem_addr, sfb_pair)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    elif cutlass.const_expr(self.direct_sfa_prefix):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        if lane == Int32(0):
+                            scale_k_tiles = (
+                                Int32(directA_mkl.shape[1]) + Int32(127)
+                            ) // Int32(128)
+                            scale_offset = (
+                                tile_coord_mnl[2] * scale_k_tiles + k_tile_global
+                            ) * Int32(512)
+                            cp_async_bulk_g2s_mbar(
+                                shared_ptr_to_u32(
+                                    elem_pointer(
+                                        sSFA,
+                                        (
+                                            Int32(0),
+                                            Int32(0),
+                                            mainloop_producer_state.index,
+                                        ),
+                                    )
+                                ),
+                                get_ptr_as_int64(directSFA_mkl, scale_offset),
+                                Int32(256),
+                                shared_ptr_to_u32(
+                                    mainloop_pipeline.producer_get_barrier(
+                                        mainloop_producer_state
+                                    )
+                                ),
+                            )
+                    elif cutlass.const_expr(self.use_m1_non_tma_sfa):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        scale_groups_per_k_tile = (
+                            self.tile_shape_mnk[2] // self.sf_vec_size
+                        )
+                        sfa_slots = self.sfa_tile_shape_mk[0] * scale_groups_per_k_tile
+                        for sfa_iter in cutlass.range_constexpr(
+                            (sfa_slots + self.num_threads_per_warp - 1)
+                            // self.num_threads_per_warp
+                        ):
+                            linear = lane + Int32(sfa_iter * self.num_threads_per_warp)
+                            m_local = linear // Int32(scale_groups_per_k_tile)
+                            scale_group = linear - m_local * Int32(
+                                scale_groups_per_k_tile
+                            )
+                            k_local_sfa = scale_group * Int32(self.sf_vec_size)
+                            k_coord_sfa = (
+                                k_tile_global * Int32(self.tile_shape_mnk[2])
+                                + k_local_sfa
+                            )
+                            if linear < Int32(sfa_slots):
+                                sSFA[
+                                    (
+                                        m_local,
+                                        k_local_sfa,
+                                        mainloop_producer_state.index,
+                                    )
+                                ] = directSFA_mkl[
+                                    (
+                                        Int32(0),
+                                        k_coord_sfa,
+                                        tile_coord_mnl[2],
+                                    )
+                                ]
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    else:
+                        cute.copy(
+                            tma_atom_sfa,
+                            tAgSFA_k,
+                            tAsSFA_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
+                    if cutlass.const_expr(self.direct_sfb_representative):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        if lane == Int32(0):
+                            scale_n_tiles = (
+                                Int32(directC_mnl.shape[1]) + Int32(127)
+                            ) // Int32(128)
+                            scale_k_tiles = (
+                                Int32(directA_mkl.shape[1]) + Int32(127)
+                            ) // Int32(128)
+                            scale_n_tile = (
+                                tile_coord_mnl[1] * Int32(self.tile_shape_mnk[1])
+                            ) // Int32(128)
+                            scale_offset = (
+                                (tile_coord_mnl[2] * scale_n_tiles + scale_n_tile)
+                                * scale_k_tiles
+                                + k_tile_global
+                            ) * Int32(512)
+                            cp_async_bulk_g2s_mbar(
+                                shared_ptr_to_u32(
+                                    elem_pointer(
+                                        sSFB,
+                                        (
+                                            Int32(0),
+                                            Int32(0),
+                                            mainloop_producer_state.index,
+                                        ),
+                                    )
+                                ),
+                                get_ptr_as_int64(directSFB_nkl, scale_offset),
+                                Int32(16),
+                                shared_ptr_to_u32(
+                                    mainloop_pipeline.producer_get_barrier(
+                                        mainloop_producer_state
+                                    )
+                                ),
+                            )
+                    if cutlass.const_expr(self.load_path == "tma"):
+                        if cutlass.const_expr(
+                            not (self.fused_quant_a and self.b_tile_major)
+                        ):
+                            if cutlass.const_expr(self.b_tile_major):
+                                cute.copy(
+                                    tma_atom_b,
+                                    tBgB_k,
+                                    tBsB_pipe,
+                                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                        mainloop_producer_state
+                                    ),
+                                    cache_policy=Int64(0x12F0000000000000),
+                                )
+                            else:
+                                if cutlass.const_expr(self.occupancy > 1):
+                                    cute.copy(
+                                        tma_atom_b,
+                                        tBgB_k,
+                                        tBsB_pipe,
+                                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                            mainloop_producer_state
+                                        ),
+                                        cache_policy=Int64(0x12F0000000000000),
+                                    )
+                                else:
+                                    cute.copy(
+                                        tma_atom_b,
+                                        tBgB_k,
+                                        tBsB_pipe,
+                                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                            mainloop_producer_state
+                                        ),
+                                    )
+                        if cutlass.const_expr(
+                            not self.manual_bk64_sf
+                            and not self.direct_sfb_representative
+                        ):
+                            cute.copy(
+                                tma_atom_sfb,
+                                tBgSFB_k,
+                                tBsSFB_pipe,
+                                tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                    mainloop_producer_state
+                                ),
+                            )
+                    if cutlass.const_expr(self.load_path == "cpasync"):
+                        cute.arch.cp_async_commit_group()
+                        cute.arch.cp_async_wait_group(0)
+                    mainloop_pipeline.producer_commit(mainloop_producer_state)
+                    mainloop_producer_state.advance()
+
+                if cutlass.const_expr(self.single_work_tile_per_cta):
+                    work_tile = WorkTileInfo(
+                        work_tile.tile_idx,
+                        cutlass.Boolean(0),
+                    )
+                else:
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
+
+            mainloop_pipeline.producer_tail(mainloop_producer_state)
+        return
+
+    @staticmethod
+    def _compute_stages(
+        tile_shape_mnk: tuple,
+        a_dtype,
+        b_dtype,
+        sf_dtype,
+        sfa_smem_layout,
+        sfb_smem_layout,
+        epi_tile: tuple,
+        c_dtype,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> tuple:
+        epi_stage_max = (tile_shape_mnk[1] // epi_tile[1]) * (
+            tile_shape_mnk[0] // epi_tile[0]
+        )
+        epi_stage = min(epi_stage_max, 4)
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_bytes = c_bytes_per_stage * epi_stage
+
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        sf_bytes_per_stage = (
+            cute.size(cute.filter_zeros(sfa_smem_layout).shape) * sf_dtype.width // 8
+            + cute.size(cute.filter_zeros(sfb_smem_layout).shape) * sf_dtype.width // 8
+        )
+        mbar_helpers_bytes = 1024
+
+        raw_ab_stage = (
+            (smem_capacity - occupancy * 1024) // occupancy
+            - mbar_helpers_bytes
+            - epi_bytes
+        ) // (ab_bytes_per_stage + sf_bytes_per_stage)
+        ab_stage = max(1, min(raw_ab_stage, 4))
+        if tile_shape_mnk[0] in (16, 64) and tile_shape_mnk[1] == 128:
+            ab_stage = max(1, min(raw_ab_stage, 5))
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk: tuple,
+        epi_tile: tuple,
+        a_dtype,
+        a_layout,
+        b_dtype,
+        b_layout,
+        ab_stage: int,
+        c_dtype,
+        c_layout,
+        epi_stage: int,
+        sf_vec_size: int,
+        tiled_mma,
+    ) -> tuple:
+        a_smem_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+
+        a_is_k_major = a_layout.is_k_major_a()
+        b_is_k_major = b_layout.is_k_major_b()
+        a_major_mode_size = tile_shape_mnk[2 if a_is_k_major else 0]
+
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                a_layout,
+                a_dtype,
+                a_major_mode_size,
+            ),
+            a_dtype,
+        )
+        a_smem_layout_staged = cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(a_smem_shape, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+        b_smem_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        b_major_mode_size = tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                b_layout,
+                b_dtype,
+                b_major_mode_size,
+            ),
+            b_dtype,
+        )
+        b_smem_layout_staged = cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+        sfa_smem_layout_staged = sm120_make_smem_layout_sfa(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+        sfb_smem_layout_staged = sm120_make_smem_layout_sfb(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+
+        c_smem_shape = epi_tile
+        c_major_mode_size = epi_tile[1] if c_layout.is_n_major_c() else epi_tile[0]
+        c_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                c_layout,
+                c_dtype,
+                c_major_mode_size,
+            ),
+            c_dtype,
+        )
+        epi_smem_layout_staged = cute.tile_to_shape(
+            c_smem_layout_atom,
+            cute.append(c_smem_shape, epi_stage),
+            order=(1, 0, 2) if c_layout.is_m_major_c() else (0, 1, 2),
+        )
+
+        return (
+            a_smem_layout_staged,
+            b_smem_layout_staged,
+            sfa_smem_layout_staged,
+            sfb_smem_layout_staged,
+            epi_smem_layout_staged,
+        )
+
+    @staticmethod
+    def _compute_grid(
+        c,
+        tile_shape_mnk: tuple,
+        max_active_clusters,
+        direct_one_m_tile_scheduler: bool,
+        split_k_slices: int,
+        large_m_unroll: bool,
+    ) -> tuple:
+        c_shape = cute.slice_(tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (1, 1, 1)
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl,
+            cluster_shape_mnl,
+            swizzle_size=(
+                16 if tile_shape_mnk == (128, 128, 64) and not large_m_unroll else 1
+            ),
+        )
+        if cutlass.const_expr(split_k_slices > 1):
+            grid = (1, split_k_slices, num_ctas_mnl[1])
+        else:
+            grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+                tile_sched_params, max_active_clusters
+            )
+        return tile_sched_params, grid
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(
+        tensor_c,
+        epi_smem_layout_staged,
+        epi_tile: tuple,
+    ) -> tuple:
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c,
+            epi_smem_layout,
+            epi_tile,
+        )
+        return tma_atom_c, tma_tensor_c
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(
+        tensor,
+        smem_layout_staged,
+        smem_tile: tuple,
+        mcast_dim: int,
+        internal_type=None,
+    ) -> tuple:
+        op = (
+            cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
+            op,
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=mcast_dim,
+            internal_type=internal_type,
+        )
+        return tma_atom, tma_tensor
+
+    @staticmethod
+    def can_implement(
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size: int,
+        c_dtype,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        c_major: str,
+        *,
+        load_path: str = "tma",
+        swap_ab: bool = False,
+    ) -> bool:
+        # The current target only supports cluster (1,1)
+        if cluster_shape_mn != (1, 1):
+            return False
+        if load_path not in _DENSE_LOAD_PATHS:
+            return False
+        if swap_ab:
+            if l != 1:
+                return False
+            if not (
+                (ab_dtype == cutlass.Float4E2M1FN and sf_vec_size == 16)
+                or (ab_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32)
+            ):
+                return False
+        if load_path == "cpasync" and (
+            ab_dtype != cutlass.Float4E2M1FN or sf_vec_size != 16 or l != 1
+        ):
+            return False
+        # FP4 experiments allow narrow N tiles. The scale-factor smem paths
+        # still allocate full 128-element SF blocks, but the live MMA tile may
+        # consume only 16/32 columns.
+        mma_check_mn = (mma_tiler_mn[1], mma_tiler_mn[0]) if swap_ab else mma_tiler_mn
+        if ab_dtype == cutlass.Float8E4M3FN:
+            if mma_check_mn not in ((16, 64), (16, 128), (32, 64), (32, 128)):
+                if mma_check_mn[0] % 64 != 0 or mma_check_mn[1] % 64 != 0:
+                    return False
+        elif ab_dtype == cutlass.Float4E2M1FN:
+            if (
+                mma_tiler_mn[0] % 64 != 0
+                or mma_tiler_mn[1] % 16 != 0
+                or mma_tiler_mn[1] > 128
+                or (mma_tiler_mn[1] < 64 and not swap_ab)
+            ):
+                return False
+        else:
+            if mma_check_mn[0] % 64 != 0 or mma_check_mn[1] % 64 != 0:
+                return False
+        # The current target supports FP4 and MXFP8 warp MMA paths.
+        if ab_dtype not in (cutlass.Float4E2M1FN, cutlass.Float8E4M3FN):
+            return False
+        # Current target MMA constraints:
+        #   sf_vec_size=16 requires sf_dtype=Float8E4M3FN
+        #   sf_vec_size=32 requires sf_dtype=Float8E8M0FNU
+        if sf_vec_size == 16 and sf_dtype != cutlass.Float8E4M3FN:
+            return False
+        if sf_vec_size == 32 and sf_dtype != cutlass.Float8E8M0FNU:
+            return False
+        if ab_dtype == cutlass.Float8E4M3FN and sf_vec_size != 32:
+            return False
+        # Public output is 16-bit; split-K internally uses FP32 partial output.
+        if c_dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float32):
+            return False
+        # A must be K-major, B must be K-major
+        if a_major != "k" or b_major != "k":
+            return False
+        # Alignment: K must be divisible by tile_k
+        tile_k = 128 if ab_dtype == cutlass.Float8E4M3FN else sf_vec_size * 8
+        if k % tile_k != 0:
+            return False
+        return True
+
+
+class _DenseGemmLaunch:
+    def __init__(
+        self,
+        n: int,
+        k: int,
+        l: int,
+        c_l: int,
+        a_major: str,
+        b_major: str,
+        c_major: str,
+        ab_dtype: torch.dtype,
+        sf_dtype: torch.dtype,
+        c_dtype: torch.dtype,
+        alpha_dtype: torch.dtype,
+        sf_vec_size: int,
+        mma_k: int,
+        tile_k: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        policy: _DenseGemmPolicy,
+        sm_count: int,
+        sm_version: str,
+        load_path: str,
+        swap_ab: bool,
+        sfb_k_reuse: bool,
+        b_tile_major: bool = False,
+        quantize_c: bool = False,
+        alpha_is_one: bool = False,
+        direct_sfa_live16: bool = False,
+        direct_m1_wo_a_inputs: bool = False,
+        target_occupancy: int = 1,
+    ):
+        self._n = n
+        self._k = k
+        self._l = l
+        self._c_l = c_l
+        self._a_major = a_major
+        self._b_major = b_major
+        self._c_major = c_major
+        self._ab_dtype = ab_dtype
+        self._sf_dtype = sf_dtype
+        self._c_dtype = c_dtype
+        self._alpha_dtype = alpha_dtype
+        self._sf_vec_size = sf_vec_size
+        self._mma_k = mma_k
+        self._tile_k = tile_k
+        self._mma_tiler_mn = mma_tiler_mn
+        self._cluster_shape_mn = cluster_shape_mn
+        self._policy = policy
+        self._sm_count = sm_count
+        self._sm_version = sm_version
+        self._load_path = load_path
+        self._swap_ab = swap_ab
+        # This experimental atom choice changes generated code. Capture the
+        # import-time setting on the launch so both in-process resolution and
+        # the persistent object cache distinguish it.
+        self._atom_shape_24 = _FLASHINFER_EXP_SM12X_DENSE_ATOM_24
+        self._sfb_k_reuse = sfb_k_reuse
+        self._b_tile_major = b_tile_major
+        self._quantize_c = quantize_c
+        self._alpha_is_one = alpha_is_one
+        self._direct_sfa_live16 = direct_sfa_live16
+        self._direct_m1_wo_a_inputs = direct_m1_wo_a_inputs
+        self._target_occupancy = target_occupancy
+        if b_tile_major:
+            if (n, k, l) == (1024, 4096, 4):
+                self._b_tile_n = 64
+            elif (n, k, l) == (4096, 4096, 1):
+                self._b_tile_n = 128
+            else:
+                raise ValueError(
+                    "tile-major B is restricted to production WO-A/WO-B shapes, "
+                    f"got {(n, k, l)}"
+                )
+        else:
+            self._b_tile_n = 0
+        if not DenseGemmKernel.can_implement(
+            ab_dtype,
+            sf_dtype,
+            sf_vec_size,
+            c_dtype,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            n,
+            k,
+            l,
+            a_major,
+            b_major,
+            c_major,
+            load_path=load_path,
+            swap_ab=swap_ab,
+        ):
+            raise TypeError(
+                "dense_gemm launch is unsupported with "
+                f"{ab_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype}, "
+                f"{mma_tiler_mn}, {cluster_shape_mn}, {n}, {k}, {l}, "
+                f"{a_major}, {b_major}, {c_major}, "
+                f"load_path={load_path}, swap_ab={swap_ab}"
+            )
+
+        self._max_active_clusters = (
+            _max_active_clusters_for(self._cluster_shape_mn, sm_count)
+            * self._target_occupancy
+        )
+        if (
+            mma_tiler_mn == (32, 64)
+            and tile_k == 128
+            and b_tile_major
+            and sfb_k_reuse
+            and alpha_is_one
+            and (n, k, l) in ((1024, 4096, 4), (4096, 4096, 1))
+        ):
+            self._max_active_clusters = min(self._max_active_clusters, 40)
+
+    def compile_key(self) -> tuple[object, ...]:
+        """Return every value that can specialize the generated kernel."""
+
+        return (
+            self._n,
+            self._k,
+            self._l,
+            self._c_l,
+            self._a_major,
+            self._b_major,
+            self._c_major,
+            self._ab_dtype,
+            self._sf_dtype,
+            self._c_dtype,
+            self._alpha_dtype,
+            self._sf_vec_size,
+            self._mma_k,
+            self._tile_k,
+            self._mma_tiler_mn,
+            self._cluster_shape_mn,
+            self._policy,
+            self._sm_count,
+            self._max_active_clusters,
+            self._sm_version,
+            self._load_path,
+            self._swap_ab,
+            self._atom_shape_24,
+            self._sfb_k_reuse,
+            self._b_tile_major,
+            self._b_tile_n,
+            self._quantize_c,
+            self._alpha_is_one,
+            self._direct_sfa_live16,
+            self._direct_m1_wo_a_inputs,
+            self._target_occupancy,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_ptr: cute.Pointer,
+        b_ptr: cute.Pointer,
+        sfa_ptr: cute.Pointer,
+        sfb_ptr: cute.Pointer,
+        c_ptr: cute.Pointer,
+        quant_c_values_ptr: cute.Pointer,
+        quant_c_scale_rows_ptr: cute.Pointer,
+        quant_c_scale_mma_ptr: cute.Pointer,
+        alpha_ptr: cute.Pointer,
+        m: cutlass.Int32,
+        current_stream: cuda.CUstream,
+    ):
+        a_tensor = cute.make_tensor(
+            a_ptr,
+            layout=cute.make_ordered_layout(
+                (m, self._k, self._l),
+                order=(0, 1, 2) if self._a_major == "m" else (1, 0, 2),
+            ),
+        )
+        if cutlass.const_expr(self._b_tile_major):
+            b_layout = cute.make_layout(
+                (
+                    (self._b_tile_n, self._n // self._b_tile_n),
+                    (128, self._k // 128),
+                    self._l,
+                ),
+                stride=(
+                    (128, self._b_tile_n * self._k),
+                    (1, self._b_tile_n * 128),
+                    self._n * self._k,
+                ),
+            )
+        else:
+            b_layout = cute.make_ordered_layout(
+                (self._n, self._k, self._l),
+                order=(0, 1, 2) if self._b_major == "n" else (1, 0, 2),
+            )
+        b_tensor = cute.make_tensor(b_ptr, layout=b_layout)
+        c_tensor = cute.make_tensor(
+            c_ptr,
+            layout=cute.make_ordered_layout(
+                (m, self._n, self._c_l),
+                order=(0, 1, 2) if self._c_major == "m" else (1, 0, 2),
+            ),
+        )
+        quant_c_width = self._n * self._l
+        quant_c_chunks = max(1, (quant_c_width + 31) // 32)
+        quant_c_k_tiles = max(1, (quant_c_width + 127) // 128)
+        quant_c_values_tensor = cute.make_tensor(
+            quant_c_values_ptr,
+            layout=cute.make_ordered_layout((m, quant_c_width), order=(1, 0)),
+        )
+        quant_c_scale_rows_tensor = cute.make_tensor(
+            quant_c_scale_rows_ptr,
+            layout=cute.make_ordered_layout((m, quant_c_chunks), order=(1, 0)),
+        )
+        quant_c_scale_mma_tensor = cute.make_tensor(
+            quant_c_scale_mma_ptr,
+            layout=cute.make_layout(
+                (32, 4, 1, 4, quant_c_k_tiles, 1),
+                stride=(
+                    16,
+                    4,
+                    quant_c_k_tiles * 512,
+                    1,
+                    512,
+                    quant_c_k_tiles * 512,
+                ),
+            ),
+        )
+        alpha_tensor = cute.make_tensor(
+            alpha_ptr,
+            layout=cute.make_ordered_layout((1,), order=(0,)),
+        )
+        sfa_tensor = cute.make_tensor(sfa_ptr, layout=cute.make_layout((1,)))
+        sfb_tensor = cute.make_tensor(sfb_ptr, layout=cute.make_layout((1,)))
+        policy = self._policy
+        DenseGemmKernel(
+            sf_vec_size=self._sf_vec_size,
+            mma_tiler_mn=self._mma_tiler_mn,
+            cluster_shape_mn=self._cluster_shape_mn,
+            mma_k=self._mma_k,
+            tile_k=self._tile_k,
+            single_work_tile_per_cta=policy.single_work_tile_per_cta,
+            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
+            split_k_slices=policy.split_k_slices,
+            split_k_atomic_bf16=policy.split_k_atomic_bf16,
+            large_m_unroll=policy.large_m_unroll,
+            # M=1 FP8 benefits from normal TMA loads for A/SFA on the
+            # standalone tiny-M profile. Keep C on the direct epilogue path;
+            # the normal TMA store did not beat it in the DSV4F TP=2 GPU5 run.
+            use_m1_non_tma_a=False,
+            use_m1_non_tma_c=policy.use_m1_non_tma and not self._swap_ab,
+            use_m1_non_tma_sfa=False,
+            load_path=self._load_path,
+            swap_ab=self._swap_ab,
+            sfb_k_reuse=self._sfb_k_reuse,
+            atom_shape_24=self._atom_shape_24,
+            b_tile_major=self._b_tile_major,
+            quantize_c=self._quantize_c,
+            alpha_is_one=self._alpha_is_one,
+            direct_sfa_live16=self._direct_sfa_live16,
+            direct_m1_wo_a_inputs=self._direct_m1_wo_a_inputs,
+            target_occupancy=self._target_occupancy,
+        )(
+            a_tensor,
+            a_tensor,
+            alpha_tensor,
+            alpha_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            c_tensor,
+            quant_c_values_tensor,
+            quant_c_scale_rows_tensor,
+            quant_c_scale_mma_tensor,
+            alpha_tensor,
+            self._max_active_clusters,
+            current_stream,
+        )
+
+
+class _DenseGemmFusedQuantALaunch(_DenseGemmLaunch):
+    """Small-M MXFP8 launch that quantizes BF16 A into each CTA's stages."""
+
+    def __init__(
+        self,
+        *args,
+        fused_quant_a_inner_span: int = 0,
+        fused_quant_a_wide: bool = False,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self._fused_quant_a_inner_span = int(fused_quant_a_inner_span)
+        self._fused_quant_a_wide = bool(fused_quant_a_wide)
+
+    def compile_key(self) -> tuple[object, ...]:
+        # Keep the fused entry point separate even if every ordinary launch
+        # specialization matches. Deriving the rest from the parent key avoids
+        # silently omitting a future codegen field here.
+        return (
+            "fused_quant_a",
+            self._fused_quant_a_inner_span,
+            self._fused_quant_a_wide,
+            *super().compile_key(),
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_placeholder_ptr: cute.Pointer,
+        a_source_ptr: cute.Pointer,
+        b_ptr: cute.Pointer,
+        sfa_placeholder_ptr: cute.Pointer,
+        sfb_ptr: cute.Pointer,
+        c_ptr: cute.Pointer,
+        alpha_ptr: cute.Pointer,
+        m: cutlass.Int32,
+        current_stream: cuda.CUstream,
+    ):
+        a_tensor = cute.make_tensor(
+            a_placeholder_ptr,
+            layout=cute.make_ordered_layout((m, self._k, 1), order=(1, 0, 2)),
+        )
+        a_source = cute.make_tensor(
+            a_source_ptr,
+            layout=cute.make_ordered_layout((m, self._k, 1), order=(1, 0, 2)),
+        )
+        if cutlass.const_expr(self._b_tile_major):
+            b_layout = cute.make_layout(
+                (
+                    (self._b_tile_n, self._n // self._b_tile_n),
+                    (128, self._k // 128),
+                    1,
+                ),
+                stride=(
+                    (128, self._b_tile_n * self._k),
+                    (1, self._b_tile_n * 128),
+                    self._n * self._k,
+                ),
+            )
+        else:
+            b_layout = cute.make_ordered_layout((self._n, self._k, 1), order=(1, 0, 2))
+        b_tensor = cute.make_tensor(b_ptr, layout=b_layout)
+        c_tensor = cute.make_tensor(
+            c_ptr,
+            layout=cute.make_ordered_layout((m, self._n, self._c_l), order=(1, 0, 2)),
+        )
+        alpha_tensor = cute.make_tensor(
+            alpha_ptr,
+            layout=cute.make_ordered_layout((1,), order=(0,)),
+        )
+        sfa_tensor = cute.make_tensor(
+            sfa_placeholder_ptr, layout=cute.make_layout((1,))
+        )
+        sfb_tensor = cute.make_tensor(sfb_ptr, layout=cute.make_layout((1,)))
+        policy = self._policy
+        DenseGemmKernel(
+            sf_vec_size=self._sf_vec_size,
+            mma_tiler_mn=self._mma_tiler_mn,
+            cluster_shape_mn=self._cluster_shape_mn,
+            mma_k=self._mma_k,
+            tile_k=self._tile_k,
+            single_work_tile_per_cta=policy.single_work_tile_per_cta,
+            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
+            split_k_slices=policy.split_k_slices,
+            split_k_atomic_bf16=policy.split_k_atomic_bf16,
+            large_m_unroll=False,
+            use_m1_non_tma_a=False,
+            use_m1_non_tma_c=policy.use_m1_non_tma,
+            use_m1_non_tma_sfa=False,
+            load_path="tma",
+            swap_ab=False,
+            sfb_k_reuse=self._sfb_k_reuse,
+            fused_quant_a=True,
+            fused_quant_a_inner_span=self._fused_quant_a_inner_span,
+            fused_quant_a_wide=self._fused_quant_a_wide,
+            atom_shape_24=self._atom_shape_24,
+            b_tile_major=self._b_tile_major,
+            target_occupancy=self._target_occupancy,
+        )(
+            a_tensor,
+            a_source,
+            alpha_tensor,
+            alpha_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            c_tensor,
+            a_tensor,
+            sfa_tensor,
+            sfa_tensor,
+            alpha_tensor,
+            self._max_active_clusters,
+            current_stream,
+        )
+
+
+@functools.cache
+def _get_compiled_dense_gemm_fused_quant_a(
+    n: int,
+    k: int,
+    c_dtype: Type[cutlass.Numeric],
+    policy: _DenseGemmPolicy,
+    mma_tiler_mn: Tuple[int, int],
+    sm_count: int,
+    sfb_k_reuse: bool,
+    b_tile_major: bool,
+    a_inner_span: int = 0,
+    kernel_c_l: int = 1,
+    a_wide: bool = False,
+) -> Callable:
+    launch = _DenseGemmFusedQuantALaunch(
+        n=n,
+        k=k,
+        l=1,
+        c_l=kernel_c_l,
+        a_major="k",
+        b_major="k",
+        c_major="n",
+        ab_dtype=cutlass.Float8E4M3FN,
+        sf_dtype=cutlass.Float8E8M0FNU,
+        c_dtype=c_dtype,
+        alpha_dtype=cutlass.Float32,
+        sf_vec_size=32,
+        mma_k=32,
+        tile_k=128,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=(1, 1),
+        policy=policy,
+        sm_count=sm_count,
+        sm_version="sm_120",
+        load_path="tma",
+        swap_ab=False,
+        sfb_k_reuse=sfb_k_reuse,
+        b_tile_major=b_tile_major,
+        fused_quant_a_inner_span=a_inner_span,
+        fused_quant_a_wide=a_wide,
+    )
+    compile_key = launch.compile_key()
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=launch,
+        cache_key=compile_key,
+    )
+    placeholders = [16] * 7
+    compiled = sm12x_compile(
+        launch,
+        make_ptr(
+            cutlass.Float8E4M3FN,
+            placeholders[0],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.BFloat16, placeholders[1], cute.AddressSpace.gmem, assumed_align=16
+        ),
+        make_ptr(
+            cutlass.Float8E4M3FN,
+            placeholders[2],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float8E8M0FNU,
+            placeholders[3],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float8E8M0FNU,
+            placeholders[4],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(c_dtype, placeholders[5], cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(
+            cutlass.Float32, placeholders[6], cute.AddressSpace.gmem, assumed_align=16
+        ),
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "gemm.dense_fused_quant_a", 4, compile_key
+        ),
+    )
+
+    def tensor_api(
+        source: torch.Tensor,
+        b: torch.Tensor,
+        sfb: torch.Tensor,
+        out: torch.Tensor,
+        alpha: torch.Tensor,
+        stream_int: Optional[int],
+    ) -> torch.Tensor:
+        source_ptr = source.data_ptr()
+        compiled(
+            make_ptr(
+                cutlass.Float8E4M3FN,
+                source_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.BFloat16, source_ptr, cute.AddressSpace.gmem, assumed_align=16
+            ),
+            make_ptr(
+                cutlass.Float8E4M3FN,
+                b.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float8E8M0FNU,
+                source_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float8E8M0FNU,
+                sfb.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(c_dtype, out.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(
+                cutlass.Float32,
+                alpha.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            int(source.shape[0]),
+            cuda_stream_from_int_or_current(stream_int),
+        )
+        return out
+
+    return tensor_api
+
+
+class _DenseGemmFusedQuantAGroupedLaunch(_DenseGemmLaunch):
+    """Grouped small-M MXFP8 launch quantizing a strided (optionally
+    inverse-RoPE) BF16 A source into each CTA's stages (WO-A)."""
+
+    def __init__(
+        self,
+        *args,
+        fused_quant_a_row_stride: int,
+        fused_quant_a_l_stride: int,
+        fused_quant_a_inv_rope: bool,
+        fused_quant_a_head_dim: int,
+        fused_quant_a_nope_dim: int,
+        fused_quant_a_rope_dim: int,
+        fused_quant_a_wide: bool,
+        positions_dtype: Type[cutlass.Numeric],
+        cos_sin_dtype: Type[cutlass.Numeric],
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self._fused_quant_a_row_stride = int(fused_quant_a_row_stride)
+        self._fused_quant_a_l_stride = int(fused_quant_a_l_stride)
+        self._fused_quant_a_inv_rope = bool(fused_quant_a_inv_rope)
+        self._fused_quant_a_head_dim = int(fused_quant_a_head_dim)
+        self._fused_quant_a_nope_dim = int(fused_quant_a_nope_dim)
+        self._fused_quant_a_rope_dim = int(fused_quant_a_rope_dim)
+        self._fused_quant_a_wide = bool(fused_quant_a_wide)
+        self._positions_dtype = positions_dtype
+        self._cos_sin_dtype = cos_sin_dtype
+
+    def compile_key(self) -> tuple[object, ...]:
+        return (
+            "fused_quant_a_grouped",
+            self._fused_quant_a_row_stride,
+            self._fused_quant_a_l_stride,
+            self._fused_quant_a_inv_rope,
+            self._fused_quant_a_head_dim,
+            self._fused_quant_a_nope_dim,
+            self._fused_quant_a_rope_dim,
+            self._fused_quant_a_wide,
+            self._positions_dtype,
+            self._cos_sin_dtype,
+            *super().compile_key(),
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_placeholder_ptr: cute.Pointer,
+        a_source_ptr: cute.Pointer,
+        positions_ptr: cute.Pointer,
+        cos_sin_ptr: cute.Pointer,
+        b_ptr: cute.Pointer,
+        sfa_placeholder_ptr: cute.Pointer,
+        sfb_ptr: cute.Pointer,
+        c_ptr: cute.Pointer,
+        alpha_ptr: cute.Pointer,
+        m: cutlass.Int32,
+        cos_sin_len: cutlass.Int32,
+        current_stream: cuda.CUstream,
+    ):
+        a_tensor = cute.make_tensor(
+            a_placeholder_ptr,
+            layout=cute.make_ordered_layout((m, self._k, 1), order=(1, 0, 2)),
+        )
+        a_source = cute.make_tensor(
+            a_source_ptr,
+            layout=cute.make_ordered_layout((m, self._k, 1), order=(1, 0, 2)),
+        )
+        positions_tensor = cute.make_tensor(
+            positions_ptr, layout=cute.make_layout((m,))
+        )
+        cos_sin_tensor = cute.make_tensor(
+            cos_sin_ptr, layout=cute.make_layout((cos_sin_len,))
+        )
+        b_tensor = cute.make_tensor(
+            b_ptr,
+            layout=cute.make_ordered_layout(
+                (self._n, self._k, self._l), order=(1, 0, 2)
+            ),
+        )
+        c_tensor = cute.make_tensor(
+            c_ptr,
+            layout=cute.make_ordered_layout((m, self._n, self._c_l), order=(1, 0, 2)),
+        )
+        alpha_tensor = cute.make_tensor(
+            alpha_ptr,
+            layout=cute.make_ordered_layout((1,), order=(0,)),
+        )
+        sfa_tensor = cute.make_tensor(
+            sfa_placeholder_ptr, layout=cute.make_layout((1,))
+        )
+        sfb_tensor = cute.make_tensor(sfb_ptr, layout=cute.make_layout((1,)))
+        policy = self._policy
+        DenseGemmKernel(
+            sf_vec_size=self._sf_vec_size,
+            mma_tiler_mn=self._mma_tiler_mn,
+            cluster_shape_mn=self._cluster_shape_mn,
+            mma_k=self._mma_k,
+            tile_k=self._tile_k,
+            single_work_tile_per_cta=policy.single_work_tile_per_cta,
+            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
+            split_k_slices=policy.split_k_slices,
+            split_k_atomic_bf16=policy.split_k_atomic_bf16,
+            large_m_unroll=False,
+            use_m1_non_tma_a=False,
+            use_m1_non_tma_c=policy.use_m1_non_tma,
+            use_m1_non_tma_sfa=False,
+            load_path="tma",
+            swap_ab=False,
+            sfb_k_reuse=self._sfb_k_reuse,
+            fused_quant_a=True,
+            fused_quant_a_row_stride=self._fused_quant_a_row_stride,
+            fused_quant_a_l_stride=self._fused_quant_a_l_stride,
+            fused_quant_a_inv_rope=self._fused_quant_a_inv_rope,
+            fused_quant_a_head_dim=self._fused_quant_a_head_dim,
+            fused_quant_a_nope_dim=self._fused_quant_a_nope_dim,
+            fused_quant_a_rope_dim=self._fused_quant_a_rope_dim,
+            fused_quant_a_wide=self._fused_quant_a_wide,
+            atom_shape_24=self._atom_shape_24,
+            target_occupancy=self._target_occupancy,
+        )(
+            a_tensor,
+            a_source,
+            positions_tensor,
+            cos_sin_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            c_tensor,
+            a_tensor,
+            sfa_tensor,
+            sfa_tensor,
+            alpha_tensor,
+            self._max_active_clusters,
+            current_stream,
+        )
+
+
+def _cutlass_positions_dtype(dtype: torch.dtype) -> Type[cutlass.Numeric]:
+    if dtype == torch.int64:
+        return cutlass.Int64
+    if dtype == torch.int32:
+        return cutlass.Int32
+    raise ValueError(f"fused inv-RoPE positions must be int32/int64, got {dtype}")
+
+
+def _cutlass_cos_sin_dtype(dtype: torch.dtype) -> Type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float32:
+        return cutlass.Float32
+    raise ValueError(f"fused inv-RoPE cos/sin cache must be bf16/fp32, got {dtype}")
+
+
+@functools.cache
+def _get_compiled_dense_gemm_fused_quant_a_grouped(
+    n: int,
+    k: int,
+    l: int,
+    policy: _DenseGemmPolicy,
+    mma_tiler_mn: Tuple[int, int],
+    sm_count: int,
+    sfb_k_reuse: bool,
+    a_row_stride: int,
+    a_l_stride: int,
+    inv_rope: bool,
+    head_dim: int,
+    nope_dim: int,
+    rope_dim: int,
+    a_wide: bool,
+    positions_dtype: Type[cutlass.Numeric],
+    cos_sin_dtype: Type[cutlass.Numeric],
+) -> Callable:
+    launch = _DenseGemmFusedQuantAGroupedLaunch(
+        n=n,
+        k=k,
+        l=l,
+        c_l=l,
+        a_major="k",
+        b_major="k",
+        c_major="n",
+        ab_dtype=cutlass.Float8E4M3FN,
+        sf_dtype=cutlass.Float8E8M0FNU,
+        c_dtype=cutlass.BFloat16,
+        alpha_dtype=cutlass.Float32,
+        sf_vec_size=32,
+        mma_k=32,
+        tile_k=128,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=(1, 1),
+        policy=policy,
+        sm_count=sm_count,
+        sm_version="sm_120",
+        load_path="tma",
+        swap_ab=False,
+        sfb_k_reuse=sfb_k_reuse,
+        fused_quant_a_row_stride=a_row_stride,
+        fused_quant_a_l_stride=a_l_stride,
+        fused_quant_a_inv_rope=inv_rope,
+        fused_quant_a_head_dim=head_dim,
+        fused_quant_a_nope_dim=nope_dim,
+        fused_quant_a_rope_dim=rope_dim,
+        fused_quant_a_wide=a_wide,
+        positions_dtype=positions_dtype,
+        cos_sin_dtype=cos_sin_dtype,
+    )
+    compile_key = launch.compile_key()
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=launch,
+        cache_key=compile_key,
+    )
+    placeholders = [16] * 9
+    compiled = sm12x_compile(
+        launch,
+        make_ptr(
+            cutlass.Float8E4M3FN,
+            placeholders[0],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.BFloat16, placeholders[1], cute.AddressSpace.gmem, assumed_align=16
+        ),
+        make_ptr(
+            positions_dtype, placeholders[2], cute.AddressSpace.gmem, assumed_align=8
+        ),
+        make_ptr(
+            cos_sin_dtype, placeholders[3], cute.AddressSpace.gmem, assumed_align=4
+        ),
+        make_ptr(
+            cutlass.Float8E4M3FN,
+            placeholders[4],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float8E8M0FNU,
+            placeholders[5],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float8E8M0FNU,
+            placeholders[6],
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.BFloat16, placeholders[7], cute.AddressSpace.gmem, assumed_align=16
+        ),
+        make_ptr(
+            cutlass.Float32, placeholders[8], cute.AddressSpace.gmem, assumed_align=16
+        ),
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "gemm.dense_fused_quant_a_grouped", 2, compile_key
+        ),
+    )
+
+    def tensor_api(
+        source: torch.Tensor,
+        positions: torch.Tensor,
+        cos_sin: torch.Tensor,
+        b: torch.Tensor,
+        sfb: torch.Tensor,
+        out: torch.Tensor,
+        alpha: torch.Tensor,
+        stream_int: Optional[int],
+    ) -> torch.Tensor:
+        source_ptr = source.data_ptr()
+        compiled(
+            make_ptr(
+                cutlass.Float8E4M3FN,
+                source_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.BFloat16, source_ptr, cute.AddressSpace.gmem, assumed_align=16
+            ),
+            make_ptr(
+                positions_dtype,
+                positions.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            ),
+            make_ptr(
+                cos_sin_dtype,
+                cos_sin.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=4,
+            ),
+            make_ptr(
+                cutlass.Float8E4M3FN,
+                b.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float8E8M0FNU,
+                source_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float8E8M0FNU,
+                sfb.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                out.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float32,
+                alpha.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            int(source.shape[0]),
+            int(cos_sin.numel()),
+            cuda_stream_from_int_or_current(stream_int),
+        )
+        return out
+
+    return tensor_api
+
+
+def dense_gemm_fused_quant_a_grouped(
+    source: torch.Tensor,
+    b: torch.Tensor,
+    sfb: torch.Tensor,
+    *,
+    groups: int,
+    out: Optional[torch.Tensor] = None,
+    positions: Optional[torch.Tensor] = None,
+    cos_sin_cache: Optional[torch.Tensor] = None,
+    head_dim: int = 0,
+    nope_dim: int = 0,
+    rope_dim: int = 0,
+    expected_m: Optional[int] = None,
+    sfb_k_replicated: bool = False,
+    mma_tiler_mn: Optional[Tuple[int, int]] = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Small-M grouped BF16-A -> MXFP8 GEMM quantizing A in each CTA (WO-A).
+
+    `source` is `[M, groups, K]` BF16 with contiguous trailing dims (rows may
+    be strided); logical GEMM operands are per-group `[M, K] x [N, K]`. When
+    `positions`/`cos_sin_cache` are given, the trailing `rope_dim` of every
+    `head_dim` block is inverse-RoPE-rotated before quantization.
+    """
+
+    if source.dtype != torch.bfloat16 or source.ndim != 3:
+        raise ValueError(
+            "fused grouped MXFP8 quantization requires BF16 [M, groups, K]"
+        )
+    m = int(source.shape[0])
+    k = int(source.shape[2])
+    if int(source.shape[1]) != groups:
+        raise ValueError(
+            f"source groups {int(source.shape[1])} != weight groups {groups}"
+        )
+    if source.stride(2) != 1 or source.stride(1) != k:
+        raise ValueError(
+            f"fused grouped MXFP8 A needs contiguous [groups, K] rows, got strides {source.stride()}"
+        )
+    row_stride = int(source.stride(0))
+    if m < 1 or m > 8 or k % 128 != 0 or row_stride % 8 != 0:
+        raise ValueError(
+            f"fused grouped MXFP8 quantization requires 1<=M<=8, K%128=0, row stride%8=0; "
+            f"got M={m}, K={k}, row_stride={row_stride}"
+        )
+    if b.ndim != 3 or int(b.shape[1]) != k or int(b.shape[2]) != groups:
+        raise ValueError(f"B must have shape [N,{k},{groups}], got {tuple(b.shape)}")
+    n = int(b.shape[0])
+    inv_rope = positions is not None or cos_sin_cache is not None
+    if inv_rope:
+        if positions is None or cos_sin_cache is None:
+            raise ValueError("inverse-RoPE needs both positions and cos_sin_cache")
+        if positions.shape != (m,):
+            raise ValueError(
+                f"positions must have shape {(m,)}, got {tuple(positions.shape)}"
+            )
+        if not positions.is_contiguous() or not cos_sin_cache.is_contiguous():
+            raise ValueError("positions and cos_sin_cache must be contiguous")
+        if cos_sin_cache.ndim != 2 or int(cos_sin_cache.shape[1]) != rope_dim:
+            raise ValueError(
+                f"cos_sin_cache must have shape [max_pos, {rope_dim}], got {tuple(cos_sin_cache.shape)}"
+            )
+        if (
+            head_dim <= 0
+            or nope_dim + rope_dim != head_dim
+            or head_dim % 32
+            or nope_dim % 32
+            or rope_dim % 32
+            or k % head_dim
+        ):
+            raise ValueError(
+                "fused inverse-RoPE requires 32-aligned head_dim = nope_dim + rope_dim "
+                f"dividing K, got head={head_dim}, nope={nope_dim}, rope={rope_dim}, K={k}"
+            )
+        positions_dtype = _cutlass_positions_dtype(positions.dtype)
+        cos_sin_dtype = _cutlass_cos_sin_dtype(cos_sin_cache.dtype)
+    else:
+        head_dim = nope_dim = rope_dim = 0
+        positions = source
+        cos_sin_cache = source
+        positions_dtype = cutlass.Int64
+        cos_sin_dtype = cutlass.BFloat16
+    sm_count = get_num_sm(source.device)
+    if mma_tiler_mn is None:
+        plan = _select_default_dense_gemm_plan(
+            m, n, k, sm_count, is_mxfp8=True, expected_m=expected_m
+        )
+        if plan.swap_ab or plan.load_path != "tma":
+            raise ValueError(
+                "fused grouped MXFP8 quantization requires the unswapped TMA plan"
+            )
+        mma_tiler_mn = plan.mma_tiler_mn
+    policy = _dense_gemm_policy_for(
+        m=m,
+        n=n,
+        k=k,
+        l=groups,
+        ab_dtype=cutlass.Float8E4M3FN,
+        c_dtype=cutlass.BFloat16,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=(1, 1),
+        sm_count=sm_count,
+        expected_m=expected_m,
+    )
+    if policy.split_k_slices != 1:
+        raise ValueError("fused grouped MXFP8 quantization does not support split-K")
+    if out is None:
+        out = _empty_dense_gemm_output(
+            m, n, groups, dtype=torch.bfloat16, device=source.device
+        )
+    if out.shape != (m, n, groups) or out.dtype != torch.bfloat16:
+        raise ValueError(
+            f"out must be BF16 with shape {(m, n, groups)}, got {out.dtype} {tuple(out.shape)}"
+        )
+    compiled = _get_compiled_dense_gemm_fused_quant_a_grouped(
+        n,
+        k,
+        groups,
+        policy,
+        mma_tiler_mn,
+        sm_count,
+        bool(sfb_k_replicated),
+        row_stride,
+        k,
+        bool(inv_rope),
+        int(head_dim),
+        int(nope_dim),
+        int(rope_dim),
+        m == 1,
+        positions_dtype,
+        cos_sin_dtype,
+    )
+    return compiled(
+        source,
+        positions,
+        cos_sin_cache,
+        b,
+        sfb,
+        out,
+        _cached_alpha_one(source.device),
+        cuda_stream_to_int(stream),
+    )
+
+
+def _dense_gemm_target_occupancy(
+    *,
+    n: int,
+    k: int,
+    l: int,
+    ab_dtype: Type[cutlass.Numeric],
+    c_dtype: Type[cutlass.Numeric],
+    tile_k: int,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    sm_count: int,
+    load_path: str,
+    swap_ab: bool,
+    b_tile_major: bool,
+) -> int:
+    tile_m, tile_n = mma_tiler_mn
+    n_tiles = ((n + tile_n - 1) // tile_n) * l
+    return (
+        2
+        if ab_dtype == cutlass.Float8E4M3FN
+        and c_dtype == cutlass.BFloat16
+        and tile_k == 128
+        and tile_m == 16
+        and k <= 1024
+        and cluster_shape_mn == (1, 1)
+        and load_path == "tma"
+        and not swap_ab
+        and not b_tile_major
+        and n_tiles >= 2 * sm_count
+        else 1
+    )
+
+
+@functools.cache
+def _get_compiled_dense_gemm(
+    n: int,
+    k: int,
+    l: int,
+    c_l: int,
+    a_major: str,
+    b_major: str,
+    c_major: str,
+    ab_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    c_dtype: Type[cutlass.Numeric],
+    alpha_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    policy: _DenseGemmPolicy,
+    sm_count: int,
+    sm_version: str,
+    load_path: str,
+    swap_ab: bool,
+    sfb_k_reuse: bool,
+    b_tile_major: bool,
+    quantize_c: bool = False,
+    alpha_is_one: bool = False,
+    direct_sfa_live16: bool = False,
+    direct_m1_wo_a_inputs: bool = False,
+) -> Callable:
+    def _make_runtime_pointers(
+        input_tensors: Optional[List[torch.Tensor]],
+        quant_c_tensors: Optional[List[torch.Tensor]] = None,
+    ) -> List[cute.Pointer]:
+        if input_tensors is None:
+            (
+                a_data_ptr,
+                b_data_ptr,
+                sfa_data_ptr,
+                sfb_data_ptr,
+                c_data_ptr,
+                alpha_data_ptr,
+            ) = [16 for _ in range(6)]
+        else:
+            (
+                a_tensor_gpu,
+                b_tensor_gpu,
+                sfa_tensor_gpu,
+                sfb_tensor_gpu,
+                c_tensor_gpu,
+                alpha_tensor_gpu,
+            ) = input_tensors
+            (
+                a_data_ptr,
+                b_data_ptr,
+                sfa_data_ptr,
+                sfb_data_ptr,
+                c_data_ptr,
+                alpha_data_ptr,
+            ) = (
+                a_tensor_gpu.data_ptr(),
+                b_tensor_gpu.data_ptr(),
+                sfa_tensor_gpu.data_ptr(),
+                sfb_tensor_gpu.data_ptr(),
+                c_tensor_gpu.data_ptr(),
+                alpha_tensor_gpu.data_ptr(),
+            )
+        if quant_c_tensors is None:
+            quant_c_values_ptr = 16
+            quant_c_scale_rows_ptr = 16
+            quant_c_scale_mma_ptr = 16
+        else:
+            (
+                quant_c_values_gpu,
+                quant_c_scale_rows_gpu,
+                quant_c_scale_mma_gpu,
+            ) = quant_c_tensors
+            quant_c_values_ptr = quant_c_values_gpu.data_ptr()
+            quant_c_scale_rows_ptr = quant_c_scale_rows_gpu.data_ptr()
+            quant_c_scale_mma_ptr = quant_c_scale_mma_gpu.data_ptr()
+
+        return [
+            make_ptr(ab_dtype, a_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(ab_dtype, b_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(sf_dtype, sfa_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(sf_dtype, sfb_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(c_dtype, c_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(
+                cutlass.Float8E4M3FN,
+                quant_c_values_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float8E8M0FNU,
+                quant_c_scale_rows_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float8E8M0FNU,
+                quant_c_scale_mma_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                alpha_dtype, alpha_data_ptr, cute.AddressSpace.gmem, assumed_align=16
+            ),
+        ]
+
+    launch = _DenseGemmLaunch(
+        n=n,
+        k=k,
+        l=l,
+        c_l=c_l,
+        a_major=a_major,
+        b_major=b_major,
+        c_major=c_major,
+        ab_dtype=ab_dtype,
+        sf_dtype=sf_dtype,
+        c_dtype=c_dtype,
+        alpha_dtype=alpha_dtype,
+        sf_vec_size=sf_vec_size,
+        mma_k=mma_k,
+        tile_k=tile_k,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        policy=policy,
+        sm_count=sm_count,
+        sm_version=sm_version,
+        load_path=load_path,
+        swap_ab=swap_ab,
+        sfb_k_reuse=sfb_k_reuse,
+        b_tile_major=b_tile_major,
+        quantize_c=quantize_c,
+        alpha_is_one=alpha_is_one,
+        direct_sfa_live16=direct_sfa_live16,
+        direct_m1_wo_a_inputs=direct_m1_wo_a_inputs,
+        target_occupancy=_dense_gemm_target_occupancy(
+            n=n,
+            k=k,
+            l=l,
+            ab_dtype=ab_dtype,
+            c_dtype=c_dtype,
+            tile_k=tile_k,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            sm_count=sm_count,
+            load_path=load_path,
+            swap_ab=swap_ab,
+            b_tile_major=b_tile_major,
+        ),
+    )
+    compile_key = launch.compile_key()
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=launch,
+        cache_key=compile_key,
+    )
+    compiled_kernel = sm12x_compile(
+        launch,
+        *_make_runtime_pointers(None),
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key("gemm.dense", 3, compile_key),
+    )
+
+    def tensor_api(
+        a_tensor_gpu: torch.Tensor,
+        b_tensor_gpu: torch.Tensor,
+        sfa_tensor_gpu: torch.Tensor,
+        sfb_tensor_gpu: torch.Tensor,
+        c_tensor_gpu: Optional[torch.Tensor] = None,
+        alpha_tensor_gpu: Optional[torch.Tensor] = None,
+        stream_int: Optional[int] = None,
+        quant_c_values_gpu: Optional[torch.Tensor] = None,
+        quant_c_scale_rows_gpu: Optional[torch.Tensor] = None,
+        quant_c_scale_mma_gpu: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        m = a_tensor_gpu.shape[0]
+        if c_tensor_gpu is None:
+            c_tensor_gpu = torch.empty(
+                (m, n, c_l),
+                dtype=cutlass_to_torch_dtype(c_dtype),
+                device=a_tensor_gpu.device,
+            )
+        if alpha_tensor_gpu is None:
+            alpha_tensor_gpu = _cached_alpha_one(a_tensor_gpu.device)
+        quant_c_tensors = None
+        if quantize_c:
+            if (
+                quant_c_values_gpu is None
+                or quant_c_scale_rows_gpu is None
+                or quant_c_scale_mma_gpu is None
+            ):
+                raise ValueError("quantized C output tensors are required")
+            quant_c_tensors = [
+                quant_c_values_gpu,
+                quant_c_scale_rows_gpu,
+                quant_c_scale_mma_gpu,
+            ]
+
+        nonlocal compiled_kernel
+        compiled_kernel(
+            *_make_runtime_pointers(
+                [
+                    a_tensor_gpu,
+                    b_tensor_gpu,
+                    sfa_tensor_gpu,
+                    sfb_tensor_gpu,
+                    c_tensor_gpu,
+                    alpha_tensor_gpu,
+                ],
+                quant_c_tensors,
+            ),
+            m,
+            cuda_stream_from_int_or_current(stream_int),
+        )
+        return c_tensor_gpu
+
+    return tensor_api
+
+
+def _dense_gemm_launch_flat(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    c_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    large_m_unroll: bool,
+    load_path: str,
+    swap_ab: bool,
+    sfb_k_reuse: bool,
+    alpha_is_one: bool,
+    stream_int: Optional[int],
+) -> None:
+    b_tile_major = b_tensor_gpu.ndim == 5
+    policy = _DenseGemmPolicy(
+        single_work_tile_per_cta=single_work_tile_per_cta,
+        direct_one_m_tile_scheduler=direct_one_m_tile_scheduler,
+        use_m1_non_tma=use_m1_non_tma,
+        split_k_slices=split_k_slices,
+        split_k_atomic_bf16=split_k_atomic_bf16,
+        large_m_unroll=large_m_unroll,
+    )
+    compiled = _get_compiled_dense_gemm(
+        n=n,
+        k=k,
+        l=l,
+        c_l=c_l,
+        a_major="k",
+        b_major="k",
+        c_major="n",
+        ab_dtype=get_cutlass_dtype(ab_dtype),
+        sf_dtype=get_cutlass_dtype(sf_dtype),
+        c_dtype=get_cutlass_dtype(c_dtype),
+        alpha_dtype=get_cutlass_dtype(alpha_dtype),
+        sf_vec_size=sf_vec_size,
+        mma_k=mma_k,
+        tile_k=tile_k,
+        mma_tiler_mn=(mma_tile_m, mma_tile_n),
+        cluster_shape_mn=(cluster_shape_m, cluster_shape_n),
+        policy=policy,
+        sm_count=sm_count,
+        sm_version="sm_120",
+        load_path=load_path,
+        swap_ab=swap_ab,
+        sfb_k_reuse=sfb_k_reuse,
+        b_tile_major=b_tile_major,
+        alpha_is_one=alpha_is_one,
+        direct_sfa_live16=_use_direct_sfa_live16(
+            m=int(a_tensor_gpu.shape[0]),
+            n=n,
+            k=k,
+            l=l,
+            sf_vec_size=sf_vec_size,
+            tile_k=tile_k,
+            mma_tiler_mn=(mma_tile_m, mma_tile_n),
+            load_path=load_path,
+            swap_ab=swap_ab,
+            b_tile_major=b_tile_major,
+            sfb_k_reuse=sfb_k_reuse,
+            alpha_is_one=alpha_is_one,
+            is_mxfp8=ab_dtype == "float8_e4m3fn",
+        ),
+        direct_m1_wo_a_inputs=_use_direct_m1_wo_a_inputs(
+            m=int(a_tensor_gpu.shape[0]),
+            n=n,
+            k=k,
+            l=l,
+            sf_vec_size=sf_vec_size,
+            tile_k=tile_k,
+            mma_tiler_mn=(mma_tile_m, mma_tile_n),
+            load_path=load_path,
+            swap_ab=swap_ab,
+            b_tile_major=b_tile_major,
+            sfb_k_reuse=sfb_k_reuse,
+            is_mxfp8=ab_dtype == "float8_e4m3fn",
+        ),
+    )
+    compiled(
+        a_tensor_gpu=a_tensor_gpu,
+        b_tensor_gpu=b_tensor_gpu,
+        sfa_tensor_gpu=sfa_tensor_gpu,
+        sfb_tensor_gpu=sfb_tensor_gpu,
+        c_tensor_gpu=c_tensor_gpu,
+        alpha_tensor_gpu=alpha_tensor_gpu,
+        stream_int=stream_int,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::dense_gemm_launch",
+    mutates_args=("c_tensor_gpu",),
+)
+def _dense_gemm_launch_op(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    c_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    large_m_unroll: bool,
+    load_path: str,
+    swap_ab: bool,
+    sfb_k_reuse: bool,
+    alpha_is_one: bool,
+    stream_int: Optional[int],
+) -> None:
+    _dense_gemm_launch_flat(
+        a_tensor_gpu,
+        b_tensor_gpu,
+        sfa_tensor_gpu,
+        sfb_tensor_gpu,
+        c_tensor_gpu,
+        alpha_tensor_gpu,
+        n,
+        k,
+        l,
+        c_l,
+        ab_dtype,
+        sf_dtype,
+        c_dtype,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tile_m,
+        mma_tile_n,
+        cluster_shape_m,
+        cluster_shape_n,
+        sm_count,
+        single_work_tile_per_cta,
+        direct_one_m_tile_scheduler,
+        use_m1_non_tma,
+        split_k_slices,
+        split_k_atomic_bf16,
+        large_m_unroll,
+        load_path,
+        swap_ab,
+        sfb_k_reuse,
+        alpha_is_one,
+        stream_int,
+    )
+
+
+@_dense_gemm_launch_op.register_fake
+def _dense_gemm_launch_fake(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    c_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    large_m_unroll: bool,
+    load_path: str,
+    swap_ab: bool,
+    sfb_k_reuse: bool,
+    alpha_is_one: bool,
+    stream_int: Optional[int],
+) -> None:
+    return None
+
+
+_ALPHA_ONE_CACHE: dict = {}
+
+
+def _cached_alpha_one(device: torch.device | str) -> torch.Tensor:
+    # Per-device cached scalar-one alpha, to avoid a per-call torch.ones((1,))
+    # host/device alloc on the generic FP8 dense-GEMM path. Mirrors
+    # wo_projection._cached_alpha_one (not imported -- wo_projection imports
+    # dense, so importing back would be circular).
+    resolved = torch.device(device)
+    if resolved.type == "cuda" and resolved.index is None:
+        resolved = torch.device("cuda", torch.cuda.current_device())
+    key = (resolved.type, resolved.index)
+    alpha = _ALPHA_ONE_CACHE.get(key)
+    if alpha is None or alpha.device != resolved:
+        alpha = torch.ones((1,), dtype=torch.float32, device=resolved)
+        _ALPHA_ONE_CACHE[key] = alpha
+    return alpha
+
+
+def _empty_dense_gemm_output(
+    m: int,
+    n: int,
+    l: int,
+    *,
+    dtype: torch.dtype,
+    device: torch.device | str,
+) -> torch.Tensor:
+    """Allocate an `[M,N,L]` dense-GEMM output in the layout the kernel writes.
+
+    The CuTe dense GEMM hardcodes ``c_major='n'`` and builds the C tensor from
+    the data pointer with order ``(1,0,2)`` -- i.e. it writes the grouped output
+    as physical ``[L,M,N]`` (an ``[M,N,L]`` view with strides ``(N,1,M*N)``) and
+    ignores the runtime tensor's actual strides. A plain contiguous ``(M,N,L)``
+    buffer (strides ``(N*L,L,1)``) would scatter the ``L`` groups to the wrong
+    offsets, so back ``L>1`` with ``[L,M,N]`` physical storage. ``L==1`` is the
+    same either way. Mirrors ``empty_dense_gemm_mnl_view`` in wo_projection.
+    """
+    if l > 1:
+        return torch.empty((l, m, n), dtype=dtype, device=device).as_strided(
+            (m, n, l), (n, 1, m * n)
+        )
+    return torch.empty((m, n, l), dtype=dtype, device=device)
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::dense_gemm_launch_functional",
+    mutates_args=(),
+)
+def _dense_gemm_launch_functional_op(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    kernel_c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    kernel_c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    large_m_unroll: bool,
+    load_path: str,
+    swap_ab: bool,
+    sfb_k_reuse: bool,
+    alpha_is_one: bool,
+    stream_int: Optional[int],
+) -> torch.Tensor:
+    m = int(a_tensor_gpu.shape[0])
+    out = _empty_dense_gemm_output(
+        m,
+        n,
+        l,
+        dtype=cutlass_to_torch_dtype(get_cutlass_dtype(c_dtype)),
+        device=a_tensor_gpu.device,
+    )
+    split_k_output = int(split_k_slices) > 1
+    if split_k_output and split_k_atomic_bf16:
+        c_tensor_gpu = out
+        out.zero_()
+    elif split_k_output:
+        split_storage = torch.empty(
+            (split_k_slices, m, n),
+            dtype=torch.float32,
+            device=a_tensor_gpu.device,
+        )
+        c_tensor_gpu = split_storage.permute(1, 2, 0)
+    else:
+        c_tensor_gpu = out
+
+    _dense_gemm_launch_flat(
+        a_tensor_gpu,
+        b_tensor_gpu,
+        sfa_tensor_gpu,
+        sfb_tensor_gpu,
+        c_tensor_gpu,
+        alpha_tensor_gpu,
+        n,
+        k,
+        l,
+        kernel_c_l,
+        ab_dtype,
+        sf_dtype,
+        kernel_c_dtype,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tile_m,
+        mma_tile_n,
+        cluster_shape_m,
+        cluster_shape_n,
+        sm_count,
+        single_work_tile_per_cta,
+        direct_one_m_tile_scheduler,
+        use_m1_non_tma,
+        split_k_slices,
+        split_k_atomic_bf16,
+        large_m_unroll,
+        load_path,
+        swap_ab,
+        sfb_k_reuse,
+        alpha_is_one,
+        stream_int,
+    )
+    if split_k_output and not split_k_atomic_bf16:
+        _reduce_split_k2_bf16(c_tensor_gpu, out, m=m, n=n)
+    return out
+
+
+@_dense_gemm_launch_functional_op.register_fake
+def _dense_gemm_launch_functional_fake(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    kernel_c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    kernel_c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    large_m_unroll: bool,
+    load_path: str,
+    swap_ab: bool,
+    sfb_k_reuse: bool,
+    alpha_is_one: bool,
+    stream_int: Optional[int],
+) -> torch.Tensor:
+    del (
+        b_tensor_gpu,
+        sfa_tensor_gpu,
+        sfb_tensor_gpu,
+        alpha_tensor_gpu,
+        k,
+        kernel_c_l,
+        ab_dtype,
+        sf_dtype,
+        kernel_c_dtype,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tile_m,
+        mma_tile_n,
+        cluster_shape_m,
+        cluster_shape_n,
+        sm_count,
+        single_work_tile_per_cta,
+        direct_one_m_tile_scheduler,
+        use_m1_non_tma,
+        split_k_slices,
+        split_k_atomic_bf16,
+        large_m_unroll,
+        load_path,
+        swap_ab,
+        sfb_k_reuse,
+        alpha_is_one,
+        stream_int,
+    )
+    return _empty_dense_gemm_output(
+        int(a_tensor_gpu.shape[0]),
+        n,
+        l,
+        dtype=cutlass_to_torch_dtype(get_cutlass_dtype(c_dtype)),
+        device=a_tensor_gpu.device,
+    )
+
+
+def _select_default_mma_tiler_mn(
+    m: int,
+    n: int,
+    sm_count: int,
+    *,
+    is_mxfp8: bool,
+    expected_m: Optional[int] = None,
+    k: Optional[int] = None,
+) -> Tuple[int, int]:
+    coarse_tile = (128, 128)
+    # The serving WO-B prefill GEMM is [M,4096] x [4096,4096]. DeepGEMM's
+    # specialized O-projection dispatch switches it from BM64/BK128 to
+    # BM128/BK64 at M>=2048, and the same exact-shape switch wins in sm12x.
+    # WO-A is deliberately excluded: its four grouped [M,512]x[1024,512]
+    # GEMMs remain faster with BM64/BK128 on this kernel.
+    if (
+        is_mxfp8
+        and expected_m is not None
+        and expected_m >= 2048
+        and k is not None
+        and (n, k) == (4096, 4096)
+    ):
+        return (128, 128)
+    if is_mxfp8 and n > 1536:
+        # DeepGEMM-style regime hint. When a caller declares expected_m, pick the
+        # per-regime optimal tile and key the compile on it: ONE kernel per
+        # (N,K,expected_m), reused for every live M in that regime under frozen
+        # resolution (M-independent within the regime). Probe optima
+        # (benchmarks/probe_dense_fp8_tile_sweep.py): exact M=1 -> 16x64
+        # (flushed common-shape decode sweep); expected_m=2..8 -> 16x128.
+        # The DSV4 TP2 q_b shape keeps that tile through M=16; its 16-row tile
+        # sustains two resident CTAs per SM, while 32x128 drops to one and loses
+        # the evict-first short-K load policy. Other wide-N shapes retain the
+        # existing 32x128 small-batch regime.
+        # <=128 (small batch) -> 32x128 (~25% faster than 64x128 at M=32..128);
+        # else -> 64x128 (the M-independent default, good to prefill).
+        if expected_m is not None:
+            # BM64/BK128 is the 20-SM Spark q_b winner. The 188-SM RTX audit
+            # keeps the following BM128/BK64 specialization instead.
+            if (
+                expected_m >= 2048
+                and (n, k) == (16384, 1024)
+                and _dense_spark_policy_for_sm_count(sm_count)
+            ):
+                return (64, 128)
+            if expected_m >= 2048 and n >= 16384 and k is not None and k <= 1024:
+                return (128, 128)
+            if expected_m == 1:
+                return (16, 64)
+            # 48-SM Spark q_b decode: (16,128) yields 128 N-tiles over the 96
+            # resident CTAs (occupancy 2), so the remainder wave streams B with
+            # only 32 CTAs and drops below the sustained-read ceiling. (16,64)
+            # quantizes the tail at 64 columns with 2/3 of CTAs still active,
+            # matching the M=1 (16,64) profile that already runs at ceiling.
+            # RTX keeps the probe-swept (16,128).
+            if (
+                expected_m <= 16
+                and (n, k) == (16384, 1024)
+                and _dense_spark_policy_for_sm_count(sm_count)
+            ):
+                return (16, 64)
+            if expected_m <= 8 or (expected_m <= 16 and (n, k) == (16384, 1024)):
+                return (16, 128)
+            if expected_m <= 128:
+                return (32, 128)
+            return (64, 128)
+        # No regime hint: keep the true single-token decode specialization and
+        # use the decode-tuned tile for tiny standalone graph shapes. Broader
+        # live-M reuse still falls back to the M-independent prefill-safe tile.
+        if m == 1:
+            return (16, 64)
+        if m <= 8:
+            return (16, 128)
+        # Wide-N MXFP8: the 128x128 pin spans only ceil(N/128) column tiles, so
+        # at small/medium M it launches ~32-64 CTAs and runs flat (~80us, B-BW
+        # starved). It is in fact the WORST tile at every M (geomean ~121us over
+        # M=2..4096; see benchmarks/probe_dense_fp8_tile_sweep.py). 64x128 is the
+        # best M-INDEPENDENT tile: it beats 128x128 at every M (1.1x-2.4x; geomean
+        # ~69us) with byte-identical output. M-independence is required because
+        # dense serving warms one kernel per (N,K) and reuses it for all live M
+        # under frozen resolution (see test_block_fp8_linear_small_live_m_reuses_
+        # prefill_dense_kernel) -- an M-dependent tile forces an illegal recompile
+        # mid-serve. (Smaller 32x128/16x128 are faster at M<=128 but regress
+        # prefill M>=2k and would break that one-kernel-per-(N,K) reuse contract.)
+        return (64, 128)
+
+    if is_mxfp8:
+        # Narrow-N MXFP8 (n <= 1536; the n > 1536 case returned above). The
+        # (128,128) coarse tile spans only ceil(N/128) column tiles (<=12 at
+        # N<=1536), so at M>=512 it launches ~32-48 CTAs on a 188-SM part and
+        # runs CTA-starved -- 2x-3.5x slower than a CTA-multiplying tile
+        # (probe_dense_fp8_tile_sweep.py: N=1024 M=512 (128,128)=63.5us vs
+        # (64,64)=18.4us; N=1536 M=512 (128,128)=65.5us vs (64,128)=24.6us).
+        # Mirror the wide-N expected_m design where we have data. Exact M=1
+        # gets the flushed common-shape decode winner (16,64). Declared prefill
+        # (expected_m>128) -> (64,128): the best narrow-N tile at M>=512 for
+        # both N=1024 and N=1536 across M=512..8192 (probe sweep), recovering
+        # both the M~512 cliff and the large-M tail (N=1024 M=4096:
+        # (64,128)=80us vs (64,64)=105us vs (128,128)=125us). Other
+        # decode/small and the no-hint default use the M-independent (64,64)
+        # (max CTAs; best at M<=512), preserving the one-kernel-per-(N,K) reuse
+        # contract.
+        if expected_m == 1 or (expected_m is None and m == 1):
+            return (16, 64)
+        if expected_m is not None and expected_m > 128:
+            return (64, 128)
+        return (64, 64)
+
+    plan_m = expected_m if expected_m is not None else m
+    if plan_m == 1 and k is not None:
+        # Flushed M=1 FP4 probe (benchmarks/probe_dense_fp4_tile_load_sweep.py)
+        # across the repo's common shapes:
+        #   * wide/medium N: (64,128)/TMA has the best geomean and wins nearly all
+        #     shapes.
+        #   * N=1024,K=5376: (64,64)/TMA wins the boundary by a small margin.
+        #   * N<=512 with long K: (64,32)/TMA+swap_ab is the only clear tiny-N win.
+        # Keep the tile selector tile-only; the launch planner below attaches
+        # swap_ab to the narrow tile.
+        if n <= 512 and k >= 4096:
+            return (64, 32)
+        if n <= 1024:
+            return (64, 64)
+        return (64, 128)
+
+    coarse_tiles = ((m + coarse_tile[0] - 1) // coarse_tile[0]) * (
+        (n + coarse_tile[1] - 1) // coarse_tile[1]
+    )
+    # The coarse CTA-count heuristic misses exact-small-M, wide-N cases: a wide
+    # N dimension can generate plenty of CTAs even while each 128-row M tile is
+    # mostly empty. Keep using the narrower 64x128 tile while the 128x128 plan
+    # still leaves the GPU below the existing half-SM occupancy proxy.
+    if n > 1536:
+        if m <= 64:
+            return (64, 128)
+        if m <= 256 and coarse_tiles < max(1, sm_count // 2):
+            return (64, 128)
+    if m <= 128 and coarse_tiles < max(1, sm_count // 2):
+        if n > 1536:
+            return (64, 128)
+        medium_tile = (128, 64)
+        medium_tiles = ((m + medium_tile[0] - 1) // medium_tile[0]) * (
+            (n + medium_tile[1] - 1) // medium_tile[1]
+        )
+        if medium_tiles < max(1, sm_count // 2):
+            return (64, 64)
+        return (128, 64)
+    return coarse_tile
+
+
+def _select_mxfp8_tile_k(
+    m: int,
+    n: int,
+    k: int,
+    expected_m: Optional[int],
+    sm_count: int,
+) -> int:
+    # Keep tile-M and tile-K as one hardware-specific q_b plan: Spark uses
+    # BM64/BK128, while the RTX specialization below remains BM128/BK64.
+    if (
+        expected_m is not None
+        and expected_m >= 2048
+        and (n, k) == (16384, 1024)
+        and _dense_spark_policy_for_sm_count(sm_count)
+    ):
+        return 128
+    # BK64 is an explicitly hinted production specialization. Choosing it from
+    # live M when expected_m is absent would change both tile K and generated
+    # code at M=2048, violating the no-hint frozen-resolution reuse contract.
+    hinted_bk64 = (
+        expected_m is not None
+        and expected_m >= 2048
+        and ((n >= 16384 and k <= 1024) or (n, k) == (4096, 4096))
+    )
+    return 64 if hinted_bk64 else 128
+
+
+def _validate_mxfp8_bk64_plan(
+    tile_k: int,
+    mma_tiler_mn: Tuple[int, int],
+    swap_ab: bool,
+) -> None:
+    if tile_k == 64 and (mma_tiler_mn[0] != 128 or swap_ab):
+        raise ValueError(
+            "MXFP8 BK64 packed-scale staging requires an unswapped "
+            f"128-row tile, got tile={mma_tiler_mn}, swap_ab={swap_ab}"
+        )
+
+
+def _select_default_dense_gemm_plan(
+    m: int,
+    n: int,
+    k: int,
+    sm_count: int,
+    *,
+    is_mxfp8: bool,
+    expected_m: Optional[int] = None,
+) -> _DenseGemmPlan:
+    tile = _select_default_mma_tiler_mn(
+        m,
+        n,
+        sm_count,
+        is_mxfp8=is_mxfp8,
+        expected_m=expected_m,
+        k=k,
+    )
+    return _DenseGemmPlan(
+        mma_tiler_mn=tile,
+        load_path="tma",
+        swap_ab=(not is_mxfp8 and tile[1] < 64),
+    )
+
+
+def dense_gemm_fused_quant_a(
+    source: torch.Tensor,
+    b: torch.Tensor,
+    sfb: torch.Tensor,
+    *,
+    out: Optional[torch.Tensor] = None,
+    expected_m: Optional[int] = None,
+    sfb_k_replicated: bool = False,
+    rhs_values_tiled: Optional[torch.Tensor] = None,
+    a_inner_span: int = 0,
+    mma_tiler_mn: Optional[Tuple[int, int]] = None,
+    _atomic_output_precleared: bool = False,
+    stream: object = None,
+) -> torch.Tensor:
+    """Small-M BF16-A -> MXFP8 GEMM with activation quantization in each CTA.
+
+    a_inner_span > 0 reads A from an L-blocked source instead of contiguous
+    rows: `source` is the `[M, span, K/span]` dense-GEMM mnl view over physical
+    `[K/span, M, span]` storage (the WO tmp group-major layout). Follows the
+    dense_gemm split-K policy (FP32 partials + fused reduce) instead of forcing
+    a single un-split kernel, which loses ~2x at M=1 for N,K >= 4096.
+    """
+
+    a_inner_span = int(a_inner_span)
+    if source.dtype != torch.bfloat16:
+        raise ValueError("fused MXFP8 activation quantization requires BF16 A")
+    if a_inner_span == 0:
+        if source.ndim != 2 or not source.is_contiguous():
+            raise ValueError(
+                "fused MXFP8 activation quantization requires contiguous BF16 [M,K]"
+            )
+        m, k = map(int, source.shape)
+    else:
+        if a_inner_span % 32 != 0:
+            raise ValueError(
+                f"fused MXFP8 a_inner_span must be a multiple of 32, got {a_inner_span}"
+            )
+        if source.ndim != 3 or int(source.shape[1]) != a_inner_span:
+            raise ValueError(
+                "L-blocked fused MXFP8 A requires an [M, span, K/span] view, "
+                f"got {tuple(source.shape)} for span={a_inner_span}"
+            )
+        m = int(source.shape[0])
+        k = a_inner_span * int(source.shape[2])
+        if source.stride() != (a_inner_span, 1, m * a_inner_span):
+            raise ValueError(
+                "L-blocked fused MXFP8 A must be a dense-GEMM mnl view over "
+                f"physical [K/span, M, span] storage, got strides {source.stride()}"
+            )
+    if m < 1 or m > 8 or k % 128 != 0:
+        raise ValueError(
+            f"fused MXFP8 activation quantization requires 1<=M<=8 and K%128=0, got M={m}, K={k}"
+        )
+    if b.ndim != 3 or int(b.shape[1]) != k or int(b.shape[2]) != 1:
+        raise ValueError(f"B must have shape [N,{k},1], got {tuple(b.shape)}")
+    n = int(b.shape[0])
+    sm_count = get_num_sm(source.device)
+    if mma_tiler_mn is None:
+        plan = _select_default_dense_gemm_plan(
+            m, n, k, sm_count, is_mxfp8=True, expected_m=expected_m
+        )
+        if plan.swap_ab or plan.load_path != "tma":
+            raise ValueError(
+                "fused MXFP8 activation quantization requires the unswapped TMA plan"
+            )
+        mma_tiler_mn = plan.mma_tiler_mn
+    b_launch = b
+    if rhs_values_tiled is not None:
+        expected_tiled_shape = (1, 32, 32, 128, 128)
+        if (n, k) != (4096, 4096) or mma_tiler_mn not in (
+            (16, 64),
+            (16, 128),
+        ):
+            raise ValueError(
+                "tile-major fused-quant RHS is restricted to the production "
+                "WO-B 16xN/BK128 plans"
+            )
+        if (
+            rhs_values_tiled.shape != expected_tiled_shape
+            or rhs_values_tiled.dtype != b.dtype
+            or rhs_values_tiled.device != b.device
+            or not rhs_values_tiled.is_contiguous()
+        ):
+            raise ValueError(
+                "tile-major fused-quant RHS must be contiguous with shape "
+                f"{expected_tiled_shape}, dtype {b.dtype}, and device {b.device}; "
+                f"got shape={tuple(rhs_values_tiled.shape)}, "
+                f"dtype={rhs_values_tiled.dtype}, device={rhs_values_tiled.device}"
+            )
+        b_launch = rhs_values_tiled
+    policy = _dense_gemm_policy_for(
+        m=m,
+        n=n,
+        k=k,
+        l=1,
+        ab_dtype=cutlass.Float8E4M3FN,
+        c_dtype=cutlass.BFloat16,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=(1, 1),
+        sm_count=sm_count,
+        expected_m=expected_m,
+    )
+    split_k_slices = policy.split_k_slices
+    split_k_output = split_k_slices > 1
+    split_k_atomic_bf16 = split_k_output and policy.split_k_atomic_bf16
+    if out is None:
+        if _atomic_output_precleared:
+            raise ValueError("a precleared fused-quant output must be caller-owned")
+        out = torch.empty((m, n, 1), dtype=torch.bfloat16, device=source.device)
+    if out.shape != (m, n, 1) or out.dtype != torch.bfloat16:
+        raise ValueError(
+            f"out must be BF16 with shape {(m, n, 1)}, got {out.dtype} {tuple(out.shape)}"
+        )
+    split_storage = None
+    if split_k_atomic_bf16:
+        if not _atomic_output_precleared:
+            out.zero_()
+        kernel_c_l = 1
+        kernel_c_dtype = cutlass.BFloat16
+        c_tensor_gpu = out
+    elif split_k_output:
+        split_storage = torch.empty(
+            (split_k_slices, m, n), dtype=torch.float32, device=source.device
+        )
+        kernel_c_l = split_k_slices
+        kernel_c_dtype = cutlass.Float32
+        c_tensor_gpu = split_storage
+    else:
+        kernel_c_l = 1
+        kernel_c_dtype = cutlass.BFloat16
+        c_tensor_gpu = out
+    compiled = _get_compiled_dense_gemm_fused_quant_a(
+        n,
+        k,
+        kernel_c_dtype,
+        policy,
+        mma_tiler_mn,
+        sm_count,
+        bool(sfb_k_replicated),
+        rhs_values_tiled is not None,
+        a_inner_span,
+        kernel_c_l,
+        m == 1,
+    )
+    compiled(
+        source,
+        b_launch,
+        sfb,
+        c_tensor_gpu,
+        _cached_alpha_one(source.device),
+        cuda_stream_to_int(stream),
+    )
+    if split_storage is not None:
+        _reduce_split_k2_bf16(split_storage.permute(1, 2, 0), out, m=m, n=n)
+    return out
+
+
+def dense_gemm(
+    lhs: Tuple[torch.Tensor, torch.Tensor],
+    rhs: Tuple[torch.Tensor, torch.Tensor],
+    out: Optional[torch.Tensor] = None,
+    *,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    sf_vec_size: int,
+    sm_count: Optional[int] = None,
+    mma_tiler_mn: Optional[Tuple[int, int]] = None,
+    cluster_shape_mn: Tuple[int, int] = (1, 1),
+    alpha: Optional[torch.Tensor] = None,
+    alpha_dtype: Optional[str] = None,
+    expected_m: Optional[int] = None,
+    load_path: Optional[Literal["tma", "cpasync"]] = None,
+    swap_ab: Optional[bool] = None,
+    sfb_k_replicated: bool = False,
+    rhs_values_tiled: Optional[torch.Tensor] = None,
+    _quantized_c: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Execute dense block-scaled GEMM for one expert-major batch stack.
+
+    expected_m: optional regime hint (DeepGEMM-style). When set, the default tile
+    is chosen for that representative M instead of being M-independent, giving a
+    per-regime-optimal kernel that is still reused across all live M in the regime
+    (e.g. expected_m<=128 selects a decode-tuned tile). Ignored when mma_tiler_mn
+    is given. Live M stays a runtime arg; only the tile (a compile key) changes.
+    """
+    a_torch, sfa_torch = lhs
+    b_torch, sfb_torch = rhs
+    if load_path is not None and load_path not in _DENSE_LOAD_PATHS:
+        raise ValueError(
+            f"dense_gemm load_path must be one of {_DENSE_LOAD_PATHS}, got {load_path!r}"
+        )
+
+    m, k, l = a_torch.shape
+    n, _, _ = b_torch.shape
+    if sm_count is None:
+        sm_count = get_num_sm(a_torch.device)
+    if ab_dtype == "float4_e2m1fn":
+        is_mxfp8 = False
+        k *= 2
+        mma_k = 64
+        tile_k = sf_vec_size * 8
+    elif ab_dtype == "float8_e4m3fn":
+        is_mxfp8 = True
+        mma_k = 32
+        tile_k = _select_mxfp8_tile_k(m, n, k, expected_m, sm_count)
+    else:
+        raise TypeError(f"dense_gemm unsupported ab_dtype: {ab_dtype}")
+
+    ab_cutlass_dtype = get_cutlass_dtype(ab_dtype)
+    c_cutlass_dtype = get_cutlass_dtype(c_dtype)
+    if mma_tiler_mn is None or load_path is None or swap_ab is None:
+        default_plan = _select_default_dense_gemm_plan(
+            m,
+            n,
+            k,
+            sm_count,
+            is_mxfp8=is_mxfp8,
+            expected_m=expected_m,
+        )
+        if mma_tiler_mn is None:
+            mma_tiler_mn = default_plan.mma_tiler_mn
+        if load_path is None:
+            load_path = default_plan.load_path
+        if swap_ab is None:
+            swap_ab = default_plan.swap_ab if mma_tiler_mn[1] < 64 else False
+    assert load_path is not None
+    assert swap_ab is not None
+    b_launch_torch = b_torch
+    if rhs_values_tiled is not None:
+        tile_n = 0
+        supported_plan = False
+        if (n, k, l) == (1024, 4096, 4):
+            tile_n = 64
+            supported_plan = mma_tiler_mn in ((16, 64), (32, 64), (64, 64))
+        elif (n, k, l) == (4096, 4096, 1):
+            tile_n = 128
+            supported_plan = mma_tiler_mn in (
+                (16, 128),
+                (32, 64),
+                (32, 128),
+            )
+        if not is_mxfp8 or not supported_plan or swap_ab or load_path != "tma":
+            raise ValueError(
+                "tile-major MXFP8 RHS is restricted to production WO-A/WO-B "
+                "Ntile/BK128 TMA plans"
+            )
+        expected_tiled_shape = (l, n // tile_n, k // 128, tile_n, 128)
+        if (
+            rhs_values_tiled.shape != expected_tiled_shape
+            or rhs_values_tiled.dtype != b_torch.dtype
+            or rhs_values_tiled.device != b_torch.device
+            or not rhs_values_tiled.is_contiguous()
+        ):
+            raise ValueError(
+                "tile-major MXFP8 RHS must be contiguous with shape "
+                f"{expected_tiled_shape}, dtype {b_torch.dtype}, and device "
+                f"{b_torch.device}; got shape={tuple(rhs_values_tiled.shape)}, "
+                f"dtype={rhs_values_tiled.dtype}, device={rhs_values_tiled.device}"
+            )
+        b_launch_torch = rhs_values_tiled
+    if is_mxfp8:
+        _validate_mxfp8_bk64_plan(tile_k, mma_tiler_mn, swap_ab)
+    # k-reuse relies on SFB being the 128x128-block weight operand; with
+    # swap_ab the smem B slot holds activations, so force it off there.
+    sfb_k_reuse = bool(sfb_k_replicated) and not swap_ab and is_mxfp8
+    if alpha_dtype is None:
+        alpha_dtype = "float32" if alpha is None else str(alpha.dtype).split(".")[-1]
+    policy = _dense_gemm_policy_for(
+        m=m,
+        n=n,
+        k=k,
+        l=l,
+        ab_dtype=ab_cutlass_dtype,
+        c_dtype=c_cutlass_dtype,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        sm_count=sm_count,
+        expected_m=expected_m,
+    )
+    split_k_slices = policy.split_k_slices
+    if swap_ab and split_k_slices != 1:
+        policy = _DenseGemmPolicy(
+            single_work_tile_per_cta=policy.single_work_tile_per_cta,
+            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
+            use_m1_non_tma=policy.use_m1_non_tma,
+            split_k_slices=1,
+            split_k_atomic_bf16=False,
+            large_m_unroll=policy.large_m_unroll,
+        )
+        split_k_slices = 1
+    split_k_output = split_k_slices > 1
+    split_k_atomic_bf16 = split_k_output and policy.split_k_atomic_bf16
+    if split_k_atomic_bf16:
+        kernel_c_l = l
+    elif split_k_output:
+        kernel_c_l = split_k_slices
+    else:
+        kernel_c_l = l
+    alpha_is_one = alpha is None
+    if alpha is None:
+        alpha = _cached_alpha_one(a_torch.device)
+    stream_int = cuda_stream_to_int(stream)
+    kernel_c_dtype_name = (
+        "float32" if split_k_output and not split_k_atomic_bf16 else c_dtype
+    )
+    if _quantized_c is not None:
+        quant_c_values, quant_c_scale_rows, quant_c_scale_mma = _quantized_c
+        quant_c_width = n * l
+        expected_scale_mma_shape = (
+            32,
+            4,
+            1,
+            4,
+            quant_c_width // 128,
+            1,
+        )
+        if (
+            split_k_output
+            or swap_ab
+            or c_dtype != "bfloat16"
+            or m < 1
+            or m > 16
+            or n % 32 != 0
+            or quant_c_width % 128 != 0
+            or mma_tiler_mn[1] != 64
+            or quant_c_values.shape != (m, quant_c_width)
+            or not quant_c_values.is_contiguous()
+            or quant_c_values.dtype != torch.float8_e4m3fn
+            or quant_c_scale_rows.shape != (m, quant_c_width // 32)
+            or not quant_c_scale_rows.is_contiguous()
+            or quant_c_scale_rows.dtype != torch.float8_e8m0fnu
+            or quant_c_scale_mma.shape != expected_scale_mma_shape
+            or quant_c_scale_mma.dtype != torch.float8_e8m0fnu
+        ):
+            raise ValueError("quantized C is restricted to the BF16 WO-A decode layout")
+        if out is None:
+            out = _empty_dense_gemm_output(
+                m,
+                n,
+                l,
+                dtype=torch.bfloat16,
+                device=a_torch.device,
+            )
+        compiled_quant_c = _get_compiled_dense_gemm(
+            n=n,
+            k=k,
+            l=l,
+            c_l=kernel_c_l,
+            a_major="k",
+            b_major="k",
+            c_major="n",
+            ab_dtype=ab_cutlass_dtype,
+            sf_dtype=get_cutlass_dtype(sf_dtype),
+            c_dtype=c_cutlass_dtype,
+            alpha_dtype=get_cutlass_dtype(alpha_dtype),
+            sf_vec_size=sf_vec_size,
+            mma_k=mma_k,
+            tile_k=tile_k,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            policy=policy,
+            sm_count=sm_count,
+            sm_version="sm_120",
+            load_path=load_path,
+            swap_ab=swap_ab,
+            sfb_k_reuse=sfb_k_reuse,
+            b_tile_major=rhs_values_tiled is not None,
+            quantize_c=True,
+            alpha_is_one=alpha_is_one,
+            direct_sfa_live16=_use_direct_sfa_live16(
+                m=m,
+                n=n,
+                k=k,
+                l=l,
+                sf_vec_size=sf_vec_size,
+                tile_k=tile_k,
+                mma_tiler_mn=mma_tiler_mn,
+                load_path=load_path,
+                swap_ab=swap_ab,
+                b_tile_major=rhs_values_tiled is not None,
+                sfb_k_reuse=sfb_k_reuse,
+                alpha_is_one=alpha_is_one,
+                is_mxfp8=is_mxfp8,
+            ),
+        )
+        return compiled_quant_c(
+            a_tensor_gpu=a_torch,
+            b_tensor_gpu=b_launch_torch,
+            sfa_tensor_gpu=sfa_torch,
+            sfb_tensor_gpu=sfb_torch,
+            c_tensor_gpu=out,
+            alpha_tensor_gpu=alpha,
+            stream_int=stream_int,
+            quant_c_values_gpu=quant_c_values,
+            quant_c_scale_rows_gpu=quant_c_scale_rows,
+            quant_c_scale_mma_gpu=quant_c_scale_mma,
+        )
+    if out is None:
+        # No caller-owned output buffer: functional launch (allocate + return
+        # inside the opaque op). The compile graph then carries no
+        # auto_functionalized dense node mutating a (possibly strided) caller
+        # view -- which inductor's decompose pass cannot remove. No is_compiling;
+        # purely caller-intent, behaviorally identical to the eager out=None path.
+        return torch.ops.flashinfer_sm12x.dense_gemm_launch_functional(
+            a_torch,
+            b_launch_torch,
+            sfa_torch,
+            sfb_torch,
+            alpha,
+            n,
+            k,
+            l,
+            kernel_c_l,
+            ab_dtype,
+            sf_dtype,
+            c_dtype,
+            kernel_c_dtype_name,
+            alpha_dtype,
+            sf_vec_size,
+            mma_k,
+            tile_k,
+            mma_tiler_mn[0],
+            mma_tiler_mn[1],
+            cluster_shape_mn[0],
+            cluster_shape_mn[1],
+            sm_count,
+            policy.single_work_tile_per_cta,
+            policy.direct_one_m_tile_scheduler,
+            policy.use_m1_non_tma,
+            policy.split_k_slices,
+            policy.split_k_atomic_bf16,
+            policy.large_m_unroll,
+            load_path,
+            swap_ab,
+            sfb_k_reuse,
+            alpha_is_one,
+            stream_int,
+        )
+    split_storage = None
+    split_scratch = None
+    if split_k_output:
+        if out is None:
+            out = torch.empty(
+                (m, n, l),
+                dtype=cutlass_to_torch_dtype(c_cutlass_dtype),
+                device=a_torch.device,
+            )
+        if split_k_atomic_bf16:
+            out.zero_()
+        else:
+            split_storage = torch.empty(
+                (split_k_slices, m, n),
+                dtype=torch.float32,
+                device=a_torch.device,
+            )
+            split_scratch = split_storage.permute(1, 2, 0)
+    elif out is None:
+        out = torch.empty(
+            (m, n, l),
+            dtype=cutlass_to_torch_dtype(c_cutlass_dtype),
+            device=a_torch.device,
+        )
+    if alpha is None:
+        alpha = _cached_alpha_one(a_torch.device)
+
+    t0 = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    cache_before = (
+        _get_compiled_dense_gemm.cache_info() if _FLASHINFER_EXP_SM12X_TIMING else None
+    )
+    t_compiled = t0
+    kernel_c_dtype_name = (
+        "float32" if split_k_output and not split_k_atomic_bf16 else c_dtype
+    )
+    c_tensor_gpu = (
+        out if split_k_atomic_bf16 else split_scratch if split_k_output else out
+    )
+    assert c_tensor_gpu is not None
+    torch.ops.flashinfer_sm12x.dense_gemm_launch(
+        a_torch,
+        b_launch_torch,
+        sfa_torch,
+        sfb_torch,
+        c_tensor_gpu,
+        alpha,
+        n,
+        k,
+        l,
+        kernel_c_l,
+        ab_dtype,
+        sf_dtype,
+        kernel_c_dtype_name,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tiler_mn[0],
+        mma_tiler_mn[1],
+        cluster_shape_mn[0],
+        cluster_shape_mn[1],
+        sm_count,
+        policy.single_work_tile_per_cta,
+        policy.direct_one_m_tile_scheduler,
+        policy.use_m1_non_tma,
+        policy.split_k_slices,
+        policy.split_k_atomic_bf16,
+        policy.large_m_unroll,
+        load_path,
+        swap_ab,
+        sfb_k_reuse,
+        alpha_is_one,
+        stream_int,
+    )
+    result = out
+    if split_k_output and not split_k_atomic_bf16:
+        assert split_scratch is not None
+        assert out is not None
+        _reduce_split_k2_bf16(split_scratch, out, m=m, n=n)
+        result = out
+    if _FLASHINFER_EXP_SM12X_TIMING:
+        t_launch = time.perf_counter()
+        cache_after = _get_compiled_dense_gemm.cache_info()
+        assert cache_before is not None
+        compile_ms = (t_compiled - t0) * 1000.0
+        launch_ms = (t_launch - t_compiled) * 1000.0
+        total_ms = (t_launch - t0) * 1000.0
+        if total_ms >= _FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS:
+            logger.warning(
+                "sm12x_dense_gemm timing m=%d n=%d k=%d l=%d ab=%s sf=%s c=%s "
+                "tile=%s load=%s swap_ab=%s cache_hit=%s compile_or_lookup=%.3fms "
+                "launch_enqueue=%.3fms total=%.3fms cache=%s",
+                m,
+                n,
+                k,
+                l,
+                ab_dtype,
+                sf_dtype,
+                c_dtype,
+                mma_tiler_mn,
+                load_path,
+                swap_ab,
+                cache_after.hits > cache_before.hits,
+                compile_ms,
+                launch_ms,
+                total_ms,
+                cache_after,
+            )
+    return result

--- a/flashinfer/experimental/sm12x/_lib/env.py
+++ b/flashinfer/experimental/sm12x/_lib/env.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Environment-variable conventions for flashinfer.experimental.sm12x.
+
+All sm12x tuning knobs use the ``FLASHINFER_EXP_SM12X_`` prefix.  Deployments
+tuned against upstream b12x may still carry ``B12X_*`` variables; on first use
+we copy those values onto their new names (never overwriting an explicitly set
+new-style variable) and emit a single DeprecationWarning naming the mapping.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+
+PREFIX = "FLASHINFER_EXP_SM12X_"
+_LEGACY_PREFIX = "B12X_"
+
+# Legacy suffixes whose new-style suffix is not a verbatim carry-over.
+_LEGACY_COMPILE_PREFIX = "CUTE_COMPILE_"  # B12X_CUTE_COMPILE_X -> ..._COMPILE_X
+_LEGACY_SPECIAL = {
+    "VLLM_ENGINE_STARTED": "ENGINE_STARTED",
+}
+
+_synced = False
+
+
+def _new_name(legacy_suffix: str) -> str:
+    if legacy_suffix in _LEGACY_SPECIAL:
+        return PREFIX + _LEGACY_SPECIAL[legacy_suffix]
+    if legacy_suffix.startswith(_LEGACY_COMPILE_PREFIX):
+        return PREFIX + "COMPILE_" + legacy_suffix[len(_LEGACY_COMPILE_PREFIX) :]
+    return PREFIX + legacy_suffix
+
+
+def sync_legacy_env() -> None:
+    """Copy ``B12X_*`` values onto ``FLASHINFER_EXP_SM12X_*`` names (once).
+
+    Explicitly-set new-style variables always win.  Runs at first import of
+    the sm12x compiler so every ported ``os.environ`` read observes the
+    mapped values.
+    """
+    global _synced
+    if _synced:
+        return
+    _synced = True
+    mapped: list[str] = []
+    for key in sorted(os.environ):
+        if not key.startswith(_LEGACY_PREFIX):
+            continue
+        new = _new_name(key[len(_LEGACY_PREFIX) :])
+        if new not in os.environ:
+            os.environ[new] = os.environ[key]
+            mapped.append(f"{key} -> {new}")
+    if mapped:
+        warnings.warn(
+            "flashinfer.experimental.sm12x picked up legacy b12x environment "
+            "variables and mapped them to their new names: "
+            + "; ".join(mapped)
+            + ". Rename these to their FLASHINFER_EXP_SM12X_* forms.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+
+def env_raw(suffix: str) -> str | None:
+    """Read an sm12x knob by suffix, e.g. ``env_raw("MLA_FORCE_SPLIT")``."""
+    sync_legacy_env()
+    return os.environ.get(PREFIX + suffix)
+
+
+def env_flag(suffix: str, *, default: bool = False) -> bool:
+    raw = env_raw(suffix)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+__all__ = ["PREFIX", "sync_legacy_env", "env_raw", "env_flag"]

--- a/flashinfer/experimental/sm12x/_lib/gating.py
+++ b/flashinfer/experimental/sm12x/_lib/gating.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Capability gating for flashinfer.experimental.sm12x.
+
+Deliberately vendored (not imported from flashinfer core): the experimental
+tree has a zero-outbound-imports rule so that core refactors can never break
+it, enforced by tests/experimental/lint/test_isolation.py.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import re
+
+MIN_CUTLASS_DSL = "4.6.0"
+
+
+def get_compute_capability(device=None) -> tuple[int, int] | None:
+    import torch
+
+    if not torch.cuda.is_available():
+        return None
+    dev = torch.device(device) if device is not None else torch.device("cuda")
+    if dev.type != "cuda":
+        return None
+    return torch.cuda.get_device_capability(dev)
+
+
+def is_sm12x(device=None) -> bool:
+    """True when the target device is consumer Blackwell (SM120/SM121)."""
+    cap = get_compute_capability(device)
+    return cap is not None and cap[0] == 12 and cap[1] in (0, 1)
+
+
+def _version_tuple(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", text)[:3])
+
+
+def cutlass_dsl_version() -> str | None:
+    for dist in ("nvidia-cutlass-dsl", "cutlass"):
+        try:
+            return importlib.metadata.version(dist)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return None
+
+
+def has_cutlass_dsl(minimum: str = MIN_CUTLASS_DSL) -> bool:
+    version = cutlass_dsl_version()
+    return version is not None and _version_tuple(version) >= _version_tuple(minimum)
+
+
+def require_cutlass_dsl(minimum: str = MIN_CUTLASS_DSL) -> None:
+    version = cutlass_dsl_version()
+    if version is None:
+        raise ImportError(
+            "flashinfer.experimental.sm12x requires nvidia-cutlass-dsl "
+            f">= {minimum} (not installed). Install with: "
+            f"pip install 'nvidia-cutlass-dsl>={minimum}'"
+        )
+    if _version_tuple(version) < _version_tuple(minimum):
+        raise ImportError(
+            f"flashinfer.experimental.sm12x requires nvidia-cutlass-dsl >= {minimum}, "
+            f"found {version}. Upgrade with: pip install 'nvidia-cutlass-dsl>={minimum}'"
+        )
+
+
+def has_triton() -> bool:
+    return importlib.util.find_spec("triton") is not None
+
+
+def require_triton(op: str) -> None:
+    if not has_triton():
+        raise ImportError(
+            f"flashinfer.experimental.sm12x.{op} requires triton (bundled with "
+            "torch on Linux x86-64; install it explicitly on other platforms)."
+        )
+
+
+def _requirement_met(requirement: str) -> bool:
+    if requirement == "triton":
+        return has_triton()
+    if requirement == "multi_gpu":
+        import torch
+
+        return torch.cuda.is_available() and torch.cuda.device_count() >= 2
+    raise ValueError(f"unknown op requirement {requirement!r}")
+
+
+def default_is_supported(device=None, *, requires: tuple[str, ...] = ()) -> bool:
+    """The standard ``is_supported`` used by ops without extra constraints."""
+    if not is_sm12x(device):
+        return False
+    if not has_cutlass_dsl():
+        return False
+    return all(_requirement_met(req) for req in requires)
+
+
+__all__ = [
+    "MIN_CUTLASS_DSL",
+    "get_compute_capability",
+    "is_sm12x",
+    "cutlass_dsl_version",
+    "has_cutlass_dsl",
+    "require_cutlass_dsl",
+    "has_triton",
+    "require_triton",
+    "default_is_supported",
+]

--- a/flashinfer/experimental/sm12x/_lib/intrinsics.py
+++ b/flashinfer/experimental/sm12x/_lib/intrinsics.py
@@ -1,0 +1,5803 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/cute/intrinsics.py @ c15e29d8 (2026-07-20) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Common utilities for FP4 quantization kernels.
+
+This module contains shared PTX intrinsics, helper functions, and reduction
+utilities used by the fused frontend kernels.
+"""
+
+import functools
+import math
+import operator
+from typing import Callable, Tuple
+
+import cutlass
+import cutlass.cute as cute
+import torch
+import torch.nn.functional as F
+from cutlass import Float32, Int32, Int64, Uint8, Uint16, Uint32, Uint64
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+FLOAT4_E2M1_MAX = 6.0  # Maximum value representable in FP4 E2M1
+FLOAT8_E4M3_MAX = 448.0  # Maximum value representable in FP8 E4M3
+SF_VEC_SIZE = 16  # Elements per scale factor block
+COPY_BITS = 128  # 128-bit vectorized loads
+_FP4_MAG_LUT = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+def align_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def make_swizzle_indices(
+    rows_padded: int, cols_padded: int, device: torch.device
+) -> torch.Tensor:
+    """Pre-compute swizzle gather indices for FP8 block-scale factors."""
+    numel = rows_padded * cols_padded
+    idx = torch.arange(numel, device=device)
+    idx_5d = idx.reshape(rows_padded // 128, 4, 32, cols_padded // 4, 4)
+    return idx_5d.permute(0, 3, 2, 1, 4).contiguous().reshape(-1)
+
+
+def swizzle_block_scale(scale: torch.Tensor) -> torch.Tensor:
+    if scale.ndim == 2:
+        scale = scale.unsqueeze(0)
+        squeeze_batch = True
+    elif scale.ndim == 3:
+        squeeze_batch = False
+    else:
+        raise ValueError(f"scale must be 2D or 3D, got {tuple(scale.shape)}")
+
+    batch, rows, cols = scale.shape
+    rows_padded = align_up(rows, 128)
+    cols_padded = align_up(cols, 4)
+
+    padded = torch.zeros(
+        (batch, rows_padded, cols_padded), dtype=scale.dtype, device=scale.device
+    )
+    padded[:, :rows, :cols] = scale
+    swizzled = padded.reshape(batch, rows_padded // 128, 4, 32, cols_padded // 4, 4)
+    swizzled = swizzled.permute(0, 1, 4, 3, 2, 5).contiguous()
+    swizzled = swizzled.reshape(batch, rows_padded, cols_padded)
+    return swizzled[0] if squeeze_batch else swizzled
+
+
+def as_grouped_scale_view(
+    scale_storage: torch.Tensor, rows: int, cols: int
+) -> torch.Tensor:
+    batch = scale_storage.shape[0]
+    rows_padded = align_up(rows, 128)
+    cols_padded = align_up(cols // SF_VEC_SIZE, 4)
+    sf = scale_storage.view(torch.float8_e4m3fn)
+    sf = sf.view(batch, rows_padded // 128, cols_padded // 4, 32, 4, 4)
+    return sf.permute(3, 4, 1, 5, 2, 0)
+
+
+def as_grouped_scale_view_mx(
+    scale_storage: torch.Tensor, rows: int, cols: int
+) -> torch.Tensor:
+    """Grouped UE8M0 scale view for vec32 (MXFP8 w4a8) block scales."""
+    batch = scale_storage.shape[0]
+    rows_padded = align_up(rows, 128)
+    cols_padded = align_up(cols // 32, 4)
+    sf = scale_storage.view(torch.float8_e8m0fnu)
+    sf = sf.view(batch, rows_padded // 128, cols_padded // 4, 32, 4, 4)
+    return sf.permute(3, 4, 1, 5, 2, 0)
+
+
+def _fp4_quantize_values(x: torch.Tensor) -> torch.Tensor:
+    sign = torch.sign(x)
+    x = torch.abs(x.clone())
+    x[(x >= 0.0) & (x <= 0.25)] = 0.0
+    x[(x > 0.25) & (x < 0.75)] = 0.5
+    x[(x >= 0.75) & (x <= 1.25)] = 1.0
+    x[(x > 1.25) & (x < 1.75)] = 1.5
+    x[(x >= 1.75) & (x <= 2.5)] = 2.0
+    x[(x > 2.5) & (x < 3.5)] = 3.0
+    x[(x >= 3.5) & (x <= 5.0)] = 4.0
+    x[x > 5.0] = 6.0
+    return x * sign
+
+
+def fp4_quantize_values_torch(x: torch.Tensor) -> torch.Tensor:
+    """Pure-Torch FP4 E2M1 quantization with kernel-matching tie-breaking."""
+    return _fp4_quantize_values(x)
+
+
+def _fp4_encode_nibbles(values: torch.Tensor) -> torch.Tensor:
+    mags = values.abs()
+    idx = torch.zeros_like(values, dtype=torch.uint8)
+    for code, mag in enumerate(_FP4_MAG_LUT):
+        idx = torch.where(mags == mag, torch.full_like(idx, code), idx)
+    sign_bit = (values < 0).to(torch.uint8) << 3
+    return idx | sign_bit
+
+
+def pack_grouped_fp4_values(values: torch.Tensor) -> torch.Tensor:
+    """Pack grouped FP4 values `[G, R, C]` into uint8 `[R, C/2, G]`."""
+    nibbles = _fp4_encode_nibbles(values)
+    packed = nibbles.view(values.shape[0], values.shape[1], values.shape[2] // 2, 2)
+    packed = packed[..., 0] | (packed[..., 1] << 4)
+    return packed.permute(1, 2, 0).contiguous()
+
+
+def _reciprocal_or_zero_torch(value: torch.Tensor) -> torch.Tensor:
+    """Match device quantizers, which map an unrepresentable zero scale to zero."""
+    return torch.where(value == 0, torch.zeros_like(value), 1.0 / value)
+
+
+def quantize_grouped_nvfp4_torch(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+    global_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-Torch grouped NVFP4 quantization with reciprocal global scales."""
+    num_groups, rows, cols = input_tensor.shape
+    if cols % SF_VEC_SIZE != 0:
+        raise ValueError(f"cols must be divisible by {SF_VEC_SIZE}, got {cols}")
+    if global_scale.numel() == 1:
+        global_scale = global_scale.expand(num_groups).contiguous()
+
+    quantized = torch.zeros(
+        (num_groups, rows, cols), dtype=torch.float32, device=input_tensor.device
+    )
+    scales = torch.zeros(
+        (num_groups, rows, cols // SF_VEC_SIZE),
+        dtype=torch.float32,
+        device=input_tensor.device,
+    )
+    for group_idx in range(num_groups):
+        valid_rows = int(row_counts[group_idx].item())
+        if valid_rows == 0:
+            continue
+        x = input_tensor[group_idx, :valid_rows].float()
+        sliced = x.view(valid_rows, cols // SF_VEC_SIZE, SF_VEC_SIZE)
+        block_max = sliced.abs().amax(dim=-1, keepdim=True).to(torch.float32)
+        scale = (
+            (global_scale[group_idx] * (block_max / FLOAT4_E2M1_MAX))
+            .to(torch.float8_e4m3fn)
+            .to(torch.float32)
+        )
+        output_scale = _reciprocal_or_zero_torch(
+            scale * _reciprocal_or_zero_torch(global_scale[group_idx])
+        )
+        clipped = torch.clamp(
+            sliced * output_scale, -FLOAT4_E2M1_MAX, FLOAT4_E2M1_MAX
+        ).view(valid_rows, cols)
+        quantized[group_idx, :valid_rows] = _fp4_quantize_values(clipped)
+        scales[group_idx, :valid_rows] = scale.squeeze(-1)
+
+    packed = pack_grouped_fp4_values(quantized)
+    swizzled = swizzle_block_scale(scales.to(torch.float8_e4m3fn))
+    scale_view = as_grouped_scale_view(swizzled.view(torch.uint8), rows, cols)
+    return packed, scale_view
+
+
+def silu_mul_quantize_grouped_nvfp4_torch(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+    global_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cols = input_tensor.shape[-1] // 2
+    left = input_tensor[..., :cols].float()
+    right = input_tensor[..., cols:].float()
+    activated = (F.silu(left) * right).to(input_tensor.dtype).to(torch.float32)
+    return quantize_grouped_nvfp4_torch(activated, row_counts, global_scale)
+
+
+def relu2_quantize_grouped_nvfp4_torch(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+    global_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-Torch grouped NVFP4 quantization for ReLU^2 FC1 outputs."""
+    activated = torch.square(F.relu(input_tensor.float()))
+    activated = activated.to(input_tensor.dtype).to(torch.float32)
+    return quantize_grouped_nvfp4_torch(activated, row_counts, global_scale)
+
+
+MX_SF_VEC_SIZE = 32  # Elements per UE8M0 scale block (MXFP8 w4a8 activations)
+_INV_FLOAT8_E4M3_MAX = 1.0 / FLOAT8_E4M3_MAX
+
+
+def pow2_ceil_ue8m0_torch(scale: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Bit-exact Torch replica of the ``pow2_ceil_ue8m0`` device intrinsic.
+
+    Rounds positive fp32 scales UP to a power of two by bumping the exponent
+    whenever the mantissa is nonzero.  Returns ``(rounded_fp32, ue8m0_u8)``;
+    a zero scale maps to (0.0, byte 0).
+    """
+    bits = scale.to(torch.float32).contiguous().view(torch.int32)
+    mant = bits & 0x007FFFFF
+    bumped = torch.where(mant != 0, (bits + 0x00800000) & 0x7F800000, bits)
+    rounded = bumped.view(torch.float32)
+    byte = ((bumped >> 23) & 0xFF).to(torch.uint8)
+    return rounded, byte
+
+
+def _ue8m0_output_scale_torch(byte: torch.Tensor) -> torch.Tensor:
+    """Torch replica of ``ue8m0_to_output_scale``: 2^(127-byte), 0 for byte 0."""
+    inv_bits = (254 - byte.to(torch.int32)).clamp(min=0) << 23
+    inv = inv_bits.view(torch.float32)
+    return torch.where(byte == 0, torch.zeros_like(inv), inv)
+
+
+def quant_dequant_mxfp8_torch(x: torch.Tensor) -> torch.Tensor:
+    """Per-32-block MXFP8 quantize-dequantize roundtrip (oracle helper).
+
+    Matches the in-kernel ``quantize_block_fp8_mx`` numerics bit-for-bit:
+    UE8M0 ceil block scale, E4M3 RN-saturating payload.
+    """
+    orig_shape = x.shape
+    cols = orig_shape[-1]
+    if cols % MX_SF_VEC_SIZE != 0:
+        raise ValueError(f"last dim must be divisible by {MX_SF_VEC_SIZE}, got {cols}")
+    blocked = x.to(torch.float32).reshape(-1, cols // MX_SF_VEC_SIZE, MX_SF_VEC_SIZE)
+    block_max = blocked.abs().amax(dim=-1, keepdim=True)
+    rounded, byte = pow2_ceil_ue8m0_torch(block_max * _INV_FLOAT8_E4M3_MAX)
+    inv = _ue8m0_output_scale_torch(byte)
+    payload = (
+        (blocked * inv)
+        .clamp(-FLOAT8_E4M3_MAX, FLOAT8_E4M3_MAX)
+        .to(torch.float8_e4m3fn)
+        .to(torch.float32)
+    )
+    return (payload * rounded).reshape(orig_shape)
+
+
+def quantize_grouped_mxfp8_torch(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-Torch grouped MXFP8 quantization (no global scale).
+
+    Mirrors ``quantize_grouped_nvfp4_torch`` for the w4a8 activation path:
+    returns ``(payload, scale_view)`` where ``payload`` is E4M3 bytes in
+    ``[R, C, G]`` order and ``scale_view`` is the swizzled UE8M0 grouped
+    view (vec32 columns).
+    """
+    num_groups, rows, cols = input_tensor.shape
+    if cols % MX_SF_VEC_SIZE != 0:
+        raise ValueError(f"cols must be divisible by {MX_SF_VEC_SIZE}, got {cols}")
+
+    payload = torch.zeros(
+        (num_groups, rows, cols), dtype=torch.uint8, device=input_tensor.device
+    )
+    scales = torch.zeros(
+        (num_groups, rows, cols // MX_SF_VEC_SIZE),
+        dtype=torch.uint8,
+        device=input_tensor.device,
+    )
+    for group_idx in range(num_groups):
+        valid_rows = int(row_counts[group_idx].item())
+        if valid_rows == 0:
+            continue
+        x = input_tensor[group_idx, :valid_rows].float()
+        blocked = x.view(valid_rows, cols // MX_SF_VEC_SIZE, MX_SF_VEC_SIZE)
+        block_max = blocked.abs().amax(dim=-1, keepdim=True)
+        rounded, byte = pow2_ceil_ue8m0_torch(block_max * _INV_FLOAT8_E4M3_MAX)
+        inv = _ue8m0_output_scale_torch(byte)
+        q = (
+            (blocked * inv)
+            .clamp(-FLOAT8_E4M3_MAX, FLOAT8_E4M3_MAX)
+            .to(torch.float8_e4m3fn)
+            .view(torch.uint8)
+            .view(valid_rows, cols)
+        )
+        payload[group_idx, :valid_rows] = q
+        scales[group_idx, :valid_rows] = byte.squeeze(-1)
+
+    payload_view = payload.permute(1, 2, 0).contiguous()
+    swizzled = swizzle_block_scale(scales)
+    scale_view = as_grouped_scale_view_mx(swizzled, rows, cols)
+    return payload_view, scale_view
+
+
+def silu_mul_quantize_grouped_mxfp8_torch(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """SiLU(left)*right then grouped MXFP8 quantization (w4a8 FC2 input)."""
+    cols = input_tensor.shape[-1] // 2
+    left = input_tensor[..., :cols].float()
+    right = input_tensor[..., cols:].float()
+    activated = (F.silu(left) * right).to(input_tensor.dtype).to(torch.float32)
+    return quantize_grouped_mxfp8_torch(activated, row_counts)
+
+
+def relu2_quantize_grouped_mxfp8_torch(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """ReLU^2 then grouped MXFP8 quantization (w4a8 FC2 input, non-gated)."""
+    activated = torch.square(F.relu(input_tensor.float()))
+    activated = activated.to(input_tensor.dtype).to(torch.float32)
+    return quantize_grouped_mxfp8_torch(activated, row_counts)
+
+
+# =============================================================================
+# Architecture Detection
+# =============================================================================
+
+
+@functools.lru_cache(maxsize=16)
+def get_sm_version(device: int | torch.device | str | None = None) -> int:
+    """Get the SM version of a CUDA device.
+
+    Args:
+        device: CUDA device to query. Can be an int (device index), torch.device,
+            device string (e.g., 'cuda:0'), or None to use current device.
+
+    Returns:
+        SM version as an integer (e.g., 120 on the current target).
+    """
+    if not torch.cuda.is_available():
+        return 80
+    if device is None:
+        device = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device)
+    return props.major * 10 + props.minor
+
+
+# =============================================================================
+# PTX Intrinsics - Cluster Operations
+# =============================================================================
+
+
+@dsl_user_op
+def set_block_rank(
+    smem_ptr: cute.Pointer, peer_cta_rank_in_cluster: Int32, *, loc=None, ip=None
+) -> Int32:
+    """Map smem pointer to address at another CTA rank in the cluster."""
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr_i32, peer_cta_rank_in_cluster.ir_value()],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def store_shared_remote(
+    val: Float32,
+    smem_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: Int32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    """Store Float32 value to shared memory on a remote CTA in the cluster."""
+    remote_smem_ptr_i32 = set_block_rank(
+        smem_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    remote_mbar_ptr_i32 = set_block_rank(
+        mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    llvm.inline_asm(
+        None,
+        [remote_smem_ptr_i32, val.ir_value(loc=loc, ip=ip), remote_mbar_ptr_i32],
+        "st.async.shared::cluster.mbarrier::complete_tx::bytes.f32 [$0], $1, [$2];",
+        "r,f,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def elem_pointer(x: cute.Tensor, coord, *, loc=None, ip=None) -> cute.Pointer:
+    """Get pointer to element at coordinate in tensor."""
+    return x.iterator + cute.crd2idx(coord, x.layout, loc=loc, ip=ip)
+
+
+# =============================================================================
+# PTX Intrinsics - 128-bit Vectorized Global Loads/Stores
+# =============================================================================
+
+
+@dsl_user_op
+def ld_global_v4_u32(
+    base_ptr: Int64, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Load 128 bits (4 x uint32) from global memory."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+        "ld.global.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+    v0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    v1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    v2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    v3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+
+    return Uint32(v0), Uint32(v1), Uint32(v2), Uint32(v3)
+
+
+# =============================================================================
+# PTX Intrinsics - Non-Coherent Global Loads
+# =============================================================================
+
+
+@dsl_user_op
+def ld_global_nc_u32(base_ptr: Int64, *, loc=None, ip=None) -> Uint32:
+    """Load 32 bits from global memory via non-coherent cache (.nc)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+            "ld.global.nc.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_global_b16(base_ptr: Int64, *, loc=None, ip=None) -> Uint32:
+    """Load one 16-bit global-memory payload into a 32-bit register.
+
+    PTX permits a bit-typed load into a wider bit register.  This is the form
+    emitted by FlashInfer for the DSV4 RoPE gather and avoids rounding the
+    address down to a word followed by a runtime halfword select.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+            "ld.global.b16 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def prefetch_global_l2(base_ptr: Int64, *, loc=None, ip=None) -> None:
+    """Prefetch a global memory line into L2."""
+    llvm.inline_asm(
+        None,
+        [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+        "prefetch.global.L2 [$0];",
+        "l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def ld_global_nc_v2_u32(base_ptr: Int64, *, loc=None, ip=None) -> Tuple[Uint32, Uint32]:
+    """Load 64 bits (2 x uint32) from global memory via non-coherent cache (.nc)."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+        "ld.global.nc.v2.u32 {$0, $1}, [$2];",
+        "=r,=r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def ld_global_nc_v4_u32(
+    base_ptr: Int64, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Load 128 bits (4 x uint32) from global memory via non-coherent cache (.nc)."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+        "ld.global.nc.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def st_global_u64(base_ptr: Int64, value: Uint64, *, loc=None, ip=None):
+    """Store 64 bits to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Uint64(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.u64 [$0], $1;",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def st_global_u8(base_ptr: Int64, value: Uint8, *, loc=None, ip=None):
+    """Store 8 bits to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Uint8(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.u8 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def st_global_f32(base_ptr: Int64, value: Float32, *, loc=None, ip=None):
+    """Store 32-bit float to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Float32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.f32 [$0], $1;",
+        "l,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def st_global_v2_f32(base_ptr: Int64, v0: Float32, v1: Float32, *, loc=None, ip=None):
+    """Store 64 bits (2 x float32) to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Float32(v0).ir_value(loc=loc, ip=ip),
+            Float32(v1).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.v2.f32 [$0], {$1, $2};",
+        "l,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def st_global_v4_f32(
+    base_ptr: Int64,
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store 128 bits (4 x float32) to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Float32(v0).ir_value(loc=loc, ip=ip),
+            Float32(v1).ir_value(loc=loc, ip=ip),
+            Float32(v2).ir_value(loc=loc, ip=ip),
+            Float32(v3).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.v4.f32 [$0], {$1, $2, $3, $4};",
+        "l,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def ld_global_v4_f32(
+    base_ptr: Int64,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Load 128 bits (4 x float32) from global memory."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+        "ld.global.v4.f32 {$0, $1, $2, $3}, [$4];",
+        "=f,=f,=f,=f,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def st_global_u32(
+    base_ptr: Int64,
+    value: Uint32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store one uint32 to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Uint32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_global_v4_u32(
+    base_ptr: Int64,
+    v0: Uint32,
+    v1: Uint32,
+    v2: Uint32,
+    v3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store 128 bits (4 x uint32) to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Uint32(v0).ir_value(loc=loc, ip=ip),
+            Uint32(v1).ir_value(loc=loc, ip=ip),
+            Uint32(v2).ir_value(loc=loc, ip=ip),
+            Uint32(v3).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.v4.u32 [$0], {$1, $2, $3, $4};",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def smem_ptr_to_addr(ptr: cute.Pointer, *, loc=None, ip=None) -> Int32:
+    """Convert a generic/smem pointer to a shared-memory u32 address for PTX."""
+    generic_addr = llvm.ptrtoint(T.i64(), ptr.llvm_ptr, loc=loc, ip=ip)
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [generic_addr],
+            "cvta.to.shared.u32 $0, $1;",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def shared_ptr_to_u32(ptr: cute.Pointer, *, loc=None, ip=None) -> Int32:
+    """Convert an address-space-3 shared-memory pointer to a u32 address."""
+    return Int32(llvm.ptrtoint(T.i32(), ptr.llvm_ptr, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def ldmatrix_m8n8x4_b16(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Issue `ldmatrix.sync.aligned.m8n8.x4.shared.b16` from a shared-memory byte address."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1), Uint32(r2), Uint32(r3)
+
+
+@dsl_user_op
+def ld_shared_u16_offset(
+    smem_addr: Int32,
+    byte_offset: int,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint16:
+    """Load a shared halfword at a compile-time byte displacement.
+
+    Keeping the result as i16 lets NVVM select a PTX ``%rs`` operand and
+    avoids a redundant ``cvt.u16.u32`` before packed FP8 decode. Embedding the
+    displacement also avoids materializing one address register per unrolled
+    K step.
+    """
+    offset = int(byte_offset)
+    address = f"[$1+{offset}]" if offset else "[$1]"
+    return Uint16(
+        llvm.inline_asm(
+            T.i16(),
+            [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+            f"ld.shared.u16 $0, {address};",
+            "=h,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_shared_u8_offset(
+    smem_addr: Int32,
+    byte_offset: int,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """Load one shared byte at a compile-time displacement, zero-extended.
+
+    This is the native ``ld.shared.u8`` form used for UE8M0 scale tables.  A
+    common row base plus an immediate displacement keeps the unrolled scale
+    cache free of word-alignment, shift, and mask instructions.
+    """
+    offset = int(byte_offset)
+    address = f"[$1+{offset}]" if offset else "[$1]"
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+            f"ld.shared.u8 $0, {address};",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ldmatrix_m8n8x2_b16(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Issue `ldmatrix.sync.aligned.m8n8.x2.shared.b16` from a shared-memory byte address."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.m8n8.x2.shared.b16 {$0, $1}, [$2];",
+        "=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1)
+
+
+@dsl_user_op
+def ldmatrix_m8n8x4_left_half_b16(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Issue `ldmatrix.sync.aligned.m8n8.x4.shared.b16` and return the left half fragment pair."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {$0, _, $1, _}, [$2];",
+        "=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1)
+
+
+@dsl_user_op
+def ldmatrix_m8n8x4_right_half_b16(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Issue `ldmatrix.sync.aligned.m8n8.x4.shared.b16` and return the right half fragment pair."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {_, $0, _, $1}, [$2];",
+        "=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1)
+
+
+@dsl_user_op
+def ldmatrix_m8n8x4_trans_b16(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Issue `ldmatrix.sync.aligned.trans.m8n8.x4.shared.b16` from a shared-memory byte address."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.trans.m8n8.x4.shared.b16 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1), Uint32(r2), Uint32(r3)
+
+
+@dsl_user_op
+def ldmatrix_m8n8x4_trans_left_half_b16(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Issue transposed `ldmatrix` and return the left half fragment pair."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.trans.m8n8.x4.shared.b16 {$0, $1, _, _}, [$2];",
+        "=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1)
+
+
+@dsl_user_op
+def ldmatrix_m8n8x4_trans_right_half_b16(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Issue transposed `ldmatrix` and return the right half fragment pair."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.trans.m8n8.x4.shared.b16 {_, _, $0, $1}, [$2];",
+        "=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1)
+
+
+@dsl_user_op
+def ld_shared_v4_u32(
+    smem_addr: Int32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Load 128 bits (4 x uint32) from shared memory. smem_addr is a u32 shared-memory address."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ld.shared.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1), Uint32(r2), Uint32(r3)
+
+
+@dsl_user_op
+def ld_shared_v2_u32(smem_addr: Int32, *, loc=None, ip=None) -> Tuple[Uint32, Uint32]:
+    """Load 64 bits (2 x uint32) from shared memory."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ld.shared.v2.u32 {$0, $1}, [$2];",
+        "=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(r0), Uint32(r1)
+
+
+@dsl_user_op
+def st_shared_u64(smem_addr: Int32, value: Uint64, *, loc=None, ip=None):
+    """Store 64 bits to shared memory. smem_addr is a u32 shared-memory address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Uint64(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.u64 [$0], $1;",
+        "r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def st_shared_v4_u32(
+    smem_addr: Int32,
+    v0: Uint32,
+    v1: Uint32,
+    v2: Uint32,
+    v3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store 128 bits (4 x uint32) to shared memory. smem_addr is a u32 shared-memory address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Uint32(v0).ir_value(loc=loc, ip=ip),
+            Uint32(v1).ir_value(loc=loc, ip=ip),
+            Uint32(v2).ir_value(loc=loc, ip=ip),
+            Uint32(v3).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.v4.u32 [$0], {$1, $2, $3, $4};",
+        "r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cp_async_bulk_g2s_mbar(
+    smem_dst_u32: Int32,
+    gmem_src_i64: Int64,
+    nbytes: Int32,
+    mbar_u32: Int32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    """Emit cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes.
+
+    CTA-scope bulk g2s gather completing on a CTA-scope mbarrier. Mirrors
+    FlashInfer cp_async_bulk_g2s (sparse_mla_sm120/arch/cp_async.cuh:64-72)
+    exactly:
+        [$0]=smem dst (u32 shared addr), [$1]=gmem src (i64 generic),
+        $2=bytes (u32), [$3]=mbar (u32 shared addr).
+    Used by the IO warp of the DSV4/GLM sparse-MLA decode port to gather a
+    whole token row (e.g. 656B or 576B+8B) in one transaction.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_dst_u32).ir_value(loc=loc, ip=ip),
+            Int64(gmem_src_i64).ir_value(loc=loc, ip=ip),
+            Int32(nbytes).ir_value(loc=loc, ip=ip),
+            Int32(mbar_u32).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes"
+        " [$0], [$1], $2, [$3];",
+        "r,l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def create_l2_evict_first_policy(*, loc=None, ip=None) -> Uint64:
+    """Create an L2 evict-first policy for one-pass streaming cache rows."""
+    return Uint64(
+        llvm.inline_asm(
+            T.i64(),
+            [],
+            "createpolicy.fractional.L2::evict_first.b64 $0, 1.0;",
+            "=l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cp_async_bulk_g2s_mbar_l2hint(
+    smem_dst_u32: Int32,
+    gmem_src_i64: Int64,
+    nbytes: Int32,
+    mbar_u32: Int32,
+    cache_policy: Uint64,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    """Bulk global-to-shared copy with an explicit L2 cache policy."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_dst_u32).ir_value(loc=loc, ip=ip),
+            Int64(gmem_src_i64).ir_value(loc=loc, ip=ip),
+            Int32(nbytes).ir_value(loc=loc, ip=ip),
+            Int32(mbar_u32).ir_value(loc=loc, ip=ip),
+            Uint64(cache_policy).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+        " [$0], [$1], $2, [$3], $4;",
+        "r,l,r,r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_shared_u8(smem_addr: Int32, value: Uint8, *, loc=None, ip=None):
+    """Store 8 bits to shared memory. smem_addr is a u32 shared-memory address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Uint8(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.u8 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def st_shared_u16(smem_addr: Int32, value: Uint32, *, loc=None, ip=None):
+    """Store the low 16 bits of a register to shared memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Uint32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.u16 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def quantize_scaled_store_shared_v2_e4m3(
+    smem_addr: Int32,
+    scaled_value0: Float32,
+    scaled_value1: Float32,
+    inv_scale: Float32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Scale, quantize, and vector-store two contiguous E4M3 bytes.
+
+    ``scaled_value*`` already include the per-candidate V scale used by the
+    preceding atomic-max pass. Keeping that multiplication in ordinary SSA
+    lets LLVM retain/reuse the products across the barrier, as FlashInfer does.
+    The E4M3 results never widen through ``Uint32`` and are written with the
+    same half-register ``st.shared.v2.b8`` form.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Float32(scaled_value0).ir_value(loc=loc, ip=ip),
+            Float32(scaled_value1).ir_value(loc=loc, ip=ip),
+            Float32(inv_scale).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b16 q0, q1;
+            .reg .f32 zero, tmp;
+            mov.f32 zero, 0f00000000;
+            mul.f32 tmp, $1, $3;
+            cvt.rn.satfinite.e4m3x2.f32 q0, zero, tmp;
+            mul.f32 tmp, $2, $3;
+            cvt.rn.satfinite.e4m3x2.f32 q1, zero, tmp;
+            st.shared.v2.b8 [$0], {q0, q1};
+        }
+        """,
+        "r,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_async_u32_shared_global(
+    smem_addr: Int32, gmem_addr: Int64, *, loc=None, ip=None
+):
+    """4-byte `cp.async.ca.shared.global` copy."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.ca.shared.global [$0], [$1], 4;",
+        "r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_async_u64_shared_global(
+    smem_addr: Int32, gmem_addr: Int64, *, loc=None, ip=None
+):
+    """8-byte `cp.async.ca.shared.global` copy."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.ca.shared.global [$0], [$1], 8;",
+        "r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_async4_shared_global(smem_addr: Int32, gmem_addr: Int64, *, loc=None, ip=None):
+    """16-byte `cp.async.cg.shared.global` copy."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.cg.shared.global [$0], [$1], 16;",
+        "r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_async4_shared_global_pred(
+    smem_addr: Int32, gmem_addr: Int64, pred: Int32, *, loc=None, ip=None
+):
+    """Predicated 16-byte `cp.async.cg.shared.global` copy."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(pred).ir_value(loc=loc, ip=ip),
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .pred p; setp.ne.b32 p, $0, 0; @p cp.async.cg.shared.global [$1], [$2], 16; }",
+        "r,r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_async4_ca_shared_global_pred(
+    smem_addr: Int32, gmem_addr: Int64, pred: Int32, *, loc=None, ip=None
+):
+    """Predicated 16-byte `cp.async.ca.shared.global` copy."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(pred).ir_value(loc=loc, ip=ip),
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .pred p; setp.ne.b32 p, $0, 0; @p cp.async.ca.shared.global [$1], [$2], 16; }",
+        "r,r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def get_ptr_as_int64(tensor: cute.Tensor, offset, *, loc=None, ip=None) -> Int64:
+    """Get the memory address of tensor[offset] as Int64."""
+    elem_ptr = tensor.iterator + offset
+    ptr_int = llvm.ptrtoint(T.i64(), elem_ptr.llvm_ptr, loc=loc, ip=ip)
+    return Int64(ptr_int)
+
+
+# =============================================================================
+# PTX Intrinsics - Global Atomics
+# =============================================================================
+
+
+@dsl_user_op
+def atomic_add_global_i32(addr: Int64, val: Int32, *, loc=None, ip=None) -> Int32:
+    """Global memory int32 atomic add. Returns old value."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(addr).ir_value(loc=loc, ip=ip),
+                Int32(val).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.add.s32 $0, [$1], $2;",
+            "=r,l,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def red_add_global_release_i32(addr: Int64, val: Int32, *, loc=None, ip=None):
+    """No-return global int32 add with a GPU-scope release fence."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "fence.acq_rel.gpu;\nred.relaxed.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_global_f32(addr: Int64, val: Float32, *, loc=None, ip=None):
+    """No-return global fp32 add reduction (relaxed device scope)."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "red.global.add.f32 [$0], $1;",
+        "l,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cvt_bf16x2_to_f16x2(packed: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Convert a u32 holding two bf16 (lo, hi) into an f16x2 u32 (lo, hi)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(packed).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 blo, bhi, hlo, hhi;
+                .reg .f32 flo, fhi;
+                mov.b32 {blo, bhi}, $1;
+                cvt.f32.bf16 flo, blo;
+                cvt.f32.bf16 fhi, bhi;
+                cvt.rn.f16.f32 hlo, flo;
+                cvt.rn.f16.f32 hhi, fhi;
+                mov.b32 $0, {hlo, hhi};
+            }
+            """,
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def red_add_global_bf16x2(addr: Int64, packed: Uint32, *, loc=None, ip=None):
+    """No-return global atomic add of a packed bf16x2 value (2 contiguous bf16).
+
+    Used by the W4A16 TC-decode FC2 epilogue to fold the per-route partial
+    outputs into the per-token output without a separate top-k-sum launch.
+    The address must be 4-byte aligned and cover two consecutive bf16 lanes.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Uint32(packed).ir_value(loc=loc, ip=ip),
+        ],
+        "red.relaxed.gpu.global.add.noftz.bf16x2 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_max_global_f32_nonnegative(addr: Int64, val: Float32, *, loc=None, ip=None):
+    """No-return global max reduction for a non-negative fp32 value.
+
+    Non-negative IEEE-754 float ordering matches unsigned integer bit ordering,
+    so this emits a no-return u32 max reduction on the value's bit pattern.
+    Callers must initialize the destination with a non-negative fp32 value.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .u32 vi; mov.b32 vi, $1; red.relaxed.gpu.global.max.u32 [$0], vi; }",
+        "l,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def atomic_cas_global_i32(
+    addr: Int64, compare: Int32, value: Int32, *, loc=None, ip=None
+) -> Int32:
+    """Global memory int32 atomic compare-and-swap. Returns old value."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(addr).ir_value(loc=loc, ip=ip),
+                Int32(compare).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.cas.b32 $0, [$1], $2, $3;",
+            "=r,l,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def atomic_add_shared_i32(addr: Int32, val: Int32, *, loc=None, ip=None) -> Int32:
+    """Shared-memory int32 atomic add (CTA-scope). Returns old value.
+
+    Uses ``atom.shared.add.s32`` with a 32-bit shared-memory address
+    (the native address width for smem on NVIDIA GPUs).
+    """
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Int32(val).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared.add.s32 $0, [$1], $2;",
+            "=r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def atomic_max_shared_f32(smem_addr: Int32, val: Float32, *, loc=None, ip=None):
+    """No-return shared atomic max for a NON-NEGATIVE fp32 ``val``.
+
+    Relies on the IEEE-754 ordering of non-negative floats matching the signed
+    int ordering of their bit patterns, so the smem max can be done with a
+    single s32 reduction. All callers consume the reduced shared slot after a
+    barrier; none needs the old or resulting value in the issuing lane.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "{.reg .s32 vi; mov.b32 vi, $1; red.shared.max.s32 [$0], vi;}",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def atomic_max_shared_f32_offset(
+    smem_addr: Int32,
+    byte_offset: int,
+    val: Float32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """No-return nonnegative FP32 shared max at a constant displacement."""
+    offset = int(byte_offset)
+    address = f"[$0+{offset}]" if offset else "[$0]"
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        f"{{.reg .s32 vi; mov.b32 vi, $1; red.shared.max.s32 {address}, vi;}}",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_shared_i32(addr: Int32, val: Int32, *, loc=None, ip=None):
+    """No-return shared-memory int32 add.
+
+    Use this when the old value is not needed. NVCC lowers equivalent C++
+    histogram increments to cheaper no-return shared atomics.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Int32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "red.shared.add.u32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def ld_shared_i32(addr: Int32, *, loc=None, ip=None) -> Int32:
+    """Volatile-style load int32 from shared memory at a 32-bit byte address."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.s32 $0, [$1];",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_shared_i32_relaxed(addr: Int32, *, loc=None, ip=None) -> Int32:
+    """Load int32 from shared memory at a 32-bit byte address."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.s32 $0, [$1];",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_shared_u32(addr: Int32, *, loc=None, ip=None) -> Uint32:
+    """Load uint32 from shared memory at a 32-bit byte address."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.u32 $0, [$1];",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def st_shared_i32(addr: Int32, val: Int32, *, loc=None, ip=None):
+    """Store int32 to shared memory at a 32-bit byte address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Int32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.s32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_shared_u32(addr: Int32, val: Uint32, *, loc=None, ip=None):
+    """Store uint32 to shared memory at a 32-bit byte address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Uint32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.u32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def ld_shared_f32(addr: Int32, *, loc=None, ip=None) -> Float32:
+    """Load float32 from shared memory at a 32-bit byte address."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.f32 $0, [$1];",
+            "=f,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_shared_f32_offset(
+    addr: Int32,
+    byte_offset: int,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """Load shared FP32 using a compile-time displacement."""
+    offset = int(byte_offset)
+    address = f"[$1+{offset}]" if offset else "[$1]"
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            f"ld.shared.f32 $0, {address};",
+            "=f,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_shared_v4_f32(
+    addr: Int32, *, loc=None, ip=None
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Load 128 bits (4 x float32) from shared memory."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [Int32(addr).ir_value(loc=loc, ip=ip)],
+        "ld.shared.v4.f32 {$0, $1, $2, $3}, [$4];",
+        "=f,=f,=f,=f,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def ld_shared_bf16_to_f32(addr: Int32, *, loc=None, ip=None) -> Float32:
+    """Load a BF16 from shared memory at a 32-bit byte address and convert to FP32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "{.reg .b16 tmp; ld.shared.b16 tmp, [$1]; cvt.f32.bf16 $0, tmp;}",
+            "=f,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def st_shared_f32(addr: Int32, val: Float32, *, loc=None, ip=None):
+    """Store float32 to shared memory at a 32-bit byte address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.f32 [$0], $1;",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_shared_f32_offset(
+    addr: Int32,
+    byte_offset: int,
+    val: Float32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store shared FP32 using a compile-time displacement."""
+    offset = int(byte_offset)
+    address = f"[$0+{offset}]" if offset else "[$0]"
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        f"st.shared.f32 {address}, $1;",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_shared_v4_f32(
+    addr: Int32,
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store 128 bits (4 x float32) to shared memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Float32(v0).ir_value(loc=loc, ip=ip),
+            Float32(v1).ir_value(loc=loc, ip=ip),
+            Float32(v2).ir_value(loc=loc, ip=ip),
+            Float32(v3).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.v4.f32 [$0], {$1, $2, $3, $4};",
+        "r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_shared_bf16_from_f32(addr: Int32, val: Float32, *, loc=None, ip=None):
+    """Convert float32 to BF16 and store one 16-bit value to shared memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b16 tmp; cvt.rn.bf16.f32 tmp, $1; st.shared.b16 [$0], tmp; }",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_shared_f16_from_f32(addr: Int32, val: Float32, *, loc=None, ip=None):
+    """Convert float32 to FP16 and store one 16-bit value to shared memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b16 tmp; cvt.rn.f16.f32 tmp, $1; st.shared.b16 [$0], tmp; }",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_global_i32(addr: Int64, val: Int32, *, loc=None, ip=None):
+    """Store int32 to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+# =============================================================================
+# PTX Intrinsics - Global Memory Barriers
+# =============================================================================
+
+
+@dsl_user_op
+def ld_global_acquire_i32(addr: Int64, *, loc=None, ip=None) -> Int32:
+    """Load int32 from global memory with acquire semantics."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.global.acquire.gpu.s32 $0, [$1];",
+            "=r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def st_global_release_i32(addr: Int64, val: Int32, *, loc=None, ip=None):
+    """Store int32 to global memory with release semantics."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.release.gpu.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def spin_wait_global_eq_i32(addr: Int64, expected: Int32, *, loc=None, ip=None):
+    """Spin-wait until *addr != expected (acquire semantics on load)."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(expected).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        ".reg .pred %p0;\n"
+        ".reg .s32 %val;\n"
+        "spin_loop:\n"
+        "  ld.global.acquire.gpu.s32 %val, [$0];\n"
+        "  setp.eq.s32 %p0, %val, $1;\n"
+        "  @%p0 bra spin_loop;\n"
+        "}",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def spin_wait_global_ge_i32(addr: Int64, target: Int32, *, loc=None, ip=None):
+    """Spin-wait until *addr >= target using acquire loads."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(target).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        ".reg .pred %p0;\n"
+        ".reg .s32 %val;\n"
+        "spin_loop_ge:\n"
+        "  ld.global.acquire.gpu.s32 %val, [$0];\n"
+        "  setp.lt.s32 %p0, %val, $1;\n"
+        "  @%p0 bra spin_loop_ge;\n"
+        "}",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def threadfence(*, loc=None, ip=None):
+    """Emit membar.gl — threadfence across global memory."""
+    llvm.inline_asm(
+        None,
+        [],
+        "membar.gl;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# =============================================================================
+# PTX Intrinsics - Scatter Atomics
+# =============================================================================
+
+
+@dsl_user_op
+def scatter_add_bf16x2(addr: Int64, val0_f32, val1_f32, *, loc=None, ip=None):
+    """BF16x2 atomic reduction add to global memory.
+
+    Packs two f32 values into bf16x2 via cvt.rn.satfinite, then does
+    red.relaxed.gpu.global.add.noftz.bf16x2. Workaround for LLVM NVPTX
+    bug that decomposes vector<2xbf16> into .v2.bf16x2 which ptxas rejects.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            val0_f32.ir_value(loc=loc, ip=ip),
+            val1_f32.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b32 packed; cvt.rn.satfinite.bf16x2.f32 packed, $2, $1; red.relaxed.gpu.global.add.noftz.bf16x2 [$0], packed; }",
+        "l,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def scatter_add_bf16(addr: Int64, val_f32, *, loc=None, ip=None):
+    """BF16 atomic reduction add to global memory.
+
+    Converts the f32 input to bf16 inside PTX and atomically accumulates it into
+    one bf16 output lane. This is intended for opt-in approximate reductions.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            val_f32.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b16 packed; cvt.rn.satfinite.bf16.f32 packed, $1; red.relaxed.gpu.global.add.noftz.bf16 [$0], packed; }",
+        "l,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def scatter_add_v4_bf16x2(
+    addr: Int64, v0, v1, v2, v3, v4, v5, v6, v7, *, loc=None, ip=None
+):
+    """Vectorized BF16x2 atomic reduction: 8 bf16 values (16 bytes) in one go.
+
+    red.global.add.noftz.v4.bf16x2 [addr], {packed0, packed1, packed2, packed3}
+    Each packed reg contains 2 bf16 values converted from f32 pairs.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            v0.ir_value(loc=loc, ip=ip),
+            v1.ir_value(loc=loc, ip=ip),
+            v2.ir_value(loc=loc, ip=ip),
+            v3.ir_value(loc=loc, ip=ip),
+            v4.ir_value(loc=loc, ip=ip),
+            v5.ir_value(loc=loc, ip=ip),
+            v6.ir_value(loc=loc, ip=ip),
+            v7.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b32 p0,p1,p2,p3;"
+        " cvt.rn.satfinite.bf16x2.f32 p0, $2, $1;"
+        " cvt.rn.satfinite.bf16x2.f32 p1, $4, $3;"
+        " cvt.rn.satfinite.bf16x2.f32 p2, $6, $5;"
+        " cvt.rn.satfinite.bf16x2.f32 p3, $8, $7;"
+        " red.global.add.noftz.v4.bf16x2 [$0], {p0, p1, p2, p3}; }",
+        "l,f,f,f,f,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+# =============================================================================
+# PTX Intrinsics - Math Operations
+# =============================================================================
+
+
+@dsl_user_op
+def rcp_approx_ftz(a: Float32, *, loc=None, ip=None) -> Float32:
+    """Fast reciprocal using PTX rcp.approx.ftz.f32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "rcp.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fmin_f32(a: Float32, b: Float32, *, loc=None, ip=None) -> Float32:
+    """Compute min of two float32 values using PTX min.f32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            "min.f32 $0, $1, $2;",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fmax_f32(a: Float32, b: Float32, *, loc=None, ip=None) -> Float32:
+    """Compute max of two float32 values using PTX max.f32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            "max.f32 $0, $1, $2;",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fabs_f32(a: Float32, *, loc=None, ip=None) -> Float32:
+    """Compute absolute value of float32 using PTX abs.f32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "abs.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+# =============================================================================
+# Half2 SIMD Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def half2_mul(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Multiply two Half2 values element-wise: (a.x*b.x, a.y*b.y)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "mul.f16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def broadcast_f32_to_half2(x: Float32, *, loc=None, ip=None) -> Uint32:
+    """Pack one float32 value into both lanes of an f16x2 register."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(x).ir_value(loc=loc, ip=ip)],
+            "cvt.rn.f16x2.f32 $0, $1, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def hadd2(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Add two Half2 values element-wise: (a.x+b.x, a.y+b.y)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "add.f16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def habs2(x: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Half2 absolute value - clears sign bits of both fp16 values."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(x).ir_value(loc=loc, ip=ip)],
+            "and.b32 $0, $1, 0x7FFF7FFF;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def hmax2(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Half2 max - element-wise max of 2 fp16 pairs."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "max.f16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def hmax_to_f32(x: Uint32, *, loc=None, ip=None) -> Float32:
+    """Extract max of 2 fp16 values in half2 as float32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(x).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 h0, h1;
+                .reg .f32 f0, f1;
+                mov.b32 {h0, h1}, $1;
+                cvt.f32.f16 f0, h0;
+                cvt.f32.f16 f1, h1;
+                max.f32 $0, f0, f1;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def half2_to_float2_scaled(
+    h2: Uint32, scale: Float32, *, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    """Convert half2 to float2 AND multiply by scale."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(h2).ir_value(loc=loc, ip=ip), Float32(scale).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 h0, h1;
+            .reg .f32 f0, f1;
+            mov.b32 {h0, h1}, $2;
+            cvt.f32.f16 f0, h0;
+            cvt.f32.f16 f1, h1;
+            mul.f32 $0, f0, $3;
+            mul.f32 $1, f1, $3;
+        }
+        """,
+        "=f,=f,r,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+    f0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    f1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+
+    return Float32(f0), Float32(f1)
+
+
+# =============================================================================
+# BFloat2 SIMD Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def bfloat2_mul(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Multiply two BFloat2 values element-wise: (a.x*b.x, a.y*b.y)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "mul.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def bfloat2_broadcast_lane(x: Uint32, lane: Int32, *, loc=None, ip=None) -> Uint32:
+    """Duplicate one BF16 lane from a packed bf16x2 register into both lanes."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Uint32(x).ir_value(loc=loc, ip=ip),
+                Int32(lane).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .pred p;
+                .reg .b32 lo, hi, val, shifted;
+                and.b32 lo, $1, 0x0000ffff;
+                shr.u32 hi, $1, 16;
+                setp.eq.s32 p, $2, 0;
+                @p  mov.b32 val, lo;
+                @!p mov.b32 val, hi;
+                shl.b32 shifted, val, 16;
+                or.b32 $0, val, shifted;
+            }
+            """,
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def broadcast_f32_to_bfloat2(x: Float32, *, loc=None, ip=None) -> Uint32:
+    """Pack one float32 value into both lanes of a bf16x2 register."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(x).ir_value(loc=loc, ip=ip)],
+            "cvt.rn.satfinite.bf16x2.f32 $0, $1, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def pack_f32x2_to_bfloat2(x0: Float32, x1: Float32, *, loc=None, ip=None) -> Uint32:
+    """Pack 2 float32 values into one bf16x2 register."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(x0).ir_value(loc=loc, ip=ip),
+                Float32(x1).ir_value(loc=loc, ip=ip),
+            ],
+            "cvt.rn.satfinite.bf16x2.f32 $0, $2, $1;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_bf16x2_to_e4m3x2(src: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Convert packed bf16x2 to packed e4m3x2 in the low 16 bits of a u32."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(src).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 out, zero;
+                cvt.rn.satfinite.e4m3x2.bf16x2 out, $1;
+                mov.u16 zero, 0;
+                mov.b32 $0, {out, zero};
+            }
+            """,
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_bf16x2x2_to_e4m3x4(lo: Uint32, hi: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Convert two bf16x2 values and pack the e4m3x2 results into one u32."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(lo).ir_value(loc=loc, ip=ip), Uint32(hi).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 out_lo, out_hi;
+                cvt.rn.satfinite.e4m3x2.bf16x2 out_lo, $1;
+                cvt.rn.satfinite.e4m3x2.bf16x2 out_hi, $2;
+                mov.b32 $0, {out_lo, out_hi};
+            }
+            """,
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def bfloat2_add(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Add two BFloat2 values element-wise: (a.x+b.x, a.y+b.y)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "add.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fp8x4_e4m3_to_bfloat2x2(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Widen 4 packed E4M3 bytes into 2 packed bf16x2 registers exactly."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 low;
+            .reg .b32 q, out0, out1, sign0, sign1, mant0, mant1, tmp, bias, bias_f32;
+            prmt.b32 q, $2, 0, 0x1302;
+
+            and.b32 sign0, q, 0x80008000;
+            shr.u32 tmp, q, 4;
+            and.b32 mant0, tmp, 0x07F007F0;
+            or.b32 out0, mant0, sign0;
+
+            shl.b32 tmp, q, 8;
+            and.b32 sign1, tmp, 0x80008000;
+            shl.b32 tmp, q, 4;
+            and.b32 mant1, tmp, 0x07F007F0;
+            or.b32 out1, mant1, sign1;
+
+            mov.b32 bias_f32, 0x7B800000;
+            cvt.rn.bf16.f32 low, bias_f32;
+            mov.b32 bias, {low, low};
+
+            mul.bf16x2 $0, out0, bias;
+            mul.bf16x2 $1, out1, bias;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def packed_dequant_e2m1x4_to_bfloat2x2(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """FE2M1 -> BF16 register dequant for one packed 4-value fragment."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 q, out1, out2, tmp;
+
+            and.b32 out1, $2, 0x80008000;
+            and.b32 tmp, $2, 0x70007000;
+            shr.u32 tmp, tmp, 6;
+            or.b32 out1, out1, tmp;
+
+            shl.b32 q, $2, 4;
+            and.b32 out2, q, 0x80008000;
+            and.b32 tmp, q, 0x70007000;
+            shr.u32 tmp, tmp, 6;
+            or.b32 out2, out2, tmp;
+
+            mov.b32 $0, out2;
+            mov.b32 $1, out1;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def packed_dequant_e2m1x4_to_half2x2(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """FE2M1 -> FP16 register dequant for one packed 4-value fragment."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 q, out1, out2, tmp;
+
+            and.b32 out1, $2, 0x80008000;
+            and.b32 tmp, $2, 0x70007000;
+            shr.u32 tmp, tmp, 3;
+            or.b32 out1, out1, tmp;
+
+            shl.b32 q, $2, 4;
+            and.b32 out2, q, 0x80008000;
+            and.b32 tmp, q, 0x70007000;
+            shr.u32 tmp, tmp, 3;
+            or.b32 out2, out2, tmp;
+
+            mov.b32 $0, out2;
+            mov.b32 $1, out1;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def packed_dequant_e4m3x4_to_bfloat2x2(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """FE4M3 scale dequant for one packed 4-value BF16 fragment."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 q, out1, out2, tmp;
+
+            and.b32 tmp, $2, 0x80008000;
+            shr.u32 out1, tmp, 1;
+            and.b32 tmp, $2, 0x7F007F00;
+            shr.u32 tmp, tmp, 4;
+            or.b32 out1, out1, tmp;
+
+            shl.b32 q, $2, 8;
+            and.b32 tmp, q, 0x80008000;
+            shr.u32 out2, tmp, 1;
+            and.b32 tmp, q, 0x7F007F00;
+            shr.u32 tmp, tmp, 4;
+            or.b32 out2, out2, tmp;
+
+            mov.b32 $0, out2;
+            mov.b32 $1, out1;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def packed_dequant_e4m3x4_to_half2x2(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """FE4M3 scale dequant for one packed 4-value FP16 fragment."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 q, out1, out2;
+
+            and.b32 out1, $2, 0xFF00FF00;
+            shr.u32 out1, out1, 1;
+
+            shl.b32 q, $2, 8;
+            and.b32 out2, q, 0xFF00FF00;
+            shr.u32 out2, out2, 1;
+
+            mov.b32 $0, out2;
+            mov.b32 $1, out1;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def packed_dequant_e8m0x4_to_bfloat2x2(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """E8M0 compute-scale dequant for one packed 4-value BF16 fragment.
+
+    The W4A16 FP4 unpack path represents E2M1 values scaled by 2^-126.  Match
+    the existing NVFP4 split by materializing E8M0 scales multiplied by 2^7 in
+    the MMA input and applying the remaining compensation in the kernel
+    epilogue.
+    """
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .u32 b0, b1, b2, b3;
+            .reg .u32 h0, h1, h2, h3;
+            .reg .u32 t0, t1;
+
+            and.b32 b0, $2, 0x000000ff;
+            shr.u32 b1, $2, 8;
+            and.b32 b1, b1, 0x000000ff;
+            shr.u32 b2, $2, 16;
+            and.b32 b2, b2, 0x000000ff;
+            shr.u32 b3, $2, 24;
+
+            add.u32 h0, b0, 7;
+            add.u32 h1, b1, 7;
+            add.u32 h2, b2, 7;
+            add.u32 h3, b3, 7;
+            shl.b32 h0, h0, 7;
+            shl.b32 h1, h1, 7;
+            shl.b32 h2, h2, 7;
+            shl.b32 h3, h3, 7;
+
+            shl.b32 t0, h2, 16;
+            or.b32 $0, h0, t0;
+            shl.b32 t1, h3, 16;
+            or.b32 $1, h1, t1;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def packed_dequant_e8m0x4_to_half2x2(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """E8M0 compute-scale dequant for one packed 4-value FP16 fragment."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .pred p0, p1, p2, p3;
+            .reg .u32 b0, b1, b2, b3;
+            .reg .s32 e0, e1, e2, e3;
+            .reg .f32 ef0, ef1, ef2, ef3;
+            .reg .f32 f0, f1, f2, f3;
+            .reg .b16 h0, h1, h2, h3;
+
+            and.b32 b0, $2, 0x000000ff;
+            shr.u32 b1, $2, 8;
+            and.b32 b1, b1, 0x000000ff;
+            shr.u32 b2, $2, 16;
+            and.b32 b2, b2, 0x000000ff;
+            shr.u32 b3, $2, 24;
+
+            setp.eq.u32 p0, b0, 0;
+            setp.eq.u32 p1, b1, 0;
+            setp.eq.u32 p2, b2, 0;
+            setp.eq.u32 p3, b3, 0;
+
+            cvt.s32.u32 e0, b0;
+            cvt.s32.u32 e1, b1;
+            cvt.s32.u32 e2, b2;
+            cvt.s32.u32 e3, b3;
+            sub.s32 e0, e0, 120;
+            sub.s32 e1, e1, 120;
+            sub.s32 e2, e2, 120;
+            sub.s32 e3, e3, 120;
+
+            cvt.rn.f32.s32 ef0, e0;
+            cvt.rn.f32.s32 ef1, e1;
+            cvt.rn.f32.s32 ef2, e2;
+            cvt.rn.f32.s32 ef3, e3;
+            ex2.approx.f32 f0, ef0;
+            ex2.approx.f32 f1, ef1;
+            ex2.approx.f32 f2, ef2;
+            ex2.approx.f32 f3, ef3;
+            selp.f32 f0, 0f00000000, f0, p0;
+            selp.f32 f1, 0f00000000, f1, p1;
+            selp.f32 f2, 0f00000000, f2, p2;
+            selp.f32 f3, 0f00000000, f3, p3;
+
+            cvt.rn.f16.f32 h0, f0;
+            cvt.rn.f16.f32 h1, f1;
+            cvt.rn.f16.f32 h2, f2;
+            cvt.rn.f16.f32 h3, f3;
+
+            setp.eq.u32 p0, b0, 255;
+            setp.eq.u32 p1, b1, 255;
+            setp.eq.u32 p2, b2, 255;
+            setp.eq.u32 p3, b3, 255;
+            selp.b16 h0, 0x7e00, h0, p0;
+            selp.b16 h1, 0x7e00, h1, p1;
+            selp.b16 h2, 0x7e00, h2, p2;
+            selp.b16 h3, 0x7e00, h3, p3;
+
+            mov.b32 $0, {h0, h2};
+            mov.b32 $1, {h1, h3};
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def bf16_mma_m16n8k16_f32(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    b0: Uint32,
+    b1: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Warp MMA helper for `mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32`."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b0).ir_value(loc=loc, ip=ip),
+            Uint32(b1).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$10, $11, $12, $13};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def f32_to_raw_bits(x: Float32, *, loc=None, ip=None) -> Uint32:
+    """Return the raw IEEE-754 bits of one float32 value."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(x).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def f32_to_tf32_bits(x: Float32, *, loc=None, ip=None) -> Uint32:
+    """Round one float32 value to TF32 format and return its 32-bit operand bits."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(x).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b32 tmp;
+                cvt.rna.tf32.f32 tmp, $1;
+                mov.b32 $0, tmp;
+            }
+            """,
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def tf32_mma_m16n8k8_f32(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    b0: Uint32,
+    b1: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Warp MMA helper for `mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32`."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b0).ir_value(loc=loc, ip=ip),
+            Uint32(b1).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$10, $11, $12, $13};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def f16_mma_m16n8k16_f32(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    b0: Uint32,
+    b1: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Warp MMA helper for `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32`."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b0).ir_value(loc=loc, ip=ip),
+            Uint32(b1).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$10, $11, $12, $13};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def bf16_mma_rhs_fragments_as_mma_a_m16n8k16_f32(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    b0_0: Uint32,
+    b1_0: Uint32,
+    b0_1: Uint32,
+    b1_1: Uint32,
+    a0: Uint32,
+    a1: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """BF16 MMA form used by the routed m-block-size-8 path.
+
+    The dequantized RHS fragments feed the hardware A operand, while the
+    routed activation fragment loaded with `ldmatrix.x2` feeds hardware B.
+    """
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(b0_0).ir_value(loc=loc, ip=ip),
+            Uint32(b1_0).ir_value(loc=loc, ip=ip),
+            Uint32(b0_1).ir_value(loc=loc, ip=ip),
+            Uint32(b1_1).ir_value(loc=loc, ip=ip),
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$10, $11, $12, $13};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def f16_mma_rhs_fragments_as_mma_a_m16n8k16_f32(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    b0_0: Uint32,
+    b1_0: Uint32,
+    b0_1: Uint32,
+    b1_1: Uint32,
+    a0: Uint32,
+    a1: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """FP16 MMA form used by the routed m-block-size-8 path."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(b0_0).ir_value(loc=loc, ip=ip),
+            Uint32(b1_0).ir_value(loc=loc, ip=ip),
+            Uint32(b0_1).ir_value(loc=loc, ip=ip),
+            Uint32(b1_1).ir_value(loc=loc, ip=ip),
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$10, $11, $12, $13};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def bf16_rowsum_m16k16_f32(
+    d0: Float32,
+    d1: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32]:
+    """Row-sum helper matching FlashInfer's m16k16 BF16 rowsum MMA."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(1065369472).ir_value(loc=loc, ip=ip),
+            Uint32(1065369472).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32
+            {$0, _, $1, _},
+            {$2, $3, $4, $5},
+            {$6, $7},
+            {$0, 0., $1, 0.};
+        }
+        """,
+        "=f,=f,r,r,r,r,r,r,0,1",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1)
+
+
+@dsl_user_op
+def bf16_mma_m16n16k16_f32(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    d4: Float32,
+    d5: Float32,
+    d6: Float32,
+    d7: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    b0: Uint32,
+    b1: Uint32,
+    b2: Uint32,
+    b3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32]:
+    """Warp MMA helper matching FlashInfer's `m16n16k16` BF16/BF16->F32 wrapper."""
+    result0 = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b0).ir_value(loc=loc, ip=ip),
+            Uint32(b1).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$10, $11, $12, $13};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    result1 = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b2).ir_value(loc=loc, ip=ip),
+            Uint32(b3).ir_value(loc=loc, ip=ip),
+            Float32(d4).ir_value(loc=loc, ip=ip),
+            Float32(d5).ir_value(loc=loc, ip=ip),
+            Float32(d6).ir_value(loc=loc, ip=ip),
+            Float32(d7).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$10, $11, $12, $13};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result0, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result0, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result0, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result0, [3], loc=loc, ip=ip)
+    r4 = llvm.extractvalue(T.f32(), result1, [0], loc=loc, ip=ip)
+    r5 = llvm.extractvalue(T.f32(), result1, [1], loc=loc, ip=ip)
+    r6 = llvm.extractvalue(T.f32(), result1, [2], loc=loc, ip=ip)
+    r7 = llvm.extractvalue(T.f32(), result1, [3], loc=loc, ip=ip)
+    return (
+        Float32(r0),
+        Float32(r1),
+        Float32(r2),
+        Float32(r3),
+        Float32(r4),
+        Float32(r5),
+        Float32(r6),
+        Float32(r7),
+    )
+
+
+@dsl_user_op
+def mxfp8_mma_m16n8k32_f32_e4m3(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    b0: Uint32,
+    b1: Uint32,
+    sfa: Uint32,
+    sfb: Uint32,
+    bid_a: int = 0,
+    tid_a: int = 0,
+    bid_b: int = 0,
+    tid_b: int = 0,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Warp MMA helper for SM120 MXFP8 block-scaled `m16n8k32` E4M3/E4M3."""
+    i16_ty = cutlass._mlir.ir.IntegerType.get_signless(16)
+    bid_a_i16 = cutlass._mlir.ir.Operation.create(
+        "llvm.mlir.constant",
+        results=[i16_ty],
+        attributes={"value": cutlass._mlir.ir.IntegerAttr.get(i16_ty, int(bid_a))},
+    ).result
+    tid_a_i16 = cutlass._mlir.ir.Operation.create(
+        "llvm.mlir.constant",
+        results=[i16_ty],
+        attributes={"value": cutlass._mlir.ir.IntegerAttr.get(i16_ty, int(tid_a))},
+    ).result
+    bid_b_i16 = cutlass._mlir.ir.Operation.create(
+        "llvm.mlir.constant",
+        results=[i16_ty],
+        attributes={"value": cutlass._mlir.ir.IntegerAttr.get(i16_ty, int(bid_b))},
+    ).result
+    tid_b_i16 = cutlass._mlir.ir.Operation.create(
+        "llvm.mlir.constant",
+        results=[i16_ty],
+        attributes={"value": cutlass._mlir.ir.IntegerAttr.get(i16_ty, int(tid_b))},
+    ).result
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b0).ir_value(loc=loc, ip=ip),
+            Uint32(b1).ir_value(loc=loc, ip=ip),
+            Uint32(sfa).ir_value(loc=loc, ip=ip),
+            bid_a_i16,
+            tid_a_i16,
+            Uint32(sfb).ir_value(loc=loc, ip=ip),
+            bid_b_i16,
+            tid_b_i16,
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.kind::mxf8f6f4.block_scale.scale_vec::1X.m16n8k32.row.col.f32.e4m3.e4m3.f32.ue8m0
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$0, $1, $2, $3},
+        {$10},
+        {$11, $12},
+        {$13},
+        {$14, $15};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,r,h,h,r,h,h,0,1,2,3",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+@dsl_user_op
+def mxfp8_mma_m16n8k32_f32_e2m1(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    b0: Uint32,
+    b1: Uint32,
+    sfa: Uint32,
+    sfb: Uint32,
+    bid_a: int = 0,
+    tid_a: int = 0,
+    bid_b: int = 0,
+    tid_b: int = 0,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """SM120 block-scaled QMMA with E4M3 A and E2M1 B containers."""
+    asm = f"""
+        mma.sync.aligned.kind::mxf8f6f4.block_scale.scale_vec::1X.m16n8k32.row.col.f32.e4m3.e2m1.f32.ue8m0
+        {{$0, $1, $2, $3}},
+        {{$4, $5, $6, $7}},
+        {{$8, $9}},
+        {{$0, $1, $2, $3}},
+        {{$10}},
+        {{{int(bid_a)}, {int(tid_a)}}},
+        {{$11}},
+        {{{int(bid_b)}, {int(tid_b)}}};
+        """
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b0).ir_value(loc=loc, ip=ip),
+            Uint32(b1).ir_value(loc=loc, ip=ip),
+            Uint32(sfa).ir_value(loc=loc, ip=ip),
+            Uint32(sfb).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        asm,
+        "=f,=f,=f,=f,r,r,r,r,r,r,r,r,0,1,2,3",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        Float32(llvm.extractvalue(T.f32(), result, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def mma_m16n8k32_f32_e4m3(
+    d0: Float32,
+    d1: Float32,
+    d2: Float32,
+    d3: Float32,
+    a0: Uint32,
+    a1: Uint32,
+    a2: Uint32,
+    a3: Uint32,
+    b0: Uint32,
+    b1: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Plain (non-block-scaled) SM120 FP8 E4M3 warp MMA `m16n8k32`.
+
+    d{0..3} are the accumulator IN-OUT (C on input, D on output)."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [
+            Uint32(a0).ir_value(loc=loc, ip=ip),
+            Uint32(a1).ir_value(loc=loc, ip=ip),
+            Uint32(a2).ir_value(loc=loc, ip=ip),
+            Uint32(a3).ir_value(loc=loc, ip=ip),
+            Uint32(b0).ir_value(loc=loc, ip=ip),
+            Uint32(b1).ir_value(loc=loc, ip=ip),
+            Float32(d0).ir_value(loc=loc, ip=ip),
+            Float32(d1).ir_value(loc=loc, ip=ip),
+            Float32(d2).ir_value(loc=loc, ip=ip),
+            Float32(d3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32
+        {$0, $1, $2, $3},
+        {$4, $5, $6, $7},
+        {$8, $9},
+        {$0, $1, $2, $3};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,0,1,2,3",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    r0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    r1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    r2 = llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)
+    r3 = llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)
+    return Float32(r0), Float32(r1), Float32(r2), Float32(r3)
+
+
+# ``mma_m16n8k16_f32_bf16`` was proven during the SM120 sparse-MLA port to be
+# bit-identical (same signature, same emitted
+# ``mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32``, same constraint
+# string and operand grouping) to the pre-existing ``bf16_mma_m16n8k16_f32``
+# above. Expose it under the port's name as a thin alias so the sparse-MLA
+# kernels can import it without duplicating the inline asm.
+mma_m16n8k16_f32_bf16 = bf16_mma_m16n8k16_f32
+
+
+@dsl_user_op
+def byte_perm(a: Uint32, b: Uint32, selector: Int32, *, loc=None, ip=None) -> Uint32:
+    """PTX byte permutation helper."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Uint32(a).ir_value(loc=loc, ip=ip),
+                Uint32(b).ir_value(loc=loc, ip=ip),
+                Int32(selector).ir_value(loc=loc, ip=ip),
+            ],
+            "prmt.b32 $0, $1, $2, $3;",
+            "=r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def frag_layout_swizzle_16b_to_8b(x: Uint32) -> Uint32:
+    tmp = cute.arch.shuffle_sync_bfly(x, offset=1)
+    x = byte_perm(x, tmp, Int32(0x5410 if cute.arch.lane_idx() & 0x1 == 0 else 0x3276))
+    tmp = cute.arch.shuffle_sync_bfly(x, offset=2)
+    x = byte_perm(x, tmp, Int32(0x5410 if cute.arch.lane_idx() & 0x2 == 0 else 0x3276))
+    return x
+
+
+@cute.jit
+def frag_layout_swizzle_16b_to_8b_trans(x: Uint32) -> Uint32:
+    tmp = cute.arch.shuffle_sync_bfly(x, offset=4)
+    x = byte_perm(x, tmp, Int32(0x6420 if cute.arch.lane_idx() & 0x4 == 0 else 0x3175))
+    tmp = cute.arch.shuffle_sync_bfly(x, offset=8)
+    x = byte_perm(x, tmp, Int32(0x5410 if cute.arch.lane_idx() & 0x8 == 0 else 0x3276))
+    tmp = cute.arch.shuffle_sync_bfly(x, offset=16)
+    x = byte_perm(x, tmp, Int32(0x5410 if cute.arch.lane_idx() & 0x10 == 0 else 0x3276))
+    return x
+
+
+@dsl_user_op
+def bfloat2_habs2(x: Uint32, *, loc=None, ip=None) -> Uint32:
+    """BFloat16x2 absolute value - clears sign bits of both bf16 values."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(x).ir_value(loc=loc, ip=ip)],
+            "and.b32 $0, $1, 0x7FFF7FFF;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def bfloat2_hmax2(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """BFloat16x2 max - element-wise max of 2 bf16 pairs."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "max.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def bfloat2_hmax_to_f32(x: Uint32, *, loc=None, ip=None) -> Float32:
+    """Extract max of 2 bf16 values in bfloat2 as float32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(x).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b32 lo, hi;
+                .reg .f32 f0, f1;
+                and.b32 lo, $1, 0xFFFF;
+                shr.b32 hi, $1, 16;
+                shl.b32 lo, lo, 16;
+                shl.b32 hi, hi, 16;
+                mov.b32 f0, lo;
+                mov.b32 f1, hi;
+                max.f32 $0, f0, f1;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def bfloat2_to_float2_scaled(
+    bf2: Uint32, scale: Float32, *, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    """Convert bfloat16x2 to float2 AND multiply by scale."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(bf2).ir_value(loc=loc, ip=ip), Float32(scale).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 lo, hi;
+            .reg .f32 f0, f1;
+            and.b32 lo, $2, 0xFFFF;
+            shr.b32 hi, $2, 16;
+            shl.b32 lo, lo, 16;
+            shl.b32 hi, hi, 16;
+            mov.b32 f0, lo;
+            mov.b32 f1, hi;
+            mul.f32 $0, f0, $3;
+            mul.f32 $1, f1, $3;
+        }
+        """,
+        "=f,=f,r,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+    f0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    f1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+
+    return Float32(f0), Float32(f1)
+
+
+# =============================================================================
+# FP8 E4M3 Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def cvt_f32_to_e4m3(a: Float32, *, loc=None, ip=None) -> Uint32:
+    """Convert float32 to E4M3 using native cvt.rn.satfinite.e4m3x2.f32."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 fp8_pair;
+                .reg .f32 zero;
+                mov.f32 zero, 0f00000000;
+                cvt.rn.satfinite.e4m3x2.f32 fp8_pair, zero, $1;
+                cvt.u32.u16 $0, fp8_pair;
+            }
+            """,
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_f32x4_to_e4m3x4(
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """Convert 4 float32 values to 4 packed E4M3 bytes (v0 in the low byte)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(v0).ir_value(loc=loc, ip=ip),
+                Float32(v1).ir_value(loc=loc, ip=ip),
+                Float32(v2).ir_value(loc=loc, ip=ip),
+                Float32(v3).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b16 lo, hi;
+                cvt.rn.satfinite.e4m3x2.f32 lo, $2, $1;
+                cvt.rn.satfinite.e4m3x2.f32 hi, $4, $3;
+                mov.b32 $0, {lo, hi};
+            }
+            """,
+            "=r,f,f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def nvfp4_scale_from_amax(
+    block_amax: Float32, global_scale: Float32, *, loc=None, ip=None
+) -> Float32:
+    """Compute block_amax * reciprocal_global_scale / 6 with CUDA tensor-scalar semantics."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Float32(block_amax).ir_value(loc=loc, ip=ip),
+                Float32(global_scale).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .f64 amax_d, gs_d, q_d, six_d;
+                cvt.f64.f32 amax_d, $1;
+                cvt.f64.f32 gs_d, $2;
+                mov.f64 six_d, 0d4018000000000000;
+                mul.rn.f64 q_d, amax_d, gs_d;
+                div.rn.f64 q_d, q_d, six_d;
+                cvt.rn.f32.f64 $0, q_d;
+            }
+            """,
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def fp8_e4m3_to_f32(fp8_val: Uint32, *, loc=None, ip=None) -> Float32:
+    """Convert FP8 E4M3 to float32."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(fp8_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .pred p_zero, p_neg;
+                .reg .u32 sign_u, exp_u, mant_u;
+                .reg .s32 exp_s;
+                .reg .f32 exp_f, mant_f, fp8_float, fp8_neg;
+
+                setp.eq.u32 p_zero, $1, 0;
+                and.b32 sign_u, $1, 0x80;
+                and.b32 mant_u, $1, 7;
+                shr.b32 exp_u, $1, 3;
+                and.b32 exp_u, exp_u, 15;
+                sub.s32 exp_s, exp_u, 7;
+                cvt.rn.f32.s32 exp_f, exp_s;
+                ex2.approx.f32 exp_f, exp_f;
+                cvt.rn.f32.u32 mant_f, mant_u;
+                fma.rn.f32 mant_f, mant_f, 0f3E000000, 0f3F800000;
+                mul.f32 fp8_float, exp_f, mant_f;
+                neg.f32 fp8_neg, fp8_float;
+                setp.ne.u32 p_neg, sign_u, 0;
+                selp.f32 fp8_float, fp8_neg, fp8_float, p_neg;
+                selp.f32 $0, 0f00000000, fp8_float, p_zero;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fp8_e4m3_to_f32_and_rcp(fp8_val: Uint32, *, loc=None, ip=None) -> Float32:
+    """Convert FP8 E4M3 to float32 AND compute reciprocal."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(fp8_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .pred p_zero;
+                .reg .u32 exp_u, mant_u;
+                .reg .s32 exp_s;
+                .reg .f32 exp_f, mant_f, fp8_float, result;
+
+                setp.eq.u32 p_zero, $1, 0;
+                and.b32 mant_u, $1, 7;
+                shr.b32 exp_u, $1, 3;
+                and.b32 exp_u, exp_u, 15;
+                sub.s32 exp_s, exp_u, 7;
+                cvt.rn.f32.s32 exp_f, exp_s;
+                ex2.approx.f32 exp_f, exp_f;
+                cvt.rn.f32.u32 mant_f, mant_u;
+                fma.rn.f32 mant_f, mant_f, 0f3E000000, 0f3F800000;
+                mul.f32 fp8_float, exp_f, mant_f;
+                rcp.approx.ftz.f32 result, fp8_float;
+                selp.f32 $0, 0f00000000, result, p_zero;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+# =============================================================================
+# E4M3 -> F16/F32 Native Conversion Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def cvt_e4m3x2_to_f16x2_pair(
+    packed_u32: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Decode 4 e4m3 bytes (packed u32) into 2 x f16x2 pairs."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32)>"),
+        [Uint32(packed_u32).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 b16_01, b16_23;
+            .reg .b32 hi32;
+            cvt.u16.u32 b16_01, $2;
+            shr.b32 hi32, $2, 16;
+            cvt.u16.u32 b16_23, hi32;
+            cvt.rn.f16x2.e4m3x2 $0, b16_01;
+            cvt.rn.f16x2.e4m3x2 $1, b16_23;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def f16x2_to_f32x2(packed_h2: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    """Unpack f16x2 (u32) to two f32 values."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32, f32)>"),
+        [Uint32(packed_h2).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 lo, hi;
+            mov.b32 {lo, hi}, $2;
+            cvt.f32.f16 $0, lo;
+            cvt.f32.f16 $1, hi;
+        }
+        """,
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), res, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), res, [1], loc=loc, ip=ip)),
+    )
+
+
+@cute.jit
+def cvt_e4m3x4_to_f32x4(
+    packed_u32: Uint32,
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Decode 4 e4m3 bytes (packed u32) to 4 x f32 via hw-native e4m3->f16->f32."""
+    h01, h23 = cvt_e4m3x2_to_f16x2_pair(packed_u32)
+    f0, f1 = f16x2_to_f32x2(h01)
+    f2, f3 = f16x2_to_f32x2(h23)
+    return f0, f1, f2, f3
+
+
+@dsl_user_op
+def cvt_e4m3_to_f32_via_f16(fp8_val: Uint32, *, loc=None, ip=None) -> Float32:
+    """Convert single E4M3 byte to f32 via hw-native cvt.rn.f16x2.e4m3x2."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(fp8_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 fp8_pair;
+                .reg .b32 h2;
+                .reg .b16 lo, hi;
+                cvt.u16.u32 fp8_pair, $1;
+                cvt.rn.f16x2.e4m3x2 h2, fp8_pair;
+                mov.b32 {lo, hi}, h2;
+                cvt.f32.f16 $0, lo;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_w4a16_packed_e4m3_scale_to_f32(
+    packed_byte: Uint32, *, loc=None, ip=None
+) -> Float32:
+    """Scalar mirror of packed_dequant_e4m3x4_to_bfloat2x2 for W4A16 scales."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(packed_byte).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b32 bits, tmp;
+                .reg .b16 bf;
+                and.b32 bits, $1, 0x80;
+                shl.b32 bits, bits, 7;
+                and.b32 tmp, $1, 0x7f;
+                shl.b32 tmp, tmp, 4;
+                or.b32 bits, bits, tmp;
+                cvt.u16.u32 bf, bits;
+                cvt.f32.bf16 $0, bf;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def dequant_kv_e4m3_pair_to_bf16x2(
+    p0: Uint16, p1: Uint16, scale_f: Float32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """FP8 -> BF16 K dequant for the BF16-QK m16n8k16 B operand.
+
+    Byte-for-byte mirror of FlashInfer's sparse_mla prefill BF16-QK inline
+    sequence (prefill_kernel.cuh:240-251): two ``cvt.rn.f16x2.e4m3x2`` decode
+    the two e4m3 byte-pairs ``p0``/``p1`` (each a u16 holding two consecutive
+    e4m3 K-dims), multiply the four resulting f16 lanes by the per-(token,blk)
+    UE8M0 ``scale_f`` in f32, then two ``cvt.rn.bf16x2.f32`` pack them back to
+    the bf16x2 ``b0``/``b1`` MMA operands. NON-saturating cvt (matches the
+    reference; the K magnitudes are bounded by the e4m3 range so satfinite is a
+    no-op, and the ref emits plain ``cvt.rn.bf16x2.f32``)."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32)>"),
+        [
+            Uint16(p0).ir_value(loc=loc, ip=ip),
+            Uint16(p1).ir_value(loc=loc, ip=ip),
+            Float32(scale_f).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b32 h2_0, h2_1;
+            .reg .b16 l0, h0, l1, h1;
+            .reg .f32 fk0, fk1, fk2, fk3;
+            cvt.rn.f16x2.e4m3x2 h2_0, $2;
+            cvt.rn.f16x2.e4m3x2 h2_1, $3;
+            mov.b32 {l0, h0}, h2_0;
+            mov.b32 {l1, h1}, h2_1;
+            cvt.f32.f16 fk0, l0;
+            cvt.f32.f16 fk1, h0;
+            cvt.f32.f16 fk2, l1;
+            cvt.f32.f16 fk3, h1;
+            mul.f32 fk0, fk0, $4;
+            mul.f32 fk1, fk1, $4;
+            mul.f32 fk2, fk2, $4;
+            mul.f32 fk3, fk3, $4;
+            cvt.rn.bf16x2.f32 $0, fk1, fk0;
+            cvt.rn.bf16x2.f32 $1, fk3, fk2;
+        }
+        """,
+        "=r,=r,h,h,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def cvt_e8m0_to_f32(e8m0_val: Uint32, *, loc=None, ip=None) -> Float32:
+    """Convert a single E8M0 scale byte to its true f32 value 2**(byte-127).
+
+    Byte 0 maps to 0.0. Unlike packed_dequant_e8m0x4_* (which fold a 2**7 bias
+    into the MMA input), this returns the unbiased scale so callers can apply it
+    directly in an f32 accumulator.
+    """
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(e8m0_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .pred p0;
+                .reg .u32 b0;
+                .reg .s32 e0;
+                .reg .f32 ef0;
+                and.b32 b0, $1, 0x000000ff;
+                setp.eq.u32 p0, b0, 0;
+                cvt.s32.u32 e0, b0;
+                sub.s32 e0, e0, 127;
+                cvt.rn.f32.s32 ef0, e0;
+                ex2.approx.f32 $0, ef0;
+                selp.f32 $0, 0f00000000, $0, p0;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_e8m0x4_to_f32x4(
+    packed: Uint32, *, loc=None, ip=None
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Decode 4 E8M0 scale bytes (packed u32) to 4 x true f32 (2**(byte-127))."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32(), T.f32(), T.f32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .pred p0, p1, p2, p3;
+            .reg .u32 b0, b1, b2, b3;
+            .reg .s32 e0, e1, e2, e3;
+            .reg .f32 ef0, ef1, ef2, ef3;
+            and.b32 b0, $4, 0x000000ff;
+            shr.u32 b1, $4, 8;
+            and.b32 b1, b1, 0x000000ff;
+            shr.u32 b2, $4, 16;
+            and.b32 b2, b2, 0x000000ff;
+            shr.u32 b3, $4, 24;
+            setp.eq.u32 p0, b0, 0;
+            setp.eq.u32 p1, b1, 0;
+            setp.eq.u32 p2, b2, 0;
+            setp.eq.u32 p3, b3, 0;
+            cvt.s32.u32 e0, b0;
+            cvt.s32.u32 e1, b1;
+            cvt.s32.u32 e2, b2;
+            cvt.s32.u32 e3, b3;
+            sub.s32 e0, e0, 127;
+            sub.s32 e1, e1, 127;
+            sub.s32 e2, e2, 127;
+            sub.s32 e3, e3, 127;
+            cvt.rn.f32.s32 ef0, e0;
+            cvt.rn.f32.s32 ef1, e1;
+            cvt.rn.f32.s32 ef2, e2;
+            cvt.rn.f32.s32 ef3, e3;
+            ex2.approx.f32 $0, ef0;
+            ex2.approx.f32 $1, ef1;
+            ex2.approx.f32 $2, ef2;
+            ex2.approx.f32 $3, ef3;
+            selp.f32 $0, 0f00000000, $0, p0;
+            selp.f32 $1, 0f00000000, $1, p1;
+            selp.f32 $2, 0f00000000, $2, p2;
+            selp.f32 $3, 0f00000000, $3, p3;
+        }
+        """,
+        "=f,=f,=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip)),
+    )
+
+
+# =============================================================================
+# FP4 (E2M1) Decode Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def fp4_decode_4bytes(
+    packed_u32: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Decode 4 FP4 bytes (packed u32) into 4 x f16x2 pairs."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32, i32, i32)>"),
+        [Uint32(packed_u32).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b8 byte0, byte1, byte2, byte3;
+            mov.b32 {byte0, byte1, byte2, byte3}, $4;
+            cvt.rn.f16x2.e2m1x2 $0, byte0;
+            cvt.rn.f16x2.e2m1x2 $1, byte1;
+            cvt.rn.f16x2.e2m1x2 $2, byte2;
+            cvt.rn.f16x2.e2m1x2 $3, byte3;
+        }
+        """,
+        "=r,=r,=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [2], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [3], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def fp4_decode_2(byte_val: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Decode 1 FP4 byte into 1 f16x2 pair."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(byte_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b8 b0;
+                cvt.u8.u32 b0, $1;
+                cvt.rn.f16x2.e2m1x2 $0, b0;
+            }
+            """,
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def e2m1x8_to_qmma_e2m1x8(
+    packed_u32: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Spread eight packed FP4 nibbles into QMMA E2M1 byte containers.
+
+    The SM120 f8f6f4 instruction expects one E2M1 value per byte with the
+    original nibble in bits 5:2.  This six-instruction spread is cheaper than
+    losslessly relabeling every value as E4M3 when no residual multiplier is
+    required.
+    """
+    res = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed_u32).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 s, t;
+            shl.b32 s, $2, 2;
+            shr.u32 t, $2, 2;
+            prmt.b32 $0, s, t, 0x5140;
+            prmt.b32 $1, s, t, 0x7362;
+            and.b32 $0, $0, 0x3C3C3C3C;
+            and.b32 $1, $1, 0x3C3C3C3C;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def e2m1x8_to_e4m3x8(packed_u32: Uint32, *, loc=None, ip=None) -> Tuple[Uint32, Uint32]:
+    """Expand 8 packed E2M1 nibbles into 8 E4M3 bytes, losslessly.
+
+    Every E2M1 value is exactly representable in E4M3, so this is a pure
+    relabeling done with two prmt magnitude-LUT lookups plus a sign pass.
+    Nibble i of the input becomes byte i of the (lo, hi) output pair.
+    """
+    res = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [Uint32(packed_u32).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 clo, chi, cslo, cshi, mlo, mhi, slo, shi;
+            .reg .b32 tbl_a, tbl_b, tbl_s, zero;
+            // E4M3 encodings of {0, .5, 1, 1.5, 2, 3, 4, 6}.
+            mov.b32 tbl_a, 0x3C383000;
+            mov.b32 tbl_b, 0x4C484440;
+            mov.b32 tbl_s, 0x00008000;
+            mov.b32 zero, 0;
+            // Magnitude codes (low 3 bits of each nibble) as prmt selectors.
+            and.b32 clo, $2, 0x00007777;
+            shr.u32 chi, $2, 16;
+            and.b32 chi, chi, 0x00007777;
+            prmt.b32 mlo, tbl_a, tbl_b, clo;
+            prmt.b32 mhi, tbl_a, tbl_b, chi;
+            // Sign bit (nibble bit 3) -> byte bit 7 via a 2-entry LUT.
+            shr.u32 cslo, $2, 3;
+            and.b32 cslo, cslo, 0x00001111;
+            shr.u32 cshi, $2, 19;
+            and.b32 cshi, cshi, 0x00001111;
+            prmt.b32 slo, tbl_s, zero, cslo;
+            prmt.b32 shi, tbl_s, zero, cshi;
+            or.b32 $0, mlo, slo;
+            or.b32 $1, mhi, shi;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def e2m1x8_mul_residual_to_e4m3x8(
+    packed_u32: Uint32, residual_h2: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Expand 8 E2M1 nibbles to E4M3 bytes with a residual multiplier.
+
+    Decodes to f16 pairs, multiplies by ``residual_h2`` (the same residual
+    broadcast to both f16 lanes), and rounds to E4M3.  Used by the w4a8
+    NVFP4 path where the per-K/16 e4m3 scale is decomposed into a shared
+    UE8M0 hardware exponent and this in-register residual.
+    """
+    res = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [
+            Uint32(packed_u32).ir_value(loc=loc, ip=ip),
+            Uint32(residual_h2).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b8 b0, b1, b2, b3;
+            .reg .b32 h0, h1, h2, h3;
+            .reg .b16 e0, e1, e2, e3;
+            mov.b32 {b0, b1, b2, b3}, $2;
+            cvt.rn.f16x2.e2m1x2 h0, b0;
+            cvt.rn.f16x2.e2m1x2 h1, b1;
+            cvt.rn.f16x2.e2m1x2 h2, b2;
+            cvt.rn.f16x2.e2m1x2 h3, b3;
+            mul.f16x2 h0, h0, $3;
+            mul.f16x2 h1, h1, $3;
+            mul.f16x2 h2, h2, $3;
+            mul.f16x2 h3, h3, $3;
+            cvt.rn.satfinite.e4m3x2.f16x2 e0, h0;
+            cvt.rn.satfinite.e4m3x2.f16x2 e1, h1;
+            cvt.rn.satfinite.e4m3x2.f16x2 e2, h2;
+            cvt.rn.satfinite.e4m3x2.f16x2 e3, h3;
+            mov.b32 $0, {e0, e1};
+            mov.b32 $1, {e2, e3};
+        }
+        """,
+        "=r,=r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
+def cvt_fp32x2_to_e2m1x2(v0: Float32, v1: Float32, *, loc=None, ip=None) -> Uint32:
+    """Convert 2 x f32 to 1 x FP4 (E2M1) byte."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(v0).ir_value(loc=loc, ip=ip),
+                Float32(v1).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b8 b;
+                cvt.rn.satfinite.e2m1x2.f32 b, $2, $1;
+                cvt.u32.u8 $0, b;
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def quant_dequant_2(
+    v0: Float32, v1: Float32, sf_f32: Float32, eff_scale: Float32
+) -> Tuple[Float32, Float32]:
+    """Quantize-dequantize pair roundtrip through FP4."""
+    inv_scale = Float32(1.0) / eff_scale
+    fp4_byte = cvt_fp32x2_to_e2m1x2(v0 * inv_scale, v1 * inv_scale)
+    h2 = fp4_decode_2(fp4_byte)
+    f0, f1 = f16x2_to_f32x2(h2)
+    return f0 * sf_f32, f1 * sf_f32
+
+
+# =============================================================================
+# Half2 FMA Dot Product Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def hfma2_4(
+    w0: Uint32,
+    x0: Uint32,
+    w1: Uint32,
+    x1: Uint32,
+    w2: Uint32,
+    x2: Uint32,
+    w3: Uint32,
+    x3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32]:
+    """4-element half2 FMA dot product returning (lo, hi) f32."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32, f32)>"),
+        [
+            Uint32(w0).ir_value(loc=loc, ip=ip),
+            Uint32(x0).ir_value(loc=loc, ip=ip),
+            Uint32(w1).ir_value(loc=loc, ip=ip),
+            Uint32(x1).ir_value(loc=loc, ip=ip),
+            Uint32(w2).ir_value(loc=loc, ip=ip),
+            Uint32(x2).ir_value(loc=loc, ip=ip),
+            Uint32(w3).ir_value(loc=loc, ip=ip),
+            Uint32(x3).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .f16x2 acc;
+            .reg .b16 lo, hi;
+            mov.b32 acc, 0;
+            fma.rn.f16x2 acc, $2, $3, acc;
+            fma.rn.f16x2 acc, $4, $5, acc;
+            fma.rn.f16x2 acc, $6, $7, acc;
+            fma.rn.f16x2 acc, $8, $9, acc;
+            mov.b32 {lo, hi}, acc;
+            cvt.f32.f16 $0, lo;
+            cvt.f32.f16 $1, hi;
+        }
+        """,
+        "=f,=f,r,r,r,r,r,r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), res, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), res, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def hfma2_4_sum(
+    w0: Uint32,
+    x0: Uint32,
+    w1: Uint32,
+    x1: Uint32,
+    w2: Uint32,
+    x2: Uint32,
+    w3: Uint32,
+    x3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """4-element half2 FMA dot product returning lane sum."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Uint32(w0).ir_value(loc=loc, ip=ip),
+                Uint32(x0).ir_value(loc=loc, ip=ip),
+                Uint32(w1).ir_value(loc=loc, ip=ip),
+                Uint32(x1).ir_value(loc=loc, ip=ip),
+                Uint32(w2).ir_value(loc=loc, ip=ip),
+                Uint32(x2).ir_value(loc=loc, ip=ip),
+                Uint32(w3).ir_value(loc=loc, ip=ip),
+                Uint32(x3).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .f16x2 acc;
+                .reg .b16 lo, hi;
+                .reg .f32 flo, fhi;
+                mov.b32 acc, 0;
+                fma.rn.f16x2 acc, $1, $2, acc;
+                fma.rn.f16x2 acc, $3, $4, acc;
+                fma.rn.f16x2 acc, $5, $6, acc;
+                fma.rn.f16x2 acc, $7, $8, acc;
+                mov.b32 {lo, hi}, acc;
+                cvt.f32.f16 flo, lo;
+                cvt.f32.f16 fhi, hi;
+                add.f32 $0, flo, fhi;
+            }
+            """,
+            "=f,r,r,r,r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def hfma2_8(
+    w0: Uint32,
+    x0: Uint32,
+    w1: Uint32,
+    x1: Uint32,
+    w2: Uint32,
+    x2: Uint32,
+    w3: Uint32,
+    x3: Uint32,
+    w4: Uint32,
+    x4: Uint32,
+    w5: Uint32,
+    x5: Uint32,
+    w6: Uint32,
+    x6: Uint32,
+    w7: Uint32,
+    x7: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32]:
+    """8-element half2 FMA dot product returning (lo, hi) f32."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32, f32)>"),
+        [
+            Uint32(w0).ir_value(loc=loc, ip=ip),
+            Uint32(x0).ir_value(loc=loc, ip=ip),
+            Uint32(w1).ir_value(loc=loc, ip=ip),
+            Uint32(x1).ir_value(loc=loc, ip=ip),
+            Uint32(w2).ir_value(loc=loc, ip=ip),
+            Uint32(x2).ir_value(loc=loc, ip=ip),
+            Uint32(w3).ir_value(loc=loc, ip=ip),
+            Uint32(x3).ir_value(loc=loc, ip=ip),
+            Uint32(w4).ir_value(loc=loc, ip=ip),
+            Uint32(x4).ir_value(loc=loc, ip=ip),
+            Uint32(w5).ir_value(loc=loc, ip=ip),
+            Uint32(x5).ir_value(loc=loc, ip=ip),
+            Uint32(w6).ir_value(loc=loc, ip=ip),
+            Uint32(x6).ir_value(loc=loc, ip=ip),
+            Uint32(w7).ir_value(loc=loc, ip=ip),
+            Uint32(x7).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .f16x2 acc;
+            .reg .b16 lo, hi;
+            mov.b32 acc, 0;
+            fma.rn.f16x2 acc, $2, $3, acc;
+            fma.rn.f16x2 acc, $4, $5, acc;
+            fma.rn.f16x2 acc, $6, $7, acc;
+            fma.rn.f16x2 acc, $8, $9, acc;
+            fma.rn.f16x2 acc, $10, $11, acc;
+            fma.rn.f16x2 acc, $12, $13, acc;
+            fma.rn.f16x2 acc, $14, $15, acc;
+            fma.rn.f16x2 acc, $16, $17, acc;
+            mov.b32 {lo, hi}, acc;
+            cvt.f32.f16 $0, lo;
+            cvt.f32.f16 $1, hi;
+        }
+        """,
+        "=f,=f,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), res, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), res, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def hfma2_8_sum(
+    w0: Uint32,
+    x0: Uint32,
+    w1: Uint32,
+    x1: Uint32,
+    w2: Uint32,
+    x2: Uint32,
+    w3: Uint32,
+    x3: Uint32,
+    w4: Uint32,
+    x4: Uint32,
+    w5: Uint32,
+    x5: Uint32,
+    w6: Uint32,
+    x6: Uint32,
+    w7: Uint32,
+    x7: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """8-element half2 FMA dot product returning lane sum."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Uint32(w0).ir_value(loc=loc, ip=ip),
+                Uint32(x0).ir_value(loc=loc, ip=ip),
+                Uint32(w1).ir_value(loc=loc, ip=ip),
+                Uint32(x1).ir_value(loc=loc, ip=ip),
+                Uint32(w2).ir_value(loc=loc, ip=ip),
+                Uint32(x2).ir_value(loc=loc, ip=ip),
+                Uint32(w3).ir_value(loc=loc, ip=ip),
+                Uint32(x3).ir_value(loc=loc, ip=ip),
+                Uint32(w4).ir_value(loc=loc, ip=ip),
+                Uint32(x4).ir_value(loc=loc, ip=ip),
+                Uint32(w5).ir_value(loc=loc, ip=ip),
+                Uint32(x5).ir_value(loc=loc, ip=ip),
+                Uint32(w6).ir_value(loc=loc, ip=ip),
+                Uint32(x6).ir_value(loc=loc, ip=ip),
+                Uint32(w7).ir_value(loc=loc, ip=ip),
+                Uint32(x7).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .f16x2 acc;
+                .reg .b16 lo, hi;
+                .reg .f32 flo, fhi;
+                mov.b32 acc, 0;
+                fma.rn.f16x2 acc, $1, $2, acc;
+                fma.rn.f16x2 acc, $3, $4, acc;
+                fma.rn.f16x2 acc, $5, $6, acc;
+                fma.rn.f16x2 acc, $7, $8, acc;
+                fma.rn.f16x2 acc, $9, $10, acc;
+                fma.rn.f16x2 acc, $11, $12, acc;
+                fma.rn.f16x2 acc, $13, $14, acc;
+                fma.rn.f16x2 acc, $15, $16, acc;
+                mov.b32 {lo, hi}, acc;
+                cvt.f32.f16 flo, lo;
+                cvt.f32.f16 fhi, hi;
+                add.f32 $0, flo, fhi;
+            }
+            """,
+            "=f,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+# =============================================================================
+# FP4 Dot Product Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def fp4_dot4_sum(
+    u_packed: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """FP4 dot product: decode 4 FP4 bytes and dot with 4 x f16x2 inputs."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Uint32(u_packed).ir_value(loc=loc, ip=ip),
+                Uint32(x0).ir_value(loc=loc, ip=ip),
+                Uint32(x1).ir_value(loc=loc, ip=ip),
+                Uint32(x2).ir_value(loc=loc, ip=ip),
+                Uint32(x3).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b8 b0, b1, b2, b3;
+                .reg .b32 h0, h1, h2, h3;
+                .reg .f16x2 acc;
+                .reg .b16 lo, hi;
+                .reg .f32 flo, fhi;
+                mov.b32 {b0, b1, b2, b3}, $1;
+                cvt.rn.f16x2.e2m1x2 h0, b0;
+                cvt.rn.f16x2.e2m1x2 h1, b1;
+                cvt.rn.f16x2.e2m1x2 h2, b2;
+                cvt.rn.f16x2.e2m1x2 h3, b3;
+                mov.b32 acc, 0;
+                fma.rn.f16x2 acc, h0, $2, acc;
+                fma.rn.f16x2 acc, h1, $3, acc;
+                fma.rn.f16x2 acc, h2, $4, acc;
+                fma.rn.f16x2 acc, h3, $5, acc;
+                mov.b32 {lo, hi}, acc;
+                cvt.f32.f16 flo, lo;
+                cvt.f32.f16 fhi, hi;
+                add.f32 $0, flo, fhi;
+            }
+            """,
+            "=f,r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def fp4_dot8_dual_sum(
+    up_a: Uint32,
+    up_b: Uint32,
+    gate_a: Uint32,
+    gate_b: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+    x4: Uint32,
+    x5: Uint32,
+    x6: Uint32,
+    x7: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32]:
+    """Fused dual FP4 dot product (up + gate) over the SAME 8 shared f16x2
+    activation words. Decodes both weight rows and runs two INDEPENDENT
+    f16x2 accumulator chains in a single inline-asm block, then reduces each
+    to f32. Bit-identical to running fp4_dot8_sum twice (same per-chain fma
+    order, same lo+hi f32 reduction) but emits one asm block so ptxas can
+    interleave the two independent fma chains for 2-way ILP and halves the
+    per-pair epilogue (mov/cvt/add) op count on the issue-bound decode loop."""
+    res = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [
+            Uint32(up_a).ir_value(loc=loc, ip=ip),
+            Uint32(up_b).ir_value(loc=loc, ip=ip),
+            Uint32(gate_a).ir_value(loc=loc, ip=ip),
+            Uint32(gate_b).ir_value(loc=loc, ip=ip),
+            Uint32(x0).ir_value(loc=loc, ip=ip),
+            Uint32(x1).ir_value(loc=loc, ip=ip),
+            Uint32(x2).ir_value(loc=loc, ip=ip),
+            Uint32(x3).ir_value(loc=loc, ip=ip),
+            Uint32(x4).ir_value(loc=loc, ip=ip),
+            Uint32(x5).ir_value(loc=loc, ip=ip),
+            Uint32(x6).ir_value(loc=loc, ip=ip),
+            Uint32(x7).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b8 ua0, ua1, ua2, ua3, ub0, ub1, ub2, ub3;
+            .reg .b8 ga0, ga1, ga2, ga3, gb0, gb1, gb2, gb3;
+            .reg .b32 uh0, uh1, uh2, uh3, uh4, uh5, uh6, uh7;
+            .reg .b32 gh0, gh1, gh2, gh3, gh4, gh5, gh6, gh7;
+            .reg .f16x2 uacc, gacc;
+            .reg .b16 ulo, uhi, glo, ghi;
+            .reg .f32 uflo, ufhi, gflo, gfhi;
+            mov.b32 {ua0, ua1, ua2, ua3}, $2;
+            mov.b32 {ub0, ub1, ub2, ub3}, $3;
+            mov.b32 {ga0, ga1, ga2, ga3}, $4;
+            mov.b32 {gb0, gb1, gb2, gb3}, $5;
+            cvt.rn.f16x2.e2m1x2 uh0, ua0;
+            cvt.rn.f16x2.e2m1x2 uh1, ua1;
+            cvt.rn.f16x2.e2m1x2 uh2, ua2;
+            cvt.rn.f16x2.e2m1x2 uh3, ua3;
+            cvt.rn.f16x2.e2m1x2 uh4, ub0;
+            cvt.rn.f16x2.e2m1x2 uh5, ub1;
+            cvt.rn.f16x2.e2m1x2 uh6, ub2;
+            cvt.rn.f16x2.e2m1x2 uh7, ub3;
+            cvt.rn.f16x2.e2m1x2 gh0, ga0;
+            cvt.rn.f16x2.e2m1x2 gh1, ga1;
+            cvt.rn.f16x2.e2m1x2 gh2, ga2;
+            cvt.rn.f16x2.e2m1x2 gh3, ga3;
+            cvt.rn.f16x2.e2m1x2 gh4, gb0;
+            cvt.rn.f16x2.e2m1x2 gh5, gb1;
+            cvt.rn.f16x2.e2m1x2 gh6, gb2;
+            cvt.rn.f16x2.e2m1x2 gh7, gb3;
+            mov.b32 uacc, 0;
+            mov.b32 gacc, 0;
+            fma.rn.f16x2 uacc, uh0, $6, uacc;
+            fma.rn.f16x2 gacc, gh0, $6, gacc;
+            fma.rn.f16x2 uacc, uh1, $7, uacc;
+            fma.rn.f16x2 gacc, gh1, $7, gacc;
+            fma.rn.f16x2 uacc, uh2, $8, uacc;
+            fma.rn.f16x2 gacc, gh2, $8, gacc;
+            fma.rn.f16x2 uacc, uh3, $9, uacc;
+            fma.rn.f16x2 gacc, gh3, $9, gacc;
+            fma.rn.f16x2 uacc, uh4, $10, uacc;
+            fma.rn.f16x2 gacc, gh4, $10, gacc;
+            fma.rn.f16x2 uacc, uh5, $11, uacc;
+            fma.rn.f16x2 gacc, gh5, $11, gacc;
+            fma.rn.f16x2 uacc, uh6, $12, uacc;
+            fma.rn.f16x2 gacc, gh6, $12, gacc;
+            fma.rn.f16x2 uacc, uh7, $13, uacc;
+            fma.rn.f16x2 gacc, gh7, $13, gacc;
+            mov.b32 {ulo, uhi}, uacc;
+            mov.b32 {glo, ghi}, gacc;
+            cvt.f32.f16 uflo, ulo;
+            cvt.f32.f16 ufhi, uhi;
+            cvt.f32.f16 gflo, glo;
+            cvt.f32.f16 gfhi, ghi;
+            add.f32 $0, uflo, ufhi;
+            add.f32 $1, gflo, gfhi;
+        }
+        """,
+        "=f,=f,r,r,r,r,r,r,r,r,r,r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    up = Float32(llvm.extractvalue(T.f32(), res, [0], loc=loc, ip=ip))
+    gate = Float32(llvm.extractvalue(T.f32(), res, [1], loc=loc, ip=ip))
+    return up, gate
+
+
+@dsl_user_op
+def fp4_dot8_sum(
+    u_a: Uint32,
+    u_b: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+    x4: Uint32,
+    x5: Uint32,
+    x6: Uint32,
+    x7: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """FP4 dot product: decode 8 FP4 bytes (2 x u32) and dot with 8 x f16x2 inputs."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Uint32(u_a).ir_value(loc=loc, ip=ip),
+                Uint32(u_b).ir_value(loc=loc, ip=ip),
+                Uint32(x0).ir_value(loc=loc, ip=ip),
+                Uint32(x1).ir_value(loc=loc, ip=ip),
+                Uint32(x2).ir_value(loc=loc, ip=ip),
+                Uint32(x3).ir_value(loc=loc, ip=ip),
+                Uint32(x4).ir_value(loc=loc, ip=ip),
+                Uint32(x5).ir_value(loc=loc, ip=ip),
+                Uint32(x6).ir_value(loc=loc, ip=ip),
+                Uint32(x7).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b8 a0, a1, a2, a3;
+                .reg .b8 b0, b1, b2, b3;
+                .reg .b32 h0, h1, h2, h3, h4, h5, h6, h7;
+                .reg .f16x2 acc;
+                .reg .b16 lo, hi;
+                .reg .f32 flo, fhi;
+                mov.b32 {a0, a1, a2, a3}, $1;
+                mov.b32 {b0, b1, b2, b3}, $2;
+                cvt.rn.f16x2.e2m1x2 h0, a0;
+                cvt.rn.f16x2.e2m1x2 h1, a1;
+                cvt.rn.f16x2.e2m1x2 h2, a2;
+                cvt.rn.f16x2.e2m1x2 h3, a3;
+                cvt.rn.f16x2.e2m1x2 h4, b0;
+                cvt.rn.f16x2.e2m1x2 h5, b1;
+                cvt.rn.f16x2.e2m1x2 h6, b2;
+                cvt.rn.f16x2.e2m1x2 h7, b3;
+                mov.b32 acc, 0;
+                fma.rn.f16x2 acc, h0, $3, acc;
+                fma.rn.f16x2 acc, h1, $4, acc;
+                fma.rn.f16x2 acc, h2, $5, acc;
+                fma.rn.f16x2 acc, h3, $6, acc;
+                fma.rn.f16x2 acc, h4, $7, acc;
+                fma.rn.f16x2 acc, h5, $8, acc;
+                fma.rn.f16x2 acc, h6, $9, acc;
+                fma.rn.f16x2 acc, h7, $10, acc;
+                mov.b32 {lo, hi}, acc;
+                cvt.f32.f16 flo, lo;
+                cvt.f32.f16 fhi, hi;
+                add.f32 $0, flo, fhi;
+            }
+            """,
+            "=f,r,r,r,r,r,r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def _f16x2_dot_sum_f32acc(a_h2: Uint32, b_h2: Uint32) -> Float32:
+    a0, a1 = f16x2_to_f32x2(a_h2)
+    b0, b1 = f16x2_to_f32x2(b_h2)
+    return a0 * b0 + a1 * b1
+
+
+@cute.jit
+def fp4_dot4_sum_f32acc(
+    u_packed: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+) -> Float32:
+    """FP4 dot product using f32 accumulation after FP4 decode."""
+    h0, h1, h2, h3 = fp4_decode_4bytes(u_packed)
+    return (
+        _f16x2_dot_sum_f32acc(h0, x0)
+        + _f16x2_dot_sum_f32acc(h1, x1)
+        + _f16x2_dot_sum_f32acc(h2, x2)
+        + _f16x2_dot_sum_f32acc(h3, x3)
+    )
+
+
+@cute.jit
+def fp4_dot8_sum_f32acc(
+    u_a: Uint32,
+    u_b: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+    x4: Uint32,
+    x5: Uint32,
+    x6: Uint32,
+    x7: Uint32,
+) -> Float32:
+    """FP4 dot product using f32 accumulation after FP4 decode."""
+    h0, h1, h2, h3 = fp4_decode_4bytes(u_a)
+    h4, h5, h6, h7 = fp4_decode_4bytes(u_b)
+    return (
+        _f16x2_dot_sum_f32acc(h0, x0)
+        + _f16x2_dot_sum_f32acc(h1, x1)
+        + _f16x2_dot_sum_f32acc(h2, x2)
+        + _f16x2_dot_sum_f32acc(h3, x3)
+        + _f16x2_dot_sum_f32acc(h4, x4)
+        + _f16x2_dot_sum_f32acc(h5, x5)
+        + _f16x2_dot_sum_f32acc(h6, x6)
+        + _f16x2_dot_sum_f32acc(h7, x7)
+    )
+
+
+# =============================================================================
+# Pack Intrinsics
+# =============================================================================
+
+
+@dsl_user_op
+def pack_f32x2_to_f16x2(a: Float32, b: Float32, *, loc=None, ip=None) -> Uint32:
+    """Pack two f32 values into one f16x2 u32."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b16 lo, hi;
+                cvt.rn.f16.f32 lo, $1;
+                cvt.rn.f16.f32 hi, $2;
+                mov.b32 $0, {lo, hi};
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+# =============================================================================
+# UE8M0 Intrinsics (for MXFP4)
+# =============================================================================
+
+
+@dsl_user_op
+def pow2_ceil_ue8m0(
+    scale: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Uint32]:
+    """Round a positive FP32 ``scale`` UP to a power of two, bit-exactly.
+
+    Returns ``(rounded_fp32, ue8m0_byte)`` where:
+      * ``rounded_fp32`` == ``__uint_as_float(power_of_2_round(__float_as_uint(scale)))``
+      * ``ue8m0_byte``   == ``(__float_as_uint(rounded_fp32) >> 23) & 0xFF``
+
+    Bit-exact replica of FlashInfer's fp8_quant.cuh rounding +
+    scale_convert.cuh fp32_to_ue8m0. Integer ops only (no lg2.approx), so unlike
+    ``cvt_f32_to_ue8m0`` it matches the FlashInfer reference bit-for-bit.
+    """
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.i32()]),
+        [Float32(scale).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .pred  p_mant;
+            .reg .b32   bits, mant;
+
+            // bits = __float_as_uint(scale)
+            mov.b32 bits, $2;
+            // mant = bits & 0x007FFFFF  (mantissa field)
+            and.b32 mant, bits, 8388607;
+            setp.ne.u32 p_mant, mant, 0;
+            // if (mant) bits = (bits + 0x00800000) & 0x7F800000
+            @p_mant add.u32 bits, bits, 8388608;
+            @p_mant and.b32 bits, bits, 2139095040;
+            // rounded fp32 scale = __uint_as_float(bits)
+            mov.b32 $0, bits;
+            // ue8m0 = (bits >> 23) & 0xFF
+            bfe.u32 $1, bits, 23, 8;
+        }
+        """,
+        "=f,=r,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    rounded = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    ue8m0 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Float32(rounded), Uint32(ue8m0)
+
+
+@dsl_user_op
+def cvt_f32_to_ue8m0(max_val: Float32, *, loc=None, ip=None) -> Uint32:
+    """
+    Convert float32 max value to UE8M0 scale factor.
+
+    UE8M0 is unsigned 8-bit exponent-only format:
+    - value = 2^(ue8m0 - 127)
+    - ue8m0 = ceil(log2(max_val)) + 127
+
+    Uses lg2.approx.f32 for fast log2 approximation.
+    Uses cvt.rpi (round towards positive infinity, i.e., ceiling).
+    Returns value clamped to [0, 255].
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(max_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .pred p_zero, p_neg, p_ovf;
+                .reg .f32 log2_val;
+                .reg .s32 exp_int, result;
+
+                // Check for zero/negative
+                setp.le.f32 p_zero, $1, 0f00000000;
+
+                // Compute ceil(log2(max_val)) using cvt.rpi (round towards +inf)
+                lg2.approx.f32 log2_val, $1;
+                cvt.rpi.s32.f32 exp_int, log2_val;
+
+                // Add bias and clamp to [0, 255]
+                add.s32 result, exp_int, 127;
+                setp.lt.s32 p_neg, result, 0;
+                setp.gt.s32 p_ovf, result, 255;
+                selp.s32 result, 0, result, p_neg;
+                selp.s32 result, 255, result, p_ovf;
+                selp.s32 $0, 0, result, p_zero;
+            }
+            """,
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def ue8m0_to_output_scale(ue8m0_val: Uint32, *, loc=None, ip=None) -> Float32:
+    """
+    Convert UE8M0 to output_scale for MXFP4 quantization.
+
+    UE8M0 value = 2^(ue8m0 - 127)
+    Returns 1 / 2^(ue8m0 - 127) = 2^(127 - ue8m0)
+    """
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(ue8m0_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .pred p_zero;
+                .reg .s32 neg_exp;
+                .reg .f32 neg_exp_f, result;
+
+                // Check for zero
+                setp.eq.u32 p_zero, $1, 0;
+
+                // Compute 2^(127 - ue8m0) = 1 / 2^(ue8m0 - 127)
+                sub.s32 neg_exp, 127, $1;
+                cvt.rn.f32.s32 neg_exp_f, neg_exp;
+                ex2.approx.f32 result, neg_exp_f;
+                selp.f32 $0, 0f00000000, result, p_zero;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+# =============================================================================
+# E2M1 Conversion
+# =============================================================================
+
+
+@dsl_user_op
+def cvt_e2m1x8_f32(
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    v4: Float32,
+    v5: Float32,
+    v6: Float32,
+    v7: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """Convert eight float32 values to eight E2M1 (4-bit) values packed into uint32."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(v0).ir_value(loc=loc, ip=ip),
+                Float32(v1).ir_value(loc=loc, ip=ip),
+                Float32(v2).ir_value(loc=loc, ip=ip),
+                Float32(v3).ir_value(loc=loc, ip=ip),
+                Float32(v4).ir_value(loc=loc, ip=ip),
+                Float32(v5).ir_value(loc=loc, ip=ip),
+                Float32(v6).ir_value(loc=loc, ip=ip),
+                Float32(v7).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b8 byte0, byte1, byte2, byte3;
+                cvt.rn.satfinite.e2m1x2.f32 byte0, $2, $1;
+                cvt.rn.satfinite.e2m1x2.f32 byte1, $4, $3;
+                cvt.rn.satfinite.e2m1x2.f32 byte2, $6, $5;
+                cvt.rn.satfinite.e2m1x2.f32 byte3, $8, $7;
+                mov.b32 $0, {byte0, byte1, byte2, byte3};
+            }
+            """,
+            "=r,f,f,f,f,f,f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+# =============================================================================
+# Warp, Block, and Cluster Reduction Utilities
+# =============================================================================
+
+
+@cute.jit
+def warp_reduce(val, op, width: cutlass.Constexpr[int] = 32):
+    """Reduce across threads in a warp using butterfly shuffle."""
+    if cutlass.const_expr(isinstance(val, cute.TensorSSA)):
+        res = cute.make_rmem_tensor(val.shape, val.dtype)
+        res.store(val)
+        for i in cutlass.range_constexpr(cute.size(val.shape)):
+            res[i] = warp_reduce(res[i], op, width)
+        return res.load()
+    else:
+        for i in cutlass.range_constexpr(int(math.log2(width))):
+            val = op(val, cute.arch.shuffle_sync_bfly(val, offset=1 << i))
+        return val
+
+
+@cute.jit
+def block_reduce(
+    val: Float32,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    init_val: Float32,
+) -> Float32:
+    """Block reduction across multiple warps using shared memory."""
+    lane_idx = cute.arch.lane_idx()
+    warp_idx = cute.arch.warp_idx()
+    warps_per_row = cute.size(reduction_buffer.shape[1])
+    row_idx = warp_idx // warps_per_row
+    col_idx = warp_idx % warps_per_row
+
+    if lane_idx == 0:
+        reduction_buffer[row_idx, col_idx] = val
+    cute.arch.barrier()
+
+    block_reduce_val = init_val
+    if lane_idx < warps_per_row:
+        block_reduce_val = reduction_buffer[row_idx, lane_idx]
+    return warp_reduce(block_reduce_val, op)
+
+
+@cute.jit
+def cluster_reduce(
+    val: Float32,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    mbar_ptr: cute.Pointer,
+    cluster_n: cutlass.Constexpr[int],
+    init_val: Float32,
+) -> Float32:
+    """Cluster reduction across multiple CTAs using mbarrier."""
+    cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+    lane_idx = cute.arch.lane_idx()
+    warp_idx = cute.arch.warp_idx()
+
+    rows_per_block = reduction_buffer.shape[0]
+    warps_per_row = reduction_buffer.shape[1][0]
+
+    row_idx = warp_idx // warps_per_row
+    col_idx = warp_idx % warps_per_row
+
+    # Warp 0 sets up mbarrier transaction count
+    if warp_idx == 0:
+        with cute.arch.elect_one():
+            num_warps = rows_per_block * warps_per_row
+            expected_bytes = num_warps * cluster_n * 4
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar_ptr, expected_bytes)
+
+    # Each lane < cluster_n writes to a different CTA's shared memory
+    if lane_idx < cluster_n:
+        store_shared_remote(
+            val,
+            elem_pointer(reduction_buffer, (row_idx, (col_idx, cta_rank_in_cluster))),
+            mbar_ptr,
+            peer_cta_rank_in_cluster=lane_idx,
+        )
+
+    # Wait for all cluster writes
+    cute.arch.mbarrier_wait(mbar_ptr, phase=0)
+
+    # Reduce across all values
+    num_total = warps_per_row * cluster_n
+    num_iter = cute.ceil_div(num_total, 32)
+
+    block_reduce_val = init_val
+    for i in cutlass.range_constexpr(num_iter):
+        idx = lane_idx + i * 32
+        if idx < num_total:
+            block_reduce_val = op(block_reduce_val, reduction_buffer[row_idx, idx])
+
+    return warp_reduce(block_reduce_val, op)
+
+
+@cute.jit
+def row_reduce(
+    x: cute.TensorSSA,
+    op: cute.ReductionOp,
+    threads_per_row: cutlass.Constexpr[int],
+    reduction_buffer: cute.Tensor,
+    mbar_ptr,
+    cluster_n: cutlass.Constexpr[int],
+    init_val: Float32,
+):
+    """Row reduction with optional cluster support."""
+    local_val = x.reduce(op, init_val=init_val, reduction_profile=0)
+
+    warp_op = {
+        cute.ReductionOp.ADD: operator.add,
+        cute.ReductionOp.MAX: cute.arch.fmax,
+    }[op]
+    warp_width = min(threads_per_row, 32)
+    warp_val = warp_reduce(local_val, warp_op, width=warp_width)
+
+    warps_per_row = max(threads_per_row // 32, 1)
+
+    if cutlass.const_expr(warps_per_row > 1 or cluster_n > 1):
+        if cutlass.const_expr(cluster_n == 1):
+            return block_reduce(warp_val, warp_op, reduction_buffer, init_val)
+        else:
+            return cluster_reduce(
+                warp_val, warp_op, reduction_buffer, mbar_ptr, cluster_n, init_val
+            )
+    else:
+        return warp_val
+
+
+# =============================================================================
+# Predicate Utility
+# =============================================================================
+
+
+@cute.jit
+def predicate_k(tXcX: cute.Tensor, limit: int) -> cute.Tensor:
+    """Create predicate tensor for bounds checking."""
+    tXpX = cute.make_rmem_tensor(
+        cute.make_layout(
+            (
+                cute.size(tXcX, mode=[0, 1]),
+                cute.size(tXcX, mode=[1]),
+                cute.size(tXcX, mode=[2]),
+            ),
+            stride=(cute.size(tXcX, mode=[2]), 0, 1),
+        ),
+        cutlass.Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(tXpX.shape[0]):
+        for rest_k in cutlass.range_constexpr(tXpX.shape[2]):
+            tXpX[rest_v, 0, rest_k] = cute.elem_less(
+                tXcX[(0, rest_v), 0, rest_k][1], limit
+            )
+    return tXpX
+
+
+# =============================================================================
+# Helper Functions for SF Block Processing (block_size=16)
+# =============================================================================
+
+
+@cute.jit
+def load_8_half2(
+    mX: cute.Tensor, mW: cute.Tensor, row_offset: Int32, col_offset: Int32, H: int
+):
+    """Load 16 elements (8 half2 pairs) of X and W from global memory.
+
+    Returns:
+        x_h2: rmem_tensor of shape (8,) containing X as half2
+        w_h2: rmem_tensor of shape (8,) containing W as half2
+    """
+    x_h2 = cute.make_rmem_tensor((8,), Uint32)
+    w_h2 = cute.make_rmem_tensor((8,), Uint32)
+
+    # Load X (2 x 128-bit loads = 16 elements)
+    x_ptr0 = get_ptr_as_int64(mX, row_offset * H + col_offset)
+    x_ptr1 = get_ptr_as_int64(mX, row_offset * H + col_offset + Int32(8))
+    x_h2[0], x_h2[1], x_h2[2], x_h2[3] = ld_global_v4_u32(x_ptr0)
+    x_h2[4], x_h2[5], x_h2[6], x_h2[7] = ld_global_v4_u32(x_ptr1)
+
+    # Load W (2 x 128-bit loads = 16 elements)
+    w_ptr0 = get_ptr_as_int64(mW, col_offset)
+    w_ptr1 = get_ptr_as_int64(mW, col_offset + Int32(8))
+    w_h2[0], w_h2[1], w_h2[2], w_h2[3] = ld_global_v4_u32(w_ptr0)
+    w_h2[4], w_h2[5], w_h2[6], w_h2[7] = ld_global_v4_u32(w_ptr1)
+
+    return x_h2, w_h2
+
+
+@cute.jit
+def half2_mul_8(x_h2: cute.Tensor, w_h2: cute.Tensor) -> cute.Tensor:
+    """Multiply 8 half2 pairs element-wise."""
+    xw_h2 = cute.make_rmem_tensor((8,), Uint32)
+    for i in cutlass.range_constexpr(8):
+        xw_h2[i] = half2_mul(x_h2[i], w_h2[i])
+    return xw_h2
+
+
+@cute.jit
+def bfloat2_mul_8(x_h2: cute.Tensor, w_h2: cute.Tensor) -> cute.Tensor:
+    """Multiply 8 bfloat2 pairs element-wise."""
+    xw_h2 = cute.make_rmem_tensor((8,), Uint32)
+    for i in cutlass.range_constexpr(8):
+        xw_h2[i] = bfloat2_mul(x_h2[i], w_h2[i])
+    return xw_h2
+
+
+@cute.jit
+def half2_max_abs_8(xw_h2: cute.Tensor) -> Uint32:
+    """Compute max absolute value across 8 half2 values using tree reduction."""
+    # Compute abs for all 8 values
+    abs_h2 = cute.make_rmem_tensor((8,), Uint32)
+    for i in cutlass.range_constexpr(8):
+        abs_h2[i] = habs2(xw_h2[i])
+
+    # Tree reduction: 8 -> 4 -> 2 -> 1
+    max_01 = hmax2(abs_h2[0], abs_h2[1])
+    max_23 = hmax2(abs_h2[2], abs_h2[3])
+    max_45 = hmax2(abs_h2[4], abs_h2[5])
+    max_67 = hmax2(abs_h2[6], abs_h2[7])
+    max_0123 = hmax2(max_01, max_23)
+    max_4567 = hmax2(max_45, max_67)
+    return hmax2(max_0123, max_4567)
+
+
+@cute.jit
+def bfloat2_max_abs_8(xw_h2: cute.Tensor) -> Uint32:
+    """Compute max absolute value across 8 bfloat2 values using tree reduction."""
+    # Compute abs for all 8 values
+    abs_h2 = cute.make_rmem_tensor((8,), Uint32)
+    for i in cutlass.range_constexpr(8):
+        abs_h2[i] = bfloat2_habs2(xw_h2[i])
+
+    # Tree reduction: 8 -> 4 -> 2 -> 1
+    max_01 = bfloat2_hmax2(abs_h2[0], abs_h2[1])
+    max_23 = bfloat2_hmax2(abs_h2[2], abs_h2[3])
+    max_45 = bfloat2_hmax2(abs_h2[4], abs_h2[5])
+    max_67 = bfloat2_hmax2(abs_h2[6], abs_h2[7])
+    max_0123 = bfloat2_hmax2(max_01, max_23)
+    max_4567 = bfloat2_hmax2(max_45, max_67)
+    return bfloat2_hmax2(max_0123, max_4567)
+
+
+@cute.jit
+def half2_to_float16(xw_h2: cute.Tensor, scale: Float32) -> cute.Tensor:
+    """Convert 8 half2 to 16 float32 with scaling."""
+    y_f32 = cute.make_rmem_tensor((16,), Float32)
+    for i in cutlass.range_constexpr(8):
+        y_f32[i * 2], y_f32[i * 2 + 1] = half2_to_float2_scaled(xw_h2[i], scale)
+    return y_f32
+
+
+@cute.jit
+def bfloat2_to_float16(xw_h2: cute.Tensor, scale: Float32) -> cute.Tensor:
+    """Convert 8 bfloat2 to 16 float32 with scaling."""
+    y_f32 = cute.make_rmem_tensor((16,), Float32)
+    for i in cutlass.range_constexpr(8):
+        y_f32[i * 2], y_f32[i * 2 + 1] = bfloat2_to_float2_scaled(xw_h2[i], scale)
+    return y_f32
+
+
+@cute.jit
+def quantize_and_pack_16(y_f32: cute.Tensor, value_scale: Float32) -> Uint64:
+    """Quantize 16 float32 values to FP4 and pack into uint64."""
+    t025 = value_scale * Float32(0.25)
+    t075 = value_scale * Float32(0.75)
+    t125 = value_scale * Float32(1.25)
+    t175 = value_scale * Float32(1.75)
+    t250 = value_scale * Float32(2.5)
+    t350 = value_scale * Float32(3.5)
+    t500 = value_scale * Float32(5.0)
+    packed = Uint64(0)
+    for i in cutlass.range_constexpr(16):
+        q = y_f32[i]
+        mag = fabs_f32(q)
+        nibble = Uint8(0)
+        if mag > t025 and mag < t075:
+            nibble = Uint8(1)
+        elif mag >= t075 and mag <= t125:
+            nibble = Uint8(2)
+        elif mag > t125 and mag < t175:
+            nibble = Uint8(3)
+        elif mag >= t175 and mag <= t250:
+            nibble = Uint8(4)
+        elif mag > t250 and mag < t350:
+            nibble = Uint8(5)
+        elif mag >= t350 and mag <= t500:
+            nibble = Uint8(6)
+        elif mag > t500:
+            nibble = Uint8(7)
+        if nibble != Uint8(0) and q < Float32(0.0):
+            nibble = nibble | Uint8(0x8)
+        packed = packed | (Uint64(nibble) << Uint64(i * 4))
+    return packed
+
+
+@cute.jit
+def quantize_and_pack_16_fast(y_f32: cute.Tensor, inv_scale: Float32) -> Uint64:
+    """Fast approximate FP4 quantize/pack for 16 float32 values."""
+    q = cute.make_rmem_tensor((16,), Float32)
+    for i in cutlass.range_constexpr(16):
+        q[i] = y_f32[i] * inv_scale
+
+    packed_lo = cvt_e2m1x8_f32(q[0], q[1], q[2], q[3], q[4], q[5], q[6], q[7])
+    packed_hi = cvt_e2m1x8_f32(q[8], q[9], q[10], q[11], q[12], q[13], q[14], q[15])
+    return (Uint64(packed_hi) << Uint64(32)) | Uint64(packed_lo)
+
+
+@cute.jit
+def quantize_block_fp4(
+    values: cute.Tensor,
+    max_abs: Float32,
+    global_scale_val: Float32,
+) -> Tuple[Uint64, cutlass.Uint8]:
+    """Quantize 16 float32 values to packed FP4 + e4m3 scale byte.
+
+    Given 16 values and their pre-computed max_abs, derives the NVFP4 block
+    scale, quantizes to FP4, and packs into a uint64.  Returns
+    (packed_fp4_u64, scale_byte).  The caller handles storage writes.
+    """
+    scale_float = max_abs * global_scale_val / Float32(FLOAT4_E2M1_MAX)
+    scale_float = fmin_f32(scale_float, Float32(FLOAT8_E4M3_MAX))
+    scale_u32 = cvt_f32_to_e4m3(scale_float)
+    scale_byte = cutlass.Uint8(scale_u32 & Uint32(0xFF))
+    quantized_scale = fp8_e4m3_to_f32(scale_u32)
+    packed64 = Uint64(0)
+    if quantized_scale != Float32(0.0) and global_scale_val != Float32(0.0):
+        packed64 = quantize_and_pack_16(values, quantized_scale / global_scale_val)
+    return packed64, scale_byte
+
+
+@cute.jit
+def quantize_block_fp4_fast(
+    values: cute.Tensor,
+    max_abs: Float32,
+    global_scale_val: Float32,
+) -> Tuple[Uint64, cutlass.Uint8]:
+    """Fast approximate FP4 block quantization using reciprocal/vector path."""
+    scale_u32 = Uint32(0)
+    scale_byte = cutlass.Uint8(0)
+    packed64 = Uint64(0)
+    if global_scale_val != Float32(0.0):
+        fp4_max_rcp = rcp_approx_ftz(Float32(FLOAT4_E2M1_MAX))
+        scale_float = global_scale_val * (max_abs * fp4_max_rcp)
+        scale_float = fmin_f32(scale_float, Float32(FLOAT8_E4M3_MAX))
+        scale_u32 = cvt_f32_to_e4m3(scale_float)
+        scale_byte = cutlass.Uint8(scale_u32 & Uint32(0xFF))
+        inv_quantized_scale = fp8_e4m3_to_f32_and_rcp(scale_u32)
+        if inv_quantized_scale != Float32(0.0):
+            packed64 = quantize_and_pack_16_fast(
+                values, inv_quantized_scale * global_scale_val
+            )
+    return packed64, scale_byte
+
+
+@cute.jit
+def max_abs_16(values: cute.Tensor) -> Float32:
+    """Compute the maximum absolute value of 16 float32 values."""
+    result = fabs_f32(values[0])
+    for i in cutlass.range_constexpr(1, 16):
+        result = fmax_f32(result, fabs_f32(values[i]))
+    return result
+
+
+@cute.jit
+def silu_mul_16(
+    gate: cute.Tensor,
+    up: cute.Tensor,
+) -> cute.Tensor:
+    """Fused SiLU(gate) * up for 16 float32 element pairs.
+
+    Used in the CompactMoEKernel epilogue to fuse the activation function
+    between GEMM1 and GEMM2, avoiding the gmem round-trip.
+    """
+    out = cute.make_rmem_tensor((16,), Float32)
+    for i in cutlass.range_constexpr(16):
+        g = gate[i]
+        sigmoid_g = cute.arch.rcp_approx(
+            Float32(1.0) + cute.math.exp(-g, fastmath=False)
+        )
+        out[i] = g * sigmoid_g * up[i]
+    return out
+
+
+@cute.jit
+def silu_mul_quantize_block_fp4(
+    gate: cute.Tensor,
+    up: cute.Tensor,
+    global_scale_val: Float32,
+) -> Tuple[Uint64, cutlass.Uint8]:
+    """Fused SiLU(gate)*up + FP4 quantize for 16 element pairs.
+
+    Combines silu_mul_16, max_abs_16, and quantize_block_fp4 into a single
+    helper for the CompactMoEKernel epilogue.
+    """
+    activated = silu_mul_16(gate, up)
+    block_max = max_abs_16(activated)
+    return quantize_block_fp4(activated, block_max, global_scale_val)
+
+
+@cute.jit
+def relu2_16(x: cute.Tensor) -> cute.Tensor:
+    """Compute ReLU^2 for 16 float32 values."""
+    out = cute.make_rmem_tensor((16,), Float32)
+    for i in cutlass.range_constexpr(16):
+        v = fmax_f32(x[i], Float32(0.0))
+        out[i] = v * v
+    return out
+
+
+@cute.jit
+def relu2_quantize_block_fp4(
+    x: cute.Tensor,
+    global_scale_val: Float32,
+) -> Tuple[Uint64, cutlass.Uint8]:
+    """Fuse ReLU^2 and FP4 quantization for 16 float32 values."""
+    activated = relu2_16(x)
+    block_max = max_abs_16(activated)
+    return quantize_block_fp4(activated, block_max, global_scale_val)
+
+
+# =============================================================================
+# MXFP8 (w4a8) Block Quantization: 32-wide UE8M0 + E4M3
+# =============================================================================
+
+
+@cute.jit
+def max_abs_32(values: cute.Tensor) -> Float32:
+    """Compute the maximum absolute value of 32 float32 values."""
+    result = fabs_f32(values[0])
+    for i in cutlass.range_constexpr(1, 32):
+        result = fmax_f32(result, fabs_f32(values[i]))
+    return result
+
+
+@cute.jit
+def quantize_block_fp8_mx(
+    values: cute.Tensor,
+    max_abs: Float32,
+) -> Tuple[cute.Tensor, Uint32]:
+    """Quantize 32 float32 values to E4M3 payload bytes + UE8M0 scale byte.
+
+    The scale is ``pow2_ceil(max_abs / 448)`` so the scaled payload never
+    exceeds the E4M3 range; the payload carries its own exponent, so the
+    power-of-two block scale handles range only.  No global scale is
+    involved (the MX scheme is self-ranging).  Returns
+    ``(payload_u32x8, ue8m0_byte)`` with value ``4*i + j`` in byte ``j`` of
+    ``payload[i]``.  An all-zero block yields scale byte 0 (decoded as a
+    zero output scale) and a zero payload.
+    """
+    scale_f = max_abs * Float32(1.0 / FLOAT8_E4M3_MAX)
+    _, scale_byte = pow2_ceil_ue8m0(scale_f)
+    inv_scale = ue8m0_to_output_scale(scale_byte)
+    payload = cute.make_rmem_tensor((8,), Uint32)
+    for i in cutlass.range_constexpr(8):
+        payload[i] = cvt_f32x4_to_e4m3x4(
+            values[i * 4 + 0] * inv_scale,
+            values[i * 4 + 1] * inv_scale,
+            values[i * 4 + 2] * inv_scale,
+            values[i * 4 + 3] * inv_scale,
+        )
+    return payload, scale_byte
+
+
+@cute.jit
+def silu_mul_32(
+    gate: cute.Tensor,
+    up: cute.Tensor,
+) -> cute.Tensor:
+    """Fused SiLU(gate) * up for 32 float32 element pairs."""
+    out = cute.make_rmem_tensor((32,), Float32)
+    for i in cutlass.range_constexpr(32):
+        g = gate[i]
+        sigmoid_g = cute.arch.rcp_approx(
+            Float32(1.0) + cute.math.exp(-g, fastmath=False)
+        )
+        out[i] = g * sigmoid_g * up[i]
+    return out
+
+
+@cute.jit
+def silu_mul_quantize_block_fp8_mx(
+    gate: cute.Tensor,
+    up: cute.Tensor,
+) -> Tuple[cute.Tensor, Uint32]:
+    """Fused SiLU(gate)*up + MXFP8 quantize for 32 element pairs."""
+    activated = silu_mul_32(gate, up)
+    block_max = max_abs_32(activated)
+    return quantize_block_fp8_mx(activated, block_max)
+
+
+@cute.jit
+def relu2_32(x: cute.Tensor) -> cute.Tensor:
+    """Compute ReLU^2 for 32 float32 values."""
+    out = cute.make_rmem_tensor((32,), Float32)
+    for i in cutlass.range_constexpr(32):
+        v = fmax_f32(x[i], Float32(0.0))
+        out[i] = v * v
+    return out
+
+
+@cute.jit
+def relu2_quantize_block_fp8_mx(
+    x: cute.Tensor,
+) -> Tuple[cute.Tensor, Uint32]:
+    """Fuse ReLU^2 and MXFP8 quantization for 32 float32 values."""
+    activated = relu2_32(x)
+    block_max = max_abs_32(activated)
+    return quantize_block_fp8_mx(activated, block_max)
+
+
+@cute.jit
+def mx_scale_from_amax32(amax: Float32) -> Tuple[Float32, Float32]:
+    """Per-32 MXFP8 block scale from a precomputed amax.
+
+    Returns ``(scale, inv_scale)`` with ``scale = pow2_ceil(amax/448)`` —
+    identical numerics to ``quantize_block_fp8_mx`` (zero amax yields
+    (0, 0), silencing the block).
+    """
+    rounded, byte = pow2_ceil_ue8m0(amax * Float32(1.0 / FLOAT8_E4M3_MAX))
+    inv_scale = ue8m0_to_output_scale(byte)
+    return rounded, inv_scale
+
+
+@cute.jit
+def quant_dequant_e4m3_2(
+    v0: Float32,
+    v1: Float32,
+    inv_scale: Float32,
+    scale: Float32,
+) -> Tuple[Float32, Float32]:
+    """Quantize-dequantize a pair through E4M3 with a power-of-two block scale.
+
+    Bit-matches the w4a8 prefill activation quantizer
+    (``quantize_block_fp8_mx``): RN-saturating E4M3 of ``v*inv_scale``,
+    decoded back and rescaled.  Used by the micro decode kernel's a8_mx mode
+    so decode numerics track the prefill recipe.
+    """
+    q0 = fp8_e4m3_to_f32(cvt_f32_to_e4m3(v0 * inv_scale)) * scale
+    q1 = fp8_e4m3_to_f32(cvt_f32_to_e4m3(v1 * inv_scale)) * scale
+    return q0, q1
+
+
+# =============================================================================
+# Helper Functions for Float32 SF Block Processing
+# =============================================================================
+
+
+@cute.jit
+def load_f32_16_from_smem(
+    sH: cute.Tensor, row_idx: Int32, col_offset: Int32
+) -> cute.Tensor:
+    """Load 16 Float32 values from shared memory."""
+    h_f32 = cute.make_rmem_tensor((16,), Float32)
+    for i in cutlass.range_constexpr(16):
+        h_f32[i] = Float32(sH[row_idx, col_offset + i])
+    return h_f32
+
+
+@cute.jit
+def compute_y_and_max_abs_f32(
+    h_f32: cute.Tensor, w_f32: cute.Tensor, rstd: Float32
+) -> Tuple[cute.Tensor, Float32]:
+    """Compute y = h * rstd * w and max_abs for 16 Float32 values."""
+    y_f32 = cute.make_rmem_tensor((16,), Float32)
+
+    # Compute y and track max_abs
+    y_f32[0] = h_f32[0] * rstd * w_f32[0]
+    max_abs = fabs_f32(y_f32[0])
+
+    for i in cutlass.range_constexpr(1, 16):
+        y_f32[i] = h_f32[i] * rstd * w_f32[i]
+        max_abs = fmax_f32(max_abs, fabs_f32(y_f32[i]))
+
+    return y_f32, max_abs
+
+
+# ---------------------------------------------------------------------------
+# NF3 (3-bit NormalFloat codebook) dequant for the W4A16 "nf3_2p1" layout.
+#
+# Input per call: 8 codes in 2+1 split-plane form — lo16 (8 x 2-bit fields,
+# code j bits 1:0 at bits 2j+1:2j) and hi8 (8 x 1-bit, code j bit 2 at bit j)
+# — plus the 8-entry bf16 codebook as 4 u32 pools (lo/hi bytes of entries
+# 0..3 and 4..7).  Output: 4 packed bf16x2 fragments in the SAME element
+# order as packed_dequant_e2m1x4 pairs: o0=(v0,v1) o1=(v2,v3) o2=(v4,v5)
+# o3=(v6,v7).
+#
+# Selector build is the carry-safe shift ladder (NOT a multiply spread — the
+# 0x249 multiply trick carries between lanes).  prmt pool selectors are the
+# 3-bit codes themselves; bit 3 of every selector nibble stays 0 so prmt
+# byte-select mode is used, never sign-replicate.
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def packed_dequant_nf3x8_to_bfloat2x4(
+    lo16: Uint32,
+    hi8: Uint32,
+    cb_lo01: Uint32,
+    cb_lo23: Uint32,
+    cb_hi01: Uint32,
+    cb_hi23: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """NF3 codebook dequant: 8 3-bit codes -> 4 bf16x2 fragments."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [
+            Uint32(lo16).ir_value(loc=loc, ip=ip),
+            Uint32(hi8).ir_value(loc=loc, ip=ip),
+            Uint32(cb_lo01).ir_value(loc=loc, ip=ip),
+            Uint32(cb_lo23).ir_value(loc=loc, ip=ip),
+            Uint32(cb_hi01).ir_value(loc=loc, ip=ip),
+            Uint32(cb_hi23).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b32 la, lb, ha, hb, t, u, s2, s1, selA, selB;
+            .reg .b32 loA, hiA, loB, hiB;
+
+            and.b32 la, $4, 0xFF;
+            shr.u32 lb, $4, 8;
+            and.b32 lb, lb, 0xFF;
+            and.b32 ha, $5, 0xF;
+            shr.u32 hb, $5, 4;
+            and.b32 hb, hb, 0xF;
+
+            shl.b32 t, la, 4;
+            or.b32 t, t, la;
+            and.b32 t, t, 0x0F0F;
+            shl.b32 s2, t, 2;
+            or.b32 s2, s2, t;
+            and.b32 s2, s2, 0x3333;
+            shl.b32 u, ha, 6;
+            or.b32 u, u, ha;
+            and.b32 u, u, 0x0303;
+            shl.b32 s1, u, 3;
+            or.b32 s1, s1, u;
+            and.b32 s1, s1, 0x1111;
+            shl.b32 s1, s1, 2;
+            or.b32 selA, s2, s1;
+
+            shl.b32 t, lb, 4;
+            or.b32 t, t, lb;
+            and.b32 t, t, 0x0F0F;
+            shl.b32 s2, t, 2;
+            or.b32 s2, s2, t;
+            and.b32 s2, s2, 0x3333;
+            shl.b32 u, hb, 6;
+            or.b32 u, u, hb;
+            and.b32 u, u, 0x0303;
+            shl.b32 s1, u, 3;
+            or.b32 s1, s1, u;
+            and.b32 s1, s1, 0x1111;
+            shl.b32 s1, s1, 2;
+            or.b32 selB, s2, s1;
+
+            prmt.b32 loA, $6, $7, selA;
+            prmt.b32 hiA, $8, $9, selA;
+            prmt.b32 $0, loA, hiA, 0x5140;
+            prmt.b32 $1, loA, hiA, 0x7362;
+            prmt.b32 loB, $6, $7, selB;
+            prmt.b32 hiB, $8, $9, selB;
+            prmt.b32 $2, loB, hiB, 0x5140;
+            prmt.b32 $3, loB, hiB, 0x7362;
+        }
+        """,
+        "=r,=r,=r,=r,r,r,r,r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    o0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    o1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    o2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    o3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+    return Uint32(o0), Uint32(o1), Uint32(o2), Uint32(o3)
+
+
+def nf3_codebook_pools(codebook) -> tuple:
+    """Host-side: 8 floats -> (cb_lo01, cb_lo23, cb_hi01, cb_hi23) u32 prmt pools.
+
+    Entry i's bf16 bytes: lo byte -> pool byte i of (cb_lo01|cb_lo23),
+    hi byte -> same slot of (cb_hi01|cb_hi23).  Pool pair {a,b} is prmt's
+    8-byte space indexed 0..7 by the 3-bit code.
+    """
+    import struct
+
+    assert len(codebook) == 8
+    lo = [0, 0]
+    hi = [0, 0]
+    for i, v in enumerate(codebook):
+        (f32_bits,) = struct.unpack("<I", struct.pack("<f", float(v)))
+        # round-to-nearest-even f32 -> bf16
+        bf16 = (f32_bits + 0x7FFF + ((f32_bits >> 16) & 1)) >> 16
+        reg, slot = divmod(i, 4)
+        lo[reg] |= (bf16 & 0xFF) << (8 * slot)
+        hi[reg] |= ((bf16 >> 8) & 0xFF) << (8 * slot)
+    return lo[0], lo[1], hi[0], hi[1]

--- a/flashinfer/experimental/sm12x/_lib/meta.py
+++ b/flashinfer/experimental/sm12x/_lib/meta.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Op metadata contract for flashinfer.experimental.sm12x.
+
+Every op directory's ``__init__.py`` is exactly: a docstring, an ``OpMeta``
+named ``META``, a ``TYPE_CHECKING`` import block, and one call to
+:func:`install_lazy_api`.  The registry test enforces the shape.
+
+This module must stay stdlib-only: op ``__init__`` files import it at
+namespace-import time, which must not pull torch/cutlass/triton.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass(frozen=True, kw_only=True)
+class Provenance:
+    """Where an op's code came from (auditable against upstream forever)."""
+
+    repo: str
+    commit: str
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpMeta:
+    """Machine-readable header describing one experimental op.
+
+    ``api_style`` declares the op's lifecycle contract:
+
+    - ``planned``:  ``Caps -> plan() -> bind() -> run*()``; ``plan`` is
+      host-side and may allocate, ``bind`` only creates views (allocation
+      free), ``run*`` is CUDA-graph-capture safe.
+    - ``oneshot``:  plain functions with domain verbs (``mm``, ``quantize``).
+    - ``stateful``: long-lived class instances (comm collectives).
+    """
+
+    name: str
+    group: str
+    api_style: Literal["planned", "oneshot", "stateful"]
+    entry_points: tuple[str, ...]
+    archs: tuple[str, ...] = ("sm120a", "sm121a")
+    dtypes: tuple[str, ...] = ()
+    recipes: tuple[str, ...] = ()
+    requires: tuple[str, ...] = ()
+    status: Literal["experimental"] = "experimental"
+    provenance: Provenance = field(
+        default_factory=lambda: Provenance(repo="", commit="", paths=())
+    )
+    test_path: str = ""
+    since: str = ""
+    notes: str = ""
+
+    @property
+    def qualname(self) -> str:
+        return f"{self.group}.{self.name}"
+
+
+def install_lazy_api(module_globals: dict[str, Any], meta: OpMeta) -> None:
+    """Wire an op module's lazy public surface from its ``META``.
+
+    Installs PEP 562 ``__getattr__``/``__dir__`` plus ``__all__`` so that
+    every entry point resolves from the op's ``api`` module on first access.
+    Importing the op module itself therefore stays side-effect free (no
+    cutlass/triton import, no torch custom-op registration).
+    """
+
+    module_name = module_globals["__name__"]
+
+    def __getattr__(name: str) -> Any:
+        if name in meta.entry_points:
+            api = importlib.import_module(".api", module_name)
+            value = getattr(api, name)
+            module_globals[name] = value
+            return value
+        raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+
+    def __dir__() -> list[str]:
+        return sorted([*meta.entry_points, "META"])
+
+    module_globals["__getattr__"] = __getattr__
+    module_globals["__dir__"] = __dir__
+    module_globals["__all__"] = [*meta.entry_points, "META"]
+
+
+__all__ = ["OpMeta", "Provenance", "install_lazy_api"]

--- a/flashinfer/experimental/sm12x/_lib/quant/__init__.py
+++ b/flashinfer/experimental/sm12x/_lib/quant/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Quantization kernels shared across op groups (gemm + quantization)."""

--- a/flashinfer/experimental/sm12x/_lib/quant/mxfp8_rows.py
+++ b/flashinfer/experimental/sm12x/_lib/quant/mxfp8_rows.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/gemm/mxfp8_quant_cute.py @ a611e365 (2026-07-02) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cutlass_dsl import Int32, Uint8, Uint32
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    compile as sm12x_compile,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    FLOAT8_E4M3_MAX,
+    cvt_f32x4_to_e4m3x4,
+    fabs_f32,
+    fmax_f32,
+    max_abs_32,
+    pow2_ceil_ue8m0,
+    quantize_block_fp8_mx,
+    ue8m0_to_output_scale,
+)
+from flashinfer.experimental.sm12x._lib.runtime_control import (
+    raise_if_kernel_resolution_frozen,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream, make_ptr
+
+
+_THREADS = 256
+_GRID_CTAS_PER_SM = 4
+_WARP_SUBGROUP_WIDTH = 4
+
+
+class _MXFP8RowsQuantLaunch:
+    def __init__(
+        self,
+        k: int,
+        source_type: type[cutlass.Numeric],
+        subgroup_width: int,
+        threads: int,
+    ) -> None:
+        self._k = int(k)
+        self._groups_k = self._k // 32
+        self._source_type = source_type
+        self._subgroup_width = int(subgroup_width)
+        self._threads = int(threads)
+        self._warps_per_cta = self._threads // 32
+
+    @cute.jit
+    def __call__(
+        self,
+        source_ptr: cute.Pointer,
+        values_ptr: cute.Pointer,
+        scale_rows_ptr: cute.Pointer,
+        scale_mma_ptr: cute.Pointer,
+        m: Int32,
+        grid_x: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        source = cute.make_tensor(
+            source_ptr,
+            cute.make_ordered_layout((m, self._k), order=(1, 0)),
+        )
+        values_u32 = cute.make_tensor(
+            values_ptr,
+            cute.make_ordered_layout((m, self._k // 4), order=(1, 0)),
+        )
+        scale_rows = cute.make_tensor(
+            scale_rows_ptr,
+            cute.make_ordered_layout((m, self._groups_k), order=(1, 0)),
+        )
+        scale_mma = cute.make_tensor(
+            scale_mma_ptr,
+            cute.make_layout((max(512, ((self._groups_k + 3) // 4) * 512),)),
+        )
+        self.kernel(source, values_u32, scale_rows, scale_mma, m).launch(
+            grid=(grid_x, 1, 1),
+            block=[self._threads, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        source: cute.Tensor,
+        values_u32: cute.Tensor,
+        scale_rows: cute.Tensor,
+        scale_mma: cute.Tensor,
+        m: Int32,
+    ) -> None:
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        if cutlass.const_expr(self._subgroup_width == 4):
+            # Eight 4-lane subgroups per warp each quantize one 32-value block.
+            # Each lane owns eight adjacent values and emits two packed words.
+            warp = Int32(tidx) // Int32(32)
+            lane = Int32(tidx) % Int32(32)
+            subgroup = lane // Int32(4)
+            lane8 = lane % Int32(4)
+            group_tiles = Int32((self._groups_k + 7) // 8)
+            task = Int32(bidx) * Int32(self._warps_per_cta) + warp
+            total_tasks = m * group_tiles
+            while task < total_tasks:
+                row = task // group_tiles
+                group = (task % group_tiles) * Int32(8) + subgroup
+                if group < Int32(self._groups_k):
+                    values = cute.make_rmem_tensor((8,), cutlass.Float32)
+                    k0 = group * Int32(32) + lane8 * Int32(8)
+                    for elem in cutlass.range_constexpr(8):
+                        values[elem] = cutlass.Float32(source[row, k0 + Int32(elem)])
+
+                    max_abs = fabs_f32(values[0])
+                    for elem in cutlass.range_constexpr(1, 8):
+                        max_abs = fmax_f32(max_abs, fabs_f32(values[elem]))
+                    for shift in cutlass.range_constexpr(2):
+                        max_abs = fmax_f32(
+                            max_abs,
+                            cute.arch.shuffle_sync_bfly(max_abs, offset=1 << shift),
+                        )
+
+                    _, scale_byte = pow2_ceil_ue8m0(
+                        max_abs * cutlass.Float32(1.0 / FLOAT8_E4M3_MAX)
+                    )
+                    if max_abs == cutlass.Float32(0.0):
+                        scale_byte = Uint32(127)
+                    inv_scale = ue8m0_to_output_scale(scale_byte)
+                    word0 = group * Int32(8) + lane8 * Int32(2)
+                    values_u32[row, word0] = cvt_f32x4_to_e4m3x4(
+                        values[0] * inv_scale,
+                        values[1] * inv_scale,
+                        values[2] * inv_scale,
+                        values[3] * inv_scale,
+                    )
+                    values_u32[row, word0 + Int32(1)] = cvt_f32x4_to_e4m3x4(
+                        values[4] * inv_scale,
+                        values[5] * inv_scale,
+                        values[6] * inv_scale,
+                        values[7] * inv_scale,
+                    )
+
+                    if lane8 == Int32(0):
+                        self._store_scale(scale_rows, scale_mma, row, group, scale_byte)
+                task += Int32(gdim) * Int32(self._warps_per_cta)
+        elif cutlass.const_expr(self._subgroup_width == 8):
+            # Four 8-lane subgroups per warp each quantize one 32-value block.
+            # Every lane owns four adjacent values, giving coalesced 128-value
+            # warp loads/stores and a cheap width-8 butterfly max reduction.
+            warp = Int32(tidx) // Int32(32)
+            lane = Int32(tidx) % Int32(32)
+            subgroup = lane // Int32(8)
+            lane4 = lane % Int32(8)
+            group_tiles = Int32((self._groups_k + 3) // 4)
+            task = Int32(bidx) * Int32(self._warps_per_cta) + warp
+            total_tasks = m * group_tiles
+            while task < total_tasks:
+                row = task // group_tiles
+                group = (task % group_tiles) * Int32(4) + subgroup
+                if group < Int32(self._groups_k):
+                    values = cute.make_rmem_tensor((4,), cutlass.Float32)
+                    k0 = group * Int32(32) + lane4 * Int32(4)
+                    for elem in cutlass.range_constexpr(4):
+                        values[elem] = cutlass.Float32(source[row, k0 + Int32(elem)])
+
+                    max_abs = fabs_f32(values[0])
+                    for elem in cutlass.range_constexpr(1, 4):
+                        max_abs = fmax_f32(max_abs, fabs_f32(values[elem]))
+                    for shift in cutlass.range_constexpr(3):
+                        max_abs = fmax_f32(
+                            max_abs,
+                            cute.arch.shuffle_sync_bfly(max_abs, offset=1 << shift),
+                        )
+
+                    _, scale_byte = pow2_ceil_ue8m0(
+                        max_abs * cutlass.Float32(1.0 / FLOAT8_E4M3_MAX)
+                    )
+                    if max_abs == cutlass.Float32(0.0):
+                        scale_byte = Uint32(127)
+                    inv_scale = ue8m0_to_output_scale(scale_byte)
+                    payload = cvt_f32x4_to_e4m3x4(
+                        values[0] * inv_scale,
+                        values[1] * inv_scale,
+                        values[2] * inv_scale,
+                        values[3] * inv_scale,
+                    )
+                    values_u32[row, group * Int32(8) + lane4] = payload
+
+                    if lane4 == Int32(0):
+                        self._store_scale(scale_rows, scale_mma, row, group, scale_byte)
+                task += Int32(gdim) * Int32(self._warps_per_cta)
+        else:
+            block = Int32(bidx) * Int32(self._threads) + Int32(tidx)
+            total_blocks = m * Int32(self._groups_k)
+            while block < total_blocks:
+                row = block // Int32(self._groups_k)
+                group = block % Int32(self._groups_k)
+                values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                k0 = group * Int32(32)
+                for elem in cutlass.range_constexpr(32):
+                    values[elem] = cutlass.Float32(source[row, k0 + Int32(elem)])
+
+                max_abs = max_abs_32(values)
+                payload, scale_byte = quantize_block_fp8_mx(values, max_abs)
+                if max_abs == cutlass.Float32(0.0):
+                    scale_byte = Uint32(127)
+
+                word0 = group * Int32(8)
+                for word in cutlass.range_constexpr(8):
+                    values_u32[row, word0 + Int32(word)] = payload[word]
+                self._store_scale(scale_rows, scale_mma, row, group, scale_byte)
+                block += Int32(gdim) * Int32(self._threads)
+
+    @cute.jit
+    def _store_scale(
+        self,
+        scale_rows: cute.Tensor,
+        scale_mma: cute.Tensor,
+        row: Int32,
+        group: Int32,
+        scale_byte: Uint32,
+    ) -> None:
+        scale_u8 = Uint8(scale_byte)
+        scale_rows[row, group] = scale_u8
+        row32 = row % Int32(32)
+        row4 = (row // Int32(32)) % Int32(4)
+        tile_m = row // Int32(128)
+        k4 = group % Int32(4)
+        tile_k = group // Int32(4)
+        scale_mma_offset = (
+            row32 * Int32(16)
+            + row4 * Int32(4)
+            + tile_m * Int32(((self._groups_k + 3) // 4) * 512)
+            + k4
+            + tile_k * Int32(512)
+        )
+        scale_mma[scale_mma_offset] = scale_u8
+
+
+@functools.cache
+def _get_compiled_mxfp8_rows_quant(
+    k: int,
+    source_dtype: torch.dtype,
+    subgroup_width: int,
+    threads: int,
+) -> Callable:
+    k = int(k)
+    if k <= 0 or k % 32 != 0:
+        raise ValueError(f"MXFP8 CuTe quantizer requires K divisible by 32, got {k}")
+    if source_dtype == torch.bfloat16:
+        source_type = cutlass.BFloat16
+        source_dtype_name = "bf16"
+    elif source_dtype == torch.float16:
+        source_type = cutlass.Float16
+        source_dtype_name = "fp16"
+    else:
+        raise TypeError(
+            f"CuTe MXFP8 quantizer requires BF16 or FP16 input, got {source_dtype}"
+        )
+    if subgroup_width not in (0, 4, 8):
+        raise ValueError(
+            f"MXFP8 CuTe quantizer subgroup width must be 0, 4, or 8, got {subgroup_width}"
+        )
+    if threads <= 0 or threads % 32 != 0:
+        raise ValueError(
+            f"MXFP8 CuTe quantizer threads must be a positive multiple of 32, got {threads}"
+        )
+    launch = _MXFP8RowsQuantLaunch(k, source_type, subgroup_width, threads)
+    cache_key = (k, source_dtype_name, int(subgroup_width), int(threads))
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=launch,
+        cache_key=cache_key,
+    )
+    raw = sm12x_compile(
+        launch,
+        make_ptr(source_type, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "gemm.mxfp8_quant_cute",
+            2,
+            cache_key,
+        ),
+    )
+
+    def launch_tensors(
+        source: torch.Tensor,
+        values: torch.Tensor,
+        scale_rows: torch.Tensor,
+        scale_mma: torch.Tensor,
+    ) -> None:
+        if subgroup_width:
+            groups_per_warp = 32 // subgroup_width
+            total_tasks = int(source.shape[0]) * (
+                (k // 32 + groups_per_warp - 1) // groups_per_warp
+            )
+            warps_per_cta = threads // 32
+            natural_grid = max(1, (total_tasks + warps_per_cta - 1) // warps_per_cta)
+            sm_count = torch.cuda.get_device_properties(
+                source.device
+            ).multi_processor_count
+            grid_x = min(natural_grid, sm_count * _GRID_CTAS_PER_SM)
+        else:
+            total_blocks = int(source.shape[0]) * (k // 32)
+            grid_x = max(1, (total_blocks + threads - 1) // threads)
+        raw(
+            make_ptr(
+                source_type,
+                source.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Uint32,
+                values.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Uint8,
+                scale_rows.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Uint8,
+                scale_mma.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            int(source.shape[0]),
+            grid_x,
+            current_cuda_stream(),
+        )
+
+    return launch_tensors
+
+
+def quantize_mxfp8_rows_cute(
+    source: torch.Tensor,
+    values: torch.Tensor,
+    scale_rows: torch.Tensor,
+    scale_mma: torch.Tensor,
+) -> None:
+    """Quantize contiguous BF16 rows into the dense-GEMM MXFP8 layouts."""
+
+    if source.dtype not in (torch.bfloat16, torch.float16):
+        raise TypeError(
+            f"CuTe MXFP8 quantizer requires BF16 or FP16 input, got {source.dtype}"
+        )
+    if source.ndim != 2 or not source.is_contiguous():
+        raise ValueError("CuTe MXFP8 quantizer requires contiguous [M,K] input")
+    subgroup_width = _WARP_SUBGROUP_WIDTH if int(source.shape[0]) > 8 else 0
+    _get_compiled_mxfp8_rows_quant(
+        int(source.shape[1]), source.dtype, subgroup_width, _THREADS
+    )(
+        source,
+        values,
+        scale_rows,
+        scale_mma,
+    )

--- a/flashinfer/experimental/sm12x/_lib/runtime_control.py
+++ b/flashinfer/experimental/sm12x/_lib/runtime_control.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/cute/runtime_control.py @ 9f2eb830 (2026-05-27) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import hashlib
+import inspect
+from threading import Lock
+
+
+class KernelResolutionFrozenError(RuntimeError):
+    """Raised when sm12x is asked to resolve a new kernel after freeze."""
+
+
+_STATE_LOCK = Lock()
+_FROZEN = False
+_FREEZE_REASON: str | None = None
+
+
+def freeze_kernel_resolution(reason: str | None = None) -> None:
+    global _FROZEN, _FREEZE_REASON
+    with _STATE_LOCK:
+        _FROZEN = True
+        _FREEZE_REASON = reason
+
+
+def unfreeze_kernel_resolution() -> None:
+    global _FROZEN, _FREEZE_REASON
+    with _STATE_LOCK:
+        _FROZEN = False
+        _FREEZE_REASON = None
+
+
+def kernel_resolution_frozen() -> bool:
+    with _STATE_LOCK:
+        return _FROZEN
+
+
+freeze_compilation = freeze_kernel_resolution
+unfreeze_compilation = unfreeze_kernel_resolution
+compilation_frozen = kernel_resolution_frozen
+
+
+def raise_if_kernel_resolution_frozen(
+    kind: str,
+    *,
+    target: object | None = None,
+    cache_key: object | None = None,
+) -> None:
+    with _STATE_LOCK:
+        frozen = _FROZEN
+        reason = _FREEZE_REASON
+    if not frozen:
+        return
+
+    details = [f"sm12x kernel resolution is frozen; refusing {kind}"]
+    target_name = _describe_target(target)
+    if target_name is not None:
+        details.append(f"target={target_name}")
+    if cache_key is not None:
+        details.append(f"key={_summarize_cache_key(cache_key)}")
+    if reason is not None:
+        details.append(f"reason={reason}")
+    details.append(
+        "warm up this kernel shape before calling flashinfer.experimental.sm12x.freeze_kernel_resolution()"
+    )
+    raise KernelResolutionFrozenError("; ".join(details))
+
+
+def _describe_target(target: object | None) -> str | None:
+    if target is None:
+        return None
+    if inspect.ismethod(target):
+        module = getattr(target.__func__, "__module__", "")
+        qualname = getattr(
+            target.__func__, "__qualname__", getattr(target.__func__, "__name__", "")
+        )
+        return f"{module}.{qualname}" if module else qualname
+    if inspect.isfunction(target):
+        module = getattr(target, "__module__", "")
+        qualname = getattr(target, "__qualname__", getattr(target, "__name__", ""))
+        return f"{module}.{qualname}" if module else qualname
+    target_type = type(target)
+    module = getattr(target_type, "__module__", "")
+    qualname = getattr(target_type, "__qualname__", target_type.__name__)
+    return f"{module}.{qualname}" if module else qualname
+
+
+def _summarize_cache_key(cache_key: object) -> str:
+    text = repr(cache_key)
+    if len(text) > 120:
+        text = text[:117] + "..."
+    digest = hashlib.sha256(repr(cache_key).encode("utf-8")).hexdigest()[:12]
+    return f"{text} [{digest}]"

--- a/flashinfer/experimental/sm12x/_lib/runtime_patches.py
+++ b/flashinfer/experimental/sm12x/_lib/runtime_patches.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/cute/runtime_patches.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import inspect
+import linecache
+import os
+from functools import wraps
+from typing import Any
+
+_COMPILE_ONLY_CACHE_WARNING = "Cache is disabled as user wants to compile only."
+_WARNING_PATCHED = False
+_MEMORY_DEBUG_PATCHED = False
+_DIRECT_FRAMEINFO_PATCHED = False
+_MEMORY_DEBUG_SNAPSHOT = {
+    "free": None,
+    "total": None,
+    "used": None,
+    "torch_allocated": None,
+    "torch_reserved": None,
+    "external": None,
+    "device": None,
+}
+
+
+def apply_cutlass_runtime_patches() -> None:
+    if _env_flag("FLASHINFER_EXP_SM12X_DISABLE_CUTLASS_RUNTIME_PATCHES", default=False):
+        return
+    _apply_compile_only_warning_patch()
+    _apply_memory_debug_patch()
+    _apply_direct_frameinfo_patch()
+
+
+def cutlass_runtime_patch_status() -> tuple[tuple[str, bool], ...]:
+    """Return effective patch state for compile-manifest provenance."""
+    return (
+        ("compile_only_warning", _WARNING_PATCHED),
+        ("memory_debug", _MEMORY_DEBUG_PATCHED),
+        ("direct_frameinfo", _DIRECT_FRAMEINFO_PATCHED),
+    )
+
+
+def _env_flag(name: str, *, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _apply_compile_only_warning_patch() -> None:
+    global _WARNING_PATCHED
+    if _WARNING_PATCHED:
+        return
+
+    try:
+        from cutlass.base_dsl.dsl import BaseDSL
+    except Exception:
+        return
+
+    original_print_warning = BaseDSL.print_warning
+    original_print_warning_once = BaseDSL.print_warning_once
+
+    @wraps(original_print_warning)
+    def patched_print_warning(self, message):
+        if message == _COMPILE_ONLY_CACHE_WARNING:
+            return None
+        return original_print_warning(self, message)
+
+    @wraps(original_print_warning_once)
+    def patched_print_warning_once(self, message):
+        if message == _COMPILE_ONLY_CACHE_WARNING:
+            return None
+        return original_print_warning_once(self, message)
+
+    BaseDSL.print_warning = patched_print_warning
+    BaseDSL.print_warning_once = patched_print_warning_once
+    _WARNING_PATCHED = True
+
+
+def _apply_memory_debug_patch() -> None:
+    global _MEMORY_DEBUG_PATCHED
+    if _MEMORY_DEBUG_PATCHED:
+        return
+    if _env_flag("CUTLASS_DSL_CUDA_MEMORY_DEBUG", default=False):
+        return
+
+    try:
+        from cutlass.base_dsl.runtime import cuda as cuda_helpers
+    except Exception:
+        return
+    if not hasattr(cuda_helpers, "_memory_debug_snapshot") or not hasattr(
+        cuda_helpers, "_memory_debug_log"
+    ):
+        _MEMORY_DEBUG_PATCHED = True
+        return
+    if getattr(cuda_helpers, "_sm12x_memory_debug_patched", False):
+        _MEMORY_DEBUG_PATCHED = True
+        return
+
+    if not hasattr(cuda_helpers, "_sm12x_original_memory_debug_snapshot"):
+        cuda_helpers._sm12x_original_memory_debug_snapshot = (
+            cuda_helpers._memory_debug_snapshot
+        )
+    if not hasattr(cuda_helpers, "_sm12x_original_memory_debug_log"):
+        cuda_helpers._sm12x_original_memory_debug_log = cuda_helpers._memory_debug_log
+
+    def _empty_memory_debug_snapshot() -> dict[str, int | None]:
+        return dict(_MEMORY_DEBUG_SNAPSHOT)
+
+    def _empty_memory_debug_log(
+        label: str, before: dict[str, int | None] | None = None
+    ) -> None:
+        return None
+
+    cuda_helpers._memory_debug_snapshot = _empty_memory_debug_snapshot
+    cuda_helpers._memory_debug_log = _empty_memory_debug_log
+    cuda_helpers._sm12x_memory_debug_patched = True
+    _MEMORY_DEBUG_PATCHED = True
+
+
+class _DirectFrameInfoInspectProxy:
+    """Preserve CUTLASS source locations without ``inspect.findsource``.
+
+    CUTLASS asks for frame information once per emitted DSL operation.  The
+    standard ``inspect.getframeinfo(..., context=1)`` implementation first
+    scans backwards from the current line to rediscover the enclosing Python
+    function.  That is quadratic for large monolithic kernels: dynamic W4A8
+    emits roughly 41k operations from a function spanning about 4k lines.
+
+    The code position already identifies the exact source line.  Fetching its
+    context directly from ``linecache`` preserves CUTLASS's filename, line,
+    column, function, and source-text location while avoiding the backwards
+    regular-expression scan.
+    """
+
+    _sm12x_direct_frameinfo = True
+
+    def __init__(self, inspect_module: Any) -> None:
+        self._inspect = inspect_module
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inspect, name)
+
+    def getframeinfo(self, frame: Any, context: int = 1) -> Any:
+        frame_info = self._inspect.getframeinfo(frame, context=0)
+        if context <= 0:
+            return frame_info
+
+        lines = linecache.getlines(frame_info.filename)
+        if not lines:
+            code_context = None
+            index = None
+        else:
+            start = frame_info.lineno - 1 - context // 2
+            start = max(0, min(start, len(lines) - context))
+            code_context = lines[start : start + context]
+            index = frame_info.lineno - 1 - start
+
+        trace_args = (
+            frame_info.filename,
+            frame_info.lineno,
+            frame_info.function,
+            code_context,
+            index,
+        )
+        if hasattr(frame_info, "positions"):
+            return inspect.Traceback(
+                *trace_args,
+                positions=frame_info.positions,
+            )
+        # Python 3.10 predates PEP 657's ``positions`` field; CUTLASS already
+        # handles that legacy Traceback shape by using lineno and column zero.
+        return inspect.Traceback(*trace_args)
+
+
+def _apply_direct_frameinfo_patch() -> None:
+    global _DIRECT_FRAMEINFO_PATCHED
+    if _DIRECT_FRAMEINFO_PATCHED:
+        return
+
+    try:
+        # CUTLASS DSL 4.6 promotes the MLIR helpers to the top-level package.
+        from cutlass._mlir_helpers import op as op_helpers
+    except Exception:
+        return
+
+    current_inspect = op_helpers.inspect
+    if getattr(current_inspect, "_sm12x_direct_frameinfo", False):
+        _DIRECT_FRAMEINFO_PATCHED = True
+        return
+
+    op_helpers.inspect = _DirectFrameInfoInspectProxy(current_inspect)
+    _DIRECT_FRAMEINFO_PATCHED = True

--- a/flashinfer/experimental/sm12x/_lib/scratch.py
+++ b/flashinfer/experimental/sm12x/_lib/scratch.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/cute/scratch.py @ 9f2eb830 (2026-05-27) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Shared caller-owned scratch plan helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScratchBufferSpec:
+    name: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device
+
+    @property
+    def nbytes(self) -> int:
+        numel = 1
+        for dim in self.shape:
+            numel *= int(dim)
+        return numel * torch.empty((), dtype=self.dtype).element_size()
+
+
+def scratch_buffer_spec(
+    name: str,
+    *,
+    nbytes: int,
+    device: torch.device,
+) -> ScratchBufferSpec:
+    return ScratchBufferSpec(
+        name=name,
+        shape=(max(int(nbytes), 1),),
+        dtype=torch.uint8,
+        device=device,
+    )
+
+
+def scratch_tensor(
+    scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+    specs: tuple[ScratchBufferSpec, ...],
+    *,
+    owner: str,
+) -> torch.Tensor:
+    if len(specs) != 1:
+        raise RuntimeError(
+            f"{owner} scratch plans currently expect exactly one scratch buffer"
+        )
+    spec = specs[0]
+    if isinstance(scratch, torch.Tensor):
+        tensor = scratch
+    elif isinstance(scratch, Mapping):
+        if spec.name not in scratch:
+            raise KeyError(f"scratch mapping is missing {spec.name!r}")
+        tensor = scratch[spec.name]
+    else:
+        if len(scratch) != 1:
+            raise ValueError(
+                f"scratch sequence must contain exactly one tensor, got {len(scratch)}"
+            )
+        tensor = scratch[0]
+    if tensor.dtype != spec.dtype:
+        raise TypeError(
+            f"{spec.name} scratch must have dtype {spec.dtype}, got {tensor.dtype}"
+        )
+    if tensor.device != spec.device:
+        raise ValueError(
+            f"{spec.name} scratch device {tensor.device} does not match {spec.device}"
+        )
+    if int(tensor.numel()) < int(spec.shape[0]):
+        raise ValueError(
+            f"{spec.name} scratch has {int(tensor.numel())} bytes, requires {int(spec.shape[0])}"
+        )
+    if not tensor.is_contiguous():
+        raise ValueError(f"{spec.name} scratch must be contiguous")
+    return tensor.reshape(-1)
+
+
+__all__ = [
+    "ScratchBufferSpec",
+    "scratch_buffer_spec",
+    "scratch_tensor",
+]

--- a/flashinfer/experimental/sm12x/_lib/scratch_layout.py
+++ b/flashinfer/experimental/sm12x/_lib/scratch_layout.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/scratch_layout.py @ ad997e28 (2026-06-07) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Shared byte-layout helpers for caller-owned scratch buffers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+SCRATCH_ALIGN_BYTES = 1024
+
+
+def align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    return ((int(value) + alignment - 1) // alignment) * alignment
+
+
+def dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def shape_numel(shape: tuple[int, ...]) -> int:
+    numel = 1
+    for dim in shape:
+        numel *= int(dim)
+    return numel
+
+
+def materialize_scratch_view(
+    scratch: torch.Tensor,
+    *,
+    offset_bytes: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int]:
+    offset_bytes = align_up(offset_bytes, max(SCRATCH_ALIGN_BYTES, dtype_nbytes(dtype)))
+    nbytes = shape_numel(shape) * dtype_nbytes(dtype)
+    view_bytes = scratch.narrow(0, offset_bytes, nbytes)
+    typed_view = view_bytes.view(dtype).view(shape)
+    return typed_view, offset_bytes + nbytes
+
+
+def materialize_scratch_strided_view(
+    scratch: torch.Tensor,
+    *,
+    offset_bytes: int,
+    shape: tuple[int, ...],
+    stride: tuple[int, ...],
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int]:
+    offset_bytes = align_up(offset_bytes, max(SCRATCH_ALIGN_BYTES, dtype_nbytes(dtype)))
+    nbytes = shape_numel(shape) * dtype_nbytes(dtype)
+    view_bytes = scratch.narrow(0, offset_bytes, nbytes)
+    typed_storage = view_bytes.view(dtype)
+    return typed_storage.as_strided(shape, stride), offset_bytes + nbytes
+
+
+def ceil_div(x: int, y: int) -> int:
+    return (int(x) + int(y) - 1) // int(y)
+
+
+# ---------------------------------------------------------------------------
+# WO-projection arena layout.
+#
+# Carved from b12x/attention/workspace.py @ 906d63d0: the WO projections share
+# a serving arena with attention, so the byte layout lived there upstream.
+# Both gemm.wo_projection and the attention workspace need it, which makes
+# _lib its home under the import-topology rule (op dirs and group _shared
+# trees may not import across groups).  The arena alignment (1024) matches
+# SCRATCH_ALIGN_BYTES, so the materialize helpers above are drop-ins for the
+# upstream _materialize_arena_view/_materialize_arena_strided_view.
+# ---------------------------------------------------------------------------
+
+WO_MXFP8_SCALE_VEC_SIZE = 32
+WO_MXFP8_SCALE_ROW_TILE = 128
+WO_MXFP8_SCALE_K_TILE = 4
+
+
+@dataclass(frozen=True, kw_only=True)
+class WOProjectionArenaLayout:
+    nbytes: int = 0
+    x_q_values_offset_bytes: int = 0
+    x_q_scale_rows_offset_bytes: int = 0
+    x_q_scale_mma_offset_bytes: int = 0
+    tmp_offset_bytes: int = 0
+    tmp_q_values_offset_bytes: int = 0
+    tmp_q_scale_rows_offset_bytes: int = 0
+    tmp_q_scale_mma_offset_bytes: int = 0
+    output_offset_bytes: int = 0
+
+
+def check_wo_mxfp8_k(k: int) -> None:
+    if int(k) <= 0 or int(k) % 128 != 0:
+        raise ValueError(
+            f"WO MXFP8 dense-GEMM K must be a positive multiple of 128, got {k}"
+        )
+
+
+def wo_mxfp8_scale_physical_shape(
+    *,
+    m: int,
+    k: int,
+    num_groups: int,
+) -> tuple[int, int, int, int, int, int]:
+    sf_k = int(k) // WO_MXFP8_SCALE_VEC_SIZE
+    return (
+        int(num_groups),
+        ceil_div(int(m), WO_MXFP8_SCALE_ROW_TILE),
+        ceil_div(sf_k, WO_MXFP8_SCALE_K_TILE),
+        32,
+        4,
+        4,
+    )
+
+
+def layout_wo_projection(
+    *,
+    offset_bytes: int,
+    tokens: int,
+    groups: int,
+    group_width: int,
+    rank: int,
+    hidden: int,
+) -> WOProjectionArenaLayout:
+    tokens = max(int(tokens), 1)
+    groups = int(groups)
+    group_width = int(group_width)
+    rank = int(rank)
+    hidden = int(hidden)
+    if groups <= 0 or group_width <= 0 or rank <= 0 or hidden <= 0:
+        raise ValueError(
+            "WO projection arena requires positive groups, group_width, rank, and hidden"
+        )
+    check_wo_mxfp8_k(group_width)
+    check_wo_mxfp8_k(rank * groups)
+
+    start = int(offset_bytes)
+    cursor = align_up(start, SCRATCH_ALIGN_BYTES)
+
+    x_q_values_offset_bytes = cursor
+    cursor += tokens * group_width * groups * dtype_nbytes(torch.float8_e4m3fn)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    x_q_scale_rows_offset_bytes = cursor
+    cursor += (
+        groups
+        * tokens
+        * (group_width // WO_MXFP8_SCALE_VEC_SIZE)
+        * dtype_nbytes(torch.float8_e8m0fnu)
+    )
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    x_q_scale_mma_offset_bytes = cursor
+    cursor += shape_numel(
+        wo_mxfp8_scale_physical_shape(
+            m=tokens,
+            k=group_width,
+            num_groups=groups,
+        )
+    ) * dtype_nbytes(torch.uint8)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    tmp_offset_bytes = cursor
+    cursor += tokens * rank * groups * dtype_nbytes(torch.bfloat16)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    tmp_q_width = rank * groups
+    tmp_q_values_offset_bytes = cursor
+    cursor += tokens * tmp_q_width * dtype_nbytes(torch.float8_e4m3fn)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    tmp_q_scale_rows_offset_bytes = cursor
+    cursor += (
+        tokens
+        * (tmp_q_width // WO_MXFP8_SCALE_VEC_SIZE)
+        * dtype_nbytes(torch.float8_e8m0fnu)
+    )
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    tmp_q_scale_mma_offset_bytes = cursor
+    cursor += shape_numel(
+        wo_mxfp8_scale_physical_shape(
+            m=tokens,
+            k=tmp_q_width,
+            num_groups=1,
+        )
+    ) * dtype_nbytes(torch.uint8)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    output_offset_bytes = cursor
+    cursor += tokens * hidden * dtype_nbytes(torch.bfloat16)
+
+    return WOProjectionArenaLayout(
+        nbytes=max(0, int(cursor) - start),
+        x_q_values_offset_bytes=x_q_values_offset_bytes,
+        x_q_scale_rows_offset_bytes=x_q_scale_rows_offset_bytes,
+        x_q_scale_mma_offset_bytes=x_q_scale_mma_offset_bytes,
+        tmp_offset_bytes=tmp_offset_bytes,
+        tmp_q_values_offset_bytes=tmp_q_values_offset_bytes,
+        tmp_q_scale_rows_offset_bytes=tmp_q_scale_rows_offset_bytes,
+        tmp_q_scale_mma_offset_bytes=tmp_q_scale_mma_offset_bytes,
+        output_offset_bytes=output_offset_bytes,
+    )

--- a/flashinfer/experimental/sm12x/_lib/smem.py
+++ b/flashinfer/experimental/sm12x/_lib/smem.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/cute/smem.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Shared-memory helpers for the CUTLASS DSL 4.6 contract."""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+
+
+def make_smem_memrange_alias(dtype, num_elems: int, ptr):
+    """Return a typed, non-owning view over an existing shared-memory range.
+
+    CUTLASS DSL 4.6 does not expose a public constructor for this alias form.
+    Keep the one required private API touchpoint here so payload carving can be
+    audited and updated without duplicating version-sensitive construction in
+    individual kernels. Allocation and byte offsets remain owned by the caller.
+    """
+    return cute.struct._MemRangeData(dtype, num_elems, ptr)
+
+
+def make_tma_aligned_payload_storage(*, payload_bytes: int, num_stages: int):
+    """Build the canonical two-barrier-array TMA shared-memory struct.
+
+    Returning the real CUTLASS type keeps its alignment and tail-padding rules
+    authoritative for both launch accounting and the kernel allocation.
+    """
+    if payload_bytes <= 0:
+        raise ValueError(f"payload_bytes must be positive, got {payload_bytes}")
+    if num_stages <= 0:
+        raise ValueError(f"num_stages must be positive, got {num_stages}")
+
+    class SharedStorage:
+        pass
+
+    mbar_struct = cute.struct.MemRange[cutlass.Int64, 2 * int(num_stages)]
+    SharedStorage.__annotations__ = {
+        "mbar_ptr_K": mbar_struct,
+        "mbar_ptr_V": mbar_struct,
+        "payload": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, int(payload_bytes)],
+            1024,
+        ],
+    }
+    return cute.struct(SharedStorage)
+
+
+__all__ = ["make_smem_memrange_alias", "make_tma_aligned_payload_storage"]

--- a/flashinfer/experimental/sm12x/_lib/utils.py
+++ b/flashinfer/experimental/sm12x/_lib/utils.py
@@ -1,0 +1,610 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/cute/utils.py @ 8de17f19 (2026-07-02) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ctypes
+import functools
+import importlib.util
+from typing import Union, Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass._mlir.dialects.cute as _cute_ir
+import cutlass.cute as cute
+import torch
+from cutlass._mlir import ir
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.cute.typing import AddressSpace, Numeric, Pointer, Type
+
+
+def ceil_div(a: int, b: int) -> int:
+    """Ceiling division."""
+    return (a + b - 1) // b
+
+
+def is_cute_dsl_available() -> bool:
+    return (
+        importlib.util.find_spec("cutlass") is not None
+        and importlib.util.find_spec("cutlass.cute") is not None
+    )
+
+
+def get_cutlass_dtype(dtype: str) -> cutlass.dtype:
+    dtype_map = {
+        "float16": cutlass.Float16,
+        "bfloat16": cutlass.BFloat16,
+        "float32": cutlass.Float32,
+        "float8_e5m2": cutlass.Float8E5M2,
+        "float8_e4m3fn": cutlass.Float8E4M3FN,
+        "float8_e8m0fnu": cutlass.Float8E8M0FNU,
+        "float4_e2m1fn": cutlass.Float4E2M1FN,
+    }
+    return dtype_map[dtype]
+
+
+def cutlass_to_torch_dtype(cutlass_dtype):
+    """
+    Return the corresponding torch.dtype per the given DSL type
+    """
+    torch_dtype = getattr(torch, cutlass_dtype.__name__.lower(), None)
+
+    torch_type_map = {
+        cutlass.TFloat32: torch.float32,
+        cutlass.Float32: torch.float32,
+        cutlass.Float16: torch.float16,
+        cutlass.BFloat16: torch.bfloat16,
+        cutlass.Float8E5M2: torch.float8_e5m2,
+        cutlass.Float8E4M3FN: torch.float8_e4m3fn,
+        cutlass.Float8E8M0FNU: torch.float8_e8m0fnu,
+        cutlass.Float8E4M3B11FNUZ: torch.float8_e4m3fnuz,
+        cutlass.Float4E2M1FN: torch.float4_e2m1fn_x2,  # FP4 packed (2 values per byte)
+    }
+    if torch_dtype is None:
+        torch_dtype = torch_type_map.get(cutlass_dtype)
+
+    if torch_dtype is None:
+        raise TypeError(f"{cutlass_dtype} is not supported by torch")
+    return torch_dtype
+
+
+_num_sm_cache: dict[int, int] = {}
+
+
+def get_num_sm(device: torch.device) -> int:
+    """Return the device SM count without exposing lru_cache to Dynamo."""
+    index = device.index
+    if index is None:
+        index = torch.cuda.current_device()
+    sm_count = _num_sm_cache.get(index)
+    if sm_count is None:
+        sm_count = torch.cuda.get_device_properties(index).multi_processor_count
+        _num_sm_cache[index] = sm_count
+    return sm_count
+
+
+@torch._dynamo.disable
+def current_cuda_stream() -> cuda.CUstream:
+    """Return the current Torch CUDA stream as a CUDA driver stream handle."""
+    return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
+def cuda_stream_to_int(stream: object | None) -> int | None:
+    """Return a raw CUDA stream handle, preserving None as a caller fallback."""
+    if stream is None:
+        return None
+    cuda_stream = getattr(stream, "cuda_stream", None)
+    if cuda_stream is not None:
+        return int(cuda_stream)
+    return int(stream)
+
+
+def cuda_stream_from_int_or_current(stream_int: int | None) -> cuda.CUstream:
+    """Use a supplied raw CUDA stream handle, or fall back to Torch's current stream."""
+    if stream_int is None:
+        return current_cuda_stream()
+    return cuda.CUstream(int(stream_int))
+
+
+# Cache for HardwareInfo - it's expensive to create on every call
+_hardware_info_cache: "cutlass.utils.HardwareInfo | None" = None
+
+
+def get_hardware_info() -> "cutlass.utils.HardwareInfo":
+    """Get cached HardwareInfo singleton.
+
+    HardwareInfo queries CUDA device capabilities, which can be expensive.
+    This function caches the singleton to avoid repeated queries.
+    """
+    global _hardware_info_cache
+    if _hardware_info_cache is None:
+        _hardware_info_cache = cutlass.utils.HardwareInfo()
+    return _hardware_info_cache
+
+
+@functools.cache
+def get_max_active_clusters(cluster_size: int) -> int:
+    """Get max active clusters for a given cluster size (cached).
+
+    Args:
+        cluster_size: Product of cluster_shape_mn dimensions.
+
+    Returns:
+        Maximum number of active clusters supported by hardware.
+    """
+    return get_hardware_info().get_max_active_clusters(cluster_size)
+
+
+# Compatibility wrapper around CuTe DSL runtime pointers.
+class _Pointer(Pointer):
+    """Runtime representation of a pointer that can inter-operate with
+    various data structures, including numpy arrays and device memory.
+
+    :param pointer: The pointer to the data
+    :type pointer: int or pointer-like object
+    :param dtype: Data type of the elements pointed to
+    :type dtype: Type
+    :param mem_space: Memory space where the pointer resides, defaults generic
+    :type mem_space: _cute_ir.AddressSpace, optional
+    :param assumed_align: Alignment of input pointer in bytes, defaults None
+    :type assumed_align: int, optional
+
+    :ivar _pointer: The underlying pointer
+    :ivar _dtype: Data type of the elements
+    :ivar _addr_space: Memory space of the pointer
+    :ivar _assumed_align: Alignment of the pointer in bytes
+    :ivar _desc: C-type descriptor for the pointer
+    :ivar _c_pointer: C-compatible pointer representation
+    """
+
+    def __init__(
+        self,
+        pointer,
+        dtype,
+        mem_space: _cute_ir.AddressSpace = _cute_ir.AddressSpace.generic,
+        assumed_align=None,
+    ):
+        self._pointer = pointer
+        self._dtype = dtype
+        self._addr_space = mem_space
+
+        if assumed_align is None:
+            self._assumed_align = dtype.width // 8
+        else:
+            self._assumed_align = assumed_align
+
+        self._desc = None
+        self._c_pointer = None
+        assert int(self._pointer) % self._assumed_align == 0, (
+            f"pointer must be {self._assumed_align} bytes aligned"
+        )
+
+    def size_in_bytes(self) -> int:
+        return ctypes.sizeof(ctypes.c_void_p(int(self._pointer)))
+
+    def __get_mlir_types__(self):
+        return [self.mlir_type]
+
+    def __c_pointers__(self):
+        if self._c_pointer is None:
+            self._desc = ctypes.c_void_p(int(self._pointer))
+            self._c_pointer = ctypes.addressof(self._desc)
+        return [self._c_pointer]
+
+    def __new_from_mlir_values__(self, values):
+        assert len(values) == 1
+        return values[0]
+
+    # Move mlir Type out of __init__ to decouple with mlir Context
+    @property
+    def mlir_type(self) -> ir.Type:
+        return _cute_ir.PtrType.get(
+            self._dtype.mlir_type, self._addr_space, self._assumed_align
+        )
+
+    @property
+    def dtype(self) -> Type[Numeric]:
+        return self._dtype
+
+    @property
+    def memspace(self):
+        return self._addr_space
+
+    def align(self, min_align: int, *, loc=None, ip=None) -> Pointer:
+        raise NotImplementedError("align is not supported in runtime")
+
+    def verify(self, expected_py_type):
+        if expected_py_type is Pointer or (
+            isinstance(expected_py_type, ir.Value) and expected_py_type.ty is Pointer
+        ):
+            return True
+
+        return False
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (self._dtype, self._addr_space, self._assumed_align)
+
+    def __str__(self) -> str:
+        return f"Ptr<0x{int(self._pointer):016x}@{self._addr_space}>"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+def make_ptr(
+    dtype: Type[Numeric],
+    value: Union[int, ctypes._Pointer],
+    mem_space: AddressSpace = AddressSpace.generic,
+    assumed_align=None,
+) -> Pointer:
+    """Create a pointer from a memory address
+
+    :param dtype: Data type of the pointer elements
+    :type dtype: Type[Numeric]
+    :param value: Memory address as integer or ctypes pointer
+    :type value: Union[int, ctypes._Pointer]
+    :param mem_space: Memory address space, defaults to AddressSpace.generic
+    :type mem_space: AddressSpace, optional
+    :param assumed_align: Alignment in bytes, defaults to None
+    :type assumed_align: int, optional
+    :return: A pointer object
+    :rtype: Pointer
+
+    .. code-block:: python
+
+        import numpy as np
+        import ctypes
+
+        from cutlass import Float32
+        from cutlass.cute.runtime import make_ptr
+
+        # Create a numpy array
+        a = np.random.randn(16, 32).astype(np.float32)
+
+        # Get pointer address as integer
+        ptr_address = a.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+
+        # Create pointer from address
+        y = make_ptr(cutlass.Float32, ptr_address)
+    """
+    # check if value is int or ctypes.POINTER
+    if isinstance(value, int):
+        address_value = value
+    elif isinstance(value, ctypes._Pointer):
+        # get address value
+        address_value = ctypes.cast(value, ctypes.c_void_p).value
+        assert address_value is not None, "Pointer address is None"
+    else:
+        raise TypeError(
+            f"Expect int or ctypes.POINTER for value but got {type(value)=}"
+        )
+
+    return _Pointer(address_value, dtype, mem_space, assumed_align=assumed_align)
+
+
+def convert_sf_to_mma_layout(
+    sf: torch.Tensor,
+    m: int,
+    k: int,
+    num_groups: int = 1,
+    sf_vec_size: int = 16,
+) -> torch.Tensor:
+    """Convert scale factors from swizzled 2D layout to 6D MMA-compatible layout.
+
+    This function converts scale factors produced by `fp4_quantize(..., is_sf_swizzled_layout=True)`
+    to the 6D layout expected by CuteDSL grouped GEMM kernels.
+
+    The swizzled scale factors from `fp4_quantize` have shape `(M, K/sf_vec_size)` but are
+    stored in a swizzled pattern internally. This function reshapes them to the explicit
+    6D MMA-compatible layout: `(32, 4, m_tiles, 4, k_tiles, num_groups)` with the
+    physical storage order `(num_groups, m_tiles, k_tiles, 32, 4, 4)`.
+
+    Layout mapping (from linear (m, k) position):
+        - m_tile = m // 128
+        - outer_m = m % 32
+        - inner_m = (m % 128) // 32
+        - k_tile = k // 4
+        - inner_k = k % 4
+        - 6D position: (outer_m, inner_m, m_tile, inner_k, k_tile, group)
+
+    Args:
+        sf: Scale factor tensor from `fp4_quantize(..., is_sf_swizzled_layout=True)`.
+            Shape: `(M, K/sf_vec_size)` or `(num_groups * M, K/sf_vec_size)`.
+        m: The M dimension (rows) of the original matrix before quantization.
+        k: The K dimension (columns) of the original matrix before quantization.
+        num_groups: Number of groups (e.g., experts). Default: 1.
+        sf_vec_size: Scale factor vector size. Default: 16.
+
+    Returns:
+        Scale factors in 6D MMA layout: `(32, 4, m_tiles, 4, k_tiles, num_groups)`.
+        This is a strided view (not contiguous) with physical storage order
+        `(num_groups, m_tiles, k_tiles, 32, 4, 4)`.
+
+    Example:
+        >>> # Quantize weight tensor
+        >>> w_q, w_sf = fp4_quantize(weight, global_scale=gs, is_sf_swizzled_layout=True)
+        >>> # Convert scale factors to MMA layout
+        >>> w_sf_mma = convert_sf_to_mma_layout(w_sf, m=weight.shape[0], k=weight.shape[1])
+
+    Note:
+        - The input `sf` must be produced with `is_sf_swizzled_layout=True`.
+        - M and K dimensions must be multiples of 128 and 64 respectively for proper alignment.
+        - For grouped tensors (e.g., expert weights), reshape to `(num_groups * M, K)`
+          before quantization, then use this function with the appropriate `num_groups`.
+        - The returned tensor is a strided view, NOT contiguous. This is intentional as
+          the CuteDSL kernel expects the specific physical memory layout.
+    """
+    sf_k = ceil_div(k, sf_vec_size)
+    m_tiles = ceil_div(m, 128)
+    k_tiles = ceil_div(sf_k, 4)
+
+    # Verify input shape
+    expected_elements = num_groups * m_tiles * k_tiles * 32 * 4 * 4
+    actual_elements = sf.numel()
+    if actual_elements != expected_elements:
+        raise ValueError(
+            f"Scale factor tensor has {actual_elements} elements, "
+            f"expected {expected_elements} for m={m}, k={k}, num_groups={num_groups}"
+        )
+
+    # Reshape from flat 2D to 6D physical storage order
+    # Physical storage: (num_groups, m_tiles, k_tiles, 32, 4, 4)
+    sf_6d = sf.view(num_groups, m_tiles, k_tiles, 32, 4, 4)
+
+    # Permute to MMA logical order: (32, 4, m_tiles, 4, k_tiles, num_groups)
+    # This creates a strided view (non-contiguous), which is what the kernel expects
+    sf_6d = sf_6d.permute(3, 4, 1, 5, 2, 0)
+
+    return sf_6d  # Return strided view, NOT contiguous
+
+
+def convert_sf_from_mma_layout(
+    sf_6d: torch.Tensor,
+    m: int,
+    k: int,
+    num_groups: int = 1,
+    sf_vec_size: int = 16,
+) -> torch.Tensor:
+    """Convert scale factors from 6D MMA layout back to 2D swizzled layout.
+
+    This is the inverse of `convert_sf_to_mma_layout`.
+
+    Args:
+        sf_6d: Scale factors in 6D MMA layout: `(32, 4, m_tiles, 4, k_tiles, num_groups)`.
+               Can be either a strided view or contiguous.
+        m: The M dimension (rows) of the original matrix.
+        k: The K dimension (columns) of the original matrix.
+        num_groups: Number of groups. Default: 1.
+        sf_vec_size: Scale factor vector size. Default: 16.
+
+    Returns:
+        Scale factors in 2D swizzled layout: `(num_groups * M_padded, K_padded/sf_vec_size)`.
+    """
+    sf_k = ceil_div(k, sf_vec_size)
+    m_tiles = ceil_div(m, 128)
+    k_tiles = ceil_div(sf_k, 4)
+
+    # Permute from MMA logical order back to storage order
+    # From: (32, 4, m_tiles, 4, k_tiles, num_groups)
+    # To: (num_groups, m_tiles, k_tiles, 32, 4, 4)
+    sf_storage = sf_6d.permute(5, 2, 4, 0, 1, 3).contiguous()
+
+    # Reshape to 2D
+    padded_m = m_tiles * 128
+    padded_sf_k = k_tiles * 4
+    sf_2d = sf_storage.reshape(num_groups * padded_m, padded_sf_k)
+
+    return sf_2d
+
+
+def get_mma_sf_shape(
+    m: int,
+    k: int,
+    num_groups: int = 1,
+    sf_vec_size: int = 16,
+) -> Tuple[int, int, int, int, int, int]:
+    """Get the 6D MMA-compatible scale factor shape.
+
+    Args:
+        m: The M dimension (rows) of the matrix.
+        k: The K dimension (columns) of the matrix.
+        num_groups: Number of groups. Default: 1.
+        sf_vec_size: Scale factor vector size. Default: 16.
+
+    Returns:
+        Shape tuple: (32, 4, m_tiles, 4, k_tiles, num_groups)
+    """
+    sf_k = ceil_div(k, sf_vec_size)
+    m_tiles = ceil_div(m, 128)
+    k_tiles = ceil_div(sf_k, 4)
+    return (32, 4, m_tiles, 4, k_tiles, num_groups)
+
+
+@dsl_user_op
+def sm120_make_smem_layout_sfa(
+    tiled_mma: cute.TiledMma,
+    tile_shape_mnk: cute.Tile,
+    sf_vec_size: int,
+    num_stages: int,
+    *,
+    loc=None,
+    ip=None,
+) -> cute.Layout:
+    """
+    Make smem layout for SFA based on:
+    1. BlockScaledBasicChunk
+    2. MMA tiler shape
+    3. Scale factor vector size
+    4. Number of stages
+
+    :param tiled_mma: The tiled MMA
+    :type tiled_mma: cute.TiledMma
+    :param mma_tiler_mnk: The mma tiler shape
+    :type mma_tiler_mnk: cute.Tile
+    :param sf_vec_size: The scale factor vector size
+    :type sf_vec_size: int
+    :param num_stages: The number of stages
+    :type num_stages: int
+
+    :return: Smem layout for SFA
+    :rtype: cute.Layout
+    """
+
+    assert sf_vec_size == 16 or sf_vec_size == 32, "sf_vec_size must be 16 or 32"
+
+    blk_mn = 128
+    blk_sf = min(4, tile_shape_mnk[2] // sf_vec_size)
+    # The global scale atom always has four K groups.  A BK64 stage consumes
+    # two groups but keeps the same row pitch inside shared memory.
+    blk_elems = blk_mn * 4
+    mma_nsf = tiled_mma.shape_mnk[2] // sf_vec_size
+
+    mn_basic_block_shape = (32, 4)
+    mn_basic_block_stride = (16, 4)
+    k_basic_block_shape = (sf_vec_size, mma_nsf)
+    k_basic_block_stride = (0, 1)
+
+    assert tile_shape_mnk[0] % (blk_mn // 8) == 0, (
+        "tile_shape_mnk[0] must be divisible by 16"
+    )
+
+    # Scale-factor tiles are quantized in 128-row blocks, so narrower MMA
+    # tiles still allocate one full SF block and consume only the live subset.
+    sfa_tile_m = max(blk_mn, ceil_div(tile_shape_mnk[0], blk_mn) * blk_mn)
+
+    sSFA_shapeM = (mn_basic_block_shape, sfa_tile_m // blk_mn)
+    sSF_strideM = (mn_basic_block_stride, blk_elems)
+
+    assert tile_shape_mnk[2] % (blk_sf * mma_nsf) == 0, (
+        "tile_shape_mnk[2] must be divisible by blk_sf * mma_nsf"
+    )
+
+    sSFA_shapeK = (
+        k_basic_block_shape,
+        blk_sf // mma_nsf,
+        tile_shape_mnk[2] // sf_vec_size // blk_sf,
+    )
+    sSF_strideK = (
+        k_basic_block_stride,
+        mma_nsf,
+        sfa_tile_m // blk_mn * blk_elems,
+    )
+
+    sSFA_shape = (sSFA_shapeM, sSFA_shapeK)
+    sSFA_stride = (sSF_strideM, sSF_strideK)
+
+    smem_layout = cute.make_layout(sSFA_shape, stride=sSFA_stride)
+
+    sfa_smem_layout_staged = cute.append(
+        smem_layout,
+        cute.make_layout(
+            num_stages, stride=cute.cosize(cute.filter_zeros(smem_layout))
+        ),
+    )
+
+    return sfa_smem_layout_staged
+
+
+@dsl_user_op
+def sm120_make_smem_layout_sfb(
+    tiled_mma: cute.TiledMma,
+    tile_shape_mnk: cute.Tile,
+    sf_vec_size: int,
+    num_stages: int,
+    *,
+    loc=None,
+    ip=None,
+) -> cute.Layout:
+    """
+    Make smem layout for SFB based on:
+    1. BlockScaledBasicChunk
+    2. MMA tiler shape
+    3. Scale factor vector size
+    4. Number of stages
+
+    :param tiled_mma: The tiled MMA
+    :type tiled_mma: cute.TiledMma
+    :param mma_tiler_mnk: The mma tiler shape
+    :type mma_tiler_mnk: cute.Tile
+    :param sf_vec_size: The scale factor vector size
+    :type sf_vec_size: int
+    :param num_stages: The number of stages
+    :type num_stages: int
+
+    :return: Smem layout for SFA
+    :rtype: cute.Layout
+    """
+
+    blk_mn = 128
+    blk_sf = min(4, tile_shape_mnk[2] // sf_vec_size)
+    # Keep the four-group atom pitch when a BK64 stage exposes two groups.
+    blk_elems = blk_mn * 4
+
+    assert sf_vec_size == 16 or sf_vec_size == 32, "sf_vec_size must be 16 or 32"
+
+    assert tile_shape_mnk[1] % (blk_mn // 8) == 0, (
+        "tile_shape_mnk[1] must be divisible by 16"
+    )
+
+    assert tile_shape_mnk[2] % sf_vec_size == 0, (
+        "tile_shape_mnk[2] must be divisible by sf_vec_size"
+    )
+
+    mma_nsf = tiled_mma.shape_mnk[2] // sf_vec_size
+
+    mn_basic_block_shape = (32, 4)
+    mn_basic_block_stride = (16, 4)
+    k_basic_block_shape = (sf_vec_size, mma_nsf)
+    k_basic_block_stride = (0, 1)
+
+    # Scale-factor tiles are quantized in 128-column blocks, so narrower MMA
+    # tiles still allocate one full SF block and consume only the live subset.
+    sfb_tile_n = max(blk_mn, ceil_div(tile_shape_mnk[1], blk_mn) * blk_mn)
+
+    sSFA_shapeN = (mn_basic_block_shape, sfb_tile_n // blk_mn)
+    sSF_strideN = (mn_basic_block_stride, blk_elems)
+
+    assert tile_shape_mnk[2] % (blk_sf * mma_nsf) == 0, (
+        "tile_shape_mnk[2] must be divisible by blk_sf * mma_nsf"
+    )
+
+    sSFA_shapeK = (
+        k_basic_block_shape,
+        blk_sf // mma_nsf,
+        tile_shape_mnk[2] // sf_vec_size // blk_sf,
+    )
+    sSF_strideK = (
+        k_basic_block_stride,
+        mma_nsf,
+        sfb_tile_n // blk_mn * blk_elems,
+    )
+
+    sSFA_shape = (sSFA_shapeN, sSFA_shapeK)
+    sSFA_stride = (sSF_strideN, sSF_strideK)
+
+    smem_layout = cute.make_layout(sSFA_shape, stride=sSFA_stride)
+
+    sfb_smem_layout_staged = cute.append(
+        smem_layout,
+        cute.make_layout(
+            num_stages, stride=cute.cosize(cute.filter_zeros(smem_layout))
+        ),
+    )
+
+    return sfb_smem_layout_staged

--- a/flashinfer/experimental/sm12x/attention/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Attention ops for flashinfer.experimental.sm12x.
+
+- ``paged``: paged-KV self-attention (decode + extend, FP8 KV, MSA
+  block-sparse variant) with on-device graph-replay metadata staging.
+- ``sparse_mla``: top-k-selected MLA decode/extend (DeepSeek-V3.2 / GLM NSA).
+- ``compressed_mla``: MLA decode directly from compressed KV pages (DSV4).
+- ``nsa_indexer``: the NSA index stage — quantize -> score -> select.
+- ``varlen``: contiguous batched/varlen attention (reduced-assurance tier).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_OP_MODULES = ("paged", "sparse_mla", "compressed_mla", "nsa_indexer", "varlen")
+
+
+def __getattr__(name: str) -> Any:
+    if name in _OP_MODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(_OP_MODULES)
+
+
+__all__ = list(_OP_MODULES)

--- a/flashinfer/experimental/sm12x/attention/_shared/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Lowering shared by attention ops: CuTe softmax/copy/pipeline helpers
+(``cute``), the FA-style building blocks and contiguous kernels
+(``contiguous``), the unified MLA kernel core (``mla``), and the shared
+serving arena (``workspace``). Imports only _lib and itself (plus lazy
+shared-arena reach-throughs to gemm/norm workspaces documented in
+``workspace.py``).
+"""

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/__init__.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/__init__.py @ 149d6bb2 (2026-06-12) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Public contiguous-attention API."""
+
+from .api import (
+    AttentionBinding,
+    AttentionPlan,
+    AttentionPlanKey,
+    AttentionScratchPlan,
+    VarlenAttentionBinding,
+    VarlenAttentionPlan,
+    VarlenAttentionPlanKey,
+    VarlenAttentionScratchPlan,
+    sm12x_attention_forward,
+    sm12x_varlen_attention_forward,
+    clear_attention_caches,
+    create_attention_plan,
+    create_varlen_attention_plan,
+    plan_attention_scratch,
+    plan_varlen_attention_scratch,
+)
+
+__all__ = [
+    "AttentionBinding",
+    "AttentionPlan",
+    "AttentionPlanKey",
+    "AttentionScratchPlan",
+    "VarlenAttentionBinding",
+    "VarlenAttentionPlan",
+    "VarlenAttentionPlanKey",
+    "VarlenAttentionScratchPlan",
+    "sm12x_attention_forward",
+    "sm12x_varlen_attention_forward",
+    "clear_attention_caches",
+    "create_attention_plan",
+    "create_varlen_attention_plan",
+    "plan_attention_scratch",
+    "plan_varlen_attention_scratch",
+]

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/api.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/api.py
@@ -1,0 +1,2548 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/api.py @ 149d6bb2 (2026-06-12) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Planner-backed public attention entrypoints for contiguous attention."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Int32
+
+from flashinfer.experimental.sm12x.attention._shared.contiguous.forward import (
+    ContiguousAttentionForwardKernel,
+)
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    compile as sm12x_compile,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream, make_ptr
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+
+_ARENA_ALIGN_BYTES = 1024
+
+
+def _torch_to_cutlass_dtype(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float16:
+        return cutlass.Float16
+    raise TypeError(
+        f"unsupported dtype {dtype}; expected torch.bfloat16 or torch.float16"
+    )
+
+
+def _contiguous_stride(shape: tuple[int, ...]) -> tuple[int, ...]:
+    if not shape:
+        return ()
+    stride = [1] * len(shape)
+    running = 1
+    for idx in range(len(shape) - 1, -1, -1):
+        stride[idx] = running
+        running *= shape[idx]
+    return tuple(stride)
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    return ((int(value) + int(alignment) - 1) // int(alignment)) * int(alignment)
+
+
+def _dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _shape_numel(shape: tuple[int, ...]) -> int:
+    numel = 1
+    for dim in shape:
+        numel *= int(dim)
+    return int(numel)
+
+
+def _lse_shape(q_shape: tuple[int, ...]) -> tuple[int, ...]:
+    if len(q_shape) == 3:
+        seqlen_q, q_heads, _ = q_shape
+        return (q_heads, seqlen_q)
+    batch, seqlen_q, q_heads, _ = q_shape
+    return (batch, q_heads, seqlen_q)
+
+
+def _seq_dims(shape: tuple[int, ...]) -> tuple[tuple[int, ...], int, int, int]:
+    if len(shape) == 3:
+        seqlen, num_heads, head_dim = shape
+        return (), seqlen, num_heads, head_dim
+    if len(shape) == 4:
+        batch, seqlen, num_heads, head_dim = shape
+        return (batch,), seqlen, num_heads, head_dim
+    raise ValueError(f"expected rank-3 or rank-4 tensor shape, got {shape}")
+
+
+def _normalize_window_size(
+    window_size: int | tuple[int, int] | None,
+) -> tuple[int, int]:
+    if window_size is None:
+        return (-1, -1)
+    if isinstance(window_size, int):
+        left = right = int(window_size)
+    else:
+        if len(window_size) != 2:
+            raise ValueError(f"window_size must have two elements, got {window_size}")
+        left, right = (int(window_size[0]), int(window_size[1]))
+    if left < -1 or right < -1:
+        raise ValueError(f"window_size values must be >= -1, got {(left, right)}")
+    return left, right
+
+
+def _resolve_max_seqlen(
+    cu_seqlens: torch.Tensor,
+    max_seqlen: int | None,
+    *,
+    name: str,
+) -> int:
+    if max_seqlen is not None:
+        resolved = int(max_seqlen)
+        if resolved < 0:
+            raise ValueError(f"{name} must be non-negative, got {resolved}")
+        return resolved
+    lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).detach().cpu()
+    return int(lengths.max().item()) if lengths.numel() else 0
+
+
+def _attention_logical_dims(
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+) -> tuple[int, int, int, int, int, int, int, int]:
+    batch_dims, seqlen_q, q_heads, _ = _seq_dims(q_shape)
+    _, seqlen_k, kv_heads, _ = _seq_dims(k_shape)
+    num_batch = batch_dims[0] if batch_dims else 1
+    qhead_per_kvhead = q_heads // kv_heads
+    logical_q_rows_static = seqlen_q * qhead_per_kvhead
+    logical_total_q_rows = logical_q_rows_static * num_batch
+    return (
+        num_batch,
+        q_heads,
+        kv_heads,
+        qhead_per_kvhead,
+        seqlen_q,
+        seqlen_k,
+        logical_q_rows_static,
+        logical_total_q_rows,
+    )
+
+
+def _varlen_attention_logical_dims(
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+    cu_seqlens_q_shape: tuple[int, ...],
+    *,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+) -> tuple[int, int, int, int, int, int]:
+    if len(q_shape) != 3 or len(k_shape) != 3:
+        raise ValueError("varlen attention expects packed rank-3 q/k/v tensors")
+    _, q_heads, _ = q_shape
+    total_q, _, _ = q_shape
+    _, kv_heads, _ = k_shape
+    num_batch = cu_seqlens_q_shape[0] - 1
+    qhead_per_kvhead = q_heads // kv_heads
+    logical_q_rows_static = max_seqlen_q * qhead_per_kvhead
+    logical_total_q_rows = total_q * qhead_per_kvhead
+    return (
+        num_batch,
+        q_heads,
+        kv_heads,
+        qhead_per_kvhead,
+        logical_q_rows_static,
+        logical_total_q_rows,
+    )
+
+
+def _select_tile_shape(head_dim: int, *, causal: bool) -> tuple[int, int]:
+    if head_dim <= 64:
+        return (128, 128)
+    if head_dim <= 128:
+        return (128, 64)
+    if head_dim == 256:
+        return (64, 32 if causal else 48)
+    raise ValueError(
+        f"unsupported head_dim={head_dim} for the current sm12x attention path"
+    )
+
+
+def _normalize_tensor_shape(t: torch.Tensor) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in t.shape)
+
+
+def _cuda_device_index(device: torch.device) -> int:
+    if device.type != "cuda":
+        raise ValueError(f"expected CUDA device, got {device}")
+    return torch.cuda.current_device() if device.index is None else int(device.index)
+
+
+@functools.cache
+def _attention_sink_placeholder(device_index: int) -> torch.Tensor:
+    return torch.empty(
+        (1,), dtype=torch.float32, device=torch.device("cuda", device_index)
+    )
+
+
+def _validate_forward_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> tuple[
+    tuple[int, ...], tuple[int, ...], tuple[int, ...], torch.device, torch.dtype
+]:
+    if q.ndim not in (3, 4):
+        raise ValueError(f"q must be rank-3 or rank-4, got rank {q.ndim}")
+    if q.ndim != k.ndim or q.ndim != v.ndim:
+        raise ValueError("q, k, and v must have the same rank")
+    if q.device.type != "cuda" or k.device != q.device or v.device != q.device:
+        raise ValueError("q, k, and v must all be CUDA tensors on the same device")
+    if q.dtype != k.dtype or q.dtype != v.dtype:
+        raise ValueError("q, k, and v must have the same dtype")
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        raise TypeError(
+            f"unsupported dtype {q.dtype}; expected torch.bfloat16 or torch.float16"
+        )
+    if not q.is_contiguous() or not k.is_contiguous() or not v.is_contiguous():
+        raise ValueError("q, k, and v must all be contiguous")
+
+    q_shape = _normalize_tensor_shape(q)
+    k_shape = _normalize_tensor_shape(k)
+    v_shape = _normalize_tensor_shape(v)
+    batch_q, _, q_heads, q_head_dim = _seq_dims(q_shape)
+    batch_k, _, kv_heads, k_head_dim = _seq_dims(k_shape)
+    batch_v, _, v_heads, v_head_dim = _seq_dims(v_shape)
+    if batch_q != batch_k or batch_q != batch_v:
+        raise ValueError("q, k, and v must have matching batch dimensions")
+    if q_head_dim != k_head_dim or q_head_dim != v_head_dim:
+        raise ValueError(
+            "q, k, and v must have matching head dimensions in the initial path"
+        )
+    if kv_heads != v_heads:
+        raise ValueError("k and v must have the same number of KV heads")
+    if q_heads % kv_heads != 0:
+        raise ValueError(f"q_heads={q_heads} must be divisible by kv_heads={kv_heads}")
+    return q_shape, k_shape, v_shape, q.device, q.dtype
+
+
+def _prepare_attention_sink_bias(
+    attention_sink_bias: torch.Tensor | None,
+    *,
+    q_shape: tuple[int, ...],
+    device: torch.device,
+) -> torch.Tensor | None:
+    if attention_sink_bias is None:
+        return None
+    _, _, q_heads, _ = _seq_dims(q_shape)
+    if attention_sink_bias.ndim != 1:
+        raise ValueError(
+            "attention_sink_bias must be rank-1 [num_q_heads], "
+            f"got {tuple(attention_sink_bias.shape)}"
+        )
+    if int(attention_sink_bias.shape[0]) != q_heads:
+        raise ValueError(
+            f"attention_sink_bias must have {q_heads} elements, "
+            f"got {int(attention_sink_bias.shape[0])}"
+        )
+    if attention_sink_bias.device != device:
+        raise ValueError("attention_sink_bias must be on the same CUDA device as q")
+    if attention_sink_bias.dtype != torch.float32:
+        attention_sink_bias = attention_sink_bias.to(torch.float32)
+    if not attention_sink_bias.is_contiguous():
+        attention_sink_bias = attention_sink_bias.contiguous()
+    return attention_sink_bias
+
+
+def _validate_attention_inputs_against_plan(
+    *,
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+    v_shape: tuple[int, ...],
+    device: torch.device,
+    dtype: torch.dtype,
+    plan: AttentionPlan,
+) -> None:
+    expected = (
+        plan.q_shape,
+        plan.k_shape,
+        plan.v_shape,
+        plan.device,
+        plan.dtype,
+    )
+    actual = (q_shape, k_shape, v_shape, device, dtype)
+    if expected != actual:
+        raise ValueError(
+            "attention plan mismatch: "
+            f"expected q/k/v/device/dtype={expected}, got {actual}"
+        )
+
+
+def _validate_varlen_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+) -> tuple[
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    torch.device,
+    torch.dtype,
+]:
+    q_shape, k_shape, v_shape, device, dtype = _validate_forward_inputs(q, k, v)
+    if len(q_shape) != 3:
+        raise ValueError("varlen attention expects packed rank-3 q/k/v tensors")
+    if cu_seqlens_q.ndim != 1 or cu_seqlens_k.ndim != 1:
+        raise ValueError("cu_seqlens_q and cu_seqlens_k must be rank-1 tensors")
+    if cu_seqlens_q.device != device or cu_seqlens_k.device != device:
+        raise ValueError(
+            "cu_seqlens_q and cu_seqlens_k must be CUDA tensors on the input device"
+        )
+    if cu_seqlens_q.dtype != torch.int32 or cu_seqlens_k.dtype != torch.int32:
+        raise TypeError("cu_seqlens_q and cu_seqlens_k must be torch.int32")
+    if not cu_seqlens_q.is_contiguous() or not cu_seqlens_k.is_contiguous():
+        raise ValueError("cu_seqlens_q and cu_seqlens_k must be contiguous")
+    if cu_seqlens_q.shape != cu_seqlens_k.shape:
+        raise ValueError(
+            "the restored varlen contiguous path currently requires matching q/k segment counts"
+        )
+    return (
+        q_shape,
+        k_shape,
+        v_shape,
+        _normalize_tensor_shape(cu_seqlens_q),
+        _normalize_tensor_shape(cu_seqlens_k),
+        device,
+        dtype,
+    )
+
+
+def _validate_varlen_inputs_against_plan(
+    *,
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+    v_shape: tuple[int, ...],
+    cu_seqlens_q_shape: tuple[int, ...],
+    cu_seqlens_k_shape: tuple[int, ...],
+    device: torch.device,
+    dtype: torch.dtype,
+    plan: VarlenAttentionPlan,
+) -> None:
+    expected = (
+        plan.q_shape,
+        plan.k_shape,
+        plan.v_shape,
+        plan.cu_seqlens_q_shape,
+        plan.cu_seqlens_k_shape,
+        plan.device,
+        plan.dtype,
+    )
+    actual = (
+        q_shape,
+        k_shape,
+        v_shape,
+        cu_seqlens_q_shape,
+        cu_seqlens_k_shape,
+        device,
+        dtype,
+    )
+    if expected != actual:
+        raise ValueError(
+            "varlen attention plan mismatch: "
+            "expected q/k/v/cu_q/cu_k/device/dtype="
+            f"{expected}, got {actual}"
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AttentionPlanKey:
+    q_shape: tuple[int, ...]
+    k_shape: tuple[int, ...]
+    v_shape: tuple[int, ...]
+    device_index: int
+    dtype: torch.dtype
+    causal: bool
+    window_size_left: int
+    window_size_right: int
+    has_attention_sink_bias: bool
+    tile_m: int
+    tile_n: int
+    num_batch: int
+    num_q_heads: int
+    num_kv_heads: int
+    qhead_per_kvhead: int
+    seqlen_q_static: int
+    seqlen_k_static: int
+    logical_q_rows_static: int
+    logical_total_q_rows: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class VarlenAttentionPlanKey:
+    q_shape: tuple[int, ...]
+    k_shape: tuple[int, ...]
+    v_shape: tuple[int, ...]
+    cu_seqlens_q_shape: tuple[int, ...]
+    cu_seqlens_k_shape: tuple[int, ...]
+    device_index: int
+    dtype: torch.dtype
+    causal: bool
+    window_size_left: int
+    window_size_right: int
+    has_attention_sink_bias: bool
+    tile_m: int
+    tile_n: int
+    max_seqlen_q: int
+    max_seqlen_k: int
+    num_batch: int
+    num_q_heads: int
+    num_kv_heads: int
+    qhead_per_kvhead: int
+    logical_q_rows_static: int
+    logical_total_q_rows: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class AttentionPlan:
+    """Exact-shape launch contract for one contiguous attention shape."""
+
+    key: AttentionPlanKey
+    compiled: object = field(repr=False, compare=False)
+    cutlass_dtype: type[cutlass.Numeric] = field(repr=False, compare=False)
+
+    def __getattr__(self, name: str):
+        return getattr(self.key, name)
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.key.device_index)
+
+
+@dataclass(frozen=True, kw_only=True)
+class VarlenAttentionPlan:
+    """Exact-shape launch contract for one packed varlen contiguous attention shape."""
+
+    key: VarlenAttentionPlanKey
+    compiled: object = field(repr=False, compare=False)
+    cutlass_dtype: type[cutlass.Numeric] = field(repr=False, compare=False)
+
+    def __getattr__(self, name: str):
+        return getattr(self.key, name)
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.key.device_index)
+
+
+@dataclass(kw_only=True)
+class AttentionWorkspace:
+    """Reusable exact-shape output buffers for one contiguous attention plan."""
+
+    q_shape: tuple[int, ...]
+    k_shape: tuple[int, ...]
+    v_shape: tuple[int, ...]
+    device: torch.device
+    dtype: torch.dtype
+    causal: bool
+    window_size_left: int
+    window_size_right: int
+    has_attention_sink_bias: bool
+    tile_m: int
+    tile_n: int
+    output: torch.Tensor
+    lse: torch.Tensor
+    plan_key: AttentionPlanKey | None = None
+
+    def bind(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        plan: AttentionPlan | None = None,
+        softmax_scale: float | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+    ) -> "AttentionBinding":
+        return build_attention_binding(
+            workspace=self,
+            q=q,
+            k=k,
+            v=v,
+            plan=plan,
+            softmax_scale=softmax_scale,
+            attention_sink_bias=attention_sink_bias,
+        )
+
+
+@dataclass(kw_only=True)
+class VarlenAttentionWorkspace:
+    """Reusable output buffers for one packed varlen contiguous attention plan."""
+
+    q_shape: tuple[int, ...]
+    k_shape: tuple[int, ...]
+    v_shape: tuple[int, ...]
+    cu_seqlens_q_shape: tuple[int, ...]
+    cu_seqlens_k_shape: tuple[int, ...]
+    device: torch.device
+    dtype: torch.dtype
+    causal: bool
+    window_size_left: int
+    window_size_right: int
+    has_attention_sink_bias: bool
+    tile_m: int
+    tile_n: int
+    max_seqlen_q: int
+    max_seqlen_k: int
+    output: torch.Tensor
+    lse: torch.Tensor
+    plan_key: VarlenAttentionPlanKey | None = None
+
+    def bind(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor | None = None,
+        plan: VarlenAttentionPlan | None = None,
+        max_seqlen_q: int | None = None,
+        max_seqlen_k: int | None = None,
+        softmax_scale: float | None = None,
+        causal: bool | None = None,
+        window_size: int | tuple[int, int] | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+    ) -> "VarlenAttentionBinding":
+        return build_varlen_attention_binding(
+            workspace=self,
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            plan=plan,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            attention_sink_bias=attention_sink_bias,
+        )
+
+
+@dataclass
+class AttentionWorkspacePool:
+    """Caller-owned exact-shape workspace cache partitioned by CUDA stream."""
+
+    workspaces: dict[tuple[int, AttentionPlanKey], AttentionWorkspace] = field(
+        default_factory=dict
+    )
+
+    def clear(self) -> None:
+        self.workspaces.clear()
+
+    def bind(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        plan: AttentionPlan,
+        softmax_scale: float | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+    ) -> "AttentionBinding":
+        return build_attention_binding(
+            workspace=self,
+            q=q,
+            k=k,
+            v=v,
+            plan=plan,
+            softmax_scale=softmax_scale,
+            attention_sink_bias=attention_sink_bias,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AttentionBinding:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    output: torch.Tensor
+    lse: torch.Tensor
+    plan: AttentionPlan
+    softmax_scale: float | None = None
+    attention_sink_bias: torch.Tensor | None = None
+
+    def run(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return sm12x_attention_forward(binding=self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class VarlenAttentionBinding:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    cu_seqlens_q: torch.Tensor
+    cu_seqlens_k: torch.Tensor
+    output: torch.Tensor
+    lse: torch.Tensor
+    plan: VarlenAttentionPlan
+    max_seqlen_q: int | None = None
+    max_seqlen_k: int | None = None
+    softmax_scale: float | None = None
+    causal: bool | None = None
+    window_size: int | tuple[int, int] | None = None
+    attention_sink_bias: torch.Tensor | None = None
+
+    def run(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return sm12x_varlen_attention_forward(binding=self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class _AttentionScratchLayout:
+    nbytes: int
+    output_offset_bytes: int
+    lse_offset_bytes: int
+
+
+@dataclass(frozen=True)
+class _AttentionScratchViews:
+    output: torch.Tensor
+    lse: torch.Tensor
+
+
+@dataclass(frozen=True)
+class AttentionScratchPlan:
+    plan: AttentionPlan
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+    _layout: _AttentionScratchLayout
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        softmax_scale: float | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+    ) -> AttentionBinding:
+        views = _attention_scratch_views_from_scratch_plan(
+            self,
+            scratch=scratch,
+        )
+        return _build_attention_binding_from_views(
+            output=views.output,
+            lse=views.lse,
+            q=q,
+            k=k,
+            v=v,
+            plan=self.plan,
+            softmax_scale=softmax_scale,
+            attention_sink_bias=attention_sink_bias,
+        )
+
+
+@dataclass(frozen=True)
+class VarlenAttentionScratchPlan:
+    plan: VarlenAttentionPlan
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+    _layout: _AttentionScratchLayout
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor | None = None,
+        max_seqlen_q: int | None = None,
+        max_seqlen_k: int | None = None,
+        softmax_scale: float | None = None,
+        causal: bool | None = None,
+        window_size: int | tuple[int, int] | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+    ) -> VarlenAttentionBinding:
+        views = _varlen_attention_scratch_views_from_scratch_plan(
+            self,
+            scratch=scratch,
+        )
+        return _build_varlen_attention_binding_from_views(
+            output=views.output,
+            lse=views.lse,
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            plan=self.plan,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            attention_sink_bias=attention_sink_bias,
+        )
+
+
+class _AttentionForwardLaunch:
+    def __init__(
+        self,
+        *,
+        q_shape: tuple[int, ...],
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+        dtype: torch.dtype,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        has_attention_sink_bias: bool,
+        tile_m: int,
+        tile_n: int,
+    ):
+        self._q_shape = q_shape
+        self._k_shape = k_shape
+        self._v_shape = v_shape
+        self._o_shape = q_shape
+        self._lse_shape = _lse_shape(q_shape)
+        self._attention_sink_bias_shape = (q_shape[-2],)
+        self._q_stride = _contiguous_stride(q_shape)
+        self._k_stride = _contiguous_stride(k_shape)
+        self._v_stride = _contiguous_stride(v_shape)
+        self._o_stride = _contiguous_stride(q_shape)
+        self._lse_stride = _contiguous_stride(self._lse_shape)
+        self._attention_sink_bias_stride = _contiguous_stride(
+            self._attention_sink_bias_shape
+        )
+        self._dtype = _torch_to_cutlass_dtype(dtype)
+        self._window_size_left = window_size_left
+        self._window_size_right = window_size_right
+        self._has_attention_sink_bias = bool(has_attention_sink_bias)
+        is_local = window_size_left != -1 or window_size_right != -1
+        (
+            self._num_batch,
+            q_heads,
+            kv_heads,
+            qhead_per_kvhead,
+            self._seqlen_q_static,
+            self._seqlen_k_static,
+            self._logical_q_rows_static,
+            self._logical_total_q_rows,
+        ) = _attention_logical_dims(q_shape, k_shape)
+        _, _, _, head_dim = _seq_dims(q_shape)
+        _, _, _, head_dim_k = _seq_dims(k_shape)
+        _, _, _, head_dim_v = _seq_dims(v_shape)
+        if not ContiguousAttentionForwardKernel.can_implement(
+            self._dtype,
+            head_dim,
+            head_dim_v,
+            tile_m,
+            tile_n,
+            1,
+            160,
+            causal,
+        ):
+            raise TypeError(
+                "sm12x attention launch is unsupported with "
+                f"dtype={dtype}, q_shape={q_shape}, k_shape={k_shape}, v_shape={v_shape}, "
+                f"causal={causal}, tile=({tile_m}, {tile_n})"
+            )
+        self._kernel = ContiguousAttentionForwardKernel(
+            self._dtype,
+            head_dim,
+            head_dim_v=head_dim_v,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=causal,
+            is_local=is_local,
+            pack_gqa=qhead_per_kvhead != 1,
+            tile_m=tile_m,
+            tile_n=tile_n,
+        )
+        assert head_dim == head_dim_k
+
+    @cute.jit
+    def __call__(
+        self,
+        q_ptr: cute.Pointer,
+        k_ptr: cute.Pointer,
+        v_ptr: cute.Pointer,
+        o_ptr: cute.Pointer,
+        lse_ptr: cute.Pointer,
+        attention_sink_bias_ptr: cute.Pointer,
+        softmax_scale: float,
+        current_stream: cuda.CUstream,
+    ):
+        q_tensor = cute.make_tensor(
+            q_ptr, layout=cute.make_layout(self._q_shape, stride=self._q_stride)
+        )
+        k_tensor = cute.make_tensor(
+            k_ptr, layout=cute.make_layout(self._k_shape, stride=self._k_stride)
+        )
+        v_tensor = cute.make_tensor(
+            v_ptr, layout=cute.make_layout(self._v_shape, stride=self._v_stride)
+        )
+        o_tensor = cute.make_tensor(
+            o_ptr, layout=cute.make_layout(self._o_shape, stride=self._o_stride)
+        )
+        lse_tensor = cute.make_tensor(
+            lse_ptr,
+            layout=cute.make_layout(self._lse_shape, stride=self._lse_stride),
+        )
+        attention_sink_bias_tensor = cute.make_tensor(
+            attention_sink_bias_ptr,
+            layout=cute.make_layout(
+                self._attention_sink_bias_shape,
+                stride=self._attention_sink_bias_stride,
+            ),
+        )
+        self._kernel(
+            q_tensor,
+            k_tensor,
+            v_tensor,
+            o_tensor,
+            lse_tensor,
+            softmax_scale,
+            learnable_sink=attention_sink_bias_tensor,
+            has_attention_sink_bias=self._has_attention_sink_bias,
+            logical_num_batch_static=self._num_batch,
+            logical_seqlen_q_static=self._seqlen_q_static,
+            logical_seqlen_k_static=self._seqlen_k_static,
+            window_size_left=(
+                None if self._window_size_left == -1 else Int32(self._window_size_left)
+            ),
+            window_size_right=(
+                None
+                if self._window_size_right == -1
+                else Int32(self._window_size_right)
+            ),
+            stream=current_stream,
+        )
+
+
+class _VarlenAttentionForwardLaunch:
+    def __init__(
+        self,
+        *,
+        q_shape: tuple[int, ...],
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+        cu_seqlens_q_shape: tuple[int, ...],
+        cu_seqlens_k_shape: tuple[int, ...],
+        dtype: torch.dtype,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        has_attention_sink_bias: bool,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        tile_m: int,
+        tile_n: int,
+    ):
+        self._q_shape = q_shape
+        self._k_shape = k_shape
+        self._v_shape = v_shape
+        self._cu_seqlens_q_shape = cu_seqlens_q_shape
+        self._cu_seqlens_k_shape = cu_seqlens_k_shape
+        self._o_shape = q_shape
+        self._lse_shape = _lse_shape(q_shape)
+        self._attention_sink_bias_shape = (q_shape[-2],)
+        self._q_stride = _contiguous_stride(q_shape)
+        self._k_stride = _contiguous_stride(k_shape)
+        self._v_stride = _contiguous_stride(v_shape)
+        self._cu_seqlens_q_stride = _contiguous_stride(cu_seqlens_q_shape)
+        self._cu_seqlens_k_stride = _contiguous_stride(cu_seqlens_k_shape)
+        self._o_stride = _contiguous_stride(q_shape)
+        self._lse_stride = _contiguous_stride(self._lse_shape)
+        self._attention_sink_bias_stride = _contiguous_stride(
+            self._attention_sink_bias_shape
+        )
+        self._dtype = _torch_to_cutlass_dtype(dtype)
+        self._window_size_left = window_size_left
+        self._window_size_right = window_size_right
+        self._has_attention_sink_bias = bool(has_attention_sink_bias)
+        self._max_seqlen_q = max_seqlen_q
+        self._max_seqlen_k = max_seqlen_k
+        is_local = window_size_left != -1 or window_size_right != -1
+        (
+            self._num_batch,
+            q_heads,
+            kv_heads,
+            qhead_per_kvhead,
+            self._logical_q_rows_static,
+            self._logical_total_q_rows,
+        ) = _varlen_attention_logical_dims(
+            q_shape,
+            k_shape,
+            cu_seqlens_q_shape,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+        )
+        _, _, head_dim = q_shape
+        _, _, head_dim_k = k_shape
+        _, _, head_dim_v = v_shape
+        if not ContiguousAttentionForwardKernel.can_implement(
+            self._dtype,
+            head_dim,
+            head_dim_v,
+            tile_m,
+            tile_n,
+            1,
+            160,
+            causal,
+        ):
+            raise TypeError(
+                "sm12x varlen attention launch is unsupported with "
+                f"dtype={dtype}, q_shape={q_shape}, k_shape={k_shape}, v_shape={v_shape}, "
+                f"causal={causal}, window=({window_size_left}, {window_size_right}), "
+                f"max_seqlen=({max_seqlen_q}, {max_seqlen_k}), tile=({tile_m}, {tile_n})"
+            )
+        self._kernel = ContiguousAttentionForwardKernel(
+            self._dtype,
+            head_dim,
+            head_dim_v=head_dim_v,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=causal,
+            is_local=is_local,
+            pack_gqa=qhead_per_kvhead != 1,
+            tile_m=tile_m,
+            tile_n=tile_n,
+        )
+        assert head_dim == head_dim_k
+
+    @cute.jit
+    def __call__(
+        self,
+        q_ptr: cute.Pointer,
+        k_ptr: cute.Pointer,
+        v_ptr: cute.Pointer,
+        o_ptr: cute.Pointer,
+        lse_ptr: cute.Pointer,
+        cu_seqlens_q_ptr: cute.Pointer,
+        cu_seqlens_k_ptr: cute.Pointer,
+        attention_sink_bias_ptr: cute.Pointer,
+        softmax_scale: float,
+        current_stream: cuda.CUstream,
+    ):
+        q_tensor = cute.make_tensor(
+            q_ptr, layout=cute.make_layout(self._q_shape, stride=self._q_stride)
+        )
+        k_tensor = cute.make_tensor(
+            k_ptr, layout=cute.make_layout(self._k_shape, stride=self._k_stride)
+        )
+        v_tensor = cute.make_tensor(
+            v_ptr, layout=cute.make_layout(self._v_shape, stride=self._v_stride)
+        )
+        o_tensor = cute.make_tensor(
+            o_ptr, layout=cute.make_layout(self._o_shape, stride=self._o_stride)
+        )
+        lse_tensor = cute.make_tensor(
+            lse_ptr,
+            layout=cute.make_layout(self._lse_shape, stride=self._lse_stride),
+        )
+        cu_seqlens_q_tensor = cute.make_tensor(
+            cu_seqlens_q_ptr,
+            layout=cute.make_layout(
+                self._cu_seqlens_q_shape,
+                stride=self._cu_seqlens_q_stride,
+            ),
+        )
+        cu_seqlens_k_tensor = cute.make_tensor(
+            cu_seqlens_k_ptr,
+            layout=cute.make_layout(
+                self._cu_seqlens_k_shape,
+                stride=self._cu_seqlens_k_stride,
+            ),
+        )
+        attention_sink_bias_tensor = cute.make_tensor(
+            attention_sink_bias_ptr,
+            layout=cute.make_layout(
+                self._attention_sink_bias_shape,
+                stride=self._attention_sink_bias_stride,
+            ),
+        )
+        self._kernel(
+            q_tensor,
+            k_tensor,
+            v_tensor,
+            o_tensor,
+            lse_tensor,
+            softmax_scale,
+            mCuSeqlensQ=cu_seqlens_q_tensor,
+            mCuSeqlensK=cu_seqlens_k_tensor,
+            learnable_sink=attention_sink_bias_tensor,
+            has_attention_sink_bias=self._has_attention_sink_bias,
+            logical_num_batch_static=self._num_batch,
+            logical_seqlen_q_static=self._max_seqlen_q,
+            logical_seqlen_k_static=self._max_seqlen_k,
+            window_size_left=(
+                None if self._window_size_left == -1 else Int32(self._window_size_left)
+            ),
+            window_size_right=(
+                None
+                if self._window_size_right == -1
+                else Int32(self._window_size_right)
+            ),
+            stream=current_stream,
+        )
+
+
+@functools.cache
+def _compile_attention(
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+    v_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    has_attention_sink_bias: bool,
+    tile_m: int,
+    tile_n: int,
+):
+    cutlass_dtype = _torch_to_cutlass_dtype(dtype)
+    launch = _AttentionForwardLaunch(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        dtype=dtype,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        has_attention_sink_bias=has_attention_sink_bias,
+        tile_m=tile_m,
+        tile_n=tile_n,
+    )
+    return sm12x_compile(
+        launch,
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=4),
+        make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=4),
+        1.0,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "attention.contiguous.forward",
+            1,
+            (
+                q_shape,
+                k_shape,
+                v_shape,
+                dtype,
+                causal,
+                window_size_left,
+                window_size_right,
+                has_attention_sink_bias,
+                tile_m,
+                tile_n,
+            ),
+        ),
+    )
+
+
+@functools.cache
+def _compile_varlen_attention(
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+    v_shape: tuple[int, ...],
+    cu_seqlens_q_shape: tuple[int, ...],
+    cu_seqlens_k_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    has_attention_sink_bias: bool,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    tile_m: int,
+    tile_n: int,
+):
+    cutlass_dtype = _torch_to_cutlass_dtype(dtype)
+    launch = _VarlenAttentionForwardLaunch(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        cu_seqlens_q_shape=cu_seqlens_q_shape,
+        cu_seqlens_k_shape=cu_seqlens_k_shape,
+        dtype=dtype,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        has_attention_sink_bias=has_attention_sink_bias,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        tile_m=tile_m,
+        tile_n=tile_n,
+    )
+    return sm12x_compile(
+        launch,
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=4),
+        make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=4),
+        make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=4),
+        make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=4),
+        1.0,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "attention.contiguous.varlen_forward",
+            1,
+            (
+                q_shape,
+                k_shape,
+                v_shape,
+                cu_seqlens_q_shape,
+                cu_seqlens_k_shape,
+                dtype,
+                causal,
+                window_size_left,
+                window_size_right,
+                has_attention_sink_bias,
+                max_seqlen_q,
+                max_seqlen_k,
+                tile_m,
+                tile_n,
+            ),
+        ),
+    )
+
+
+@functools.cache
+def _get_attention_plan(
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+    v_shape: tuple[int, ...],
+    device_index: int,
+    dtype: torch.dtype,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    has_attention_sink_bias: bool,
+    tile_m: int,
+    tile_n: int,
+) -> AttentionPlan:
+    (
+        num_batch,
+        num_q_heads,
+        num_kv_heads,
+        qhead_per_kvhead,
+        seqlen_q_static,
+        seqlen_k_static,
+        logical_q_rows_static,
+        logical_total_q_rows,
+    ) = _attention_logical_dims(q_shape, k_shape)
+    return AttentionPlan(
+        key=AttentionPlanKey(
+            q_shape=q_shape,
+            k_shape=k_shape,
+            v_shape=v_shape,
+            device_index=device_index,
+            dtype=dtype,
+            causal=causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            has_attention_sink_bias=has_attention_sink_bias,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            num_batch=num_batch,
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            qhead_per_kvhead=qhead_per_kvhead,
+            seqlen_q_static=seqlen_q_static,
+            seqlen_k_static=seqlen_k_static,
+            logical_q_rows_static=logical_q_rows_static,
+            logical_total_q_rows=logical_total_q_rows,
+        ),
+        compiled=_compile_attention(
+            q_shape,
+            k_shape,
+            v_shape,
+            dtype,
+            causal,
+            window_size_left,
+            window_size_right,
+            has_attention_sink_bias,
+            tile_m,
+            tile_n,
+        ),
+        cutlass_dtype=_torch_to_cutlass_dtype(dtype),
+    )
+
+
+@functools.cache
+def _get_varlen_attention_plan(
+    q_shape: tuple[int, ...],
+    k_shape: tuple[int, ...],
+    v_shape: tuple[int, ...],
+    cu_seqlens_q_shape: tuple[int, ...],
+    cu_seqlens_k_shape: tuple[int, ...],
+    device_index: int,
+    dtype: torch.dtype,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    has_attention_sink_bias: bool,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    tile_m: int,
+    tile_n: int,
+) -> VarlenAttentionPlan:
+    (
+        num_batch,
+        num_q_heads,
+        num_kv_heads,
+        qhead_per_kvhead,
+        logical_q_rows_static,
+        logical_total_q_rows,
+    ) = _varlen_attention_logical_dims(
+        q_shape,
+        k_shape,
+        cu_seqlens_q_shape,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+    )
+    return VarlenAttentionPlan(
+        key=VarlenAttentionPlanKey(
+            q_shape=q_shape,
+            k_shape=k_shape,
+            v_shape=v_shape,
+            cu_seqlens_q_shape=cu_seqlens_q_shape,
+            cu_seqlens_k_shape=cu_seqlens_k_shape,
+            device_index=device_index,
+            dtype=dtype,
+            causal=causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            has_attention_sink_bias=has_attention_sink_bias,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            num_batch=num_batch,
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            qhead_per_kvhead=qhead_per_kvhead,
+            logical_q_rows_static=logical_q_rows_static,
+            logical_total_q_rows=logical_total_q_rows,
+        ),
+        compiled=_compile_varlen_attention(
+            q_shape,
+            k_shape,
+            v_shape,
+            cu_seqlens_q_shape,
+            cu_seqlens_k_shape,
+            dtype,
+            causal,
+            window_size_left,
+            window_size_right,
+            has_attention_sink_bias,
+            max_seqlen_q,
+            max_seqlen_k,
+            tile_m,
+            tile_n,
+        ),
+        cutlass_dtype=_torch_to_cutlass_dtype(dtype),
+    )
+
+
+def clear_attention_caches() -> None:
+    """Clear global compile caches owned by the sm12x attention integration."""
+    _compile_attention.cache_clear()
+    _compile_varlen_attention.cache_clear()
+    _get_attention_plan.cache_clear()
+    _get_varlen_attention_plan.cache_clear()
+
+
+def _validate_workspace(
+    workspace: AttentionWorkspace,
+    *,
+    plan: AttentionPlan,
+) -> None:
+    expected = (
+        plan.q_shape,
+        plan.k_shape,
+        plan.v_shape,
+        plan.device,
+        plan.dtype,
+        plan.causal,
+        plan.window_size_left,
+        plan.window_size_right,
+        plan.has_attention_sink_bias,
+        plan.tile_m,
+        plan.tile_n,
+    )
+    actual = (
+        workspace.q_shape,
+        workspace.k_shape,
+        workspace.v_shape,
+        workspace.device,
+        workspace.dtype,
+        workspace.causal,
+        workspace.window_size_left,
+        workspace.window_size_right,
+        workspace.has_attention_sink_bias,
+        workspace.tile_m,
+        workspace.tile_n,
+    )
+    if expected != actual:
+        raise ValueError(
+            "workspace shape mismatch: "
+            "expected q/k/v/device/dtype/causal/window/sink/tile="
+            f"{expected}, got {actual}"
+        )
+    if workspace.plan_key is not None and workspace.plan_key != plan.key:
+        raise ValueError(
+            f"workspace plan mismatch: expected {workspace.plan_key}, got {plan.key}"
+        )
+
+
+def _validate_varlen_workspace(
+    workspace: VarlenAttentionWorkspace,
+    *,
+    plan: VarlenAttentionPlan,
+) -> None:
+    expected = (
+        plan.q_shape,
+        plan.k_shape,
+        plan.v_shape,
+        plan.cu_seqlens_q_shape,
+        plan.cu_seqlens_k_shape,
+        plan.device,
+        plan.dtype,
+        plan.causal,
+        plan.window_size_left,
+        plan.window_size_right,
+        plan.has_attention_sink_bias,
+        plan.tile_m,
+        plan.tile_n,
+        plan.max_seqlen_q,
+        plan.max_seqlen_k,
+    )
+    actual = (
+        workspace.q_shape,
+        workspace.k_shape,
+        workspace.v_shape,
+        workspace.cu_seqlens_q_shape,
+        workspace.cu_seqlens_k_shape,
+        workspace.device,
+        workspace.dtype,
+        workspace.causal,
+        workspace.window_size_left,
+        workspace.window_size_right,
+        workspace.has_attention_sink_bias,
+        workspace.tile_m,
+        workspace.tile_n,
+        workspace.max_seqlen_q,
+        workspace.max_seqlen_k,
+    )
+    if expected != actual:
+        raise ValueError(
+            "varlen workspace shape mismatch: "
+            "expected q/k/v/cu_q/cu_k/device/dtype/causal/window/sink/tile/max_seqlen="
+            f"{expected}, got {actual}"
+        )
+    if workspace.plan_key is not None and workspace.plan_key != plan.key:
+        raise ValueError(
+            "varlen workspace plan mismatch: "
+            f"expected {workspace.plan_key}, got {plan.key}"
+        )
+
+
+def _validate_attention_output_lse(
+    *,
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    plan: AttentionPlan | VarlenAttentionPlan,
+) -> None:
+    if output.shape != plan.q_shape:
+        raise ValueError(
+            f"attention output must have shape {plan.q_shape}, got {tuple(output.shape)}"
+        )
+    if output.device != plan.device:
+        raise ValueError(
+            f"attention output device {output.device} does not match plan device {plan.device}"
+        )
+    if output.dtype != plan.dtype:
+        raise ValueError(
+            f"attention output dtype {output.dtype} does not match plan dtype {plan.dtype}"
+        )
+    expected_lse_shape = _lse_shape(plan.q_shape)
+    if lse.shape != expected_lse_shape:
+        raise ValueError(
+            f"attention lse must have shape {expected_lse_shape}, got {tuple(lse.shape)}"
+        )
+    if lse.device != plan.device:
+        raise ValueError(
+            f"attention lse device {lse.device} does not match plan device {plan.device}"
+        )
+    if lse.dtype != torch.float32:
+        raise ValueError(
+            f"attention lse must have dtype torch.float32, got {lse.dtype}"
+        )
+
+
+def _attention_scratch_layout(
+    *,
+    q_shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> _AttentionScratchLayout:
+    cursor = 0
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+    output_offset_bytes = cursor
+    cursor += _shape_numel(q_shape) * _dtype_nbytes(dtype)
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+    lse_offset_bytes = cursor
+    cursor += _shape_numel(_lse_shape(q_shape)) * _dtype_nbytes(torch.float32)
+    return _AttentionScratchLayout(
+        nbytes=max(int(cursor), 1),
+        output_offset_bytes=output_offset_bytes,
+        lse_offset_bytes=lse_offset_bytes,
+    )
+
+
+def _arena_view(
+    arena: torch.Tensor,
+    *,
+    offset_bytes: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    offset_bytes = _align_up(
+        offset_bytes, max(_ARENA_ALIGN_BYTES, _dtype_nbytes(dtype))
+    )
+    nbytes = _shape_numel(shape) * _dtype_nbytes(dtype)
+    return arena.narrow(0, offset_bytes, nbytes).view(dtype).view(shape)
+
+
+def _attention_workspace_from_arena(
+    plan: AttentionPlan,
+    *,
+    layout: _AttentionScratchLayout,
+    arena: torch.Tensor,
+) -> AttentionWorkspace:
+    views = _attention_scratch_views_from_arena(plan, layout=layout, arena=arena)
+    return AttentionWorkspace(
+        q_shape=plan.q_shape,
+        k_shape=plan.k_shape,
+        v_shape=plan.v_shape,
+        device=plan.device,
+        dtype=plan.dtype,
+        causal=plan.causal,
+        window_size_left=plan.window_size_left,
+        window_size_right=plan.window_size_right,
+        has_attention_sink_bias=plan.has_attention_sink_bias,
+        tile_m=plan.tile_m,
+        tile_n=plan.tile_n,
+        output=views.output,
+        lse=views.lse,
+        plan_key=getattr(plan, "key", None),
+    )
+
+
+def _attention_scratch_views_from_arena(
+    plan: AttentionPlan,
+    *,
+    layout: _AttentionScratchLayout,
+    arena: torch.Tensor,
+) -> _AttentionScratchViews:
+    output = _arena_view(
+        arena,
+        offset_bytes=layout.output_offset_bytes,
+        shape=plan.q_shape,
+        dtype=plan.dtype,
+    )
+    lse = _arena_view(
+        arena,
+        offset_bytes=layout.lse_offset_bytes,
+        shape=_lse_shape(plan.q_shape),
+        dtype=torch.float32,
+    )
+    return _AttentionScratchViews(output=output, lse=lse)
+
+
+def _varlen_attention_workspace_from_arena(
+    plan: VarlenAttentionPlan,
+    *,
+    layout: _AttentionScratchLayout,
+    arena: torch.Tensor,
+) -> VarlenAttentionWorkspace:
+    views = _varlen_attention_scratch_views_from_arena(
+        plan,
+        layout=layout,
+        arena=arena,
+    )
+    return VarlenAttentionWorkspace(
+        q_shape=plan.q_shape,
+        k_shape=plan.k_shape,
+        v_shape=plan.v_shape,
+        cu_seqlens_q_shape=plan.cu_seqlens_q_shape,
+        cu_seqlens_k_shape=plan.cu_seqlens_k_shape,
+        device=plan.device,
+        dtype=plan.dtype,
+        causal=plan.causal,
+        window_size_left=plan.window_size_left,
+        window_size_right=plan.window_size_right,
+        has_attention_sink_bias=plan.has_attention_sink_bias,
+        tile_m=plan.tile_m,
+        tile_n=plan.tile_n,
+        max_seqlen_q=plan.max_seqlen_q,
+        max_seqlen_k=plan.max_seqlen_k,
+        output=views.output,
+        lse=views.lse,
+        plan_key=getattr(plan, "key", None),
+    )
+
+
+def _varlen_attention_scratch_views_from_arena(
+    plan: VarlenAttentionPlan,
+    *,
+    layout: _AttentionScratchLayout,
+    arena: torch.Tensor,
+) -> _AttentionScratchViews:
+    output = _arena_view(
+        arena,
+        offset_bytes=layout.output_offset_bytes,
+        shape=plan.q_shape,
+        dtype=plan.dtype,
+    )
+    lse = _arena_view(
+        arena,
+        offset_bytes=layout.lse_offset_bytes,
+        shape=_lse_shape(plan.q_shape),
+        dtype=torch.float32,
+    )
+    return _AttentionScratchViews(output=output, lse=lse)
+
+
+def _attention_workspace_from_scratch_plan(
+    scratch_plan: AttentionScratchPlan,
+    *,
+    scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+) -> AttentionWorkspace:
+    arena = scratch_tensor(
+        scratch,
+        scratch_plan._scratch_specs,
+        owner="contiguous attention",
+    )
+    return _attention_workspace_from_arena(
+        scratch_plan.plan,
+        layout=scratch_plan._layout,
+        arena=arena,
+    )
+
+
+def _attention_scratch_views_from_scratch_plan(
+    scratch_plan: AttentionScratchPlan,
+    *,
+    scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+) -> _AttentionScratchViews:
+    arena = scratch_tensor(
+        scratch,
+        scratch_plan._scratch_specs,
+        owner="contiguous attention",
+    )
+    return _attention_scratch_views_from_arena(
+        scratch_plan.plan,
+        layout=scratch_plan._layout,
+        arena=arena,
+    )
+
+
+def _varlen_attention_workspace_from_scratch_plan(
+    scratch_plan: VarlenAttentionScratchPlan,
+    *,
+    scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+) -> VarlenAttentionWorkspace:
+    arena = scratch_tensor(
+        scratch,
+        scratch_plan._scratch_specs,
+        owner="varlen contiguous attention",
+    )
+    return _varlen_attention_workspace_from_arena(
+        scratch_plan.plan,
+        layout=scratch_plan._layout,
+        arena=arena,
+    )
+
+
+def _varlen_attention_scratch_views_from_scratch_plan(
+    scratch_plan: VarlenAttentionScratchPlan,
+    *,
+    scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+) -> _AttentionScratchViews:
+    arena = scratch_tensor(
+        scratch,
+        scratch_plan._scratch_specs,
+        owner="varlen contiguous attention",
+    )
+    return _varlen_attention_scratch_views_from_arena(
+        scratch_plan.plan,
+        layout=scratch_plan._layout,
+        arena=arena,
+    )
+
+
+def build_attention_binding(
+    *,
+    workspace: AttentionWorkspace | AttentionWorkspacePool,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    plan: AttentionPlan | None = None,
+    softmax_scale: float | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+) -> AttentionBinding:
+    q_shape, k_shape, v_shape, device, dtype = _validate_forward_inputs(q, k, v)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    has_attention_sink_bias = attention_sink_bias is not None
+    if plan is None:
+        if isinstance(workspace, AttentionWorkspacePool):
+            raise TypeError("workspace pools require an explicit AttentionPlan")
+        if has_attention_sink_bias != workspace.has_attention_sink_bias:
+            raise ValueError(
+                "attention_sink_bias mismatch: "
+                f"workspace expects {workspace.has_attention_sink_bias}, "
+                f"got {has_attention_sink_bias}"
+            )
+        plan = _get_attention_plan(
+            q_shape,
+            k_shape,
+            v_shape,
+            _cuda_device_index(workspace.device),
+            workspace.dtype,
+            workspace.causal,
+            workspace.window_size_left,
+            workspace.window_size_right,
+            workspace.has_attention_sink_bias,
+            workspace.tile_m,
+            workspace.tile_n,
+        )
+    if has_attention_sink_bias != plan.has_attention_sink_bias:
+        raise ValueError(
+            "attention_sink_bias mismatch: "
+            f"plan expects {plan.has_attention_sink_bias}, got {has_attention_sink_bias}"
+        )
+    _validate_attention_inputs_against_plan(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        device=device,
+        dtype=dtype,
+        plan=plan,
+    )
+    resolved_workspace = _resolve_attention_workspace(workspace, plan=plan)
+    _validate_attention_output_lse(
+        output=resolved_workspace.output,
+        lse=resolved_workspace.lse,
+        plan=plan,
+    )
+    return _build_attention_binding_from_views(
+        output=resolved_workspace.output,
+        lse=resolved_workspace.lse,
+        q=q,
+        k=k,
+        v=v,
+        plan=plan,
+        softmax_scale=softmax_scale,
+        attention_sink_bias=attention_sink_bias,
+    )
+
+
+def _build_attention_binding_from_views(
+    *,
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    plan: AttentionPlan,
+    softmax_scale: float | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+) -> AttentionBinding:
+    q_shape, k_shape, v_shape, device, dtype = _validate_forward_inputs(q, k, v)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    has_attention_sink_bias = attention_sink_bias is not None
+    if has_attention_sink_bias != plan.has_attention_sink_bias:
+        raise ValueError(
+            "attention_sink_bias mismatch: "
+            f"plan expects {plan.has_attention_sink_bias}, got {has_attention_sink_bias}"
+        )
+    _validate_attention_inputs_against_plan(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        device=device,
+        dtype=dtype,
+        plan=plan,
+    )
+    _validate_attention_output_lse(output=output, lse=lse, plan=plan)
+    return AttentionBinding(
+        q=q,
+        k=k,
+        v=v,
+        output=output,
+        lse=lse,
+        plan=plan,
+        softmax_scale=softmax_scale,
+        attention_sink_bias=attention_sink_bias,
+    )
+
+
+def build_varlen_attention_binding(
+    *,
+    workspace: VarlenAttentionWorkspace,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor | None = None,
+    plan: VarlenAttentionPlan | None = None,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+    softmax_scale: float | None = None,
+    causal: bool | None = None,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+) -> VarlenAttentionBinding:
+    if cu_seqlens_k is None:
+        cu_seqlens_k = cu_seqlens_q
+    (
+        q_shape,
+        k_shape,
+        v_shape,
+        cu_seqlens_q_shape,
+        cu_seqlens_k_shape,
+        device,
+        dtype,
+    ) = _validate_varlen_inputs(q, k, v, cu_seqlens_q, cu_seqlens_k)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    has_attention_sink_bias = attention_sink_bias is not None
+    if plan is None:
+        if has_attention_sink_bias != workspace.has_attention_sink_bias:
+            raise ValueError(
+                "attention_sink_bias mismatch: "
+                f"workspace expects {workspace.has_attention_sink_bias}, "
+                f"got {has_attention_sink_bias}"
+            )
+        resolved_max_seqlen_q = (
+            workspace.max_seqlen_q
+            if max_seqlen_q is None
+            else _resolve_max_seqlen(cu_seqlens_q, max_seqlen_q, name="max_seqlen_q")
+        )
+        resolved_max_seqlen_k = (
+            workspace.max_seqlen_k
+            if max_seqlen_k is None
+            else _resolve_max_seqlen(cu_seqlens_k, max_seqlen_k, name="max_seqlen_k")
+        )
+        resolved_causal = workspace.causal if causal is None else bool(causal)
+        if window_size is None:
+            window_size_left = workspace.window_size_left
+            window_size_right = workspace.window_size_right
+        else:
+            window_size_left, window_size_right = _normalize_window_size(window_size)
+        plan = _get_varlen_attention_plan(
+            q_shape,
+            k_shape,
+            v_shape,
+            cu_seqlens_q_shape,
+            cu_seqlens_k_shape,
+            _cuda_device_index(workspace.device),
+            workspace.dtype,
+            resolved_causal,
+            window_size_left,
+            window_size_right,
+            workspace.has_attention_sink_bias,
+            resolved_max_seqlen_q,
+            resolved_max_seqlen_k,
+            workspace.tile_m,
+            workspace.tile_n,
+        )
+    if has_attention_sink_bias != plan.has_attention_sink_bias:
+        raise ValueError(
+            "attention_sink_bias mismatch: "
+            f"plan expects {plan.has_attention_sink_bias}, got {has_attention_sink_bias}"
+        )
+    if max_seqlen_q is not None and int(max_seqlen_q) != plan.max_seqlen_q:
+        raise ValueError(
+            f"max_seqlen_q mismatch: plan has {plan.max_seqlen_q}, got {max_seqlen_q}"
+        )
+    if max_seqlen_k is not None and int(max_seqlen_k) != plan.max_seqlen_k:
+        raise ValueError(
+            f"max_seqlen_k mismatch: plan has {plan.max_seqlen_k}, got {max_seqlen_k}"
+        )
+    if causal is not None and bool(causal) != plan.causal:
+        raise ValueError(f"causal mismatch: plan has {plan.causal}, got {causal}")
+    if window_size is not None:
+        window_size_left, window_size_right = _normalize_window_size(window_size)
+        if (
+            window_size_left != plan.window_size_left
+            or window_size_right != plan.window_size_right
+        ):
+            raise ValueError(
+                "window_size mismatch: "
+                f"plan has {(plan.window_size_left, plan.window_size_right)}, "
+                f"got {(window_size_left, window_size_right)}"
+            )
+    _validate_varlen_inputs_against_plan(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        cu_seqlens_q_shape=cu_seqlens_q_shape,
+        cu_seqlens_k_shape=cu_seqlens_k_shape,
+        device=device,
+        dtype=dtype,
+        plan=plan,
+    )
+    _validate_varlen_workspace(workspace, plan=plan)
+    _validate_attention_output_lse(
+        output=workspace.output, lse=workspace.lse, plan=plan
+    )
+    return _build_varlen_attention_binding_from_views(
+        output=workspace.output,
+        lse=workspace.lse,
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        plan=plan,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        attention_sink_bias=attention_sink_bias,
+    )
+
+
+def _build_varlen_attention_binding_from_views(
+    *,
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor | None = None,
+    plan: VarlenAttentionPlan,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+    softmax_scale: float | None = None,
+    causal: bool | None = None,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+) -> VarlenAttentionBinding:
+    if cu_seqlens_k is None:
+        cu_seqlens_k = cu_seqlens_q
+    (
+        q_shape,
+        k_shape,
+        v_shape,
+        cu_seqlens_q_shape,
+        cu_seqlens_k_shape,
+        device,
+        dtype,
+    ) = _validate_varlen_inputs(q, k, v, cu_seqlens_q, cu_seqlens_k)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    has_attention_sink_bias = attention_sink_bias is not None
+    if has_attention_sink_bias != plan.has_attention_sink_bias:
+        raise ValueError(
+            "attention_sink_bias mismatch: "
+            f"plan expects {plan.has_attention_sink_bias}, got {has_attention_sink_bias}"
+        )
+    if max_seqlen_q is not None and int(max_seqlen_q) != plan.max_seqlen_q:
+        raise ValueError(
+            f"max_seqlen_q mismatch: plan has {plan.max_seqlen_q}, got {max_seqlen_q}"
+        )
+    if max_seqlen_k is not None and int(max_seqlen_k) != plan.max_seqlen_k:
+        raise ValueError(
+            f"max_seqlen_k mismatch: plan has {plan.max_seqlen_k}, got {max_seqlen_k}"
+        )
+    if causal is not None and bool(causal) != plan.causal:
+        raise ValueError(f"causal mismatch: plan has {plan.causal}, got {causal}")
+    if window_size is not None:
+        window_size_left, window_size_right = _normalize_window_size(window_size)
+        if (
+            window_size_left != plan.window_size_left
+            or window_size_right != plan.window_size_right
+        ):
+            raise ValueError(
+                "window_size mismatch: "
+                f"plan has {(plan.window_size_left, plan.window_size_right)}, "
+                f"got {(window_size_left, window_size_right)}"
+            )
+    _validate_varlen_inputs_against_plan(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        cu_seqlens_q_shape=cu_seqlens_q_shape,
+        cu_seqlens_k_shape=cu_seqlens_k_shape,
+        device=device,
+        dtype=dtype,
+        plan=plan,
+    )
+    _validate_attention_output_lse(output=output, lse=lse, plan=plan)
+    return VarlenAttentionBinding(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        output=output,
+        lse=lse,
+        plan=plan,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        attention_sink_bias=attention_sink_bias,
+    )
+
+
+def plan_attention_scratch(plan: AttentionPlan) -> AttentionScratchPlan:
+    layout = _attention_scratch_layout(q_shape=plan.q_shape, dtype=plan.dtype)
+    return AttentionScratchPlan(
+        plan=plan,
+        _layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "contiguous_attention.scratch",
+                nbytes=layout.nbytes,
+                device=plan.device,
+            ),
+        ),
+    )
+
+
+def plan_varlen_attention_scratch(
+    plan: VarlenAttentionPlan,
+) -> VarlenAttentionScratchPlan:
+    layout = _attention_scratch_layout(q_shape=plan.q_shape, dtype=plan.dtype)
+    return VarlenAttentionScratchPlan(
+        plan=plan,
+        _layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "varlen_contiguous_attention.scratch",
+                nbytes=layout.nbytes,
+                device=plan.device,
+            ),
+        ),
+    )
+
+
+def allocate_attention_workspace_for_plan(plan: AttentionPlan) -> AttentionWorkspace:
+    """Allocate reusable scratch for one exact contiguous attention plan."""
+    output = torch.empty(plan.q_shape, dtype=plan.dtype, device=plan.device)
+    lse = torch.empty(_lse_shape(plan.q_shape), dtype=torch.float32, device=plan.device)
+    return AttentionWorkspace(
+        q_shape=plan.q_shape,
+        k_shape=plan.k_shape,
+        v_shape=plan.v_shape,
+        device=plan.device,
+        dtype=plan.dtype,
+        causal=plan.causal,
+        window_size_left=plan.window_size_left,
+        window_size_right=plan.window_size_right,
+        has_attention_sink_bias=plan.has_attention_sink_bias,
+        tile_m=plan.tile_m,
+        tile_n=plan.tile_n,
+        output=output,
+        lse=lse,
+        plan_key=plan.key,
+    )
+
+
+def allocate_varlen_attention_workspace_for_plan(
+    plan: VarlenAttentionPlan,
+) -> VarlenAttentionWorkspace:
+    """Allocate reusable scratch for one exact packed varlen attention plan."""
+    output = torch.empty(plan.q_shape, dtype=plan.dtype, device=plan.device)
+    lse = torch.empty(_lse_shape(plan.q_shape), dtype=torch.float32, device=plan.device)
+    return VarlenAttentionWorkspace(
+        q_shape=plan.q_shape,
+        k_shape=plan.k_shape,
+        v_shape=plan.v_shape,
+        cu_seqlens_q_shape=plan.cu_seqlens_q_shape,
+        cu_seqlens_k_shape=plan.cu_seqlens_k_shape,
+        device=plan.device,
+        dtype=plan.dtype,
+        causal=plan.causal,
+        window_size_left=plan.window_size_left,
+        window_size_right=plan.window_size_right,
+        has_attention_sink_bias=plan.has_attention_sink_bias,
+        tile_m=plan.tile_m,
+        tile_n=plan.tile_n,
+        max_seqlen_q=plan.max_seqlen_q,
+        max_seqlen_k=plan.max_seqlen_k,
+        output=output,
+        lse=lse,
+        plan_key=plan.key,
+    )
+
+
+def allocate_attention_workspace_pool() -> AttentionWorkspacePool:
+    """Allocate an explicit caller-owned workspace pool for contiguous attention."""
+    return AttentionWorkspacePool()
+
+
+def _resolve_attention_workspace(
+    workspace: AttentionWorkspace | AttentionWorkspacePool,
+    *,
+    plan: AttentionPlan,
+) -> AttentionWorkspace:
+    if isinstance(workspace, AttentionWorkspace):
+        _validate_workspace(workspace, plan=plan)
+        return workspace
+    if not isinstance(workspace, AttentionWorkspacePool):
+        raise TypeError(
+            "workspace must be an AttentionWorkspace or AttentionWorkspacePool"
+        )
+
+    stream_key = int(torch.cuda.current_stream(plan.device).cuda_stream)
+    key = (stream_key, plan.key)
+    resolved = workspace.workspaces.get(key)
+    if resolved is None:
+        resolved = allocate_attention_workspace_for_plan(plan)
+        workspace.workspaces[key] = resolved
+    return resolved
+
+
+def create_attention_plan(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    causal: bool = True,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    tile_shape: tuple[int, int] | None = None,
+) -> AttentionPlan:
+    """Create one exact contiguous attention launch plan."""
+    q_shape, k_shape, v_shape, device, dtype = _validate_forward_inputs(q, k, v)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    _, _, _, head_dim = _seq_dims(q_shape)
+    tile_m, tile_n = tile_shape or _select_tile_shape(head_dim, causal=causal)
+    window_size_left, window_size_right = _normalize_window_size(window_size)
+    return _get_attention_plan(
+        q_shape,
+        k_shape,
+        v_shape,
+        _cuda_device_index(device),
+        dtype,
+        causal,
+        window_size_left,
+        window_size_right,
+        attention_sink_bias is not None,
+        tile_m,
+        tile_n,
+    )
+
+
+def create_varlen_attention_plan(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor | None = None,
+    *,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+    causal: bool = False,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    tile_shape: tuple[int, int] | None = None,
+) -> VarlenAttentionPlan:
+    """Create one exact packed varlen contiguous attention launch plan."""
+    if cu_seqlens_k is None:
+        cu_seqlens_k = cu_seqlens_q
+    (
+        q_shape,
+        k_shape,
+        v_shape,
+        cu_seqlens_q_shape,
+        cu_seqlens_k_shape,
+        device,
+        dtype,
+    ) = _validate_varlen_inputs(q, k, v, cu_seqlens_q, cu_seqlens_k)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    max_seqlen_q = _resolve_max_seqlen(
+        cu_seqlens_q,
+        max_seqlen_q,
+        name="max_seqlen_q",
+    )
+    max_seqlen_k = _resolve_max_seqlen(
+        cu_seqlens_k,
+        max_seqlen_k,
+        name="max_seqlen_k",
+    )
+    _, _, head_dim = q_shape
+    tile_m, tile_n = tile_shape or _select_tile_shape(head_dim, causal=causal)
+    window_size_left, window_size_right = _normalize_window_size(window_size)
+    return _get_varlen_attention_plan(
+        q_shape,
+        k_shape,
+        v_shape,
+        cu_seqlens_q_shape,
+        cu_seqlens_k_shape,
+        _cuda_device_index(device),
+        dtype,
+        causal,
+        window_size_left,
+        window_size_right,
+        attention_sink_bias is not None,
+        max_seqlen_q,
+        max_seqlen_k,
+        tile_m,
+        tile_n,
+    )
+
+
+def allocate_attention_workspace(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    causal: bool = True,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    tile_shape: tuple[int, int] | None = None,
+) -> AttentionWorkspace:
+    """Allocate one exact-shape workspace for `sm12x_attention_forward`."""
+    plan = create_attention_plan(
+        q,
+        k,
+        v,
+        causal=causal,
+        window_size=window_size,
+        attention_sink_bias=attention_sink_bias,
+        tile_shape=tile_shape,
+    )
+    return allocate_attention_workspace_for_plan(plan)
+
+
+def allocate_varlen_attention_workspace(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor | None = None,
+    *,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+    causal: bool = False,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    tile_shape: tuple[int, int] | None = None,
+) -> VarlenAttentionWorkspace:
+    """Allocate one exact-shape workspace for `sm12x_varlen_attention_forward`."""
+    plan = create_varlen_attention_plan(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        causal=causal,
+        window_size=window_size,
+        attention_sink_bias=attention_sink_bias,
+        tile_shape=tile_shape,
+    )
+    return allocate_varlen_attention_workspace_for_plan(plan)
+
+
+def sm12x_attention_forward(
+    q: torch.Tensor | None = None,
+    k: torch.Tensor | None = None,
+    v: torch.Tensor | None = None,
+    *,
+    plan: AttentionPlan | None = None,
+    softmax_scale: float | None = None,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    binding: AttentionBinding | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Execute contiguous self-attention using the restored forward kernel."""
+    output: torch.Tensor | None = None
+    lse: torch.Tensor | None = None
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("q", q),
+                ("k", k),
+                ("v", v),
+                ("plan", plan),
+                ("softmax_scale", softmax_scale),
+                ("attention_sink_bias", attention_sink_bias),
+            )
+            if value is not None
+        ]
+        if window_size is not None:
+            extras.append("window_size")
+        if extras:
+            raise ValueError(
+                "attention binding owns runtime tensors, outputs, plan, and options; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        q = binding.q
+        k = binding.k
+        v = binding.v
+        output = binding.output
+        lse = binding.lse
+        plan = binding.plan
+        softmax_scale = binding.softmax_scale
+        attention_sink_bias = binding.attention_sink_bias
+    else:
+        raise TypeError("sm12x_attention_forward requires binding")
+    if q is None or k is None or v is None:
+        raise TypeError("attention binding is missing q, k, or v")
+    q_shape, k_shape, v_shape, device, dtype = _validate_forward_inputs(q, k, v)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    has_attention_sink_bias = attention_sink_bias is not None
+    if plan is None:
+        raise TypeError("attention binding is missing plan")
+    resolved_plan = plan
+    if has_attention_sink_bias != resolved_plan.has_attention_sink_bias:
+        raise ValueError(
+            "attention_sink_bias mismatch: "
+            f"plan expects {resolved_plan.has_attention_sink_bias}, got {has_attention_sink_bias}"
+        )
+    if window_size is not None:
+        window_size_left, window_size_right = _normalize_window_size(window_size)
+        if (
+            window_size_left != resolved_plan.window_size_left
+            or window_size_right != resolved_plan.window_size_right
+        ):
+            raise ValueError(
+                "window_size mismatch: "
+                f"plan has {(resolved_plan.window_size_left, resolved_plan.window_size_right)}, "
+                f"got {(window_size_left, window_size_right)}"
+            )
+    _validate_attention_inputs_against_plan(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        device=device,
+        dtype=dtype,
+        plan=resolved_plan,
+    )
+    if output is None or lse is None:
+        raise TypeError("attention binding is missing output or lse")
+    else:
+        _validate_attention_output_lse(output=output, lse=lse, plan=resolved_plan)
+    _, _, _, head_dim = _seq_dims(q_shape)
+    if softmax_scale is None:
+        softmax_scale = head_dim**-0.5
+    if attention_sink_bias is None:
+        attention_sink_bias = _attention_sink_placeholder(resolved_plan.device_index)
+
+    resolved_plan.compiled(
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            q.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            k.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            v.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            output.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            lse.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            attention_sink_bias.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        float(softmax_scale),
+        current_cuda_stream(),
+    )
+    return output, lse
+
+
+def sm12x_varlen_attention_forward(
+    q: torch.Tensor | None = None,
+    k: torch.Tensor | None = None,
+    v: torch.Tensor | None = None,
+    cu_seqlens_q: torch.Tensor | None = None,
+    cu_seqlens_k: torch.Tensor | None = None,
+    *,
+    plan: VarlenAttentionPlan | None = None,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+    softmax_scale: float | None = None,
+    causal: bool | None = None,
+    window_size: int | tuple[int, int] | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    binding: VarlenAttentionBinding | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Execute packed varlen contiguous attention using cu_seqlens metadata."""
+    output: torch.Tensor | None = None
+    lse: torch.Tensor | None = None
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("q", q),
+                ("k", k),
+                ("v", v),
+                ("cu_seqlens_q", cu_seqlens_q),
+                ("cu_seqlens_k", cu_seqlens_k),
+                ("plan", plan),
+                ("max_seqlen_q", max_seqlen_q),
+                ("max_seqlen_k", max_seqlen_k),
+                ("softmax_scale", softmax_scale),
+                ("causal", causal),
+                ("attention_sink_bias", attention_sink_bias),
+            )
+            if value is not None
+        ]
+        if window_size is not None:
+            extras.append("window_size")
+        if extras:
+            raise ValueError(
+                "varlen attention binding owns runtime tensors, outputs, plan, and options; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        q = binding.q
+        k = binding.k
+        v = binding.v
+        cu_seqlens_q = binding.cu_seqlens_q
+        cu_seqlens_k = binding.cu_seqlens_k
+        output = binding.output
+        lse = binding.lse
+        plan = binding.plan
+        max_seqlen_q = binding.max_seqlen_q
+        max_seqlen_k = binding.max_seqlen_k
+        softmax_scale = binding.softmax_scale
+        causal = binding.causal
+        window_size = binding.window_size
+        attention_sink_bias = binding.attention_sink_bias
+    else:
+        raise TypeError("sm12x_varlen_attention_forward requires binding")
+    if q is None or k is None or v is None or cu_seqlens_q is None:
+        raise TypeError("varlen attention binding is missing q, k, v, or cu_seqlens_q")
+    if cu_seqlens_k is None:
+        cu_seqlens_k = cu_seqlens_q
+    (
+        q_shape,
+        k_shape,
+        v_shape,
+        cu_seqlens_q_shape,
+        cu_seqlens_k_shape,
+        device,
+        dtype,
+    ) = _validate_varlen_inputs(q, k, v, cu_seqlens_q, cu_seqlens_k)
+    attention_sink_bias = _prepare_attention_sink_bias(
+        attention_sink_bias,
+        q_shape=q_shape,
+        device=device,
+    )
+    has_attention_sink_bias = attention_sink_bias is not None
+    if plan is None:
+        raise TypeError("varlen attention binding is missing plan")
+    resolved_plan = plan
+    if has_attention_sink_bias != resolved_plan.has_attention_sink_bias:
+        raise ValueError(
+            "attention_sink_bias mismatch: "
+            f"plan expects {resolved_plan.has_attention_sink_bias}, got {has_attention_sink_bias}"
+        )
+    if max_seqlen_q is not None and int(max_seqlen_q) != resolved_plan.max_seqlen_q:
+        raise ValueError(
+            f"max_seqlen_q mismatch: plan has {resolved_plan.max_seqlen_q}, got {max_seqlen_q}"
+        )
+    if max_seqlen_k is not None and int(max_seqlen_k) != resolved_plan.max_seqlen_k:
+        raise ValueError(
+            f"max_seqlen_k mismatch: plan has {resolved_plan.max_seqlen_k}, got {max_seqlen_k}"
+        )
+    if causal is not None and bool(causal) != resolved_plan.causal:
+        raise ValueError(
+            f"causal mismatch: plan has {resolved_plan.causal}, got {causal}"
+        )
+    if window_size is not None:
+        window_size_left, window_size_right = _normalize_window_size(window_size)
+        if (
+            window_size_left != resolved_plan.window_size_left
+            or window_size_right != resolved_plan.window_size_right
+        ):
+            raise ValueError(
+                "window_size mismatch: "
+                f"plan has {(resolved_plan.window_size_left, resolved_plan.window_size_right)}, "
+                f"got {(window_size_left, window_size_right)}"
+            )
+    _validate_varlen_inputs_against_plan(
+        q_shape=q_shape,
+        k_shape=k_shape,
+        v_shape=v_shape,
+        cu_seqlens_q_shape=cu_seqlens_q_shape,
+        cu_seqlens_k_shape=cu_seqlens_k_shape,
+        device=device,
+        dtype=dtype,
+        plan=resolved_plan,
+    )
+    if output is None or lse is None:
+        raise TypeError("varlen attention binding is missing output or lse")
+    else:
+        _validate_attention_output_lse(output=output, lse=lse, plan=resolved_plan)
+    _, _, head_dim = q_shape
+    if softmax_scale is None:
+        softmax_scale = head_dim**-0.5
+    if attention_sink_bias is None:
+        attention_sink_bias = _attention_sink_placeholder(resolved_plan.device_index)
+
+    resolved_plan.compiled(
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            q.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            k.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            v.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            resolved_plan.cutlass_dtype,
+            output.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            lse.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            cu_seqlens_q.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            cu_seqlens_k.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            attention_sink_bias.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        float(softmax_scale),
+        current_cuda_stream(),
+    )
+    return output, lse
+
+
+__all__ = [
+    "AttentionBinding",
+    "AttentionPlan",
+    "AttentionPlanKey",
+    "AttentionScratchPlan",
+    "VarlenAttentionBinding",
+    "VarlenAttentionPlan",
+    "VarlenAttentionPlanKey",
+    "VarlenAttentionScratchPlan",
+    "sm12x_attention_forward",
+    "sm12x_varlen_attention_forward",
+    "clear_attention_caches",
+    "create_attention_plan",
+    "create_varlen_attention_plan",
+    "plan_attention_scratch",
+    "plan_varlen_attention_scratch",
+]

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/block_info.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/block_info.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/block_info.py @ 95ebfdf1 (2026-05-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, const_expr
+
+from flashinfer.experimental.sm12x.attention._shared.contiguous.seqlen_info import (
+    SeqlenInfoQK,
+)
+
+
+@dataclass(frozen=True)
+class BlockInfo:
+    tile_m: cutlass.Constexpr[int]
+    tile_n: cutlass.Constexpr[int]
+    is_causal: cutlass.Constexpr[bool]
+    is_local: cutlass.Constexpr[bool] = False
+    window_size_left: Optional[Int32] = None
+    window_size_right: Optional[Int32] = None
+    qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+
+    @cute.jit
+    def get_n_block_min_max(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        m_block: Int32,
+    ) -> Tuple[Int32, Int32]:
+        n_block_max = cute.ceil_div(seqlen_info.seqlen_k, self.tile_n)
+        if const_expr(
+            self.is_causal or (self.is_local and self.window_size_right is not None)
+        ):
+            m_idx_max = (m_block + 1) * self.tile_m
+            if const_expr(self.qhead_per_kvhead_packgqa > 1):
+                m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
+            n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            n_idx_right = (
+                n_idx if const_expr(self.is_causal) else n_idx + self.window_size_right
+            )
+            n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
+        n_block_min = Int32(0)
+        if const_expr(self.is_local and self.window_size_left is not None):
+            m_idx_min = m_block * self.tile_m
+            if const_expr(self.qhead_per_kvhead_packgqa > 1):
+                m_idx_min = m_idx_min // self.qhead_per_kvhead_packgqa
+            n_idx = m_idx_min + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            n_idx_left = n_idx - self.window_size_left
+            n_block_min = cutlass.max(n_idx_left // self.tile_n, 0)
+        return n_block_min, n_block_max
+
+    @cute.jit
+    def get_n_block_min_causal_local_mask(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        m_block: Int32,
+        n_block_min: Int32,
+    ) -> Int32:
+        m_idx_min = m_block * self.tile_m
+        if const_expr(self.qhead_per_kvhead_packgqa > 1):
+            m_idx_min = m_idx_min // self.qhead_per_kvhead_packgqa
+        n_idx = m_idx_min + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+        n_idx_right = (
+            n_idx
+            if const_expr(not self.is_local or self.window_size_right is None)
+            else n_idx + self.window_size_right
+        )
+        return cutlass.max(n_block_min, n_idx_right // self.tile_n)
+
+    @cute.jit
+    def get_n_block_min_before_local_mask(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        m_block: Int32,
+        n_block_min: Int32,
+    ) -> Int32:
+        if const_expr(not self.is_local or self.window_size_left is None):
+            return n_block_min
+        m_idx_max = (m_block + 1) * self.tile_m
+        if const_expr(self.qhead_per_kvhead_packgqa > 1):
+            m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
+        n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+        n_idx_left = n_idx - self.window_size_left
+        return cutlass.max(n_block_min, cute.ceil_div(n_idx_left, self.tile_n))

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/cute_dsl_utils.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/cute_dsl_utils.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/cute_dsl_utils.py @ 87134e57 (2026-05-02) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from dataclasses import dataclass, fields
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import JitArgument
+from cutlass.cutlass_dsl import NumericMeta
+
+StaticTypes = (cutlass.Constexpr, NumericMeta, int, bool, str, float, type(None))
+
+
+def _partition_fields(obj):
+    all_fields = {field.name: getattr(obj, field.name) for field in fields(obj)}
+    constexpr = {
+        name: value
+        for name, value in all_fields.items()
+        if isinstance(value, StaticTypes)
+    }
+    non_constexpr = {
+        name: value
+        for name, value in all_fields.items()
+        if not isinstance(value, StaticTypes)
+    }
+    return constexpr, non_constexpr
+
+
+def _new_from_mlir_values(self, values):
+    constexpr_fields, non_constexpr_fields = _partition_fields(self)
+    for (name, field), n_items in zip(non_constexpr_fields.items(), self._values_pos):
+        non_constexpr_fields[name] = cutlass.new_from_mlir_values(
+            field, values[:n_items]
+        )
+        values = values[n_items:]
+    return self.__class__(**non_constexpr_fields, **constexpr_fields)
+
+
+@dataclass
+class ParamsBase(JitArgument):
+    def __c_pointers__(self):
+        all_fields = [getattr(self, field.name) for field in fields(self)]
+        non_constexpr_fields = [
+            field for field in all_fields if not isinstance(field, StaticTypes)
+        ]
+        c_ptrs = []
+        for obj in non_constexpr_fields:
+            if hasattr(obj, "__c_pointers__"):
+                c_ptrs.extend(obj.__c_pointers__())
+        return c_ptrs
+
+    def __get_mlir_types__(self):
+        all_fields = [getattr(self, field.name) for field in fields(self)]
+        non_constexpr_fields = [
+            field for field in all_fields if not isinstance(field, StaticTypes)
+        ]
+        types, self._values_pos = [], []
+        for obj in non_constexpr_fields:
+            if hasattr(obj, "__get_mlir_types__"):
+                obj_types = obj.__get_mlir_types__()
+            else:
+                obj_values = cutlass.extract_mlir_values(obj)
+                obj_types = [value.type for value in obj_values]
+            types.extend(obj_types)
+            self._values_pos.append(len(obj_types))
+        return types
+
+    def __extract_mlir_values__(self):
+        _, non_constexpr_fields = _partition_fields(self)
+        values, self._values_pos = [], []
+        for obj in non_constexpr_fields.values():
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    __new_from_mlir_values__ = _new_from_mlir_values
+
+
+def assume_strides_aligned(t):
+    divby = 128 // t.element_type.width
+    strides = tuple(
+        s if isinstance(s, int) else cute.assume(s, divby=divby) for s in t.stride[:-1]
+    )
+    return (*strides, t.stride[-1])
+
+
+def assume_tensor_aligned(t):
+    if t is None:
+        return None
+    return cute.make_tensor(
+        t.iterator, cute.make_layout(t.shape, stride=assume_strides_aligned(t))
+    )

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/forward.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/forward.py
@@ -1,0 +1,1397 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/forward.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# SM120 (Blackwell GeForce / DGX Spark) forward pass.
+#
+# This is a real SM120 forward kernel skeleton:
+# - SM90-style outer structure (tile scheduler + TMA producer/consumer split)
+# - SM80-style warp MMA math core
+# - 160-thread CTA: 4 compute warps + 1 TMA producer warp
+#
+# The initial slice is intentionally narrow:
+# - fixed-length and packed varlen Q/K/V
+# - no block sparsity
+
+import math
+from functools import partial
+from typing import Callable, Optional, Type
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+from cutlass.cute.nvgpu import cpasync, warp, warpgroup
+from cutlass.utils import LayoutEnum
+import cutlass.utils.hopper_helpers as sm90_utils_basic
+import cutlass.utils as utils_basic
+
+from flashinfer.experimental.sm12x.attention._shared.cute import copy as cute_copy
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as cute_ops
+from flashinfer.experimental.sm12x.attention._shared.cute import (
+    pipeline as cute_pipeline,
+)
+from flashinfer.experimental.sm12x.attention._shared.contiguous import layout_utils
+from flashinfer.experimental.sm12x.attention._shared.contiguous.cute_dsl_utils import (
+    assume_tensor_aligned,
+)
+from flashinfer.experimental.sm12x.attention._shared.contiguous.mask import (
+    AttentionMask,
+)
+from flashinfer.experimental.sm12x.attention._shared.contiguous.softmax import Softmax
+from flashinfer.experimental.sm12x.attention._shared.contiguous.seqlen_info import (
+    SeqlenInfoQK,
+)
+from flashinfer.experimental.sm12x.attention._shared.contiguous.block_info import (
+    BlockInfo,
+)
+from flashinfer.experimental.sm12x.attention._shared.contiguous.pack_gqa import (
+    PackGQA,
+    pack_gqa_layout,
+)
+from flashinfer.experimental.sm12x.attention._shared.contiguous.named_barrier import (
+    NamedBarrierFwd,
+)
+from flashinfer.experimental.sm12x.attention._shared.contiguous.tile_scheduler import (
+    SingleTileScheduler,
+    SingleTileVarlenScheduler,
+    TileSchedulerArguments,
+)
+
+
+def _make_contiguous_shared_storage_cls(
+    dtype,
+    *,
+    q_numel: int,
+    k_numel: int,
+    v_numel: int,
+    num_stages: int,
+    buffer_align_bytes: int = 1024,
+):
+    """Build the allocation type used for both fit policy and the kernel."""
+    sQ_struct, sK_struct, sV_struct = [
+        cute.struct.Align[
+            cute.struct.MemRange[dtype, int(numel)],
+            buffer_align_bytes,
+        ]
+        for numel in (q_numel, k_numel, v_numel)
+    ]
+    mbar_ptr_Q_struct = cute.struct.MemRange[cutlass.Int64, 1]
+    mbar_ptr_K_struct = cute.struct.MemRange[cutlass.Int64, num_stages * 2]
+    mbar_ptr_V_struct = cute.struct.MemRange[cutlass.Int64, num_stages * 2]
+
+    @cute.struct
+    class SharedStorageQKV:
+        mbar_ptr: mbar_ptr_Q_struct
+        mbar_ptr_K: mbar_ptr_K_struct
+        mbar_ptr_V: mbar_ptr_V_struct
+        sV: sV_struct
+        sQ: sQ_struct
+        sK: sK_struct
+
+    return SharedStorageQKV
+
+
+@cute.jit
+def warp_mma_gemm(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsA: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_A: cute.TiledCopy,
+    smem_thr_copy_B: cute.TiledCopy,
+    A_in_regs: cutlass.Constexpr = False,
+    B_in_regs: cutlass.Constexpr = False,
+):
+    tCrA_copy_view = smem_thr_copy_A.retile(tCrA)
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    if const_expr(not A_in_regs):
+        cute.copy(smem_thr_copy_A, tCsA[None, None, 0], tCrA_copy_view[None, None, 0])
+    if const_expr(not B_in_regs):
+        cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCsA.shape[2])):
+        if k < cute.size(tCsA.shape[2]) - 1:
+            if const_expr(not A_in_regs):
+                cute.copy(
+                    smem_thr_copy_A,
+                    tCsA[None, None, k + 1],
+                    tCrA_copy_view[None, None, k + 1],
+                )
+            if const_expr(not B_in_regs):
+                cute.copy(
+                    smem_thr_copy_B,
+                    tCsB[None, None, k + 1],
+                    tCrB_copy_view[None, None, k + 1],
+                )
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+@cute.jit
+def warp_mma_gemm_rs(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_B: cute.TiledCopy,
+):
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
+        if const_expr(k < cute.size(tCrA.shape[2]) - 1):
+            cute.copy(
+                smem_thr_copy_B,
+                tCsB[None, None, k + 1],
+                tCrB_copy_view[None, None, k + 1],
+            )
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+class ContiguousAttentionForwardKernel:
+    arch = 120
+
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        qhead_per_kvhead: int = 1,
+        is_causal: bool = False,
+        is_local: bool = False,
+        pack_gqa: bool = True,
+        tile_m: int = 128,
+        tile_n: int = 128,
+        num_stages: int = 1,
+        num_threads: int = 160,
+        num_compute_warps: int = 4,
+        score_mod: Optional[cutlass.Constexpr] = None,
+        mask_mod: Optional[cutlass.Constexpr] = None,
+        has_aux_tensors: bool = False,
+        mma_pv_is_rs: bool = True,
+    ):
+        self.dtype = dtype
+        hdim_multiple_of = 16
+        self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        head_dim_v = head_dim if head_dim_v is None else head_dim_v
+        self.same_hdim_kv = head_dim == head_dim_v
+        self.tile_hdimv = int(
+            math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of
+        )
+        self.check_hdim_oob = head_dim != self.tile_hdim
+        self.check_hdim_v_oob = head_dim_v != self.tile_hdimv
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.pack_gqa = pack_gqa
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.num_threads = num_threads
+        self.num_stages = num_stages
+        self.score_mod = score_mod
+        self.mask_mod = mask_mod
+        self.qk_acc_dtype = Float32
+        assert self.score_mod is None, (
+            "score_mod is not part of the initial sm12x transplant"
+        )
+        assert self.mask_mod is None, (
+            "mask_mod is not part of the initial sm12x transplant"
+        )
+        self.mma_pv_is_rs = mma_pv_is_rs
+        assert self.mma_pv_is_rs, (
+            "SM120 rewrite currently only supports register-sourced PV"
+        )
+        self.buffer_align_bytes = 1024
+        self.num_compute_warps = num_compute_warps
+        assert self.num_compute_warps >= 1
+        self.num_threads_per_warp = 32
+        self.producer_warp_idx = self.num_compute_warps
+        self.use_tma_KV = True
+
+    def _check_type(
+        self,
+        mQ_type: Type[cutlass.Numeric],
+        mK_type: Type[cutlass.Numeric],
+        mV_type: Type[cutlass.Numeric],
+        mO_type: Type[cutlass.Numeric],
+        mLSE_type: Type[cutlass.Numeric] | None,
+        mCuSeqlensQ_type: Type[cutlass.Numeric] | None,
+        mCuSeqlensK_type: Type[cutlass.Numeric] | None,
+        learnable_sink_type: Type[cutlass.Numeric] | None,
+    ):
+        if const_expr(not (mQ_type == mO_type)):
+            raise TypeError("Q and O tensors must have the same data type")
+        if const_expr(not (mK_type == mV_type)):
+            raise TypeError("K and V tensors must have the same data type")
+        if const_expr(mQ_type not in [cutlass.Float16, cutlass.BFloat16]):
+            raise TypeError("Q/O tensors must be Float16 or BFloat16")
+        if const_expr(mK_type not in [cutlass.Float16, cutlass.BFloat16]):
+            raise TypeError("K/V tensors must be Float16 or BFloat16")
+        if const_expr(mLSE_type not in [None, Float32]):
+            raise TypeError("LSE tensor must be Float32")
+        if const_expr(mCuSeqlensQ_type not in [None, Int32]):
+            raise TypeError("cu_seqlens_q tensor must be Int32")
+        if const_expr(mCuSeqlensK_type not in [None, Int32]):
+            raise TypeError("cu_seqlens_k tensor must be Int32")
+        if const_expr(learnable_sink_type not in [None, Float32]):
+            raise TypeError("learnable sink tensor must be Float32")
+        assert mQ_type == self.dtype
+        assert mK_type == self.dtype
+
+    def _setup_attributes(self):
+        (
+            sQ_layout_atom,
+            sK_layout_atom,
+            sV_layout_atom,
+            sO_layout_atom,
+            sP_layout_atom,
+        ) = self._get_smem_layout_atom()
+        self.sQ_layout = cute.tile_to_shape(
+            sQ_layout_atom, (self.tile_m, self.tile_hdim), (0, 1)
+        )
+        self.sK_layout = cute.tile_to_shape(
+            sK_layout_atom,
+            (self.tile_n, self.tile_hdim, self.num_stages),
+            (0, 1, 2),
+        )
+        self.sV_layout = cute.tile_to_shape(
+            sV_layout_atom,
+            (self.tile_n, self.tile_hdimv, self.num_stages),
+            (0, 1, 2),
+        )
+        self.sO_layout = cute.tile_to_shape(
+            sO_layout_atom, (self.tile_m, self.tile_hdimv), (0, 1)
+        )
+        self.sP_layout = (
+            cute.tile_to_shape(sP_layout_atom, (self.tile_m, self.tile_n), (0, 1))
+            if const_expr(sP_layout_atom is not None)
+            else None
+        )
+
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.dtype.width
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        tQK_shape_dim_1 = sQ_layout_atom.outer.shape[1] // async_copy_elems
+        assert self.num_Q_load_threads % tQK_shape_dim_1 == 0
+        assert self.num_producer_threads % tQK_shape_dim_1 == 0
+        tQ_layout = cute.make_ordered_layout(
+            (self.num_Q_load_threads // tQK_shape_dim_1, tQK_shape_dim_1),
+            order=(1, 0),
+        )
+        tK_layout = cute.make_ordered_layout(
+            (self.num_producer_threads // tQK_shape_dim_1, tQK_shape_dim_1),
+            order=(1, 0),
+        )
+        assert self.tile_m % tQ_layout.shape[0] == 0
+        tV_shape_dim_1 = sV_layout_atom.outer.shape[1] // async_copy_elems
+        tV_layout = cute.make_ordered_layout(
+            (self.num_producer_threads // tV_shape_dim_1, tV_shape_dim_1),
+            order=(1, 0),
+        )
+        tO_layout = cute.make_ordered_layout(
+            (self.num_epilogue_threads // tV_shape_dim_1, tV_shape_dim_1),
+            order=(1, 0),
+        )
+        assert self.tile_m % tO_layout.shape[0] == 0
+        vQKV_layout = cute.make_layout((1, async_copy_elems))
+        vO_layout = vQKV_layout
+        self.gmem_tiled_copy_Q = cute.make_tiled_copy_tv(
+            atom_async_copy, tQ_layout, vQKV_layout
+        )
+        self.gmem_tiled_copy_K = cute.make_tiled_copy_tv(
+            atom_async_copy, tK_layout, vQKV_layout
+        )
+        self.gmem_tiled_copy_V = cute.make_tiled_copy_tv(
+            atom_async_copy, tV_layout, vQKV_layout
+        )
+        self.gmem_tiled_copy_O = cute.make_tiled_copy_tv(
+            atom_universal_copy, tO_layout, vO_layout
+        )
+
+    @staticmethod
+    def shared_storage_bytes(
+        dtype,
+        head_dim,
+        head_dim_v,
+        tile_m,
+        tile_n,
+        num_stages,
+    ) -> int:
+        tile_hdim = int(math.ceil(head_dim / 16) * 16)
+        tile_hdimv = int(math.ceil(head_dim_v / 16) * 16)
+        SharedStorage = _make_contiguous_shared_storage_cls(
+            dtype,
+            q_numel=tile_m * tile_hdim,
+            k_numel=tile_n * tile_hdim * num_stages,
+            v_numel=tile_n * tile_hdimv * num_stages,
+            num_stages=num_stages,
+        )
+        return int(SharedStorage.size_in_bytes())
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        head_dim_v,
+        tile_m,
+        tile_n,
+        num_stages,
+        num_threads,
+        is_causal,
+        num_compute_warps=4,
+    ) -> bool:
+        del is_causal
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if head_dim_v % 8 != 0:
+            return False
+        if num_compute_warps < 1:
+            return False
+        if tile_m % (num_compute_warps * 16) != 0:
+            return False
+        if tile_n % 16 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        if num_threads != (num_compute_warps + 1) * 32:
+            return False
+        smem_usage = ContiguousAttentionForwardKernel.shared_storage_bytes(
+            dtype,
+            head_dim,
+            head_dim_v,
+            tile_m,
+            tile_n,
+            num_stages,
+        )
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_120")
+        if smem_usage > smem_capacity:
+            return False
+        return True
+
+    def _get_smem_layout_atom(self):
+        sQ_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(
+                LayoutEnum.ROW_MAJOR, self.dtype, self.tile_hdim
+            ),
+            self.dtype,
+        )
+        sK_layout_atom = sQ_layout_atom
+        sV_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(
+                LayoutEnum.ROW_MAJOR, self.dtype, self.tile_hdimv
+            ),
+            self.dtype,
+        )
+        sO_layout_atom = sV_layout_atom
+        sP_layout_atom = None
+        return (
+            sQ_layout_atom,
+            sK_layout_atom,
+            sV_layout_atom,
+            sO_layout_atom,
+            sP_layout_atom,
+        )
+
+    def _get_tiled_mma(self):
+        tiled_mma_qk = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, Float32, (16, 8, 16)),
+            (self.num_compute_warps, 1, 1),
+            permutation_mnk=(self.num_compute_warps * 16, 16, 16),
+        )
+        tiled_mma_pv = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, Float32, (16, 8, 16)),
+            (self.num_compute_warps, 1, 1),
+            permutation_mnk=(self.num_compute_warps * 16, 16, 16),
+        )
+        return tiled_mma_qk, tiled_mma_pv
+
+    def _get_shared_storage_cls(self):
+        return _make_contiguous_shared_storage_cls(
+            self.dtype,
+            q_numel=cute.cosize(self.sQ_layout),
+            k_numel=cute.cosize(self.sK_layout),
+            v_numel=cute.cosize(self.sV_layout),
+            num_stages=self.num_stages,
+            buffer_align_bytes=self.buffer_align_bytes,
+        )
+
+    @cute.jit
+    def epilogue(
+        self,
+        acc_O: cute.Tensor,
+        lse: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        sO: cute.Tensor,
+        seqlen: SeqlenInfoQK,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: Optional[cute.CopyAtom],
+        tiled_mma: cute.TiledMma,
+        tidx: Int32,
+        m_block: Int32,
+        head_idx: Int32,
+        batch_idx: Int32,
+    ):
+        del tma_atom_O
+        rO = cute.make_fragment_like(acc_O, self.dtype)
+        rO.store(acc_O.load().to(self.dtype))
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.Epilogue),
+            number_of_threads=self.num_epilogue_threads,
+        )
+        smem_copy_atom_O = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=2 * self.dtype.width,
+        )
+        smem_thr_copy_O = cute.make_tiled_copy_C(smem_copy_atom_O, tiled_mma).get_slice(
+            tidx
+        )
+        taccOrO = smem_thr_copy_O.retile(rO)
+        taccOsO = smem_thr_copy_O.partition_D(sO)
+        cute.copy(smem_copy_atom_O, taccOrO, taccOsO)
+
+        cO = cute.make_identity_tensor((self.tile_m, self.tile_hdimv))
+        pack_gqa = PackGQA(
+            self.tile_m, self.tile_hdimv, self.check_hdim_v_oob, self.qhead_per_kvhead
+        )
+        if const_expr(mLSE is not None):
+            if const_expr(not seqlen.has_cu_seqlens_q):
+                mLSE_cur = mLSE[None, head_idx, batch_idx]
+            else:
+                offset = (
+                    seqlen.offset_q
+                    if const_expr(not self.pack_gqa)
+                    else (0, seqlen.offset_q)
+                )
+                mLSE_cur = cute.domain_offset((offset,), mLSE[None, head_idx])
+            if const_expr(not self.pack_gqa):
+                gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (m_block,))
+                gLSE_expanded_layout = cute.append(
+                    gLSE.layout, cute.make_layout((self.tile_hdimv,), stride=(0,))
+                )
+                gLSE_expanded = cute.make_tensor(gLSE.iterator, gLSE_expanded_layout)
+                thr_mma = tiled_mma.get_slice(tidx)
+                taccOgLSE = layout_utils.reshape_acc_to_mn(
+                    thr_mma.partition_C(gLSE_expanded)
+                )
+                taccOcO = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cO))
+                t0accOcO = layout_utils.reshape_acc_to_mn(
+                    thr_mma.get_slice(0).partition_C(cO)
+                )
+                if taccOcO[0][1] == 0:
+                    for m in cutlass.range_constexpr(cute.size(taccOgLSE.shape[1])):
+                        if (
+                            t0accOcO[m, 0][0]
+                            < seqlen.seqlen_q - m_block * self.tile_m - taccOcO[0][0]
+                        ):
+                            taccOgLSE[m, 0] = lse[m]
+            else:
+                pack_gqa.store_LSE(
+                    mLSE_cur, lse, tiled_mma, tidx, m_block, seqlen.seqlen_q
+                )
+
+        if const_expr(not seqlen.has_cu_seqlens_q):
+            mO_cur = mO[None, None, head_idx, batch_idx]
+        else:
+            offset = (
+                seqlen.offset_q
+                if const_expr(not self.pack_gqa)
+                else (0, seqlen.offset_q)
+            )
+            mO_cur = cute.domain_offset((offset, 0), mO[None, None, head_idx])
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.Epilogue),
+            number_of_threads=self.num_epilogue_threads,
+        )
+        gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+        tOsO = gmem_thr_copy_O.partition_S(sO)
+        tOrO = cute.make_fragment_like(tOsO, self.dtype)
+        cute.autovec_copy(tOsO, tOrO)
+        if const_expr(not self.pack_gqa):
+            gO = cute.local_tile(mO_cur, (self.tile_m, self.tile_hdimv), (m_block, 0))
+            tOgO = gmem_thr_copy_O.partition_D(gO)
+            tOcO = gmem_thr_copy_O.partition_S(cO)
+            t0OcO = gmem_tiled_copy_O.get_slice(0).partition_S(cO)
+            tOpO = cute_ops.predicate_k(tOcO, limit=mO.shape[1])
+            for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+                if (
+                    t0OcO[0, rest_m, 0][0]
+                    < seqlen.seqlen_q - m_block * self.tile_m - tOcO[0][0]
+                ):
+                    cute.copy(
+                        gmem_tiled_copy_O,
+                        tOrO[None, rest_m, None],
+                        tOgO[None, rest_m, None],
+                        pred=tOpO[None, rest_m, None]
+                        if const_expr(self.check_hdim_v_oob)
+                        else None,
+                    )
+        else:
+            pack_gqa.store_O(
+                mO_cur, tOrO, gmem_tiled_copy_O, tidx, m_block, seqlen.seqlen_q
+            )
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        learnable_sink: Optional[cute.Tensor] = None,
+        has_attention_sink_bias: cutlass.Constexpr = False,
+        blocksparse_tensors=None,
+        aux_tensors=None,
+        logical_num_batch_static: cutlass.Constexpr = 1,
+        logical_seqlen_q_static: cutlass.Constexpr = 0,
+        logical_seqlen_k_static: cutlass.Constexpr = 0,
+        stream: cuda.CUstream = None,
+    ):
+        assert blocksparse_tensors is None
+        self._check_type(
+            *(
+                t.element_type if t is not None else None
+                for t in (
+                    mQ,
+                    mK,
+                    mV,
+                    mO,
+                    mLSE,
+                    mCuSeqlensQ,
+                    mCuSeqlensK,
+                    learnable_sink,
+                )
+            )
+        )
+
+        self.num_threads = (self.num_compute_warps + 1) * self.num_threads_per_warp
+        self.num_mma_threads = self.num_compute_warps * self.num_threads_per_warp
+        self.num_producer_threads = self.num_threads_per_warp
+        self.num_Q_load_threads = self.num_mma_threads
+        self.num_epilogue_threads = self.num_mma_threads
+        self.num_mma_regs = 248
+        self.num_producer_regs = 80
+        self.use_tma_Q = True
+        self.use_tma_KV = True
+        self.use_tma_O = False
+
+        mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
+        Q_layout_transpose = (
+            [1, 3, 2, 0] if const_expr(cute.rank(mQ) == 4) else [0, 2, 1]
+        )
+        O_layout_transpose = (
+            [1, 3, 2, 0] if const_expr(cute.rank(mO) == 4) else [0, 2, 1]
+        )
+        mQ = cute.make_tensor(
+            mQ.iterator, cute.select(mQ.layout, mode=Q_layout_transpose)
+        )
+        mO = cute.make_tensor(
+            mO.iterator, cute.select(mO.layout, mode=O_layout_transpose)
+        )
+        KV_layout_transpose = (
+            [1, 3, 2, 0] if const_expr(cute.rank(mK) == 4) else [0, 2, 1]
+        )
+        mK, mV = [
+            cute.make_tensor(
+                t.iterator, cute.select(t.layout, mode=KV_layout_transpose)
+            )
+            for t in (mK, mV)
+        ]
+        if const_expr(mLSE is not None):
+            LSE_layout_transpose = (
+                [2, 1, 0] if const_expr(cute.rank(mLSE) == 3) else [1, 0]
+            )
+            mLSE = cute.make_tensor(
+                mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose)
+            )
+
+        q_heads_unpacked = mQ.shape[2]
+        kv_heads = mK.shape[2]
+        logical_num_head = kv_heads if const_expr(self.pack_gqa) else q_heads_unpacked
+        logical_q_rows_static = logical_seqlen_q_static * (
+            self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1
+        )
+        logical_num_block = cute.ceil_div(logical_q_rows_static, self.tile_m)
+        logical_total_q = (
+            mQ.shape[0] * (self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1)
+            if const_expr(mCuSeqlensQ is not None)
+            else logical_q_rows_static * logical_num_batch_static
+        )
+
+        tiled_mma_qk, tiled_mma_pv = self._get_tiled_mma()
+        self._setup_attributes()
+        SharedStorage = self._get_shared_storage_cls()
+        self.launch_smem_bytes = int(SharedStorage.size_in_bytes())
+        expected_launch_smem_bytes = self.shared_storage_bytes(
+            self.dtype,
+            self.tile_hdim,
+            self.tile_hdimv,
+            self.tile_m,
+            self.tile_n,
+            self.num_stages,
+        )
+        if const_expr(self.launch_smem_bytes != expected_launch_smem_bytes):
+            raise AssertionError(
+                "contiguous typed shared-memory policy/allocation mismatch: "
+                f"policy={expected_launch_smem_bytes}, allocation={self.launch_smem_bytes}"
+            )
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_120")
+        if const_expr(self.launch_smem_bytes > smem_capacity):
+            raise ValueError(
+                f"contiguous typed shared storage requires {self.launch_smem_bytes} B, "
+                f"but SM120 permits {smem_capacity} B per CTA"
+            )
+
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(mLSE is not None):
+                mLSE = pack_gqa_layout(
+                    mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1
+                )
+
+        gmem_tiled_copy_Q = cpasync.CopyBulkTensorTileG2SOp()
+        gmem_tiled_copy_KV = cpasync.CopyBulkTensorTileG2SOp()
+        gmem_tiled_copy_O = cpasync.CopyBulkTensorTileS2GOp()
+        sK_tma_layout = cute.select(self.sK_layout, mode=[0, 1])
+        sV_tma_layout = cute.select(self.sV_layout, mode=[0, 1])
+        self.tma_copy_bytes = {
+            "Q": cute.size_in_bytes(mQ.element_type, self.sQ_layout),
+            "K": cute.size_in_bytes(mK.element_type, sK_tma_layout),
+            "V": cute.size_in_bytes(mV.element_type, sV_tma_layout),
+        }
+
+        tma_atom_Q, tma_tensor_Q = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_Q,
+            mQ,
+            self.sQ_layout,
+            (self.tile_m, self.tile_hdim),
+        )
+        TileScheduler = (
+            SingleTileVarlenScheduler
+            if const_expr(mCuSeqlensQ is not None)
+            else SingleTileScheduler
+        )
+        tile_sched_args = TileSchedulerArguments(
+            num_block=logical_num_block,
+            num_head=logical_num_head,
+            num_batch=(
+                logical_num_batch_static
+                if const_expr(mCuSeqlensQ is None)
+                else mCuSeqlensQ.shape[0] - 1
+            ),
+            seqlen_k=logical_seqlen_k_static,
+            headdim=mQ.shape[1],
+            headdim_v=mV.shape[1],
+            total_q=logical_total_q,
+            tile_shape_mn=(self.tile_m, self.tile_n),
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead
+            if const_expr(self.pack_gqa)
+            else 1,
+            mCuSeqlensQ=mCuSeqlensQ,
+            element_size=self.dtype.width // 8,
+            lpt=self.is_causal or self.is_local,
+        )
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+        softmax_scale_log2, softmax_scale = cute_ops.compute_softmax_scale_log2(
+            softmax_scale
+        )
+        tma_atom_O, tma_tensor_O = None, None
+        if const_expr(self.use_tma_O):
+            tma_atom_O, tma_tensor_O = cpasync.make_tiled_tma_atom(
+                gmem_tiled_copy_O,
+                mO,
+                self.sO_layout,
+                (self.tile_m, self.tile_hdimv),
+            )
+        tma_atom_K, tma_tensor_K = (None, None)
+        tma_atom_V, tma_tensor_V = (None, None)
+        if const_expr(self.use_tma_KV):
+            tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+                gmem_tiled_copy_KV,
+                mK,
+                sK_tma_layout,
+                (self.tile_n, self.tile_hdim),
+                1,
+            )
+            tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+                gmem_tiled_copy_KV,
+                mV,
+                sV_tma_layout,
+                (self.tile_n, self.tile_hdimv),
+                1,
+            )
+        self.kernel(
+            tma_tensor_Q,
+            tma_tensor_K if const_expr(self.use_tma_KV) else mK,
+            tma_tensor_V if const_expr(self.use_tma_KV) else mV,
+            tma_tensor_O if const_expr(self.use_tma_O) else mO,
+            mLSE,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            learnable_sink,
+            has_attention_sink_bias,
+            tma_atom_Q,
+            tma_atom_K if const_expr(self.use_tma_KV) else None,
+            tma_atom_V if const_expr(self.use_tma_KV) else None,
+            tma_atom_O,
+            softmax_scale_log2,
+            softmax_scale,
+            window_size_left,
+            window_size_right,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sO_layout,
+            self.gmem_tiled_copy_Q,
+            self.gmem_tiled_copy_O,
+            tiled_mma_qk,
+            tiled_mma_pv,
+            tile_sched_params,
+            TileScheduler,
+            SharedStorage,
+            logical_seqlen_q_static,
+            logical_seqlen_k_static,
+            aux_tensors,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mAttentionSinkBias: cute.Tensor,
+        has_attention_sink_bias: cutlass.Constexpr,
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_K: Optional[cute.CopyAtom],
+        tma_atom_V: Optional[cute.CopyAtom],
+        tma_atom_O: Optional[cute.CopyAtom],
+        softmax_scale_log2: Float32,
+        softmax_scale: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        tile_sched_params,
+        TileScheduler: cutlass.Constexpr,
+        SharedStorage: cutlass.Constexpr,
+        logical_seqlen_q_static: cutlass.Constexpr,
+        logical_seqlen_k_static: cutlass.Constexpr,
+        aux_tensors=None,
+    ):
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_Q)
+            cpasync.prefetch_descriptor(tma_atom_K)
+            cpasync.prefetch_descriptor(tma_atom_V)
+            if const_expr(tma_atom_O is not None):
+                cpasync.prefetch_descriptor(tma_atom_O)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_Q = storage.mbar_ptr.data_ptr()
+        if warp_idx == 0:
+            cute.arch.mbarrier_init(mbar_ptr_Q, 1)
+        cute.arch.sync_threads()
+
+        pipeline_kv_consumer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, self.num_compute_warps
+        )
+        pipeline_kv_producer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread
+        )
+        pipeline_k = cute_pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.mbar_ptr_K.data_ptr(),
+            num_stages=self.num_stages,
+            producer_group=pipeline_kv_producer_group,
+            consumer_group=pipeline_kv_consumer_group,
+            tx_count=self.tma_copy_bytes["K"],
+            defer_sync=True,
+        )
+        pipeline_v = cute_pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.mbar_ptr_V.data_ptr(),
+            num_stages=self.num_stages,
+            producer_group=pipeline_kv_producer_group,
+            consumer_group=pipeline_kv_consumer_group,
+            tx_count=self.tma_copy_bytes["V"],
+            defer_sync=False,
+        )
+
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+        sVt = layout_utils.transpose_view(sV)
+        sO = storage.sQ.get_tensor(
+            sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype
+        )
+
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.is_local,
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead
+            if const_expr(self.pack_gqa)
+            else 1,
+        )
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=logical_seqlen_q_static,
+            seqlen_k_static=logical_seqlen_k_static,
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+        )
+        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
+
+        if warp_idx == self.producer_warp_idx:
+            cute.arch.setmaxregister_decrease(self.num_producer_regs)
+            self.load(
+                mQ,
+                mK,
+                mV,
+                sQ,
+                sK,
+                sV,
+                tma_atom_Q,
+                tma_atom_K,
+                tma_atom_V,
+                pipeline_k,
+                pipeline_v,
+                mbar_ptr_Q,
+                block_info,
+                SeqlenInfoCls,
+                TileSchedulerCls,
+            )
+        elif warp_idx < self.num_compute_warps:
+            cute.arch.setmaxregister_increase(self.num_mma_regs)
+            tidx = cute.arch.thread_idx()[0]
+            self.mma(
+                tiled_mma_qk,
+                tiled_mma_pv,
+                mQ,
+                mO,
+                mLSE,
+                sQ,
+                sK,
+                sV,
+                sVt,
+                sO,
+                pipeline_k,
+                pipeline_v,
+                mbar_ptr_Q,
+                gmem_tiled_copy_Q,
+                gmem_tiled_copy_O,
+                tma_atom_O,
+                tidx,
+                softmax_scale_log2,
+                softmax_scale,
+                mAttentionSinkBias,
+                has_attention_sink_bias,
+                block_info,
+                SeqlenInfoCls,
+                TileSchedulerCls,
+                aux_tensors,
+            )
+
+    @cute.jit
+    def load(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+        pipeline_k: cute_pipeline.PipelineTmaAsync,
+        pipeline_v: cute_pipeline.PipelineTmaAsync,
+        mbar_ptr_Q: cutlass.Pointer,
+        block_info: BlockInfo,
+        SeqlenInfoCls: Callable,
+        TileSchedulerCls: Callable,
+    ):
+        kv_producer_state = cute_pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.num_stages
+        )
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            del split_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            if const_expr(cute.rank(mQ) == 4):
+                mQ_batch = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)
+            elif const_expr(seqlen.has_cu_seqlens_q):
+                mQ_batch = seqlen.offset_batch_Q(mQ, batch_idx, dim=2)
+            else:
+                mQ_batch = mQ
+            mQ_cur = mQ_batch[None, None, head_idx]
+            gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
+            load_Q, _, _ = cute_copy.tma_get_copy_fn(
+                tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True
+            )
+            head_idx_kv = (
+                head_idx
+                if const_expr(self.pack_gqa)
+                else head_idx // self.qhead_per_kvhead
+            )
+            if const_expr(cute.rank(mK) == 4):
+                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[
+                    None, None, head_idx_kv
+                ]
+                mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=3)[
+                    None, None, head_idx_kv
+                ]
+            elif const_expr(seqlen.has_cu_seqlens_k):
+                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=2)[
+                    None, None, head_idx_kv
+                ]
+                mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=2)[
+                    None, None, head_idx_kv
+                ]
+            else:
+                mK_cur = mK[None, None, head_idx_kv]
+                mV_cur = mV[None, None, head_idx_kv]
+            gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (None, 0))
+            gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdimv), (None, 0))
+            load_K, _, _ = cute_copy.tma_get_copy_fn(
+                tma_atom_K,
+                0,
+                cute.make_layout(1),
+                gK,
+                sK,
+            )
+            load_K = cute_copy.tma_producer_copy_fn(load_K, pipeline_k)
+            load_V, _, _ = cute_copy.tma_get_copy_fn(
+                tma_atom_V,
+                0,
+                cute.make_layout(1),
+                gV,
+                sV,
+            )
+            load_V = cute_copy.tma_producer_copy_fn(load_V, pipeline_v)
+
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(
+                    mbar_ptr_Q, self.tma_copy_bytes["Q"]
+                )
+            load_Q(tma_bar_ptr=mbar_ptr_Q)
+            for n_tile in cutlass.range(n_block_max - n_block_min, unroll=1):
+                n_block = n_block_max - 1 - n_tile
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block, producer_state=kv_producer_state)
+                pipeline_v.producer_acquire(kv_producer_state)
+                load_V(src_idx=n_block, producer_state=kv_producer_state)
+                kv_producer_state.advance()
+
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierFwd.PFull),
+                number_of_threads=self.num_threads,
+            )
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+
+        pipeline_k.producer_tail(kv_producer_state.clone())
+        pipeline_v.producer_tail(kv_producer_state.clone())
+
+    @cute.jit
+    def mma_one_n_block(
+        self,
+        n_block: Int32,
+        kv_consumer_state,
+        thr_mma_qk: cute.TiledMma,
+        thr_mma_pv: cute.TiledMma,
+        tSrQ: cute.Tensor,
+        tSrK: cute.Tensor,
+        tOrVt: cute.Tensor,
+        acc_O: cute.Tensor,
+        smem_thr_copy_Q: cute.TiledCopy,
+        smem_thr_copy_K: cute.TiledCopy,
+        smem_thr_copy_V: cute.TiledCopy,
+        tSsQ: cute.Tensor,
+        tSsK: cute.Tensor,
+        tOsVt: cute.Tensor,
+        pipeline_k: cutlass.pipeline.PipelineAsync,
+        pipeline_v: cutlass.pipeline.PipelineAsync,
+        softmax: Softmax,
+        seqlen: SeqlenInfoQK,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
+        mask_fn: Callable,
+        aux_tensors=None,
+        fastdiv_mods=None,
+        is_first_n_block: cutlass.Constexpr = False,
+    ):
+        pipeline_k.consumer_wait(
+            kv_consumer_state, pipeline_k.consumer_try_wait(kv_consumer_state)
+        )
+        acc_shape_S = thr_mma_qk.partition_shape_C((self.tile_m, self.tile_n))
+        acc_S = cute.make_rmem_tensor(acc_shape_S, Float32)
+        acc_S.fill(0.0)
+        warp_mma_gemm(
+            thr_mma_qk,
+            acc_S,
+            tSrQ,
+            tSrK,
+            tSsQ,
+            tSsK[
+                None,
+                None,
+                None,
+                kv_consumer_state.index if const_expr(self.num_stages > 1) else 0,
+            ],
+            smem_thr_copy_Q,
+            smem_thr_copy_K,
+        )
+        pipeline_k.consumer_release(kv_consumer_state)
+
+        mask_fn(acc_S, n_block=n_block)
+        row_scale = softmax.online_softmax(
+            acc_S, is_first=is_first_n_block, check_inf=True
+        )
+        softmax.rescale_O(acc_O, row_scale)
+
+        rP = cute.make_fragment_like(acc_S, self.dtype)
+        rP.store(acc_S.load().to(self.dtype))
+        tOrP = layout_utils.reshape_acc_to_frgA(rP)
+
+        pipeline_v.consumer_wait(
+            kv_consumer_state, pipeline_v.consumer_try_wait(kv_consumer_state)
+        )
+        warp_mma_gemm_rs(
+            thr_mma_pv,
+            acc_O,
+            tOrP,
+            tOrVt,
+            tOsVt[
+                None,
+                None,
+                None,
+                kv_consumer_state.index if const_expr(self.num_stages > 1) else 0,
+            ],
+            smem_thr_copy_V,
+        )
+        pipeline_v.consumer_release(kv_consumer_state)
+        kv_consumer_state.advance()
+        return kv_consumer_state
+
+    @cute.jit
+    def mma(
+        self,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        mQ: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        sVt: cute.Tensor,
+        sO: cute.Tensor,
+        pipeline_k: cutlass.pipeline.PipelineAsync,
+        pipeline_v: cutlass.pipeline.PipelineAsync,
+        mbar_ptr_Q: cutlass.Pointer,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: cute.CopyAtom,
+        tidx: Int32,
+        softmax_scale_log2: Float32,
+        softmax_scale: Optional[Float32],
+        mAttentionSinkBias: cute.Tensor,
+        has_attention_sink_bias: cutlass.Constexpr,
+        block_info: BlockInfo,
+        SeqlenInfoCls: Callable,
+        TileSchedulerCls: Callable,
+        aux_tensors=None,
+    ):
+        thr_mma_qk = tiled_mma_qk.get_slice(tidx)
+        thr_mma_pv = tiled_mma_pv.get_slice(tidx)
+        tSrQ = thr_mma_qk.make_fragment_A(thr_mma_qk.partition_A(sQ))
+        tSrK = thr_mma_qk.make_fragment_B(thr_mma_qk.partition_B(sK[None, None, 0]))
+        tOrVt = thr_mma_pv.make_fragment_B(thr_mma_pv.partition_B(sVt[None, None, 0]))
+        acc_shape_O = thr_mma_pv.partition_shape_C((self.tile_m, self.tile_hdimv))
+        acc_O = cute.make_rmem_tensor(acc_shape_O, Float32)
+        cO = cute.make_identity_tensor((self.tile_m, self.tile_hdimv))
+        taccOcO = thr_mma_pv.partition_C(cO)
+        taccOcO_mn = layout_utils.reshape_acc_to_mn(taccOcO)
+
+        smem_copy_atom_QK = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self.dtype,
+        )
+        smem_copy_atom_V = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+            self.dtype,
+        )
+        smem_thr_copy_Q = cute_ops.make_tiled_copy_A(
+            smem_copy_atom_QK, tiled_mma_qk
+        ).get_slice(tidx)
+        smem_thr_copy_K = cute_ops.make_tiled_copy_B(
+            smem_copy_atom_QK, tiled_mma_qk
+        ).get_slice(tidx)
+        smem_thr_copy_V = cute_ops.make_tiled_copy_B(
+            smem_copy_atom_V, tiled_mma_pv
+        ).get_slice(tidx)
+        tSsQ = smem_thr_copy_Q.partition_S(sQ)
+        tSsK = smem_thr_copy_K.partition_S(sK)
+        tOsVt = smem_thr_copy_V.partition_S(sVt)
+
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        softmax_num_rows = acc_O.shape[0][0] * acc_O.shape[1]
+        softmax = Softmax.create(
+            softmax_scale_log2,
+            num_rows=softmax_num_rows,
+            softmax_scale=softmax_scale,
+        )
+        q_consumer_phase = Int32(0)
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            del split_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            cute.arch.mbarrier_wait(mbar_ptr_Q, phase=q_consumer_phase)
+            q_consumer_phase ^= 1
+
+            softmax.reset()
+            acc_O.fill(0.0)
+            kv_consumer_state = cute_pipeline.make_pipeline_state(
+                cutlass.pipeline.PipelineUserType.Consumer, self.num_stages
+            )
+
+            mask = AttentionMask(
+                self.tile_m,
+                self.tile_n,
+                seqlen,
+                block_info.window_size_left,
+                block_info.window_size_right,
+                self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            )
+            mask_fn = partial(
+                mask.apply_mask,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                m_block=m_block,
+                thr_mma=thr_mma_qk,
+                mask_causal=self.is_causal,
+                mask_local=self.is_local,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=None,
+                mask_mod=self.mask_mod,
+            )
+
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+            if n_block_max > n_block_min:
+                kv_consumer_state = self.mma_one_n_block(
+                    n_block_max - 1,
+                    kv_consumer_state,
+                    thr_mma_qk,
+                    thr_mma_pv,
+                    tSrQ,
+                    tSrK,
+                    tOrVt,
+                    acc_O,
+                    smem_thr_copy_Q,
+                    smem_thr_copy_K,
+                    smem_thr_copy_V,
+                    tSsQ,
+                    tSsK,
+                    tOsVt,
+                    pipeline_k,
+                    pipeline_v,
+                    softmax,
+                    seqlen,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    partial(mask_fn, mask_seqlen=True),
+                    aux_tensors=aux_tensors,
+                    is_first_n_block=True,
+                )
+                n_block_max -= 1
+
+                if const_expr(self.is_causal or self.is_local):
+                    n_block_min_causal_local_mask = (
+                        block_info.get_n_block_min_causal_local_mask(
+                            seqlen, m_block, n_block_min
+                        )
+                    )
+                    for n_tile in cutlass.range(
+                        n_block_max - n_block_min_causal_local_mask, unroll=1
+                    ):
+                        kv_consumer_state = self.mma_one_n_block(
+                            n_block_max - 1 - n_tile,
+                            kv_consumer_state,
+                            thr_mma_qk,
+                            thr_mma_pv,
+                            tSrQ,
+                            tSrK,
+                            tOrVt,
+                            acc_O,
+                            smem_thr_copy_Q,
+                            smem_thr_copy_K,
+                            smem_thr_copy_V,
+                            tSsQ,
+                            tSsK,
+                            tOsVt,
+                            pipeline_k,
+                            pipeline_v,
+                            softmax,
+                            seqlen,
+                            batch_idx,
+                            head_idx,
+                            m_block,
+                            partial(mask_fn, mask_seqlen=False),
+                            aux_tensors=aux_tensors,
+                        )
+                    n_block_max = cutlass.min(
+                        n_block_max, n_block_min_causal_local_mask
+                    )
+
+                n_block_min_before_local_mask = (
+                    block_info.get_n_block_min_before_local_mask(
+                        seqlen, m_block, n_block_min
+                    )
+                )
+                n_block_min_before_local_mask = cutlass.min(
+                    n_block_min_before_local_mask, n_block_max
+                )
+                for n_tile in cutlass.range(
+                    n_block_max - n_block_min_before_local_mask, unroll=1
+                ):
+                    kv_consumer_state = self.mma_one_n_block(
+                        n_block_max - 1 - n_tile,
+                        kv_consumer_state,
+                        thr_mma_qk,
+                        thr_mma_pv,
+                        tSrQ,
+                        tSrK,
+                        tOrVt,
+                        acc_O,
+                        smem_thr_copy_Q,
+                        smem_thr_copy_K,
+                        smem_thr_copy_V,
+                        tSsQ,
+                        tSsK,
+                        tOsVt,
+                        pipeline_k,
+                        pipeline_v,
+                        softmax,
+                        seqlen,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        partial(mask_fn, mask_seqlen=False),
+                        aux_tensors=aux_tensors,
+                    )
+                n_block_max = n_block_min_before_local_mask
+
+                if const_expr(
+                    self.is_local and block_info.window_size_left is not None
+                ):
+                    for n_tile in cutlass.range(n_block_max - n_block_min, unroll=1):
+                        kv_consumer_state = self.mma_one_n_block(
+                            n_block_max - 1 - n_tile,
+                            kv_consumer_state,
+                            thr_mma_qk,
+                            thr_mma_pv,
+                            tSrQ,
+                            tSrK,
+                            tOrVt,
+                            acc_O,
+                            smem_thr_copy_Q,
+                            smem_thr_copy_K,
+                            smem_thr_copy_V,
+                            tSsQ,
+                            tSsK,
+                            tOsVt,
+                            pipeline_k,
+                            pipeline_v,
+                            softmax,
+                            seqlen,
+                            batch_idx,
+                            head_idx,
+                            m_block,
+                            partial(mask_fn, mask_seqlen=False),
+                            aux_tensors=aux_tensors,
+                        )
+            sink_val = None
+            if const_expr(has_attention_sink_bias):
+                sink_val = cute.make_rmem_tensor(softmax.num_rows, Float32)
+                for r in cutlass.range_constexpr(softmax.num_rows):
+                    if const_expr(self.pack_gqa):
+                        row_idx = m_block * self.tile_m + taccOcO_mn[r, 0][0]
+                        q_token_idx = row_idx // self.qhead_per_kvhead
+                        q_head_in_group = row_idx - q_token_idx * self.qhead_per_kvhead
+                        q_head_idx = head_idx * self.qhead_per_kvhead + q_head_in_group
+                    else:
+                        q_head_idx = head_idx
+                    sink_val[r] = mAttentionSinkBias[q_head_idx]
+            row_scale = softmax.finalize(sink_val=sink_val)
+            softmax.rescale_O(acc_O, row_scale)
+            self.epilogue(
+                acc_O,
+                softmax.row_sum,
+                mO,
+                mLSE,
+                sO,
+                seqlen,
+                gmem_tiled_copy_O,
+                tma_atom_O,
+                tiled_mma_pv,
+                tidx,
+                m_block,
+                head_idx,
+                batch_idx,
+            )
+
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierFwd.PFull),
+                number_of_threads=self.num_threads,
+            )
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/layout_utils.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/layout_utils.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/layout_utils.py @ 87134e57 (2026-05-02) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr
+
+
+def transpose_view(a: cute.Tensor) -> cute.Tensor:
+    shape = (a.shape[1], a.shape[0], *a.shape[2:])
+    order = (1, 0, *range(2, cute.rank(a)))
+    return cute.composition(a, cute.make_ordered_layout(shape, order=order))
+
+
+def convert_layout_acc_mn(
+    acc_layout: cute.Layout, transpose: bool = False
+) -> cute.Layout:
+    acc_layout_col_major = cute.make_layout(acc_layout.shape)
+    shape = (
+        (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+        (
+            acc_layout_col_major.shape[0][0],
+            *acc_layout_col_major.shape[0][2:],
+            acc_layout_col_major.shape[2],
+        ),
+        *acc_layout_col_major.shape[3:],
+    )
+    stride = (
+        (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+        (
+            acc_layout_col_major.stride[0][0],
+            *acc_layout_col_major.stride[0][2:],
+            acc_layout_col_major.stride[2],
+        ),
+        *acc_layout_col_major.stride[3:],
+    )
+    if const_expr(transpose):
+        shape = (shape[1], shape[0], *shape[2:])
+        stride = (stride[1], stride[0], *stride[2:])
+    return cute.composition(acc_layout, cute.make_layout(shape, stride=stride))
+
+
+def reshape_acc_to_mn(acc: cute.Tensor, transpose: bool = False) -> cute.Tensor:
+    return cute.make_tensor(
+        acc.iterator, convert_layout_acc_mn(acc.layout, transpose=transpose)
+    )
+
+
+@cute.jit
+def convert_layout_acc_frgA(acc_layout: cute.Layout) -> cute.Layout:
+    if const_expr(cute.rank(acc_layout.shape[0]) == 3):
+        div = 2 if const_expr(acc_layout.shape[0][2] % 2 == 0) else 1
+        l = cute.logical_divide(acc_layout, ((None, None, div), None, None))
+        return cute.make_layout(
+            (
+                (l.shape[0][0], l.shape[0][1], l.shape[0][2][0]),
+                l.shape[1],
+                (l.shape[0][2][1], l.shape[2]),
+            ),
+            stride=(
+                (l.stride[0][0], l.stride[0][1], l.stride[0][2][0]),
+                l.stride[1],
+                (l.stride[0][2][1], l.stride[2]),
+            ),
+        )
+    l = cute.logical_divide(acc_layout, (None, None, 2))
+    return cute.make_layout(
+        (
+            (l.shape[0], l.shape[2][0]),
+            l.shape[1],
+            l.shape[2][1],
+        ),
+        stride=(
+            (l.stride[0], l.stride[2][0]),
+            l.stride[1],
+            l.stride[2][1],
+        ),
+    )
+
+
+def reshape_acc_to_frgA(acc: cute.Tensor) -> cute.Tensor:
+    return cute.make_tensor(acc.iterator, convert_layout_acc_frgA(acc.layout))

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/mask.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/mask.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/mask.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+
+from flashinfer.experimental.sm12x.attention._shared.contiguous import layout_utils
+from flashinfer.experimental.sm12x.attention._shared.contiguous.seqlen_info import (
+    SeqlenInfoQK,
+)
+
+
+@dataclass(frozen=True)
+class AttentionMask:
+    tile_m: cutlass.Constexpr[int]
+    tile_n: cutlass.Constexpr[int]
+    seqlen_info: SeqlenInfoQK
+    window_size_left: Optional[Int32] = None
+    window_size_right: Optional[Int32] = None
+    qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+    swap_AB: cutlass.Constexpr[bool] = False
+
+    @property
+    def seqlen_q(self) -> Int32:
+        return self.seqlen_info.seqlen_q
+
+    @property
+    def seqlen_k(self) -> Int32:
+        return self.seqlen_info.seqlen_k
+
+    @cute.jit
+    def apply_mask(
+        self,
+        acc_S: cute.Tensor,
+        batch_idx: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        m_block: cutlass.Int32,
+        n_block: cutlass.Int32,
+        thr_mma: cute.TiledMma,
+        mask_seqlen: cutlass.Constexpr[bool],
+        mask_causal: cutlass.Constexpr[bool],
+        mask_local: cutlass.Constexpr[bool] = False,
+        mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+    ) -> None:
+        del batch_idx, head_idx, mask_seqlen, mask_mod, aux_tensors, fastdiv_mods
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.swap_AB)
+        acc_shape = (
+            (self.tile_m, self.tile_n)
+            if const_expr(not self.swap_AB)
+            else (self.tile_n, self.tile_m)
+        )
+        cS = cute.make_identity_tensor(acc_shape)
+        tScS_mn = layout_utils.reshape_acc_to_mn(
+            thr_mma.partition_C(cS), transpose=self.swap_AB
+        )
+        t0ScS_mn = layout_utils.reshape_acc_to_mn(
+            thr_mma.get_slice(0).partition_C(cS),
+            transpose=self.swap_AB,
+        )
+        row_dim = 0 if const_expr(not self.swap_AB) else 1
+        col_dim = 1 if const_expr(not self.swap_AB) else 0
+        thr_col_offset = tScS_mn[0][col_dim]
+        if n_block < 0:
+            n_block = 0
+        for r in cutlass.range_constexpr(cute.size(tScS_mn.shape[0])):
+            row_idx = tScS_mn[r, 0][row_dim] + m_block * self.tile_m
+            q_row_idx = (
+                row_idx // self.qhead_per_kvhead_packgqa
+                if const_expr(self.qhead_per_kvhead_packgqa != 1)
+                else row_idx
+            )
+            for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                col_idx = (
+                    t0ScS_mn[0, c][col_dim] + thr_col_offset + n_block * self.tile_n
+                )
+                masked = (q_row_idx >= self.seqlen_q) | (col_idx >= self.seqlen_k)
+                if const_expr(mask_causal):
+                    masked = masked | (
+                        col_idx >= q_row_idx + 1 + self.seqlen_k - self.seqlen_q
+                    )
+                if const_expr(mask_local):
+                    anchor = q_row_idx + self.seqlen_k - self.seqlen_q
+                    if const_expr(self.window_size_left is not None):
+                        masked = masked | (col_idx < anchor - self.window_size_left)
+                    if const_expr(self.window_size_right is not None):
+                        masked = masked | (
+                            col_idx >= anchor + self.window_size_right + 1
+                        )
+                acc_S_mn[r, c] = cutlass.select_(masked, -Float32.inf, acc_S_mn[r, c])

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/named_barrier.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/named_barrier.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/named_barrier.py @ 87134e57 (2026-05-02) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+import enum
+
+
+class NamedBarrierFwd(enum.IntEnum):
+    Epilogue = enum.auto()
+    PFull = enum.auto()
+    PEmpty = enum.auto()
+    KVConvert = enum.auto()

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/pack_gqa.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/pack_gqa.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/pack_gqa.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+import cutlass
+import cutlass.cute as cute
+
+from flashinfer.experimental.sm12x.attention._shared.contiguous import layout_utils
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as cute_ops
+
+
+def pack_gqa_layout(T, qhead_per_kvhead, nheads_kv, head_idx):
+    head_stride = T.stride[head_idx]
+    shape_packed = (
+        (qhead_per_kvhead, T.shape[0]),
+        *[T.shape[i] for i in range(1, head_idx)],
+        nheads_kv,
+        *[T.shape[i] for i in range(head_idx + 1, len(T.shape))],
+    )
+    stride_packed = (
+        (head_stride, T.stride[0]),
+        *[T.stride[i] for i in range(1, head_idx)],
+        head_stride * qhead_per_kvhead,
+        *[T.stride[i] for i in range(head_idx + 1, len(T.shape))],
+    )
+    return cute.make_tensor(
+        T.iterator, cute.make_layout(shape_packed, stride=stride_packed)
+    )
+
+
+class PackGQA:
+    def __init__(
+        self,
+        m_block_size: cutlass.Constexpr[int],
+        head_dim_padded: cutlass.Constexpr[int],
+        check_hdim_oob: cutlass.Constexpr[bool],
+        qhead_per_kvhead: cutlass.Constexpr[bool],
+    ):
+        self.m_block_size = m_block_size
+        self.head_dim_padded = head_dim_padded
+        self.check_hdim_oob = check_hdim_oob
+        self.qhead_per_kvhead = qhead_per_kvhead
+
+    @cute.jit
+    def compute_ptr(
+        self,
+        tensor: cute.Tensor,
+        cRows: cute.Tensor,
+        tidx: cutlass.Int32,
+        block: cutlass.Int32,
+        threads_per_row: cutlass.Constexpr[int],
+        num_threads: cutlass.Constexpr[int],
+    ):
+        num_ptr_per_thread = cute.ceil_div(cute.size(cRows), threads_per_row)
+        tPrPtr = cute.make_rmem_tensor(num_ptr_per_thread, cutlass.Int64)
+        for i in cutlass.range_constexpr(num_ptr_per_thread):
+            row = i * num_threads + cRows[tidx % threads_per_row][0]
+            idx = block * self.m_block_size + row
+            m_idx = idx // self.qhead_per_kvhead
+            h_idx = idx - m_idx * self.qhead_per_kvhead
+            tPrPtr[i] = cute_ops.elem_pointer(tensor, ((h_idx, m_idx),)).toint()
+        return tPrPtr
+
+    @cute.jit
+    def store_LSE(
+        self,
+        mLSE: cute.Tensor,
+        tLSErLSE: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        tidx: cutlass.Int32,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        thr_mma = tiled_mma.get_slice(tidx)
+        caccO = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
+        taccOcO = thr_mma.partition_C(caccO)
+        taccOcO_row = layout_utils.reshape_acc_to_mn(taccOcO)[None, 0]
+        threads_per_row = tiled_mma.tv_layout_C.shape[0][0]
+        num_threads = tiled_mma.size
+        tPrLSEPtr = self.compute_ptr(
+            mLSE, taccOcO_row, tidx, block, threads_per_row, num_threads
+        )
+        for m in cutlass.range_constexpr(cute.size(tLSErLSE)):
+            lse_ptr_i64 = cute_ops.shuffle_sync(
+                tPrLSEPtr[m // threads_per_row],
+                m % threads_per_row,
+                width=threads_per_row,
+            )
+            lse_gmem_ptr = cute.make_ptr(
+                mLSE.element_type,
+                lse_ptr_i64,
+                cute.AddressSpace.gmem,
+                assumed_align=4,
+            )
+            row = block * self.m_block_size + taccOcO_row[m][0]
+            if taccOcO[0][1] == 0 and row < seqlen * self.qhead_per_kvhead:
+                mLSE_copy = cute.make_tensor(lse_gmem_ptr, (1,))
+                mLSE_copy[0] = tLSErLSE[m]
+
+    @cute.jit
+    def store_O(
+        self,
+        mO: cute.Tensor,
+        tOrO: cute.Tensor,
+        gmem_tiled_copy: cute.TiledCopy,
+        tidx: cutlass.Int32,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        gmem_thr_copy = gmem_tiled_copy.get_slice(tidx)
+        cO = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
+        tOcO = gmem_thr_copy.partition_S(cO)
+        t0OcO = gmem_thr_copy.get_slice(0).partition_S(cO)
+        tOpO = cute_ops.predicate_k(tOcO, limit=mO.shape[1])
+        tOcO_row = tOcO[0, None, 0]
+        threads_per_row = gmem_tiled_copy.layout_tv_tiled.shape[0][0]
+        num_threads = gmem_tiled_copy.size
+        tPrOPtr = self.compute_ptr(
+            mO[None, 0], tOcO_row, tidx, block, threads_per_row, num_threads
+        )
+        for m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+            o_ptr_i64 = cute_ops.shuffle_sync(
+                tPrOPtr[m // threads_per_row],
+                m % threads_per_row,
+                width=threads_per_row,
+            )
+            o_gmem_ptr = cute.make_ptr(
+                mO.element_type,
+                o_ptr_i64,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            if (
+                t0OcO[0, m, 0][0]
+                < seqlen * self.qhead_per_kvhead
+                - block * self.m_block_size
+                - tOcO_row[0][0]
+            ):
+                mO_cur = cute.make_tensor(o_gmem_ptr, (self.head_dim_padded,))
+                elems_per_load = cute.size(tOrO.shape[0][0])
+                mO_cur_copy = cute.tiled_divide(mO_cur, (elems_per_load,))
+                for k in cutlass.range_constexpr(cute.size(tOrO.shape[2])):
+                    ki = tOcO[0, 0, k][1] // elems_per_load
+                    cute.copy(
+                        gmem_thr_copy,
+                        tOrO[None, m, k],
+                        mO_cur_copy[None, ki],
+                        pred=tOpO[None, m, k]
+                        if cutlass.const_expr(self.check_hdim_oob)
+                        else None,
+                    )

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/seqlen_info.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/seqlen_info.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/seqlen_info.py @ 95ebfdf1 (2026-05-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from dataclasses import dataclass
+from typing import Optional
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, const_expr
+
+
+@dataclass(frozen=True)
+class SeqlenInfoQK:
+    offset_q: Int32
+    offset_k: Int32
+    padded_offset_q: Int32
+    padded_offset_k: Int32
+    seqlen_q: Int32
+    seqlen_k: Int32
+    has_cu_seqlens_q: cutlass.Constexpr[bool]
+    has_cu_seqlens_k: cutlass.Constexpr[bool]
+
+    @staticmethod
+    def create(
+        batch_idx: Int32,
+        seqlen_q_static: Int32,
+        seqlen_k_static: Int32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        tile_m: cutlass.Constexpr[Int32] = 128,
+        tile_n: cutlass.Constexpr[Int32] = 128,
+    ):
+        offset_q = (
+            Int32(0) if const_expr(mCuSeqlensQ is None) else mCuSeqlensQ[batch_idx]
+        )
+        offset_k = (
+            Int32(0) if const_expr(mCuSeqlensK is None) else mCuSeqlensK[batch_idx]
+        )
+        padded_offset_q = (
+            Int32(0)
+            if const_expr(mCuSeqlensQ is None)
+            else cute.assume(
+                (offset_q + batch_idx * tile_m) // tile_m * tile_m, divby=tile_m
+            )
+        )
+        padded_offset_k = (
+            Int32(0)
+            if const_expr(mCuSeqlensK is None)
+            else cute.assume(
+                (offset_k + batch_idx * tile_n) // tile_n * tile_n, divby=tile_n
+            )
+        )
+        seqlen_q = (
+            seqlen_q_static
+            if const_expr(mCuSeqlensQ is None)
+            else mCuSeqlensQ[batch_idx + 1] - offset_q
+        )
+        seqlen_k = (
+            seqlen_k_static
+            if const_expr(mCuSeqlensK is None)
+            else mCuSeqlensK[batch_idx + 1] - offset_k
+        )
+        return SeqlenInfoQK(
+            offset_q,
+            offset_k,
+            padded_offset_q,
+            padded_offset_k,
+            seqlen_q,
+            seqlen_k,
+            has_cu_seqlens_q=mCuSeqlensQ is not None,
+            has_cu_seqlens_k=mCuSeqlensK is not None,
+        )
+
+    def offset_batch_Q(
+        self,
+        mQ: cute.Tensor,
+        batch_idx: Int32,
+        dim: int,
+        padded: cutlass.Constexpr[bool] = False,
+    ) -> cute.Tensor:
+        if const_expr(not self.has_cu_seqlens_q):
+            idx = (None,) * dim + (batch_idx,) + (None,) * (cute.rank(mQ) - 1 - dim)
+            return mQ[idx]
+        offset_q = self.offset_q if const_expr(not padded) else self.padded_offset_q
+        offset = offset_q if const_expr(cute.rank(mQ.shape[0]) == 1) else (0, offset_q)
+        idx = (offset,) + (None,) * (cute.rank(mQ) - 1)
+        return cute.domain_offset(idx, mQ)
+
+    def offset_batch_K(
+        self,
+        mK: cute.Tensor,
+        batch_idx: Int32,
+        dim: int,
+        padded: cutlass.Constexpr[bool] = False,
+        multiple: int = 1,
+    ) -> cute.Tensor:
+        if const_expr(not self.has_cu_seqlens_k):
+            idx = (None,) * dim + (batch_idx,) + (None,) * (cute.rank(mK) - 1 - dim)
+            return mK[idx]
+        offset_k = self.offset_k if const_expr(not padded) else self.padded_offset_k
+        offset_k *= multiple
+        idx = (offset_k,) + (None,) * (cute.rank(mK) - 1)
+        return cute.domain_offset(idx, mK)

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/softmax.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/softmax.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/softmax.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+import math
+import operator
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32
+
+from flashinfer.experimental.sm12x.attention._shared.contiguous import layout_utils
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as cute_ops
+from flashinfer.experimental.sm12x.attention._shared.contiguous.cute_dsl_utils import (
+    ParamsBase,
+)
+
+
+@dataclass
+class Softmax(ParamsBase):
+    scale_log2: Float32
+    num_rows: cutlass.Constexpr[int]
+    row_max: cute.Tensor
+    row_sum: cute.Tensor
+    arch: cutlass.Constexpr[int] = 80
+    softmax_scale: Float32 | None = None
+
+    @staticmethod
+    def create(
+        scale_log2: Float32,
+        num_rows: cutlass.Constexpr[int],
+        arch: cutlass.Constexpr[int] = 80,
+        softmax_scale: Float32 | None = None,
+    ):
+        row_max = cute.make_rmem_tensor(num_rows, Float32)
+        row_sum = cute.make_rmem_tensor(num_rows, Float32)
+        return Softmax(scale_log2, num_rows, row_max, row_sum, arch, softmax_scale)
+
+    def _row_layout(self) -> cute.Layout:
+        return cute.make_layout((self.num_rows,), stride=(1,))
+
+    def reset(self) -> None:
+        self.row_max.fill(-Float32.inf)
+        self.row_sum.fill(0.0)
+
+    def _compute_row_max(
+        self, acc_S_row: cute.TensorSSA, init_val: float | Float32 | None = None
+    ) -> Float32:
+        return cute_ops.fmax_reduce(acc_S_row, init_val, arch=self.arch)
+
+    def _compute_row_sum(
+        self, acc_S_row_exp: cute.TensorSSA, init_val: float | Float32 | None = None
+    ) -> Float32:
+        return cute_ops.fadd_reduce(acc_S_row_exp, init_val, arch=self.arch)
+
+    def online_softmax(
+        self,
+        acc_S: cute.Tensor,
+        is_first: cutlass.Constexpr[bool] = False,
+        check_inf: cutlass.Constexpr[bool] = True,
+    ) -> cute.Tensor:
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
+        row_scale = cute.make_rmem_tensor(self._row_layout(), Float32)
+
+        for r in range(int(self.num_rows)):
+            acc_S_row = acc_S_mn[r, None].load()
+            row_max_cur = cute_ops.fmax_reduce(
+                acc_S_row,
+                init_val=self.row_max[r] if cutlass.const_expr(not is_first) else None,
+                arch=self.arch,
+            )
+            row_max_cur = cute.arch.warp_reduction_max(row_max_cur, threads_in_group=4)
+            row_max_prev = self.row_max[r]
+            self.row_max[r] = row_max_cur
+            if cutlass.const_expr(check_inf):
+                row_max_cur = Float32(
+                    cutlass.select_(row_max_cur == -Float32.inf, 0.0, row_max_cur)
+                )
+            row_max_cur_scaled = row_max_cur * self.scale_log2
+            acc_S_row_exp = cute.math.exp2(
+                acc_S_row * self.scale_log2 - row_max_cur_scaled,
+                fastmath=True,
+            )
+            if cutlass.const_expr(is_first):
+                acc_S_row_sum = cute_ops.fadd_reduce(
+                    acc_S_row_exp, init_val=None, arch=self.arch
+                )
+                row_scale[r] = 1.0
+            else:
+                row_scale[r] = cute.math.exp2(
+                    (row_max_prev - row_max_cur) * self.scale_log2,
+                    fastmath=True,
+                )
+                acc_S_row_sum = cute_ops.fadd_reduce(
+                    acc_S_row_exp,
+                    init_val=self.row_sum[r] * row_scale[r],
+                    arch=self.arch,
+                )
+
+            self.row_sum[r] = acc_S_row_sum
+            acc_S_mn[r, None].store(acc_S_row_exp)
+
+        return row_scale
+
+    def finalize(
+        self, final_scale: Float32 = 1.0, sink_val: Float32 | cute.Tensor | None = None
+    ) -> cute.Tensor:
+        if cutlass.const_expr(
+            sink_val is not None and isinstance(sink_val, cute.Tensor)
+        ):
+            assert cute.size(sink_val) == self.num_rows
+        self.row_sum.store(
+            cute_ops.warp_reduce(self.row_sum.load(), operator.add, width=4)
+        )
+        row_scale = cute.make_rmem_tensor(self._row_layout(), Float32)
+
+        for r in range(int(self.num_rows)):
+            if cutlass.const_expr(sink_val is not None):
+                sink_val_cur = (
+                    sink_val if not isinstance(sink_val, cute.Tensor) else sink_val[r]
+                )
+                self.row_sum[r] += cute.math.exp2(
+                    sink_val_cur * math.log2(math.e)
+                    - self.row_max[r] * self.scale_log2,
+                    fastmath=True,
+                )
+
+            row_sum_cur = self.row_sum[r]
+            row_sum_is_zero_or_nan = (row_sum_cur == 0.0) | (row_sum_cur != row_sum_cur)
+            safe_row_sum = Float32(
+                cutlass.select_(row_sum_is_zero_or_nan, 1.0, row_sum_cur)
+            )
+            row_scale[r] = cute.arch.rcp_approx(safe_row_sum) * final_scale
+            row_lse = (
+                self.row_max[r] * self.scale_log2
+                + cute.math.log2(safe_row_sum, fastmath=True)
+            ) * math.log(2.0)
+            self.row_sum[r] = Float32(
+                cutlass.select_(row_sum_is_zero_or_nan, -Float32.inf, row_lse)
+            )
+        return row_scale
+
+    def rescale_O(self, acc_O: cute.Tensor, row_scale: cute.Tensor) -> None:
+        acc_O_mn = layout_utils.reshape_acc_to_mn(acc_O)
+        for r in range(int(self.num_rows)):
+            acc_O_mn[r, None].store(acc_O_mn[r, None].load() * row_scale[r])

--- a/flashinfer/experimental/sm12x/attention/_shared/contiguous/tile_scheduler.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/contiguous/tile_scheduler.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/contiguous/tile_scheduler.py @ 16aba799 (2026-05-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32
+from cutlass._mlir import ir
+
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as cute_ops
+from flashinfer.experimental.sm12x.attention._shared.contiguous.cute_dsl_utils import (
+    ParamsBase,
+)
+
+
+class WorkTileInfo(cutlass.utils.WorkTileInfo):
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "WorkTileInfo":
+        assert len(values) == 5
+        new_tile_idx = cutlass.new_from_mlir_values(self._tile_idx, values[:-1])
+        new_is_valid_tile = cutlass.new_from_mlir_values(
+            self._is_valid_tile, [values[-1]]
+        )
+        return WorkTileInfo(new_tile_idx, new_is_valid_tile)
+
+
+@dataclass
+class TileSchedulerArguments(ParamsBase):
+    num_block: Int32
+    num_head: Int32
+    num_batch: Int32
+    seqlen_k: Int32
+    headdim: Int32
+    headdim_v: Int32
+    total_q: Int32
+    tile_shape_mn: cutlass.Constexpr[Tuple[int, int]]
+    cluster_shape_mn: cutlass.Constexpr[Tuple[int, int]] = (1, 1)
+    mCuSeqlensQ: cute.Tensor | None = None
+    qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+    element_size: cutlass.Constexpr[int] = 2
+    is_persistent: cutlass.Constexpr[bool] = False
+    lpt: cutlass.Constexpr[bool] = False
+    head_swizzle: cutlass.Constexpr[bool] = False
+
+
+class SingleTileScheduler:
+    @dataclass
+    class Params(ParamsBase):
+        num_block: Int32
+        num_head: Int32
+        num_batch: Int32
+        cluster_shape_mn: cutlass.Constexpr[Tuple[int, int]] = (1, 1)
+
+        @staticmethod
+        def create(args: TileSchedulerArguments, *, loc=None, ip=None):
+            del loc, ip
+            return SingleTileScheduler.Params(
+                args.num_block,
+                args.num_head,
+                args.num_batch,
+                args.cluster_shape_mn,
+            )
+
+    def __init__(
+        self,
+        params: "SingleTileScheduler.Params",
+        blk_coord: cute.Coord,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.params = params
+        self._blk_coord = blk_coord
+        self._is_first_block = True
+        self._loc = loc
+        self._ip = ip
+
+    @staticmethod
+    def to_underlying_arguments(args: TileSchedulerArguments, *, loc=None, ip=None):
+        return SingleTileScheduler.Params.create(args, loc=loc, ip=ip)
+
+    @staticmethod
+    def create(params: "SingleTileScheduler.Params", *, loc=None, ip=None):
+        return SingleTileScheduler(params, cute.arch.block_idx(), loc=loc, ip=ip)
+
+    @staticmethod
+    def get_grid_shape(params: "SingleTileScheduler.Params", *, loc=None, ip=None):
+        del loc, ip
+        assert params.cluster_shape_mn[1] == 1
+        return (
+            cute.round_up(params.num_block, params.cluster_shape_mn[0]),
+            params.num_head,
+            params.num_batch,
+        )
+
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        del loc, ip
+        block_idx, head_idx, batch_idx = self._blk_coord
+        return WorkTileInfo(
+            (block_idx, head_idx, batch_idx, Int32(0)), self._is_first_block
+        )
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        del loc, ip
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        del loc, ip
+        self._is_first_block = False
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.params, self._blk_coord]:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.params, self._blk_coord], self._values_pos):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return SingleTileScheduler(*(tuple(obj_list)), loc=self._loc)
+
+
+class SingleTileVarlenScheduler:
+    @dataclass
+    class Params(ParamsBase):
+        num_head: Int32
+        num_batch: Int32
+        total_q: Int32
+        max_kvblock_in_l2: Int32
+        tile_shape_mn: cutlass.Constexpr[Tuple[int, int]]
+        mCuSeqlensQ: Optional[cute.Tensor] = None
+        qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+        lpt: cutlass.Constexpr[bool] = False
+        head_swizzle: cutlass.Constexpr[bool] = False
+        cluster_shape_m: cutlass.Constexpr[int] = 1
+
+        @staticmethod
+        @cute.jit
+        def create(args: TileSchedulerArguments, *, loc=None, ip=None):
+            del loc, ip
+            size_l2 = 50 * 1024 * 1024
+            max_kvblock_in_l2 = size_l2 // (
+                (args.headdim + args.headdim_v)
+                * args.element_size
+                * args.tile_shape_mn[1]
+            )
+            assert args.mCuSeqlensQ is not None, "mCuSeqlensQ must be provided"
+            assert args.cluster_shape_mn[1] == 1, (
+                "Only cluster_shape_mn[1] == 1 is supported"
+            )
+            return SingleTileVarlenScheduler.Params(
+                num_head=args.num_head,
+                num_batch=args.num_batch,
+                total_q=args.total_q,
+                max_kvblock_in_l2=max_kvblock_in_l2,
+                tile_shape_mn=args.tile_shape_mn,
+                mCuSeqlensQ=args.mCuSeqlensQ,
+                qhead_per_kvhead_packgqa=args.qhead_per_kvhead_packgqa,
+                lpt=args.lpt,
+                head_swizzle=args.head_swizzle,
+                cluster_shape_m=args.cluster_shape_mn[0],
+            )
+
+    def __init__(self, params: Params, tile_idx: Int32, *, loc=None, ip=None):
+        self.params = params
+        self._tile_idx = tile_idx
+        self._is_first_block = True
+        self._loc = loc
+        self._ip = ip
+
+    @staticmethod
+    def to_underlying_arguments(args: TileSchedulerArguments, *, loc=None, ip=None):
+        return SingleTileVarlenScheduler.Params.create(args, loc=loc, ip=ip)
+
+    @staticmethod
+    def create(params: Params, *, loc=None, ip=None):
+        tile_idx, _, _ = cute.arch.block_idx()
+        return SingleTileVarlenScheduler(params, tile_idx, loc=loc, ip=ip)
+
+    @staticmethod
+    def get_grid_shape(params: Params, *, loc=None, ip=None):
+        del loc, ip
+        total_blocks_max = (
+            params.total_q
+            + params.num_batch * (params.cluster_shape_m * params.tile_shape_mn[0] - 1)
+        ) // params.tile_shape_mn[0]
+        total_blocks_max = (
+            total_blocks_max // params.cluster_shape_m * params.cluster_shape_m
+        )
+        return (total_blocks_max * params.num_head, Int32(1), Int32(1))
+
+    @cute.jit
+    def _get_num_m_blocks(self, lane: Int32, bidb_start: Int32) -> Int32:
+        params = self.params
+        batch_idx = lane + bidb_start
+        assert params.mCuSeqlensQ is not None
+        cur_cu_seqlen = Int32(0)
+        if batch_idx <= params.num_batch:
+            cur_cu_seqlen = params.mCuSeqlensQ[batch_idx]
+        next_cu_seqlen = cute.arch.shuffle_sync_down(cur_cu_seqlen, offset=1)
+        seqlen = next_cu_seqlen - cur_cu_seqlen
+        if cutlass.const_expr(params.qhead_per_kvhead_packgqa > 1):
+            seqlen *= params.qhead_per_kvhead_packgqa
+        return (
+            cute.ceil_div(
+                cute.ceil_div(seqlen, params.tile_shape_mn[0]), params.cluster_shape_m
+            )
+            if batch_idx < params.num_batch and lane < cute.arch.WARP_SIZE - 1
+            else Int32(0)
+        )
+
+    @cute.jit
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        del loc, ip
+        params = self.params
+        lane_idx = cute.arch.lane_idx()
+        num_m_blocks = self._get_num_m_blocks(lane_idx, bidb_start=0)
+        num_m_blocks_cumulative = cute_ops.warp_prefix_sum(num_m_blocks, lane_idx)
+        m_blocks_in_group = cute.arch.shuffle_sync(
+            num_m_blocks_cumulative, cute.arch.WARP_SIZE - 1
+        )
+        group_end_tile = m_blocks_in_group * params.num_head
+        block, head_idx, batch_idx = Int32(0), Int32(0), Int32(0)
+        next_tile_idx = self._tile_idx // params.cluster_shape_m
+        while group_end_tile <= next_tile_idx:
+            batch_idx += cute.arch.WARP_SIZE - 1
+            if batch_idx >= params.num_batch:
+                batch_idx = Int32(params.num_batch)
+                group_end_tile = next_tile_idx + 1
+            else:
+                num_m_blocks = self._get_num_m_blocks(lane_idx, bidb_start=batch_idx)
+                num_m_blocks_cumulative = cute_ops.warp_prefix_sum(
+                    num_m_blocks, lane_idx
+                )
+                m_blocks_in_group = cute.arch.shuffle_sync(
+                    num_m_blocks_cumulative, cute.arch.WARP_SIZE - 1
+                )
+                group_end_tile += m_blocks_in_group * params.num_head
+        is_valid = False
+        if batch_idx >= params.num_batch:
+            block, head_idx, batch_idx = Int32(0), Int32(0), Int32(params.num_batch)
+        else:
+            group_start_tile = group_end_tile - m_blocks_in_group * params.num_head
+            batch_idx_in_group = cute.arch.popc(
+                cute.arch.vote_ballot_sync(
+                    group_start_tile + num_m_blocks_cumulative * params.num_head
+                    <= next_tile_idx
+                )
+            )
+            batch_idx += batch_idx_in_group
+            num_m_blocks_prev_lane = (
+                0
+                if batch_idx_in_group == 0
+                else cute.arch.shuffle_sync(
+                    num_m_blocks_cumulative, batch_idx_in_group - 1
+                )
+            )
+            num_m_blocks = cute.arch.shuffle_sync(num_m_blocks, batch_idx_in_group)
+            mh_block = (
+                next_tile_idx
+                - group_start_tile
+                - num_m_blocks_prev_lane * params.num_head
+            )
+            if cutlass.const_expr(params.lpt or params.head_swizzle):
+                num_n_blocks = (
+                    num_m_blocks
+                    * params.tile_shape_mn[0]
+                    // params.qhead_per_kvhead_packgqa
+                    // params.tile_shape_mn[1]
+                )
+                nheads_in_l2 = (
+                    16
+                    if num_n_blocks * 16 <= params.max_kvblock_in_l2
+                    else (
+                        8
+                        if num_n_blocks * 8 <= params.max_kvblock_in_l2
+                        else (
+                            4
+                            if num_n_blocks * 4 <= params.max_kvblock_in_l2
+                            else (
+                                2 if num_n_blocks * 2 <= params.max_kvblock_in_l2 else 1
+                            )
+                        )
+                    )
+                )
+                nheads_in_l2 = min(nheads_in_l2, params.num_head)
+                mh_in_l2 = nheads_in_l2 * num_m_blocks
+                section_idx = mh_block // mh_in_l2
+                l2_mod = mh_block - section_idx * mh_in_l2
+                nheads_in_this_section = (
+                    nheads_in_l2
+                    if nheads_in_l2 * (section_idx + 1) <= params.num_head
+                    else params.num_head - section_idx * nheads_in_l2
+                )
+                block = l2_mod // nheads_in_this_section
+                head_idx_residual = l2_mod - block * nheads_in_this_section
+                head_idx = section_idx * nheads_in_l2 + head_idx_residual
+                if cutlass.const_expr(params.lpt):
+                    block = num_m_blocks - 1 - block
+            else:
+                head_idx = mh_block // num_m_blocks
+                block = mh_block - head_idx * num_m_blocks
+            is_valid = self._is_first_block and batch_idx < params.num_batch
+            if cutlass.const_expr(params.cluster_shape_m > 1):
+                bidx_in_cluster = cute.arch.block_in_cluster_idx()
+                block = block * params.cluster_shape_m + bidx_in_cluster[0]
+        return WorkTileInfo(
+            (Int32(block), Int32(head_idx), Int32(batch_idx), Int32(0)), is_valid
+        )
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        del loc, ip
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        del loc, ip
+        self._is_first_block = False
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.params, self._tile_idx]:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.params, self._tile_idx], self._values_pos):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return SingleTileVarlenScheduler(*(tuple(obj_list)), loc=self._loc)

--- a/flashinfer/experimental/sm12x/attention/_shared/cute/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/cute/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/_cute/__init__.py @ 16aba799 (2026-05-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Private CuTe helper layer shared by attention kernels."""

--- a/flashinfer/experimental/sm12x/attention/_shared/cute/copy.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/cute/copy.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/_cute/copy.py @ 16aba799 (2026-05-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Minimal donor TMA copy helpers shared by attention kernels."""
+
+from typing import Callable
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cutlass_dsl import dsl_user_op
+
+
+@dsl_user_op
+def tma_get_copy_fn(
+    atom: cute.CopyAtom,
+    cta_coord: cute.Coord,
+    cta_layout: cute.Layout,
+    src_tensor: cute.Tensor,
+    dst_tensor: cute.Tensor,
+    filter_zeros: bool = False,
+    single_stage: bool = False,
+    *,
+    loc=None,
+    ip=None,
+    **kwargs,
+) -> Callable:
+    src_is_smem = const_expr(
+        isinstance(src_tensor.iterator, cute.Pointer)
+        and src_tensor.memspace == cute.AddressSpace.smem
+    )
+    smem_tensor, gmem_tensor = (
+        (src_tensor, dst_tensor) if src_is_smem else (dst_tensor, src_tensor)
+    )
+    group_rank_smem = const_expr(
+        cute.rank(smem_tensor) - (1 if not single_stage else 0)
+    )
+    group_rank_gmem = const_expr(
+        cute.rank(gmem_tensor) - (1 if not single_stage else 0)
+    )
+    s, g = cpasync.tma_partition(
+        atom,
+        cta_coord,
+        cta_layout,
+        cute.group_modes(smem_tensor, 0, group_rank_smem),
+        cute.group_modes(gmem_tensor, 0, group_rank_gmem),
+        loc=loc,
+        ip=ip,
+    )
+    if const_expr(filter_zeros):
+        s = cute.filter_zeros(s)
+        g = cute.filter_zeros(g)
+    src, dst = (s, g) if src_is_smem else (g, s)
+
+    @dsl_user_op
+    def copy_tma(src_idx, dst_idx, *, loc=None, ip=None, **new_kwargs):
+        cute.copy(
+            atom,
+            src[None, src_idx],
+            dst[None, dst_idx],
+            **new_kwargs,
+            **kwargs,
+            loc=loc,
+            ip=ip,
+        )
+
+    @dsl_user_op
+    def copy_tma_single_stage(*, loc=None, ip=None, **new_kwargs):
+        cute.copy(atom, src, dst, **new_kwargs, **kwargs, loc=loc, ip=ip)
+
+    return (copy_tma if const_expr(not single_stage) else copy_tma_single_stage), s, g
+
+
+def tma_producer_copy_fn(copy: Callable, pipeline: cutlass.pipeline.PipelineAsync):
+    def copy_fn(src_idx, producer_state: cutlass.pipeline.PipelineState, **new_kwargs):
+        copy(
+            src_idx=src_idx,
+            dst_idx=producer_state.index,
+            tma_bar_ptr=pipeline.producer_get_barrier(producer_state),
+            **new_kwargs,
+        )
+
+    return copy_fn

--- a/flashinfer/experimental/sm12x/attention/_shared/cute/ops.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/cute/ops.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/_cute/ops.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+import math
+from typing import Callable, Optional
+
+import cutlass
+import cutlass.cute as cute
+
+from cutlass import Float32, const_expr
+from cutlass._mlir.dialects import llvm, nvvm
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+
+LOG2_E = math.log2(math.e)
+
+
+def compute_softmax_scale_log2(softmax_scale):
+    return softmax_scale * LOG2_E, None
+
+
+def make_tiled_copy_A(
+    copy_atom: cute.CopyAtom,
+    tiled_mma: cute.TiledMma,
+    swapAB: cutlass.Constexpr[bool] = False,
+) -> cute.TiledCopy:
+    return (
+        cute.make_tiled_copy_B(copy_atom, tiled_mma)
+        if const_expr(swapAB)
+        else cute.make_tiled_copy_A(copy_atom, tiled_mma)
+    )
+
+
+def make_tiled_copy_B(
+    copy_atom: cute.CopyAtom,
+    tiled_mma: cute.TiledMma,
+    swapAB: cutlass.Constexpr[bool] = False,
+) -> cute.TiledCopy:
+    return (
+        cute.make_tiled_copy_A(copy_atom, tiled_mma)
+        if const_expr(swapAB)
+        else cute.make_tiled_copy_B(copy_atom, tiled_mma)
+    )
+
+
+@cute.jit
+def warp_reduce(
+    val: cute.TensorSSA | cute.Numeric,
+    op: Callable,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.TensorSSA | cute.Numeric:
+    if const_expr(isinstance(val, cute.TensorSSA)):
+        res = cute.make_rmem_tensor(val.shape, val.dtype)
+        res.store(val)
+        for i in cutlass.range_constexpr(cute.size(val.shape)):
+            res[i] = warp_reduce(res[i], op, width)
+        return res.load()
+    for i in cutlass.range_constexpr(int(math.log2(width))):
+        val = op(val, cute.arch.shuffle_sync_bfly(val, offset=1 << i))
+    return val
+
+
+@dsl_user_op
+def fmax(
+    a: float | Float32,
+    b: float | Float32,
+    c: float | Float32 | None = None,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    from cutlass import CUDA_VERSION
+
+    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9:
+        return Float32(
+            nvvm.fmax(
+                T.f32(),
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+    return Float32(
+        nvvm.fmax(
+            Float32(a).ir_value(loc=loc, ip=ip),
+            Float32(b).ir_value(loc=loc, ip=ip),
+            c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def fmax_reduce(
+    x: cute.TensorSSA,
+    init_val: float | Float32 | None = None,
+    arch: cutlass.Constexpr[int] = 80,
+) -> Float32:
+    if const_expr(arch < 100 or cute.size(x.shape) % 8 != 0):
+        res = cute.make_rmem_tensor(x.shape, Float32)
+        res.store(x)
+        local_max = [res[0], res[1], res[2], res[3]]
+        for i in cutlass.range_constexpr(4, cute.size(x.shape), 4):
+            local_max[0] = fmax(local_max[0], res[i + 0])
+            local_max[1] = fmax(local_max[1], res[i + 1])
+            local_max[2] = fmax(local_max[2], res[i + 2])
+            local_max[3] = fmax(local_max[3], res[i + 3])
+        local_max[0] = fmax(local_max[0], local_max[1])
+        local_max[2] = fmax(local_max[2], local_max[3])
+        local_max[0] = fmax(local_max[0], local_max[2])
+        return (
+            local_max[0]
+            if const_expr(init_val is None)
+            else fmax(local_max[0], init_val)
+        )
+    res = cute.make_rmem_tensor(x.shape, Float32)
+    res.store(x)
+    local_max_0 = (
+        fmax(init_val, res[0], res[1])
+        if const_expr(init_val is not None)
+        else fmax(res[0], res[1])
+    )
+    local_max = [
+        local_max_0,
+        fmax(res[2], res[3]),
+        fmax(res[4], res[5]),
+        fmax(res[6], res[7]),
+    ]
+    for i in cutlass.range_constexpr(8, cute.size(x.shape), 8):
+        local_max[0] = fmax(local_max[0], res[i], res[i + 1])
+        local_max[1] = fmax(local_max[1], res[i + 2], res[i + 3])
+        local_max[2] = fmax(local_max[2], res[i + 4], res[i + 5])
+        local_max[3] = fmax(local_max[3], res[i + 6], res[i + 7])
+    local_max[0] = fmax(local_max[0], local_max[1])
+    return fmax(local_max[0], local_max[2], local_max[3])
+
+
+@cute.jit
+def fadd_reduce(
+    x: cute.TensorSSA,
+    init_val: float | Float32 | None = None,
+    arch: cutlass.Constexpr[int] = 80,
+) -> Float32:
+    if const_expr(arch < 100 or cute.size(x.shape) % 8 != 0):
+        if const_expr(init_val is None):
+            init_val = Float32.zero
+        return x.reduce(cute.ReductionOp.ADD, init_val, 0)
+    res = cute.make_rmem_tensor(x.shape, Float32)
+    res.store(x)
+    local_sum_0 = (
+        cute.arch.add_packed_f32x2((init_val, 0.0), (res[0], res[1]))
+        if const_expr(init_val is not None)
+        else (res[0], res[1])
+    )
+    local_sum = [local_sum_0, (res[2], res[3]), (res[4], res[5]), (res[6], res[7])]
+    for i in cutlass.range_constexpr(8, cute.size(x.shape), 8):
+        local_sum[0] = cute.arch.add_packed_f32x2(
+            local_sum[0], (res[i + 0], res[i + 1])
+        )
+        local_sum[1] = cute.arch.add_packed_f32x2(
+            local_sum[1], (res[i + 2], res[i + 3])
+        )
+        local_sum[2] = cute.arch.add_packed_f32x2(
+            local_sum[2], (res[i + 4], res[i + 5])
+        )
+        local_sum[3] = cute.arch.add_packed_f32x2(
+            local_sum[3], (res[i + 6], res[i + 7])
+        )
+    local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], local_sum[1])
+    local_sum[2] = cute.arch.add_packed_f32x2(local_sum[2], local_sum[3])
+    local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], local_sum[2])
+    return local_sum[0][0] + local_sum[0][1]
+
+
+@dsl_user_op
+def elem_pointer(
+    x: cute.Tensor, coord: cute.Coord, *, loc=None, ip=None
+) -> cute.Pointer:
+    return x.iterator + cute.crd2idx(coord, x.layout, loc=loc, ip=ip)
+
+
+@cute.jit
+def predicate_k(tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
+    tApA = cute.make_rmem_tensor(
+        cute.make_layout(
+            (
+                cute.size(tAcA, mode=[0, 1]),
+                cute.size(tAcA, mode=[1]),
+                cute.size(tAcA, mode=[2]),
+            ),
+            stride=(cute.size(tAcA, mode=[2]), 0, 1),
+        ),
+        cutlass.Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(tApA.shape[0]):
+        for rest_k in cutlass.range_constexpr(tApA.shape[2]):
+            tApA[rest_v, 0, rest_k] = cute.elem_less(
+                tAcA[(0, rest_v), 0, rest_k][1], limit
+            )
+    return tApA
+
+
+@cute.jit
+def shuffle_sync(
+    value: cute.Numeric,
+    offset: cute.typing.Int,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.Numeric:
+    assert value.width % 32 == 0
+    mask = cute.arch.WARP_SIZE - width
+    clamp = cute.arch.WARP_SIZE - 1
+    mask_and_clamp = mask << 8 | clamp
+    val = cute.make_rmem_tensor(cute.make_layout((1,), stride=(1,)), type(value))
+    val[0] = value
+    val_i32 = cute.recast_tensor(val, cutlass.Int32)
+    for i in cutlass.range_constexpr(cute.size(val_i32)):
+        val_i32[i] = cute.arch.shuffle_sync(
+            val_i32[i], offset, mask_and_clamp=mask_and_clamp
+        )
+    return val[0]
+
+
+@cute.jit
+def warp_prefix_sum(
+    val: cutlass.Int32, lane: Optional[cutlass.Int32] = None
+) -> cutlass.Int32:
+    if const_expr(lane is None):
+        lane = cute.arch.lane_idx()
+    for i in cutlass.range_constexpr(int(math.log2(cute.arch.WARP_SIZE))):
+        offset = 1 << i
+        partial_sum = cute.arch.shuffle_sync_up(val, offset=offset, mask_and_clamp=0)
+        if lane >= offset:
+            val += partial_sum
+    return val

--- a/flashinfer/experimental/sm12x/attention/_shared/cute/pipeline.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/cute/pipeline.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/_cute/pipeline.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from dataclasses import dataclass
+from typing import Optional
+
+import cutlass.cute as cute
+from cutlass import Boolean, Int32, const_expr
+from cutlass.cutlass_dsl import dsl_user_op, if_generate
+from cutlass.pipeline import NamedBarrier as NamedBarrierOg
+from cutlass.pipeline import PipelineAsync as PipelineAsyncOg
+from cutlass.pipeline import PipelineState
+from cutlass.pipeline import PipelineTmaAsync as PipelineTmaAsyncOg
+from cutlass.pipeline import PipelineUserType
+
+
+class PipelineStateSimple:
+    def __init__(self, stages: int, phase_index: Int32):
+        self._stages = stages
+        self._phase_index = phase_index
+
+    def clone(self, *, loc=None, ip=None) -> "PipelineStateSimple":
+        return PipelineStateSimple(self.stages, self._phase_index)
+
+    @property
+    def stages(self) -> int:
+        return self._stages
+
+    @property
+    def index(self) -> Int32:
+        return (
+            Int32(0)
+            if const_expr(self._stages == 1)
+            else self._phase_index % self._stages
+        )
+
+    @property
+    def phase(self) -> Int32:
+        return (
+            self._phase_index
+            if const_expr(self._stages == 1)
+            else self._phase_index // self._stages
+        )
+
+    def advance(self, *, loc=None, ip=None):
+        if const_expr(self._stages == 1):
+            self._phase_index ^= 1
+        else:
+            self._phase_index += 1
+
+    def __extract_mlir_values__(self):
+        return [self._phase_index.ir_value()]
+
+    def __new_from_mlir_values__(self, values):
+        return PipelineStateSimple(self.stages, Int32(values[0]))
+
+
+def make_pipeline_state(type: PipelineUserType, stages: int):
+    if type is PipelineUserType.Producer:
+        return PipelineStateSimple(stages, Int32(stages))
+    if type is PipelineUserType.Consumer:
+        return PipelineStateSimple(stages, Int32(0))
+    assert False, "invalid PipelineUserType"
+
+
+@dataclass(frozen=True)
+class PipelineTmaAsync(PipelineTmaAsyncOg):
+    @staticmethod
+    def create(*args, **kwargs):
+        obj = PipelineTmaAsyncOg.create(*args, **kwargs)
+        object.__setattr__(obj, "__class__", PipelineTmaAsync)
+        return obj
+
+    @dsl_user_op
+    def producer_acquire(
+        self,
+        state: PipelineState,
+        try_acquire_token: Optional[Boolean] = None,
+        extra_tx_count: int = 0,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        if_generate(
+            try_acquire_token is None or try_acquire_token == 0,
+            lambda: self.sync_object_empty.wait(
+                state.index, state.phase, loc=loc, ip=ip
+            ),
+            loc=loc,
+            ip=ip,
+        )
+        if const_expr(extra_tx_count == 0):
+            self.sync_object_full.arrive(
+                state.index, self.producer_mask, loc=loc, ip=ip
+            )
+        else:
+            tx_count = self.sync_object_full.tx_count + extra_tx_count
+            self.sync_object_full.arrive_and_expect_tx(
+                state.index, tx_count, loc=loc, ip=ip
+            )

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/__init__.py @ 16aba799 (2026-05-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from .api import (
+    MLASparseDecodeMetadata,
+    MLASparseExtendMetadata,
+    clear_mla_caches,
+    sparse_mla_decode_forward,
+    sparse_mla_extend_forward,
+)
+from .compressed_api import (
+    compressed_mla_decode_forward,
+    compressed_mla_split_chunks_for_contract,
+)
+
+__all__ = [
+    "MLASparseDecodeMetadata",
+    "MLASparseExtendMetadata",
+    "clear_mla_caches",
+    "compressed_mla_decode_forward",
+    "compressed_mla_split_chunks_for_contract",
+    "sparse_mla_decode_forward",
+    "sparse_mla_extend_forward",
+]

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/api.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/api.py
@@ -1,0 +1,888 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/api.py @ e130f195 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Sparse MLA API oriented around the NSA runtime contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import os
+from typing import Literal
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # Keep the pure-PyTorch fallback usable outside vLLM images.
+    triton = None
+    tl = None
+
+from .merge import clear_sparse_mla_merge_kernel_cache
+from .reference import sparse_mla_reference
+from .traits import kv_fp8_rope_enabled
+
+_MLA_STRATEGY_ENV = "FLASHINFER_EXP_SM12X_MLA_PREFILL_STRATEGY"
+_MLA_FORCE_SINGLE_PASS_ENV = "FLASHINFER_EXP_SM12X_MLA_FORCE_SINGLE_PASS"
+_MLA_FORCE_SPLIT_ENV = "FLASHINFER_EXP_SM12X_MLA_FORCE_SPLIT"
+_MLA_SM120_BACKEND = "sm120"
+# GLM_NSA uncompressed decode contract (q_head_dim = d_nope+d_rope = 512+64).
+_MLA_UNIFIED_GLM_Q_HEAD_DIM = 576
+_MLA_SINGLE_PASS_TARGET_Q_ROWS = 2048
+_MLA_SINGLE_PASS_TARGET_TOPK = 2048
+_LN2 = math.log(2.0)
+
+
+if triton is not None and tl is not None:
+
+    @triton.jit
+    def _split_decode_final_lse_kernel(
+        tmp_lse_ptr,
+        out_lse_ptr,
+        tmp_lse_stride_b: tl.constexpr,
+        tmp_lse_stride_h: tl.constexpr,
+        tmp_lse_stride_c: tl.constexpr,
+        out_lse_stride_b: tl.constexpr,
+        out_lse_stride_h: tl.constexpr,
+        chunk_count: tl.constexpr,
+        block_c: tl.constexpr,
+        natural_scale: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        head = tl.program_id(1)
+        offs = tl.arange(0, block_c)
+        valid = offs < chunk_count
+        vals = tl.load(
+            tmp_lse_ptr
+            + row * tmp_lse_stride_b
+            + head * tmp_lse_stride_h
+            + offs * tmp_lse_stride_c,
+            mask=valid,
+            other=-float("inf"),
+        )
+        vals = tl.where(vals != vals, -float("inf"), vals)
+        lse_max = tl.max(vals, axis=0)
+        safe_max = tl.where(lse_max == -float("inf"), 0.0, lse_max)
+        lse_sum = tl.sum(tl.exp2(vals - safe_max), axis=0)
+        lse_base2 = safe_max + tl.log2(lse_sum)
+        out = lse_base2
+        if natural_scale:
+            out = out * 0.69314718055994530942
+        out = tl.where(lse_max == -float("inf"), -float("inf"), out)
+        tl.store(out_lse_ptr + row * out_lse_stride_b + head * out_lse_stride_h, out)
+
+
+@dataclass(frozen=True)
+class MLASparseDecodeMetadata:
+    page_table_1: torch.Tensor
+    cache_seqlens_int32: torch.Tensor
+    nsa_cache_seqlens_int32: torch.Tensor
+    max_seq_len_k: int
+
+
+@dataclass(frozen=True)
+class MLASparseExtendMetadata:
+    selected_token_offsets: torch.Tensor
+    cache_seqlens_int32: torch.Tensor
+    nsa_cache_seqlens_int32: torch.Tensor
+    nsa_cu_seqlens_q: torch.Tensor
+    nsa_cu_seqlens_k: torch.Tensor
+    max_seq_len_q: int
+    max_seq_len_k: int
+    mode: Literal["extend", "verify", "target_verify", "draft_extend"] = "extend"
+
+
+def clear_mla_caches() -> None:
+    """Clear any cached MLA runtime state."""
+    clear_sparse_mla_merge_kernel_cache()
+
+
+def _is_cuda_graph_capture_active(device: torch.device) -> bool:
+    return device.type == "cuda" and torch.cuda.is_current_stream_capturing()
+
+
+def _validate_tensor_storage_bounds(tensor: torch.Tensor, *, name: str) -> None:
+    if tensor.numel() == 0:
+        return
+    min_offset = int(tensor.storage_offset())
+    max_offset = int(tensor.storage_offset())
+    for size, stride in zip(tensor.shape, tensor.stride(), strict=True):
+        extent = (int(size) - 1) * int(stride)
+        if extent >= 0:
+            max_offset += extent
+        else:
+            min_offset += extent
+    storage_elems = tensor.untyped_storage().nbytes() // tensor.element_size()
+    if min_offset < 0 or max_offset >= storage_elems:
+        raise ValueError(
+            f"{name} view is out of storage bounds: shape={tuple(tensor.shape)} "
+            f"stride={tuple(tensor.stride())} storage_offset={int(tensor.storage_offset())} "
+            f"storage_elems={storage_elems}"
+        )
+
+
+def _is_supported_packed_kv_cache_view(
+    tensor: torch.Tensor,
+    *,
+    page_size: int,
+) -> bool:
+    if tensor.ndim != 3 or int(tensor.shape[1]) != int(page_size):
+        return False
+    if int(tensor.stride(2)) != 1:
+        return False
+    if int(tensor.stride(1)) != int(tensor.shape[2]):
+        return False
+    page_elems = int(tensor.shape[1]) * int(tensor.shape[2])
+    return int(tensor.stride(0)) >= page_elems
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "0").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _resolve_kv_fp8_rope(value: bool | None) -> bool:
+    # Cache layout is a process-lifetime ABI: only the literal operator gate
+    # value "1" enables it; unset and every other value retain the 432-byte ABI.
+    if value is not None:
+        return bool(value)
+    return kv_fp8_rope_enabled()
+
+
+def _use_sm120_sparse_mla(*, backend: str | None, device: torch.device) -> bool:
+    """Return whether the active SM120 sparse MLA kernel path is available."""
+    if backend is not None and backend != _MLA_SM120_BACKEND:
+        raise ValueError(
+            f"backend must be None or {_MLA_SM120_BACKEND!r}; legacy sparse MLA "
+            f"kernels have been retired, got {backend!r}"
+        )
+    if device.type != "cuda":
+        return False
+    from flashinfer.experimental.sm12x._lib.intrinsics import get_sm_version
+
+    return get_sm_version(device) >= 120
+
+
+def _resolve_mla_prefill_strategy() -> Literal["auto", "single", "split"]:
+    if _env_flag(_MLA_FORCE_SINGLE_PASS_ENV):
+        return "single"
+    if _env_flag(_MLA_FORCE_SPLIT_ENV):
+        return "split"
+
+    value = os.environ.get(_MLA_STRATEGY_ENV, "auto").strip().lower()
+    if value in ("auto", ""):
+        return "auto"
+    if value in ("single", "single-pass", "nonsplit", "onepass"):
+        return "single"
+    if value == "split":
+        return "split"
+    raise ValueError(
+        f"{_MLA_STRATEGY_ENV} must be auto, split, or single-pass/nonsplit; got {value!r}"
+    )
+
+
+def _apply_mla_prefill_strategy(
+    *,
+    split_cfg,
+    workspace: object,
+    active_token_counts: torch.Tensor,
+    device: torch.device,
+    q_rows: int,
+    topk_width: int,
+):
+    if split_cfg is None:
+        return None
+
+    strategy = _resolve_mla_prefill_strategy()
+    if strategy == "single":
+        return None
+    if strategy == "split":
+        return split_cfg
+    if (
+        workspace.mode in ("extend", "verify", "draft_extend")
+        and int(workspace.max_batch) == 1
+        and int(q_rows) >= _MLA_SINGLE_PASS_TARGET_Q_ROWS
+        and int(topk_width) >= _MLA_SINGLE_PASS_TARGET_TOPK
+    ):
+        return None
+
+    return split_cfg
+
+
+def _get_mla_output_view(
+    *,
+    workspace: object,
+    q_all: torch.Tensor,
+    v_head_dim: int,
+) -> torch.Tensor:
+    rows = int(q_all.shape[0])
+    heads = int(q_all.shape[1])
+    v_head_dim = int(v_head_dim)
+    output_buffer = workspace.output_buffer
+    if output_buffer is None:
+        raise RuntimeError("workspace is missing MLA output buffer")
+    if output_buffer.device != q_all.device:
+        raise ValueError(
+            f"workspace MLA output buffer is on {output_buffer.device}, expected {q_all.device}"
+        )
+    if output_buffer.dtype != q_all.dtype:
+        raise TypeError(
+            f"workspace MLA output buffer has dtype {output_buffer.dtype}, expected {q_all.dtype}"
+        )
+    if output_buffer.ndim != 3:
+        raise ValueError(
+            f"workspace MLA output buffer must be rank 3, got {output_buffer.ndim}"
+        )
+    if (
+        int(output_buffer.shape[0]) < rows
+        or int(output_buffer.shape[1]) < heads
+        or int(output_buffer.shape[2]) < v_head_dim
+    ):
+        raise ValueError(
+            "workspace MLA output buffer is too small: "
+            f"buffer={tuple(output_buffer.shape)} required=({rows}, {heads}, {v_head_dim})"
+        )
+    _validate_tensor_storage_bounds(output_buffer, name="workspace MLA output buffer")
+    return output_buffer[:rows, :heads, :v_head_dim]
+
+
+def _validate_split_control_tensors(
+    *,
+    workspace: object,
+) -> None:
+    for name, tensor in (
+        ("kv_chunk_size_ptr", workspace.kv_chunk_size_ptr),
+        ("num_chunks_ptr", workspace.num_chunks_ptr),
+    ):
+        if tensor is None:
+            raise RuntimeError(f"workspace is missing {name}")
+        if tensor.shape != (1,):
+            raise ValueError(f"{name} must have shape (1,), got {tuple(tensor.shape)}")
+        if tensor.dtype != torch.int32:
+            raise TypeError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+        if tensor.device != workspace.device:
+            raise ValueError(
+                f"{name} device {tensor.device} does not match workspace device {workspace.device}"
+            )
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_split_workspace_views(
+    *,
+    workspace: object,
+    q_rows: int,
+    num_heads: int,
+    v_head_dim: int,
+    launch_num_chunks: int,
+) -> None:
+    _validate_split_control_tensors(workspace=workspace)
+    if workspace.tmp_output is None or workspace.tmp_lse is None:
+        raise RuntimeError("workspace is missing split MLA buffers")
+
+    q_rows = int(q_rows)
+    num_heads = int(num_heads)
+    v_head_dim = int(v_head_dim)
+    launch_num_chunks = int(launch_num_chunks)
+    tmp_output = workspace.tmp_output
+    tmp_lse = workspace.tmp_lse
+
+    if tmp_output.device != workspace.device or tmp_lse.device != workspace.device:
+        raise ValueError("split MLA scratch buffers must be on the workspace device")
+    if tmp_output.dtype != workspace.dtype:
+        raise TypeError(
+            f"split MLA tmp_output dtype {tmp_output.dtype} does not match workspace dtype {workspace.dtype}"
+        )
+    if tmp_lse.dtype != torch.float32:
+        raise TypeError(
+            f"split MLA tmp_lse must have dtype torch.float32, got {tmp_lse.dtype}"
+        )
+    if tmp_output.ndim != 4:
+        raise ValueError(
+            f"split MLA tmp_output must be rank-4, got {tuple(tmp_output.shape)}"
+        )
+    if tmp_lse.ndim != 3:
+        raise ValueError(
+            f"split MLA tmp_lse must be rank-3, got {tuple(tmp_lse.shape)}"
+        )
+    _validate_tensor_storage_bounds(tmp_output, name="split MLA tmp_output")
+    _validate_tensor_storage_bounds(tmp_lse, name="split MLA tmp_lse")
+    required_output = (q_rows, num_heads, launch_num_chunks, v_head_dim)
+    if (
+        int(tmp_output.shape[0]) < q_rows
+        or int(tmp_output.shape[1]) < num_heads
+        or int(tmp_output.shape[2]) < launch_num_chunks
+        or int(tmp_output.shape[3]) < v_head_dim
+    ):
+        raise ValueError(
+            "split MLA tmp_output is too small: "
+            f"buffer={tuple(tmp_output.shape)} required>={required_output}"
+        )
+    required_lse = (q_rows, num_heads, launch_num_chunks)
+    if (
+        int(tmp_lse.shape[0]) < q_rows
+        or int(tmp_lse.shape[1]) < num_heads
+        or int(tmp_lse.shape[2]) < launch_num_chunks
+    ):
+        raise ValueError(
+            "split MLA tmp_lse is too small: "
+            f"buffer={tuple(tmp_lse.shape)} required>={required_lse}"
+        )
+
+
+def _resolve_sparse_mla_binding(
+    *,
+    binding,
+    q_all: torch.Tensor | None,
+    selected_indices: torch.Tensor | None,
+    cache_seqlens_int32: torch.Tensor | None,
+    nsa_cache_seqlens_int32: torch.Tensor | None,
+    selected_name: str,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    object,
+]:
+    if binding is None:
+        raise TypeError("sparse MLA forward requires binding")
+
+    extras = [
+        name
+        for name, value in (
+            ("q_all", q_all),
+            (selected_name, selected_indices),
+            ("cache_seqlens_int32", cache_seqlens_int32),
+            ("nsa_cache_seqlens_int32", nsa_cache_seqlens_int32),
+        )
+        if value is not None
+    ]
+    if extras:
+        raise ValueError(
+            "sparse MLA binding owns runtime tensors and scratch; "
+            f"do not also pass {', '.join(extras)}"
+        )
+    return (
+        binding.q,
+        binding.selected_indices,
+        binding.cache_seqlens_int32,
+        binding.nsa_cache_seqlens_int32,
+        binding.scratch,
+    )
+
+
+def sparse_mla_decode_forward(
+    *,
+    q_all: torch.Tensor | None = None,
+    kv_cache: torch.Tensor,
+    page_table_1: torch.Tensor | None = None,
+    cache_seqlens_int32: torch.Tensor | None = None,
+    nsa_cache_seqlens_int32: torch.Tensor | None = None,
+    binding=None,
+    sm_scale: float,
+    latent_scale: float = 1.0,
+    v_head_dim: int | None = None,
+    return_lse: bool = False,
+    lse_scale: Literal["base2", "natural"] = "base2",
+    attn_sink: torch.Tensor | None = None,
+    identity_page_table: bool = False,
+    backend: str | None = None,
+    forced_num_splits: int | None = None,
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    q_all, page_table_1, cache_seqlens_int32, nsa_cache_seqlens_int32, workspace = (
+        _resolve_sparse_mla_binding(
+            binding=binding,
+            q_all=q_all,
+            selected_indices=page_table_1,
+            cache_seqlens_int32=cache_seqlens_int32,
+            nsa_cache_seqlens_int32=nsa_cache_seqlens_int32,
+            selected_name="page_table_1",
+        )
+    )
+    if v_head_dim is None:
+        v_head_dim = workspace.v_head_dim
+    return _run_sparse_mla(
+        q_all=q_all,
+        kv_cache=kv_cache,
+        selected_indices=page_table_1,
+        cache_seqlens_int32=cache_seqlens_int32,
+        active_token_counts=nsa_cache_seqlens_int32,
+        workspace=workspace,
+        sm_scale=sm_scale,
+        latent_scale=latent_scale,
+        v_head_dim=v_head_dim,
+        return_lse=return_lse,
+        lse_scale=lse_scale,
+        attn_sink=attn_sink,
+        identity_page_table=identity_page_table,
+        backend=backend,
+        forced_num_splits=forced_num_splits,
+        scale_format=scale_format,
+        fp8_rope=fp8_rope,
+    )
+
+
+def sparse_mla_extend_forward(
+    *,
+    q_all: torch.Tensor | None = None,
+    kv_cache: torch.Tensor,
+    selected_token_offsets: torch.Tensor | None = None,
+    cache_seqlens_int32: torch.Tensor | None = None,
+    nsa_cache_seqlens_int32: torch.Tensor | None = None,
+    binding=None,
+    sm_scale: float,
+    latent_scale: float = 1.0,
+    v_head_dim: int | None = None,
+    return_lse: bool = False,
+    lse_scale: Literal["base2", "natural"] = "base2",
+    identity_page_table: bool = False,
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    (
+        q_all,
+        selected_token_offsets,
+        cache_seqlens_int32,
+        nsa_cache_seqlens_int32,
+        workspace,
+    ) = _resolve_sparse_mla_binding(
+        binding=binding,
+        q_all=q_all,
+        selected_indices=selected_token_offsets,
+        cache_seqlens_int32=cache_seqlens_int32,
+        nsa_cache_seqlens_int32=nsa_cache_seqlens_int32,
+        selected_name="selected_token_offsets",
+    )
+    if v_head_dim is None:
+        v_head_dim = workspace.v_head_dim
+    return _run_sparse_mla(
+        q_all=q_all,
+        kv_cache=kv_cache,
+        selected_indices=selected_token_offsets,
+        cache_seqlens_int32=cache_seqlens_int32,
+        active_token_counts=nsa_cache_seqlens_int32,
+        workspace=workspace,
+        sm_scale=sm_scale,
+        latent_scale=latent_scale,
+        v_head_dim=v_head_dim,
+        return_lse=return_lse,
+        lse_scale=lse_scale,
+        identity_page_table=identity_page_table,
+        scale_format=scale_format,
+        fp8_rope=fp8_rope,
+    )
+
+
+def _run_sparse_mla(
+    *,
+    q_all: torch.Tensor,
+    kv_cache: torch.Tensor,
+    selected_indices: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    active_token_counts: torch.Tensor,
+    workspace: object,
+    sm_scale: float,
+    latent_scale: float = 1.0,
+    v_head_dim: int,
+    return_lse: bool = False,
+    lse_scale: Literal["base2", "natural"] = "base2",
+    attn_sink: torch.Tensor | None = None,
+    identity_page_table: bool = False,
+    backend: str | None = None,
+    forced_num_splits: int | None = None,
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    if q_all.ndim != 3:
+        raise ValueError(f"q_all must be rank-3, got {tuple(q_all.shape)}")
+    if kv_cache.ndim != 3:
+        raise ValueError(f"kv_cache must be rank-3, got {tuple(kv_cache.shape)}")
+    if selected_indices.ndim != 2:
+        raise ValueError(
+            f"selected indices must be rank-2, got {tuple(selected_indices.shape)}"
+        )
+    if cache_seqlens_int32.ndim != 1:
+        raise ValueError(
+            "cache_seqlens_int32 must be rank-1, "
+            f"got {tuple(cache_seqlens_int32.shape)}"
+        )
+    if active_token_counts.ndim != 1:
+        raise ValueError(
+            "nsa_cache_seqlens_int32 must be rank-1, "
+            f"got {tuple(active_token_counts.shape)}"
+        )
+    if not q_all.is_contiguous():
+        raise ValueError("q_all must be contiguous for sparse MLA")
+    if not kv_cache.is_contiguous():
+        if not _is_supported_packed_kv_cache_view(
+            kv_cache,
+            page_size=int(workspace.page_size),
+        ):
+            raise ValueError(
+                "kv_cache must be contiguous or a packed page-strided view for sparse MLA; "
+                f"got shape={tuple(kv_cache.shape)} stride={tuple(kv_cache.stride())}"
+            )
+        _validate_tensor_storage_bounds(kv_cache, name="sparse MLA kv_cache")
+    if not selected_indices.is_contiguous():
+        raise ValueError("selected indices must be contiguous for sparse MLA")
+    if not cache_seqlens_int32.is_contiguous():
+        raise ValueError("cache_seqlens_int32 must be contiguous for sparse MLA")
+    if not active_token_counts.is_contiguous():
+        raise ValueError("nsa_cache_seqlens_int32 must be contiguous for sparse MLA")
+    if q_all.device != workspace.device:
+        raise ValueError(
+            f"q_all device {q_all.device} does not match workspace device {workspace.device}"
+        )
+    if kv_cache.device != workspace.device:
+        raise ValueError(
+            f"kv_cache device {kv_cache.device} does not match workspace device {workspace.device}"
+        )
+    if selected_indices.device != workspace.device:
+        raise ValueError(
+            "selected indices device "
+            f"{selected_indices.device} does not match workspace device {workspace.device}"
+        )
+    if cache_seqlens_int32.device != workspace.device:
+        raise ValueError(
+            "cache_seqlens_int32 device "
+            f"{cache_seqlens_int32.device} does not match workspace device {workspace.device}"
+        )
+    if active_token_counts.device != workspace.device:
+        raise ValueError(
+            "nsa_cache_seqlens_int32 device "
+            f"{active_token_counts.device} does not match workspace device {workspace.device}"
+        )
+    if q_all.dtype != workspace.dtype:
+        raise ValueError(
+            f"q_all dtype {q_all.dtype} does not match workspace dtype {workspace.dtype}"
+        )
+    if kv_cache.dtype != workspace.kv_dtype:
+        raise ValueError(
+            f"kv_cache dtype {kv_cache.dtype} does not match workspace kv_dtype {workspace.kv_dtype}"
+        )
+    if selected_indices.dtype != torch.int32:
+        raise ValueError(
+            f"selected indices must have dtype torch.int32, got {selected_indices.dtype}"
+        )
+    if cache_seqlens_int32.dtype != torch.int32:
+        raise ValueError(
+            "cache_seqlens_int32 must have dtype torch.int32, "
+            f"got {cache_seqlens_int32.dtype}"
+        )
+    if active_token_counts.dtype != torch.int32:
+        raise ValueError(
+            "nsa_cache_seqlens_int32 must have dtype torch.int32, "
+            f"got {active_token_counts.dtype}"
+        )
+    if int(v_head_dim) != workspace.v_head_dim:
+        raise ValueError(
+            f"v_head_dim {v_head_dim} does not match workspace v_head_dim {workspace.v_head_dim}"
+        )
+    _sm120_route = _use_sm120_sparse_mla(backend=backend, device=q_all.device)
+    # NVFP4 (scale_format=2) selection: explicit kwarg wins; otherwise the
+    # scratch/workspace planned kv_cache_dtype supplies it. None -> inferred
+    # from q_head_dim inside the kernel launchers (fp8 GLM default).
+    scale_format_for_call = (
+        scale_format
+        if scale_format is not None
+        else getattr(workspace, "scale_format", None)
+    )
+    if int(scale_format_for_call or -1) == 2 and fp8_rope is None:
+        # Normal vLLM calls arrive through sm12x.integration.mla, whose stable
+        # public signature does not carry this new option. The allocated record
+        # is therefore the authoritative process-lifetime ABI at this boundary;
+        # derive the specialization from it instead of rereading a mutable env.
+        record_bytes = int(kv_cache.shape[-1])
+        if record_bytes not in (368, 432):
+            raise ValueError(
+                "NVFP4 sparse MLA cache record must be 368 or 432 bytes, got "
+                f"{record_bytes}"
+            )
+        fp8_rope_for_call = record_bytes == 368
+    else:
+        fp8_rope_for_call = _resolve_kv_fp8_rope(fp8_rope)
+    if int(scale_format_for_call or -1) == 2:
+        expected_record_bytes = 368 if fp8_rope_for_call else 432
+        if int(kv_cache.shape[-1]) != expected_record_bytes:
+            raise ValueError(
+                "NVFP4 sparse MLA cache record disagrees with KV_FP8_ROPE: "
+                f"got {int(kv_cache.shape[-1])} bytes, expected "
+                f"{expected_record_bytes}"
+            )
+        if not _sm120_route:
+            raise NotImplementedError(
+                "NVFP4 sparse MLA requires the active SM120 kernel path"
+            )
+    if attn_sink is not None:
+        attn_sink = attn_sink.detach()
+        if not _sm120_route:
+            raise ValueError(
+                "sparse MLA attn_sink requires the active SM120 kernel path"
+            )
+        if attn_sink.ndim != 1 or int(attn_sink.shape[0]) != int(q_all.shape[1]):
+            raise ValueError(
+                f"attn_sink must have shape ({int(q_all.shape[1])},), got {tuple(attn_sink.shape)}"
+            )
+        if attn_sink.device != workspace.device:
+            raise ValueError(
+                f"attn_sink device {attn_sink.device} does not match workspace device {workspace.device}"
+            )
+        if attn_sink.dtype != torch.float32:
+            raise ValueError(
+                f"attn_sink must have dtype torch.float32, got {attn_sink.dtype}"
+            )
+        if not attn_sink.is_contiguous():
+            raise ValueError("attn_sink must be contiguous for fused sparse MLA")
+    if q_all.shape[0] > workspace.max_total_q:
+        raise ValueError(
+            f"q_all rows {q_all.shape[0]} exceed workspace capacity {workspace.max_total_q}"
+        )
+    if q_all.shape[0] != selected_indices.shape[0]:
+        raise ValueError(
+            f"selected-index rows {selected_indices.shape[0]} do not match q_all rows {q_all.shape[0]}"
+        )
+    if selected_indices.shape[0] != active_token_counts.shape[0]:
+        raise ValueError(
+            "selected-index rows "
+            f"{selected_indices.shape[0]} do not match nsa_cache_seqlens_int32 rows "
+            f"{active_token_counts.shape[0]}"
+        )
+    if cache_seqlens_int32.shape[0] > workspace.max_batch:
+        raise ValueError(
+            "cache_seqlens_int32 batch "
+            f"{cache_seqlens_int32.shape[0]} exceeds workspace capacity {workspace.max_batch}"
+        )
+    if selected_indices.shape[1] > workspace.topk:
+        raise ValueError(
+            f"selected-index width {selected_indices.shape[1]} exceeds workspace topk {workspace.topk}"
+        )
+    if q_all.shape[1] != workspace.num_q_heads:
+        raise ValueError(
+            f"q_all num_heads {q_all.shape[1]} does not match workspace num_q_heads {workspace.num_q_heads}"
+        )
+    if q_all.shape[-1] != workspace.head_dim:
+        raise ValueError(
+            f"q_all head_dim {q_all.shape[-1]} does not match workspace head_dim {workspace.head_dim}"
+        )
+    if _sm120_route:
+        q_head_dim = int(q_all.shape[-1])
+        if q_head_dim != _MLA_UNIFIED_GLM_Q_HEAD_DIM:
+            raise ValueError(
+                f"SM120 sparse MLA decode requires the GLM_NSA contract "
+                f"(q_head_dim={_MLA_UNIFIED_GLM_Q_HEAD_DIM}); got q_head_dim={q_head_dim}"
+            )
+        if workspace.mode in ("extend", "verify", "draft_extend"):
+            return _run_sm120_prefill(
+                q_all=q_all,
+                kv_cache=kv_cache,
+                selected_indices=selected_indices,
+                active_token_counts=active_token_counts,
+                workspace=workspace,
+                sm_scale=float(sm_scale),
+                latent_scale=float(latent_scale),
+                v_head_dim=int(v_head_dim),
+                attn_sink=attn_sink,
+                return_lse=return_lse,
+                lse_scale=lse_scale,
+                scale_format=scale_format_for_call,
+                fp8_rope=fp8_rope_for_call,
+            )
+        from .kernel import run_unified_decode
+
+        return run_unified_decode(
+            q_all=q_all,
+            swa_k_cache=kv_cache,
+            swa_indices=selected_indices,
+            swa_topk_lengths=active_token_counts,
+            workspace=workspace,
+            sm_scale=float(sm_scale),
+            latent_scale=float(latent_scale),
+            swa_page_size=int(workspace.page_size),
+            attn_sink=attn_sink,
+            return_lse=return_lse,
+            lse_scale=lse_scale,
+            forced_num_splits=forced_num_splits,
+            scale_format_override=scale_format_for_call,
+            fp8_rope_override=fp8_rope_for_call,
+        )
+    if _is_cuda_graph_capture_active(q_all.device):
+        raise RuntimeError(
+            "sm12x MLA would use the PyTorch reference during CUDA graph capture; "
+            "the active SM120 sparse MLA kernel path is unavailable for this device"
+        )
+    if identity_page_table:
+        raise RuntimeError(
+            "identity page-table sparse MLA requires the active SM120 kernel path"
+        )
+    reference_kwargs = dict(
+        q_all=q_all,
+        kv_cache=kv_cache,
+        page_table_1=selected_indices,
+        active_token_counts=active_token_counts,
+        sm_scale=sm_scale,
+        v_head_dim=v_head_dim,
+    )
+    if return_lse:
+        reference_kwargs["return_lse"] = True
+    output = sparse_mla_reference(**reference_kwargs)
+    if return_lse:
+        output, lse = output
+        if lse_scale == "natural":
+            lse = lse * _LN2
+    if return_lse:
+        return output, lse
+    return output
+
+
+def _run_sm120_prefill(
+    *,
+    q_all: torch.Tensor,
+    kv_cache: torch.Tensor,
+    selected_indices: torch.Tensor,
+    active_token_counts: torch.Tensor,
+    workspace: object,
+    sm_scale: float,
+    latent_scale: float,
+    v_head_dim: int,
+    attn_sink: torch.Tensor | None,
+    return_lse: bool,
+    lse_scale: Literal["base2", "natural"],
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Route a prefill-like call to the active SM120 single-pass prefill."""
+    from .kernel import run_unified_prefill
+
+    output = _get_mla_output_view(
+        workspace=workspace,
+        q_all=q_all,
+        v_head_dim=v_head_dim,
+    )
+    _, lse_base2 = run_unified_prefill(
+        q=q_all,
+        kv_cache=kv_cache,
+        topk_indices=selected_indices,
+        sm_scale=float(sm_scale),
+        latent_scale=float(latent_scale),
+        page_block_size=int(workspace.page_size),
+        topk_length=active_token_counts,
+        attn_sink=attn_sink,
+        output=output,
+        scale_format=scale_format,
+        fp8_rope=fp8_rope,
+    )
+    if not return_lse:
+        return output
+    lse = lse_base2 if lse_scale == "base2" else (lse_base2 * _LN2)
+    return output, lse
+
+
+def _final_lse_from_split_workspace(
+    *,
+    workspace: object,
+    q_rows: int,
+    num_heads: int,
+    launch_num_chunks: int,
+    scale: Literal["base2", "natural"] = "base2",
+) -> torch.Tensor:
+    if workspace.tmp_lse is None:
+        raise RuntimeError("workspace is missing split MLA LSE buffer")
+    if workspace.final_lse is None:
+        raise RuntimeError("workspace is missing final MLA LSE buffer")
+    q_rows = int(q_rows)
+    num_heads = int(num_heads)
+    chunk_count = int(launch_num_chunks)
+    if chunk_count <= 0:
+        raise ValueError(f"launch_num_chunks must be positive, got {chunk_count}")
+    if workspace.tmp_lse.ndim != 3:
+        raise ValueError(
+            f"workspace split MLA LSE buffer must be rank-3, got {tuple(workspace.tmp_lse.shape)}"
+        )
+    _validate_tensor_storage_bounds(
+        workspace.tmp_lse, name="workspace split MLA LSE buffer"
+    )
+    if (
+        int(workspace.tmp_lse.shape[0]) < q_rows
+        or int(workspace.tmp_lse.shape[1]) < num_heads
+        or int(workspace.tmp_lse.shape[2]) < chunk_count
+    ):
+        raise ValueError(
+            "workspace split MLA LSE buffer is too small: "
+            f"buffer={tuple(workspace.tmp_lse.shape)} required>=({q_rows}, {num_heads}, {chunk_count})"
+        )
+    if workspace.final_lse.ndim != 2:
+        raise ValueError(
+            f"workspace final MLA LSE buffer must be rank-2, got {tuple(workspace.final_lse.shape)}"
+        )
+    _validate_tensor_storage_bounds(
+        workspace.final_lse, name="workspace final MLA LSE buffer"
+    )
+    if (
+        int(workspace.final_lse.shape[0]) < q_rows
+        or int(workspace.final_lse.shape[1]) < num_heads
+    ):
+        raise ValueError(
+            "workspace final MLA LSE buffer is too small: "
+            f"buffer={tuple(workspace.final_lse.shape)} required>=({q_rows}, {num_heads})"
+        )
+    final_lse = workspace.final_lse[:q_rows, :num_heads]
+    if final_lse.dtype != torch.float32:
+        raise TypeError(
+            f"workspace final MLA LSE buffer must be FP32, got {final_lse.dtype}"
+        )
+    chunk_lse = workspace.tmp_lse[:q_rows, :num_heads, :chunk_count]
+    if chunk_lse.dtype != torch.float32:
+        raise TypeError(
+            f"workspace split MLA LSE buffer must be FP32, got {chunk_lse.dtype}"
+        )
+    if (
+        triton is not None
+        and chunk_lse.device.type == "cuda"
+        and final_lse.device == chunk_lse.device
+    ):
+        block_c = triton.next_power_of_2(chunk_count)
+        _split_decode_final_lse_kernel[(q_rows, num_heads)](
+            chunk_lse,
+            final_lse,
+            chunk_lse.stride(0),
+            chunk_lse.stride(1),
+            chunk_lse.stride(2),
+            final_lse.stride(0),
+            final_lse.stride(1),
+            chunk_count,
+            block_c,
+            scale == "natural",
+        )
+        return final_lse
+    chunk_lse.mul_(_LN2)
+    torch.logsumexp(chunk_lse, dim=-1, out=final_lse)
+    if scale == "natural":
+        return final_lse
+    final_lse.div_(_LN2)
+    return final_lse
+
+
+def _get_sm_scale_tensor(
+    *,
+    workspace: object,
+    device: torch.device,
+    sm_scale: float,
+) -> torch.Tensor:
+    sm_scale_tensor = workspace.sm_scale_tensor
+    if (
+        sm_scale_tensor is None
+        or sm_scale_tensor.device != device
+        or sm_scale_tensor.dtype != torch.float32
+    ):
+        sm_scale_tensor = torch.empty((1,), dtype=torch.float32, device=device)
+        workspace.sm_scale_tensor = sm_scale_tensor
+        workspace.sm_scale_value = None
+    sm_scale_value = float(sm_scale)
+    if workspace.sm_scale_value != sm_scale_value:
+        sm_scale_tensor.fill_(sm_scale_value)
+        workspace.sm_scale_value = sm_scale_value
+    return sm_scale_tensor

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/compressed_api.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/compressed_api.py
@@ -1,0 +1,705 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/compressed_api.py @ c368a837 (2026-07-14) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Compressed sparse MLA integration through the shared sparse-MLA core."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+import torch
+
+from .api import (
+    _get_mla_output_view,
+    _use_sm120_sparse_mla,
+    _validate_tensor_storage_bounds,
+)
+from .compressed_config import (
+    compressed_mla_split_chunks_for_contract,
+)
+from .compressed_reference import (
+    COMPRESSED_MLA_DSV4_PAGE_SIZE,
+    COMPRESSED_MLA_HEAD_DIM,
+    compressed_mla_page_nbytes,
+)
+
+
+_LN2 = math.log(2.0)
+
+
+def _should_use_sm121_single_pass_decode(
+    *,
+    rows: int,
+    heads: int,
+    swa_width: int,
+    indexed_width: int,
+    swa_page_size: int,
+    indexed_page_size: int | None,
+    compute_capability: tuple[int, int] | None = None,
+) -> bool:
+    """Select the 32-head final-output kernel for Spark's one-wave decode."""
+
+    if compute_capability is None:
+        if not torch.cuda.is_available():
+            return False
+        compute_capability = tuple(torch.cuda.get_device_capability())
+    if compute_capability != (12, 1):
+        return False
+    if rows < 16 or heads != 32 or int(swa_page_size) != 64:
+        return False
+    if indexed_width and int(indexed_page_size or 0) != 64:
+        return False
+    chunks = (int(swa_width) + 63) // 64 + (int(indexed_width) + 63) // 64
+    return chunks <= 10
+
+
+def compressed_mla_decode_forward(
+    *,
+    q_all: torch.Tensor | None = None,
+    swa_k_cache: torch.Tensor,
+    swa_indices: torch.Tensor | None = None,
+    swa_topk_lengths: torch.Tensor | None = None,
+    binding=None,
+    sm_scale: float,
+    swa_page_size: int = COMPRESSED_MLA_DSV4_PAGE_SIZE,
+    indexed_k_cache: torch.Tensor | None = None,
+    indexed_indices: torch.Tensor | None = None,
+    indexed_topk_lengths: torch.Tensor | None = None,
+    indexed_page_size: int | None = None,
+    indexed_page_table: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    expected_num_q_heads: int | None = None,
+    return_lse: bool = False,
+    lse_scale: Literal["base2", "natural"] = "base2",
+    backend: str | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Run compressed sparse MLA decode directly from compressed KV pages.
+
+    ``out``, when given, is the final O destination: the kernel/merge writes it
+    directly (no workspace-to-caller copy). Must be a contiguous BF16
+    [rows, heads, 512] tensor on q's device; anything else raises.
+    """
+
+    if lse_scale not in ("base2", "natural"):
+        raise ValueError(f"lse_scale must be 'base2' or 'natural', got {lse_scale!r}")
+
+    if binding is None:
+        raise TypeError("compressed_mla_decode_forward requires binding")
+    extras = [
+        name
+        for name, value in (
+            ("q_all", q_all),
+            ("swa_indices", swa_indices),
+            ("swa_topk_lengths", swa_topk_lengths),
+            ("indexed_indices", indexed_indices),
+            ("indexed_topk_lengths", indexed_topk_lengths),
+            ("indexed_page_table", indexed_page_table),
+        )
+        if value is not None
+    ]
+    if extras:
+        raise ValueError(
+            "compressed MLA binding owns q and index tensors; "
+            f"do not also pass {', '.join(extras)}"
+        )
+    scratch = getattr(binding, "scratch", None)
+    if scratch is None:
+        raise TypeError("compressed MLA binding is missing scratch")
+    q_all = getattr(binding, "q")
+    swa_indices = getattr(binding, "swa_indices")
+    swa_topk_lengths = getattr(binding, "swa_lengths")
+    indexed_indices = getattr(binding, "indexed_indices", None)
+    indexed_topk_lengths = getattr(binding, "indexed_lengths", None)
+    indexed_page_table = getattr(binding, "indexed_page_table", None)
+
+    q3 = _normalize_compressed_q(q_all)
+    rows, heads, _ = q3.shape
+    if expected_num_q_heads is not None and heads != int(expected_num_q_heads):
+        raise ValueError(
+            f"q_all local heads must match expected_num_q_heads={int(expected_num_q_heads)}, got {heads}"
+        )
+    if int(q3.shape[-1]) != COMPRESSED_MLA_HEAD_DIM:
+        raise ValueError(
+            f"compressed_mla_decode_forward is DSV4 (q_head_dim="
+            f"{COMPRESSED_MLA_HEAD_DIM}) by construction; got q_head_dim="
+            f"{int(q3.shape[-1])}"
+        )
+    if not _use_sm120_sparse_mla(backend=backend, device=q3.device):
+        raise RuntimeError(
+            "compressed sparse MLA requires the active SM120 sparse MLA kernel path; "
+            "legacy compressed sparse MLA kernels have been retired"
+        )
+    swa_k_cache = _compressed_mla_cache_byte_view(swa_k_cache, name="swa_k_cache")
+    _validate_compressed_cache_layout(
+        swa_k_cache,
+        page_size=swa_page_size,
+        name="swa_k_cache",
+    )
+
+    swa_indices_2d = _normalize_index_matrix(swa_indices, name="swa_indices")
+    if swa_indices_2d.device != q3.device:
+        raise ValueError("swa_indices must be on the same device as q_all")
+    if swa_indices_2d.shape[0] != rows:
+        raise ValueError("swa_indices row count must match q_all")
+    _validate_lengths(
+        swa_topk_lengths,
+        rows=rows,
+        name="swa_topk_lengths",
+    )
+    if swa_topk_lengths.device != q3.device:
+        raise ValueError("swa_topk_lengths must be on the same device as q_all")
+
+    has_indexed = (
+        indexed_k_cache is not None
+        or indexed_indices is not None
+        or indexed_topk_lengths is not None
+    )
+    if has_indexed:
+        if (
+            indexed_k_cache is None
+            or indexed_indices is None
+            or indexed_topk_lengths is None
+        ):
+            raise ValueError(
+                "indexed_k_cache, indexed_indices, and indexed_topk_lengths must be provided together"
+            )
+        if indexed_page_size is None:
+            raise ValueError(
+                "indexed_page_size is required when indexed_k_cache is provided"
+            )
+        if indexed_page_table is not None:
+            raise ValueError(
+                "SM120 sparse-MLA decode does not support a mapped indexed_page_table; "
+                "the extra cache is addressed by raw slot id"
+            )
+        indexed_k_cache = _compressed_mla_cache_byte_view(
+            indexed_k_cache, name="indexed_k_cache"
+        )
+        _validate_compressed_cache_layout(
+            indexed_k_cache,
+            page_size=int(indexed_page_size),
+            name="indexed_k_cache",
+        )
+        indexed_indices_2d = _normalize_index_matrix(
+            indexed_indices, name="indexed_indices"
+        )
+        if indexed_indices_2d.device != q3.device:
+            raise ValueError("indexed_indices must be on the same device as q_all")
+        if indexed_indices_2d.shape[0] != rows:
+            raise ValueError("indexed_indices row count must match q_all")
+        _validate_lengths(
+            indexed_topk_lengths,
+            rows=rows,
+            name="indexed_topk_lengths",
+        )
+        if indexed_topk_lengths.device != q3.device:
+            raise ValueError("indexed_topk_lengths must be on the same device as q_all")
+    else:
+        indexed_indices_2d = None
+        if indexed_page_table is not None:
+            raise ValueError(
+                "indexed_page_table requires indexed_k_cache/indices/lengths"
+            )
+
+    if attn_sink is not None:
+        attn_sink = attn_sink.detach()
+        if attn_sink.shape != (heads,):
+            raise ValueError(
+                f"attn_sink must have shape [{heads}], got {tuple(attn_sink.shape)}"
+            )
+        if attn_sink.device != q3.device:
+            raise ValueError(
+                f"attn_sink device {attn_sink.device} does not match q_all device {q3.device}"
+            )
+        if attn_sink.dtype != torch.float32:
+            raise TypeError(
+                f"attn_sink must have dtype torch.float32, got {attn_sink.dtype}"
+            )
+        if not attn_sink.is_contiguous():
+            raise ValueError("attn_sink must be contiguous")
+
+    _validate_compressed_mla_scratch(
+        scratch=scratch,
+        rows=rows,
+        heads=heads,
+        width=swa_indices_2d.shape[1]
+        + (indexed_indices_2d.shape[1] if has_indexed else 0),
+    )
+
+    if out is not None:
+        _validate_compressed_mla_out(out, q3=q3)
+
+    if scratch.mode in ("extend", "verify", "draft_extend"):
+        return _run_sm120_compressed_prefill(
+            q3=q3,
+            swa_k_cache=swa_k_cache,
+            swa_indices=swa_indices_2d,
+            swa_topk_lengths=swa_topk_lengths,
+            workspace=scratch,
+            sm_scale=sm_scale,
+            swa_page_size=swa_page_size,
+            indexed_k_cache=indexed_k_cache if has_indexed else None,
+            indexed_indices=indexed_indices_2d,
+            indexed_topk_lengths=indexed_topk_lengths if has_indexed else None,
+            indexed_page_size=indexed_page_size if has_indexed else None,
+            attn_sink=attn_sink,
+            return_lse=return_lse,
+            lse_scale=lse_scale,
+            out=out,
+        )
+
+    if _should_use_sm121_single_pass_decode(
+        rows=rows,
+        heads=heads,
+        swa_width=int(swa_indices_2d.shape[1]),
+        indexed_width=(int(indexed_indices_2d.shape[1]) if has_indexed else 0),
+        swa_page_size=int(swa_page_size),
+        indexed_page_size=(int(indexed_page_size) if has_indexed else None),
+    ):
+        return _run_sm120_compressed_prefill(
+            q3=q3,
+            swa_k_cache=swa_k_cache,
+            swa_indices=swa_indices_2d,
+            swa_topk_lengths=swa_topk_lengths,
+            workspace=scratch,
+            sm_scale=sm_scale,
+            swa_page_size=swa_page_size,
+            indexed_k_cache=indexed_k_cache if has_indexed else None,
+            indexed_indices=indexed_indices_2d,
+            indexed_topk_lengths=indexed_topk_lengths if has_indexed else None,
+            indexed_page_size=indexed_page_size if has_indexed else None,
+            attn_sink=attn_sink,
+            return_lse=return_lse,
+            lse_scale=lse_scale,
+            out=out,
+        )
+
+    from .kernel import run_unified_decode
+
+    return run_unified_decode(
+        q_all=q3,
+        swa_k_cache=swa_k_cache,
+        swa_indices=swa_indices_2d,
+        swa_topk_lengths=swa_topk_lengths,
+        workspace=scratch,
+        sm_scale=sm_scale,
+        swa_page_size=swa_page_size,
+        indexed_k_cache=indexed_k_cache if has_indexed else None,
+        indexed_indices=indexed_indices_2d,
+        indexed_topk_lengths=indexed_topk_lengths if has_indexed else None,
+        indexed_page_size=indexed_page_size if has_indexed else None,
+        attn_sink=attn_sink,
+        return_lse=return_lse,
+        lse_scale=lse_scale,
+        out=out,
+    )
+
+
+def _validate_compressed_mla_out(out: torch.Tensor, *, q3: torch.Tensor) -> None:
+    rows, heads, _ = q3.shape
+    expected = (int(rows), int(heads), COMPRESSED_MLA_HEAD_DIM)
+    if tuple(out.shape) != expected:
+        raise ValueError(
+            f"compressed MLA out must have shape {expected}, got {tuple(out.shape)}"
+        )
+    if out.dtype != torch.bfloat16:
+        raise TypeError(f"compressed MLA out must be bfloat16, got {out.dtype}")
+    if out.device != q3.device:
+        raise ValueError(
+            f"compressed MLA out device {out.device} does not match q device {q3.device}"
+        )
+    if not out.is_contiguous():
+        raise ValueError("compressed MLA out must be contiguous")
+
+
+def _run_sm120_compressed_prefill(
+    *,
+    q3: torch.Tensor,
+    swa_k_cache: torch.Tensor,
+    swa_indices: torch.Tensor,
+    swa_topk_lengths: torch.Tensor,
+    workspace: object,
+    sm_scale: float,
+    swa_page_size: int,
+    indexed_k_cache: torch.Tensor | None,
+    indexed_indices: torch.Tensor | None,
+    indexed_topk_lengths: torch.Tensor | None,
+    indexed_page_size: int | None,
+    attn_sink: torch.Tensor | None,
+    return_lse: bool,
+    lse_scale: Literal["base2", "natural"],
+    out: torch.Tensor | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Route a DSV4 prefill-like (extend/verify/draft_extend) compressed call to the
+    active SM120 single-pass prefill.
+
+    Mirrors upstream's num_tokens>64 prefill orchestrator: ONE 384-thread CTA per
+    (token, HPB head-group) over ALL topk tiles (FINAL_BF16 epilogue, no split-K
+    merge). Main cache OR the DSV4 DUAL-CACHE union (extra tokens). Per-token
+    ``swa_topk_lengths`` is the per-token main topk_length; attn_sink + return_lse
+    are supported. An unsupported prefill shape RAISEs inside run_unified_prefill
+    (error like upstream, NOT a legacy fallback).
+    """
+    from .kernel import run_unified_prefill
+
+    swa_indices_2d = _normalize_index_matrix(swa_indices, name="swa_indices")
+    if out is not None:
+        output = out
+    else:
+        output = _get_mla_output_view(
+            workspace=workspace,
+            q_all=q3,
+            v_head_dim=COMPRESSED_MLA_HEAD_DIM,
+        )
+
+    extra_kwargs: dict = {}
+    if indexed_k_cache is not None:
+        extra_kwargs = dict(
+            extra_kv_cache=indexed_k_cache,
+            extra_indices=_normalize_index_matrix(
+                indexed_indices, name="indexed_indices"
+            ),
+            extra_topk_length=indexed_topk_lengths,
+            extra_page_block_size=int(indexed_page_size),
+        )
+
+    _, lse_base2 = run_unified_prefill(
+        q=q3,
+        kv_cache=swa_k_cache,
+        topk_indices=swa_indices_2d,
+        sm_scale=float(sm_scale),
+        page_block_size=int(swa_page_size),
+        topk_length=swa_topk_lengths,
+        attn_sink=attn_sink,
+        output=output,
+        **extra_kwargs,
+    )
+    if not return_lse:
+        return output
+    lse = lse_base2 if lse_scale == "base2" else (lse_base2 * _LN2)
+    return output, lse
+
+
+def _stage_fixed_compressed_mla_inputs(
+    *,
+    workspace: object,
+    q_all: torch.Tensor,
+    swa_indices: torch.Tensor,
+    swa_lengths: torch.Tensor,
+    indexed_indices: torch.Tensor,
+    indexed_lengths: torch.Tensor,
+    indexed_page_table: torch.Tensor,
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
+    q_stage = workspace.compressed_mla_q_stage
+    swa_indices_stage = workspace.compressed_mla_swa_indices_stage
+    swa_lengths_stage = workspace.compressed_mla_swa_lengths_stage
+    indexed_indices_stage = workspace.compressed_mla_indexed_indices_stage
+    indexed_lengths_stage = workspace.compressed_mla_indexed_lengths_stage
+    indexed_page_table_stage = workspace.compressed_mla_indexed_page_table_stage
+    if (
+        q_stage is None
+        or swa_indices_stage is None
+        or swa_lengths_stage is None
+        or indexed_indices_stage is None
+        or indexed_lengths_stage is None
+        or indexed_page_table_stage is None
+    ):
+        raise RuntimeError(
+            "fixed compressed MLA scratch is missing capacity staging buffers; "
+            "set reserve_compressed_mla_staging=True when planning scratch"
+        )
+
+    rows = int(q_all.shape[0])
+    cap_rows = int(workspace.max_total_q)
+    if rows > cap_rows:
+        raise ValueError(
+            f"q rows {rows} exceed fixed compressed MLA staging capacity {cap_rows}"
+        )
+    if q_stage.shape != (cap_rows, int(workspace.num_q_heads), COMPRESSED_MLA_HEAD_DIM):
+        raise ValueError(
+            "compressed MLA q staging buffer shape mismatch: "
+            f"got {tuple(q_stage.shape)}, expected "
+            f"({cap_rows}, {int(workspace.num_q_heads)}, {COMPRESSED_MLA_HEAD_DIM})"
+        )
+    for name, stage in (
+        ("swa_lengths", swa_lengths_stage),
+        ("indexed_lengths", indexed_lengths_stage),
+    ):
+        if stage.shape != (cap_rows,):
+            raise ValueError(
+                f"compressed MLA {name} staging buffer shape mismatch: "
+                f"got {tuple(stage.shape)}, expected ({cap_rows},)"
+            )
+        if stage.dtype != torch.int32:
+            raise TypeError(
+                f"compressed MLA {name} staging buffer must be int32, got {stage.dtype}"
+            )
+        if stage.device != q_all.device:
+            raise ValueError(
+                f"compressed MLA {name} staging buffer must be on {q_all.device}"
+            )
+    q_stage[:rows].copy_(q_all.detach())
+
+    swa_indices_view = _stage_fixed_int_matrix(
+        swa_indices_stage,
+        swa_indices,
+        rows=rows,
+        cap_rows=cap_rows,
+        name="swa_indices",
+    )
+    indexed_indices_view = _stage_fixed_int_matrix(
+        indexed_indices_stage,
+        indexed_indices,
+        rows=rows,
+        cap_rows=cap_rows,
+        name="indexed_indices",
+    )
+    indexed_page_table_view = _stage_fixed_int_matrix(
+        indexed_page_table_stage,
+        indexed_page_table,
+        rows=rows,
+        cap_rows=cap_rows,
+        name="indexed_page_table",
+    )
+    swa_lengths_view = swa_lengths_stage[:cap_rows]
+    indexed_lengths_view = indexed_lengths_stage[:cap_rows]
+    swa_lengths_view[:rows].copy_(swa_lengths.detach())
+    indexed_lengths_view[:rows].copy_(indexed_lengths.detach())
+    if rows < cap_rows:
+        swa_lengths_view[rows:].zero_()
+        indexed_lengths_view[rows:].zero_()
+
+    return (
+        q_stage,
+        swa_indices_view,
+        swa_lengths_view,
+        indexed_indices_view,
+        indexed_lengths_view,
+        indexed_page_table_view,
+    )
+
+
+def _stage_fixed_int_matrix(
+    stage: torch.Tensor,
+    source: torch.Tensor,
+    *,
+    rows: int,
+    cap_rows: int,
+    name: str,
+) -> torch.Tensor:
+    width = int(source.shape[1])
+    if int(stage.shape[0]) < cap_rows or int(stage.shape[1]) < width:
+        raise ValueError(
+            f"{name} staging buffer is too small: stage={tuple(stage.shape)} "
+            f"required=({cap_rows}, {width})"
+        )
+    view = stage.reshape(-1)[: cap_rows * width].view(cap_rows, width)
+    if rows:
+        view[:rows].copy_(source.detach())
+    return view
+
+
+def _normalize_compressed_q(q: torch.Tensor) -> torch.Tensor:
+    if q.ndim == 4 and q.shape[1] == 1:
+        q = q[:, 0]
+    if q.ndim != 3 or q.shape[-1] != COMPRESSED_MLA_HEAD_DIM:
+        raise ValueError(
+            f"q_all must have shape [rows, heads, {COMPRESSED_MLA_HEAD_DIM}], got {tuple(q.shape)}"
+        )
+    if q.dtype != torch.bfloat16:
+        raise TypeError(f"q_all must have dtype torch.bfloat16, got {q.dtype}")
+    if not q.is_contiguous():
+        raise ValueError("q_all must be contiguous for compressed MLA")
+    return q.detach()
+
+
+def _validate_compressed_cache_layout(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    name: str,
+) -> None:
+    page_size = int(page_size)
+    if page_size <= 0:
+        raise ValueError(f"{name} page_size must be positive, got {page_size}")
+    expected_page_nbytes = compressed_mla_page_nbytes(page_size)
+    if int(cache.shape[1]) != expected_page_nbytes:
+        raise ValueError(
+            f"{name} page byte width must be {expected_page_nbytes} for page_size "
+            f"{page_size}, got {int(cache.shape[1])}"
+        )
+
+
+def _compressed_mla_cache_byte_view(cache: torch.Tensor, *, name: str) -> torch.Tensor:
+    if cache.dtype == torch.uint8:
+        byte_cache = cache
+    elif cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
+        byte_cache = cache.detach().view(torch.uint8)
+    else:
+        raise TypeError(
+            f"{name} must have dtype torch.uint8 or FP8 storage, got {cache.dtype}"
+        )
+    if byte_cache.ndim != 2:
+        raise ValueError(
+            f"{name} must have shape [pages, page_bytes], got {tuple(cache.shape)}"
+        )
+    if int(byte_cache.stride(1)) != 1:
+        raise ValueError(
+            f"{name} page payload must be contiguous in the last dimension, "
+            f"got stride {tuple(byte_cache.stride())}"
+        )
+    return byte_cache
+
+
+def _validate_compressed_launch_views(
+    *,
+    tmp_output: torch.Tensor,
+    tmp_lse: torch.Tensor,
+    q_rows: int,
+    heads: int,
+    launch_num_chunks: int,
+    direct_output: bool,
+) -> None:
+    if tmp_output is None or tmp_lse is None:
+        raise RuntimeError("compressed MLA launch is missing scratch/output buffers")
+    q_rows = int(q_rows)
+    heads = int(heads)
+    launch_num_chunks = int(launch_num_chunks)
+    if tmp_output.dtype != torch.bfloat16:
+        raise TypeError(
+            f"compressed MLA tmp_output must be BF16, got {tmp_output.dtype}"
+        )
+    if tmp_lse.dtype != torch.float32:
+        raise TypeError(f"compressed MLA tmp_lse must be FP32, got {tmp_lse.dtype}")
+    if tmp_output.device != tmp_lse.device:
+        raise ValueError(
+            "compressed MLA tmp_output and tmp_lse must be on the same device"
+        )
+    _validate_tensor_storage_bounds(tmp_output, name="compressed MLA tmp_output")
+    _validate_tensor_storage_bounds(tmp_lse, name="compressed MLA tmp_lse")
+    if direct_output:
+        if tmp_output.ndim != 3:
+            raise ValueError(
+                f"compressed MLA direct output must be rank-3, got {tuple(tmp_output.shape)}"
+            )
+        required = (q_rows, heads, COMPRESSED_MLA_HEAD_DIM)
+        if (
+            int(tmp_output.shape[0]) < q_rows
+            or int(tmp_output.shape[1]) < heads
+            or int(tmp_output.shape[2]) < COMPRESSED_MLA_HEAD_DIM
+        ):
+            raise ValueError(
+                "compressed MLA direct output is too small: "
+                f"buffer={tuple(tmp_output.shape)} required>={required}"
+            )
+    else:
+        if tmp_output.ndim != 4:
+            raise ValueError(
+                f"compressed MLA split output must be rank-4, got {tuple(tmp_output.shape)}"
+            )
+        required = (q_rows, heads, launch_num_chunks, COMPRESSED_MLA_HEAD_DIM)
+        if (
+            int(tmp_output.shape[0]) < q_rows
+            or int(tmp_output.shape[1]) < heads
+            or int(tmp_output.shape[2]) < launch_num_chunks
+            or int(tmp_output.shape[3]) < COMPRESSED_MLA_HEAD_DIM
+        ):
+            raise ValueError(
+                "compressed MLA split output is too small: "
+                f"buffer={tuple(tmp_output.shape)} required>={required}"
+            )
+    if tmp_lse.ndim != 3:
+        raise ValueError(
+            f"compressed MLA tmp_lse must be rank-3, got {tuple(tmp_lse.shape)}"
+        )
+    required_lse = (q_rows, heads, max(1, launch_num_chunks))
+    if (
+        int(tmp_lse.shape[0]) < q_rows
+        or int(tmp_lse.shape[1]) < heads
+        or int(tmp_lse.shape[2]) < max(1, launch_num_chunks)
+    ):
+        raise ValueError(
+            "compressed MLA tmp_lse is too small: "
+            f"buffer={tuple(tmp_lse.shape)} required>={required_lse}"
+        )
+
+
+def _is_row_shared_index_matrix(indices: torch.Tensor) -> bool:
+    return (
+        indices.ndim == 2
+        and int(indices.stride(0)) == 0
+        and int(indices.stride(1)) == 1
+    )
+
+
+def _normalize_index_matrix(
+    indices: torch.Tensor,
+    *,
+    name: str,
+    allow_row_shared: bool = False,
+) -> torch.Tensor:
+    if indices.ndim == 3 and indices.shape[1] == 1:
+        indices = indices[:, 0]
+    if indices.ndim != 2:
+        raise ValueError(
+            f"{name} must have shape [rows, width] or [rows, 1, width], got {tuple(indices.shape)}"
+        )
+    if indices.dtype != torch.int32:
+        raise TypeError(f"{name} must have dtype torch.int32, got {indices.dtype}")
+    if not indices.is_contiguous() and not (
+        allow_row_shared and _is_row_shared_index_matrix(indices)
+    ):
+        raise ValueError(f"{name} must be contiguous for compressed MLA")
+    return indices
+
+
+def _validate_lengths(
+    lengths: torch.Tensor,
+    *,
+    rows: int,
+    name: str,
+) -> None:
+    if lengths.shape != (rows,):
+        raise ValueError(f"{name} must have shape [{rows}], got {tuple(lengths.shape)}")
+    if lengths.dtype != torch.int32:
+        raise TypeError(f"{name} must have dtype torch.int32, got {lengths.dtype}")
+    if not lengths.is_contiguous():
+        raise ValueError(f"{name} must be contiguous for compressed MLA")
+
+
+def _validate_compressed_mla_scratch(
+    scratch: object,
+    *,
+    rows: int,
+    heads: int,
+    width: int,
+) -> None:
+    if rows > scratch.max_total_q:
+        raise ValueError(
+            f"q rows {rows} exceed compressed MLA scratch max_total_q {scratch.max_total_q}"
+        )
+    if rows > scratch.max_batch and scratch.mode == "decode":
+        raise ValueError(
+            f"decode rows {rows} exceed compressed MLA scratch max_batch {scratch.max_batch}"
+        )
+    if heads != scratch.num_q_heads:
+        raise ValueError(
+            f"q_all num_heads {heads} does not match compressed MLA scratch num_q_heads {scratch.num_q_heads}"
+        )
+    if scratch.head_dim != COMPRESSED_MLA_HEAD_DIM:
+        raise ValueError(
+            f"compressed MLA scratch head_dim must be {COMPRESSED_MLA_HEAD_DIM}, got {scratch.head_dim}"
+        )
+    if scratch.v_head_dim != COMPRESSED_MLA_HEAD_DIM:
+        raise ValueError(
+            f"compressed MLA scratch v_head_dim must be {COMPRESSED_MLA_HEAD_DIM}, got {scratch.v_head_dim}"
+        )
+    if width > scratch.topk:
+        raise ValueError(
+            f"compressed MLA width {width} exceeds scratch topk {scratch.topk}"
+        )

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/compressed_config.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/compressed_config.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/compressed_config.py @ fabb087a (2026-06-08) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Compressed MLA kernel planning helpers shared by runtime and scratch plans."""
+
+from __future__ import annotations
+
+from flashinfer.experimental.sm12x.attention._shared.workspace import (
+    SparseMLASplitDecodeConfig,
+)
+
+
+_COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE = 12
+# vLLM captures MTP decode graphs with rows = requests * (1 + draft tokens).
+# Keep those graph-capacity rows on the decode split contract; switching to the
+# batched split contract at 66+ rows can poison smaller decode graph replays.
+_COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS = 256
+_COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE = 64
+_COMPRESSED_MLA_BATCHED_SPLIT_CHUNK_SIZE = 1024
+_COMPRESSED_MLA_SPLIT_MAX_CHUNKS = 256
+
+
+def compressed_mla_split_config_for_contract(
+    *,
+    rows: int,
+    width: int,
+    max_chunks: int | None = None,
+) -> SparseMLASplitDecodeConfig:
+    rows = max(int(rows), 1)
+    width = max(int(width), 1)
+    chunk_limit = _COMPRESSED_MLA_SPLIT_MAX_CHUNKS
+    if max_chunks is not None:
+        chunk_limit = max(1, min(int(max_chunks), chunk_limit))
+
+    decode_chunks = (
+        width + _COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE - 1
+    ) // _COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE
+    if rows <= _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS and decode_chunks <= chunk_limit:
+        return SparseMLASplitDecodeConfig(
+            chunk_size=_COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE,
+            num_chunks=decode_chunks,
+        )
+
+    wide_decode_chunks = (
+        width + _COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE - 1
+    ) // _COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE
+    if (
+        rows <= _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS
+        and wide_decode_chunks <= chunk_limit
+    ):
+        return SparseMLASplitDecodeConfig(
+            chunk_size=_COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE,
+            num_chunks=wide_decode_chunks,
+        )
+
+    chunks = (
+        width + _COMPRESSED_MLA_BATCHED_SPLIT_CHUNK_SIZE - 1
+    ) // _COMPRESSED_MLA_BATCHED_SPLIT_CHUNK_SIZE
+    if chunks <= chunk_limit:
+        return SparseMLASplitDecodeConfig(
+            chunk_size=_COMPRESSED_MLA_BATCHED_SPLIT_CHUNK_SIZE,
+            num_chunks=chunks,
+        )
+
+    chunk_size = (width + chunk_limit - 1) // chunk_limit
+    return SparseMLASplitDecodeConfig(chunk_size=chunk_size, num_chunks=chunk_limit)
+
+
+def compressed_mla_split_chunks_for_contract(
+    *,
+    rows: int,
+    width: int,
+    max_chunks: int | None = None,
+) -> int:
+    return compressed_mla_split_config_for_contract(
+        rows=rows,
+        width=width,
+        max_chunks=max_chunks,
+    ).num_chunks
+
+
+__all__ = [
+    "compressed_mla_split_chunks_for_contract",
+    "compressed_mla_split_config_for_contract",
+]

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/compressed_reference.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/compressed_reference.py
@@ -1,0 +1,485 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/compressed_reference.py @ 313da89d (2026-05-26) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Reference helpers for compressed sparse MLA attention.
+
+The compressed sparse MLA KV page stores each token as a 448-dimension FP8 noPE
+vector, a 64-dimension BF16 RoPE vector, and seven UE8M0 scale bytes for the
+noPE groups.  Within each page the token payloads are packed first, followed by
+the per-token scale region:
+
+    [page_size * 576 payload bytes][page_size * 8 scale bytes][padding]
+
+The padding rounds page byte size up to a 576-byte multiple, matching the
+SGLang memory-pool contract.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+COMPRESSED_MLA_NOPE_DIM = 448
+COMPRESSED_MLA_ROPE_DIM = 64
+COMPRESSED_MLA_HEAD_DIM = COMPRESSED_MLA_NOPE_DIM + COMPRESSED_MLA_ROPE_DIM
+COMPRESSED_MLA_NOPE_GROUP_SIZE = 64
+COMPRESSED_MLA_NOPE_GROUPS = COMPRESSED_MLA_NOPE_DIM // COMPRESSED_MLA_NOPE_GROUP_SIZE
+COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN = (
+    COMPRESSED_MLA_NOPE_DIM + COMPRESSED_MLA_ROPE_DIM * 2
+)
+COMPRESSED_MLA_SCALE_BYTES_PER_TOKEN = 8
+COMPRESSED_MLA_BYTES_PER_TOKEN = (
+    COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN + COMPRESSED_MLA_SCALE_BYTES_PER_TOKEN
+)
+COMPRESSED_MLA_FP8_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+COMPRESSED_MLA_UE8M0_BIAS = 127
+
+COMPRESSED_MLA_LOCAL_Q_HEADS_TP2 = 32
+COMPRESSED_MLA_TOTAL_Q_HEADS = 64
+COMPRESSED_MLA_KV_HEADS = 1
+# SGLang's DSV4 backend hard-codes a 256-token physical KV page. Keep that
+# distinct from the 128-token sliding SWA window.
+COMPRESSED_MLA_DSV4_PAGE_SIZE = 256
+COMPRESSED_MLA_C4_PAGE_SIZE = COMPRESSED_MLA_DSV4_PAGE_SIZE // 4
+COMPRESSED_MLA_C128_PAGE_SIZE = COMPRESSED_MLA_DSV4_PAGE_SIZE // 128
+COMPRESSED_MLA_SWA_TOKENS = 128
+COMPRESSED_MLA_INDEX_TOPK = 512
+
+
+def compressed_mla_page_nbytes(page_size: int) -> int:
+    """Return the padded byte count per compressed-MLA KV page."""
+
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    unpadded = page_size * COMPRESSED_MLA_BYTES_PER_TOKEN
+    return (
+        math.ceil(unpadded / COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN)
+        * COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN
+    )
+
+
+def compressed_mla_scale_region_offset(page_size: int) -> int:
+    """Return the byte offset at which UE8M0 scales start inside a page."""
+
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    return page_size * COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN
+
+
+def ue8m0_to_float(scale_ue8m0: torch.Tensor) -> torch.Tensor:
+    """Decode UE8M0 scale bytes using the standard exponent bias."""
+
+    exponent = scale_ue8m0.to(torch.int32) - COMPRESSED_MLA_UE8M0_BIAS
+    ones = torch.ones_like(exponent, dtype=torch.float32)
+    return torch.ldexp(ones, exponent)
+
+
+def _float_to_ue8m0_scale(max_abs: torch.Tensor) -> torch.Tensor:
+    safe = torch.where(
+        max_abs > 0, max_abs / COMPRESSED_MLA_FP8_MAX, torch.ones_like(max_abs)
+    )
+    exponent = torch.ceil(torch.log2(safe)).to(torch.int32)
+    exponent = torch.clamp(
+        exponent, -COMPRESSED_MLA_UE8M0_BIAS, 255 - COMPRESSED_MLA_UE8M0_BIAS
+    )
+    exponent = torch.where(max_abs > 0, exponent, torch.zeros_like(exponent))
+    return (exponent + COMPRESSED_MLA_UE8M0_BIAS).to(torch.uint8)
+
+
+def quantize_compressed_mla_nope_reference(
+    k_nope: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize noPE rows into E4M3 FP8 plus seven UE8M0 scale bytes."""
+
+    if k_nope.shape[-1] != COMPRESSED_MLA_NOPE_DIM:
+        raise ValueError(
+            f"k_nope last dim must be {COMPRESSED_MLA_NOPE_DIM}, got {k_nope.shape[-1]}"
+        )
+    grouped = k_nope.float().reshape(
+        *k_nope.shape[:-1], COMPRESSED_MLA_NOPE_GROUPS, COMPRESSED_MLA_NOPE_GROUP_SIZE
+    )
+    max_abs = grouped.abs().amax(dim=-1)
+    scale_ue8m0 = _float_to_ue8m0_scale(max_abs)
+    scale = ue8m0_to_float(scale_ue8m0).unsqueeze(-1)
+    scaled = torch.clamp(
+        grouped / scale, -COMPRESSED_MLA_FP8_MAX, COMPRESSED_MLA_FP8_MAX
+    )
+    quantized = scaled.reshape(k_nope.shape).to(torch.float8_e4m3fn)
+    return quantized, scale_ue8m0
+
+
+def pack_compressed_mla_kv_cache_reference(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    *,
+    page_size: int,
+    num_pages: int | None = None,
+) -> torch.Tensor:
+    """Pack K/V rows into the flat compressed-MLA uint8 page-buffer layout."""
+
+    if k_nope.ndim != 2 or k_nope.shape[-1] != COMPRESSED_MLA_NOPE_DIM:
+        raise ValueError(
+            f"k_nope must have shape [tokens, {COMPRESSED_MLA_NOPE_DIM}], got {tuple(k_nope.shape)}"
+        )
+    if k_rope.ndim != 2 or k_rope.shape[-1] != COMPRESSED_MLA_ROPE_DIM:
+        raise ValueError(
+            f"k_rope must have shape [tokens, {COMPRESSED_MLA_ROPE_DIM}], got {tuple(k_rope.shape)}"
+        )
+    if k_nope.shape[0] != k_rope.shape[0]:
+        raise ValueError("k_nope and k_rope must have the same token count")
+
+    n_tokens = int(k_nope.shape[0])
+    min_pages = math.ceil(n_tokens / page_size)
+    if num_pages is None:
+        num_pages = min_pages
+    if num_pages < min_pages:
+        raise ValueError(
+            f"num_pages {num_pages} cannot hold {n_tokens} tokens at page_size {page_size}"
+        )
+
+    page_nbytes = compressed_mla_page_nbytes(page_size)
+    scale_offset = compressed_mla_scale_region_offset(page_size)
+    cache = torch.zeros(
+        (num_pages, page_nbytes), dtype=torch.uint8, device=k_nope.device
+    )
+    if n_tokens == 0:
+        return cache
+
+    k_nope_fp8, scale_ue8m0 = quantize_compressed_mla_nope_reference(k_nope)
+    payload = torch.as_strided(
+        cache,
+        (num_pages, page_size, COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN),
+        (page_nbytes, COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN, 1),
+    )
+    scales = torch.as_strided(
+        cache,
+        (num_pages, page_size, COMPRESSED_MLA_SCALE_BYTES_PER_TOKEN),
+        (page_nbytes, COMPRESSED_MLA_SCALE_BYTES_PER_TOKEN, 1),
+        storage_offset=scale_offset,
+    )
+    token_ids = torch.arange(n_tokens, dtype=torch.int64, device=k_nope.device)
+    pages = token_ids // page_size
+    token_offsets = token_ids % page_size
+
+    payload[pages, token_offsets, :COMPRESSED_MLA_NOPE_DIM] = k_nope_fp8.view(
+        torch.uint8
+    ).view(n_tokens, COMPRESSED_MLA_NOPE_DIM)
+    payload[
+        pages,
+        token_offsets,
+        COMPRESSED_MLA_NOPE_DIM:COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN,
+    ] = (
+        k_rope.to(torch.bfloat16)
+        .view(torch.uint8)
+        .view(n_tokens, COMPRESSED_MLA_ROPE_DIM * 2)
+    )
+    scales[pages, token_offsets, :COMPRESSED_MLA_NOPE_GROUPS] = scale_ue8m0.reshape(
+        n_tokens, COMPRESSED_MLA_NOPE_GROUPS
+    )
+    return cache
+
+
+def unpack_compressed_mla_kv_cache_reference(
+    kv_cache: torch.Tensor,
+    *,
+    page_size: int,
+    n_tokens: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Unpack every token from a flat compressed-MLA KV page buffer."""
+
+    _validate_flat_cache(kv_cache, page_size=page_size)
+    num_pages = int(kv_cache.shape[0])
+    total_tokens = num_pages * page_size
+    if n_tokens is None:
+        n_tokens = total_tokens
+    if n_tokens < 0 or n_tokens > total_tokens:
+        raise ValueError(f"n_tokens must be in [0, {total_tokens}], got {n_tokens}")
+    if n_tokens == 0:
+        empty_nope = torch.empty(
+            (0, COMPRESSED_MLA_NOPE_DIM), dtype=torch.float32, device=kv_cache.device
+        )
+        empty_rope = torch.empty(
+            (0, COMPRESSED_MLA_ROPE_DIM), dtype=torch.float32, device=kv_cache.device
+        )
+        return empty_nope, empty_rope
+
+    indices = torch.arange(n_tokens, dtype=torch.int64, device=kv_cache.device)
+    return gather_compressed_mla_kv_cache_reference(
+        kv_cache, indices, page_size=page_size
+    )
+
+
+def gather_compressed_mla_kv_cache_reference(
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    page_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather full 512-d K/V rows from flat token indices."""
+
+    _validate_flat_cache(kv_cache, page_size=page_size)
+    if indices.ndim != 1:
+        raise ValueError(f"indices must be rank-1, got {tuple(indices.shape)}")
+    if indices.numel() == 0:
+        empty = torch.empty(
+            (0, COMPRESSED_MLA_HEAD_DIM), dtype=torch.float32, device=kv_cache.device
+        )
+        return empty, empty
+
+    page_nbytes = compressed_mla_page_nbytes(page_size)
+    scale_offset = compressed_mla_scale_region_offset(page_size)
+    flat_cache = kv_cache.reshape(-1)
+    idx = indices.to(torch.int64)
+    if bool((idx < 0).any()):
+        raise ValueError("indices must be non-negative")
+    pages = idx // page_size
+    token_offsets = idx % page_size
+    if bool((pages >= kv_cache.shape[0]).any()):
+        raise ValueError("indices exceed kv_cache page capacity")
+
+    token_base = (
+        pages * page_nbytes + token_offsets * COMPRESSED_MLA_NOPE_ROPE_BYTES_PER_TOKEN
+    )
+    nope_offsets = token_base[:, None] + torch.arange(
+        COMPRESSED_MLA_NOPE_DIM, device=kv_cache.device, dtype=torch.int64
+    )
+    rope_byte_offsets = (
+        token_base[:, None]
+        + COMPRESSED_MLA_NOPE_DIM
+        + torch.arange(
+            COMPRESSED_MLA_ROPE_DIM * 2, device=kv_cache.device, dtype=torch.int64
+        )
+    )
+    scale_offsets = (
+        pages[:, None] * page_nbytes
+        + scale_offset
+        + token_offsets[:, None] * COMPRESSED_MLA_SCALE_BYTES_PER_TOKEN
+        + torch.arange(
+            COMPRESSED_MLA_NOPE_GROUPS, device=kv_cache.device, dtype=torch.int64
+        )
+    )
+
+    nope_fp8 = (
+        flat_cache[nope_offsets]
+        .contiguous()
+        .view(torch.float8_e4m3fn)
+        .view(-1, COMPRESSED_MLA_NOPE_DIM)
+    )
+    scale = ue8m0_to_float(flat_cache[scale_offsets]).view(
+        -1, COMPRESSED_MLA_NOPE_GROUPS, 1
+    )
+    nope = (
+        nope_fp8.to(torch.float32).view(
+            -1, COMPRESSED_MLA_NOPE_GROUPS, COMPRESSED_MLA_NOPE_GROUP_SIZE
+        )
+        * scale
+    ).reshape(-1, COMPRESSED_MLA_NOPE_DIM)
+    rope = (
+        flat_cache[rope_byte_offsets]
+        .contiguous()
+        .view(torch.bfloat16)
+        .view(-1, COMPRESSED_MLA_ROPE_DIM)
+        .to(torch.float32)
+    )
+    full = torch.cat((nope, rope), dim=-1)
+    return full, full
+
+
+def compressed_sparse_mla_reference(
+    q: torch.Tensor,
+    swa_k_cache: torch.Tensor,
+    swa_indices: torch.Tensor,
+    swa_topk_lengths: torch.Tensor,
+    *,
+    sm_scale: float,
+    attn_sink: torch.Tensor | None = None,
+    extra_k_cache: torch.Tensor | None = None,
+    extra_indices: torch.Tensor | None = None,
+    extra_topk_lengths: torch.Tensor | None = None,
+    swa_page_size: int = COMPRESSED_MLA_DSV4_PAGE_SIZE,
+    extra_page_size: int | None = None,
+    return_lse: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Reference sparse MLA attention over SWA plus optional C4/C128 stream."""
+
+    q3 = _normalize_q(q)
+    rows, heads, _ = q3.shape
+    swa_indices_2d = _normalize_indices(swa_indices, name="swa_indices")
+    if swa_indices_2d.shape[0] != rows:
+        raise ValueError("swa_indices row count must match q")
+    if swa_topk_lengths.shape != (rows,):
+        raise ValueError(
+            f"swa_topk_lengths must have shape [{rows}], got {tuple(swa_topk_lengths.shape)}"
+        )
+    _validate_flat_cache(swa_k_cache, page_size=swa_page_size)
+
+    has_extra = (
+        extra_k_cache is not None
+        or extra_indices is not None
+        or extra_topk_lengths is not None
+    )
+    if has_extra:
+        if extra_k_cache is None or extra_indices is None or extra_topk_lengths is None:
+            raise ValueError(
+                "extra_k_cache, extra_indices, and extra_topk_lengths must be provided together"
+            )
+        if extra_page_size is None:
+            raise ValueError(
+                "extra_page_size is required when extra_k_cache is provided"
+            )
+        extra_indices_2d = _normalize_indices(extra_indices, name="extra_indices")
+        if extra_indices_2d.shape[0] != rows:
+            raise ValueError("extra_indices row count must match q")
+        if extra_topk_lengths.shape != (rows,):
+            raise ValueError(
+                f"extra_topk_lengths must have shape [{rows}], got {tuple(extra_topk_lengths.shape)}"
+            )
+        _validate_flat_cache(extra_k_cache, page_size=extra_page_size)
+    else:
+        extra_indices_2d = None
+
+    if attn_sink is not None and attn_sink.shape != (heads,):
+        raise ValueError(
+            f"attn_sink must have shape [{heads}], got {tuple(attn_sink.shape)}"
+        )
+
+    out = torch.empty(
+        (rows, heads, COMPRESSED_MLA_HEAD_DIM), dtype=torch.float32, device=q3.device
+    )
+    lse = torch.empty((rows, heads), dtype=torch.float32, device=q3.device)
+    q_f32 = q3.float()
+
+    for row in range(rows):
+        swa_len = _valid_prefix_length(
+            swa_topk_lengths[row], swa_indices_2d[row], swa_indices_2d.shape[1]
+        )
+        if (
+            has_extra
+            and extra_indices_2d is not None
+            and extra_topk_lengths is not None
+        ):
+            extra_len = _valid_prefix_length(
+                extra_topk_lengths[row],
+                extra_indices_2d[row],
+                extra_indices_2d.shape[1],
+            )
+            if extra_len:
+                assert extra_k_cache is not None
+                assert extra_page_size is not None
+                extra_k, extra_v = gather_compressed_mla_kv_cache_reference(
+                    extra_k_cache,
+                    extra_indices_2d[row, :extra_len],
+                    page_size=extra_page_size,
+                )
+            else:
+                extra_k = torch.empty(
+                    (0, COMPRESSED_MLA_HEAD_DIM), dtype=torch.float32, device=q3.device
+                )
+                extra_v = extra_k
+        else:
+            extra_len = 0
+            extra_k = torch.empty(
+                (0, COMPRESSED_MLA_HEAD_DIM), dtype=torch.float32, device=q3.device
+            )
+            extra_v = extra_k
+
+        if swa_len:
+            swa_k, swa_v = gather_compressed_mla_kv_cache_reference(
+                swa_k_cache, swa_indices_2d[row, :swa_len], page_size=swa_page_size
+            )
+        else:
+            swa_k = torch.empty(
+                (0, COMPRESSED_MLA_HEAD_DIM), dtype=torch.float32, device=q3.device
+            )
+            swa_v = swa_k
+
+        if extra_len:
+            k = torch.cat((swa_k, extra_k), dim=0)
+            v = torch.cat((swa_v, extra_v), dim=0)
+        else:
+            k = swa_k
+            v = swa_v
+
+        if k.shape[0] == 0:
+            if attn_sink is None:
+                out[row].zero_()
+                lse[row].fill_(-float("inf"))
+            else:
+                out[row].zero_()
+                lse[row] = attn_sink.float()
+            continue
+
+        scores = torch.matmul(q_f32[row], k.t()) * float(sm_scale)
+        if attn_sink is None:
+            row_m = scores.max(dim=-1).values
+            weights = torch.exp(scores - row_m[:, None])
+            denom = weights.sum(dim=-1)
+        else:
+            sink = attn_sink.float()
+            row_m = torch.maximum(scores.max(dim=-1).values, sink)
+            weights = torch.exp(scores - row_m[:, None])
+            denom = weights.sum(dim=-1) + torch.exp(sink - row_m)
+        out[row] = torch.matmul(weights, v) / denom[:, None]
+        lse[row] = row_m + torch.log(denom)
+
+    result = out.to(q3.dtype)
+    if return_lse:
+        return result, lse
+    return result
+
+
+def _bounded_length(length: torch.Tensor, width: int) -> int:
+    value = int(length.item())
+    if value < 0:
+        raise ValueError(f"topk length must be non-negative, got {value}")
+    return min(value, width)
+
+
+def _valid_prefix_length(
+    length: torch.Tensor, indices: torch.Tensor, width: int
+) -> int:
+    limit = _bounded_length(length, width)
+    if limit == 0:
+        return 0
+    active = indices[:limit].to(torch.int64)
+    negative = torch.nonzero(active < 0, as_tuple=False)
+    if negative.numel() == 0:
+        return limit
+    return int(negative[0, 0].item())
+
+
+def _normalize_q(q: torch.Tensor) -> torch.Tensor:
+    if q.ndim == 4 and q.shape[1] == 1:
+        q = q[:, 0]
+    if q.ndim != 3 or q.shape[-1] != COMPRESSED_MLA_HEAD_DIM:
+        raise ValueError(
+            f"q must have shape [rows, heads, {COMPRESSED_MLA_HEAD_DIM}], got {tuple(q.shape)}"
+        )
+    return q
+
+
+def _normalize_indices(indices: torch.Tensor, *, name: str) -> torch.Tensor:
+    if indices.ndim == 3 and indices.shape[1] == 1:
+        indices = indices[:, 0]
+    if indices.ndim != 2:
+        raise ValueError(
+            f"{name} must have shape [rows, width] or [rows, 1, width], got {tuple(indices.shape)}"
+        )
+    return indices
+
+
+def _validate_flat_cache(kv_cache: torch.Tensor, *, page_size: int) -> None:
+    if kv_cache.ndim != 2:
+        raise ValueError(
+            f"kv_cache must be a flat [pages, page_nbytes] uint8 buffer, got {tuple(kv_cache.shape)}"
+        )
+    if kv_cache.dtype is not torch.uint8:
+        raise TypeError(f"kv_cache must be uint8, got {kv_cache.dtype}")
+    expected = compressed_mla_page_nbytes(page_size)
+    if kv_cache.shape[1] != expected:
+        raise ValueError(
+            f"kv_cache page byte width must be {expected} for page_size {page_size}, got {kv_cache.shape[1]}"
+        )

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/decode_math.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/decode_math.py
@@ -1,0 +1,3010 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/decode_math.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""DSV4 sparse-MLA decode MATH stages (P5) -- the QK path (S0-S3).
+
+100%-CuTeDSL single-CTA DSV4 decode for ONE query token over HPB=16 heads with
+8 math warps (256 threads). This module currently implements the QK score path:
+
+  * S0  Q-quant       : BF16 Q -> per-(QUANT_TILE=64) absmax -> pow2 UE8M0 scale
+                        -> E4M3 quantize into ``q_fp8`` + FP32 pow2 scale into
+                        ``q_sc``; Q-rope copied bf16 into ``q_rope``.
+  * S1  QK-NoPE       : block-scaled FP8 MMA (mxfp8 m16n8k32, ue8m0 selectors)
+                        with REAL sfa (Q pow2 exponent byte from ``q_sc``) and
+                        sfb (K UE8M0 footer byte from ``kv_sc``). NUM_SCALES=7 x
+                        (QUANT_TILE/32)=2 = 14 block-scaled MMAs.
+  * S2  QK-RoPE       : bf16 m16n8k16 accumulating into the SAME qk regs over
+                        D_ROPE=64 (4 K-steps) = 4 bf16 MMAs.
+  * S3  mask + scale  : invalid candidates (idx<0 OR past split_cand_end) -> -inf
+                        (-Float32.inf, the rs-1 base-2 merge sentinel); then
+                        qk *= sm_scale * LOG2E.
+
+The DATA PATH follows FlashInfer ``decode_dsv4_kernel.cuh`` (S0 ``fp8_quant.cuh``
+``quantize_q_to_smem``; S1/S2 the chunk-loop QK block at decode_dsv4 :372-454).
+The ldmatrix loaders mirror ``arch/ldmatrix_sm120.cuh`` (FLAT byte addressing on
+the linear smem regions finalized in ``smem.py``) rather than the GLM onepass
+``_permuted_offset_128b`` XOR swizzle (see the smem.py module docstring).
+
+KEY DIVERGENCE from ``kernel_onepass.py`` (blueprint ORCHESTRATOR NOTE):
+``kernel_onepass`` pre-dequantizes K to bf16 and passes ``unit_scale``
+(0x7F7F7F7F) into the block-scaled MMA. DSV4 instead keeps the FP8 nope bytes RAW
+in smem and feeds the REAL UE8M0 K footer byte + Q pow2 exponent byte as the
+``sfa``/``sfb`` selectors -- the hardware ue8m0 path, zero-cost scaling.
+
+Per-warp QK score fragment layout (single source of truth for the PV agent):
+  * 8 math warps; warp ``w`` owns candidates ``[w*8, w*8+8)`` (DSV4_QK_N_TILES=1
+    so one m16n8 N-tile per warp -> 8 candidate columns per warp; 8 warps cover
+    BI=64).
+  * The MMA M dimension is the HPB=16 heads; N is the candidate column.
+  * Per lane, the m16n8 fragment is 4 FP32 accumulators ``qk[0..3]``:
+      gid = lane >> 2 ;  tid = lane & 3
+      qk[0] = score[head=gid     , cand=w*8 + tid*2    ]
+      qk[1] = score[head=gid     , cand=w*8 + tid*2 + 1]
+      qk[2] = score[head=gid + 8 , cand=w*8 + tid*2    ]
+      qk[3] = score[head=gid + 8 , cand=w*8 + tid*2 + 1]
+    (gid in [0,8) covers heads 0..15 across the two row groups; tid in [0,4)
+    covers the 8 candidate columns in pairs.)
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Int64, Uint32
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+from flashinfer.experimental.sm12x.attention._shared.cute.ops import LOG2_E
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_max_shared_f32,
+    byte_perm,
+    cvt_f32_to_e4m3,
+    cvt_e4m3_to_f32_via_f16,
+    fabs_f32,
+    f16x2_to_f32x2,
+    fmax_f32,
+    fmin_f32,
+    fp8_e4m3_to_f32,
+    fp4_decode_2,
+    get_ptr_as_int64,
+    ld_global_nc_v2_u32,
+    ld_shared_v2_u32,
+    ld_shared_v4_u32,
+    ld_shared_f32,
+    ld_shared_u8_offset,
+    ld_shared_u32,
+    ldmatrix_m8n8x2_b16,
+    ldmatrix_m8n8x4_b16,
+    mma_m16n8k16_f32_bf16,
+    mma_m16n8k32_f32_e4m3,
+    mxfp8_mma_m16n8k32_f32_e4m3,
+    pack_f32x2_to_bfloat2,
+    pow2_ceil_ue8m0,
+    rcp_approx_ftz,
+    shared_ptr_to_u32,
+    st_shared_bf16_from_f32,
+    st_shared_f32,
+    st_shared_u32,
+    st_shared_u8,
+    st_global_v4_u32,
+)
+
+
+@dsl_user_op
+def _exp2_approx_ftz_f32(a: Float32, *, loc=None, ip=None) -> Float32:
+    """``exp2f``-equivalent base-2 exponential (``ex2.approx.ftz.f32``).
+
+    Matches kernel.py ``_exp2_approx_ftz_f32`` and the decode-dsv4 base-2 online
+    softmax (``exp2f``). FTZ is harmless at the score magnitudes here."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "ex2.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _log2_approx_ftz_f32(a: Float32, *, loc=None, ip=None) -> Float32:
+    """``log2f``-equivalent (``lg2.approx.ftz.f32``) for the base-2 LSE epilogue."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "lg2.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _f32_to_bits(a: Float32, *, loc=None, ip=None) -> Uint32:
+    """Reinterpret a Float32 as its raw u32 IEEE-754 bits (mov.b32)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _u32_to_f32(a: Uint32, *, loc=None, ip=None) -> Float32:
+    """Reinterpret a Uint32 as its raw Float32 IEEE-754 value (mov.b32).
+
+    GLM ARBITRARY_FP32 path: the 4 inline K scale bytes are an arbitrary fp32
+    (NOT a UE8M0 exponent byte), so the smem word is reinterpreted whole."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _cvt_f32x2_to_e4m3x2(
+    v0: Float32,
+    v1: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """Convert two f32 values to packed E4M3 with one native conversion."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(v0).ir_value(loc=loc, ip=ip),
+                Float32(v1).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b16 fp8_pair;
+                cvt.rn.satfinite.e4m3x2.f32 fp8_pair, $2, $1;
+                cvt.u32.u16 $0, fp8_pair;
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _cvt_e4m3x2_to_f16x2(
+    packed: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """Convert two packed E4M3 values to packed F16 with one instruction."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(packed).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 fp8_pair;
+                cvt.u16.u32 fp8_pair, $1;
+                cvt.rn.f16x2.e4m3x2 $0, fp8_pair;
+            }
+            """,
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _st_shared_u16(
+    smem_addr: Int32,
+    value: Uint32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store the low 16 bits of ``value`` to shared memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Uint32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.u16 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# ── DSV4 QK-path compile-time geometry (one CTA, one chunk) ──────────────────
+_FP8_MAX = 448.0
+_FP8_MIN = -448.0
+# NVFP4 MLA latent record geometry inside the staged 288-byte smem row:
+# 256B packed E2M1 data, then 32 E4M3 group-16 scale bytes at offset 256.
+_NVFP4_SCALE_OFFSET = 256
+_NVFP4_SCALE_GROUP = 16
+_NEG_INF = float("-inf")
+# Intra-kernel softmax mask sentinel (FlashInfer decode_dsv4 :443). Large FINITE
+# negative so a fully-invalid warp's (qk - local_max) is 0, not inf - inf = nan.
+# The merge -inf sentinel is emitted only at S7 (empty-block LSE).
+_QK_MASK = -1e30
+
+# 8 math warps, BI=64 candidates -> 8 candidates per warp = one m16n8 N-tile.
+_N_WARPS = 8
+_ENTRIES_PER_WARP = 8  # BI // _N_WARPS
+_QK_N_TILES = 1  # _ENTRIES_PER_WARP // 8
+
+# S7 epilogue modes (cutlass.Constexpr int keys). The decode/split path writes
+# PER-SPLIT NORMALIZED partials + base-2 LSE into mid_out/mid_lse for the reused
+# split.py merge (PARTIAL_WRITEBACK, the DEFAULT so decode stays byte-identical).
+# The prefill single-pass path writes the FINAL normalized BF16 O directly into
+# output[token,h,d] + a base-2 LSE with an optional attn_sink fold (FINAL_BF16).
+EPILOGUE_PARTIAL_WRITEBACK = 0
+EPILOGUE_FINAL_BF16 = 1
+
+
+@cute.jit
+def _smem_byte(base_addr: Int32, byte_off) -> Int32:
+    """Flat smem byte address (base u32 + byte offset); no XOR swizzle."""
+    return base_addr + Int32(byte_off)
+
+
+# =============================================================================
+# S0 -- Q quantization to smem (BF16 -> E4M3 + pow2 UE8M0 scale)
+# Port of fp8_quant.cuh::quantize_q_to_smem. Outputs q_fp8 / q_sc / q_rope.
+# =============================================================================
+@cute.jit
+def s0_quantize_q_to_smem(
+    q_token: cute.Tensor,  # (NUM_HEADS, D_QK) bf16 view for this token
+    q_fp8_base_addr: Int32,  # u32 smem addr of q_fp8 (HPB x Q_NOPE_STRIDE)
+    q_sc_view: cute.Tensor,  # smem fp32 view (HPB*NUM_SCALES,) -- pow2 scales
+    q_rope_base_addr: Int32,  # u32 smem addr of q_rope (HPB x D_ROPE bf16)
+    amax_view: cute.Tensor,  # smem fp32 scratch (>= HPB*NUM_SCALES) reused as amax
+    head_base: Int32,  # first head index of this CTA (h_start)
+    valid_hpb: Int32,  # number of valid heads (<= HPB)
+    tid: Int32,  # flat thread id in [0, MATH_THREADS)
+    *,
+    d_nope: cutlass.Constexpr,  # 448
+    d_rope: cutlass.Constexpr,  # 64
+    d_qk: cutlass.Constexpr,  # 512
+    quant_tile: cutlass.Constexpr,  # 64
+    num_scales: cutlass.Constexpr,  # 7
+    hpb: cutlass.Constexpr,  # 16
+    q_nope_stride: cutlass.Constexpr,  # 464
+    q_rope_stride: cutlass.Constexpr,  # D_ROPE plus optional bank-layout pad
+    num_threads: cutlass.Constexpr,  # 256
+    barrier_id: cutlass.Constexpr,  # named-barrier slot for the math-only sync
+    barrier_threads: cutlass.Constexpr = 0,  # barrier width override (0 -> num_threads)
+    fused_subgroup_quant: cutlass.Constexpr = False,
+    subgroup_amax: cutlass.Constexpr = False,
+    vectorized_rope_copy: cutlass.Constexpr = False,
+    packed_q_scale_words: cutlass.Constexpr = False,
+):
+    """S0: cooperative BF16->E4M3 Q quant with per-tile pow2 UE8M0 scale.
+
+    Mirrors fp8_quant.cuh exactly:
+      1. copy Q-rope bf16 -> smem (zero-fill invalid heads)
+      2. init amax[HPB*NUM_SCALES] = 0
+      3. per-(head,tile) absmax via atomicMax-on-int (atomic_max_shared_f32)
+      4. raw = max(amax,1e-4)/FP8_MAX ; pow2-ceil -> q_sc (FP32 pow2 scale)
+      5. quantize q_nope * (1/q_sc) -> E4M3 into q_fp8 (zero-fill invalid heads)
+    The caller fences (named barrier) AFTER this returns so S1 reads a coherent
+    Q stage. The internal barriers separate the 5 phases.
+
+    ``barrier_threads`` widens the named barrier beyond ``num_threads`` for the
+    native-H16 two-group decode (each 128-thread group strides its own staging
+    with ``num_threads`` while both groups share one 256-wide barrier domain).
+    0 keeps the historical num_threads-wide barrier (byte-identical).
+    """
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
+
+    # --- Step 1: copy Q-rope bf16 -> smem; zero-fill invalid heads. ---
+    if cutlass.const_expr(vectorized_rope_copy):
+        chunks_per_head = d_rope // 4
+        i = tid
+        while i < Int32(hpb * chunks_per_head):
+            h = i // Int32(chunks_per_head)
+            chunk = i - h * Int32(chunks_per_head)
+            d = chunk * Int32(4)
+            q0 = Uint32(0)
+            q1 = Uint32(0)
+            if h < valid_hpb:
+                q_off = cute.crd2idx((head_base + h, Int32(d_nope) + d), q_token.layout)
+                q0, q1 = ld_global_nc_v2_u32(get_ptr_as_int64(q_token, q_off))
+            s_addr = q_rope_base_addr + (h * Int32(q_rope_stride) + d) * Int32(2)
+            st_shared_u32(s_addr, q0)
+            st_shared_u32(s_addr + Int32(4), q1)
+            i += Int32(num_threads)
+    else:
+        i = tid
+        while i < Int32(hpb * d_rope):
+            h = i // Int32(d_rope)
+            d = i - h * Int32(d_rope)
+            s_byte = (h * Int32(q_rope_stride) + d) * Int32(2)
+            val = Float32(0.0)
+            if h < valid_hpb:
+                val = Float32(q_token[head_base + h, Int32(d_nope) + d])
+            st_shared_bf16_from_f32(_smem_byte(q_rope_base_addr, s_byte), val)
+            i += Int32(num_threads)
+
+    # --- Steps 2-3: per-(head,tile) absmax over valid heads. ---
+    # Keep the dynamic-loop index names distinct across const_expr branches:
+    # CuTe joins same-named Python locals before pruning and rejects None->Int32.
+    if cutlass.const_expr(fused_subgroup_quant):
+        # Native DSV4 gives each 8-lane subgroup one complete 64-value tile.
+        # Keep its eight values per lane live through the reduction so scale
+        # construction and quantization need no shared amax round-trip or
+        # second global Q load.
+        lane8 = tid & Int32(7)
+        fused_slot = tid >> Int32(3)
+        while fused_slot < Int32(hpb * num_scales):
+            h = fused_slot // Int32(num_scales)
+            blk = fused_slot - h * Int32(num_scales)
+            values = [Float32(0.0) for _ in range(quant_tile // 8)]
+            amax = Float32(0.0)
+            for k in cutlass.range_constexpr(quant_tile // 8):
+                d = blk * Int32(quant_tile) + lane8 + Int32(k * 8)
+                if h < valid_hpb:
+                    values[k] = Float32(q_token[head_base + h, d])
+                amax = fmax_f32(amax, fabs_f32(values[k]))
+            for offset in (1, 2, 4):
+                amax = fmax_f32(amax, cute.arch.shuffle_sync_bfly(amax, offset=offset))
+
+            raw = fmax_f32(amax, Float32(1e-4)) * Float32(1.0 / _FP8_MAX)
+            rounded, _ue8m0 = pow2_ceil_ue8m0(raw)
+            if lane8 == Int32(0):
+                q_sc_view[fused_slot] = rounded
+
+            inv_scale = Float32(1.0) / rounded
+            for k in cutlass.range_constexpr(quant_tile // 8):
+                d = blk * Int32(quant_tile) + lane8 + Int32(k * 8)
+                v = values[k] * inv_scale
+                v = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), v))
+                fp8_bits = cvt_f32_to_e4m3(v)
+                out_byte = h * Int32(q_nope_stride) + d
+                st_shared_u8(
+                    _smem_byte(q_fp8_base_addr, out_byte),
+                    (fp8_bits & Uint32(0xFF)).to(cutlass.Uint8),
+                )
+            fused_slot += Int32(num_threads // 8)
+
+        cute.arch.barrier(**bar_kw)
+        return
+
+    if cutlass.const_expr(subgroup_amax):
+        # Native DSV4 uses 64-value tiles. Four 8-lane subgroups per warp each
+        # own one tile, so every max has a single writer and needs no atomic.
+        lane8 = tid & Int32(7)
+        subgroup_slot = tid >> Int32(3)
+        while subgroup_slot < valid_hpb * Int32(num_scales):
+            h = subgroup_slot // Int32(num_scales)
+            blk = subgroup_slot - h * Int32(num_scales)
+            amax = Float32(0.0)
+            for k in cutlass.range_constexpr(quant_tile // 8):
+                d = blk * Int32(quant_tile) + lane8 + Int32(k * 8)
+                amax = fmax_f32(amax, fabs_f32(Float32(q_token[head_base + h, d])))
+            for offset in (1, 2, 4):
+                amax = fmax_f32(amax, cute.arch.shuffle_sync_bfly(amax, offset=offset))
+            if lane8 == Int32(0):
+                amax_view[subgroup_slot] = amax
+            subgroup_slot += Int32(num_threads // 8)
+    else:
+        i = tid
+        while i < Int32(hpb * num_scales):
+            amax_view[i] = Float32(0.0)
+            i += Int32(num_threads)
+        cute.arch.barrier(**bar_kw)
+
+        idx = tid
+        while idx < valid_hpb * Int32(d_nope):
+            h = idx // Int32(d_nope)
+            d = idx - h * Int32(d_nope)
+            blk = d // Int32(quant_tile)
+            v = Float32(q_token[head_base + h, d])
+            amax_slot = h * Int32(num_scales) + blk
+            amax_addr = shared_ptr_to_u32(amax_view.iterator) + amax_slot * Int32(4)
+            atomic_max_shared_f32(amax_addr, fabs_f32(v))
+            idx += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    # --- Step 4: scale = pow2_ceil(max(amax,1e-4)/FP8_MAX) -> q_sc (FP32). ---
+    i = tid
+    while i < Int32(hpb * num_scales):
+        raw = fmax_f32(amax_view[i], Float32(1e-4)) * Float32(1.0 / _FP8_MAX)
+        rounded, _ue8m0 = pow2_ceil_ue8m0(raw)
+        q_sc_view[i] = rounded
+        if cutlass.const_expr(packed_q_scale_words):
+            h = i // Int32(num_scales)
+            blk = i - h * Int32(num_scales)
+            st_shared_u8(
+                q_fp8_base_addr + h * Int32(q_nope_stride) + Int32(d_nope) + blk,
+                (_ue8m0 & Uint32(0xFF)).to(cutlass.Uint8),
+            )
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    # --- Step 5: quantize q_nope to E4M3 into q_fp8; zero-fill invalid heads. ---
+    idx = tid
+    while idx < Int32(hpb * d_nope):
+        h = idx // Int32(d_nope)
+        d = idx - h * Int32(d_nope)
+        blk = d // Int32(quant_tile)
+        out_byte = h * Int32(q_nope_stride) + d
+        fp8_bits = Uint32(0)
+        if h < valid_hpb:
+            si = Float32(1.0) / q_sc_view[h * Int32(num_scales) + blk]
+            v = Float32(q_token[head_base + h, d]) * si
+            v = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), v))
+            fp8_bits = cvt_f32_to_e4m3(v)
+        st_shared_u8(
+            _smem_byte(q_fp8_base_addr, out_byte),
+            (fp8_bits & Uint32(0xFF)).to(cutlass.Uint8),
+        )
+        idx += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+
+@cute.jit
+def s0_load_q_bf16_to_smem(
+    q_token: cute.Tensor,  # (NUM_HEADS, D_QK) bf16 view for this token
+    q_nope_bf16_base_addr: Int32,  # u32 smem addr of BF16 Q-NoPE
+    q_rope_base_addr: Int32,  # u32 smem addr of q_rope (HPB x q_rope_stride bf16)
+    head_base: Int32,  # first head index of this CTA (h_start)
+    valid_hpb: Int32,  # number of valid heads (<= HPB)
+    tid: Int32,  # flat thread id in [0, MATH_THREADS)
+    *,
+    d_nope: cutlass.Constexpr,  # 512
+    d_rope: cutlass.Constexpr,  # 64
+    hpb: cutlass.Constexpr,  # 16
+    q_nope_bf16_stride: cutlass.Constexpr,  # D_NOPE + 8
+    q_rope_stride: cutlass.Constexpr,  # D_ROPE plus optional bank-layout pad
+    num_threads: cutlass.Constexpr,  # 256
+    barrier_id: cutlass.Constexpr,
+    barrier_threads: cutlass.Constexpr = 0,  # barrier width override (0 -> num_threads)
+):
+    """S0 (NVFP4): stage Q-NoPE and Q-RoPE as BF16.
+
+    This is the decode-local counterpart to the MG prefill BF16-QK path: no Q
+    FP8 quantization and no Q scale side buffer. Invalid tail heads are zeroed so
+    the regular VALID_HPB-gated epilogue can reuse the same tile geometry.
+    """
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
+
+    i = tid
+    while i < Int32(hpb * d_nope):
+        h = i // Int32(d_nope)
+        d = i - h * Int32(d_nope)
+        val = Float32(0.0)
+        if h < valid_hpb:
+            val = Float32(q_token[head_base + h, d])
+        st_shared_bf16_from_f32(
+            q_nope_bf16_base_addr + (h * Int32(q_nope_bf16_stride) + d) * Int32(2),
+            val,
+        )
+        i += Int32(num_threads)
+
+    i = tid
+    while i < Int32(hpb * d_rope):
+        h = i // Int32(d_rope)
+        d = i - h * Int32(d_rope)
+        val = Float32(0.0)
+        if h < valid_hpb:
+            val = Float32(q_token[head_base + h, Int32(d_nope) + d])
+        st_shared_bf16_from_f32(
+            _smem_byte(q_rope_base_addr, (h * Int32(q_rope_stride) + d) * Int32(2)),
+            val,
+        )
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+
+# =============================================================================
+# S0b -- REMOVED (P10f). The prior GLM K dequant+requant stage forced K/V back
+# through e4m3 to use a UNIT block-scale selector, which DISCARDED the per-group
+# e4m3 mantissa headroom (K-dequant cos 0.99968 -> 0.99627) and cost ~0.003 cos
+# end-to-end. GLM now keeps RAW e4m3 K/V and applies its arbitrary fp32 group
+# scale AFTER the MMA: S1 (QK) post-MMA FP32 scale (legacy
+# _accumulate_scaled_score_frag), S6 (V) inline per-group fp32 V-scale. DSV4
+# (UE8M0_BYTE) never ran S0b, so its trace/PTX are unchanged.
+# =============================================================================
+
+
+# =============================================================================
+# S1 -- QK-NoPE block-scaled FP8 MMA (ue8m0 selectors, REAL sfa/sfb)
+# =============================================================================
+@cute.jit
+def s1_qk_nope_block_scaled(
+    qk,  # length-4 python list of Float32 (in/out accum)
+    q_fp8_base_addr: Int32,  # u32 smem addr of q_fp8
+    kv_fp8_base_addr: Int32,  # u32 smem addr of kv_fp8[buf]
+    q_sc_view: cute.Tensor,  # smem fp32 view (HPB*NUM_SCALES,)
+    kv_sc_base_addr: Int32,  # u32 smem addr of kv_sc[buf] (BI x 8 footer bytes)
+    warp_first_cand: Int32,  # first candidate of this warp (warp_id * 8)
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    num_scales: cutlass.Constexpr,  # 7
+    quant_tile: cutlass.Constexpr,  # 64
+    q_nope_stride: cutlass.Constexpr,  # 464
+    kv_smem_stride: cutlass.Constexpr,  # 464
+    scale_bytes_per_token: cutlass.Constexpr,  # 8
+    scale_format: cutlass.Constexpr = 0,  # ScaleFormat.UE8M0_BYTE (0) / ARBITRARY_FP32 (1)
+    valid_hpb: cutlass.Constexpr = 16,
+):
+    """S1: accumulate Q_nope . K_nope into qk[0..3] via NUM_SCALES*(QUANT_TILE/32)
+    block-scaled MMAs (14 DSV4 / 16 GLM).
+
+    range_constexpr-unrolled NUM_SCALES x (QUANT_TILE/32) so the (default-0)
+    bid/tid selectors fold to i16 immediates. sfa = the UE8M0 exponent byte of
+    the Q pow2 scale (extracted from the FP32 q_sc) -- IDENTICAL for both models
+    (Q is always quantized to a pow2 UE8M0 scale in S0).
+
+    sfb DIVERGES on ``scale_format`` (const_expr):
+      * UE8M0_BYTE (DSV4): sfb = the K footer UE8M0 byte (kv_sc[cand*8 + blk]).
+        The raw e4m3 K is kept and the real pow2 K selector applies (zero cost).
+        All NUM_SCALES groups accumulate DIRECTLY into qk (the K pow2 magnitude
+        is folded by the hardware ue8m0 selector).
+      * ARBITRARY_FP32 (GLM, P10f): sfb = UNIT (0x7F) on the RAW e4m3 K (NO S0b
+        requant -- that threw away the per-group e4m3 mantissa headroom). The
+        block-scaled MMA of group ``blk`` runs into a SEPARATE per-group temp
+        accumulator (UNIT K, real pow2 sfa on Q), then the temp is multiplied by
+        the per-CANDIDATE arbitrary fp32 group scale ``k_scale[cand, blk]`` and
+        accumulated into qk in FP32 -- EXACTLY legacy kernel.py
+        _accumulate_scaled_score_frag (:1308-1311) post-MMA FP32 scaling. The
+        arbitrary fp32 K scale (~5e-5, NON-power-of-2) cannot be represented by a
+        ue8m0 selector, so it must apply AFTER the MMA. The inline fp32 group
+        scale lives at ``cand*KV_SMEM_STRIDE + D_NOPE + blk*4`` (4B), where
+        D_NOPE == NUM_SCALES*QUANT_TILE.
+
+      * NVFP4_E4M3: Q-NoPE is already staged as BF16; packed E2M1 K data and
+        E4M3 group-16 scales are dequantized in registers, multiplied by the
+        per-layer outer scale, and fed to the BF16 m16n8k16 MMA. No FP8
+        block-scale selectors are used in this branch.
+
+    A (Q) loaded via ldmatrix.x4 (FP8 A 16x32 for scale_format 0/1, BF16 A
+    16x16 for scale_format 2); B follows the matching FP8 or BF16 path.
+    """
+    if cutlass.const_expr(scale_format == 2):
+        return s1_qk_nope_nvfp4_bf16(
+            qk,
+            q_fp8_base_addr,
+            kv_fp8_base_addr,
+            warp_first_cand,
+            lane,
+            latent_scale,
+            num_scales=num_scales,
+            quant_tile=quant_tile,
+            q_nope_bf16_stride=q_nope_stride,
+            kv_smem_stride=kv_smem_stride,
+        )
+
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    # GLM only: this lane's two candidate columns (c0 -> qk[0]/qk[2],
+    # c1 -> qk[1]/qk[3]); inline fp32 group-scale base byte D_NOPE.
+    glm_c0 = warp_first_cand + tid * Int32(2)
+    glm_c1 = glm_c0 + Int32(1)
+    glm_scale_base = Int32(num_scales) * Int32(quant_tile)  # == D_NOPE
+
+    # ldmatrix A (Q) row/col -- arch/ldmatrix_sm120.cuh ldmatrix_load_A_fp8.
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(16)
+    # ldmatrix B (K) row/col -- ldmatrix_load_B_fp8.
+    b_row = lane & Int32(7)
+    b_col = ((lane >> Int32(3)) & Int32(1)) * Int32(16)
+
+    # sfa head index: (gid + (lane&1)*8) -- matches decode_dsv4 :378.
+    sfa_head = gid + (lane & Int32(1)) * Int32(8)
+    # sfb candidate row = warp_first_cand + gid (the N-tile base + gid). nt=0.
+    sfb_cand = warp_first_cand + gid
+    if cutlass.const_expr(scale_format == 0):
+        sfb_row_addr = kv_sc_base_addr + sfb_cand * Int32(scale_bytes_per_token)
+    hi = cutlass.const_expr(valid_hpb > 8)
+
+    for blk in cutlass.range_constexpr(num_scales):
+        # sfa = exponent byte of the FP32 pow2 Q scale for this (head, blk).
+        q_scale = q_sc_view[sfa_head * Int32(num_scales) + Int32(blk)]
+        sfa = _fp32_to_ue8m0_byte(q_scale)
+        if cutlass.const_expr(scale_format == 0):
+            # DSV4 UE8M0_BYTE: sfb = K footer UE8M0 byte for this candidate + blk.
+            sfb = ld_shared_u8_offset(sfb_row_addr, blk)
+        else:
+            # GLM ARBITRARY_FP32 (P10f): raw e4m3 K, UNIT block-scale; the per-group
+            # arbitrary fp32 scale is applied AFTER the MMA (below).
+            sfb = Uint32(0x7F)
+        # GLM accumulates each group's partial into a SEPARATE temp so the
+        # arbitrary fp32 group scale can be applied post-MMA; DSV4 accumulates
+        # directly into qk (byte-identical to the pre-P10f trace).
+        if cutlass.const_expr(scale_format == 0):
+            acc0, acc1, acc2, acc3 = qk[0], qk[1], qk[2], qk[3]
+        else:
+            acc0 = Float32(0.0)
+            acc1 = Float32(0.0)
+            acc2 = Float32(0.0)
+            acc3 = Float32(0.0)
+        for ks in cutlass.range_constexpr(quant_tile // 32):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(32)
+            # A operand: Q (16 heads x 32 fp8 K-dims) at q_fp8 + ko.
+            a_addr = _smem_byte(
+                q_fp8_base_addr, a_row * Int32(q_nope_stride) + ko + a_col
+            )
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+            # B operand: K (8 cands x 32 fp8 K-dims) at kv_fp8 + cand_base*stride + ko.
+            b_addr = _smem_byte(
+                kv_fp8_base_addr,
+                warp_first_cand * Int32(kv_smem_stride)
+                + b_row * Int32(kv_smem_stride)
+                + ko
+                + b_col,
+            )
+            b0, b1 = ldmatrix_m8n8x2_b16(b_addr)
+            acc0, acc1, acc2, acc3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                acc0,
+                acc1,
+                acc2,
+                acc3,
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+                sfa,
+                sfb,
+            )
+        if cutlass.const_expr(scale_format == 0):
+            qk[0] = acc0
+            qk[1] = acc1
+            if cutlass.const_expr(hi):
+                qk[2] = acc2
+                qk[3] = acc3
+        else:
+            # GLM: post-MMA FP32 scale by the per-candidate arbitrary fp32 group
+            # scale (legacy _accumulate_scaled_score_frag). c0 -> qk[0]/qk[2];
+            # c1 -> qk[1]/qk[3]. Scale read from the inline fp32 footer (the same
+            # bytes io.py gathers in the kv_fp8 nope bulk).
+            ks0 = _u32_to_f32(
+                ld_shared_u32(
+                    kv_fp8_base_addr
+                    + glm_c0 * Int32(kv_smem_stride)
+                    + glm_scale_base
+                    + Int32(blk) * Int32(4)
+                )
+            )
+            ks1 = _u32_to_f32(
+                ld_shared_u32(
+                    kv_fp8_base_addr
+                    + glm_c1 * Int32(kv_smem_stride)
+                    + glm_scale_base
+                    + Int32(blk) * Int32(4)
+                )
+            )
+            qk[0] = qk[0] + acc0 * ks0
+            qk[1] = qk[1] + acc1 * ks1
+            if cutlass.const_expr(hi):
+                qk[2] = qk[2] + acc2 * ks0
+                qk[3] = qk[3] + acc3 * ks1
+    return qk
+
+
+@cute.jit
+def s1_qk_nope_nvfp4_bf16(
+    qk,
+    q_nope_bf16_base_addr: Int32,
+    kv_fp4_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    num_scales: cutlass.Constexpr,  # 8 logical 64-dim FP4 K steps
+    quant_tile: cutlass.Constexpr,  # 64
+    q_nope_bf16_stride: cutlass.Constexpr,  # 520 elems
+    kv_smem_stride: cutlass.Constexpr,  # 288 bytes
+):
+    """S1 (NVFP4): BF16 QK-NoPE over in-register dequantized E2M1 K.
+
+    Storage has 32 E4M3 scales per token (group-16). The outer loop keeps the
+    logical FP4 K-step count at 512/64=8, and the inner loop feeds four BF16
+    m16n8k16 MMAs per 64-dim step.
+    """
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    kv_gid_row = warp_first_cand + gid
+
+    for blk in cutlass.range_constexpr(num_scales):
+        for ks in cutlass.range_constexpr(quant_tile // 16):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(16)
+            b0 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            b1 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2) + Int32(8),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a_byte = a_row * Int32(q_nope_bf16_stride * 2) + (ko + a_col) * Int32(2)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_byte(q_nope_bf16_base_addr, a_byte)
+            )
+            qk[0], qk[1], qk[2], qk[3] = mma_m16n8k16_f32_bf16(
+                qk[0],
+                qk[1],
+                qk[2],
+                qk[3],
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+            )
+    return qk
+
+
+@cute.jit
+def s1_qk_nope_block_scaled_glm_h8_swap_ab(
+    qk,
+    q_fp8_base_addr: Int32,
+    kv_fp8_base_addr: Int32,
+    q_sc_view: cute.Tensor,
+    warp_first_cand: Int32,
+    lane: Int32,
+    *,
+    num_scales: cutlass.Constexpr,
+    quant_tile: cutlass.Constexpr,
+    q_nope_stride: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+):
+    """GLM TP8 QK-NoPE with the logical operands swapped.
+
+    Hardware A is a 16-candidate K tile and hardware B is Q transposed into the
+    eight-column role.  The m16n8 output is therefore fully occupied instead of
+    padding the eight query heads to sixteen rows.  Four warps cover BI=64.
+
+    Fragment ownership is::
+
+        qk[0] = score[cand=base+gid,   head=2*tid]
+        qk[1] = score[cand=base+gid,   head=2*tid+1]
+        qk[2] = score[cand=base+gid+8, head=2*tid]
+        qk[3] = score[cand=base+gid+8, head=2*tid+1]
+
+    GLM's arbitrary K scale remains a candidate-wise FP32 post-MMA multiply.
+    Q's pow2 scale moves from SFA to SFB, matching its new hardware-B role.
+    """
+    gid = lane >> Int32(2)
+
+    # A: sixteen candidate rows from K.
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(16)
+    # B: eight query-head rows.  scale_vec::1X SFB consumes q_sc[gid].
+    b_row = lane & Int32(7)
+    b_col = ((lane >> Int32(3)) & Int32(1)) * Int32(16)
+    sfb_head = gid
+
+    cand0 = warp_first_cand + gid
+    cand1 = cand0 + Int32(8)
+    glm_scale_base = Int32(num_scales) * Int32(quant_tile)
+
+    for blk in cutlass.range_constexpr(num_scales):
+        sfa = Uint32(0x7F)  # raw GLM K; arbitrary scale is applied below
+        sfb = _fp32_to_ue8m0_byte(q_sc_view[sfb_head * Int32(num_scales) + Int32(blk)])
+        acc0 = Float32(0.0)
+        acc1 = Float32(0.0)
+        acc2 = Float32(0.0)
+        acc3 = Float32(0.0)
+        for ks in cutlass.range_constexpr(quant_tile // 32):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(32)
+            a_addr = _smem_byte(
+                kv_fp8_base_addr,
+                warp_first_cand * Int32(kv_smem_stride)
+                + a_row * Int32(kv_smem_stride)
+                + ko
+                + a_col,
+            )
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+            b_addr = _smem_byte(
+                q_fp8_base_addr,
+                b_row * Int32(q_nope_stride) + ko + b_col,
+            )
+            b0, b1 = ldmatrix_m8n8x2_b16(b_addr)
+            acc0, acc1, acc2, acc3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                acc0,
+                acc1,
+                acc2,
+                acc3,
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+                sfa,
+                sfb,
+            )
+
+        ks0 = _u32_to_f32(
+            ld_shared_u32(
+                kv_fp8_base_addr
+                + cand0 * Int32(kv_smem_stride)
+                + glm_scale_base
+                + Int32(blk) * Int32(4)
+            )
+        )
+        ks1 = _u32_to_f32(
+            ld_shared_u32(
+                kv_fp8_base_addr
+                + cand1 * Int32(kv_smem_stride)
+                + glm_scale_base
+                + Int32(blk) * Int32(4)
+            )
+        )
+        qk[0] = qk[0] + acc0 * ks0
+        qk[1] = qk[1] + acc1 * ks0
+        qk[2] = qk[2] + acc2 * ks1
+        qk[3] = qk[3] + acc3 * ks1
+    return qk
+
+
+@cute.jit
+def s1_qk_nope_block_scaled_dsv4_h8_swap_ab(
+    qk,
+    q_fp8_base_addr: Int32,
+    kv_fp8_base_addr: Int32,
+    q_sc_view: cute.Tensor,
+    kv_sc_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    *,
+    num_scales: cutlass.Constexpr,
+    quant_tile: cutlass.Constexpr,
+    q_nope_stride: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    scale_bytes_per_token: cutlass.Constexpr,
+    packed_footer_words: cutlass.Constexpr = False,
+    packed_q_scale_words: cutlass.Constexpr = False,
+):
+    """DSV4 H8 QK with candidates in hardware A and heads in hardware B.
+
+    Four warps cover the 64-candidate window.  Unlike the H16 orientation, both
+    operands are regular ldmatrix tiles; the per-candidate UE8M0 K scale moves to
+    SFA and the per-head Q scale moves to SFB.  Fragment ownership matches the
+    GLM H8 swapped path.
+    """
+    gid = lane >> Int32(2)
+
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(16)
+    b_row = lane & Int32(7)
+    b_col = ((lane >> Int32(3)) & Int32(1)) * Int32(16)
+
+    # scale_vec::1X selector ownership follows the physical operand tiles.
+    sfa_cand = warp_first_cand + gid + (lane & Int32(1)) * Int32(8)
+    sfb_head = gid
+
+    footer_lo = Uint32(0)
+    footer_hi = Uint32(0)
+    if cutlass.const_expr(packed_footer_words):
+        footer_lo, footer_hi = ld_shared_v2_u32(
+            kv_sc_base_addr + sfa_cand * Int32(scale_bytes_per_token)
+        )
+    q_scale_lo = Uint32(0)
+    q_scale_hi = Uint32(0)
+    if cutlass.const_expr(packed_q_scale_words):
+        q_scale_lo, q_scale_hi = ld_shared_v2_u32(
+            q_fp8_base_addr
+            + sfb_head * Int32(q_nope_stride)
+            + Int32(num_scales * quant_tile)
+        )
+
+    for blk in cutlass.range_constexpr(num_scales):
+        if cutlass.const_expr(packed_footer_words):
+            sfa = _packed_u8(footer_lo, footer_hi, blk)
+        else:
+            sfa = _ld_u8_zext(
+                kv_sc_base_addr,
+                sfa_cand * Int32(scale_bytes_per_token) + Int32(blk),
+            )
+        if cutlass.const_expr(packed_q_scale_words):
+            sfb = _packed_u8(q_scale_lo, q_scale_hi, blk)
+        else:
+            sfb = _fp32_to_ue8m0_byte(
+                q_sc_view[sfb_head * Int32(num_scales) + Int32(blk)]
+            )
+        for ks in cutlass.range_constexpr(quant_tile // 32):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(32)
+            a_addr = _smem_byte(
+                kv_fp8_base_addr,
+                warp_first_cand * Int32(kv_smem_stride)
+                + a_row * Int32(kv_smem_stride)
+                + ko
+                + a_col,
+            )
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+            b_addr = _smem_byte(
+                q_fp8_base_addr,
+                b_row * Int32(q_nope_stride) + ko + b_col,
+            )
+            b0, b1 = ldmatrix_m8n8x2_b16(b_addr)
+            qk[0], qk[1], qk[2], qk[3] = mxfp8_mma_m16n8k32_f32_e4m3(
+                qk[0],
+                qk[1],
+                qk[2],
+                qk[3],
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+                sfa,
+                sfb,
+            )
+    return qk
+
+
+# =============================================================================
+# S2 -- QK-RoPE bf16 m16n8k16 MMA (accumulate into the SAME qk regs)
+# =============================================================================
+@cute.jit
+def s2_qk_rope_bf16(
+    qk,  # length-4 python list of Float32 (in/out accum)
+    q_rope_base_addr: Int32,  # u32 smem addr of q_rope (HPB x D_ROPE bf16)
+    kv_rope_base_addr: Int32,  # u32 smem addr of kv_rope[buf] (BI x D_ROPE bf16)
+    warp_first_cand: Int32,
+    lane: Int32,
+    *,
+    d_rope: cutlass.Constexpr,  # 64
+    q_rope_stride: cutlass.Constexpr,
+    valid_hpb: cutlass.Constexpr = 16,
+    fp8_rope: cutlass.Constexpr = False,
+):
+    """S2: accumulate Q_rope . K_rope into qk[0..3] via D_ROPE/16=4 bf16 MMAs.
+
+    A (Q-rope, 16x16 bf16) via ldmatrix.x4 (ldmatrix_load_A_bf16); B (K-rope)
+    via per-lane scalar u32 reads -- the N-major rope smem layout can't feed
+    ldmatrix.x2 here (decode_dsv4 :401-425).
+    """
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    # Each lane's K-rope entry = warp_first_cand + gid (nt=0).
+    entry = warp_first_cand + gid
+    hi = cutlass.const_expr(valid_hpb > 8)
+
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        # A: Q-rope (bf16) at q_rope + ks*16 (elems).
+        a_byte = a_row * Int32(q_rope_stride * 2) + (ko + a_col) * Int32(2)
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(_smem_byte(q_rope_base_addr, a_byte))
+        # B: flag-off retains the exact BF16 scalar loads.  Flag-on interprets
+        # the staged 80-byte tail as fp32 scale at +0, pad through +15, then
+        # 64 E4M3 values at +16 and reconstructs each pair to BF16 registers.
+        if cutlass.const_expr(fp8_rope):
+            b0 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr,
+                entry,
+                ko + tid * Int32(2),
+                d_rope=d_rope,
+            )
+            b1 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr,
+                entry,
+                ko + tid * Int32(2) + Int32(8),
+                d_rope=d_rope,
+            )
+        else:
+            row_byte = entry * Int32(d_rope * 2) + ko * Int32(2)
+            b0 = _ld_u32(kv_rope_base_addr, row_byte + tid * Int32(2) * Int32(2))
+            b1 = _ld_u32(
+                kv_rope_base_addr, row_byte + (tid * Int32(2) + Int32(8)) * Int32(2)
+            )
+        d0, d1, d2, d3 = mma_m16n8k16_f32_bf16(
+            qk[0],
+            qk[1],
+            qk[2],
+            qk[3],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+        )
+        qk[0] = d0
+        qk[1] = d1
+        if cutlass.const_expr(hi):
+            qk[2] = d2
+            qk[3] = d3
+    return qk
+
+
+@cute.jit
+def s2_qk_rope_bf16_glm_h8_swap_ab(
+    qk,
+    q_rope_base_addr: Int32,
+    kv_rope_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    *,
+    d_rope: cutlass.Constexpr,
+    q_rope_stride: cutlass.Constexpr,
+    kv_rope_stride_bytes: cutlass.Constexpr,
+):
+    """GLM TP8 RoPE dot product in the same swapped fragment layout as S1."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    q_head = gid
+
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        a_byte = (warp_first_cand + a_row) * Int32(kv_rope_stride_bytes) + (
+            ko + a_col
+        ) * Int32(2)
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(_smem_byte(kv_rope_base_addr, a_byte))
+        row_byte = q_head * Int32(q_rope_stride * 2) + ko * Int32(2)
+        b0 = _ld_u32(q_rope_base_addr, row_byte + tid * Int32(2) * Int32(2))
+        b1 = _ld_u32(
+            q_rope_base_addr,
+            row_byte + (tid * Int32(2) + Int32(8)) * Int32(2),
+        )
+        qk[0], qk[1], qk[2], qk[3] = mma_m16n8k16_f32_bf16(
+            qk[0],
+            qk[1],
+            qk[2],
+            qk[3],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+        )
+    return qk
+
+
+# =============================================================================
+# S3 -- mask invalid candidates -> -inf, then qk *= sm_scale * LOG2E
+# =============================================================================
+@cute.jit
+def s3_mask_and_scale(
+    qk,  # length-4 python list of Float32 (in/out)
+    sTokenIdx: cute.Tensor,  # smem int32 validity buffer (BI,)
+    warp_first_cand: Int32,
+    split_cand_start: Int32,  # chunk_in_section * DSV4_CAND_WINDOW
+    split_cand_end: Int32,  # min(start + CAND_WINDOW, section_len)
+    section_len: Int32,
+    sm_scale_log2: Float32,  # sm_scale * LOG2E
+    lane: Int32,
+):
+    """S3: mask + base-2 prescale. Validity = staged token index (gap #9).
+
+    The lane owns candidate columns c0 = warp_first_cand + tid*2 and c1 = c0+1
+    (qk[0],qk[2] -> c0 ; qk[1],qk[3] -> c1). Invalid if the absolute candidate
+    position is past split_cand_end OR the staged raw slot id is < 0.
+
+    Masked qk is set to ``-1e30`` (NOT -inf) -- matches decode_dsv4 :443. After
+    the ``* sm_scale_log2`` this is a large FINITE negative (~-6.38e28); the S4
+    online softmax relies on this finiteness so a fully-invalid warp's
+    ``qk - local_max`` is 0 (not the ``inf - inf = nan`` that -inf would give).
+    The merge sentinel (-inf empty-block LSE) is emitted separately in S7."""
+    tid = lane & Int32(3)
+    c0 = warp_first_cand + tid * Int32(2)
+    c1 = c0 + Int32(1)
+    abs_c0 = c0 + split_cand_start
+    abs_c1 = c1 + split_cand_start
+
+    idx0 = Int32(-1)
+    if abs_c0 < section_len:
+        idx0 = Int32(sTokenIdx[c0])
+    idx1 = Int32(-1)
+    if abs_c1 < section_len:
+        idx1 = Int32(sTokenIdx[c1])
+
+    if abs_c0 >= split_cand_end or idx0 < Int32(0):
+        qk[0] = Float32(_QK_MASK)
+        qk[2] = Float32(_QK_MASK)
+    if abs_c1 >= split_cand_end or idx1 < Int32(0):
+        qk[1] = Float32(_QK_MASK)
+        qk[3] = Float32(_QK_MASK)
+
+    qk[0] = qk[0] * sm_scale_log2
+    qk[1] = qk[1] * sm_scale_log2
+    qk[2] = qk[2] * sm_scale_log2
+    qk[3] = qk[3] * sm_scale_log2
+    return qk
+
+
+@cute.jit
+def s3_mask_and_scale_glm_h8_swap_ab(
+    qk,
+    sTokenIdx: cute.Tensor,
+    warp_first_cand: Int32,
+    split_cand_start: Int32,
+    split_cand_end: Int32,
+    section_len: Int32,
+    sm_scale_log2: Float32,
+    lane: Int32,
+):
+    """Mask the two candidate rows owned by a swapped GLM TP8 fragment."""
+    gid = lane >> Int32(2)
+    c0 = warp_first_cand + gid
+    c1 = c0 + Int32(8)
+    abs_c0 = c0 + split_cand_start
+    abs_c1 = c1 + split_cand_start
+
+    idx0 = Int32(-1)
+    if abs_c0 < section_len:
+        idx0 = Int32(sTokenIdx[c0])
+    idx1 = Int32(-1)
+    if abs_c1 < section_len:
+        idx1 = Int32(sTokenIdx[c1])
+
+    if abs_c0 >= split_cand_end or idx0 < Int32(0):
+        qk[0] = Float32(_QK_MASK)
+        qk[1] = Float32(_QK_MASK)
+    if abs_c1 >= split_cand_end or idx1 < Int32(0):
+        qk[2] = Float32(_QK_MASK)
+        qk[3] = Float32(_QK_MASK)
+
+    for i in cutlass.range_constexpr(4):
+        qk[i] = qk[i] * sm_scale_log2
+    return qk
+
+
+# ── small smem byte-access helpers (typed loads the imported ops don't cover) ─
+@cute.jit
+def _fp32_to_ue8m0_byte(scale: Float32) -> Uint32:
+    """sfa = (float_as_uint(scale) >> 23) & 0xFF -- scale_convert.cuh fp32_to_ue8m0.
+
+    ``scale`` is already a pow2 (mantissa 0) so this is its exponent byte; the
+    block-scaled MMA uses only the low byte of the u32 (scale_vec::1X)."""
+    bits = _f32_to_bits(scale)
+    return (bits >> Uint32(23)) & Uint32(0xFF)
+
+
+@cute.jit
+def _ld_u8_zext(base_addr: Int32, byte_off: Int32) -> Uint32:
+    """Load one u8 from smem (base+byte_off), zero-extended to u32."""
+    word = byte_off & ~Int32(3)
+    sh = (byte_off & Int32(3)) * Int32(8)
+    val = ld_shared_u32(base_addr + word)
+    return (val >> sh.to(Uint32)) & Uint32(0xFF)
+
+
+@cute.jit
+def _packed_u8(
+    lo: Uint32,
+    hi: Uint32,
+    byte_idx: cutlass.Constexpr,
+) -> Uint32:
+    if cutlass.const_expr(byte_idx < 4):
+        return (lo >> Uint32(byte_idx * 8)) & Uint32(0xFF)
+    return (hi >> Uint32((byte_idx - 4) * 8)) & Uint32(0xFF)
+
+
+@cute.jit
+def _ld_u32(base_addr: Int32, byte_off: Int32) -> Uint32:
+    return ld_shared_u32(base_addr + byte_off)
+
+
+@cute.jit
+def _ld_u16_zext(base_addr: Int32, byte_off: Int32) -> Uint32:
+    """Load one u16 (bf16) from smem (base+byte_off), zero-extended to u32.
+
+    ``byte_off`` is always 2-byte aligned (bf16 or packed FP8-pair element).
+    Use the native halfword shared-memory instruction rather than loading the
+    containing word and dynamically selecting its low/high half.  The latter
+    costs address masking plus SHF/LOP3 on every BF16-QK K step.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [(base_addr + byte_off).ir_value()],
+            "ld.shared.u16 $0, [$1];",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def _fp8_rope_pair_bfloat2(
+    kv_rope_base_addr: Int32,
+    entry: Int32,
+    dim_even: Int32,
+    *,
+    d_rope: cutlass.Constexpr,
+) -> Uint32:
+    """Dequant one E4M3 RoPE pair from the staged 368-byte-record tail."""
+    row_byte = entry * Int32(d_rope * 2)
+    scale = ld_shared_f32(kv_rope_base_addr + row_byte)
+    packed = _ld_u16_zext(
+        kv_rope_base_addr,
+        row_byte + Int32(16) + dim_even,
+    )
+    v0 = cvt_e4m3_to_f32_via_f16(packed & Uint32(0xFF)) * scale
+    v1 = cvt_e4m3_to_f32_via_f16((packed >> Uint32(8)) & Uint32(0xFF)) * scale
+    return pack_f32x2_to_bfloat2(v0, v1)
+
+
+@cute.jit
+def _bf16x2_extract_lane_u16(packed: Uint32, lane: Int32) -> Uint32:
+    sh = (lane & Int32(1)) * Int32(16)
+    return (packed >> sh.to(Uint32)) & Uint32(0xFFFF)
+
+
+@cute.jit
+def _nvfp4_pair_bfloat2(
+    kv_fp4_base_addr: Int32,
+    entry: Int32,
+    dim_even: Int32,
+    latent_scale: Float32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+) -> Uint32:
+    """Dequant E2M1 * inline E4M3 * per-layer outer scale to bf16x2."""
+    data_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride) + (dim_even // Int32(2)),
+    )
+    vals_h2 = fp4_decode_2(data_byte)
+    v0, v1 = f16x2_to_f32x2(vals_h2)
+    scale_group = dim_even // Int32(_NVFP4_SCALE_GROUP)
+    scale_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride) + Int32(_NVFP4_SCALE_OFFSET) + scale_group,
+    )
+    scale_f = cvt_e4m3_to_f32_via_f16(scale_byte)
+    # This is the single NVFP4 decode dequant point shared by QK and P.V.
+    # Apply s_l before BF16 packing so both MMAs consume the same true-magnitude
+    # latent; the separate BF16 RoPE path never calls this helper.
+    return pack_f32x2_to_bfloat2(
+        (v0 * scale_f) * latent_scale,
+        (v1 * scale_f) * latent_scale,
+    )
+
+
+@cute.jit
+def _nvfp4_scalar_bf16_u16(
+    kv_fp4_base_addr: Int32,
+    entry: Int32,
+    dim: Int32,
+    latent_scale: Float32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+) -> Uint32:
+    pair = _nvfp4_pair_bfloat2(
+        kv_fp4_base_addr,
+        entry,
+        dim & ~Int32(1),
+        latent_scale,
+        kv_smem_stride=kv_smem_stride,
+    )
+    return _bf16x2_extract_lane_u16(pair, dim & Int32(1))
+
+
+@cute.jit
+def _ue8m0_byte_to_fp32(byte: Uint32) -> Float32:
+    """value = 2^(byte - 127) -- scale_convert.cuh ue8m0_to_fp32 (the V-scale).
+
+    Reconstructs the FP32 power-of-2 from its UE8M0 exponent byte by placing the
+    byte in the IEEE-754 exponent field (zero mantissa)."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(byte & Uint32(0xFF)).ir_value()],
+            "{ .reg .b32 b; shl.b32 b, $1, 23; mov.b32 $0, b; }",
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def _ue8m0_zext_byte_to_fp32(byte: Uint32) -> Float32:
+    """Expand an already zero-extended UE8M0 byte to its FP32 power of two.
+
+    Native ``ld.shared.u8`` and the ``prmt(..., 0, 0x777x)`` scale-cache form
+    both guarantee that the upper 24 bits are zero, so masking again only adds
+    an instruction and diverges from the native prefill PTX.
+    """
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(byte).ir_value()],
+            "{ .reg .b32 b; shl.b32 b, $1, 23; mov.b32 $0, b; }",
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+# =============================================================================
+# S4 -- online softmax (warp-local + cross-warp + cross-chunk rescale)
+# Port of decode_dsv4 :456-566 + online_softmax.cuh; base-2 (exp2f).
+# =============================================================================
+@cute.jit
+def s4_online_softmax(
+    qk,  # length-4 Float32 (masked, base-2-prescaled)
+    p,  # length-4 Float32 out: exp2(qk - local_max)
+    acc_nope,  # list[N_V_CHUNKS] of length-4 Float32 lists (in/out)
+    acc_rope,  # length-4 Float32 list (in/out)
+    global_max,  # length-2 Float32 list (in/out): [row0, row1]
+    global_sum,  # length-2 Float32 list (in/out)
+    reduce_max_addr: Int32,  # u32 smem addr of warp_max (N_WARPS*HPB f32)
+    reduce_sum_addr: Int32,  # u32 smem addr of warp_sum (N_WARPS*HPB f32)
+    is_first_chunk: cutlass.Constexpr,  # True for the very first chunk in the loop
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,  # flat thread id [0, MATH_THREADS)
+    *,
+    n_v_chunks: cutlass.Constexpr,  # 7
+    hpb: cutlass.Constexpr,  # 16
+    n_warps: cutlass.Constexpr,  # 8
+    valid_hpb: cutlass.Constexpr,  # <= HPB
+    num_threads: cutlass.Constexpr,  # 256
+    barrier_id: cutlass.Constexpr,  # math-only named-barrier slot
+    n_acc_tiles: cutlass.Constexpr = None,  # len(acc_nope); defaults to n_v_chunks
+):
+    """S4: per-warp + cross-warp max/sum, exp2(qk-max), cross-chunk rescale.
+
+    Returns ``(p, warp_rescale0, warp_rescale1)``; mutates ``acc_nope`` /
+    ``acc_rope`` (rescaled by the cross-chunk alpha) and ``global_max`` /
+    ``global_sum`` in place. ``p`` is exp2(qk - local_max) (the warp-local-frame
+    probabilities); the caller multiplies by ``warp_rescale`` before storing
+    sm_p_full (kills all-invalid-warp spurious 1s). Exactly decode_dsv4
+    :456-587."""
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    # alpha "has-prev-max" guard threshold == decode_dsv4 :520 (> -1e29f).
+    _NI = Float32(-1e29)
+
+    # --- per-warp local max over the 2 physical rows (gid heads, gid+8 heads). ---
+    local_max0 = fmax_f32(qk[0], qk[1])
+    local_max1 = fmax_f32(qk[2], qk[3])
+    # shfl_xor offsets {2,1} finish the 8-lane (tid in [0,4) over 2-lane pairs)
+    # reduction across the candidate columns of this warp's N-tile.
+    local_max0 = fmax_f32(local_max0, cute.arch.shuffle_sync_bfly(local_max0, offset=2))
+    local_max1 = fmax_f32(local_max1, cute.arch.shuffle_sync_bfly(local_max1, offset=2))
+    local_max0 = fmax_f32(local_max0, cute.arch.shuffle_sync_bfly(local_max0, offset=1))
+    local_max1 = fmax_f32(local_max1, cute.arch.shuffle_sync_bfly(local_max1, offset=1))
+
+    # --- p = exp2(qk - local_max); local sum over the 4 frag entries. ---
+    p[0] = _exp2_approx_ftz_f32(qk[0] - local_max0)
+    p[1] = _exp2_approx_ftz_f32(qk[1] - local_max0)
+    p[2] = _exp2_approx_ftz_f32(qk[2] - local_max1)
+    p[3] = _exp2_approx_ftz_f32(qk[3] - local_max1)
+    local_sum0 = p[0] + p[1]
+    local_sum1 = p[2] + p[3]
+    local_sum0 = local_sum0 + cute.arch.shuffle_sync_bfly(local_sum0, offset=2)
+    local_sum1 = local_sum1 + cute.arch.shuffle_sync_bfly(local_sum1, offset=2)
+    local_sum0 = local_sum0 + cute.arch.shuffle_sync_bfly(local_sum0, offset=1)
+    local_sum1 = local_sum1 + cute.arch.shuffle_sync_bfly(local_sum1, offset=1)
+
+    # --- cross-warp reduce: stage per-warp (max,sum) for heads gid / gid+8. ---
+    if tid == Int32(0):
+        st_shared_f32(
+            reduce_max_addr + (warp_id * Int32(hpb) + gid) * Int32(4), local_max0
+        )
+        st_shared_f32(
+            reduce_max_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
+            local_max1,
+        )
+        st_shared_f32(
+            reduce_sum_addr + (warp_id * Int32(hpb) + gid) * Int32(4), local_sum0
+        )
+        st_shared_f32(
+            reduce_sum_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
+            local_sum1,
+        )
+    cute.arch.barrier(**bar_kw)
+
+    # one thread per head folds the 8 warps' (max,sum) into a block reduction.
+    if tid_flat < Int32(valid_hpb):
+        h = tid_flat
+        bmax = Float32(-1e30)
+        for w in cutlass.range_constexpr(n_warps):
+            wm = ld_shared_f32(reduce_max_addr + (Int32(w) * Int32(hpb) + h) * Int32(4))
+            bmax = fmax_f32(bmax, wm)
+        bsum = Float32(0.0)
+        for w in cutlass.range_constexpr(n_warps):
+            wm = ld_shared_f32(reduce_max_addr + (Int32(w) * Int32(hpb) + h) * Int32(4))
+            ws = ld_shared_f32(reduce_sum_addr + (Int32(w) * Int32(hpb) + h) * Int32(4))
+            bsum = bsum + ws * _exp2_approx_ftz_f32(wm - bmax)
+        st_shared_f32(reduce_max_addr + h * Int32(4), bmax)
+        st_shared_f32(reduce_sum_addr + h * Int32(4), bsum)
+    cute.arch.barrier(**bar_kw)
+
+    block_local_max0 = ld_shared_f32(reduce_max_addr + gid * Int32(4))
+    block_local_max1 = ld_shared_f32(reduce_max_addr + (gid + Int32(8)) * Int32(4))
+    block_local_sum0 = ld_shared_f32(reduce_sum_addr + gid * Int32(4))
+    block_local_sum1 = ld_shared_f32(reduce_sum_addr + (gid + Int32(8)) * Int32(4))
+
+    # --- online softmax update (cross-chunk). ---
+    new_gmax0 = fmax_f32(global_max[0], block_local_max0)
+    new_gmax1 = fmax_f32(global_max[1], block_local_max1)
+    alpha0 = Float32(0.0)
+    alpha1 = Float32(0.0)
+    if global_max[0] > _NI:
+        alpha0 = _exp2_approx_ftz_f32(global_max[0] - new_gmax0)
+    if global_max[1] > _NI:
+        alpha1 = _exp2_approx_ftz_f32(global_max[1] - new_gmax1)
+    block_rescale0 = _exp2_approx_ftz_f32(block_local_max0 - new_gmax0)
+    block_rescale1 = _exp2_approx_ftz_f32(block_local_max1 - new_gmax1)
+    warp_rescale0 = _exp2_approx_ftz_f32(local_max0 - new_gmax0)
+    warp_rescale1 = _exp2_approx_ftz_f32(local_max1 - new_gmax1)
+
+    _n_acc = cutlass.const_expr(n_acc_tiles if n_acc_tiles is not None else n_v_chunks)
+    if cutlass.const_expr(not is_first_chunk):
+        for vc in cutlass.range_constexpr(_n_acc):
+            acc_nope[vc][0] = acc_nope[vc][0] * alpha0
+            acc_nope[vc][1] = acc_nope[vc][1] * alpha0
+            acc_nope[vc][2] = acc_nope[vc][2] * alpha1
+            acc_nope[vc][3] = acc_nope[vc][3] * alpha1
+        acc_rope[0] = acc_rope[0] * alpha0
+        acc_rope[1] = acc_rope[1] * alpha0
+        acc_rope[2] = acc_rope[2] * alpha1
+        acc_rope[3] = acc_rope[3] * alpha1
+        global_sum[0] = global_sum[0] * alpha0 + block_local_sum0 * block_rescale0
+        global_sum[1] = global_sum[1] * alpha1 + block_local_sum1 * block_rescale1
+    else:
+        global_sum[0] = block_local_sum0 * block_rescale0
+        global_sum[1] = block_local_sum1 * block_rescale1
+    global_max[0] = new_gmax0
+    global_max[1] = new_gmax1
+
+    return p, warp_rescale0, warp_rescale1
+
+
+@cute.jit
+def s4_online_softmax_glm_h8_swap_ab(
+    qk,
+    p,
+    acc_nope,
+    acc_rope,
+    global_max,
+    global_sum,
+    reduce_max_addr: Int32,
+    reduce_sum_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    n_acc_tiles: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    rope_tiles_per_warp: cutlass.Constexpr = 0,
+    barrier_threads: cutlass.Constexpr = 0,  # barrier width override (0 -> num_threads)
+):
+    """Online softmax for the swapped 16-candidate x 8-head score tile.
+
+    ``global_{max,sum}[0:2]`` track the head pair ``(2*tid, 2*tid+1)``.
+    PV accumulators instead use the ordinary output-row ownership (head=gid),
+    so the cross-chunk alpha is shuffled from the lane owning that head pair
+    before rescaling the accumulator rows.
+    """
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    head0 = tid * Int32(2)
+    head1 = head0 + Int32(1)
+    _NI = Float32(-1e29)
+
+    local_max0 = fmax_f32(qk[0], qk[2])
+    local_max1 = fmax_f32(qk[1], qk[3])
+    for off in (4, 8, 16):
+        local_max0 = fmax_f32(
+            local_max0, cute.arch.shuffle_sync_bfly(local_max0, offset=off)
+        )
+        local_max1 = fmax_f32(
+            local_max1, cute.arch.shuffle_sync_bfly(local_max1, offset=off)
+        )
+
+    p[0] = _exp2_approx_ftz_f32(qk[0] - local_max0)
+    p[1] = _exp2_approx_ftz_f32(qk[1] - local_max1)
+    p[2] = _exp2_approx_ftz_f32(qk[2] - local_max0)
+    p[3] = _exp2_approx_ftz_f32(qk[3] - local_max1)
+    local_sum0 = p[0] + p[2]
+    local_sum1 = p[1] + p[3]
+    for off in (4, 8, 16):
+        local_sum0 = local_sum0 + cute.arch.shuffle_sync_bfly(local_sum0, offset=off)
+        local_sum1 = local_sum1 + cute.arch.shuffle_sync_bfly(local_sum1, offset=off)
+
+    # Lanes 0..3 (gid==0) own the four head pairs for this warp.
+    if gid == Int32(0):
+        st_shared_f32(
+            reduce_max_addr + (warp_id * Int32(hpb) + head0) * Int32(4),
+            local_max0,
+        )
+        st_shared_f32(
+            reduce_max_addr + (warp_id * Int32(hpb) + head1) * Int32(4),
+            local_max1,
+        )
+        st_shared_f32(
+            reduce_sum_addr + (warp_id * Int32(hpb) + head0) * Int32(4),
+            local_sum0,
+        )
+        st_shared_f32(
+            reduce_sum_addr + (warp_id * Int32(hpb) + head1) * Int32(4),
+            local_sum1,
+        )
+    cute.arch.barrier(**bar_kw)
+
+    if tid_flat < Int32(8):
+        h = tid_flat
+        bmax = Float32(-1e30)
+        for w in cutlass.range_constexpr(n_warps):
+            wm = ld_shared_f32(reduce_max_addr + (Int32(w) * Int32(hpb) + h) * Int32(4))
+            bmax = fmax_f32(bmax, wm)
+        bsum = Float32(0.0)
+        for w in cutlass.range_constexpr(n_warps):
+            wm = ld_shared_f32(reduce_max_addr + (Int32(w) * Int32(hpb) + h) * Int32(4))
+            ws = ld_shared_f32(reduce_sum_addr + (Int32(w) * Int32(hpb) + h) * Int32(4))
+            bsum = bsum + ws * _exp2_approx_ftz_f32(wm - bmax)
+        st_shared_f32(reduce_max_addr + h * Int32(4), bmax)
+        st_shared_f32(reduce_sum_addr + h * Int32(4), bsum)
+    cute.arch.barrier(**bar_kw)
+
+    block_max0 = ld_shared_f32(reduce_max_addr + head0 * Int32(4))
+    block_max1 = ld_shared_f32(reduce_max_addr + head1 * Int32(4))
+    block_sum0 = ld_shared_f32(reduce_sum_addr + head0 * Int32(4))
+    block_sum1 = ld_shared_f32(reduce_sum_addr + head1 * Int32(4))
+
+    new_gmax0 = fmax_f32(global_max[0], block_max0)
+    new_gmax1 = fmax_f32(global_max[1], block_max1)
+    alpha0 = Float32(0.0)
+    alpha1 = Float32(0.0)
+    if global_max[0] > _NI:
+        alpha0 = _exp2_approx_ftz_f32(global_max[0] - new_gmax0)
+    if global_max[1] > _NI:
+        alpha1 = _exp2_approx_ftz_f32(global_max[1] - new_gmax1)
+
+    block_rescale0 = _exp2_approx_ftz_f32(block_max0 - new_gmax0)
+    block_rescale1 = _exp2_approx_ftz_f32(block_max1 - new_gmax1)
+    warp_rescale0 = _exp2_approx_ftz_f32(local_max0 - new_gmax0)
+    warp_rescale1 = _exp2_approx_ftz_f32(local_max1 - new_gmax1)
+
+    # Source lanes 0..3 carry alpha for pairs (0,1), (2,3), (4,5), (6,7).
+    pair_lane = gid >> Int32(1)
+    row_alpha0 = cute.arch.shuffle_sync(alpha0, pair_lane)
+    row_alpha1 = cute.arch.shuffle_sync(alpha1, pair_lane)
+    row_alpha = row_alpha0
+    if (gid & Int32(1)) != Int32(0):
+        row_alpha = row_alpha1
+    for at in cutlass.range_constexpr(n_acc_tiles):
+        acc_nope[at][0] = acc_nope[at][0] * row_alpha
+        acc_nope[at][1] = acc_nope[at][1] * row_alpha
+    for rt in cutlass.range_constexpr(rope_tiles_per_warp):
+        acc_rope[rt * 4 + 0] = acc_rope[rt * 4 + 0] * row_alpha
+        acc_rope[rt * 4 + 1] = acc_rope[rt * 4 + 1] * row_alpha
+
+    global_sum[0] = global_sum[0] * alpha0 + block_sum0 * block_rescale0
+    global_sum[1] = global_sum[1] * alpha1 + block_sum1 * block_rescale1
+    global_max[0] = new_gmax0
+    global_max[1] = new_gmax1
+    return p, warp_rescale0, warp_rescale1
+
+
+# =============================================================================
+# S5 -- sm_p_full fill (normalized P -> bf16) + w_head_sc zero-init
+# Port of decode_dsv4 :568-593.
+# =============================================================================
+@cute.jit
+def s5_fill_sm_p_full(
+    w_pre,  # length-4 Float32 (= p * warp_rescale)
+    sm_p_full_addr: Int32,  # u32 smem addr of sm_p_full (HPB x BI bf16)
+    w_head_sc_view: cute.Tensor,  # smem fp32 view (N_V_CHUNKS*HPB,)
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    bi: cutlass.Constexpr,  # 64
+    sm_p_stride: cutlass.Constexpr,
+    n_v_chunks: cutlass.Constexpr,  # 7
+    hpb: cutlass.Constexpr,  # 16
+    num_threads: cutlass.Constexpr,  # 256
+    barrier_id: cutlass.Constexpr,
+):
+    """S5: store warp-rescaled P (bf16) to sm_p_full; zero w_head_sc. The caller
+    barriers AFTER this so S6/S6b read coherent sm_p_full / w_head_sc."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    cand_col_base = warp_id * Int32(8)  # ENTRIES_PER_WARP = 8 (DSV4_QK_N_TILES=1)
+    c0 = cand_col_base + tid * Int32(2)
+    c1 = c0 + Int32(1)
+    # sm_p_full[head][cand] bf16.
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (gid * Int32(sm_p_stride) + c0) * Int32(2), w_pre[0]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (gid * Int32(sm_p_stride) + c1) * Int32(2), w_pre[1]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c0) * Int32(2),
+        w_pre[2],
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c1) * Int32(2),
+        w_pre[3],
+    )
+
+    # zero-init w_head_sc (cooperative; covered by the caller's barrier).
+    i = tid_flat
+    while i < Int32(n_v_chunks * hpb):
+        w_head_sc_view[i] = Float32(0.0)
+        i += Int32(num_threads)
+
+
+# =============================================================================
+# S6 -- XV-NoPE: per-vc absmax + P re-quant + PLAIN m16n8k32.e4m3 MMA
+# Port of decode_dsv4 :595-671.
+# =============================================================================
+@cute.jit
+def s6_xv_nope(
+    w_pre,  # length-4 Float32 (= p * warp_rescale)
+    acc_nope,  # list[N_V_CHUNKS*NT_PER_WARP_XV] of length-4 (in/out)
+    kv_fp8_base_addr: Int32,  # u32 smem addr of kv_fp8[buf]
+    kv_sc_base_addr: Int32,  # u32 smem addr of kv_sc[buf] (BI x 8 footer)
+    w_head_sc_view: cute.Tensor,  # smem fp32 view (N_V_CHUNKS*HPB,)
+    w_fp8_base_addr: Int32,  # u32 smem addr of w_fp8 (2 x HPB x W_FP8_STRIDE)
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    latent_scale: Float32,
+    *,
+    n_v_chunks: cutlass.Constexpr,  # 7
+    v_chunk: cutlass.Constexpr,  # QUANT_TILE = 64
+    hpb: cutlass.Constexpr,  # 16
+    bi: cutlass.Constexpr,  # 64
+    kv_smem_stride: cutlass.Constexpr,  # 464
+    w_fp8_stride: cutlass.Constexpr,  # BI + 16 = 80
+    n_warps: cutlass.Constexpr,  # 8
+    scale_bytes_per_token: cutlass.Constexpr,  # 8
+    nt_per_warp_xv: cutlass.Constexpr = 1,  # 1 DSV4 / 2 GLM (V_CHUNK/N_WARPS/8)
+    scale_format: cutlass.Constexpr = 0,  # UE8M0_BYTE (0) / ARBITRARY_FP32 (1)
+    num_threads: cutlass.Constexpr,  # 256
+    barrier_id: cutlass.Constexpr,
+    valid_hpb: cutlass.Constexpr = 16,
+    pack_hilo_rows: cutlass.Constexpr = False,
+    sm_p_full_addr: Int32 = None,  # NVFP4 BF16 PV only
+    sm_p_stride: cutlass.Constexpr = 0,  # NVFP4: bf16 elems per sm_p row (0 -> BI)
+):
+    """S6: accumulate W . V_nope into acc_nope[vc*NT+nt][0..3] via PLAIN fp8 MMAs
+    (14 DSV4 / 16 GLM = N_V_CHUNKS * NT_PER_WARP_XV * (BI/32)).
+
+    Per V-chunk vc: (1) absmax of |w_pre * V_scale| into w_head_sc[vc][head];
+    (2) normalize w_head_sc -> max/FP8_MAX; (3) re-quant W to e4m3 into
+    w_fp8[vc&1]; (4) per N-tile nt a PLAIN m16n8k32 MMA (W ldmatrix.x4 A, V via
+    d2_load_b prmt B), post-scaled by the per-head w_head_sc. XV_KSTEPS = BI/32.
+
+    ``scale_format`` (const_expr) selects the V scale:
+      * UE8M0_BYTE (DSV4): V_scale = ue8m0_to_fp32(kv_sc footer byte for vc).
+      * ARBITRARY_FP32 (GLM, P10f): V keeps RAW e4m3 (no S0b requant), so
+        V_scale = the per-(candidate, vc) inline arbitrary fp32 group scale read
+        from the kv_fp8 footer at ``cand*KV_SMEM_STRIDE + D_NOPE + vc*4`` (4B),
+        where D_NOPE == N_V_CHUNKS*V_CHUNK (V-chunk vc == scale group vc since
+        V_CHUNK == QUANT_TILE for GLM). This keeps V's per-group e4m3 mantissa
+        headroom instead of requantizing it away.
+
+    GLM 2-PASS W (P10f): a single e4m3 W (3-bit mantissa) is the dominant PV
+    error for GLM (the arbitrary fp32 V scale spreads W's dynamic range, so the
+    per-head W scale can't capture it -> ~0.9993 cos < the 0.9995 gate). GLM
+    therefore quantizes W into a HIGH e4m3 byte + a LOW e4m3 residual byte
+    (~7 effective mantissa bits) and runs the PLAIN MMA TWICE per (vc, nt),
+    accumulating both into the SAME fp32 xv (W_PASSES=2). The legacy GLM kernel
+    sidesteps this with a bf16 P.V MMA; the residual-split keeps the unified e4m3
+    W.V MMA infrastructure (DSV4 shares it at W_PASSES=1, byte-identical). The
+    fp32 V scale is folded into BOTH W passes via the w_head_sc normalizer.
+    For an eight-head TP8 shard, ``pack_hilo_rows`` stores HIGH in MMA rows
+    0..7 and LOW in the otherwise-unused rows 8..15. One m16 MMA then produces
+    both components, preserving the residual-split math while replacing the
+    two serial MMAs with one.
+    ``nt_per_warp_xv`` (const_expr) tiles each V_CHUNK across N_WARPS*8 columns
+    NT times: GLM's 128-dim V_CHUNK needs NT=2 (8 warps x 8 dims = 64 per nt).
+
+    ``scale_format == NVFP4_E4M3`` (const_expr) bypasses the FP8 W machinery
+    entirely: BF16 probabilities staged in sm_p (``sm_p_full_addr``) are the A
+    operand and V is dequantized in registers from packed E2M1 + E4M3 group-16
+    scales (see ``s6_xv_nope_nvfp4_bf16``)."""
+    if cutlass.const_expr(scale_format == 2):
+        return s6_xv_nope_nvfp4_bf16(
+            acc_nope,
+            sm_p_full_addr,
+            kv_fp8_base_addr,
+            warp_id,
+            lane,
+            latent_scale,
+            n_v_chunks=n_v_chunks,
+            v_chunk=v_chunk,
+            bi=bi,
+            kv_smem_stride=kv_smem_stride,
+            n_warps=n_warps,
+            nt_per_warp_xv=nt_per_warp_xv,
+            sm_p_stride=(sm_p_stride if sm_p_stride else bi),
+        )
+
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    warp_first_cand = warp_id * Int32(8)
+    cand_e0 = warp_first_cand + tid * Int32(2)
+    cand_e1 = cand_e0 + Int32(1)
+    hi = cutlass.const_expr(valid_hpb > 8)
+
+    glm_scale_base = Int32(n_v_chunks) * Int32(v_chunk)  # == D_NOPE (GLM)
+
+    def _vsc(cand: Int32, vc: int):
+        if cutlass.const_expr(scale_format == 0):
+            return _ue8m0_byte_to_fp32(
+                _ld_u8_zext(
+                    kv_sc_base_addr, cand * Int32(scale_bytes_per_token) + Int32(vc)
+                )
+            )
+        # GLM ARBITRARY_FP32 (P10f): per-(candidate, vc) inline arbitrary fp32
+        # group scale (V keeps raw e4m3). vc == scale group (V_CHUNK==QUANT_TILE).
+        return _u32_to_f32(
+            ld_shared_u32(
+                kv_fp8_base_addr
+                + cand * Int32(kv_smem_stride)
+                + glm_scale_base
+                + Int32(vc) * Int32(4)
+            )
+        )
+
+    # --- (1) per-vc per-head absmax of |w_pre * V_scale| -> w_head_sc. ---
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        vsc0 = _vsc(cand_e0, vc)
+        vsc1 = _vsc(cand_e1, vc)
+        m0 = fmax_f32(fabs_f32(w_pre[0] * vsc0), fabs_f32(w_pre[1] * vsc1))
+        w_head_sc_base = shared_ptr_to_u32(w_head_sc_view.iterator)
+        sc0_addr = w_head_sc_base + (Int32(vc) * Int32(hpb) + gid) * Int32(4)
+        atomic_max_shared_f32(sc0_addr, m0)
+        if cutlass.const_expr(hi):
+            m1 = fmax_f32(fabs_f32(w_pre[2] * vsc0), fabs_f32(w_pre[3] * vsc1))
+            sc1_addr = w_head_sc_base + (
+                Int32(vc) * Int32(hpb) + gid + Int32(8)
+            ) * Int32(4)
+            atomic_max_shared_f32(sc1_addr, m1)
+    cute.arch.barrier(**bar_kw)
+
+    # --- (2) normalize w_head_sc -> max(.,1e-10)/FP8_MAX. ---
+    i = tid_flat
+    while i < Int32(n_v_chunks * valid_hpb):
+        vc = i // Int32(valid_hpb)
+        h = i - vc * Int32(valid_hpb)
+        slot = vc * Int32(hpb) + h
+        scale = fmax_f32(w_head_sc_view[slot], Float32(1e-10)) * Float32(1.0 / _FP8_MAX)
+        w_head_sc_view[slot] = scale
+        if cutlass.const_expr(pack_hilo_rows):
+            # The upper eight head slots are unused by a TP8 shard. Cache the
+            # reciprocal there once per (V chunk, head), replacing the same
+            # reciprocal redundantly computed by every candidate lane/warp.
+            w_head_sc_view[slot + Int32(8)] = Float32(1.0) / scale
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    # --- (3)+(4) per-vc re-quant + per-nt PLAIN MMA. w_fp8 double-buffered. ---
+    if cutlass.const_expr(scale_format == 0):
+        # DSV4 (UE8M0_BYTE): the ORIGINAL single-pass W path, kept VERBATIM so the
+        # DSV4 trace/PTX is byte-identical.
+        for vc in cutlass.range_constexpr(n_v_chunks):
+            w_fp8_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(hpb * w_fp8_stride)
+            si0 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
+            vsc0 = _vsc(cand_e0, vc)
+            vsc1 = _vsc(cand_e1, vc)
+            f00 = _quant_e4m3_byte(w_pre[0] * vsc0 * si0)
+            f01 = _quant_e4m3_byte(w_pre[1] * vsc1 * si0)
+            st_shared_u8(
+                w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e0, f00.to(cutlass.Uint8)
+            )
+            st_shared_u8(
+                w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e1, f01.to(cutlass.Uint8)
+            )
+            if cutlass.const_expr(hi):
+                si1 = (
+                    Float32(1.0)
+                    / w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+                )
+                f10 = _quant_e4m3_byte(w_pre[2] * vsc0 * si1)
+                f11 = _quant_e4m3_byte(w_pre[3] * vsc1 * si1)
+                st_shared_u8(
+                    w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e0,
+                    f10.to(cutlass.Uint8),
+                )
+                st_shared_u8(
+                    w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e1,
+                    f11.to(cutlass.Uint8),
+                )
+            cute.arch.barrier(**bar_kw)
+
+            sc0 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
+            if cutlass.const_expr(hi):
+                sc1 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+            # A (W) ldmatrix.x4 row/col -- ldmatrix_load_A_fp8 (nt-invariant).
+            a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+            a_col = (lane >> Int32(4)) * Int32(16)
+            for nt in cutlass.range_constexpr(nt_per_warp_xv):
+                # dim = vc*V_CHUNK + (nt*N_WARPS + warp_id)*8 (covers the full V_CHUNK).
+                dim = Int32(vc) * Int32(v_chunk) + (
+                    Int32(nt) * Int32(n_warps) + warp_id
+                ) * Int32(8)
+                xv0 = Float32(0.0)
+                xv1 = Float32(0.0)
+                xv2 = Float32(0.0)
+                xv3 = Float32(0.0)
+                for kstep in cutlass.range_constexpr(bi // 32):
+                    ko = Int32(kstep) * Int32(32)
+                    a_addr = w_fp8_addr + a_row * Int32(w_fp8_stride) + ko + a_col
+                    a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+                    b0, b1 = _d2_load_b_fp8(
+                        kv_fp8_base_addr, ko, dim, lane, kv_smem_stride=kv_smem_stride
+                    )
+                    xv0, xv1, xv2, xv3 = mma_m16n8k32_f32_e4m3(
+                        xv0, xv1, xv2, xv3, a0, a1, a2, a3, b0, b1
+                    )
+                at = vc * nt_per_warp_xv + nt
+                acc_nope[at][0] = acc_nope[at][0] + xv0 * sc0
+                acc_nope[at][1] = acc_nope[at][1] + xv1 * sc0
+                if cutlass.const_expr(hi):
+                    acc_nope[at][2] = acc_nope[at][2] + xv2 * sc1
+                    acc_nope[at][3] = acc_nope[at][3] + xv3 * sc1
+        return acc_nope
+
+    if cutlass.const_expr(pack_hilo_rows):
+        # GLM TP8: valid_hpb==8 leaves the upper half of every m16 A tile idle.
+        # Put the residual for head h in row h+8, then add the corresponding
+        # upper output fragment to the lower one. The same per-head scale
+        # applies to both rows because LOW is a residual in normalized-W space.
+        for vc in cutlass.range_constexpr(n_v_chunks):
+            w_fp8_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(hpb * w_fp8_stride)
+            si0 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+            sc0 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
+            vsc0 = _vsc(cand_e0, vc)
+            vsc1 = _vsc(cand_e1, vc)
+            wn00 = w_pre[0] * vsc0 * si0
+            wn01 = w_pre[1] * vsc1 * si0
+            vc00 = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), wn00))
+            vc01 = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), wn01))
+            fhi2 = _cvt_f32x2_to_e4m3x2(vc00, vc01)
+            hi00, hi01 = f16x2_to_f32x2(_cvt_e4m3x2_to_f16x2(fhi2))
+            resid00 = vc00 - hi00
+            resid01 = vc01 - hi01
+            resid00 = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), resid00))
+            resid01 = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), resid01))
+            flo2 = _cvt_f32x2_to_e4m3x2(resid00, resid01)
+            _st_shared_u16(
+                w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e0,
+                fhi2,
+            )
+            _st_shared_u16(
+                w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e0,
+                flo2,
+            )
+            cute.arch.barrier(**bar_kw)
+
+            a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+            a_col = (lane >> Int32(4)) * Int32(16)
+            for nt in cutlass.range_constexpr(nt_per_warp_xv):
+                dim = Int32(vc) * Int32(v_chunk) + (
+                    Int32(nt) * Int32(n_warps) + warp_id
+                ) * Int32(8)
+                xv0 = Float32(0.0)
+                xv1 = Float32(0.0)
+                xv2 = Float32(0.0)
+                xv3 = Float32(0.0)
+                for kstep in cutlass.range_constexpr(bi // 32):
+                    ko = Int32(kstep) * Int32(32)
+                    a_addr = w_fp8_addr + a_row * Int32(w_fp8_stride) + ko + a_col
+                    a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+                    b0, b1 = _d2_load_b_fp8(
+                        kv_fp8_base_addr,
+                        ko,
+                        dim,
+                        lane,
+                        kv_smem_stride=kv_smem_stride,
+                    )
+                    xv0, xv1, xv2, xv3 = mma_m16n8k32_f32_e4m3(
+                        xv0, xv1, xv2, xv3, a0, a1, a2, a3, b0, b1
+                    )
+                at = vc * nt_per_warp_xv + nt
+                acc_nope[at][0] = acc_nope[at][0] + (xv0 + xv2) * sc0
+                acc_nope[at][1] = acc_nope[at][1] + (xv1 + xv3) * sc0
+        return acc_nope
+
+    # GLM (ARBITRARY_FP32, P10f): 2-pass W (HIGH + LOW e4m3 residual) -> ~7 mantissa
+    # bits, run the PLAIN MMA twice per (vc, nt) into the SAME fp32 xv. This is a
+    # SEPARATE const_expr branch, so DSV4 (above) is untouched.
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        w_fp8_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(hpb * w_fp8_stride)
+        si0 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
+        sc0 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
+        if cutlass.const_expr(hi):
+            si1 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+            sc1 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+        vsc0 = _vsc(cand_e0, vc)
+        vsc1 = _vsc(cand_e1, vc)
+        a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+        a_col = (lane >> Int32(4)) * Int32(16)
+        # normalized W (= w_pre * V_scale / w_head_sc), the e4m3 quant target.
+        wn00 = w_pre[0] * vsc0 * si0
+        wn01 = w_pre[1] * vsc1 * si0
+        if cutlass.const_expr(hi):
+            wn10 = w_pre[2] * vsc0 * si1
+            wn11 = w_pre[3] * vsc1 * si1
+        # per-nt fp32 accumulators, carried across the W hi/lo passes.
+        xv = [
+            [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+            for _ in range(nt_per_warp_xv)
+        ]
+        for wpass in cutlass.range_constexpr(2):
+            if cutlass.const_expr(wpass > 0):
+                # serialize: the prev pass's MMA reads of w_fp8 must finish before
+                # we overwrite it with the residual bytes (same double-buffer slot).
+                cute.arch.barrier(**bar_kw)
+                # LOW residual = e4m3(Wn - dequant(hi_byte)); halves W's quant error.
+                f00 = _quant_e4m3_residual_byte(wn00)
+                f01 = _quant_e4m3_residual_byte(wn01)
+                if cutlass.const_expr(hi):
+                    f10 = _quant_e4m3_residual_byte(wn10)
+                    f11 = _quant_e4m3_residual_byte(wn11)
+            else:
+                f00 = _quant_e4m3_byte(wn00)
+                f01 = _quant_e4m3_byte(wn01)
+                if cutlass.const_expr(hi):
+                    f10 = _quant_e4m3_byte(wn10)
+                    f11 = _quant_e4m3_byte(wn11)
+            st_shared_u8(
+                w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e0, f00.to(cutlass.Uint8)
+            )
+            st_shared_u8(
+                w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e1, f01.to(cutlass.Uint8)
+            )
+            if cutlass.const_expr(hi):
+                st_shared_u8(
+                    w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e0,
+                    f10.to(cutlass.Uint8),
+                )
+                st_shared_u8(
+                    w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e1,
+                    f11.to(cutlass.Uint8),
+                )
+            cute.arch.barrier(**bar_kw)
+
+            for nt in cutlass.range_constexpr(nt_per_warp_xv):
+                # dim = vc*V_CHUNK + (nt*N_WARPS + warp_id)*8 (covers the full V_CHUNK).
+                dim = Int32(vc) * Int32(v_chunk) + (
+                    Int32(nt) * Int32(n_warps) + warp_id
+                ) * Int32(8)
+                xv0 = xv[nt][0]
+                xv1 = xv[nt][1]
+                xv2 = xv[nt][2]
+                xv3 = xv[nt][3]
+                for kstep in cutlass.range_constexpr(bi // 32):
+                    ko = Int32(kstep) * Int32(32)
+                    a_addr = w_fp8_addr + a_row * Int32(w_fp8_stride) + ko + a_col
+                    a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+                    b0, b1 = _d2_load_b_fp8(
+                        kv_fp8_base_addr, ko, dim, lane, kv_smem_stride=kv_smem_stride
+                    )
+                    xv0, xv1, xv2, xv3 = mma_m16n8k32_f32_e4m3(
+                        xv0, xv1, xv2, xv3, a0, a1, a2, a3, b0, b1
+                    )
+                xv[nt][0] = xv0
+                xv[nt][1] = xv1
+                xv[nt][2] = xv2
+                xv[nt][3] = xv3
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            at = vc * nt_per_warp_xv + nt
+            acc_nope[at][0] = acc_nope[at][0] + xv[nt][0] * sc0
+            acc_nope[at][1] = acc_nope[at][1] + xv[nt][1] * sc0
+            if cutlass.const_expr(hi):
+                acc_nope[at][2] = acc_nope[at][2] + xv[nt][2] * sc1
+                acc_nope[at][3] = acc_nope[at][3] + xv[nt][3] * sc1
+    return acc_nope
+
+
+@cute.jit
+def s6_xv_nope_nvfp4_bf16(
+    acc_nope,
+    sm_p_full_addr: Int32,
+    kv_fp4_base_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    n_v_chunks: cutlass.Constexpr,  # 8
+    v_chunk: cutlass.Constexpr,  # 64
+    bi: cutlass.Constexpr,  # 64
+    kv_smem_stride: cutlass.Constexpr,  # 288 bytes
+    n_warps: cutlass.Constexpr,  # 8
+    nt_per_warp_xv: cutlass.Constexpr,  # 1
+    sm_p_stride: cutlass.Constexpr = 0,  # bf16 elems per sm_p row (0 -> BI)
+):
+    """S6 (NVFP4): BF16 P.V over in-register dequantized E2M1 V.
+
+    V is the same 512-dim MLA latent as K-NoPE. The BF16 probabilities staged by
+    S5 are used directly as the A operand; each B scalar is dequantized from the
+    packed E2M1 byte and its E4M3 group-16 scale.
+    """
+    p_stride = cutlass.const_expr(sm_p_stride if sm_p_stride else bi)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            dim_base = Int32(vc) * Int32(v_chunk) + (
+                Int32(nt) * Int32(n_warps) + warp_id
+            ) * Int32(8)
+            col = dim_base + gid
+            xv0 = Float32(0.0)
+            xv1 = Float32(0.0)
+            xv2 = Float32(0.0)
+            xv3 = Float32(0.0)
+            for ks in cutlass.range_constexpr(bi // 16):
+                k_base = Int32(ks) * Int32(16)
+                a_byte = (a_row * Int32(p_stride) + (k_base + a_col)) * Int32(2)
+                a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_full_addr + a_byte)
+
+                ent0 = k_base + tid * Int32(2)
+                v0 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0,
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                v1 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0 + Int32(1),
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                v8 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0 + Int32(8),
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                v9 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0 + Int32(9),
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                b0 = v0 | (v1 << Uint32(16))
+                b1 = v8 | (v9 << Uint32(16))
+                xv0, xv1, xv2, xv3 = mma_m16n8k16_f32_bf16(
+                    xv0,
+                    xv1,
+                    xv2,
+                    xv3,
+                    a0,
+                    a1,
+                    a2,
+                    a3,
+                    b0,
+                    b1,
+                )
+            at = vc * nt_per_warp_xv + nt
+            acc_nope[at][0] = acc_nope[at][0] + xv0
+            acc_nope[at][1] = acc_nope[at][1] + xv1
+            acc_nope[at][2] = acc_nope[at][2] + xv2
+            acc_nope[at][3] = acc_nope[at][3] + xv3
+    return acc_nope
+
+
+@cute.jit
+def s6_xv_nope_glm_h8_swap_ab(
+    w_pre,
+    acc_nope,
+    kv_fp8_base_addr: Int32,
+    w_head_sc_view: cute.Tensor,
+    w_fp8_base_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    n_v_chunks: cutlass.Constexpr,
+    v_chunk: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    bi: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    w_fp8_stride: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    nt_per_warp_xv: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+):
+    """GLM TP8 packed HIGH/LOW PV fed directly by swapped-score fragments.
+
+    Four warps each own sixteen candidates.  HIGH for each of the eight heads
+    occupies W rows 0..7 and the e4m3 residual occupies rows 8..15, so one
+    m16n8k32 MMA accumulates both precision passes.  The ordinary MMA output-row
+    mapping is retained for the epilogue (lane gid owns head gid).
+    """
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    head0 = tid * Int32(2)
+    head1 = head0 + Int32(1)
+    cand0 = warp_id * Int32(16) + gid
+    cand1 = cand0 + Int32(8)
+    glm_scale_base = Int32(n_v_chunks) * Int32(v_chunk)
+
+    def _vsc(cand: Int32, vc: int):
+        return _u32_to_f32(
+            ld_shared_u32(
+                kv_fp8_base_addr
+                + cand * Int32(kv_smem_stride)
+                + glm_scale_base
+                + Int32(vc) * Int32(4)
+            )
+        )
+
+    # Clear both the lower scale slots and the upper reciprocal scratch slots.
+    i = tid_flat
+    while i < Int32(n_v_chunks * hpb):
+        w_head_sc_view[i] = Float32(0.0)
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        vsc0 = _vsc(cand0, vc)
+        vsc1 = _vsc(cand1, vc)
+        m0 = fmax_f32(fabs_f32(w_pre[0] * vsc0), fabs_f32(w_pre[2] * vsc1))
+        m1 = fmax_f32(fabs_f32(w_pre[1] * vsc0), fabs_f32(w_pre[3] * vsc1))
+        scale_base = shared_ptr_to_u32(w_head_sc_view.iterator)
+        atomic_max_shared_f32(
+            scale_base + (Int32(vc) * Int32(hpb) + head0) * Int32(4), m0
+        )
+        atomic_max_shared_f32(
+            scale_base + (Int32(vc) * Int32(hpb) + head1) * Int32(4), m1
+        )
+    cute.arch.barrier(**bar_kw)
+
+    i = tid_flat
+    while i < Int32(n_v_chunks * 8):
+        vc = i // Int32(8)
+        h = i - vc * Int32(8)
+        slot = vc * Int32(hpb) + h
+        scale = fmax_f32(w_head_sc_view[slot], Float32(1e-10)) * Float32(1.0 / _FP8_MAX)
+        w_head_sc_view[slot] = scale
+        w_head_sc_view[slot + Int32(8)] = Float32(1.0) / scale
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(16)
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        w_fp8_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(hpb * w_fp8_stride)
+        si0 = w_head_sc_view[Int32(vc) * Int32(hpb) + head0 + Int32(8)]
+        si1 = w_head_sc_view[Int32(vc) * Int32(hpb) + head1 + Int32(8)]
+        vsc0 = _vsc(cand0, vc)
+        vsc1 = _vsc(cand1, vc)
+
+        wn00 = w_pre[0] * vsc0 * si0
+        wn01 = w_pre[1] * vsc0 * si1
+        wn10 = w_pre[2] * vsc1 * si0
+        wn11 = w_pre[3] * vsc1 * si1
+
+        f00 = _quant_e4m3_byte(wn00)
+        f01 = _quant_e4m3_byte(wn01)
+        f10 = _quant_e4m3_byte(wn10)
+        f11 = _quant_e4m3_byte(wn11)
+        r00 = _quant_e4m3_residual_byte(wn00)
+        r01 = _quant_e4m3_residual_byte(wn01)
+        r10 = _quant_e4m3_residual_byte(wn10)
+        r11 = _quant_e4m3_residual_byte(wn11)
+
+        st_shared_u8(
+            w_fp8_addr + head0 * Int32(w_fp8_stride) + cand0,
+            f00.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + head1 * Int32(w_fp8_stride) + cand0,
+            f01.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + head0 * Int32(w_fp8_stride) + cand1,
+            f10.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + head1 * Int32(w_fp8_stride) + cand1,
+            f11.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + (head0 + Int32(8)) * Int32(w_fp8_stride) + cand0,
+            r00.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + (head1 + Int32(8)) * Int32(w_fp8_stride) + cand0,
+            r01.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + (head0 + Int32(8)) * Int32(w_fp8_stride) + cand1,
+            r10.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + (head1 + Int32(8)) * Int32(w_fp8_stride) + cand1,
+            r11.to(cutlass.Uint8),
+        )
+        cute.arch.barrier(**bar_kw)
+
+        # The PV MMA's output rows use the ordinary m16 fragment mapping:
+        # this lane owns row/head ``gid`` irrespective of the score fragment's
+        # ``2*tid`` head pair used above to populate W.
+        sc_row = w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            dim = Int32(vc) * Int32(v_chunk) + (
+                Int32(nt) * Int32(n_warps) + warp_id
+            ) * Int32(8)
+            xv0 = Float32(0.0)
+            xv1 = Float32(0.0)
+            xv2 = Float32(0.0)
+            xv3 = Float32(0.0)
+            for kstep in cutlass.range_constexpr(bi // 32):
+                ko = Int32(kstep) * Int32(32)
+                a_addr = w_fp8_addr + a_row * Int32(w_fp8_stride) + ko + a_col
+                a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+                b0, b1 = _d2_load_b_fp8(
+                    kv_fp8_base_addr,
+                    ko,
+                    dim,
+                    lane,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                xv0, xv1, xv2, xv3 = mma_m16n8k32_f32_e4m3(
+                    xv0,
+                    xv1,
+                    xv2,
+                    xv3,
+                    a0,
+                    a1,
+                    a2,
+                    a3,
+                    b0,
+                    b1,
+                )
+            at = vc * nt_per_warp_xv + nt
+            acc_nope[at][0] = acc_nope[at][0] + (xv0 + xv2) * sc_row
+            acc_nope[at][1] = acc_nope[at][1] + (xv1 + xv3) * sc_row
+    return acc_nope
+
+
+@cute.jit
+def s6_xv_nope_dsv4_h8_swap_ab(
+    w_pre,
+    acc_nope,
+    kv_fp8_base_addr: Int32,
+    kv_sc_base_addr: Int32,
+    w_head_sc_view: cute.Tensor,
+    w_fp8_base_addr: Int32,
+    sm_p_full_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    n_v_chunks: cutlass.Constexpr,
+    v_chunk: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    bi: cutlass.Constexpr,
+    sm_p_stride: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    w_fp8_stride: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    nt_per_warp_xv: cutlass.Constexpr,
+    scale_bytes_per_token: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    barrier_threads: cutlass.Constexpr = 0,  # barrier width override (0 -> num_threads)
+    packed_footer_words: cutlass.Constexpr = False,
+):
+    """DSV4 H8 PV fed directly by the swapped score fragment.
+
+    The lower eight W rows hold the eight query heads.  Four warps each stage
+    sixteen candidate probabilities, then two N tiles per warp cover every
+    64-wide V group.  The same probability stores also populate the BF16 matrix
+    consumed by the RoPE PV path.
+    """
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    head0 = tid * Int32(2)
+    head1 = head0 + Int32(1)
+    cand0 = warp_id * Int32(16) + gid
+    cand1 = cand0 + Int32(8)
+
+    # Swapped score-fragment ownership -> ordinary [head, candidate] staging.
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head0 * Int32(sm_p_stride) + cand0) * Int32(2), w_pre[0]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head1 * Int32(sm_p_stride) + cand0) * Int32(2), w_pre[1]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head0 * Int32(sm_p_stride) + cand1) * Int32(2), w_pre[2]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head1 * Int32(sm_p_stride) + cand1) * Int32(2), w_pre[3]
+    )
+
+    i = tid_flat
+    while i < Int32(n_v_chunks * hpb):
+        w_head_sc_view[i] = Float32(0.0)
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    def _vsc(cand: Int32, vc: int):
+        return _ue8m0_byte_to_fp32(
+            _ld_u8_zext(
+                kv_sc_base_addr,
+                cand * Int32(scale_bytes_per_token) + Int32(vc),
+            )
+        )
+
+    scale_base = shared_ptr_to_u32(w_head_sc_view.iterator)
+    max_footer0_lo = Uint32(0)
+    max_footer0_hi = Uint32(0)
+    max_footer1_lo = Uint32(0)
+    max_footer1_hi = Uint32(0)
+    if cutlass.const_expr(packed_footer_words):
+        max_footer0_lo, max_footer0_hi = ld_shared_v2_u32(
+            kv_sc_base_addr + cand0 * Int32(scale_bytes_per_token)
+        )
+        max_footer1_lo, max_footer1_hi = ld_shared_v2_u32(
+            kv_sc_base_addr + cand1 * Int32(scale_bytes_per_token)
+        )
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        if cutlass.const_expr(packed_footer_words):
+            vsc0 = _ue8m0_zext_byte_to_fp32(
+                _packed_u8(max_footer0_lo, max_footer0_hi, vc)
+            )
+            vsc1 = _ue8m0_zext_byte_to_fp32(
+                _packed_u8(max_footer1_lo, max_footer1_hi, vc)
+            )
+        else:
+            vsc0 = _vsc(cand0, vc)
+            vsc1 = _vsc(cand1, vc)
+        atomic_max_shared_f32(
+            scale_base + (Int32(vc) * Int32(hpb) + head0) * Int32(4),
+            fmax_f32(fabs_f32(w_pre[0] * vsc0), fabs_f32(w_pre[2] * vsc1)),
+        )
+        atomic_max_shared_f32(
+            scale_base + (Int32(vc) * Int32(hpb) + head1) * Int32(4),
+            fmax_f32(fabs_f32(w_pre[1] * vsc0), fabs_f32(w_pre[3] * vsc1)),
+        )
+    cute.arch.barrier(**bar_kw)
+
+    # Lower slots hold the dequant scale; upper slots hold its reciprocal.
+    i = tid_flat
+    while i < Int32(n_v_chunks * 8):
+        vc = i // Int32(8)
+        h = i - vc * Int32(8)
+        slot = vc * Int32(hpb) + h
+        scale = fmax_f32(w_head_sc_view[slot], Float32(1e-10)) * Float32(1.0 / _FP8_MAX)
+        w_head_sc_view[slot] = scale
+        w_head_sc_view[slot + Int32(8)] = Float32(1.0) / scale
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    quant_footer0_lo = Uint32(0)
+    quant_footer0_hi = Uint32(0)
+    quant_footer1_lo = Uint32(0)
+    quant_footer1_hi = Uint32(0)
+    if cutlass.const_expr(packed_footer_words):
+        quant_footer0_lo, quant_footer0_hi = ld_shared_v2_u32(
+            kv_sc_base_addr + cand0 * Int32(scale_bytes_per_token)
+        )
+        quant_footer1_lo, quant_footer1_hi = ld_shared_v2_u32(
+            kv_sc_base_addr + cand1 * Int32(scale_bytes_per_token)
+        )
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(16)
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        w_fp8_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(hpb * w_fp8_stride)
+        si0 = w_head_sc_view[Int32(vc) * Int32(hpb) + head0 + Int32(8)]
+        si1 = w_head_sc_view[Int32(vc) * Int32(hpb) + head1 + Int32(8)]
+        if cutlass.const_expr(packed_footer_words):
+            vsc0 = _ue8m0_zext_byte_to_fp32(
+                _packed_u8(quant_footer0_lo, quant_footer0_hi, vc)
+            )
+            vsc1 = _ue8m0_zext_byte_to_fp32(
+                _packed_u8(quant_footer1_lo, quant_footer1_hi, vc)
+            )
+        else:
+            vsc0 = _vsc(cand0, vc)
+            vsc1 = _vsc(cand1, vc)
+
+        f00 = _quant_e4m3_byte(w_pre[0] * vsc0 * si0)
+        f01 = _quant_e4m3_byte(w_pre[1] * vsc0 * si1)
+        f10 = _quant_e4m3_byte(w_pre[2] * vsc1 * si0)
+        f11 = _quant_e4m3_byte(w_pre[3] * vsc1 * si1)
+        st_shared_u8(
+            w_fp8_addr + head0 * Int32(w_fp8_stride) + cand0,
+            f00.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + head1 * Int32(w_fp8_stride) + cand0,
+            f01.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + head0 * Int32(w_fp8_stride) + cand1,
+            f10.to(cutlass.Uint8),
+        )
+        st_shared_u8(
+            w_fp8_addr + head1 * Int32(w_fp8_stride) + cand1,
+            f11.to(cutlass.Uint8),
+        )
+        cute.arch.barrier(**bar_kw)
+
+        sc_row = w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            dim = Int32(vc) * Int32(v_chunk) + (
+                Int32(nt) * Int32(n_warps) + warp_id
+            ) * Int32(8)
+            xv0 = Float32(0.0)
+            xv1 = Float32(0.0)
+            xv2 = Float32(0.0)
+            xv3 = Float32(0.0)
+            for kstep in cutlass.range_constexpr(bi // 32):
+                ko = Int32(kstep) * Int32(32)
+                a_addr = w_fp8_addr + a_row * Int32(w_fp8_stride) + ko + a_col
+                a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_addr)
+                b0, b1 = _d2_load_b_fp8(
+                    kv_fp8_base_addr,
+                    ko,
+                    dim,
+                    lane,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                xv0, xv1, xv2, xv3 = mma_m16n8k32_f32_e4m3(
+                    xv0, xv1, xv2, xv3, a0, a1, a2, a3, b0, b1
+                )
+            at = vc * nt_per_warp_xv + nt
+            acc_nope[at][0] = acc_nope[at][0] + xv0 * sc_row
+            acc_nope[at][1] = acc_nope[at][1] + xv1 * sc_row
+    return acc_nope
+
+
+# =============================================================================
+# S6b -- XV-RoPE: bf16 m16n8k16 MMA (V_HAS_ROPE gate), V read from sm_kv_rope
+# Port of decode_dsv4 :673-708.
+# =============================================================================
+@cute.jit
+def s6b_xv_rope(
+    acc_rope,  # length-4 Float32 (in/out)
+    sm_p_full_addr: Int32,  # u32 smem addr of sm_p_full (HPB x BI bf16)
+    kv_rope_base_addr: Int32,  # u32 smem addr of kv_rope[buf] (BI x D_ROPE bf16)
+    warp_id: Int32,
+    lane: Int32,
+    *,
+    bi: cutlass.Constexpr,  # 64
+    sm_p_stride: cutlass.Constexpr,
+    d_rope: cutlass.Constexpr,  # 64
+    n_warps: cutlass.Constexpr,  # 8
+):
+    """S6b: acc_rope += P . V_rope via D_ROPE/N_WARPS->BI/16=4 bf16 m16n8k16 MMAs.
+
+    A (P) via ldmatrix.x4 from sm_p_full (bf16, stride BI); B (V_rope) via
+    per-lane scalar u16 reads from sm_kv_rope packed into b0/b1. Each warp owns
+    ROPE_DIMS_PER_WARP = D_ROPE/N_WARPS = 8 rope dims (n_col = warp_id*8)."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    rope_dim_base = warp_id * Int32(d_rope // n_warps)  # ROPE_DIMS_PER_WARP = 8
+    col = rope_dim_base + gid  # nt=0 -> n_col = rope_dim_base
+
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+
+    for ks in cutlass.range_constexpr(bi // 16):
+        k_base = Int32(ks) * Int32(16)
+        # A: sm_p_full[0][ks*16].
+        a_byte = (a_row * Int32(sm_p_stride) + (k_base + a_col)) * Int32(2)
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_full_addr + a_byte)
+        # B: per-lane scalar reads of v[ent][col], packed (ent0,ent1)/(ent8,ent9).
+        ent0 = k_base + tid * Int32(2)
+        v0 = _ld_u16_zext(kv_rope_base_addr, (ent0 * Int32(d_rope) + col) * Int32(2))
+        v1 = _ld_u16_zext(
+            kv_rope_base_addr, ((ent0 + Int32(1)) * Int32(d_rope) + col) * Int32(2)
+        )
+        v8 = _ld_u16_zext(
+            kv_rope_base_addr, ((ent0 + Int32(8)) * Int32(d_rope) + col) * Int32(2)
+        )
+        v9 = _ld_u16_zext(
+            kv_rope_base_addr, ((ent0 + Int32(9)) * Int32(d_rope) + col) * Int32(2)
+        )
+        b0 = v0 | (v1 << Uint32(16))
+        b1 = v8 | (v9 << Uint32(16))
+        acc_rope[0], acc_rope[1], acc_rope[2], acc_rope[3] = mma_m16n8k16_f32_bf16(
+            acc_rope[0],
+            acc_rope[1],
+            acc_rope[2],
+            acc_rope[3],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+        )
+    return acc_rope
+
+
+@cute.jit
+def s6b_xv_rope_h8_swap_ab(
+    acc_rope,
+    sm_p_full_addr: Int32,
+    kv_rope_base_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    *,
+    bi: cutlass.Constexpr,
+    sm_p_stride: cutlass.Constexpr,
+    d_rope: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    tiles_per_warp: cutlass.Constexpr,
+    kv_rope_stride_bytes: cutlass.Constexpr,
+):
+    """H8 RoPE PV: two 8-column N tiles per warp cover D_ROPE=64."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+
+    for nt in cutlass.range_constexpr(tiles_per_warp):
+        col = (Int32(nt) * Int32(n_warps) + warp_id) * Int32(8) + gid
+        r = nt * 4
+        for ks in cutlass.range_constexpr(bi // 16):
+            k_base = Int32(ks) * Int32(16)
+            a_byte = (a_row * Int32(sm_p_stride) + k_base + a_col) * Int32(2)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_full_addr + a_byte)
+            ent0 = k_base + tid * Int32(2)
+            v0 = _ld_u16_zext(
+                kv_rope_base_addr,
+                ent0 * Int32(kv_rope_stride_bytes) + col * Int32(2),
+            )
+            v1 = _ld_u16_zext(
+                kv_rope_base_addr,
+                (ent0 + Int32(1)) * Int32(kv_rope_stride_bytes) + col * Int32(2),
+            )
+            v8 = _ld_u16_zext(
+                kv_rope_base_addr,
+                (ent0 + Int32(8)) * Int32(kv_rope_stride_bytes) + col * Int32(2),
+            )
+            v9 = _ld_u16_zext(
+                kv_rope_base_addr,
+                (ent0 + Int32(9)) * Int32(kv_rope_stride_bytes) + col * Int32(2),
+            )
+            b0 = v0 | (v1 << Uint32(16))
+            b1 = v8 | (v9 << Uint32(16))
+            (
+                acc_rope[r + 0],
+                acc_rope[r + 1],
+                acc_rope[r + 2],
+                acc_rope[r + 3],
+            ) = mma_m16n8k16_f32_bf16(
+                acc_rope[r + 0],
+                acc_rope[r + 1],
+                acc_rope[r + 2],
+                acc_rope[r + 3],
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+            )
+    return acc_rope
+
+
+# =============================================================================
+# S7 -- epilogue: per-SPLIT NORMALIZED partial writeback in split.py's convention
+# Port of decode_dsv4 :725-783, adapted to the rs-1 base-2 merge (split.py:1138).
+# =============================================================================
+@cute.jit
+def s7_epilogue(
+    acc_nope,  # list[N_V_CHUNKS*NT_PER_WARP_XV] of length-4
+    acc_rope,  # length-4 Float32 (unused if not v_has_rope)
+    global_max,  # length-2 Float32 list
+    global_sum,  # length-2 Float32 list
+    out_o: cute.Tensor,  # (HPB, D_V) bf16 O view (partial mid_out OR final output)
+    out_lse: cute.Tensor,  # (HPB,) f32 base-2 LSE view (mid_lse OR out_lse)
+    warp_id: Int32,
+    lane: Int32,
+    *,
+    n_v_chunks: cutlass.Constexpr,  # 7
+    v_chunk: cutlass.Constexpr,  # QUANT_TILE = 64
+    d_nope: cutlass.Constexpr,  # 448
+    d_rope: cutlass.Constexpr,  # 64
+    n_warps: cutlass.Constexpr,  # 8
+    valid_hpb: cutlass.Constexpr,  # <= HPB
+    nt_per_warp_xv: cutlass.Constexpr = 1,  # 1 DSV4 / 2 GLM
+    v_has_rope: cutlass.Constexpr = True,  # True DSV4 / False GLM (V == nope only)
+    rope_tiles_per_warp: cutlass.Constexpr = 1,
+    epilogue_mode: cutlass.Constexpr = EPILOGUE_PARTIAL_WRITEBACK,
+    has_attn_sink: cutlass.Constexpr = False,  # FINAL_BF16 only: fold per-head sink
+    attn_sink=None,  # (heads,) f32 view (FINAL_BF16 + has_attn_sink)
+    head_base: Int32 = None,  # first head index of this CTA (sink indexing)
+    fast_rcp: cutlass.Constexpr = False,
+    staging_base_addr: Int32 = None,
+    d_v: cutlass.Constexpr = 0,
+    num_threads: cutlass.Constexpr = 0,
+    barrier_id: cutlass.Constexpr = 0,
+    coalesced_output: cutlass.Constexpr = False,
+):
+    """S7: normalized O + base-2 LSE epilogue. ``epilogue_mode`` (const_expr)
+    selects the destination + normalizer convention; the (gid, d0) output-write
+    geometry is IDENTICAL for both, so only the per-row inverse-normalizer and the
+    LSE fold diverge.
+
+    PARTIAL_WRITEBACK (DEFAULT, decode/split -- byte-identical to the prior decode
+    epilogue): write this SPLIT's NORMALIZED partial O + base-2 LSE in the exact
+    active split merge convention (SparseMLASplitDecodeMergeKernel in merge.py).
+    The merge reduces over the split axis assuming each partial is the
+    PER-SPLIT-NORMALIZED output (acc / this split's softmax sum) tagged with the
+    split's base-2 LSE (log2(sum) + max). inv_g = 1/global_sum (0 if empty);
+    O[head][dim] = acc * inv_g; base-2 LSE = log2(global_sum) + global_max. Empty
+    split -> LSE = -inf sentinel (the merge's skip condition) and O = 0.
+    ``num_splits=1`` is the trivial 1-split merge (partial == final O).
+
+    FINAL_BF16 (prefill single-pass): the CTA processed ALL topk in one online
+    softmax, so ``global_sum``/``global_max`` are the FINAL row sum l / max m and
+    we write the FINAL normalized BF16 O directly into output[token,h,d] (this
+    out_o view), plus the FINAL base-2 LSE (NO merge). With ``has_attn_sink`` the
+    FlashMLA V4 sink folds into BOTH the normalizer and the LSE
+    (prefill_kernel.cuh:485-560, base-2 domain):
+        il  = 1 / (l + exp2(sink_log2 - m))          (vs 1/l without sink)
+        lse = log2(l) + m ; lse += log2(1 + exp2(sink_log2 - lse))  (empty -> sink_log2)
+    where sink_log2 = attn_sink[head] * LOG2E. This is algebraically the FlashMLA
+    ``out *= sigmoid(lse_e - sink)`` + log-sum-exp LSE fold the prefill reference
+    cross-checks."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+
+    # ── per-physical-row inverse normalizer (gid heads, gid+8 heads). ──
+    if cutlass.const_expr(epilogue_mode == EPILOGUE_FINAL_BF16 and has_attn_sink):
+        # FINAL_BF16 + sink: il = 1/(l + exp2(sink_log2 - m)) (FlashInfer:494).
+        s0 = Float32(attn_sink[head_base + gid]) * Float32(LOG2_E)
+        denom0 = global_sum[0] + _exp2_approx_ftz_f32(s0 - global_max[0])
+        inv_g0 = Float32(0.0)
+        if denom0 > Float32(0.0):
+            if cutlass.const_expr(fast_rcp):
+                inv_g0 = rcp_approx_ftz(denom0)
+            else:
+                inv_g0 = Float32(1.0) / denom0
+        inv_g1 = Float32(0.0)
+        if cutlass.const_expr(valid_hpb > 8):
+            s1 = Float32(attn_sink[head_base + gid + Int32(8)]) * Float32(LOG2_E)
+            denom1 = global_sum[1] + _exp2_approx_ftz_f32(s1 - global_max[1])
+            if denom1 > Float32(0.0):
+                if cutlass.const_expr(fast_rcp):
+                    inv_g1 = rcp_approx_ftz(denom1)
+                else:
+                    inv_g1 = Float32(1.0) / denom1
+    else:
+        # PARTIAL_WRITEBACK or FINAL_BF16-without-sink: il = 1/l (0 if empty).
+        inv_g0 = Float32(0.0)
+        inv_g1 = Float32(0.0)
+        if global_sum[0] > Float32(0.0):
+            if cutlass.const_expr(fast_rcp):
+                inv_g0 = rcp_approx_ftz(global_sum[0])
+            else:
+                inv_g0 = Float32(1.0) / global_sum[0]
+        if global_sum[1] > Float32(0.0):
+            if cutlass.const_expr(fast_rcp):
+                inv_g1 = rcp_approx_ftz(global_sum[1])
+            else:
+                inv_g1 = Float32(1.0) / global_sum[1]
+
+    # NoPE dims: d0 = vc*V_CHUNK + (nt*N_WARPS + warp_id)*8 + tid*2 (per N-tile).
+    # Cast to the output element type (bf16 for the split.py mid_out partials AND
+    # the prefill final output; the merge consumes bf16 -- fp32 also works for the
+    # standalone probe). Output-write geometry is mode-invariant.
+    _ot = out_o.element_type
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            at = vc * nt_per_warp_xv + nt
+            d0 = (
+                Int32(vc) * Int32(v_chunk)
+                + (Int32(nt) * Int32(n_warps) + warp_id) * Int32(8)
+                + tid * Int32(2)
+            )
+            if cutlass.const_expr(coalesced_output):
+                st_shared_bf16_from_f32(
+                    staging_base_addr + (gid * Int32(d_v) + d0) * Int32(2),
+                    acc_nope[at][0] * inv_g0,
+                )
+                st_shared_bf16_from_f32(
+                    staging_base_addr + (gid * Int32(d_v) + d0 + Int32(1)) * Int32(2),
+                    acc_nope[at][1] * inv_g0,
+                )
+                if cutlass.const_expr(valid_hpb > 8):
+                    st_shared_bf16_from_f32(
+                        staging_base_addr
+                        + ((gid + Int32(8)) * Int32(d_v) + d0) * Int32(2),
+                        acc_nope[at][2] * inv_g1,
+                    )
+                    st_shared_bf16_from_f32(
+                        staging_base_addr
+                        + ((gid + Int32(8)) * Int32(d_v) + d0 + Int32(1)) * Int32(2),
+                        acc_nope[at][3] * inv_g1,
+                    )
+            else:
+                out_o[gid, d0] = (acc_nope[at][0] * inv_g0).to(_ot)
+                out_o[gid, d0 + Int32(1)] = (acc_nope[at][1] * inv_g0).to(_ot)
+                if cutlass.const_expr(valid_hpb > 8):
+                    out_o[gid + Int32(8), d0] = (acc_nope[at][2] * inv_g1).to(_ot)
+                    out_o[gid + Int32(8), d0 + Int32(1)] = (
+                        acc_nope[at][3] * inv_g1
+                    ).to(_ot)
+
+    # RoPE dims (DSV4 only: V_HAS_ROPE). GLM V == nope-only so this is elided.
+    if cutlass.const_expr(v_has_rope):
+        for nt in cutlass.range_constexpr(rope_tiles_per_warp):
+            r = nt * 4
+            rd0 = (
+                Int32(d_nope)
+                + (Int32(nt) * Int32(n_warps) + warp_id) * Int32(8)
+                + tid * Int32(2)
+            )
+            if cutlass.const_expr(coalesced_output):
+                st_shared_bf16_from_f32(
+                    staging_base_addr + (gid * Int32(d_v) + rd0) * Int32(2),
+                    acc_rope[r + 0] * inv_g0,
+                )
+                st_shared_bf16_from_f32(
+                    staging_base_addr + (gid * Int32(d_v) + rd0 + Int32(1)) * Int32(2),
+                    acc_rope[r + 1] * inv_g0,
+                )
+                if cutlass.const_expr(valid_hpb > 8):
+                    st_shared_bf16_from_f32(
+                        staging_base_addr
+                        + ((gid + Int32(8)) * Int32(d_v) + rd0) * Int32(2),
+                        acc_rope[r + 2] * inv_g1,
+                    )
+                    st_shared_bf16_from_f32(
+                        staging_base_addr
+                        + ((gid + Int32(8)) * Int32(d_v) + rd0 + Int32(1)) * Int32(2),
+                        acc_rope[r + 3] * inv_g1,
+                    )
+            else:
+                out_o[gid, rd0] = (acc_rope[r + 0] * inv_g0).to(_ot)
+                out_o[gid, rd0 + Int32(1)] = (acc_rope[r + 1] * inv_g0).to(_ot)
+                if cutlass.const_expr(valid_hpb > 8):
+                    out_o[gid + Int32(8), rd0] = (acc_rope[r + 2] * inv_g1).to(_ot)
+                    out_o[gid + Int32(8), rd0 + Int32(1)] = (
+                        acc_rope[r + 3] * inv_g1
+                    ).to(_ot)
+
+    if cutlass.const_expr(coalesced_output):
+        cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+        stores_per_head = d_v // 8
+        store_idx = warp_id * Int32(32) + lane
+        while store_idx < Int32(valid_hpb * stores_per_head):
+            h = store_idx // Int32(stores_per_head)
+            d8 = (store_idx - h * Int32(stores_per_head)) * Int32(8)
+            v0, v1, v2, v3 = ld_shared_v4_u32(
+                staging_base_addr + (h * Int32(d_v) + d8) * Int32(2)
+            )
+            st_global_v4_u32(
+                get_ptr_as_int64(out_o, h.to(Int64) * Int64(d_v) + d8.to(Int64)),
+                v0,
+                v1,
+                v2,
+                v3,
+            )
+            store_idx += Int32(num_threads)
+
+    # base-2 LSE (warp 0, tid 0 owns one head pair via gid). The PARTIAL_WRITEBACK
+    # path is the EXACT prior decode epilogue (byte-identical IR); the FINAL_BF16 +
+    # sink fold is a const_expr-gated addition that is fully elided for decode.
+    if warp_id == Int32(0) and tid == Int32(0):
+        lse0 = Float32(_NEG_INF)
+        lse1 = Float32(_NEG_INF)
+        if global_sum[0] > Float32(0.0):
+            lse0 = _log2_approx_ftz_f32(global_sum[0]) + global_max[0]
+        if global_sum[1] > Float32(0.0):
+            lse1 = _log2_approx_ftz_f32(global_sum[1]) + global_max[1]
+        if cutlass.const_expr(epilogue_mode == EPILOGUE_FINAL_BF16 and has_attn_sink):
+            # FlashMLA sink fold: lse += log2(1 + exp2(sink_log2 - lse)); empty ->
+            # sink_log2 (prefill_kernel.cuh:548-560).
+            sink0 = Float32(attn_sink[head_base + gid]) * Float32(LOG2_E)
+            if lse0 > Float32(_NEG_INF):
+                lse0 = lse0 + _log2_approx_ftz_f32(
+                    Float32(1.0) + _exp2_approx_ftz_f32(sink0 - lse0)
+                )
+            else:
+                lse0 = sink0
+            if cutlass.const_expr(valid_hpb > 8):
+                sink1 = Float32(attn_sink[head_base + gid + Int32(8)]) * Float32(LOG2_E)
+                if lse1 > Float32(_NEG_INF):
+                    lse1 = lse1 + _log2_approx_ftz_f32(
+                        Float32(1.0) + _exp2_approx_ftz_f32(sink1 - lse1)
+                    )
+                else:
+                    lse1 = sink1
+        out_lse[gid] = lse0
+        if cutlass.const_expr(valid_hpb > 8):
+            out_lse[gid + Int32(8)] = lse1
+
+
+# ── extra typed helpers for the PV path ───────────────────────────────────────
+@cute.jit
+def _quant_e4m3_byte(v: Float32) -> Uint32:
+    """Clamp to [FP8_MIN, FP8_MAX] then cvt.rn.satfinite.e4m3 -> low byte."""
+    vc = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), v))
+    return cvt_f32_to_e4m3(vc) & Uint32(0xFF)
+
+
+@cute.jit
+def _quant_e4m3_bounded_byte(v: Float32) -> Uint32:
+    """Quantize an already-bounded value with saturating E4M3 conversion.
+
+    This is for paths whose scale construction proves ``abs(v) <= FP8_MAX``.
+    The saturating conversion handles any rounding overshoot without a redundant
+    min/max pair at every call site.
+    """
+    return cvt_f32_to_e4m3(v) & Uint32(0xFF)
+
+
+@cute.jit
+def _quant_e4m3_residual_byte(v: Float32) -> Uint32:
+    """LOW e4m3 residual byte for the GLM 2-pass W (P10f): quantize ``v`` to e4m3
+    (the HIGH byte), dequant it back to f32, and quantize the residual
+    ``v - dequant(hi)`` to e4m3. (HIGH @ V + LOW @ V) recovers ~7 mantissa bits of
+    W, halving the e4m3 W quant error that otherwise floors GLM PV at ~0.9993 cos.
+    The HIGH byte itself is re-derived here (cheap) so the caller only stages bytes."""
+    vc = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), v))
+    hi_byte = cvt_f32_to_e4m3(vc) & Uint32(0xFF)
+    resid = vc - fp8_e4m3_to_f32(hi_byte)
+    resid = fmax_f32(Float32(_FP8_MIN), fmin_f32(Float32(_FP8_MAX), resid))
+    return cvt_f32_to_e4m3(resid) & Uint32(0xFF)
+
+
+@cute.jit
+def _d2_load_b_fp8(
+    kv_fp8_base_addr: Int32,
+    entry_base: Int32,
+    dim: Int32,
+    lane: Int32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+):
+    """Direct-B synthesizer for the PLAIN fp8 XV MMA (d2_load_b.cuh).
+
+    Produces b0/b1 (QMMA.16832 B operand) from kv_fp8[entry][dim] without a
+    transpose buffer: 8 LDS.32 + 6 prmt. b0 byte j = V[entry_base+tid*4+j][dim+gid]
+    (K=0..15); b1 = the +16 entries (K=16..31)."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    d = dim + gid
+    d_base = d & ~Int32(3)
+    d_sel = d & Int32(3)
+    sel = ((Int32(4) + d_sel) << Int32(4)) | d_sel
+
+    r0 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + tid * Int32(4) + Int32(0)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    r1 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + tid * Int32(4) + Int32(1)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    r2 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + tid * Int32(4) + Int32(2)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    r3 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + tid * Int32(4) + Int32(3)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    t01 = byte_perm(r0, r1, sel)
+    t23 = byte_perm(r2, r3, sel)
+    b0 = byte_perm(t01, t23, Int32(0x5410))
+
+    r0 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + Int32(16) + tid * Int32(4) + Int32(0)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    r1 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + Int32(16) + tid * Int32(4) + Int32(1)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    r2 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + Int32(16) + tid * Int32(4) + Int32(2)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    r3 = ld_shared_u32(
+        kv_fp8_base_addr
+        + (entry_base + Int32(16) + tid * Int32(4) + Int32(3)) * Int32(kv_smem_stride)
+        + d_base
+    )
+    t01 = byte_perm(r0, r1, sel)
+    t23 = byte_perm(r2, r3, sel)
+    b1 = byte_perm(t01, t23, Int32(0x5410))
+    return b0, b1

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/io.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/io.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/io.py @ e130f195 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Sparse-MLA decode IO-warp PRODUCER (P6 warp-specialized pipeline).
+
+The generic SM120 decode CTA uses 8 math warps plus one IO warp; native GLM H8
+uses 4 math warps plus one IO warp. This module is the producer body: per chunk
+it waits on the ``empty`` mbarrier for the target KV buffer, gathers the BI=64
+candidate rows from the paged FP8 KV cache into the double-buffered smem KV
+regions via ``cp.async.bulk``, gathers DSV4 UE8M0 footer scales when present,
+and signals ``full`` via
+``mbarrier_arrive_and_expect_tx`` so the bulk completion drives the transaction
+count to zero.
+
+Protocol (raw mbarrier ops; modeled EXACTLY on FlashInfer
+``decode_dsv4_kernel.cuh`` :243-323 ``issue_gather`` + the ``is_io`` producer
+loop, and ``common/kv_cache_io.cuh`` ``io_bulk_gather_tile``/``io_gather_scales``):
+
+  * ``mbar_full[s]``  : IO leader (io_lane 0) arrives + expect_tx(BULK_TX_BYTES);
+                        the cp.async.bulk completions decrement the transaction
+                        count. The full barrier flips its phase only when BOTH
+                        the arrival (1, by the leader) AND tx==0 are met -- i.e.
+                        when every byte of buffer ``s`` has landed.
+  * ``mbar_empty[s]`` : the math consumer arrives (one math thread) when it is
+                        done reading buffer ``s``; the IO warp waits on it
+                        before overwriting ``s``.
+
+The IO warp NEVER touches a math-only named barrier (``bar.sync 3, 256``) --
+that would deadlock (256-count waiter that the IO warp can't satisfy and
+shouldn't join). It only touches mbarriers + its own loads.
+
+FOOTER caveat (matches FlashInfer): the 7+1 UE8M0 footer bytes per token live
+in gmem in a BLOCK-STRUCTURED (FlashMLA footer ABI) region -- the BI tokens are
+NOT contiguous (different ``local_idx`` / ``block_idx``), so there is no single
+16B-aligned ``BI*8`` gmem region to cp.async.bulk. Per-token 8B cp.async.bulk
+is also illegal (must be 16B-aligned). So the footer is gathered with SCALAR
+``ld.global.nc`` (one v2.u32 = the 8 footer bytes/token) into the CONTIGUOUS
+smem ``kv_sc`` buffer, then a CTA-scope fence (``fence_acq_rel_cta`` ==
+``__threadfence_block``) orders those scalar stores before the leader's
+expect_tx -- exactly as ``issue_gather`` does (:268-285). The grouped footer
+thus lands in smem as a contiguous BI*8=512B region; the math reads it FLAT.
+The bulk transaction count (``BULK_TX_BYTES``) covers ONLY the nope+rope data
+(BI*(448+128)); the footer is NOT part of the mbarrier tx.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Int64, Uint32
+
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    cp_async_bulk_g2s_mbar,
+    get_ptr_as_int64,
+    ld_global_nc_v2_u32,
+    shared_ptr_to_u32,
+    st_shared_u32,
+)
+
+# DSV4 KV gmem IO stride: DATA portion only (448 nope + 64 rope * 2B = 576),
+# 16B aligned for cp.async.bulk. == FlashInfer KVIOTraits<DSV4>::IO_STRIDE.
+_DSV4_IO_STRIDE = 576
+_DSV4_NOPE_BYTES = 448  # FP8 nope; == D_NOPE; bulk #1 per entry.
+_DSV4_ROPE_BYTES = 128  # BF16 rope; == D_ROPE * 2; bulk #2 per entry.
+_DSV4_FOOTER_BYTES = 8  # 7 UE8M0 + 1 pad; == SCALE_BYTES_PER_TOKEN.
+
+# GLM (ARBITRARY_FP32) KV gmem layout: per-token 656B contiguous record
+# (reference.pack_mla_kv_cache_reference): 512 e4m3 nope + 16 inline fp32 scales
+# (4 groups x 4B) + 128 bf16 rope. There is NO grouped footer -- the inline
+# scales travel WITH the nope (bulk #1), so the nope+scales region (528B) and the
+# rope (128B) are both 16B-aligned cp.async.bulk copies. == GLM_KV_GMEM_STRIDE.
+_GLM_GMEM_STRIDE = 656
+_GLM_NOPE_SCALE_BYTES = 528  # 512 e4m3 + 16 inline fp32; bulk #1 (-> kv_fp8 row).
+_GLM_ROPE_BYTES = 128  # 64 bf16; bulk #2 (-> kv_rope).
+
+# NVFP4 MLA latent layout: 256B E2M1 NoPE + 32B E4M3 scales + 16B pad + 128B
+# BF16 RoPE. The NoPE+scale+pad region is staged as a 288B row; decode math
+# dequants the E2M1 data and E4M3 group-16 scales in registers.
+_NVFP4_GMEM_STRIDE = 432
+_NVFP4_NOPE_SCALE_BYTES = 288
+_NVFP4_ROPE_BYTES = 128
+_NVFP4_ROPE_SRC = 304
+# GLM-only KV_FP8_ROPE tail.  The latent bytes [0,288) are identical to the
+# stock record; [288,304) holds fp32 scale + 12B zero pad and [304,368) is E4M3.
+_NVFP4_FP8_ROPE_GMEM_STRIDE = 368
+_NVFP4_FP8_ROPE_TAIL_BYTES = 80
+_NVFP4_FP8_ROPE_TAIL_SRC = 288
+
+# IO warp width (one warp = 32 threads; FlashInfer DSV4_IO_THREADS).
+_IO_THREADS = 32
+
+
+@cute.jit
+def io_issue_gather(
+    kv_cache_u8: cute.Tensor,  # flat 1-D u8 view of the paged DSV4 KV cache
+    topk_indices: cute.Tensor,  # 1-D int32 topk slice for this query token
+    kv_fp8_dst_addr: Int32,  # u32 smem addr of kv_fp8[buf] (BI x KV_SMEM_STRIDE)
+    kv_rope_dst_addr: Int32,  # u32 smem addr of kv_rope[buf] (BI x D_ROPE bf16)
+    kv_sc_dst_addr: Int32,  # u32 smem addr of kv_sc[buf] (BI x 8 footer)
+    token_idx_view: cute.Tensor,  # smem int32 validity buffer (BI,) for THIS buf
+    full_mbar_ptr,  # cute.Pointer (u64) of mbar_full[buf]
+    g_start: Int32,  # absolute candidate offset of entry 0 (chunk_in_section*CAND_WINDOW)
+    g_end: Int32,  # min(g_start + CAND_WINDOW, section_len)
+    page_block_size: Int32,  # pbs: tokens per paged block (THIS section)
+    stride_kv_block: Int64,  # per-block byte stride in gmem (THIS section)
+    io_lane: Int32,  # lane within the IO warp [0, 32)
+    *,
+    bi: cutlass.Constexpr,  # 64
+    kv_smem_stride: cutlass.Constexpr,  # 464 DSV4 / 528 GLM (smem nope row stride)
+    rope_smem_stride: cutlass.Constexpr,  # 64 (D_ROPE bf16 elems)
+    scale_bytes_per_token: cutlass.Constexpr,  # 8 (DSV4 footer); unused for GLM
+    bulk_tx_bytes: cutlass.Constexpr,  # BI*(448+128)=36864 DSV4 / BI*(528+128)=41984 GLM
+    scale_format: cutlass.Constexpr = 0,  # UE8M0_BYTE (0) / ARBITRARY_FP32 (1)
+    fp8_rope: cutlass.Constexpr = False,
+    io_threads: cutlass.Constexpr = _IO_THREADS,  # 32 (decode 1 IO warp) / 128 (prefill 4 IO warps)
+    packed_glm: cutlass.Constexpr = False,
+    packed_dsv4: cutlass.Constexpr = False,
+    split_mbar_arrival: cutlass.Constexpr = False,
+    overlap_footer_gather: cutlass.Constexpr = False,
+):
+    """Producer body for ONE chunk into buffer ``buf`` (caller selects the dst
+    addrs + full_mbar_ptr for ``buf``). Mirrors FlashInfer ``issue_gather``:
+
+    ``io_threads`` (const_expr) is the number of IO threads sharing this gather
+    (32 for the decode single IO warp, 128 for the prefill 4 IO warps). The entry
+    stride + unroll count both fold to ``io_threads`` so the BI=64 entries are
+    distributed across the available IO threads (prefill: 1 pass of 64 over 128
+    threads; decode: 2 passes of 32). ``io_lane`` is the lane within the whole IO
+    group ([0, io_threads)). Defaulting to 32 keeps the decode PTX byte-identical.
+
+      1. SCALAR footer gather (32 IO threads stride over BI entries; v2.u32 read
+         of the 8 footer bytes, clamped-invalid -> 0) into the contiguous smem
+         ``kv_sc`` buffer; in the SAME pass stage the raw topk index (incl the
+         -1 sentinel) into the ``token_idx`` validity buffer (gap #9 single
+         source of truth for the S3 consumer mask).
+      2. CTA-scope fence so those footer/index stores are visible before the
+         leader's expect_tx (mbarrier.try_wait.parity has NO implicit fence).
+      3. IO leader (io_lane 0) arrive + expect_tx(BULK_TX_BYTES) on full[buf].
+      4. cp.async.bulk each entry; DSV4 issues separate NoPE (448B) and RoPE
+         (128B) copies, while packed GLM H8 issues one contiguous 656B copy.
+         Bulk completion decrements the full[buf] transaction count.
+
+    DUAL-CACHE (DSV4 only; FlashInfer ``issue_gather`` :243-306): this function
+    gathers ONE chunk from ONE section. The dual-cache section dispatch lives in
+    the KERNEL IO loop (launch.py): for a MAIN chunk it calls this with the main
+    cache / indices / page_block_size / stride_kv_block; for an EXTRA chunk it
+    calls this with the extra cache / extra indices / pbs_extra /
+    stride_extra_kv_block. The smem dst layout + per-entry byte geometry are
+    IDENTICAL across sections, so this body is section-agnostic and the no-extra
+    DSV4 / GLM PTX is unchanged (the caller never emits the extra branch).
+    """
+    # Section-agnostic gather: ``kv_cache_u8`` / ``topk_indices`` /
+    # ``page_block_size`` / ``stride_kv_block`` are THIS section's pool (the caller
+    # selects main vs extra). Aliased to the historical ``_section_*`` names used
+    # by the per-entry addressing below.
+    _section_kv = kv_cache_u8
+    _section_idx = topk_indices
+    _section_pbs = page_block_size
+    _section_stride = stride_kv_block
+
+    # Per-model gmem geometry (const_expr). DSV4: 576B data + grouped 8B footer;
+    # GLM: 656B contiguous (528 nope+inline-scales + 128 rope), NO footer.
+    # NVFP4: 432B contiguous (288 nope+E4M3-scales+pad + 128 rope), NO footer.
+    if cutlass.const_expr(scale_format == 0):
+        _IOS = Int64(_DSV4_IO_STRIDE)  # 576 per-token data stride
+        _NOPE = Int32(_DSV4_NOPE_BYTES)  # 448 -> kv_fp8 (e4m3 nope)
+        _ROPE = Int32(_DSV4_ROPE_BYTES)  # 128 -> kv_rope
+        _ROPE_SRC = Int64(_DSV4_NOPE_BYTES)  # rope follows nope in the record
+    elif cutlass.const_expr(scale_format == 2):
+        _NOPE = Int32(_NVFP4_NOPE_SCALE_BYTES)
+        if cutlass.const_expr(fp8_rope):
+            _IOS = Int64(_NVFP4_FP8_ROPE_GMEM_STRIDE)
+            # Stage scale+pad+FP8 payload contiguously in the existing 128-byte
+            # BF16-rope smem row. decode_math interprets scale at +0 and E4M3 at +16.
+            _ROPE = Int32(_NVFP4_FP8_ROPE_TAIL_BYTES)
+            _ROPE_SRC = Int64(_NVFP4_FP8_ROPE_TAIL_SRC)
+        else:
+            _IOS = Int64(_NVFP4_GMEM_STRIDE)
+            _ROPE = Int32(_NVFP4_ROPE_BYTES)
+            _ROPE_SRC = Int64(_NVFP4_ROPE_SRC)
+    else:
+        _IOS = Int64(_GLM_GMEM_STRIDE)  # 656 per-token contiguous record
+        _NOPE = Int32(_GLM_NOPE_SCALE_BYTES)  # 528 nope+inline-fp32 -> kv_fp8
+        _ROPE = Int32(_GLM_ROPE_BYTES)  # 128 -> kv_rope
+        _ROPE_SRC = Int64(_GLM_NOPE_SCALE_BYTES)  # rope follows nope+scales
+    _FOOT = Int32(scale_bytes_per_token)
+
+    def _issue_payload_entry(entry: Int32, idx_raw: Int32):
+        full_mbar_u32 = shared_ptr_to_u32(full_mbar_ptr)
+        idx = idx_raw
+        if idx < Int32(0):
+            idx = Int32(0)
+        block_idx = idx // _section_pbs
+        local_idx = idx - block_idx * _section_pbs
+        data_base_off = Int64(block_idx) * _section_stride + Int64(local_idx) * _IOS
+        data_base_i64 = get_ptr_as_int64(_section_kv, data_base_off)
+
+        if cutlass.const_expr(packed_glm):
+            cp_async_bulk_g2s_mbar(
+                kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                data_base_i64,
+                Int32(_GLM_GMEM_STRIDE),
+                full_mbar_u32,
+            )
+        elif cutlass.const_expr(packed_dsv4):
+            cp_async_bulk_g2s_mbar(
+                kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                data_base_i64,
+                Int32(_DSV4_IO_STRIDE),
+                full_mbar_u32,
+            )
+        else:
+            cp_async_bulk_g2s_mbar(
+                kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                data_base_i64,
+                _NOPE,
+                full_mbar_u32,
+            )
+            cp_async_bulk_g2s_mbar(
+                kv_rope_dst_addr + entry * Int32(rope_smem_stride * 2),
+                data_base_i64 + _ROPE_SRC,
+                _ROPE,
+                full_mbar_u32,
+            )
+
+    def _issue_payload():
+        eo = Int32(0)
+        for _ in cutlass.range_constexpr((bi + io_threads - 1) // io_threads):
+            entry = eo + io_lane
+            if entry < Int32(bi):
+                cand_pos = g_start + entry
+                idx_raw = Int32(-1)
+                if cand_pos < g_end:
+                    idx_raw = Int32(_section_idx[cand_pos])
+                idx = idx_raw
+                if idx < Int32(0):
+                    idx = Int32(0)
+                block_idx = idx // _section_pbs
+                local_idx = idx - block_idx * _section_pbs
+                data_base_off = (
+                    Int64(block_idx) * _section_stride + Int64(local_idx) * _IOS
+                )
+                data_base_i64 = get_ptr_as_int64(_section_kv, data_base_off)
+                full_mbar_u32 = shared_ptr_to_u32(full_mbar_ptr)
+
+                if cutlass.const_expr(packed_glm):
+                    cp_async_bulk_g2s_mbar(
+                        kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                        data_base_i64,
+                        Int32(_GLM_GMEM_STRIDE),
+                        full_mbar_u32,
+                    )
+                elif cutlass.const_expr(packed_dsv4):
+                    cp_async_bulk_g2s_mbar(
+                        kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                        data_base_i64,
+                        Int32(_DSV4_IO_STRIDE),
+                        full_mbar_u32,
+                    )
+                else:
+                    cp_async_bulk_g2s_mbar(
+                        kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                        data_base_i64,
+                        _NOPE,
+                        full_mbar_u32,
+                    )
+                    cp_async_bulk_g2s_mbar(
+                        kv_rope_dst_addr + entry * Int32(rope_smem_stride * 2),
+                        data_base_i64 + _ROPE_SRC,
+                        _ROPE,
+                        full_mbar_u32,
+                    )
+            eo += Int32(io_threads)
+
+    # Native H16 can overlap the random scalar footer load with the much larger
+    # payload transfer. Its producer leaders set the transaction count without
+    # arriving; their post-footer arrivals remain the release condition.
+    if cutlass.const_expr(overlap_footer_gather):
+        if (io_lane & Int32(31)) == Int32(0):
+            cute.arch.mbarrier_expect_tx(full_mbar_ptr, Int32(bulk_tx_bytes // 2))
+        # H16 has exactly one row per IO thread. Start the random footer load,
+        # launch the independent payload copy, and only then consume the footer
+        # result in shared stores so the two memory operations overlap.
+        overlap_entry = io_lane
+        overlap_cand_pos = g_start + overlap_entry
+        overlap_idx_raw = Int32(-1)
+        if overlap_cand_pos < g_end:
+            overlap_idx_raw = Int32(_section_idx[overlap_cand_pos])
+        token_idx_view[overlap_entry] = overlap_idx_raw
+
+        overlap_f0 = Uint32(0)
+        overlap_f1 = Uint32(0)
+        if overlap_idx_raw >= Int32(0):
+            overlap_block_idx = overlap_idx_raw // _section_pbs
+            overlap_local_idx = overlap_idx_raw - overlap_block_idx * _section_pbs
+            overlap_scale_base_off = (
+                Int64(overlap_block_idx) * _section_stride
+                + Int64(_section_pbs) * _IOS
+                + Int64(overlap_local_idx) * Int64(_FOOT)
+            )
+            overlap_f0, overlap_f1 = ld_global_nc_v2_u32(
+                get_ptr_as_int64(_section_kv, overlap_scale_base_off)
+            )
+
+        _issue_payload_entry(overlap_entry, overlap_idx_raw)
+        overlap_s_byte = overlap_entry * _FOOT
+        st_shared_u32(kv_sc_dst_addr + overlap_s_byte, overlap_f0)
+        st_shared_u32(kv_sc_dst_addr + overlap_s_byte + Int32(4), overlap_f1)
+        cute.arch.fence_acq_rel_cta()
+        if (io_lane & Int32(31)) == Int32(0):
+            cute.arch.mbarrier_arrive(full_mbar_ptr)
+        return
+
+    # --- (1) per-entry validity index staging + (DSV4 only) scalar footer gather. ---
+    eo = Int32(0)
+    for _ in cutlass.range_constexpr((bi + io_threads - 1) // io_threads):
+        entry = eo + io_lane
+        if entry < Int32(bi):
+            cand_pos = g_start + entry
+            idx_raw = Int32(-1)
+            if cand_pos < g_end:
+                idx_raw = Int32(_section_idx[cand_pos])
+            # gap #9: stage the raw index (incl -1) for the S3 consumer mask.
+            token_idx_view[entry] = idx_raw
+            if cutlass.const_expr(scale_format == 0):
+                # DSV4 grouped UE8M0 footer -> contiguous smem kv_sc. GLM has no
+                # footer (inline scales travel in the kv_fp8 nope bulk).
+                f0 = Uint32(0)
+                f1 = Uint32(0)
+                if idx_raw >= Int32(0):
+                    block_idx = idx_raw // _section_pbs
+                    local_idx = idx_raw - block_idx * _section_pbs
+                    scale_base_off = (
+                        Int64(block_idx) * _section_stride
+                        + Int64(_section_pbs) * _IOS
+                        + Int64(local_idx) * Int64(_FOOT)
+                    )
+                    f0, f1 = ld_global_nc_v2_u32(
+                        get_ptr_as_int64(_section_kv, scale_base_off)
+                    )
+                s_byte = entry * _FOOT
+                st_shared_u32(kv_sc_dst_addr + s_byte, f0)
+                st_shared_u32(kv_sc_dst_addr + s_byte + Int32(4), f1)
+        eo += Int32(io_threads)
+
+    # --- (2) CTA-scope fence: footer/index stores visible before release. ---
+    # == FlashInfer __threadfence_block() (issue_gather :281). try_wait.parity
+    # has no implicit memory fence so this acq-rel is load-bearing.
+    cute.arch.fence_acq_rel_cta()
+
+    # --- (3) Publish the footer stores, or start the conventional payload. ---
+    if cutlass.const_expr(overlap_footer_gather):
+        if (io_lane & Int32(31)) == Int32(0):
+            cute.arch.mbarrier_arrive(full_mbar_ptr)
+    else:
+        if cutlass.const_expr(split_mbar_arrival):
+            # Native H16 has two producer warps, each responsible for 32 of the
+            # 64 packed rows. Each leader contributes half the transaction bytes.
+            if (io_lane & Int32(31)) == Int32(0):
+                cute.arch.mbarrier_arrive_and_expect_tx(
+                    full_mbar_ptr, Int32(bulk_tx_bytes // 2)
+                )
+        else:
+            if io_lane == Int32(0):
+                cute.arch.mbarrier_arrive_and_expect_tx(
+                    full_mbar_ptr, Int32(bulk_tx_bytes)
+                )
+        _issue_payload()

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/io_mg.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/io_mg.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/io_mg.py @ e130f195 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""DSV4 MG prefill IO helper.
+
+FlashInfer DSV4 prefill bulk-stages only the 448-byte NoPE FP8 payload into
+shared memory. The 64-dim RoPE component is consumed from global/L2 by the math
+warps, while the 8-byte UE8M0 footer is scalar-gathered into a contiguous smem
+scale buffer.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Int64, Uint32, Uint64
+
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    cp_async_bulk_g2s_mbar_l2hint,
+    get_ptr_as_int64,
+    ld_global_nc_v2_u32,
+    shared_ptr_to_u32,
+    st_shared_u32,
+)
+
+
+_DSV4_IO_STRIDE = 576
+_DSV4_NOPE_BYTES = 448
+_DSV4_FOOTER_BYTES = 8
+_IO_THREADS = 128
+
+# GLM (ARBITRARY_FP32) KV gmem layout: per-token 656B contiguous record
+# (512 e4m3 nope + 16 inline fp32 scales + 128 bf16 rope). NO grouped footer --
+# the inline fp32 scales travel WITH the nope (bulk #1, 528B -> kv_fp8 row). The
+# MG path reads rope from global/L2 (no smem staging), so only the 528B bulk is
+# issued here.
+_GLM_IO_STRIDE = 656
+_GLM_NOPE_SCALE_BYTES = 528
+# NVFP4 MLA latent record: 256B E2M1 NoPE + 32B E4M3 group-16 scales + 16B pad
+# + 128B BF16 RoPE. The 288B NoPE+scales+pad region bulk-copies into the kv_fp8
+# row; RoPE is read from global/L2 by the math exactly like GLM.
+_NVFP4_IO_STRIDE = 432
+_NVFP4_NOPE_SCALE_BYTES = 288
+_NVFP4_FP8_ROPE_IO_STRIDE = 368
+
+
+@cute.jit
+def io_issue_gather_dsv4_nope(
+    kv_cache_u8: cute.Tensor,
+    topk_indices: cute.Tensor,
+    kv_fp8_dst_addr: Int32,
+    kv_sc_dst_addr: Int32,
+    full_mbar_ptr,
+    g_start: Int32,
+    g_end: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    io_lane: Int32,
+    cache_policy: Uint64,
+    *,
+    bi: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    io_threads: cutlass.Constexpr = _IO_THREADS,
+):
+    """Gather one BI=64 DSV4 prefill tile into MG smem.
+
+    This is the DSV4-only equivalent of FlashInfer
+    ``io_gather_scales`` + ``io_bulk_gather_tile`` with
+    ``KV_SMEM_COPY_BYTES == D_NOPE``.
+    """
+    _ios = Int64(_DSV4_IO_STRIDE)
+    _nope = Int32(_DSV4_NOPE_BYTES)
+    _foot = Int32(_DSV4_FOOTER_BYTES)
+
+    eo = Int32(0)
+    for _ in cutlass.range_constexpr((bi + io_threads - 1) // io_threads):
+        entry = eo + io_lane
+        if entry < Int32(bi):
+            cand_pos = g_start + entry
+            idx_raw = Int32(-1)
+            if cand_pos < g_end:
+                idx_raw = Int32(topk_indices[cand_pos])
+
+            f0 = Uint32(0)
+            f1 = Uint32(0)
+            if idx_raw >= Int32(0):
+                block_idx = idx_raw // page_block_size
+                local_idx = idx_raw - block_idx * page_block_size
+                scale_base_off = (
+                    Int64(block_idx) * stride_kv_block
+                    + Int64(page_block_size) * _ios
+                    + Int64(local_idx) * Int64(_foot)
+                )
+                f0, f1 = ld_global_nc_v2_u32(
+                    get_ptr_as_int64(kv_cache_u8, scale_base_off)
+                )
+            s_byte = entry * _foot
+            st_shared_u32(kv_sc_dst_addr + s_byte, f0)
+            st_shared_u32(kv_sc_dst_addr + s_byte + Int32(4), f1)
+        eo += Int32(io_threads)
+
+    cute.arch.fence_acq_rel_cta()
+
+    if io_lane == Int32(0):
+        cute.arch.mbarrier_arrive_and_expect_tx(
+            full_mbar_ptr, Int32(bi * _DSV4_NOPE_BYTES)
+        )
+
+    full_mbar_u32 = shared_ptr_to_u32(full_mbar_ptr)
+    eo = Int32(0)
+    for _ in cutlass.range_constexpr((bi + io_threads - 1) // io_threads):
+        entry = eo + io_lane
+        if entry < Int32(bi):
+            cand_pos = g_start + entry
+            idx_raw = Int32(-1)
+            if cand_pos < g_end:
+                idx_raw = Int32(topk_indices[cand_pos])
+            idx = idx_raw
+            if idx < Int32(0):
+                idx = Int32(0)
+            block_idx = idx // page_block_size
+            local_idx = idx - block_idx * page_block_size
+            data_base_off = Int64(block_idx) * stride_kv_block + Int64(local_idx) * _ios
+            cp_async_bulk_g2s_mbar_l2hint(
+                kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                get_ptr_as_int64(kv_cache_u8, data_base_off),
+                _nope,
+                full_mbar_u32,
+                cache_policy,
+            )
+        eo += Int32(io_threads)
+
+
+@cute.jit
+def io_issue_gather_glm_mg(
+    kv_cache_u8: cute.Tensor,
+    topk_indices: cute.Tensor,
+    kv_fp8_dst_addr: Int32,
+    full_mbar_ptr,
+    g_start: Int32,
+    g_end: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    io_lane: Int32,
+    cache_policy: Uint64,
+    *,
+    bi: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,  # 528 GLM / 288 NVFP4 (smem nope row stride)
+    io_threads: cutlass.Constexpr = _IO_THREADS,
+    scale_format: cutlass.Constexpr = 1,
+    fp8_rope: cutlass.Constexpr = False,
+):
+    """Gather one BI=64 GLM prefill tile into MG smem.
+
+    GLM analogue of ``io_issue_gather_dsv4_nope``: the per-token 656B record's
+    NoPE+inline-fp32-scales (528B) bulk-copies into the kv_fp8 row (the inline
+    fp32 scales travel WITH the nope and are read post-MMA by the math). There is
+    NO grouped UE8M0 footer (so NO scalar scale gather) and -- like the DSV4 MG
+    path -- RoPE is read from global/L2 by the math (NOT staged to smem), so the
+    528-stride GLM KV fits the carveout for mg_n_hg==2. Single full mbarrier (the
+    MG convention): the leader arrives + expect_tx over the BI 528B bulks.
+
+    ``scale_format`` (const_expr): ARBITRARY_FP32 (1, GLM 656B/528B) or
+    NVFP4_E4M3 (2, NVFP4 432B/288B) record geometry."""
+    if cutlass.const_expr(scale_format == 2):
+        if cutlass.const_expr(fp8_rope):
+            _ios = Int64(_NVFP4_FP8_ROPE_IO_STRIDE)
+        else:
+            _ios = Int64(_NVFP4_IO_STRIDE)
+        _nope = Int32(_NVFP4_NOPE_SCALE_BYTES)
+    else:
+        _ios = Int64(_GLM_IO_STRIDE)
+        _nope = Int32(_GLM_NOPE_SCALE_BYTES)
+
+    if io_lane == Int32(0):
+        cute.arch.mbarrier_arrive_and_expect_tx(full_mbar_ptr, Int32(bi) * _nope)
+
+    full_mbar_u32 = shared_ptr_to_u32(full_mbar_ptr)
+    eo = Int32(0)
+    for _ in cutlass.range_constexpr((bi + io_threads - 1) // io_threads):
+        entry = eo + io_lane
+        if entry < Int32(bi):
+            cand_pos = g_start + entry
+            idx_raw = Int32(-1)
+            if cand_pos < g_end:
+                idx_raw = Int32(topk_indices[cand_pos])
+            idx = idx_raw
+            if idx < Int32(0):
+                idx = Int32(0)
+            block_idx = idx // page_block_size
+            local_idx = idx - block_idx * page_block_size
+            data_base_off = Int64(block_idx) * stride_kv_block + Int64(local_idx) * _ios
+            # NoPE + inline fp32 scales (528B) -> kv_fp8 row.
+            cp_async_bulk_g2s_mbar_l2hint(
+                kv_fp8_dst_addr + entry * Int32(kv_smem_stride),
+                get_ptr_as_int64(kv_cache_u8, data_base_off),
+                _nope,
+                full_mbar_u32,
+                cache_policy,
+            )
+        eo += Int32(io_threads)

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/kernel.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/kernel.py
@@ -1,0 +1,3214 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/kernel.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Launch / dispatch entrypoints for the active SM120 sparse-MLA backend.
+
+The ``run_unified_decode`` entrypoint builds views, plans split-K chunk ranges,
+launches the warp-specialized decode grid, and runs the shared base-2 split merge
+to produce final output. DSV4 compressed MLA and GLM_NSA use the same promoted
+SM120 runtime; the retired pre-unification kernels have been removed.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import replace
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as cutlass_utils
+import torch
+from cutlass import Float32, Int32, Int64
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.experimental.sm12x.attention._shared.cute.ops import LOG2_E
+from flashinfer.experimental.sm12x._lib.compiler import (
+    DimKey,
+    KernelCompileSpec,
+    key_field,
+    tensor_key,
+)
+from flashinfer.experimental.sm12x._lib.compiler import (
+    launch as sm12x_launch,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import shared_ptr_to_u32
+
+from .decode_math import (
+    s0_load_q_bf16_to_smem,
+    s0_quantize_q_to_smem,
+    s1_qk_nope_block_scaled,
+    s1_qk_nope_block_scaled_dsv4_h8_swap_ab,
+    s1_qk_nope_block_scaled_glm_h8_swap_ab,
+    s2_qk_rope_bf16,
+    s2_qk_rope_bf16_glm_h8_swap_ab,
+    s3_mask_and_scale,
+    s3_mask_and_scale_glm_h8_swap_ab,
+    s4_online_softmax,
+    s4_online_softmax_glm_h8_swap_ab,
+    s5_fill_sm_p_full,
+    s6_xv_nope,
+    s6_xv_nope_dsv4_h8_swap_ab,
+    s6_xv_nope_glm_h8_swap_ab,
+    s6b_xv_rope,
+    s6b_xv_rope_h8_swap_ab,
+    s7_epilogue,
+)
+from .io import io_issue_gather
+from .smem import get_unified_shared_storage_cls, make_smem_layout
+from .traits import (
+    ModelType,
+    ScaleFormat,
+    infer_model_type,
+    make_unified_traits,
+)
+
+# natural-log of 2 (base2 <-> natural LSE conversion).
+_LN2 = math.log(2.0)
+
+# BI=64 candidates per chunk (one full/empty KV buffer window). The split-K
+# planner cuts the topk into chunk-aligned ranges so split partials are disjoint
+# and the merge is exact (split boundary == chunk boundary).
+_CAND_WINDOW = 64
+
+# DSV4 compressed contract head dim (q_nope 448 + q_rope 64).
+_DSV4_HEAD_DIM = 512
+# GLM_NSA uncompressed contract head dim (q_nope 512 + q_rope 64).
+_GLM_HEAD_DIM = 576
+# GLM per-token packed cache record (reference.pack_mla_kv_cache_reference).
+_GLM_KV_GMEM_STRIDE = 656
+# DSV4 H8 packs the contiguous 576-byte data record into a 592-byte smem row.
+# The 16-byte pad preserves KV_SMEM_STRIDE/4 % 32 == 20, matching the generic
+# 464-byte row's bank rotation while allowing one bulk copy per candidate.
+_DSV4_PACKED_SMEM_STRIDE = 592
+_DSV4_PACKED_ROPE_OFFSET = 448
+# Largest DSV4 trace regime validated for the H8 specialization: 2 SWA chunks
+# plus 128 indexed chunks.  Keep this shape-only so graph capture and replay
+# select identical launch geometry without inspecting runtime tensor values.
+_DSV4_H8_MAX_CHUNKS = 130
+
+
+@dsl_user_op
+def _exit_thread(
+    *,
+    loc=None,
+    ip=None,
+):
+    """Terminate a thread after a CTA-uniform empty-split decision."""
+    llvm.inline_asm(
+        None,
+        [],
+        "exit;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+# Optional decode num_splits override (P9b AutoTuner sweep hook). ``<= 0`` (or an
+# unparseable value, or unset) means "use the FlashInfer-ported wave-balanced
+# heuristic"; ``>= 1`` pins num_splits to that value (still clamped to
+# [1, num_chunks] and to the workspace split capacity). Read PER CALL (not cached
+# at import) so a sweep / AutoTuner can flip it between launches.
+_MLA_SM120_NUM_SPLITS_ENV = "FLASHINFER_EXP_SM12X_MLA_SM120_NUM_SPLITS"
+
+# Exact GLM TP8 decode specialization: four math warps, swapped QK A/B, and
+# packed HIGH/LOW PV.  Default-on; the per-call escape hatch exists for numeric
+# and performance A/B diagnostics without changing serving code.
+_MLA_SM120_GLM_H8_NATIVE_ENV = "FLASHINFER_EXP_SM12X_MLA_SM120_GLM_H8_NATIVE"
+
+# Native DSV4 H16 two-group decode (two 8-head H8 groups sharing one KV
+# pipeline per CTA): halves h_blocks (CTA count + KV gather traffic) and runs
+# 8 math warps (2/scheduler) so the two groups' serial chunk chains interleave.
+# Opt-in while being validated: unset/0 -> off; 1/true/on/yes -> on.
+_MLA_SM120_DSV4_H16_NATIVE_ENV = "FLASHINFER_EXP_SM12X_MLA_SM120_DSV4_H16_NATIVE"
+
+# FlashInfer's decode-dsv4 chunks_per_block wave-balance cap
+# (csrc/sparse_mla_sm120_decode_dsv4.cu:85). cpb candidates whose last-wave tail
+# gap looks small but require more than this many integer waves are rejected.
+_CEIL_WAVES_MAX = 3
+
+# Observability: the most recent decode split plan (read by benchmarks / the
+# P9c AutoTuner sweep to report num_splits_used). Pure side-channel -- does NOT
+# affect numerics or the launch. Keys are informational.
+LAST_DECODE_PLAN: dict = {}
+
+
+def _env_num_splits_override() -> int:
+    """Read ``FLASHINFER_EXP_SM12X_MLA_SM120_NUM_SPLITS`` per call. ``<= 0`` / unset / bad -> 0
+    (heuristic). Mirrors FlashInfer's ``chunks_per_block_override <= 0 -> C++
+    heuristic`` convention, but for OUR num_splits (== FlashInfer's active block
+    count num_splits_eff)."""
+    raw = os.environ.get(_MLA_SM120_NUM_SPLITS_ENV)
+    if raw is None:
+        return 0
+    try:
+        v = int(raw.strip())
+    except (TypeError, ValueError):
+        return 0
+    return v if v > 0 else 0
+
+
+def _env_glm_h8_native_enabled() -> bool:
+    raw = os.environ.get(_MLA_SM120_GLM_H8_NATIVE_ENV)
+    return raw is None or raw.strip().lower() not in {"0", "false", "off", "no"}
+
+
+def _env_dsv4_h16_native_mode() -> bool | None:
+    """Tri-state H16 override: None = auto policy, False = never, True = always."""
+    raw = os.environ.get(_MLA_SM120_DSV4_H16_NATIVE_ENV)
+    if raw is None:
+        return None
+    text = raw.strip().lower()
+    if text in {"1", "true", "on", "yes"}:
+        return True
+    if text in {"0", "false", "off", "no"}:
+        return False
+    return None
+
+
+# Auto H8/H16 policy constants (measured on RTX PRO 6000 Blackwell, 188 SMs).
+# H16 wins when the shape is KV-gather-bound (many chunks -> halving h_blocks
+# halves gather traffic) or when the H8 grid would exceed ~1.4 waves of
+# 1-CTA/SM blocks; the H8 CTA keeps a ~4us-lower fixed latency, so it wins the
+# small-rows sub-wave regime.
+_DSV4_H16_MIN_BW_CHUNKS = 24
+_DSV4_H16_MIN_BW_ROWS = 2
+_DSV4_H16_H8_CTA_LIMIT = 256
+
+
+def _dsv4_h16_auto(
+    *,
+    rows: int,
+    heads: int,
+    num_chunks: int,
+    h8_num_splits: int,
+    sm_count: int | None = None,
+) -> bool:
+    h8_ctas = rows * (heads // 8) * max(1, int(h8_num_splits))
+    # Spark reaches a full H8 launch wave much earlier than the 188-SM tuning
+    # target. C128's 130-chunk gather is enough to amortize H16 even at B=1;
+    # shorter gathers usually need B=8 before sharing each KV stage across 16
+    # heads wins. Two short-gather wave cliffs are exceptions: C4/B7's H8 plan
+    # launches more than two waves, while C1/B13-15 halves its launch grid with
+    # H16. Both regimes are measured wins on the 48-SM Spark.
+    if sm_count is not None and sm_count <= 64:
+        if num_chunks >= 128:
+            return True
+        if rows >= 8 and num_chunks > 2:
+            return True
+        if heads == 32 and sm_count == 48:
+            if num_chunks == 2 and 13 <= rows <= 15:
+                return True
+            if num_chunks == 10 and h8_ctas > 2 * sm_count:
+                return True
+    if num_chunks >= _DSV4_H16_MIN_BW_CHUNKS and rows >= _DSV4_H16_MIN_BW_ROWS:
+        return True
+    return h8_ctas > _DSV4_H16_H8_CTA_LIMIT
+
+
+def _dsv4_spark_short_gather_num_splits(
+    *,
+    rows: int,
+    heads: int,
+    num_chunks: int,
+    sm_count: int | None,
+    native_dsv4_h16: bool,
+) -> int | None:
+    """Return measured Spark split overrides for DSV4 TP2 short gathers."""
+    if not native_dsv4_h16 or heads != 32 or sm_count is None or sm_count != 48:
+        return None
+    if num_chunks == 2 and 13 <= rows <= 15:
+        return 1
+    if num_chunks == 10:
+        return {7: 2, 13: 4, 14: 3}.get(rows)
+    return None
+
+
+def _wave_balanced_num_splits(
+    *, num_chunks: int, per_token_head: int, sm_count: int
+) -> int:
+    """Replicate FlashInfer's decode-dsv4 occupancy decision in OUR chunk-range
+    parameterization, returning OUR ``num_splits`` (== FlashInfer's active block
+    count ``num_splits_eff``).
+
+    FlashInfer splits MAXIMALLY: its ``num_splits`` == ``num_chunks`` (one block
+    per KV chunk; sparse_mla_sm120.py:259-260,286), then a C++ heuristic
+    (csrc/sparse_mla_sm120_decode_dsv4.cu:69-102) picks ``chunks_per_block`` to
+    wave-balance the launch and computes ``num_splits_eff = ceil(num_splits /
+    cpb)`` ACTIVE blocks. Our UnifiedDecodeKernel processes a contiguous
+    chunk-RANGE per CTA, so OUR ``num_splits`` directly IS that active count: we
+    port the cpb tail-gap search VERBATIM over ``num_chunks`` chunks, then return
+    ``ceil(num_chunks / cpb*)``.
+
+    Tail-gap formula (VERBATIM from the .cu):
+        per_token_head = num_tokens * H_BLOCKS
+        for cpb in 1..num_chunks:                  # FlashInfer: 1..num_splits
+            eff    = ceil(num_chunks / cpb)
+            active = per_token_head * eff
+            ceil_w = ceil(active / sm_count)
+            if ceil_w > CEIL_WAVES_MAX(=3): continue
+            waves  = active / sm_count
+            gap    = ceil_w - waves
+            pick cpb minimizing gap (tie -> larger cpb, fewer launched blocks)
+        num_splits = ceil(num_chunks / cpb*)       # == FlashInfer num_splits_eff
+    """
+    num_chunks = max(int(num_chunks), 1)
+    per_token_head = max(int(per_token_head), 1)
+    sm_count = max(int(sm_count), 1)
+
+    chunks_per_block = 1
+    best_gap = 2.0
+    for cpb in range(1, num_chunks + 1):
+        eff = (num_chunks + cpb - 1) // cpb
+        active = per_token_head * eff
+        ceil_w = (active + sm_count - 1) // sm_count
+        if ceil_w > _CEIL_WAVES_MAX:
+            continue
+        waves = active / sm_count
+        gap = ceil_w - waves
+        if gap < best_gap - 1e-6 or (gap < best_gap + 1e-6 and cpb > chunks_per_block):
+            best_gap = gap
+            chunks_per_block = cpb
+    # OUR num_splits == FlashInfer's num_splits_eff = ceil(num_splits / cpb*),
+    # where FlashInfer's num_splits == num_chunks (maximal split).
+    return (num_chunks + chunks_per_block - 1) // chunks_per_block
+
+
+# ---------------------------------------------------------------------------
+# Split-K planning. Reuse the compressed planner's chunk-count idiom but pin the
+# per-split chunk granularity to the kernel's BI=64 window so split boundaries
+# land on chunk boundaries (a candidate is processed by exactly one split ->
+# multi-split is numerically identical to single-split).
+# ---------------------------------------------------------------------------
+def plan_unified_decode_splits(
+    *,
+    topk: int,
+    max_chunks: int,
+    forced_num_splits: int | None = None,
+    num_tokens: int = 1,
+    h_blocks: int = 1,
+    sm_count: int | None = None,
+    extra_topk: int = 0,
+    preferred_num_splits: int | None = None,
+) -> tuple[int, int, int]:
+    """Return ``(num_chunks, num_splits, chunks_per_split)``.
+
+    ``num_chunks = ceil(topk / BI) + ceil(extra_topk / BI)`` is the number of
+    BI=64 candidate windows spanning BOTH the main and the EXTRA cache sections
+    (DSV4 dual-cache; ``extra_topk=0`` reduces to the single-cache main count).
+    ``num_splits`` is chosen by replicating FlashInfer's decode launch tuning:
+    FlashInfer splits MAXIMALLY (one block per KV chunk) then wave-balances via a
+    chunks_per_block heuristic to an ACTIVE block count
+    ``num_splits_eff = ceil(num_chunks / cpb*)``. Our CTA owns a chunk-RANGE, so
+    OUR ``num_splits`` directly IS that active count -- we port the same
+    CEIL_WAVES_MAX=3 tail-gap search (see ``_wave_balanced_num_splits``).
+
+    Override precedence (highest first):
+      1. ``forced_num_splits`` (explicit caller arg -- multi-split numeric checks).
+      2. ``FLASHINFER_EXP_SM12X_MLA_SM120_NUM_SPLITS`` env (>=1 pins; <=0/unset -> heuristic).
+      3. ``preferred_num_splits`` (shape-only hardware policy, when provided).
+      4. The FlashInfer-ported wave-balanced heuristic (needs ``sm_count``;
+         falls back to 1 if ``sm_count`` is unavailable).
+
+    ``num_splits`` is clamped to ``[1, num_chunks]`` and to ``max_chunks`` (the
+    workspace mid_out/mid_lse split capacity).
+    """
+    # ZERO-WIDTH MAIN (DSV4 dual-cache, all KV in the EXTRA cache): topk==0 means
+    # NO main chunks -- the main section is elided and the decode attends ONLY the
+    # extra chunks. Keep ceil(0/BI)==0 here (do NOT floor topk to 1, which would
+    # fabricate a phantom main chunk that the num_main_chunks==0 dispatch would
+    # then mis-route as an over-allocated extra chunk). The single-cache /
+    # no-extra empty decode is still protected by the num_chunks>=1 floor below.
+    topk = max(int(topk), 0)
+    extra_topk = max(int(extra_topk), 0)
+    # num_chunks spans main + extra sections (FlashInfer num_splits = ceil(topk/BI)
+    # + ceil(extra_topk/BI)); the wave-balance heuristic then picks the active
+    # block count over the COMBINED chunk count. Floored to >=1 so a fully-empty
+    # decode (topk==0 and extra_topk==0) still launches one (masked) chunk.
+    num_chunks = max(
+        1,
+        (topk + _CAND_WINDOW - 1) // _CAND_WINDOW
+        + ((extra_topk + _CAND_WINDOW - 1) // _CAND_WINDOW),
+    )
+
+    if forced_num_splits is not None:
+        num_splits = max(1, int(forced_num_splits))
+    else:
+        env_override = _env_num_splits_override()
+        if env_override > 0:
+            num_splits = env_override
+        elif preferred_num_splits is not None:
+            num_splits = max(1, int(preferred_num_splits))
+        elif sm_count and sm_count > 0:
+            num_splits = _wave_balanced_num_splits(
+                num_chunks=num_chunks,
+                per_token_head=max(1, int(num_tokens)) * max(1, int(h_blocks)),
+                sm_count=int(sm_count),
+            )
+        else:
+            num_splits = 1
+
+    num_splits = min(num_splits, num_chunks, max(1, int(max_chunks)))
+    chunks_per_split = (num_chunks + num_splits - 1) // num_splits
+    return num_chunks, num_splits, chunks_per_split
+
+
+class UnifiedDecodeKernel:
+    """Warp-specialized sparse-MLA decode with split-K partial writeback.
+
+    Grid = (num_tokens, H_BLOCKS, num_splits). Each CTA owns one query token, one
+    HPB=16-head block, and one chunk-range slice (split). The generic path uses
+    8 math warps plus one IO warp; native DSV4 H16 uses two IO warps, while the
+    native GLM and DSV4 H8 paths use 4 math warps plus one IO warp. Math consumes
+    the double-buffered KV gathered with
+    cp.async.bulk and mbarriers (io.py), then runs S0-S6b over the split's chunks
+    and S7 writes this split's NORMALIZED partial O + base-2 LSE into mid_out /
+    mid_lse in the exact split.py merge convention.
+    """
+
+    def __init__(
+        self,
+        traits,
+        layout,
+        page_block_size,
+        chunks_per_split,
+        h_blocks,
+        num_splits,
+        num_heads,
+        q_head_dim,
+        topk,
+        extra_topk,
+        q_stride,
+        swa_indices_stride0,
+        extra_indices_stride0,
+        mid_out_stride,
+        mid_lse_stride,
+        has_extra=False,
+        pbs_extra=1,
+        valid_hpb=None,
+        head_block_offset=0,
+        per_token_len=False,
+        native_glm_h8=False,
+        native_dsv4_h8=False,
+        native_dsv4_h16=False,
+    ):
+        self.traits = traits
+        self.layout = layout
+        self.page_block_size = int(page_block_size)
+        self.chunks_per_split = int(chunks_per_split)
+        self.h_blocks = int(h_blocks)
+        self.num_splits = int(num_splits)
+        self.num_heads = int(num_heads)
+        self.q_head_dim = int(q_head_dim)
+        self.topk = int(topk)
+        self.extra_topk = int(extra_topk)
+        self.q_stride_row = int(q_stride[0])
+        self.q_stride_head = int(q_stride[1])
+        self.q_stride_dim = int(q_stride[2])
+        self.swa_indices_stride_row = int(swa_indices_stride0)
+        self.extra_indices_stride_row = int(extra_indices_stride0)
+        self.mid_out_stride_row = int(mid_out_stride[0])
+        self.mid_out_stride_head = int(mid_out_stride[1])
+        self.mid_out_stride_split = int(mid_out_stride[2])
+        self.mid_out_stride_dim = int(mid_out_stride[3])
+        self.mid_lse_stride_row = int(mid_lse_stride[0])
+        self.mid_lse_stride_head = int(mid_lse_stride[1])
+        self.mid_lse_stride_split = int(mid_lse_stride[2])
+        # DSV4 dual-cache (P7c). When False the extra-section code is const_expr-
+        # elided -> no-extra DSV4 / GLM PTX byte-identical.
+        self.has_extra = bool(has_extra)
+        self.pbs_extra = int(pbs_extra)
+        # P10b multi-token per-token topk_length. When False the section_len /
+        # extra_section_len are uniform Int32 scalars (the byte-identical base /
+        # uniform-length path; the per-token length tensors never enter the device
+        # entry). When True a per-token int32 length tensor is read in-kernel at
+        # t=blockIdx.x and clamped to [0, topk] -> the per-CTA section bound. The
+        # launcher routes here ONLY for a genuinely-mixed-length multi-token batch
+        # (a uniform batch collapses to the scalar path -> PTX byte-identical).
+        self.per_token_len = bool(per_token_len)
+        self.native_glm_h8 = bool(native_glm_h8)
+        self.native_dsv4_h8 = bool(native_dsv4_h8)
+        # Native H16: two independent 8-head H8 groups (4 math warps each)
+        # sharing the CTA's packed KV stage. Grid keeps HPB=16 head blocks.
+        self.native_dsv4_h16 = bool(native_dsv4_h16)
+        self.native_h8 = self.native_glm_h8 or self.native_dsv4_h8
+        if self.native_dsv4_h8 or self.native_dsv4_h16:
+            packed_span = int(layout.kv_bufs) * int(
+                traits.bi
+            ) * _DSV4_PACKED_SMEM_STRIDE + int(layout.kv_bufs) * int(
+                layout.kv_sc_buf_bytes
+            )
+            available_span = int(layout.mbar_off) - int(layout.kv_fp8_off)
+            if packed_span > available_span:
+                raise ValueError(
+                    "DSV4 H8 packed KV stage exceeds its shared-memory alias: "
+                    f"need {packed_span} bytes, have {available_span}"
+                )
+        # VALID_HPB (small-TP / non-multiple-of-16 head shards). Upstream
+        # VALID_HPB=min(NUM_HEADS,HPB) (decode_dsv4_kernel.cuh:152): the kernel
+        # computes a FULL HPB=16 tile with zero-Q padding then gates output/LSE
+        # writes to valid_hpb rows. ``valid_hpb`` is a const_expr (s0/s4/s7 gate on
+        # it). When valid_hpb == t.hpb (the FULL-block default) the s0/s4/s7 calls
+        # pass the IDENTICAL constexpr value as the pre-P10 kernel, so the
+        # full-block trace + PTX stay byte-identical. A REMAINDER block (heads not
+        # a multiple of 16) is launched as a SEPARATE 1-block grid with
+        # valid_hpb=remainder and head_block_offset shifting head_base to the
+        # tail head range.
+        self.valid_hpb = int(valid_hpb) if valid_hpb is not None else int(traits.hpb)
+        # head_block_offset shifts head_base = (head_block + offset) * hpb so a
+        # remainder-only 1-block grid writes the correct (tail) head range. When 0
+        # (the full-block / base path) the const_expr branch is elided -> the
+        # head_base computation is byte-identical to the pre-P10 kernel.
+        self.head_block_offset = int(head_block_offset)
+        self.math_threads = int(traits.math_threads)
+        self.block_threads = 320 if self.native_dsv4_h16 else int(traits.block_threads)
+        self.io_threads = self.block_threads - self.math_threads
+
+    @cute.jit
+    def __call__(
+        self,
+        q_all: cute.Tensor,  # (rows, heads, D_QK) bf16
+        kv_cache_u8: cute.Tensor,  # flat (pages*page_nbytes,) u8 (MAIN cache)
+        swa_indices: cute.Tensor,  # (rows, topk) int32 (MAIN indices)
+        mid_out: cute.Tensor,  # (rows, heads, splits, D_V) bf16 partials
+        mid_lse: cute.Tensor,  # (rows, heads, splits) f32 base-2 LSE
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        section_len: Int32,  # MAIN per-row valid topk length
+        stride_kv_block: Int64,  # MAIN per-block byte stride
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        # SINGLE-CACHE entry: the deployed eight data args plus the runtime
+        # latent_scale (and stream). The dispatcher selects this (func=kernel ->
+        # __call__) when has_extra=False; extra-section args never enter it.
+        self.kernel(
+            q_all,
+            kv_cache_u8,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            sm_scale_log2,
+            latent_scale,
+            section_len,
+            stride_kv_block,
+        ).launch(
+            grid=(num_tokens, self.h_blocks, self.num_splits),
+            block=[self.block_threads, 1, 1],
+            # The unified DSV4/GLM decode layouts consume 93--101 KiB of
+            # shared memory, so only one CTA can reside on an SM120 SM.  Make
+            # that existing resource contract visible to ptxas so it need not
+            # target artificial multi-CTA register occupancy.
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.jit
+    def call_extra(
+        self,
+        q_all: cute.Tensor,  # (rows, heads, D_QK) bf16
+        kv_cache_u8: cute.Tensor,  # flat (pages*page_nbytes,) u8 (MAIN cache)
+        swa_indices: cute.Tensor,  # (rows, topk) int32 (MAIN indices)
+        mid_out: cute.Tensor,  # (rows, heads, splits, D_V) bf16 partials
+        mid_lse: cute.Tensor,  # (rows, heads, splits) f32 base-2 LSE
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        section_len: Int32,  # MAIN per-row valid topk length
+        stride_kv_block: Int64,  # MAIN per-block byte stride
+        extra_kv_cache_u8: cute.Tensor,  # flat u8 EXTRA cache (DSV4 dual-cache)
+        extra_indices: cute.Tensor,  # (rows, extra_topk) int32
+        extra_section_len: Int32,  # EXTRA per-row valid length
+        num_main_chunks: Int32,  # ceil(main_len/BI); chunks >= this read the EXTRA cache
+        stride_extra_kv_block: Int64,  # EXTRA per-block byte stride
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        # DUAL-CACHE entry (DSV4 P7c): the dispatcher selects this (func=
+        # kernel.call_extra) only when has_extra=True, so its DISTINCT mangled name
+        # never collides with the single-cache __call__. It launches
+        # the 14-param @cute.kernel (self.kernel_extra), which shares the body via
+        # _kernel_body(has_extra=True).
+        self.kernel_extra(
+            q_all,
+            kv_cache_u8,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            sm_scale_log2,
+            latent_scale,
+            section_len,
+            stride_kv_block,
+            extra_kv_cache_u8,
+            extra_indices,
+            extra_section_len,
+            num_main_chunks,
+            stride_extra_kv_block,
+        ).launch(
+            grid=(num_tokens, self.h_blocks, self.num_splits),
+            block=[self.block_threads, 1, 1],
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.jit
+    def call_pertok(
+        self,
+        q_all: cute.Tensor,  # (rows, heads, D_QK) bf16
+        kv_cache_u8: cute.Tensor,  # flat (pages*page_nbytes,) u8 (MAIN cache)
+        swa_indices: cute.Tensor,  # (rows, topk) int32 (MAIN indices)
+        mid_out: cute.Tensor,  # (rows, heads, splits, D_V) bf16 partials
+        mid_lse: cute.Tensor,  # (rows, heads, splits) f32 base-2 LSE
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        topk_length: cute.Tensor,  # (rows,) int32 per-token MAIN valid length
+        stride_kv_block: Int64,  # MAIN per-block byte stride
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        # SINGLE-CACHE PER-TOKEN entry (P10b multi-token mixed-length): a DISTINCT
+        # mangled name (the topk_length tensor replaces the section_len scalar) so
+        # it never collides with the byte-identical uniform-length __call__. Each
+        # CTA reads section_len = clamp(topk_length[blockIdx.x], 0, topk) -> the
+        # per-token section bound; over-allocated chunks for short tokens are fully
+        # masked (idx<0 + section bound) so their partials are -inf and the merge
+        # ignores them.
+        self.kernel_pertok(
+            q_all,
+            kv_cache_u8,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            sm_scale_log2,
+            latent_scale,
+            topk_length,
+            stride_kv_block,
+        ).launch(
+            grid=(num_tokens, self.h_blocks, self.num_splits),
+            block=[self.block_threads, 1, 1],
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.jit
+    def call_extra_pertok(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor,
+        mid_out: cute.Tensor,
+        mid_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        topk_length: cute.Tensor,  # (rows,) int32 per-token MAIN valid length
+        stride_kv_block: Int64,
+        extra_kv_cache_u8: cute.Tensor,
+        extra_indices: cute.Tensor,
+        extra_topk_length: cute.Tensor,  # (rows,) int32 per-token EXTRA valid length
+        num_main_chunks: Int32,  # ceil(MAX main_len/BI); chunks >= this read EXTRA
+        stride_extra_kv_block: Int64,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        # DUAL-CACHE PER-TOKEN entry (P10b): both the MAIN and EXTRA section lengths
+        # are read per-token (topk_length / extra_topk_length at t=blockIdx.x). The
+        # main/extra chunk split (num_main_chunks) stays UNIFORM (workspace geometry
+        # over the MAX topk); per-token clamping zeroes the over-allocated chunks.
+        self.kernel_extra_pertok(
+            q_all,
+            kv_cache_u8,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            sm_scale_log2,
+            latent_scale,
+            topk_length,
+            stride_kv_block,
+            extra_kv_cache_u8,
+            extra_indices,
+            extra_topk_length,
+            num_main_chunks,
+            stride_extra_kv_block,
+        ).launch(
+            grid=(num_tokens, self.h_blocks, self.num_splits),
+            block=[self.block_threads, 1, 1],
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor,
+        mid_out: cute.Tensor,
+        mid_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        section_len: Int32,
+        stride_kv_block: Int64,
+    ):
+        t = self.traits
+        L = self.layout
+        tid = Int32(cute.arch.thread_idx()[0])
+        lane = cute.arch.lane_idx()
+        warp_id = tid >> Int32(5)
+
+        token_idx, head_block, split_idx = cute.arch.block_idx()
+        token_idx = Int32(token_idx)
+        head_block = Int32(head_block)
+        split_idx = Int32(split_idx)
+        # REMAINDER-block grids shift head_base to the tail head range; the offset
+        # const_expr is elided (==0) for the full-block / base path -> byte-identical.
+        if cutlass.const_expr(self.head_block_offset != 0):
+            head_block = head_block + Int32(self.head_block_offset)
+        head_base = head_block * Int32(8 if self.native_h8 else t.hpb)
+
+        # The launch grid is capacity-based and therefore fixed across CUDA-graph
+        # replay.  Compact this split to the chunks that are valid for the current
+        # row, and retire a wholly empty CTA before it allocates/initializes the KV
+        # pipeline.  The merge treats LSE=-inf as a neutral partial and does not
+        # read the corresponding (potentially stale) mid_out row.
+        cps = Int32(self.chunks_per_split)
+        split_first_chunk = split_idx * cps
+        split_last_chunk = split_first_chunk + cps
+        main_valid_chunks = (section_len + Int32(_CAND_WINDOW - 1)) // Int32(
+            _CAND_WINDOW
+        )
+        if main_valid_chunks < Int32(0):
+            main_valid_chunks = Int32(0)
+        max_main_chunks = Int32((self.topk + _CAND_WINDOW - 1) // _CAND_WINDOW)
+        if main_valid_chunks > max_main_chunks:
+            main_valid_chunks = max_main_chunks
+        main_chunk_end = split_last_chunk
+        if main_chunk_end > main_valid_chunks:
+            main_chunk_end = main_valid_chunks
+        active_chunks = main_chunk_end - split_first_chunk
+        if active_chunks < Int32(0):
+            active_chunks = Int32(0)
+        if active_chunks == Int32(0):
+            if tid < Int32(self.valid_hpb):
+                mid_lse[token_idx, head_base + tid, split_idx] = Float32(-Float32.inf)
+            _exit_thread()
+
+        smem = cutlass_utils.SmemAllocator()
+        SharedStorage = get_unified_shared_storage_cls(t)
+        st = smem.allocate(SharedStorage)
+
+        q_fp8_addr = shared_ptr_to_u32(st.q_fp8.data_ptr())
+        q_rope_addr = shared_ptr_to_u32(st.q_rope.data_ptr())
+        kv_fp8_addr = shared_ptr_to_u32(st.kv_fp8.data_ptr())
+        if cutlass.const_expr(t.has_extra_cache):
+            kv_sc_addr = shared_ptr_to_u32(st.kv_sc.data_ptr())
+        else:
+            kv_sc_addr = Int32(0)
+        kv_rope_addr = shared_ptr_to_u32(st.kv_rope.data_ptr())
+        reduce_addr = shared_ptr_to_u32(st.reduce.data_ptr())
+        reduce_max_addr = reduce_addr + Int32(L.reduce_warp_max_off - L.reduce_off)
+        reduce_sum_addr = reduce_addr + Int32(L.reduce_warp_sum_off - L.reduce_off)
+        w_fp8_addr = shared_ptr_to_u32(st.w_fp8.data_ptr())
+        sm_p_full_addr = shared_ptr_to_u32(st.sm_p_full.data_ptr())
+
+        q_sc_view = st.q_sc.get_tensor(cute.make_layout(int(L.q_sc_bytes // 4)))
+        amax_view = st.reduce.get_tensor(cute.make_layout(int(L.reduce_bytes // 4)))
+        token_idx_view = st.token_idx.get_tensor(
+            cute.make_layout(int(L.token_idx_buf_bytes * L.token_idx_bufs // 4))
+        )
+        w_head_sc_view = st.w_head_sc.get_tensor(
+            cute.make_layout(int(L.w_head_sc_bytes // 4))
+        )
+
+        # Math warps are consumers; the final warp is the IO producer.
+        is_io = warp_id >= Int32(self.math_threads // 32)
+
+        # Native H8 stages one contiguous data record per candidate. GLM keeps
+        # its 656-byte source layout; DSV4 pads its 576-byte source record to a
+        # bank-friendly 592-byte shared row and puts the two 512-byte scale
+        # footers immediately after the data buffers. Both alias the existing
+        # kv_fp8/kv_sc/kv_rope allocation, so graph-time workspace is unchanged.
+        staged_kv_stride = t.kv_smem_stride
+        if cutlass.const_expr(self.native_glm_h8):
+            staged_kv_stride = _GLM_KV_GMEM_STRIDE
+        if cutlass.const_expr(self.native_dsv4_h8):
+            staged_kv_stride = _DSV4_PACKED_SMEM_STRIDE
+        kv_fp8_buf = Int32(t.bi * staged_kv_stride)
+        kv_rope_buf = Int32(L.kv_rope_buf_bytes)
+        kv_sc_buf = Int32(L.kv_sc_buf_bytes)
+        if cutlass.const_expr(self.native_dsv4_h8):
+            kv_rope_addr = kv_fp8_addr + Int32(_DSV4_PACKED_ROPE_OFFSET)
+            kv_rope_buf = kv_fp8_buf
+            kv_sc_addr = kv_fp8_addr + Int32(2) * kv_fp8_buf
+        tok_buf_elems = Int32(L.token_idx_buf_bytes // 4)
+
+        # mbarrier array: full[0], full[1], empty[0], empty[1] (u64 each).
+        mbar_base = st.mbar.data_ptr()
+        n_buf = int(L.kv_bufs)
+
+        full_arrivals = 2 if self.native_dsv4_h16 else 1
+        if tid == Int32(0):
+            for s in cutlass.range_constexpr(n_buf):
+                cute.arch.mbarrier_init(mbar_base + s, Int32(full_arrivals))
+                cute.arch.mbarrier_init(mbar_base + n_buf + s, Int32(1))  # empty[s]
+        cute.arch.barrier()  # Full-CTA structural fence.
+
+        # swa_indices for THIS token row: a 1-D (topk,) slice.
+        topk_row = cute.make_tensor(
+            swa_indices.iterator
+            + token_idx.to(Int64) * Int64(self.swa_indices_stride_row),
+            cute.make_layout(self.topk),
+        )
+        # q for THIS token row: a 2-D (heads, D_QK) view (s0 indexes [head_base+h, d]).
+        q_token = cute.make_tensor(
+            q_all.iterator + token_idx.to(Int64) * Int64(self.q_stride_row),
+            cute.make_layout(
+                (self.num_heads, self.q_head_dim),
+                stride=(self.q_stride_head, self.q_stride_dim),
+            ),
+        )
+        warp_first_cand = warp_id * Int32(8)
+        if cutlass.const_expr(self.native_h8):
+            warp_first_cand = warp_id * Int32(16)
+
+        # ════════════════════════════════════════════════════════════════════
+        # IO WARP (PRODUCER) vs MATH WARPS (CONSUMER).
+        # ════════════════════════════════════════════════════════════════════
+        if is_io:
+            io_lane = tid - Int32(self.math_threads)
+            prod_phase = Int32(1)
+            prod_idx = Int32(0)
+            for lc in cutlass.range(active_chunks, unroll=1):
+                ci = split_first_chunk + Int32(lc)
+                buf = Int32(lc) & Int32(1)
+                g_start = ci * Int32(_CAND_WINDOW)
+                g_end = g_start + Int32(_CAND_WINDOW)
+                if g_end > section_len:
+                    g_end = section_len
+
+                cute.arch.mbarrier_wait(mbar_base + n_buf + prod_idx, phase=prod_phase)
+
+                tok_buf_view = cute.make_tensor(
+                    token_idx_view.iterator + buf * tok_buf_elems,
+                    cute.make_layout(int(L.token_idx_buf_bytes // 4)),
+                )
+                io_issue_gather(
+                    kv_cache_u8,
+                    topk_row,
+                    kv_fp8_addr + buf * kv_fp8_buf,
+                    kv_rope_addr + buf * kv_rope_buf,
+                    kv_sc_addr + buf * kv_sc_buf,
+                    tok_buf_view,
+                    mbar_base + buf,  # full[buf]
+                    g_start,
+                    g_end,
+                    Int32(self.page_block_size),
+                    stride_kv_block,
+                    io_lane,
+                    bi=t.bi,
+                    kv_smem_stride=staged_kv_stride,
+                    rope_smem_stride=t.d_rope,
+                    scale_bytes_per_token=8,
+                    bulk_tx_bytes=t.bulk_tx_bytes,
+                    scale_format=t.scale_format,
+                    io_threads=self.io_threads,
+                    split_mbar_arrival=self.native_dsv4_h16,
+                    fp8_rope=t.fp8_rope,
+                    packed_glm=self.native_glm_h8,
+                    packed_dsv4=self.native_dsv4_h8,
+                )
+                prod_idx += Int32(1)
+                if prod_idx == Int32(n_buf):
+                    prod_idx = Int32(0)
+                    prod_phase ^= Int32(1)
+
+        else:
+            # MATH WARPS (CONSUMER, warps 0-7 = 256 threads).
+            n_acc_tiles = int(t.n_v_chunks) * int(t.nt_per_warp_xv)
+            if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                s0_load_q_bf16_to_smem(
+                    q_token,
+                    q_fp8_addr,
+                    q_rope_addr,
+                    head_base,
+                    Int32(self.valid_hpb),
+                    tid,
+                    d_nope=t.d_nope,
+                    d_rope=t.d_rope,
+                    hpb=t.hpb,
+                    q_nope_bf16_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=self.math_threads,
+                    barrier_id=2,
+                )
+            else:
+                s0_quantize_q_to_smem(
+                    q_token,
+                    q_fp8_addr,
+                    q_sc_view,
+                    q_rope_addr,
+                    amax_view,
+                    head_base,
+                    Int32(self.valid_hpb),
+                    tid,
+                    d_nope=t.d_nope,
+                    d_rope=t.d_rope,
+                    d_qk=t.d_nope + t.d_rope,
+                    quant_tile=t.quant_tile,
+                    num_scales=t.num_scales,
+                    hpb=(8 if self.native_h8 else t.hpb),
+                    q_nope_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=self.math_threads,
+                    barrier_id=2,
+                    fused_subgroup_quant=self.native_dsv4_h8,
+                    subgroup_amax=self.native_dsv4_h8,
+                    vectorized_rope_copy=self.native_dsv4_h8,
+                    packed_q_scale_words=self.native_dsv4_h16,
+                )
+
+            accn_frag = cute.make_rmem_tensor(n_acc_tiles * 4, Float32)
+            rope_acc_elems = 8 if self.native_dsv4_h8 else 4
+            accr_frag = cute.make_rmem_tensor(rope_acc_elems, Float32)
+            gmax_frag = cute.make_rmem_tensor(2, Float32)
+            gsum_frag = cute.make_rmem_tensor(2, Float32)
+            for k in cutlass.range_constexpr(n_acc_tiles * 4):
+                accn_frag[k] = Float32(0.0)
+            for k in cutlass.range_constexpr(rope_acc_elems):
+                accr_frag[k] = Float32(0.0)
+            gmax_frag[0] = Float32(-1e30)
+            gmax_frag[1] = Float32(-1e30)
+            gsum_frag[0] = Float32(0.0)
+            gsum_frag[1] = Float32(0.0)
+
+            cons_phase = Int32(0)
+            cons_idx = Int32(0)
+
+            for lc in cutlass.range(active_chunks, unroll=1):
+                ci = split_first_chunk + Int32(lc)
+                split_cand_start = ci * Int32(_CAND_WINDOW)
+                buf = Int32(lc) & Int32(1)
+
+                kv_fp8_b = kv_fp8_addr + buf * kv_fp8_buf
+                kv_rope_b = kv_rope_addr + buf * kv_rope_buf
+                kv_sc_b = kv_sc_addr + buf * kv_sc_buf
+                tok_buf_view = cute.make_tensor(
+                    token_idx_view.iterator + buf * tok_buf_elems,
+                    cute.make_layout(int(L.token_idx_buf_bytes // 4)),
+                )
+
+                acc_nope = [
+                    [
+                        accn_frag[at * 4 + 0],
+                        accn_frag[at * 4 + 1],
+                        accn_frag[at * 4 + 2],
+                        accn_frag[at * 4 + 3],
+                    ]
+                    for at in range(n_acc_tiles)
+                ]
+                acc_rope = [accr_frag[k] for k in range(rope_acc_elems)]
+                global_max = [gmax_frag[0], gmax_frag[1]]
+                global_sum = [gsum_frag[0], gsum_frag[1]]
+
+                cute.arch.mbarrier_wait(mbar_base + cons_idx, phase=cons_phase)
+                cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+
+                # P10f: GLM keeps RAW e4m3 K/V (no S0b dequant+requant -- that
+                # discarded the per-group e4m3 mantissa headroom and cost ~0.003
+                # cos). The arbitrary fp32 group scale is applied POST-MMA in S1
+                # (QK) / inline in S6 (V). DSV4 (UE8M0_BYTE) is unaffected (it never
+                # ran S0b: scale_format==0), so its trace/PTX stay byte-identical.
+
+                qk = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                split_cand_end = split_cand_start + Int32(_CAND_WINDOW)
+                if split_cand_end > section_len:
+                    split_cand_end = section_len
+                if cutlass.const_expr(self.native_h8):
+                    if cutlass.const_expr(self.native_glm_h8):
+                        qk = s1_qk_nope_block_scaled_glm_h8_swap_ab(
+                            qk,
+                            q_fp8_addr,
+                            kv_fp8_b,
+                            q_sc_view,
+                            warp_first_cand,
+                            lane,
+                            num_scales=t.num_scales,
+                            quant_tile=t.quant_tile,
+                            q_nope_stride=t.q_nope_stride,
+                            kv_smem_stride=staged_kv_stride,
+                        )
+                        h8_rope_addr = kv_fp8_b + Int32(t.kv_smem_stride)
+                        h8_rope_stride = staged_kv_stride
+                    else:
+                        qk = s1_qk_nope_block_scaled_dsv4_h8_swap_ab(
+                            qk,
+                            q_fp8_addr,
+                            kv_fp8_b,
+                            q_sc_view,
+                            kv_sc_b,
+                            warp_first_cand,
+                            lane,
+                            num_scales=t.num_scales,
+                            quant_tile=t.quant_tile,
+                            q_nope_stride=t.q_nope_stride,
+                            kv_smem_stride=staged_kv_stride,
+                            scale_bytes_per_token=8,
+                            packed_footer_words=self.native_dsv4_h16,
+                            packed_q_scale_words=self.native_dsv4_h16,
+                        )
+                        h8_rope_addr = kv_rope_b
+                        h8_rope_stride = staged_kv_stride
+                    qk = s2_qk_rope_bf16_glm_h8_swap_ab(
+                        qk,
+                        q_rope_addr,
+                        h8_rope_addr,
+                        warp_first_cand,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                        kv_rope_stride_bytes=h8_rope_stride,
+                    )
+                    qk = s3_mask_and_scale_glm_h8_swap_ab(
+                        qk,
+                        tok_buf_view,
+                        warp_first_cand,
+                        split_cand_start,
+                        split_cand_end,
+                        section_len,
+                        sm_scale_log2,
+                        lane,
+                    )
+                    p = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                    p, wr0, wr1 = s4_online_softmax_glm_h8_swap_ab(
+                        qk,
+                        p,
+                        acc_nope,
+                        acc_rope,
+                        global_max,
+                        global_sum,
+                        reduce_max_addr,
+                        reduce_sum_addr,
+                        warp_id,
+                        lane,
+                        tid,
+                        n_acc_tiles=n_acc_tiles,
+                        hpb=t.hpb,
+                        n_warps=4,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        rope_tiles_per_warp=(2 if self.native_dsv4_h8 else 0),
+                    )
+                    w_pre = [
+                        p[0] * wr0,
+                        p[1] * wr1,
+                        p[2] * wr0,
+                        p[3] * wr1,
+                    ]
+                    if cutlass.const_expr(self.native_glm_h8):
+                        acc_nope = s6_xv_nope_glm_h8_swap_ab(
+                            w_pre,
+                            acc_nope,
+                            kv_fp8_b,
+                            w_head_sc_view,
+                            w_fp8_addr,
+                            warp_id,
+                            lane,
+                            tid,
+                            n_v_chunks=t.n_v_chunks,
+                            v_chunk=t.quant_tile,
+                            hpb=t.hpb,
+                            bi=t.bi,
+                            kv_smem_stride=staged_kv_stride,
+                            w_fp8_stride=t.bi + 16,
+                            n_warps=4,
+                            nt_per_warp_xv=t.nt_per_warp_xv,
+                            num_threads=self.math_threads,
+                            barrier_id=3,
+                        )
+                    else:
+                        acc_nope = s6_xv_nope_dsv4_h8_swap_ab(
+                            w_pre,
+                            acc_nope,
+                            kv_fp8_b,
+                            kv_sc_b,
+                            w_head_sc_view,
+                            w_fp8_addr,
+                            sm_p_full_addr,
+                            warp_id,
+                            lane,
+                            tid,
+                            n_v_chunks=t.n_v_chunks,
+                            v_chunk=t.quant_tile,
+                            hpb=t.hpb,
+                            bi=t.bi,
+                            sm_p_stride=L.sm_p_full_stride,
+                            kv_smem_stride=staged_kv_stride,
+                            w_fp8_stride=t.bi + 16,
+                            n_warps=4,
+                            nt_per_warp_xv=t.nt_per_warp_xv,
+                            scale_bytes_per_token=8,
+                            num_threads=self.math_threads,
+                            barrier_id=3,
+                            packed_footer_words=self.native_dsv4_h16,
+                        )
+                else:
+                    qk = s1_qk_nope_block_scaled(
+                        qk,
+                        q_fp8_addr,
+                        kv_fp8_b,
+                        q_sc_view,
+                        kv_sc_b,
+                        warp_first_cand,
+                        lane,
+                        latent_scale,
+                        num_scales=t.num_scales,
+                        quant_tile=t.quant_tile,
+                        q_nope_stride=t.q_nope_stride,
+                        kv_smem_stride=t.kv_smem_stride,
+                        scale_bytes_per_token=8,
+                        scale_format=t.scale_format,
+                    )
+                    qk = s2_qk_rope_bf16(
+                        qk,
+                        q_rope_addr,
+                        kv_rope_b,
+                        warp_first_cand,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                        fp8_rope=t.fp8_rope,
+                    )
+                    qk = s3_mask_and_scale(
+                        qk,
+                        tok_buf_view,
+                        warp_first_cand,
+                        split_cand_start,
+                        split_cand_end,
+                        section_len,
+                        sm_scale_log2,
+                        lane,
+                    )
+                    p = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                    p, wr0, wr1 = s4_online_softmax(
+                        qk,
+                        p,
+                        acc_nope,
+                        acc_rope,
+                        global_max,
+                        global_sum,
+                        reduce_max_addr,
+                        reduce_sum_addr,
+                        False,
+                        warp_id,
+                        lane,
+                        tid,
+                        n_v_chunks=t.n_v_chunks,
+                        hpb=t.hpb,
+                        n_warps=8,
+                        valid_hpb=self.valid_hpb,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        n_acc_tiles=n_acc_tiles,
+                    )
+                    w_pre = [
+                        p[0] * wr0,
+                        p[1] * wr0,
+                        p[2] * wr1,
+                        p[3] * wr1,
+                    ]
+                    s5_fill_sm_p_full(
+                        w_pre,
+                        sm_p_full_addr,
+                        w_head_sc_view,
+                        warp_id,
+                        lane,
+                        tid,
+                        bi=t.bi,
+                        sm_p_stride=L.sm_p_full_stride,
+                        n_v_chunks=t.n_v_chunks,
+                        hpb=t.hpb,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                    )
+                    cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+                    acc_nope = s6_xv_nope(
+                        w_pre,
+                        acc_nope,
+                        kv_fp8_b,
+                        kv_sc_b,
+                        w_head_sc_view,
+                        w_fp8_addr,
+                        warp_id,
+                        lane,
+                        tid,
+                        latent_scale,
+                        n_v_chunks=t.n_v_chunks,
+                        v_chunk=t.quant_tile,
+                        hpb=t.hpb,
+                        bi=t.bi,
+                        kv_smem_stride=t.kv_smem_stride,
+                        w_fp8_stride=t.bi + 16,
+                        n_warps=8,
+                        scale_bytes_per_token=8,
+                        nt_per_warp_xv=t.nt_per_warp_xv,
+                        scale_format=t.scale_format,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        sm_p_full_addr=sm_p_full_addr,
+                        sm_p_stride=L.sm_p_full_stride,
+                    )
+
+                # S6b (XV-RoPE) is DSV4-only (V_HAS_ROPE). const_expr-elided for GLM.
+                if cutlass.const_expr(t.v_has_rope):
+                    if cutlass.const_expr(self.native_dsv4_h8):
+                        acc_rope = s6b_xv_rope_h8_swap_ab(
+                            acc_rope,
+                            sm_p_full_addr,
+                            kv_rope_b,
+                            warp_id,
+                            lane,
+                            bi=t.bi,
+                            sm_p_stride=L.sm_p_full_stride,
+                            d_rope=t.d_rope,
+                            n_warps=4,
+                            tiles_per_warp=2,
+                            kv_rope_stride_bytes=staged_kv_stride,
+                        )
+                    else:
+                        acc_rope = s6b_xv_rope(
+                            acc_rope,
+                            sm_p_full_addr,
+                            kv_rope_b,
+                            warp_id,
+                            lane,
+                            bi=t.bi,
+                            sm_p_stride=L.sm_p_full_stride,
+                            d_rope=t.d_rope,
+                            n_warps=8,
+                        )
+
+                for at in cutlass.range_constexpr(n_acc_tiles):
+                    accn_frag[at * 4 + 0] = acc_nope[at][0]
+                    accn_frag[at * 4 + 1] = acc_nope[at][1]
+                    accn_frag[at * 4 + 2] = acc_nope[at][2]
+                    accn_frag[at * 4 + 3] = acc_nope[at][3]
+                for k in cutlass.range_constexpr(rope_acc_elems):
+                    accr_frag[k] = acc_rope[k]
+                gmax_frag[0] = global_max[0]
+                gmax_frag[1] = global_max[1]
+                gsum_frag[0] = global_sum[0]
+                gsum_frag[1] = global_sum[1]
+
+                cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+                if tid == Int32(0):
+                    cute.arch.mbarrier_arrive(mbar_base + n_buf + cons_idx)
+                cons_idx += Int32(1)
+                if cons_idx == Int32(n_buf):
+                    cons_idx = Int32(0)
+                    cons_phase ^= Int32(1)
+
+            # ── S7: write this split's NORMALIZED partial + base-2 LSE into
+            #    mid_out[token, :, split, :] / mid_lse[token, :, split]. ──
+            fin_acc_nope = [
+                [
+                    accn_frag[at * 4 + 0],
+                    accn_frag[at * 4 + 1],
+                    accn_frag[at * 4 + 2],
+                    accn_frag[at * 4 + 3],
+                ]
+                for at in range(n_acc_tiles)
+            ]
+            fin_acc_rope = [accr_frag[k] for k in range(rope_acc_elems)]
+            fin_gmax = [gmax_frag[0], gmax_frag[1]]
+            fin_gsum = [gsum_frag[0], gsum_frag[1]]
+            if cutlass.const_expr(self.native_h8):
+                gid = lane >> Int32(2)
+                pair_lane = gid >> Int32(1)
+                row_gmax0 = cute.arch.shuffle_sync(gmax_frag[0], pair_lane)
+                row_gmax1 = cute.arch.shuffle_sync(gmax_frag[1], pair_lane)
+                row_gsum0 = cute.arch.shuffle_sync(gsum_frag[0], pair_lane)
+                row_gsum1 = cute.arch.shuffle_sync(gsum_frag[1], pair_lane)
+                fin_gmax[0] = row_gmax0
+                fin_gsum[0] = row_gsum0
+                if (gid & Int32(1)) != Int32(0):
+                    fin_gmax[0] = row_gmax1
+                    fin_gsum[0] = row_gsum1
+
+            # mid_out[token, head_base + h, split, dim]: (HPB, D_V) view for this
+            # (token, head_block, split). mid_out stride = (h*S*Dv, S*Dv, Dv, 1).
+            out_o = cute.make_tensor(
+                mid_out.iterator
+                + token_idx.to(Int64) * Int64(self.mid_out_stride_row)
+                + head_base.to(Int64) * Int64(self.mid_out_stride_head)
+                + split_idx.to(Int64) * Int64(self.mid_out_stride_split),
+                cute.make_layout(
+                    (t.hpb, t.d_v),
+                    stride=(self.mid_out_stride_head, self.mid_out_stride_dim),
+                ),
+            )
+            # mid_lse[token, head_base + h, split]: (HPB,) view.
+            out_lse = cute.make_tensor(
+                mid_lse.iterator
+                + token_idx.to(Int64) * Int64(self.mid_lse_stride_row)
+                + head_base.to(Int64) * Int64(self.mid_lse_stride_head)
+                + split_idx.to(Int64) * Int64(self.mid_lse_stride_split),
+                cute.make_layout((t.hpb,), stride=(self.mid_lse_stride_head,)),
+            )
+            s7_epilogue(
+                fin_acc_nope,
+                fin_acc_rope,
+                fin_gmax,
+                fin_gsum,
+                out_o,
+                out_lse,
+                warp_id,
+                lane,
+                n_v_chunks=t.n_v_chunks,
+                v_chunk=t.quant_tile,
+                d_nope=t.d_nope,
+                d_rope=t.d_rope,
+                n_warps=(4 if self.native_h8 else 8),
+                valid_hpb=self.valid_hpb,
+                nt_per_warp_xv=t.nt_per_warp_xv,
+                v_has_rope=t.v_has_rope,
+                rope_tiles_per_warp=(2 if self.native_dsv4_h8 else 1),
+            )
+
+    @cute.kernel
+    def kernel_extra(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor,
+        mid_out: cute.Tensor,
+        mid_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        section_len: Int32,
+        stride_kv_block: Int64,
+        extra_kv_cache_u8: cute.Tensor,
+        extra_indices: cute.Tensor,
+        extra_section_len: Int32,
+        num_main_chunks: Int32,
+        stride_extra_kv_block: Int64,
+    ):
+        # DUAL-CACHE @cute.kernel: 14 device params; threads the real extra-section
+        # args into the shared body (has_extra=True).
+        self._kernel_body(
+            q_all,
+            kv_cache_u8,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            sm_scale_log2,
+            latent_scale,
+            section_len,
+            stride_kv_block,
+            extra_kv_cache_u8,
+            extra_indices,
+            extra_section_len,
+            num_main_chunks,
+            stride_extra_kv_block,
+            swa_indices,
+            extra_indices,  # length tensors unused (per_token_len=False)
+            has_extra=True,
+            per_token_len=False,
+        )
+
+    @cute.kernel
+    def kernel_pertok(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor,
+        mid_out: cute.Tensor,
+        mid_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        topk_length: cute.Tensor,
+        stride_kv_block: Int64,
+    ):
+        # SINGLE-CACHE PER-TOKEN @cute.kernel (P10b): the per-token MAIN length
+        # tensor replaces the scalar section_len; the body reads
+        # section_len = clamp(topk_length[blockIdx.x], 0, topk) per CTA. The scalar
+        # section_len/extra_section_len/num_main_chunks args are dummies (elided by
+        # per_token_len/has_extra const_expr); the extra tensor slots alias
+        # swa_indices (never read when has_extra=False).
+        self._kernel_body(
+            q_all,
+            kv_cache_u8,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            sm_scale_log2,
+            latent_scale,
+            Int32(0),
+            stride_kv_block,
+            kv_cache_u8,
+            swa_indices,
+            Int32(0),
+            Int32(0),
+            stride_kv_block,
+            topk_length,
+            swa_indices,
+            has_extra=False,
+            per_token_len=True,
+        )
+
+    @cute.kernel
+    def kernel_extra_pertok(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor,
+        mid_out: cute.Tensor,
+        mid_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        topk_length: cute.Tensor,
+        stride_kv_block: Int64,
+        extra_kv_cache_u8: cute.Tensor,
+        extra_indices: cute.Tensor,
+        extra_topk_length: cute.Tensor,
+        num_main_chunks: Int32,
+        stride_extra_kv_block: Int64,
+    ):
+        # DUAL-CACHE PER-TOKEN @cute.kernel (P10b): both MAIN and EXTRA section
+        # lengths are read per-token (topk_length / extra_topk_length at
+        # t=blockIdx.x). num_main_chunks (the uniform main/extra chunk split) stays
+        # a scalar; per-token clamping masks the over-allocated chunks.
+        self._kernel_body(
+            q_all,
+            kv_cache_u8,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            sm_scale_log2,
+            latent_scale,
+            Int32(0),
+            stride_kv_block,
+            extra_kv_cache_u8,
+            extra_indices,
+            Int32(0),
+            num_main_chunks,
+            stride_extra_kv_block,
+            topk_length,
+            extra_topk_length,
+            has_extra=True,
+            per_token_len=True,
+        )
+
+    @cute.jit
+    def _kernel_body(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor,
+        mid_out: cute.Tensor,
+        mid_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        section_len: Int32,
+        stride_kv_block: Int64,
+        extra_kv_cache_u8: cute.Tensor,
+        extra_indices: cute.Tensor,
+        extra_section_len: Int32,
+        num_main_chunks: Int32,
+        stride_extra_kv_block: Int64,
+        topk_length: cute.Tensor,
+        extra_topk_length: cute.Tensor,
+        *,
+        has_extra: cutlass.Constexpr,
+        per_token_len: cutlass.Constexpr,
+    ):
+        t = self.traits
+        L = self.layout
+        tid = Int32(cute.arch.thread_idx()[0])
+        lane = cute.arch.lane_idx()
+        warp_id = tid >> Int32(5)
+
+        token_idx, head_block, split_idx = cute.arch.block_idx()
+        token_idx = Int32(token_idx)
+        head_block = Int32(head_block)
+        split_idx = Int32(split_idx)
+        # REMAINDER-block grids shift head_base to the tail head range; the offset
+        # const_expr is elided (==0) for the full-block / base path -> byte-identical.
+        if cutlass.const_expr(self.head_block_offset != 0):
+            head_block = head_block + Int32(self.head_block_offset)
+        head_base = head_block * Int32(8 if self.native_h8 else t.hpb)
+
+        # Load and clamp replay-time lengths before touching the shared KV
+        # pipeline. Capacity planning, launch geometry, and workspace addresses
+        # remain fixed across CUDA-graph capture and replay.
+        if cutlass.const_expr(per_token_len):
+            topk_total = Int32(self.topk)
+            section_len = Int32(topk_length[token_idx])
+            if section_len < Int32(0):
+                section_len = Int32(0)
+            if section_len > topk_total:
+                section_len = topk_total
+            if cutlass.const_expr(has_extra):
+                extra_total = Int32(self.extra_topk)
+                extra_section_len = Int32(extra_topk_length[token_idx])
+                if extra_section_len < Int32(0):
+                    extra_section_len = Int32(0)
+                if extra_section_len > extra_total:
+                    extra_section_len = extra_total
+
+        # Compact this split's intersection with the independently valid main
+        # and extra chunk prefixes. This also handles a short-main gap before the
+        # fixed extra-section boundary. Producer and consumer use the same compact
+        # order, so their mbarrier phases remain matched.
+        cps = Int32(self.chunks_per_split)
+        split_first_chunk = split_idx * cps
+        split_last_chunk = split_first_chunk + cps
+
+        main_valid_chunks = (section_len + Int32(_CAND_WINDOW - 1)) // Int32(
+            _CAND_WINDOW
+        )
+        if main_valid_chunks < Int32(0):
+            main_valid_chunks = Int32(0)
+        max_main_chunks = Int32((self.topk + _CAND_WINDOW - 1) // _CAND_WINDOW)
+        if main_valid_chunks > max_main_chunks:
+            main_valid_chunks = max_main_chunks
+        main_chunk_end = split_last_chunk
+        if main_chunk_end > main_valid_chunks:
+            main_chunk_end = main_valid_chunks
+        main_chunk_count = main_chunk_end - split_first_chunk
+        if main_chunk_count < Int32(0):
+            main_chunk_count = Int32(0)
+
+        extra_first_chunk = split_first_chunk
+        extra_chunk_count = Int32(0)
+        if cutlass.const_expr(has_extra):
+            extra_valid_chunks = (extra_section_len + Int32(_CAND_WINDOW - 1)) // Int32(
+                _CAND_WINDOW
+            )
+            if extra_valid_chunks < Int32(0):
+                extra_valid_chunks = Int32(0)
+            max_extra_chunks = Int32(
+                (self.extra_topk + _CAND_WINDOW - 1) // _CAND_WINDOW
+            )
+            if extra_valid_chunks > max_extra_chunks:
+                extra_valid_chunks = max_extra_chunks
+            if extra_first_chunk < num_main_chunks:
+                extra_first_chunk = num_main_chunks
+            extra_chunk_end = split_last_chunk
+            extra_valid_end = num_main_chunks + extra_valid_chunks
+            if extra_chunk_end > extra_valid_end:
+                extra_chunk_end = extra_valid_end
+            extra_chunk_count = extra_chunk_end - extra_first_chunk
+            if extra_chunk_count < Int32(0):
+                extra_chunk_count = Int32(0)
+
+        active_chunks = main_chunk_count + extra_chunk_count
+        if active_chunks == Int32(0):
+            if tid < Int32(self.valid_hpb):
+                mid_lse[token_idx, head_base + tid, split_idx] = Float32(-Float32.inf)
+            _exit_thread()
+
+        smem = cutlass_utils.SmemAllocator()
+        SharedStorage = get_unified_shared_storage_cls(t)
+        st = smem.allocate(SharedStorage)
+
+        q_fp8_addr = shared_ptr_to_u32(st.q_fp8.data_ptr())
+        q_rope_addr = shared_ptr_to_u32(st.q_rope.data_ptr())
+        kv_fp8_addr = shared_ptr_to_u32(st.kv_fp8.data_ptr())
+        if cutlass.const_expr(t.has_extra_cache):
+            kv_sc_addr = shared_ptr_to_u32(st.kv_sc.data_ptr())
+        else:
+            kv_sc_addr = Int32(0)
+        kv_rope_addr = shared_ptr_to_u32(st.kv_rope.data_ptr())
+        reduce_addr = shared_ptr_to_u32(st.reduce.data_ptr())
+        reduce_max_addr = reduce_addr + Int32(L.reduce_warp_max_off - L.reduce_off)
+        reduce_sum_addr = reduce_addr + Int32(L.reduce_warp_sum_off - L.reduce_off)
+        w_fp8_addr = shared_ptr_to_u32(st.w_fp8.data_ptr())
+        sm_p_full_addr = shared_ptr_to_u32(st.sm_p_full.data_ptr())
+
+        q_sc_view = st.q_sc.get_tensor(cute.make_layout(int(L.q_sc_bytes // 4)))
+        amax_view = st.reduce.get_tensor(cute.make_layout(int(L.reduce_bytes // 4)))
+        token_idx_view = st.token_idx.get_tensor(
+            cute.make_layout(int(L.token_idx_buf_bytes * L.token_idx_bufs // 4))
+        )
+        w_head_sc_view = st.w_head_sc.get_tensor(
+            cute.make_layout(int(L.w_head_sc_bytes // 4))
+        )
+
+        # Math warps are consumers; the final warp is the IO producer.
+        is_io = warp_id >= Int32(self.math_threads // 32)
+
+        # Match the single-cache body's allocation-preserving packed H8 layout.
+        staged_kv_stride = t.kv_smem_stride
+        if cutlass.const_expr(self.native_glm_h8):
+            staged_kv_stride = _GLM_KV_GMEM_STRIDE
+        if cutlass.const_expr(self.native_dsv4_h8 or self.native_dsv4_h16):
+            staged_kv_stride = _DSV4_PACKED_SMEM_STRIDE
+        kv_fp8_buf = Int32(t.bi * staged_kv_stride)
+        kv_rope_buf = Int32(L.kv_rope_buf_bytes)
+        kv_sc_buf = Int32(L.kv_sc_buf_bytes)
+        if cutlass.const_expr(self.native_dsv4_h8 or self.native_dsv4_h16):
+            kv_rope_addr = kv_fp8_addr + Int32(_DSV4_PACKED_ROPE_OFFSET)
+            kv_rope_buf = kv_fp8_buf
+            kv_sc_addr = kv_fp8_addr + Int32(2) * kv_fp8_buf
+        tok_buf_elems = Int32(L.token_idx_buf_bytes // 4)
+
+        # mbarrier array: full[0], full[1], empty[0], empty[1] (u64 each).
+        mbar_base = st.mbar.data_ptr()
+        n_buf = int(L.kv_bufs)
+
+        full_arrivals = 2 if self.native_dsv4_h16 else 1
+        if tid == Int32(0):
+            for s in cutlass.range_constexpr(n_buf):
+                cute.arch.mbarrier_init(mbar_base + s, Int32(full_arrivals))
+                cute.arch.mbarrier_init(mbar_base + n_buf + s, Int32(1))  # empty[s]
+        cute.arch.barrier()  # Full-CTA structural fence.
+
+        # swa_indices for THIS token row: a 1-D (topk,) slice.
+        # ZERO-WIDTH MAIN (DSV4 dual-cache, all KV in the EXTRA cache):
+        # self.topk == 0 means there are NO main chunks (num_main_chunks
+        # ==0) and the main section is never gathered/scanned. cute.make_layout(0)
+        # is illegal (size must be strictly positive), so build a degenerate
+        # 1-extent main view instead -- it is never referenced because every
+        # ``ci < num_main_chunks(==0)`` branch is unreachable, so the kernel
+        # attends ONLY the extra section. This is a const_expr (concrete-shape
+        # trace), so the non-zero-main DSV4/GLM traces are byte-identical.
+        if cutlass.const_expr(self.topk == 0):
+            topk_row = cute.make_tensor(
+                swa_indices.iterator
+                + token_idx.to(Int64) * Int64(self.swa_indices_stride_row),
+                cute.make_layout(1),
+            )
+        else:
+            topk_row = cute.make_tensor(
+                swa_indices.iterator
+                + token_idx.to(Int64) * Int64(self.swa_indices_stride_row),
+                cute.make_layout(self.topk),
+            )
+        # extra_indices for THIS token row (DSV4 dual-cache). Built ONLY when
+        # has_extra (extra_indices is None otherwise); const_expr-elided so the
+        # no-extra trace never references the extra tensor.
+        if cutlass.const_expr(has_extra):
+            extra_row = cute.make_tensor(
+                extra_indices.iterator
+                + token_idx.to(Int64) * Int64(self.extra_indices_stride_row),
+                cute.make_layout(self.extra_topk),
+            )
+        else:
+            extra_row = topk_row
+        # q for THIS token row: a 2-D (heads, D_QK) view (s0 indexes [head_base+h, d]).
+        q_token = cute.make_tensor(
+            q_all.iterator + token_idx.to(Int64) * Int64(self.q_stride_row),
+            cute.make_layout(
+                (self.num_heads, self.q_head_dim),
+                stride=(self.q_stride_head, self.q_stride_dim),
+            ),
+        )
+        warp_first_cand = warp_id * Int32(8)
+        if cutlass.const_expr(self.native_h8):
+            warp_first_cand = warp_id * Int32(16)
+
+        # Native H16 two-group mapping: math warps 0-3 are group 0 (heads
+        # [head_base, head_base+8)), warps 4-7 group 1 (+8). Each group runs
+        # the H8 math on its own staging half; the KV stage/mbarriers/token
+        # buffer are shared. group/warp_sel/tid_sel collapse to the identity
+        # for every other specialization (const_expr elided).
+        group = Int32(0)
+        warp_sel = warp_id
+        tid_sel = tid
+        if cutlass.const_expr(self.native_dsv4_h16):
+            group = warp_id >> Int32(2)
+            warp_sel = warp_id & Int32(3)
+            tid_sel = tid - group * Int32(128)
+            warp_first_cand = warp_sel * Int32(16)
+
+        # ════════════════════════════════════════════════════════════════════
+        # IO WARP (PRODUCER) vs MATH WARPS (CONSUMER).
+        # ════════════════════════════════════════════════════════════════════
+        if is_io:
+            io_lane = tid - Int32(self.math_threads)
+            prod_phase = Int32(1)
+            prod_idx = Int32(0)
+            for lc in cutlass.range(active_chunks, unroll=1):
+                active_idx = Int32(lc)
+                ci = split_first_chunk + active_idx
+                if cutlass.const_expr(has_extra):
+                    if active_idx >= main_chunk_count:
+                        ci = extra_first_chunk + active_idx - main_chunk_count
+                buf = Int32(lc) & Int32(1)
+
+                cute.arch.mbarrier_wait(mbar_base + n_buf + prod_idx, phase=prod_phase)
+
+                tok_buf_view = cute.make_tensor(
+                    token_idx_view.iterator + buf * tok_buf_elems,
+                    cute.make_layout(int(L.token_idx_buf_bytes // 4)),
+                )
+                io_kw = dict(
+                    bi=t.bi,
+                    kv_smem_stride=staged_kv_stride,
+                    rope_smem_stride=t.d_rope,
+                    scale_bytes_per_token=8,
+                    bulk_tx_bytes=t.bulk_tx_bytes,
+                    scale_format=t.scale_format,
+                    io_threads=self.io_threads,
+                    split_mbar_arrival=self.native_dsv4_h16,
+                    fp8_rope=t.fp8_rope,
+                    packed_glm=self.native_glm_h8,
+                    packed_dsv4=self.native_dsv4_h8 or self.native_dsv4_h16,
+                    overlap_footer_gather=self.native_dsv4_h16,
+                )
+                # Per-chunk section dispatch (DSV4 dual-cache; FlashInfer
+                # decode_dsv4 :243-322). chunks [0, num_main_chunks) gather from the
+                # MAIN cache; chunks >= num_main_chunks gather from the EXTRA cache
+                # (different base ptr / page size / indices / stride). is_extra is
+                # uniform across the IO warp (derived from the chunk index) so the
+                # runtime branch is divergence-free. When has_extra=False this is
+                # const_expr-pinned to the main gather -> byte-identical PTX.
+                if cutlass.const_expr(has_extra):
+                    if ci >= num_main_chunks:
+                        cis = ci - num_main_chunks
+                        g_start = cis * Int32(_CAND_WINDOW)
+                        g_end = g_start + Int32(_CAND_WINDOW)
+                        if g_end > extra_section_len:
+                            g_end = extra_section_len
+                        io_issue_gather(
+                            extra_kv_cache_u8,
+                            extra_row,
+                            kv_fp8_addr + buf * kv_fp8_buf,
+                            kv_rope_addr + buf * kv_rope_buf,
+                            kv_sc_addr + buf * kv_sc_buf,
+                            tok_buf_view,
+                            mbar_base + buf,
+                            g_start,
+                            g_end,
+                            Int32(self.pbs_extra),
+                            stride_extra_kv_block,
+                            io_lane,
+                            **io_kw,
+                        )
+                    else:
+                        g_start = ci * Int32(_CAND_WINDOW)
+                        g_end = g_start + Int32(_CAND_WINDOW)
+                        if g_end > section_len:
+                            g_end = section_len
+                        io_issue_gather(
+                            kv_cache_u8,
+                            topk_row,
+                            kv_fp8_addr + buf * kv_fp8_buf,
+                            kv_rope_addr + buf * kv_rope_buf,
+                            kv_sc_addr + buf * kv_sc_buf,
+                            tok_buf_view,
+                            mbar_base + buf,
+                            g_start,
+                            g_end,
+                            Int32(self.page_block_size),
+                            stride_kv_block,
+                            io_lane,
+                            **io_kw,
+                        )
+                else:
+                    g_start = ci * Int32(_CAND_WINDOW)
+                    g_end = g_start + Int32(_CAND_WINDOW)
+                    if g_end > section_len:
+                        g_end = section_len
+                    io_issue_gather(
+                        kv_cache_u8,
+                        topk_row,
+                        kv_fp8_addr + buf * kv_fp8_buf,
+                        kv_rope_addr + buf * kv_rope_buf,
+                        kv_sc_addr + buf * kv_sc_buf,
+                        tok_buf_view,
+                        mbar_base + buf,
+                        g_start,
+                        g_end,
+                        Int32(self.page_block_size),
+                        stride_kv_block,
+                        io_lane,
+                        **io_kw,
+                    )
+                prod_idx += Int32(1)
+                if prod_idx == Int32(n_buf):
+                    prod_idx = Int32(0)
+                    prod_phase ^= Int32(1)
+
+        else:
+            # MATH WARPS (CONSUMER, warps 0-7 = 256 threads).
+            n_acc_tiles = int(t.n_v_chunks) * int(t.nt_per_warp_xv)
+
+            # ── Native H16 per-group staging bases. Identity aliases when the
+            #    two-group mode is off (const_expr; zero IR change). Each group
+            #    strides its cooperative loops by nt_stage=128 threads while
+            #    every named barrier spans the full bt_stage=256-thread math
+            #    domain (barrier_threads override), so the groups share one
+            #    barrier schedule but touch disjoint staging halves. ──
+            q_fp8_stage = q_fp8_addr
+            q_rope_stage = q_rope_addr
+            q_sc_stage_view = q_sc_view
+            amax_stage_view = amax_view
+            reduce_max_stage = reduce_max_addr
+            reduce_sum_stage = reduce_sum_addr
+            w_fp8_stage = w_fp8_addr
+            sm_p_stage = sm_p_full_addr
+            w_head_sc_stage_view = w_head_sc_view
+            head_base_stage = head_base
+            nt_stage = 128 if self.native_dsv4_h16 else self.math_threads
+            bt_stage = self.math_threads if self.native_dsv4_h16 else 0
+            if cutlass.const_expr(self.native_dsv4_h16):
+                head_base_stage = head_base + group * Int32(8)
+                q_fp8_stage = q_fp8_addr + group * Int32(8 * t.q_nope_stride)
+                q_rope_stage = q_rope_addr + group * Int32(8 * L.q_rope_stride * 2)
+                q_sc_stage_view = cute.make_tensor(
+                    q_sc_view.iterator + group * Int32(8 * t.num_scales),
+                    cute.make_layout(int(8 * t.num_scales)),
+                )
+                amax_stage_view = cute.make_tensor(
+                    amax_view.iterator + group * Int32(64),
+                    cute.make_layout(64),
+                )
+                reduce_max_stage = reduce_max_addr + group * Int32(4 * t.hpb * 4)
+                reduce_sum_stage = reduce_sum_addr + group * Int32(4 * t.hpb * 4)
+                w_fp8_stage = w_fp8_addr + group * Int32(8 * (t.bi + 16))
+                sm_p_stage = sm_p_full_addr + group * Int32(8 * L.sm_p_full_stride * 2)
+                # Group 1 gets the dedicated tail region (w_head_sc packs
+                # scale+reciprocal across its full 16-wide row, so the groups
+                # cannot split one row).
+                w_head_sc_stage_view = cute.make_tensor(
+                    w_head_sc_view.iterator
+                    + group * Int32((L.w_head_sc2_off - L.w_head_sc_off) // 4),
+                    cute.make_layout(int(L.w_head_sc_bytes // 4)),
+                )
+
+            if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                s0_load_q_bf16_to_smem(
+                    q_token,
+                    q_fp8_stage,
+                    q_rope_stage,
+                    head_base_stage,
+                    Int32(self.valid_hpb),
+                    tid_sel,
+                    d_nope=t.d_nope,
+                    d_rope=t.d_rope,
+                    hpb=t.hpb,
+                    q_nope_bf16_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=nt_stage,
+                    barrier_id=2,
+                    barrier_threads=bt_stage,
+                )
+            else:
+                s0_quantize_q_to_smem(
+                    q_token,
+                    q_fp8_stage,
+                    q_sc_stage_view,
+                    q_rope_stage,
+                    amax_stage_view,
+                    head_base_stage,
+                    Int32(8 if self.native_dsv4_h16 else self.valid_hpb),
+                    tid_sel,
+                    d_nope=t.d_nope,
+                    d_rope=t.d_rope,
+                    d_qk=t.d_nope + t.d_rope,
+                    quant_tile=t.quant_tile,
+                    num_scales=t.num_scales,
+                    hpb=(8 if (self.native_h8 or self.native_dsv4_h16) else t.hpb),
+                    q_nope_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=nt_stage,
+                    barrier_id=2,
+                    barrier_threads=bt_stage,
+                    fused_subgroup_quant=self.native_dsv4_h8,
+                    subgroup_amax=(self.native_dsv4_h8 or self.native_dsv4_h16),
+                    vectorized_rope_copy=(self.native_dsv4_h8 or self.native_dsv4_h16),
+                    packed_q_scale_words=self.native_dsv4_h16,
+                )
+
+            accn_frag = cute.make_rmem_tensor(n_acc_tiles * 4, Float32)
+            rope_acc_elems = 8 if (self.native_dsv4_h8 or self.native_dsv4_h16) else 4
+            accr_frag = cute.make_rmem_tensor(rope_acc_elems, Float32)
+            gmax_frag = cute.make_rmem_tensor(2, Float32)
+            gsum_frag = cute.make_rmem_tensor(2, Float32)
+            for k in cutlass.range_constexpr(n_acc_tiles * 4):
+                accn_frag[k] = Float32(0.0)
+            for k in cutlass.range_constexpr(rope_acc_elems):
+                accr_frag[k] = Float32(0.0)
+            gmax_frag[0] = Float32(-1e30)
+            gmax_frag[1] = Float32(-1e30)
+            gsum_frag[0] = Float32(0.0)
+            gsum_frag[1] = Float32(0.0)
+
+            cons_phase = Int32(0)
+            cons_idx = Int32(0)
+
+            for lc in cutlass.range(active_chunks, unroll=1):
+                active_idx = Int32(lc)
+                ci = split_first_chunk + active_idx
+                if cutlass.const_expr(has_extra):
+                    if active_idx >= main_chunk_count:
+                        ci = extra_first_chunk + active_idx - main_chunk_count
+                split_cand_start = ci * Int32(_CAND_WINDOW)
+                buf = Int32(lc) & Int32(1)
+
+                kv_fp8_b = kv_fp8_addr + buf * kv_fp8_buf
+                kv_rope_b = kv_rope_addr + buf * kv_rope_buf
+                kv_sc_b = kv_sc_addr + buf * kv_sc_buf
+                tok_buf_view = cute.make_tensor(
+                    token_idx_view.iterator + buf * tok_buf_elems,
+                    cute.make_layout(int(L.token_idx_buf_bytes // 4)),
+                )
+
+                acc_nope = [
+                    [
+                        accn_frag[at * 4 + 0],
+                        accn_frag[at * 4 + 1],
+                        accn_frag[at * 4 + 2],
+                        accn_frag[at * 4 + 3],
+                    ]
+                    for at in range(n_acc_tiles)
+                ]
+                acc_rope = [accr_frag[k] for k in range(rope_acc_elems)]
+                global_max = [gmax_frag[0], gmax_frag[1]]
+                global_sum = [gsum_frag[0], gsum_frag[1]]
+
+                cute.arch.mbarrier_wait(mbar_base + cons_idx, phase=cons_phase)
+                cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+
+                # P10f: GLM keeps RAW e4m3 K/V (no S0b dequant+requant -- that
+                # discarded the per-group e4m3 mantissa headroom and cost ~0.003
+                # cos). The arbitrary fp32 group scale is applied POST-MMA in S1
+                # (QK) / inline in S6 (V). DSV4 (UE8M0_BYTE) is unaffected (it never
+                # ran S0b: scale_format==0), so its trace/PTX stay byte-identical.
+
+                qk = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                if cutlass.const_expr(self.native_h8 or self.native_dsv4_h16):
+                    if cutlass.const_expr(self.native_glm_h8):
+                        qk = s1_qk_nope_block_scaled_glm_h8_swap_ab(
+                            qk,
+                            q_fp8_stage,
+                            kv_fp8_b,
+                            q_sc_stage_view,
+                            warp_first_cand,
+                            lane,
+                            num_scales=t.num_scales,
+                            quant_tile=t.quant_tile,
+                            q_nope_stride=t.q_nope_stride,
+                            kv_smem_stride=staged_kv_stride,
+                        )
+                        h8_rope_addr = kv_fp8_b + Int32(t.kv_smem_stride)
+                        h8_rope_stride = staged_kv_stride
+                    else:
+                        qk = s1_qk_nope_block_scaled_dsv4_h8_swap_ab(
+                            qk,
+                            q_fp8_stage,
+                            kv_fp8_b,
+                            q_sc_stage_view,
+                            kv_sc_b,
+                            warp_first_cand,
+                            lane,
+                            num_scales=t.num_scales,
+                            quant_tile=t.quant_tile,
+                            q_nope_stride=t.q_nope_stride,
+                            kv_smem_stride=staged_kv_stride,
+                            scale_bytes_per_token=8,
+                            packed_footer_words=self.native_dsv4_h16,
+                            packed_q_scale_words=self.native_dsv4_h16,
+                        )
+                        h8_rope_addr = kv_rope_b
+                        h8_rope_stride = staged_kv_stride
+                    qk = s2_qk_rope_bf16_glm_h8_swap_ab(
+                        qk,
+                        q_rope_stage,
+                        h8_rope_addr,
+                        warp_first_cand,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                        kv_rope_stride_bytes=h8_rope_stride,
+                    )
+                    sc_start = split_cand_start
+                    sec_len = section_len
+                    if cutlass.const_expr(has_extra):
+                        if ci >= num_main_chunks:
+                            sc_start = (ci - num_main_chunks) * Int32(_CAND_WINDOW)
+                            sec_len = extra_section_len
+                    sc_end = sc_start + Int32(_CAND_WINDOW)
+                    if sc_end > sec_len:
+                        sc_end = sec_len
+                    qk = s3_mask_and_scale_glm_h8_swap_ab(
+                        qk,
+                        tok_buf_view,
+                        warp_first_cand,
+                        sc_start,
+                        sc_end,
+                        sec_len,
+                        sm_scale_log2,
+                        lane,
+                    )
+                    p = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                    p, wr0, wr1 = s4_online_softmax_glm_h8_swap_ab(
+                        qk,
+                        p,
+                        acc_nope,
+                        acc_rope,
+                        global_max,
+                        global_sum,
+                        reduce_max_stage,
+                        reduce_sum_stage,
+                        warp_sel,
+                        lane,
+                        tid_sel,
+                        n_acc_tiles=n_acc_tiles,
+                        hpb=t.hpb,
+                        n_warps=4,
+                        num_threads=nt_stage,
+                        barrier_id=3,
+                        rope_tiles_per_warp=(
+                            2 if (self.native_dsv4_h8 or self.native_dsv4_h16) else 0
+                        ),
+                        barrier_threads=bt_stage,
+                    )
+                    w_pre = [
+                        p[0] * wr0,
+                        p[1] * wr1,
+                        p[2] * wr0,
+                        p[3] * wr1,
+                    ]
+                    if cutlass.const_expr(self.native_glm_h8):
+                        acc_nope = s6_xv_nope_glm_h8_swap_ab(
+                            w_pre,
+                            acc_nope,
+                            kv_fp8_b,
+                            w_head_sc_view,
+                            w_fp8_addr,
+                            warp_id,
+                            lane,
+                            tid,
+                            n_v_chunks=t.n_v_chunks,
+                            v_chunk=t.quant_tile,
+                            hpb=t.hpb,
+                            bi=t.bi,
+                            kv_smem_stride=staged_kv_stride,
+                            w_fp8_stride=t.bi + 16,
+                            n_warps=4,
+                            nt_per_warp_xv=t.nt_per_warp_xv,
+                            num_threads=self.math_threads,
+                            barrier_id=3,
+                        )
+                    else:
+                        acc_nope = s6_xv_nope_dsv4_h8_swap_ab(
+                            w_pre,
+                            acc_nope,
+                            kv_fp8_b,
+                            kv_sc_b,
+                            w_head_sc_stage_view,
+                            w_fp8_stage,
+                            sm_p_stage,
+                            warp_sel,
+                            lane,
+                            tid_sel,
+                            n_v_chunks=t.n_v_chunks,
+                            v_chunk=t.quant_tile,
+                            hpb=t.hpb,
+                            bi=t.bi,
+                            sm_p_stride=L.sm_p_full_stride,
+                            kv_smem_stride=staged_kv_stride,
+                            w_fp8_stride=t.bi + 16,
+                            n_warps=4,
+                            nt_per_warp_xv=t.nt_per_warp_xv,
+                            scale_bytes_per_token=8,
+                            num_threads=nt_stage,
+                            barrier_id=3,
+                            barrier_threads=bt_stage,
+                            packed_footer_words=self.native_dsv4_h16,
+                        )
+                else:
+                    qk = s1_qk_nope_block_scaled(
+                        qk,
+                        q_fp8_addr,
+                        kv_fp8_b,
+                        q_sc_view,
+                        kv_sc_b,
+                        warp_first_cand,
+                        lane,
+                        latent_scale,
+                        num_scales=t.num_scales,
+                        quant_tile=t.quant_tile,
+                        q_nope_stride=t.q_nope_stride,
+                        kv_smem_stride=t.kv_smem_stride,
+                        scale_bytes_per_token=8,
+                        scale_format=t.scale_format,
+                    )
+                    qk = s2_qk_rope_bf16(
+                        qk,
+                        q_rope_addr,
+                        kv_rope_b,
+                        warp_first_cand,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                        fp8_rope=t.fp8_rope,
+                    )
+
+                    # Per-chunk section dispatch for the S3 mask: compare the
+                    # candidate's offset within its main/extra section.
+                    if cutlass.const_expr(has_extra):
+                        sc_start = split_cand_start
+                        sec_len = section_len
+                        if ci >= num_main_chunks:
+                            sc_start = (ci - num_main_chunks) * Int32(_CAND_WINDOW)
+                            sec_len = extra_section_len
+                        sc_end = sc_start + Int32(_CAND_WINDOW)
+                        if sc_end > sec_len:
+                            sc_end = sec_len
+                        qk = s3_mask_and_scale(
+                            qk,
+                            tok_buf_view,
+                            warp_first_cand,
+                            sc_start,
+                            sc_end,
+                            sec_len,
+                            sm_scale_log2,
+                            lane,
+                        )
+                    else:
+                        split_cand_end = split_cand_start + Int32(_CAND_WINDOW)
+                        if split_cand_end > section_len:
+                            split_cand_end = section_len
+                        qk = s3_mask_and_scale(
+                            qk,
+                            tok_buf_view,
+                            warp_first_cand,
+                            split_cand_start,
+                            split_cand_end,
+                            section_len,
+                            sm_scale_log2,
+                            lane,
+                        )
+
+                    p = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                    p, wr0, wr1 = s4_online_softmax(
+                        qk,
+                        p,
+                        acc_nope,
+                        acc_rope,
+                        global_max,
+                        global_sum,
+                        reduce_max_addr,
+                        reduce_sum_addr,
+                        False,
+                        warp_id,
+                        lane,
+                        tid,
+                        n_v_chunks=t.n_v_chunks,
+                        hpb=t.hpb,
+                        n_warps=8,
+                        valid_hpb=self.valid_hpb,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        n_acc_tiles=n_acc_tiles,
+                    )
+                    w_pre = [
+                        p[0] * wr0,
+                        p[1] * wr0,
+                        p[2] * wr1,
+                        p[3] * wr1,
+                    ]
+                    s5_fill_sm_p_full(
+                        w_pre,
+                        sm_p_full_addr,
+                        w_head_sc_view,
+                        warp_id,
+                        lane,
+                        tid,
+                        bi=t.bi,
+                        sm_p_stride=L.sm_p_full_stride,
+                        n_v_chunks=t.n_v_chunks,
+                        hpb=t.hpb,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                    )
+                    cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+                    acc_nope = s6_xv_nope(
+                        w_pre,
+                        acc_nope,
+                        kv_fp8_b,
+                        kv_sc_b,
+                        w_head_sc_view,
+                        w_fp8_addr,
+                        warp_id,
+                        lane,
+                        tid,
+                        latent_scale,
+                        n_v_chunks=t.n_v_chunks,
+                        v_chunk=t.quant_tile,
+                        hpb=t.hpb,
+                        bi=t.bi,
+                        kv_smem_stride=t.kv_smem_stride,
+                        w_fp8_stride=t.bi + 16,
+                        n_warps=8,
+                        scale_bytes_per_token=8,
+                        nt_per_warp_xv=t.nt_per_warp_xv,
+                        scale_format=t.scale_format,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        sm_p_full_addr=sm_p_full_addr,
+                        sm_p_stride=L.sm_p_full_stride,
+                    )
+
+                # S6b (XV-RoPE) is DSV4-only (V_HAS_ROPE). const_expr-elided for GLM.
+                if cutlass.const_expr(t.v_has_rope):
+                    if cutlass.const_expr(self.native_dsv4_h8 or self.native_dsv4_h16):
+                        acc_rope = s6b_xv_rope_h8_swap_ab(
+                            acc_rope,
+                            sm_p_stage,
+                            kv_rope_b,
+                            warp_sel,
+                            lane,
+                            bi=t.bi,
+                            sm_p_stride=L.sm_p_full_stride,
+                            d_rope=t.d_rope,
+                            n_warps=4,
+                            tiles_per_warp=2,
+                            kv_rope_stride_bytes=staged_kv_stride,
+                        )
+                    else:
+                        acc_rope = s6b_xv_rope(
+                            acc_rope,
+                            sm_p_full_addr,
+                            kv_rope_b,
+                            warp_id,
+                            lane,
+                            bi=t.bi,
+                            sm_p_stride=L.sm_p_full_stride,
+                            d_rope=t.d_rope,
+                            n_warps=8,
+                        )
+
+                for at in cutlass.range_constexpr(n_acc_tiles):
+                    accn_frag[at * 4 + 0] = acc_nope[at][0]
+                    accn_frag[at * 4 + 1] = acc_nope[at][1]
+                    accn_frag[at * 4 + 2] = acc_nope[at][2]
+                    accn_frag[at * 4 + 3] = acc_nope[at][3]
+                for k in cutlass.range_constexpr(rope_acc_elems):
+                    accr_frag[k] = acc_rope[k]
+                gmax_frag[0] = global_max[0]
+                gmax_frag[1] = global_max[1]
+                gsum_frag[0] = global_sum[0]
+                gsum_frag[1] = global_sum[1]
+
+                cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+                if tid == Int32(0):
+                    cute.arch.mbarrier_arrive(mbar_base + n_buf + cons_idx)
+                cons_idx += Int32(1)
+                if cons_idx == Int32(n_buf):
+                    cons_idx = Int32(0)
+                    cons_phase ^= Int32(1)
+
+            # ── S7: write this split's NORMALIZED partial + base-2 LSE into
+            #    mid_out[token, :, split, :] / mid_lse[token, :, split]. ──
+            fin_acc_nope = [
+                [
+                    accn_frag[at * 4 + 0],
+                    accn_frag[at * 4 + 1],
+                    accn_frag[at * 4 + 2],
+                    accn_frag[at * 4 + 3],
+                ]
+                for at in range(n_acc_tiles)
+            ]
+            fin_acc_rope = [accr_frag[k] for k in range(rope_acc_elems)]
+            fin_gmax = [gmax_frag[0], gmax_frag[1]]
+            fin_gsum = [gsum_frag[0], gsum_frag[1]]
+            if cutlass.const_expr(self.native_h8 or self.native_dsv4_h16):
+                gid = lane >> Int32(2)
+                pair_lane = gid >> Int32(1)
+                row_gmax0 = cute.arch.shuffle_sync(gmax_frag[0], pair_lane)
+                row_gmax1 = cute.arch.shuffle_sync(gmax_frag[1], pair_lane)
+                row_gsum0 = cute.arch.shuffle_sync(gsum_frag[0], pair_lane)
+                row_gsum1 = cute.arch.shuffle_sync(gsum_frag[1], pair_lane)
+                fin_gmax[0] = row_gmax0
+                fin_gsum[0] = row_gsum0
+                if (gid & Int32(1)) != Int32(0):
+                    fin_gmax[0] = row_gmax1
+                    fin_gsum[0] = row_gsum1
+
+            # mid_out[token, head_base + h, split, dim]: (HPB, D_V) view for this
+            # (token, head_block, split). mid_out stride = (h*S*Dv, S*Dv, Dv, 1).
+            out_o = cute.make_tensor(
+                mid_out.iterator
+                + token_idx.to(Int64) * Int64(self.mid_out_stride_row)
+                + head_base_stage.to(Int64) * Int64(self.mid_out_stride_head)
+                + split_idx.to(Int64) * Int64(self.mid_out_stride_split),
+                cute.make_layout(
+                    (t.hpb, t.d_v),
+                    stride=(self.mid_out_stride_head, self.mid_out_stride_dim),
+                ),
+            )
+            # mid_lse[token, head_base + h, split]: (HPB,) view.
+            out_lse = cute.make_tensor(
+                mid_lse.iterator
+                + token_idx.to(Int64) * Int64(self.mid_lse_stride_row)
+                + head_base_stage.to(Int64) * Int64(self.mid_lse_stride_head)
+                + split_idx.to(Int64) * Int64(self.mid_lse_stride_split),
+                cute.make_layout((t.hpb,), stride=(self.mid_lse_stride_head,)),
+            )
+            s7_epilogue(
+                fin_acc_nope,
+                fin_acc_rope,
+                fin_gmax,
+                fin_gsum,
+                out_o,
+                out_lse,
+                warp_sel,
+                lane,
+                n_v_chunks=t.n_v_chunks,
+                v_chunk=t.quant_tile,
+                d_nope=t.d_nope,
+                d_rope=t.d_rope,
+                n_warps=(4 if (self.native_h8 or self.native_dsv4_h16) else 8),
+                valid_hpb=(8 if self.native_dsv4_h16 else self.valid_hpb),
+                nt_per_warp_xv=t.nt_per_warp_xv,
+                v_has_rope=t.v_has_rope,
+                rope_tiles_per_warp=(
+                    2 if (self.native_dsv4_h8 or self.native_dsv4_h16) else 1
+                ),
+            )
+
+
+def _to_cute(x, dtype, align=16, dynamic_layout=False):
+    c = from_dlpack(x, assumed_align=align)
+    c.element_type = dtype
+    if dynamic_layout and x.ndim >= 1:
+        leading_dim = next(
+            (idx for idx, stride in enumerate(x.stride()) if stride == 1), None
+        )
+        if leading_dim is not None:
+            c = c.mark_layout_dynamic(leading_dim=leading_dim)
+    return c
+
+
+def _cache_base_tensor(cache: torch.Tensor) -> torch.Tensor:
+    # Contiguous cache can use the historical flat view. Packed vLLM cache views
+    # are non-contiguous tensors whose storage_offset points at this layer's
+    # payload inside a larger packed block. Do not reshape those: reshape would
+    # materialize a contiguous copy and lose the packed layout.
+    if cache.is_contiguous():
+        return cache.reshape(-1)
+    if cache.ndim < 2:
+        return cache
+
+    # Kernels compute raw byte offsets as block * stride_kv_block + in-page byte.
+    # Give Cute a 1-D view over the physical byte span for this layer so
+    # pointer+offset arithmetic stays raw-address based while preserving the
+    # original storage_offset. The explicit stride_kv_block argument still
+    # carries the packed block stride; this view only defines the base pointer.
+    span = 1
+    for size, stride in zip(cache.shape, cache.stride(), strict=True):
+        span += (int(size) - 1) * int(stride)
+    return torch.as_strided(cache, size=(span,), stride=(1,))
+
+
+def _cache_block_stride_bytes(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    model_type: int,
+    record_bytes: int | None = None,
+) -> int:
+    from flashinfer.experimental.sm12x.attention._shared.mla.compressed_reference import (
+        compressed_mla_page_nbytes,
+    )
+
+    if int(model_type) == int(ModelType.GLM_NSA):
+        # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
+        # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
+        rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+        expected = int(page_size) * rec
+    else:
+        expected = int(compressed_mla_page_nbytes(int(page_size)))
+    # Contiguous inputs are flattened before launch, so their original rank is
+    # not a physical-layout contract and the standard page stride applies.
+    # Packed vLLM page views are non-contiguous and carry the physical
+    # per-block stride in dimension 0.
+    if not cache.is_contiguous() and cache.ndim >= 2:
+        stride = int(cache.stride(0)) * int(cache.element_size())
+        if stride < expected:
+            raise ValueError(
+                f"SM120 sparse MLA cache block stride {stride} is smaller than "
+                f"page payload {expected}"
+            )
+        return stride
+    return expected
+
+
+def _topk_bucket(topk: int) -> int:
+    """Coarse topk bucket for the compile key (chunks_per_split is the real
+    specialization driver; the bucket just keeps the key compact)."""
+    return 1 << (max(int(topk), 1) - 1).bit_length()
+
+
+def _sparse_mla_decode_grid_flat_launch(
+    q_all: torch.Tensor,
+    kv_flat: torch.Tensor,
+    swa_indices: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    swa_len_t: torch.Tensor,
+    extra_kv_flat: torch.Tensor,
+    extra_indices_t: torch.Tensor,
+    extra_len_t: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    model_type: int,
+    compute_mode: int,
+    scale_format: int,
+    fp8_rope: bool,
+    swa_page_size: int,
+    topk: int,
+    extra_topk: int,
+    num_main_chunks: int,
+    num_splits: int,
+    chunks_per_split: int,
+    stride_kv_block: int,
+    pbs_extra: int,
+    stride_extra_kv_block: int,
+    grid_h_blocks: int,
+    valid_hpb: int,
+    head_block_offset: int,
+    has_extra: bool,
+    per_token_len: bool,
+) -> None:
+    q_head_dim = int(q_all.shape[-1])
+    rows = int(q_all.shape[0])
+    heads = int(q_all.shape[1])
+    native_glm_h8 = bool(
+        int(model_type) == int(ModelType.GLM_NSA)
+        and heads == 8
+        and int(valid_hpb) == 8
+        and int(grid_h_blocks) == 1
+        and int(head_block_offset) == 0
+        and not bool(has_extra)
+        # NVFP4 records are validated on the generic HPB=16 arm only.
+        and int(scale_format) != int(ScaleFormat.NVFP4_E4M3)
+        and _env_glm_h8_native_enabled()
+    )
+    native_dsv4_h8 = bool(
+        int(model_type) == int(ModelType.DSV4) and int(valid_hpb) == 8
+    )
+    native_dsv4_h16 = bool(
+        int(model_type) == int(ModelType.DSV4)
+        and int(valid_hpb) == 16
+        and int(head_block_offset) == 0
+        and (int(topk) + _CAND_WINDOW - 1) // _CAND_WINDOW
+        + (int(extra_topk) + _CAND_WINDOW - 1) // _CAND_WINDOW
+        <= _DSV4_H8_MAX_CHUNKS
+        and bool(per_token_len)
+        and _env_dsv4_h16_native_mode() is not False
+    )
+    native_h8 = native_glm_h8 or native_dsv4_h8
+    traits = make_unified_traits(
+        int(model_type),
+        int(compute_mode),
+        int(scale_format),
+        fp8_rope=bool(fp8_rope),
+    )
+    if native_h8:
+        # Four warps cover 4*16 candidates in swapped QK.  PV keeps the same
+        # output coverage with twice the H16 N-tiles per warp.
+        traits = replace(
+            traits,
+            nt_per_warp_xv=int(traits.nt_per_warp_xv) * 2,
+            math_threads=128,
+            block_threads=160,
+        )
+    elif native_dsv4_h16:
+        # Two H8 groups of four warps each keep the H8 per-warp tile shape:
+        # 16 swapped QK candidates + doubled PV N-tiles, 256 math threads.
+        traits = replace(
+            traits,
+            nt_per_warp_xv=int(traits.nt_per_warp_xv) * 2,
+        )
+    layout = make_smem_layout(traits)
+    hpb = int(traits.hpb)
+    d_v = int(traits.d_v)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    if per_token_len:
+        pertok_base = (
+            _to_cute(q_all, cutlass.BFloat16, dynamic_layout=True),
+            _to_cute(kv_flat, cutlass.Uint8, align=16),
+            _to_cute(swa_indices, cutlass.Int32, align=4, dynamic_layout=True),
+            _to_cute(mid_out, cutlass.BFloat16, align=16, dynamic_layout=True),
+            _to_cute(mid_lse, cutlass.Float32, align=4, dynamic_layout=True),
+            Float32(float(sm_scale) * LOG2_E),
+            Float32(float(latent_scale)),
+            _to_cute(swa_len_t, cutlass.Int32, align=4, dynamic_layout=True),
+            Int64(stride_kv_block),
+        )
+        if has_extra:
+            args = pertok_base + (
+                _to_cute(extra_kv_flat, cutlass.Uint8, align=16),
+                _to_cute(extra_indices_t, cutlass.Int32, align=4, dynamic_layout=True),
+                _to_cute(extra_len_t, cutlass.Int32, align=4, dynamic_layout=True),
+                Int32(num_main_chunks),
+                Int64(stride_extra_kv_block),
+                Int32(rows),
+                stream,
+            )
+        else:
+            args = pertok_base + (Int32(rows), stream)
+    else:
+        base_args = (
+            _to_cute(q_all, cutlass.BFloat16, dynamic_layout=True),
+            _to_cute(kv_flat, cutlass.Uint8, align=16),
+            _to_cute(swa_indices, cutlass.Int32, align=4, dynamic_layout=True),
+            _to_cute(mid_out, cutlass.BFloat16, align=16, dynamic_layout=True),
+            _to_cute(mid_lse, cutlass.Float32, align=4, dynamic_layout=True),
+            Float32(float(sm_scale) * LOG2_E),
+            Float32(float(latent_scale)),
+            Int32(topk),
+            Int64(stride_kv_block),
+        )
+        if has_extra:
+            args = base_args + (
+                _to_cute(extra_kv_flat, cutlass.Uint8, align=16),
+                _to_cute(extra_indices_t, cutlass.Int32, align=4, dynamic_layout=True),
+                Int32(extra_topk),
+                Int32(num_main_chunks),
+                Int64(stride_extra_kv_block),
+                Int32(rows),
+                stream,
+            )
+        else:
+            args = base_args + (Int32(rows), stream)
+
+    kernel = UnifiedDecodeKernel(
+        traits,
+        layout,
+        int(swa_page_size),
+        int(chunks_per_split),
+        h_blocks=int(grid_h_blocks),
+        num_splits=int(num_splits),
+        num_heads=heads,
+        q_head_dim=q_head_dim,
+        topk=topk,
+        extra_topk=extra_topk,
+        q_stride=tuple(q_all.stride()),
+        swa_indices_stride0=int(swa_indices.stride(0)),
+        extra_indices_stride0=int(extra_indices_t.stride(0)),
+        mid_out_stride=tuple(mid_out.stride()),
+        mid_lse_stride=tuple(mid_lse.stride()),
+        has_extra=bool(has_extra),
+        pbs_extra=int(pbs_extra),
+        valid_hpb=int(valid_hpb),
+        head_block_offset=int(head_block_offset),
+        per_token_len=bool(per_token_len),
+        native_glm_h8=native_glm_h8,
+        native_dsv4_h8=native_dsv4_h8,
+        native_dsv4_h16=native_dsv4_h16,
+    )
+    spec_fields = [
+        key_field("model_type", traits.model_type),
+        key_field("compute_mode", traits.compute_mode),
+        key_field("scale_format", traits.scale_format),
+        key_field("fp8_rope", int(traits.fp8_rope)),
+        key_field("num_heads", heads),
+        key_field("hpb", hpb),
+        key_field("valid_hpb", int(valid_hpb)),
+        key_field("head_block_offset", int(head_block_offset)),
+        key_field("grid_h_blocks", int(grid_h_blocks)),
+        key_field("num_splits", int(num_splits)),
+        key_field("chunks_per_split", int(chunks_per_split)),
+        key_field("page_block_size", int(swa_page_size)),
+        key_field("topk_bucket", _topk_bucket(topk)),
+        key_field("has_extra", int(has_extra)),
+        key_field("pbs_extra", int(pbs_extra)),
+        key_field("extra_topk_bucket", _topk_bucket(extra_topk) if has_extra else 0),
+        key_field("per_token_len", int(per_token_len)),
+        key_field("native_glm_h8", int(native_glm_h8)),
+        key_field("native_dsv4_h8", int(native_dsv4_h8)),
+        key_field("native_dsv4_h16", int(native_dsv4_h16)),
+        tensor_key(
+            "q_all",
+            q_all,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(heads),
+                DimKey.exact(q_head_dim),
+            ),
+        ),
+        tensor_key(
+            "swa_indices",
+            swa_indices,
+            dims=(DimKey.dynamic(), DimKey.bucket(topk)),
+        ),
+        tensor_key(
+            "mid_out",
+            mid_out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(heads),
+                DimKey.bucket(num_splits),
+                DimKey.exact(d_v),
+            ),
+        ),
+        tensor_key(
+            "mid_lse",
+            mid_lse,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(heads),
+                DimKey.bucket(num_splits),
+            ),
+        ),
+    ]
+    if has_extra:
+        spec_fields.append(
+            tensor_key(
+                "extra_indices",
+                extra_indices_t,
+                dims=(DimKey.dynamic(), DimKey.bucket(max(extra_topk, 1))),
+            )
+        )
+    if per_token_len:
+        spec_fields.append(
+            tensor_key("topk_length", swa_len_t, dims=(DimKey.dynamic(),))
+        )
+        if has_extra:
+            spec_fields.append(
+                tensor_key(
+                    "extra_topk_length",
+                    extra_len_t,
+                    dims=(DimKey.dynamic(),),
+                )
+            )
+    compile_spec = KernelCompileSpec.from_fields(
+        "attention.mla.sm120.decode",
+        # v17 adds the runtime FP8-RoPE record format specialization.  The
+        # explicit cache key does not hash source, so this ABI bump rejects
+        # cubins compiled for the 432-byte BF16-RoPE record.
+        17,
+        *spec_fields,
+    )
+    if per_token_len:
+        entry = kernel.call_extra_pertok if has_extra else kernel.call_pertok
+    else:
+        entry = kernel.call_extra if has_extra else kernel
+    sm12x_launch(
+        entry,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::sparse_mla_sm120_decode_grid",
+    mutates_args=("mid_out", "mid_lse"),
+)
+def _sparse_mla_decode_grid_op(
+    q_all: torch.Tensor,
+    kv_flat: torch.Tensor,
+    swa_indices: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    swa_len_t: torch.Tensor,
+    extra_kv_flat: torch.Tensor,
+    extra_indices_t: torch.Tensor,
+    extra_len_t: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    model_type: int,
+    compute_mode: int,
+    scale_format: int,
+    fp8_rope: bool,
+    swa_page_size: int,
+    topk: int,
+    extra_topk: int,
+    num_main_chunks: int,
+    num_splits: int,
+    chunks_per_split: int,
+    stride_kv_block: int,
+    pbs_extra: int,
+    stride_extra_kv_block: int,
+    grid_h_blocks: int,
+    valid_hpb: int,
+    head_block_offset: int,
+    has_extra: bool,
+    per_token_len: bool,
+) -> None:
+    _sparse_mla_decode_grid_flat_launch(
+        q_all,
+        kv_flat,
+        swa_indices,
+        mid_out,
+        mid_lse,
+        swa_len_t,
+        extra_kv_flat,
+        extra_indices_t,
+        extra_len_t,
+        sm_scale,
+        latent_scale,
+        model_type,
+        compute_mode,
+        scale_format,
+        fp8_rope,
+        swa_page_size,
+        topk,
+        extra_topk,
+        num_main_chunks,
+        num_splits,
+        chunks_per_split,
+        stride_kv_block,
+        pbs_extra,
+        stride_extra_kv_block,
+        grid_h_blocks,
+        valid_hpb,
+        head_block_offset,
+        has_extra,
+        per_token_len,
+    )
+
+
+@_sparse_mla_decode_grid_op.register_fake
+def _sparse_mla_decode_grid_fake(
+    q_all: torch.Tensor,
+    kv_flat: torch.Tensor,
+    swa_indices: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    swa_len_t: torch.Tensor,
+    extra_kv_flat: torch.Tensor,
+    extra_indices_t: torch.Tensor,
+    extra_len_t: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    model_type: int,
+    compute_mode: int,
+    scale_format: int,
+    fp8_rope: bool,
+    swa_page_size: int,
+    topk: int,
+    extra_topk: int,
+    num_main_chunks: int,
+    num_splits: int,
+    chunks_per_split: int,
+    stride_kv_block: int,
+    pbs_extra: int,
+    stride_extra_kv_block: int,
+    grid_h_blocks: int,
+    valid_hpb: int,
+    head_block_offset: int,
+    has_extra: bool,
+    per_token_len: bool,
+) -> None:
+    return None
+
+
+def run_unified_decode(
+    *,
+    q_all: torch.Tensor,
+    swa_k_cache: torch.Tensor,
+    swa_indices: torch.Tensor,
+    swa_topk_lengths: torch.Tensor,
+    workspace,
+    sm_scale: float,
+    latent_scale: float = 1.0,
+    swa_page_size: int,
+    indexed_k_cache: torch.Tensor | None = None,
+    indexed_indices: torch.Tensor | None = None,
+    indexed_topk_lengths: torch.Tensor | None = None,
+    indexed_page_size: int | None = None,
+    indexed_page_table: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    return_lse: bool = False,
+    lse_scale: str = "base2",
+    forced_num_splits: int | None = None,
+    out: torch.Tensor | None = None,
+    scale_format_override: int | None = None,
+    fp8_rope_override: bool | None = None,
+):
+    """Active SM120 sparse-MLA decode: kernel (split-K partials) + merge.
+
+    Routes DSV4 (q_head_dim==512, UE8M0 footer) AND GLM_NSA (q_head_dim==576,
+    ARBITRARY_FP32 inline scales) to the SAME warp-specialized kernel via the
+    cute.constexpr traits branches (model_type/scale_format/v_has_rope). The
+    dispatch gate guarantees SM120; this entrypoint rejects unsupported features
+    so an accidental route never silently mis-computes.
+
+    DSV4 DUAL-CACHE (P7c): when ``indexed_k_cache`` / ``indexed_indices`` /
+    ``indexed_topk_lengths`` are supplied (the "extra"-tokens second KV pool), the
+    decode attends over the UNION of the MAIN paged topk cache and the EXTRA cache
+    in ONE online softmax. The chunk loop processes ``num_main_chunks =
+    ceil(topk/BI)`` main chunks (gathering from the main cache) then
+    ``num_extra_chunks = ceil(extra_topk/BI)`` extra chunks (gathering from
+    ``indexed_k_cache`` with ``indexed_page_size`` / its own per-block stride);
+    ``num_splits`` spans both. The extra cache is DSV4-only (GLM has no extra
+    section). With no extra cache the kernel is compiled with ``has_extra=False``
+    so the extra-section code is const_expr-elided (PTX byte-identical).
+    """
+    has_extra = (
+        indexed_k_cache is not None
+        or indexed_indices is not None
+        or indexed_topk_lengths is not None
+    )
+    # Mapped extra page table is GENUINELY-UPSTREAM-UNSUPPORTED (upstream is
+    # raw-slot-id only; no page-table indirection). RAISE, not fallback. Checked
+    # BEFORE the has_extra branch so a mapped page table passed WITHOUT the extra
+    # trio is still a hard error (never silently ignored / silently routed).
+    if indexed_page_table is not None:
+        raise ValueError(
+            "SM120 sparse MLA decode: indexed_page_table (mapped extra pages) is "
+            "unsupported on SM120 sparse-MLA; upstream addresses the extra cache "
+            "by raw slot id only"
+        )
+    if has_extra:
+        # Partial dual-cache trio is a HARD ERROR (upstream ICHECKs extra_indices
+        # requires extra_kv_cache; sparse_mla_sm120.cu:171-174). NOT a fallback.
+        if (
+            indexed_k_cache is None
+            or indexed_indices is None
+            or indexed_page_size is None
+        ):
+            raise ValueError(
+                "SM120 sparse MLA decode dual-cache requires indexed_k_cache, "
+                "indexed_indices, and indexed_page_size together (partial extra "
+                "trio is unsupported, matching upstream sparse_mla_sm120.cu:171-174)"
+            )
+        if int(q_all.shape[-1]) != _DSV4_HEAD_DIM:
+            raise ValueError(
+                "SM120 sparse MLA decode dual-cache (extra tokens) is DSV4-only "
+                "(q_head_dim==512); GLM/DSV3.2 has no extra cache"
+            )
+
+    q_head_dim = int(q_all.shape[-1])
+    if q_head_dim not in (_DSV4_HEAD_DIM, _GLM_HEAD_DIM):
+        raise NotImplementedError(
+            f"SM120 sparse MLA decode supports q_head_dim 512 (DSV4) or 576 (GLM); "
+            f"got {q_head_dim}"
+        )
+
+    rows, heads, _ = q_all.shape
+    hpb = 16
+    if heads <= 0:
+        raise ValueError(f"SM120 sparse MLA decode requires heads > 0, got {heads}")
+
+    # attn_sink [num_heads] f32: upstream applies it in the DECODE MERGE
+    # (sparse_mla_sm120_decode_dsv4.cu:128-129). Validate shape/dtype/device; the
+    # fold itself is wired into the split.py sink-merge below (no kernel change).
+    if attn_sink is not None:
+        attn_sink = attn_sink.detach()
+        if attn_sink.shape != (heads,):
+            raise ValueError(
+                f"SM120 sparse MLA decode attn_sink must have shape [{heads}], "
+                f"got {tuple(attn_sink.shape)}"
+            )
+        if attn_sink.dtype != torch.float32:
+            raise TypeError(
+                f"SM120 sparse MLA decode attn_sink must be float32, got {attn_sink.dtype}"
+            )
+        if attn_sink.device != q_all.device:
+            raise ValueError(
+                "SM120 sparse MLA decode attn_sink must be on the same device as q_all"
+            )
+        if not attn_sink.is_contiguous():
+            raise ValueError("SM120 sparse MLA decode attn_sink must be contiguous")
+    if lse_scale not in ("base2", "natural"):
+        raise ValueError(
+            f"SM120 sparse MLA decode lse_scale must be 'base2' or 'natural', got {lse_scale!r}"
+        )
+    # VALID_HPB<16 / non-multiple-of-16 heads (small-TP shards): upstream
+    # VALID_HPB=min(NUM_HEADS,HPB) (decode_dsv4_kernel.cuh:152) computes a full
+    # HPB=16 tile with zero-Q padding and gates writes to valid_hpb rows. We
+    # realise this with up to TWO grid launches: ``h_blocks_full`` full blocks
+    # (valid_hpb=16) plus one REMAINDER block (valid_hpb=heads%16) when heads is
+    # not a multiple of 16. heads in {8} -> 0 full blocks + 1 remainder block of
+    # valid_hpb=8. The base case (heads multiple of 16, e.g. 128) is a single
+    # full-block grid -> byte-identical to the pre-P10 kernel.
+    h_blocks_full = heads // hpb
+    rem_heads = heads % hpb
+    h_blocks = h_blocks_full + (1 if rem_heads else 0)
+
+    model_type, compute_mode, scale_format = infer_model_type(
+        q_head_dim, swa_k_cache.dtype
+    )
+    if scale_format_override is not None:
+        scale_format = int(scale_format_override)
+    if scale_format == ScaleFormat.NVFP4_E4M3 and fp8_rope_override is None:
+        record_bytes = int(swa_k_cache.shape[-1])
+        if record_bytes not in (368, 432):
+            raise ValueError(
+                f"NVFP4 cache record must be 368 or 432 bytes, got {record_bytes}"
+            )
+        fp8_rope_override = record_bytes == 368
+    traits = make_unified_traits(
+        model_type,
+        compute_mode,
+        scale_format,
+        fp8_rope=fp8_rope_override,
+    )
+    if scale_format == ScaleFormat.NVFP4_E4M3 and int(swa_k_cache.shape[-1]) != int(
+        traits.kv_gmem_stride
+    ):
+        raise ValueError(
+            "NVFP4 cache record width disagrees with fp8_rope_override: "
+            f"got {int(swa_k_cache.shape[-1])} bytes, expected "
+            f"{int(traits.kv_gmem_stride)}"
+        )
+    d_v = int(traits.d_v)  # output O dim (512 for both; V == nope for GLM)
+
+    topk = int(swa_indices.shape[1])
+    extra_topk = int(indexed_indices.shape[1]) if has_extra else 0
+    num_main_chunks = (topk + _CAND_WINDOW - 1) // _CAND_WINDOW
+    num_extra_chunks = (extra_topk + _CAND_WINDOW - 1) // _CAND_WINDOW
+    # The swapped H8 DSV4 kernel is validated across the traced C1/C4/C128
+    # regimes, including C128's three chunks per split. This is a shape-only
+    # policy decision, so capture and replay use the same kernel and workspace.
+    max_chunks = int(workspace.max_chunks_per_row)
+    # SM count read early: both the H8/H16 policy and the split plan need it.
+    sm_count = None
+    if q_all.is_cuda:
+        sm_count = int(
+            torch.cuda.get_device_properties(q_all.device).multi_processor_count
+        )
+
+    h16_allowed = bool(
+        int(model_type) == int(ModelType.DSV4)
+        and heads % 16 == 0
+        and num_main_chunks + num_extra_chunks <= _DSV4_H8_MAX_CHUNKS
+    )
+    h16_mode = _env_dsv4_h16_native_mode()
+    if h16_allowed and h16_mode is None:
+        # AUTO policy: pre-plan the H8 grid, then choose by regime (see
+        # _dsv4_h16_auto): gather-bound many-chunk shapes and >1.4-wave H8
+        # grids go H16; the sub-wave latency regime keeps H8.
+        _nc8, _ns8, _ = plan_unified_decode_splits(
+            topk=topk,
+            max_chunks=max_chunks,
+            forced_num_splits=forced_num_splits,
+            num_tokens=rows,
+            h_blocks=heads // 8,
+            sm_count=sm_count,
+            extra_topk=extra_topk,
+        )
+        native_dsv4_h16 = _dsv4_h16_auto(
+            rows=rows, heads=heads, num_chunks=_nc8, h8_num_splits=_ns8
+        )
+    else:
+        native_dsv4_h16 = bool(h16_allowed and h16_mode)
+    native_dsv4_h8 = bool(
+        int(model_type) == int(ModelType.DSV4)
+        and heads % 8 == 0
+        and num_main_chunks + num_extra_chunks <= _DSV4_H8_MAX_CHUNKS
+        and not native_dsv4_h16
+    )
+    if native_dsv4_h8:
+        hpb = 8
+        h_blocks_full = heads // hpb
+        rem_heads = heads % hpb
+        h_blocks = h_blocks_full + (1 if rem_heads else 0)
+
+    # ── P10b PER-TOKEN topk_length threading ──────────────────────────────────
+    # Decide whether to route to the per-token kernel (section_len read per CTA
+    # from a (rows,) int32 length tensor) or the byte-identical UNIFORM scalar
+    # path. The scalar path is taken when every token's length equals the full
+    # topk (the common decode contract: swa_topk_lengths[t] == topk for all t, OR
+    # the caller -1-pads indices past the length so the uniform full-topk section
+    # bound + the S3 idx<0 mask already realise the per-token length). For a
+    # GENUINELY-mixed-length batch (some topk_length[t] < topk) the per-token
+    # kernel reads each token's clamped length, so over-allocated chunks for short
+    # tokens are fully masked (-> mid_lse=-inf -> merge ignores). A batch is uniform
+    # ONLY when EVERY row's length >= the full section width (so the scalar bound
+    # already equals each clamped length); a single SHORT row (lt[0] < cap) is NOT
+    # uniform and must take the per-token clamp path.
+    def _length_tensor(lengths, name, cap):
+        if lengths is None:
+            return None, True
+        if not isinstance(lengths, torch.Tensor):
+            raise TypeError(f"SM120 sparse MLA decode {name} must be a torch.Tensor")
+        if lengths.shape != (rows,):
+            raise ValueError(
+                f"SM120 sparse MLA decode {name} must have shape [{rows}], "
+                f"got {tuple(lengths.shape)}"
+            )
+        lt = lengths.to(device=q_all.device, dtype=torch.int32).contiguous()
+        # CUDA serving must not read length values back to the host to choose a
+        # kernel. The per-token path reads each token's CLAMPED length in-kernel,
+        # so it is correct for uniform full-width rows and genuinely-short rows;
+        # it only skips the scalar fast path. NOTE: rows==1 is NOT automatically
+        # uniform here -- a single row whose length is SHORTER than the section
+        # width (lt[0] < cap) must still be clamped, so it is per-token, not
+        # scalar.
+        if q_all.is_cuda:
+            return lt, False
+        # Uniform iff every token's CLAMPED length is the full section width: then
+        # the scalar section bound (Int32(cap)) already equals every token's length
+        # -> byte-identical scalar path. A length >= cap clamps to cap in-kernel, so
+        # >= (not ==) is the correct full-section test (seqlen can exceed topk).
+        is_uniform = bool(torch.all(lt >= int(cap)).item())
+        return lt, is_uniform
+
+    swa_len_t, main_uniform = _length_tensor(swa_topk_lengths, "swa_topk_lengths", topk)
+    if has_extra:
+        extra_len_t, extra_uniform = _length_tensor(
+            indexed_topk_lengths, "indexed_topk_lengths", extra_topk
+        )
+    else:
+        extra_len_t, extra_uniform = None, True
+    # Per-token kernel only when there IS a length tensor that is not uniform.
+    per_token_len = (swa_len_t is not None and not main_uniform) or (
+        has_extra and extra_len_t is not None and not extra_uniform
+    )
+    if per_token_len:
+        # Both length tensors must exist for the per-token entries (the kernel reads
+        # topk_length[t] / extra_topk_length[t]). Synthesize a full-length tensor
+        # for whichever section is uniform / unset so the read collapses to topk.
+        if swa_len_t is None:
+            swa_len_t = torch.full(
+                (rows,), topk, dtype=torch.int32, device=q_all.device
+            )
+        if has_extra and extra_len_t is None:
+            extra_len_t = torch.full(
+                (rows,), extra_topk, dtype=torch.int32, device=q_all.device
+            )
+    preferred_num_splits = None
+    if int(model_type) == int(ModelType.DSV4):
+        preferred_num_splits = _dsv4_spark_short_gather_num_splits(
+            rows=rows,
+            heads=heads,
+            num_chunks=num_main_chunks + num_extra_chunks,
+            sm_count=sm_count,
+            native_dsv4_h16=native_dsv4_h16,
+        )
+    num_chunks, num_splits, chunks_per_split = plan_unified_decode_splits(
+        topk=topk,
+        max_chunks=max_chunks,
+        forced_num_splits=forced_num_splits,
+        num_tokens=rows,
+        h_blocks=h_blocks,
+        sm_count=sm_count,
+        extra_topk=extra_topk,
+        preferred_num_splits=preferred_num_splits,
+    )
+    # Side-channel record of the chosen split plan (benchmarks / AutoTuner read
+    # LAST_DECODE_PLAN["num_splits"]). Informational only.
+    native_glm_h8 = bool(
+        int(model_type) == int(ModelType.GLM_NSA)
+        and int(heads) == 8
+        and not has_extra
+        # NVFP4 records (432B, packed E2M1+E4M3) are validated on the generic
+        # HPB=16 arm only; the packed-656B H8 staging would misread them.
+        and int(traits.scale_format) != int(ScaleFormat.NVFP4_E4M3)
+        and _env_glm_h8_native_enabled()
+    )
+    native_h8 = native_glm_h8 or native_dsv4_h8
+    LAST_DECODE_PLAN.clear()
+    LAST_DECODE_PLAN.update(
+        model_type=str(model_type),
+        native_glm_h8=native_glm_h8,
+        native_dsv4_h8=native_dsv4_h8,
+        native_dsv4_h16=native_dsv4_h16,
+        heads_per_block=(8 if native_h8 else 16),
+        math_warps=(4 if native_h8 else 8),
+        block_threads=(
+            160
+            if native_h8
+            else (320 if native_dsv4_h16 else int(traits.block_threads))
+        ),
+        io_warps=(2 if native_dsv4_h16 else 1),
+        kv_stage_packed=native_h8 or native_dsv4_h16,
+        kv_smem_stride=(
+            _GLM_KV_GMEM_STRIDE
+            if native_glm_h8
+            else (
+                _DSV4_PACKED_SMEM_STRIDE
+                if (native_dsv4_h8 or native_dsv4_h16)
+                else int(traits.kv_smem_stride)
+            )
+        ),
+        kv_gmem_stride=int(traits.kv_gmem_stride),
+        fp8_rope=bool(traits.fp8_rope),
+        qk_candidates_per_warp=(16 if (native_h8 or native_dsv4_h16) else 8),
+        qk_swap_ab=native_h8 or native_dsv4_h16,
+        topk=int(topk),
+        extra_topk=int(extra_topk),
+        has_extra=bool(has_extra),
+        num_main_chunks=int(num_main_chunks),
+        num_chunks=int(num_chunks),
+        num_splits=int(num_splits),
+        chunks_per_split=int(chunks_per_split),
+        num_tokens=int(rows),
+        h_blocks=int(h_blocks),
+        sm_count=(int(sm_count) if sm_count else None),
+        per_token_len=bool(per_token_len),
+    )
+    # Workspace mid_out/mid_lse must hold num_splits partials per (token, head).
+    if num_splits > max_chunks:
+        raise ValueError(
+            f"SM120 sparse MLA decode num_splits {num_splits} exceeds workspace "
+            f"max_chunks_per_row {max_chunks}"
+        )
+
+    if workspace.tmp_output is None or workspace.tmp_lse is None:
+        raise RuntimeError(
+            "SM120 sparse MLA decode workspace is missing mid_out/mid_lse"
+        )
+
+    # mid_out / mid_lse views over the workspace split buffers (the merge's
+    # exact tmp_output[rows,heads,chunks,dim] / tmp_lse[rows,heads,chunks]). The
+    # partial O dim is d_v (512) for both models.
+    mid_out = workspace.tmp_output[:rows, :heads, :num_splits, :d_v]
+    mid_lse = workspace.tmp_lse[:rows, :heads, :num_splits]
+
+    stride_kv_block = _cache_block_stride_bytes(
+        swa_k_cache,
+        page_size=int(swa_page_size),
+        model_type=int(model_type),
+        record_bytes=int(traits.kv_gmem_stride),
+    )
+
+    # ── EXTRA (indexed) cache views. When there is no extra cache they alias the
+    #    main cache / main indices and the kernel's has_extra=False const_expr
+    #    elides the extra-section reads -> PTX byte-identical. ──
+    if has_extra:
+        pbs_extra = int(indexed_page_size)
+        stride_extra_kv_block = _cache_block_stride_bytes(
+            indexed_k_cache,
+            page_size=pbs_extra,
+            model_type=int(model_type),
+        )
+        extra_kv_flat = _cache_base_tensor(indexed_k_cache)
+        extra_indices_t = indexed_indices.contiguous()
+    else:
+        pbs_extra = 1
+        stride_extra_kv_block = 0
+        extra_kv_flat = _cache_base_tensor(
+            swa_k_cache
+        )  # alias (never read when has_extra=False)
+        extra_indices_t = swa_indices  # alias (never read)
+
+    if out is not None:
+        if tuple(out.shape) != (rows, heads, d_v):
+            raise ValueError(
+                f"SM120 sparse MLA decode out must have shape "
+                f"{(rows, heads, d_v)}, got {tuple(out.shape)}"
+            )
+        if out.dtype != torch.bfloat16:
+            raise TypeError(
+                f"SM120 sparse MLA decode out must be bfloat16, got {out.dtype}"
+            )
+        if out.device != q_all.device:
+            raise ValueError(
+                "SM120 sparse MLA decode out must be on the same device as q_all"
+            )
+        if not out.is_contiguous():
+            raise ValueError("SM120 sparse MLA decode out must be contiguous")
+        output = out
+    else:
+        output = workspace.output_buffer[:rows, :heads, :d_v]
+
+    kv_flat = _cache_base_tensor(swa_k_cache)
+    swa_len_for_op = swa_len_t if swa_len_t is not None else swa_indices
+    extra_len_for_op = extra_len_t if extra_len_t is not None else swa_indices
+
+    def _launch_grid(grid_h_blocks: int, valid_hpb: int, head_block_offset: int):
+        torch.ops.flashinfer_sm12x.sparse_mla_sm120_decode_grid(
+            q_all,
+            kv_flat,
+            swa_indices,
+            mid_out,
+            mid_lse,
+            swa_len_for_op,
+            extra_kv_flat,
+            extra_indices_t,
+            extra_len_for_op,
+            float(sm_scale),
+            float(latent_scale),
+            int(model_type),
+            int(traits.compute_mode),
+            int(traits.scale_format),
+            bool(traits.fp8_rope),
+            int(swa_page_size),
+            int(topk),
+            int(extra_topk),
+            int(num_main_chunks),
+            int(num_splits),
+            int(chunks_per_split),
+            int(stride_kv_block),
+            int(pbs_extra),
+            int(stride_extra_kv_block),
+            int(grid_h_blocks),
+            int(valid_hpb),
+            int(head_block_offset),
+            bool(has_extra),
+            bool(per_token_len),
+        )
+
+    if h_blocks_full > 0:
+        # FULL HPB=16 head-blocks (the base path when heads is a multiple of 16).
+        _launch_grid(h_blocks_full, hpb, 0)
+    if rem_heads:
+        # REMAINDER tail head-block: a 1-block grid with valid_hpb=rem_heads at
+        # head_block offset h_blocks_full (so head_base = h_blocks_full*16).
+        _launch_grid(1, rem_heads, h_blocks_full)
+
+    # ── REUSED base-2 merge over the split axis -> final O. num_splits=1 is the
+    #    trivial 1-split merge (partial == final O). ──
+    from .merge import (
+        build_sparse_mla_split_decode_merge_binding,
+        run_sparse_mla_split_decode_merge,
+    )
+
+    # When attn_sink is supplied, the merge SELECTS the sink-folding merge kernel
+    # (merge.py SparseMLASplitDecodeSinkMergeKernel) which applies the FlashMLA V4
+    # fold output *= sigmoid(lse_e - sink) directly into O (exactly upstream's
+    # sink-in-merge design, sparse_mla_sm120_decode_dsv4.cu:128-129). With no sink
+    # it is the plain base-2 merge -> PTX/numerics byte-identical to the base path.
+    merge_binding = build_sparse_mla_split_decode_merge_binding(
+        tmp_output=mid_out,
+        tmp_lse=mid_lse,
+        num_chunks_ptr=workspace.num_chunks_ptr,
+        output=output,
+        num_chunks=num_splits,
+        attn_sink=attn_sink,
+        scratch=workspace,
+    )
+    run_sparse_mla_split_decode_merge(binding=merge_binding)
+    if not return_lse:
+        return output
+
+    # return_lse: reconstruct the FINAL LSE from the per-split base-2 mid_lse
+    # (logsumexp over the split axis, base2->natural). mid_lse aliases
+    # workspace.tmp_lse[:rows,:heads,:num_splits], so reuse the shared helper.
+    from flashinfer.experimental.sm12x.attention._shared.mla.api import (
+        _final_lse_from_split_workspace,
+    )
+
+    lse_natural = _final_lse_from_split_workspace(
+        workspace=workspace,
+        q_rows=rows,
+        num_heads=heads,
+        launch_num_chunks=num_splits,
+        scale="natural",
+    )
+    if attn_sink is not None:
+        # Fold the per-head sink into the LSE in the natural-log domain (the merge
+        # already folded it into O): lse' = log(exp(lse) + exp(sink)).
+        sink = attn_sink.float().view(1, heads)
+        lse_natural = torch.logaddexp(lse_natural.float(), sink)
+    if lse_scale == "base2":
+        return output, (lse_natural / _LN2)
+    return output, lse_natural
+
+
+def run_unified_prefill(*args, **kwargs):
+    """Active SM120 sparse-MLA DSV4 prefill (P8).
+
+    Thin re-export of ``prefill.run_unified_prefill`` (the correctness-first
+    single-pass DSV4 prefill that REUSES the proven 288-thread / 1-IO-warp decode
+    pipeline with a FINAL_BF16 epilogue). Imported lazily so launch.py has no hard
+    dependency on the prefill module's CuTe symbols at import time."""
+    from .prefill import run_unified_prefill as _impl
+
+    return _impl(*args, **kwargs)

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/kv_cache.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/kv_cache.py
@@ -1,0 +1,493 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/kv_cache.py @ 345dd0a6 (2026-07-18) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""nvfp4_ds_mla KV_FP8_ROPE=1 record writer (SM120).
+
+``concat_and_cache_nvfp4_mla_fp8_rope`` quantizes the MLA compressed latent
+(512 16-bit dims) plus the decoupled RoPE key (64 dims) into the compact
+368 B/token ``nvfp4_ds_mla`` record that this package's fp8-RoPE sparse-MLA
+readers consume (``traits.kv_gmem_stride == 368``; offsets anchored by
+``prefill_mg._NVFP4_FP8_ROPE_SCALE_OFFSET == 288`` and
+``prefill_mg._NVFP4_ROPE_GMEM_OFFSET == 304``):
+
+    [   0, 256)  packed E2M1 NoPE (512 x 4-bit, 32 group-16 blocks)
+    [ 256, 288)  32 x E4M3 group scale bytes (group amax / 6.0)
+    [ 288, 292)  fp32 RoPE scale (rope amax / 448.0)
+    [ 292, 304)  zero pad
+    [ 304, 368)  64 x E4M3 RoPE
+
+This is the KV_FP8_ROPE=1 layout: the stock 432 B record's [288, 304) pad
+carries the fp32 RoPE scale and the RoPE bytes stay at their stock offset,
+re-encoded E4M3 (128 B BF16 -> 64 B E4M3), so the record shrinks in place.
+
+One CTA per token; ``slot_mapping`` entries < 0 are skipped (padded CUDA
+graph slots). The quantization recipe is the standard NVFP4 one at an
+implicit global scale of 1.0, spelled with the same PTX conversions the
+rest of this package uses: ``amax * rcp.approx.ftz(6.0)`` ->
+``cvt.rn.satfinite.e4m3x2`` scale byte -> hardware-exact E4M3 decode
+(``cvt.rn.f16x2.e4m3x2`` -- denormal-correct, the same decode the read
+path applies) -> ``rcp.approx.ftz`` inverse ->
+``cvt.rn.satfinite.e2m1x2`` packing (``quantize_and_pack_16_fast``).
+
+The RoPE lane stores ``scale = amax / 448.0`` as fp32 at [288, 292) and
+``cvt.rn.satfinite.e4m3x2(v / scale)`` bytes at [304, 368); the readers
+reconstruct ``e4m3_decode(byte) * scale``
+(``prefill_mg._ld_global_nvfp4_fp8_rope_bfloat2``).
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Float32, Int32, Int64, Uint32, Uint64
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    launch as sm12x_launch,
+    tensor_compile_fact,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    cvt_e4m3_to_f32_via_f16,
+    cvt_f32_to_e4m3,
+    cvt_f32x4_to_e4m3x4,
+    f16x2_to_f32x2,
+    fabs_f32,
+    fmax_f32,
+    get_ptr_as_int64,
+    max_abs_16,
+    quantize_and_pack_16_fast,
+    rcp_approx_ftz,
+    st_global_f32,
+    st_global_u64,
+    st_global_u8,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+
+_KV_LORA_RANK = 512
+_PE_DIM = 64
+_GROUP_SIZE = 16
+_NUM_GROUPS = _KV_LORA_RANK // _GROUP_SIZE  # 32
+_NOPE_BYTES = _KV_LORA_RANK // 2  # 256
+_SCALE_BYTES = _NUM_GROUPS  # 32
+# KV_FP8_ROPE=1 record geometry (matches the shipped readers: fp32 scale in
+# the stock record's pad, E4M3 RoPE at the stock RoPE offset).
+_ROPE_SCALE_OFFSET = _NOPE_BYTES + _SCALE_BYTES  # 288
+_PAD_OFFSET = _ROPE_SCALE_OFFSET + 4  # 292
+_PAD_BYTES = 12
+_ROPE_OFFSET = _PAD_OFFSET + _PAD_BYTES  # 304
+_RECORD_BYTES = _ROPE_OFFSET + _PE_DIM  # 368
+_THREADS = 128
+# E4M3 rope scale: exact compile-time f32 constant (double 1/448 rounded to
+# f32 once), NOT a runtime rcp.approx -- torch references must mirror this.
+_E4M3_MAX_RCP = 1.0 / 448.0
+
+
+@dsl_user_op
+def _ld_global_u32(base_ptr: Int64, *, loc=None, ip=None) -> Uint32:
+    """Plain (coherent) 32-bit global load."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+            "ld.global.b32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _bf16x2_to_f32x2(bf2: Uint32, *, loc=None, ip=None):
+    """Exact promotion of packed bfloat16x2 to two float32 (no scaling)."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(bf2).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 lo, hi;
+            and.b32 lo, $2, 0xFFFF;
+            shr.b32 hi, $2, 16;
+            shl.b32 lo, lo, 16;
+            shl.b32 hi, hi, 16;
+            mov.b32 $0, lo;
+            mov.b32 $1, hi;
+        }
+        """,
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    f0 = llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)
+    f1 = llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)
+    return Float32(f0), Float32(f1)
+
+
+class ConcatAndCacheNvfp4MlaFp8RopeKernel:
+    """Per-token KV_FP8_ROPE=1 nvfp4_ds_mla record writer.
+
+    Thread mapping (128 threads/CTA): threads 0-31 quantize one 16-dim
+    group each (eight coherent 32-bit loads -> exact f32 promote -> E2M1
+    pack + E4M3 scale byte); threads 0-11 zero the [292, 304) pad; thread
+    32 quantizes the RoPE lane to E4M3 with one fp32 per-token scale.
+    """
+
+    def __init__(self, block_size: int, is_bf16: bool):
+        self.block_size = int(block_size)
+        self.is_bf16 = bool(is_bf16)
+
+    @cute.jit
+    def __call__(
+        self,
+        kv_c: cute.Tensor,  # (num_tokens, 512) bf16/f16
+        k_pe: cute.Tensor,  # (num_tokens, 64) bf16/f16
+        kv_cache: cute.Tensor,  # (num_blocks, block_size, 368) u8
+        slot_mapping: cute.Tensor,  # (num_tokens, 1) int64
+        kv_c_stride: Int32,  # kv_c.stride(0), elements
+        k_pe_stride: Int32,  # k_pe.stride(0), elements
+        block_stride: Int64,  # kv_cache.stride(0), bytes
+        entry_stride: Int32,  # kv_cache.stride(1), bytes
+        slot_capacity: Int32,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            kv_c,
+            k_pe,
+            kv_cache,
+            slot_mapping,
+            kv_c_stride,
+            k_pe_stride,
+            block_stride,
+            entry_stride,
+            slot_capacity,
+        ).launch(
+            grid=(num_tokens, 1, 1),
+            block=[_THREADS, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        kv_c: cute.Tensor,
+        k_pe: cute.Tensor,
+        kv_cache: cute.Tensor,
+        slot_mapping: cute.Tensor,
+        kv_c_stride: Int32,
+        k_pe_stride: Int32,
+        block_stride: Int64,
+        entry_stride: Int32,
+        slot_capacity: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        token_idx, _, _ = cute.arch.block_idx()
+        tid = Int32(tidx)
+        token = Int32(token_idx)
+
+        slot = Int64(slot_mapping[token])
+        if (slot >= Int64(0)) & (slot < slot_capacity.to(Int64)):
+            # Capacity is host-asserted in (0, 2^31), so the block/offset
+            # split is safe in Int32 after the Int64 bounds check.
+            slot32 = slot.to(Int32)
+            block_idx = slot32 // Int32(self.block_size)
+            block_off = slot32 % Int32(self.block_size)
+            dst = (
+                get_ptr_as_int64(kv_cache, 0)
+                + block_idx.to(Int64) * block_stride
+                + (block_off * entry_stride).to(Int64)
+            )
+
+            # --- NoPE: one 16-dim group per thread -> 8 B E2M1 + 1 scale byte.
+            if tid < Int32(_NUM_GROUPS):
+                src_elem = token * kv_c_stride + tid * Int32(_GROUP_SIZE)
+                vals = cute.make_rmem_tensor((_GROUP_SIZE,), Float32)
+                for i in cutlass.range_constexpr(_GROUP_SIZE // 2):
+                    pair = _ld_global_u32(
+                        get_ptr_as_int64(kv_c, src_elem + Int32(2 * i))
+                    )
+                    if cutlass.const_expr(self.is_bf16):
+                        f0, f1 = _bf16x2_to_f32x2(pair)
+                    else:
+                        f0, f1 = f16x2_to_f32x2(pair)
+                    vals[2 * i] = f0
+                    vals[2 * i + 1] = f1
+
+                # NVFP4 block quant at global scale 1.0: scale byte =
+                # e4m3(amax/6); values scaled by rcp.approx.ftz of the
+                # hardware-exact decode of that byte (what the reader
+                # multiplies back), then satfinite E2M1.
+                group_amax = max_abs_16(vals)
+                scale_f32 = group_amax * rcp_approx_ftz(Float32(6.0))
+                scale_u32 = cvt_f32_to_e4m3(scale_f32)
+                decoded_scale = cvt_e4m3_to_f32_via_f16(scale_u32)
+                packed64 = Uint64(0)
+                if decoded_scale != Float32(0.0):
+                    packed64 = quantize_and_pack_16_fast(
+                        vals, rcp_approx_ftz(decoded_scale)
+                    )
+                st_global_u64(dst + (tid * Int32(8)).to(Int64), packed64)
+                st_global_u8(
+                    dst + Int64(_NOPE_BYTES) + tid.to(Int64),
+                    cutlass.Uint8(scale_u32 & Uint32(0xFF)),
+                )
+
+            # --- Zero pad [292, 304).
+            if tid < Int32(_PAD_BYTES):
+                st_global_u8(
+                    dst + Int64(_PAD_OFFSET) + tid.to(Int64),
+                    cutlass.Uint8(0),
+                )
+
+            # --- RoPE lane: amax -> fp32 scale at [288, 292) -> satfinite
+            # E4M3 bytes at [304, 368).
+            if tid == Int32(_NUM_GROUPS):
+                rope_vals = cute.make_rmem_tensor((_PE_DIM,), Float32)
+                for i in cutlass.range_constexpr(_PE_DIM // 2):
+                    pair = _ld_global_u32(
+                        get_ptr_as_int64(k_pe, token * k_pe_stride + Int32(2 * i))
+                    )
+                    if cutlass.const_expr(self.is_bf16):
+                        f0, f1 = _bf16x2_to_f32x2(pair)
+                    else:
+                        f0, f1 = f16x2_to_f32x2(pair)
+                    rope_vals[2 * i] = f0
+                    rope_vals[2 * i + 1] = f1
+                rope_amax = Float32(0.0)
+                for i in cutlass.range_constexpr(_PE_DIM):
+                    rope_amax = fmax_f32(rope_amax, fabs_f32(rope_vals[i]))
+                rope_scale = rope_amax * Float32(_E4M3_MAX_RCP)
+                st_global_f32(dst + Int64(_ROPE_SCALE_OFFSET), rope_scale)
+                for w in cutlass.range_constexpr(_PE_DIM // 8):
+                    q8 = Uint64(0)
+                    if rope_scale != Float32(0.0):
+                        inv = rcp_approx_ftz(rope_scale)
+                        lo = cvt_f32x4_to_e4m3x4(
+                            rope_vals[8 * w + 0] * inv,
+                            rope_vals[8 * w + 1] * inv,
+                            rope_vals[8 * w + 2] * inv,
+                            rope_vals[8 * w + 3] * inv,
+                        )
+                        hi = cvt_f32x4_to_e4m3x4(
+                            rope_vals[8 * w + 4] * inv,
+                            rope_vals[8 * w + 5] * inv,
+                            rope_vals[8 * w + 6] * inv,
+                            rope_vals[8 * w + 7] * inv,
+                        )
+                        q8 = lo.to(Uint64) | (hi.to(Uint64) << Uint64(32))
+                    st_global_u64(dst + Int64(_ROPE_OFFSET + 8 * w), q8)
+
+
+@lru_cache(maxsize=None)
+def _build_concat_and_cache_nvfp4_mla_fp8_rope_kernel(
+    block_size: int, is_bf16: bool
+) -> ConcatAndCacheNvfp4MlaFp8RopeKernel:
+    return ConcatAndCacheNvfp4MlaFp8RopeKernel(block_size, is_bf16)
+
+
+def clear_nvfp4_mla_fp8_rope_kv_cache_kernel_cache() -> None:
+    _build_concat_and_cache_nvfp4_mla_fp8_rope_kernel.cache_clear()
+
+
+def _torch_to_cutlass_dtype(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float16:
+        return cutlass.Float16
+    if dtype == torch.uint8:
+        return cutlass.Uint8
+    if dtype == torch.int64:
+        return cutlass.Int64
+    raise TypeError(f"unsupported dtype {dtype}")
+
+
+def _to_kernel_tensor(
+    tensor: torch.Tensor,
+    *,
+    assumed_align: int,
+    leading_dim: int,
+) -> cute.Tensor:
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = _torch_to_cutlass_dtype(tensor.dtype)
+    return cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+
+def _concat_and_cache_nvfp4_mla_fp8_rope_flat_launch(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    num_tokens = int(slot_mapping.shape[0])
+    if num_tokens == 0:
+        return
+    block_size = int(kv_cache.shape[1])
+    slot_capacity = int(kv_cache.shape[0]) * block_size
+    is_bf16 = kv_c.dtype == torch.bfloat16
+    kernel = _build_concat_and_cache_nvfp4_mla_fp8_rope_kernel(block_size, is_bf16)
+
+    args = (
+        _to_kernel_tensor(kv_c, assumed_align=4, leading_dim=1),
+        _to_kernel_tensor(k_pe, assumed_align=4, leading_dim=1),
+        _to_kernel_tensor(kv_cache, assumed_align=16, leading_dim=2),
+        _to_kernel_tensor(slot_mapping, assumed_align=8, leading_dim=0),
+        Int32(int(kv_c.stride(0))),
+        Int32(int(k_pe.stride(0))),
+        Int64(int(kv_cache.stride(0))),
+        Int32(int(kv_cache.stride(1))),
+        Int32(slot_capacity),
+        Int32(num_tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_compile_fact("kv_c", kv_c, dynamic_dims=(0,), dynamic_strides=(0,)),
+        tensor_compile_fact("k_pe", k_pe, dynamic_dims=(0,), dynamic_strides=(0,)),
+        tensor_compile_fact(
+            "kv_cache",
+            kv_cache,
+            dynamic_dims=(0,),
+            dynamic_strides=(0, 1),
+        ),
+        tensor_compile_fact("slot_mapping", slot_mapping, dynamic_dims=(0,)),
+        str(kv_c.dtype),
+        block_size,
+    )
+    spec = KernelCompileSpec.from_key(
+        "attention.mla.nvfp4_fp8_rope_kv_cache",
+        2,
+        cache_key,
+        labels=(
+            "kv_c",
+            "k_pe",
+            "kv_cache",
+            "slot_mapping",
+            "kv_dtype",
+            "block_size",
+        ),
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::concat_and_cache_nvfp4_mla_fp8_rope",
+    mutates_args=("kv_cache",),
+)
+def _concat_and_cache_nvfp4_mla_fp8_rope_op(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    _concat_and_cache_nvfp4_mla_fp8_rope_flat_launch(kv_c, k_pe, kv_cache, slot_mapping)
+
+
+@_concat_and_cache_nvfp4_mla_fp8_rope_op.register_fake
+def _concat_and_cache_nvfp4_mla_fp8_rope_fake(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    return None
+
+
+def concat_and_cache_nvfp4_mla_fp8_rope(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    scale: torch.Tensor | None = None,
+) -> None:
+    """Write ``num_tokens`` KV_FP8_ROPE=1 nvfp4_ds_mla records.
+
+    :param kv_c: MLA compressed latent, ``(>= num_tokens, 512)`` bf16/f16.
+    :param k_pe: decoupled RoPE key, ``(>= num_tokens, 64)``, same dtype.
+    :param kv_cache: paged cache viewed ``(num_blocks, block_size, 368)``
+        uint8; mutated in place.
+    :param slot_mapping: ``(num_tokens,)`` int64 flat slot ids; entries outside
+        ``[0, num_blocks * block_size)`` are skipped.
+    :param scale: accepted for signature parity with the fp8 cache-op
+        family; the nvfp4_ds_mla record has an implicit global scale of 1.0
+        (group scales carry all magnitude), so it is unused.
+    """
+    del scale
+    if kv_c.ndim != 2 or int(kv_c.shape[1]) != _KV_LORA_RANK:
+        raise ValueError(
+            f"kv_c must be (num_tokens, {_KV_LORA_RANK}), got {tuple(kv_c.shape)}"
+        )
+    if k_pe.ndim != 2 or int(k_pe.shape[1]) != _PE_DIM:
+        raise ValueError(
+            f"k_pe must be (num_tokens, {_PE_DIM}), got {tuple(k_pe.shape)}"
+        )
+    if kv_c.dtype not in (torch.bfloat16, torch.float16):
+        raise TypeError(f"kv_c must be bf16/f16, got {kv_c.dtype}")
+    if k_pe.dtype != kv_c.dtype:
+        raise TypeError(f"k_pe dtype {k_pe.dtype} must match kv_c dtype {kv_c.dtype}")
+    if kv_cache.ndim != 3 or int(kv_cache.shape[2]) != _RECORD_BYTES:
+        raise ValueError(
+            "kv_cache must be (num_blocks, block_size, "
+            f"{_RECORD_BYTES}) uint8, got {tuple(kv_cache.shape)}"
+        )
+    if int(kv_cache.shape[0]) <= 0 or int(kv_cache.shape[1]) <= 0:
+        raise ValueError("kv_cache num_blocks and block_size must be positive")
+    if kv_cache.dtype != torch.uint8:
+        raise TypeError(f"kv_cache must be uint8, got {kv_cache.dtype}")
+    if slot_mapping.ndim != 1 or slot_mapping.dtype != torch.int64:
+        raise TypeError(
+            "slot_mapping must be a 1-D int64 tensor, got "
+            f"{tuple(slot_mapping.shape)} {slot_mapping.dtype}"
+        )
+    if not slot_mapping.is_contiguous():
+        raise ValueError("slot_mapping must be contiguous")
+    num_tokens = int(slot_mapping.shape[0])
+    if int(kv_c.shape[0]) < num_tokens or int(k_pe.shape[0]) < num_tokens:
+        raise ValueError(
+            f"kv_c/k_pe must cover slot_mapping's {num_tokens} tokens, got "
+            f"{int(kv_c.shape[0])}/{int(k_pe.shape[0])} rows"
+        )
+    if kv_c.stride(1) != 1 or k_pe.stride(1) != 1 or kv_cache.stride(2) != 1:
+        raise ValueError(
+            "kv_c/k_pe rows and kv_cache records must be innermost-contiguous"
+        )
+    if kv_c.stride(0) % 2 != 0 or kv_c.data_ptr() % 4 != 0:
+        # The group loads are 32-bit (element pairs), same as the CUDA writer.
+        raise ValueError("kv_c rows must be 4-byte aligned (even row stride)")
+    if k_pe.stride(0) % 2 != 0 or k_pe.data_ptr() % 4 != 0:
+        raise ValueError("k_pe rows must be 4-byte aligned (even row stride)")
+    if (
+        kv_cache.data_ptr() % 16 != 0
+        or kv_cache.stride(0) % 16 != 0
+        or kv_cache.stride(1) % 16 != 0
+    ):
+        raise ValueError("kv_cache records must be 16-byte aligned")
+    if int(kv_cache.shape[0]) * int(kv_cache.shape[1]) >= 2**31:
+        raise ValueError("kv_cache slot capacity must fit in int32")
+    if not (
+        kv_c.is_cuda and k_pe.is_cuda and kv_cache.is_cuda and slot_mapping.is_cuda
+    ):
+        raise ValueError("all tensors must be on CUDA")
+    if len({kv_c.device, k_pe.device, kv_cache.device, slot_mapping.device}) != 1:
+        raise ValueError("all tensors must be on the same device")
+
+    torch.ops.flashinfer_sm12x.concat_and_cache_nvfp4_mla_fp8_rope(
+        kv_c, k_pe, kv_cache, slot_mapping
+    )

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/merge.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/merge.py
@@ -1,0 +1,807 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/merge.py @ 17428af5 (2026-07-01) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Split-axis merge for the active sparse MLA SM120 kernels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Float32, Int32
+from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as attention_ops
+from flashinfer.experimental.sm12x.attention._shared.workspace import _SPLIT_MAX_CHUNKS
+from flashinfer.experimental.sm12x._lib.compiler import (
+    DimKey,
+    KernelCompileSpec,
+    launch as sm12x_launch,
+    tensor_compile_fact,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+
+from .decode_math import _exp2_approx_ftz_f32
+from .reference import _MLA_GROUP_SIZE, _MLA_NOPE_DIM
+
+
+_MLA_SCALE_GROUPS = _MLA_NOPE_DIM // _MLA_GROUP_SIZE
+_MLA_WARP_THREADS = 32
+
+
+def _raise_binding_extras(api_name: str, extras: list[str]) -> None:
+    raise ValueError(
+        f"{api_name} binding owns runtime tensors, scratch, and kernel options; "
+        f"do not also pass {', '.join(extras)}"
+    )
+
+
+def _require_bound_arg(value, *, api_name: str, name: str):
+    if value is None:
+        raise TypeError(f"{api_name} requires {name} or binding")
+    return value
+
+
+@dataclass(frozen=True, kw_only=True)
+class SparseMLASplitDecodeMergeBinding:
+    tmp_output: torch.Tensor
+    tmp_lse: torch.Tensor
+    num_chunks_ptr: torch.Tensor
+    output: torch.Tensor
+    num_chunks: int | None = None
+    attn_sink: torch.Tensor | None = None
+    scratch: object | None = None
+
+    def run(self) -> None:
+        run_sparse_mla_split_decode_merge(binding=self)
+
+
+def build_sparse_mla_split_decode_merge_binding(
+    *,
+    tmp_output: torch.Tensor,
+    tmp_lse: torch.Tensor,
+    num_chunks_ptr: torch.Tensor,
+    output: torch.Tensor,
+    num_chunks: int | None = None,
+    attn_sink: torch.Tensor | None = None,
+    scratch: object | None = None,
+) -> SparseMLASplitDecodeMergeBinding:
+    return SparseMLASplitDecodeMergeBinding(
+        tmp_output=tmp_output,
+        tmp_lse=tmp_lse,
+        num_chunks_ptr=num_chunks_ptr,
+        output=output,
+        num_chunks=num_chunks,
+        attn_sink=attn_sink,
+        scratch=scratch,
+    )
+
+
+def _validate_tensor_storage_bounds(tensor: torch.Tensor, *, name: str) -> None:
+    if tensor.numel() == 0:
+        return
+    min_offset = int(tensor.storage_offset())
+    max_offset = int(tensor.storage_offset())
+    for size, stride in zip(tensor.shape, tensor.stride(), strict=True):
+        extent = (int(size) - 1) * int(stride)
+        if extent >= 0:
+            max_offset += extent
+        else:
+            min_offset += extent
+    storage_elems = tensor.untyped_storage().nbytes() // tensor.element_size()
+    if min_offset < 0 or max_offset >= storage_elems:
+        raise ValueError(
+            f"{name} view is out of storage bounds: shape={tuple(tensor.shape)} "
+            f"stride={tuple(tensor.stride())} storage_offset={int(tensor.storage_offset())} "
+            f"storage_elems={storage_elems}"
+        )
+
+
+def _validate_split_control_tensor(
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    device: torch.device,
+) -> None:
+    if tensor.shape != (1,):
+        raise ValueError(f"{name} must have shape (1,), got {tuple(tensor.shape)}")
+    if tensor.dtype != torch.int32:
+        raise TypeError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+    if tensor.device != device:
+        raise ValueError(f"{name} must be on {device}, got {tensor.device}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _torch_to_cutlass_dtype(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float16:
+        return cutlass.Float16
+    if dtype == torch.float32:
+        return cutlass.Float32
+    if dtype == torch.int32:
+        return cutlass.Int32
+    if dtype == torch.uint8:
+        return cutlass.Uint8
+    if dtype == torch.uint32:
+        return cutlass.Uint32
+    raise TypeError(f"unsupported dtype {dtype}")
+
+
+def _to_kernel_tensor(
+    tensor: torch.Tensor,
+    dtype: type[cutlass.Numeric],
+    *,
+    assumed_align: int = 16,
+) -> cute.Tensor:
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = dtype
+    leading_dim = next(
+        (idx for idx, stride in enumerate(tensor.stride()) if stride == 1), None
+    )
+    if leading_dim is not None and tensor.ndim >= 2:
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+    return cute_tensor
+
+
+def _tensor_meta_key(
+    tensor: torch.Tensor,
+    *,
+    dynamic_dims: tuple[int, ...] = (),
+) -> tuple[tuple[object, ...], tuple[int, ...], str, tuple[str, int | None]]:
+    dynamic_dim_set = set(dynamic_dims)
+    return (
+        tuple(
+            DimKey.dynamic() if idx in dynamic_dim_set else int(dim)
+            for idx, dim in enumerate(tensor.shape)
+        ),
+        tuple(tensor.stride()),
+        str(tensor.dtype),
+        (tensor.device.type, tensor.device.index),
+    )
+
+
+def _tensor_compile_key(
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    dynamic_dims: tuple[int, ...] = (),
+    dynamic_strides: tuple[int, ...] = (),
+) -> tuple[object, ...]:
+    return tensor_compile_fact(
+        name,
+        tensor,
+        dynamic_dims=dynamic_dims,
+        dynamic_strides=dynamic_strides,
+    )
+
+
+@cute.jit
+def _split_output_lane_view(
+    tmp_output: cute.Tensor,
+    q_idx: Int32,
+    head_idx: Int32,
+    out_base: Int32,
+) -> cute.Tensor:
+    return cute.make_tensor(
+        attention_ops.elem_pointer(tmp_output, (q_idx, head_idx, Int32(0), out_base)),
+        cute.make_layout(
+            (tmp_output.shape[2], 4),
+            stride=(tmp_output.stride[2], 1),
+        ),
+    )
+
+
+@cute.jit
+def _split_lse_head_view(
+    tmp_lse: cute.Tensor,
+    q_idx: Int32,
+    head_idx: Int32,
+) -> cute.Tensor:
+    return cute.make_tensor(
+        attention_ops.elem_pointer(tmp_lse, (q_idx, head_idx, Int32(0))),
+        cute.make_layout(
+            (tmp_lse.shape[2],),
+            stride=(tmp_lse.stride[2],),
+        ),
+    )
+
+
+class SparseMLASplitDecodeMergeKernel:
+    """Reduce normalized chunk partials into the final decode output."""
+
+    def __init__(self, static_num_chunks: int | None = None):
+        self.static_num_chunks = static_num_chunks
+
+    @cute.jit
+    def __call__(
+        self,
+        tmp_output: cute.Tensor,
+        tmp_lse: cute.Tensor,
+        num_chunks_ptr: cute.Tensor,
+        output: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            tmp_output,
+            tmp_lse,
+            num_chunks_ptr,
+            output,
+        ).launch(
+            grid=(output.shape[0], output.shape[1], _MLA_SCALE_GROUPS),
+            block=[_MLA_WARP_THREADS, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tmp_output: cute.Tensor,
+        tmp_lse: cute.Tensor,
+        num_chunks_ptr: cute.Tensor,
+        output: cute.Tensor,
+    ):
+        lane = cute.arch.lane_idx()
+        q_idx, head_idx, group_idx = cute.arch.block_idx()
+        q_idx = Int32(q_idx)
+        head_idx = Int32(head_idx)
+        group_idx = Int32(group_idx)
+
+        acc = cute.make_rmem_tensor((4,), Float32)
+        for frag_idx in cutlass.range_constexpr(4):
+            acc[frag_idx] = Float32(0.0)
+
+        out_base = group_idx * Int32(_MLA_GROUP_SIZE) + lane * Int32(4)
+        tmp_output_lane = _split_output_lane_view(tmp_output, q_idx, head_idx, out_base)
+        tmp_lse_head = _split_lse_head_view(tmp_lse, q_idx, head_idx)
+        merged_m = Float32(-Float32.inf)
+        merged_d = Float32(1.0)
+        chunk_idx = Int32(0)
+        if cutlass.const_expr(self.static_num_chunks is None):
+            num_chunks = Int32(num_chunks_ptr[Int32(0)])
+        else:
+            num_chunks = Int32(self.static_num_chunks)
+        if num_chunks > Int32(_SPLIT_MAX_CHUNKS):
+            num_chunks = Int32(_SPLIT_MAX_CHUNKS)
+
+        while chunk_idx < num_chunks and merged_m == Float32(-Float32.inf):
+            part_lse = Float32(tmp_lse_head[chunk_idx])
+            if part_lse != Float32(-Float32.inf):
+                acc[0] = Float32(tmp_output_lane[chunk_idx, Int32(0)])
+                acc[1] = Float32(tmp_output_lane[chunk_idx, Int32(1)])
+                acc[2] = Float32(tmp_output_lane[chunk_idx, Int32(2)])
+                acc[3] = Float32(tmp_output_lane[chunk_idx, Int32(3)])
+                merged_m = Float32(part_lse)
+                merged_d = Float32(1.0)
+            chunk_idx += Int32(1)
+
+        while chunk_idx < num_chunks:
+            part_lse = Float32(tmp_lse_head[chunk_idx])
+            if part_lse != Float32(-Float32.inf):
+                new_m = attention_ops.fmax(merged_m, part_lse)
+                prev_scale = _exp2_approx_ftz_f32(merged_m - new_m)
+                part_scale = _exp2_approx_ftz_f32(part_lse - new_m)
+                merged_d = Float32(merged_d * prev_scale + part_scale)
+                acc[0] = Float32(
+                    acc[0] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(0)]) * part_scale
+                )
+                acc[1] = Float32(
+                    acc[1] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(1)]) * part_scale
+                )
+                acc[2] = Float32(
+                    acc[2] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(2)]) * part_scale
+                )
+                acc[3] = Float32(
+                    acc[3] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(3)]) * part_scale
+                )
+                merged_m = Float32(new_m)
+            chunk_idx += Int32(1)
+
+        if merged_m == Float32(-Float32.inf):
+            output[q_idx, head_idx, out_base + Int32(0)] = Float32(0.0).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(1)] = Float32(0.0).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(2)] = Float32(0.0).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(3)] = Float32(0.0).to(
+                output.element_type
+            )
+        else:
+            inv_d = cute.arch.rcp_approx(merged_d)
+            output[q_idx, head_idx, out_base + Int32(0)] = Float32(acc[0] * inv_d).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(1)] = Float32(acc[1] * inv_d).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(2)] = Float32(acc[2] * inv_d).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(3)] = Float32(acc[3] * inv_d).to(
+                output.element_type
+            )
+
+
+class SparseMLASplitDecodeSinkMergeKernel:
+    """Reduce chunk partials and fold a zero-value attention sink into softmax."""
+
+    def __init__(self, static_num_chunks: int | None = None):
+        self.static_num_chunks = static_num_chunks
+
+    @cute.jit
+    def __call__(
+        self,
+        tmp_output: cute.Tensor,
+        tmp_lse: cute.Tensor,
+        num_chunks_ptr: cute.Tensor,
+        attn_sink: cute.Tensor,
+        output: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            tmp_output,
+            tmp_lse,
+            num_chunks_ptr,
+            attn_sink,
+            output,
+        ).launch(
+            grid=(output.shape[0], output.shape[1], _MLA_SCALE_GROUPS),
+            block=[_MLA_WARP_THREADS, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tmp_output: cute.Tensor,
+        tmp_lse: cute.Tensor,
+        num_chunks_ptr: cute.Tensor,
+        attn_sink: cute.Tensor,
+        output: cute.Tensor,
+    ):
+        lane = cute.arch.lane_idx()
+        q_idx, head_idx, group_idx = cute.arch.block_idx()
+        q_idx = Int32(q_idx)
+        head_idx = Int32(head_idx)
+        group_idx = Int32(group_idx)
+
+        acc = cute.make_rmem_tensor((4,), Float32)
+        for frag_idx in cutlass.range_constexpr(4):
+            acc[frag_idx] = Float32(0.0)
+
+        out_base = group_idx * Int32(_MLA_GROUP_SIZE) + lane * Int32(4)
+        tmp_output_lane = _split_output_lane_view(tmp_output, q_idx, head_idx, out_base)
+        tmp_lse_head = _split_lse_head_view(tmp_lse, q_idx, head_idx)
+        merged_m = Float32(-Float32.inf)
+        merged_d = Float32(1.0)
+        chunk_idx = Int32(0)
+        if cutlass.const_expr(self.static_num_chunks is None):
+            num_chunks = Int32(num_chunks_ptr[Int32(0)])
+        else:
+            num_chunks = Int32(self.static_num_chunks)
+        if num_chunks > Int32(_SPLIT_MAX_CHUNKS):
+            num_chunks = Int32(_SPLIT_MAX_CHUNKS)
+
+        while chunk_idx < num_chunks and merged_m == Float32(-Float32.inf):
+            part_lse = Float32(tmp_lse_head[chunk_idx])
+            if part_lse != Float32(-Float32.inf):
+                acc[0] = Float32(tmp_output_lane[chunk_idx, Int32(0)])
+                acc[1] = Float32(tmp_output_lane[chunk_idx, Int32(1)])
+                acc[2] = Float32(tmp_output_lane[chunk_idx, Int32(2)])
+                acc[3] = Float32(tmp_output_lane[chunk_idx, Int32(3)])
+                merged_m = Float32(part_lse)
+                merged_d = Float32(1.0)
+            chunk_idx += Int32(1)
+
+        while chunk_idx < num_chunks:
+            part_lse = Float32(tmp_lse_head[chunk_idx])
+            if part_lse != Float32(-Float32.inf):
+                new_m = attention_ops.fmax(merged_m, part_lse)
+                prev_scale = _exp2_approx_ftz_f32(merged_m - new_m)
+                part_scale = _exp2_approx_ftz_f32(part_lse - new_m)
+                merged_d = Float32(merged_d * prev_scale + part_scale)
+                acc[0] = Float32(
+                    acc[0] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(0)]) * part_scale
+                )
+                acc[1] = Float32(
+                    acc[1] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(1)]) * part_scale
+                )
+                acc[2] = Float32(
+                    acc[2] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(2)]) * part_scale
+                )
+                acc[3] = Float32(
+                    acc[3] * prev_scale
+                    + Float32(tmp_output_lane[chunk_idx, Int32(3)]) * part_scale
+                )
+                merged_m = Float32(new_m)
+            chunk_idx += Int32(1)
+
+        if merged_m == Float32(-Float32.inf):
+            output[q_idx, head_idx, out_base + Int32(0)] = Float32(0.0).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(1)] = Float32(0.0).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(2)] = Float32(0.0).to(
+                output.element_type
+            )
+            output[q_idx, head_idx, out_base + Int32(3)] = Float32(0.0).to(
+                output.element_type
+            )
+        else:
+            sink_m = Float32(attn_sink[head_idx] * attention_ops.LOG2_E)
+            new_m = attention_ops.fmax(merged_m, sink_m)
+            prev_scale = _exp2_approx_ftz_f32(merged_m - new_m)
+            sink_scale = _exp2_approx_ftz_f32(sink_m - new_m)
+            merged_d = Float32(merged_d * prev_scale + sink_scale)
+            inv_d = cute.arch.rcp_approx(merged_d)
+            output[q_idx, head_idx, out_base + Int32(0)] = Float32(
+                acc[0] * prev_scale * inv_d
+            ).to(output.element_type)
+            output[q_idx, head_idx, out_base + Int32(1)] = Float32(
+                acc[1] * prev_scale * inv_d
+            ).to(output.element_type)
+            output[q_idx, head_idx, out_base + Int32(2)] = Float32(
+                acc[2] * prev_scale * inv_d
+            ).to(output.element_type)
+            output[q_idx, head_idx, out_base + Int32(3)] = Float32(
+                acc[3] * prev_scale * inv_d
+            ).to(output.element_type)
+
+
+@lru_cache(maxsize=None)
+def _build_sparse_mla_split_merge_kernel(
+    static_num_chunks: int | None = None,
+) -> SparseMLASplitDecodeMergeKernel:
+    return SparseMLASplitDecodeMergeKernel(static_num_chunks)
+
+
+@lru_cache(maxsize=None)
+def _build_sparse_mla_split_sink_merge_kernel(
+    static_num_chunks: int | None = None,
+) -> SparseMLASplitDecodeSinkMergeKernel:
+    return SparseMLASplitDecodeSinkMergeKernel(static_num_chunks)
+
+
+def clear_sparse_mla_merge_kernel_cache() -> None:
+    _build_sparse_mla_split_merge_kernel.cache_clear()
+    _build_sparse_mla_split_sink_merge_kernel.cache_clear()
+
+
+def _sparse_mla_split_decode_merge_flat_launch(
+    tmp_output: torch.Tensor,
+    tmp_lse: torch.Tensor,
+    num_chunks_ptr: torch.Tensor,
+    output: torch.Tensor,
+    attn_sink: torch.Tensor,
+    contract_tmp_output: torch.Tensor,
+    contract_tmp_lse: torch.Tensor,
+    contract_output: torch.Tensor,
+    static_num_chunks: int,
+    has_attn_sink: bool,
+) -> None:
+    static_num_chunks_or_none = (
+        int(static_num_chunks) if int(static_num_chunks) > 0 else None
+    )
+    if not has_attn_sink:
+        merge_kernel = _build_sparse_mla_split_merge_kernel(static_num_chunks_or_none)
+        merge_args = (
+            _to_kernel_tensor(tmp_output, _torch_to_cutlass_dtype(tmp_output.dtype)),
+            _to_kernel_tensor(tmp_lse, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(num_chunks_ptr, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(output, _torch_to_cutlass_dtype(output.dtype)),
+            current_cuda_stream(),
+        )
+        merge_cache_key = (
+            _tensor_compile_key(
+                "tmp_output",
+                contract_tmp_output,
+                dynamic_dims=(0, 2),
+                dynamic_strides=(2,),
+            ),
+            _tensor_compile_key(
+                "tmp_lse",
+                contract_tmp_lse,
+                dynamic_dims=(0, 2),
+                dynamic_strides=(0, 1),
+            ),
+            _tensor_meta_key(num_chunks_ptr),
+            _tensor_compile_key(
+                "output",
+                contract_output,
+                dynamic_dims=(0,),
+            ),
+            str(tmp_output.dtype),
+            str(output.dtype),
+            static_num_chunks_or_none,
+        )
+        merge_spec = KernelCompileSpec.from_key(
+            "attention.mla.merge",
+            4,
+            merge_cache_key,
+            labels=(
+                "tmp_output",
+                "tmp_lse",
+                "num_chunks_ptr",
+                "output",
+                "tmp_output_dtype",
+                "output_dtype",
+                "static_num_chunks",
+            ),
+        )
+        sm12x_launch(
+            merge_kernel,
+            compile_spec=merge_spec,
+            compile_args=merge_args,
+            runtime_args=merge_args,
+        )
+        return
+
+    merge_kernel = _build_sparse_mla_split_sink_merge_kernel(static_num_chunks_or_none)
+    merge_args = (
+        _to_kernel_tensor(tmp_output, _torch_to_cutlass_dtype(tmp_output.dtype)),
+        _to_kernel_tensor(tmp_lse, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(num_chunks_ptr, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(attn_sink, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(output, _torch_to_cutlass_dtype(output.dtype)),
+        current_cuda_stream(),
+    )
+    merge_cache_key = (
+        _tensor_compile_key(
+            "tmp_output",
+            contract_tmp_output,
+            dynamic_dims=(0, 2),
+            dynamic_strides=(2,),
+        ),
+        _tensor_compile_key(
+            "tmp_lse",
+            contract_tmp_lse,
+            dynamic_dims=(0, 2),
+            dynamic_strides=(0, 1),
+        ),
+        _tensor_meta_key(num_chunks_ptr),
+        _tensor_meta_key(attn_sink),
+        _tensor_compile_key(
+            "output",
+            contract_output,
+            dynamic_dims=(0,),
+        ),
+        str(tmp_output.dtype),
+        str(output.dtype),
+        "attn_sink",
+        static_num_chunks_or_none,
+    )
+    merge_spec = KernelCompileSpec.from_key(
+        "attention.mla.sink_merge",
+        4,
+        merge_cache_key,
+        labels=(
+            "tmp_output",
+            "tmp_lse",
+            "num_chunks_ptr",
+            "attn_sink",
+            "output",
+            "tmp_output_dtype",
+            "output_dtype",
+            "kind",
+            "static_num_chunks",
+        ),
+    )
+    sm12x_launch(
+        merge_kernel,
+        compile_spec=merge_spec,
+        compile_args=merge_args,
+        runtime_args=merge_args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::sparse_mla_sm120_split_decode_merge",
+    mutates_args=("output",),
+)
+def _sparse_mla_split_decode_merge_op(
+    tmp_output: torch.Tensor,
+    tmp_lse: torch.Tensor,
+    num_chunks_ptr: torch.Tensor,
+    output: torch.Tensor,
+    attn_sink: torch.Tensor,
+    contract_tmp_output: torch.Tensor,
+    contract_tmp_lse: torch.Tensor,
+    contract_output: torch.Tensor,
+    static_num_chunks: int,
+    has_attn_sink: bool,
+) -> None:
+    _sparse_mla_split_decode_merge_flat_launch(
+        tmp_output,
+        tmp_lse,
+        num_chunks_ptr,
+        output,
+        attn_sink,
+        contract_tmp_output,
+        contract_tmp_lse,
+        contract_output,
+        static_num_chunks,
+        has_attn_sink,
+    )
+
+
+@_sparse_mla_split_decode_merge_op.register_fake
+def _sparse_mla_split_decode_merge_fake(
+    tmp_output: torch.Tensor,
+    tmp_lse: torch.Tensor,
+    num_chunks_ptr: torch.Tensor,
+    output: torch.Tensor,
+    attn_sink: torch.Tensor,
+    contract_tmp_output: torch.Tensor,
+    contract_tmp_lse: torch.Tensor,
+    contract_output: torch.Tensor,
+    static_num_chunks: int,
+    has_attn_sink: bool,
+) -> None:
+    return None
+
+
+def run_sparse_mla_split_decode_merge(
+    *,
+    tmp_output: torch.Tensor | None = None,
+    tmp_lse: torch.Tensor | None = None,
+    num_chunks_ptr: torch.Tensor | None = None,
+    num_chunks: int | None = None,
+    output: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    workspace: object | None = None,
+    binding: SparseMLASplitDecodeMergeBinding | None = None,
+) -> None:
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("tmp_output", tmp_output),
+                ("tmp_lse", tmp_lse),
+                ("num_chunks_ptr", num_chunks_ptr),
+                ("num_chunks", num_chunks),
+                ("output", output),
+                ("attn_sink", attn_sink),
+                ("workspace", workspace),
+            )
+            if value is not None
+        ]
+        if extras:
+            _raise_binding_extras("run_sparse_mla_split_decode_merge", extras)
+        tmp_output = binding.tmp_output
+        tmp_lse = binding.tmp_lse
+        num_chunks_ptr = binding.num_chunks_ptr
+        num_chunks = binding.num_chunks
+        output = binding.output
+        attn_sink = binding.attn_sink
+        workspace = binding.scratch
+
+    tmp_output = _require_bound_arg(
+        tmp_output,
+        api_name="run_sparse_mla_split_decode_merge",
+        name="tmp_output",
+    )
+    tmp_lse = _require_bound_arg(
+        tmp_lse,
+        api_name="run_sparse_mla_split_decode_merge",
+        name="tmp_lse",
+    )
+    num_chunks_ptr = _require_bound_arg(
+        num_chunks_ptr,
+        api_name="run_sparse_mla_split_decode_merge",
+        name="num_chunks_ptr",
+    )
+    output = _require_bound_arg(
+        output,
+        api_name="run_sparse_mla_split_decode_merge",
+        name="output",
+    )
+
+    if tmp_output.device != output.device or tmp_lse.device != output.device:
+        raise ValueError("sparse MLA merge tensors must be on the same device")
+    if tmp_lse.dtype != torch.float32:
+        raise TypeError(f"tmp_lse must have dtype torch.float32, got {tmp_lse.dtype}")
+    if tmp_output.dtype != output.dtype:
+        raise TypeError(
+            f"tmp_output dtype {tmp_output.dtype} must match output dtype {output.dtype}"
+        )
+    if tmp_output.ndim != 4:
+        raise ValueError(
+            f"tmp_output must have shape [rows, heads, chunks, dim], got {tuple(tmp_output.shape)}"
+        )
+    if tmp_lse.ndim != 3:
+        raise ValueError(
+            f"tmp_lse must have shape [rows, heads, chunks], got {tuple(tmp_lse.shape)}"
+        )
+    if output.ndim != 3:
+        raise ValueError(
+            f"output must have shape [rows, heads, dim], got {tuple(output.shape)}"
+        )
+    if (
+        int(tmp_output.shape[0]) < int(output.shape[0])
+        or int(tmp_output.shape[1]) < int(output.shape[1])
+        or int(tmp_output.shape[3]) < int(output.shape[2])
+        or int(tmp_lse.shape[0]) < int(output.shape[0])
+        or int(tmp_lse.shape[1]) < int(output.shape[1])
+        or int(tmp_lse.shape[2]) < int(tmp_output.shape[2])
+    ):
+        raise ValueError(
+            "sparse MLA merge scratch/output shapes are inconsistent: "
+            f"tmp_output={tuple(tmp_output.shape)} tmp_lse={tuple(tmp_lse.shape)} "
+            f"output={tuple(output.shape)}"
+        )
+    _validate_tensor_storage_bounds(tmp_output, name="sparse MLA merge tmp_output")
+    _validate_tensor_storage_bounds(tmp_lse, name="sparse MLA merge tmp_lse")
+    _validate_tensor_storage_bounds(output, name="sparse MLA merge output")
+    _validate_split_control_tensor(
+        num_chunks_ptr,
+        name="num_chunks_ptr",
+        device=output.device,
+    )
+    if num_chunks is not None:
+        num_chunks = int(num_chunks)
+        if num_chunks <= 0:
+            raise ValueError(f"num_chunks must be positive, got {num_chunks}")
+        if num_chunks > min(int(tmp_output.shape[2]), _SPLIT_MAX_CHUNKS):
+            raise ValueError(
+                "num_chunks exceeds merge scratch capacity: "
+                f"{num_chunks} > min({int(tmp_output.shape[2])}, {_SPLIT_MAX_CHUNKS})"
+            )
+    _cto = getattr(workspace, "_contract_tmp_output", None)
+    _ctl = getattr(workspace, "_contract_tmp_lse", None)
+    _co = getattr(workspace, "_contract_output", None)
+
+    has_attn_sink = attn_sink is not None
+    if has_attn_sink:
+        attn_sink = attn_sink.detach()
+        if attn_sink.dtype != torch.float32:
+            raise ValueError(
+                f"attn_sink must have dtype torch.float32, got {attn_sink.dtype}"
+            )
+        if attn_sink.device != output.device:
+            raise ValueError("attn_sink must be on the same CUDA device as output")
+        if attn_sink.ndim != 1 or int(attn_sink.shape[0]) != int(output.shape[1]):
+            raise ValueError(
+                f"attn_sink must have shape ({int(output.shape[1])},), got {tuple(attn_sink.shape)}"
+            )
+        if not attn_sink.is_contiguous():
+            raise ValueError("attn_sink must be contiguous for the fused merge path")
+
+    torch.ops.flashinfer_sm12x.sparse_mla_sm120_split_decode_merge(
+        tmp_output,
+        tmp_lse,
+        num_chunks_ptr,
+        output,
+        attn_sink if attn_sink is not None else tmp_lse,
+        _cto if _cto is not None else tmp_output,
+        _ctl if _ctl is not None else tmp_lse,
+        _co if _co is not None else output,
+        int(num_chunks or 0),
+        bool(has_attn_sink),
+    )
+
+
+__all__ = [
+    "SparseMLASplitDecodeMergeBinding",
+    "build_sparse_mla_split_decode_merge_binding",
+    "clear_sparse_mla_merge_kernel_cache",
+    "run_sparse_mla_split_decode_merge",
+]

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/packed.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/packed.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/packed.py @ 74e3e6b7 (2026-06-13) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Packed sparse-MLA cache view helpers shared by active runtime code."""
+
+from __future__ import annotations
+
+import torch
+
+from .reference import _MLA_NOPE_DIM, _MLA_SCALE_BYTES
+
+
+def view_last_dim_as_u32(tensor: torch.Tensor) -> torch.Tensor:
+    if not tensor.is_contiguous():
+        tensor = tensor.contiguous()
+    byte_width = tensor.shape[-1] * tensor.element_size()
+    if byte_width % 4 != 0:
+        raise ValueError(
+            f"last dimension byte-width must be divisible by 4, got {byte_width}"
+        )
+    byte_view = tensor.view(torch.uint8).reshape(*tensor.shape[:-1], byte_width)
+    return byte_view.view(torch.uint32).reshape(*tensor.shape[:-1], byte_width // 4)
+
+
+def extract_packed_kv_runtime_views(
+    kv_cache: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    kv_rows_bytes = kv_cache[:, 0, :].view(torch.uint8)
+    kv_rows_u32 = view_last_dim_as_u32(kv_rows_bytes)
+    kv_scales = kv_rows_bytes[:, _MLA_NOPE_DIM : _MLA_NOPE_DIM + _MLA_SCALE_BYTES].view(
+        torch.float32
+    )
+    return kv_rows_u32, kv_scales
+
+
+# Backward-compatible private spelling for internal callers that only need the
+# layout helper, not the retired kernel module.
+_extract_packed_kv_runtime_views = extract_packed_kv_runtime_views
+
+
+__all__ = [
+    "_extract_packed_kv_runtime_views",
+    "extract_packed_kv_runtime_views",
+    "view_last_dim_as_u32",
+]

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/prefill.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/prefill.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/prefill.py @ e130f195 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Unified SM120 sparse-MLA *prefill* DISPATCHER.
+
+``run_unified_prefill`` is the prefill front door: it infers the model/compute/
+scale traits, normalizes inputs, and routes to the FlashInfer-shaped multi-group
+(MG) prefill kernel in ``prefill_mg.py`` (``run_unified_prefill_mg``). There is NO
+decode-reuse fallback -- an unsupported shape HARD-FAILS (raise-not-fallback,
+matching upstream).
+
+Supported (MG) shapes:
+  * DSV4/GLM single-cache: heads % 8 == 0
+  * DSV4 single-cache: topk in {512, 1024, 2048} (FP8-QK) or 128 (BF16-QK)
+    with 8-aligned heads split into a paired-head MG prefix plus optional
+    single-group tails.
+  * DSV4 dual-cache (extra/indexed tokens): topk==128, heads % 8 == 0,
+    pbs_extra in {2, 64} (BF16-QK), using the same head partitioning.
+  * GLM_NSA: topk in {512, 1024, 2048}
+Anything else (other topk, unsupported heads, GLM dual, etc.) raises ValueError.
+DSV4 + GLM DECODE kernels are untouched and stay byte-identical.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from .traits import (
+    ComputeMode,
+    ModelType,
+    ScaleFormat,
+    infer_model_type,
+    make_unified_traits,
+)
+
+# DSV4 compressed contract head dim (q_nope 448 + q_rope 64).
+_DSV4_HEAD_DIM = 512
+# GLM_NSA uncompressed contract head dim (q_nope 512 + q_rope 64).
+_GLM_HEAD_DIM = 576
+# GLM per-token packed cache record (reference.pack_mla_kv_cache_reference).
+_GLM_KV_GMEM_STRIDE = 656
+
+
+def _cache_block_stride_bytes(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    model_type: ModelType,
+    record_bytes: int | None = None,
+) -> int:
+    from flashinfer.experimental.sm12x.attention._shared.mla.compressed_reference import (
+        compressed_mla_page_nbytes,
+    )
+
+    if model_type == ModelType.GLM_NSA:
+        # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
+        # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
+        rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+        expected = int(page_size) * rec
+    else:
+        expected = int(compressed_mla_page_nbytes(int(page_size)))
+    # Contiguous inputs are flattened before launch, so their original rank is
+    # not a physical-layout contract and the standard page stride applies.
+    # Only packed, non-contiguous vLLM views preserve a real per-block stride in
+    # dimension 0.
+    if not cache.is_contiguous() and cache.ndim >= 2:
+        stride = int(cache.stride(0)) * int(cache.element_size())
+        if stride < expected:
+            raise ValueError(
+                f"SM120 sparse MLA cache block stride {stride} is smaller than "
+                f"page payload {expected}"
+            )
+        return stride
+    return expected
+
+
+def _mg_head_partitions(heads: int, hpb: int = 16) -> tuple[tuple[int, int, int], ...]:
+    """Return ``(mg_n_hg, active_heads, head_offset)`` partitions for 8-aligned heads."""
+    heads = int(heads)
+    hpb = int(hpb)
+    if heads <= 0 or heads % (hpb // 2) != 0:
+        return ()
+
+    parts: list[tuple[int, int, int]] = []
+    paired_width = 2 * hpb
+    paired_heads = (heads // paired_width) * paired_width
+    if paired_heads:
+        parts.append((2, paired_heads, 0))
+
+    offset = paired_heads
+    rem = heads - paired_heads
+    if rem >= hpb:
+        parts.append((1, hpb, offset))
+        offset += hpb
+        rem -= hpb
+    if rem:
+        parts.append((1, rem, offset))
+    return tuple(parts)
+
+
+def run_unified_prefill(
+    *,
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    topk_indices: torch.Tensor,
+    sm_scale: float,
+    page_block_size: int,
+    topk_length: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    output: torch.Tensor | None = None,
+    lse_out: torch.Tensor | None = None,
+    stride_kv_block: int | None = None,
+    extra_kv_cache: torch.Tensor | None = None,
+    extra_indices: torch.Tensor | None = None,
+    extra_topk_length: torch.Tensor | None = None,
+    extra_page_block_size: int | None = None,
+    stride_extra_kv_block: int | None = None,
+    workspace=None,
+    scale_format: int | None = None,
+    latent_scale: float = 1.0,
+    fp8_rope: bool | None = None,
+):
+    """Unified SM120 sparse-MLA single-pass prefill -> BF16 O + base-2 LSE.
+
+    Pure DISPATCHER: validates the contract, infers traits, and routes to the
+    FlashInfer-shaped multi-group (MG) prefill kernel (``run_unified_prefill_mg``).
+    Unsupported shapes HARD-FAIL (raise-not-fallback); there is no decode-reuse path.
+
+    Routes DSV4 (q_head_dim==512, UE8M0 footer, V_HAS_ROPE) AND GLM_NSA
+    (q_head_dim==576, ARBITRARY_FP32 inline scales, V==nope) through the SAME kernel
+    via the traits const_expr branches (model_type/scale_format/v_has_rope/
+    nt_per_warp_xv), exactly like the decode launcher. DSV4 additionally supports a
+    DUAL-CACHE union (extra_kv_cache / extra_indices / extra_topk_length /
+    extra_page_block_size): the CTA attends over the UNION of the MAIN topk cache and
+    the EXTRA cache in ONE online softmax (num_main_tiles main chunks then the extra
+    chunks). The extra cache is DSV4-only (GLM has no extra section -> RAISE).
+
+    Args:
+      q:            (T, heads, D_QK) bf16. D_QK 512 (DSV4) or 576 (GLM_NSA).
+      kv_cache:     flat uint8 MAIN KV cache (reshaped to 1-D).
+      topk_indices: (T, topk) int32 flat slot ids (-1 = invalid sentinel).
+      sm_scale:     softmax scale (typically D_QK**-0.5).
+      page_block_size: tokens per MAIN KV block (64 for DSV4/GLM).
+      topk_length:  optional (T,) int32 per-token MAIN valid length; entries past it
+                    are masked. Defaults to full ``topk`` for every token.
+      attn_sink:    optional (heads,) fp32 per-head natural-log sink, folded into
+                    the normalizer + base-2 LSE (FlashMLA V4).
+      output:       optional pre-allocated (T, heads, D_V) bf16 output (else made).
+      lse_out:      optional pre-allocated (T, heads) f32 base-2 LSE (else made).
+      stride_kv_block: per-block gmem byte stride for the MAIN cache. Derived from
+                    page_block_size + model_type when omitted.
+      extra_kv_cache / extra_indices / extra_topk_length / extra_page_block_size:
+                    DSV4 dual-cache EXTRA pool (all-or-none; partial trio RAISEs).
+      stride_extra_kv_block: EXTRA per-block byte stride (derived when omitted).
+      latent_scale: per-layer outer scale for the reconstructed NVFP4 latent.
+      workspace:    unused (prefill is single-pass, no split/merge workspace);
+                    accepted for launcher-signature symmetry.
+
+    Returns (O[T, heads, D_V=512] bf16, lse[T, heads] f32 base-2).
+    """
+    del workspace  # prefill is single-pass; no split/merge workspace needed.
+
+    q_head_dim = int(q.shape[-1])
+    if q_head_dim not in (_DSV4_HEAD_DIM, _GLM_HEAD_DIM):
+        # Genuinely-unsupported contract -> error like upstream (infer_model_type
+        # ICHECKs d_qk in {512, 576}). NOT a legacy fallback.
+        raise ValueError(
+            f"SM120 sparse MLA prefill supports DSV4 (q_head_dim=512) or GLM_NSA "
+            f"(q_head_dim=576); got q_head_dim={q_head_dim}"
+        )
+
+    num_tokens, heads, _ = q.shape
+    hpb = 16
+    if heads % (hpb // 2) != 0:
+        # 8-head tails use MG n_hg==1 + valid_hpb=8: one M=16 tile with 8 real
+        # Q rows and 8 zero-padded rows. Other sub-8 head counts remain
+        # unsupported -> RAISE (not legacy).
+        raise ValueError(
+            f"SM120 sparse MLA prefill requires heads divisible by {hpb // 2}, got {heads}"
+        )
+
+    model_type, compute_mode, inferred_scale_format = infer_model_type(
+        q_head_dim, kv_cache.dtype
+    )
+    if scale_format is None:
+        scale_format = inferred_scale_format
+    else:
+        scale_format = int(scale_format)
+        if q_head_dim == _GLM_HEAD_DIM and scale_format == ScaleFormat.NVFP4_E4M3:
+            # NVFP4 GLM-family prefill runs the BF16-QK MG arm (native E2M1
+            # dequant + BF16 MMA); FP8 compute would misread the 432B record.
+            compute_mode = ComputeMode.BF16
+        elif scale_format != inferred_scale_format:
+            raise ValueError(
+                "SM120 sparse MLA prefill scale_format does not match q_head_dim: "
+                f"q_head_dim={q_head_dim}, inferred={int(inferred_scale_format)}, "
+                f"override={int(scale_format)}"
+            )
+    traits = make_unified_traits(
+        model_type, compute_mode, scale_format, fp8_rope=fp8_rope
+    )
+    d_v = int(traits.d_v)
+
+    # ── DSV4 dual-cache: validate the extra trio (all-or-none) and that it is DSV4. ──
+    has_extra = (
+        extra_kv_cache is not None
+        or extra_indices is not None
+        or extra_topk_length is not None
+    )
+    if has_extra:
+        if (
+            extra_kv_cache is None
+            or extra_indices is None
+            or extra_page_block_size is None
+        ):
+            raise ValueError(
+                "SM120 sparse MLA prefill dual-cache requires extra_kv_cache, "
+                "extra_indices, and extra_page_block_size together (partial extra "
+                "trio is unsupported, matching upstream sparse_mla_sm120.cu:171-174)"
+            )
+        if model_type != ModelType.DSV4:
+            raise ValueError(
+                "SM120 sparse MLA prefill dual-cache (extra tokens) is DSV4-only "
+                "(q_head_dim==512); GLM/DSV3.2 has no extra cache"
+            )
+
+    topk = int(topk_indices.shape[1])
+
+    device = q.device
+    if topk_length is None:
+        topk_length = torch.full((num_tokens,), topk, dtype=torch.int32, device=device)
+    else:
+        topk_length = topk_length.to(device=device, dtype=torch.int32).contiguous()
+
+    if stride_kv_block is None:
+        stride_kv_block = _cache_block_stride_bytes(
+            kv_cache,
+            page_size=int(page_block_size),
+            model_type=model_type,
+            record_bytes=int(traits.kv_gmem_stride),
+        )
+
+    q = q.contiguous()
+    topk_indices = topk_indices.contiguous()
+    if output is None:
+        output = torch.empty(
+            (num_tokens, heads, d_v), dtype=torch.bfloat16, device=device
+        )
+    if lse_out is None:
+        lse_out = torch.empty((num_tokens, heads), dtype=torch.float32, device=device)
+
+    def _run_partitioned_mg(
+        *,
+        compute_mode: int,
+        model_type: int,
+        scale_format: int,
+        extra_kv_cache=None,
+        extra_indices=None,
+        extra_topk_length=None,
+        extra_page_block_size=None,
+        stride_extra_kv_block=None,
+    ):
+        from .prefill_mg import run_unified_prefill_mg
+
+        partitions = _mg_head_partitions(heads, hpb)
+        if not partitions:
+            raise ValueError(
+                f"SM120 sparse MLA prefill requires heads divisible by {hpb // 2}, got {heads}"
+            )
+        for mg_n_hg, active_heads, head_offset in partitions:
+            kwargs = dict(
+                q=q,
+                kv_cache=kv_cache,
+                topk_indices=topk_indices,
+                sm_scale=sm_scale,
+                latent_scale=latent_scale,
+                page_block_size=page_block_size,
+                topk_length=topk_length,
+                attn_sink=attn_sink,
+                output=output,
+                lse_out=lse_out,
+                stride_kv_block=stride_kv_block,
+                compute_mode=compute_mode,
+                mg_n_hg=mg_n_hg,
+                model_type=model_type,
+                scale_format=scale_format,
+                fp8_rope=bool(traits.fp8_rope),
+            )
+            if extra_kv_cache is not None:
+                kwargs.update(
+                    extra_kv_cache=extra_kv_cache,
+                    extra_indices=extra_indices,
+                    extra_topk_length=extra_topk_length,
+                    extra_page_block_size=extra_page_block_size,
+                    stride_extra_kv_block=stride_extra_kv_block,
+                )
+            if len(partitions) > 1 or active_heads != heads or head_offset != 0:
+                kwargs.update(active_heads=active_heads, head_offset=head_offset)
+            run_unified_prefill_mg(**kwargs)
+        return output, lse_out
+
+    # ── MG (multi-head-group) gate ────────────────────────────────────────────
+    # DSV4 main-cache. The MG kernel is parameterized by the head-group count
+    # ``mg_n_hg`` (a const_expr; one HPB=16 head group per group):
+    #   * paired 32-head prefix -> MG_N_HG=2
+    #   * optional 16-head tail -> MG_N_HG=1
+    #   * optional 8-head tail  -> MG_N_HG=1 + VALID_HPB=8
+    # The dispatcher partitions every 8-aligned head count into that sequence.
+    #
+    # Within each group count, two FlashInfer-shaped QK specializations route:
+    #   * topk in {512, 1024, 2048}  -> FP8-QK MG  (block-scaled E4M3 QK).
+    #   * topk == 128                -> BF16-QK MG (S0 skips the FP8 Q-quant
+    #     prologue; S1 dequants K e4m3->bf16 inline and runs a bf16 m16n8k16 QK;
+    #     XV stays FP8). FlashInfer routes topk==128 to this BF16-QK kernel (the
+    #     small K-loop where the Q-quant prologue would dominate); it lands a
+    #     TIGHTER numeric (no Q-quant loss) than FP8.
+    _mg_enabled = os.environ.get(
+        "FLASHINFER_EXP_SM12X_MLA_SM120_PREFILL_MG", "1"
+    ) not in ("0", "false", "False", "off")
+    # ── GLM (ARBITRARY_FP32, q=576, v_has_rope=False) MG gate ──────────────────
+    # GLM has the SAME FlashInfer MG head-group structure as DSV4 (one CTA fuses
+    # MG_N_HG HPB head groups, sharing the KV gather), differing only in the math
+    # arms (post-MMA fp32 QK scale, raw-V + 2-pass-W XV, no XV-rope) and the
+    # 656/528 KV geometry -- all const_expr-selected in the SAME MG kernel. Route
+    # GLM prefill uses MG for every supported shard. The TP8 / eight-local-head
+    # case keeps VALID_HPB=8; its PV path packs HIGH and LOW residual rows into
+    # the two halves of the otherwise half-empty m16 tile:
+    #   8 heads               -> MG_N_HG=1 + VALID_HPB=8
+    #   paired 32-head prefix -> MG_N_HG=2
+    #   optional 16-head tail -> MG_N_HG=1
+    #   optional 8-head tail  -> MG_N_HG=1 + VALID_HPB=8
+    # topk in {512,1024,2048}.
+    _mg_glm = (
+        _mg_enabled
+        and not has_extra
+        and model_type == ModelType.GLM_NSA
+        and scale_format == ScaleFormat.ARBITRARY_FP32
+    )
+    if _mg_glm and topk in (512, 1024, 2048):
+        return _run_partitioned_mg(
+            compute_mode=ComputeMode.FP8,
+            model_type=ModelType.GLM_NSA,
+            scale_format=ScaleFormat.ARBITRARY_FP32,
+        )
+    # ── NVFP4 (E2M1 + E4M3 group-16, GLM-family) MG gate ───────────────────────
+    # Same MG head-group structure as GLM; the math arms are the BF16-QK path
+    # with native in-register E2M1/E4M3 dequant (the same math as the validated
+    # NVFP4 decode). topk==128 additionally routes here (BF16-QK shape).
+    _mg_nvfp4 = (
+        _mg_enabled
+        and not has_extra
+        and model_type == ModelType.GLM_NSA
+        and scale_format == ScaleFormat.NVFP4_E4M3
+    )
+    if _mg_nvfp4 and topk in (128, 512, 1024, 2048):
+        return _run_partitioned_mg(
+            compute_mode=ComputeMode.BF16,
+            model_type=ModelType.GLM_NSA,
+            scale_format=ScaleFormat.NVFP4_E4M3,
+        )
+    _mg_base = (
+        _mg_enabled
+        and not has_extra
+        and model_type == ModelType.DSV4
+        and compute_mode == ComputeMode.FP8  # infer_model_type always FP8 for DSV4
+        and scale_format == 0
+    )
+    if _mg_base and topk in (512, 1024, 2048):
+        return _run_partitioned_mg(
+            compute_mode=ComputeMode.FP8,
+            model_type=ModelType.DSV4,
+            scale_format=ScaleFormat.UE8M0_BYTE,
+        )
+    if _mg_base and topk == 128:
+        return _run_partitioned_mg(
+            compute_mode=ComputeMode.BF16,
+            model_type=ModelType.DSV4,
+            scale_format=ScaleFormat.UE8M0_BYTE,
+        )
+
+    # ── DSV4 dual-cache (has_extra) -> MG (BF16-QK), with strip-and-raise. ──────
+    # FI ships DSV4 dual-cache as topk==128, BF16-QK. 8-aligned head counts split
+    # into a paired prefix plus optional 16/8-head single-group tails. Everything
+    # else RAISEs (the decode-reuse has_extra body has been removed -- no fallback).
+    if has_extra:
+        if model_type == ModelType.DSV4 and int(topk) == 128:
+            return _run_partitioned_mg(
+                compute_mode=ComputeMode.BF16,
+                model_type=ModelType.DSV4,
+                scale_format=ScaleFormat.UE8M0_BYTE,
+                extra_kv_cache=extra_kv_cache,
+                extra_indices=extra_indices,
+                extra_topk_length=extra_topk_length,
+                extra_page_block_size=extra_page_block_size,
+                stride_extra_kv_block=stride_extra_kv_block,
+            )
+        raise ValueError(
+            f"DSV4 dual-cache prefill (heads={heads}, topk={topk}, "
+            f"pbs_extra={int(extra_page_block_size)}) requires MG dispatch; only "
+            "DSV4 topk==128 with heads divisible by 8 is supported. "
+            "No decode-reuse fallback."
+        )
+
+    # No MG gate matched. There is NO decode-reuse fallback: an unsupported
+    # prefill shape HARD-FAILS (matching upstream's raise-not-fallback contract).
+    raise ValueError(
+        "SM120 sparse MLA prefill: unsupported shape "
+        f"(model_type={int(model_type)}, heads={heads}, topk={topk}, "
+        f"compute_mode={int(compute_mode)}, scale_format={int(scale_format)}, "
+        f"has_extra={has_extra}, FLASHINFER_EXP_SM12X_MLA_SM120_PREFILL_MG={'0' if not _mg_enabled else '1'}). "
+        "Supported (MG) shapes: single-cache heads%8==0; "
+        "DSV4 single-cache topk in {512, 1024, 2048} (FP8) or 128 "
+        "(BF16-QK, heads%8==0); "
+        "DSV4 dual-cache topk==128 with heads%8==0 and pbs_extra in {2, 64}; "
+        "GLM_NSA topk in {512, 1024, 2048}; "
+        "NVFP4 (GLM-family, scale_format=2) topk in {128, 512, 1024, 2048}. "
+        "No decode-reuse fallback."
+    )

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/prefill_mg.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/prefill_mg.py
@@ -1,0 +1,4319 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/prefill_mg.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""FlashInfer-shaped SM120 DSV4/GLM MG prefill path.
+
+One CTA handles up to two HPB=16 head groups and reuses a single NoPE KV gather
+across them. GLM TP8 uses a half-full head group and packs the accurate PV
+HIGH/LOW residual pair into the lower/upper rows of one m16 MMA. The DSV4 RoPE
+payload is intentionally not bulk-staged into smem; QK-RoPE and XV-RoPE read it
+from global/L2.
+"""
+
+from __future__ import annotations
+
+import os
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as cutlass_utils
+import torch
+from cutlass import Float32, Int32, Int64, Uint32
+from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.experimental.sm12x.attention._shared.cute.ops import LOG2_E
+from flashinfer.experimental.sm12x._lib.compiler import (
+    DimKey,
+    KernelCompileSpec,
+    key_field,
+    tensor_key,
+)
+from flashinfer.experimental.sm12x._lib.compiler import launch as sm12x_launch
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_max_shared_f32_offset,
+    byte_perm,
+    create_l2_evict_first_policy,
+    cvt_e4m3_to_f32_via_f16,
+    dequant_kv_e4m3_pair_to_bf16x2,
+    f16x2_to_f32x2,
+    fmax_f32,
+    fmin_f32,
+    fp4_decode_2,
+    get_ptr_as_int64,
+    ld_global_b16,
+    ld_global_nc_u32,
+    ld_global_v4_f32,
+    ld_shared_f32_offset,
+    ld_shared_u16_offset,
+    ld_shared_u8_offset,
+    ld_shared_v4_u32,
+    ldmatrix_m8n8x4_b16,
+    mma_m16n8k16_f32_bf16,
+    mma_m16n8k32_f32_e4m3,
+    pack_f32x2_to_bfloat2,
+    quantize_scaled_store_shared_v2_e4m3,
+    rcp_approx_ftz,
+    shared_ptr_to_u32,
+    st_shared_bf16_from_f32,
+    st_shared_f32_offset,
+)
+
+from .decode_math import (
+    EPILOGUE_FINAL_BF16,
+    _d2_load_b_fp8,
+    _exp2_approx_ftz_f32,
+    _ld_u8_zext,
+    _ue8m0_zext_byte_to_fp32,
+    ld_shared_f32,
+    s0_quantize_q_to_smem,
+    s1_qk_nope_block_scaled,
+    s6_xv_nope,
+    st_shared_f32,
+    s7_epilogue,
+)
+from .io_mg import io_issue_gather_dsv4_nope, io_issue_gather_glm_mg
+from .smem_mg import get_prefill_mg_shared_storage_cls, make_smem_layout_mg
+from .traits import ComputeMode, ModelType, ScaleFormat, make_unified_traits
+
+
+_CAND_WINDOW = 64
+_DSV4_HEAD_DIM = 512
+_GLM_HEAD_DIM = 576
+_PREFILL_BLOCK_THREADS = 384
+_PREFILL_IO_THREADS = 128
+_IO_REGS = 32
+_MATH_REGS = 232
+_H32_IO_REGS = 24
+_H32_MATH_REGS = 240
+_DSV4_IO_STRIDE = 576
+_DSV4_ROPE_GMEM_OFFSET = 448
+# GLM (ARBITRARY_FP32) per-token record: 512 e4m3 nope + 16 inline fp32 scales +
+# 128 bf16 rope == 656B. RoPE byte offset within the record == 528 (D_NOPE +
+# 4*4 inline-scale bytes). MG reads it from global/L2 (no smem staging).
+_GLM_IO_STRIDE = 656
+_GLM_ROPE_GMEM_OFFSET = 528
+# NVFP4 MLA latent record: 256B packed E2M1 NoPE + 32B E4M3 group-16 scales +
+# 16B pad + 128B bf16 rope == 432B. RoPE byte offset within the record == 304.
+# Inside the staged 288B smem row the scale bytes sit at offset 256.
+_NVFP4_IO_STRIDE = 432
+_NVFP4_ROPE_GMEM_OFFSET = 304
+_NVFP4_FP8_ROPE_IO_STRIDE = 368
+_NVFP4_FP8_ROPE_SCALE_OFFSET = 288
+_NVFP4_SCALE_OFFSET = 256
+_NVFP4_SCALE_GROUP = 16
+
+
+@cute.jit
+def _ld_global_index_i32(index_base_ptr: Int64, entry: Int32) -> Int32:
+    """Load one selected-token index directly from the tile's global row."""
+    return Int32(ld_global_nc_u32(index_base_ptr + entry.to(Int64) * Int64(4)))
+
+
+@cute.jit
+def s3_mask_and_scale_global(
+    qk,
+    index_base_ptr: Int64,
+    warp_first_cand: Int32,
+    split_cand_start: Int32,
+    split_cand_end: Int32,
+    section_len: Int32,
+    sm_scale_log2: Float32,
+    lane: Int32,
+):
+    """FI-shaped S3: validate candidates from the global selected-index row."""
+    tid = lane & Int32(3)
+    c0 = warp_first_cand + tid * Int32(2)
+    c1 = c0 + Int32(1)
+    abs_c0 = c0 + split_cand_start
+    abs_c1 = c1 + split_cand_start
+
+    idx0 = Int32(-1)
+    if abs_c0 < section_len:
+        idx0 = _ld_global_index_i32(index_base_ptr, c0)
+    idx1 = Int32(-1)
+    if abs_c1 < section_len:
+        idx1 = _ld_global_index_i32(index_base_ptr, c1)
+
+    if abs_c0 >= split_cand_end or idx0 < Int32(0):
+        qk[0] = Float32(-1.0e30)
+        qk[2] = Float32(-1.0e30)
+    if abs_c1 >= split_cand_end or idx1 < Int32(0):
+        qk[1] = Float32(-1.0e30)
+        qk[3] = Float32(-1.0e30)
+
+    qk[0] = qk[0] * sm_scale_log2
+    qk[1] = qk[1] * sm_scale_log2
+    qk[2] = qk[2] * sm_scale_log2
+    qk[3] = qk[3] * sm_scale_log2
+    return qk
+
+
+@cute.jit
+def _wfp8_row_xor(row: Int32) -> Int32:
+    """FlashInfer DSV4-dual W (A-operand) smem-bank-conflict swizzle.
+
+    Matches ``wfp8_row_xor`` in ldmatrix_sm120.cuh:76 (``row ^ (row >> 3)``).
+    A self-inverse bijection on [0, 15] (it flips bit 0 with bit 3), so applying
+    it symmetrically at the W store AND the ldmatrix load is numerically identity
+    -- it is a pure smem-bank-conflict swizzle. Only the DSV4 dual ``pbs_extra==2``
+    XV path enables it (USE_WFP8_ROW_XOR = DUAL_CACHE && pbs_extra==2,
+    prefill_kernel.cuh:624); every other caller passes ``row_xor=False`` and stays
+    byte-identical (the const_expr gate elides this call so the address arithmetic
+    is textually unchanged).
+    """
+    return row ^ (row >> Int32(3))
+
+
+def _to_cute(x, dtype, align=16, dynamic_layout=False):
+    c = from_dlpack(x, assumed_align=align)
+    c.element_type = dtype
+    if dynamic_layout and x.ndim >= 1:
+        leading_dim = next(
+            (idx for idx, stride in enumerate(x.stride()) if stride == 1), None
+        )
+        if leading_dim is not None:
+            c = c.mark_layout_dynamic(leading_dim=leading_dim)
+    return c
+
+
+def _cache_base_tensor(cache: torch.Tensor) -> torch.Tensor:
+    if cache.is_contiguous():
+        return cache.reshape(-1)
+    if cache.ndim < 2:
+        return cache
+
+    # Packed vLLM cache views retain page subdimensions and a storage_offset
+    # into a larger per-block allocation. The MG kernels do raw pointer-offset
+    # indexing, so expose this layer's full physical span as a 1-D view and keep
+    # the packed block stride in the explicit stride argument.
+    span = 1
+    for size, stride in zip(cache.shape, cache.stride(), strict=True):
+        span += (int(size) - 1) * int(stride)
+    return torch.as_strided(cache, size=(span,), stride=(1,))
+
+
+def _cache_block_stride_bytes(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    is_glm: bool,
+    record_bytes: int | None = None,
+) -> int:
+    from flashinfer.experimental.sm12x.attention._shared.mla.compressed_reference import (
+        compressed_mla_page_nbytes,
+    )
+
+    if is_glm:
+        # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
+        # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
+        rec = int(record_bytes) if record_bytes is not None else _GLM_IO_STRIDE
+        expected = int(page_size) * rec
+    else:
+        expected = int(compressed_mla_page_nbytes(int(page_size)))
+    # Contiguous inputs are flattened before launch, so their original rank is
+    # not a physical-layout contract and the standard page stride applies.
+    # Packed vLLM page views are non-contiguous and carry the physical
+    # per-block stride in dimension 0.
+    if not cache.is_contiguous() and cache.ndim >= 2:
+        stride = int(cache.stride(0)) * int(cache.element_size())
+        if stride < expected:
+            raise ValueError(
+                f"SM120 sparse MLA prefill cache block stride {stride} is "
+                f"smaller than page payload {expected}"
+            )
+        return stride
+    return expected
+
+
+def _topk_bucket(topk: int) -> int:
+    return 1 << (max(int(topk), 1) - 1).bit_length()
+
+
+@cute.jit
+def _smem_byte(base_addr: Int32, byte_off) -> Int32:
+    return base_addr + Int32(byte_off)
+
+
+@cute.jit
+def _dsv4_record_off(
+    idx: Int32, page_block_size: Int32, stride_kv_block: Int64
+) -> Int64:
+    block_idx = idx // page_block_size
+    local_idx = idx - block_idx * page_block_size
+    return Int64(block_idx) * stride_kv_block + Int64(local_idx) * Int64(
+        _DSV4_IO_STRIDE
+    )
+
+
+@cute.jit
+def _dsv4_rope_base_off(
+    idx: Int32, page_block_size: Int32, stride_kv_block: Int64
+) -> Int64:
+    """Full DSV4 RoPE-record offset used by the QK prefetch paths."""
+    if idx < Int32(0):
+        idx = Int32(0)
+    return _dsv4_record_off(idx, page_block_size, stride_kv_block) + Int64(
+        _DSV4_ROPE_GMEM_OFFSET
+    )
+
+
+@cute.jit
+def _ld_global_dsv4_rope_b16(
+    rope_dim_ptr: Int64,
+    idx: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+) -> Uint32:
+    out = Uint32(0)
+    if idx >= Int32(0):
+        byte_off = _dsv4_record_off(idx, page_block_size, stride_kv_block)
+        out = ld_global_b16(rope_dim_ptr + byte_off)
+    return out
+
+
+@cute.jit
+def s2_qk_rope_global_dsv4(
+    qk,
+    q_rope_base_addr: Int32,
+    kv_cache_u8: cute.Tensor,
+    index_base_ptr: Int64,
+    warp_first_cand: Int32,
+    lane: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    d_rope: cutlass.Constexpr,
+):
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    entry = warp_first_cand + gid
+    idx = _ld_global_index_i32(index_base_ptr, entry)
+    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block)
+
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        a_byte = a_row * Int32(d_rope * 2) + (ko + a_col) * Int32(2)
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(_smem_byte(q_rope_base_addr, a_byte))
+        b0 = ld_global_nc_u32(
+            get_ptr_as_int64(
+                kv_cache_u8, rope_base + Int64(ko + tid * Int32(2)) * Int64(2)
+            )
+        )
+        b1 = ld_global_nc_u32(
+            get_ptr_as_int64(
+                kv_cache_u8,
+                rope_base + Int64(ko + Int32(8) + tid * Int32(2)) * Int64(2),
+            )
+        )
+        qk[0], qk[1], qk[2], qk[3] = mma_m16n8k16_f32_bf16(
+            qk[0], qk[1], qk[2], qk[3], a0, a1, a2, a3, b0, b1
+        )
+    return qk
+
+
+@cute.jit
+def s2_qk_rope_global_mg_dsv4(
+    qk0,
+    qk1,
+    q_rope_g0_addr: Int32,
+    q_rope_g1_addr: Int32,
+    kv_cache_u8: cute.Tensor,
+    index_base_ptr: Int64,
+    warp_first_cand: Int32,
+    lane: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    d_rope: cutlass.Constexpr,
+    q_rope_stride: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
+):
+    """Fused DSV4 QK-RoPE.
+
+    The KV-RoPE B operand (b0/b1) depends only on the candidate token and the
+    rope chunk -- NOT on the head group. FlashInfer's prefill prefetches it once
+    per tile (``prefetch_kv_rope``) and reuses it for both groups
+    (``compute_qk_rope`` x MG_N_HG). This fuses the per-group
+    ``s2_qk_rope_global_dsv4`` calls so the vectorized (b16-pair = nc.u32) KV-RoPE
+    gather runs ONCE per CTA tile instead of once per head group, halving the
+    QK-RoPE global loads. Numerically identical: same B operands, same MMAs. When
+    ``n_hg==1`` the group-1 ldmatrix+MMA const_expr-elides.
+    """
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    entry = warp_first_cand + gid
+    idx = _ld_global_index_i32(index_base_ptr, entry)
+    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block)
+
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        # KV-RoPE B operand: loaded once, shared across both head groups.
+        b0 = ld_global_nc_u32(
+            get_ptr_as_int64(
+                kv_cache_u8, rope_base + Int64(ko + tid * Int32(2)) * Int64(2)
+            )
+        )
+        b1 = ld_global_nc_u32(
+            get_ptr_as_int64(
+                kv_cache_u8,
+                rope_base + Int64(ko + Int32(8) + tid * Int32(2)) * Int64(2),
+            )
+        )
+        a_byte = (a_row * Int32(q_rope_stride) + (ko + a_col)) * Int32(2)
+        a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(_smem_byte(q_rope_g0_addr, a_byte))
+        qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+            qk0[0], qk0[1], qk0[2], qk0[3], a00, a01, a02, a03, b0, b1
+        )
+        if cutlass.const_expr(n_hg == 2):
+            a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(_smem_byte(q_rope_g1_addr, a_byte))
+            qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+                qk1[0], qk1[1], qk1[2], qk1[3], a10, a11, a12, a13, b0, b1
+            )
+    return qk0, qk1
+
+
+# =============================================================================
+# GLM (ARBITRARY_FP32) MG QK-RoPE from global/L2.
+#
+# Like the DSV4 MG path, GLM MG reads the KV-RoPE B operand from global/L2 (no
+# smem staging), so the 528-stride GLM KV fits the carveout for mg_n_hg==2. The
+# GLM record is 656B (512 nope + 16 inline fp32 scales + 128 bf16 rope), so the
+# rope byte offset within a token record is 528. The numerics are identical to
+# the validated GLM decode path (decode_math.s2_qk_rope_bf16): same bf16 rope
+# values, same per-lane scalar packing into the bf16 m16n8k16 MMA B operand.
+# =============================================================================
+@cute.jit
+def _glm_rope_base_off(
+    idx: Int32, page_block_size: Int32, stride_kv_block: Int64
+) -> Int64:
+    if idx < Int32(0):
+        idx = Int32(0)
+    block_idx = idx // page_block_size
+    local_idx = idx - block_idx * page_block_size
+    return (
+        Int64(block_idx) * stride_kv_block
+        + Int64(local_idx) * Int64(_GLM_IO_STRIDE)
+        + Int64(_GLM_ROPE_GMEM_OFFSET)
+    )
+
+
+@cute.jit
+def _nvfp4_rope_base_off(
+    idx: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    fp8_rope: cutlass.Constexpr = False,
+) -> Int64:
+    if idx < Int32(0):
+        idx = Int32(0)
+    block_idx = idx // page_block_size
+    local_idx = idx - block_idx * page_block_size
+    if cutlass.const_expr(fp8_rope):
+        record_stride = Int64(_NVFP4_FP8_ROPE_IO_STRIDE)
+    else:
+        record_stride = Int64(_NVFP4_IO_STRIDE)
+    return (
+        Int64(block_idx) * stride_kv_block
+        + Int64(local_idx) * record_stride
+        + Int64(_NVFP4_ROPE_GMEM_OFFSET)
+    )
+
+
+@cute.jit
+def _ld_global_glm_rope_u32(
+    kv_cache_u8: cute.Tensor,
+    rope_base: Int64,
+    elem: Int32,
+) -> Uint32:
+    """Load two consecutive bf16 rope elems (one u32) from global at rope_base +
+    elem*2 bytes. ``elem`` is even (the lane reads bf16 pairs)."""
+    return ld_global_nc_u32(
+        get_ptr_as_int64(kv_cache_u8, rope_base + Int64(elem) * Int64(2))
+    )
+
+
+@cute.jit
+def _ld_global_nvfp4_fp8_rope_bfloat2(
+    kv_cache_u8: cute.Tensor,
+    rope_base: Int64,
+    elem_even: Int32,
+    scale: Float32,
+) -> Uint32:
+    """Load/dequant two adjacent E4M3 post-RoPE values to packed BF16."""
+    pair = ld_global_b16(get_ptr_as_int64(kv_cache_u8, rope_base + Int64(elem_even)))
+    v0 = cvt_e4m3_to_f32_via_f16(pair & Uint32(0xFF)) * scale
+    v1 = cvt_e4m3_to_f32_via_f16((pair >> Uint32(8)) & Uint32(0xFF)) * scale
+    return pack_f32x2_to_bfloat2(v0, v1)
+
+
+@cute.jit
+def s2_qk_rope_regs_mg_glm(
+    qk0,
+    qk1,
+    q_rope_regs0,
+    q_rope_regs1,
+    kv_cache_u8: cute.Tensor,
+    index_base_ptr: Int64,
+    warp_first_cand: Int32,
+    lane: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    d_rope: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
+    scale_format: cutlass.Constexpr = 1,
+    fp8_rope: cutlass.Constexpr = False,
+):
+    """GLM MG QK-RoPE. Mirrors ``s2_qk_rope_regs_mg_dsv4`` (registerized Q-rope A,
+    KV-rope B from global) but with the GLM record geometry and the GLM B-operand
+    packing (decode_math.s2_qk_rope_bf16): each lane's K-rope entry is
+    ``warp_first_cand + gid`` (NOT the DSV4 nt/tid layout), and b0/b1 are two
+    consecutive bf16 rope-pairs of THAT one entry's rope row. The B operand
+    depends only on the candidate token + rope chunk, so it is gathered once and
+    reused across both head groups (n_hg==2).
+
+    ``scale_format`` (const_expr) selects the record geometry: ARBITRARY_FP32
+    (1, 656B record, rope at 528) or NVFP4_E4M3 (2, 432B record, rope at 304).
+    The rope payload itself is BF16 in BOTH formats -- bit-identical loads."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    entry = warp_first_cand + gid
+    idx = _ld_global_index_i32(index_base_ptr, entry)
+    if cutlass.const_expr(scale_format == 2):
+        rope_base = _nvfp4_rope_base_off(
+            idx,
+            page_block_size,
+            stride_kv_block,
+            fp8_rope=fp8_rope,
+        )
+    else:
+        rope_base = _glm_rope_base_off(idx, page_block_size, stride_kv_block)
+    hi0 = cutlass.const_expr(valid_hpb > 8)
+
+    if cutlass.const_expr(scale_format == 2 and fp8_rope):
+        rope_scale, _, _, _ = ld_global_v4_f32(
+            get_ptr_as_int64(
+                kv_cache_u8,
+                rope_base
+                + Int64(_NVFP4_FP8_ROPE_SCALE_OFFSET - _NVFP4_ROPE_GMEM_OFFSET),
+            )
+        )
+    else:
+        rope_scale = Float32(1.0)
+
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        # decode_math.s2_qk_rope_bf16 B packing: b0 = rope[ko + tid*2 .. +1],
+        # b1 = rope[ko + tid*2 + 8 .. +9] of this entry's rope row.
+        if cutlass.const_expr(scale_format == 2 and fp8_rope):
+            b0 = _ld_global_nvfp4_fp8_rope_bfloat2(
+                kv_cache_u8, rope_base, ko + tid * Int32(2), rope_scale
+            )
+            b1 = _ld_global_nvfp4_fp8_rope_bfloat2(
+                kv_cache_u8,
+                rope_base,
+                ko + tid * Int32(2) + Int32(8),
+                rope_scale,
+            )
+        else:
+            b0 = _ld_global_glm_rope_u32(kv_cache_u8, rope_base, ko + tid * Int32(2))
+            b1 = _ld_global_glm_rope_u32(
+                kv_cache_u8, rope_base, ko + tid * Int32(2) + Int32(8)
+            )
+        base = Int32(ks) * Int32(4)
+        d0, d1, d2, d3 = mma_m16n8k16_f32_bf16(
+            qk0[0],
+            qk0[1],
+            qk0[2],
+            qk0[3],
+            q_rope_regs0[base + 0],
+            q_rope_regs0[base + 1],
+            q_rope_regs0[base + 2],
+            q_rope_regs0[base + 3],
+            b0,
+            b1,
+        )
+        qk0[0] = d0
+        qk0[1] = d1
+        if cutlass.const_expr(hi0):
+            qk0[2] = d2
+            qk0[3] = d3
+        if cutlass.const_expr(n_hg == 2):
+            qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+                qk1[0],
+                qk1[1],
+                qk1[2],
+                qk1[3],
+                q_rope_regs1[base + 0],
+                q_rope_regs1[base + 1],
+                q_rope_regs1[base + 2],
+                q_rope_regs1[base + 3],
+                b0,
+                b1,
+            )
+    return qk0, qk1
+
+
+# =============================================================================
+# BF16-QK (ComputeMode.BF16) MG specialization
+#
+# Mirrors FlashInfer's sparse_mla prefill BF16-QK path (prefill_kernel.cuh
+# :788-931 / common/q_rope.cuh): S0 loads Q-NoPE straight to BF16 smem (NO FP8
+# Q-quant prologue); S1 QK-NoPE does per-thread inline FP8->BF16 K dequant
+# (cvt.rn.f16x2.e4m3x2 * UE8M0 fp32 scale -> cvt.rn.bf16x2.f32) and a bf16
+# m16n8k16 MMA, fusing the two head groups so the K dequant + B operand run ONCE
+# per K-step. XV (S5/S6) stays FP8 -- unchanged from the FP8 path.
+# =============================================================================
+@cute.jit
+def s0_load_q_bf16_to_smem_mg(
+    q_token: cute.Tensor,  # (NUM_HEADS, D_QK) bf16 view for this token
+    q_nope_bf16_g0_addr: Int32,  # smem addr of group-0 Q-NoPE bf16 buffer
+    q_nope_bf16_g1_addr: Int32,  # smem addr of group-1 Q-NoPE bf16 buffer
+    q_rope_g0_addr: Int32,  # smem addr of group-0 Q-rope bf16 scratch
+    q_rope_g1_addr: Int32,  # smem addr of group-1 Q-rope bf16 scratch
+    head_base: Int32,  # first head index of this CTA (h_start)
+    tid: Int32,
+    *,
+    d_nope: cutlass.Constexpr,  # 448
+    d_rope: cutlass.Constexpr,  # 64
+    hpb: cutlass.Constexpr,  # 16
+    q_nope_bf16_stride: cutlass.Constexpr,  # D_NOPE + 8
+    q_rope_stride: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,  # 256
+    barrier_id: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
+):
+    """S0 (BF16): cooperative gmem->smem BF16 copy of Q-NoPE + Q-rope for the
+    ``n_hg`` head groups. Counterpart to ``s0_quantize_q_to_smem`` -- NO FP8
+    quant, no amax/scale (FlashInfer ``load_q_bf16_to_smem``). All HPB heads of
+    each group are valid (heads % HPB == 0). The cooperative loops span
+    ``n_hg * hpb * d_*`` (one group for n_hg==1); the per-group g==1 store target
+    selection const_expr-elides for n_hg==1 since the loop never reaches g==1.
+
+    ``valid_hpb`` is smaller than ``hpb`` only for the heads==8 small-TP shard.
+    Those inactive rows are zero-filled so the M=16 QK MMA remains well-defined
+    while the epilogue gates stores to the real rows only."""
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+
+    # Q-NoPE -> bf16 smem (all groups). group g head h dim d.
+    i = tid
+    while i < Int32(n_hg * hpb * d_nope):
+        g = i // Int32(hpb * d_nope)
+        rem = i - g * Int32(hpb * d_nope)
+        h = rem // Int32(d_nope)
+        d = rem - h * Int32(d_nope)
+        dst = q_nope_bf16_g0_addr
+        if cutlass.const_expr(n_hg == 2):
+            if g != Int32(0):
+                dst = q_nope_bf16_g1_addr
+        if cutlass.const_expr(valid_hpb == hpb):
+            val = Float32(q_token[head_base + g * Int32(hpb) + h, d])
+        else:
+            val = Float32(0.0)
+            if h < valid_hpb:
+                val = Float32(q_token[head_base + g * Int32(hpb) + h, d])
+        st_shared_bf16_from_f32(
+            dst + (h * Int32(q_nope_bf16_stride) + d) * Int32(2), val
+        )
+        i += Int32(num_threads)
+
+    # Q-rope -> bf16 smem scratch (all groups), with a bank-layout row pad.
+    i = tid
+    while i < Int32(n_hg * hpb * d_rope):
+        g = i // Int32(hpb * d_rope)
+        rem = i - g * Int32(hpb * d_rope)
+        h = rem // Int32(d_rope)
+        d = rem - h * Int32(d_rope)
+        dst = q_rope_g0_addr
+        if cutlass.const_expr(n_hg == 2):
+            if g != Int32(0):
+                dst = q_rope_g1_addr
+        if cutlass.const_expr(valid_hpb == hpb):
+            val = Float32(q_token[head_base + g * Int32(hpb) + h, Int32(d_nope) + d])
+        else:
+            val = Float32(0.0)
+            if h < valid_hpb:
+                val = Float32(
+                    q_token[head_base + g * Int32(hpb) + h, Int32(d_nope) + d]
+                )
+        st_shared_bf16_from_f32(dst + (h * Int32(q_rope_stride) + d) * Int32(2), val)
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+
+@cute.jit
+def reload_q_rope_bf16_to_smem_mg(
+    q_token: cute.Tensor,
+    q_rope_g0_addr: Int32,
+    q_rope_g1_addr: Int32,
+    head_base: Int32,
+    tid: Int32,
+    *,
+    d_nope: cutlass.Constexpr,
+    d_rope: cutlass.Constexpr,
+    q_rope_stride: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
+):
+    """Restore BF16 Q-RoPE into its W_FP8-aliased scratch between tiles."""
+    i = tid
+    while i < Int32(n_hg * hpb * d_rope):
+        g = i // Int32(hpb * d_rope)
+        rem = i - g * Int32(hpb * d_rope)
+        h = rem // Int32(d_rope)
+        d = rem - h * Int32(d_rope)
+        dst = q_rope_g0_addr
+        if cutlass.const_expr(n_hg == 2):
+            if g != Int32(0):
+                dst = q_rope_g1_addr
+        if cutlass.const_expr(valid_hpb == hpb):
+            val = Float32(q_token[head_base + g * Int32(hpb) + h, Int32(d_nope) + d])
+        else:
+            val = Float32(0.0)
+            if h < valid_hpb:
+                val = Float32(
+                    q_token[head_base + g * Int32(hpb) + h, Int32(d_nope) + d]
+                )
+        st_shared_bf16_from_f32(dst + (h * Int32(q_rope_stride) + d) * Int32(2), val)
+        i += Int32(num_threads)
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+
+
+@cute.jit
+def preload_q_rope_regs_mg(
+    q_rope_base_addr: Int32,
+    lane: Int32,
+    *,
+    d_rope: cutlass.Constexpr,  # 64
+    q_rope_stride: cutlass.Constexpr,
+):
+    """Preload one head group's Q-rope (bf16) A operands into registers, ONCE
+    before the main loop (FlashInfer ``preload_q_rope_regs``).
+
+    Keep these as sixteen independent SSA values.  Both a Python list and a
+    CuTe register tensor that cross the dynamic tile loop become addressable
+    local arrays in the current DSL lowering, producing sixteen STL.64 stores
+    in the prologue and sixteen LDL.64 reloads per tile.  DSV4/GLM both have a
+    fixed 64-d RoPE, so spelling out the four ldmatrix operations is exact and
+    lets ptxas allocate the fragments as ordinary registers.
+    """
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    a_byte = a_row * Int32(q_rope_stride * 2) + a_col * Int32(2)
+    a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(_smem_byte(q_rope_base_addr, a_byte))
+    a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(
+        _smem_byte(q_rope_base_addr, a_byte + Int32(32))
+    )
+    a20, a21, a22, a23 = ldmatrix_m8n8x4_b16(
+        _smem_byte(q_rope_base_addr, a_byte + Int32(64))
+    )
+    a30, a31, a32, a33 = ldmatrix_m8n8x4_b16(
+        _smem_byte(q_rope_base_addr, a_byte + Int32(96))
+    )
+    return (
+        a00,
+        a01,
+        a02,
+        a03,
+        a10,
+        a11,
+        a12,
+        a13,
+        a20,
+        a21,
+        a22,
+        a23,
+        a30,
+        a31,
+        a32,
+        a33,
+    )
+
+
+@cute.jit
+def s1_qk_nope_bf16_mg2(
+    qk0,
+    qk1,
+    q_nope_bf16_g0_addr: Int32,
+    q_nope_bf16_g1_addr: Int32,
+    kv_fp8_base_addr: Int32,
+    kv_sc_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    *,
+    num_scales: cutlass.Constexpr,  # 7
+    quant_tile: cutlass.Constexpr,  # 64
+    q_nope_bf16_stride: cutlass.Constexpr,  # D_NOPE + 8
+    kv_smem_stride: cutlass.Constexpr,  # 448 (BF16 layout)
+    scale_bytes_per_token: cutlass.Constexpr,  # 8
+    n_hg: cutlass.Constexpr = 2,
+):
+    """S1 (BF16): fused QK-NoPE bf16 m16n8k16 MMA with per-thread inline
+    FP8->BF16 K dequant.
+
+    Byte-for-byte mirror of FlashInfer prefill_kernel.cuh:883-932. The K B
+    operand (b0/b1) and the per-(token,blk) UE8M0 scale depend only on the
+    candidate token, NOT on the head group, so the dequant runs ONCE per K-step
+    and feeds both groups' bf16 MMAs. NUM_SCALES blk x QUANT_TILE/16 ks = 7*4=28
+    bf16 m16n8k16 MMAs per group. NO block-scaled FP8 MMA. When ``n_hg==1`` the
+    group-1 ldmatrix+MMA const_expr-elides (single-group MG, heads==16).
+    """
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    # ldmatrix A (Q bf16 16x16): row/col -- ldmatrix_load_A_bf16.
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    # The K row this lane group reads for the dequant B operand.
+    kv_gid_row = warp_first_cand + gid
+    kv_lane_base = (
+        kv_fp8_base_addr + kv_gid_row * Int32(kv_smem_stride) + tid * Int32(2)
+    )
+    kv_sc_row_base = kv_sc_base_addr + kv_gid_row * Int32(scale_bytes_per_token)
+
+    for blk in cutlass.range_constexpr(num_scales):
+        # DSV4 UE8M0_BYTE: per-(token,blk) fp32 scale from the K footer scale buf.
+        scale_f = _ue8m0_zext_byte_to_fp32(ld_shared_u8_offset(kv_sc_row_base, blk))
+        for ks in cutlass.range_constexpr(quant_tile // 16):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(16)
+            # K dequant B operand: two e4m3 byte-pairs (u16) -> bf16x2 b0/b1.
+            # _ld_u16_zext handles the 2-byte (non-4-aligned) offsets safely.
+            p0 = ld_shared_u16_offset(kv_lane_base, blk * quant_tile + ks * 16)
+            p1 = ld_shared_u16_offset(kv_lane_base, blk * quant_tile + ks * 16 + 8)
+            b0, b1 = dequant_kv_e4m3_pair_to_bf16x2(p0, p1, scale_f)
+            # Group 0 A operand + MMA.
+            a_byte = a_row * Int32(q_nope_bf16_stride * 2) + (ko + a_col) * Int32(2)
+            a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(
+                _smem_byte(q_nope_bf16_g0_addr, a_byte)
+            )
+            qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+                qk0[0], qk0[1], qk0[2], qk0[3], a00, a01, a02, a03, b0, b1
+            )
+            # Group 1 A operand + MMA (same b0/b1). Elided when n_hg==1.
+            if cutlass.const_expr(n_hg == 2):
+                a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(
+                    _smem_byte(q_nope_bf16_g1_addr, a_byte)
+                )
+                qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+                    qk1[0], qk1[1], qk1[2], qk1[3], a10, a11, a12, a13, b0, b1
+                )
+    return qk0, qk1
+
+
+@cute.jit
+def _nvfp4_pair_bfloat2_mg(
+    kv_fp4_base_addr: Int32,
+    entry: Int32,
+    dim_even: Int32,
+    latent_scale: Float32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+) -> Uint32:
+    """Dequant E2M1 * inline E4M3 * per-layer outer scale to bf16x2."""
+    data_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride) + (dim_even // Int32(2)),
+    )
+    vals_h2 = fp4_decode_2(data_byte)
+    v0, v1 = f16x2_to_f32x2(vals_h2)
+    scale_group = dim_even // Int32(_NVFP4_SCALE_GROUP)
+    scale_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride) + Int32(_NVFP4_SCALE_OFFSET) + scale_group,
+    )
+    scale_f = cvt_e4m3_to_f32_via_f16(scale_byte)
+    # Prefill QK has its own MG B-operand loader.  Restore s_l here, before
+    # BF16 packing/MMA, to match decode QK and the shared decode P.V helper.
+    return pack_f32x2_to_bfloat2(
+        (v0 * scale_f) * latent_scale,
+        (v1 * scale_f) * latent_scale,
+    )
+
+
+@cute.jit
+def s1_qk_nope_nvfp4_bf16_mg2(
+    qk0,
+    qk1,
+    q_nope_bf16_g0_addr: Int32,
+    q_nope_bf16_g1_addr: Int32,
+    kv_fp4_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    num_scales: cutlass.Constexpr,
+    quant_tile: cutlass.Constexpr,
+    q_nope_bf16_stride: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+):
+    """S1 (NVFP4): MG BF16 QK-NoPE with native E2M1/E4M3 in-register dequant.
+
+    Same MMA packing as ``s1_qk_nope_bf16_mg2`` but the K/B operand comes from
+    the packed 288-byte NVFP4 row (256B E2M1 + 32B E4M3 group-16 scales); the
+    same math path as the validated NVFP4 decode ``s1_qk_nope_nvfp4_bf16``."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    kv_gid_row = warp_first_cand + gid
+
+    for blk in cutlass.range_constexpr(num_scales):
+        for ks in cutlass.range_constexpr(quant_tile // 16):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(16)
+            b0 = _nvfp4_pair_bfloat2_mg(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            b1 = _nvfp4_pair_bfloat2_mg(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2) + Int32(8),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a_byte = a_row * Int32(q_nope_bf16_stride * 2) + (ko + a_col) * Int32(2)
+            a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(
+                _smem_byte(q_nope_bf16_g0_addr, a_byte)
+            )
+            qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+                qk0[0], qk0[1], qk0[2], qk0[3], a00, a01, a02, a03, b0, b1
+            )
+            if cutlass.const_expr(n_hg == 2):
+                a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(
+                    _smem_byte(q_nope_bf16_g1_addr, a_byte)
+                )
+                qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+                    qk1[0], qk1[1], qk1[2], qk1[3], a10, a11, a12, a13, b0, b1
+                )
+    return qk0, qk1
+
+
+@cute.jit
+def s5_fill_sm_p_full_mg2_nvfp4(
+    w_pre0,
+    w_pre1,
+    weight_smem_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    *,
+    bi: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    sm_p_stride: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+):
+    """Stage MG per-warp BF16 probabilities for the NVFP4 BF16 P.V.
+
+    Reuses the dead W_FP8 region exactly like ``s6b_xv_rope_global_mg_dsv4``:
+    the NVFP4 arm never writes FP8 W, so after S4 the region is free. A leading
+    barrier orders the PREVIOUS tile's P readers before this tile's stores; the
+    caller barriers again after this returns, before the S6 ldmatrix reads."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    warp_first_cand = warp_id * Int32(8)
+    c0 = warp_first_cand + tid * Int32(2)
+    c1 = c0 + Int32(1)
+    group_stride = Int32(sm_p_stride * hpb * 2)
+    sm_p_g0_addr = weight_smem_addr
+    sm_p_g1_addr = weight_smem_addr + group_stride
+
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + (gid * Int32(sm_p_stride) + c0) * Int32(2), w_pre0[0]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + (gid * Int32(sm_p_stride) + c1) * Int32(2), w_pre0[1]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c0) * Int32(2),
+        w_pre0[2],
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c1) * Int32(2),
+        w_pre0[3],
+    )
+    if cutlass.const_expr(n_hg == 2):
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + (gid * Int32(sm_p_stride) + c0) * Int32(2),
+            w_pre1[0],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + (gid * Int32(sm_p_stride) + c1) * Int32(2),
+            w_pre1[1],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c0) * Int32(2),
+            w_pre1[2],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c1) * Int32(2),
+            w_pre1[3],
+        )
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+
+
+@cute.jit
+def prefetch_kv_rope_regs_dsv4(
+    rope_base_ptr: Int64,
+    lane: Int32,
+    *,
+    d_rope: cutlass.Constexpr,
+):
+    """Prefetch one candidate's KV-RoPE B operands before the NoPE MMAs."""
+    tid = lane & Int32(3)
+    regs = cute.make_rmem_tensor((d_rope // 16 * 2,), Uint32)
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        base = ks * 2
+        regs[base + 0] = ld_global_nc_u32(
+            rope_base_ptr + Int64(ko + tid * Int32(2)) * Int64(2)
+        )
+        regs[base + 1] = ld_global_nc_u32(
+            rope_base_ptr + Int64(ko + Int32(8) + tid * Int32(2)) * Int64(2)
+        )
+    return regs
+
+
+@cute.jit
+def s2_qk_rope_prefetched_mg_dsv4_scalar(
+    qk0,
+    qk1,
+    q000: Uint32,
+    q001: Uint32,
+    q002: Uint32,
+    q003: Uint32,
+    q010: Uint32,
+    q011: Uint32,
+    q012: Uint32,
+    q013: Uint32,
+    q020: Uint32,
+    q021: Uint32,
+    q022: Uint32,
+    q023: Uint32,
+    q030: Uint32,
+    q031: Uint32,
+    q032: Uint32,
+    q033: Uint32,
+    q100: Uint32,
+    q101: Uint32,
+    q102: Uint32,
+    q103: Uint32,
+    q110: Uint32,
+    q111: Uint32,
+    q112: Uint32,
+    q113: Uint32,
+    q120: Uint32,
+    q121: Uint32,
+    q122: Uint32,
+    q123: Uint32,
+    q130: Uint32,
+    q131: Uint32,
+    q132: Uint32,
+    q133: Uint32,
+    kv_rope_regs,
+    *,
+    n_hg: cutlass.Constexpr = 2,
+):
+    """DSV4 BF16 QK-RoPE with persistent Q fragments as scalar SSA values.
+
+    The CuTe lowering makes a Q-fragment list/tensor that crosses the dynamic
+    candidate loop addressable, which generates a local-memory store in the
+    prologue and a local-memory reload on every tile. Keep all 32 fragments as
+    explicit operands through the four fixed DSV4 RoPE MMAs instead. The MMA
+    helper is inline PTX, so this is also an explicit register-allocation
+    boundary for LLVM/ptxas without adding any capture-time state.
+    """
+    qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+        qk0[0],
+        qk0[1],
+        qk0[2],
+        qk0[3],
+        q000,
+        q001,
+        q002,
+        q003,
+        kv_rope_regs[0],
+        kv_rope_regs[1],
+    )
+    qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+        qk0[0],
+        qk0[1],
+        qk0[2],
+        qk0[3],
+        q010,
+        q011,
+        q012,
+        q013,
+        kv_rope_regs[2],
+        kv_rope_regs[3],
+    )
+    qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+        qk0[0],
+        qk0[1],
+        qk0[2],
+        qk0[3],
+        q020,
+        q021,
+        q022,
+        q023,
+        kv_rope_regs[4],
+        kv_rope_regs[5],
+    )
+    qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+        qk0[0],
+        qk0[1],
+        qk0[2],
+        qk0[3],
+        q030,
+        q031,
+        q032,
+        q033,
+        kv_rope_regs[6],
+        kv_rope_regs[7],
+    )
+    if cutlass.const_expr(n_hg == 2):
+        qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+            qk1[0],
+            qk1[1],
+            qk1[2],
+            qk1[3],
+            q100,
+            q101,
+            q102,
+            q103,
+            kv_rope_regs[0],
+            kv_rope_regs[1],
+        )
+        qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+            qk1[0],
+            qk1[1],
+            qk1[2],
+            qk1[3],
+            q110,
+            q111,
+            q112,
+            q113,
+            kv_rope_regs[2],
+            kv_rope_regs[3],
+        )
+        qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+            qk1[0],
+            qk1[1],
+            qk1[2],
+            qk1[3],
+            q120,
+            q121,
+            q122,
+            q123,
+            kv_rope_regs[4],
+            kv_rope_regs[5],
+        )
+        qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+            qk1[0],
+            qk1[1],
+            qk1[2],
+            qk1[3],
+            q130,
+            q131,
+            q132,
+            q133,
+            kv_rope_regs[6],
+            kv_rope_regs[7],
+        )
+    return qk0, qk1
+
+
+@cute.jit
+def s2_qk_rope_shared_prefetched_mg_dsv4(
+    qk0,
+    qk1,
+    q_rope_g0_addr: Int32,
+    q_rope_g1_addr: Int32,
+    kv_rope_regs,
+    lane: Int32,
+    *,
+    d_rope: cutlass.Constexpr,
+    q_rope_stride: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+):
+    """BF16 QK-RoPE with persistent shared Q and prefetched KV operands."""
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        a_byte = (a_row * Int32(q_rope_stride) + (ko + a_col)) * Int32(2)
+        bbase = ks * 2
+        a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(q_rope_g0_addr + a_byte)
+        qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+            qk0[0],
+            qk0[1],
+            qk0[2],
+            qk0[3],
+            a00,
+            a01,
+            a02,
+            a03,
+            kv_rope_regs[bbase + 0],
+            kv_rope_regs[bbase + 1],
+        )
+        if cutlass.const_expr(n_hg == 2):
+            a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(q_rope_g1_addr + a_byte)
+            qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+                qk1[0],
+                qk1[1],
+                qk1[2],
+                qk1[3],
+                a10,
+                a11,
+                a12,
+                a13,
+                kv_rope_regs[bbase + 0],
+                kv_rope_regs[bbase + 1],
+            )
+    return qk0, qk1
+
+
+@cute.jit
+def s2_qk_rope_regs_mg_dsv4(
+    qk0,
+    qk1,
+    q_rope_regs0,
+    q_rope_regs1,
+    kv_cache_u8: cute.Tensor,
+    index_base_ptr: Int64,
+    warp_first_cand: Int32,
+    lane: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    d_rope: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+):
+    """Fused BF16 QK-RoPE with interleaved B loads for non-dual SWA."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    entry = warp_first_cand + gid
+    idx = _ld_global_index_i32(index_base_ptr, entry)
+    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block)
+
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        b0 = ld_global_nc_u32(
+            get_ptr_as_int64(
+                kv_cache_u8,
+                rope_base + Int64(ko + tid * Int32(2)) * Int64(2),
+            )
+        )
+        b1 = ld_global_nc_u32(
+            get_ptr_as_int64(
+                kv_cache_u8,
+                rope_base + Int64(ko + Int32(8) + tid * Int32(2)) * Int64(2),
+            )
+        )
+        base = Int32(ks) * Int32(4)
+        qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+            qk0[0],
+            qk0[1],
+            qk0[2],
+            qk0[3],
+            q_rope_regs0[base + 0],
+            q_rope_regs0[base + 1],
+            q_rope_regs0[base + 2],
+            q_rope_regs0[base + 3],
+            b0,
+            b1,
+        )
+        if cutlass.const_expr(n_hg == 2):
+            qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+                qk1[0],
+                qk1[1],
+                qk1[2],
+                qk1[3],
+                q_rope_regs1[base + 0],
+                q_rope_regs1[base + 1],
+                q_rope_regs1[base + 2],
+                q_rope_regs1[base + 3],
+                b0,
+                b1,
+            )
+    return qk0, qk1
+
+
+@cute.jit
+def s6b_xv_rope_global_dsv4(
+    acc_rope,
+    sm_p_full_addr: Int32,
+    kv_cache_u8: cute.Tensor,
+    index_base_ptr: Int64,
+    warp_id: Int32,
+    lane: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    bi: cutlass.Constexpr,
+    d_rope: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+):
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    rope_dim_base = warp_id * Int32(d_rope // n_warps)
+    dim_n = rope_dim_base + gid
+    rope_dim_ptr = get_ptr_as_int64(
+        kv_cache_u8,
+        Int64(_DSV4_ROPE_GMEM_OFFSET) + Int64(dim_n) * Int64(2),
+    )
+
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+
+    for ks in cutlass.range_constexpr(bi // 16):
+        k_base = Int32(ks) * Int32(16)
+        a_byte = (a_row * Int32(bi) + (k_base + a_col)) * Int32(2)
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_full_addr + a_byte)
+
+        ent0 = k_base + tid * Int32(2)
+        idx0 = _ld_global_index_i32(index_base_ptr, ent0)
+        idx1 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(1))
+        idx8 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(8))
+        idx9 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(9))
+        v0 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx0, page_block_size, stride_kv_block
+        )
+        v1 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx1, page_block_size, stride_kv_block
+        )
+        v8 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx8, page_block_size, stride_kv_block
+        )
+        v9 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx9, page_block_size, stride_kv_block
+        )
+        b0 = v0 | (v1 << Uint32(16))
+        b1 = v8 | (v9 << Uint32(16))
+        acc_rope[0], acc_rope[1], acc_rope[2], acc_rope[3] = mma_m16n8k16_f32_bf16(
+            acc_rope[0], acc_rope[1], acc_rope[2], acc_rope[3], a0, a1, a2, a3, b0, b1
+        )
+    return acc_rope
+
+
+@cute.jit
+def s6b_xv_rope_global_mg_dsv4(
+    acc_rope0,
+    acc_rope1,
+    w_pre0,
+    w_pre1,
+    weight_smem_addr: Int32,
+    kv_cache_u8: cute.Tensor,
+    index_base_ptr: Int64,
+    warp_id: Int32,
+    lane: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    bi: cutlass.Constexpr,
+    sm_p_stride: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    d_rope: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+):
+    two = cutlass.const_expr(n_hg == 2)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    rope_dim_base = warp_id * Int32(d_rope // n_warps)
+    dim_n = rope_dim_base + gid
+    rope_dim_ptr = get_ptr_as_int64(
+        kv_cache_u8,
+        Int64(_DSV4_ROPE_GMEM_OFFSET) + Int64(dim_n) * Int64(2),
+    )
+
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+
+    # W_FP8 is dead after XV-NoPE.  Synchronize its final readers, then stage
+    # this warp's current weights into the same region for XV-RoPE.  This is the
+    # native MG lifetime: no separate persistent sm_p_full allocation.
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+    warp_first_cand = warp_id * Int32(8)
+    cand_e0 = warp_first_cand + tid * Int32(2)
+    cand_e1 = cand_e0 + Int32(1)
+    group_stride = Int32(sm_p_stride * hpb * 2)
+    sm_p_g0_addr = weight_smem_addr
+    sm_p_g1_addr = weight_smem_addr + group_stride
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + (gid * Int32(sm_p_stride) + cand_e0) * Int32(2), w_pre0[0]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + (gid * Int32(sm_p_stride) + cand_e1) * Int32(2), w_pre0[1]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + cand_e0) * Int32(2),
+        w_pre0[2],
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + cand_e1) * Int32(2),
+        w_pre0[3],
+    )
+    if cutlass.const_expr(two):
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + (gid * Int32(sm_p_stride) + cand_e0) * Int32(2),
+            w_pre1[0],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + (gid * Int32(sm_p_stride) + cand_e1) * Int32(2),
+            w_pre1[1],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + cand_e0) * Int32(2),
+            w_pre1[2],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + cand_e1) * Int32(2),
+            w_pre1[3],
+        )
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+
+    for ks in cutlass.range_constexpr(bi // 16):
+        k_base = Int32(ks) * Int32(16)
+        ent0 = k_base + tid * Int32(2)
+        idx0 = _ld_global_index_i32(index_base_ptr, ent0)
+        idx1 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(1))
+        idx8 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(8))
+        idx9 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(9))
+        v0 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx0, page_block_size, stride_kv_block
+        )
+        v1 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx1, page_block_size, stride_kv_block
+        )
+        v8 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx8, page_block_size, stride_kv_block
+        )
+        v9 = _ld_global_dsv4_rope_b16(
+            rope_dim_ptr, idx9, page_block_size, stride_kv_block
+        )
+        b0 = v0 | (v1 << Uint32(16))
+        b1 = v8 | (v9 << Uint32(16))
+
+        a_byte = (a_row * Int32(sm_p_stride) + (k_base + a_col)) * Int32(2)
+        a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(sm_p_g0_addr + a_byte)
+        acc_rope0[0], acc_rope0[1], acc_rope0[2], acc_rope0[3] = mma_m16n8k16_f32_bf16(
+            acc_rope0[0],
+            acc_rope0[1],
+            acc_rope0[2],
+            acc_rope0[3],
+            a00,
+            a01,
+            a02,
+            a03,
+            b0,
+            b1,
+        )
+        if cutlass.const_expr(two):
+            a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(sm_p_g1_addr + a_byte)
+            acc_rope1[0], acc_rope1[1], acc_rope1[2], acc_rope1[3] = (
+                mma_m16n8k16_f32_bf16(
+                    acc_rope1[0],
+                    acc_rope1[1],
+                    acc_rope1[2],
+                    acc_rope1[3],
+                    a10,
+                    a11,
+                    a12,
+                    a13,
+                    b0,
+                    b1,
+                )
+            )
+    return acc_rope0, acc_rope1
+
+
+@cute.jit
+def s4_online_softmax_mg2(
+    qk0,
+    qk1,
+    p0,
+    p1,
+    acc0,
+    acc1,
+    rope0,
+    rope1,
+    gs0,
+    gs1,
+    acc0_frag: cute.Tensor,
+    acc1_frag: cute.Tensor,
+    rope0_frag: cute.Tensor,
+    rope1_frag: cute.Tensor,
+    gsum0_frag: cute.Tensor,
+    gsum1_frag: cute.Tensor,
+    reduce_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    n_v_chunks: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    n_acc_tiles: cutlass.Constexpr,
+    reduce_group_bytes: cutlass.Constexpr,
+    reduce_sum_off: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
+):
+    """S4 online softmax with FlashInfer-style deferred row sums. Every group-1
+    statement is gated inline behind ``const_expr(n_hg == 2)`` so the n_hg==2
+    trace is the original interleaved instruction stream (byte-identical) and
+    n_hg==1 cleanly elides all qk1/acc1/rope1/gs1/reduce1 work (single HPB head
+    group; the cross-warp reduce spans tid_flat < hpb, group 0 only)."""
+    two = cutlass.const_expr(n_hg == 2)
+    hi0 = cutlass.const_expr(valid_hpb > 8)
+    reduce_heads = cutlass.const_expr(n_hg * hpb if n_hg == 2 else valid_hpb)
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+
+    lm00 = fmax_f32(qk0[0], qk0[1])
+    if cutlass.const_expr(hi0):
+        lm01 = fmax_f32(qk0[2], qk0[3])
+    if cutlass.const_expr(two):
+        lm10 = fmax_f32(qk1[0], qk1[1])
+        lm11 = fmax_f32(qk1[2], qk1[3])
+    lm00 = fmax_f32(lm00, cute.arch.shuffle_sync_bfly(lm00, offset=2))
+    if cutlass.const_expr(hi0):
+        lm01 = fmax_f32(lm01, cute.arch.shuffle_sync_bfly(lm01, offset=2))
+    if cutlass.const_expr(two):
+        lm10 = fmax_f32(lm10, cute.arch.shuffle_sync_bfly(lm10, offset=2))
+        lm11 = fmax_f32(lm11, cute.arch.shuffle_sync_bfly(lm11, offset=2))
+    lm00 = fmax_f32(lm00, cute.arch.shuffle_sync_bfly(lm00, offset=1))
+    if cutlass.const_expr(hi0):
+        lm01 = fmax_f32(lm01, cute.arch.shuffle_sync_bfly(lm01, offset=1))
+    if cutlass.const_expr(two):
+        lm10 = fmax_f32(lm10, cute.arch.shuffle_sync_bfly(lm10, offset=1))
+        lm11 = fmax_f32(lm11, cute.arch.shuffle_sync_bfly(lm11, offset=1))
+
+    reduce_warp_head_addr = reduce_addr + (warp_id * Int32(hpb) + gid) * Int32(4)
+    if tid == Int32(0):
+        st_shared_f32_offset(reduce_warp_head_addr, 0, lm00)
+        if cutlass.const_expr(hi0):
+            st_shared_f32_offset(reduce_warp_head_addr, 8 * 4, lm01)
+        if cutlass.const_expr(two):
+            st_shared_f32_offset(reduce_warp_head_addr, reduce_group_bytes, lm10)
+            st_shared_f32_offset(
+                reduce_warp_head_addr, reduce_group_bytes + 8 * 4, lm11
+            )
+    cute.arch.barrier(**bar_kw)
+
+    if tid_flat < Int32(reduce_heads):
+        if cutlass.const_expr(two):
+            group = tid_flat // Int32(hpb)
+            h = tid_flat - group * Int32(hpb)
+        else:
+            group = Int32(0)
+            h = tid_flat
+        reduce_head_addr = (
+            reduce_addr + group * Int32(reduce_group_bytes) + h * Int32(4)
+        )
+        old_m = ld_shared_f32_offset(reduce_head_addr, reduce_sum_off)
+        bmax = Float32(-1e30)
+        for w in cutlass.range_constexpr(n_warps):
+            wm = ld_shared_f32_offset(reduce_head_addr, w * hpb * 4)
+            bmax = fmax_f32(bmax, wm)
+        new_m = fmax_f32(old_m, bmax)
+        alpha = _exp2_approx_ftz_f32(old_m - new_m)
+        # The max-reduction tile is dead after this thread has consumed its
+        # column. Reuse warp slots 0 and 1 for the alpha/new-max broadcast,
+        # exactly as FI does. The sum region's first HPB values hold persistent
+        # max until the post-loop sum reduction overwrites that scratch.
+        st_shared_f32_offset(reduce_head_addr, reduce_sum_off, new_m)
+        st_shared_f32_offset(reduce_head_addr, 0, alpha)
+        st_shared_f32_offset(reduce_head_addr, hpb * 4, new_m)
+    cute.arch.barrier(**bar_kw)
+
+    reduce_lane_head_addr = reduce_addr + gid * Int32(4)
+    alpha00 = ld_shared_f32_offset(reduce_lane_head_addr, 0)
+    ngm00 = ld_shared_f32_offset(reduce_lane_head_addr, hpb * 4)
+    if cutlass.const_expr(hi0):
+        alpha01 = ld_shared_f32_offset(reduce_lane_head_addr, 8 * 4)
+        ngm01 = ld_shared_f32_offset(reduce_lane_head_addr, hpb * 4 + 8 * 4)
+    if cutlass.const_expr(two):
+        alpha10 = ld_shared_f32_offset(reduce_lane_head_addr, reduce_group_bytes)
+        alpha11 = ld_shared_f32_offset(
+            reduce_lane_head_addr, reduce_group_bytes + 8 * 4
+        )
+        ngm10 = ld_shared_f32_offset(
+            reduce_lane_head_addr, reduce_group_bytes + hpb * 4
+        )
+        ngm11 = ld_shared_f32_offset(
+            reduce_lane_head_addr,
+            reduce_group_bytes + hpb * 4 + 8 * 4,
+        )
+
+    # Match FI's online-softmax fast path.  A row whose running maximum did
+    # not change has alpha==1 exactly, so rescaling its persistent accumulators
+    # is mathematically and numerically a no-op.  Write the persistent register
+    # tensors inside the device branch, then rebuild the Python-list views
+    # below.  Mutating a nested Python list in a dynamic CuTe branch does not
+    # form loop-carried SSA results and the lowering silently dead-codes those
+    # updates; register-tensor writes are represented explicitly through the
+    # control-flow merge.
+    if cutlass.const_expr(hi0):
+        if fmin_f32(alpha00, alpha01) < Float32(1.0):
+            for vc in cutlass.range_constexpr(n_acc_tiles):
+                acc0_frag[vc * 4 + 0] = acc0_frag[vc * 4 + 0] * alpha00
+                acc0_frag[vc * 4 + 1] = acc0_frag[vc * 4 + 1] * alpha00
+                acc0_frag[vc * 4 + 2] = acc0_frag[vc * 4 + 2] * alpha01
+                acc0_frag[vc * 4 + 3] = acc0_frag[vc * 4 + 3] * alpha01
+            rope0_frag[0] = rope0_frag[0] * alpha00
+            rope0_frag[1] = rope0_frag[1] * alpha00
+            rope0_frag[2] = rope0_frag[2] * alpha01
+            rope0_frag[3] = rope0_frag[3] * alpha01
+            gsum0_frag[0] = gsum0_frag[0] * alpha00
+            gsum0_frag[1] = gsum0_frag[1] * alpha01
+    else:
+        if alpha00 < Float32(1.0):
+            for vc in cutlass.range_constexpr(n_acc_tiles):
+                acc0_frag[vc * 4 + 0] = acc0_frag[vc * 4 + 0] * alpha00
+                acc0_frag[vc * 4 + 1] = acc0_frag[vc * 4 + 1] * alpha00
+            rope0_frag[0] = rope0_frag[0] * alpha00
+            rope0_frag[1] = rope0_frag[1] * alpha00
+            gsum0_frag[0] = gsum0_frag[0] * alpha00
+
+    if cutlass.const_expr(two):
+        if fmin_f32(alpha10, alpha11) < Float32(1.0):
+            for vc in cutlass.range_constexpr(n_acc_tiles):
+                acc1_frag[vc * 4 + 0] = acc1_frag[vc * 4 + 0] * alpha10
+                acc1_frag[vc * 4 + 1] = acc1_frag[vc * 4 + 1] * alpha10
+                acc1_frag[vc * 4 + 2] = acc1_frag[vc * 4 + 2] * alpha11
+                acc1_frag[vc * 4 + 3] = acc1_frag[vc * 4 + 3] * alpha11
+            rope1_frag[0] = rope1_frag[0] * alpha10
+            rope1_frag[1] = rope1_frag[1] * alpha10
+            rope1_frag[2] = rope1_frag[2] * alpha11
+            rope1_frag[3] = rope1_frag[3] * alpha11
+            gsum1_frag[0] = gsum1_frag[0] * alpha10
+            gsum1_frag[1] = gsum1_frag[1] * alpha11
+
+    for vc in cutlass.range_constexpr(n_acc_tiles):
+        acc0[vc][0] = acc0_frag[vc * 4 + 0]
+        acc0[vc][1] = acc0_frag[vc * 4 + 1]
+        acc0[vc][2] = acc0_frag[vc * 4 + 2]
+        acc0[vc][3] = acc0_frag[vc * 4 + 3]
+    rope0[0] = rope0_frag[0]
+    rope0[1] = rope0_frag[1]
+    rope0[2] = rope0_frag[2]
+    rope0[3] = rope0_frag[3]
+    gs0[0] = gsum0_frag[0]
+    gs0[1] = gsum0_frag[1]
+    if cutlass.const_expr(two):
+        for vc in cutlass.range_constexpr(n_acc_tiles):
+            acc1[vc][0] = acc1_frag[vc * 4 + 0]
+            acc1[vc][1] = acc1_frag[vc * 4 + 1]
+            acc1[vc][2] = acc1_frag[vc * 4 + 2]
+            acc1[vc][3] = acc1_frag[vc * 4 + 3]
+        rope1[0] = rope1_frag[0]
+        rope1[1] = rope1_frag[1]
+        rope1[2] = rope1_frag[2]
+        rope1[3] = rope1_frag[3]
+        gs1[0] = gsum1_frag[0]
+        gs1[1] = gsum1_frag[1]
+
+    p0[0] = _exp2_approx_ftz_f32(qk0[0] - ngm00)
+    p0[1] = _exp2_approx_ftz_f32(qk0[1] - ngm00)
+    if cutlass.const_expr(hi0):
+        p0[2] = _exp2_approx_ftz_f32(qk0[2] - ngm01)
+        p0[3] = _exp2_approx_ftz_f32(qk0[3] - ngm01)
+    else:
+        p0[2] = Float32(0.0)
+        p0[3] = Float32(0.0)
+    if cutlass.const_expr(two):
+        p1[0] = _exp2_approx_ftz_f32(qk1[0] - ngm10)
+        p1[1] = _exp2_approx_ftz_f32(qk1[1] - ngm10)
+        p1[2] = _exp2_approx_ftz_f32(qk1[2] - ngm11)
+        p1[3] = _exp2_approx_ftz_f32(qk1[3] - ngm11)
+
+    ls00 = p0[0] + p0[1]
+    if cutlass.const_expr(hi0):
+        ls01 = p0[2] + p0[3]
+    if cutlass.const_expr(two):
+        ls10 = p1[0] + p1[1]
+        ls11 = p1[2] + p1[3]
+    ls00 = ls00 + cute.arch.shuffle_sync_bfly(ls00, offset=2)
+    if cutlass.const_expr(hi0):
+        ls01 = ls01 + cute.arch.shuffle_sync_bfly(ls01, offset=2)
+    if cutlass.const_expr(two):
+        ls10 = ls10 + cute.arch.shuffle_sync_bfly(ls10, offset=2)
+        ls11 = ls11 + cute.arch.shuffle_sync_bfly(ls11, offset=2)
+    ls00 = ls00 + cute.arch.shuffle_sync_bfly(ls00, offset=1)
+    if cutlass.const_expr(hi0):
+        ls01 = ls01 + cute.arch.shuffle_sync_bfly(ls01, offset=1)
+    if cutlass.const_expr(two):
+        ls10 = ls10 + cute.arch.shuffle_sync_bfly(ls10, offset=1)
+        ls11 = ls11 + cute.arch.shuffle_sync_bfly(ls11, offset=1)
+
+    gs0[0] = gs0[0] + ls00
+    if cutlass.const_expr(hi0):
+        gs0[1] = gs0[1] + ls01
+    if cutlass.const_expr(two):
+        gs1[0] = gs1[0] + ls10
+        gs1[1] = gs1[1] + ls11
+    return (
+        p0,
+        p1,
+        Float32(1.0),
+        Float32(1.0),
+        Float32(1.0),
+        Float32(1.0),
+    )
+
+
+@cute.jit
+def s4_finalize_row_sum_mg2(
+    gs0,
+    gs1,
+    reduce0_sum_addr: Int32,
+    reduce1_sum_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    hpb: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
+):
+    """Final cross-warp row-sum reduction for deferred MG softmax. Group-1
+    statements gate inline behind ``const_expr(n_hg == 2)`` (n_hg==2 trace
+    unchanged); n_hg==1 reduces only group 0 (tid_flat < hpb)."""
+    two = cutlass.const_expr(n_hg == 2)
+    hi0 = cutlass.const_expr(valid_hpb > 8)
+    reduce_heads = cutlass.const_expr(n_hg * hpb if n_hg == 2 else valid_hpb)
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+
+    # The sum scratch still holds the persistent max that the caller's
+    # final_gmax reads consume; every warp must finish those reads before the
+    # stores below reuse the region (racecheck-confirmed hazard otherwise).
+    cute.arch.barrier(**bar_kw)
+
+    if tid == Int32(0):
+        st_shared_f32(
+            reduce0_sum_addr + (warp_id * Int32(hpb) + gid) * Int32(4), gs0[0]
+        )
+        if cutlass.const_expr(hi0):
+            st_shared_f32(
+                reduce0_sum_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
+                gs0[1],
+            )
+        if cutlass.const_expr(two):
+            st_shared_f32(
+                reduce1_sum_addr + (warp_id * Int32(hpb) + gid) * Int32(4), gs1[0]
+            )
+            st_shared_f32(
+                reduce1_sum_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
+                gs1[1],
+            )
+    cute.arch.barrier(**bar_kw)
+
+    if tid_flat < Int32(reduce_heads):
+        if cutlass.const_expr(two):
+            group = tid_flat // Int32(hpb)
+            h = tid_flat - group * Int32(hpb)
+        else:
+            group = Int32(0)
+            h = tid_flat
+        rsum = reduce0_sum_addr
+        if cutlass.const_expr(two):
+            if group != Int32(0):
+                rsum = reduce1_sum_addr
+        total = Float32(0.0)
+        for w in cutlass.range_constexpr(n_warps):
+            total = total + ld_shared_f32(rsum + (Int32(w) * Int32(hpb) + h) * Int32(4))
+        st_shared_f32(rsum + h * Int32(4), total)
+    cute.arch.barrier(**bar_kw)
+
+    gs0[0] = ld_shared_f32(reduce0_sum_addr + gid * Int32(4))
+    if cutlass.const_expr(hi0):
+        gs0[1] = ld_shared_f32(reduce0_sum_addr + (gid + Int32(8)) * Int32(4))
+    if cutlass.const_expr(two):
+        gs1[0] = ld_shared_f32(reduce1_sum_addr + gid * Int32(4))
+        gs1[1] = ld_shared_f32(reduce1_sum_addr + (gid + Int32(8)) * Int32(4))
+    return gs0, gs1
+
+
+@cute.jit
+def s6_xv_nope_mg_dsv4(
+    w_pre0,
+    w_pre1,
+    acc0,
+    acc1,
+    kv_fp8_base_addr: Int32,
+    kv_sc_base_addr: Int32,
+    w_head_sc_view: cute.Tensor,
+    w_fp8_base_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    n_v_chunks: cutlass.Constexpr,
+    v_chunk: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    bi: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    w_fp8_stride: cutlass.Constexpr,
+    w_fp8_group_stride: cutlass.Constexpr,
+    w_fp8_parity_stride: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    scale_bytes_per_token: cutlass.Constexpr,
+    nt_per_warp_xv: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+    row_xor: cutlass.Constexpr = False,
+):
+    """FlashInfer-shaped DSV4 MG XV-NoPE for ``n_hg`` HPB head groups.
+
+    V scales and V B operands are shared across the head groups. This fuses the
+    decode-style S5/S6 calls used by the first correctness port while keeping the
+    same DSV4 FP8 W-quantization math. Every group-1 statement gates inline behind
+    ``const_expr(n_hg == 2)`` (n_hg==2 trace byte-identical); n_hg==1 elides the
+    group-1 sm_p / W-quant stores + the second per-k XV MMA, so the per-CTA XV
+    ldmatrix/mma count halves. The w_head_sc zero/scale loops span
+    ``n_hg * n_v_chunks * hpb`` (one group's worth for n_hg==1).
+    """
+    two = cutlass.const_expr(n_hg == 2)
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    warp_first_cand = warp_id * Int32(8)
+    cand_e0 = warp_first_cand + tid * Int32(2)
+    i = tid_flat
+    while i < Int32(n_hg * n_v_chunks * hpb):
+        w_head_sc_view[i] = Float32(0.0)
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    w_head_sc_base = shared_ptr_to_u32(w_head_sc_view.iterator)
+    w_head_sc_lane_base = w_head_sc_base + gid * Int32(4)
+    # Match the native MG schedule: each lane owns the same two candidate
+    # scales for both head groups, and those scales are reused by the absmax
+    # pass and the W-quantization pass.  The dual-head-group trace keeps only
+    # the four packed words live across the intervening barriers and expands
+    # one scale pair at each use.  Keeping all 2*N_V_CHUNKS decoded Float32
+    # values live makes CUTLASS 4.6 spill the H32 trace at the safe 232-register
+    # math-warp limit.  The single-head-group trace retains the lower-work
+    # decode-once schedule.
+    vsc_cache0 = []
+    vsc_cache1 = []
+    vsc_e0_base = kv_sc_base_addr + cand_e0 * Int32(scale_bytes_per_token)
+    # e0/e1 are adjacent scale rows (8 bytes each), and e0 is even, so one
+    # aligned 16-byte load fetches both candidates exactly as FI's
+    # ``ld.shared.v4.b32`` + ``prmt`` sequence does.
+    sc0_lo, sc0_hi, sc1_lo, sc1_hi = ld_shared_v4_u32(vsc_e0_base)
+    if cutlass.const_expr(n_hg == 1):
+        for vc in cutlass.range_constexpr(n_v_chunks):
+            if cutlass.const_expr(vc < 4):
+                sc0_word = sc0_lo
+                sc1_word = sc1_lo
+                sc_byte = vc
+            else:
+                sc0_word = sc0_hi
+                sc1_word = sc1_hi
+                sc_byte = vc - 4
+            selector = Int32(0x7770 + sc_byte)
+            vsc_cache0.append(
+                _ue8m0_zext_byte_to_fp32(byte_perm(sc0_word, Uint32(0), selector))
+            )
+            vsc_cache1.append(
+                _ue8m0_zext_byte_to_fp32(byte_perm(sc1_word, Uint32(0), selector))
+            )
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        if cutlass.const_expr(n_hg == 2):
+            if cutlass.const_expr(vc < 4):
+                sc0_word = sc0_lo
+                sc1_word = sc1_lo
+                sc_byte = vc
+            else:
+                sc0_word = sc0_hi
+                sc1_word = sc1_hi
+                sc_byte = vc - 4
+            selector = Int32(0x7770 + sc_byte)
+            vsc0 = _ue8m0_zext_byte_to_fp32(byte_perm(sc0_word, Uint32(0), selector))
+            vsc1 = _ue8m0_zext_byte_to_fp32(byte_perm(sc1_word, Uint32(0), selector))
+        else:
+            vsc0 = vsc_cache0[vc]
+            vsc1 = vsc_cache1[vc]
+        m00 = fmax_f32(w_pre0[0] * vsc0, w_pre0[1] * vsc1)
+        m01 = fmax_f32(w_pre0[2] * vsc0, w_pre0[3] * vsc1)
+        if cutlass.const_expr(two):
+            m10 = fmax_f32(w_pre1[0] * vsc0, w_pre1[1] * vsc1)
+            m11 = fmax_f32(w_pre1[2] * vsc0, w_pre1[3] * vsc1)
+        atomic_max_shared_f32_offset(w_head_sc_lane_base, vc * hpb * 4, m00)
+        atomic_max_shared_f32_offset(w_head_sc_lane_base, (vc * hpb + 8) * 4, m01)
+        if cutlass.const_expr(two):
+            atomic_max_shared_f32_offset(
+                w_head_sc_lane_base,
+                (n_v_chunks * hpb + vc * hpb) * 4,
+                m10,
+            )
+            atomic_max_shared_f32_offset(
+                w_head_sc_lane_base,
+                (n_v_chunks * hpb + vc * hpb + 8) * 4,
+                m11,
+            )
+    cute.arch.barrier(**bar_kw)
+
+    i = tid_flat
+    while i < Int32(n_hg * n_v_chunks * hpb):
+        w_head_sc_view[i] = fmax_f32(w_head_sc_view[i], Float32(1e-10)) * Float32(
+            1.0 / 448.0
+        )
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    # ldmatrix A-operand load row. FI applies the SAME row^(row>>3) swizzle on the
+    # load (ldmatrix_load_A_fp8_layout<ROW_XOR>, ldmatrix_sm120.cuh:79-86) so it is
+    # symmetric with the store -> numerically identity. const_expr(row_xor=False)
+    # leaves a_row_eff == a_row (load address arithmetic textually unchanged).
+    if cutlass.const_expr(row_xor):
+        a_row_eff = _wfp8_row_xor(a_row)
+    else:
+        a_row_eff = a_row
+    a_col = (lane >> Int32(4)) * Int32(16)
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        w_fp8_parity_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(w_fp8_parity_stride)
+        w_fp8_g0 = w_fp8_parity_addr
+        w_fp8_g1 = w_fp8_parity_addr + Int32(w_fp8_group_stride)
+
+        sc00 = ld_shared_f32_offset(w_head_sc_lane_base, vc * hpb * 4)
+        sc01 = ld_shared_f32_offset(w_head_sc_lane_base, (vc * hpb + 8) * 4)
+        if cutlass.const_expr(two):
+            sc10 = ld_shared_f32_offset(
+                w_head_sc_lane_base,
+                (n_v_chunks * hpb + vc * hpb) * 4,
+            )
+            sc11 = ld_shared_f32_offset(
+                w_head_sc_lane_base,
+                (n_v_chunks * hpb + vc * hpb + 8) * 4,
+            )
+        si00 = rcp_approx_ftz(sc00)
+        si01 = rcp_approx_ftz(sc01)
+        if cutlass.const_expr(two):
+            si10 = rcp_approx_ftz(sc10)
+            si11 = rcp_approx_ftz(sc11)
+
+        if cutlass.const_expr(n_hg == 2):
+            if cutlass.const_expr(vc < 4):
+                sc0_word = sc0_lo
+                sc1_word = sc1_lo
+                sc_byte = vc
+            else:
+                sc0_word = sc0_hi
+                sc1_word = sc1_hi
+                sc_byte = vc - 4
+            selector = Int32(0x7770 + sc_byte)
+            vsc0 = _ue8m0_zext_byte_to_fp32(byte_perm(sc0_word, Uint32(0), selector))
+            vsc1 = _ue8m0_zext_byte_to_fp32(byte_perm(sc1_word, Uint32(0), selector))
+        else:
+            vsc0 = vsc_cache0[vc]
+            vsc1 = vsc_cache1[vc]
+
+        # W (A-operand) store rows. FI stores at wrow0=gid, wrow1=gid+8 and, for
+        # the dual pbs_extra==2 path, applies the bank-conflict swizzle row^(row>>3)
+        # (prefill_kernel.cuh:1258-1262). const_expr(row_xor=False) -> r0/r8 are the
+        # literal gid / gid+8, so the no-rowxor store address arithmetic is
+        # textually identical to today (byte-identical PTX). Columns (cand_e0/e1)
+        # are NEVER swizzled.
+        if cutlass.const_expr(row_xor):
+            r0 = _wfp8_row_xor(gid)
+            r8 = _wfp8_row_xor(gid + Int32(8))
+        else:
+            r0 = gid
+            r8 = gid + Int32(8)
+
+        quantize_scaled_store_shared_v2_e4m3(
+            w_fp8_g0 + r0 * Int32(w_fp8_stride) + cand_e0,
+            w_pre0[0] * vsc0,
+            w_pre0[1] * vsc1,
+            si00,
+        )
+        quantize_scaled_store_shared_v2_e4m3(
+            w_fp8_g0 + r8 * Int32(w_fp8_stride) + cand_e0,
+            w_pre0[2] * vsc0,
+            w_pre0[3] * vsc1,
+            si01,
+        )
+        if cutlass.const_expr(two):
+            quantize_scaled_store_shared_v2_e4m3(
+                w_fp8_g1 + r0 * Int32(w_fp8_stride) + cand_e0,
+                w_pre1[0] * vsc0,
+                w_pre1[1] * vsc1,
+                si10,
+            )
+            quantize_scaled_store_shared_v2_e4m3(
+                w_fp8_g1 + r8 * Int32(w_fp8_stride) + cand_e0,
+                w_pre1[2] * vsc0,
+                w_pre1[3] * vsc1,
+                si11,
+            )
+        cute.arch.barrier(**bar_kw)
+
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            at = vc * nt_per_warp_xv + nt
+            dim = Int32(vc) * Int32(v_chunk) + (
+                Int32(nt) * Int32(n_warps) + warp_id
+            ) * Int32(8)
+            xv00 = Float32(0.0)
+            xv01 = Float32(0.0)
+            xv02 = Float32(0.0)
+            xv03 = Float32(0.0)
+            if cutlass.const_expr(two):
+                xv10 = Float32(0.0)
+                xv11 = Float32(0.0)
+                xv12 = Float32(0.0)
+                xv13 = Float32(0.0)
+            for kstep in cutlass.range_constexpr(bi // 32):
+                ko = Int32(kstep) * Int32(32)
+                b0, b1 = _d2_load_b_fp8(
+                    kv_fp8_base_addr, ko, dim, lane, kv_smem_stride=kv_smem_stride
+                )
+                a_addr0 = w_fp8_g0 + a_row_eff * Int32(w_fp8_stride) + ko + a_col
+                a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(a_addr0)
+                xv00, xv01, xv02, xv03 = mma_m16n8k32_f32_e4m3(
+                    xv00, xv01, xv02, xv03, a00, a01, a02, a03, b0, b1
+                )
+                if cutlass.const_expr(two):
+                    a_addr1 = w_fp8_g1 + a_row_eff * Int32(w_fp8_stride) + ko + a_col
+                    a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(a_addr1)
+                    xv10, xv11, xv12, xv13 = mma_m16n8k32_f32_e4m3(
+                        xv10, xv11, xv12, xv13, a10, a11, a12, a13, b0, b1
+                    )
+
+            acc0[at][0] = acc0[at][0] + xv00 * sc00
+            acc0[at][1] = acc0[at][1] + xv01 * sc00
+            acc0[at][2] = acc0[at][2] + xv02 * sc01
+            acc0[at][3] = acc0[at][3] + xv03 * sc01
+            if cutlass.const_expr(two):
+                acc1[at][0] = acc1[at][0] + xv10 * sc10
+                acc1[at][1] = acc1[at][1] + xv11 * sc10
+                acc1[at][2] = acc1[at][2] + xv12 * sc11
+                acc1[at][3] = acc1[at][3] + xv13 * sc11
+    return acc0, acc1
+
+
+class UnifiedPrefillMGKernel:
+    def __init__(
+        self,
+        traits,
+        layout,
+        page_block_size,
+        num_tiles,
+        replicate_h,
+        num_heads,
+        q_stride,
+        indices_stride0,
+        output_stride,
+        out_lse_stride,
+        has_sink,
+        topk,
+        has_extra=False,
+        pbs_extra=1,
+        num_main_tiles=0,
+        extra_topk=0,
+        extra_indices_stride0=0,
+        row_xor=False,
+        head_offset=0,
+        valid_hpb=None,
+        pack_hilo_rows=False,
+    ):
+        self.traits = traits
+        self.layout = layout
+        self.page_block_size = int(page_block_size)
+        self.num_tiles = int(num_tiles)
+        self.replicate_h = int(replicate_h)
+        self.num_heads = int(num_heads)
+        self.q_stride_row = int(q_stride[0])
+        self.q_stride_head = int(q_stride[1])
+        self.q_stride_dim = int(q_stride[2])
+        self.indices_stride_row = int(indices_stride0)
+        self.output_stride_row = int(output_stride[0])
+        self.output_stride_head = int(output_stride[1])
+        self.output_stride_dim = int(output_stride[2])
+        self.out_lse_stride_row = int(out_lse_stride[0])
+        self.out_lse_stride_head = int(out_lse_stride[1])
+        self.has_sink = bool(has_sink)
+        self.topk = int(topk)
+        # DSV4 dual-cache (has_extra) prefill onto MG. All default to current
+        # behavior apart from the shared outer-scale runtime scalar:
+        # has_extra=False const_expr-elides every extra-section arm in _body,
+        # row_xor=False keeps the s6_xv_nope_mg_dsv4 address arithmetic textually
+        # unchanged. The union spans num_main_tiles main chunks (gathered from the
+        # main cache) then ceil(extra_section_len/64) extra chunks (gathered from
+        # the extra cache, page_block_size=pbs_extra).
+        self.has_extra = bool(has_extra)
+        self.pbs_extra = int(pbs_extra)
+        self.num_main_tiles = int(num_main_tiles)
+        self.extra_topk = int(extra_topk)
+        self.extra_indices_stride_row = int(extra_indices_stride0)
+        self.row_xor = bool(row_xor)
+        self.head_offset = int(head_offset)
+        self.valid_hpb = int(traits.hpb if valid_hpb is None else valid_hpb)
+        self.pack_hilo_rows = bool(pack_hilo_rows)
+        # MG head-group count (1 for heads==16, 2 for heads % 32 == 0). Derived
+        # from the layout (heads_per_cta // hpb) and threaded as a compile-time
+        # const so every group-1 op const_expr-elides for n_hg==1.
+        self.mg_n_hg = int(layout.heads_per_cta // traits.hpb)
+        self.math_threads = int(traits.math_threads)
+        self.block_threads = _PREFILL_BLOCK_THREADS
+        # H32 register-pool policy: give the CUTLASS 4.6 DSV4 FP8 trace eight
+        # more math-warp registers while returning the same amount from the IO
+        # warpgroup. Keep the budget pinned to the exact topk512 specialization;
+        # every other trace retains the 232/32 split.
+        self.use_h32_240_24_reg_budget = bool(
+            int(traits.model_type) == int(ModelType.DSV4)
+            and int(traits.compute_mode) == int(ComputeMode.FP8)
+            and int(traits.scale_format) == int(ScaleFormat.UE8M0_BYTE)
+            and not bool(traits.fp8_rope)
+            and self.num_heads == 32
+            and self.mg_n_hg == 2
+            and self.valid_hpb == 16
+            and self.num_tiles == 8
+            and self.page_block_size == 64
+            and self.topk == 512
+            and self.replicate_h == 1
+            and self.q_stride_row == 16384
+            and self.q_stride_head == 512
+            and self.q_stride_dim == 1
+            and self.indices_stride_row == 512
+            and self.output_stride_row == 16384
+            and self.output_stride_head == 512
+            and self.output_stride_dim == 1
+            and self.out_lse_stride_row == 32
+            and self.out_lse_stride_head == 1
+            and not self.has_sink
+            and not self.has_extra
+            and self.pbs_extra == 1
+            and self.num_main_tiles == 0
+            and self.extra_topk == 0
+            and self.extra_indices_stride_row == 512
+            and not self.row_xor
+            and self.head_offset == 0
+            and not self.pack_hilo_rows
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        indices: cute.Tensor,
+        topk_length: cute.Tensor,
+        attn_sink: cute.Tensor,
+        output: cute.Tensor,
+        out_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        stride_kv_block: Int64,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            q_all,
+            kv_cache_u8,
+            indices,
+            topk_length,
+            attn_sink,
+            output,
+            out_lse,
+            sm_scale_log2,
+            latent_scale,
+            stride_kv_block,
+        ).launch(
+            grid=(num_tokens * Int32(self.replicate_h), 1, 1),
+            block=[self.block_threads, 1, 1],
+            # This is a one-CTA/SM warp-specialized kernel.  Emit the same
+            # launch bound as the native implementation so ptxas can honor the
+            # IO-warp setmaxnreg.dec / math-warp setmaxnreg.inc contract instead
+            # of imposing the 384-thread static ~168-register ceiling on every
+            # warp.  The bound is compile-time metadata and does not affect
+            # graph capture or replay state.
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.jit
+    def call_dual(
+        self,
+        q_all: cute.Tensor,  # (T, heads, D_QK) bf16
+        kv_cache_u8: cute.Tensor,  # flat u8 MAIN cache
+        indices: cute.Tensor,  # (T, topk) int32 MAIN indices
+        topk_length: cute.Tensor,  # (T,) int32 per-token MAIN valid length
+        attn_sink: cute.Tensor,  # (heads,) f32 (dummy 1-elem when no sink)
+        output: cute.Tensor,  # (T, heads, D_V) bf16
+        out_lse: cute.Tensor,  # (T, heads) f32 base-2 LSE
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        stride_kv_block: Int64,  # MAIN per-block byte stride
+        extra_kv_cache_u8: cute.Tensor,  # flat u8 EXTRA cache (DSV4 dual-cache)
+        extra_indices: cute.Tensor,  # (T, extra_topk) int32
+        extra_topk_length: cute.Tensor,  # (T,) int32 per-token EXTRA valid length
+        stride_extra_kv_block: Int64,  # EXTRA per-block byte stride
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        # DUAL-CACHE entry (DSV4 dual-cache prefill onto MG): the dispatcher selects
+        # this (entry=kernel.call_dual) only when has_extra=True, so its DISTINCT
+        # mangled name never collides with the single-cache __call__.
+        # Launches the 14-param @cute.kernel (self.kernel_dual), which shares the
+        # body via _body(has_extra=True, row_xor=self.row_xor). The extra device
+        # args are appended AFTER stride_kv_block in the order:
+        # extra_kv_cache_u8, extra_indices, extra_topk_length, stride_extra_kv_block.
+        self.kernel_dual(
+            q_all,
+            kv_cache_u8,
+            indices,
+            topk_length,
+            attn_sink,
+            output,
+            out_lse,
+            sm_scale_log2,
+            latent_scale,
+            stride_kv_block,
+            extra_kv_cache_u8,
+            extra_indices,
+            extra_topk_length,
+            stride_extra_kv_block,
+        ).launch(
+            grid=(num_tokens * Int32(self.replicate_h), 1, 1),
+            block=[self.block_threads, 1, 1],
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        indices: cute.Tensor,
+        topk_length: cute.Tensor,
+        attn_sink: cute.Tensor,
+        output: cute.Tensor,
+        out_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        stride_kv_block: Int64,
+    ):
+        # SINGLE-CACHE @cute.kernel (10 device params): the DSV4-main /
+        # DSV4-BF16 / GLM MG prefill path. Threads dummy extra args (aliased to the
+        # main tensors) into the shared body with has_extra=False so the
+        # extra-section code is fully const_expr-elided.
+        self._body(
+            q_all,
+            kv_cache_u8,
+            indices,
+            topk_length,
+            attn_sink,
+            output,
+            out_lse,
+            sm_scale_log2,
+            latent_scale,
+            stride_kv_block,
+            kv_cache_u8,
+            indices,
+            topk_length,
+            stride_kv_block,
+            has_extra=False,
+            row_xor=False,
+        )
+
+    @cute.kernel
+    def kernel_dual(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        indices: cute.Tensor,
+        topk_length: cute.Tensor,
+        attn_sink: cute.Tensor,
+        output: cute.Tensor,
+        out_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        stride_kv_block: Int64,
+        extra_kv_cache_u8: cute.Tensor,
+        extra_indices: cute.Tensor,
+        extra_topk_length: cute.Tensor,
+        stride_extra_kv_block: Int64,
+    ):
+        # DUAL-CACHE @cute.kernel (14 device params): threads the real extra-section
+        # args into the shared body (has_extra=True, row_xor=self.row_xor).
+        self._body(
+            q_all,
+            kv_cache_u8,
+            indices,
+            topk_length,
+            attn_sink,
+            output,
+            out_lse,
+            sm_scale_log2,
+            latent_scale,
+            stride_kv_block,
+            extra_kv_cache_u8,
+            extra_indices,
+            extra_topk_length,
+            stride_extra_kv_block,
+            has_extra=True,
+            row_xor=cutlass.const_expr(self.row_xor),
+        )
+
+    @cute.jit
+    def _body(
+        self,
+        q_all: cute.Tensor,
+        kv_cache_u8: cute.Tensor,
+        indices: cute.Tensor,
+        topk_length: cute.Tensor,
+        attn_sink: cute.Tensor,
+        output: cute.Tensor,
+        out_lse: cute.Tensor,
+        sm_scale_log2: Float32,
+        latent_scale: Float32,
+        stride_kv_block: Int64,
+        extra_kv_cache_u8: cute.Tensor,
+        extra_indices: cute.Tensor,
+        extra_topk_length: cute.Tensor,
+        stride_extra_kv_block: Int64,
+        *,
+        has_extra: cutlass.Constexpr = False,
+        row_xor: cutlass.Constexpr = False,
+    ):
+        t = self.traits
+        L = self.layout
+        tid = Int32(cute.arch.thread_idx()[0])
+        lane = cute.arch.lane_idx()
+        warp_id = tid >> Int32(5)
+        block_x, _, _ = cute.arch.block_idx()
+        block_x = Int32(block_x)
+        rep_h = Int32(self.replicate_h)
+        token_idx = block_x // rep_h
+        h_tile = block_x - token_idx * rep_h
+        head_base = Int32(self.head_offset) + h_tile * Int32(L.heads_per_cta)
+
+        bf16_qk = cutlass.const_expr(t.compute_mode == ComputeMode.BF16)
+        # Keep BF16 Q-RoPE resident in registers for every MG regime, matching
+        # the native kernel.  The one-CTA launch bound gives math warps the
+        # intended dynamic register budget, so the old SWA/C128 shared-memory
+        # restore specialization is no longer needed.  This remains a fully
+        # compile-time choice with no graph-replay state or allocation.
+        reload_bf16_qrope = cutlass.const_expr(False)
+        # GLM (ARBITRARY_FP32) const_expr arm: post-MMA fp32 QK scale, GLM 2-pass
+        # W XV, V==nope (no XV-rope), 656/528 KV geometry, KV-rope from global/L2,
+        # Q-rope registerized (aliased onto W_FP8). DSV4 is the scale_format==0 /
+        # has_extra arm and is byte-identical.
+        is_glm = cutlass.const_expr(t.model_type == ModelType.GLM_NSA)
+        # NVFP4 (E2M1 + E4M3 group-16) GLM-family arm: BF16-QK with native
+        # in-register dequant, BF16 P.V staged in the dead W_FP8 region, and
+        # the 432B/288B record geometry. is_glm stays true for NVFP4 so the
+        # shared GLM staging (io gather / kv_sc absence / q_rope alias) applies.
+        is_nvfp4 = cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3)
+        q_head_dim = cutlass.const_expr(_GLM_HEAD_DIM if is_glm else _DSV4_HEAD_DIM)
+        # Compile-time head-group count: 1 (heads==16) or 2 (heads % 32 == 0). All
+        # group-1 work below const_expr-elides when n_hg==1 (single-group MG).
+        n_hg = cutlass.const_expr(self.mg_n_hg)
+
+        smem = cutlass_utils.SmemAllocator()
+        SharedStorage = get_prefill_mg_shared_storage_cls(t, n_hg)
+        st = smem.allocate(SharedStorage)
+
+        kv_fp8_addr = shared_ptr_to_u32(st.kv_fp8.data_ptr())
+        reduce_addr = shared_ptr_to_u32(st.reduce.data_ptr())
+        w_fp8_addr = shared_ptr_to_u32(st.w_fp8.data_ptr())
+        # GLM has no kv_sc footer (its fp32 scales are inline).  DSV4 stages
+        # XV-RoPE weights into the W_FP8 region after XV-NoPE consumes it.
+        if cutlass.const_expr(is_glm):
+            kv_sc_addr = Int32(0)
+        else:
+            kv_sc_addr = shared_ptr_to_u32(st.kv_sc.data_ptr())
+
+        if cutlass.const_expr(bf16_qk):
+            # BF16 Q-RoPE scratch aliases W_FP8 and is reloaded between tiles.
+            q_nope_bf16_addr = shared_ptr_to_u32(st.q_nope_bf16.data_ptr())
+            q_fp8_addr = Int32(0)
+            q_rope_addr = w_fp8_addr
+            q_sc_view_all = None
+        else:
+            q_nope_bf16_addr = Int32(0)
+            q_fp8_addr = shared_ptr_to_u32(st.q_fp8.data_ptr())
+            # GLM FP8 registerizes Q-rope: its scratch ALIASES W_FP8 (S0-only),
+            # exactly like the BF16 path. DSV4 FP8 keeps a dedicated q_rope field.
+            if cutlass.const_expr(is_glm):
+                q_rope_addr = w_fp8_addr
+            else:
+                q_rope_addr = shared_ptr_to_u32(st.q_rope.data_ptr())
+            q_sc_view_all = st.q_sc.get_tensor(cute.make_layout(int(L.q_sc_bytes // 4)))
+
+        amax_view = st.reduce.get_tensor(
+            cute.make_layout(int(L.reduce_group_bytes // 4))
+        )
+        w_head_sc_view_all = st.w_head_sc.get_tensor(
+            cute.make_layout(int(L.w_head_sc_bytes // 4))
+        )
+
+        is_io = warp_id >= Int32(self.math_threads // 32)
+
+        kv_fp8_buf = Int32(L.kv_fp8_buf_bytes)
+        kv_sc_buf = Int32(L.kv_sc_buf_bytes)
+
+        q_fp8_g0 = q_fp8_addr
+        q_fp8_g1 = q_fp8_addr + Int32(L.q_fp8_group_bytes)
+        q_rope_g0 = q_rope_addr
+        q_rope_g1 = q_rope_addr + Int32(L.q_rope_group_bytes)
+        q_nope_bf16_g0 = q_nope_bf16_addr
+        q_nope_bf16_g1 = q_nope_bf16_addr + Int32(L.q_nope_bf16_group_bytes)
+        reduce_g0 = reduce_addr
+        reduce_g1 = reduce_addr + Int32(L.reduce_group_bytes)
+        # GLM calls the per-group decode s6_xv_nope, which expects a CONTIGUOUS
+        # per-group W_FP8 double-buffer [parity0(hpb)][parity1(hpb)] addressed by
+        # ``(vc&1)*hpb*w_fp8_stride``. So each GLM group gets its own
+        # 2*w_fp8_group_bytes slab (the total is identical to the DSV4 MG
+        # [par0:g0,g1][par1:g0,g1] interleave; only the per-group base differs).
+        glm_w_fp8_g0 = w_fp8_addr
+        glm_w_fp8_g1 = w_fp8_addr + Int32(2 * L.w_fp8_group_bytes)
+
+        if cutlass.const_expr(not bf16_qk):
+            q_sc_g0 = cute.make_tensor(
+                q_sc_view_all.iterator, cute.make_layout(int(L.q_sc_group_bytes // 4))
+            )
+            q_sc_g1 = cute.make_tensor(
+                q_sc_view_all.iterator + Int32(L.q_sc_group_bytes // 4),
+                cute.make_layout(int(L.q_sc_group_bytes // 4)),
+            )
+        w_head_sc_g0 = cute.make_tensor(
+            w_head_sc_view_all.iterator,
+            cute.make_layout(int(L.w_head_sc_group_bytes // 4)),
+        )
+        w_head_sc_g1 = cute.make_tensor(
+            w_head_sc_view_all.iterator + Int32(L.w_head_sc_group_bytes // 4),
+            cute.make_layout(int(L.w_head_sc_group_bytes // 4)),
+        )
+
+        mbar_base = st.mbar.data_ptr()
+        n_buf = int(L.kv_bufs)
+        if tid == Int32(0):
+            for s in cutlass.range_constexpr(n_buf):
+                cute.arch.mbarrier_init(mbar_base + s, Int32(1))
+        # Persistent online-softmax max lives in the row-sum scratch while the
+        # tile loop is active. The final sum reduction reuses this region only
+        # after every lane has loaded its final max for the epilogue.
+        if tid < Int32(n_hg * t.hpb):
+            m_group = tid // Int32(t.hpb)
+            m_head = tid - m_group * Int32(t.hpb)
+            m_base = reduce_g0 + Int32(L.reduce_warp_sum_group_off)
+            if cutlass.const_expr(n_hg == 2):
+                if m_group != Int32(0):
+                    m_base = reduce_g1 + Int32(L.reduce_warp_sum_group_off)
+            st_shared_f32(m_base + m_head * Int32(4), Float32(-1e30))
+        cute.arch.barrier()
+
+        section_len = Int32(topk_length[token_idx])
+        if section_len < Int32(0):
+            section_len = Int32(0)
+        if section_len > Int32(self.topk):
+            section_len = Int32(self.topk)
+        is_empty_row = section_len == Int32(0)
+        actual_tiles = (section_len + Int32(_CAND_WINDOW - 1)) // Int32(_CAND_WINDOW)
+
+        # DSV4 dual-cache (has_extra) union. main occupies COMPILE-TIME
+        # num_main_tiles slots (= ceil(topk/64)); extra runs ceil(extra_section_len
+        # /64) chunks. loop_tiles drives BOTH the IO prefetch loop and the math
+        # loop. const_expr(not has_extra) pins loop_tiles == actual_tiles (the exact
+        # current runtime value), so the no-extra trace + PTX are byte-identical.
+        num_main_tiles = Int32(self.num_main_tiles)
+        if cutlass.const_expr(has_extra):
+            extra_total = Int32(self.extra_topk)
+            extra_section_len = Int32(extra_topk_length[token_idx])
+            if extra_section_len < Int32(0):
+                extra_section_len = Int32(0)
+            if extra_section_len > extra_total:
+                extra_section_len = extra_total
+            is_empty_row = is_empty_row and (extra_section_len == Int32(0))
+            num_extra_tiles = (extra_section_len + Int32(_CAND_WINDOW - 1)) // Int32(
+                _CAND_WINDOW
+            )
+            loop_tiles = num_main_tiles + num_extra_tiles
+        else:
+            extra_section_len = section_len
+            loop_tiles = actual_tiles
+
+        topk_row = cute.make_tensor(
+            indices.iterator + token_idx.to(Int64) * Int64(self.indices_stride_row),
+            cute.make_layout(self.topk),
+        )
+        # extra_indices for THIS token row (DSV4 dual-cache). Built ONLY when
+        # has_extra; const_expr-elided so the no-extra trace never references it.
+        if cutlass.const_expr(has_extra):
+            extra_row = cute.make_tensor(
+                extra_indices.iterator
+                + token_idx.to(Int64) * Int64(self.extra_indices_stride_row),
+                cute.make_layout(self.extra_topk),
+            )
+        else:
+            extra_row = topk_row
+        q_token = cute.make_tensor(
+            q_all.iterator + token_idx.to(Int64) * Int64(self.q_stride_row),
+            cute.make_layout(
+                (self.num_heads, q_head_dim),
+                stride=(self.q_stride_head, self.q_stride_dim),
+            ),
+        )
+        warp_first_cand = warp_id * Int32(8)
+
+        if is_io:
+            if cutlass.const_expr(self.use_h32_240_24_reg_budget):
+                cute.arch.setmaxregister_decrease(_H32_IO_REGS)
+            else:
+                cute.arch.setmaxregister_decrease(_IO_REGS)
+            io_lane = tid - Int32(self.math_threads)
+            kv_l2_policy = create_l2_evict_first_policy()
+
+            # PROLOGUE: gather tile 0. For has_extra the launcher ASSERTs
+            # num_main_tiles>=1 (topk==128 => 2), so tile 0 is ALWAYS the MAIN
+            # section here -- no extra-prologue arm is needed. The guard becomes
+            # loop_tiles>0 (== actual_tiles when not has_extra -> byte-identical).
+            if loop_tiles > Int32(0):
+                g_end0 = Int32(_CAND_WINDOW)
+                if g_end0 > section_len:
+                    g_end0 = section_len
+                if cutlass.const_expr(is_glm):
+                    io_issue_gather_glm_mg(
+                        kv_cache_u8,
+                        topk_row,
+                        kv_fp8_addr,
+                        mbar_base,
+                        Int32(0),
+                        g_end0,
+                        Int32(self.page_block_size),
+                        stride_kv_block,
+                        io_lane,
+                        kv_l2_policy,
+                        bi=t.bi,
+                        kv_smem_stride=L.kv_smem_stride,
+                        io_threads=_PREFILL_IO_THREADS,
+                        scale_format=t.scale_format,
+                        fp8_rope=t.fp8_rope,
+                    )
+                else:
+                    io_issue_gather_dsv4_nope(
+                        kv_cache_u8,
+                        topk_row,
+                        kv_fp8_addr,
+                        kv_sc_addr,
+                        mbar_base,
+                        Int32(0),
+                        g_end0,
+                        Int32(self.page_block_size),
+                        stride_kv_block,
+                        io_lane,
+                        kv_l2_policy,
+                        bi=t.bi,
+                        kv_smem_stride=L.kv_smem_stride,
+                        io_threads=_PREFILL_IO_THREADS,
+                    )
+
+            for lc in cutlass.range(loop_tiles, unroll=1):
+                next_lc = Int32(lc) + Int32(1)
+                if next_lc < loop_tiles:
+                    buf = next_lc & Int32(1)
+                    # Per-tile section dispatch (DSV4 dual-cache). The OUTER guard
+                    # is const_expr(has_extra) so the whole dual arm is compile-time
+                    # elided when not has_extra -> the no-extra `else` branch traces
+                    # textually identical to today (byte-identical). has_extra is
+                    # DSV4-only (GLM dual RAISEs), so the dual arm is DSV4-only:
+                    # tiles >= num_main_tiles re-base into the EXTRA section and
+                    # gather from the EXTRA cache (its own base ptr / page size /
+                    # indices / stride); earlier tiles gather MAIN. The gather helper
+                    # is section-agnostic so only the tensors/pbs/stride differ.
+                    if cutlass.const_expr(has_extra):
+                        if next_lc >= num_main_tiles:
+                            cis = next_lc - num_main_tiles
+                            g_start = cis * Int32(_CAND_WINDOW)
+                            g_end = g_start + Int32(_CAND_WINDOW)
+                            if g_end > extra_section_len:
+                                g_end = extra_section_len
+                            io_issue_gather_dsv4_nope(
+                                extra_kv_cache_u8,
+                                extra_row,
+                                kv_fp8_addr + buf * kv_fp8_buf,
+                                kv_sc_addr + buf * kv_sc_buf,
+                                mbar_base + buf,
+                                g_start,
+                                g_end,
+                                Int32(self.pbs_extra),
+                                stride_extra_kv_block,
+                                io_lane,
+                                kv_l2_policy,
+                                bi=t.bi,
+                                kv_smem_stride=L.kv_smem_stride,
+                                io_threads=_PREFILL_IO_THREADS,
+                            )
+                        else:
+                            g_start = next_lc * Int32(_CAND_WINDOW)
+                            g_end = g_start + Int32(_CAND_WINDOW)
+                            if g_end > section_len:
+                                g_end = section_len
+                            io_issue_gather_dsv4_nope(
+                                kv_cache_u8,
+                                topk_row,
+                                kv_fp8_addr + buf * kv_fp8_buf,
+                                kv_sc_addr + buf * kv_sc_buf,
+                                mbar_base + buf,
+                                g_start,
+                                g_end,
+                                Int32(self.page_block_size),
+                                stride_kv_block,
+                                io_lane,
+                                kv_l2_policy,
+                                bi=t.bi,
+                                kv_smem_stride=L.kv_smem_stride,
+                                io_threads=_PREFILL_IO_THREADS,
+                            )
+                    else:
+                        g_start = next_lc * Int32(_CAND_WINDOW)
+                        g_end = g_start + Int32(_CAND_WINDOW)
+                        if g_end > section_len:
+                            g_end = section_len
+                        if cutlass.const_expr(is_glm):
+                            io_issue_gather_glm_mg(
+                                kv_cache_u8,
+                                topk_row,
+                                kv_fp8_addr + buf * kv_fp8_buf,
+                                mbar_base + buf,
+                                g_start,
+                                g_end,
+                                Int32(self.page_block_size),
+                                stride_kv_block,
+                                io_lane,
+                                kv_l2_policy,
+                                bi=t.bi,
+                                kv_smem_stride=L.kv_smem_stride,
+                                io_threads=_PREFILL_IO_THREADS,
+                                scale_format=t.scale_format,
+                                fp8_rope=t.fp8_rope,
+                            )
+                        else:
+                            io_issue_gather_dsv4_nope(
+                                kv_cache_u8,
+                                topk_row,
+                                kv_fp8_addr + buf * kv_fp8_buf,
+                                kv_sc_addr + buf * kv_sc_buf,
+                                mbar_base + buf,
+                                g_start,
+                                g_end,
+                                Int32(self.page_block_size),
+                                stride_kv_block,
+                                io_lane,
+                                kv_l2_policy,
+                                bi=t.bi,
+                                kv_smem_stride=L.kv_smem_stride,
+                                io_threads=_PREFILL_IO_THREADS,
+                            )
+                cute.arch.barrier(barrier_id=1, number_of_threads=self.block_threads)
+
+        else:
+            if cutlass.const_expr(self.use_h32_240_24_reg_budget):
+                cute.arch.setmaxregister_increase(_H32_MATH_REGS)
+            else:
+                cute.arch.setmaxregister_increase(_MATH_REGS)
+            n_acc_tiles = int(t.n_v_chunks) * int(t.nt_per_warp_xv)
+            if cutlass.const_expr(bf16_qk):
+                # S0 (BF16): stage Q-NoPE and Q-RoPE in shared memory.  The
+                # selected specialization either consumes Q-RoPE from this
+                # aliased scratch (restoring it between tiles), or snapshots it
+                # into registers once before W_FP8 takes over the same storage.
+                s0_load_q_bf16_to_smem_mg(
+                    q_token,
+                    q_nope_bf16_g0,
+                    q_nope_bf16_g1,
+                    q_rope_g0,
+                    q_rope_g1,
+                    head_base,
+                    tid,
+                    d_nope=t.d_nope,
+                    d_rope=t.d_rope,
+                    hpb=t.hpb,
+                    q_nope_bf16_stride=L.q_nope_bf16_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=self.math_threads,
+                    barrier_id=2,
+                    n_hg=n_hg,
+                    valid_hpb=self.valid_hpb,
+                )
+                if cutlass.const_expr(is_nvfp4):
+                    # NVFP4 QK-RoPE uses the GLM B-operand packing, so keep the
+                    # Q-rope A operands as the GLM-style register ARRAYS (not
+                    # the DSV4 scalar snapshot). W_FP8 is then free for the
+                    # BF16 P staging in S5/S6.
+                    q_rope_regs0 = preload_q_rope_regs_mg(
+                        q_rope_g0,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        q_rope_regs1 = preload_q_rope_regs_mg(
+                            q_rope_g1,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                        )
+                    else:
+                        q_rope_regs1 = q_rope_regs0  # never read when n_hg==1.
+                    cute.arch.barrier(barrier_id=2, number_of_threads=self.math_threads)
+                elif cutlass.const_expr(not reload_bf16_qrope):
+                    (
+                        q000,
+                        q001,
+                        q002,
+                        q003,
+                        q010,
+                        q011,
+                        q012,
+                        q013,
+                        q020,
+                        q021,
+                        q022,
+                        q023,
+                        q030,
+                        q031,
+                        q032,
+                        q033,
+                    ) = preload_q_rope_regs_mg(
+                        q_rope_g0,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        (
+                            q100,
+                            q101,
+                            q102,
+                            q103,
+                            q110,
+                            q111,
+                            q112,
+                            q113,
+                            q120,
+                            q121,
+                            q122,
+                            q123,
+                            q130,
+                            q131,
+                            q132,
+                            q133,
+                        ) = preload_q_rope_regs_mg(
+                            q_rope_g1,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                        )
+                    else:
+                        # Group 1 is const-expr elided, but bind its scalar
+                        # operands so both specializations trace one function.
+                        q100, q101, q102, q103 = q000, q001, q002, q003
+                        q110, q111, q112, q113 = q010, q011, q012, q013
+                        q120, q121, q122, q123 = q020, q021, q022, q023
+                        q130, q131, q132, q133 = q030, q031, q032, q033
+                    cute.arch.barrier(barrier_id=2, number_of_threads=self.math_threads)
+            else:
+                s0_quantize_q_to_smem(
+                    q_token,
+                    q_fp8_g0,
+                    q_sc_g0,
+                    q_rope_g0,
+                    amax_view,
+                    head_base,
+                    Int32(self.valid_hpb),
+                    tid,
+                    d_nope=t.d_nope,
+                    d_rope=t.d_rope,
+                    d_qk=t.d_nope + t.d_rope,
+                    quant_tile=t.quant_tile,
+                    num_scales=t.num_scales,
+                    hpb=t.hpb,
+                    q_nope_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=self.math_threads,
+                    barrier_id=2,
+                )
+                if cutlass.const_expr(n_hg == 2):
+                    s0_quantize_q_to_smem(
+                        q_token,
+                        q_fp8_g1,
+                        q_sc_g1,
+                        q_rope_g1,
+                        amax_view,
+                        head_base + Int32(t.hpb),
+                        Int32(t.hpb),
+                        tid,
+                        d_nope=t.d_nope,
+                        d_rope=t.d_rope,
+                        d_qk=t.d_nope + t.d_rope,
+                        quant_tile=t.quant_tile,
+                        num_scales=t.num_scales,
+                        hpb=t.hpb,
+                        q_nope_stride=t.q_nope_stride,
+                        q_rope_stride=L.q_rope_stride,
+                        num_threads=self.math_threads,
+                        barrier_id=2,
+                    )
+                if cutlass.const_expr(is_glm):
+                    # GLM FP8 registerizes Q-rope (the smem scratch aliases W_FP8,
+                    # only live in S0/XV-free): preload the bf16 Q-rope A operands
+                    # to registers, then sync so W_FP8 is free for S6 -- exactly
+                    # like the BF16 path. DSV4 FP8 keeps Q-rope in smem (no preload).
+                    q_rope_regs0 = preload_q_rope_regs_mg(
+                        q_rope_g0,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        q_rope_regs1 = preload_q_rope_regs_mg(
+                            q_rope_g1,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                        )
+                    else:
+                        q_rope_regs1 = q_rope_regs0  # never read when n_hg==1.
+                    cute.arch.barrier(barrier_id=2, number_of_threads=self.math_threads)
+
+            acc0_frag = cute.make_rmem_tensor(n_acc_tiles * 4, Float32)
+            acc1_frag = cute.make_rmem_tensor(n_acc_tiles * 4, Float32)
+            rope0_frag = cute.make_rmem_tensor(4, Float32)
+            rope1_frag = cute.make_rmem_tensor(4, Float32)
+            gsum0_frag = cute.make_rmem_tensor(2, Float32)
+            gsum1_frag = cute.make_rmem_tensor(2, Float32)
+            for k in cutlass.range_constexpr(n_acc_tiles * 4):
+                acc0_frag[k] = Float32(0.0)
+                acc1_frag[k] = Float32(0.0)
+            for k in cutlass.range_constexpr(4):
+                rope0_frag[k] = Float32(0.0)
+                rope1_frag[k] = Float32(0.0)
+            gsum0_frag[0] = Float32(0.0)
+            gsum0_frag[1] = Float32(0.0)
+            gsum1_frag[0] = Float32(0.0)
+            gsum1_frag[1] = Float32(0.0)
+
+            if loop_tiles > Int32(0):
+                cute.arch.mbarrier_wait(mbar_base, phase=0)
+
+            for lc in cutlass.range(loop_tiles, unroll=1):
+                ci = Int32(lc)
+                # Per-tile section geometry (DSV4 dual-cache). An EXTRA tile (ci >=
+                # num_main_tiles) re-bases the candidate offset WITHIN its section
+                # and swaps in the extra section length; the s3 mask is
+                # section-agnostic (masks abs_cand >= sec_len_now). The math reads
+                # only the buffered smem the IO gathered, so it is correct as long
+                # as the rope reads (below) use the matching cache geometry.
+                # const_expr(not has_extra) pins the main expressions (the literal
+                # section_len) -> byte-identical.
+                # Default to the MAIN section. Under const_expr(has_extra) an EXTRA
+                # tile (ci >= num_main_tiles) re-bases the candidate offset WITHIN its
+                # section and swaps in the extra section length. The OUTER guard is
+                # const_expr so the whole rebase is compile-time elided when not
+                # has_extra -> the no-extra trace is byte-identical (split_cand_start
+                # / sec_len_now are the literal main expressions, exactly as today).
+                split_cand_start = ci * Int32(_CAND_WINDOW)
+                sec_len_now = section_len
+                if cutlass.const_expr(has_extra):
+                    if ci >= num_main_tiles:
+                        cis = ci - num_main_tiles
+                        split_cand_start = cis * Int32(_CAND_WINDOW)
+                        sec_len_now = extra_section_len
+                split_cand_end = split_cand_start + Int32(_CAND_WINDOW)
+                if split_cand_end > sec_len_now:
+                    split_cand_end = sec_len_now
+                buf = ci & Int32(1)
+                kv_fp8_b = kv_fp8_addr + buf * kv_fp8_buf
+                kv_sc_b = kv_sc_addr + buf * kv_sc_buf
+                # Match FI's ``ib``: math reads the selected-index tile directly
+                # from global/L2.  A raw pointer can be selected dynamically for
+                # the dual-cache phase without staging a 64-entry smem copy.
+                index_base_ptr = get_ptr_as_int64(topk_row, split_cand_start)
+                if cutlass.const_expr(has_extra):
+                    if ci >= num_main_tiles:
+                        index_base_ptr = get_ptr_as_int64(extra_row, split_cand_start)
+
+                # MAIN rope geometry used by the non-dual FP8 / GLM arms.
+                rope_cache = kv_cache_u8
+                rope_pbs = Int32(self.page_block_size)
+                rope_stride = stride_kv_block
+
+                acc0 = [
+                    [
+                        acc0_frag[at * 4 + 0],
+                        acc0_frag[at * 4 + 1],
+                        acc0_frag[at * 4 + 2],
+                        acc0_frag[at * 4 + 3],
+                    ]
+                    for at in range(n_acc_tiles)
+                ]
+                rope0 = [rope0_frag[0], rope0_frag[1], rope0_frag[2], rope0_frag[3]]
+                gs0 = [gsum0_frag[0], gsum0_frag[1]]
+                qk0 = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                acc1 = [
+                    [
+                        acc1_frag[at * 4 + 0],
+                        acc1_frag[at * 4 + 1],
+                        acc1_frag[at * 4 + 2],
+                        acc1_frag[at * 4 + 3],
+                    ]
+                    for at in range(n_acc_tiles)
+                ]
+                rope1 = [rope1_frag[0], rope1_frag[1], rope1_frag[2], rope1_frag[3]]
+                gs1 = [gsum1_frag[0], gsum1_frag[1]]
+                qk1 = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+
+                if cutlass.const_expr(is_nvfp4):
+                    # NVFP4 QK: native E2M1+E4M3 in-register dequant feeding the
+                    # BF16 MMA -- the same math path as the validated NVFP4
+                    # decode. QK-RoPE reads the record's BF16 rope from global
+                    # via the GLM helper with the 432B/304-offset geometry.
+                    qk0, qk1 = s1_qk_nope_nvfp4_bf16_mg2(
+                        qk0,
+                        qk1,
+                        q_nope_bf16_g0,
+                        q_nope_bf16_g1,
+                        kv_fp8_b,
+                        warp_first_cand,
+                        lane,
+                        latent_scale,
+                        num_scales=t.num_scales,
+                        quant_tile=t.quant_tile,
+                        q_nope_bf16_stride=L.q_nope_bf16_stride,
+                        kv_smem_stride=L.kv_smem_stride,
+                        n_hg=n_hg,
+                    )
+                    qk0, qk1 = s2_qk_rope_regs_mg_glm(
+                        qk0,
+                        qk1,
+                        q_rope_regs0,
+                        q_rope_regs1,
+                        rope_cache,
+                        index_base_ptr,
+                        warp_first_cand,
+                        lane,
+                        rope_pbs,
+                        rope_stride,
+                        d_rope=t.d_rope,
+                        n_hg=n_hg,
+                        valid_hpb=self.valid_hpb,
+                        scale_format=t.scale_format,
+                        fp8_rope=t.fp8_rope,
+                    )
+                elif cutlass.const_expr(bf16_qk):
+                    if cutlass.const_expr(reload_bf16_qrope):
+                        # Tile 0 consumes the S0 copy. S6 overwrites the aliased
+                        # W_FP8 scratch, so restore only the 4 KiB Q-RoPE slice
+                        # for each subsequent tile before issuing its QK work.
+                        if ci > Int32(0):
+                            reload_q_rope_bf16_to_smem_mg(
+                                q_token,
+                                q_rope_g0,
+                                q_rope_g1,
+                                head_base,
+                                tid,
+                                d_nope=t.d_nope,
+                                d_rope=t.d_rope,
+                                q_rope_stride=L.q_rope_stride,
+                                hpb=t.hpb,
+                                num_threads=self.math_threads,
+                                barrier_id=2,
+                                n_hg=n_hg,
+                                valid_hpb=self.valid_hpb,
+                            )
+                    # Match FlashInfer's latency-hiding schedule: issue all
+                    # KV-RoPE global loads before the long NoPE MMA chain, then
+                    # consume the prefetched B operands in S2. The selected raw
+                    # pointer also lets the dual-cache path share one S2 body.
+                    rope_entry = warp_first_cand + (lane >> Int32(2))
+                    rope_idx = _ld_global_index_i32(index_base_ptr, rope_entry)
+                    rope_base = _dsv4_rope_base_off(
+                        rope_idx, Int32(self.page_block_size), stride_kv_block
+                    )
+                    rope_base_ptr = get_ptr_as_int64(kv_cache_u8, rope_base)
+                    if cutlass.const_expr(has_extra):
+                        if ci >= num_main_tiles:
+                            rope_base = _dsv4_rope_base_off(
+                                rope_idx,
+                                Int32(self.pbs_extra),
+                                stride_extra_kv_block,
+                            )
+                            rope_base_ptr = get_ptr_as_int64(
+                                extra_kv_cache_u8, rope_base
+                            )
+                    kv_rope_regs = prefetch_kv_rope_regs_dsv4(
+                        rope_base_ptr, lane, d_rope=t.d_rope
+                    )
+                    # BF16-QK: fused two-group bf16 m16n8k16 QK-NoPE with inline
+                    # FP8->BF16 K dequant (NO block-scaled FP8 MMA, NO Q-quant).
+                    qk0, qk1 = s1_qk_nope_bf16_mg2(
+                        qk0,
+                        qk1,
+                        q_nope_bf16_g0,
+                        q_nope_bf16_g1,
+                        kv_fp8_b,
+                        kv_sc_b,
+                        warp_first_cand,
+                        lane,
+                        num_scales=t.num_scales,
+                        quant_tile=t.quant_tile,
+                        q_nope_bf16_stride=L.q_nope_bf16_stride,
+                        kv_smem_stride=L.kv_smem_stride,
+                        scale_bytes_per_token=8,
+                        n_hg=n_hg,
+                    )
+                    if cutlass.const_expr(reload_bf16_qrope):
+                        qk0, qk1 = s2_qk_rope_shared_prefetched_mg_dsv4(
+                            qk0,
+                            qk1,
+                            q_rope_g0,
+                            q_rope_g1,
+                            kv_rope_regs,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                            n_hg=n_hg,
+                        )
+                    else:
+                        qk0, qk1 = s2_qk_rope_prefetched_mg_dsv4_scalar(
+                            qk0,
+                            qk1,
+                            q000,
+                            q001,
+                            q002,
+                            q003,
+                            q010,
+                            q011,
+                            q012,
+                            q013,
+                            q020,
+                            q021,
+                            q022,
+                            q023,
+                            q030,
+                            q031,
+                            q032,
+                            q033,
+                            q100,
+                            q101,
+                            q102,
+                            q103,
+                            q110,
+                            q111,
+                            q112,
+                            q113,
+                            q120,
+                            q121,
+                            q122,
+                            q123,
+                            q130,
+                            q131,
+                            q132,
+                            q133,
+                            kv_rope_regs,
+                            n_hg=n_hg,
+                        )
+                else:
+                    qk0 = s1_qk_nope_block_scaled(
+                        qk0,
+                        q_fp8_g0,
+                        kv_fp8_b,
+                        q_sc_g0,
+                        kv_sc_b,
+                        warp_first_cand,
+                        lane,
+                        latent_scale,
+                        num_scales=t.num_scales,
+                        quant_tile=t.quant_tile,
+                        q_nope_stride=t.q_nope_stride,
+                        kv_smem_stride=L.kv_smem_stride,
+                        scale_bytes_per_token=8,
+                        scale_format=t.scale_format,
+                        valid_hpb=self.valid_hpb,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        qk1 = s1_qk_nope_block_scaled(
+                            qk1,
+                            q_fp8_g1,
+                            kv_fp8_b,
+                            q_sc_g1,
+                            kv_sc_b,
+                            warp_first_cand,
+                            lane,
+                            latent_scale,
+                            num_scales=t.num_scales,
+                            quant_tile=t.quant_tile,
+                            q_nope_stride=t.q_nope_stride,
+                            kv_smem_stride=L.kv_smem_stride,
+                            scale_bytes_per_token=8,
+                            scale_format=t.scale_format,
+                            valid_hpb=t.hpb,
+                        )
+                    if cutlass.const_expr(is_glm):
+                        # GLM QK-RoPE: Q-rope A from preloaded registers, KV-rope B
+                        # from global/L2 (GLM record packing), once per tile reused
+                        # across head groups. v_has_rope=False so there is no XV-rope.
+                        qk0, qk1 = s2_qk_rope_regs_mg_glm(
+                            qk0,
+                            qk1,
+                            q_rope_regs0,
+                            q_rope_regs1,
+                            rope_cache,
+                            index_base_ptr,
+                            warp_first_cand,
+                            lane,
+                            rope_pbs,
+                            rope_stride,
+                            d_rope=t.d_rope,
+                            n_hg=n_hg,
+                            valid_hpb=self.valid_hpb,
+                            scale_format=t.scale_format,
+                            fp8_rope=t.fp8_rope,
+                        )
+                    else:
+                        # Fused QK-RoPE: KV-RoPE B operand gathered ONCE per CTA tile
+                        # (vectorized nc.u32 b16-pair), reused across head groups --
+                        # matches FlashInfer's prefetch_kv_rope reuse.
+                        qk0, qk1 = s2_qk_rope_global_mg_dsv4(
+                            qk0,
+                            qk1,
+                            q_rope_g0,
+                            q_rope_g1,
+                            rope_cache,
+                            index_base_ptr,
+                            warp_first_cand,
+                            lane,
+                            rope_pbs,
+                            rope_stride,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                            n_hg=n_hg,
+                            valid_hpb=self.valid_hpb,
+                        )
+                qk0 = s3_mask_and_scale_global(
+                    qk0,
+                    index_base_ptr,
+                    warp_first_cand,
+                    split_cand_start,
+                    split_cand_end,
+                    sec_len_now,
+                    sm_scale_log2,
+                    lane,
+                )
+                if cutlass.const_expr(n_hg == 2):
+                    qk1 = s3_mask_and_scale_global(
+                        qk1,
+                        index_base_ptr,
+                        warp_first_cand,
+                        split_cand_start,
+                        split_cand_end,
+                        sec_len_now,
+                        sm_scale_log2,
+                        lane,
+                    )
+                p0 = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                p1 = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+                p0, p1, wr00, wr01, wr10, wr11 = s4_online_softmax_mg2(
+                    qk0,
+                    qk1,
+                    p0,
+                    p1,
+                    acc0,
+                    acc1,
+                    rope0,
+                    rope1,
+                    gs0,
+                    gs1,
+                    acc0_frag,
+                    acc1_frag,
+                    rope0_frag,
+                    rope1_frag,
+                    gsum0_frag,
+                    gsum1_frag,
+                    reduce_addr,
+                    warp_id,
+                    lane,
+                    tid,
+                    n_v_chunks=t.n_v_chunks,
+                    hpb=t.hpb,
+                    n_warps=8,
+                    num_threads=self.math_threads,
+                    barrier_id=3,
+                    n_acc_tiles=n_acc_tiles,
+                    reduce_group_bytes=L.reduce_group_bytes,
+                    reduce_sum_off=L.reduce_warp_sum_group_off,
+                    n_hg=n_hg,
+                    valid_hpb=self.valid_hpb,
+                )
+                w_pre0 = [p0[0] * wr00, p0[1] * wr00, p0[2] * wr01, p0[3] * wr01]
+                w_pre1 = [p1[0] * wr10, p1[1] * wr10, p1[2] * wr11, p1[3] * wr11]
+
+                if cutlass.const_expr(is_nvfp4):
+                    # NVFP4 XV-NoPE: BF16 P.V with native E2M1+E4M3 V dequant
+                    # (decode s6_xv_nope scale_format==2 branch). The BF16 P
+                    # tiles are staged into the dead W_FP8 region (per-group
+                    # base + sm_p_full_stride rows), exactly like the DSV4
+                    # XV-RoPE weight staging. No FP8 W quant, no w_head_sc.
+                    s5_fill_sm_p_full_mg2_nvfp4(
+                        w_pre0,
+                        w_pre1,
+                        w_fp8_addr,
+                        warp_id,
+                        lane,
+                        bi=t.bi,
+                        hpb=t.hpb,
+                        sm_p_stride=L.sm_p_full_stride,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        n_hg=n_hg,
+                    )
+                    sm_p_g0 = w_fp8_addr
+                    sm_p_g1 = w_fp8_addr + Int32(L.sm_p_full_stride * t.hpb * 2)
+                    acc0 = s6_xv_nope(
+                        w_pre0,
+                        acc0,
+                        kv_fp8_b,
+                        kv_sc_b,
+                        w_head_sc_g0,
+                        glm_w_fp8_g0,
+                        warp_id,
+                        lane,
+                        tid,
+                        latent_scale,
+                        n_v_chunks=t.n_v_chunks,
+                        v_chunk=t.quant_tile,
+                        hpb=t.hpb,
+                        bi=t.bi,
+                        kv_smem_stride=L.kv_smem_stride,
+                        w_fp8_stride=t.bi + 16,
+                        n_warps=8,
+                        scale_bytes_per_token=8,
+                        nt_per_warp_xv=t.nt_per_warp_xv,
+                        scale_format=t.scale_format,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        sm_p_full_addr=sm_p_g0,
+                        sm_p_stride=L.sm_p_full_stride,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        acc1 = s6_xv_nope(
+                            w_pre1,
+                            acc1,
+                            kv_fp8_b,
+                            kv_sc_b,
+                            w_head_sc_g1,
+                            glm_w_fp8_g1,
+                            warp_id,
+                            lane,
+                            tid,
+                            latent_scale,
+                            n_v_chunks=t.n_v_chunks,
+                            v_chunk=t.quant_tile,
+                            hpb=t.hpb,
+                            bi=t.bi,
+                            kv_smem_stride=L.kv_smem_stride,
+                            w_fp8_stride=t.bi + 16,
+                            n_warps=8,
+                            scale_bytes_per_token=8,
+                            nt_per_warp_xv=t.nt_per_warp_xv,
+                            scale_format=t.scale_format,
+                            num_threads=self.math_threads,
+                            barrier_id=3,
+                            sm_p_full_addr=sm_p_g1,
+                            sm_p_stride=L.sm_p_full_stride,
+                        )
+                elif cutlass.const_expr(is_glm):
+                    # GLM XV-NoPE: the per-group decode s6_xv_nope (raw-e4m3 V +
+                    # per-(cand,vc) inline fp32 group scale + 2-pass W HIGH+LOW
+                    # residual). V scales + V B operands come from the SHARED kv_fp8
+                    # smem the IO gathered once per tile, so the two groups still
+                    # share the KV gather (the MG win). v_has_rope=False -> NO S6b
+                    # XV-rope.
+                    #
+                    # w_head_sc ZERO-INIT: the decode s6_xv_nope's per-(vc,head)
+                    # absmax is an atomicMax-on-fp32 that ASSUMES w_head_sc was
+                    # pre-zeroed (decode does it in s5_fill_sm_p_full; the DSV4 MG
+                    # fused s6_xv_nope_mg_dsv4 does it internally). GLM calls the bare
+                    # decode s6 with NO s5/sm_p_full, so the prefill arm MUST zero
+                    # w_head_sc itself -- otherwise the FIRST tile of the FIRST launch
+                    # atomicMaxes against uninitialized smem (catastrophic on cold
+                    # launch) and later tiles never reset it (stale max bias).
+                    i_hs = tid
+                    while i_hs < Int32(n_hg * t.n_v_chunks * self.valid_hpb):
+                        group_span = Int32(t.n_v_chunks * self.valid_hpb)
+                        g_hs = i_hs // group_span
+                        rem_hs = i_hs - g_hs * group_span
+                        vc_hs = rem_hs // Int32(self.valid_hpb)
+                        h_hs = rem_hs - vc_hs * Int32(self.valid_hpb)
+                        slot_hs = (
+                            g_hs * Int32(t.n_v_chunks * t.hpb)
+                            + vc_hs * Int32(t.hpb)
+                            + h_hs
+                        )
+                        w_head_sc_view_all[slot_hs] = Float32(0.0)
+                        i_hs += Int32(self.math_threads)
+                    cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+                    acc0 = s6_xv_nope(
+                        w_pre0,
+                        acc0,
+                        kv_fp8_b,
+                        kv_sc_b,
+                        w_head_sc_g0,
+                        glm_w_fp8_g0,
+                        warp_id,
+                        lane,
+                        tid,
+                        latent_scale,
+                        n_v_chunks=t.n_v_chunks,
+                        v_chunk=t.quant_tile,
+                        hpb=t.hpb,
+                        bi=t.bi,
+                        kv_smem_stride=L.kv_smem_stride,
+                        w_fp8_stride=t.bi + 16,
+                        n_warps=8,
+                        scale_bytes_per_token=8,
+                        nt_per_warp_xv=t.nt_per_warp_xv,
+                        scale_format=t.scale_format,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        valid_hpb=self.valid_hpb,
+                        pack_hilo_rows=self.pack_hilo_rows,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        acc1 = s6_xv_nope(
+                            w_pre1,
+                            acc1,
+                            kv_fp8_b,
+                            kv_sc_b,
+                            w_head_sc_g1,
+                            glm_w_fp8_g1,
+                            warp_id,
+                            lane,
+                            tid,
+                            latent_scale,
+                            n_v_chunks=t.n_v_chunks,
+                            v_chunk=t.quant_tile,
+                            hpb=t.hpb,
+                            bi=t.bi,
+                            kv_smem_stride=L.kv_smem_stride,
+                            w_fp8_stride=t.bi + 16,
+                            n_warps=8,
+                            scale_bytes_per_token=8,
+                            nt_per_warp_xv=t.nt_per_warp_xv,
+                            scale_format=t.scale_format,
+                            num_threads=self.math_threads,
+                            barrier_id=3,
+                            valid_hpb=t.hpb,
+                        )
+                else:
+                    acc0, acc1 = s6_xv_nope_mg_dsv4(
+                        w_pre0,
+                        w_pre1,
+                        acc0,
+                        acc1,
+                        kv_fp8_b,
+                        kv_sc_b,
+                        w_head_sc_view_all,
+                        w_fp8_addr,
+                        warp_id,
+                        lane,
+                        tid,
+                        n_v_chunks=t.n_v_chunks,
+                        v_chunk=t.quant_tile,
+                        hpb=t.hpb,
+                        bi=t.bi,
+                        kv_smem_stride=L.kv_smem_stride,
+                        w_fp8_stride=t.bi + 16,
+                        w_fp8_group_stride=L.w_fp8_group_bytes,
+                        w_fp8_parity_stride=L.w_fp8_parity_bytes,
+                        n_warps=8,
+                        scale_bytes_per_token=8,
+                        nt_per_warp_xv=t.nt_per_warp_xv,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        n_hg=n_hg,
+                        row_xor=cutlass.const_expr(row_xor),
+                    )
+                    # XV-RoPE: per-tile section switch mirrors the QK-rope above (the
+                    # cute.Tensor cannot be re-bound in a dynamic if). const_expr(not
+                    # has_extra) elides the dual arm -> a single MAIN call,
+                    # byte-identical.
+                    if cutlass.const_expr(has_extra):
+                        if ci >= num_main_tiles:
+                            rope0, rope1 = s6b_xv_rope_global_mg_dsv4(
+                                rope0,
+                                rope1,
+                                w_pre0,
+                                w_pre1,
+                                w_fp8_addr,
+                                extra_kv_cache_u8,
+                                index_base_ptr,
+                                warp_id,
+                                lane,
+                                Int32(self.pbs_extra),
+                                stride_extra_kv_block,
+                                bi=t.bi,
+                                sm_p_stride=L.sm_p_full_stride,
+                                hpb=t.hpb,
+                                d_rope=t.d_rope,
+                                n_warps=8,
+                                num_threads=self.math_threads,
+                                barrier_id=3,
+                                n_hg=n_hg,
+                            )
+                        else:
+                            rope0, rope1 = s6b_xv_rope_global_mg_dsv4(
+                                rope0,
+                                rope1,
+                                w_pre0,
+                                w_pre1,
+                                w_fp8_addr,
+                                kv_cache_u8,
+                                index_base_ptr,
+                                warp_id,
+                                lane,
+                                Int32(self.page_block_size),
+                                stride_kv_block,
+                                bi=t.bi,
+                                sm_p_stride=L.sm_p_full_stride,
+                                hpb=t.hpb,
+                                d_rope=t.d_rope,
+                                n_warps=8,
+                                num_threads=self.math_threads,
+                                barrier_id=3,
+                                n_hg=n_hg,
+                            )
+                    else:
+                        rope0, rope1 = s6b_xv_rope_global_mg_dsv4(
+                            rope0,
+                            rope1,
+                            w_pre0,
+                            w_pre1,
+                            w_fp8_addr,
+                            rope_cache,
+                            index_base_ptr,
+                            warp_id,
+                            lane,
+                            rope_pbs,
+                            rope_stride,
+                            bi=t.bi,
+                            sm_p_stride=L.sm_p_full_stride,
+                            hpb=t.hpb,
+                            d_rope=t.d_rope,
+                            n_warps=8,
+                            num_threads=self.math_threads,
+                            barrier_id=3,
+                            n_hg=n_hg,
+                        )
+                for at in cutlass.range_constexpr(n_acc_tiles):
+                    acc0_frag[at * 4 + 0] = acc0[at][0]
+                    acc0_frag[at * 4 + 1] = acc0[at][1]
+                    acc0_frag[at * 4 + 2] = acc0[at][2]
+                    acc0_frag[at * 4 + 3] = acc0[at][3]
+                rope0_frag[0] = rope0[0]
+                rope0_frag[1] = rope0[1]
+                rope0_frag[2] = rope0[2]
+                rope0_frag[3] = rope0[3]
+                gsum0_frag[0] = gs0[0]
+                gsum0_frag[1] = gs0[1]
+                if cutlass.const_expr(n_hg == 2):
+                    for at in cutlass.range_constexpr(n_acc_tiles):
+                        acc1_frag[at * 4 + 0] = acc1[at][0]
+                        acc1_frag[at * 4 + 1] = acc1[at][1]
+                        acc1_frag[at * 4 + 2] = acc1[at][2]
+                        acc1_frag[at * 4 + 3] = acc1[at][3]
+                    rope1_frag[0] = rope1[0]
+                    rope1_frag[1] = rope1[1]
+                    rope1_frag[2] = rope1[2]
+                    rope1_frag[3] = rope1[3]
+                    gsum1_frag[0] = gs1[0]
+                    gsum1_frag[1] = gs1[1]
+
+                cute.arch.barrier(barrier_id=1, number_of_threads=self.block_threads)
+                next_lc = ci + Int32(1)
+                if next_lc < loop_tiles:
+                    next_phase = (next_lc >> Int32(1)) & Int32(1)
+                    cute.arch.mbarrier_wait(
+                        mbar_base + (next_lc & Int32(1)), phase=next_phase
+                    )
+
+            final_gid = lane >> Int32(2)
+            final_gmax0 = [
+                ld_shared_f32(
+                    reduce_g0
+                    + Int32(L.reduce_warp_sum_group_off)
+                    + final_gid * Int32(4)
+                ),
+                Float32(-1e30),
+            ]
+            if cutlass.const_expr(self.valid_hpb > 8):
+                final_gmax0[1] = ld_shared_f32(
+                    reduce_g0
+                    + Int32(L.reduce_warp_sum_group_off)
+                    + (final_gid + Int32(8)) * Int32(4)
+                )
+            final_gmax1 = [Float32(-1e30), Float32(-1e30)]
+            if cutlass.const_expr(n_hg == 2):
+                final_gmax1[0] = ld_shared_f32(
+                    reduce_g1
+                    + Int32(L.reduce_warp_sum_group_off)
+                    + final_gid * Int32(4)
+                )
+                final_gmax1[1] = ld_shared_f32(
+                    reduce_g1
+                    + Int32(L.reduce_warp_sum_group_off)
+                    + (final_gid + Int32(8)) * Int32(4)
+                )
+
+            if is_empty_row:
+                gsum0_frag[0] = Float32(0.0)
+                gsum0_frag[1] = Float32(0.0)
+                if cutlass.const_expr(n_hg == 2):
+                    gsum1_frag[0] = Float32(0.0)
+                    gsum1_frag[1] = Float32(0.0)
+
+            final_sum0 = [gsum0_frag[0], gsum0_frag[1]]
+            final_sum1 = [gsum1_frag[0], gsum1_frag[1]]
+            final_sum0, final_sum1 = s4_finalize_row_sum_mg2(
+                final_sum0,
+                final_sum1,
+                reduce_g0 + Int32(L.reduce_warp_sum_group_off),
+                reduce_g1 + Int32(L.reduce_warp_sum_group_off),
+                warp_id,
+                lane,
+                tid,
+                hpb=t.hpb,
+                n_warps=8,
+                num_threads=self.math_threads,
+                barrier_id=3,
+                n_hg=n_hg,
+                valid_hpb=self.valid_hpb,
+            )
+            gsum0_frag[0] = final_sum0[0]
+            gsum0_frag[1] = final_sum0[1]
+            if cutlass.const_expr(n_hg == 2):
+                gsum1_frag[0] = final_sum1[0]
+                gsum1_frag[1] = final_sum1[1]
+
+            fin0 = [
+                [
+                    acc0_frag[at * 4 + 0],
+                    acc0_frag[at * 4 + 1],
+                    acc0_frag[at * 4 + 2],
+                    acc0_frag[at * 4 + 3],
+                ]
+                for at in range(n_acc_tiles)
+            ]
+            rope0 = [rope0_frag[0], rope0_frag[1], rope0_frag[2], rope0_frag[3]]
+            out_o0 = cute.make_tensor(
+                output.iterator
+                + token_idx.to(Int64) * Int64(self.output_stride_row)
+                + head_base.to(Int64) * Int64(self.output_stride_head),
+                cute.make_layout(
+                    (self.valid_hpb, t.d_v),
+                    stride=(self.output_stride_head, self.output_stride_dim),
+                ),
+            )
+            out_lse0 = cute.make_tensor(
+                out_lse.iterator
+                + token_idx.to(Int64) * Int64(self.out_lse_stride_row)
+                + head_base.to(Int64) * Int64(self.out_lse_stride_head),
+                cute.make_layout((self.valid_hpb,), stride=(self.out_lse_stride_head,)),
+            )
+            s7_epilogue(
+                fin0,
+                rope0,
+                final_gmax0,
+                [gsum0_frag[0], gsum0_frag[1]],
+                out_o0,
+                out_lse0,
+                warp_id,
+                lane,
+                n_v_chunks=t.n_v_chunks,
+                v_chunk=t.quant_tile,
+                d_nope=t.d_nope,
+                d_rope=t.d_rope,
+                n_warps=8,
+                valid_hpb=self.valid_hpb,
+                nt_per_warp_xv=t.nt_per_warp_xv,
+                v_has_rope=t.v_has_rope,
+                epilogue_mode=EPILOGUE_FINAL_BF16,
+                has_attn_sink=self.has_sink,
+                attn_sink=attn_sink,
+                head_base=head_base,
+                fast_rcp=True,
+                staging_base_addr=kv_fp8_addr,
+                d_v=t.d_v,
+                num_threads=self.math_threads,
+                barrier_id=3,
+                coalesced_output=cutlass.const_expr(
+                    self.output_stride_dim == 1 and self.output_stride_head == t.d_v
+                ),
+            )
+
+            # Group-1 epilogue: const_expr-elided for n_hg==1 (single-group MG ->
+            # only group-0 output). The inter-group barrier (group-0 epilogue reads
+            # smem the group-1 path reuses) is part of the gated block, so n_hg==1
+            # emits neither it nor any group-1 instruction.
+            if cutlass.const_expr(n_hg == 2):
+                cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+
+                fin1 = [
+                    [
+                        acc1_frag[at * 4 + 0],
+                        acc1_frag[at * 4 + 1],
+                        acc1_frag[at * 4 + 2],
+                        acc1_frag[at * 4 + 3],
+                    ]
+                    for at in range(n_acc_tiles)
+                ]
+                rope1 = [rope1_frag[0], rope1_frag[1], rope1_frag[2], rope1_frag[3]]
+                head_base1 = head_base + Int32(t.hpb)
+                out_o1 = cute.make_tensor(
+                    output.iterator
+                    + token_idx.to(Int64) * Int64(self.output_stride_row)
+                    + head_base1.to(Int64) * Int64(self.output_stride_head),
+                    cute.make_layout(
+                        (t.hpb, t.d_v),
+                        stride=(self.output_stride_head, self.output_stride_dim),
+                    ),
+                )
+                out_lse1 = cute.make_tensor(
+                    out_lse.iterator
+                    + token_idx.to(Int64) * Int64(self.out_lse_stride_row)
+                    + head_base1.to(Int64) * Int64(self.out_lse_stride_head),
+                    cute.make_layout((t.hpb,), stride=(self.out_lse_stride_head,)),
+                )
+                s7_epilogue(
+                    fin1,
+                    rope1,
+                    final_gmax1,
+                    [gsum1_frag[0], gsum1_frag[1]],
+                    out_o1,
+                    out_lse1,
+                    warp_id,
+                    lane,
+                    n_v_chunks=t.n_v_chunks,
+                    v_chunk=t.quant_tile,
+                    d_nope=t.d_nope,
+                    d_rope=t.d_rope,
+                    n_warps=8,
+                    valid_hpb=t.hpb,
+                    nt_per_warp_xv=t.nt_per_warp_xv,
+                    v_has_rope=t.v_has_rope,
+                    epilogue_mode=EPILOGUE_FINAL_BF16,
+                    has_attn_sink=self.has_sink,
+                    attn_sink=attn_sink,
+                    head_base=head_base1,
+                    fast_rcp=True,
+                    staging_base_addr=kv_fp8_addr,
+                    d_v=t.d_v,
+                    num_threads=self.math_threads,
+                    barrier_id=3,
+                    coalesced_output=cutlass.const_expr(
+                        self.output_stride_dim == 1 and self.output_stride_head == t.d_v
+                    ),
+                )
+
+
+def _sparse_mla_prefill_mg_flat_launch(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink_t: torch.Tensor,
+    output: torch.Tensor,
+    lse_out: torch.Tensor,
+    extra_kv_flat: torch.Tensor,
+    extra_indices_t: torch.Tensor,
+    extra_len_t: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    page_block_size: int,
+    topk: int,
+    num_tiles: int,
+    stride_kv_block: int,
+    has_sink: bool,
+    compute_mode: int,
+    mg_n_hg: int,
+    model_type: int,
+    scale_format: int,
+    fp8_rope: bool,
+    has_extra: bool,
+    extra_topk: int,
+    num_main_tiles: int,
+    pbs_extra: int,
+    stride_extra_kv_block: int,
+    row_xor: bool,
+    *,
+    active_heads: int | None = None,
+    head_offset: int = 0,
+) -> None:
+    traits = make_unified_traits(
+        int(model_type), compute_mode, int(scale_format), fp8_rope=bool(fp8_rope)
+    )
+    layout = make_smem_layout_mg(traits, int(mg_n_hg))
+    q_head_dim = int(q.shape[2])
+    total_heads = int(q.shape[1])
+    if active_heads is None:
+        active_heads = total_heads
+    active_heads = int(active_heads)
+    head_offset = int(head_offset)
+    heads_per_cta = int(layout.heads_per_cta)
+    if active_heads <= 0:
+        raise ValueError(
+            f"SM120 sparse MLA MG prefill requires active_heads>0, got {active_heads}"
+        )
+    if head_offset < 0 or head_offset + active_heads > total_heads:
+        raise ValueError(
+            "SM120 sparse MLA MG prefill head range out of bounds: "
+            f"head_offset={head_offset}, active_heads={active_heads}, total_heads={total_heads}"
+        )
+    if active_heads % heads_per_cta == 0:
+        valid_hpb = int(traits.hpb)
+        replicate_h = active_heads // heads_per_cta
+    elif int(mg_n_hg) == 1 and active_heads == int(traits.hpb) // 2:
+        valid_hpb = active_heads
+        replicate_h = 1
+    else:
+        raise ValueError(
+            "SM120 sparse MLA MG prefill active head range must be divisible by "
+            f"heads_per_cta={heads_per_cta} (or active_heads==hpb//2 with "
+            f"mg_n_hg==1 for the 8-head shard); got active_heads={active_heads}"
+        )
+    pack_hilo_rows = (
+        int(model_type) == int(ModelType.GLM_NSA)
+        and int(scale_format) == int(ScaleFormat.ARBITRARY_FP32)
+        and int(mg_n_hg) == 1
+        and valid_hpb == 8
+        and os.environ.get("FLASHINFER_EXP_SM12X_MLA_SM120_PREFILL_PACK_HILO_ROWS", "1")
+        not in ("0", "false", "False", "off")
+    )
+    # DSV4 dual-cache MG: the union puts tile 0 in the MAIN section, so
+    # num_main_tiles MUST be >= 1 (topk==128 => 2). All-extra (num_main_tiles==0)
+    # has no extra-prologue arm and is forbidden.
+    if bool(has_extra) and int(num_main_tiles) < 1:
+        raise ValueError(
+            "SM120 sparse MLA MG dual-cache prefill requires num_main_tiles>=1 "
+            f"(topk>=1); got num_main_tiles={num_main_tiles}"
+        )
+    kernel = UnifiedPrefillMGKernel(
+        traits,
+        layout,
+        int(page_block_size),
+        int(num_tiles),
+        replicate_h=replicate_h,
+        num_heads=total_heads,
+        q_stride=tuple(q.stride()),
+        indices_stride0=int(topk_indices.stride(0)),
+        output_stride=tuple(output.stride()),
+        out_lse_stride=tuple(lse_out.stride()),
+        has_sink=bool(has_sink),
+        topk=int(topk),
+        has_extra=bool(has_extra),
+        pbs_extra=int(pbs_extra),
+        num_main_tiles=int(num_main_tiles),
+        extra_topk=int(extra_topk),
+        extra_indices_stride0=int(extra_indices_t.stride(0)),
+        row_xor=bool(row_xor),
+        head_offset=head_offset,
+        valid_hpb=valid_hpb,
+        pack_hilo_rows=pack_hilo_rows,
+    )
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    base_args = (
+        _to_cute(q, cutlass.BFloat16, dynamic_layout=True),
+        _to_cute(kv_flat, cutlass.Uint8, align=16),
+        _to_cute(topk_indices, cutlass.Int32, align=4, dynamic_layout=True),
+        _to_cute(topk_length, cutlass.Int32, align=4, dynamic_layout=True),
+        _to_cute(attn_sink_t, cutlass.Float32, align=4),
+        _to_cute(output, cutlass.BFloat16, align=16, dynamic_layout=True),
+        _to_cute(lse_out, cutlass.Float32, align=4, dynamic_layout=True),
+        Float32(float(sm_scale) * LOG2_E),
+        Float32(float(latent_scale)),
+        Int64(stride_kv_block),
+    )
+    if has_extra:
+        # call_dual signature: ... stride_kv_block, extra_kv, extra_indices,
+        # extra_topk_length, stride_extra_kv_block, num_tokens, stream.
+        args = base_args + (
+            _to_cute(extra_kv_flat, cutlass.Uint8, align=16),
+            _to_cute(extra_indices_t, cutlass.Int32, align=4, dynamic_layout=True),
+            _to_cute(extra_len_t, cutlass.Int32, align=4, dynamic_layout=True),
+            Int64(stride_extra_kv_block),
+            Int32(int(q.shape[0])),
+            stream,
+        )
+    else:
+        args = base_args + (Int32(int(q.shape[0])), stream)
+    spec_fields = [
+        key_field("model_type", int(model_type)),
+        key_field("compute_mode", int(compute_mode)),
+        key_field("scale_format", int(scale_format)),
+        key_field("fp8_rope", int(traits.fp8_rope)),
+        key_field("num_heads", total_heads),
+        key_field("heads_per_cta", heads_per_cta),
+        key_field("mg_n_hg", int(mg_n_hg)),
+        key_field("valid_hpb", int(valid_hpb)),
+        key_field("pack_hilo_rows", int(pack_hilo_rows)),
+        key_field("num_tiles", int(num_tiles)),
+        key_field("page_block_size", int(page_block_size)),
+        key_field("topk_bucket", _topk_bucket(topk)),
+        key_field("has_sink", int(has_sink)),
+        tensor_key(
+            "q",
+            q,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(total_heads),
+                DimKey.exact(q_head_dim),
+            ),
+        ),
+        tensor_key(
+            "topk_indices", topk_indices, dims=(DimKey.dynamic(), DimKey.bucket(topk))
+        ),
+        tensor_key(
+            "output",
+            output,
+            dims=(DimKey.dynamic(), DimKey.exact(total_heads), DimKey.exact(512)),
+        ),
+        tensor_key(
+            "out_lse", lse_out, dims=(DimKey.dynamic(), DimKey.exact(total_heads))
+        ),
+    ]
+    if active_heads != total_heads or head_offset != 0:
+        spec_fields.extend(
+            [
+                key_field("active_heads", active_heads),
+                key_field("head_offset", head_offset),
+            ]
+        )
+    if has_extra:
+        # The dual key_fields are appended ONLY for has_extra so the single-cache
+        # shape key remains free of dual-only fields. The explicit v2 version
+        # below deliberately invalidates the old device ABI.
+        spec_fields.extend(
+            [
+                key_field("has_extra", int(has_extra)),
+                key_field("num_main_tiles", int(num_main_tiles)),
+                key_field("pbs_extra", int(pbs_extra)),
+                key_field("extra_topk_bucket", _topk_bucket(extra_topk)),
+                key_field("row_xor", int(row_xor)),
+                tensor_key(
+                    "extra_indices",
+                    extra_indices_t,
+                    dims=(DimKey.dynamic(), DimKey.bucket(max(extra_topk, 1))),
+                ),
+            ]
+        )
+    compile_spec = KernelCompileSpec.from_fields(
+        "attention.mla.sm120.prefill_mg",
+        # v3 adds the FP8-RoPE record specialization/read path. The explicit
+        # cache key does not hash source, so do not reuse v2 KLD-only cubins.
+        3,
+        *spec_fields,
+    )
+    entry = kernel.call_dual if has_extra else kernel
+    sm12x_launch(entry, compile_spec=compile_spec, compile_args=args, runtime_args=args)
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::sparse_mla_sm120_prefill_mg",
+    mutates_args=("output", "lse_out"),
+)
+def _sparse_mla_prefill_mg_op(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink_t: torch.Tensor,
+    output: torch.Tensor,
+    lse_out: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    page_block_size: int,
+    topk: int,
+    num_tiles: int,
+    stride_kv_block: int,
+    has_sink: bool,
+    compute_mode: int,
+    mg_n_hg: int,
+    model_type: int,
+    scale_format: int,
+    fp8_rope: bool,
+) -> None:
+    # SINGLE-CACHE op (DSV4 main / DSV4-BF16 / GLM MG). It carries the new
+    # latent_scale runtime scalar and passes has_extra=False with extra device
+    # args aliased to the main tensors (never read under const_expr(False)).
+    _sparse_mla_prefill_mg_flat_launch(
+        q,
+        kv_flat,
+        topk_indices,
+        topk_length,
+        attn_sink_t,
+        output,
+        lse_out,
+        kv_flat,  # extra_kv_flat alias (never read)
+        topk_indices,  # extra_indices alias (never read)
+        topk_length,  # extra_len alias (never read)
+        sm_scale,
+        latent_scale,
+        page_block_size,
+        topk,
+        num_tiles,
+        stride_kv_block,
+        has_sink,
+        compute_mode,
+        mg_n_hg,
+        model_type,
+        scale_format,
+        fp8_rope,
+        False,  # has_extra
+        0,  # extra_topk
+        0,  # num_main_tiles
+        1,  # pbs_extra
+        0,  # stride_extra_kv_block
+        False,  # row_xor
+    )
+
+
+@_sparse_mla_prefill_mg_op.register_fake
+def _sparse_mla_prefill_mg_fake(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink_t: torch.Tensor,
+    output: torch.Tensor,
+    lse_out: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    page_block_size: int,
+    topk: int,
+    num_tiles: int,
+    stride_kv_block: int,
+    has_sink: bool,
+    compute_mode: int,
+    mg_n_hg: int,
+    model_type: int,
+    scale_format: int,
+    fp8_rope: bool,
+) -> None:
+    return None
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::sparse_mla_sm120_prefill_mg_dual",
+    mutates_args=("output", "lse_out"),
+)
+def _sparse_mla_prefill_mg_dual_op(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink_t: torch.Tensor,
+    output: torch.Tensor,
+    lse_out: torch.Tensor,
+    extra_kv_flat: torch.Tensor,
+    extra_indices_t: torch.Tensor,
+    extra_len_t: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    page_block_size: int,
+    topk: int,
+    num_tiles: int,
+    stride_kv_block: int,
+    has_sink: bool,
+    compute_mode: int,
+    mg_n_hg: int,
+    model_type: int,
+    scale_format: int,
+    extra_topk: int,
+    num_main_tiles: int,
+    pbs_extra: int,
+    stride_extra_kv_block: int,
+    row_xor: bool,
+) -> None:
+    # DUAL-CACHE op (DSV4 has_extra union -> MG). Separate from the single-cache
+    # op; both carry the same outer-scale runtime scalar. has_extra is implicitly
+    # True here.
+    _sparse_mla_prefill_mg_flat_launch(
+        q,
+        kv_flat,
+        topk_indices,
+        topk_length,
+        attn_sink_t,
+        output,
+        lse_out,
+        extra_kv_flat,
+        extra_indices_t,
+        extra_len_t,
+        sm_scale,
+        latent_scale,
+        page_block_size,
+        topk,
+        num_tiles,
+        stride_kv_block,
+        has_sink,
+        compute_mode,
+        mg_n_hg,
+        model_type,
+        scale_format,
+        False,  # fp8_rope (dual cache is DSV4-only)
+        True,  # has_extra
+        extra_topk,
+        num_main_tiles,
+        pbs_extra,
+        stride_extra_kv_block,
+        row_xor,
+    )
+
+
+@_sparse_mla_prefill_mg_dual_op.register_fake
+def _sparse_mla_prefill_mg_dual_fake(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink_t: torch.Tensor,
+    output: torch.Tensor,
+    lse_out: torch.Tensor,
+    extra_kv_flat: torch.Tensor,
+    extra_indices_t: torch.Tensor,
+    extra_len_t: torch.Tensor,
+    sm_scale: float,
+    latent_scale: float,
+    page_block_size: int,
+    topk: int,
+    num_tiles: int,
+    stride_kv_block: int,
+    has_sink: bool,
+    compute_mode: int,
+    mg_n_hg: int,
+    model_type: int,
+    scale_format: int,
+    extra_topk: int,
+    num_main_tiles: int,
+    pbs_extra: int,
+    stride_extra_kv_block: int,
+    row_xor: bool,
+) -> None:
+    return None
+
+
+def run_unified_prefill_mg(
+    *,
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    topk_indices: torch.Tensor,
+    sm_scale: float,
+    page_block_size: int,
+    topk_length: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    output: torch.Tensor | None = None,
+    lse_out: torch.Tensor | None = None,
+    stride_kv_block: int | None = None,
+    compute_mode: int = ComputeMode.FP8,
+    mg_n_hg: int = 2,
+    model_type: int = ModelType.DSV4,
+    scale_format: int | None = None,
+    latent_scale: float = 1.0,
+    fp8_rope: bool | None = None,
+    extra_kv_cache: torch.Tensor | None = None,
+    extra_indices: torch.Tensor | None = None,
+    extra_topk_length: torch.Tensor | None = None,
+    extra_page_block_size: int | None = None,
+    stride_extra_kv_block: int | None = None,
+    active_heads: int | None = None,
+    head_offset: int = 0,
+):
+    model_type = int(model_type)
+    is_glm = model_type == ModelType.GLM_NSA
+    # DSV4 dual-cache (has_extra) union. all-or-none + DSV4-only (GLM has no extra
+    # section). Forced BF16-QK by the caller (FI ships dual-cache as BF16 only).
+    has_extra = extra_kv_cache is not None
+    if has_extra:
+        if extra_indices is None or extra_page_block_size is None:
+            raise ValueError(
+                "SM120 sparse MLA MG dual-cache prefill requires extra_kv_cache, "
+                "extra_indices, and extra_page_block_size together"
+            )
+        if is_glm:
+            raise ValueError(
+                "SM120 sparse MLA MG dual-cache prefill is DSV4-only "
+                "(q_head_dim==512); GLM/DSV3.2 has no extra cache"
+            )
+    if scale_format is None:
+        scale_format = ScaleFormat.ARBITRARY_FP32 if is_glm else ScaleFormat.UE8M0_BYTE
+    scale_format = int(scale_format)
+    expected_qdim = _GLM_HEAD_DIM if is_glm else _DSV4_HEAD_DIM
+    if int(q.shape[-1]) != expected_qdim:
+        raise ValueError(
+            f"SM120 sparse MLA MG prefill ({'GLM' if is_glm else 'DSV4'}) expects "
+            f"q_head_dim={expected_qdim}, got {int(q.shape[-1])}"
+        )
+    if int(mg_n_hg) not in (1, 2):
+        raise ValueError(
+            f"SM120 sparse MLA MG prefill supports mg_n_hg in {{1, 2}}, got {mg_n_hg}"
+        )
+    num_tokens, heads, _ = q.shape
+    total_heads = int(heads)
+    if active_heads is None:
+        active_heads = total_heads
+    active_heads = int(active_heads)
+    head_offset = int(head_offset)
+    if active_heads <= 0:
+        raise ValueError(
+            f"SM120 sparse MLA MG prefill requires active_heads>0, got {active_heads}"
+        )
+    if head_offset < 0 or head_offset + active_heads > total_heads:
+        raise ValueError(
+            "SM120 sparse MLA MG prefill head range out of bounds: "
+            f"head_offset={head_offset}, active_heads={active_heads}, total_heads={total_heads}"
+        )
+    if scale_format == ScaleFormat.NVFP4_E4M3:
+        record_bytes = int(kv_cache.shape[-1])
+        if fp8_rope is None:
+            if record_bytes not in (368, 432):
+                raise ValueError(
+                    "NVFP4 sparse MLA MG cache record must be 368 or 432 bytes, "
+                    f"got {record_bytes}"
+                )
+            fp8_rope = record_bytes == 368
+        expected_record_bytes = 368 if fp8_rope else 432
+        if record_bytes != expected_record_bytes:
+            raise ValueError(
+                "NVFP4 sparse MLA MG cache record disagrees with fp8_rope: "
+                f"got {record_bytes} bytes, expected {expected_record_bytes}"
+            )
+    traits = make_unified_traits(
+        model_type, int(compute_mode), scale_format, fp8_rope=fp8_rope
+    )
+    # heads_per_cta = mg_n_hg * HPB. mg_n_hg==2 covers paired head groups; mg_n_hg==1
+    # covers a single-group launch, including 16-head tails and the heads==8
+    # valid_hpb shard. The caller picks mg_n_hg and active head range.
+    heads_per_cta = int(mg_n_hg) * int(traits.hpb)
+    full_head_tile = active_heads % heads_per_cta == 0
+    valid_hpb_shard = int(mg_n_hg) == 1 and active_heads == int(traits.hpb) // 2
+    if not full_head_tile and not valid_hpb_shard:
+        raise ValueError(
+            f"SM120 sparse MLA MG prefill (mg_n_hg={mg_n_hg}) requires heads divisible "
+            f"by {heads_per_cta} (or active_heads==hpb//2 with mg_n_hg==1 for the "
+            f"8-head shard), got active_heads={active_heads}"
+        )
+
+    topk = int(topk_indices.shape[1])
+    num_main_tiles = (topk + _CAND_WINDOW - 1) // _CAND_WINDOW
+    device = q.device
+    if topk_length is None:
+        topk_length = torch.full((num_tokens,), topk, dtype=torch.int32, device=device)
+    else:
+        topk_length = topk_length.to(device=device, dtype=torch.int32).contiguous()
+
+    has_sink = attn_sink is not None
+    if has_sink:
+        attn_sink_t = attn_sink.to(device=device, dtype=torch.float32).contiguous()
+    else:
+        # ``has_sink=False`` const-expr-elides every device read of this
+        # argument. Reuse one caller-owned int32 length word as an f32-typed
+        # placeholder instead of allocating a CUDA tensor on every serving
+        # launch (including during graph capture).
+        attn_sink_t = topk_length.view(torch.float32)[:1]
+
+    if stride_kv_block is None:
+        stride_kv_block = _cache_block_stride_bytes(
+            kv_cache,
+            page_size=int(page_block_size),
+            is_glm=bool(is_glm),
+            record_bytes=int(traits.kv_gmem_stride),
+        )
+
+    q = q.contiguous()
+    topk_indices = topk_indices.contiguous()
+    if output is None:
+        output = torch.empty(
+            (num_tokens, heads, int(traits.d_v)), dtype=torch.bfloat16, device=device
+        )
+    if lse_out is None:
+        lse_out = torch.empty((num_tokens, heads), dtype=torch.float32, device=device)
+
+    if has_extra:
+        # DSV4 dual-cache union -> the separate dual op. num_main_tiles main chunks
+        # then ceil(extra_topk/64) extra chunks; the kernel masks each section by
+        # its per-token length. row_xor = (pbs_extra == 2) (FI USE_WFP8_ROW_XOR).
+        pbs_extra = int(extra_page_block_size)
+        if stride_extra_kv_block is None:
+            stride_extra_kv_block = _cache_block_stride_bytes(
+                extra_kv_cache,
+                page_size=pbs_extra,
+                is_glm=False,
+            )
+        extra_topk = int(extra_indices.shape[1])
+        num_extra_tiles = (extra_topk + _CAND_WINDOW - 1) // _CAND_WINDOW
+        num_tiles = num_main_tiles + num_extra_tiles
+        row_xor = pbs_extra == 2
+        extra_indices_t = extra_indices.contiguous()
+        if extra_topk_length is None:
+            extra_len_t = torch.full(
+                (num_tokens,), extra_topk, dtype=torch.int32, device=device
+            )
+        else:
+            extra_len_t = extra_topk_length.to(
+                device=device, dtype=torch.int32
+            ).contiguous()
+        if full_head_tile and active_heads == total_heads and head_offset == 0:
+            torch.ops.flashinfer_sm12x.sparse_mla_sm120_prefill_mg_dual(
+                q,
+                _cache_base_tensor(kv_cache),
+                topk_indices,
+                topk_length,
+                attn_sink_t,
+                output,
+                lse_out,
+                _cache_base_tensor(extra_kv_cache),
+                extra_indices_t,
+                extra_len_t,
+                float(sm_scale),
+                float(latent_scale),
+                int(page_block_size),
+                int(topk),
+                int(num_tiles),
+                int(stride_kv_block),
+                bool(has_sink),
+                int(compute_mode),
+                int(mg_n_hg),
+                model_type,
+                scale_format,
+                int(extra_topk),
+                int(num_main_tiles),
+                int(pbs_extra),
+                int(stride_extra_kv_block),
+                bool(row_xor),
+            )
+        else:
+            _sparse_mla_prefill_mg_flat_launch(
+                q,
+                _cache_base_tensor(kv_cache),
+                topk_indices,
+                topk_length,
+                attn_sink_t,
+                output,
+                lse_out,
+                _cache_base_tensor(extra_kv_cache),
+                extra_indices_t,
+                extra_len_t,
+                float(sm_scale),
+                float(latent_scale),
+                int(page_block_size),
+                int(topk),
+                int(num_tiles),
+                int(stride_kv_block),
+                bool(has_sink),
+                int(compute_mode),
+                int(mg_n_hg),
+                model_type,
+                scale_format,
+                False,  # fp8_rope (dual cache is DSV4-only)
+                True,  # has_extra
+                int(extra_topk),
+                int(num_main_tiles),
+                int(pbs_extra),
+                int(stride_extra_kv_block),
+                bool(row_xor),
+                active_heads=active_heads,
+                head_offset=head_offset,
+            )
+        return output, lse_out
+
+    if full_head_tile and active_heads == total_heads and head_offset == 0:
+        torch.ops.flashinfer_sm12x.sparse_mla_sm120_prefill_mg(
+            q,
+            _cache_base_tensor(kv_cache),
+            topk_indices,
+            topk_length,
+            attn_sink_t,
+            output,
+            lse_out,
+            float(sm_scale),
+            float(latent_scale),
+            int(page_block_size),
+            int(topk),
+            int(num_main_tiles),
+            int(stride_kv_block),
+            bool(has_sink),
+            int(compute_mode),
+            int(mg_n_hg),
+            model_type,
+            scale_format,
+            bool(traits.fp8_rope),
+        )
+    else:
+        _sparse_mla_prefill_mg_flat_launch(
+            q,
+            _cache_base_tensor(kv_cache),
+            topk_indices,
+            topk_length,
+            attn_sink_t,
+            output,
+            lse_out,
+            _cache_base_tensor(kv_cache),  # extra_kv_flat alias (never read)
+            topk_indices,  # extra_indices alias (never read)
+            topk_length,  # extra_len alias (never read)
+            float(sm_scale),
+            float(latent_scale),
+            int(page_block_size),
+            int(topk),
+            int(num_main_tiles),
+            int(stride_kv_block),
+            bool(has_sink),
+            int(compute_mode),
+            int(mg_n_hg),
+            model_type,
+            scale_format,
+            bool(traits.fp8_rope),
+            False,  # has_extra
+            0,  # extra_topk
+            0,  # num_main_tiles
+            1,  # pbs_extra
+            0,  # stride_extra_kv_block
+            False,  # row_xor
+            active_heads=active_heads,
+            head_offset=head_offset,
+        )
+    return output, lse_out

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/reference.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/reference.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/reference.py @ e9a11f2c (2026-06-28) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Simple PyTorch MLA references for the NSA packed-cache contract."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+_FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+_FP8_E4M3_MIN = float(torch.finfo(torch.float8_e4m3fn).min)
+_LN2 = math.log(2.0)
+_MLA_NOPE_DIM = 512
+_MLA_ROPE_DIM = 64
+_MLA_GROUP_SIZE = 128
+_MLA_SCALE_BYTES = (_MLA_NOPE_DIM // _MLA_GROUP_SIZE) * 4
+_MLA_PACKED_DIM = 656
+
+
+def _as_2d_cache(x: torch.Tensor, expected_dim: int, name: str) -> torch.Tensor:
+    if x.ndim == 3:
+        if x.shape[1] != 1:
+            raise ValueError(f"{name} middle dimension must be 1, got {tuple(x.shape)}")
+        x = x[:, 0, :]
+    if x.ndim != 2:
+        raise ValueError(f"{name} must be rank-2 or rank-3, got {tuple(x.shape)}")
+    if x.shape[1] != expected_dim:
+        raise ValueError(
+            f"{name} last dimension must be {expected_dim}, got {x.shape[1]}"
+        )
+    return x.contiguous()
+
+
+def pack_mla_kv_cache_reference(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    *,
+    group_size: int = _MLA_GROUP_SIZE,
+) -> torch.Tensor:
+    """Pack MLA KV cache into the FP8+scale+rope byte layout used by NSA."""
+
+    if group_size != _MLA_GROUP_SIZE:
+        raise ValueError(
+            f"Only group_size={_MLA_GROUP_SIZE} is supported in the reference."
+        )
+
+    k_nope_2d = _as_2d_cache(k_nope, _MLA_NOPE_DIM, "k_nope")
+    k_rope_2d = _as_2d_cache(k_rope, _MLA_ROPE_DIM, "k_rope")
+    if k_nope_2d.shape[0] != k_rope_2d.shape[0]:
+        raise ValueError("k_nope and k_rope must have the same token count")
+    if k_rope_2d.dtype != torch.bfloat16:
+        raise ValueError(
+            "k_rope must have dtype torch.bfloat16 because the packed MLA layout "
+            f"stores raw BF16 rope bytes, got {k_rope_2d.dtype}"
+        )
+
+    quant_bytes: list[torch.Tensor] = []
+    scale_bytes: list[torch.Tensor] = []
+    for block_start in range(0, _MLA_NOPE_DIM, group_size):
+        block = k_nope_2d[:, block_start : block_start + group_size].to(torch.float32)
+        scale = block.abs().amax(dim=1) / _FP8_E4M3_MAX
+        scale = torch.where(scale > 0, scale, torch.ones_like(scale))
+        quant = (block / scale.unsqueeze(1)).clamp(_FP8_E4M3_MIN, _FP8_E4M3_MAX)
+        quant = quant.to(torch.float8_e4m3fn)
+        quant_bytes.append(quant.view(torch.uint8).reshape(block.shape[0], group_size))
+        scale_bytes.append(scale.view(torch.uint8).reshape(block.shape[0], 4))
+
+    rope_bytes = k_rope_2d.view(torch.uint8).reshape(
+        k_rope_2d.shape[0], _MLA_ROPE_DIM * 2
+    )
+    packed = torch.cat(
+        [torch.cat(quant_bytes, dim=1), torch.cat(scale_bytes, dim=1), rope_bytes],
+        dim=1,
+    )
+    return packed.unsqueeze(1).contiguous()
+
+
+def unpack_mla_kv_cache_reference(
+    kv_cache: torch.Tensor,
+    *,
+    group_size: int = _MLA_GROUP_SIZE,
+) -> torch.Tensor:
+    """Unpack the NSA MLA byte layout back into dequantized K tensors."""
+
+    if group_size != _MLA_GROUP_SIZE:
+        raise ValueError(
+            f"Only group_size={_MLA_GROUP_SIZE} is supported in the reference."
+        )
+
+    packed = _as_2d_cache(kv_cache, _MLA_PACKED_DIM, "kv_cache").view(torch.uint8)
+    num_tokens = packed.shape[0]
+    num_groups = _MLA_NOPE_DIM // group_size
+
+    nope_q = packed[:, :_MLA_NOPE_DIM].contiguous().view(torch.float8_e4m3fn)
+    nope_q = nope_q.reshape(num_tokens, _MLA_NOPE_DIM).to(torch.float32)
+    scales = packed[:, _MLA_NOPE_DIM : _MLA_NOPE_DIM + num_groups * 4].contiguous()
+    scales = scales.view(torch.float32).reshape(num_tokens, num_groups)
+    rope = packed[:, _MLA_NOPE_DIM + num_groups * 4 :].contiguous().view(torch.bfloat16)
+    rope = rope.reshape(num_tokens, _MLA_ROPE_DIM).to(torch.float32)
+
+    nope = nope_q.reshape(num_tokens, num_groups, group_size) * scales.unsqueeze(-1)
+    nope = nope.reshape(num_tokens, _MLA_NOPE_DIM)
+    return torch.cat([nope, rope], dim=1).unsqueeze(1).contiguous()
+
+
+def dense_mla_reference(
+    *,
+    q_all: torch.Tensor,
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    page_table_1: torch.Tensor,
+    sm_scale: float,
+    v_head_dim: int,
+) -> torch.Tensor:
+    """Reference attention using the unquantized MLA cache tensors."""
+
+    k_nope_2d = _as_2d_cache(k_nope, _MLA_NOPE_DIM, "k_nope").to(torch.float32)
+    k_rope_2d = _as_2d_cache(k_rope, _MLA_ROPE_DIM, "k_rope").to(torch.float32)
+    k_all = torch.cat([k_nope_2d, k_rope_2d], dim=1)
+    return _sparse_attention_reference(
+        q_all=q_all,
+        k_all=k_all,
+        v_all=k_nope_2d[:, :v_head_dim],
+        page_table_1=page_table_1,
+        sm_scale=sm_scale,
+    )
+
+
+def sparse_mla_reference(
+    *,
+    q_all: torch.Tensor,
+    kv_cache: torch.Tensor,
+    page_table_1: torch.Tensor,
+    active_token_counts: torch.Tensor | None = None,
+    sm_scale: float,
+    v_head_dim: int,
+    return_lse: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Reference attention using the packed NSA MLA cache layout."""
+
+    kv = unpack_mla_kv_cache_reference(kv_cache).squeeze(1).to(torch.float32)
+    return _sparse_attention_reference(
+        q_all=q_all,
+        k_all=kv,
+        v_all=kv[:, :v_head_dim],
+        page_table_1=page_table_1,
+        active_token_counts=active_token_counts,
+        sm_scale=sm_scale,
+        return_lse=return_lse,
+    )
+
+
+def _sparse_attention_reference(
+    *,
+    q_all: torch.Tensor,
+    k_all: torch.Tensor,
+    v_all: torch.Tensor,
+    page_table_1: torch.Tensor,
+    active_token_counts: torch.Tensor | None = None,
+    sm_scale: float,
+    return_lse: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    if q_all.ndim != 3:
+        raise ValueError(f"q_all must be rank-3, got {tuple(q_all.shape)}")
+    if page_table_1.ndim != 2:
+        raise ValueError(
+            f"page_table_1 must be rank-2, got {tuple(page_table_1.shape)}"
+        )
+    if page_table_1.shape[0] != q_all.shape[0]:
+        raise ValueError(
+            f"page_table_1 rows {page_table_1.shape[0]} do not match q rows {q_all.shape[0]}"
+        )
+    if active_token_counts is not None:
+        if (
+            active_token_counts.ndim != 1
+            or active_token_counts.shape[0] != q_all.shape[0]
+        ):
+            raise ValueError(
+                "active_token_counts must be rank-1 with one entry per query row, "
+                f"got {tuple(active_token_counts.shape)}"
+            )
+
+    out = torch.zeros(
+        (q_all.shape[0], q_all.shape[1], v_all.shape[1]),
+        dtype=torch.float32,
+        device=q_all.device,
+    )
+    lse_base2 = torch.full(
+        (q_all.shape[0], q_all.shape[1]),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_all.device,
+    )
+    q_all_f = q_all.to(torch.float32)
+    num_kv = k_all.shape[0]
+    width = page_table_1.shape[1]
+    if num_kv == 0 or width == 0:
+        output = out.to(q_all.dtype)
+        return (output, lse_base2) if return_lse else output
+
+    positions = torch.arange(width, dtype=torch.long, device=q_all.device)
+    tiny = torch.finfo(torch.float32).tiny
+
+    for row in range(q_all.shape[0]):
+        selected = page_table_1[row].to(torch.long)
+        active_mask = torch.ones((width,), dtype=torch.bool, device=q_all.device)
+        if active_token_counts is not None:
+            token_end = active_token_counts[row].to(torch.long).clamp(min=0, max=width)
+            active_mask = positions < token_end
+        valid_mask = active_mask & (selected >= 0) & (selected < num_kv)
+        safe_selected = selected.clamp(0, num_kv - 1)
+
+        k_sel = k_all.index_select(0, safe_selected)
+        v_sel = v_all.index_select(0, safe_selected)
+        scores = torch.matmul(q_all_f[row], k_sel.transpose(0, 1)) * float(sm_scale)
+        scores = torch.where(
+            valid_mask.unsqueeze(0),
+            scores,
+            torch.full_like(scores, float("-inf")),
+        )
+        row_max = scores.amax(dim=-1, keepdim=True)
+        finite_row = torch.isfinite(row_max)
+        safe_row_max = torch.where(finite_row, row_max, torch.zeros_like(row_max))
+        exp_scores = torch.where(
+            valid_mask.unsqueeze(0),
+            torch.exp(scores - safe_row_max),
+            torch.zeros_like(scores),
+        )
+        denom = exp_scores.sum(dim=-1, keepdim=True)
+        probs = exp_scores / denom.clamp_min(tiny)
+        out[row] = torch.matmul(probs, v_sel)
+        if return_lse:
+            row_lse = torch.log(denom) + safe_row_max
+            row_lse = torch.where(
+                finite_row,
+                row_lse,
+                torch.full_like(row_lse, float("-inf")),
+            )
+            lse_base2[row] = row_lse.squeeze(-1) / _LN2
+
+    output = out.to(q_all.dtype)
+    return (output, lse_base2) if return_lse else output

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/smem.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/smem.py
@@ -1,0 +1,556 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/smem.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Shared-memory layout factory for the unified SM120 sparse-MLA backend.
+
+Given a :class:`UnifiedMLATraits`, compute ``const_expr`` byte offsets for the
+FlashInfer DSV4 ``DecodeDsv4Smem`` layout and build a ``cute.struct``
+``SharedStorage`` allocatable via ``cutlass.utils.SmemAllocator`` (idiom:
+one typed ``cute.struct`` allocation through ``SmemAllocator``).
+
+The byte offsets are pinned to the AUTHORITATIVE FlashInfer DSV4 kernel
+(``decode_dsv4_kernel.cuh:47`` ``DecodeDsv4Smem`` + ``common/fp8_quant.cuh`` +
+``common/d2_load_b.cuh`` + ``common/kv_cache_io.cuh``). The decode-DSV4 math
+addresses every smem region as a FLAT, LINEAR ``base + row*STRIDE + col`` array
+(``ldmatrix_load_A_fp8`` / ``ldmatrix_load_B_fp8`` / ``d2_load_b_fp8`` all index
+that way) -- it does NOT use the ``_permuted_offset_128b`` XOR bank-swizzle that
+the GLM ``kernel_onepass`` QK path uses. The bank-conflict mitigation for DSV4
+comes from the STRIDE choice instead (``KV_SMEM_STRIDE=464``: ``464/4 % 32 = 20``
+-> clean; ``d2_load_b.cuh:44``). So every sub-region here is a plain linear
+array at the documented stride; the IO loader (``io.py``) and the math write
+and read it as ``entry * STRIDE + dim``.
+
+Regions (DSV4 ``DecodeDsv4Smem`` order; offsets are const_expr ints):
+  * ``q_rope``   HPB x D_ROPE bf16            (linear ``h*D_ROPE + d``)
+  * ``q_fp8``    HPB x Q_NOPE_STRIDE staging  (FP8 normally; BF16 for NVFP4)
+  * ``q_sc``     HPB x NUM_SCALES fp32        (power-of-2 FP32; converted to the
+                                               UE8M0 ``sfa`` selector at use via
+                                               ``pow2_ceil_ue8m0`` -- matches
+                                               ``fp8_quant.cuh`` storing FP32)
+  * ``kv_fp8[2]``  BI x KV_SMEM_STRIDE fp8    (NoPE only + 16B pad; double-buf)
+  * ``kv_sc[2]``   BI x SCALE_BYTES_PER_TOKEN (DSV4 UE8M0 footer bytes; double-buf)
+                                               -- DSV4-ONLY (has_extra_cache); for
+                                               GLM the scales are inline in the
+                                               ``kv_fp8`` ``KV_SMEM_STRIDE`` row.
+  * ``kv_rope[2]`` BI x D_ROPE bf16           (linear ``entry*D_ROPE + d``)
+  * ``mbar``       full[2] + empty[2] u64     (P6 warp-specialized pipeline: a
+                                               full/empty mbarrier pair per KV
+                                               buffer. full[s]: IO producer
+                                               arrives + expect_tx, bulk
+                                               completion drives tx; empty[s]:
+                                               math consumer arrives when done
+                                               reading buffer s. Order:
+                                               full[0],full[1],empty[0],empty[1])
+  * ``reduce``     2 x N_WARPS x HPB fp32     (warp_max | warp_sum cross-warp tree)
+  * ``w_head_sc``  N_V_CHUNKS x HPB fp32      (per-vc per-head XV output scale)
+  * ``w_fp8[2]``   HPB x (BI + 16) fp8        (re-quantized P; double-buf across vc)
+  * ``token_idx[2]`` BI int32                 (staged raw topk index incl -1
+                                               sentinel; gap #9 single source of
+                                               truth for the consumer mask)
+  * ``sm_p_full``  HPB x BI bf16              (normalized P; 128B-aligned for the
+                                               S6b ldmatrix.x4 read)
+
+Total dynamic smem stays < the SM120 carveout (~92KB DSV4, ~96KB GLM) and the
+import-time asserts pin ``KV_SMEM_STRIDE`` to the traits.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+
+from .traits import ScaleFormat, UnifiedMLATraits
+
+
+# SM120 dynamic-smem opt-in carveout cap: (100-1)*1024 (see cutlass
+# SMEM_CAPACITY_MAP; proven launchable by .sm120port/probes/gate_g2_smem.py).
+SM120_SMEM_CARVEOUT_BYTES = 101376
+
+# Double-buffered KV gather (full/empty parity). The P5 synchronous loader only
+# uses buf 0 per chunk, but the two-buffer sizing is pinned now so the P6
+# mbarrier pipeline (w_fp8[vc&1]-style ping-pong) drops in without a relayout.
+_KV_BUF_COUNT = 2
+
+# w_fp8 is double-buffered across the XV vc loop (w_fp8[vc&1]) to drop the
+# read-after-write bar_sync between consecutive vc iterations (FlashInfer
+# decode_dsv4_kernel.cuh:112 OFF_W_FP8 + parity).
+_W_FP8_BUF_COUNT = 2
+
+# token-index validity buffer is staged per KV buffer (one int32 row of BI
+# candidates per buf) so the consumer mask matches the buffered KV.
+_TOKEN_IDX_BUF_COUNT = _KV_BUF_COUNT
+
+# Number of math warps participating in the cross-warp softmax reduce (8 warps =
+# 256 math threads). The IO warp (P6) is excluded from this reduce.
+_MATH_WARPS = 8
+
+# w_fp8 ldmatrix pad: the XV W A-operand is loaded with ldmatrix.x4 over BI
+# columns; FlashInfer pads the row to (BI + 16) (W_FP8_STRIDE) for the load.
+_W_FP8_PAD = 16
+
+# Per-stage mbarrier cost: full[KV_BUF_COUNT] + empty[KV_BUF_COUNT], 8B (u64)
+# each. The P6 warp-specialized pipeline needs a full/empty pair PER buffer
+# (FlashInfer decode_dsv4_kernel.cuh:226 mbar_full(s)/mbar_empty(s) for s in
+# [0, DSV4_KV_BUF_COUNT)) so the IO producer and math consumer ping-pong on
+# independent parities. Layout order: full[0], full[1], empty[0], empty[1].
+_MBAR_BYTES = 2 * _KV_BUF_COUNT * 8
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+@dataclass(frozen=True)
+class SmemLayout:
+    """Resolved const_expr byte offsets + region sizes for one specialization.
+
+    All fields are plain Python ints (captured into the @cute.jit closure and
+    constant-folded). ``total_bytes`` is the dynamic-smem request asserted
+    against the SM120 carveout. Strides (``q_nope_stride`` / ``kv_smem_stride`` /
+    ``q_sc_stride`` etc.) are echoed so the loader + math index the regions with
+    the SAME const_expr the layout was built from.
+    """
+
+    # --- Q staging (single buffer; HPB heads). ---
+    # q_rope FIRST to match FlashInfer DecodeDsv4Smem OFF_Q_ROPE = 0.
+    q_rope_off: int
+    q_rope_bytes: int
+    q_rope_stride: int  # D_ROPE plus optional bank-conflict pad
+
+    q_fp8_off: int
+    q_fp8_bytes: int
+    q_nope_stride: int  # Q_NOPE_STRIDE (fp8 bytes per head row; 448 + 16 pad)
+
+    q_sc_off: int
+    q_sc_bytes: int
+    q_sc_stride: int  # NUM_SCALES (fp32 power-of-2 scales per head)
+
+    # --- Double-buffered KV stage. ---
+    # kv_fp8: NoPE fp8 ONLY at KV_SMEM_STRIDE (448 + 16 pad); GLM inline-scale
+    # bytes also live in this stride; DSV4 footer scales are in kv_sc.
+    kv_fp8_off: int
+    kv_fp8_buf_bytes: int  # per buf == BI * KV_SMEM_STRIDE
+    kv_smem_stride: int
+
+    # kv_sc: DSV4 UE8M0 footer bytes (SCALE_BYTES_PER_TOKEN per entry).
+    # DSV4-only (has_extra_cache); 0 bytes for GLM (scales inline in kv_fp8 row).
+    kv_sc_off: int
+    kv_sc_buf_bytes: int  # per buf == BI * SCALE_BYTES_PER_TOKEN (0 if inline)
+    kv_sc_stride: int  # SCALE_BYTES_PER_TOKEN (0 if inline)
+
+    # kv_rope: V/K rope bf16, linear entry*D_ROPE + d.
+    kv_rope_off: int
+    kv_rope_buf_bytes: int  # per buf == BI * D_ROPE * 2
+    kv_rope_stride: int  # D_ROPE (bf16 elems per entry row)
+
+    kv_bufs: int
+
+    # --- P6 pipeline placeholder (full + empty mbarrier pair). ---
+    mbar_off: int
+    mbar_bytes: int
+
+    # --- cross-warp softmax reduce scratch (warp_max | warp_sum). ---
+    reduce_off: int
+    reduce_bytes: int
+    reduce_warp_max_off: int  # == reduce_off
+    reduce_warp_sum_off: int  # == reduce_off + N_WARPS * HPB * 4
+
+    # --- per-vc per-head output scale (fp32). ---
+    w_head_sc_off: int
+    w_head_sc_bytes: int
+    w_head_sc_stride: int  # HPB (one row of HPB scales per vc)
+
+    # --- re-quantized-P staging for the XV MMA (double-buffered across vc). ---
+    w_fp8_off: int
+    w_fp8_buf_bytes: int  # per buf == HPB * (BI + 16)
+    w_fp8_stride: int  # BI + 16
+    w_fp8_bufs: int
+
+    # --- staged raw-token-index validity buffer (incl. -1 sentinel), int32. ---
+    token_idx_off: int
+    token_idx_buf_bytes: int  # per buf == BI * 4
+    token_idx_bufs: int
+
+    # --- static sm_p_full score staging (HPB x BI bf16; 128B aligned). ---
+    sm_p_full_off: int
+    sm_p_full_bytes: int
+    sm_p_full_stride: int  # BI (bf16 elems per head row)
+
+    # --- second-group w_head_sc for the native H16 two-group decode. ---
+    # The base w_head_sc row packs scale [0,8) + reciprocal [8,16) for ONE
+    # 8-head group, so the H16 kernel's second group gets its own region.
+    # Appended at the TAIL so every pre-existing offset stays byte-identical.
+    w_head_sc2_off: int
+    w_head_sc2_bytes: int
+
+    total_bytes: int
+
+
+def make_smem_layout(traits: UnifiedMLATraits) -> SmemLayout:
+    """Compute the const_expr smem byte layout for ``traits``.
+
+    Region order + sizing mirror FlashInfer ``DecodeDsv4Smem`` exactly. Each
+    region is a flat linear array at its documented stride. const_expr keys:
+      * ``model_type``  -> d_nope/quant_tile/num_scales/n_v_chunks +
+        q_nope_stride/kv_smem_stride (464 DSV4 / 528 GLM)
+      * ``scale_format``/``has_extra_cache`` -> the separate ``kv_sc`` footer
+        buffer (DSV4 UE8M0 footer) vs inline scales in the kv row (GLM)
+      * ``v_has_rope`` does NOT change the layout (kv_rope is allocated for both;
+        for GLM the XV-rope stage is dead-code-eliminated but K-rope still reads
+        kv_rope, and Q-rope is always present)
+    """
+    bi = traits.bi
+    hpb = traits.hpb
+    d_rope = traits.d_rope
+    num_scales = traits.num_scales
+    n_v_chunks = traits.n_v_chunks
+    kv_smem_stride = traits.kv_smem_stride
+    q_nope_stride = traits.q_nope_stride
+    bufs = _KV_BUF_COUNT
+
+    off = 0
+
+    # --- Q rope (bf16), FlashInfer OFF_Q_ROPE = 0. ---
+    q_rope_off = off
+    # DSV4's 64-bf16 rows otherwise repeat every 128 bytes and alias banks
+    # across heads during the native H8/H16 scalar Q-RoPE loads.
+    q_rope_stride = d_rope + (8 if traits.has_extra_cache else 0)
+    q_rope_bytes = hpb * q_rope_stride * 2
+    off = q_rope_off + q_rope_bytes  # FlashInfer packs Q regions back-to-back
+
+    # --- Q-NoPE staging. FP8 normally; BF16 for native NVFP4 cache math. ---
+    q_fp8_off = off
+    q_element_bytes = 2 if traits.scale_format == ScaleFormat.NVFP4_E4M3 else 1
+    q_fp8_bytes = hpb * q_nope_stride * q_element_bytes
+    off = q_fp8_off + q_fp8_bytes
+
+    # --- Q per-head scales: FP32 power-of-2 (converted to UE8M0 sfa at use). ---
+    q_sc_off = off
+    q_sc_stride = num_scales
+    q_sc_bytes = hpb * num_scales * 4
+    off = q_sc_off + q_sc_bytes
+
+    # 128B-align the start of the (large) KV region for clean vectorized stores.
+    off = _align_up(off, 128)
+
+    # --- Double-buffered KV nope (fp8) at KV_SMEM_STRIDE. ---
+    kv_fp8_off = off
+    kv_fp8_buf_bytes = bi * kv_smem_stride
+    off = kv_fp8_off + kv_fp8_buf_bytes * bufs
+
+    # --- Double-buffered KV footer scales (DSV4 UE8M0; inline -> 0 for GLM). ---
+    kv_sc_off = off
+    if traits.has_extra_cache:
+        # DSV4: 8 footer bytes/token (7 UE8M0 + 1 pad). Separately gathered.
+        kv_sc_stride = 8  # SCALE_BYTES_PER_TOKEN
+        kv_sc_buf_bytes = bi * kv_sc_stride
+        off = kv_sc_off + kv_sc_buf_bytes * bufs
+    else:
+        # GLM: scales are INLINE in the kv_fp8 KV_SMEM_STRIDE row (no footer buf).
+        kv_sc_stride = 0
+        kv_sc_buf_bytes = 0
+
+    # --- Double-buffered KV rope (bf16) linear entry*D_ROPE + d. ---
+    kv_rope_off = off
+    kv_rope_stride = d_rope
+    kv_rope_buf_bytes = bi * d_rope * 2
+    off = kv_rope_off + kv_rope_buf_bytes * bufs
+
+    # --- P6 mbarrier pair placeholder (16B aligned; reserved, unused in P5). ---
+    off = _align_up(off, 16)
+    mbar_off = off
+    mbar_bytes = _MBAR_BYTES
+    off = mbar_off + mbar_bytes
+
+    # --- cross-warp softmax reduce scratch: warp_max | warp_sum (fp32). ---
+    reduce_off = off
+    reduce_warp_max_off = reduce_off
+    reduce_warp_sum_off = reduce_off + _MATH_WARPS * hpb * 4
+    reduce_bytes = 2 * _MATH_WARPS * hpb * 4
+    off = reduce_off + reduce_bytes
+
+    # --- per-vc per-head output scale (fp32), N_V_CHUNKS rows of HPB. ---
+    w_head_sc_off = off
+    w_head_sc_stride = hpb
+    w_head_sc_bytes = n_v_chunks * hpb * 4
+    off = w_head_sc_off + w_head_sc_bytes
+
+    # --- re-quantized-P staging for XV MMA: HPB x (BI + 16), double-buffered. ---
+    w_fp8_off = off
+    w_fp8_stride = bi + _W_FP8_PAD
+    w_fp8_buf_bytes = hpb * w_fp8_stride
+    w_fp8_bufs = _W_FP8_BUF_COUNT
+    off = w_fp8_off + w_fp8_buf_bytes * w_fp8_bufs
+
+    # --- staged raw-token-index validity buffer (incl -1 sentinel), int32. ---
+    # 16-align for clean int32 indexing; double-buffered to track the KV buf.
+    off = _align_up(off, 16)
+    token_idx_off = off
+    token_idx_buf_bytes = bi * 4
+    token_idx_bufs = _TOKEN_IDX_BUF_COUNT
+    off = token_idx_off + token_idx_buf_bytes * token_idx_bufs
+
+    # --- static sm_p_full (bf16), 128B-aligned for the S6b ldmatrix.x4 read. ---
+    off = _align_up(off, 128)
+    sm_p_full_off = off
+    sm_p_full_stride = bi + (8 if traits.has_extra_cache else 0)
+    sm_p_full_bytes = hpb * sm_p_full_stride * 2
+    off = sm_p_full_off + sm_p_full_bytes
+
+    # --- native H16 group-1 w_head_sc (tail region; base offsets unchanged).
+    #     DSV4-only: GLM has no two-group H16 mode and sits near the carveout.
+    #     The extra 8*BI bf16 rows keep group 1's S6b ldmatrix.x4 A-loads (which
+    #     always touch 16 sm_p rows from the group base at +8 rows) inside the
+    #     allocation; those rows are read-garbage/compute-discarded, exactly
+    #     like the H8 kernel's rows 8-15. ---
+    off = _align_up(off, 16)
+    w_head_sc2_off = off
+    w_head_sc2_bytes = (
+        n_v_chunks * hpb * 4 + 8 * sm_p_full_stride * 2 if traits.has_extra_cache else 0
+    )
+    off = w_head_sc2_off + w_head_sc2_bytes
+
+    total_bytes = _align_up(off, 128)
+
+    return SmemLayout(
+        q_rope_off=q_rope_off,
+        q_rope_bytes=q_rope_bytes,
+        q_rope_stride=q_rope_stride,
+        q_fp8_off=q_fp8_off,
+        q_fp8_bytes=q_fp8_bytes,
+        q_nope_stride=q_nope_stride,
+        q_sc_off=q_sc_off,
+        q_sc_bytes=q_sc_bytes,
+        q_sc_stride=q_sc_stride,
+        kv_fp8_off=kv_fp8_off,
+        kv_fp8_buf_bytes=kv_fp8_buf_bytes,
+        kv_smem_stride=kv_smem_stride,
+        kv_sc_off=kv_sc_off,
+        kv_sc_buf_bytes=kv_sc_buf_bytes,
+        kv_sc_stride=kv_sc_stride,
+        kv_rope_off=kv_rope_off,
+        kv_rope_buf_bytes=kv_rope_buf_bytes,
+        kv_rope_stride=kv_rope_stride,
+        kv_bufs=bufs,
+        mbar_off=mbar_off,
+        mbar_bytes=mbar_bytes,
+        reduce_off=reduce_off,
+        reduce_bytes=reduce_bytes,
+        reduce_warp_max_off=reduce_warp_max_off,
+        reduce_warp_sum_off=reduce_warp_sum_off,
+        w_head_sc_off=w_head_sc_off,
+        w_head_sc_bytes=w_head_sc_bytes,
+        w_head_sc_stride=w_head_sc_stride,
+        w_fp8_off=w_fp8_off,
+        w_fp8_buf_bytes=w_fp8_buf_bytes,
+        w_fp8_stride=w_fp8_stride,
+        w_fp8_bufs=w_fp8_bufs,
+        token_idx_off=token_idx_off,
+        token_idx_buf_bytes=token_idx_buf_bytes,
+        token_idx_bufs=token_idx_bufs,
+        sm_p_full_off=sm_p_full_off,
+        sm_p_full_bytes=sm_p_full_bytes,
+        sm_p_full_stride=sm_p_full_stride,
+        w_head_sc2_off=w_head_sc2_off,
+        w_head_sc2_bytes=w_head_sc2_bytes,
+        total_bytes=total_bytes,
+    )
+
+
+def get_unified_shared_storage_cls(traits: UnifiedMLATraits):
+    """Build the ``cute.struct`` ``SharedStorage`` for one specialization.
+
+    Each region is a typed ``cute.struct.MemRange`` (128B/16B-aligned where the
+    math/ldmatrix needs it) so a single
+    ``SmemAllocator().allocate(SharedStorage)`` reserves the whole layout.
+    Sub-regions are NAMED typed fields -- the kernel obtains a flat-linear
+    ``cute.Tensor`` view via ``<field>.get_tensor(layout)`` (or a u32 smem
+    address via ``shared_ptr_to_u32(<field>.data_ptr())`` for the
+    ldmatrix/st.shared.v4 path). See the ``*_view`` / ``*_addr`` helpers below.
+
+    Buffers that are double-buffered in the layout (``kv_fp8`` / ``kv_sc`` /
+    ``kv_rope`` / ``w_fp8`` / ``token_idx``) are allocated as a single MemRange
+    of ``bufs * buf_bytes``; the kernel selects buffer ``b`` via the const_expr
+    ``*_buf_bytes`` offset. DSV4-only fields are omitted from GLM entirely so
+    CUTLASS DSL 4.6's typed-allocation size and offsets remain byte-identical to
+    :func:`make_smem_layout`.
+    """
+    layout = make_smem_layout(traits)
+
+    class SharedStorage:
+        pass
+
+    kv_sc_field = (
+        {
+            "kv_sc": cute.struct.MemRange[
+                cutlass.Uint8,
+                int(layout.kv_sc_buf_bytes * layout.kv_bufs),
+            ]
+        }
+        if traits.has_extra_cache
+        else {}
+    )
+    w_head_sc2_field = (
+        {
+            "w_head_sc2": cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32, int(layout.w_head_sc2_bytes // 4)
+                ],
+                16,
+            ]
+        }
+        if traits.has_extra_cache
+        else {}
+    )
+    SharedStorage.__annotations__ = {
+        # Q staging (single buffer). q_rope first (FlashInfer OFF_Q_ROPE = 0).
+        "q_rope": cute.struct.Align[
+            cute.struct.MemRange[cutlass.BFloat16, int(layout.q_rope_bytes // 2)],
+            128,
+        ],
+        "q_fp8": cute.struct.MemRange[cutlass.Uint8, int(layout.q_fp8_bytes)],
+        "q_sc": cute.struct.MemRange[cutlass.Float32, int(layout.q_sc_bytes // 4)],
+        # Double-buffered KV. 128B-align the big nope region.
+        "kv_fp8": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.Uint8, int(layout.kv_fp8_buf_bytes * layout.kv_bufs)
+            ],
+            128,
+        ],
+        **kv_sc_field,
+        # 16B-align kv_rope for cp.async.bulk and ldmatrix. DSV4's footer is
+        # already 128B-sized; GLM has no footer field at all.
+        "kv_rope": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.BFloat16, int(layout.kv_rope_buf_bytes * layout.kv_bufs // 2)
+            ],
+            16,
+        ],
+        # P6 mbarrier array (u64 full[2]+empty[2]). 16B-aligned.
+        "mbar": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint64, int(layout.mbar_bytes // 8)],
+            16,
+        ],
+        # cross-warp reduce scratch (warp_max | warp_sum fp32).
+        "reduce": cute.struct.MemRange[cutlass.Float32, int(layout.reduce_bytes // 4)],
+        # per-vc per-head output scale (fp32).
+        "w_head_sc": cute.struct.MemRange[
+            cutlass.Float32, int(layout.w_head_sc_bytes // 4)
+        ],
+        # re-quantized-P (fp8), double-buffered across vc.
+        "w_fp8": cute.struct.MemRange[
+            cutlass.Uint8, int(layout.w_fp8_buf_bytes * layout.w_fp8_bufs)
+        ],
+        # staged raw-token-index validity buffer (incl -1), int32, double-buffered.
+        "token_idx": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.Int32,
+                int(layout.token_idx_buf_bytes * layout.token_idx_bufs // 4),
+            ],
+            16,
+        ],
+        # static sm_p_full (bf16), 128B-aligned for ldmatrix.x4.
+        "sm_p_full": cute.struct.Align[
+            cute.struct.MemRange[cutlass.BFloat16, int(layout.sm_p_full_bytes // 2)],
+            128,
+        ],
+        # Native DSV4 H16 group-1 w_head_sc tail (16B-aligned). GLM has no
+        # two-group H16 mode, so it has no placeholder field or tail padding.
+        **w_head_sc2_field,
+    }
+    storage_cls = cute.struct(SharedStorage)
+
+    expected_offsets = {
+        "q_rope": layout.q_rope_off,
+        "q_fp8": layout.q_fp8_off,
+        "q_sc": layout.q_sc_off,
+        "kv_fp8": layout.kv_fp8_off,
+        "kv_rope": layout.kv_rope_off,
+        "mbar": layout.mbar_off,
+        "reduce": layout.reduce_off,
+        "w_head_sc": layout.w_head_sc_off,
+        "w_fp8": layout.w_fp8_off,
+        "token_idx": layout.token_idx_off,
+        "sm_p_full": layout.sm_p_full_off,
+    }
+    if traits.has_extra_cache:
+        expected_offsets["kv_sc"] = layout.kv_sc_off
+        expected_offsets["w_head_sc2"] = layout.w_head_sc2_off
+    actual_offsets = dict(storage_cls._offsets)
+    if actual_offsets != expected_offsets:
+        raise ValueError(
+            "typed MLA SharedStorage offsets diverge from SmemLayout: "
+            f"typed={actual_offsets}, logical={expected_offsets}"
+        )
+    typed_bytes = int(storage_cls.size_in_bytes())
+    if typed_bytes != layout.total_bytes:
+        raise ValueError(
+            "typed MLA SharedStorage size diverges from SmemLayout: "
+            f"typed={typed_bytes}, logical={layout.total_bytes}"
+        )
+    return storage_cls
+
+
+# ---------------------------------------------------------------------------
+# Module-level size + stride assertions for BOTH validated models. These run at
+# import time (pure Python) and guard against a layout change blowing the SM120
+# carveout or desyncing KV_SMEM_STRIDE / Q_NOPE_STRIDE from the traits.
+# ---------------------------------------------------------------------------
+def _assert_model(model_type: int, compute_mode: int, scale_format: int) -> int:
+    # Imported lazily to keep this module's top-level import order simple.
+    from .traits import make_unified_traits
+
+    traits = make_unified_traits(model_type, compute_mode, scale_format)
+    layout = make_smem_layout(traits)
+    # This constructor validates every typed field offset and the exact total
+    # that CUTLASS DSL 4.6 infers for the launch's dynamic shared memory.
+    get_unified_shared_storage_cls(traits)
+    assert layout.kv_smem_stride == traits.kv_smem_stride, (
+        f"KV_SMEM_STRIDE mismatch: layout={layout.kv_smem_stride} "
+        f"traits={traits.kv_smem_stride}"
+    )
+    assert layout.q_nope_stride == traits.q_nope_stride, (
+        f"Q_NOPE_STRIDE mismatch: layout={layout.q_nope_stride} "
+        f"traits={traits.q_nope_stride}"
+    )
+    # DSV4 has the separate UE8M0 footer buffer; GLM keeps scales inline.
+    if traits.has_extra_cache:
+        assert layout.kv_sc_buf_bytes == traits.bi * 8, (
+            f"DSV4 kv_sc footer buf must be BI*8; got {layout.kv_sc_buf_bytes}"
+        )
+    else:
+        assert layout.kv_sc_buf_bytes == 0, (
+            f"GLM scales are inline; kv_sc footer buf must be 0, "
+            f"got {layout.kv_sc_buf_bytes}"
+        )
+    # Sub-region offsets must be monotonic + non-overlapping (sanity on packing).
+    assert layout.q_rope_off == 0
+    assert layout.q_fp8_off >= layout.q_rope_off + layout.q_rope_bytes
+    assert layout.kv_fp8_off >= layout.q_sc_off + layout.q_sc_bytes
+    assert layout.total_bytes < SM120_SMEM_CARVEOUT_BYTES, (
+        f"smem layout {layout.total_bytes}B exceeds SM120 carveout "
+        f"{SM120_SMEM_CARVEOUT_BYTES}B for model_type={model_type}"
+    )
+    return layout.total_bytes
+
+
+def _run_module_asserts() -> None:
+    from .traits import ComputeMode, ModelType, ScaleFormat
+
+    dsv4 = _assert_model(ModelType.DSV4, ComputeMode.FP8, ScaleFormat.UE8M0_BYTE)
+    _assert_model(ModelType.DSV4, ComputeMode.BF16, ScaleFormat.UE8M0_BYTE)
+    glm = _assert_model(ModelType.GLM_NSA, ComputeMode.FP8, ScaleFormat.ARBITRARY_FP32)
+    _assert_model(ModelType.GLM_NSA, ComputeMode.BF16, ScaleFormat.ARBITRARY_FP32)
+    _assert_model(ModelType.GLM_NSA, ComputeMode.BF16, ScaleFormat.NVFP4_E4M3)
+    # Sanity on the expected magnitudes (~92KB DSV4, ~96KB GLM after the
+    # double-buffered KV + footer + w_fp8 refinements).
+    assert 80 * 1024 <= dsv4 <= 96 * 1024, f"DSV4 smem {dsv4}B outside ~92KB band"
+    assert 88 * 1024 <= glm <= SM120_SMEM_CARVEOUT_BYTES, (
+        f"GLM smem {glm}B outside ~96KB band"
+    )
+
+
+_run_module_asserts()

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/smem_mg.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/smem_mg.py
@@ -1,0 +1,530 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/smem_mg.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""FlashInfer-shaped MG shared-memory layout for DSV4 SM120 prefill.
+
+This layout mirrors the DSV4 ``SmemLayoutMG`` contract used by FlashInfer prefill:
+two HPB head groups per CTA, one double-buffered NoPE KV stage, separate UE8M0
+scale buffers, and no DSV4 RoPE KV staging. RoPE is loaded from global/L2 by the
+math path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+
+from .smem import SM120_SMEM_CARVEOUT_BYTES
+from .traits import ComputeMode, UnifiedMLATraits
+
+
+_MG_N_HG = 2
+_KV_BUF_COUNT = 2
+_W_FP8_BUF_COUNT = 2
+_MATH_WARPS = 8
+_W_FP8_PAD = 16
+_MBAR_BYTES = _KV_BUF_COUNT * 8
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+@dataclass(frozen=True)
+class SmemLayoutMG:
+    mg_n_hg: int
+    heads_per_cta: int
+
+    # BF16-QK (ComputeMode.BF16) layout divergences. For the FP8 path these are
+    # all 0/False and the layout is byte-identical to the validated FP8 layout.
+    bf16_qk: bool
+    q_nope_bf16_off: int
+    q_nope_bf16_group_bytes: int
+    q_nope_bf16_bytes: int
+    q_nope_bf16_stride: int
+
+    q_rope_off: int
+    q_rope_group_bytes: int
+    q_rope_bytes: int
+    q_rope_stride: int
+
+    q_fp8_off: int
+    q_fp8_group_bytes: int
+    q_fp8_bytes: int
+    q_nope_stride: int
+
+    q_sc_off: int
+    q_sc_group_bytes: int
+    q_sc_bytes: int
+    q_sc_stride: int
+
+    kv_fp8_off: int
+    kv_fp8_buf_bytes: int
+    kv_smem_stride: int
+
+    kv_sc_off: int
+    kv_sc_buf_bytes: int
+    kv_sc_stride: int
+
+    # kv_rope: GLM-only V/K rope bf16 staging (linear entry*D_ROPE + d),
+    # double-buffered. DSV4 MG reads rope from global/L2, so kv_rope_buf_bytes==0
+    # and the field is never indexed for DSV4 (const_expr-elided).
+    kv_rope_off: int
+    kv_rope_buf_bytes: int
+    kv_rope_stride: int
+
+    kv_bufs: int
+
+    mbar_off: int
+    mbar_bytes: int
+
+    reduce_off: int
+    reduce_group_bytes: int
+    reduce_warp_max_group_off: int
+    reduce_warp_sum_group_off: int
+    reduce_bytes: int
+
+    w_head_sc_off: int
+    w_head_sc_group_bytes: int
+    w_head_sc_bytes: int
+    w_head_sc_stride: int
+
+    w_fp8_off: int
+    w_fp8_group_bytes: int
+    w_fp8_parity_bytes: int
+    w_fp8_stride: int
+    w_fp8_bufs: int
+
+    sm_p_full_off: int
+    sm_p_full_group_bytes: int
+    sm_p_full_bytes: int
+    sm_p_full_stride: int
+
+    total_bytes: int
+
+
+def make_smem_layout_mg(
+    traits: UnifiedMLATraits, mg_n_hg: int = _MG_N_HG
+) -> SmemLayoutMG:
+    # DSV4 (has_extra_cache) staged the 448B NoPE only (rope from global, UE8M0
+    # footer in kv_sc). GLM (ARBITRARY_FP32, no extra cache) stages the 528B
+    # NoPE+inline-fp32-scales row (scales inline, NO footer) PLUS a kv_rope buffer
+    # (GLM has no global-rope path in MG). Both share the rest of the MG layout.
+    is_glm = not traits.has_extra_cache
+    if mg_n_hg not in (1, 2):
+        raise ValueError(
+            f"MG prefill layout supports mg_n_hg in {{1, 2}}, got {mg_n_hg}"
+        )
+
+    bi = traits.bi
+    hpb = traits.hpb
+    d_rope = traits.d_rope
+    d_nope = traits.d_nope
+    num_scales = traits.num_scales
+    n_v_chunks = traits.n_v_chunks
+    q_nope_stride = traits.q_nope_stride
+    bufs = _KV_BUF_COUNT
+    # MG head-group count: 2 (heads % 32 == 0, the validated path) or 1 (heads ==
+    # 16, the small-TP shard). All *_bytes (group buffers) below are mg_n_hg *
+    # *_group_bytes, so mg_n_hg==1 allocates exactly one head group's smem (half
+    # the reduce / W / Q / sm_p region). The per-group *_group_bytes are identical
+    # across both, so the group-0 byte offsets the kernel computes are unchanged.
+    heads_per_cta = mg_n_hg * hpb
+
+    bf16_qk = traits.compute_mode == ComputeMode.BF16
+    # BF16-QK and GLM FP8 use Q-rope scratch aliased onto W_FP8. BF16 reloads
+    # that small scratch cooperatively between tiles instead of keeping the
+    # ldmatrix fragments live (and spilled) across the full kernel.
+    alias_qrope = bf16_qk or is_glm
+    # Keep the model-native padded KV row in both compute modes.  DSV4's 464-B
+    # stride (448-B payload + 16-B pad) is part of the shared-memory bank layout,
+    # not merely copy padding; FlashInfer retains it for BF16 QK as well.  The
+    # XV-RoPE weights alias W_FP8 below, so the padded double buffer still fits
+    # the SM120 carveout.
+    kv_smem_stride = traits.kv_smem_stride
+
+    off = 0
+
+    if bf16_qk:
+        # Q-NoPE stored as BF16 (no FP8 quant), HPB x (D_NOPE+8) per group. The
+        # +8 bf16 tail keeps each head row 16 B-aligned for ldmatrix.x4. The FP8
+        # q_fp8 / q_sc regions do not exist; their fields are zeroed below.
+        q_nope_bf16_off = off
+        q_nope_bf16_stride = d_nope + 8
+        q_nope_bf16_group_bytes = hpb * q_nope_bf16_stride * 2
+        q_nope_bf16_bytes = mg_n_hg * q_nope_bf16_group_bytes
+        off = q_nope_bf16_off + q_nope_bf16_bytes
+        # Assigned after W_FP8 is laid out below.
+        q_fp8_off = 0
+        q_fp8_group_bytes = 0
+        q_fp8_bytes = 0
+        q_sc_off = 0
+        q_sc_stride = 0
+        q_sc_group_bytes = 0
+        q_sc_bytes = 0
+    else:
+        q_nope_bf16_off = 0
+        q_nope_bf16_stride = 0
+        q_nope_bf16_group_bytes = 0
+        q_nope_bf16_bytes = 0
+
+        # GLM consumes the aliased Q-RoPE tile through ldmatrix.x4.  A 64-bf16
+        # row aliases every row onto one bank group; the 8-element pad rotates
+        # rows by one 16-B bank group.  DSV4 FP8 keeps its established layout.
+        q_rope_stride = d_rope + (8 if is_glm else 0)
+        q_rope_group_bytes = hpb * q_rope_stride * 2
+        q_rope_bytes = mg_n_hg * q_rope_group_bytes
+        if alias_qrope:
+            # GLM FP8: Q-rope is preloaded to registers once (S0) then its smem
+            # scratch ALIASES W_FP8 (live only in S6). Assigned after W_FP8 off is
+            # known, below. Reserve no inline q_rope region here.
+            q_rope_off = 0
+        else:
+            q_rope_off = off
+            off = q_rope_off + q_rope_bytes
+
+        q_fp8_off = off
+        q_fp8_group_bytes = hpb * q_nope_stride
+        q_fp8_bytes = mg_n_hg * q_fp8_group_bytes
+        off = q_fp8_off + q_fp8_bytes
+
+        q_sc_off = off
+        q_sc_stride = num_scales
+        q_sc_group_bytes = hpb * num_scales * 4
+        q_sc_bytes = mg_n_hg * q_sc_group_bytes
+        off = q_sc_off + q_sc_bytes
+
+    off = _align_up(off, 128)
+    kv_fp8_off = off
+    kv_fp8_buf_bytes = bi * kv_smem_stride
+    off = kv_fp8_off + kv_fp8_buf_bytes * bufs
+
+    kv_sc_off = off
+    if is_glm:
+        # GLM: scales are INLINE in the kv_fp8 KV_SMEM_STRIDE row (no footer buf).
+        kv_sc_stride = 0
+        kv_sc_buf_bytes = 0
+    else:
+        kv_sc_stride = 8
+        kv_sc_buf_bytes = bi * kv_sc_stride
+        off = kv_sc_off + kv_sc_buf_bytes * bufs
+
+    # MG reads KV-rope from global/L2 for BOTH models (no smem staging), so the
+    # kv_rope buffer is always empty. Kept as zeroed fields for layout symmetry.
+    kv_rope_off = off
+    kv_rope_stride = d_rope
+    kv_rope_buf_bytes = 0
+
+    off = _align_up(off, 16)
+    mbar_off = off
+    mbar_bytes = _MBAR_BYTES
+    off = mbar_off + mbar_bytes
+
+    reduce_off = off
+    reduce_group_bytes = 2 * _MATH_WARPS * hpb * 4
+    reduce_warp_max_group_off = 0
+    reduce_warp_sum_group_off = _MATH_WARPS * hpb * 4
+    reduce_bytes = mg_n_hg * reduce_group_bytes
+    off = reduce_off + reduce_bytes
+
+    w_head_sc_off = off
+    w_head_sc_stride = hpb
+    w_head_sc_group_bytes = n_v_chunks * hpb * 4
+    w_head_sc_bytes = mg_n_hg * w_head_sc_group_bytes
+    off = w_head_sc_off + w_head_sc_bytes
+
+    w_fp8_off = off
+    w_fp8_stride = bi + _W_FP8_PAD
+    w_fp8_group_bytes = hpb * w_fp8_stride
+    w_fp8_parity_bytes = mg_n_hg * w_fp8_group_bytes
+    w_fp8_bufs = _W_FP8_BUF_COUNT
+    off = w_fp8_off + w_fp8_parity_bytes * w_fp8_bufs
+
+    if alias_qrope:
+        # Q-rope smem scratch ALIASES the W_FP8 region (see above). Only live in
+        # S0 (written by the cooperative load, immediately read to registers).
+        # Shared by the BF16-QK (DSV4) and FP8 GLM paths.
+        q_rope_off = w_fp8_off
+        q_rope_stride = d_rope + 8
+        q_rope_group_bytes = hpb * q_rope_stride * 2
+        q_rope_bytes = mg_n_hg * q_rope_group_bytes
+        assert q_rope_bytes <= w_fp8_parity_bytes * w_fp8_bufs, (
+            "Q-rope scratch does not fit in the aliased W_FP8 region"
+        )
+
+    # XV-RoPE runs after XV-NoPE has consumed W_FP8.  Reuse that dead region for
+    # the BF16 softmax-weight tile exactly as the native MG kernel does instead
+    # of reserving a separate 4-KiB sm_p_full allocation.
+    sm_p_full_off = w_fp8_off
+    # A BI=64 bf16 row is exactly 128 B, so all sixteen rows presented to an
+    # ldmatrix.x4 start in the same shared-memory bank group.  Add one 16-B
+    # bank-group step per row: successive rows then cover all eight groups
+    # before repeating, while the two padded head-group tiles still fit in the
+    # dead double-buffered W_FP8 allocation (2 * 16 * 72 * 2 = 4608 B <= 5120 B).
+    sm_p_full_stride = bi + 8
+    sm_p_full_group_bytes = hpb * sm_p_full_stride * 2
+    sm_p_full_bytes = mg_n_hg * sm_p_full_group_bytes
+    assert sm_p_full_bytes <= w_fp8_parity_bytes * w_fp8_bufs, (
+        "XV-RoPE weight tile does not fit in the aliased W_FP8 region"
+    )
+
+    total_bytes = _align_up(off, 128)
+
+    return SmemLayoutMG(
+        mg_n_hg=mg_n_hg,
+        heads_per_cta=heads_per_cta,
+        bf16_qk=bf16_qk,
+        q_nope_bf16_off=q_nope_bf16_off,
+        q_nope_bf16_group_bytes=q_nope_bf16_group_bytes,
+        q_nope_bf16_bytes=q_nope_bf16_bytes,
+        q_nope_bf16_stride=q_nope_bf16_stride,
+        q_rope_off=q_rope_off,
+        q_rope_group_bytes=q_rope_group_bytes,
+        q_rope_bytes=q_rope_bytes,
+        q_rope_stride=q_rope_stride,
+        q_fp8_off=q_fp8_off,
+        q_fp8_group_bytes=q_fp8_group_bytes,
+        q_fp8_bytes=q_fp8_bytes,
+        q_nope_stride=q_nope_stride,
+        q_sc_off=q_sc_off,
+        q_sc_group_bytes=q_sc_group_bytes,
+        q_sc_bytes=q_sc_bytes,
+        q_sc_stride=q_sc_stride,
+        kv_fp8_off=kv_fp8_off,
+        kv_fp8_buf_bytes=kv_fp8_buf_bytes,
+        kv_smem_stride=kv_smem_stride,
+        kv_sc_off=kv_sc_off,
+        kv_sc_buf_bytes=kv_sc_buf_bytes,
+        kv_sc_stride=kv_sc_stride,
+        kv_rope_off=kv_rope_off,
+        kv_rope_buf_bytes=kv_rope_buf_bytes,
+        kv_rope_stride=kv_rope_stride,
+        kv_bufs=bufs,
+        mbar_off=mbar_off,
+        mbar_bytes=mbar_bytes,
+        reduce_off=reduce_off,
+        reduce_group_bytes=reduce_group_bytes,
+        reduce_warp_max_group_off=reduce_warp_max_group_off,
+        reduce_warp_sum_group_off=reduce_warp_sum_group_off,
+        reduce_bytes=reduce_bytes,
+        w_head_sc_off=w_head_sc_off,
+        w_head_sc_group_bytes=w_head_sc_group_bytes,
+        w_head_sc_bytes=w_head_sc_bytes,
+        w_head_sc_stride=w_head_sc_stride,
+        w_fp8_off=w_fp8_off,
+        w_fp8_group_bytes=w_fp8_group_bytes,
+        w_fp8_parity_bytes=w_fp8_parity_bytes,
+        w_fp8_stride=w_fp8_stride,
+        w_fp8_bufs=w_fp8_bufs,
+        sm_p_full_off=sm_p_full_off,
+        sm_p_full_group_bytes=sm_p_full_group_bytes,
+        sm_p_full_bytes=sm_p_full_bytes,
+        sm_p_full_stride=sm_p_full_stride,
+        total_bytes=total_bytes,
+    )
+
+
+def get_prefill_mg_shared_storage_cls(
+    traits: UnifiedMLATraits, mg_n_hg: int = _MG_N_HG
+):
+    layout = make_smem_layout_mg(traits, mg_n_hg)
+
+    class SharedStorageMG:
+        pass
+
+    is_glm = not traits.has_extra_cache
+
+    # Tail (kv_fp8 .. w_fp8) is identical across DSV4 compute modes. DSV4
+    # stages a separate UE8M0 footer ``kv_sc`` (rope from global/L2). GLM has NO
+    # footer (the 4 inline fp32 scales travel in the kv_fp8 528B row) and also
+    # reads rope from global/L2, so it allocates NEITHER kv_sc nor kv_rope. Each
+    # model is its own compiled specialization, so the GLM struct cannot perturb
+    # the DSV4 struct.
+    if is_glm:
+        kv_scale_field = {}
+    else:
+        kv_scale_field = {
+            "kv_sc": cute.struct.MemRange[
+                cutlass.Uint8, int(layout.kv_sc_buf_bytes * layout.kv_bufs)
+            ],
+        }
+
+    # Only the Q prologue differs across compute modes: DSV4 FP8 stages {q_rope,
+    # q_fp8, q_sc}; BF16 + GLM FP8 stage Q-rope into a scratch aliased onto the
+    # W_FP8 region (no separate q_rope field).
+    tail = {
+        "kv_fp8": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.Uint8, int(layout.kv_fp8_buf_bytes * layout.kv_bufs)
+            ],
+            128,
+        ],
+        **kv_scale_field,
+        "mbar": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint64, int(layout.mbar_bytes // 8)],
+            16,
+        ],
+        "reduce": cute.struct.MemRange[cutlass.Float32, int(layout.reduce_bytes // 4)],
+        "w_head_sc": cute.struct.MemRange[
+            cutlass.Float32, int(layout.w_head_sc_bytes // 4)
+        ],
+        "w_fp8": cute.struct.MemRange[
+            cutlass.Uint8, int(layout.w_fp8_parity_bytes * layout.w_fp8_bufs)
+        ],
+    }
+
+    if layout.bf16_qk:
+        SharedStorageMG.__annotations__ = {
+            "q_nope_bf16": cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.BFloat16, int(layout.q_nope_bf16_bytes // 2)
+                ],
+                128,
+            ],
+            **tail,
+        }
+    elif is_glm:
+        # GLM FP8: {q_fp8, q_sc} only; Q-rope scratch aliases W_FP8 (no field).
+        SharedStorageMG.__annotations__ = {
+            "q_fp8": cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint8, int(layout.q_fp8_bytes)], 128
+            ],
+            "q_sc": cute.struct.MemRange[cutlass.Float32, int(layout.q_sc_bytes // 4)],
+            **tail,
+        }
+    else:
+        SharedStorageMG.__annotations__ = {
+            "q_rope": cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, int(layout.q_rope_bytes // 2)],
+                128,
+            ],
+            "q_fp8": cute.struct.MemRange[cutlass.Uint8, int(layout.q_fp8_bytes)],
+            "q_sc": cute.struct.MemRange[cutlass.Float32, int(layout.q_sc_bytes // 4)],
+            **tail,
+        }
+
+    storage_cls = cute.struct(SharedStorageMG)
+    if layout.bf16_qk:
+        expected_offsets = {"q_nope_bf16": layout.q_nope_bf16_off}
+    elif is_glm:
+        expected_offsets = {
+            "q_fp8": layout.q_fp8_off,
+            "q_sc": layout.q_sc_off,
+        }
+    else:
+        expected_offsets = {
+            "q_rope": layout.q_rope_off,
+            "q_fp8": layout.q_fp8_off,
+            "q_sc": layout.q_sc_off,
+        }
+    expected_offsets["kv_fp8"] = layout.kv_fp8_off
+    if not is_glm:
+        expected_offsets["kv_sc"] = layout.kv_sc_off
+    expected_offsets.update(
+        {
+            "mbar": layout.mbar_off,
+            "reduce": layout.reduce_off,
+            "w_head_sc": layout.w_head_sc_off,
+            "w_fp8": layout.w_fp8_off,
+        }
+    )
+
+    actual_offsets = dict(storage_cls._offsets)
+    if actual_offsets != expected_offsets:
+        raise ValueError(
+            "typed MLA MG SharedStorage offsets diverge from SmemLayoutMG: "
+            f"typed={actual_offsets}, logical={expected_offsets}"
+        )
+    typed_bytes = int(storage_cls.size_in_bytes())
+    if typed_bytes != layout.total_bytes:
+        raise ValueError(
+            "typed MLA MG SharedStorage size diverges from SmemLayoutMG: "
+            f"typed={typed_bytes}, logical={layout.total_bytes}"
+        )
+    return storage_cls
+
+
+def _run_module_asserts() -> None:
+    from .traits import ComputeMode, ModelType, ScaleFormat, make_unified_traits
+
+    traits = make_unified_traits(
+        ModelType.DSV4, ComputeMode.FP8, ScaleFormat.UE8M0_BYTE
+    )
+    layout = make_smem_layout_mg(traits)
+    assert not layout.bf16_qk
+    assert layout.kv_smem_stride == 464
+    assert layout.kv_fp8_buf_bytes == 64 * 464
+    assert layout.kv_sc_buf_bytes == 64 * 8
+    assert layout.q_rope_off == 0
+    assert layout.total_bytes < SM120_SMEM_CARVEOUT_BYTES, (
+        f"MG prefill smem {layout.total_bytes}B exceeds SM120 carveout "
+        f"{SM120_SMEM_CARVEOUT_BYTES}B"
+    )
+
+    bf16 = make_unified_traits(ModelType.DSV4, ComputeMode.BF16, ScaleFormat.UE8M0_BYTE)
+    bl = make_smem_layout_mg(bf16)
+    assert bl.bf16_qk
+    assert bl.kv_smem_stride == 464
+    assert bl.q_nope_bf16_stride == 448 + 8
+    assert bl.q_rope_off == bl.w_fp8_off
+    assert bl.total_bytes < SM120_SMEM_CARVEOUT_BYTES, (
+        f"BF16 MG prefill smem {bl.total_bytes}B exceeds SM120 carveout "
+        f"{SM120_SMEM_CARVEOUT_BYTES}B"
+    )
+
+    # mg_n_hg==1 (heads==16): one head group. Every group buffer is exactly half
+    # the mg_n_hg==2 size; the per-group *_group_bytes (and so the group-0 byte
+    # offsets the kernel computes) are byte-identical to the 2-group layout, only
+    # the region totals (and downstream offs) shrink. Fits trivially.
+    fp8_1 = make_smem_layout_mg(traits, mg_n_hg=1)
+    assert fp8_1.mg_n_hg == 1 and fp8_1.heads_per_cta == 16
+    assert fp8_1.reduce_group_bytes == layout.reduce_group_bytes
+    assert fp8_1.reduce_bytes == layout.reduce_bytes // 2
+    assert fp8_1.w_head_sc_group_bytes == layout.w_head_sc_group_bytes
+    assert fp8_1.w_head_sc_bytes == layout.w_head_sc_bytes // 2
+    assert fp8_1.w_fp8_group_bytes == layout.w_fp8_group_bytes
+    assert fp8_1.w_fp8_parity_bytes == layout.w_fp8_parity_bytes // 2
+    assert fp8_1.q_fp8_group_bytes == layout.q_fp8_group_bytes
+    assert fp8_1.q_fp8_bytes == layout.q_fp8_bytes // 2
+    assert fp8_1.sm_p_full_group_bytes == layout.sm_p_full_group_bytes
+    assert fp8_1.sm_p_full_bytes == layout.sm_p_full_bytes // 2
+    assert fp8_1.total_bytes <= layout.total_bytes
+    assert fp8_1.total_bytes < SM120_SMEM_CARVEOUT_BYTES
+    get_prefill_mg_shared_storage_cls(traits, mg_n_hg=1)
+    get_prefill_mg_shared_storage_cls(traits, mg_n_hg=2)
+
+    bf16_1 = make_smem_layout_mg(bf16, mg_n_hg=1)
+    assert bf16_1.mg_n_hg == 1 and bf16_1.bf16_qk
+    assert bf16_1.q_nope_bf16_group_bytes == bl.q_nope_bf16_group_bytes
+    assert bf16_1.q_nope_bf16_bytes == bl.q_nope_bf16_bytes // 2
+    assert bf16_1.q_rope_off == bf16_1.w_fp8_off
+    assert bf16_1.total_bytes < SM120_SMEM_CARVEOUT_BYTES
+    get_prefill_mg_shared_storage_cls(bf16, mg_n_hg=1)
+    get_prefill_mg_shared_storage_cls(bf16, mg_n_hg=2)
+
+    # GLM (ARBITRARY_FP32, no extra cache): kv_smem_stride 528 (512 nope + 16
+    # inline fp32 scales), NO kv_sc footer (inline scales), NO kv_rope (rope read
+    # from global/L2), Q-rope aliased onto W_FP8 -- so mg_n_hg==2 fits the carveout.
+    glm = make_unified_traits(
+        ModelType.GLM_NSA, ComputeMode.FP8, ScaleFormat.ARBITRARY_FP32
+    )
+    for nhg in (1, 2):
+        gl = make_smem_layout_mg(glm, mg_n_hg=nhg)
+        assert not gl.bf16_qk
+        assert gl.heads_per_cta == nhg * 16
+        assert gl.kv_smem_stride == 528
+        assert gl.kv_fp8_buf_bytes == 64 * 528
+        assert gl.kv_sc_buf_bytes == 0  # inline scales, no footer.
+        assert gl.kv_rope_buf_bytes == 0  # rope from global/L2 (DSV4 MG design).
+        assert gl.q_rope_off == gl.w_fp8_off  # Q-rope scratch aliases W_FP8.
+        assert gl.total_bytes < SM120_SMEM_CARVEOUT_BYTES, (
+            f"GLM MG prefill smem {gl.total_bytes}B exceeds SM120 carveout "
+            f"{SM120_SMEM_CARVEOUT_BYTES}B (mg_n_hg={nhg})"
+        )
+        get_prefill_mg_shared_storage_cls(glm, mg_n_hg=nhg)
+
+
+_run_module_asserts()

--- a/flashinfer/experimental/sm12x/attention/_shared/mla/traits.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/mla/traits.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/mla/traits.py @ e130f195 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Per-model traits for the unified SM120 sparse-MLA CuTeDSL backend.
+
+Pure Python (no `cute` import): this module is consumed both by the launcher
+and by `smem.py`/`launch.py`, and its enums double as `cutlass.const_expr`
+specialization keys (int-valued) and as `KernelCompileSpec` `KeyField` entries.
+
+All per-model constants are transcribed VERBATIM from
+`.sm120port/verified_traits.md` (DSV4 and GLM_NSA columns). DSV3.2 / POW2_FP32
+are DROPPED per `.sm120port/scope_decisions.md`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+KV_FP8_ROPE_ENV = "KV_FP8_ROPE"
+KV_FP8_ROPE_ENABLED = os.environ.get(KV_FP8_ROPE_ENV, "0") == "1"
+
+
+def kv_fp8_rope_enabled() -> bool:
+    """Return the strict runtime gate for the GLM NVFP4 RoPE sub-record."""
+    return KV_FP8_ROPE_ENABLED
+
+
+# ---------------------------------------------------------------------------
+# const_expr specialization keys (int-valued so they can key cutlass.const_expr
+# branches AND KernelCompileSpec KeyField entries). DSV3_2 / POW2_FP32 dropped.
+# ---------------------------------------------------------------------------
+class ModelType:
+    DSV4 = 0
+    GLM_NSA = 1
+
+
+class ComputeMode:
+    FP8 = 0
+    BF16 = 1
+
+
+class ScaleFormat:
+    UE8M0_BYTE = 0  # DSV4: power-of-2 exponent bytes in an 8B footer.
+    ARBITRARY_FP32 = 1  # GLM: arbitrary FP32 inline scales (reference.py).
+    NVFP4_E4M3 = 2  # GLM/DS MLA latent: E2M1 data + E4M3 group-16 scales.
+
+
+@dataclass(frozen=True)
+class UnifiedMLATraits:
+    """Frozen, hashable trait bundle for one (model, compute, scale) tuple.
+
+    Mirrors FlashInfer's ``KVCacheTraits<MT>`` + ``ComputeTraits<MT,CM>`` so the
+    traced kernel can constant-fold every model-divergent point. Hashable so it
+    is usable in ``functools.lru_cache`` / ``KernelCompileSpec`` keys.
+    """
+
+    model_type: int
+    compute_mode: int
+    scale_format: int
+    d_nope: int
+    d_rope: int
+    d_v: int
+    quant_tile: int
+    num_scales: int
+    n_v_chunks: int
+    nt_per_warp_xv: int
+    kv_gmem_stride: int
+    kv_smem_stride: int
+    q_nope_stride: int
+    bi: int
+    hpb: int
+    block_threads: int
+    math_threads: int
+    bulk_tx_bytes: int
+    v_has_rope: bool
+    has_extra_cache: bool
+    fp8_rope: bool
+    rope_gmem_offset: int
+    rope_payload_bytes: int
+    rope_scale_offset: int
+
+
+def make_unified_traits(
+    model_type: int,
+    compute_mode: int,
+    scale_format: int,
+    fp8_rope: bool | None = None,
+) -> UnifiedMLATraits:
+    """Build the trait bundle for one specialization tuple.
+
+    Constants come straight from `.sm120port/verified_traits.md`. Raises
+    ``ValueError`` for the dropped DSV3.2 / POW2_FP32 combinations and for any
+    (model, scale_format) mismatch.
+    """
+    # Resolve the process-wide cache ABI once per traits construction.  The gate
+    # is deliberately orthogonal to ScaleFormat.NVFP4_E4M3 so the latent's E2M1
+    # data, E4M3 group scales, and outer-scale reconstruction remain unchanged.
+    fp8_rope_requested = kv_fp8_rope_enabled() if fp8_rope is None else bool(fp8_rope)
+
+    # BF16 compute_mode is deferred (both decode targets are FP8) but the enum
+    # value is accepted so the const_expr branch can exist; FP8 is the only
+    # validated path today.
+    if compute_mode not in (ComputeMode.FP8, ComputeMode.BF16):
+        raise ValueError(f"unsupported compute_mode {compute_mode!r}")
+
+    if model_type == ModelType.DSV4:
+        if scale_format != ScaleFormat.UE8M0_BYTE:
+            raise ValueError(
+                "DSV4 requires ScaleFormat.UE8M0_BYTE (footer); "
+                f"got scale_format={scale_format!r}"
+            )
+        # DSV4 column of verified_traits.md (UE8M0_BYTE, V_HAS_ROPE=true).
+        return UnifiedMLATraits(
+            model_type=ModelType.DSV4,
+            compute_mode=compute_mode,
+            scale_format=ScaleFormat.UE8M0_BYTE,
+            d_nope=448,
+            d_rope=64,
+            d_v=512,
+            quant_tile=64,
+            num_scales=7,  # 448/64
+            n_v_chunks=7,
+            nt_per_warp_xv=1,  # 64/8/8
+            kv_gmem_stride=584,  # 448 + 128 + 8
+            kv_smem_stride=464,  # 448 + 16
+            q_nope_stride=464,
+            bi=64,  # cands/chunk
+            hpb=16,  # heads/CTA
+            block_threads=288,  # 9 warps
+            math_threads=256,  # 8 warps
+            bulk_tx_bytes=36864,  # 64*(448+128); footer excluded (16-align caveat)
+            v_has_rope=True,
+            has_extra_cache=True,  # DSV4 dual-cache only
+            fp8_rope=False,
+            rope_gmem_offset=448,
+            rope_payload_bytes=128,
+            rope_scale_offset=-1,
+        )
+
+    if model_type == ModelType.GLM_NSA:
+        if scale_format == ScaleFormat.NVFP4_E4M3:
+            # NVFP4 MLA latent cache: 256B packed E2M1 NoPE + 32B E4M3
+            # group-16 scales + 16B pad + 128B BF16 RoPE. Decode stages Q-NoPE
+            # as BF16 and dequants FP4 K/V in-register for BF16 QK/PV MMAs.
+            use_fp8_rope = fp8_rope_requested
+            return UnifiedMLATraits(
+                model_type=ModelType.GLM_NSA,
+                compute_mode=ComputeMode.BF16,
+                scale_format=ScaleFormat.NVFP4_E4M3,
+                d_nope=512,
+                d_rope=64,
+                d_v=512,
+                quant_tile=64,
+                num_scales=8,  # logical FP4 steps; storage has 32 group-16 scales
+                n_v_chunks=8,
+                nt_per_warp_xv=1,
+                kv_gmem_stride=368 if use_fp8_rope else 432,
+                kv_smem_stride=288,
+                q_nope_stride=520,  # BF16 Q-NoPE smem stride: D_NOPE + 8 elems.
+                bi=64,
+                hpb=16,
+                block_threads=288,
+                math_threads=256,
+                # Decode stages the unchanged 288-byte latent plus either the
+                # 128-byte BF16 rope or the aligned 80-byte scale/pad/FP8 tail.
+                bulk_tx_bytes=23552 if use_fp8_rope else 26624,
+                v_has_rope=False,
+                has_extra_cache=False,
+                fp8_rope=use_fp8_rope,
+                rope_gmem_offset=304,
+                rope_payload_bytes=64 if use_fp8_rope else 128,
+                rope_scale_offset=288 if use_fp8_rope else -1,
+            )
+        if scale_format != ScaleFormat.ARBITRARY_FP32:
+            raise ValueError(
+                "GLM_NSA requires ScaleFormat.ARBITRARY_FP32 (inline) or "
+                "ScaleFormat.NVFP4_E4M3; "
+                f"got scale_format={scale_format!r}"
+            )
+        # GLM_NSA column of verified_traits.md (ARBITRARY_FP32, V_HAS_ROPE=false).
+        return UnifiedMLATraits(
+            model_type=ModelType.GLM_NSA,
+            compute_mode=compute_mode,
+            scale_format=ScaleFormat.ARBITRARY_FP32,
+            d_nope=512,
+            d_rope=64,
+            d_v=512,
+            quant_tile=128,
+            num_scales=4,  # 512/128
+            n_v_chunks=4,
+            nt_per_warp_xv=2,  # 128/8/8
+            kv_gmem_stride=656,
+            kv_smem_stride=528,  # 512 + 4*4
+            q_nope_stride=528,
+            bi=64,  # cands/chunk
+            hpb=16,  # heads/CTA
+            block_threads=288,
+            math_threads=256,
+            bulk_tx_bytes=41984,  # 64*(528+128)
+            v_has_rope=False,
+            has_extra_cache=False,
+            fp8_rope=False,
+            rope_gmem_offset=528,
+            rope_payload_bytes=128,
+            rope_scale_offset=-1,
+        )
+
+    raise ValueError(
+        f"unsupported model_type {model_type!r} (DSV3_2 is dropped; "
+        "valid: ModelType.DSV4, ModelType.GLM_NSA)"
+    )
+
+
+def infer_model_type(q_head_dim: int, kv_dtype) -> tuple[int, int, int]:
+    """Map (q_head_dim, kv_dtype) -> (model_type, compute_mode, scale_format).
+
+    ``q_head_dim`` is ``d_nope + d_rope``:
+      - DSV4:  448 + 64 = 512 -> (DSV4, FP8, UE8M0_BYTE)
+      - GLM:   512 + 64 = 576 -> (GLM_NSA, FP8, ARBITRARY_FP32)
+
+    Both decode targets are FP8 today; ``kv_dtype`` is accepted for the future
+    BF16 const_expr branch but does not currently change the result.
+    """
+    if q_head_dim == 512:
+        return (ModelType.DSV4, ComputeMode.FP8, ScaleFormat.UE8M0_BYTE)
+    if q_head_dim == 576:
+        return (ModelType.GLM_NSA, ComputeMode.FP8, ScaleFormat.ARBITRARY_FP32)
+    raise ValueError(
+        f"unsupported q_head_dim={q_head_dim!r}; expected 512 (DSV4) or 576 (GLM_NSA)"
+    )

--- a/flashinfer/experimental/sm12x/attention/_shared/workspace.py
+++ b/flashinfer/experimental/sm12x/attention/_shared/workspace.py
@@ -1,0 +1,2644 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/workspace.py @ c368a837 (2026-07-14) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Workspace state shared by sparse attention and indexer execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+
+_MLA_PACKED_DIM = 656
+_INDEX_HEAD_DIM = 128
+_INDEXER_BLOCK_K = 64
+_INDEXER_PREFILL_BLOCK_K = 256
+_INDEXER_TILE_BLOCK_Q = 32
+_PAGED_INDEXER_TILE_BLOCK_K = 512
+_ARENA_ALIGN_BYTES = 1024
+_MHC_MULT = 4
+_MHC_PARTIALS = 25
+_MHC_DEFAULT_SPLIT_K = 64
+_WO_MXFP8_SCALE_VEC_SIZE = 32
+_WO_MXFP8_SCALE_ROW_TILE = 128
+_WO_MXFP8_SCALE_K_TILE = 4
+_SPLIT_CHUNK_LADDER = (8, 16, 32, 64, 128, 256, 512, 1024)
+_SPLIT_MAX_CHUNKS = 256
+_SPLIT_MAX_WIDTH = _SPLIT_CHUNK_LADDER[-1] * _SPLIT_MAX_CHUNKS
+
+
+class SM12XIndexerTopKPositionBufferUnavailable(RuntimeError):
+    """Raised when an arena does not reserve reusable top-k merge positions."""
+
+
+@dataclass(frozen=True)
+class SparseMLASplitDecodeConfig:
+    chunk_size: int
+    num_chunks: int
+
+
+@dataclass(frozen=True)
+class _PagedIndexerTiledTopKPlan:
+    topk: int
+    block_q: int
+    block_k: int
+    q_rows: int
+    num_k_tiles: int
+
+
+@dataclass(frozen=True)
+class _PagedIndexerTiledScorerPlan:
+    block_q: int
+    block_k: int
+    q_rows: int
+    width_tokens: int
+    source_page_width: int
+
+
+def _canonical_device(device: torch.device | str) -> torch.device:
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None:
+        return torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
+def _shape_only_cuda_tensor(
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a tiny CUDA tensor whose shape/stride/dtype/device are stable.
+
+    Used as a phantom in host-launcher cache keys so that varying batch sizes
+    do not trigger CUTLASS recompilation.  The tensor is never read by kernels.
+    """
+    base = torch.empty(1, dtype=dtype, device=device)
+    return base.as_strided(shape, (0,) * len(shape))
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    return ((int(value) + alignment - 1) // alignment) * alignment
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def default_sparse_mla_split_decode_config_for_width(
+    width: int,
+    *,
+    max_chunks: int = _SPLIT_MAX_CHUNKS,
+) -> SparseMLASplitDecodeConfig | None:
+    if width <= _SPLIT_CHUNK_LADDER[0] or width > _SPLIT_MAX_WIDTH:
+        return None
+
+    max_chunks = max(1, min(int(max_chunks), _SPLIT_MAX_CHUNKS))
+    for chunk_size in _SPLIT_CHUNK_LADDER:
+        num_chunks = _ceil_div(width, chunk_size)
+        if num_chunks <= max_chunks:
+            return SparseMLASplitDecodeConfig(
+                chunk_size=chunk_size,
+                num_chunks=num_chunks,
+            )
+    return None
+
+
+def forced_sparse_mla_split_decode_config_for_width(
+    width: int,
+    *,
+    max_chunks: int = _SPLIT_MAX_CHUNKS,
+) -> SparseMLASplitDecodeConfig | None:
+    if width <= 0 or width > _SPLIT_MAX_WIDTH:
+        return None
+
+    max_chunks = max(1, min(int(max_chunks), _SPLIT_MAX_CHUNKS))
+    for chunk_size in _SPLIT_CHUNK_LADDER:
+        num_chunks = _ceil_div(width, chunk_size)
+        if num_chunks <= max_chunks:
+            return SparseMLASplitDecodeConfig(
+                chunk_size=chunk_size,
+                num_chunks=num_chunks,
+            )
+    return None
+
+
+def _dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _resolve_contiguous_topk_supertile_k(value: int) -> int:
+    value = int(value)
+    if value <= 0:
+        return 0
+    return _align_up(value, _INDEXER_BLOCK_K)
+
+
+def _resolve_paged_topk_supertile_k(value: int) -> int:
+    value = int(value)
+    if value <= 0:
+        return 0
+    return _align_up(value, _PAGED_INDEXER_TILE_BLOCK_K)
+
+
+def _resolve_paged_indexer_persistent_ctas(
+    *,
+    device: torch.device,
+    q_rows: int,
+) -> int:
+    if device.type != "cuda":
+        return 1
+    num_sms = int(torch.cuda.get_device_properties(device).multi_processor_count)
+    persistent_ctas = max(num_sms * 4, 1)
+    if int(q_rows) >= 4:
+        persistent_ctas = max(persistent_ctas // 2, 1)
+    return persistent_ctas
+
+
+def _shape_numel(shape: tuple[int, ...]) -> int:
+    numel = 1
+    for dim in shape:
+        numel *= int(dim)
+    return numel
+
+
+def _materialize_arena_view(
+    arena: torch.Tensor,
+    *,
+    offset_bytes: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int]:
+    offset_bytes = _align_up(
+        offset_bytes, max(_ARENA_ALIGN_BYTES, _dtype_nbytes(dtype))
+    )
+    nbytes = _shape_numel(shape) * _dtype_nbytes(dtype)
+    view_bytes = arena.narrow(0, offset_bytes, nbytes)
+    typed_view = view_bytes.view(dtype).view(shape)
+    return typed_view, offset_bytes + nbytes
+
+
+def _materialize_arena_strided_view(
+    arena: torch.Tensor,
+    *,
+    offset_bytes: int,
+    shape: tuple[int, ...],
+    stride: tuple[int, ...],
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int]:
+    offset_bytes = _align_up(
+        offset_bytes, max(_ARENA_ALIGN_BYTES, _dtype_nbytes(dtype))
+    )
+    nbytes = _shape_numel(shape) * _dtype_nbytes(dtype)
+    view_bytes = arena.narrow(0, offset_bytes, nbytes)
+    typed_storage = view_bytes.view(dtype)
+    return typed_storage.as_strided(shape, stride), offset_bytes + nbytes
+
+
+def _split_tmp_output_stride(
+    *,
+    max_total_q: int,
+    num_q_heads: int,
+    max_chunks_per_row: int,
+    v_head_dim: int,
+) -> tuple[int, int, int, int]:
+    del max_chunks_per_row
+    row_stride = int(num_q_heads) * int(v_head_dim)
+    head_stride = int(v_head_dim)
+    chunk_stride = int(max_total_q) * int(num_q_heads) * int(v_head_dim)
+    return (row_stride, head_stride, chunk_stride, 1)
+
+
+def _allocate_split_tmp_output(
+    *,
+    max_total_q: int,
+    num_q_heads: int,
+    max_chunks_per_row: int,
+    v_head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    shape = (
+        int(max_total_q),
+        int(num_q_heads),
+        int(max_chunks_per_row),
+        int(v_head_dim),
+    )
+    storage = torch.empty(_shape_numel(shape), dtype=dtype, device=device)
+    return storage.as_strided(
+        shape,
+        _split_tmp_output_stride(
+            max_total_q=max_total_q,
+            num_q_heads=num_q_heads,
+            max_chunks_per_row=max_chunks_per_row,
+            v_head_dim=v_head_dim,
+        ),
+    )
+
+
+def _split_output_buffer_from_tmp(tmp_output: torch.Tensor) -> torch.Tensor:
+    if tmp_output.ndim != 4:
+        raise ValueError(f"tmp_output must be rank 4, got {tmp_output.ndim}")
+    output = tmp_output[:, :, 0, :]
+    if not output.is_contiguous():
+        raise RuntimeError(
+            "split MLA tmp_output layout must make chunk 0 a contiguous output buffer"
+        )
+    return output
+
+
+def _encode_indexer_k_tma_descriptor(
+    k_quant_bytes: torch.Tensor,
+    *,
+    block_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Encode a stable TMA descriptor for the fixed indexer K workspace."""
+    if k_quant_bytes.ndim != 2 or k_quant_bytes.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k_quant_bytes must have shape (rows, {_INDEX_HEAD_DIM}), got {tuple(k_quant_bytes.shape)}"
+        )
+    if k_quant_bytes.dtype != torch.uint8:
+        raise TypeError(
+            f"k_quant_bytes must be dtype torch.uint8, got {k_quant_bytes.dtype}"
+        )
+
+    import cuda.bindings.driver as cuda
+
+    U64 = cuda.cuuint64_t
+    U32 = cuda.cuuint32_t
+    row_bytes = int(k_quant_bytes.stride(0)) * k_quant_bytes.element_size()
+    base_ptr = int(k_quant_bytes.data_ptr())
+    total_rows = int(k_quant_bytes.shape[0])
+
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8,
+        2,
+        base_ptr,
+        [U64(_INDEX_HEAD_DIM), U64(total_rows)],
+        [U64(row_bytes)],
+        [U32(_INDEX_HEAD_DIM), U32(int(block_k))],
+        [U32(1), U32(1)],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(
+            f"cuTensorMapEncodeTiled failed for indexer K workspace: {result}"
+        )
+
+    desc = torch.tensor(
+        [int(word) for word in tensor_map.opaque],
+        dtype=torch.uint64,
+        device=k_quant_bytes.device,
+    )
+    desc_ptrs = torch.tensor(
+        [int(desc.data_ptr())], dtype=torch.int64, device=k_quant_bytes.device
+    )
+    return desc, desc_ptrs
+
+
+SM12XWorkspaceMode = Literal["decode", "extend", "verify", "draft_extend"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XAttentionArenaCaps:
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    indexer_num_q_heads: int
+    head_dim: int
+    max_v_head_dim: int
+    topk: int
+    max_page_table_width: int
+    extend_max_total_q: int
+    extend_max_batch: int
+    extend_max_kv_rows: int
+    paged_max_q_rows: int
+    paged_max_batch: int
+    indexer_topk: int | None = None
+    indexer_max_k_rows: int | None = None
+    mla_max_total_q: int | None = None
+    mla_max_q_chunks: int | None = None
+    page_size: int = 64
+    padded_heads: int = 128
+    max_chunks_per_row: int = 64
+    reserve_extend_indexer_logits: bool = True
+    reserve_paged_indexer_logits: bool = True
+    reserve_compressed_mla_staging: bool = False
+    reserve_mhc: bool = False
+    mhc_max_tokens: int = 0
+    mhc_hidden_size: int = 0
+    mhc_split_k: int = _MHC_DEFAULT_SPLIT_K
+    reserve_wo_projection: bool = False
+    wo_max_tokens: int = 0
+    wo_groups: int = 0
+    wo_group_width: int = 0
+    wo_rank: int = 0
+    wo_hidden_size: int = 0
+    extend_indexer_tile_logits_k_rows: int = 0
+    paged_indexer_logits_q_rows: int = 0
+    paged_indexer_logits_k_rows: int = 0
+    paged_indexer_tile_logits_k_rows: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "device", _canonical_device(self.device))
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(
+            self,
+            "indexer_num_q_heads",
+            max(int(self.indexer_num_q_heads), 1),
+        )
+        object.__setattr__(self, "head_dim", max(int(self.head_dim), 1))
+        object.__setattr__(self, "max_v_head_dim", max(int(self.max_v_head_dim), 1))
+        object.__setattr__(self, "topk", max(int(self.topk), 1))
+        indexer_topk = self.topk if self.indexer_topk is None else self.indexer_topk
+        object.__setattr__(self, "indexer_topk", max(int(indexer_topk), 1))
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            max(int(self.max_page_table_width), 1),
+        )
+        object.__setattr__(
+            self,
+            "extend_max_total_q",
+            max(int(self.extend_max_total_q), 1),
+        )
+        object.__setattr__(
+            self,
+            "extend_max_batch",
+            max(int(self.extend_max_batch), 1),
+        )
+        object.__setattr__(
+            self,
+            "extend_max_kv_rows",
+            max(int(self.extend_max_kv_rows), 0),
+        )
+        indexer_max_k_rows = (
+            int(self.extend_max_kv_rows)
+            if self.indexer_max_k_rows is None
+            else int(self.indexer_max_k_rows)
+        )
+        object.__setattr__(
+            self,
+            "indexer_max_k_rows",
+            max(indexer_max_k_rows, 0),
+        )
+        object.__setattr__(
+            self,
+            "paged_max_q_rows",
+            max(int(self.paged_max_q_rows), 1),
+        )
+        object.__setattr__(
+            self,
+            "paged_max_batch",
+            max(int(self.paged_max_batch), 1),
+        )
+        if self.mla_max_total_q is None:
+            mla_max_total_q = max(
+                int(self.extend_max_total_q),
+                int(self.paged_max_q_rows),
+                1,
+            )
+        else:
+            mla_max_total_q = max(int(self.mla_max_total_q), 1)
+        object.__setattr__(self, "mla_max_total_q", mla_max_total_q)
+        if self.mla_max_q_chunks is not None:
+            object.__setattr__(
+                self,
+                "mla_max_q_chunks",
+                max(int(self.mla_max_q_chunks), 1),
+            )
+        object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+        object.__setattr__(self, "padded_heads", max(int(self.padded_heads), 1))
+        object.__setattr__(
+            self,
+            "max_chunks_per_row",
+            max(int(self.max_chunks_per_row), 1),
+        )
+        object.__setattr__(
+            self,
+            "reserve_paged_indexer_logits",
+            bool(self.reserve_paged_indexer_logits),
+        )
+        object.__setattr__(
+            self,
+            "reserve_compressed_mla_staging",
+            bool(self.reserve_compressed_mla_staging),
+        )
+        object.__setattr__(self, "reserve_mhc", bool(self.reserve_mhc))
+        object.__setattr__(self, "mhc_max_tokens", max(int(self.mhc_max_tokens), 0))
+        object.__setattr__(self, "mhc_hidden_size", max(int(self.mhc_hidden_size), 0))
+        object.__setattr__(self, "mhc_split_k", max(int(self.mhc_split_k), 1))
+        if self.reserve_mhc and (
+            int(self.mhc_max_tokens) <= 0 or int(self.mhc_hidden_size) <= 0
+        ):
+            raise ValueError(
+                "reserve_mhc requires positive mhc_max_tokens and mhc_hidden_size"
+            )
+        object.__setattr__(
+            self, "reserve_wo_projection", bool(self.reserve_wo_projection)
+        )
+        object.__setattr__(self, "wo_max_tokens", max(int(self.wo_max_tokens), 0))
+        object.__setattr__(self, "wo_groups", max(int(self.wo_groups), 0))
+        object.__setattr__(self, "wo_group_width", max(int(self.wo_group_width), 0))
+        object.__setattr__(self, "wo_rank", max(int(self.wo_rank), 0))
+        object.__setattr__(self, "wo_hidden_size", max(int(self.wo_hidden_size), 0))
+        if self.reserve_wo_projection:
+            if (
+                int(self.wo_max_tokens) <= 0
+                or int(self.wo_groups) <= 0
+                or int(self.wo_group_width) <= 0
+                or int(self.wo_rank) <= 0
+                or int(self.wo_hidden_size) <= 0
+            ):
+                raise ValueError(
+                    "reserve_wo_projection requires positive wo_max_tokens, "
+                    "wo_groups, wo_group_width, wo_rank, and wo_hidden_size"
+                )
+            _check_wo_mxfp8_k(int(self.wo_group_width))
+            _check_wo_mxfp8_k(int(self.wo_rank) * int(self.wo_groups))
+        object.__setattr__(
+            self,
+            "extend_indexer_tile_logits_k_rows",
+            _resolve_contiguous_topk_supertile_k(
+                self.extend_indexer_tile_logits_k_rows
+            ),
+        )
+        paged_indexer_logits_q_rows = int(self.paged_indexer_logits_q_rows)
+        if paged_indexer_logits_q_rows <= 0:
+            paged_indexer_logits_q_rows = int(self.paged_max_q_rows)
+        if paged_indexer_logits_q_rows > int(self.paged_max_q_rows):
+            raise ValueError(
+                "paged_indexer_logits_q_rows "
+                f"{paged_indexer_logits_q_rows} exceeds paged_max_q_rows "
+                f"{self.paged_max_q_rows}"
+            )
+        object.__setattr__(
+            self,
+            "paged_indexer_logits_q_rows",
+            max(paged_indexer_logits_q_rows, 1),
+        )
+        object.__setattr__(
+            self,
+            "paged_indexer_logits_k_rows",
+            _resolve_contiguous_topk_supertile_k(self.paged_indexer_logits_k_rows),
+        )
+        object.__setattr__(
+            self,
+            "paged_indexer_tile_logits_k_rows",
+            _resolve_paged_topk_supertile_k(self.paged_indexer_tile_logits_k_rows),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XAttentionWorkspaceContract:
+    mode: SM12XWorkspaceMode
+    max_total_q: int
+    max_batch: int
+    max_paged_q_rows: int
+    max_kv_rows: int
+    v_head_dim: int
+    indexer_num_q_heads: int
+    max_page_table_width: int
+    topk: int | None = None
+    max_chunks_per_row: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "max_total_q", max(int(self.max_total_q), 1))
+        object.__setattr__(self, "max_batch", max(int(self.max_batch), 1))
+        object.__setattr__(
+            self,
+            "max_paged_q_rows",
+            max(int(self.max_paged_q_rows), 1),
+        )
+        object.__setattr__(self, "max_kv_rows", max(int(self.max_kv_rows), 0))
+        object.__setattr__(self, "v_head_dim", max(int(self.v_head_dim), 1))
+        object.__setattr__(
+            self,
+            "indexer_num_q_heads",
+            max(int(self.indexer_num_q_heads), 1),
+        )
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            max(int(self.max_page_table_width), 1),
+        )
+        if self.topk is not None:
+            object.__setattr__(self, "topk", max(int(self.topk), 1))
+        if self.max_chunks_per_row is not None:
+            object.__setattr__(
+                self,
+                "max_chunks_per_row",
+                max(int(self.max_chunks_per_row), 1),
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
+class _SM12XWOProjectionArenaLayout:
+    nbytes: int = 0
+    x_q_values_offset_bytes: int = 0
+    x_q_scale_rows_offset_bytes: int = 0
+    x_q_scale_mma_offset_bytes: int = 0
+    tmp_offset_bytes: int = 0
+    tmp_q_values_offset_bytes: int = 0
+    tmp_q_scale_rows_offset_bytes: int = 0
+    tmp_q_scale_mma_offset_bytes: int = 0
+    output_offset_bytes: int = 0
+
+
+def _check_wo_mxfp8_k(k: int) -> None:
+    if int(k) <= 0 or int(k) % 128 != 0:
+        raise ValueError(
+            f"WO MXFP8 dense-GEMM K must be a positive multiple of 128, got {k}"
+        )
+
+
+def _wo_mxfp8_scale_physical_shape(
+    *,
+    m: int,
+    k: int,
+    num_groups: int,
+) -> tuple[int, int, int, int, int, int]:
+    sf_k = int(k) // _WO_MXFP8_SCALE_VEC_SIZE
+    return (
+        int(num_groups),
+        _ceil_div(int(m), _WO_MXFP8_SCALE_ROW_TILE),
+        _ceil_div(sf_k, _WO_MXFP8_SCALE_K_TILE),
+        32,
+        4,
+        4,
+    )
+
+
+def _layout_wo_projection(
+    *,
+    offset_bytes: int,
+    tokens: int,
+    groups: int,
+    group_width: int,
+    rank: int,
+    hidden: int,
+) -> _SM12XWOProjectionArenaLayout:
+    tokens = max(int(tokens), 1)
+    groups = int(groups)
+    group_width = int(group_width)
+    rank = int(rank)
+    hidden = int(hidden)
+    if groups <= 0 or group_width <= 0 or rank <= 0 or hidden <= 0:
+        raise ValueError(
+            "WO projection arena requires positive groups, group_width, rank, and hidden"
+        )
+    _check_wo_mxfp8_k(group_width)
+    _check_wo_mxfp8_k(rank * groups)
+
+    start = int(offset_bytes)
+    cursor = _align_up(start, _ARENA_ALIGN_BYTES)
+
+    x_q_values_offset_bytes = cursor
+    cursor += tokens * group_width * groups * _dtype_nbytes(torch.float8_e4m3fn)
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+
+    x_q_scale_rows_offset_bytes = cursor
+    cursor += (
+        groups
+        * tokens
+        * (group_width // _WO_MXFP8_SCALE_VEC_SIZE)
+        * _dtype_nbytes(torch.float8_e8m0fnu)
+    )
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+
+    x_q_scale_mma_offset_bytes = cursor
+    cursor += _shape_numel(
+        _wo_mxfp8_scale_physical_shape(
+            m=tokens,
+            k=group_width,
+            num_groups=groups,
+        )
+    ) * _dtype_nbytes(torch.uint8)
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+
+    tmp_offset_bytes = cursor
+    cursor += tokens * rank * groups * _dtype_nbytes(torch.bfloat16)
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+
+    tmp_q_width = rank * groups
+    tmp_q_values_offset_bytes = cursor
+    cursor += tokens * tmp_q_width * _dtype_nbytes(torch.float8_e4m3fn)
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+
+    tmp_q_scale_rows_offset_bytes = cursor
+    cursor += (
+        tokens
+        * (tmp_q_width // _WO_MXFP8_SCALE_VEC_SIZE)
+        * _dtype_nbytes(torch.float8_e8m0fnu)
+    )
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+
+    tmp_q_scale_mma_offset_bytes = cursor
+    cursor += _shape_numel(
+        _wo_mxfp8_scale_physical_shape(
+            m=tokens,
+            k=tmp_q_width,
+            num_groups=1,
+        )
+    ) * _dtype_nbytes(torch.uint8)
+    cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+
+    output_offset_bytes = cursor
+    cursor += tokens * hidden * _dtype_nbytes(torch.bfloat16)
+
+    return _SM12XWOProjectionArenaLayout(
+        nbytes=max(0, int(cursor) - start),
+        x_q_values_offset_bytes=x_q_values_offset_bytes,
+        x_q_scale_rows_offset_bytes=x_q_scale_rows_offset_bytes,
+        x_q_scale_mma_offset_bytes=x_q_scale_mma_offset_bytes,
+        tmp_offset_bytes=tmp_offset_bytes,
+        tmp_q_values_offset_bytes=tmp_q_values_offset_bytes,
+        tmp_q_scale_rows_offset_bytes=tmp_q_scale_rows_offset_bytes,
+        tmp_q_scale_mma_offset_bytes=tmp_q_scale_mma_offset_bytes,
+        output_offset_bytes=output_offset_bytes,
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class _SM12XAttentionArenaLayout:
+    arena_nbytes: int
+    mla_phase_nbytes: int
+    indexer_phase_nbytes: int
+    indexer_k_rows: int
+    mla_tmp_q_chunks: int
+    paged_logits_q_rows: int
+    paged_logits_width_tokens: int
+    paged_tile_logits_width_tokens: int
+    ragged_kv_nbytes: int
+    output_buffer_nbytes: int
+    final_lse_nbytes: int
+    compressed_q_stage_nbytes: int
+    compressed_index_stage_nbytes: int
+    compressed_page_table_stage_nbytes: int
+    compressed_lengths_stage_nbytes: int
+    indexer_logits_nbytes: int
+    indexer_contiguous_logits_nbytes: int
+    indexer_contiguous_tile_logits_nbytes: int
+    indexer_contiguous_topk_indices_nbytes: int
+    indexer_contiguous_topk_values_nbytes: int
+    indexer_contiguous_topk_scratch_indices_nbytes: int
+    indexer_contiguous_topk_scratch_values_nbytes: int
+    indexer_contiguous_topk_position_nbytes: int
+    indexer_contiguous_candidate_values_nbytes: int
+    indexer_contiguous_candidate_indices_nbytes: int
+    indexer_contiguous_lengths_nbytes: int
+    indexer_contiguous_mapped_indices_nbytes: int
+    indexer_paged_logits_nbytes: int
+    mhc_nbytes: int
+    mhc_partials_nbytes: int
+    mhc_y_nbytes: int
+    mhc_post_nbytes: int
+    mhc_comb_nbytes: int
+    mhc_out_nbytes: int
+    wo_projection_layout: _SM12XWOProjectionArenaLayout
+    ragged_kv_offset_bytes: int
+    tmp_output_offset_bytes: int
+    tmp_lse_offset_bytes: int
+    output_buffer_offset_bytes: int
+    final_lse_offset_bytes: int
+    compressed_q_stage_offset_bytes: int
+    compressed_swa_indices_stage_offset_bytes: int
+    compressed_swa_lengths_stage_offset_bytes: int
+    compressed_indexed_indices_stage_offset_bytes: int
+    compressed_indexed_lengths_stage_offset_bytes: int
+    compressed_indexed_page_table_stage_offset_bytes: int
+    indexer_k_quant_offset_bytes: int
+    indexer_k_scale_offset_bytes: int
+    indexer_contiguous_logits_offset_bytes: int
+    indexer_contiguous_tile_logits_offset_bytes: int
+    indexer_contiguous_topk_indices_offset_bytes: int
+    indexer_contiguous_topk_values_offset_bytes: int
+    indexer_contiguous_topk_scratch_indices_offset_bytes: int
+    indexer_contiguous_topk_scratch_values_offset_bytes: int
+    indexer_contiguous_topk_position_offset_bytes: int
+    indexer_contiguous_candidate_values_offset_bytes: int
+    indexer_contiguous_candidate_indices_offset_bytes: int
+    indexer_contiguous_lengths_offset_bytes: int
+    indexer_contiguous_mapped_indices_offset_bytes: int
+    indexer_paged_logits_offset_bytes: int
+    mhc_partials_offset_bytes: int
+    mhc_y_offset_bytes: int
+    mhc_post_offset_bytes: int
+    mhc_comb_offset_bytes: int
+    mhc_out_offset_bytes: int
+
+
+@dataclass(kw_only=True)
+class SM12XAttentionArena:
+    caps: SM12XAttentionArenaCaps
+    shared_arena: torch.Tensor
+    shared_arena_nbytes: int
+    mla_phase_nbytes: int
+    indexer_phase_nbytes: int
+    indexer_k_rows: int
+    mla_tmp_q_chunks: int
+    paged_logits_q_rows: int
+    paged_logits_width_tokens: int
+    paged_tile_logits_width_tokens: int
+    ragged_kv_nbytes: int
+    output_buffer_nbytes: int
+    final_lse_nbytes: int
+    compressed_q_stage_nbytes: int
+    compressed_index_stage_nbytes: int
+    compressed_page_table_stage_nbytes: int
+    compressed_lengths_stage_nbytes: int
+    indexer_logits_nbytes: int
+    indexer_contiguous_logits_nbytes: int
+    indexer_contiguous_tile_logits_nbytes: int
+    indexer_contiguous_topk_indices_nbytes: int
+    indexer_contiguous_topk_values_nbytes: int
+    indexer_contiguous_topk_scratch_indices_nbytes: int
+    indexer_contiguous_topk_scratch_values_nbytes: int
+    indexer_contiguous_topk_position_nbytes: int
+    indexer_contiguous_candidate_values_nbytes: int
+    indexer_contiguous_candidate_indices_nbytes: int
+    indexer_contiguous_lengths_nbytes: int
+    indexer_contiguous_mapped_indices_nbytes: int
+    indexer_paged_logits_nbytes: int
+    mhc_nbytes: int
+    mhc_partials_nbytes: int
+    mhc_y_nbytes: int
+    mhc_post_nbytes: int
+    mhc_comb_nbytes: int
+    mhc_out_nbytes: int
+    wo_projection_layout: _SM12XWOProjectionArenaLayout
+    ragged_kv_offset_bytes: int
+    tmp_output_offset_bytes: int
+    tmp_lse_offset_bytes: int
+    output_buffer_offset_bytes: int
+    final_lse_offset_bytes: int
+    compressed_q_stage_offset_bytes: int
+    compressed_swa_indices_stage_offset_bytes: int
+    compressed_swa_lengths_stage_offset_bytes: int
+    compressed_indexed_indices_stage_offset_bytes: int
+    compressed_indexed_lengths_stage_offset_bytes: int
+    compressed_indexed_page_table_stage_offset_bytes: int
+    indexer_k_quant_offset_bytes: int
+    indexer_k_scale_offset_bytes: int
+    indexer_contiguous_logits_offset_bytes: int
+    indexer_contiguous_tile_logits_offset_bytes: int
+    indexer_contiguous_topk_indices_offset_bytes: int
+    indexer_contiguous_topk_values_offset_bytes: int
+    indexer_contiguous_topk_scratch_indices_offset_bytes: int
+    indexer_contiguous_topk_scratch_values_offset_bytes: int
+    indexer_contiguous_topk_position_offset_bytes: int
+    indexer_contiguous_candidate_values_offset_bytes: int
+    indexer_contiguous_candidate_indices_offset_bytes: int
+    indexer_contiguous_lengths_offset_bytes: int
+    indexer_contiguous_mapped_indices_offset_bytes: int
+    indexer_paged_logits_offset_bytes: int
+    mhc_partials_offset_bytes: int
+    mhc_y_offset_bytes: int
+    mhc_post_offset_bytes: int
+    mhc_comb_offset_bytes: int
+    mhc_out_offset_bytes: int
+
+    @classmethod
+    def _layout(cls, caps: SM12XAttentionArenaCaps) -> _SM12XAttentionArenaLayout:
+        indexer_q_rows = max(
+            int(caps.extend_max_total_q), int(caps.paged_max_q_rows), 1
+        )
+        mla_max_total_q = max(int(caps.mla_max_total_q or indexer_q_rows), 1)
+        max_paged_q_rows = max(int(caps.paged_max_q_rows), 1)
+        paged_logits_q_rows = max(int(caps.paged_indexer_logits_q_rows), 1)
+        max_kv_rows = max(int(caps.extend_max_kv_rows), 1)
+        raw_indexer_k_rows = max(int(caps.indexer_max_k_rows or 0), 0)
+        indexer_k_rows = (
+            0
+            if raw_indexer_k_rows == 0
+            else _align_up(raw_indexer_k_rows, _INDEXER_BLOCK_K)
+        )
+        default_mla_tmp_q_chunks = mla_max_total_q * int(caps.max_chunks_per_row)
+        mla_tmp_q_chunks = (
+            default_mla_tmp_q_chunks
+            if caps.mla_max_q_chunks is None
+            else int(caps.mla_max_q_chunks)
+        )
+        mla_tmp_q_chunks = max(int(mla_tmp_q_chunks), 1)
+        indexer_topk = int(caps.indexer_topk)
+        paged_width_tokens = max(
+            int(caps.max_page_table_width) * int(caps.page_size),
+            1,
+        )
+        paged_logits_width_tokens = paged_width_tokens
+        if int(caps.paged_indexer_logits_k_rows) > 0:
+            paged_logits_width_tokens = min(
+                paged_width_tokens,
+                int(caps.paged_indexer_logits_k_rows),
+            )
+        paged_tile_logits_width_tokens = 0
+        if int(caps.paged_indexer_tile_logits_k_rows) > 0:
+            paged_tile_logits_width_tokens = min(
+                paged_width_tokens,
+                int(caps.paged_indexer_tile_logits_k_rows),
+            )
+
+        mla_offset = 0
+        mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+        ragged_kv_offset_bytes = mla_offset
+        mla_offset += max_kv_rows * _MLA_PACKED_DIM * _dtype_nbytes(caps.kv_dtype)
+        mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+
+        tmp_output_offset_bytes = mla_offset
+        mla_offset += (
+            mla_tmp_q_chunks
+            * int(caps.num_q_heads)
+            * int(caps.max_v_head_dim)
+            * _dtype_nbytes(caps.dtype)
+        )
+        mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+        tmp_lse_offset_bytes = mla_offset
+        mla_offset += (
+            mla_tmp_q_chunks * int(caps.num_q_heads) * _dtype_nbytes(torch.float32)
+        )
+        mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+        output_buffer_offset_bytes = tmp_output_offset_bytes
+        output_buffer_nbytes = 0
+        final_lse_offset_bytes = mla_offset
+        final_lse_nbytes = (
+            mla_max_total_q * int(caps.num_q_heads) * _dtype_nbytes(torch.float32)
+        )
+        mla_offset += final_lse_nbytes
+        mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+
+        compressed_q_stage_offset_bytes = mla_offset
+        compressed_q_stage_nbytes = 0
+        compressed_index_stage_nbytes = 0
+        compressed_page_table_stage_nbytes = 0
+        compressed_lengths_stage_nbytes = 0
+        compressed_swa_indices_stage_offset_bytes = (
+            compressed_swa_lengths_stage_offset_bytes
+        ) = 0
+        compressed_indexed_indices_stage_offset_bytes = (
+            compressed_indexed_lengths_stage_offset_bytes
+        ) = 0
+        compressed_indexed_page_table_stage_offset_bytes = 0
+        if caps.reserve_compressed_mla_staging:
+            compressed_q_stage_nbytes = (
+                mla_max_total_q
+                * int(caps.num_q_heads)
+                * int(caps.head_dim)
+                * _dtype_nbytes(caps.dtype)
+            )
+            mla_offset += compressed_q_stage_nbytes
+            mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+            compressed_swa_indices_stage_offset_bytes = mla_offset
+            compressed_index_stage_nbytes = (
+                mla_max_total_q * int(caps.topk) * _dtype_nbytes(torch.int32)
+            )
+            mla_offset += compressed_index_stage_nbytes
+            mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+            compressed_swa_lengths_stage_offset_bytes = mla_offset
+            compressed_lengths_stage_nbytes = mla_max_total_q * _dtype_nbytes(
+                torch.int32
+            )
+            mla_offset += compressed_lengths_stage_nbytes
+            mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+            compressed_indexed_indices_stage_offset_bytes = mla_offset
+            mla_offset += compressed_index_stage_nbytes
+            mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+            compressed_indexed_lengths_stage_offset_bytes = mla_offset
+            mla_offset += compressed_lengths_stage_nbytes
+            mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+            compressed_indexed_page_table_stage_offset_bytes = mla_offset
+            compressed_page_table_stage_nbytes = (
+                mla_max_total_q
+                * int(caps.max_page_table_width)
+                * _dtype_nbytes(torch.int32)
+            )
+            mla_offset += compressed_page_table_stage_nbytes
+            mla_offset = _align_up(mla_offset, _ARENA_ALIGN_BYTES)
+        mla_phase_nbytes = int(mla_offset)
+
+        extend_offset = 0
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_k_quant_offset_bytes = extend_offset
+        extend_offset += indexer_k_rows * _INDEX_HEAD_DIM
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_k_scale_offset_bytes = extend_offset
+        extend_offset += indexer_k_rows * _dtype_nbytes(torch.float32)
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_logits_offset_bytes = extend_offset
+        if caps.reserve_extend_indexer_logits:
+            contiguous_logits_nbytes = (
+                int(caps.extend_max_total_q)
+                * indexer_k_rows
+                * _dtype_nbytes(torch.float32)
+            )
+        else:
+            contiguous_logits_nbytes = 0
+        extend_offset += contiguous_logits_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_tile_logits_offset_bytes = extend_offset
+        contiguous_tile_logits_k_rows = min(
+            indexer_k_rows,
+            _resolve_contiguous_topk_supertile_k(
+                caps.extend_indexer_tile_logits_k_rows
+            ),
+        )
+        paged_tile_logits_k_rows = int(paged_tile_logits_width_tokens)
+        contiguous_tile_logits_q_rows = _align_up(
+            int(caps.extend_max_total_q),
+            _INDEXER_TILE_BLOCK_Q,
+        )
+        paged_tile_logits_q_rows = _align_up(
+            max_paged_q_rows,
+            _INDEXER_TILE_BLOCK_Q,
+        )
+        contiguous_tile_logits_nbytes = 0
+        if contiguous_tile_logits_k_rows:
+            contiguous_tile_logits_nbytes = max(
+                contiguous_tile_logits_nbytes,
+                contiguous_tile_logits_q_rows
+                * contiguous_tile_logits_k_rows
+                * _dtype_nbytes(torch.float32),
+            )
+            extend_candidate_chunks = (
+                indexer_k_rows + contiguous_tile_logits_k_rows - 1
+            ) // contiguous_tile_logits_k_rows
+        else:
+            extend_candidate_chunks = 0
+        if paged_tile_logits_k_rows:
+            contiguous_tile_logits_nbytes = max(
+                contiguous_tile_logits_nbytes,
+                paged_tile_logits_q_rows
+                * paged_tile_logits_k_rows
+                * _dtype_nbytes(torch.float32),
+            )
+        extend_offset += contiguous_tile_logits_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_topk_indices_offset_bytes = extend_offset
+        contiguous_topk_indices_nbytes = (
+            indexer_q_rows * indexer_topk * _dtype_nbytes(torch.int32)
+        )
+        extend_offset += contiguous_topk_indices_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_topk_values_offset_bytes = extend_offset
+        contiguous_topk_values_nbytes = (
+            indexer_q_rows * indexer_topk * _dtype_nbytes(torch.float32)
+        )
+        extend_offset += contiguous_topk_values_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_topk_scratch_indices_offset_bytes = extend_offset
+        contiguous_topk_scratch_indices_nbytes = (
+            indexer_q_rows * indexer_topk * _dtype_nbytes(torch.int32)
+        )
+        extend_offset += contiguous_topk_scratch_indices_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_topk_scratch_values_offset_bytes = extend_offset
+        contiguous_topk_scratch_values_nbytes = (
+            indexer_q_rows * indexer_topk * _dtype_nbytes(torch.float32)
+        )
+        extend_offset += contiguous_topk_scratch_values_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        paged_candidate_chunks = (
+            (paged_width_tokens + paged_logits_width_tokens - 1)
+            // paged_logits_width_tokens
+            if caps.reserve_paged_indexer_logits and paged_logits_width_tokens > 0
+            else 0
+        )
+        if paged_tile_logits_k_rows:
+            paged_tile_candidate_chunks = (
+                paged_width_tokens + paged_tile_logits_k_rows - 1
+            ) // paged_tile_logits_k_rows
+            paged_candidate_chunks = max(
+                paged_candidate_chunks,
+                paged_tile_candidate_chunks,
+            )
+        candidate_chunks = max(extend_candidate_chunks, paged_candidate_chunks)
+        # Streaming-fold carry double-buffer: when more than one supertile chunk is
+        # possible the fold needs exactly two (M, topk) carry halves to ping-pong;
+        # otherwise no carry buffer is needed. This replaces the old map+merge slab
+        # (candidate_chunks halves) and its merge_positions int64 buffer.
+        fold_carry_chunks = 2 if int(candidate_chunks) > 1 else 0
+        # merge_positions is gone with the merge step; keep the field at zero bytes.
+        indexer_contiguous_topk_position_offset_bytes = extend_offset
+        contiguous_topk_position_nbytes = 0
+        indexer_contiguous_candidate_values_offset_bytes = extend_offset
+        extend_candidate_values_nbytes = (
+            int(fold_carry_chunks)
+            * indexer_q_rows
+            * indexer_topk
+            * _dtype_nbytes(torch.float32)
+        )
+        extend_offset += extend_candidate_values_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_candidate_indices_offset_bytes = extend_offset
+        extend_candidate_indices_nbytes = (
+            int(fold_carry_chunks)
+            * indexer_q_rows
+            * indexer_topk
+            * _dtype_nbytes(torch.int32)
+        )
+        extend_offset += extend_candidate_indices_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_lengths_offset_bytes = extend_offset
+        contiguous_lengths_nbytes = indexer_q_rows * _dtype_nbytes(torch.int32)
+        extend_offset += contiguous_lengths_nbytes
+        extend_offset = _align_up(extend_offset, _ARENA_ALIGN_BYTES)
+        indexer_contiguous_mapped_indices_offset_bytes = extend_offset
+        extend_mapped_indices_nbytes = (
+            indexer_q_rows * indexer_topk * _dtype_nbytes(torch.int32)
+        )
+        extend_offset += extend_mapped_indices_nbytes
+
+        paged_offset = 0
+        paged_offset = _align_up(paged_offset, _ARENA_ALIGN_BYTES)
+        indexer_paged_logits_offset_bytes = paged_offset
+        paged_logits_nbytes = 0
+        if caps.reserve_paged_indexer_logits:
+            paged_logits_nbytes = (
+                paged_logits_q_rows
+                * paged_logits_width_tokens
+                * _dtype_nbytes(torch.float32)
+            )
+        paged_offset += paged_logits_nbytes
+
+        indexer_phase_nbytes = int(max(extend_offset, paged_offset))
+        attention_phase_nbytes = max(mla_phase_nbytes, indexer_phase_nbytes, 1)
+        aux_offset = attention_phase_nbytes
+        mhc_partials_offset_bytes = mhc_y_offset_bytes = 0
+        mhc_post_offset_bytes = mhc_comb_offset_bytes = mhc_out_offset_bytes = 0
+        mhc_partials_nbytes = mhc_y_nbytes = mhc_post_nbytes = 0
+        mhc_comb_nbytes = mhc_out_nbytes = 0
+        if caps.reserve_mhc:
+            aux_offset = _align_up(aux_offset, _ARENA_ALIGN_BYTES)
+            mhc_partials_offset_bytes = aux_offset
+            mhc_partials_nbytes = (
+                int(caps.mhc_max_tokens)
+                * int(caps.mhc_split_k)
+                * _MHC_PARTIALS
+                * _dtype_nbytes(torch.float32)
+            )
+            aux_offset += mhc_partials_nbytes
+            aux_offset = _align_up(aux_offset, _ARENA_ALIGN_BYTES)
+            mhc_y_offset_bytes = aux_offset
+            mhc_y_nbytes = (
+                int(caps.mhc_max_tokens)
+                * int(caps.mhc_hidden_size)
+                * _dtype_nbytes(caps.dtype)
+            )
+            aux_offset += mhc_y_nbytes
+            aux_offset = _align_up(aux_offset, _ARENA_ALIGN_BYTES)
+            mhc_post_offset_bytes = aux_offset
+            mhc_post_nbytes = (
+                int(caps.mhc_max_tokens) * _MHC_MULT * _dtype_nbytes(torch.float32)
+            )
+            aux_offset += mhc_post_nbytes
+            aux_offset = _align_up(aux_offset, _ARENA_ALIGN_BYTES)
+            mhc_comb_offset_bytes = aux_offset
+            mhc_comb_nbytes = (
+                int(caps.mhc_max_tokens)
+                * _MHC_MULT
+                * _MHC_MULT
+                * _dtype_nbytes(torch.float32)
+            )
+            aux_offset += mhc_comb_nbytes
+            aux_offset = _align_up(aux_offset, _ARENA_ALIGN_BYTES)
+            mhc_out_offset_bytes = aux_offset
+            mhc_out_nbytes = (
+                int(caps.mhc_max_tokens)
+                * _MHC_MULT
+                * int(caps.mhc_hidden_size)
+                * _dtype_nbytes(caps.dtype)
+            )
+            aux_offset += mhc_out_nbytes
+        mhc_nbytes = max(0, int(aux_offset) - int(attention_phase_nbytes))
+
+        wo_projection_layout = _SM12XWOProjectionArenaLayout()
+        if caps.reserve_wo_projection:
+            wo_projection_layout = _layout_wo_projection(
+                offset_bytes=aux_offset,
+                tokens=int(caps.wo_max_tokens),
+                groups=int(caps.wo_groups),
+                group_width=int(caps.wo_group_width),
+                rank=int(caps.wo_rank),
+                hidden=int(caps.wo_hidden_size),
+            )
+            aux_offset += wo_projection_layout.nbytes
+        arena_nbytes = max(attention_phase_nbytes, int(aux_offset), 1)
+        ragged_kv_nbytes = max_kv_rows * _MLA_PACKED_DIM * _dtype_nbytes(caps.kv_dtype)
+        return _SM12XAttentionArenaLayout(
+            arena_nbytes=int(arena_nbytes),
+            mla_phase_nbytes=mla_phase_nbytes,
+            indexer_phase_nbytes=indexer_phase_nbytes,
+            indexer_k_rows=int(indexer_k_rows),
+            mla_tmp_q_chunks=int(mla_tmp_q_chunks),
+            paged_logits_q_rows=int(paged_logits_q_rows),
+            paged_logits_width_tokens=int(paged_logits_width_tokens),
+            paged_tile_logits_width_tokens=int(paged_tile_logits_width_tokens),
+            ragged_kv_nbytes=ragged_kv_nbytes,
+            output_buffer_nbytes=output_buffer_nbytes,
+            final_lse_nbytes=final_lse_nbytes,
+            compressed_q_stage_nbytes=compressed_q_stage_nbytes,
+            compressed_index_stage_nbytes=compressed_index_stage_nbytes,
+            compressed_page_table_stage_nbytes=compressed_page_table_stage_nbytes,
+            compressed_lengths_stage_nbytes=compressed_lengths_stage_nbytes,
+            indexer_logits_nbytes=max(
+                contiguous_logits_nbytes,
+                contiguous_tile_logits_nbytes,
+                contiguous_topk_indices_nbytes,
+                contiguous_topk_values_nbytes,
+                contiguous_topk_scratch_indices_nbytes,
+                contiguous_topk_scratch_values_nbytes,
+                contiguous_topk_position_nbytes,
+                extend_candidate_values_nbytes,
+                extend_candidate_indices_nbytes,
+                contiguous_lengths_nbytes,
+                extend_mapped_indices_nbytes,
+                paged_logits_nbytes,
+            ),
+            indexer_contiguous_logits_nbytes=contiguous_logits_nbytes,
+            indexer_contiguous_tile_logits_nbytes=contiguous_tile_logits_nbytes,
+            indexer_contiguous_topk_indices_nbytes=contiguous_topk_indices_nbytes,
+            indexer_contiguous_topk_values_nbytes=contiguous_topk_values_nbytes,
+            indexer_contiguous_topk_scratch_indices_nbytes=contiguous_topk_scratch_indices_nbytes,
+            indexer_contiguous_topk_scratch_values_nbytes=contiguous_topk_scratch_values_nbytes,
+            indexer_contiguous_topk_position_nbytes=contiguous_topk_position_nbytes,
+            indexer_contiguous_candidate_values_nbytes=extend_candidate_values_nbytes,
+            indexer_contiguous_candidate_indices_nbytes=extend_candidate_indices_nbytes,
+            indexer_contiguous_lengths_nbytes=contiguous_lengths_nbytes,
+            indexer_contiguous_mapped_indices_nbytes=extend_mapped_indices_nbytes,
+            indexer_paged_logits_nbytes=paged_logits_nbytes,
+            mhc_nbytes=mhc_nbytes,
+            mhc_partials_nbytes=mhc_partials_nbytes,
+            mhc_y_nbytes=mhc_y_nbytes,
+            mhc_post_nbytes=mhc_post_nbytes,
+            mhc_comb_nbytes=mhc_comb_nbytes,
+            mhc_out_nbytes=mhc_out_nbytes,
+            wo_projection_layout=wo_projection_layout,
+            ragged_kv_offset_bytes=ragged_kv_offset_bytes,
+            tmp_output_offset_bytes=tmp_output_offset_bytes,
+            tmp_lse_offset_bytes=tmp_lse_offset_bytes,
+            output_buffer_offset_bytes=output_buffer_offset_bytes,
+            final_lse_offset_bytes=final_lse_offset_bytes,
+            compressed_q_stage_offset_bytes=compressed_q_stage_offset_bytes,
+            compressed_swa_indices_stage_offset_bytes=compressed_swa_indices_stage_offset_bytes,
+            compressed_swa_lengths_stage_offset_bytes=compressed_swa_lengths_stage_offset_bytes,
+            compressed_indexed_indices_stage_offset_bytes=compressed_indexed_indices_stage_offset_bytes,
+            compressed_indexed_lengths_stage_offset_bytes=compressed_indexed_lengths_stage_offset_bytes,
+            compressed_indexed_page_table_stage_offset_bytes=compressed_indexed_page_table_stage_offset_bytes,
+            indexer_k_quant_offset_bytes=indexer_k_quant_offset_bytes,
+            indexer_k_scale_offset_bytes=indexer_k_scale_offset_bytes,
+            indexer_contiguous_logits_offset_bytes=indexer_contiguous_logits_offset_bytes,
+            indexer_contiguous_tile_logits_offset_bytes=indexer_contiguous_tile_logits_offset_bytes,
+            indexer_contiguous_topk_indices_offset_bytes=indexer_contiguous_topk_indices_offset_bytes,
+            indexer_contiguous_topk_values_offset_bytes=indexer_contiguous_topk_values_offset_bytes,
+            indexer_contiguous_topk_scratch_indices_offset_bytes=indexer_contiguous_topk_scratch_indices_offset_bytes,
+            indexer_contiguous_topk_scratch_values_offset_bytes=indexer_contiguous_topk_scratch_values_offset_bytes,
+            indexer_contiguous_topk_position_offset_bytes=indexer_contiguous_topk_position_offset_bytes,
+            indexer_contiguous_candidate_values_offset_bytes=indexer_contiguous_candidate_values_offset_bytes,
+            indexer_contiguous_candidate_indices_offset_bytes=indexer_contiguous_candidate_indices_offset_bytes,
+            indexer_contiguous_lengths_offset_bytes=indexer_contiguous_lengths_offset_bytes,
+            indexer_contiguous_mapped_indices_offset_bytes=indexer_contiguous_mapped_indices_offset_bytes,
+            indexer_paged_logits_offset_bytes=indexer_paged_logits_offset_bytes,
+            mhc_partials_offset_bytes=mhc_partials_offset_bytes,
+            mhc_y_offset_bytes=mhc_y_offset_bytes,
+            mhc_post_offset_bytes=mhc_post_offset_bytes,
+            mhc_comb_offset_bytes=mhc_comb_offset_bytes,
+            mhc_out_offset_bytes=mhc_out_offset_bytes,
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        caps: SM12XAttentionArenaCaps,
+        *,
+        shared_arena: torch.Tensor | None,
+        storage: str,
+    ) -> "SM12XAttentionArena":
+        layout = cls._layout(caps)
+        if shared_arena is None:
+            shared_arena = torch.empty(
+                (layout.arena_nbytes,),
+                dtype=torch.uint8,
+                device=caps.device,
+            )
+        elif shared_arena.dtype != torch.uint8:
+            raise TypeError(
+                f"shared_arena must have dtype torch.uint8, got {shared_arena.dtype}"
+            )
+        elif shared_arena.device != caps.device:
+            raise ValueError(
+                f"shared_arena device {shared_arena.device} does not match caps device {caps.device}"
+            )
+        elif shared_arena.numel() < layout.arena_nbytes:
+            raise ValueError(
+                f"shared_arena has {shared_arena.numel()} bytes, but attention arena requires {layout.arena_nbytes}"
+            )
+        arena = cls(
+            caps=caps,
+            shared_arena=shared_arena,
+            shared_arena_nbytes=layout.arena_nbytes,
+            mla_phase_nbytes=layout.mla_phase_nbytes,
+            indexer_phase_nbytes=layout.indexer_phase_nbytes,
+            indexer_k_rows=layout.indexer_k_rows,
+            mla_tmp_q_chunks=layout.mla_tmp_q_chunks,
+            paged_logits_q_rows=layout.paged_logits_q_rows,
+            paged_logits_width_tokens=layout.paged_logits_width_tokens,
+            paged_tile_logits_width_tokens=layout.paged_tile_logits_width_tokens,
+            ragged_kv_nbytes=layout.ragged_kv_nbytes,
+            output_buffer_nbytes=layout.output_buffer_nbytes,
+            final_lse_nbytes=layout.final_lse_nbytes,
+            compressed_q_stage_nbytes=layout.compressed_q_stage_nbytes,
+            compressed_index_stage_nbytes=layout.compressed_index_stage_nbytes,
+            compressed_page_table_stage_nbytes=layout.compressed_page_table_stage_nbytes,
+            compressed_lengths_stage_nbytes=layout.compressed_lengths_stage_nbytes,
+            indexer_logits_nbytes=layout.indexer_logits_nbytes,
+            indexer_contiguous_logits_nbytes=layout.indexer_contiguous_logits_nbytes,
+            indexer_contiguous_tile_logits_nbytes=layout.indexer_contiguous_tile_logits_nbytes,
+            indexer_contiguous_topk_indices_nbytes=layout.indexer_contiguous_topk_indices_nbytes,
+            indexer_contiguous_topk_values_nbytes=layout.indexer_contiguous_topk_values_nbytes,
+            indexer_contiguous_topk_scratch_indices_nbytes=layout.indexer_contiguous_topk_scratch_indices_nbytes,
+            indexer_contiguous_topk_scratch_values_nbytes=layout.indexer_contiguous_topk_scratch_values_nbytes,
+            indexer_contiguous_topk_position_nbytes=layout.indexer_contiguous_topk_position_nbytes,
+            indexer_contiguous_candidate_values_nbytes=layout.indexer_contiguous_candidate_values_nbytes,
+            indexer_contiguous_candidate_indices_nbytes=layout.indexer_contiguous_candidate_indices_nbytes,
+            indexer_contiguous_lengths_nbytes=layout.indexer_contiguous_lengths_nbytes,
+            indexer_contiguous_mapped_indices_nbytes=layout.indexer_contiguous_mapped_indices_nbytes,
+            indexer_paged_logits_nbytes=layout.indexer_paged_logits_nbytes,
+            mhc_nbytes=layout.mhc_nbytes,
+            mhc_partials_nbytes=layout.mhc_partials_nbytes,
+            mhc_y_nbytes=layout.mhc_y_nbytes,
+            mhc_post_nbytes=layout.mhc_post_nbytes,
+            mhc_comb_nbytes=layout.mhc_comb_nbytes,
+            mhc_out_nbytes=layout.mhc_out_nbytes,
+            wo_projection_layout=layout.wo_projection_layout,
+            ragged_kv_offset_bytes=layout.ragged_kv_offset_bytes,
+            tmp_output_offset_bytes=layout.tmp_output_offset_bytes,
+            tmp_lse_offset_bytes=layout.tmp_lse_offset_bytes,
+            output_buffer_offset_bytes=layout.output_buffer_offset_bytes,
+            final_lse_offset_bytes=layout.final_lse_offset_bytes,
+            compressed_q_stage_offset_bytes=layout.compressed_q_stage_offset_bytes,
+            compressed_swa_indices_stage_offset_bytes=layout.compressed_swa_indices_stage_offset_bytes,
+            compressed_swa_lengths_stage_offset_bytes=layout.compressed_swa_lengths_stage_offset_bytes,
+            compressed_indexed_indices_stage_offset_bytes=layout.compressed_indexed_indices_stage_offset_bytes,
+            compressed_indexed_lengths_stage_offset_bytes=layout.compressed_indexed_lengths_stage_offset_bytes,
+            compressed_indexed_page_table_stage_offset_bytes=layout.compressed_indexed_page_table_stage_offset_bytes,
+            indexer_k_quant_offset_bytes=layout.indexer_k_quant_offset_bytes,
+            indexer_k_scale_offset_bytes=layout.indexer_k_scale_offset_bytes,
+            indexer_contiguous_logits_offset_bytes=layout.indexer_contiguous_logits_offset_bytes,
+            indexer_contiguous_tile_logits_offset_bytes=layout.indexer_contiguous_tile_logits_offset_bytes,
+            indexer_contiguous_topk_indices_offset_bytes=layout.indexer_contiguous_topk_indices_offset_bytes,
+            indexer_contiguous_topk_values_offset_bytes=layout.indexer_contiguous_topk_values_offset_bytes,
+            indexer_contiguous_topk_scratch_indices_offset_bytes=layout.indexer_contiguous_topk_scratch_indices_offset_bytes,
+            indexer_contiguous_topk_scratch_values_offset_bytes=layout.indexer_contiguous_topk_scratch_values_offset_bytes,
+            indexer_contiguous_topk_position_offset_bytes=layout.indexer_contiguous_topk_position_offset_bytes,
+            indexer_contiguous_candidate_values_offset_bytes=layout.indexer_contiguous_candidate_values_offset_bytes,
+            indexer_contiguous_candidate_indices_offset_bytes=layout.indexer_contiguous_candidate_indices_offset_bytes,
+            indexer_contiguous_lengths_offset_bytes=layout.indexer_contiguous_lengths_offset_bytes,
+            indexer_contiguous_mapped_indices_offset_bytes=layout.indexer_contiguous_mapped_indices_offset_bytes,
+            indexer_paged_logits_offset_bytes=layout.indexer_paged_logits_offset_bytes,
+            mhc_partials_offset_bytes=layout.mhc_partials_offset_bytes,
+            mhc_y_offset_bytes=layout.mhc_y_offset_bytes,
+            mhc_post_offset_bytes=layout.mhc_post_offset_bytes,
+            mhc_comb_offset_bytes=layout.mhc_comb_offset_bytes,
+            mhc_out_offset_bytes=layout.mhc_out_offset_bytes,
+        )
+        return arena
+
+    @classmethod
+    def allocate(cls, caps: SM12XAttentionArenaCaps) -> "SM12XAttentionArena":
+        return cls._build(caps, shared_arena=None, storage="standalone")
+
+    @classmethod
+    def from_shared_arena(
+        cls,
+        caps: SM12XAttentionArenaCaps,
+        shared_arena: torch.Tensor,
+    ) -> "SM12XAttentionArena":
+        """Materialize an attention arena over caller-owned uint8 storage."""
+        return cls._build(caps, shared_arena=shared_arena, storage="shared")
+
+    @classmethod
+    def required_nbytes(cls, caps: SM12XAttentionArenaCaps) -> int:
+        """Return the backing-store byte requirement without retaining storage."""
+        return cls._layout(caps).arena_nbytes
+
+    def make_mhc_workspace(self):
+        if not self.caps.reserve_mhc or self.mhc_nbytes <= 0:
+            raise RuntimeError(
+                "attention arena was allocated without mHC workspace capacity"
+            )
+        from flashinfer.experimental.sm12x.norm.mhc._impl import MHCWorkspace
+
+        max_tokens = int(self.caps.mhc_max_tokens)
+        hidden_size = int(self.caps.mhc_hidden_size)
+        split_k = int(self.caps.mhc_split_k)
+        partials, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.mhc_partials_offset_bytes,
+            shape=(max_tokens, split_k, _MHC_PARTIALS),
+            dtype=torch.float32,
+        )
+        y, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.mhc_y_offset_bytes,
+            shape=(max_tokens, hidden_size),
+            dtype=self.caps.dtype,
+        )
+        post, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.mhc_post_offset_bytes,
+            shape=(max_tokens, _MHC_MULT),
+            dtype=torch.float32,
+        )
+        comb, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.mhc_comb_offset_bytes,
+            shape=(max_tokens, _MHC_MULT, _MHC_MULT),
+            dtype=torch.float32,
+        )
+        out, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.mhc_out_offset_bytes,
+            shape=(max_tokens, _MHC_MULT, hidden_size),
+            dtype=self.caps.dtype,
+        )
+        return MHCWorkspace(
+            partials=partials,
+            y=y,
+            post=post,
+            comb=comb,
+            out=out,
+            split_k=split_k,
+        )
+
+    def make_wo_projection_workspace(self, tokens: int | None = None):
+        if not self.caps.reserve_wo_projection or self.wo_projection_layout.nbytes <= 0:
+            raise RuntimeError(
+                "attention arena was allocated without WO projection workspace capacity"
+            )
+        from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+            MXFP8Rows,
+            WOProjectionWorkspace,
+        )
+
+        max_tokens = int(self.caps.wo_max_tokens)
+        tokens = max_tokens if tokens is None else int(tokens)
+        if tokens <= 0 or tokens > max_tokens:
+            raise ValueError(
+                f"WO projection tokens={tokens} exceeds arena capacity {max_tokens}"
+            )
+
+        groups = int(self.caps.wo_groups)
+        group_width = int(self.caps.wo_group_width)
+        rank = int(self.caps.wo_rank)
+        hidden = int(self.caps.wo_hidden_size)
+        layout = _layout_wo_projection(
+            offset_bytes=self.wo_projection_layout.x_q_values_offset_bytes,
+            tokens=tokens,
+            groups=groups,
+            group_width=group_width,
+            rank=rank,
+            hidden=hidden,
+        )
+        if layout.nbytes > self.wo_projection_layout.nbytes:
+            raise RuntimeError(
+                "WO projection workspace layout exceeds reserved arena capacity: "
+                f"requested={layout.nbytes}, reserved={self.wo_projection_layout.nbytes}"
+            )
+
+        def mxfp8_rows(
+            *,
+            values_offset_bytes: int,
+            scale_rows_offset_bytes: int,
+            scale_mma_offset_bytes: int,
+            m: int,
+            k: int,
+            num_groups: int,
+        ) -> MXFP8Rows:
+            if num_groups == 1:
+                values, _ = _materialize_arena_view(
+                    self.shared_arena,
+                    offset_bytes=values_offset_bytes,
+                    shape=(m, k),
+                    dtype=torch.float8_e4m3fn,
+                )
+            else:
+                values, _ = _materialize_arena_strided_view(
+                    self.shared_arena,
+                    offset_bytes=values_offset_bytes,
+                    shape=(m, k, num_groups),
+                    stride=(k, 1, m * k),
+                    dtype=torch.float8_e4m3fn,
+                )
+            scale_rows, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=scale_rows_offset_bytes,
+                shape=(num_groups, m, k // _WO_MXFP8_SCALE_VEC_SIZE),
+                dtype=torch.float8_e8m0fnu,
+            )
+            scale_physical_u8, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=scale_mma_offset_bytes,
+                shape=_wo_mxfp8_scale_physical_shape(
+                    m=m,
+                    k=k,
+                    num_groups=num_groups,
+                ),
+                dtype=torch.uint8,
+            )
+            if m % _WO_MXFP8_SCALE_ROW_TILE:
+                scale_physical_u8.fill_(127)
+            scale_mma = scale_physical_u8.view(torch.float8_e8m0fnu).permute(
+                3,
+                4,
+                1,
+                5,
+                2,
+                0,
+            )
+            return MXFP8Rows(
+                values=values,
+                scale_rows=scale_rows,
+                scale_mma=scale_mma,
+            )
+
+        x_q = mxfp8_rows(
+            values_offset_bytes=layout.x_q_values_offset_bytes,
+            scale_rows_offset_bytes=layout.x_q_scale_rows_offset_bytes,
+            scale_mma_offset_bytes=layout.x_q_scale_mma_offset_bytes,
+            m=tokens,
+            k=group_width,
+            num_groups=groups,
+        )
+        tmp, _ = _materialize_arena_strided_view(
+            self.shared_arena,
+            offset_bytes=layout.tmp_offset_bytes,
+            shape=(tokens, rank, groups),
+            stride=(rank, 1, tokens * rank),
+            dtype=torch.bfloat16,
+        )
+        tmp_q = mxfp8_rows(
+            values_offset_bytes=layout.tmp_q_values_offset_bytes,
+            scale_rows_offset_bytes=layout.tmp_q_scale_rows_offset_bytes,
+            scale_mma_offset_bytes=layout.tmp_q_scale_mma_offset_bytes,
+            m=tokens,
+            k=rank * groups,
+            num_groups=1,
+        )
+        output, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=layout.output_offset_bytes,
+            shape=(tokens, hidden, 1),
+            dtype=torch.bfloat16,
+        )
+        return WOProjectionWorkspace(
+            x_q=x_q,
+            tmp=tmp,
+            tmp_q=tmp_q,
+            output=output,
+        )
+
+    def _make_workspace_views(
+        self,
+        contract: SM12XAttentionWorkspaceContract,
+        *,
+        use_cuda_graph: bool = False,
+    ) -> "SM12XAttentionWorkspace":
+        workspace_topk = (
+            int(contract.topk) if contract.topk is not None else int(self.caps.topk)
+        )
+        workspace_indexer_topk = min(workspace_topk, int(self.caps.indexer_topk))
+        if contract.v_head_dim > self.caps.max_v_head_dim:
+            raise ValueError(
+                f"workspace v_head_dim {contract.v_head_dim} exceeds arena max_v_head_dim {self.caps.max_v_head_dim}"
+            )
+        if (
+            contract.max_total_q > self.caps.extend_max_total_q
+            and contract.max_total_q > self.caps.paged_max_q_rows
+        ):
+            raise ValueError(
+                f"workspace max_total_q {contract.max_total_q} exceeds arena capacities "
+                f"(extend={self.caps.extend_max_total_q}, paged={self.caps.paged_max_q_rows})"
+            )
+        if contract.max_batch > max(
+            self.caps.extend_max_batch, self.caps.paged_max_batch
+        ):
+            raise ValueError(
+                f"workspace max_batch {contract.max_batch} exceeds arena capacities "
+                f"(extend={self.caps.extend_max_batch}, paged={self.caps.paged_max_batch})"
+            )
+        if contract.max_paged_q_rows > self.caps.paged_max_q_rows:
+            raise ValueError(
+                f"workspace max_paged_q_rows {contract.max_paged_q_rows} exceeds arena paged_max_q_rows {self.caps.paged_max_q_rows}"
+            )
+        if contract.max_kv_rows > self.caps.extend_max_kv_rows:
+            raise ValueError(
+                f"workspace max_kv_rows {contract.max_kv_rows} exceeds arena extend_max_kv_rows {self.caps.extend_max_kv_rows}"
+            )
+        if contract.indexer_num_q_heads > self.caps.indexer_num_q_heads:
+            raise ValueError(
+                "workspace indexer_num_q_heads "
+                f"{contract.indexer_num_q_heads} exceeds arena indexer_num_q_heads "
+                f"{self.caps.indexer_num_q_heads}"
+            )
+        if contract.max_page_table_width > self.caps.max_page_table_width:
+            raise ValueError(
+                "workspace max_page_table_width "
+                f"{contract.max_page_table_width} exceeds arena max_page_table_width "
+                f"{self.caps.max_page_table_width}"
+            )
+        if workspace_topk > int(self.caps.topk):
+            raise ValueError(
+                f"workspace topk {workspace_topk} exceeds arena topk {self.caps.topk}"
+            )
+        if (
+            contract.max_kv_rows > 0 or workspace_topk > 1
+        ) and contract.max_total_q > int(self.caps.mla_max_total_q):
+            raise ValueError(
+                f"workspace MLA max_total_q {contract.max_total_q} exceeds arena mla_max_total_q {self.caps.mla_max_total_q}"
+            )
+        workspace_max_chunks_per_row = (
+            int(contract.max_chunks_per_row)
+            if contract.max_chunks_per_row is not None
+            else int(self.caps.max_chunks_per_row)
+        )
+        if workspace_max_chunks_per_row > int(self.caps.max_chunks_per_row):
+            raise ValueError(
+                "workspace max_chunks_per_row "
+                f"{workspace_max_chunks_per_row} exceeds arena max_chunks_per_row "
+                f"{self.caps.max_chunks_per_row}"
+            )
+        workspace_q_chunks = int(contract.max_total_q) * workspace_max_chunks_per_row
+        if workspace_q_chunks > int(self.mla_tmp_q_chunks):
+            raise ValueError(
+                "workspace MLA split scratch "
+                f"{workspace_q_chunks} q-chunks exceeds arena capacity "
+                f"{self.mla_tmp_q_chunks}"
+            )
+        workspace = SM12XAttentionWorkspace(
+            arena=self,
+            contract=contract,
+            mode=contract.mode,
+            device=self.caps.device,
+            dtype=self.caps.dtype,
+            kv_dtype=self.caps.kv_dtype,
+            num_q_heads=self.caps.num_q_heads,
+            indexer_num_q_heads=contract.indexer_num_q_heads,
+            head_dim=self.caps.head_dim,
+            v_head_dim=contract.v_head_dim,
+            topk=workspace_topk,
+            indexer_topk=workspace_indexer_topk,
+            max_page_table_width=contract.max_page_table_width,
+            max_total_q=contract.max_total_q,
+            max_batch=contract.max_batch,
+            max_paged_q_rows=contract.max_paged_q_rows,
+            max_kv_rows=contract.max_kv_rows,
+            page_size=self.caps.page_size,
+            padded_heads=self.caps.padded_heads,
+            use_cuda_graph=use_cuda_graph,
+            fixed_capacity=True,
+            max_chunks_per_row=workspace_max_chunks_per_row,
+            shared_arena=self.shared_arena,
+            shared_arena_nbytes=self.shared_arena_nbytes,
+            mla_phase_nbytes=self.mla_phase_nbytes,
+            indexer_phase_nbytes=self.indexer_phase_nbytes,
+            indexer_k_rows=self.indexer_k_rows,
+            paged_logits_q_rows=self.paged_logits_q_rows,
+            paged_logits_width_tokens=self.paged_logits_width_tokens,
+            paged_tile_logits_width_tokens=self.paged_tile_logits_width_tokens,
+            ragged_kv_nbytes=self.ragged_kv_nbytes,
+            compressed_q_stage_nbytes=self.compressed_q_stage_nbytes,
+            compressed_index_stage_nbytes=self.compressed_index_stage_nbytes,
+            compressed_page_table_stage_nbytes=self.compressed_page_table_stage_nbytes,
+            compressed_lengths_stage_nbytes=self.compressed_lengths_stage_nbytes,
+            indexer_logits_nbytes=self.indexer_logits_nbytes,
+            indexer_contiguous_logits_nbytes=self.indexer_contiguous_logits_nbytes,
+            indexer_contiguous_tile_logits_nbytes=self.indexer_contiguous_tile_logits_nbytes,
+            indexer_contiguous_topk_indices_nbytes=self.indexer_contiguous_topk_indices_nbytes,
+            indexer_contiguous_topk_values_nbytes=self.indexer_contiguous_topk_values_nbytes,
+            indexer_contiguous_topk_scratch_indices_nbytes=self.indexer_contiguous_topk_scratch_indices_nbytes,
+            indexer_contiguous_topk_scratch_values_nbytes=self.indexer_contiguous_topk_scratch_values_nbytes,
+            indexer_contiguous_topk_position_nbytes=self.indexer_contiguous_topk_position_nbytes,
+            indexer_contiguous_candidate_values_nbytes=self.indexer_contiguous_candidate_values_nbytes,
+            indexer_contiguous_candidate_indices_nbytes=self.indexer_contiguous_candidate_indices_nbytes,
+            indexer_contiguous_lengths_nbytes=self.indexer_contiguous_lengths_nbytes,
+            indexer_contiguous_mapped_indices_nbytes=self.indexer_contiguous_mapped_indices_nbytes,
+            indexer_paged_logits_nbytes=self.indexer_paged_logits_nbytes,
+        )
+        workspace._allocate_fixed_capacity_views()
+        workspace._initialize_split_chunk_config_if_needed()
+        workspace._allocate_contract_phantoms()
+        if use_cuda_graph:
+            workspace._allocate_paged_indexer_runtime_metadata()
+        # Reserve the fused-indexer decode merge scratch now, at construction (before any
+        # lock/capture), so every architecture-specific fused route fits without a live
+        # allocation.
+        workspace._reserve_fused_indexer_scratch()
+        return workspace
+
+    def make_workspace(
+        self,
+        contract: SM12XAttentionWorkspaceContract,
+        *,
+        use_cuda_graph: bool = False,
+    ) -> "SM12XAttentionWorkspace":
+        return self._make_workspace_views(
+            contract,
+            use_cuda_graph=use_cuda_graph,
+        )
+
+
+@dataclass(kw_only=True)
+class SM12XAttentionWorkspace:
+    arena: SM12XAttentionArena | None = None
+    contract: SM12XAttentionWorkspaceContract | None = None
+    mode: SM12XWorkspaceMode
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    indexer_num_q_heads: int = 0
+    head_dim: int
+    v_head_dim: int
+    topk: int
+    indexer_topk: int = 0
+    max_page_table_width: int = 1
+    max_total_q: int
+    max_batch: int
+    max_paged_q_rows: int = 0
+    max_kv_rows: int = 0
+    page_size: int = 64
+    padded_heads: int = 128
+    use_cuda_graph: bool = False
+    fixed_capacity: bool = False
+    max_chunks_per_row: int = 64
+    paged_indexer_real_page_table_runtime: torch.Tensor | None = None
+    paged_indexer_seqlens_per_query_runtime: torch.Tensor | None = None
+    paged_indexer_active_width_runtime: torch.Tensor | None = None
+    paged_indexer_active_width_cap: torch.Tensor | None = None
+    paged_indexer_schedule_metadata_runtime: torch.Tensor | None = None
+    tmp_output: torch.Tensor | None = None
+    tmp_lse: torch.Tensor | None = None
+    output_buffer: torch.Tensor | None = None
+    final_lse: torch.Tensor | None = None
+    ragged_kv_cache: torch.Tensor | None = None
+    kv_chunk_size_ptr: torch.Tensor | None = None
+    num_chunks_ptr: torch.Tensor | None = None
+    sm_scale_tensor: torch.Tensor | None = None
+    sm_scale_value: float | None = None
+    kv_chunk_size_value: int | None = None
+    num_chunks_value: int | None = None
+    shared_arena: torch.Tensor | None = None
+    shared_arena_nbytes: int = 0
+    mla_phase_nbytes: int = 0
+    indexer_phase_nbytes: int = 0
+    indexer_k_rows: int = 0
+    paged_logits_q_rows: int = 0
+    paged_logits_width_tokens: int = 0
+    paged_tile_logits_width_tokens: int = 0
+    ragged_kv_nbytes: int = 0
+    output_buffer_nbytes: int = 0
+    final_lse_nbytes: int = 0
+    compressed_q_stage_nbytes: int = 0
+    compressed_index_stage_nbytes: int = 0
+    compressed_page_table_stage_nbytes: int = 0
+    compressed_lengths_stage_nbytes: int = 0
+    indexer_logits_nbytes: int = 0
+    indexer_contiguous_logits_nbytes: int = 0
+    indexer_contiguous_tile_logits_nbytes: int = 0
+    indexer_contiguous_topk_indices_nbytes: int = 0
+    indexer_contiguous_topk_values_nbytes: int = 0
+    indexer_contiguous_topk_scratch_indices_nbytes: int = 0
+    indexer_contiguous_topk_scratch_values_nbytes: int = 0
+    indexer_contiguous_topk_position_nbytes: int = 0
+    indexer_contiguous_candidate_values_nbytes: int = 0
+    indexer_contiguous_candidate_indices_nbytes: int = 0
+    indexer_contiguous_lengths_nbytes: int = 0
+    indexer_contiguous_mapped_indices_nbytes: int = 0
+    indexer_paged_logits_nbytes: int = 0
+    indexer_k_quant_bytes: torch.Tensor | None = None
+    indexer_k_scales: torch.Tensor | None = None
+    indexer_k_tma_desc: torch.Tensor | None = None
+    indexer_k_tma_desc_ptrs: torch.Tensor | None = None
+    indexer_k_tma_prefill_desc: torch.Tensor | None = None
+    indexer_k_tma_prefill_desc_ptrs: torch.Tensor | None = None
+    indexer_contiguous_logits: torch.Tensor | None = None
+    indexer_contiguous_tile_logits: torch.Tensor | None = None
+    indexer_contiguous_topk_indices: torch.Tensor | None = None
+    indexer_contiguous_topk_values: torch.Tensor | None = None
+    indexer_contiguous_topk_scratch_indices: torch.Tensor | None = None
+    indexer_contiguous_topk_scratch_values: torch.Tensor | None = None
+    indexer_contiguous_topk_positions: torch.Tensor | None = None
+    indexer_contiguous_candidate_values: torch.Tensor | None = None
+    indexer_contiguous_candidate_indices: torch.Tensor | None = None
+    indexer_contiguous_lengths: torch.Tensor | None = None
+    indexer_contiguous_mapped_indices: torch.Tensor | None = None
+    indexer_paged_logits: torch.Tensor | None = None
+    compressed_mla_q_stage: torch.Tensor | None = None
+    compressed_mla_swa_indices_stage: torch.Tensor | None = None
+    compressed_mla_swa_lengths_stage: torch.Tensor | None = None
+    compressed_mla_indexed_indices_stage: torch.Tensor | None = None
+    compressed_mla_indexed_lengths_stage: torch.Tensor | None = None
+    compressed_mla_indexed_page_table_stage: torch.Tensor | None = None
+    # Phantom tensors for stable host-launcher cache keys (fixed_capacity only).
+    _contract_q: torch.Tensor | None = None
+    _contract_kv_rows: torch.Tensor | None = None
+    _contract_kv_scales: torch.Tensor | None = None
+    _contract_page_table: torch.Tensor | None = None
+    _contract_indexer_cache_seqlens: torch.Tensor | None = None
+    _contract_output: torch.Tensor | None = None
+    _contract_tmp_output: torch.Tensor | None = None
+    _contract_tmp_lse: torch.Tensor | None = None
+    # Fused-indexer cross-CTA merge scratch (pack_v, pack_i, state). Reserved EAGERLY at
+    # construction at a FIXED, seq-/batch-independent architecture-policy capacity so a
+    # live fused decode never allocates after lock_workspace()/graph capture.
+    _sm12x_fused_indexer_scratch: (
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
+    ) = None
+    _indexer_contiguous_tiled_topk_prewarmed: bool = False
+    _paged_indexer_tiled_topk_prewarmed: bool = False
+    _paged_indexer_tiled_topk_plan: _PagedIndexerTiledTopKPlan | None = None
+    _paged_indexer_tiled_scorer_prewarmed: bool = False
+    _paged_indexer_tiled_scorer_plan: _PagedIndexerTiledScorerPlan | None = None
+
+    def __post_init__(self) -> None:
+        self.device = _canonical_device(self.device)
+        self.num_q_heads = int(self.num_q_heads)
+        self.indexer_num_q_heads = int(self.indexer_num_q_heads) or int(
+            self.num_q_heads
+        )
+        self.indexer_topk = int(self.indexer_topk) or int(self.topk)
+        self.max_page_table_width = max(int(self.max_page_table_width), 1)
+        self.max_paged_q_rows = max(int(self.max_paged_q_rows), 1)
+        self.max_chunks_per_row = max(int(self.max_chunks_per_row), 1)
+
+    def runtime_metadata_nbytes(self) -> int:
+        if not self.use_cuda_graph:
+            return 0
+        num_sms = 1
+        if self.device.type == "cuda":
+            num_sms = torch.cuda.get_device_properties(
+                self.device
+            ).multi_processor_count
+        return (
+            int(self.max_paged_q_rows)
+            * int(self.max_page_table_width)
+            * _dtype_nbytes(torch.int32)
+            + int(self.max_paged_q_rows) * _dtype_nbytes(torch.int32)
+            + _dtype_nbytes(torch.int32)
+            + (int(num_sms) + 1) * 2 * _dtype_nbytes(torch.int32)
+        )
+
+    def standalone_scratch_nbytes(self) -> int:
+        if self.fixed_capacity:
+            return 0
+        return (
+            int(self.max_total_q)
+            * int(self.num_q_heads)
+            * int(self.max_chunks_per_row)
+            * int(self.v_head_dim)
+            * _dtype_nbytes(self.dtype)
+            + int(self.max_total_q)
+            * int(self.num_q_heads)
+            * int(self.max_chunks_per_row)
+            * _dtype_nbytes(torch.float32)
+            + 2 * _dtype_nbytes(torch.int32)
+        )
+
+    @classmethod
+    def for_contract(
+        cls,
+        *,
+        mode: Literal["decode", "extend", "verify", "draft_extend"],
+        device: torch.device | str,
+        dtype: torch.dtype,
+        kv_dtype: torch.dtype,
+        num_q_heads: int,
+        indexer_num_q_heads: int | None = None,
+        head_dim: int,
+        v_head_dim: int,
+        topk: int,
+        max_page_table_width: int | None = None,
+        max_total_q: int,
+        max_batch: int,
+        max_paged_q_rows: int | None = None,
+        max_kv_rows: int | None = None,
+        indexer_max_k_rows: int | None = None,
+        reserve_paged_indexer_logits: bool = True,
+        paged_indexer_logits_q_rows: int = 0,
+        paged_indexer_logits_k_rows: int = 0,
+        paged_indexer_tile_logits_k_rows: int = 0,
+        page_size: int = 64,
+        use_cuda_graph: bool = False,
+        padded_heads: int = 128,
+        max_chunks_per_row: int = 64,
+    ) -> SM12XAttentionWorkspace:
+        device = _canonical_device(device)
+        if indexer_num_q_heads is None:
+            indexer_num_q_heads = num_q_heads
+        if max_page_table_width is None:
+            max_page_table_width = topk
+        if max_paged_q_rows is None:
+            max_paged_q_rows = max_batch
+        workspace = cls(
+            mode=mode,
+            device=device,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            num_q_heads=num_q_heads,
+            indexer_num_q_heads=indexer_num_q_heads,
+            head_dim=head_dim,
+            v_head_dim=v_head_dim,
+            topk=topk,
+            max_page_table_width=max_page_table_width,
+            max_total_q=int(max_total_q),
+            max_batch=int(max_batch),
+            max_paged_q_rows=int(max_paged_q_rows),
+            max_kv_rows=max(0, int(max_kv_rows)) if max_kv_rows is not None else 0,
+            page_size=page_size,
+            padded_heads=padded_heads,
+            use_cuda_graph=use_cuda_graph,
+            max_chunks_per_row=max_chunks_per_row,
+        )
+        workspace._allocate_split_buffers()
+        if use_cuda_graph:
+            workspace._allocate_paged_indexer_runtime_metadata()
+        return workspace
+
+    @classmethod
+    def for_fixed_capacity(
+        cls,
+        *,
+        mode: Literal["decode", "extend", "verify", "draft_extend"],
+        device: torch.device | str,
+        dtype: torch.dtype,
+        kv_dtype: torch.dtype,
+        num_q_heads: int,
+        indexer_num_q_heads: int | None = None,
+        head_dim: int,
+        v_head_dim: int,
+        topk: int,
+        max_page_table_width: int | None = None,
+        max_total_q: int,
+        max_batch: int,
+        max_paged_q_rows: int | None = None,
+        max_kv_rows: int | None = None,
+        indexer_max_k_rows: int | None = None,
+        page_size: int = 64,
+        use_cuda_graph: bool = False,
+        padded_heads: int = 128,
+        reserve_paged_indexer_logits: bool = True,
+        paged_indexer_logits_q_rows: int = 0,
+        paged_indexer_logits_k_rows: int = 0,
+        paged_indexer_tile_logits_k_rows: int = 0,
+        max_chunks_per_row: int = 64,
+        reserve_compressed_mla_staging: bool = False,
+    ) -> SM12XAttentionWorkspace:
+        device = _canonical_device(device)
+        if indexer_num_q_heads is None:
+            indexer_num_q_heads = num_q_heads
+        topk = int(topk)
+        if max_page_table_width is None:
+            max_page_table_width = topk
+        max_page_table_width = max(int(max_page_table_width), 1)
+        if max_paged_q_rows is None:
+            max_paged_q_rows = max_batch
+        max_paged_q_rows = max(int(max_paged_q_rows), 1)
+        caps = SM12XAttentionArenaCaps(
+            device=device,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            num_q_heads=num_q_heads,
+            indexer_num_q_heads=indexer_num_q_heads,
+            head_dim=head_dim,
+            max_v_head_dim=v_head_dim,
+            topk=topk,
+            max_page_table_width=max_page_table_width,
+            extend_max_total_q=max_total_q,
+            extend_max_batch=max_batch,
+            extend_max_kv_rows=max(0, int(max_kv_rows))
+            if max_kv_rows is not None
+            else 0,
+            indexer_max_k_rows=(
+                None if indexer_max_k_rows is None else max(0, int(indexer_max_k_rows))
+            ),
+            paged_max_q_rows=max_paged_q_rows,
+            paged_max_batch=max_batch,
+            page_size=page_size,
+            padded_heads=padded_heads,
+            max_chunks_per_row=max_chunks_per_row,
+            reserve_paged_indexer_logits=reserve_paged_indexer_logits,
+            reserve_compressed_mla_staging=reserve_compressed_mla_staging,
+            paged_indexer_logits_q_rows=int(paged_indexer_logits_q_rows),
+            paged_indexer_logits_k_rows=int(paged_indexer_logits_k_rows),
+            paged_indexer_tile_logits_k_rows=int(paged_indexer_tile_logits_k_rows),
+        )
+        arena = SM12XAttentionArena.allocate(caps)
+        contract = SM12XAttentionWorkspaceContract(
+            mode=mode,
+            max_total_q=max_total_q,
+            max_batch=max_batch,
+            max_paged_q_rows=max_paged_q_rows,
+            max_kv_rows=max(0, int(max_kv_rows)) if max_kv_rows is not None else 0,
+            v_head_dim=v_head_dim,
+            indexer_num_q_heads=indexer_num_q_heads,
+            max_page_table_width=max_page_table_width,
+            topk=topk,
+            max_chunks_per_row=max_chunks_per_row,
+        )
+        return arena.make_workspace(contract, use_cuda_graph=use_cuda_graph)
+
+    def _reserve_fused_indexer_scratch(self) -> None:
+        """Eagerly allocate the fused-indexer cross-CTA merge scratch at a FIXED capacity.
+
+        Sized once at construction from the workspace contract -- pack = num_sms * topk
+        (seq- AND batch-independent: the merge candidate count is capped by per-CTA top-k
+        trimming), while state rows follow the architecture-specific routing policy. This
+        is allocated BEFORE lock_workspace()/graph capture. Idempotent; no-op off CUDA."""
+        if self._sm12x_fused_indexer_scratch is not None:
+            return
+        if self.device is None or self.device.type != "cuda":
+            return
+        topk = int(self.indexer_topk)
+        if topk <= 0:
+            return
+        from flashinfer.experimental.sm12x.attention.nsa_indexer.fused_indexer import (
+            fused_indexer_scratch_max_rows,
+            fused_indexer_scratch_capacity,
+        )
+
+        props = torch.cuda.get_device_properties(self.device)
+        num_sms = props.multi_processor_count
+        max_rows = fused_indexer_scratch_max_rows(
+            topk=topk,
+            num_heads=int(self.indexer_num_q_heads),
+            compute_capability=(int(props.major), int(props.minor)),
+        )
+        pack_elems, state_words = fused_indexer_scratch_capacity(
+            max_rows, topk, num_sms
+        )
+        self._sm12x_fused_indexer_scratch = (
+            torch.empty((pack_elems,), dtype=torch.float32, device=self.device),
+            torch.empty((pack_elems,), dtype=torch.int32, device=self.device),
+            torch.zeros((state_words,), dtype=torch.int32, device=self.device),
+        )
+
+    def get_fused_indexer_scratch(
+        self, *, topk: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return the eagerly-reserved fused merge scratch (pack_v, pack_i, state).
+
+        Reserves on first call as a fallback, but the normal construction path reserves it
+        up front, so in serving this never allocates after the workspace is locked."""
+        self._reserve_fused_indexer_scratch()
+        cache = self._sm12x_fused_indexer_scratch
+        if cache is None:
+            raise RuntimeError(
+                "fused indexer scratch unavailable (non-CUDA workspace or topk<=0)"
+            )
+        from flashinfer.experimental.sm12x.attention.nsa_indexer.fused_indexer import (
+            fused_indexer_scratch_max_rows,
+            fused_indexer_scratch_capacity,
+        )
+
+        props = torch.cuda.get_device_properties(self.device)
+        num_sms = props.multi_processor_count
+        max_rows = fused_indexer_scratch_max_rows(
+            topk=int(topk),
+            num_heads=int(self.indexer_num_q_heads),
+            compute_capability=(int(props.major), int(props.minor)),
+        )
+        need_pack, need_state = fused_indexer_scratch_capacity(
+            max_rows, int(topk), num_sms
+        )
+        if cache[0].numel() < need_pack or cache[2].numel() < need_state:
+            raise RuntimeError(
+                f"fused indexer scratch reserved for topk<={self.topk} but call needs "
+                f"topk={topk}: pack have={cache[0].numel()} need={need_pack}"
+            )
+        return cache
+
+    def _allocate_paged_indexer_runtime_metadata(self) -> None:
+        if self.paged_indexer_real_page_table_runtime is None:
+            self.paged_indexer_real_page_table_runtime = torch.empty(
+                (self.max_paged_q_rows, self.max_page_table_width),
+                dtype=torch.int32,
+                device=self.device,
+            )
+        if self.paged_indexer_seqlens_per_query_runtime is None:
+            self.paged_indexer_seqlens_per_query_runtime = torch.empty(
+                (self.max_paged_q_rows,),
+                dtype=torch.int32,
+                device=self.device,
+            )
+        if self.paged_indexer_active_width_runtime is None:
+            self.paged_indexer_active_width_runtime = torch.empty(
+                (1,),
+                dtype=torch.int32,
+                device=self.device,
+            )
+        if self.paged_indexer_active_width_cap is None:
+            width_cap = max(
+                int(self.paged_logits_width_tokens),
+                int(self.max_page_table_width) * int(self.page_size),
+                1,
+            )
+            self.paged_indexer_active_width_cap = torch.full(
+                (1,),
+                int(width_cap),
+                dtype=torch.int32,
+                device=self.device,
+            )
+        if self.paged_indexer_schedule_metadata_runtime is None:
+            num_sms = 1
+            if self.device.type == "cuda":
+                num_sms = torch.cuda.get_device_properties(
+                    self.device
+                ).multi_processor_count
+            self.paged_indexer_schedule_metadata_runtime = torch.empty(
+                (int(num_sms) + 1, 2),
+                dtype=torch.int32,
+                device=self.device,
+            )
+
+    def _allocate_fixed_capacity_views(self) -> None:
+        if self.arena is None:
+            raise RuntimeError(
+                "_allocate_fixed_capacity_views requires an arena-backed workspace"
+            )
+        max_total_q = max(int(self.max_total_q), 1)
+        max_paged_q_rows = max(int(self.max_paged_q_rows), 1)
+        indexer_q_rows = max(max_total_q, max_paged_q_rows)
+        max_kv_rows = max(int(self.max_kv_rows), 1)
+        indexer_k_rows = (
+            int(self.arena.indexer_k_rows)
+            if self.arena is not None
+            else (
+                0
+                if int(self.max_kv_rows) <= 0
+                else _align_up(max_kv_rows, _INDEXER_BLOCK_K)
+            )
+        )
+        paged_width_tokens = (
+            max(int(self.arena.paged_logits_width_tokens), 1)
+            if self.arena is not None and int(self.arena.paged_logits_width_tokens) > 0
+            else max(int(self.max_page_table_width) * int(self.page_size), 1)
+        )
+        self.shared_arena = self.arena.shared_arena
+        self.shared_arena_nbytes = self.arena.shared_arena_nbytes
+        self.mla_phase_nbytes = self.arena.mla_phase_nbytes
+        self.indexer_phase_nbytes = self.arena.indexer_phase_nbytes
+        self.ragged_kv_nbytes = self.arena.ragged_kv_nbytes
+        self.output_buffer_nbytes = self.arena.output_buffer_nbytes
+        self.final_lse_nbytes = self.arena.final_lse_nbytes
+        self.compressed_q_stage_nbytes = self.arena.compressed_q_stage_nbytes
+        self.compressed_index_stage_nbytes = self.arena.compressed_index_stage_nbytes
+        self.compressed_page_table_stage_nbytes = (
+            self.arena.compressed_page_table_stage_nbytes
+        )
+        self.compressed_lengths_stage_nbytes = (
+            self.arena.compressed_lengths_stage_nbytes
+        )
+        self.paged_logits_q_rows = self.arena.paged_logits_q_rows
+        self.indexer_contiguous_logits_nbytes = (
+            self.arena.indexer_contiguous_logits_nbytes
+        )
+        self.indexer_contiguous_tile_logits_nbytes = (
+            self.arena.indexer_contiguous_tile_logits_nbytes
+        )
+        self.indexer_contiguous_topk_indices_nbytes = (
+            self.arena.indexer_contiguous_topk_indices_nbytes
+        )
+        self.indexer_contiguous_topk_values_nbytes = (
+            self.arena.indexer_contiguous_topk_values_nbytes
+        )
+        self.indexer_contiguous_topk_scratch_indices_nbytes = (
+            self.arena.indexer_contiguous_topk_scratch_indices_nbytes
+        )
+        self.indexer_contiguous_topk_scratch_values_nbytes = (
+            self.arena.indexer_contiguous_topk_scratch_values_nbytes
+        )
+        self.indexer_contiguous_topk_position_nbytes = (
+            self.arena.indexer_contiguous_topk_position_nbytes
+        )
+        self.indexer_contiguous_candidate_values_nbytes = (
+            self.arena.indexer_contiguous_candidate_values_nbytes
+        )
+        self.indexer_contiguous_candidate_indices_nbytes = (
+            self.arena.indexer_contiguous_candidate_indices_nbytes
+        )
+        self.indexer_contiguous_lengths_nbytes = (
+            self.arena.indexer_contiguous_lengths_nbytes
+        )
+        self.indexer_contiguous_mapped_indices_nbytes = (
+            self.arena.indexer_contiguous_mapped_indices_nbytes
+        )
+        self.indexer_paged_logits_nbytes = self.arena.indexer_paged_logits_nbytes
+        self.indexer_logits_nbytes = self.arena.indexer_logits_nbytes
+
+        assert self.shared_arena is not None
+        self.ragged_kv_cache, mla_offset = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.arena.ragged_kv_offset_bytes,
+            shape=(max_kv_rows, 1, _MLA_PACKED_DIM),
+            dtype=self.kv_dtype,
+        )
+        self.tmp_output, mla_offset = _materialize_arena_strided_view(
+            self.shared_arena,
+            offset_bytes=self.arena.tmp_output_offset_bytes,
+            shape=(
+                max_total_q,
+                int(self.num_q_heads),
+                int(self.max_chunks_per_row),
+                int(self.v_head_dim),
+            ),
+            stride=_split_tmp_output_stride(
+                max_total_q=max_total_q,
+                num_q_heads=int(self.num_q_heads),
+                max_chunks_per_row=int(self.max_chunks_per_row),
+                v_head_dim=int(self.v_head_dim),
+            ),
+            dtype=self.dtype,
+        )
+        self.tmp_lse, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.arena.tmp_lse_offset_bytes,
+            shape=(max_total_q, int(self.num_q_heads), int(self.max_chunks_per_row)),
+            dtype=torch.float32,
+        )
+        self.output_buffer = _split_output_buffer_from_tmp(self.tmp_output)
+        self.final_lse, _ = _materialize_arena_view(
+            self.shared_arena,
+            offset_bytes=self.arena.final_lse_offset_bytes,
+            shape=(max_total_q, int(self.num_q_heads)),
+            dtype=torch.float32,
+        )
+        if self.compressed_q_stage_nbytes:
+            self.compressed_mla_q_stage, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.compressed_q_stage_offset_bytes,
+                shape=(max_total_q, int(self.num_q_heads), int(self.head_dim)),
+                dtype=self.dtype,
+            )
+            self.compressed_mla_swa_indices_stage, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.compressed_swa_indices_stage_offset_bytes,
+                shape=(max_total_q, int(self.topk)),
+                dtype=torch.int32,
+            )
+            self.compressed_mla_swa_lengths_stage, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.compressed_swa_lengths_stage_offset_bytes,
+                shape=(max_total_q,),
+                dtype=torch.int32,
+            )
+            self.compressed_mla_indexed_indices_stage, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.compressed_indexed_indices_stage_offset_bytes,
+                shape=(max_total_q, int(self.topk)),
+                dtype=torch.int32,
+            )
+            self.compressed_mla_indexed_lengths_stage, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.compressed_indexed_lengths_stage_offset_bytes,
+                shape=(max_total_q,),
+                dtype=torch.int32,
+            )
+            self.compressed_mla_indexed_page_table_stage, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.compressed_indexed_page_table_stage_offset_bytes,
+                shape=(max_total_q, int(self.max_page_table_width)),
+                dtype=torch.int32,
+            )
+
+        if indexer_k_rows > 0:
+            self.indexer_k_quant_bytes, extend_offset = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_k_quant_offset_bytes,
+                shape=(indexer_k_rows, _INDEX_HEAD_DIM),
+                dtype=torch.uint8,
+            )
+            self.indexer_k_scales, extend_offset = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_k_scale_offset_bytes,
+                shape=(indexer_k_rows,),
+                dtype=torch.float32,
+            )
+            (
+                self.indexer_k_tma_desc,
+                self.indexer_k_tma_desc_ptrs,
+            ) = _encode_indexer_k_tma_descriptor(
+                self.indexer_k_quant_bytes,
+                block_k=_INDEXER_BLOCK_K,
+            )
+            (
+                self.indexer_k_tma_prefill_desc,
+                self.indexer_k_tma_prefill_desc_ptrs,
+            ) = _encode_indexer_k_tma_descriptor(
+                self.indexer_k_quant_bytes,
+                block_k=_INDEXER_PREFILL_BLOCK_K,
+            )
+        else:
+            self.indexer_k_quant_bytes = None
+            self.indexer_k_scales = None
+            self.indexer_k_tma_desc = None
+            self.indexer_k_tma_desc_ptrs = None
+            self.indexer_k_tma_prefill_desc = None
+            self.indexer_k_tma_prefill_desc_ptrs = None
+        if self.indexer_contiguous_logits_nbytes:
+            self.indexer_contiguous_logits, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_logits_offset_bytes,
+                shape=(max_total_q * indexer_k_rows,),
+                dtype=torch.float32,
+            )
+        else:
+            self.indexer_contiguous_logits = None
+        if self.indexer_contiguous_tile_logits_nbytes:
+            self.indexer_contiguous_tile_logits, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_tile_logits_offset_bytes,
+                shape=(
+                    self.indexer_contiguous_tile_logits_nbytes
+                    // _dtype_nbytes(torch.float32),
+                ),
+                dtype=torch.float32,
+            )
+        else:
+            self.indexer_contiguous_tile_logits = None
+        if self.indexer_contiguous_topk_indices_nbytes:
+            self.indexer_contiguous_topk_indices, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_topk_indices_offset_bytes,
+                shape=(indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.int32,
+            )
+        else:
+            self.indexer_contiguous_topk_indices = None
+        if self.indexer_contiguous_topk_values_nbytes:
+            self.indexer_contiguous_topk_values, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_topk_values_offset_bytes,
+                shape=(indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.float32,
+            )
+        else:
+            self.indexer_contiguous_topk_values = None
+        if self.indexer_contiguous_topk_scratch_indices_nbytes:
+            self.indexer_contiguous_topk_scratch_indices, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_topk_scratch_indices_offset_bytes,
+                shape=(indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.int32,
+            )
+        else:
+            self.indexer_contiguous_topk_scratch_indices = None
+        if self.indexer_contiguous_topk_scratch_values_nbytes:
+            self.indexer_contiguous_topk_scratch_values, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_topk_scratch_values_offset_bytes,
+                shape=(indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.float32,
+            )
+        else:
+            self.indexer_contiguous_topk_scratch_values = None
+        if self.indexer_contiguous_topk_position_nbytes:
+            self.indexer_contiguous_topk_positions, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_topk_position_offset_bytes,
+                shape=(indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.int64,
+            )
+        else:
+            self.indexer_contiguous_topk_positions = None
+        if self.indexer_contiguous_candidate_values_nbytes:
+            candidate_chunks = self.indexer_contiguous_candidate_values_nbytes // (
+                indexer_q_rows * int(self.indexer_topk) * _dtype_nbytes(torch.float32)
+            )
+            self.indexer_contiguous_candidate_values, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_candidate_values_offset_bytes,
+                shape=(candidate_chunks, indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.float32,
+            )
+        else:
+            self.indexer_contiguous_candidate_values = None
+        if self.indexer_contiguous_candidate_indices_nbytes:
+            candidate_chunks = self.indexer_contiguous_candidate_indices_nbytes // (
+                indexer_q_rows * int(self.indexer_topk) * _dtype_nbytes(torch.int32)
+            )
+            self.indexer_contiguous_candidate_indices, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_candidate_indices_offset_bytes,
+                shape=(candidate_chunks, indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.int32,
+            )
+        else:
+            self.indexer_contiguous_candidate_indices = None
+        if self.indexer_contiguous_lengths_nbytes:
+            self.indexer_contiguous_lengths, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_lengths_offset_bytes,
+                shape=(indexer_q_rows,),
+                dtype=torch.int32,
+            )
+        else:
+            self.indexer_contiguous_lengths = None
+        if self.indexer_contiguous_mapped_indices_nbytes:
+            self.indexer_contiguous_mapped_indices, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_contiguous_mapped_indices_offset_bytes,
+                shape=(indexer_q_rows, int(self.indexer_topk)),
+                dtype=torch.int32,
+            )
+        else:
+            self.indexer_contiguous_mapped_indices = None
+        if self.indexer_paged_logits_nbytes and max_paged_q_rows <= int(
+            self.paged_logits_q_rows
+        ):
+            self.indexer_paged_logits, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.indexer_paged_logits_offset_bytes,
+                shape=(max_paged_q_rows * paged_width_tokens,),
+                dtype=torch.float32,
+            )
+        else:
+            self.indexer_paged_logits = None
+
+    def _allocate_split_buffers(self) -> None:
+        if self.mode not in ("decode", "extend", "verify", "draft_extend"):
+            return
+        if self.fixed_capacity:
+            if self.shared_arena is None:
+                self._allocate_fixed_capacity_views()
+        elif self.tmp_output is None:
+            self.tmp_output = _allocate_split_tmp_output(
+                max_total_q=self.max_total_q,
+                num_q_heads=self.num_q_heads,
+                max_chunks_per_row=self.max_chunks_per_row,
+                v_head_dim=self.v_head_dim,
+                dtype=self.dtype,
+                device=self.device,
+            )
+        if self.tmp_lse is None:
+            self.tmp_lse = torch.empty(
+                (self.max_total_q, self.num_q_heads, self.max_chunks_per_row),
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if self.output_buffer is None:
+            if self.tmp_output is None:
+                raise RuntimeError("workspace is missing split MLA output scratch")
+            self.output_buffer = _split_output_buffer_from_tmp(self.tmp_output)
+        if self.final_lse is None:
+            self.final_lse = torch.empty(
+                (self.max_total_q, self.num_q_heads),
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if self.kv_chunk_size_ptr is None:
+            self.kv_chunk_size_ptr = torch.empty(
+                (1,), dtype=torch.int32, device=self.device
+            )
+            self.kv_chunk_size_value = None
+        if self.num_chunks_ptr is None:
+            self.num_chunks_ptr = torch.empty(
+                (1,), dtype=torch.int32, device=self.device
+            )
+            self.num_chunks_value = None
+
+    def _initialize_split_chunk_config_if_needed(self) -> None:
+        self._allocate_split_buffers()
+        if not (self.fixed_capacity or self.use_cuda_graph):
+            return
+        if self.kv_chunk_size_value is not None and self.num_chunks_value is not None:
+            return
+        split_cfg = default_sparse_mla_split_decode_config_for_width(
+            int(self.topk),
+            max_chunks=self.max_chunks_per_row,
+        )
+        if split_cfg is None:
+            return
+        assert self.kv_chunk_size_ptr is not None
+        assert self.num_chunks_ptr is not None
+        self.kv_chunk_size_ptr.fill_(int(split_cfg.chunk_size))
+        self.num_chunks_ptr.fill_(int(split_cfg.num_chunks))
+        self.kv_chunk_size_value = int(split_cfg.chunk_size)
+        self.num_chunks_value = int(split_cfg.num_chunks)
+
+    def set_split_chunk_config(self, *, kv_chunk_size: int, num_chunks: int) -> None:
+        if num_chunks <= 0 or num_chunks > self.max_chunks_per_row:
+            raise ValueError(
+                f"num_chunks must be in [1, {self.max_chunks_per_row}], got {num_chunks}"
+            )
+        if kv_chunk_size <= 0:
+            raise ValueError(f"kv_chunk_size must be positive, got {kv_chunk_size}")
+        self._allocate_split_buffers()
+        assert self.kv_chunk_size_ptr is not None
+        assert self.num_chunks_ptr is not None
+        if self.kv_chunk_size_value != int(kv_chunk_size):
+            self.kv_chunk_size_ptr.fill_(int(kv_chunk_size))
+            self.kv_chunk_size_value = int(kv_chunk_size)
+        if self.num_chunks_value != int(num_chunks):
+            self.num_chunks_ptr.fill_(int(num_chunks))
+            self.num_chunks_value = int(num_chunks)
+
+    def set_decode_chunk_config(self, *, kv_chunk_size: int, num_chunks: int) -> None:
+        self.set_split_chunk_config(kv_chunk_size=kv_chunk_size, num_chunks=num_chunks)
+
+    def gather_ragged_kv_rows(
+        self,
+        *,
+        kv_cache: torch.Tensor,
+        row_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if kv_cache.ndim != 3:
+            raise ValueError(f"kv_cache must be rank-3, got {tuple(kv_cache.shape)}")
+        if row_ids.ndim != 1:
+            raise ValueError(f"row_ids must be rank-1, got {tuple(row_ids.shape)}")
+        if kv_cache.device != self.device:
+            raise ValueError(
+                f"kv_cache device {kv_cache.device} does not match workspace device {self.device}"
+            )
+        if row_ids.device != self.device:
+            raise ValueError(
+                f"row_ids device {row_ids.device} does not match workspace device {self.device}"
+            )
+        if kv_cache.dtype != self.kv_dtype:
+            raise ValueError(
+                f"kv_cache dtype {kv_cache.dtype} does not match workspace kv_dtype {self.kv_dtype}"
+            )
+
+        row_count = int(row_ids.shape[0])
+        capacity = max(int(self.max_kv_rows), row_count, 1)
+        expected_row_shape = tuple(int(dim) for dim in kv_cache.shape[1:])
+        buffer = self.ragged_kv_cache
+        if (
+            buffer is None
+            or buffer.device != self.device
+            or buffer.dtype != kv_cache.dtype
+            or tuple(int(dim) for dim in buffer.shape[1:]) != expected_row_shape
+            or buffer.shape[0] < capacity
+        ):
+            if self.fixed_capacity and buffer is not None:
+                raise ValueError(
+                    f"row_count {row_count} exceeds fixed-capacity ragged KV workspace {buffer.shape[0]}"
+                )
+            buffer = torch.empty(
+                (capacity, *expected_row_shape),
+                dtype=kv_cache.dtype,
+                device=self.device,
+            )
+            self.ragged_kv_cache = buffer
+            self.max_kv_rows = capacity
+            self._refresh_ragged_kv_contracts()
+        elif self._contract_kv_rows is None or self._contract_kv_scales is None:
+            self._refresh_ragged_kv_contracts()
+
+        assert buffer is not None
+        if row_count != 0:
+            kv_bytes = kv_cache.view(torch.uint8)
+            gathered_bytes = buffer[:row_count].view(torch.uint8)
+            torch.index_select(kv_bytes, 0, row_ids.to(torch.long), out=gathered_bytes)
+        # Return the full-capacity scratch buffer so launcher cache keys follow
+        # workspace capacity instead of the live ragged row count for this prefill.
+        return buffer
+
+    def bind_compressed_mla(
+        self,
+        *,
+        q: torch.Tensor,
+        swa_indices: torch.Tensor,
+        swa_lengths: torch.Tensor,
+        indexed_indices: torch.Tensor | None = None,
+        indexed_lengths: torch.Tensor | None = None,
+        indexed_page_table: torch.Tensor | None = None,
+    ):
+        from flashinfer.experimental.sm12x.attention.compressed_mla._scratch import (
+            build_compressed_mla_binding,
+        )
+
+        return build_compressed_mla_binding(
+            workspace=self,
+            q=q,
+            swa_indices=swa_indices,
+            swa_lengths=swa_lengths,
+            indexed_indices=indexed_indices,
+            indexed_lengths=indexed_lengths,
+            indexed_page_table=indexed_page_table,
+        )
+
+    def bind_sparse_mla(
+        self,
+        *,
+        q: torch.Tensor,
+        selected_indices: torch.Tensor,
+        cache_seqlens_int32: torch.Tensor,
+        nsa_cache_seqlens_int32: torch.Tensor,
+    ):
+        from flashinfer.experimental.sm12x.attention.sparse_mla._scratch import (
+            build_sparse_mla_binding,
+        )
+
+        return build_sparse_mla_binding(
+            scratch=self,
+            q=q,
+            selected_indices=selected_indices,
+            cache_seqlens_int32=cache_seqlens_int32,
+            nsa_cache_seqlens_int32=nsa_cache_seqlens_int32,
+        )
+
+    def contract_kv_tensors_for(
+        self,
+        kv_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Return stable KV phantoms only for the ragged scratch allocation.
+
+        Extend/verify share a workspace in SGLang. After a ragged prefill allocates
+        `ragged_kv_cache`, later paged launches must not reuse those KV phantoms or
+        they can collide with a launcher compiled for a different KV layout.
+        """
+        buffer = self.ragged_kv_cache
+        if buffer is None:
+            return None, None
+        if kv_cache.device != buffer.device or kv_cache.dtype != buffer.dtype:
+            return None, None
+        if kv_cache.ndim != buffer.ndim:
+            return None, None
+        if kv_cache.data_ptr() != buffer.data_ptr():
+            return None, None
+        if tuple(int(dim) for dim in kv_cache.shape[1:]) != tuple(
+            int(dim) for dim in buffer.shape[1:]
+        ):
+            return None, None
+        return self._contract_kv_rows, self._contract_kv_scales
+
+    def _refresh_ragged_kv_contracts(self) -> None:
+        if self.ragged_kv_cache is None:
+            self._contract_kv_rows = None
+            self._contract_kv_scales = None
+            return
+
+        from flashinfer.experimental.sm12x.attention._shared.mla.packed import (
+            _extract_packed_kv_runtime_views,
+        )
+
+        kv_rows_u32, kv_scales = _extract_packed_kv_runtime_views(self.ragged_kv_cache)
+        self._contract_kv_rows = _shape_only_cuda_tensor(
+            tuple(int(dim) for dim in kv_rows_u32.shape),
+            dtype=kv_rows_u32.dtype,
+            device=self.device,
+        )
+        self._contract_kv_scales = _shape_only_cuda_tensor(
+            tuple(int(dim) for dim in kv_scales.shape),
+            dtype=kv_scales.dtype,
+            device=self.device,
+        )
+
+    def _allocate_contract_phantoms(self) -> None:
+        """Create zero-stride phantom tensors at max capacity for stable cache keys."""
+        # q is viewed as uint32 in the kernel: (max_total_q, num_q_heads, head_dim // 4).
+        self._contract_q = _shape_only_cuda_tensor(
+            (self.max_total_q, self.num_q_heads, self.head_dim // 4),
+            dtype=torch.uint32,
+            device=self.device,
+        )
+        self._contract_page_table = _shape_only_cuda_tensor(
+            (self.max_total_q, self.topk),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self._contract_indexer_cache_seqlens = _shape_only_cuda_tensor(
+            (self.max_total_q,),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self._contract_output = _shape_only_cuda_tensor(
+            (self.max_total_q, self.num_q_heads, self.v_head_dim),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        if self.tmp_output is not None and self.tmp_lse is not None:
+            self._contract_tmp_output = _shape_only_cuda_tensor(
+                (
+                    self.max_total_q,
+                    self.num_q_heads,
+                    self.max_chunks_per_row,
+                    self.v_head_dim,
+                ),
+                dtype=self.dtype,
+                device=self.device,
+            )
+            self._contract_tmp_lse = _shape_only_cuda_tensor(
+                (self.max_total_q, self.num_q_heads, self.max_chunks_per_row),
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if self.ragged_kv_cache is not None:
+            self._refresh_ragged_kv_contracts()

--- a/flashinfer/experimental/sm12x/attention/compressed_mla/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/compressed_mla/__init__.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Compressed MLA decode for SM12x (DeepSeek-V3.2).
+
+Decode directly from compressed KV pages: a sliding-window cache plus an
+indexed (top-k-selected) cache, fused-merged into the caller's output.
+Head dim is fixed to DSV4's 512 + 64. Single-pass decode on SM121.
+
+Planned lifecycle: ``plan(Caps(...))`` -> ``bind`` (views only) -> ``run``
+(capture safe). ``split_chunks_for_contract`` exposes the fixed
+split-planning contract integrations preplan against.
+
+Example:
+    from flashinfer.experimental.sm12x.attention import compressed_mla
+
+    plan    = compressed_mla.plan(compressed_mla.Caps(...))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = compressed_mla.bind(plan, scratch=scratch, q=q,
+                                  swa_indices=idx, swa_lengths=lens, ...)
+    out = compressed_mla.run(swa_k_cache=swa, binding=binding,
+                             sm_scale=scale, ...)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="compressed_mla",
+    group="attention",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "Binding",
+        "Scratch",
+        "plan",
+        "bind",
+        "run",
+        "split_chunks_for_contract",
+        "is_supported",
+        "clear_caches",
+    ),
+    dtypes=("bf16", "fp8_e4m3"),
+    recipes=("dsv4",),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=(
+            "b12x/attention/mla/compressed_api.py",
+            "b12x/integration/compressed_scratch.py",
+        ),
+    ),
+    test_path="tests/experimental/attention/test_compressed_mla.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Binding,
+        Caps,
+        Plan,
+        Scratch,
+        bind,
+        clear_caches,
+        is_supported,
+        plan,
+        run,
+        split_chunks_for_contract,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/attention/compressed_mla/_scratch.py
+++ b/flashinfer/experimental/sm12x/attention/compressed_mla/_scratch.py
@@ -1,0 +1,640 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/compressed_scratch.py @ 149d6bb2 (2026-06-12) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Caller-owned scratch plans for compressed MLA paths."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+
+from flashinfer.experimental.sm12x.attention._shared.mla.compressed_config import (
+    compressed_mla_split_config_for_contract,
+)
+from flashinfer.experimental.sm12x.attention._shared.mla.compressed_reference import (
+    COMPRESSED_MLA_HEAD_DIM,
+)
+from flashinfer.experimental.sm12x.attention._shared.workspace import (
+    _split_output_buffer_from_tmp,
+    _split_tmp_output_stride,
+)
+from flashinfer.experimental.sm12x._lib.scratch_layout import (
+    SCRATCH_ALIGN_BYTES,
+    align_up,
+    dtype_nbytes,
+    materialize_scratch_strided_view,
+    materialize_scratch_view,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XCompressedMLAScratchCaps:
+    device: torch.device | str
+    num_q_heads: int
+    max_q_rows: int
+    max_width: int
+    max_page_table_width: int | None = None
+    dtype: torch.dtype = torch.bfloat16
+    kv_dtype: torch.dtype = torch.uint8
+    head_dim: int = COMPRESSED_MLA_HEAD_DIM
+    v_head_dim: int = COMPRESSED_MLA_HEAD_DIM
+    max_batch: int | None = None
+    max_kv_rows: int = 0
+    max_chunks_per_row: int = 64
+    max_q_chunks: int | None = None
+    page_size: int = 64
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "max_q_rows", max(int(self.max_q_rows), 1))
+        object.__setattr__(self, "max_width", max(int(self.max_width), 1))
+        max_page_table_width = (
+            self.max_width
+            if self.max_page_table_width is None
+            else self.max_page_table_width
+        )
+        object.__setattr__(
+            self, "max_page_table_width", max(int(max_page_table_width), 1)
+        )
+        object.__setattr__(self, "head_dim", max(int(self.head_dim), 1))
+        object.__setattr__(self, "v_head_dim", max(int(self.v_head_dim), 1))
+        max_batch = self.max_q_rows if self.max_batch is None else self.max_batch
+        object.__setattr__(self, "max_batch", max(int(max_batch), 1))
+        object.__setattr__(self, "max_kv_rows", max(int(self.max_kv_rows), 0))
+        object.__setattr__(
+            self, "max_chunks_per_row", max(int(self.max_chunks_per_row), 1)
+        )
+        if self.max_q_chunks is not None:
+            object.__setattr__(self, "max_q_chunks", max(int(self.max_q_chunks), 1))
+        object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+
+
+@dataclass(frozen=True, kw_only=True)
+class _SM12XCompressedMLAScratchLayout:
+    nbytes: int
+    max_q_chunks: int
+    tmp_output_offset_bytes: int
+    tmp_lse_offset_bytes: int
+    final_lse_offset_bytes: int
+    kv_chunk_size_offset_bytes: int
+    num_chunks_offset_bytes: int
+    sm_scale_offset_bytes: int
+
+
+@dataclass(kw_only=True)
+class SM12XCompressedMLAScratch:
+    """Component-owned compressed MLA scratch views over caller-owned storage."""
+
+    shared_scratch: torch.Tensor
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    head_dim: int
+    v_head_dim: int
+    topk: int
+    max_page_table_width: int
+    max_total_q: int
+    max_batch: int
+    max_kv_rows: int
+    max_chunks_per_row: int
+    page_size: int
+    mode: str = "decode"
+    fixed_capacity: bool = True
+    use_cuda_graph: bool = False
+    tmp_output: torch.Tensor | None = None
+    tmp_lse: torch.Tensor | None = None
+    output_buffer: torch.Tensor | None = None
+    final_lse: torch.Tensor | None = None
+    kv_chunk_size_ptr: torch.Tensor | None = None
+    num_chunks_ptr: torch.Tensor | None = None
+    sm_scale_tensor: torch.Tensor | None = None
+    kv_chunk_size_value: int | None = None
+    num_chunks_value: int | None = None
+    sm_scale_value: float | None = None
+    _contract_q: torch.Tensor | None = None
+    _contract_page_table: torch.Tensor | None = None
+    _contract_indexer_cache_seqlens: torch.Tensor | None = None
+    _contract_output: torch.Tensor | None = None
+    _contract_tmp_output: torch.Tensor | None = None
+    _contract_tmp_lse: torch.Tensor | None = None
+
+    def set_split_chunk_config(self, *, kv_chunk_size: int, num_chunks: int) -> None:
+        if num_chunks <= 0 or num_chunks > self.max_chunks_per_row:
+            raise ValueError(
+                f"num_chunks must be in [1, {self.max_chunks_per_row}], got {num_chunks}"
+            )
+        if kv_chunk_size <= 0:
+            raise ValueError(f"kv_chunk_size must be positive, got {kv_chunk_size}")
+        if self.kv_chunk_size_ptr is None or self.num_chunks_ptr is None:
+            raise RuntimeError(
+                "compressed MLA scratch is missing split-control tensors"
+            )
+        if self.kv_chunk_size_value != int(kv_chunk_size):
+            self.kv_chunk_size_ptr.fill_(int(kv_chunk_size))
+            self.kv_chunk_size_value = int(kv_chunk_size)
+        if self.num_chunks_value != int(num_chunks):
+            self.num_chunks_ptr.fill_(int(num_chunks))
+            self.num_chunks_value = int(num_chunks)
+
+    def bind(
+        self,
+        *,
+        q: torch.Tensor,
+        swa_indices: torch.Tensor,
+        swa_lengths: torch.Tensor,
+        indexed_indices: torch.Tensor | None = None,
+        indexed_lengths: torch.Tensor | None = None,
+        indexed_page_table: torch.Tensor | None = None,
+    ) -> "SM12XCompressedMLABinding":
+        return build_compressed_mla_binding(
+            scratch=self,
+            q=q,
+            swa_indices=swa_indices,
+            swa_lengths=swa_lengths,
+            indexed_indices=indexed_indices,
+            indexed_lengths=indexed_lengths,
+            indexed_page_table=indexed_page_table,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XCompressedMLABinding:
+    scratch: object
+    q: torch.Tensor
+    swa_indices: torch.Tensor
+    swa_lengths: torch.Tensor
+    indexed_indices: torch.Tensor | None = None
+    indexed_lengths: torch.Tensor | None = None
+    indexed_page_table: torch.Tensor | None = None
+
+
+def _compressed_mla_scratch_layout(
+    caps: SM12XCompressedMLAScratchCaps,
+) -> _SM12XCompressedMLAScratchLayout:
+    max_total_q = max(int(caps.max_q_rows), 1)
+    max_chunks_per_row = max(int(caps.max_chunks_per_row), 1)
+    default_q_chunks = max_total_q * max_chunks_per_row
+    max_q_chunks = (
+        default_q_chunks
+        if caps.max_q_chunks is None
+        else max(int(caps.max_q_chunks), default_q_chunks)
+    )
+
+    cursor = 0
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+    tmp_output_offset_bytes = cursor
+    cursor += (
+        max_q_chunks
+        * int(caps.num_q_heads)
+        * int(caps.v_head_dim)
+        * dtype_nbytes(caps.dtype)
+    )
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    tmp_lse_offset_bytes = cursor
+    cursor += max_q_chunks * int(caps.num_q_heads) * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    final_lse_offset_bytes = cursor
+    cursor += max_total_q * int(caps.num_q_heads) * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    kv_chunk_size_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    num_chunks_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    sm_scale_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    return _SM12XCompressedMLAScratchLayout(
+        nbytes=max(int(cursor), SCRATCH_ALIGN_BYTES),
+        max_q_chunks=max_q_chunks,
+        tmp_output_offset_bytes=tmp_output_offset_bytes,
+        tmp_lse_offset_bytes=tmp_lse_offset_bytes,
+        final_lse_offset_bytes=final_lse_offset_bytes,
+        kv_chunk_size_offset_bytes=kv_chunk_size_offset_bytes,
+        num_chunks_offset_bytes=num_chunks_offset_bytes,
+        sm_scale_offset_bytes=sm_scale_offset_bytes,
+    )
+
+
+def _shape_only_scratch_tensor(
+    scratch: torch.Tensor,
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    base = scratch.narrow(0, 0, dtype_nbytes(dtype)).view(dtype)
+    return base.as_strided(shape, (0,) * len(shape))
+
+
+def _install_compressed_mla_contract_phantoms(
+    scratch: SM12XCompressedMLAScratch,
+) -> None:
+    storage = scratch.shared_scratch
+    scratch._contract_q = _shape_only_scratch_tensor(
+        storage,
+        (
+            int(scratch.max_total_q),
+            int(scratch.num_q_heads),
+            int(scratch.head_dim) // 4,
+        ),
+        dtype=torch.uint32,
+    )
+    scratch._contract_page_table = _shape_only_scratch_tensor(
+        storage,
+        (int(scratch.max_total_q), int(scratch.topk)),
+        dtype=torch.int32,
+    )
+    scratch._contract_indexer_cache_seqlens = _shape_only_scratch_tensor(
+        storage,
+        (int(scratch.max_total_q),),
+        dtype=torch.int32,
+    )
+    scratch._contract_output = _shape_only_scratch_tensor(
+        storage,
+        (
+            int(scratch.max_total_q),
+            int(scratch.num_q_heads),
+            int(scratch.v_head_dim),
+        ),
+        dtype=scratch.dtype,
+    )
+    scratch._contract_tmp_output = _shape_only_scratch_tensor(
+        storage,
+        (
+            int(scratch.max_total_q),
+            int(scratch.num_q_heads),
+            int(scratch.max_chunks_per_row),
+            int(scratch.v_head_dim),
+        ),
+        dtype=scratch.dtype,
+    )
+    scratch._contract_tmp_lse = _shape_only_scratch_tensor(
+        storage,
+        (
+            int(scratch.max_total_q),
+            int(scratch.num_q_heads),
+            int(scratch.max_chunks_per_row),
+        ),
+        dtype=torch.float32,
+    )
+
+
+def _materialize_compressed_mla_scratch(
+    caps: SM12XCompressedMLAScratchCaps,
+    scratch_storage: torch.Tensor,
+    layout: _SM12XCompressedMLAScratchLayout,
+) -> SM12XCompressedMLAScratch:
+    max_total_q = max(int(caps.max_q_rows), 1)
+    tmp_output, _ = materialize_scratch_strided_view(
+        scratch_storage,
+        offset_bytes=layout.tmp_output_offset_bytes,
+        shape=(
+            max_total_q,
+            int(caps.num_q_heads),
+            int(caps.max_chunks_per_row),
+            int(caps.v_head_dim),
+        ),
+        stride=_split_tmp_output_stride(
+            max_total_q=max_total_q,
+            num_q_heads=int(caps.num_q_heads),
+            max_chunks_per_row=int(caps.max_chunks_per_row),
+            v_head_dim=int(caps.v_head_dim),
+        ),
+        dtype=caps.dtype,
+    )
+    tmp_lse, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.tmp_lse_offset_bytes,
+        shape=(max_total_q, int(caps.num_q_heads), int(caps.max_chunks_per_row)),
+        dtype=torch.float32,
+    )
+    final_lse, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.final_lse_offset_bytes,
+        shape=(max_total_q, int(caps.num_q_heads)),
+        dtype=torch.float32,
+    )
+    kv_chunk_size_ptr, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.kv_chunk_size_offset_bytes,
+        shape=(1,),
+        dtype=torch.int32,
+    )
+    num_chunks_ptr, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.num_chunks_offset_bytes,
+        shape=(1,),
+        dtype=torch.int32,
+    )
+    sm_scale_tensor, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.sm_scale_offset_bytes,
+        shape=(1,),
+        dtype=torch.float32,
+    )
+    scratch = SM12XCompressedMLAScratch(
+        shared_scratch=scratch_storage,
+        device=caps.device,
+        dtype=caps.dtype,
+        kv_dtype=caps.kv_dtype,
+        num_q_heads=caps.num_q_heads,
+        head_dim=caps.head_dim,
+        v_head_dim=caps.v_head_dim,
+        topk=caps.max_width,
+        max_page_table_width=caps.max_page_table_width,
+        max_total_q=caps.max_q_rows,
+        max_batch=caps.max_batch,
+        max_kv_rows=caps.max_kv_rows,
+        max_chunks_per_row=caps.max_chunks_per_row,
+        page_size=caps.page_size,
+        tmp_output=tmp_output,
+        tmp_lse=tmp_lse,
+        output_buffer=_split_output_buffer_from_tmp(tmp_output),
+        final_lse=final_lse,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        num_chunks_ptr=num_chunks_ptr,
+        sm_scale_tensor=sm_scale_tensor,
+    )
+    _install_compressed_mla_contract_phantoms(scratch)
+    split_cfg = compressed_mla_split_config_for_contract(
+        rows=caps.max_q_rows,
+        width=caps.max_width,
+        max_chunks=caps.max_chunks_per_row,
+    )
+    scratch.set_split_chunk_config(
+        kv_chunk_size=split_cfg.chunk_size,
+        num_chunks=split_cfg.num_chunks,
+    )
+    return scratch
+
+
+def _validate_device(
+    tensor: torch.Tensor,
+    *,
+    scratch: object | None = None,
+    name: str,
+) -> None:
+    if scratch is None:
+        raise TypeError("_validate_device requires scratch")
+    if tensor.device != scratch.device:
+        raise ValueError(
+            f"{name} device {tensor.device} does not match scratch device {scratch.device}"
+        )
+
+
+def _normalize_q(q: torch.Tensor, *, scratch: object) -> torch.Tensor:
+    if q.ndim == 4 and q.shape[1] == 1:
+        q = q[:, 0]
+    if q.ndim != 3:
+        raise ValueError(
+            f"q must be rank-3 or [rows, 1, heads, dim], got {tuple(q.shape)}"
+        )
+    if int(q.shape[1]) != int(scratch.num_q_heads):
+        raise ValueError(
+            f"q heads {int(q.shape[1])} do not match scratch heads {scratch.num_q_heads}"
+        )
+    if int(q.shape[2]) != COMPRESSED_MLA_HEAD_DIM:
+        raise ValueError(
+            f"q head_dim must be {COMPRESSED_MLA_HEAD_DIM}, got {int(q.shape[2])}"
+        )
+    if q.dtype != torch.bfloat16:
+        raise TypeError(f"q must have dtype torch.bfloat16, got {q.dtype}")
+    if not q.is_contiguous():
+        raise ValueError("q must be contiguous")
+    _validate_device(q, scratch=scratch, name="q")
+    if int(q.shape[0]) > int(scratch.max_total_q):
+        raise ValueError(
+            f"q rows {int(q.shape[0])} exceed scratch capacity {scratch.max_total_q}"
+        )
+    return q.detach()
+
+
+def _is_row_shared_i32_matrix(tensor: torch.Tensor) -> bool:
+    return (
+        tensor.ndim == 2 and int(tensor.stride(0)) == 0 and int(tensor.stride(1)) == 1
+    )
+
+
+def _normalize_i32_matrix(
+    tensor: torch.Tensor,
+    *,
+    scratch: object,
+    rows: int,
+    name: str,
+    allow_row_shared: bool = False,
+) -> torch.Tensor:
+    if tensor.ndim == 3 and tensor.shape[1] == 1:
+        tensor = tensor[:, 0]
+    if tensor.ndim != 2:
+        raise ValueError(
+            f"{name} must be rank-2 or [rows, 1, width], got {tuple(tensor.shape)}"
+        )
+    if tensor.dtype != torch.int32:
+        raise TypeError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+    if not tensor.is_contiguous() and not (
+        allow_row_shared and _is_row_shared_i32_matrix(tensor)
+    ):
+        raise ValueError(f"{name} must be contiguous")
+    _validate_device(tensor, scratch=scratch, name=name)
+    if int(tensor.shape[0]) != int(rows):
+        raise ValueError(
+            f"{name} rows {int(tensor.shape[0])} do not match q rows {rows}"
+        )
+    return tensor
+
+
+def _validate_i32_vector(
+    tensor: torch.Tensor, *, scratch: object, rows: int, name: str
+) -> torch.Tensor:
+    if tensor.shape != (int(rows),):
+        raise ValueError(f"{name} must have shape ({rows},), got {tuple(tensor.shape)}")
+    if tensor.dtype != torch.int32:
+        raise TypeError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    _validate_device(tensor, scratch=scratch, name=name)
+    return tensor
+
+
+def build_compressed_mla_binding(
+    *,
+    scratch: object,
+    q: torch.Tensor,
+    swa_indices: torch.Tensor,
+    swa_lengths: torch.Tensor,
+    indexed_indices: torch.Tensor | None = None,
+    indexed_lengths: torch.Tensor | None = None,
+    indexed_page_table: torch.Tensor | None = None,
+) -> SM12XCompressedMLABinding:
+    q = _normalize_q(q, scratch=scratch)
+    rows = int(q.shape[0])
+    swa_indices = _normalize_i32_matrix(
+        swa_indices,
+        scratch=scratch,
+        rows=rows,
+        name="swa_indices",
+    )
+    if int(swa_indices.shape[1]) > int(scratch.topk):
+        raise ValueError(
+            f"swa_indices width {int(swa_indices.shape[1])} exceeds scratch topk {scratch.topk}"
+        )
+    swa_lengths = _validate_i32_vector(
+        swa_lengths,
+        scratch=scratch,
+        rows=rows,
+        name="swa_lengths",
+    )
+    if (indexed_indices is None) != (indexed_lengths is None):
+        raise ValueError(
+            "indexed_indices and indexed_lengths must be provided together"
+        )
+    indexed_width = 0
+    if indexed_indices is not None:
+        indexed_indices = _normalize_i32_matrix(
+            indexed_indices,
+            scratch=scratch,
+            rows=rows,
+            name="indexed_indices",
+        )
+        indexed_width = int(indexed_indices.shape[1])
+        indexed_lengths = _validate_i32_vector(
+            indexed_lengths,  # type: ignore[arg-type]
+            scratch=scratch,
+            rows=rows,
+            name="indexed_lengths",
+        )
+    if indexed_page_table is not None:
+        indexed_page_table = _normalize_i32_matrix(
+            indexed_page_table,
+            scratch=scratch,
+            rows=rows,
+            name="indexed_page_table",
+            allow_row_shared=True,
+        )
+        if int(indexed_page_table.shape[1]) > int(scratch.max_page_table_width):
+            raise ValueError(
+                "indexed_page_table width "
+                f"{int(indexed_page_table.shape[1])} exceeds scratch capacity {scratch.max_page_table_width}"
+            )
+    total_width = int(swa_indices.shape[1]) + indexed_width
+    if total_width > int(scratch.topk):
+        raise ValueError(
+            f"compressed MLA width {total_width} exceeds scratch topk {scratch.topk}"
+        )
+    return SM12XCompressedMLABinding(
+        scratch=scratch,
+        q=q,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+        indexed_indices=indexed_indices,
+        indexed_lengths=indexed_lengths,
+        indexed_page_table=indexed_page_table,
+    )
+
+
+def _validate_i32_contiguous(
+    tensor: torch.Tensor,
+    *,
+    scratch: object | None = None,
+    name: str,
+    ndim: int,
+) -> None:
+    if tensor.ndim != ndim:
+        raise ValueError(f"{name} must be rank-{ndim}, got {tuple(tensor.shape)}")
+    if tensor.dtype != torch.int32:
+        raise ValueError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    _validate_device(tensor, scratch=scratch, name=name)
+
+
+@dataclass(frozen=True)
+class SM12XCompressedMLAScratchPlan:
+    caps: SM12XCompressedMLAScratchCaps
+    layout: _SM12XCompressedMLAScratchLayout
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        q: torch.Tensor,
+        swa_indices: torch.Tensor,
+        swa_lengths: torch.Tensor,
+        indexed_indices: torch.Tensor | None = None,
+        indexed_lengths: torch.Tensor | None = None,
+        indexed_page_table: torch.Tensor | None = None,
+    ) -> SM12XCompressedMLABinding:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="compressed MLA",
+        )
+        scratch_views = _materialize_compressed_mla_scratch(
+            self.caps,
+            scratch_storage,
+            self.layout,
+        )
+        return build_compressed_mla_binding(
+            scratch=scratch_views,
+            q=q,
+            swa_indices=swa_indices,
+            swa_lengths=swa_lengths,
+            indexed_indices=indexed_indices,
+            indexed_lengths=indexed_lengths,
+            indexed_page_table=indexed_page_table,
+        )
+
+
+def plan_compressed_mla_scratch(
+    caps: SM12XCompressedMLAScratchCaps,
+) -> SM12XCompressedMLAScratchPlan:
+    layout = _compressed_mla_scratch_layout(caps)
+    return SM12XCompressedMLAScratchPlan(
+        caps=caps,
+        layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "compressed_mla.scratch",
+                nbytes=int(layout.nbytes),
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+__all__ = [
+    "ScratchBufferSpec",
+    "SM12XCompressedMLABinding",
+    "SM12XCompressedMLAScratch",
+    "SM12XCompressedMLAScratchCaps",
+    "SM12XCompressedMLAScratchPlan",
+    "build_compressed_mla_binding",
+    "plan_compressed_mla_scratch",
+]

--- a/flashinfer/experimental/sm12x/attention/compressed_mla/api.py
+++ b/flashinfer/experimental/sm12x/attention/compressed_mla/api.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for attention.compressed_mla (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from .._shared.mla.api import (
+    clear_mla_caches as clear_caches,
+)
+from .._shared.mla.compressed_api import (
+    compressed_mla_decode_forward as run,
+)
+from .._shared.mla.compressed_api import (
+    compressed_mla_split_chunks_for_contract as split_chunks_for_contract,
+)
+from ._scratch import (
+    SM12XCompressedMLABinding as Binding,
+)
+from ._scratch import (
+    SM12XCompressedMLAScratch as Scratch,
+)
+from ._scratch import (
+    SM12XCompressedMLAScratchCaps as Caps,
+)
+from ._scratch import (
+    SM12XCompressedMLAScratchPlan as Plan,
+)
+from ._scratch import (
+    plan_compressed_mla_scratch as plan,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "Binding",
+    "Scratch",
+    "plan",
+    "bind",
+    "run",
+    "split_chunks_for_contract",
+    "is_supported",
+    "clear_caches",
+]

--- a/flashinfer/experimental/sm12x/attention/compressed_mla/reference.py
+++ b/flashinfer/experimental/sm12x/attention/compressed_mla/reference.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-torch compressed-MLA semantics (re-export; the implementation lives
+with the shared MLA core it describes)."""
+
+from .._shared.mla.compressed_reference import *  # noqa: F403

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/__init__.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""NSA indexer for SM12x: the index stage of Native Sparse Attention.
+
+A three-stage pipeline whose outputs feed ``attention.sparse_mla`` /
+``attention.compressed_mla``:
+
+1. quantize — ``quantize_q_fp8`` (index-Q to FP8 e4m3, MXFP8 tiling;
+   INDEX_HEAD_DIM 128).
+2. score — MQA logits between index-Q and the FP8 index-K cache:
+   ``logits_paged`` / ``logits_contiguous``, block-score reduction via
+   ``block_scores_paged`` / ``block_scores_contiguous``.
+3. select — ``topk_blocks`` / ``topk_tiled`` and the q2k index builders
+   ``q2k_indices_decode`` / ``q2k_indices_prefill`` (+ query-position
+   helpers).
+
+Planning: one ``Caps``/``plan`` pair sizes the caller-owned scratch; facet
+binds produce ``PagedBinding`` / ``ContiguousBinding`` / ``MSAPagedBinding``
+/ ``MSAContiguousBinding`` (views only, capture safe). ``plan_paged_schedule``
+builds the paged-MQA schedule metadata. The persistent top-k-2048 selector
+ships as its own facet (``*_persistent_topk2048``). Paged index-K packing
+helpers (``PagedMetadata``, ``prepare_paged_metadata``, ``index_topk_fp8``)
+round out the cache-side contract.
+
+Pure-torch semantics live in ``reference.py`` and ``msa_reference.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="nsa_indexer",
+    group="attention",
+    api_style="planned",
+    entry_points=(
+        # planning + scratch
+        "Caps",
+        "Plan",
+        "PagedScratch",
+        "ContiguousScratch",
+        "PagedBinding",
+        "ContiguousBinding",
+        "MSAPagedBinding",
+        "MSAContiguousBinding",
+        "plan",
+        "bind_paged",
+        "bind_contiguous",
+        "bind_msa_paged",
+        "bind_msa_contiguous",
+        # stage 1: quantize
+        "quantize_q_fp8",
+        # stage 2: score
+        "logits_paged",
+        "logits_contiguous",
+        "block_scores_paged",
+        "block_scores_contiguous",
+        "ScoreMode",
+        "OutputMode",
+        # stage 3: select
+        "topk_blocks",
+        "topk_tiled",
+        "q2k_indices_decode",
+        "q2k_indices_prefill",
+        "query_positions_decode",
+        "query_positions_prefill",
+        "resolve_contiguous_prefill_block_k",
+        # paged schedule + cache-side contract
+        "plan_paged_schedule",
+        "uses_paged_schedule",
+        "PagedMetadata",
+        "PagedDecodeMetadata",
+        "ContiguousMetadata",
+        "prepare_paged_metadata",
+        "index_topk_fp8",
+        "resolve_local_num_q_heads",
+        "resolve_replicated_num_q_heads",
+        "INDEX_HEAD_DIM",
+        "PAGED_INDEX_PAGE_SIZE",
+        "SOURCE_LAYOUT_PAGED",
+        "SOURCE_LAYOUT_CONTIGUOUS",
+        # persistent top-k facet
+        "PersistentTopK2048Caps",
+        "PersistentTopK2048Plan",
+        "PersistentTopK2048Binding",
+        "plan_persistent_topk2048",
+        "bind_persistent_topk2048",
+        "run_persistent_topk2048",
+        "supports_persistent_topk2048",
+        "persistent_topk2048_scratch_nbytes",
+        # maintenance
+        "is_supported",
+        "clear_caches",
+    ),
+    dtypes=("bf16", "fp8_e4m3"),
+    recipes=("dsv4", "glm_nsa", "msa"),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/attention/indexer/",),
+    ),
+    test_path="tests/experimental/attention/test_nsa_indexer.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import *  # noqa: F401,F403
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/_impl.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/_impl.py
@@ -1,0 +1,1882 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/api.py @ 118a3b70 (2026-06-12) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""NSA indexer API for paged and contiguous logits contracts."""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+import torch
+
+from .kernel import (
+    IndexerScoreMode,
+    IndexerOutputMode,
+    PAGED_MQA_LOGITS_SCHEDULE_PAGES_PER_SPLIT,
+    _should_use_schedule_multi_row_kernel,
+    clear_indexer_kernel_cache,
+    _should_use_schedule_single_row_kernel,
+    run_paged_logits_kernel,
+    supports_paged_logits_kernel,
+)
+from .contiguous_kernel import (
+    _PREFILL512_BLOCK_K,
+    _PREFILL512_BLOCK_Q,
+    _PREFILL_BLOCK_K,
+    _PREFILL_BLOCK_Q,
+    build_indexer_contiguous_logits_kernel_binding,
+    resolve_contiguous_prefill_block_k,
+    run_contiguous_block_scores_kernel,
+    run_contiguous_logits_kernel,
+    supports_contiguous_logits_kernel,
+)
+from .msa_reference import (
+    MSA_BLOCK_TOKENS,
+    MSA_SM_SCALE,
+    MSA_TOPK_BLOCKS,
+    msa_contiguous_block_scores_reference,
+    msa_paged_decode_block_scores_reference,
+    quantize_msa_q_fp8_reference,
+)
+from .reference import contiguous_logits_reference
+from .schedule_metadata import (
+    build_paged_mqa_schedule_metadata_torch,
+    build_paged_mqa_schedule_metadata_triton,
+)
+from .tiled_topk import (
+    _resolve_supertile_k,
+    clear_tiled_topk_kernel_cache,
+    run_tiled_topk,
+)
+from .persistent_topk import clear_persistent_topk2048_kernel_cache
+
+
+_INDEX_HEAD_DIM = 128
+_INT32_MAX = torch.iinfo(torch.int32).max
+_VALIDATE_PAGE_IDS = bool(
+    int(os.getenv("FLASHINFER_EXP_SM12X_NSA_VALIDATE_PAGE_IDS", "0"))
+)
+
+
+def _is_cuda_graph_capture_active(device: torch.device) -> bool:
+    return device.type == "cuda" and torch.cuda.is_current_stream_capturing()
+
+
+@dataclass(frozen=True)
+class IndexerPagedDecodeMetadata:
+    real_page_table: torch.Tensor
+    cache_seqlens_int32: torch.Tensor
+    paged_mqa_schedule_metadata: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class IndexerContiguousMetadata:
+    k_start: torch.Tensor
+    k_end: torch.Tensor
+
+
+def build_paged_mqa_schedule_metadata(
+    context_lens: torch.Tensor,
+    block_kv: int,
+    num_sms: int | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build paged-MQA schedule metadata on the input device."""
+
+    if context_lens.ndim not in (1, 2):
+        raise ValueError(
+            f"context_lens must be rank-1 or rank-2, got {tuple(context_lens.shape)}"
+        )
+    if context_lens.ndim == 2 and context_lens.shape[1] == 0:
+        raise ValueError(
+            "context_lens rank-2 input must have a non-empty trailing dimension"
+        )
+    if context_lens.dtype != torch.int32:
+        raise ValueError(
+            f"context_lens must have dtype torch.int32, got {context_lens.dtype}"
+        )
+    if not context_lens.is_contiguous():
+        raise ValueError("context_lens must be contiguous")
+    if block_kv <= 0:
+        raise ValueError(f"block_kv must be positive, got {block_kv}")
+    if out is not None:
+        if out.ndim != 2 or out.shape[1] != 2:
+            raise ValueError(
+                f"out must have shape (num_sms + 1, 2), got {tuple(out.shape)}"
+            )
+        if out.dtype != torch.int32:
+            raise ValueError(f"out must have dtype torch.int32, got {out.dtype}")
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
+        if out.device != context_lens.device:
+            raise ValueError(
+                f"out device {out.device} does not match context_lens device {context_lens.device}"
+            )
+        if num_sms is None:
+            num_sms = out.shape[0] - 1
+    if num_sms is None:
+        if context_lens.device.type == "cuda":
+            num_sms = torch.cuda.get_device_properties(
+                context_lens.device
+            ).multi_processor_count
+        else:
+            num_sms = 1
+    if num_sms <= 0:
+        raise ValueError(f"num_sms must be positive, got {num_sms}")
+    if out is not None and out.shape[0] != num_sms + 1:
+        raise ValueError(
+            f"out leading dimension {out.shape[0]} does not match num_sms + 1 ({num_sms + 1})"
+        )
+
+    schedule = out
+    if schedule is None:
+        schedule = torch.empty(
+            (num_sms + 1, 2),
+            dtype=torch.int32,
+            device=context_lens.device,
+        )
+    builder = (
+        build_paged_mqa_schedule_metadata_triton
+        if context_lens.device.type == "cuda"
+        else build_paged_mqa_schedule_metadata_torch
+    )
+    return builder(
+        context_lens,
+        block_kv=block_kv,
+        num_sms=num_sms,
+        pages_per_split=PAGED_MQA_LOGITS_SCHEDULE_PAGES_PER_SPLIT,
+        out=schedule,
+    )
+
+
+def clear_indexer_caches() -> None:
+    """Clear any cached NSA indexer runtime state."""
+    clear_indexer_kernel_cache()
+    clear_tiled_topk_kernel_cache()
+    clear_persistent_topk2048_kernel_cache()
+    _cached_width_cap_tensor.cache_clear()
+
+
+def uses_paged_mqa_schedule(
+    *,
+    q_rows: int,
+    max_pages: int,
+) -> bool:
+    """Return whether decode should use a schedule-driven scorer path."""
+    return _should_use_schedule_single_row_kernel(
+        q_rows=q_rows,
+        max_pages=max_pages,
+    ) or _should_use_schedule_multi_row_kernel(
+        q_rows=q_rows,
+        max_pages=max_pages,
+    )
+
+
+def _normalize_weights(
+    weights: torch.Tensor,
+    *,
+    q_rows: int,
+    num_heads: int,
+    require_float32: bool = False,
+) -> torch.Tensor:
+    if weights.ndim == 3:
+        if weights.shape[2] != 1:
+            raise ValueError(
+                f"weights rank-3 input must have trailing dimension 1, got {tuple(weights.shape)}"
+            )
+        weights = weights.squeeze(2)
+    if weights.ndim != 2:
+        raise ValueError(
+            f"weights must be rank-2 or rank-3, got {tuple(weights.shape)}"
+        )
+    if weights.shape != (q_rows, num_heads):
+        raise ValueError(
+            f"weights shape must be {(q_rows, num_heads)}, got {tuple(weights.shape)}"
+        )
+    if require_float32 and weights.dtype != torch.float32:
+        raise ValueError(
+            f"strict indexer contiguous requires torch.float32 weights, got {weights.dtype}"
+        )
+    return weights.to(torch.float32)
+
+
+@lru_cache(maxsize=64)
+def _cached_width_cap_tensor(
+    width: int,
+    device_type: str,
+    device_index: int | None,
+) -> torch.Tensor:
+    return torch.tensor(
+        [width], dtype=torch.int32, device=torch.device(device_type, device_index)
+    )
+
+
+def _make_active_width_tensor(
+    *,
+    seqlens_per_query: torch.Tensor,
+    width: int,
+) -> torch.Tensor:
+    if seqlens_per_query.ndim != 1:
+        raise ValueError(
+            "seqlens_per_query must be rank-1 when computing active width, got "
+            f"{tuple(seqlens_per_query.shape)}"
+        )
+    active_width = seqlens_per_query.amax().reshape(1)
+    if _is_cuda_graph_capture_active(seqlens_per_query.device):
+        return active_width.clamp_(min=0, max=int(width))
+    width_cap = _cached_width_cap_tensor(
+        int(width),
+        seqlens_per_query.device.type,
+        seqlens_per_query.device.index,
+    )
+    return torch.minimum(active_width, width_cap)
+
+
+def quantize_msa_q_fp8(q: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize MSA index-Q rows into the production FP8+scale contract."""
+
+    return quantize_msa_q_fp8_reference(q)
+
+
+def msa_decode_query_positions(cache_seqlens_int32: torch.Tensor) -> torch.Tensor:
+    """Return decode query token positions from cache lengths."""
+
+    if cache_seqlens_int32.ndim != 1:
+        raise ValueError(
+            f"cache_seqlens_int32 must be rank-1, got {tuple(cache_seqlens_int32.shape)}"
+        )
+    if cache_seqlens_int32.dtype != torch.int32:
+        raise ValueError(
+            f"cache_seqlens_int32 must have dtype torch.int32, got {cache_seqlens_int32.dtype}"
+        )
+    return cache_seqlens_int32 - 1
+
+
+def msa_prefill_query_positions(
+    cu_seqlens_q: torch.Tensor,
+    total_q: int,
+) -> torch.Tensor:
+    """Return packed prefill query token positions."""
+
+    if cu_seqlens_q.ndim != 1:
+        raise ValueError(
+            f"cu_seqlens_q must be rank-1, got {tuple(cu_seqlens_q.shape)}"
+        )
+    if cu_seqlens_q.dtype != torch.int32:
+        raise ValueError(
+            f"cu_seqlens_q must have dtype torch.int32, got {cu_seqlens_q.dtype}"
+        )
+    total_q = int(total_q)
+    if total_q < 0:
+        raise ValueError(f"total_q must be non-negative, got {total_q}")
+    return torch.arange(total_q, dtype=torch.int32, device=cu_seqlens_q.device)
+
+
+def _validate_msa_block_scores_selection(
+    *,
+    block_scores: torch.Tensor,
+    query_positions: torch.Tensor,
+    block_base: torch.Tensor | None,
+    topk: int,
+    out_indices: torch.Tensor | None,
+) -> tuple[int, int, int]:
+    if block_scores.ndim != 3:
+        raise ValueError(
+            f"block_scores must be rank-3, got {tuple(block_scores.shape)}"
+        )
+    if block_scores.dtype != torch.float32:
+        raise ValueError(
+            f"block_scores must have dtype torch.float32, got {block_scores.dtype}"
+        )
+    num_heads, q_rows, num_blocks = map(int, block_scores.shape)
+    if query_positions.ndim != 1 or query_positions.shape[0] != q_rows:
+        raise ValueError(
+            f"query_positions must have shape ({q_rows},), got {tuple(query_positions.shape)}"
+        )
+    if query_positions.dtype != torch.int32:
+        raise ValueError(
+            f"query_positions must have dtype torch.int32, got {query_positions.dtype}"
+        )
+    if query_positions.device != block_scores.device:
+        raise ValueError("query_positions device must match block_scores")
+    if block_base is not None:
+        if block_base.ndim != 1 or block_base.shape[0] != q_rows:
+            raise ValueError(
+                f"block_base must have shape ({q_rows},), got {tuple(block_base.shape)}"
+            )
+        if block_base.dtype != torch.int32:
+            raise ValueError(
+                f"block_base must have dtype torch.int32, got {block_base.dtype}"
+            )
+        if block_base.device != block_scores.device:
+            raise ValueError("block_base device must match block_scores")
+    if out_indices is not None:
+        if out_indices.dtype != torch.int32:
+            raise ValueError(
+                f"out_indices must have dtype torch.int32, got {out_indices.dtype}"
+            )
+        if out_indices.device != block_scores.device:
+            raise ValueError("out_indices device must match block_scores")
+        if (
+            out_indices.ndim != 3
+            or out_indices.shape[0] < num_heads
+            or out_indices.shape[1] < q_rows
+            or out_indices.shape[2] < topk
+        ):
+            raise ValueError(
+                f"out_indices must have shape at least ({num_heads}, {q_rows}, {topk}), "
+                f"got {tuple(out_indices.shape)}"
+            )
+    return num_heads, q_rows, num_blocks
+
+
+def msa_topk_blocks(
+    *,
+    block_scores: torch.Tensor,
+    query_positions: torch.Tensor,
+    block_base: torch.Tensor | None = None,
+    topk: int = MSA_TOPK_BLOCKS,
+    out_indices: torch.Tensor | None = None,
+    score_scratch: torch.Tensor | None = None,
+    top_values: torch.Tensor | None = None,
+    top_indices: torch.Tensor | None = None,
+    sort_values: torch.Tensor | None = None,
+    sort_indices: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Select MSA block ids from raw block scores.
+
+    Output ids are ascending and batch-local when ``block_base`` is provided.
+    Invalid trailing entries are ``-1``.
+    """
+
+    topk = int(topk)
+    if topk < 0:
+        raise ValueError(f"topk must be non-negative, got {topk}")
+    num_heads, q_rows, num_blocks = _validate_msa_block_scores_selection(
+        block_scores=block_scores,
+        query_positions=query_positions,
+        block_base=block_base,
+        topk=topk,
+        out_indices=out_indices,
+    )
+    if out_indices is None:
+        result = torch.full(
+            (num_heads, q_rows, topk),
+            -1,
+            dtype=torch.int32,
+            device=block_scores.device,
+        )
+    else:
+        result = out_indices[:num_heads, :q_rows, :topk]
+        result.fill_(-1)
+    if topk == 0 or num_blocks == 0:
+        return result
+
+    if score_scratch is not None:
+        if (
+            score_scratch.dtype != torch.float32
+            or score_scratch.device != block_scores.device
+        ):
+            raise ValueError("score_scratch must be float32 on the block_scores device")
+        if (
+            score_scratch.ndim != 3
+            or score_scratch.shape[0] < num_heads
+            or score_scratch.shape[1] < q_rows
+            or score_scratch.shape[2] < num_blocks
+        ):
+            raise ValueError(
+                f"score_scratch must have shape at least ({num_heads}, {q_rows}, {num_blocks}), "
+                f"got {tuple(score_scratch.shape)}"
+            )
+        scores = score_scratch[:num_heads, :q_rows, :num_blocks]
+        scores.copy_(block_scores)
+    else:
+        scores = block_scores.clone()
+    local_blocks = torch.div(query_positions, MSA_BLOCK_TOKENS, rounding_mode="floor")
+    valid_local = (local_blocks >= 0) & (local_blocks < num_blocks)
+    scatter_idx = (
+        local_blocks.clamp(min=0, max=num_blocks - 1)
+        .to(torch.long)
+        .view(1, q_rows, 1)
+        .expand(num_heads, q_rows, 1)
+    )
+    current_local = torch.gather(scores, 2, scatter_idx)
+    force_values = torch.where(
+        valid_local.view(1, q_rows, 1),
+        torch.full_like(current_local, float("inf")),
+        current_local,
+    )
+    scores.scatter_(2, scatter_idx, force_values)
+
+    gather_k = min(topk, num_blocks)
+    topk_out = None
+    if top_values is not None or top_indices is not None:
+        if top_values is None or top_indices is None:
+            raise ValueError("top_values and top_indices must be provided together")
+        if (
+            top_values.dtype != torch.float32
+            or top_values.device != block_scores.device
+        ):
+            raise ValueError("top_values must be float32 on the block_scores device")
+        if (
+            top_indices.dtype != torch.int64
+            or top_indices.device != block_scores.device
+        ):
+            raise ValueError("top_indices must be int64 on the block_scores device")
+        if (
+            top_values.ndim != 3
+            or top_indices.ndim != 3
+            or top_values.shape[0] < num_heads
+            or top_values.shape[1] < q_rows
+            or top_values.shape[2] < gather_k
+            or top_indices.shape[0] < num_heads
+            or top_indices.shape[1] < q_rows
+            or top_indices.shape[2] < gather_k
+        ):
+            raise ValueError("top-k scratch tensors are too small")
+        topk_out = (
+            top_values[:num_heads, :q_rows, :gather_k],
+            top_indices[:num_heads, :q_rows, :gather_k],
+        )
+    top_values, top_indices = torch.topk(
+        scores,
+        k=gather_k,
+        dim=2,
+        largest=True,
+        sorted=False,
+        out=topk_out,
+    )
+    if out_indices is not None:
+        local_indices = result[:, :, :gather_k]
+        local_indices.copy_(top_indices)
+        if block_base is not None:
+            local_indices.sub_(block_base.view(1, q_rows, 1))
+    elif sort_values is not None:
+        if (
+            sort_values.dtype != torch.int32
+            or sort_values.device != block_scores.device
+        ):
+            raise ValueError("sort_values must be int32 on the block_scores device")
+        if (
+            sort_values.ndim != 3
+            or sort_values.shape[0] < num_heads
+            or sort_values.shape[1] < q_rows
+            or sort_values.shape[2] < gather_k
+        ):
+            raise ValueError("sort_values scratch tensor is too small")
+        local_indices = sort_values[:num_heads, :q_rows, :gather_k]
+        local_indices.copy_(top_indices)
+        if block_base is not None:
+            local_indices.sub_(block_base.view(1, q_rows, 1))
+    else:
+        local_indices = top_indices.to(torch.int32)
+        if block_base is not None:
+            local_indices = local_indices - block_base.view(1, q_rows, 1)
+    valid = (top_values > float("-inf")) & (local_indices >= 0)
+    local_indices.masked_fill_(~valid, _INT32_MAX)
+    sort_out = None
+    if sort_values is not None and sort_indices is not None:
+        if (
+            sort_indices.dtype != torch.int64
+            or sort_indices.device != block_scores.device
+        ):
+            raise ValueError("sort_indices must be int64 on the block_scores device")
+        if (
+            sort_indices.ndim != 3
+            or sort_indices.shape[0] < num_heads
+            or sort_indices.shape[1] < q_rows
+            or sort_indices.shape[2] < gather_k
+        ):
+            raise ValueError("sort_indices scratch tensor is too small")
+        sort_out = (
+            sort_values[:num_heads, :q_rows, :gather_k],
+            sort_indices[:num_heads, :q_rows, :gather_k],
+        )
+    if sort_out is None:
+        sorted_indices = torch.sort(local_indices, dim=2).values
+    else:
+        sorted_indices = torch.sort(local_indices, dim=2, out=sort_out).values
+    sorted_indices.masked_fill_(sorted_indices == _INT32_MAX, -1)
+    result[:, :, :gather_k].copy_(sorted_indices)
+    return result
+
+
+def _validate_paged_decode_inputs(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    real_page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    paged_mqa_schedule_metadata: torch.Tensor | None,
+) -> torch.Tensor:
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"q_fp8 head_dim must be {_INDEX_HEAD_DIM}, got {q_fp8.shape[2]}"
+        )
+    if real_page_table.ndim != 2:
+        raise ValueError(
+            f"real_page_table must be rank-2, got {tuple(real_page_table.shape)}"
+        )
+    if real_page_table.dtype != torch.int32:
+        raise ValueError(
+            f"real_page_table must have dtype torch.int32, got {real_page_table.dtype}"
+        )
+    if cache_seqlens_int32.ndim != 1:
+        raise ValueError(
+            "cache_seqlens_int32 must be rank-1, got "
+            f"{tuple(cache_seqlens_int32.shape)}"
+        )
+    if real_page_table.shape[0] != cache_seqlens_int32.shape[0]:
+        raise ValueError(
+            f"real_page_table rows {real_page_table.shape[0]} do not match "
+            f"cache_seqlens rows {cache_seqlens_int32.shape[0]}"
+        )
+    if real_page_table.shape[0] > q_fp8.shape[0]:
+        raise ValueError(
+            f"real_page_table rows {real_page_table.shape[0]} exceed q rows {q_fp8.shape[0]}"
+        )
+    if real_page_table.device != q_fp8.device:
+        raise ValueError(
+            f"real_page_table device {real_page_table.device} does not match q_fp8 device {q_fp8.device}"
+        )
+    if cache_seqlens_int32.device != q_fp8.device:
+        raise ValueError(
+            f"cache_seqlens_int32 device {cache_seqlens_int32.device} does not match "
+            f"q_fp8 device {q_fp8.device}"
+        )
+    if paged_mqa_schedule_metadata is not None:
+        if paged_mqa_schedule_metadata.ndim != 2:
+            raise ValueError(
+                "paged_mqa_schedule_metadata must be rank-2, got "
+                f"{tuple(paged_mqa_schedule_metadata.shape)}"
+            )
+        if paged_mqa_schedule_metadata.shape[1] != 2:
+            raise ValueError(
+                "paged_mqa_schedule_metadata trailing dimension must be 2, got "
+                f"{tuple(paged_mqa_schedule_metadata.shape)}"
+            )
+        if paged_mqa_schedule_metadata.shape[0] < 2:
+            raise ValueError(
+                "paged_mqa_schedule_metadata must have at least two rows, got "
+                f"{tuple(paged_mqa_schedule_metadata.shape)}"
+            )
+        if paged_mqa_schedule_metadata.dtype != torch.int32:
+            raise ValueError(
+                "paged_mqa_schedule_metadata must have dtype torch.int32, got "
+                f"{paged_mqa_schedule_metadata.dtype}"
+            )
+        if not paged_mqa_schedule_metadata.is_contiguous():
+            raise ValueError("paged_mqa_schedule_metadata must be contiguous")
+        if paged_mqa_schedule_metadata.device != q_fp8.device:
+            raise ValueError(
+                "paged_mqa_schedule_metadata device "
+                f"{paged_mqa_schedule_metadata.device} does not match q_fp8 device {q_fp8.device}"
+            )
+    return _normalize_weights(weights, q_rows=q_fp8.shape[0], num_heads=q_fp8.shape[1])
+
+
+def paged_decode_logits(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    metadata: IndexerPagedDecodeMetadata | None = None,
+    page_size: int = 64,
+    preinitialize_invalid_logits: bool = True,
+    active_width_override: torch.Tensor | None = None,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    binding=None,
+) -> torch.Tensor:
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("metadata", metadata),
+                ("active_width_override", active_width_override),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "paged indexer binding owns metadata, scratch, and active width; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        metadata = binding.metadata
+        active_width_override = binding.active_width
+    if metadata is None:
+        raise TypeError("paged_decode_logits requires metadata or binding")
+    score_mode = int(score_mode)
+    if score_mode not in (IndexerScoreMode.NSA_RELU_SUM, IndexerScoreMode.MSA_BILINEAR):
+        raise ValueError(f"unsupported indexer score_mode {score_mode}")
+
+    weights_f = _validate_paged_decode_inputs(
+        q_fp8=q_fp8,
+        weights=weights,
+        real_page_table=metadata.real_page_table,
+        cache_seqlens_int32=metadata.cache_seqlens_int32,
+        paged_mqa_schedule_metadata=metadata.paged_mqa_schedule_metadata,
+    )
+
+    valid_q_rows = metadata.real_page_table.shape[0]
+    full_q_rows = q_fp8.shape[0]
+    width_tokens = metadata.real_page_table.shape[1] * page_size
+    if valid_q_rows == 0 or width_tokens == 0:
+        return torch.full(
+            (full_q_rows, width_tokens),
+            float("-inf"),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+
+    seqlens_valid = metadata.cache_seqlens_int32.contiguous()
+    if active_width_override is None:
+        active_width = _make_active_width_tensor(
+            seqlens_per_query=seqlens_valid, width=width_tokens
+        )
+    else:
+        if active_width_override.shape != (1,):
+            raise ValueError(
+                f"active_width_override must have shape (1,), got {tuple(active_width_override.shape)}"
+            )
+        if active_width_override.dtype != torch.int32:
+            raise ValueError(
+                "active_width_override must have dtype torch.int32, got "
+                f"{active_width_override.dtype}"
+            )
+        if active_width_override.device != q_fp8.device:
+            raise ValueError(
+                "active_width_override device "
+                f"{active_width_override.device} does not match q_fp8 device {q_fp8.device}"
+            )
+        active_width = active_width_override
+
+    validate_page_ids = q_fp8.device.type != "cuda" or (
+        _VALIDATE_PAGE_IDS and not _is_cuda_graph_capture_active(q_fp8.device)
+    )
+    if validate_page_ids:
+        active_width_host = min(width_tokens, int(active_width.item()))
+        if active_width_host > 0:
+            max_page_capacity = index_k_cache.shape[0]
+            positions = torch.arange(
+                active_width_host,
+                dtype=torch.int32,
+                device=q_fp8.device,
+            ).unsqueeze(0)
+            page_cols = torch.div(positions, page_size, rounding_mode="floor").to(
+                torch.long
+            )
+            page_cols = page_cols.expand(valid_q_rows, -1)
+            candidate_pages = metadata.real_page_table.gather(1, page_cols)
+            candidate_valid_mask = (positions < seqlens_valid.unsqueeze(1)) & (
+                candidate_pages >= 0
+            )
+            overflow_mask = candidate_valid_mask & (
+                candidate_pages >= max_page_capacity
+            )
+            if torch.any(overflow_mask):
+                bad = int(candidate_pages[overflow_mask].max().item())
+                raise ValueError(
+                    f"real_page_table page id {bad} exceeds index_k_cache page capacity {max_page_capacity}"
+                )
+
+    if not supports_paged_logits_kernel(
+        q_fp8=q_fp8[:valid_q_rows],
+        weights=weights_f[:valid_q_rows],
+        index_k_cache=index_k_cache,
+        real_page_table=metadata.real_page_table,
+        seqlens_per_query=seqlens_valid,
+        page_size=page_size,
+    ):
+        raise NotImplementedError(
+            "SM12X sparse NSA paged logits requires the production CUDA FP8 "
+            "kernel contract; refusing to run the reference fallback. "
+            f"q_fp8 shape={tuple(q_fp8.shape)} dtype={q_fp8.dtype} "
+            f"device={q_fp8.device}, weights shape={tuple(weights_f.shape)} "
+            f"dtype={weights_f.dtype}, index_k_cache shape={tuple(index_k_cache.shape)} "
+            f"dtype={index_k_cache.dtype}, real_page_table shape="
+            f"{tuple(metadata.real_page_table.shape)} dtype="
+            f"{metadata.real_page_table.dtype}, cache_seqlens shape="
+            f"{tuple(seqlens_valid.shape)} dtype={seqlens_valid.dtype}, "
+            f"page_size={page_size}"
+        )
+
+    schedule_metadata = None
+    if uses_paged_mqa_schedule(
+        q_rows=valid_q_rows,
+        max_pages=int(metadata.real_page_table.shape[1]),
+    ):
+        schedule_metadata = metadata.paged_mqa_schedule_metadata
+        if schedule_metadata is None:
+            if _is_cuda_graph_capture_active(q_fp8.device):
+                raise ValueError(
+                    "paged_mqa_schedule_metadata must be precomputed before CUDA graph capture "
+                    "for the scheduled decode path"
+                )
+            schedule_metadata = build_paged_mqa_schedule_metadata(
+                seqlens_valid, page_size
+            )
+    logits_valid = run_paged_logits_kernel(
+        q_fp8=q_fp8[:valid_q_rows],
+        weights=weights_f[:valid_q_rows],
+        index_k_cache=index_k_cache,
+        real_page_table=metadata.real_page_table,
+        seqlens_per_query=seqlens_valid,
+        schedule_metadata=schedule_metadata,
+        active_width=active_width,
+        page_size=page_size,
+        preinitialize_invalid_logits=preinitialize_invalid_logits,
+        score_mode=score_mode,
+    )
+    if valid_q_rows == full_q_rows:
+        return logits_valid
+
+    logits = torch.full(
+        (full_q_rows, width_tokens),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    logits[:valid_q_rows].copy_(logits_valid)
+    return logits
+
+
+def _validate_msa_q_inputs(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+) -> tuple[int, int]:
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"q_fp8 head_dim must be {_INDEX_HEAD_DIM}, got {q_fp8.shape[2]}"
+        )
+    if q_fp8.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            f"q_fp8 must have dtype torch.float8_e4m3fn, got {q_fp8.dtype}"
+        )
+    if q_scale.ndim != 2 or q_scale.shape != q_fp8.shape[:2]:
+        raise ValueError(
+            f"q_scale must have shape {tuple(q_fp8.shape[:2])}, got {tuple(q_scale.shape)}"
+        )
+    if q_scale.dtype != torch.float32:
+        raise ValueError(f"q_scale must have dtype torch.float32, got {q_scale.dtype}")
+    if q_scale.device != q_fp8.device:
+        raise ValueError("q_scale device must match q_fp8")
+    return int(q_fp8.shape[0]), int(q_fp8.shape[1])
+
+
+def _validate_msa_block_scores_out(
+    *,
+    out: torch.Tensor | None,
+    num_heads: int,
+    q_rows: int,
+    num_blocks: int,
+    device: torch.device,
+) -> torch.Tensor | None:
+    if out is None:
+        return None
+    if out.dtype != torch.float32:
+        raise ValueError(f"out must have dtype torch.float32, got {out.dtype}")
+    if out.device != device:
+        raise ValueError("out device must match q_fp8")
+    if (
+        out.ndim != 3
+        or out.shape[0] < num_heads
+        or out.shape[1] < q_rows
+        or out.shape[2] < num_blocks
+    ):
+        raise ValueError(
+            f"out must have shape at least ({num_heads}, {q_rows}, {num_blocks}), "
+            f"got {tuple(out.shape)}"
+        )
+    return out[:num_heads, :q_rows, :num_blocks]
+
+
+def msa_paged_decode_block_scores(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    metadata: IndexerPagedDecodeMetadata | None = None,
+    page_size: int = 64,
+    out: torch.Tensor | None = None,
+    binding=None,
+) -> torch.Tensor:
+    """Score MSA decode candidates and max-pool over 128-token KV blocks."""
+
+    active_width_override = None
+    page_scores_scratch = None
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("metadata", metadata),
+                ("out", out),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "MSA paged binding owns metadata and block-score buffers; do not also pass "
+                f"{', '.join(extras)}"
+            )
+        metadata = binding.metadata
+        active_width_override = getattr(binding, "active_width", None)
+        page_scores_scratch = getattr(binding, "page_scores", None)
+        out = getattr(binding, "block_scores", None)
+    if metadata is None:
+        raise TypeError("msa_paged_decode_block_scores requires metadata or binding")
+    q_rows, num_heads = _validate_msa_q_inputs(q_fp8=q_fp8, q_scale=q_scale)
+    if metadata.real_page_table.ndim != 2:
+        raise ValueError(
+            f"real_page_table must be rank-2, got {tuple(metadata.real_page_table.shape)}"
+        )
+    if metadata.cache_seqlens_int32.ndim != 1:
+        raise ValueError(
+            "cache_seqlens_int32 must be rank-1, got "
+            f"{tuple(metadata.cache_seqlens_int32.shape)}"
+        )
+    valid_q_rows = int(metadata.real_page_table.shape[0])
+    if metadata.cache_seqlens_int32.shape[0] != valid_q_rows:
+        raise ValueError("real_page_table rows must match cache_seqlens_int32")
+    if valid_q_rows > q_rows:
+        raise ValueError(
+            f"metadata describes {valid_q_rows} q rows, but q_fp8 has {q_rows}"
+        )
+    width_tokens = int(metadata.real_page_table.shape[1]) * int(page_size)
+    num_blocks = math.ceil(width_tokens / MSA_BLOCK_TOKENS)
+    out_view = _validate_msa_block_scores_out(
+        out=out,
+        num_heads=num_heads,
+        q_rows=q_rows,
+        num_blocks=num_blocks,
+        device=q_fp8.device,
+    )
+    if out_view is None:
+        block_scores = torch.full(
+            (num_heads, q_rows, num_blocks),
+            float("-inf"),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+    else:
+        block_scores = out_view
+        block_scores.fill_(float("-inf"))
+    if valid_q_rows == 0 or width_tokens == 0:
+        return block_scores
+
+    if q_fp8.device.type != "cuda":
+        ref = msa_paged_decode_block_scores_reference(
+            q_fp8=q_fp8,
+            q_scale=q_scale,
+            index_k_cache=index_k_cache,
+            real_page_table=metadata.real_page_table,
+            cache_seqlens_int32=metadata.cache_seqlens_int32,
+            page_size=page_size,
+        )
+        block_scores.copy_(ref[:, :q_rows, :num_blocks])
+        return block_scores
+
+    max_pages = int(metadata.real_page_table.shape[1])
+    use_page_max = os.getenv(
+        "FLASHINFER_EXP_SM12X_MSA_DECODE_PAGEMAX", "1"
+    ) != "0" and uses_paged_mqa_schedule(q_rows=valid_q_rows, max_pages=max_pages)
+    if use_page_max:
+        weights = q_scale[:valid_q_rows].contiguous() * MSA_SM_SCALE
+        seqlens_valid = metadata.cache_seqlens_int32.contiguous()
+        if active_width_override is None:
+            active_width = _make_active_width_tensor(
+                seqlens_per_query=seqlens_valid,
+                width=width_tokens,
+            )
+        else:
+            active_width = active_width_override
+        schedule_metadata = metadata.paged_mqa_schedule_metadata
+        if schedule_metadata is None:
+            if _is_cuda_graph_capture_active(q_fp8.device):
+                raise ValueError(
+                    "paged_mqa_schedule_metadata must be precomputed before CUDA graph capture "
+                    "for MSA scheduled page-max decode"
+                )
+            schedule_metadata = build_paged_mqa_schedule_metadata(
+                seqlens_valid, page_size
+            )
+        page_scores = run_paged_logits_kernel(
+            q_fp8=q_fp8[:valid_q_rows],
+            weights=weights,
+            index_k_cache=index_k_cache,
+            real_page_table=metadata.real_page_table,
+            seqlens_per_query=seqlens_valid,
+            schedule_metadata=schedule_metadata,
+            active_width=active_width,
+            page_size=page_size,
+            preinitialize_invalid_logits=True,
+            score_mode=IndexerScoreMode.MSA_BILINEAR,
+            output_mode=IndexerOutputMode.PAGE_HEAD_MAX,
+            page_scores=page_scores_scratch,
+        )
+        paired = page_scores.view(num_heads, valid_q_rows, -1, 2).amax(dim=3)
+        block_scores[:, :valid_q_rows, :].copy_(paired[:, :, :num_blocks])
+        return block_scores
+
+    q_expanded = (
+        q_fp8[:valid_q_rows]
+        .contiguous()
+        .reshape(
+            valid_q_rows * num_heads,
+            1,
+            _INDEX_HEAD_DIM,
+        )
+    )
+    weights = (
+        q_scale[:valid_q_rows].contiguous().reshape(valid_q_rows * num_heads, 1)
+        * MSA_SM_SCALE
+    )
+    metadata_expanded = IndexerPagedDecodeMetadata(
+        real_page_table=metadata.real_page_table.repeat_interleave(num_heads, dim=0),
+        cache_seqlens_int32=metadata.cache_seqlens_int32.repeat_interleave(num_heads),
+        paged_mqa_schedule_metadata=None,
+    )
+    token_logits = paged_decode_logits(
+        q_fp8=q_expanded,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        metadata=metadata_expanded,
+        page_size=page_size,
+        preinitialize_invalid_logits=True,
+        score_mode=IndexerScoreMode.MSA_BILINEAR,
+    )
+    padded_width = num_blocks * MSA_BLOCK_TOKENS
+    if padded_width != width_tokens:
+        pooled_input = torch.full(
+            (valid_q_rows * num_heads, padded_width),
+            float("-inf"),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+        pooled_input[:, :width_tokens].copy_(token_logits)
+    else:
+        pooled_input = token_logits
+    pooled = (
+        pooled_input.view(valid_q_rows, num_heads, num_blocks, MSA_BLOCK_TOKENS)
+        .amax(dim=3)
+        .permute(1, 0, 2)
+        .contiguous()
+    )
+    block_scores[:, :valid_q_rows, :].copy_(pooled)
+    return block_scores
+
+
+def msa_q2k_indices_decode(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    metadata: IndexerPagedDecodeMetadata | None = None,
+    topk: int = MSA_TOPK_BLOCKS,
+    out_indices: torch.Tensor | None = None,
+    binding=None,
+) -> torch.Tensor:
+    """Run MSA decode score, block max-pool, local forcing, and top-k selection."""
+
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("metadata", metadata),
+                ("out_indices", out_indices),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "MSA paged binding owns metadata and q2k output; do not also pass "
+                f"{', '.join(extras)}"
+            )
+        metadata = binding.metadata
+        if getattr(binding, "topk", None) is not None:
+            topk = int(binding.topk)
+        out_indices = getattr(binding, "q2k_indices", None)
+    if metadata is None:
+        raise TypeError("msa_q2k_indices_decode requires metadata or binding")
+    q_rows, num_heads = _validate_msa_q_inputs(q_fp8=q_fp8, q_scale=q_scale)
+    topk = int(topk)
+    if topk < 0:
+        raise ValueError(f"topk must be non-negative, got {topk}")
+    if out_indices is not None:
+        if out_indices.dtype != torch.int32:
+            raise ValueError(
+                f"out_indices must have dtype torch.int32, got {out_indices.dtype}"
+            )
+        if out_indices.device != q_fp8.device:
+            raise ValueError("out_indices device must match q_fp8")
+        if (
+            out_indices.ndim != 3
+            or out_indices.shape[0] < num_heads
+            or out_indices.shape[1] < q_rows
+            or out_indices.shape[2] < topk
+        ):
+            raise ValueError(
+                f"out_indices must have shape at least ({num_heads}, {q_rows}, {topk}), "
+                f"got {tuple(out_indices.shape)}"
+            )
+    valid_q_rows = int(metadata.real_page_table.shape[0])
+    if valid_q_rows > q_rows:
+        raise ValueError(
+            f"metadata describes {valid_q_rows} q rows, but q_fp8 has {q_rows}"
+        )
+    block_scores = msa_paged_decode_block_scores(
+        q_fp8=q_fp8,
+        q_scale=q_scale,
+        index_k_cache=index_k_cache,
+        metadata=None if binding is not None else metadata,
+        binding=binding,
+    )
+    if out_indices is None:
+        result = torch.full(
+            (num_heads, q_rows, topk),
+            -1,
+            dtype=torch.int32,
+            device=q_fp8.device,
+        )
+    else:
+        result = out_indices[:num_heads, :q_rows, :topk]
+        result.fill_(-1)
+    if valid_q_rows == 0:
+        return result
+    selected = msa_topk_blocks(
+        block_scores=block_scores[:, :valid_q_rows, :],
+        query_positions=msa_decode_query_positions(metadata.cache_seqlens_int32),
+        topk=topk,
+        out_indices=result[:, :valid_q_rows, :],
+        score_scratch=getattr(binding, "topk_score_scratch", None)
+        if binding is not None
+        else None,
+        top_values=getattr(binding, "topk_values", None)
+        if binding is not None
+        else None,
+        top_indices=getattr(binding, "topk_indices", None)
+        if binding is not None
+        else None,
+        sort_values=getattr(binding, "sort_values", None)
+        if binding is not None
+        else None,
+        sort_indices=getattr(binding, "sort_indices", None)
+        if binding is not None
+        else None,
+    )
+    if selected.data_ptr() != result[:, :valid_q_rows, :].data_ptr():
+        result[:, :valid_q_rows, :].copy_(selected)
+    return result
+
+
+def contiguous_logits(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    metadata: IndexerContiguousMetadata | None = None,
+    preinitialize_invalid_logits: bool = True,
+    tile_logits: torch.Tensor | None = None,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    binding=None,
+) -> torch.Tensor:
+    strict_binding = False
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("metadata", metadata),
+                ("tile_logits", tile_logits),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "indexer contiguous binding owns metadata, scratch, "
+                f"and tile logits; do not also pass {', '.join(extras)}"
+            )
+        strict_binding = bool(getattr(binding, "strict", False))
+        metadata = binding.metadata
+        tile_logits = binding.tile_logits
+    if metadata is None:
+        raise TypeError("contiguous_logits requires metadata or binding")
+    score_mode = int(score_mode)
+    if score_mode not in (IndexerScoreMode.NSA_RELU_SUM, IndexerScoreMode.MSA_BILINEAR):
+        raise ValueError(f"unsupported indexer score_mode {score_mode}")
+    k_start = metadata.k_start
+    k_end = metadata.k_end
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"q_fp8 head_dim must be {_INDEX_HEAD_DIM}, got {q_fp8.shape[2]}"
+        )
+    _normalize_weights(weights, q_rows=q_fp8.shape[0], num_heads=q_fp8.shape[1])
+    if k_start.ndim != 1 or k_end.ndim != 1:
+        raise ValueError(
+            f"k_start and k_end must be rank-1, got {tuple(k_start.shape)} and {tuple(k_end.shape)}"
+        )
+    if k_start.shape != k_end.shape:
+        raise ValueError(
+            f"k_start and k_end must have the same shape, got {tuple(k_start.shape)} vs {tuple(k_end.shape)}"
+        )
+    if k_start.device != q_fp8.device or k_end.device != q_fp8.device:
+        raise ValueError("k_start and k_end must be on the same device as q_fp8")
+
+    weights_f = _normalize_weights(
+        weights,
+        q_rows=q_fp8.shape[0],
+        num_heads=q_fp8.shape[1],
+        require_float32=strict_binding,
+    )
+    k_quant, k_scale = kv_fp8
+    if supports_contiguous_logits_kernel(
+        q_fp8=q_fp8,
+        weights=weights_f,
+        k_quant=k_quant,
+        k_scale=k_scale,
+        k_start=k_start,
+        k_end=k_end,
+    ):
+        result = run_contiguous_logits_kernel(
+            q_fp8=q_fp8,
+            weights=weights_f,
+            k_quant=k_quant,
+            k_scale=k_scale,
+            k_start=k_start,
+            k_end=k_end,
+            preinitialize_invalid_logits=preinitialize_invalid_logits,
+            tile_logits=tile_logits,
+            score_mode=score_mode,
+        )
+        return result
+
+    if score_mode != IndexerScoreMode.NSA_RELU_SUM:
+        raise NotImplementedError(
+            "contiguous_logits score_mode=MSA_BILINEAR requires the CUDA FP8 scorer contract"
+        )
+
+    return contiguous_logits_reference(
+        q_fp8=q_fp8,
+        weights=weights_f,
+        kv_fp8=kv_fp8,
+        k_start=k_start,
+        k_end=k_end,
+    )
+
+
+def msa_contiguous_block_scores(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    metadata: IndexerContiguousMetadata | None = None,
+    out: torch.Tensor | None = None,
+    binding=None,
+) -> torch.Tensor:
+    """Score MSA prefill candidates and max-pool over global 128-token K blocks."""
+
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("metadata", metadata),
+                ("out", out),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "MSA contiguous binding owns metadata and block-score buffers; do not also pass "
+                f"{', '.join(extras)}"
+            )
+        metadata = binding.metadata
+        out = getattr(binding, "block_scores", None)
+    if metadata is None:
+        raise TypeError("msa_contiguous_block_scores requires metadata or binding")
+    q_rows, num_heads = _validate_msa_q_inputs(q_fp8=q_fp8, q_scale=q_scale)
+    k_start = metadata.k_start
+    k_end = metadata.k_end
+    if k_start.ndim != 1 or k_end.ndim != 1 or k_start.shape != k_end.shape:
+        raise ValueError(
+            "MSA contiguous metadata requires matching rank-1 k_start/k_end"
+        )
+    if k_start.shape[0] > q_rows:
+        raise ValueError(
+            f"metadata describes {k_start.shape[0]} q rows, but q_fp8 has {q_rows}"
+        )
+    if k_start.dtype != torch.int32 or k_end.dtype != torch.int32:
+        raise ValueError("k_start and k_end must have dtype torch.int32")
+    if not _is_cuda_graph_capture_active(q_fp8.device):
+        misaligned = torch.remainder(k_start, MSA_BLOCK_TOKENS) != 0
+        if bool(torch.any(misaligned).item()):
+            raise ValueError("MSA contiguous k_start values must be 128-token aligned")
+    k_quant, k_scale = kv_fp8
+    k_rows = int(k_quant.shape[0])
+    num_blocks = math.ceil(k_rows / MSA_BLOCK_TOKENS)
+    out_view = _validate_msa_block_scores_out(
+        out=out,
+        num_heads=num_heads,
+        q_rows=q_rows,
+        num_blocks=num_blocks,
+        device=q_fp8.device,
+    )
+    if out_view is None:
+        block_scores = torch.full(
+            (num_heads, q_rows, num_blocks),
+            float("-inf"),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+    else:
+        block_scores = out_view
+        block_scores.fill_(float("-inf"))
+    valid_q_rows = int(k_start.shape[0])
+    if valid_q_rows == 0 or k_rows == 0:
+        return block_scores
+
+    if q_fp8.device.type != "cuda":
+        ref = msa_contiguous_block_scores_reference(
+            q_fp8=q_fp8,
+            q_scale=q_scale,
+            kv_fp8=kv_fp8,
+            k_start=k_start,
+            k_end=k_end,
+        )
+        block_scores.copy_(ref[:, :q_rows, :num_blocks])
+        return block_scores
+
+    weights = q_scale.contiguous() * MSA_SM_SCALE
+    kernel_kwargs = {}
+    if binding is not None and bool(getattr(binding, "strict", False)):
+        scratch = binding.scratch
+        if not hasattr(scratch, "prepare_k_padding"):
+            raise RuntimeError(
+                "strict MSA contiguous binding requires plan-owned scratch"
+            )
+        if not q_fp8.is_contiguous():
+            raise ValueError("strict MSA contiguous binding requires contiguous q_fp8")
+        if not k_quant.is_contiguous() or not k_scale.is_contiguous():
+            raise ValueError(
+                "strict MSA contiguous binding requires contiguous K tensors"
+            )
+        scratch.prepare_k_padding(k_rows=k_rows)
+        if k_quant.data_ptr() != scratch.k_quant.data_ptr():
+            raise ValueError("strict MSA contiguous K values must be a scratch prefix")
+        if k_scale.data_ptr() != scratch.k_scale.data_ptr():
+            raise ValueError("strict MSA contiguous K scales must be a scratch prefix")
+        q_bytes = q_fp8.view(torch.uint8)
+        kernel_kwargs.update(
+            q_bytes=q_bytes,
+            q_u32=q_bytes.view(torch.uint32).view(
+                int(q_fp8.shape[0]),
+                int(q_fp8.shape[1]),
+                _INDEX_HEAD_DIM // 4,
+            ),
+            weights_kernel=weights.contiguous(),
+            k_quant_bytes=scratch.k_quant.view(torch.uint8),
+            k_scale_kernel=scratch.k_scale,
+            k_start_kernel=k_start,
+            k_end_kernel=k_end,
+            out_kernel=scratch.dummy_logits,
+            tile_logits_kernel=scratch.tile_logits,
+            k_tma_prefill_desc_ptrs=scratch.k_tma_prefill_desc_ptrs,
+        )
+    return run_contiguous_block_scores_kernel(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_quant=k_quant,
+        k_scale=k_scale,
+        k_start=k_start,
+        k_end=k_end,
+        block_scores=block_scores,
+        num_blocks_out=num_blocks,
+        **kernel_kwargs,
+    )
+
+
+def msa_q2k_indices_prefill(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    metadata: IndexerContiguousMetadata | None = None,
+    query_positions: torch.Tensor | None = None,
+    block_base: torch.Tensor | None = None,
+    topk: int = MSA_TOPK_BLOCKS,
+    out_indices: torch.Tensor | None = None,
+    binding=None,
+) -> torch.Tensor:
+    """Run MSA prefill score, block max-pool, local forcing, and top-k selection."""
+
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("metadata", metadata),
+                ("out_indices", out_indices),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "MSA contiguous binding owns metadata and q2k output; do not also pass "
+                f"{', '.join(extras)}"
+            )
+        metadata = binding.metadata
+        if getattr(binding, "topk", None) is not None:
+            topk = int(binding.topk)
+        out_indices = getattr(binding, "q2k_indices", None)
+    if metadata is None:
+        raise TypeError("msa_q2k_indices_prefill requires metadata or binding")
+    q_rows, num_heads = _validate_msa_q_inputs(q_fp8=q_fp8, q_scale=q_scale)
+    valid_q_rows = int(metadata.k_start.shape[0])
+    if valid_q_rows > q_rows:
+        raise ValueError(
+            f"metadata describes {valid_q_rows} q rows, but q_fp8 has {q_rows}"
+        )
+    topk = int(topk)
+    if topk < 0:
+        raise ValueError(f"topk must be non-negative, got {topk}")
+    if out_indices is not None:
+        if out_indices.dtype != torch.int32:
+            raise ValueError(
+                f"out_indices must have dtype torch.int32, got {out_indices.dtype}"
+            )
+        if out_indices.device != q_fp8.device:
+            raise ValueError("out_indices device must match q_fp8")
+        if (
+            out_indices.ndim != 3
+            or out_indices.shape[0] < num_heads
+            or out_indices.shape[1] < q_rows
+            or out_indices.shape[2] < topk
+        ):
+            raise ValueError(
+                f"out_indices must have shape at least ({num_heads}, {q_rows}, {topk}), "
+                f"got {tuple(out_indices.shape)}"
+            )
+    block_scores = msa_contiguous_block_scores(
+        q_fp8=q_fp8,
+        q_scale=q_scale,
+        kv_fp8=kv_fp8,
+        metadata=None if binding is not None else metadata,
+        binding=binding,
+    )
+    if out_indices is None:
+        result = torch.full(
+            (num_heads, q_rows, topk),
+            -1,
+            dtype=torch.int32,
+            device=q_fp8.device,
+        )
+    else:
+        result = out_indices[:num_heads, :q_rows, :topk]
+        result.fill_(-1)
+    if valid_q_rows == 0:
+        return result
+    if query_positions is None:
+        query_positions = metadata.k_end - 1
+    else:
+        query_positions = query_positions[:valid_q_rows]
+    if block_base is None:
+        block_base = torch.div(
+            metadata.k_start, MSA_BLOCK_TOKENS, rounding_mode="floor"
+        )
+    else:
+        block_base = block_base[:valid_q_rows]
+    selected = msa_topk_blocks(
+        block_scores=block_scores[:, :valid_q_rows, :],
+        query_positions=query_positions,
+        block_base=block_base,
+        topk=topk,
+        out_indices=result[:, :valid_q_rows, :],
+        score_scratch=getattr(binding, "topk_score_scratch", None)
+        if binding is not None
+        else None,
+        top_values=getattr(binding, "topk_values", None)
+        if binding is not None
+        else None,
+        top_indices=getattr(binding, "topk_indices", None)
+        if binding is not None
+        else None,
+        sort_values=getattr(binding, "sort_values", None)
+        if binding is not None
+        else None,
+        sort_indices=getattr(binding, "sort_indices", None)
+        if binding is not None
+        else None,
+    )
+    if selected.data_ptr() != result[:, :valid_q_rows, :].data_ptr():
+        result[:, :valid_q_rows, :].copy_(selected)
+    return result
+
+
+def _reference_topk_indices_from_logits(
+    logits: torch.Tensor,
+    *,
+    topk: int,
+    output_values: torch.Tensor | None = None,
+    output_indices: torch.Tensor | None = None,
+) -> torch.Tensor:
+    topk = int(topk)
+    if topk < 0:
+        raise ValueError(f"topk must be non-negative, got {topk}")
+    num_rows = int(logits.shape[0])
+    result = torch.full((num_rows, topk), -1, dtype=torch.int32, device=logits.device)
+    values = torch.full(
+        (num_rows, topk), float("-inf"), dtype=torch.float32, device=logits.device
+    )
+    gather_k = min(topk, int(logits.shape[1]))
+    if gather_k:
+        topk_pos = torch.argsort(logits, dim=1, descending=True, stable=True)[
+            :, :gather_k
+        ]
+        topk_values = torch.gather(logits, 1, topk_pos)
+        result[:, :gather_k] = torch.where(
+            torch.isfinite(topk_values),
+            topk_pos.to(torch.int32),
+            torch.full_like(topk_pos, -1, dtype=torch.int32),
+        )
+        values[:, :gather_k] = topk_values
+
+    if output_indices is not None:
+        if output_indices.dtype != torch.int32:
+            raise ValueError(
+                f"output_indices must have dtype torch.int32, got {output_indices.dtype}"
+            )
+        if output_indices.device != logits.device:
+            raise ValueError("output_indices device must match logits")
+        if (
+            output_indices.ndim != 2
+            or output_indices.shape[0] < num_rows
+            or output_indices.shape[1] < topk
+        ):
+            raise ValueError(
+                f"output_indices must have shape at least ({num_rows}, {topk}), got {tuple(output_indices.shape)}"
+            )
+        output_indices[:num_rows, :topk].copy_(result)
+        result = output_indices[:num_rows, :topk]
+
+    if output_values is not None:
+        if output_values.dtype != torch.float32:
+            raise ValueError(
+                f"output_values must have dtype torch.float32, got {output_values.dtype}"
+            )
+        if output_values.device != logits.device:
+            raise ValueError("output_values device must match logits")
+        if (
+            output_values.ndim != 2
+            or output_values.shape[0] < num_rows
+            or output_values.shape[1] < topk
+        ):
+            raise ValueError(
+                f"output_values must have shape at least ({num_rows}, {topk}), got {tuple(output_values.shape)}"
+            )
+        output_values[:num_rows, :topk].copy_(values)
+
+    return result
+
+
+def contiguous_tiled_topk(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    metadata: IndexerContiguousMetadata | None = None,
+    topk: int | None = None,
+    tile_logits: torch.Tensor | None = None,
+    lengths: torch.Tensor | None = None,
+    output_values: torch.Tensor | None = None,
+    output_indices: torch.Tensor | None = None,
+    candidate_values: torch.Tensor | None = None,
+    candidate_indices: torch.Tensor | None = None,
+    merge_positions: torch.Tensor | None = None,
+    supertile_k: int | None = None,
+    binding=None,
+) -> torch.Tensor:
+    """Run the prefill NSA scorer in K-supertiles and consume each tile with tiled topk."""
+
+    strict_binding = False
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("metadata", metadata),
+                ("tile_logits", tile_logits),
+                ("lengths", lengths),
+                ("output_values", output_values),
+                ("output_indices", output_indices),
+                ("candidate_values", candidate_values),
+                ("candidate_indices", candidate_indices),
+                ("merge_positions", merge_positions),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "indexer contiguous binding owns metadata, scratch, "
+                "and top-k scratch buffers; do not also pass "
+                f"{', '.join(extras)}"
+            )
+        if topk is None:
+            topk = binding.topk
+        elif binding.topk is not None and int(topk) != int(binding.topk):
+            raise ValueError(
+                f"topk {int(topk)} does not match bound topk {int(binding.topk)}"
+            )
+        strict_binding = bool(getattr(binding, "strict", False))
+        metadata = binding.metadata
+        tile_logits = binding.tile_logits
+        lengths = binding.lengths
+        output_values = binding.output_values
+        output_indices = binding.output_indices
+        candidate_values = binding.candidate_values
+        candidate_indices = binding.candidate_indices
+        merge_positions = binding.merge_positions
+        if binding.supertile_k is not None:
+            supertile_k = int(binding.supertile_k)
+    if metadata is None:
+        raise TypeError("contiguous_tiled_topk requires metadata or binding")
+    if topk is None:
+        raise TypeError("contiguous_tiled_topk requires topk or a binding with topk")
+    topk = int(topk)
+    if topk < 0:
+        raise ValueError(f"topk must be non-negative, got {topk}")
+    k_start = metadata.k_start
+    k_end = metadata.k_end
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if k_start.ndim != 1 or k_end.ndim != 1 or k_start.shape != k_end.shape:
+        raise ValueError(
+            "tiled topk requires matching rank-1 k_start and k_end tensors"
+        )
+    weights_f = _normalize_weights(
+        weights, q_rows=q_fp8.shape[0], num_heads=q_fp8.shape[1]
+    )
+    k_quant, k_scale = kv_fp8
+    if not supports_contiguous_logits_kernel(
+        q_fp8=q_fp8,
+        weights=weights_f,
+        k_quant=k_quant,
+        k_scale=k_scale,
+        k_start=k_start,
+        k_end=k_end,
+    ):
+        if strict_binding:
+            raise RuntimeError(
+                "strict indexer contiguous binding requires the CUDA FP8 scorer "
+                "contract; reference logits fallback is disabled"
+            )
+        if lengths is not None:
+            if lengths.ndim != 1 or lengths.shape[0] < int(k_start.shape[0]):
+                raise ValueError(
+                    f"lengths must have shape at least ({int(k_start.shape[0])},), got {tuple(lengths.shape)}"
+                )
+            if lengths.dtype != torch.int32:
+                raise ValueError(
+                    f"lengths must have dtype torch.int32, got {lengths.dtype}"
+                )
+            if lengths.device != q_fp8.device:
+                raise ValueError(
+                    f"lengths device {lengths.device} does not match q_fp8 device {q_fp8.device}"
+                )
+            torch.sub(k_end, k_start, out=lengths[: int(k_start.shape[0])])
+        logits = contiguous_logits_reference(
+            q_fp8=q_fp8,
+            weights=weights_f,
+            kv_fp8=kv_fp8,
+            k_start=k_start,
+            k_end=k_end,
+        )
+        return _reference_topk_indices_from_logits(
+            logits[: int(k_start.shape[0])],
+            topk=topk,
+            output_values=output_values,
+            output_indices=output_indices,
+        )
+    prefill_block_k = (
+        int(binding.prefill_block_k)
+        if binding is not None and binding.prefill_block_k is not None
+        else resolve_contiguous_prefill_block_k(
+            valid_q_rows=int(k_start.shape[0]),
+            k_rows=int(k_quant.shape[0]),
+            num_heads=int(q_fp8.shape[1]),
+        )
+    )
+    if prefill_block_k is None:
+        # This API explicitly requests tiled logits for immediate tiled top-k.
+        # The decode scorer does not produce that layout, so force the standard
+        # prefill scorer for small q batches instead of failing.
+        prefill_block_k = _PREFILL_BLOCK_K
+    block_q = (
+        _PREFILL512_BLOCK_Q
+        if prefill_block_k == _PREFILL512_BLOCK_K
+        else _PREFILL_BLOCK_Q
+    )
+
+    num_q_rows = int(k_start.shape[0])
+    num_q_tiles = (num_q_rows + block_q - 1) // block_q
+    num_k_tiles = (int(k_quant.shape[0]) + prefill_block_k - 1) // prefill_block_k
+    tile_size = block_q * prefill_block_k
+    resolved_supertile_k = _resolve_supertile_k(supertile_k, block_k=prefill_block_k)
+    supertile_tiles = max(1, resolved_supertile_k // prefill_block_k)
+    num_chunks = (num_k_tiles + supertile_tiles - 1) // supertile_tiles
+    max_chunk_tiles = min(supertile_tiles, num_k_tiles)
+    chunk_tile_elements = num_q_tiles * max_chunk_tiles * tile_size
+
+    if tile_logits is None:
+        if strict_binding:
+            raise RuntimeError(
+                "strict indexer contiguous binding is missing tile_logits"
+            )
+        tile_logits = torch.empty(
+            (chunk_tile_elements,),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+    elif int(tile_logits.numel()) < chunk_tile_elements:
+        raise ValueError(
+            f"tile_logits has {int(tile_logits.numel())} elements, expected at least "
+            f"{chunk_tile_elements} for the largest K-supertile"
+        )
+
+    if lengths is None:
+        if strict_binding:
+            raise RuntimeError("strict indexer contiguous binding is missing lengths")
+        global_lengths = (k_end - k_start).contiguous()
+    else:
+        if lengths.ndim != 1 or lengths.shape[0] < num_q_rows:
+            raise ValueError(
+                f"lengths must have shape at least ({num_q_rows},), got {tuple(lengths.shape)}"
+            )
+        if lengths.dtype != torch.int32:
+            raise ValueError(
+                f"lengths must have dtype torch.int32, got {lengths.dtype}"
+            )
+        if lengths.device != q_fp8.device:
+            raise ValueError(
+                f"lengths device {lengths.device} does not match q_fp8 device {q_fp8.device}"
+            )
+        if not lengths.is_contiguous():
+            raise ValueError("lengths must be contiguous")
+        global_lengths = lengths[:num_q_rows]
+        torch.sub(k_end, k_start, out=global_lengths)
+    if strict_binding and (output_values is None or output_indices is None):
+        raise RuntimeError(
+            "strict indexer contiguous binding is missing output top-k buffers"
+        )
+
+    def _run_contiguous_scorer(
+        *,
+        tile_k_offset: int,
+        tile_num_k_tiles: int,
+    ) -> None:
+        if not strict_binding:
+            run_contiguous_logits_kernel(
+                q_fp8=q_fp8,
+                weights=weights_f,
+                k_quant=k_quant,
+                k_scale=k_scale,
+                k_start=k_start,
+                k_end=k_end,
+                preinitialize_invalid_logits=True,
+                tile_logits=tile_logits,
+                tile_k_offset=tile_k_offset,
+                tile_num_k_tiles=tile_num_k_tiles,
+                prefill_block_k=prefill_block_k,
+            )
+            return
+
+        if binding is None:
+            raise RuntimeError("strict indexer contiguous path requires a binding")
+        scratch = binding.scratch
+        if tile_logits is None:
+            raise RuntimeError(
+                "strict indexer contiguous binding is missing tile logits"
+            )
+        if not hasattr(scratch, "prepare_k_padding"):
+            raise RuntimeError(
+                "strict indexer contiguous binding requires plan-owned scratch"
+            )
+        if not q_fp8.is_contiguous():
+            raise ValueError("strict indexer contiguous requires contiguous q_fp8")
+        if not weights_f.is_contiguous():
+            raise ValueError("strict indexer contiguous requires contiguous weights")
+        if not k_quant.is_contiguous() or not k_scale.is_contiguous():
+            raise ValueError("strict indexer contiguous requires contiguous K tensors")
+        scratch.prepare_k_padding(k_rows=int(k_quant.shape[0]))
+        scratch_k_quant = scratch.k_quant
+        scratch_k_scale = scratch.k_scale
+        if k_quant.data_ptr() != scratch_k_quant.data_ptr():
+            raise ValueError(
+                "strict indexer contiguous K values must be a scratch prefix"
+            )
+        if k_scale.data_ptr() != scratch_k_scale.data_ptr():
+            raise ValueError(
+                "strict indexer contiguous K scales must be a scratch prefix"
+            )
+        q_bytes = q_fp8.view(torch.uint8)
+        q_u32 = q_bytes.view(torch.uint32).view(
+            int(q_fp8.shape[0]),
+            int(q_fp8.shape[1]),
+            _INDEX_HEAD_DIM // 4,
+        )
+        kernel_binding = build_indexer_contiguous_logits_kernel_binding(
+            q_fp8=q_fp8,
+            weights=weights_f,
+            k_quant=k_quant,
+            k_scale=k_scale,
+            k_start=k_start,
+            k_end=k_end,
+            preinitialize_invalid_logits=True,
+            tile_logits=tile_logits,
+            tile_k_offset=tile_k_offset,
+            tile_num_k_tiles=tile_num_k_tiles,
+            prefill_block_k=prefill_block_k,
+            q_u32=q_u32,
+            q_bytes=q_bytes,
+            weights_kernel=weights_f,
+            k_quant_bytes=scratch_k_quant.view(torch.uint8),
+            k_scale_kernel=scratch_k_scale,
+            k_start_kernel=k_start,
+            k_end_kernel=k_end,
+            out_kernel=scratch.dummy_logits,
+            out_view=scratch.dummy_logits,
+            k_tma_desc_ptrs=scratch.k_tma_desc_ptrs,
+            k_tma_prefill_desc_ptrs=scratch.k_tma_prefill_desc_ptrs,
+        )
+        run_contiguous_logits_kernel(binding=kernel_binding)
+
+    if num_chunks <= 1:
+        # Dead tiles (entirely out of causal/length range) are left UNWRITTEN by
+        # the tiled-output contiguous kernel (it `pass`es, trusting run_tiled_topk's
+        # k_start/k_end mask). Pre-clear to -inf so any stale value in those slots
+        # of the (reused) scratch can never win the tiled top-k.
+        tile_logits[:chunk_tile_elements].fill_(float("-inf"))
+        _run_contiguous_scorer(
+            tile_k_offset=0,
+            tile_num_k_tiles=num_k_tiles,
+        )
+        _, topk_indices = run_tiled_topk(
+            tile_logits=tile_logits,
+            k_start=k_start,
+            lengths=global_lengths,
+            topk=topk,
+            block_q=block_q,
+            block_k=prefill_block_k,
+            output_values=output_values,
+            output_indices=output_indices,
+            num_k_tiles=num_k_tiles,
+        )
+        return topk_indices
+
+    # Streaming fold over K-supertiles: each chunk folds the previous chunk's running
+    # top-k (carry) into its own radix selection, so the final chunk's output is the
+    # exact global top-k. The reused candidate_values/candidate_indices buffers serve
+    # as a (2, M, topk) carry double-buffer (read prev half, write next half); the
+    # final chunk writes the user output. No (num_chunks, ...) slab, no merge.
+    if (candidate_values is None) != (candidate_indices is None):
+        raise ValueError(
+            "candidate_values and candidate_indices must be provided together"
+        )
+    if candidate_values is None:
+        if strict_binding:
+            raise RuntimeError(
+                "strict indexer contiguous binding is missing carry buffers"
+            )
+        candidate_values = torch.empty(
+            (2, num_q_rows, topk),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+        candidate_indices = torch.empty(
+            (2, num_q_rows, topk),
+            dtype=torch.int32,
+            device=q_fp8.device,
+        )
+    else:
+        assert candidate_indices is not None
+        if candidate_values.ndim != 3 or candidate_indices.ndim != 3:
+            raise ValueError(
+                f"carry buffers must have shape at least (2, {num_q_rows}, {topk})"
+            )
+        if candidate_values.shape[0] < 2 or candidate_values.shape[1] < num_q_rows:
+            raise ValueError(
+                "candidate_values shape "
+                f"{tuple(candidate_values.shape)} is smaller than required "
+                f"(2, {num_q_rows}, {topk})"
+            )
+        if candidate_indices.shape[0] < 2 or candidate_indices.shape[1] < num_q_rows:
+            raise ValueError(
+                "candidate_indices shape "
+                f"{tuple(candidate_indices.shape)} is smaller than required "
+                f"(2, {num_q_rows}, {topk})"
+            )
+        if candidate_values.shape[2] != topk or candidate_indices.shape[2] != topk:
+            raise ValueError(
+                "carry buffer top-k dimension must match requested topk "
+                f"{topk}, got {candidate_values.shape[2]} and {candidate_indices.shape[2]}"
+            )
+        if candidate_values.dtype != torch.float32:
+            raise ValueError(
+                f"candidate_values must have dtype torch.float32, got {candidate_values.dtype}"
+            )
+        if candidate_indices.dtype != torch.int32:
+            raise ValueError(
+                f"candidate_indices must have dtype torch.int32, got {candidate_indices.dtype}"
+            )
+        if (
+            candidate_values.device != q_fp8.device
+            or candidate_indices.device != q_fp8.device
+        ):
+            raise ValueError("carry buffer devices must match q_fp8")
+    carry_buf_values = candidate_values[:2, :num_q_rows, :]
+    carry_buf_indices = candidate_indices[:2, :num_q_rows, :]
+
+    topk_indices = output_indices
+    for chunk_idx in range(num_chunks):
+        chunk_tile_begin = chunk_idx * supertile_tiles
+        chunk_tile_end = min(chunk_tile_begin + supertile_tiles, num_k_tiles)
+        chunk_tiles = chunk_tile_end - chunk_tile_begin
+        chunk_start = chunk_tile_begin * prefill_block_k
+        chunk_rows = chunk_tiles * prefill_block_k
+        # tile_logits is reused across chunks; dead tiles are not rewritten by the
+        # kernel, so a stale logit from a previous chunk at the same offset could
+        # otherwise survive into this chunk's tiled top-k. Pre-clear to -inf.
+        tile_logits[: num_q_tiles * chunk_tiles * tile_size].fill_(float("-inf"))
+        _run_contiguous_scorer(
+            tile_k_offset=chunk_tile_begin,
+            tile_num_k_tiles=chunk_tiles,
+        )
+        is_first = chunk_idx == 0
+        is_last = chunk_idx == num_chunks - 1
+        carry_values = carry_buf_values[(chunk_idx - 1) % 2]
+        carry_indices = carry_buf_indices[(chunk_idx - 1) % 2]
+        out_v = output_values if is_last else carry_buf_values[chunk_idx % 2]
+        out_i = output_indices if is_last else carry_buf_indices[chunk_idx % 2]
+        _, topk_indices = run_tiled_topk(
+            tile_logits=tile_logits,
+            k_start=k_start,
+            lengths=global_lengths,
+            topk=topk,
+            block_q=block_q,
+            block_k=prefill_block_k,
+            output_values=out_v,
+            output_indices=out_i,
+            num_k_tiles=chunk_tiles,
+            input_index_offset=chunk_start,
+            input_extent=chunk_rows,
+            output_index_offset=chunk_start,
+            carry_values=carry_values,
+            carry_indices=carry_indices,
+            is_first=is_first,
+        )
+    return topk_indices

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/api.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/api.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for attention.nsa_indexer (docs in the op ``__init__``).
+
+Naming: uniform ``_paged`` / ``_contiguous`` suffixes replace the upstream
+``msa_`` / ``paged_`` / ``contiguous_`` prefix mix; the pipeline stage is the
+verb (quantize -> logits/block_scores -> topk/q2k_indices).
+"""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from ._impl import (
+    IndexerContiguousMetadata as ContiguousMetadata,
+)
+from ._impl import (
+    IndexerPagedDecodeMetadata as PagedDecodeMetadata,
+)
+from ._impl import (
+    build_paged_mqa_schedule_metadata as plan_paged_schedule,
+)
+from ._impl import (
+    clear_indexer_caches as clear_caches,
+)
+from ._impl import (
+    contiguous_logits as logits_contiguous,
+)
+from ._impl import (
+    contiguous_tiled_topk as topk_tiled,
+)
+from ._impl import (
+    msa_contiguous_block_scores as block_scores_contiguous,
+)
+from ._impl import (
+    msa_decode_query_positions as query_positions_decode,
+)
+from ._impl import (
+    msa_paged_decode_block_scores as block_scores_paged,
+)
+from ._impl import (
+    msa_prefill_query_positions as query_positions_prefill,
+)
+from ._impl import (
+    msa_q2k_indices_decode as q2k_indices_decode,
+)
+from ._impl import (
+    msa_q2k_indices_prefill as q2k_indices_prefill,
+)
+from ._impl import (
+    msa_topk_blocks as topk_blocks,
+)
+from ._impl import (
+    paged_decode_logits as logits_paged,
+)
+from ._impl import (
+    quantize_msa_q_fp8 as quantize_q_fp8,
+)
+from ._impl import (
+    resolve_contiguous_prefill_block_k,
+)
+from ._impl import (
+    uses_paged_mqa_schedule as uses_paged_schedule,
+)
+from .kernel import (
+    IndexerOutputMode as OutputMode,
+)
+from .kernel import (
+    IndexerScoreMode as ScoreMode,
+)
+from .paged import (
+    INDEX_HEAD_DIM,
+    PAGED_INDEX_PAGE_SIZE,
+    index_topk_fp8,
+    resolve_local_num_q_heads,
+    resolve_replicated_num_q_heads,
+)
+from .paged import (
+    IndexerPagedMetadata as PagedMetadata,
+)
+from .paged import (
+    prepare_paged_indexer_metadata as prepare_paged_metadata,
+)
+from .persistent_topk import (
+    SM12XPersistentTopK2048Binding as PersistentTopK2048Binding,
+)
+from .persistent_topk import (
+    SM12XPersistentTopK2048ScratchCaps as PersistentTopK2048Caps,
+)
+from .persistent_topk import (
+    SM12XPersistentTopK2048ScratchPlan as PersistentTopK2048Plan,
+)
+from .persistent_topk import (
+    build_persistent_topk2048_binding as bind_persistent_topk2048,
+)
+from .persistent_topk import (
+    persistent_topk2048_scratch_nbytes,
+)
+from .persistent_topk import (
+    plan_persistent_topk2048_scratch as plan_persistent_topk2048,
+)
+from .persistent_topk import (
+    run_persistent_topk2048,
+    supports_persistent_topk2048,
+)
+from .scratch import (
+    INDEXER_SOURCE_LAYOUT_CONTIGUOUS as SOURCE_LAYOUT_CONTIGUOUS,
+)
+from .scratch import (
+    INDEXER_SOURCE_LAYOUT_PAGED as SOURCE_LAYOUT_PAGED,
+)
+from .scratch import (
+    SM12XIndexerContiguousBinding as ContiguousBinding,
+)
+from .scratch import (
+    SM12XIndexerContiguousScratch as ContiguousScratch,
+)
+from .scratch import (
+    SM12XIndexerMSAContiguousBinding as MSAContiguousBinding,
+)
+from .scratch import (
+    SM12XIndexerMSAPagedBinding as MSAPagedBinding,
+)
+from .scratch import (
+    SM12XIndexerPagedBinding as PagedBinding,
+)
+from .scratch import (
+    SM12XIndexerPagedScratch as PagedScratch,
+)
+from .scratch import (
+    SM12XIndexerScratchCaps as Caps,
+)
+from .scratch import (
+    SM12XIndexerScratchPlan as Plan,
+)
+from .scratch import (
+    build_indexer_contiguous_binding as bind_contiguous,
+)
+from .scratch import (
+    build_indexer_msa_contiguous_binding as bind_msa_contiguous,
+)
+from .scratch import (
+    build_indexer_msa_paged_binding as bind_msa_paged,
+)
+from .scratch import (
+    build_indexer_paged_binding as bind_paged,
+)
+from .scratch import (
+    plan_indexer_scratch as plan,
+)
+from . import META
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = list(META.entry_points)

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/contiguous_kernel.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/contiguous_kernel.py
@@ -1,0 +1,3369 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/contiguous_kernel.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""CuTeDSL contiguous logits kernel for the non-paged NSA contract."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from functools import lru_cache
+import os
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Boolean, Float32, Int32, Uint32
+from cutlass.base_dsl.compiler import OptLevel, PtxasOptions
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.core import make_swizzle
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import Int64, T
+
+from flashinfer.experimental.sm12x.attention._shared.cute import copy as cute_copy
+from flashinfer.experimental.sm12x.attention._shared.cute import (
+    pipeline as cute_pipeline,
+)
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as attention_ops
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    launch as sm12x_launch,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    frag_layout_swizzle_16b_to_8b,
+    get_ptr_as_int64,
+    ld_shared_v4_u32,
+    ldmatrix_m8n8x4_b16,
+    ldmatrix_m8n8x4_left_half_b16,
+    ldmatrix_m8n8x4_right_half_b16,
+    mxfp8_mma_m16n8k32_f32_e4m3,
+    shared_ptr_to_u32,
+    st_global_v2_f32,
+    st_global_v4_f32,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+from .kernel import IndexerScoreMode
+
+
+_INDEX_HEAD_DIM = 128
+_FP8_ROW_U32 = _INDEX_HEAD_DIM // 4
+_FP8_ROW_VECS = _INDEX_HEAD_DIM // 16
+_BLOCK_Q = 32
+_BLOCK_K = 64
+_WARP_THREADS = 32
+_WARPS_Q = _BLOCK_Q // 16
+_WARPS_K = _BLOCK_K // 16
+_WARPS_PER_CTA = _WARPS_Q * _WARPS_K
+_THREADS_PER_CTA = _WARPS_PER_CTA * _WARP_THREADS
+_MAX_Q_HEADS = 64
+_CONTIGUOUS_TMA_DESC_CACHE_SIZE = 32
+
+_PREFILL_BLOCK_Q = 32  # Same Q tile size as decode
+_PREFILL_BLOCK_K = 256  # 4x K tile — fewer CTAs, more work per CTA
+_PREFILL_WARPS_Q = _PREFILL_BLOCK_Q // 16  # 2
+_PREFILL_WARPS_K = 4  # 4 K-warps, each covering 32 K-rows via num_mma_kv=2
+_PREFILL_WARPS_PER_CTA = _PREFILL_WARPS_Q * _PREFILL_WARPS_K  # 8
+_PREFILL_THREADS_PER_CTA = _PREFILL_WARPS_PER_CTA * _WARP_THREADS  # 256
+_PREFILL_NUM_MMA_Q = 1  # same as decode
+_PREFILL_NUM_MMA_KV = 4  # each K-warp covers 64 K-rows (4x16)
+
+_PREFILL_Q_STAGE_ROWS = _PREFILL_BLOCK_Q  # 32 Q rows per tile
+_PREFILL_Q_STAGE_COLS = _INDEX_HEAD_DIM  # 128 bytes per Q row
+_PREFILL_WEIGHT_COLS = _MAX_Q_HEADS  # 64 heads per Q row
+_PREFILL_Q_HEADS_BATCH = (
+    8  # Number of Q heads staged in smem at once (fits in 102KB SMEM).
+)
+_PREFILL_Q_STAGE_BYTES = _PREFILL_Q_STAGE_ROWS * _PREFILL_Q_STAGE_COLS
+_PREFILL_WEIGHT_BYTES = _PREFILL_BLOCK_Q * _PREFILL_WEIGHT_COLS * 4  # 8KB
+
+_PREFILL512_BLOCK_Q = _PREFILL_BLOCK_Q
+_PREFILL512_BLOCK_K = 512
+_PREFILL512_WARPS_Q = _PREFILL512_BLOCK_Q // 16
+_PREFILL512_WARPS_K = 4
+_PREFILL512_WARPS_PER_CTA = _PREFILL512_WARPS_Q * _PREFILL512_WARPS_K
+_PREFILL512_THREADS_PER_CTA = _PREFILL512_WARPS_PER_CTA * _WARP_THREADS
+_PREFILL512_NUM_MMA_Q = 1
+_PREFILL512_NUM_MMA_KV = 8
+_PREFILL512_Q_HEADS_BATCH = 7  # Exp29: BF16 weights free 4KB smem, 10 batches vs 11
+_PREFILL512_H32_Q_HEADS_BATCH = 7
+_PREFILL512_H32_WEIGHT_COLS = 32
+
+_NSA_CONTIGUOUS_PREFILL_THRESHOLD_ENV = (
+    "FLASHINFER_EXP_SM12X_NSA_CONTIGUOUS_PREFILL_THRESHOLD"
+)
+_NSA_CONTIGUOUS_PREFILL_BLOCK_K_ENV = (
+    "FLASHINFER_EXP_SM12X_NSA_CONTIGUOUS_PREFILL_BLOCK_K"
+)
+_PREFILL512_MIN_Q_ROWS = 1024
+_PREFILL512_MIN_K_ROWS = 4096
+_PREFILL512_SUPPORTED_NUM_HEADS = (32, 64)
+_CONTIGUOUS_TMA_DESC_WORDS = 16
+
+
+def _assume_contiguous_k_tma_source_aligned(t: cute.Tensor) -> cute.Tensor:
+    divby = 128 // t.element_type.width
+    strides = []
+    for dim, stride in enumerate(t.stride):
+        if dim == 1 or isinstance(stride, int):
+            strides.append(stride)
+        else:
+            strides.append(cute.assume(stride, divby=divby))
+    return cute.make_tensor(
+        t.iterator, cute.make_layout(t.shape, stride=tuple(strides))
+    )
+
+
+def _make_contiguous_k_tma_source(k_quant_bytes: cute.Tensor) -> cute.Tensor:
+    return _assume_contiguous_k_tma_source_aligned(k_quant_bytes)
+
+
+def _make_contiguous_k_tma_smem_layout(block_k: int) -> cute.Layout:
+    return cute.make_composed_layout(
+        make_swizzle(3, 4, 3),
+        0,
+        cute.make_layout(
+            (block_k, _INDEX_HEAD_DIM),
+            stride=(_INDEX_HEAD_DIM, 1),
+        ),
+    )
+
+
+def _make_contiguous_k_tma_smem_stage_layout(block_k: int) -> cute.Layout:
+    return cute.tile_to_shape(
+        _make_contiguous_k_tma_smem_layout(block_k),
+        (block_k, _INDEX_HEAD_DIM, 1),
+        (0, 1, 2),
+    )
+
+
+@lru_cache(maxsize=16)
+def _dummy_contiguous_k_tma_desc_ptrs(device_index: int) -> torch.Tensor:
+    return torch.zeros(
+        (1,), dtype=torch.int64, device=torch.device("cuda", device_index)
+    )
+
+
+def _raise_binding_extras(api_name: str, extras: list[str]) -> None:
+    raise ValueError(
+        f"{api_name} binding owns runtime tensors and kernel options; "
+        f"do not also pass {', '.join(extras)}"
+    )
+
+
+def _require_bound_arg(value, *, api_name: str, name: str):
+    if value is None:
+        raise TypeError(f"{api_name} requires {name} or binding")
+    return value
+
+
+@dataclass(frozen=True, kw_only=True)
+class IndexerContiguousLogitsKernelBinding:
+    q_fp8: torch.Tensor
+    weights: torch.Tensor
+    k_quant: torch.Tensor
+    k_scale: torch.Tensor
+    k_start: torch.Tensor
+    k_end: torch.Tensor
+    preinitialize_invalid_logits: bool = True
+    tile_logits: torch.Tensor | None = None
+    tile_k_offset: int = 0
+    tile_num_k_tiles: int | None = None
+    prefill_block_k: int | None = None
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM
+    q_u32: torch.Tensor | None = None
+    q_bytes: torch.Tensor | None = None
+    weights_kernel: torch.Tensor | None = None
+    k_quant_bytes: torch.Tensor | None = None
+    k_scale_kernel: torch.Tensor | None = None
+    k_start_kernel: torch.Tensor | None = None
+    k_end_kernel: torch.Tensor | None = None
+    out_kernel: torch.Tensor | None = None
+    out_view: torch.Tensor | None = None
+    k_tma_desc_ptrs: torch.Tensor | None = None
+    k_tma_prefill_desc_ptrs: torch.Tensor | None = None
+
+    def run(self) -> torch.Tensor:
+        return run_contiguous_logits_kernel(binding=self)
+
+
+def build_indexer_contiguous_logits_kernel_binding(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    k_quant: torch.Tensor,
+    k_scale: torch.Tensor,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+    preinitialize_invalid_logits: bool = True,
+    tile_logits: torch.Tensor | None = None,
+    tile_k_offset: int = 0,
+    tile_num_k_tiles: int | None = None,
+    prefill_block_k: int | None = None,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    q_u32: torch.Tensor | None = None,
+    q_bytes: torch.Tensor | None = None,
+    weights_kernel: torch.Tensor | None = None,
+    k_quant_bytes: torch.Tensor | None = None,
+    k_scale_kernel: torch.Tensor | None = None,
+    k_start_kernel: torch.Tensor | None = None,
+    k_end_kernel: torch.Tensor | None = None,
+    out_kernel: torch.Tensor | None = None,
+    out_view: torch.Tensor | None = None,
+    k_tma_desc_ptrs: torch.Tensor | None = None,
+    k_tma_prefill_desc_ptrs: torch.Tensor | None = None,
+) -> IndexerContiguousLogitsKernelBinding:
+    return IndexerContiguousLogitsKernelBinding(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_quant=k_quant,
+        k_scale=k_scale,
+        k_start=k_start,
+        k_end=k_end,
+        preinitialize_invalid_logits=bool(preinitialize_invalid_logits),
+        tile_logits=tile_logits,
+        tile_k_offset=int(tile_k_offset),
+        tile_num_k_tiles=None if tile_num_k_tiles is None else int(tile_num_k_tiles),
+        prefill_block_k=None if prefill_block_k is None else int(prefill_block_k),
+        score_mode=int(score_mode),
+        q_u32=q_u32,
+        q_bytes=q_bytes,
+        weights_kernel=weights_kernel,
+        k_quant_bytes=k_quant_bytes,
+        k_scale_kernel=k_scale_kernel,
+        k_start_kernel=k_start_kernel,
+        k_end_kernel=k_end_kernel,
+        out_kernel=out_kernel,
+        out_view=out_view,
+        k_tma_desc_ptrs=k_tma_desc_ptrs,
+        k_tma_prefill_desc_ptrs=k_tma_prefill_desc_ptrs,
+    )
+
+
+def _to_kernel_tensor(
+    tensor: torch.Tensor,
+    dtype: type[cutlass.Numeric],
+    *,
+    assumed_align: int = 16,
+) -> cutlass.cute.Tensor:
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = dtype
+    leading_dim = next(
+        (idx for idx, stride in enumerate(tensor.stride()) if stride == 1), None
+    )
+    if leading_dim is not None and tensor.ndim >= 1:
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+    return cute_tensor
+
+
+def _tensor_meta_key(
+    tensor: torch.Tensor,
+) -> tuple[tuple[int, ...], tuple[int, ...], str, tuple[str, int | None]]:
+    return (
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        str(tensor.dtype),
+        (tensor.device.type, tensor.device.index),
+    )
+
+
+def _contiguous_logits_compile_facts(
+    *,
+    variant: str,
+    tiled_output: bool,
+    score_mode: int,
+    q_u32: torch.Tensor,
+    weights: torch.Tensor,
+    k_quant_bytes: torch.Tensor,
+    k_scale: torch.Tensor,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+    logits_out: torch.Tensor,
+    tile_logits: torch.Tensor,
+    block_k: int,
+    block_score_output: bool = False,
+    block_scores: torch.Tensor | None = None,
+    q_heads_batch: int | None = None,
+) -> tuple[object, ...]:
+    facts: list[object] = [
+        ("variant", variant),
+        ("tiled_output", bool(tiled_output)),
+        ("score_mode", int(score_mode)),
+        ("head_dim", _INDEX_HEAD_DIM),
+        ("q_heads", int(q_u32.shape[1])),
+        ("q_u32_cols", int(q_u32.shape[2])),
+        ("q_u32_stride_head", int(q_u32.stride(1))),
+        ("q_u32_stride_col", int(q_u32.stride(2))),
+        ("weights_stride_q", int(weights.stride(0))),
+        ("weights_stride_head", int(weights.stride(1))),
+        ("k_quant_stride_row", int(k_quant_bytes.stride(0))),
+        ("k_quant_stride_col", int(k_quant_bytes.stride(1))),
+        ("k_scale_stride", int(k_scale.stride(0))),
+        ("k_start_stride", int(k_start.stride(0))),
+        ("k_end_stride", int(k_end.stride(0))),
+        ("block_k", int(block_k)),
+        ("block_score_output", bool(block_score_output)),
+    ]
+    if q_heads_batch is not None:
+        facts.append(("q_heads_batch", int(q_heads_batch)))
+    if tiled_output:
+        tile_logits_flat = tile_logits.reshape(-1)
+        facts.append(("tile_logits_stride", int(tile_logits_flat.stride(0))))
+    else:
+        facts.extend(
+            [
+                ("logits_stride_q", int(logits_out.stride(0))),
+                ("logits_stride_k", int(logits_out.stride(1))),
+            ]
+        )
+    if block_scores is not None:
+        facts.extend(
+            [
+                ("block_scores_heads", int(block_scores.shape[0])),
+                ("block_scores_blocks", int(block_scores.shape[2])),
+                ("block_scores_stride_head", int(block_scores.stride(0))),
+                ("block_scores_stride_q", int(block_scores.stride(1))),
+                ("block_scores_stride_block", int(block_scores.stride(2))),
+            ]
+        )
+    return tuple(facts)
+
+
+def _pad_kv_rows(
+    *,
+    k_quant: torch.Tensor,
+    k_scale: torch.Tensor,
+    pad_block_k: int = _BLOCK_K,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    padded_rows = ((k_quant.shape[0] + pad_block_k - 1) // pad_block_k) * pad_block_k
+    k_quant = k_quant.contiguous()
+    k_scale = k_scale.contiguous()
+    if padded_rows == k_quant.shape[0]:
+        return k_quant, k_scale
+
+    k_quant_padded = torch.empty(
+        (padded_rows, _INDEX_HEAD_DIM),
+        dtype=k_quant.dtype,
+        device=k_quant.device,
+    )
+    k_scale_padded = torch.empty(
+        (padded_rows,),
+        dtype=k_scale.dtype,
+        device=k_scale.device,
+    )
+    k_quant_padded[: k_quant.shape[0]].copy_(k_quant)
+    k_quant_padded[k_quant.shape[0] :].zero_()
+    k_scale_padded[: k_scale.shape[0]].copy_(k_scale)
+    k_scale_padded[k_scale.shape[0] :].zero_()
+    return k_quant_padded, k_scale_padded
+
+
+def _view_last_dim_as_u32(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype != torch.uint8:
+        raise ValueError(f"expected uint8 tensor, got {tensor.dtype}")
+    if tensor.stride(-1) != 1:
+        raise ValueError(f"expected contiguous last dim, got stride={tensor.stride()}")
+    if tensor.shape[-1] % 4 != 0:
+        raise ValueError(f"last dim must be divisible by 4, got {tensor.shape[-1]}")
+    out_shape = (*tensor.shape[:-1], tensor.shape[-1] // 4)
+    return tensor.view(torch.uint32).view(out_shape)
+
+
+@lru_cache(maxsize=1)
+def get_sparse_nsa_contiguous_shared_storage_cls():
+    class SharedStorage:
+        pass
+
+    SharedStorage.__annotations__ = {
+        "mbar_ptr_k": cute.struct.MemRange[cutlass.Int64, 1],
+        "tile_live": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, 1],
+            16,
+        ],
+        "k_perm": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, _BLOCK_K * _INDEX_HEAD_DIM],
+            1024,
+        ],
+        "scales": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _BLOCK_K],
+            16,
+        ],
+        "k_start": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, _BLOCK_Q],
+            16,
+        ],
+        "k_end": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, _BLOCK_Q],
+            16,
+        ],
+    }
+
+    return cute.struct(SharedStorage)
+
+
+@lru_cache(maxsize=1)
+def get_sparse_nsa_contiguous_prefill_shared_storage_cls():
+    class SharedStorage:
+        pass
+
+    SharedStorage.__annotations__ = {
+        "mbar_ptr_k": cute.struct.MemRange[cutlass.Int64, 1],
+        "tile_live": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, 1],
+            16,
+        ],
+        "k_perm": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, _PREFILL_BLOCK_K * _INDEX_HEAD_DIM],
+            1024,
+        ],
+        "q_bytes_smem": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.Uint8,
+                _PREFILL_Q_STAGE_ROWS * _PREFILL_Q_STAGE_COLS * _PREFILL_Q_HEADS_BATCH,
+            ],
+            1024,
+        ],
+        "w_smem": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _PREFILL_BLOCK_Q * _MAX_Q_HEADS],
+            1024,
+        ],
+        "scales": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _PREFILL_BLOCK_K],
+            16,
+        ],
+        "k_start": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, _PREFILL_BLOCK_Q],
+            16,
+        ],
+        "k_end": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, _PREFILL_BLOCK_Q],
+            16,
+        ],
+        "block_partial": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _PREFILL_WARPS_K * _PREFILL_BLOCK_Q],
+            16,
+        ],
+    }
+
+    return cute.struct(SharedStorage)
+
+
+@cute.jit
+def _reduce_quad_max(value: Float32) -> Float32:
+    value = attention_ops.fmax(value, cute.arch.shuffle_sync_bfly(value, offset=1))
+    value = attention_ops.fmax(value, cute.arch.shuffle_sync_bfly(value, offset=2))
+    return value
+
+
+def _encode_contiguous_k_tma_descriptor_into(
+    k_quant_bytes: torch.Tensor,
+    desc: torch.Tensor,
+    desc_ptrs: torch.Tensor,
+    *,
+    block_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k_quant_bytes.ndim != 2 or k_quant_bytes.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k_quant_bytes must have shape (rows, {_INDEX_HEAD_DIM}), "
+            f"got {tuple(k_quant_bytes.shape)}"
+        )
+    if k_quant_bytes.dtype != torch.uint8:
+        raise TypeError(
+            f"k_quant_bytes must have dtype torch.uint8, got {k_quant_bytes.dtype}"
+        )
+    if desc.shape != (_CONTIGUOUS_TMA_DESC_WORDS,) or desc.dtype != torch.uint64:
+        raise ValueError(
+            "desc must be a uint64 tensor with shape "
+            f"({_CONTIGUOUS_TMA_DESC_WORDS},), got {tuple(desc.shape)} "
+            f"and {desc.dtype}"
+        )
+    if desc_ptrs.shape != (1,) or desc_ptrs.dtype != torch.int64:
+        raise ValueError(
+            "desc_ptrs must be an int64 tensor with shape (1,), got "
+            f"{tuple(desc_ptrs.shape)} and {desc_ptrs.dtype}"
+        )
+    if desc.device != k_quant_bytes.device or desc_ptrs.device != k_quant_bytes.device:
+        raise ValueError("descriptor tensors must be on the K tensor device")
+
+    U64 = cuda.cuuint64_t
+    U32 = cuda.cuuint32_t
+    row_bytes = int(k_quant_bytes.stride(0)) * k_quant_bytes.element_size()
+    base_ptr = int(k_quant_bytes.data_ptr())
+    total_rows = int(k_quant_bytes.shape[0])
+
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8,
+        2,
+        base_ptr,
+        [U64(_INDEX_HEAD_DIM), U64(total_rows)],
+        [U64(row_bytes)],
+        [U32(_INDEX_HEAD_DIM), U32(int(block_k))],
+        [U32(1), U32(1)],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed: {result}")
+
+    desc.copy_(
+        torch.tensor(
+            [int(word) for word in tensor_map.opaque],
+            dtype=torch.uint64,
+        ),
+        non_blocking=True,
+    )
+    desc_ptrs.copy_(
+        torch.tensor([int(desc.data_ptr())], dtype=torch.int64),
+        non_blocking=True,
+    )
+    return desc, desc_ptrs
+
+
+def _encode_contiguous_k_tma_descriptor(
+    k_quant_bytes: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k_quant_bytes.ndim != 2 or k_quant_bytes.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k_quant_bytes must have shape (rows, {_INDEX_HEAD_DIM}), got {tuple(k_quant_bytes.shape)}"
+        )
+    if k_quant_bytes.dtype != torch.uint8:
+        raise TypeError(
+            f"k_quant_bytes must have dtype torch.uint8, got {k_quant_bytes.dtype}"
+        )
+
+    # Phase 3: Always use SWIZZLE_128B — hardware XOR pattern matches _permuted_offset_128b
+    U64 = cuda.cuuint64_t
+    U32 = cuda.cuuint32_t
+    row_bytes = int(k_quant_bytes.stride(0)) * k_quant_bytes.element_size()
+    base_ptr = int(k_quant_bytes.data_ptr())
+    total_rows = int(k_quant_bytes.shape[0])
+
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8,
+        2,
+        base_ptr,
+        [U64(_INDEX_HEAD_DIM), U64(total_rows)],
+        [U64(row_bytes)],
+        [U32(_INDEX_HEAD_DIM), U32(_BLOCK_K)],
+        [U32(1), U32(1)],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed: {result}")
+
+    desc = torch.tensor(
+        [int(word) for word in tensor_map.opaque],
+        dtype=torch.uint64,
+        device=k_quant_bytes.device,
+    )
+    desc_ptrs = torch.tensor(
+        [int(desc.data_ptr())], dtype=torch.int64, device=k_quant_bytes.device
+    )
+    return desc, desc_ptrs
+
+
+def _get_cached_contiguous_k_tma_descriptor(
+    k_quant_bytes: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    key = (
+        int(k_quant_bytes.data_ptr()),
+        tuple(k_quant_bytes.shape),
+        tuple(k_quant_bytes.stride()),
+        str(k_quant_bytes.dtype),
+        (k_quant_bytes.device.type, k_quant_bytes.device.index),
+    )
+    cache = getattr(_get_cached_contiguous_k_tma_descriptor, "_cache", None)
+    if cache is None:
+        cache = OrderedDict()
+        setattr(_get_cached_contiguous_k_tma_descriptor, "_cache", cache)
+    cached = cache.get(key)
+    if cached is not None:
+        cache.move_to_end(key)
+        return cached
+    desc = _encode_contiguous_k_tma_descriptor(k_quant_bytes)
+    cache[key] = desc
+    if len(cache) > _CONTIGUOUS_TMA_DESC_CACHE_SIZE:
+        cache.popitem(last=False)
+    return desc
+
+
+def _encode_contiguous_k_tma_descriptor_prefill(
+    k_quant_bytes: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """TMA descriptor for prefill kernel with _PREFILL_BLOCK_K=256 tile."""
+    if k_quant_bytes.ndim != 2 or k_quant_bytes.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k_quant_bytes must have shape (rows, {_INDEX_HEAD_DIM}), got {tuple(k_quant_bytes.shape)}"
+        )
+    if k_quant_bytes.dtype != torch.uint8:
+        raise TypeError(
+            f"k_quant_bytes must be dtype torch.uint8, got {k_quant_bytes.dtype}"
+        )
+
+    U64 = cuda.cuuint64_t
+    U32 = cuda.cuuint32_t
+    row_bytes = int(k_quant_bytes.stride(0)) * k_quant_bytes.element_size()
+    base_ptr = int(k_quant_bytes.data_ptr())
+    total_rows = int(k_quant_bytes.shape[0])
+
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8,
+        2,
+        base_ptr,
+        [U64(_INDEX_HEAD_DIM), U64(total_rows)],
+        [U64(row_bytes)],
+        [U32(_INDEX_HEAD_DIM), U32(_PREFILL_BLOCK_K)],
+        [U32(1), U32(1)],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled (prefill) failed: {result}")
+
+    desc = torch.tensor(
+        [int(word) for word in tensor_map.opaque],
+        dtype=torch.uint64,
+        device=k_quant_bytes.device,
+    )
+    desc_ptrs = torch.tensor(
+        [int(desc.data_ptr())], dtype=torch.int64, device=k_quant_bytes.device
+    )
+    return desc, desc_ptrs
+
+
+def _get_cached_contiguous_k_tma_descriptor_prefill(
+    k_quant_bytes: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    key = (
+        int(k_quant_bytes.data_ptr()),
+        tuple(k_quant_bytes.shape),
+        tuple(k_quant_bytes.stride()),
+        str(k_quant_bytes.dtype),
+        (k_quant_bytes.device.type, k_quant_bytes.device.index),
+        "prefill",
+    )
+    cache = getattr(_get_cached_contiguous_k_tma_descriptor_prefill, "_cache", None)
+    if cache is None:
+        cache = OrderedDict()
+        setattr(_get_cached_contiguous_k_tma_descriptor_prefill, "_cache", cache)
+    cached = cache.get(key)
+    if cached is not None:
+        cache.move_to_end(key)
+        return cached
+    desc = _encode_contiguous_k_tma_descriptor_prefill(k_quant_bytes)
+    cache[key] = desc
+    if len(cache) > _CONTIGUOUS_TMA_DESC_CACHE_SIZE:
+        cache.popitem(last=False)
+    return desc
+
+
+def _encode_contiguous_k_tma_descriptor_prefill512(
+    k_quant_bytes: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """TMA descriptor for the BK=512 prefill kernel's 256-row load subtiles."""
+    if k_quant_bytes.ndim != 2 or k_quant_bytes.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k_quant_bytes must have shape (rows, {_INDEX_HEAD_DIM}), got {tuple(k_quant_bytes.shape)}"
+        )
+    if k_quant_bytes.dtype != torch.uint8:
+        raise TypeError(
+            f"k_quant_bytes must be dtype torch.uint8, got {k_quant_bytes.dtype}"
+        )
+
+    U64 = cuda.cuuint64_t
+    U32 = cuda.cuuint32_t
+    row_bytes = int(k_quant_bytes.stride(0)) * k_quant_bytes.element_size()
+    base_ptr = int(k_quant_bytes.data_ptr())
+    total_rows = int(k_quant_bytes.shape[0])
+
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8,
+        2,
+        base_ptr,
+        [U64(_INDEX_HEAD_DIM), U64(total_rows)],
+        [U64(row_bytes)],
+        [U32(_INDEX_HEAD_DIM), U32(_PREFILL_BLOCK_K)],
+        [U32(1), U32(1)],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled (prefill512) failed: {result}")
+
+    desc = torch.tensor(
+        [int(word) for word in tensor_map.opaque],
+        dtype=torch.uint64,
+        device=k_quant_bytes.device,
+    )
+    desc_ptrs = torch.tensor(
+        [int(desc.data_ptr())], dtype=torch.int64, device=k_quant_bytes.device
+    )
+    return desc, desc_ptrs
+
+
+def _get_cached_contiguous_k_tma_descriptor_prefill512(
+    k_quant_bytes: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    key = (
+        int(k_quant_bytes.data_ptr()),
+        tuple(k_quant_bytes.shape),
+        tuple(k_quant_bytes.stride()),
+        str(k_quant_bytes.dtype),
+        (k_quant_bytes.device.type, k_quant_bytes.device.index),
+        "prefill512",
+    )
+    cache = getattr(_get_cached_contiguous_k_tma_descriptor_prefill512, "_cache", None)
+    if cache is None:
+        cache = OrderedDict()
+        setattr(_get_cached_contiguous_k_tma_descriptor_prefill512, "_cache", cache)
+    cached = cache.get(key)
+    if cached is not None:
+        cache.move_to_end(key)
+        return cached
+    desc = _encode_contiguous_k_tma_descriptor_prefill512(k_quant_bytes)
+    cache[key] = desc
+    if len(cache) > _CONTIGUOUS_TMA_DESC_CACHE_SIZE:
+        cache.popitem(last=False)
+    return desc
+
+
+@cute.jit
+def _issue_contiguous_k_tma_copy(
+    load_tma,
+    producer_state,
+    mbar_ptr,
+    expected_bytes,
+    k_tile_idx,
+):
+    full_mbar_ptr = mbar_ptr + producer_state.index
+    with cute.arch.elect_one():
+        cute.arch.mbarrier_arrive_and_expect_tx(full_mbar_ptr, expected_bytes)
+    load_tma(
+        src_idx=k_tile_idx, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr
+    )
+
+
+@cute.jit
+def _issue_contiguous_k_tma_copy_pair(
+    load_tma0,
+    load_tma1,
+    producer_state,
+    mbar_ptr,
+    expected_bytes,
+    k_tile_idx0,
+    k_tile_idx1,
+):
+    full_mbar_ptr = mbar_ptr + producer_state.index
+    with cute.arch.elect_one():
+        cute.arch.mbarrier_arrive_and_expect_tx(full_mbar_ptr, expected_bytes)
+    load_tma0(
+        src_idx=k_tile_idx0, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr
+    )
+    load_tma1(
+        src_idx=k_tile_idx1, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr
+    )
+
+
+@cute.jit
+def _permuted_offset_128b(row_idx, vec_idx, row_stride_128b):
+    return row_idx * row_stride_128b + (vec_idx ^ (row_idx % 8))
+
+
+@cute.jit
+def _smem_addr_from_b128_offset(base_addr: Int32, offset_128b):
+    return base_addr + Int32(offset_128b * 16)
+
+
+@cute.jit
+def _advance_offset_by_row_128b(offset_128b, step_size, row_stride_128b):
+    return offset_128b + step_size * row_stride_128b
+
+
+@cute.jit
+def _advance_offset_by_column_128b_2(offset_128b, step_idx):
+    xor_term = Int32(0x2) + (Int32(0x4) if step_idx % 2 == 1 else Int32(0))
+    extra = Int32(8) if step_idx % 4 == 3 else Int32(0)
+    return (offset_128b ^ xor_term) + extra
+
+
+@cute.jit
+def _zero_score_frag(score_frag: cute.Tensor) -> None:
+    for reg_id in cutlass.range_constexpr(8):
+        score_frag[0, 0, reg_id] = Float32(0.0)
+
+
+@cute.jit
+def _pack_q_mxfp8_reg_global(
+    q_u32: cute.Tensor,
+    head_idx: Int32,
+    abs_row: Int32,
+    col_pair_base: Int32,
+    valid_q_rows: Int32,
+) -> Uint32:
+    """Pack 4 FP8 bytes from global q_u32 into one MMA register word.
+
+    Original smem path accessed s_q_bytes[row, col_pair_base+{0,1,8,9}].
+    Global view is u32, so we read two u32 values and extract the same
+    4 bytes via shifts.  Uses cutlass.select_ to avoid early return
+    (not allowed in CuTe JIT functions).
+    """
+    u32_idx_lo = col_pair_base // Int32(4)
+    u32_idx_hi = u32_idx_lo + Int32(2)
+    byte_shift = (col_pair_base % Int32(4)) * Int32(8)
+    lo = (
+        Uint32(q_u32[abs_row, head_idx, u32_idx_lo])
+        if abs_row < valid_q_rows
+        else Uint32(0)
+    )
+    hi = (
+        Uint32(q_u32[abs_row, head_idx, u32_idx_hi])
+        if abs_row < valid_q_rows
+        else Uint32(0)
+    )
+    lo_half = (lo >> byte_shift) & Uint32(0xFFFF)
+    hi_half = ((hi >> byte_shift) & Uint32(0xFFFF)) << Int32(16)
+    return lo_half | hi_half
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_mxfp8_raw(
+    s_frag: cute.Tensor,
+    q_u32: cute.Tensor,
+    head_idx: Int32,
+    q_tile_base: Int32,
+    valid_q_rows: Int32,
+    k_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_k,
+):
+    # This helper is decode-only: its sole call site maps one 16-row Q MMA
+    # tile per warp.  Keeping that invariant structural lets the two Q-row
+    # pointers stay materialized across the unrolled K dimension without
+    # silently aliasing a future second Q tile.
+    num_mma_q = 1
+    unit_scale = Uint32(0x7F7F7F7F)
+    group_id = lane // Int32(4)
+    thread_id_in_group = lane % Int32(4)
+    row_base_q = warp_q_idx * Int32(16)
+    abs_row_0 = q_tile_base + row_base_q + group_id
+    abs_row_8 = abs_row_0 + Int32(8)
+    q_row_0 = cute.make_tensor(
+        q_u32.iterator + cute.crd2idx((abs_row_0, head_idx, Int32(0)), q_u32.layout),
+        cute.make_layout((_FP8_ROW_U32,), stride=(1,)),
+    )
+    q_row_8 = cute.make_tensor(
+        q_u32.iterator + cute.crd2idx((abs_row_8, head_idx, Int32(0)), q_u32.layout),
+        cute.make_layout((_FP8_ROW_U32,), stride=(1,)),
+    )
+    k_offset = _permuted_offset_128b(
+        row_base
+        + warp_kv_idx * num_mma_kv * Int32(16)
+        + Int32(8) * (lane // Int32(16))
+        + lane % Int32(8),
+        (lane % Int32(16)) // Int32(8),
+        upcast_stride_k,
+    )
+    for mma_pair in cutlass.range_constexpr(num_mma_d_qk // 2):
+        q_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        # RAW fragment order on BOTH operands: each Q fragment register is one
+        # aligned u32 read (bytes {4t..4t+3} of the k-half), so the byte
+        # gather + shift chain and the K-side 16b->8b swizzles both vanish.
+        u32_lo = Int32(mma_pair * 8) + thread_id_in_group
+        u32_hi = u32_lo + Int32(4)
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            q_regs[mma_q, 0] = (
+                Uint32(q_row_0[u32_lo]) if abs_row_0 < valid_q_rows else Uint32(0)
+            )
+            q_regs[mma_q, 1] = (
+                Uint32(q_row_8[u32_lo]) if abs_row_8 < valid_q_rows else Uint32(0)
+            )
+            q_regs[mma_q, 2] = (
+                Uint32(q_row_0[u32_hi]) if abs_row_0 < valid_q_rows else Uint32(0)
+            )
+            q_regs[mma_q, 3] = (
+                Uint32(q_row_8[u32_hi]) if abs_row_8 < valid_q_rows else Uint32(0)
+            )
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            b0_k0, b1_k0 = ldmatrix_m8n8x4_left_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            b0_k1, b1_k1 = ldmatrix_m8n8x4_right_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, Int32(16), upcast_stride_k
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    q_regs[mma_q, 0],
+                    q_regs[mma_q, 1],
+                    q_regs[mma_q, 2],
+                    q_regs[mma_q, 3],
+                    b0_k0,
+                    b0_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                d4, d5, d6, d7 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    q_regs[mma_q, 0],
+                    q_regs[mma_q, 1],
+                    q_regs[mma_q, 2],
+                    q_regs[mma_q, 3],
+                    b1_k0,
+                    b1_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            num_mma_kv * Int32(16) * upcast_stride_k
+        )
+
+
+class SparseNSAContiguousLogitsKernel:
+    """Ragged logits kernel with Q and weights read from global memory.
+
+    Phase 1+2+3: Q/weights from global, warp-ballot liveness, TMA SWIZZLE_128B (no k_linear/repack).
+    """
+
+    def __init__(
+        self,
+        *,
+        tiled_output: bool = False,
+        score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    ):
+        self._tiled_output = tiled_output
+        self._score_mode = int(score_mode)
+
+    @cute.jit
+    def __call__(
+        self,
+        q_u32: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        k_scales: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        logits_out: cute.Tensor,
+        tile_logits: cute.Tensor,
+        valid_q_rows: Int32,
+        valid_k_rows: Int32,
+        k_tile_offset: Int32,
+        output_num_k_tiles: Int32,
+        write_invalid_logits: Int32,
+        stream: cuda.CUstream,
+    ):
+        k_tma_source = _make_contiguous_k_tma_source(k_quant_bytes)
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            k_tma_source,
+            _make_contiguous_k_tma_smem_layout(_BLOCK_K),
+            (_BLOCK_K, _INDEX_HEAD_DIM),
+            1,
+        )
+        self.kernel(
+            q_u32,
+            weights,
+            k_quant_bytes,
+            tma_tensor_k,
+            k_tma_desc_ptrs,
+            k_scales,
+            k_start,
+            k_end,
+            logits_out,
+            tile_logits,
+            valid_q_rows,
+            valid_k_rows,
+            k_tile_offset,
+            output_num_k_tiles,
+            write_invalid_logits,
+            tma_atom_k,
+        ).launch(
+            grid=(
+                (valid_q_rows + _BLOCK_Q - 1) // _BLOCK_Q,
+                output_num_k_tiles,
+                1,
+            ),
+            block=[_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_u32: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_tensor: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        k_scales: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        logits_out: cute.Tensor,
+        tile_logits: cute.Tensor,
+        valid_q_rows: Int32,
+        valid_k_rows: Int32,
+        k_tile_offset: Int32,
+        output_num_k_tiles: Int32,
+        write_invalid_logits: Int32,
+        tma_atom_k: cute.CopyAtom,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        q_tile_idx, local_k_tile_idx, _ = cute.arch.block_idx()
+        k_tile_idx = local_k_tile_idx + Int32(k_tile_offset)
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+        warp_q_idx = warp_idx // Int32(_WARPS_K)
+        warp_k_idx = warp_idx - warp_q_idx * Int32(_WARPS_K)
+
+        q_tile_base = q_tile_idx * Int32(_BLOCK_Q)
+        k_tile_base = k_tile_idx * Int32(_BLOCK_K)
+        valid_q_rows = Int32(valid_q_rows)
+        k_total_rows = Int32(valid_k_rows)
+        num_heads = Int32(q_u32.shape[1])
+
+        smem = cutlass.utils.SmemAllocator()
+
+        SharedStorage = get_sparse_nsa_contiguous_shared_storage_cls()
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_k = storage.mbar_ptr_k.data_ptr()
+        k_perm_base_addr = shared_ptr_to_u32(storage.k_perm.data_ptr())
+        s_k_perm_bytes = storage.k_perm.get_tensor(
+            cute.make_layout((_BLOCK_K * _INDEX_HEAD_DIM,), stride=(1,))
+        )
+        s_k_tma_stage = cute.make_tensor(
+            s_k_perm_bytes.iterator,
+            _make_contiguous_k_tma_smem_stage_layout(_BLOCK_K),
+        )
+        load_k_tma, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.local_tile(k_tma_tensor, (_BLOCK_K, _INDEX_HEAD_DIM), (None, 0)),
+            s_k_tma_stage,
+        )
+        s_scales = storage.scales.get_tensor(cute.make_layout((_BLOCK_K,), stride=(1,)))
+        s_k_start = storage.k_start.get_tensor(
+            cute.make_layout((_BLOCK_Q,), stride=(1,))
+        )
+        s_k_end = storage.k_end.get_tensor(cute.make_layout((_BLOCK_Q,), stride=(1,)))
+        s_tile_live = storage.tile_live.get_tensor(cute.make_layout((1,), stride=(1,)))
+
+        if tx == 0:
+            cute.arch.mbarrier_init(mbar_ptr_k, Int32(1))
+        row_linear = tx
+        while row_linear < Int32(_BLOCK_Q):
+            q_row = q_tile_base + row_linear
+            s_k_start[row_linear] = (
+                Int32(k_start[q_row]) if q_row < valid_q_rows else Int32(0)
+            )
+            s_k_end[row_linear] = (
+                Int32(k_end[q_row]) if q_row < valid_q_rows else Int32(0)
+            )
+            row_linear += Int32(_THREADS_PER_CTA)
+        cute.arch.sync_threads()
+
+        # Phase 2: Parallel liveness via warp ballot
+        # Warp 0 threads (tx 0-31) each check one Q-row; ballot
+        # combines all 32 predicates in one hardware instruction.
+        if warp_idx == Int32(0):
+            tile_k_end = k_tile_base + Int32(_BLOCK_K)
+            if tile_k_end > k_total_rows:
+                tile_k_end = k_total_rows
+            row_start = Int32(s_k_start[tx])
+            row_end = Int32(s_k_end[tx])
+            row_live = (
+                (row_end > k_tile_base)
+                & (row_start < tile_k_end)
+                & (k_tile_base < tile_k_end)
+            )
+            ballot = cute.arch.vote_ballot_sync(Boolean(row_live))
+            if tx == Int32(0):
+                s_tile_live[Int32(0)] = ballot
+        cute.arch.sync_threads()
+        if s_tile_live[Int32(0)] != Int32(0):
+            producer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            consumer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            if warp_idx == Int32(0):
+                cpasync.prefetch_descriptor(tma_atom_k)
+            if warp_idx == Int32(0):
+                _issue_contiguous_k_tma_copy(
+                    load_k_tma,
+                    producer_state,
+                    mbar_ptr_k,
+                    Int32(_BLOCK_K * _INDEX_HEAD_DIM),
+                    k_tile_idx,
+                )
+            cute.arch.mbarrier_wait(
+                mbar_ptr_k + consumer_state.index,
+                phase=consumer_state.phase,
+            )
+            cute.arch.sync_threads()
+
+            scale_linear = tx
+            while scale_linear < Int32(_BLOCK_K):
+                s_scales[scale_linear] = Float32(k_scales[k_tile_base + scale_linear])
+                scale_linear += Int32(_THREADS_PER_CTA)
+            cute.arch.sync_threads()
+
+            frag_layout = cute.make_layout((1, 1, 8), stride=(8, 8, 1))
+            acc_frag = cute.make_rmem_tensor(frag_layout, Float32)
+            _zero_score_frag(acc_frag)
+
+            head_idx = Int32(0)
+            while head_idx < num_heads:
+                score_frag = cute.make_rmem_tensor(frag_layout, Float32)
+                _zero_score_frag(score_frag)
+                _literal_qk_mma_into_sfrag_mxfp8_raw(
+                    score_frag,
+                    q_u32,
+                    head_idx,
+                    q_tile_base,
+                    valid_q_rows,
+                    k_perm_base_addr,
+                    lane,
+                    warp_q_idx,
+                    warp_k_idx,
+                    Int32(0),
+                    Int32(1),
+                    Int32(_INDEX_HEAD_DIM // 16),
+                    Int32(_FP8_ROW_VECS),
+                )
+                lane_group = lane // Int32(4)
+                q_local_0 = warp_q_idx * Int32(16) + lane_group
+                q_local_8 = q_local_0 + Int32(8)
+                w_val_0 = (
+                    Float32(weights[q_tile_base + q_local_0, head_idx])
+                    if q_tile_base + q_local_0 < valid_q_rows
+                    else Float32(0.0)
+                )
+                w_val_8 = (
+                    Float32(weights[q_tile_base + q_local_8, head_idx])
+                    if q_tile_base + q_local_8 < valid_q_rows
+                    else Float32(0.0)
+                )
+                for reg_id in cutlass.range_constexpr(8):
+                    row_slot = (reg_id % 4) // 2
+                    q_local = warp_q_idx * Int32(16) + lane_group + Int32(8 * row_slot)
+                    if q_local < Int32(_BLOCK_Q):
+                        w_val = w_val_0 if row_slot == 0 else w_val_8
+                        if cutlass.const_expr(
+                            self._score_mode == IndexerScoreMode.MSA_BILINEAR
+                        ):
+                            acc_frag[0, 0, reg_id] = Float32(
+                                acc_frag[0, 0, reg_id]
+                                + score_frag[0, 0, reg_id] * w_val
+                            )
+                        else:
+                            acc_frag[0, 0, reg_id] = Float32(
+                                acc_frag[0, 0, reg_id]
+                                + attention_ops.fmax(
+                                    score_frag[0, 0, reg_id], Float32(0.0)
+                                )
+                                * w_val
+                            )
+                head_idx += Int32(1)
+
+            lane_group = lane // Int32(4)
+            lane_pair_base = Int32(2) * (lane % Int32(4))
+            for reg_id in cutlass.range_constexpr(8):
+                row_slot = (reg_id % 4) // 2
+                q_local = warp_q_idx * Int32(16) + lane_group + Int32(8 * row_slot)
+                k_local = (
+                    warp_k_idx * Int32(16)
+                    + lane_pair_base
+                    + Int32(8 * (reg_id // 4))
+                    + Int32(reg_id % 2)
+                )
+                q_row = q_tile_base + q_local
+                k_row = k_tile_base + k_local
+                if (
+                    q_local < Int32(_BLOCK_Q)
+                    and k_local < Int32(_BLOCK_K)
+                    and q_row < valid_q_rows
+                    and k_row < k_total_rows
+                ):
+                    row_start = Int32(s_k_start[q_local])
+                    row_end = Int32(s_k_end[q_local])
+                    if k_row >= row_start and k_row < row_end:
+                        logits_out[q_row, k_row] = Float32(
+                            acc_frag[0, 0, reg_id] * s_scales[k_local]
+                        )
+                    elif write_invalid_logits != Int32(0):
+                        logits_out[q_row, k_row] = Float32(-Float32.inf)
+        else:
+            if write_invalid_logits != Int32(0):
+                lane_group = lane // Int32(4)
+                lane_pair_base = Int32(2) * (lane % Int32(4))
+                for reg_id in cutlass.range_constexpr(8):
+                    row_slot = (reg_id % 4) // 2
+                    q_local = warp_q_idx * Int32(16) + lane_group + Int32(8 * row_slot)
+                    k_local = (
+                        warp_k_idx * Int32(16)
+                        + lane_pair_base
+                        + Int32(8 * (reg_id // 4))
+                        + Int32(reg_id % 2)
+                    )
+                    q_row = q_tile_base + q_local
+                    k_row = k_tile_base + k_local
+                    if (
+                        q_local < Int32(_BLOCK_Q)
+                        and k_local < Int32(_BLOCK_K)
+                        and q_row < valid_q_rows
+                        and k_row < k_total_rows
+                    ):
+                        logits_out[q_row, k_row] = Float32(-Float32.inf)
+
+
+def cp_async_128b_pred(
+    smem_addr: Int32, gmem_addr: Int64, predicate: Int32, *, loc=None, ip=None
+):
+    """Async 16B global→shared copy, predicated. Both addresses must be 16B-aligned."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(predicate).ir_value(loc=loc, ip=ip),
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        " .reg .pred p;\n"
+        " setp.ne.b32 p, $0, 0;\n"
+        " @p cp.async.cg.shared.global.L2::128B [$1], [$2], 16;\n"
+        "}",
+        "r,r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+def ld_shared_u32(smem_addr: Int32, *, loc=None, ip=None) -> Uint32:
+    """Load 32 bits from shared memory."""
+    result = llvm.inline_asm(
+        T.i32(),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ld.shared.u32 {$0}, [$1];",
+        "=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Uint32(result)
+
+
+def ld_shared_f32(smem_addr: Int32, *, loc=None, ip=None) -> Float32:
+    """Load 32 bits from shared memory as Float32."""
+    result = llvm.inline_asm(
+        T.f32(),
+        [Int32(smem_addr).ir_value(loc=loc, ip=ip)],
+        "ld.shared.f32 {$0}, [$1];",
+        "=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Float32(result)
+
+
+def st_shared_v4_f32(
+    smem_addr: Int32,
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store 128 bits (4 x f32) to shared memory. smem_addr is a u32 shared-memory address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Float32(v0).ir_value(loc=loc, ip=ip),
+            Float32(v1).ir_value(loc=loc, ip=ip),
+            Float32(v2).ir_value(loc=loc, ip=ip),
+            Float32(v3).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.v4.f32 [$0], {$1, $2, $3, $4};",
+        "r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+def get_sparse_nsa_prefill512_shared_storage_cls(q_heads_batch: int):
+    q_heads_batch = int(q_heads_batch)
+
+    class SharedStorage:
+        pass
+
+    SharedStorage.__annotations__ = {
+        "mbar_ptr_k": cute.struct.MemRange[cutlass.Int64, 1],
+        "tile_live": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, 1],
+            16,
+        ],
+        "tile_full": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, 1],
+            16,
+        ],
+        "k_start": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, _PREFILL512_BLOCK_Q],
+            16,
+        ],
+        "k_end": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Int32, _PREFILL512_BLOCK_Q],
+            16,
+        ],
+        "scales": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _PREFILL512_BLOCK_K],
+            16,
+        ],
+        "k_perm": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, _PREFILL512_BLOCK_K * _INDEX_HEAD_DIM],
+            1024,
+        ],
+        "q_bytes_smem": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.Uint8,
+                _PREFILL_Q_STAGE_ROWS * _PREFILL_Q_STAGE_COLS * q_heads_batch,
+            ],
+            1024,
+        ],
+    }
+
+    return cute.struct(SharedStorage)
+
+
+@cute.jit
+def _pack_q_mxfp8_reg_smem_ptr(
+    q_smem_base: Int32,
+    row_local: Int32,
+    col_pair_base: Int32,
+) -> Uint32:
+    """Pack 4 FP8 bytes from swizzled smem into one MMA register word.
+
+    Reads bytes at [row_local, col_pair_base+0], [row_local, col_pair_base+1],
+    [row_local, col_pair_base+8], [row_local, col_pair_base+9].
+    Uses _permuted_offset_128b to match the swizzled write layout.
+    """
+    vec_idx = col_pair_base // Int32(16)
+    word_pair = (col_pair_base // Int32(4)) % Int32(4)
+    byte_shift = (col_pair_base % Int32(4)) * Int32(8)
+    q_rs = Int32(_PREFILL_Q_STAGE_COLS // 16)
+    addr = q_smem_base + _permuted_offset_128b(row_local, vec_idx, q_rs) * Int32(16)
+    v0, v1, v2, v3 = ld_shared_v4_u32(addr)
+    lo = v0 if word_pair == Int32(0) else v1
+    hi = v2 if word_pair == Int32(0) else v3
+    lo_half = (lo >> byte_shift) & Uint32(0xFFFF)
+    hi_half = ((hi >> byte_shift) & Uint32(0xFFFF)) << Int32(16)
+    return lo_half | hi_half
+
+
+@cute.jit
+def _prefill_qk_mma_from_smem_q(
+    s_frag: cute.Tensor,
+    q_smem_base: Int32,
+    k_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_k,
+) -> None:
+    """QK MMA using Q from smem (via raw pointer) instead of global memory."""
+    unit_scale = Uint32(0x7F7F7F7F)
+    k_offset = _permuted_offset_128b(
+        row_base
+        + warp_kv_idx * num_mma_kv * Int32(16)
+        + Int32(8) * (lane // Int32(16))
+        + lane % Int32(8),
+        (lane % Int32(16)) // Int32(8),
+        upcast_stride_k,
+    )
+    q_rs = Int32(_PREFILL_Q_STAGE_COLS // 16)
+    for mma_pair in cutlass.range_constexpr(num_mma_d_qk // 2):
+        q_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        # RAW fragment order on BOTH operands (see the paged stream scorer):
+        # Q comes straight off ldmatrix.x4 over the permuted Q stage (one
+        # instruction per 16-row tile instead of four 16B-load+extract packs),
+        # and the K halves skip the 16b->8b fragment swizzles entirely.
+        q_row_in_tile = lane & Int32(15)
+        q_half = lane >> Int32(4)
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            row_base_q = warp_q_idx * Int32(16) + mma_q * Int32(16)
+            q_addr = q_smem_base + _permuted_offset_128b(
+                row_base_q + q_row_in_tile,
+                Int32(2 * mma_pair) + q_half,
+                q_rs,
+            ) * Int32(16)
+            qa0, qa1, qa2, qa3 = ldmatrix_m8n8x4_b16(q_addr)
+            q_regs[mma_q, 0] = qa0
+            q_regs[mma_q, 1] = qa1
+            q_regs[mma_q, 2] = qa2
+            q_regs[mma_q, 3] = qa3
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            b0_k0, b1_k0 = ldmatrix_m8n8x4_left_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            b0_k1, b1_k1 = ldmatrix_m8n8x4_right_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, Int32(16), upcast_stride_k
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    q_regs[mma_q, 0],
+                    q_regs[mma_q, 1],
+                    q_regs[mma_q, 2],
+                    q_regs[mma_q, 3],
+                    b0_k0,
+                    b0_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                d4, d5, d6, d7 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    q_regs[mma_q, 0],
+                    q_regs[mma_q, 1],
+                    q_regs[mma_q, 2],
+                    q_regs[mma_q, 3],
+                    b1_k0,
+                    b1_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            num_mma_kv * Int32(16) * upcast_stride_k
+        )
+
+
+class SparseNSAContiguousLogitsPrefillKernel:
+    """Prefill-specialized contiguous logits kernel with _PREFILL_BLOCK_K=256.
+
+    Uses 2 Q-warps x 4 K-warps = 256 threads. Each K-warp covers 64 K-rows
+    (num_mma_kv=4), so the CTA processes 256 K rows per tile. This quarters the
+    K-CTA count versus the decode tile, reducing redundant Q reads from global
+    memory. Q is staged into shared memory per head to avoid redundant scattered
+    global reads.
+    """
+
+    def __init__(
+        self,
+        *,
+        tiled_output: bool = False,
+        score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+        block_score_output: bool = False,
+    ):
+        self._tiled_output = tiled_output
+        self._score_mode = int(score_mode)
+        self._block_score_output = bool(block_score_output)
+
+    @cute.jit
+    def __call__(
+        self,
+        q_u32: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        k_scales: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        logits_out: cute.Tensor,
+        tile_logits: cute.Tensor,
+        block_scores: cute.Tensor,
+        valid_q_rows: Int32,
+        valid_k_rows: Int32,
+        num_blocks_out: Int32,
+        k_tile_offset: Int32,
+        output_num_k_tiles: Int32,
+        write_invalid_logits: Int32,
+        stream: cuda.CUstream,
+    ):
+        k_tma_source = _make_contiguous_k_tma_source(k_quant_bytes)
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            k_tma_source,
+            _make_contiguous_k_tma_smem_layout(_PREFILL_BLOCK_K),
+            (_PREFILL_BLOCK_K, _INDEX_HEAD_DIM),
+            1,
+        )
+        self.kernel(
+            q_u32,
+            weights,
+            k_quant_bytes,
+            tma_tensor_k,
+            k_tma_desc_ptrs,
+            k_scales,
+            k_start,
+            k_end,
+            logits_out,
+            tile_logits,
+            block_scores,
+            valid_q_rows,
+            valid_k_rows,
+            num_blocks_out,
+            k_tile_offset,
+            output_num_k_tiles,
+            write_invalid_logits,
+            tma_atom_k,
+        ).launch(
+            grid=(
+                (valid_q_rows + _PREFILL_BLOCK_Q - 1) // _PREFILL_BLOCK_Q,
+                output_num_k_tiles,
+                1,
+            ),
+            block=[_PREFILL_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_u32: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_tensor: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        k_scales: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        logits_out: cute.Tensor,
+        tile_logits: cute.Tensor,
+        block_scores: cute.Tensor,
+        valid_q_rows: Int32,
+        valid_k_rows: Int32,
+        num_blocks_out: Int32,
+        k_tile_offset: Int32,
+        output_num_k_tiles: Int32,
+        write_invalid_logits: Int32,
+        tma_atom_k: cute.CopyAtom,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        q_tile_idx, local_k_tile_idx, _ = cute.arch.block_idx()
+        k_tile_idx = local_k_tile_idx + Int32(k_tile_offset)
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+        warp_k_idx = warp_idx % Int32(_PREFILL_WARPS_K)
+        warp_q_idx = warp_idx // Int32(_PREFILL_WARPS_K)
+
+        q_tile_base = q_tile_idx * Int32(_PREFILL_BLOCK_Q)
+        k_tile_base = k_tile_idx * Int32(_PREFILL_BLOCK_K)
+        valid_q_rows = Int32(valid_q_rows)
+        k_total_rows = Int32(valid_k_rows)
+        TILED_OUTPUT = cutlass.const_expr(self._tiled_output)
+        BLOCK_SCORE_OUTPUT = cutlass.const_expr(self._block_score_output)
+        num_heads = Int32(q_u32.shape[1])
+
+        smem = cutlass.utils.SmemAllocator()
+
+        SharedStorage = get_sparse_nsa_contiguous_prefill_shared_storage_cls()
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_k = storage.mbar_ptr_k.data_ptr()
+        k_perm_base_addr = shared_ptr_to_u32(storage.k_perm.data_ptr())
+        s_k_perm_bytes = storage.k_perm.get_tensor(
+            cute.make_layout((_PREFILL_BLOCK_K * _INDEX_HEAD_DIM,), stride=(1,))
+        )
+        s_k_tma_stage = cute.make_tensor(
+            s_k_perm_bytes.iterator,
+            _make_contiguous_k_tma_smem_stage_layout(_PREFILL_BLOCK_K),
+        )
+        load_k_tma, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.local_tile(
+                k_tma_tensor, (_PREFILL_BLOCK_K, _INDEX_HEAD_DIM), (None, 0)
+            ),
+            s_k_tma_stage,
+        )
+        s_scales = storage.scales.get_tensor(
+            cute.make_layout((_PREFILL_BLOCK_K,), stride=(1,))
+        )
+        s_k_start = storage.k_start.get_tensor(
+            cute.make_layout((_PREFILL_BLOCK_Q,), stride=(1,))
+        )
+        s_k_end = storage.k_end.get_tensor(
+            cute.make_layout((_PREFILL_BLOCK_Q,), stride=(1,))
+        )
+        s_tile_live = storage.tile_live.get_tensor(cute.make_layout((1,), stride=(1,)))
+        s_block_partial = storage.block_partial.get_tensor(
+            cute.make_layout(
+                (_PREFILL_WARPS_K, _PREFILL_BLOCK_Q),
+                stride=(_PREFILL_BLOCK_Q, 1),
+            )
+        )
+
+        if tx == 0:
+            cute.arch.mbarrier_init(mbar_ptr_k, Int32(1))
+        row_linear = tx
+        while row_linear < Int32(_PREFILL_BLOCK_Q):
+            q_row = q_tile_base + row_linear
+            s_k_start[row_linear] = (
+                Int32(k_start[q_row]) if q_row < valid_q_rows else Int32(0)
+            )
+            s_k_end[row_linear] = (
+                Int32(k_end[q_row]) if q_row < valid_q_rows else Int32(0)
+            )
+            row_linear += Int32(_PREFILL_THREADS_PER_CTA)
+        cute.arch.sync_threads()
+
+        # Single ballot liveness check (32 Q-rows, same as decode)
+        if warp_idx == Int32(0):
+            tile_k_end = k_tile_base + Int32(_PREFILL_BLOCK_K)
+            if tile_k_end > k_total_rows:
+                tile_k_end = k_total_rows
+            row_start = Int32(s_k_start[tx])
+            row_end = Int32(s_k_end[tx])
+            row_live = (
+                (row_end > k_tile_base)
+                & (row_start < tile_k_end)
+                & (k_tile_base < tile_k_end)
+            )
+            ballot = cute.arch.vote_ballot_sync(Boolean(row_live))
+            if tx == Int32(0):
+                s_tile_live[Int32(0)] = ballot
+        cute.arch.sync_threads()
+
+        if s_tile_live[Int32(0)] != Int32(0):
+            # q_bytes_smem now batches _PREFILL_Q_HEADS_BATCH Q heads (32KB for 8),
+            # w_smem sits after all Q buffers.
+            q_smem_base = k_perm_base_addr + Int32(_PREFILL_BLOCK_K * _INDEX_HEAD_DIM)
+            w_smem_base = q_smem_base + Int32(
+                _PREFILL_Q_STAGE_BYTES * _PREFILL_Q_HEADS_BATCH
+            )
+            # TMA load K-tile (256 rows x 128 bytes = 32 KB)
+            producer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            consumer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            if warp_idx == Int32(0):
+                cpasync.prefetch_descriptor(tma_atom_k)
+            if warp_idx == Int32(0):
+                _issue_contiguous_k_tma_copy(
+                    load_k_tma,
+                    producer_state,
+                    mbar_ptr_k,
+                    Int32(_PREFILL_BLOCK_K * _INDEX_HEAD_DIM),
+                    k_tile_idx,
+                )
+            cute.arch.mbarrier_wait(
+                mbar_ptr_k + consumer_state.index,
+                phase=consumer_state.phase,
+            )
+
+            # Overlap: issue weight loads before TMA sync (no K dependency)
+            w_linear = tx * Int32(4)
+            while w_linear < Int32(_PREFILL_BLOCK_Q * _MAX_Q_HEADS):
+                w_q_local = w_linear // num_heads
+                w_head = w_linear % num_heads
+                w_q_row = q_tile_base + w_q_local
+                w0 = (
+                    Float32(weights[w_q_row, w_head])
+                    if (w_q_row < valid_q_rows and w_head < num_heads)
+                    else Float32(0.0)
+                )
+                w1 = (
+                    Float32(weights[w_q_row, w_head + Int32(1)])
+                    if (w_q_row < valid_q_rows and w_head + Int32(1) < num_heads)
+                    else Float32(0.0)
+                )
+                w2 = (
+                    Float32(weights[w_q_row, w_head + Int32(2)])
+                    if (w_q_row < valid_q_rows and w_head + Int32(2) < num_heads)
+                    else Float32(0.0)
+                )
+                w3 = (
+                    Float32(weights[w_q_row, w_head + Int32(3)])
+                    if (w_q_row < valid_q_rows and w_head + Int32(3) < num_heads)
+                    else Float32(0.0)
+                )
+                st_shared_v4_f32(
+                    w_smem_base + w_linear * Int32(4),
+                    w0,
+                    w1,
+                    w2,
+                    w3,
+                )
+                w_linear += Int32(_PREFILL_THREADS_PER_CTA * 4)
+            cute.arch.sync_threads()
+
+            # Load scales (256 values) after TMA arrival
+            scale_linear = tx
+            while scale_linear < Int32(_PREFILL_BLOCK_K):
+                s_scales[scale_linear] = Float32(k_scales[k_tile_base + scale_linear])
+                scale_linear += Int32(_PREFILL_THREADS_PER_CTA)
+            cute.arch.sync_threads()
+
+            # Accumulator
+            acc_layout = cute.make_layout(
+                (1, _PREFILL_NUM_MMA_KV, 8), stride=(16, 8, 1)
+            )
+            acc_frag = cute.make_rmem_tensor(acc_layout, Float32)
+            for mma_kv in cutlass.range_constexpr(_PREFILL_NUM_MMA_KV):
+                for reg_id in cutlass.range_constexpr(8):
+                    acc_frag[Int32(0), mma_kv, reg_id] = Float32(0.0)
+
+            # Precompute weight smem offsets (only 2 distinct q_local values per thread).
+            lane_group_pre = lane // Int32(4)
+            q_local_rs0 = warp_q_idx * Int32(16) + lane_group_pre
+            q_local_rs1 = q_local_rs0 + Int32(8)
+            w_off_rs0 = q_local_rs0 * num_heads * Int32(4)
+            w_off_rs1 = q_local_rs1 * num_heads * Int32(4)
+
+            # Batched Q staging: stage _PREFILL_Q_HEADS_BATCH heads into smem at once,
+            # then compute QK for all of them before moving to the next batch.
+            threads_per_row = Int32(8)
+            row_local = tx // threads_per_row
+            col_group = tx % threads_per_row
+            u32_col_base = col_group * Int32(4)
+            q_row = q_tile_base + row_local
+            in_bounds_pred = (
+                Int32(1)
+                if (row_local < Int32(_PREFILL_Q_STAGE_ROWS) and q_row < valid_q_rows)
+                else Int32(0)
+            )
+            q_smem_stride = Int32(_PREFILL_Q_STAGE_BYTES)
+            q_rs = Int32(_PREFILL_Q_STAGE_COLS // 16)
+            thread_offset = _permuted_offset_128b(row_local, col_group, q_rs) * Int32(
+                16
+            )
+            q_row_for_async = (
+                q_row if row_local < Int32(_PREFILL_Q_STAGE_ROWS) else Int32(0)
+            )
+
+            batch_base_head = Int32(0)
+            while batch_base_head < num_heads:
+                # Stage batch of heads into contiguous smem regions.
+                for block_offset in cutlass.range_constexpr(_PREFILL_Q_HEADS_BATCH):
+                    head_in_batch = Int32(block_offset)
+                    global_head = batch_base_head + head_in_batch
+                    if global_head < num_heads:
+                        gmem_u32_offset = (
+                            q_row_for_async * num_heads + global_head
+                        ) * Int32(_INDEX_HEAD_DIM // 4) + u32_col_base
+                        cp_async_128b_pred(
+                            q_smem_base + head_in_batch * q_smem_stride + thread_offset,
+                            get_ptr_as_int64(q_u32, gmem_u32_offset),
+                            in_bounds_pred,
+                        )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.sync_threads()
+
+                # Compute QK for each head in the batch (reads from stable smem).
+                for block_offset in cutlass.range_constexpr(_PREFILL_Q_HEADS_BATCH):
+                    head_idx = batch_base_head + Int32(block_offset)
+                    if head_idx < num_heads:
+                        curr_mma_base = (
+                            q_smem_base + Int32(block_offset) * q_smem_stride
+                        )
+
+                        score_frag = cute.make_rmem_tensor(acc_layout, Float32)
+                        for mma_kv in cutlass.range_constexpr(_PREFILL_NUM_MMA_KV):
+                            for reg_id in cutlass.range_constexpr(8):
+                                score_frag[Int32(0), mma_kv, reg_id] = Float32(0.0)
+                        _prefill_qk_mma_from_smem_q(
+                            score_frag,
+                            curr_mma_base,
+                            k_perm_base_addr,
+                            lane,
+                            warp_q_idx,
+                            warp_k_idx,
+                            Int32(0),
+                            Int32(_PREFILL_NUM_MMA_Q),
+                            Int32(_PREFILL_NUM_MMA_KV),
+                            Int32(_INDEX_HEAD_DIM // 16),
+                            Int32(_FP8_ROW_VECS),
+                        )
+                        # Accumulate per K-sub-tile (q_local always in [0,31], no bounds check needed)
+                        lane_group = lane // Int32(4)
+                        w_rs0 = ld_shared_f32(
+                            w_smem_base + w_off_rs0 + head_idx * Int32(4)
+                        )
+                        w_rs1 = ld_shared_f32(
+                            w_smem_base + w_off_rs1 + head_idx * Int32(4)
+                        )
+                        if BLOCK_SCORE_OUTPUT:
+                            lane_pair_base = Int32(2) * (lane % Int32(4))
+                            local_max_rs0 = Float32(-Float32.inf)
+                            local_max_rs1 = Float32(-Float32.inf)
+                            for mma_kv in cutlass.range_constexpr(_PREFILL_NUM_MMA_KV):
+                                for reg_id in cutlass.range_constexpr(8):
+                                    row_slot = (reg_id % 4) // 2
+                                    q_local = (
+                                        warp_q_idx * Int32(16)
+                                        + lane_group
+                                        + Int32(8 * row_slot)
+                                    )
+                                    k_local = (
+                                        warp_k_idx * Int32(_PREFILL_NUM_MMA_KV * 16)
+                                        + mma_kv * Int32(16)
+                                        + lane_pair_base
+                                        + Int32(8 * (reg_id // 4))
+                                        + Int32(reg_id % 2)
+                                    )
+                                    q_row = q_tile_base + q_local
+                                    k_row = k_tile_base + k_local
+                                    row_start = Int32(s_k_start[q_local])
+                                    row_end = Int32(s_k_end[q_local])
+                                    if (
+                                        q_row < valid_q_rows
+                                        and k_row < k_total_rows
+                                        and k_row >= row_start
+                                        and k_row < row_end
+                                    ):
+                                        w_val = w_rs0 if row_slot == Int32(0) else w_rs1
+                                        score = Float32(
+                                            score_frag[Int32(0), mma_kv, reg_id]
+                                            * w_val
+                                            * s_scales[k_local]
+                                        )
+                                        if row_slot == Int32(0):
+                                            local_max_rs0 = attention_ops.fmax(
+                                                local_max_rs0,
+                                                score,
+                                            )
+                                        else:
+                                            local_max_rs1 = attention_ops.fmax(
+                                                local_max_rs1,
+                                                score,
+                                            )
+                            local_max_rs0 = _reduce_quad_max(local_max_rs0)
+                            local_max_rs1 = _reduce_quad_max(local_max_rs1)
+                            if lane % Int32(4) == Int32(0):
+                                s_block_partial[warp_k_idx, q_local_rs0] = local_max_rs0
+                                s_block_partial[warp_k_idx, q_local_rs1] = local_max_rs1
+                            cute.arch.sync_threads()
+                            if tx < Int32(64):
+                                q_local_out = tx % Int32(_PREFILL_BLOCK_Q)
+                                block_local = tx // Int32(_PREFILL_BLOCK_Q)
+                                block_idx = k_tile_idx * Int32(2) + block_local
+                                q_row_out = q_tile_base + q_local_out
+                                v = attention_ops.fmax(
+                                    s_block_partial[
+                                        block_local * Int32(2), q_local_out
+                                    ],
+                                    s_block_partial[
+                                        block_local * Int32(2) + Int32(1), q_local_out
+                                    ],
+                                )
+                                if (
+                                    q_row_out < valid_q_rows
+                                    and block_idx < num_blocks_out
+                                ):
+                                    block_scores[head_idx, q_row_out, block_idx] = v
+                            cute.arch.sync_threads()
+                        else:
+                            for mma_kv in cutlass.range_constexpr(_PREFILL_NUM_MMA_KV):
+                                for reg_id in cutlass.range_constexpr(8):
+                                    row_slot = (reg_id % 4) // 2
+                                    q_local = (
+                                        warp_q_idx * Int32(16)
+                                        + lane_group
+                                        + Int32(8 * row_slot)
+                                    )
+                                    w_val = w_rs0 if row_slot == Int32(0) else w_rs1
+                                    if cutlass.const_expr(
+                                        self._score_mode
+                                        == IndexerScoreMode.MSA_BILINEAR
+                                    ):
+                                        acc_frag[Int32(0), mma_kv, reg_id] = Float32(
+                                            acc_frag[Int32(0), mma_kv, reg_id]
+                                            + score_frag[Int32(0), mma_kv, reg_id]
+                                            * w_val
+                                        )
+                                    else:
+                                        acc_frag[Int32(0), mma_kv, reg_id] = Float32(
+                                            acc_frag[Int32(0), mma_kv, reg_id]
+                                            + attention_ops.fmax(
+                                                score_frag[Int32(0), mma_kv, reg_id],
+                                                Float32(0.0),
+                                            )
+                                            * w_val
+                                        )
+                # The next batch reuses the same Q shared-memory slots.
+                cute.arch.sync_threads()
+                batch_base_head += Int32(_PREFILL_Q_HEADS_BATCH)
+
+            # Write back — each K-warp covers NUM_MMA_KV * 16 K-rows
+            lane_group = lane // Int32(4)
+            lane_pair_base = Int32(2) * (lane % Int32(4))
+            if BLOCK_SCORE_OUTPUT:
+                pass
+            elif TILED_OUTPUT:
+                for mma_kv in cutlass.range_constexpr(_PREFILL_NUM_MMA_KV):
+                    for reg_id in cutlass.range_constexpr(8):
+                        row_slot = (reg_id % 4) // 2
+                        q_local = (
+                            warp_q_idx * Int32(16) + lane_group + Int32(8 * row_slot)
+                        )
+                        k_local = (
+                            warp_k_idx * Int32(_PREFILL_NUM_MMA_KV * 16)
+                            + mma_kv * Int32(16)
+                            + lane_pair_base
+                            + Int32(8 * (reg_id // 4))
+                            + Int32(reg_id % 2)
+                        )
+                        if (
+                            q_local < Int32(_PREFILL_BLOCK_Q)
+                            and k_local < Int32(_PREFILL_BLOCK_K)
+                            and q_tile_base + q_local < valid_q_rows
+                        ):
+                            _tile_id = (
+                                q_tile_idx * Int32(output_num_k_tiles)
+                                + local_k_tile_idx
+                            )
+                            _offset_in_tile = (
+                                q_local * Int32(_PREFILL_BLOCK_K) + k_local
+                            )
+                            _flat_offset = (
+                                _tile_id * Int32(_PREFILL_BLOCK_Q * _PREFILL_BLOCK_K)
+                                + _offset_in_tile
+                            )
+                            tile_logits[_flat_offset] = Float32(
+                                acc_frag[Int32(0), mma_kv, reg_id] * s_scales[k_local]
+                            )
+            else:
+                for mma_kv in cutlass.range_constexpr(_PREFILL_NUM_MMA_KV):
+                    for reg_id in cutlass.range_constexpr(8):
+                        row_slot = (reg_id % 4) // 2
+                        q_local = (
+                            warp_q_idx * Int32(16) + lane_group + Int32(8 * row_slot)
+                        )
+                        k_local = (
+                            warp_k_idx * Int32(_PREFILL_NUM_MMA_KV * 16)
+                            + mma_kv * Int32(16)
+                            + lane_pair_base
+                            + Int32(8 * (reg_id // 4))
+                            + Int32(reg_id % 2)
+                        )
+                        q_row = q_tile_base + q_local
+                        k_row = k_tile_base + k_local
+                        if (
+                            q_local < Int32(_PREFILL_BLOCK_Q)
+                            and k_local < Int32(_PREFILL_BLOCK_K)
+                            and q_row < valid_q_rows
+                            and k_row < k_total_rows
+                        ):
+                            row_start = Int32(s_k_start[q_local])
+                            row_end = Int32(s_k_end[q_local])
+                            if k_row >= row_start and k_row < row_end:
+                                logits_out[q_row, k_row] = Float32(
+                                    acc_frag[Int32(0), mma_kv, reg_id]
+                                    * s_scales[k_local]
+                                )
+                            elif write_invalid_logits != Int32(0):
+                                logits_out[q_row, k_row] = Float32(-Float32.inf)
+        else:
+            if BLOCK_SCORE_OUTPUT:
+                pass  # dead tile; host -inf prefill covers block scores
+            elif TILED_OUTPUT:
+                pass  # dead tile; topk filters with k_start/lengths
+            elif write_invalid_logits != Int32(0):
+                lane_group = lane // Int32(4)
+                lane_pair_base = Int32(2) * (lane % Int32(4))
+                for mma_kv in cutlass.range_constexpr(_PREFILL_NUM_MMA_KV):
+                    for reg_id in cutlass.range_constexpr(8):
+                        row_slot = (reg_id % 4) // 2
+                        q_local = (
+                            warp_q_idx * Int32(16) + lane_group + Int32(8 * row_slot)
+                        )
+                        k_local = (
+                            warp_k_idx * Int32(_PREFILL_NUM_MMA_KV * 16)
+                            + mma_kv * Int32(16)
+                            + lane_pair_base
+                            + Int32(8 * (reg_id // 4))
+                            + Int32(reg_id % 2)
+                        )
+                        q_row = q_tile_base + q_local
+                        k_row = k_tile_base + k_local
+                        if (
+                            q_local < Int32(_PREFILL_BLOCK_Q)
+                            and k_local < Int32(_PREFILL_BLOCK_K)
+                            and q_row < valid_q_rows
+                            and k_row < k_total_rows
+                        ):
+                            logits_out[q_row, k_row] = Float32(-Float32.inf)
+
+
+class SparseNSAContiguousLogitsPrefillKernelBlockScores(
+    SparseNSAContiguousLogitsPrefillKernel
+):
+    """Distinct compile identity for the MSA block-score specialization.
+
+    The implementation and ABI intentionally remain inherited from the
+    prefill logits kernel.  A concrete type prevents two semantically distinct
+    compile specs from collapsing onto one generated CUDA entry-point symbol,
+    which is required for exact per-launch resource accounting.
+    """
+
+
+class SparseNSAContiguousLogitsPrefill512Kernel:
+    """Experimental prefill scorer with _PREFILL512_BLOCK_K=512.
+
+    This halves the K-CTA count versus the BK=256 prefill scorer. To keep
+    shared-memory use under the launch limit, it batches a small group of Q
+    heads in shared memory.
+    """
+
+    def __init__(
+        self,
+        *,
+        tiled_output: bool = False,
+        q_heads_batch: int = _PREFILL512_Q_HEADS_BATCH,
+        score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    ):
+        self._tiled_output = tiled_output
+        self._q_heads_batch = int(q_heads_batch)
+        self._score_mode = int(score_mode)
+
+    @cute.jit
+    def __call__(
+        self,
+        q_u32: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        k_scales: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        logits_out: cute.Tensor,
+        tile_logits: cute.Tensor,
+        valid_q_rows: Int32,
+        valid_k_rows: Int32,
+        k_tile_offset: Int32,
+        output_num_k_tiles: Int32,
+        write_invalid_logits: Int32,
+        stream: cuda.CUstream,
+    ):
+        k_tma_source = _make_contiguous_k_tma_source(k_quant_bytes)
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            k_tma_source,
+            _make_contiguous_k_tma_smem_layout(_PREFILL_BLOCK_K),
+            (_PREFILL_BLOCK_K, _INDEX_HEAD_DIM),
+            1,
+        )
+        self.kernel(
+            q_u32,
+            weights,
+            k_quant_bytes,
+            tma_tensor_k,
+            k_tma_desc_ptrs,
+            k_scales,
+            k_start,
+            k_end,
+            logits_out,
+            tile_logits,
+            valid_q_rows,
+            valid_k_rows,
+            k_tile_offset,
+            output_num_k_tiles,
+            write_invalid_logits,
+            tma_atom_k,
+        ).launch(
+            grid=(
+                (valid_q_rows + _PREFILL512_BLOCK_Q - 1) // _PREFILL512_BLOCK_Q,
+                output_num_k_tiles,
+                1,
+            ),
+            block=[_PREFILL512_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_u32: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_tensor: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        k_scales: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        logits_out: cute.Tensor,
+        tile_logits: cute.Tensor,
+        valid_q_rows: Int32,
+        valid_k_rows: Int32,
+        k_tile_offset: Int32,
+        output_num_k_tiles: Int32,
+        write_invalid_logits: Int32,
+        tma_atom_k: cute.CopyAtom,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        q_tile_idx, local_k_tile_idx, _ = cute.arch.block_idx()
+        k_tile_idx = local_k_tile_idx + Int32(k_tile_offset)
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+        warp_k_idx = warp_idx % Int32(_PREFILL512_WARPS_K)
+        warp_q_idx = warp_idx // Int32(_PREFILL512_WARPS_K)
+
+        q_tile_base = q_tile_idx * Int32(_PREFILL512_BLOCK_Q)
+        k_tile_base = k_tile_idx * Int32(_PREFILL512_BLOCK_K)
+        valid_q_rows = Int32(valid_q_rows)
+        k_total_rows = Int32(valid_k_rows)
+        TILED_OUTPUT = cutlass.const_expr(self._tiled_output)
+        Q_HEADS_BATCH = cutlass.const_expr(self._q_heads_batch)
+        num_heads = Int32(q_u32.shape[1])
+
+        smem = cutlass.utils.SmemAllocator()
+
+        SharedStorage = get_sparse_nsa_prefill512_shared_storage_cls(
+            self._q_heads_batch,
+        )
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_k = storage.mbar_ptr_k.data_ptr()
+        k_perm_base_addr = shared_ptr_to_u32(storage.k_perm.data_ptr())
+        s_k_perm_bytes = storage.k_perm.get_tensor(
+            cute.make_layout((_PREFILL512_BLOCK_K * _INDEX_HEAD_DIM,), stride=(1,))
+        )
+        s_k_tma_stage0 = cute.make_tensor(
+            s_k_perm_bytes.iterator,
+            _make_contiguous_k_tma_smem_stage_layout(_PREFILL_BLOCK_K),
+        )
+        s_k_tma_stage1 = cute.make_tensor(
+            s_k_perm_bytes.iterator + Int32(_PREFILL_BLOCK_K * _INDEX_HEAD_DIM),
+            _make_contiguous_k_tma_smem_stage_layout(_PREFILL_BLOCK_K),
+        )
+        g_k_tma_tile = cute.local_tile(
+            k_tma_tensor,
+            (_PREFILL_BLOCK_K, _INDEX_HEAD_DIM),
+            (None, 0),
+        )
+        load_k_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            g_k_tma_tile,
+            s_k_tma_stage0,
+        )
+        load_k_tma1, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            g_k_tma_tile,
+            s_k_tma_stage1,
+        )
+        s_scales = storage.scales.get_tensor(
+            cute.make_layout((_PREFILL512_BLOCK_K,), stride=(1,))
+        )
+        s_k_start = storage.k_start.get_tensor(
+            cute.make_layout((_PREFILL512_BLOCK_Q,), stride=(1,))
+        )
+        s_k_end = storage.k_end.get_tensor(
+            cute.make_layout((_PREFILL512_BLOCK_Q,), stride=(1,))
+        )
+        s_tile_live = storage.tile_live.get_tensor(cute.make_layout((1,), stride=(1,)))
+        s_tile_full = storage.tile_full.get_tensor(cute.make_layout((1,), stride=(1,)))
+
+        if tx == 0:
+            cute.arch.mbarrier_init(mbar_ptr_k, Int32(1))
+        row_linear = tx
+        while row_linear < Int32(_PREFILL512_BLOCK_Q):
+            q_row = q_tile_base + row_linear
+            s_k_start[row_linear] = (
+                Int32(k_start[q_row]) if q_row < valid_q_rows else Int32(0)
+            )
+            s_k_end[row_linear] = (
+                Int32(k_end[q_row]) if q_row < valid_q_rows else Int32(0)
+            )
+            row_linear += Int32(_PREFILL512_THREADS_PER_CTA)
+        cute.arch.sync_threads()
+
+        if warp_idx == Int32(0):
+            tile_k_end = k_tile_base + Int32(_PREFILL512_BLOCK_K)
+            if tile_k_end > k_total_rows:
+                tile_k_end = k_total_rows
+            row_start = Int32(s_k_start[tx])
+            row_end = Int32(s_k_end[tx])
+            physical_tile_full = tile_k_end == k_tile_base + Int32(_PREFILL512_BLOCK_K)
+            row_live = (
+                (row_end > k_tile_base)
+                & (row_start < tile_k_end)
+                & (k_tile_base < tile_k_end)
+            )
+            row_full = (
+                (q_tile_base + tx < valid_q_rows)
+                & physical_tile_full
+                & (row_start <= k_tile_base)
+                & (row_end >= tile_k_end)
+            )
+            ballot = cute.arch.vote_ballot_sync(Boolean(row_live))
+            full_ballot = cute.arch.vote_ballot_sync(Boolean(row_full))
+            if tx == Int32(0):
+                s_tile_live[Int32(0)] = ballot
+                s_tile_full[Int32(0)] = (
+                    Int32(1) if full_ballot == Int32(-1) else Int32(0)
+                )
+        cute.arch.sync_threads()
+
+        if s_tile_live[Int32(0)] != Int32(0):
+            q_smem_base = k_perm_base_addr + Int32(
+                _PREFILL512_BLOCK_K * _INDEX_HEAD_DIM
+            )
+            producer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            consumer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            if warp_idx == Int32(0):
+                cpasync.prefetch_descriptor(tma_atom_k)
+            if warp_idx == Int32(0):
+                k_subtile_idx = k_tile_idx * Int32(2)
+                _issue_contiguous_k_tma_copy_pair(
+                    load_k_tma0,
+                    load_k_tma1,
+                    producer_state,
+                    mbar_ptr_k,
+                    Int32(_PREFILL512_BLOCK_K * _INDEX_HEAD_DIM),
+                    k_subtile_idx,
+                    k_subtile_idx + Int32(1),
+                )
+            # Exp40: weight staging removed — weights read from gmem directly (hidden by QK MMA latency).
+            # Only stage scales while the K TMA copy is in flight.
+            scale_linear = tx
+            while scale_linear < Int32(_PREFILL512_BLOCK_K):
+                s_scales[scale_linear] = Float32(k_scales[k_tile_base + scale_linear])
+                scale_linear += Int32(_PREFILL512_THREADS_PER_CTA)
+
+            acc_layout = cute.make_layout(
+                (1, _PREFILL512_NUM_MMA_KV, 8), stride=(16, 8, 1)
+            )
+            acc_frag = cute.make_rmem_tensor(acc_layout, Float32)
+            for mma_kv in cutlass.range_constexpr(_PREFILL512_NUM_MMA_KV):
+                for reg_id in cutlass.range_constexpr(8):
+                    acc_frag[Int32(0), mma_kv, reg_id] = Float32(0.0)
+
+            # Exp38: compute Q staging variables and issue first Q-head batch
+            # cp_async BEFORE mbarrier_wait — Q loads from gmem, independent of K TMA.
+            # This overlaps first-batch Q staging latency with K TMA tail + weight/scale loads.
+            threads_per_row = Int32(8)
+            row_local = tx // threads_per_row
+            col_group = tx % threads_per_row
+            u32_col_base = col_group * Int32(4)
+            q_row = q_tile_base + row_local
+            in_bounds_pred = (
+                Int32(1)
+                if (row_local < Int32(_PREFILL_Q_STAGE_ROWS) and q_row < valid_q_rows)
+                else Int32(0)
+            )
+            q_smem_stride = Int32(_PREFILL_Q_STAGE_BYTES)
+            q_rs = Int32(_PREFILL_Q_STAGE_COLS // 16)
+            thread_offset = _permuted_offset_128b(row_local, col_group, q_rs) * Int32(
+                16
+            )
+            q_row_for_async = (
+                q_row if row_local < Int32(_PREFILL_Q_STAGE_ROWS) else Int32(0)
+            )
+
+            batch_base_head = Int32(0)
+            for block_offset in cutlass.range_constexpr(Q_HEADS_BATCH):
+                head_in_batch = Int32(block_offset)
+                global_head = batch_base_head + head_in_batch
+                if global_head < num_heads:
+                    gmem_u32_offset = (
+                        q_row_for_async * num_heads + global_head
+                    ) * Int32(_INDEX_HEAD_DIM // 4) + u32_col_base
+                    cp_async_128b_pred(
+                        q_smem_base + head_in_batch * q_smem_stride + thread_offset,
+                        get_ptr_as_int64(q_u32, gmem_u32_offset),
+                        in_bounds_pred,
+                    )
+            cute.arch.cp_async_commit_group()
+
+            cute.arch.mbarrier_wait(
+                mbar_ptr_k + consumer_state.index,
+                phase=consumer_state.phase,
+            )
+            cute.arch.sync_threads()
+
+            lane_group_pre = lane // Int32(4)
+            q_local_rs0 = warp_q_idx * Int32(16) + lane_group_pre
+            q_local_rs1 = q_local_rs0 + Int32(8)
+            # Pipelined Q-head batch loop: overlap staging of batch N+1 with compute of batch N
+            # Prologue: first Q-head batch already staged above before mbarrier_wait
+
+            while batch_base_head < num_heads:
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.sync_threads()
+
+                for block_offset in cutlass.range_constexpr(Q_HEADS_BATCH):
+                    head_idx = batch_base_head + Int32(block_offset)
+                    if head_idx < num_heads:
+                        curr_mma_base = (
+                            q_smem_base + Int32(block_offset) * q_smem_stride
+                        )
+
+                        score_frag = cute.make_rmem_tensor(acc_layout, Float32)
+                        for mma_kv in cutlass.range_constexpr(_PREFILL512_NUM_MMA_KV):
+                            for reg_id in cutlass.range_constexpr(8):
+                                score_frag[Int32(0), mma_kv, reg_id] = Float32(0.0)
+                        _prefill_qk_mma_from_smem_q(
+                            score_frag,
+                            curr_mma_base,
+                            k_perm_base_addr,
+                            lane,
+                            warp_q_idx,
+                            warp_k_idx,
+                            Int32(0),
+                            Int32(_PREFILL512_NUM_MMA_Q),
+                            Int32(_PREFILL512_NUM_MMA_KV),
+                            Int32(_INDEX_HEAD_DIM // 16),
+                            Int32(_FP8_ROW_VECS),
+                        )
+                        lane_group = lane // Int32(4)
+                        q_row_rs0 = q_tile_base + q_local_rs0
+                        q_row_rs1 = q_tile_base + q_local_rs1
+                        w_rs0 = (
+                            Float32(weights[q_row_rs0, head_idx])
+                            if q_row_rs0 < valid_q_rows
+                            else Float32(0.0)
+                        )
+                        w_rs1 = (
+                            Float32(weights[q_row_rs1, head_idx])
+                            if q_row_rs1 < valid_q_rows
+                            else Float32(0.0)
+                        )
+                        for mma_kv in cutlass.range_constexpr(_PREFILL512_NUM_MMA_KV):
+                            for reg_id in cutlass.range_constexpr(8):
+                                row_slot = (reg_id % 4) // 2
+                                w_val = w_rs0 if row_slot == Int32(0) else w_rs1
+                                if cutlass.const_expr(
+                                    self._score_mode == IndexerScoreMode.MSA_BILINEAR
+                                ):
+                                    acc_frag[Int32(0), mma_kv, reg_id] = Float32(
+                                        acc_frag[Int32(0), mma_kv, reg_id]
+                                        + score_frag[Int32(0), mma_kv, reg_id] * w_val
+                                    )
+                                else:
+                                    acc_frag[Int32(0), mma_kv, reg_id] = Float32(
+                                        acc_frag[Int32(0), mma_kv, reg_id]
+                                        + attention_ops.fmax(
+                                            score_frag[Int32(0), mma_kv, reg_id],
+                                            Float32(0.0),
+                                        )
+                                        * w_val
+                                    )
+                cute.arch.sync_threads()
+                batch_base_head += Int32(Q_HEADS_BATCH)
+
+                # Issue Q staging for next batch (overlapped with current sync overhead)
+                if batch_base_head < num_heads:
+                    for block_offset in cutlass.range_constexpr(Q_HEADS_BATCH):
+                        head_in_batch = Int32(block_offset)
+                        global_head = batch_base_head + head_in_batch
+                        if global_head < num_heads:
+                            gmem_u32_offset = (
+                                q_row_for_async * num_heads + global_head
+                            ) * Int32(_INDEX_HEAD_DIM // 4) + u32_col_base
+                            cp_async_128b_pred(
+                                q_smem_base
+                                + head_in_batch * q_smem_stride
+                                + thread_offset,
+                                get_ptr_as_int64(q_u32, gmem_u32_offset),
+                                in_bounds_pred,
+                            )
+                    cute.arch.cp_async_commit_group()
+
+            lane_group = lane // Int32(4)
+            lane_pair_base = Int32(2) * (lane % Int32(4))
+            if TILED_OUTPUT:
+                for mma_kv in cutlass.range_constexpr(_PREFILL512_NUM_MMA_KV):
+                    for reg_id in cutlass.range_constexpr(8):
+                        row_slot = (reg_id % 4) // 2
+                        q_local = (
+                            warp_q_idx * Int32(16) + lane_group + Int32(8 * row_slot)
+                        )
+                        k_local = (
+                            warp_k_idx * Int32(_PREFILL512_NUM_MMA_KV * 16)
+                            + mma_kv * Int32(16)
+                            + lane_pair_base
+                            + Int32(8 * (reg_id // 4))
+                            + Int32(reg_id % 2)
+                        )
+                        if (
+                            q_local < Int32(_PREFILL512_BLOCK_Q)
+                            and k_local < Int32(_PREFILL512_BLOCK_K)
+                            and q_tile_base + q_local < valid_q_rows
+                        ):
+                            _tile_id = (
+                                q_tile_idx * Int32(output_num_k_tiles)
+                                + local_k_tile_idx
+                            )
+                            _offset_in_tile = (
+                                q_local * Int32(_PREFILL512_BLOCK_K) + k_local
+                            )
+                            _flat_offset = (
+                                _tile_id
+                                * Int32(_PREFILL512_BLOCK_Q * _PREFILL512_BLOCK_K)
+                                + _offset_in_tile
+                            )
+                            tile_logits[_flat_offset] = Float32(
+                                acc_frag[Int32(0), mma_kv, reg_id] * s_scales[k_local]
+                            )
+            else:
+                if s_tile_full[Int32(0)] != Int32(0):
+                    q_full_row0 = q_tile_base + warp_q_idx * Int32(16) + lane_group
+                    q_full_row1 = q_full_row0 + Int32(8)
+                    out_base0 = q_full_row0 * k_total_rows + k_tile_base
+                    out_base1 = q_full_row1 * k_total_rows + k_tile_base
+                    for mma_kv in cutlass.range_constexpr(_PREFILL512_NUM_MMA_KV):
+                        k_pair0 = (
+                            warp_k_idx * Int32(_PREFILL512_NUM_MMA_KV * 16)
+                            + mma_kv * Int32(16)
+                            + lane_pair_base
+                        )
+                        k_pair1 = k_pair0 + Int32(8)
+                        scale0 = s_scales[k_pair0]
+                        scale1 = s_scales[k_pair0 + Int32(1)]
+                        scale8 = s_scales[k_pair1]
+                        scale9 = s_scales[k_pair1 + Int32(1)]
+                        st_global_v2_f32(
+                            get_ptr_as_int64(logits_out, out_base0 + k_pair0),
+                            Float32(acc_frag[Int32(0), mma_kv, 0] * scale0),
+                            Float32(acc_frag[Int32(0), mma_kv, 1] * scale1),
+                        )
+                        st_global_v2_f32(
+                            get_ptr_as_int64(logits_out, out_base1 + k_pair0),
+                            Float32(acc_frag[Int32(0), mma_kv, 2] * scale0),
+                            Float32(acc_frag[Int32(0), mma_kv, 3] * scale1),
+                        )
+                        st_global_v2_f32(
+                            get_ptr_as_int64(logits_out, out_base0 + k_pair1),
+                            Float32(acc_frag[Int32(0), mma_kv, 4] * scale8),
+                            Float32(acc_frag[Int32(0), mma_kv, 5] * scale9),
+                        )
+                        st_global_v2_f32(
+                            get_ptr_as_int64(logits_out, out_base1 + k_pair1),
+                            Float32(acc_frag[Int32(0), mma_kv, 6] * scale8),
+                            Float32(acc_frag[Int32(0), mma_kv, 7] * scale9),
+                        )
+                else:
+                    for mma_kv in cutlass.range_constexpr(_PREFILL512_NUM_MMA_KV):
+                        for reg_id in cutlass.range_constexpr(8):
+                            row_slot = (reg_id % 4) // 2
+                            q_local = (
+                                warp_q_idx * Int32(16)
+                                + lane_group
+                                + Int32(8 * row_slot)
+                            )
+                            k_local = (
+                                warp_k_idx * Int32(_PREFILL512_NUM_MMA_KV * 16)
+                                + mma_kv * Int32(16)
+                                + lane_pair_base
+                                + Int32(8 * (reg_id // 4))
+                                + Int32(reg_id % 2)
+                            )
+                            q_row = q_tile_base + q_local
+                            k_row = k_tile_base + k_local
+                            if (
+                                q_local < Int32(_PREFILL512_BLOCK_Q)
+                                and k_local < Int32(_PREFILL512_BLOCK_K)
+                                and q_row < valid_q_rows
+                                and k_row < k_total_rows
+                            ):
+                                row_start = Int32(s_k_start[q_local])
+                                row_end = Int32(s_k_end[q_local])
+                                if k_row >= row_start and k_row < row_end:
+                                    logits_out[q_row, k_row] = Float32(
+                                        acc_frag[Int32(0), mma_kv, reg_id]
+                                        * s_scales[k_local]
+                                    )
+                                elif write_invalid_logits != Int32(0):
+                                    logits_out[q_row, k_row] = Float32(-Float32.inf)
+        else:
+            if TILED_OUTPUT:
+                pass  # dead tile; topk kernel uses k_start/k_end to filter
+            else:
+                if write_invalid_logits != Int32(0):
+                    lane_group = lane // Int32(4)
+                    lane_pair_base = Int32(2) * (lane % Int32(4))
+                    if (
+                        q_tile_base + Int32(_PREFILL512_BLOCK_Q) <= valid_q_rows
+                        and k_tile_base + Int32(_PREFILL512_BLOCK_K) <= k_total_rows
+                    ):
+                        neg_inf = Float32(-Float32.inf)
+                        for fill_iter in cutlass.range_constexpr(
+                            (_PREFILL512_BLOCK_Q * _PREFILL512_BLOCK_K)
+                            // (_PREFILL512_THREADS_PER_CTA * 4)
+                        ):
+                            fill_linear = tx * Int32(4) + Int32(
+                                fill_iter * _PREFILL512_THREADS_PER_CTA * 4
+                            )
+                            q_local = fill_linear // Int32(_PREFILL512_BLOCK_K)
+                            k_local = fill_linear - q_local * Int32(_PREFILL512_BLOCK_K)
+                            out_base = (
+                                (q_tile_base + q_local) * k_total_rows
+                                + k_tile_base
+                                + k_local
+                            )
+                            st_global_v4_f32(
+                                get_ptr_as_int64(logits_out, out_base),
+                                neg_inf,
+                                neg_inf,
+                                neg_inf,
+                                neg_inf,
+                            )
+                    else:
+                        for mma_kv in cutlass.range_constexpr(_PREFILL512_NUM_MMA_KV):
+                            for reg_id in cutlass.range_constexpr(8):
+                                row_slot = (reg_id % 4) // 2
+                                q_local = (
+                                    warp_q_idx * Int32(16)
+                                    + lane_group
+                                    + Int32(8 * row_slot)
+                                )
+                                k_local = (
+                                    warp_k_idx * Int32(_PREFILL512_NUM_MMA_KV * 16)
+                                    + mma_kv * Int32(16)
+                                    + lane_pair_base
+                                    + Int32(8 * (reg_id // 4))
+                                    + Int32(reg_id % 2)
+                                )
+                                q_row = q_tile_base + q_local
+                                k_row = k_tile_base + k_local
+                                if (
+                                    q_local < Int32(_PREFILL512_BLOCK_Q)
+                                    and k_local < Int32(_PREFILL512_BLOCK_K)
+                                    and q_row < valid_q_rows
+                                    and k_row < k_total_rows
+                                ):
+                                    logits_out[q_row, k_row] = Float32(-Float32.inf)
+
+
+@lru_cache(maxsize=16)
+def _build_sparse_nsa_contiguous_prefill_kernel(
+    *,
+    tiled_output: bool = False,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    block_score_output: bool = False,
+) -> SparseNSAContiguousLogitsPrefillKernel:
+    kernel_type = (
+        SparseNSAContiguousLogitsPrefillKernelBlockScores
+        if block_score_output
+        else SparseNSAContiguousLogitsPrefillKernel
+    )
+    return kernel_type(
+        tiled_output=tiled_output,
+        score_mode=score_mode,
+        block_score_output=block_score_output,
+    )
+
+
+@lru_cache(maxsize=16)
+def _build_sparse_nsa_contiguous_prefill512_kernel(
+    *,
+    tiled_output: bool = False,
+    num_heads: int = 0,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+) -> SparseNSAContiguousLogitsPrefill512Kernel:
+    if int(num_heads) == _PREFILL512_H32_WEIGHT_COLS:
+        return SparseNSAContiguousLogitsPrefill512Kernel(
+            tiled_output=tiled_output,
+            q_heads_batch=_PREFILL512_H32_Q_HEADS_BATCH,
+            score_mode=score_mode,
+        )
+    return SparseNSAContiguousLogitsPrefill512Kernel(
+        tiled_output=tiled_output,
+        score_mode=score_mode,
+    )
+
+
+@lru_cache(maxsize=16)
+def _build_sparse_nsa_contiguous_kernel(
+    *,
+    tiled_output: bool = False,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+) -> SparseNSAContiguousLogitsKernel:
+    return SparseNSAContiguousLogitsKernel(
+        tiled_output=tiled_output,
+        score_mode=score_mode,
+    )
+
+
+def _use_sparse_nsa_contiguous_prefill(valid_q_rows: int) -> bool:
+    prefill_env = os.environ.get(_NSA_CONTIGUOUS_PREFILL_THRESHOLD_ENV, None)
+    if prefill_env is not None:
+        return int(prefill_env) > 0
+    return valid_q_rows >= 256
+
+
+def _prefill512_unsupported_reasons(
+    *,
+    valid_q_rows: int,
+    k_rows: int,
+    num_heads: int,
+) -> list[str]:
+    reasons: list[str] = []
+    if valid_q_rows < _PREFILL512_MIN_Q_ROWS:
+        reasons.append(f"valid_q_rows={valid_q_rows} < {_PREFILL512_MIN_Q_ROWS}")
+    if k_rows < _PREFILL512_MIN_K_ROWS:
+        reasons.append(f"k_rows={k_rows} < {_PREFILL512_MIN_K_ROWS}")
+    if num_heads not in _PREFILL512_SUPPORTED_NUM_HEADS:
+        reasons.append(
+            f"num_heads={num_heads} not in {_PREFILL512_SUPPORTED_NUM_HEADS}"
+        )
+    return reasons
+
+
+def resolve_contiguous_prefill_block_k(
+    *,
+    valid_q_rows: int,
+    k_rows: int,
+    num_heads: int,
+) -> int | None:
+    """Resolve the contiguous scorer path for the current shape.
+
+    Returns None for the decode scorer, 256 for the existing prefill tile, or
+    512 for the larger experimental prefill tile.
+    """
+
+    valid_q_rows = int(valid_q_rows)
+    k_rows = int(k_rows)
+    num_heads = int(num_heads)
+    if valid_q_rows <= 0 or k_rows <= 0:
+        return None
+    if not _use_sparse_nsa_contiguous_prefill(valid_q_rows):
+        return None
+
+    block_k_env = (
+        os.environ.get(_NSA_CONTIGUOUS_PREFILL_BLOCK_K_ENV, "auto").strip().lower()
+    )
+    if block_k_env in ("", "auto"):
+        return (
+            _PREFILL512_BLOCK_K
+            if not _prefill512_unsupported_reasons(
+                valid_q_rows=valid_q_rows,
+                k_rows=k_rows,
+                num_heads=num_heads,
+            )
+            else _PREFILL_BLOCK_K
+        )
+    if block_k_env == str(_PREFILL_BLOCK_K):
+        return _PREFILL_BLOCK_K
+    if block_k_env == str(_PREFILL512_BLOCK_K):
+        reasons = _prefill512_unsupported_reasons(
+            valid_q_rows=valid_q_rows,
+            k_rows=k_rows,
+            num_heads=num_heads,
+        )
+        if reasons:
+            raise ValueError(
+                f"{_NSA_CONTIGUOUS_PREFILL_BLOCK_K_ENV}=512 is unsupported for this shape: "
+                + "; ".join(reasons)
+            )
+        return _PREFILL512_BLOCK_K
+    raise ValueError(
+        f"{_NSA_CONTIGUOUS_PREFILL_BLOCK_K_ENV} must be auto, 256, or 512; got {block_k_env!r}"
+    )
+
+
+def supports_contiguous_logits_kernel(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    k_quant: torch.Tensor,
+    k_scale: torch.Tensor,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+) -> bool:
+    if q_fp8.device.type != "cuda":
+        return False
+    if q_fp8.ndim != 3 or q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        return False
+    if q_fp8.shape[1] > _MAX_Q_HEADS:
+        return False
+    if weights.ndim != 2 or weights.shape != q_fp8.shape[:2]:
+        return False
+    if k_quant.ndim != 2 or k_quant.shape[1] != _INDEX_HEAD_DIM:
+        return False
+    if k_scale.ndim != 1 or k_scale.shape[0] != k_quant.shape[0]:
+        return False
+    if k_start.ndim != 1 or k_end.ndim != 1 or k_start.shape != k_end.shape:
+        return False
+    if k_start.shape[0] > q_fp8.shape[0]:
+        return False
+    if q_fp8.dtype != torch.float8_e4m3fn:
+        return False
+    if weights.dtype != torch.float32:
+        return False
+    if k_quant.dtype != torch.float8_e4m3fn:
+        return False
+    if k_scale.dtype != torch.float32:
+        return False
+    if k_start.dtype != torch.int32 or k_end.dtype != torch.int32:
+        return False
+    if not (
+        q_fp8.device
+        == weights.device
+        == k_quant.device
+        == k_scale.device
+        == k_start.device
+        == k_end.device
+    ):
+        return False
+    return True
+
+
+def run_contiguous_logits_kernel(
+    *,
+    q_fp8: torch.Tensor | None = None,
+    weights: torch.Tensor | None = None,
+    k_quant: torch.Tensor | None = None,
+    k_scale: torch.Tensor | None = None,
+    k_start: torch.Tensor | None = None,
+    k_end: torch.Tensor | None = None,
+    preinitialize_invalid_logits: bool | None = None,
+    tile_logits: torch.Tensor | None = None,
+    tile_k_offset: int | None = None,
+    tile_num_k_tiles: int | None = None,
+    prefill_block_k: int | None = None,
+    score_mode: int | None = None,
+    binding: IndexerContiguousLogitsKernelBinding | None = None,
+) -> torch.Tensor:
+    staged_binding = binding
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("q_fp8", q_fp8),
+                ("weights", weights),
+                ("k_quant", k_quant),
+                ("k_scale", k_scale),
+                ("k_start", k_start),
+                ("k_end", k_end),
+                ("preinitialize_invalid_logits", preinitialize_invalid_logits),
+                ("tile_logits", tile_logits),
+                ("tile_k_offset", tile_k_offset),
+                ("tile_num_k_tiles", tile_num_k_tiles),
+                ("prefill_block_k", prefill_block_k),
+                ("score_mode", score_mode),
+            )
+            if value is not None
+        ]
+        if extras:
+            _raise_binding_extras("run_contiguous_logits_kernel", extras)
+        q_fp8 = binding.q_fp8
+        weights = binding.weights
+        k_quant = binding.k_quant
+        k_scale = binding.k_scale
+        k_start = binding.k_start
+        k_end = binding.k_end
+        preinitialize_invalid_logits = binding.preinitialize_invalid_logits
+        tile_logits = binding.tile_logits
+        tile_k_offset = binding.tile_k_offset
+        tile_num_k_tiles = binding.tile_num_k_tiles
+        prefill_block_k = binding.prefill_block_k
+        score_mode = binding.score_mode
+
+    q_fp8 = _require_bound_arg(
+        q_fp8, api_name="run_contiguous_logits_kernel", name="q_fp8"
+    )
+    weights = _require_bound_arg(
+        weights, api_name="run_contiguous_logits_kernel", name="weights"
+    )
+    k_quant = _require_bound_arg(
+        k_quant, api_name="run_contiguous_logits_kernel", name="k_quant"
+    )
+    k_scale = _require_bound_arg(
+        k_scale, api_name="run_contiguous_logits_kernel", name="k_scale"
+    )
+    k_start = _require_bound_arg(
+        k_start, api_name="run_contiguous_logits_kernel", name="k_start"
+    )
+    k_end = _require_bound_arg(
+        k_end, api_name="run_contiguous_logits_kernel", name="k_end"
+    )
+    preinitialize_invalid_logits = (
+        True
+        if preinitialize_invalid_logits is None
+        else bool(preinitialize_invalid_logits)
+    )
+    tile_k_offset = 0 if tile_k_offset is None else int(tile_k_offset)
+    score_mode = (
+        IndexerScoreMode.NSA_RELU_SUM if score_mode is None else int(score_mode)
+    )
+    if score_mode not in (IndexerScoreMode.NSA_RELU_SUM, IndexerScoreMode.MSA_BILINEAR):
+        raise ValueError(f"unsupported indexer score_mode {score_mode}")
+
+    if not supports_contiguous_logits_kernel(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_quant=k_quant,
+        k_scale=k_scale,
+        k_start=k_start,
+        k_end=k_end,
+    ):
+        raise ValueError(
+            "sparse NSA contiguous logits kernel only supports the exact CUDA FP8 contract"
+        )
+
+    q_rows_total = int(q_fp8.shape[0])
+    valid_q_rows = int(k_start.shape[0])
+    k_rows = int(k_quant.shape[0])
+    if not preinitialize_invalid_logits and valid_q_rows != q_rows_total:
+        raise ValueError(
+            "preinitialize_invalid_logits=False requires all q rows to be valid; "
+            f"got q_rows={q_rows_total} and valid_q_rows={valid_q_rows}"
+        )
+
+    # Dispatch: use prefill kernels for large q_len, decode kernel otherwise.
+    # BK=512 is deliberately limited to target-ish long-prefill shapes; other
+    # shapes keep the validated BK=256 prefill tile.
+    if prefill_block_k is None:
+        _prefill_block_k = resolve_contiguous_prefill_block_k(
+            valid_q_rows=valid_q_rows,
+            k_rows=k_rows,
+            num_heads=int(q_fp8.shape[1]),
+        )
+    else:
+        _prefill_block_k = int(prefill_block_k)
+        if _prefill_block_k not in (_PREFILL_BLOCK_K, _PREFILL512_BLOCK_K):
+            raise ValueError(
+                "prefill_block_k must be "
+                f"{_PREFILL_BLOCK_K} or {_PREFILL512_BLOCK_K}, "
+                f"got {_prefill_block_k}"
+            )
+    if tile_logits is not None and _prefill_block_k is None:
+        # Tiled output is only produced by the prefill scorer. The threshold
+        # resolver may prefer the decode scorer for small q batches, but callers
+        # that pass tile_logits are explicitly requesting the tiled layout.
+        _prefill_block_k = _PREFILL_BLOCK_K
+    _use_prefill = _prefill_block_k is not None
+    _tiled_output = tile_logits is not None
+    _grid_block_k = _prefill_block_k if _use_prefill else _BLOCK_K
+    full_num_k_tiles = max(1, (k_rows + _grid_block_k - 1) // _grid_block_k)
+    output_num_k_tiles = full_num_k_tiles
+    if tile_num_k_tiles is not None:
+        output_num_k_tiles = int(tile_num_k_tiles)
+    tile_k_offset = int(tile_k_offset)
+    if tile_k_offset < 0:
+        raise ValueError(f"tile_k_offset must be non-negative, got {tile_k_offset}")
+    if output_num_k_tiles <= 0:
+        raise ValueError(f"tile_num_k_tiles must be positive, got {output_num_k_tiles}")
+    if tile_k_offset + output_num_k_tiles > full_num_k_tiles:
+        raise ValueError(
+            "tile K range exceeds source K tiles: "
+            f"offset={tile_k_offset}, tiles={output_num_k_tiles}, full={full_num_k_tiles}"
+        )
+    if (tile_k_offset != 0 or tile_num_k_tiles is not None) and not (
+        _tiled_output and _use_prefill
+    ):
+        raise ValueError(
+            "tile_k_offset/tile_num_k_tiles are only supported for tiled prefill output"
+        )
+
+    if _tiled_output and _use_prefill:
+        _block_q_prefill = (
+            _PREFILL512_BLOCK_Q
+            if _prefill_block_k == _PREFILL512_BLOCK_K
+            else _PREFILL_BLOCK_Q
+        )
+        num_q_tiles = (valid_q_rows + _block_q_prefill - 1) // _block_q_prefill
+        if tile_logits is None:
+            # 2D layout: (num_tiles, tile_size) where tile_size = block_q * block_k
+            # 1D flat layout: total elements = num_tiles * tile_size
+            # flat_offset = (q_tile_idx * num_k_tiles + k_tile_idx) * tile_size + q_local * block_k + k_local
+            num_tiles = num_q_tiles * output_num_k_tiles
+            tile_size = _block_q_prefill * _prefill_block_k
+            tile_logits = torch.empty(
+                (num_tiles * tile_size,),
+                dtype=torch.float32,
+                device=q_fp8.device,
+            )
+        else:
+            expected_elements = (
+                num_q_tiles * output_num_k_tiles * _block_q_prefill * _prefill_block_k
+            )
+            if int(tile_logits.numel()) < expected_elements:
+                raise ValueError(
+                    f"tile_logits has {int(tile_logits.numel())} elements, expected at least "
+                    f"{expected_elements} for {num_q_tiles}x{output_num_k_tiles} tiles"
+                )
+        # Store metadata for run_tiled_topk
+        tile_logits._sm12x_num_q_tiles = num_q_tiles
+        tile_logits._sm12x_num_k_tiles = output_num_k_tiles
+        tile_logits._sm12x_block_q = _block_q_prefill
+        tile_logits._sm12x_block_k = _prefill_block_k
+        preinitialize_invalid_logits = True
+
+    if staged_binding is not None and staged_binding.q_u32 is not None:
+        required_staged = {
+            "q_bytes": staged_binding.q_bytes,
+            "weights_kernel": staged_binding.weights_kernel,
+            "k_quant_bytes": staged_binding.k_quant_bytes,
+            "k_scale_kernel": staged_binding.k_scale_kernel,
+            "k_start_kernel": staged_binding.k_start_kernel,
+            "k_end_kernel": staged_binding.k_end_kernel,
+            "out_kernel": staged_binding.out_kernel,
+            "out_view": staged_binding.out_view,
+        }
+        missing = [name for name, value in required_staged.items() if value is None]
+        if missing:
+            raise ValueError(
+                "staged indexer contiguous binding is missing " + ", ".join(missing)
+            )
+        q_u32 = staged_binding.q_u32
+        q_bytes_kernel = staged_binding.q_bytes
+        weights_kernel = staged_binding.weights_kernel
+        k_quant_bytes = staged_binding.k_quant_bytes
+        k_scale_kernel = staged_binding.k_scale_kernel
+        k_start_kernel = staged_binding.k_start_kernel
+        k_end_kernel = staged_binding.k_end_kernel
+        out_kernel = staged_binding.out_kernel
+        out_view = staged_binding.out_view
+    else:
+        if _tiled_output and _use_prefill:
+            # In tiled mode, no need for the full scatter matrix
+            out_kernel = torch.empty((1, 1), dtype=torch.float32, device=q_fp8.device)
+        elif preinitialize_invalid_logits:
+            out_kernel = torch.full(
+                (q_rows_total, k_rows),
+                float("-inf"),
+                dtype=torch.float32,
+                device=q_fp8.device,
+            )
+        else:
+            out_kernel = torch.empty(
+                (q_rows_total, k_rows),
+                dtype=torch.float32,
+                device=q_fp8.device,
+            )
+        out_view = out_kernel
+        if valid_q_rows == 0 or k_rows == 0:
+            return out_view
+
+        q_bytes = q_fp8.contiguous().view(torch.uint8)
+        q_bytes_kernel = q_bytes
+        _pad_k = _prefill_block_k if _use_prefill else _BLOCK_K
+        k_quant_padded, k_scale_padded = _pad_kv_rows(
+            k_quant=k_quant, k_scale=k_scale, pad_block_k=_pad_k
+        )
+        k_quant_bytes = k_quant_padded.contiguous().view(torch.uint8)
+        q_u32 = _view_last_dim_as_u32(q_bytes)
+        weights_kernel = weights.contiguous()
+        k_scale_kernel = k_scale_padded.contiguous()
+        k_start_kernel = k_start.contiguous()
+        k_end_kernel = k_end.contiguous()
+
+    if valid_q_rows == 0 or k_rows == 0:
+        return out_view
+
+    device_index = q_fp8.device.index or 0
+    k_tma_desc_ptrs = (
+        staged_binding.k_tma_prefill_desc_ptrs
+        if _use_prefill
+        and staged_binding is not None
+        and staged_binding.k_tma_prefill_desc_ptrs is not None
+        else (
+            staged_binding.k_tma_desc_ptrs
+            if staged_binding is not None and staged_binding.k_tma_desc_ptrs is not None
+            else _dummy_contiguous_k_tma_desc_ptrs(device_index)
+        )
+    )
+
+    if _prefill_block_k == _PREFILL512_BLOCK_K:
+        kernel = _build_sparse_nsa_contiguous_prefill512_kernel(
+            tiled_output=_tiled_output,
+            num_heads=int(q_fp8.shape[1]),
+            score_mode=score_mode,
+        )
+    elif _use_prefill:
+        kernel = _build_sparse_nsa_contiguous_prefill_kernel(
+            tiled_output=_tiled_output,
+            score_mode=score_mode,
+            block_score_output=False,
+        )
+    else:
+        kernel = _build_sparse_nsa_contiguous_kernel(
+            tiled_output=_tiled_output,
+            score_mode=score_mode,
+        )
+
+    if tile_logits is not None and _tiled_output:
+        tile_logits_kernel = tile_logits
+    elif staged_binding is not None:
+        # TILED_OUTPUT is a compile-time false branch for this launch, so the
+        # kernel cannot dereference tile_logits.  Preserve the historical 1x1
+        # argument layout with a storage-aliasing view instead of allocating a
+        # throwaway CUDA tensor on every staged replay.
+        tile_logits_kernel = out_kernel.as_strided((1, 1), (1, 1))
+    else:
+        tile_logits_kernel = torch.empty(
+            (1, 1), dtype=torch.float32, device=q_fp8.device
+        )
+    if staged_binding is not None:
+        # run_contiguous_logits_kernel always compiles BLOCK_SCORE_OUTPUT=False;
+        # this argument is therefore constexpr-dead.  Keep its rank/strides
+        # stable while aliasing caller-owned output storage for graph replay.
+        block_scores_kernel = out_kernel.as_strided((1, 1, 1), (1, 1, 1))
+    else:
+        block_scores_kernel = torch.empty(
+            (1, 1, 1), dtype=torch.float32, device=q_fp8.device
+        )
+
+    if _use_prefill and _prefill_block_k == _PREFILL_BLOCK_K:
+        write_invalid_logits = 0 if preinitialize_invalid_logits else 1
+        args = (
+            _to_kernel_tensor(q_u32, cutlass.Uint32),
+            _to_kernel_tensor(weights_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(k_quant_bytes, cutlass.Uint8),
+            _to_kernel_tensor(k_tma_desc_ptrs, cutlass.Int64, assumed_align=8),
+            _to_kernel_tensor(k_scale_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(k_start_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(k_end_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(out_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(tile_logits_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(block_scores_kernel, cutlass.Float32, assumed_align=4),
+            valid_q_rows,
+            k_rows,
+            Int32(0),
+            Int32(tile_k_offset),
+            Int32(output_num_k_tiles),
+            write_invalid_logits,
+            current_cuda_stream(),
+        )
+    elif _use_prefill:
+        write_invalid_logits = 0 if preinitialize_invalid_logits else 1
+        args = (
+            _to_kernel_tensor(q_u32, cutlass.Uint32),
+            _to_kernel_tensor(weights_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(k_quant_bytes, cutlass.Uint8),
+            _to_kernel_tensor(k_tma_desc_ptrs, cutlass.Int64, assumed_align=8),
+            _to_kernel_tensor(k_scale_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(k_start_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(k_end_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(out_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(tile_logits_kernel, cutlass.Float32, assumed_align=4),
+            valid_q_rows,
+            k_rows,
+            Int32(tile_k_offset),
+            Int32(output_num_k_tiles),
+            write_invalid_logits,
+            current_cuda_stream(),
+        )
+    else:
+        write_invalid_logits = 0 if preinitialize_invalid_logits else 1
+        args = (
+            _to_kernel_tensor(q_u32, cutlass.Uint32),
+            _to_kernel_tensor(weights_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(k_quant_bytes, cutlass.Uint8),
+            _to_kernel_tensor(k_tma_desc_ptrs, cutlass.Int64, assumed_align=8),
+            _to_kernel_tensor(k_scale_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(k_start_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(k_end_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(out_kernel, cutlass.Float32, assumed_align=4),
+            _to_kernel_tensor(tile_logits_kernel, cutlass.Float32, assumed_align=4),
+            valid_q_rows,
+            k_rows,
+            Int32(tile_k_offset),
+            Int32(output_num_k_tiles),
+            write_invalid_logits,
+            current_cuda_stream(),
+        )
+    if _use_prefill:
+        _prefill_cache_variant = (
+            "prefill512_h32"
+            if _prefill_block_k == _PREFILL512_BLOCK_K
+            and int(q_fp8.shape[1]) == _PREFILL512_H32_WEIGHT_COLS
+            else (
+                "prefill512" if _prefill_block_k == _PREFILL512_BLOCK_K else "prefill"
+            )
+        )
+        q_heads_batch = (
+            (
+                _PREFILL512_H32_Q_HEADS_BATCH
+                if _prefill_cache_variant == "prefill512_h32"
+                else _PREFILL512_Q_HEADS_BATCH
+            )
+            if _prefill_block_k == _PREFILL512_BLOCK_K
+            else None
+        )
+        facts = _contiguous_logits_compile_facts(
+            variant=_prefill_cache_variant,
+            tiled_output=_tiled_output,
+            score_mode=score_mode,
+            q_u32=q_u32,
+            weights=weights_kernel,
+            k_quant_bytes=k_quant_bytes,
+            k_scale=k_scale_kernel,
+            k_start=k_start_kernel,
+            k_end=k_end_kernel,
+            logits_out=out_kernel,
+            tile_logits=tile_logits_kernel,
+            block_k=_prefill_block_k,
+            block_score_output=False,
+            q_heads_batch=q_heads_batch,
+        )
+    else:
+        facts = _contiguous_logits_compile_facts(
+            variant="decode",
+            tiled_output=_tiled_output,
+            score_mode=score_mode,
+            q_u32=q_u32,
+            weights=weights_kernel,
+            k_quant_bytes=k_quant_bytes,
+            k_scale=k_scale_kernel,
+            k_start=k_start_kernel,
+            k_end=k_end_kernel,
+            logits_out=out_kernel,
+            tile_logits=tile_logits_kernel,
+            block_k=_BLOCK_K,
+            block_score_output=False,
+        )
+    compile_spec = KernelCompileSpec.from_facts(
+        "attention.indexer.contiguous_logits",
+        3,
+        *facts,
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+        compile_kwargs=(
+            {
+                "dsl_compile_options": (
+                    OptLevel(2),
+                    PtxasOptions("--register-usage-level=4"),
+                )
+            }
+            if not _use_prefill
+            else None
+        ),
+    )
+    if _tiled_output and _use_prefill:
+        return tile_logits
+    return out_view
+
+
+def run_contiguous_block_scores_kernel(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    k_quant: torch.Tensor,
+    k_scale: torch.Tensor,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+    block_scores: torch.Tensor | None = None,
+    num_blocks_out: int | None = None,
+    q_u32: torch.Tensor | None = None,
+    q_bytes: torch.Tensor | None = None,
+    weights_kernel: torch.Tensor | None = None,
+    k_quant_bytes: torch.Tensor | None = None,
+    k_scale_kernel: torch.Tensor | None = None,
+    k_start_kernel: torch.Tensor | None = None,
+    k_end_kernel: torch.Tensor | None = None,
+    out_kernel: torch.Tensor | None = None,
+    tile_logits_kernel: torch.Tensor | None = None,
+    k_tma_prefill_desc_ptrs: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if not supports_contiguous_logits_kernel(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_quant=k_quant,
+        k_scale=k_scale,
+        k_start=k_start,
+        k_end=k_end,
+    ):
+        raise ValueError(
+            "MSA contiguous block-score kernel only supports the production CUDA FP8 contract"
+        )
+    if int(q_fp8.shape[1]) > 8:
+        raise ValueError(
+            "MSA contiguous block-score kernel supports at most 8 index heads"
+        )
+    if weights.dtype != torch.float32:
+        raise ValueError(f"weights must have dtype torch.float32, got {weights.dtype}")
+    q_rows_total = int(q_fp8.shape[0])
+    valid_q_rows = int(k_start.shape[0])
+    k_rows = int(k_quant.shape[0])
+    num_heads = int(q_fp8.shape[1])
+    inferred_blocks = (k_rows + _PREFILL_BLOCK_K // 2 - 1) // (_PREFILL_BLOCK_K // 2)
+    if num_blocks_out is None:
+        num_blocks_out = inferred_blocks
+    num_blocks_out = int(num_blocks_out)
+    if num_blocks_out < inferred_blocks:
+        raise ValueError(
+            f"num_blocks_out {num_blocks_out} is smaller than required {inferred_blocks}"
+        )
+    if block_scores is None:
+        block_scores = torch.full(
+            (num_heads, q_rows_total, num_blocks_out),
+            float("-inf"),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+    else:
+        if block_scores.dtype != torch.float32:
+            raise ValueError(
+                f"block_scores must have dtype torch.float32, got {block_scores.dtype}"
+            )
+        if block_scores.device != q_fp8.device:
+            raise ValueError("block_scores device must match q_fp8")
+        if (
+            block_scores.ndim != 3
+            or int(block_scores.shape[0]) < num_heads
+            or int(block_scores.shape[1]) < q_rows_total
+            or int(block_scores.shape[2]) < num_blocks_out
+        ):
+            raise ValueError(
+                "block_scores must have shape at least "
+                f"({num_heads}, {q_rows_total}, {num_blocks_out}), got "
+                f"{tuple(block_scores.shape)}"
+            )
+        block_scores = block_scores[:num_heads, :q_rows_total, :num_blocks_out]
+        block_scores.fill_(float("-inf"))
+    if valid_q_rows == 0 or k_rows == 0:
+        return block_scores
+
+    if q_bytes is None:
+        q_bytes = q_fp8.contiguous().view(torch.uint8)
+    if q_u32 is None:
+        q_u32 = _view_last_dim_as_u32(q_bytes)
+    if weights_kernel is None:
+        weights_kernel = weights.contiguous()
+    if k_quant_bytes is None or k_scale_kernel is None:
+        k_quant_padded, k_scale_padded = _pad_kv_rows(
+            k_quant=k_quant,
+            k_scale=k_scale,
+            pad_block_k=_PREFILL_BLOCK_K,
+        )
+        k_quant_bytes = k_quant_padded.contiguous().view(torch.uint8)
+        k_scale_kernel = k_scale_padded.contiguous()
+    if k_start_kernel is None:
+        k_start_kernel = k_start.contiguous()
+    if k_end_kernel is None:
+        k_end_kernel = k_end.contiguous()
+    if out_kernel is None:
+        out_kernel = torch.empty((1, 1), dtype=torch.float32, device=q_fp8.device)
+    if tile_logits_kernel is None:
+        tile_logits_kernel = torch.empty(
+            (1, 1), dtype=torch.float32, device=q_fp8.device
+        )
+    if k_tma_prefill_desc_ptrs is None:
+        device_index = q_fp8.device.index or 0
+        k_tma_prefill_desc_ptrs = _dummy_contiguous_k_tma_desc_ptrs(device_index)
+
+    output_num_k_tiles = max(1, (k_rows + _PREFILL_BLOCK_K - 1) // _PREFILL_BLOCK_K)
+    kernel = _build_sparse_nsa_contiguous_prefill_kernel(
+        tiled_output=False,
+        score_mode=IndexerScoreMode.MSA_BILINEAR,
+        block_score_output=True,
+    )
+    args = (
+        _to_kernel_tensor(q_u32, cutlass.Uint32),
+        _to_kernel_tensor(weights_kernel, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(k_quant_bytes, cutlass.Uint8),
+        _to_kernel_tensor(k_tma_prefill_desc_ptrs, cutlass.Int64, assumed_align=8),
+        _to_kernel_tensor(k_scale_kernel, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(k_start_kernel, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(k_end_kernel, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(out_kernel, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(tile_logits_kernel, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(block_scores, cutlass.Float32, assumed_align=4),
+        valid_q_rows,
+        k_rows,
+        Int32(num_blocks_out),
+        Int32(0),
+        Int32(output_num_k_tiles),
+        Int32(0),
+        current_cuda_stream(),
+    )
+    facts = _contiguous_logits_compile_facts(
+        variant="prefill_msa_blockmax",
+        tiled_output=False,
+        score_mode=IndexerScoreMode.MSA_BILINEAR,
+        q_u32=q_u32,
+        weights=weights_kernel,
+        k_quant_bytes=k_quant_bytes,
+        k_scale=k_scale_kernel,
+        k_start=k_start_kernel,
+        k_end=k_end_kernel,
+        logits_out=out_kernel,
+        tile_logits=tile_logits_kernel,
+        block_k=_PREFILL_BLOCK_K,
+        block_score_output=True,
+        block_scores=block_scores,
+    )
+    compile_spec = KernelCompileSpec.from_facts(
+        "attention.indexer.contiguous_block_scores",
+        2,
+        *facts,
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+    return block_scores

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/fused_indexer.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/fused_indexer.py
@@ -1,0 +1,2796 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/fused_indexer.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Unified FUSED indexer kernel: score q·k AND select top-k in one launch.
+
+Design (see plan): a row-cooperative persistent kernel where each CTA streams a
+slice of one query row's K, scores q·k via ``mxfp8`` MMA into shared memory
+(m = heads / MQA), folds each scored sub-tile into an in-SMEM running top-k via
+the ``tiled_topk`` radix (coarse-8-bit-histogram + byte-refine), and CTAs merge
+in turn. Logits never reach global memory — peak per-row working set is
+O(topk), not O(K). contiguous K/V vs paged K/V is a constexpr K-loader
+specialization; the score assembly and top-k are identical (always m = heads).
+
+This module is the SCAFFOLD: launch config, dispatch gates, scratch trio, and
+the kernel class shell. The fused score→select kernel body lands per the phased
+plan (Phase 1 = paged; Phase 2 = CONTIGUOUS_MLA loader; Phase 3 = topk 512 /
+paged_output). The m=heads score helpers are reused from
+``sm12x/attention/indexer/kernel.py`` (``_compute_mxfp8_tile_partials`` et al.)
+and the radix select / virtual-index loaders from
+``sm12x/attention/indexer/tiled_topk.py``; nothing is reinvented here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+
+import cutlass
+import cutlass.cute as cute
+import cuda.bindings.driver as cuda
+import torch
+from cutlass import Float32, Int32, Int64, Uint32
+from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    launch as sm12x_launch,
+    tensor_compile_fact,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import shared_ptr_to_u32
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+
+# Kept in lock-step with the source kernels we fuse.
+from flashinfer.experimental.sm12x.attention.nsa_indexer.persistent_topk import (
+    _RADIX,
+    _RADIX_THRESHOLD,
+    _STATE_ARRIVAL_COUNTER,
+    _STATE_OUTPUT_COUNTER,
+    _STATE_WORDS as _COOP_STATE_WORDS,
+    _global_state_ptr,
+    _group_barrier,
+    _state_offset,
+)
+from flashinfer.experimental.sm12x.attention.nsa_indexer.tiled_topk import (
+    _SCAN_UNROLL,
+    _SMEM_CANDS,
+    _SUPPORTED_TOPK,
+    _THREADS_PER_CTA as _RADIX_THREADS,
+    _convert_to_uint8,
+    _convert_to_uint32,
+    _smem_ld,
+    _smem_red_add,
+    _smem_st,
+    _smem_xadd,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import ld_shared_f32
+from flashinfer.experimental.sm12x.attention.nsa_indexer.kernel import (
+    _stream_issue_k_page_cp_async,
+    _INDEX_HEAD_DIM,
+    _PAGE_SIZE,
+    _PAGED_Q_HEAD_TILE,
+    _PAGED_THREADS_PER_CTA,
+    _PAGED_TOKENS_PER_GROUP,
+    _PAGED_WARPS_PER_CTA,
+    _WARP_THREADS,
+    _compute_mxfp8_tile_partials,
+    _compute_mxfp8_tile_partials_qldm,
+    _stage_q_permuted,
+    _load_index_k_page_scalar,
+    _num_q_head_tiles,
+    _permuted_offset_128b,
+    _reduce_column_pair_sum,
+    _repack_k_page_to_permuted,
+    _smem_addr_from_b128_offset,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_add_global_i32,
+    fmax_f32,
+    get_ptr_as_int64,
+    ld_global_nc_u32,
+    ld_global_v4_u32,
+    ldmatrix_m8n8x4_b16,
+    ld_shared_v4_u32,
+    mxfp8_mma_m16n8k32_f32_e4m3,
+    st_shared_u8,
+    st_shared_v4_u32,
+    threadfence,
+)
+
+_THREADS_PER_CTA = 1024
+# Per-CTA K-slice cap (cooperative split granularity). Matches persistent_topk's
+# chunking knob; the fused kernel streams this slice through MMA sub-tiles rather
+# than materializing it.
+_MAX_CHUNK_ELEMENTS = 8192
+
+# Constexpr K/V-layout specialization (the ONLY contiguous-vs-paged divergence in the
+# fused kernel — everything downstream of the SMEM staging tile is shared).
+KV_LAYOUT_CONTIGUOUS_MLA = 0
+KV_LAYOUT_PAGED = 1
+
+# Route metadata is capture-static; live seqlen is deliberately not a policy input,
+# so vLLM graph replay cannot switch backends.  The generic policy retains its
+# measured small-row limit.  C4's heads=64/topk=512 and GLM's heads=32/topk=2048
+# shapes are materially different. GLM was measured at 8K, 16K, 32K, and 131K
+# capacity. L2-flushed DSV4F measurements select fused through B16 for C4 on
+# both RTX-class SM120 and GB10/SM121.
+# Prefill remains packed-contiguous and never reaches this decode-only resolver.
+FUSED_MAX_ROWS = 6
+_C4_SM12X_FUSED_MAX_ROWS = 16
+# GLM re-measured after the two-level tiled fold landed: fused keeps rows 1-16
+# (wins/ties at 8K, dominant at 32K-131K, e.g. r1@131K 41us vs 90us tiled) but
+# loses rows 32-64 everywhere (r64@131K 1541us vs 1043us tiled, r64@8K 100 vs
+# 78) -- the 2-CTAs-per-group merge and one-resident-CTA occupancy starve it.
+_GLM32_FUSED_MAX_ROWS = 16
+FUSED_MIN_WIDTH = 20480  # (capacity-sizing only; no longer a routing gate)
+
+
+@cute.jit
+def _load_flat_k_tile_scalar(
+    k_quant_flat: cute.Tensor,  # [k_rows, 128] uint8
+    abs_base: Int32,
+    valid_rows: Int32,
+    s_k_page_stage: cute.Tensor,
+    lane_linear: Int32,
+):
+    """CONTIGUOUS_MLA K-load: stage a 64-row tile of contiguous K starting at abs_base.
+
+    Rows >= valid_rows are zero-filled (so the MMA contributes 0 for them — masked
+    out anyway by the staging-write valid_slots guard).
+    """
+    linear = lane_linear
+    total = Int32(_PAGE_SIZE * _INDEX_HEAD_DIM)
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM)
+        col = linear - row * Int32(_INDEX_HEAD_DIM)
+        b = cutlass.Uint8(0)
+        if row < valid_rows:
+            b = k_quant_flat[abs_base + row, col]
+        s_k_page_stage[row, col, Int32(0)] = b
+        linear += Int32(_PAGED_THREADS_PER_CTA)
+
+
+# --- wide (all-thread) page loaders ------------------------------------------
+# The per-page K load dominates the fused per-page cost. The kernel.py scalar
+# loaders stride by _PAGED_THREADS_PER_CTA (128), so a 8 KB page is 64 sequential
+# coalesced rounds. These widen the stride to n_threads (up to 1024) so the page
+# loads in ~8 rounds. Same coalesced byte pattern (consecutive tx -> consecutive
+# col), just 8x more threads in flight to hide latency.
+@cute.jit
+def _load_index_k_page_wide(
+    k_quant_bytes: cute.Tensor,  # [pages, 64, 128] uint8
+    page_id: Int32,
+    s_k_page_stage: cute.Tensor,
+    tx: Int32,
+    n_threads: Int32,
+):
+    linear = tx
+    total = Int32(_PAGE_SIZE * _INDEX_HEAD_DIM)
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM)
+        col = linear - row * Int32(_INDEX_HEAD_DIM)
+        s_k_page_stage[row, col, Int32(0)] = k_quant_bytes[page_id, row, col]
+        linear += n_threads
+
+
+@cute.jit
+def _load_flat_k_tile_wide(
+    k_quant_flat: cute.Tensor,  # [k_rows, 128] uint8
+    abs_base: Int32,
+    valid_rows: Int32,
+    s_k_page_stage: cute.Tensor,
+    tx: Int32,
+    n_threads: Int32,
+):
+    linear = tx
+    total = Int32(_PAGE_SIZE * _INDEX_HEAD_DIM)
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM)
+        col = linear - row * Int32(_INDEX_HEAD_DIM)
+        b = cutlass.Uint8(0)
+        if row < valid_rows:
+            b = k_quant_flat[abs_base + row, col]
+        s_k_page_stage[row, col, Int32(0)] = b
+        linear += n_threads
+
+
+@cute.jit
+def _load_permute_k_page_g2s(
+    k_quant_bytes: cute.Tensor,  # [pages, 64, 128] uint8 (16B-aligned base)
+    page_id: Int32,
+    page_stride_bytes: Int64,  # dim-0 byte stride; 8192 for contiguous K, 8448 for
+    # the packed paged cache (64*128 quant + 64*4 scales / page)
+    k_perm_base_addr: Int32,
+    tx: Int32,
+    n_threads: Int32,
+):
+    """paged fused global->shared load + permute: read 16-byte K granules straight
+    from global into the ldmatrix-permuted SMEM layout. Replaces the scalar
+    linear load + separate SMEM->SMEM repack pass (and its barrier) with one
+    vectorized pass. Granule addresses are 16B-aligned (page*page_stride_bytes +
+    row*128 + vec*16); page_stride_bytes MUST be the real dim-0 stride of
+    k_quant_bytes (the packed paged cache interleaves per-page scales, so its page
+    stride is 8448, not the contiguous 8192) — using a hardcoded stride reads the
+    wrong page for the packed layout. It stays 16B-aligned (8448 = 16*528).
+    """
+    page_elem_base = Int64(page_id) * page_stride_bytes
+    linear = tx
+    total = Int32(_PAGE_SIZE * (_INDEX_HEAD_DIM // 16))
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM // 16)
+        vec_idx = linear - row * Int32(_INDEX_HEAD_DIM // 16)
+        g_addr = get_ptr_as_int64(
+            k_quant_bytes,
+            page_elem_base
+            + Int64(row) * Int64(_INDEX_HEAD_DIM)
+            + Int64(vec_idx) * Int64(16),
+        )
+        v0, v1, v2, v3 = ld_global_v4_u32(g_addr)
+        dst_addr = _smem_addr_from_b128_offset(
+            k_perm_base_addr,
+            _permuted_offset_128b(row, vec_idx, Int32(_INDEX_HEAD_DIM // 16)),
+        )
+        st_shared_v4_u32(dst_addr, v0, v1, v2, v3)
+        linear += n_threads
+
+
+@cute.jit
+def _repack_k_page_wide(
+    k_linear_base_addr: Int32,
+    k_perm_base_addr: Int32,
+    tx: Int32,
+    n_threads: Int32,
+):
+    linear = tx
+    total = Int32(_PAGE_SIZE * (_INDEX_HEAD_DIM // 16))
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM // 16)
+        vec_idx = linear - row * Int32(_INDEX_HEAD_DIM // 16)
+        src_addr = k_linear_base_addr + Int32(row * _INDEX_HEAD_DIM + vec_idx * 16)
+        dst_addr = _smem_addr_from_b128_offset(
+            k_perm_base_addr,
+            _permuted_offset_128b(row, vec_idx, Int32(_INDEX_HEAD_DIM // 16)),
+        )
+        v0, v1, v2, v3 = ld_shared_v4_u32(src_addr)
+        st_shared_v4_u32(dst_addr, v0, v1, v2, v3)
+        linear += n_threads
+
+
+@dataclass(frozen=True)
+class _FusedLaunchConfig:
+    chunk_size: int
+    ctas_per_group: int
+    num_groups: int
+    total_ctas: int
+
+
+def _align_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _resolve_fused_launch_config(
+    num_rows: int, width: int, device: torch.device
+) -> _FusedLaunchConfig:
+    """Row-cooperative split — cloned from persistent_topk._resolve_launch_config.
+
+    One group owns one query row; ``ctas_per_group`` CTAs split the row's K of
+    ``width`` tokens; groups persist grid-stride over rows.
+    """
+    max_chunk = max(_MAX_CHUNK_ELEMENTS, _THREADS_PER_CTA)
+    ctas_per_group = max(1, (width + max_chunk - 1) // max_chunk)
+    chunk_size = min(
+        max_chunk, _align_up((width + ctas_per_group - 1) // ctas_per_group, 1)
+    )
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    num_groups = min(max(num_rows, 1), max(1, num_sms // ctas_per_group))
+    total_ctas = max(1, num_groups * ctas_per_group)
+    return _FusedLaunchConfig(
+        chunk_size=chunk_size,
+        ctas_per_group=ctas_per_group,
+        num_groups=num_groups,
+        total_ctas=total_ctas,
+    )
+
+
+# --- scratch sizing (per-group combine state + inter-CTA carry slab) ----------
+# Combine state per group: arrival + output counters + a small relay slot. The
+# inter-CTA carry slab holds each CTA's published running top-k (value f32 +
+# index i32) for the next CTA in the relay to fold.
+_STATE_WORDS_PER_GROUP = 4  # arrival_counter, output_counter, relay_phase, pad
+
+# Cross-CTA merge auto-switch (ctas_per_group>1): a group whose live row K length
+# seq_len <= this uses the serial last-CTA reduction (no grid barriers); larger
+# rows use the cooperative grid-barrier radix. Measured crossover ~32-64k (sm120,
+# rows=1, topk=512). Both arms are exact, so this only trades perf, not results.
+_LAST_CTA_MERGE_MAX = 49152
+# Sentinel "never coop" threshold: larger than any live seq_len, so the per-group
+# auto-switch always takes the serial last-CTA arm (used when ctas_per_group*topk is
+# too small for coop's grid barriers to ever pay off -- see run_fused_paged_indexer).
+_FORCE_LAST_CTA = 1 << 30
+
+# The fused cooperative merge uses persistent_topk's 772-word state layout.
+# Histograms occupy [0, 768); the fused path uses the two otherwise-generic
+# scalar slots as its candidate-total and end-of-launch cleanup counters.
+_FUSED_STATE_TOTAL = 3 * _RADIX
+_FUSED_STATE_CLEANUP = _FUSED_STATE_TOTAL + 1
+
+
+@cute.jit
+def _load_q_bytes_g2s_v4(
+    q_bytes: cute.Tensor,
+    q_idx: Int32,
+    q_row_stride_bytes: Int64,
+    real_q_bytes: cutlass.Constexpr[int],
+    padded_q_bytes: cutlass.Constexpr[int],
+    q_smem_base_addr: Int32,
+    tx: Int32,
+    n_threads: Int32,
+):
+    """Vectorized 16-byte query staging for the common contiguous-head layout."""
+    linear_vec = tx
+    total_vecs = Int32(int(padded_q_bytes) // 16)
+    real_vecs = Int32(int(real_q_bytes) // 16)
+    row_base = Int64(q_idx) * q_row_stride_bytes
+    while linear_vec < total_vecs:
+        v0 = Uint32(0)
+        v1 = Uint32(0)
+        v2 = Uint32(0)
+        v3 = Uint32(0)
+        if linear_vec < real_vecs:
+            q_addr = get_ptr_as_int64(q_bytes, row_base + Int64(linear_vec) * Int64(16))
+            v0, v1, v2, v3 = ld_global_v4_u32(q_addr)
+        st_shared_v4_u32(q_smem_base_addr + linear_vec * Int32(16), v0, v1, v2, v3)
+        linear_vec += n_threads
+
+
+@cute.jit
+def _score_tokens_direct_k(
+    q_perm_base_addr: Int32,
+    s_w: cute.Tensor,
+    num_heads: Int32,
+    k_quant_bytes: cute.Tensor,
+    k_byte_off: Int32,
+    lane: Int32,
+    num_q_head_tiles: cutlass.Constexpr[int],
+):
+    """Score 8 tokens against every head tile with K read straight from L2.
+
+    Byte-identical to the smem-staged score core: each lane loads exactly the
+    bytes ldmatrix.m8n8x4.b16 would hand it (reg m, lane l = token l//4,
+    byte-quad l%4 of K half m), preserving the raw-fragment convention the
+    MMA relies on without staging K through shared memory. k_byte_off is the
+    lane's base byte offset (page + token-row + quad). After the butterfly
+    reduction every lane holds the two column totals for columns
+    2*(lane%4) and 2*(lane%4)+1, summed over all head tiles.
+    """
+    # num_heads is unreferenced: s_w is zero-padded to the padded head count.
+    q_row = lane & Int32(15)
+    q_half = lane >> Int32(4)
+    k0_0 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off))
+    k1_0 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(16)))
+    k0_1 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(32)))
+    k1_1 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(48)))
+    k0_2 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(64)))
+    k1_2 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(80)))
+    k0_3 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(96)))
+    k1_3 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(112)))
+    total0 = Float32(0.0)
+    total1 = Float32(0.0)
+    qgrp = lane // Int32(4)
+    for tile in cutlass.range_constexpr(num_q_head_tiles):
+        acc0 = Float32(0.0)
+        acc1 = Float32(0.0)
+        acc2 = Float32(0.0)
+        acc3 = Float32(0.0)
+        q_tile_base = q_perm_base_addr + Int32(
+            tile * _PAGED_Q_HEAD_TILE * _INDEX_HEAD_DIM
+        )
+        for step in cutlass.range_constexpr(_INDEX_HEAD_DIM // 32):
+            q_addr = _smem_addr_from_b128_offset(
+                q_tile_base,
+                _permuted_offset_128b(
+                    q_row, Int32(2 * step) + q_half, Int32(_INDEX_HEAD_DIM // 16)
+                ),
+            )
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(q_addr)
+            if cutlass.const_expr(step == 0):
+                bk0 = k0_0
+                bk1 = k1_0
+            elif cutlass.const_expr(step == 1):
+                bk0 = k0_1
+                bk1 = k1_1
+            elif cutlass.const_expr(step == 2):
+                bk0 = k0_2
+                bk1 = k1_2
+            else:
+                bk0 = k0_3
+                bk1 = k1_3
+            d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                acc0,
+                acc1,
+                acc2,
+                acc3,
+                a0,
+                a1,
+                a2,
+                a3,
+                bk0,
+                bk1,
+                Uint32(0x7F7F7F7F),
+                Uint32(0x7F7F7F7F),
+            )
+            acc0 = d0
+            acc1 = d1
+            acc2 = d2
+            acc3 = d3
+        head0 = Int32(tile * _PAGED_Q_HEAD_TILE) + qgrp
+        head1 = head0 + Int32(8)
+        w0 = Float32(s_w[head0])
+        w1 = Float32(s_w[head1])
+        p0 = Float32(fmax_f32(acc0, Float32(0.0)) * w0)
+        p0 = Float32(p0 + fmax_f32(acc2, Float32(0.0)) * w1)
+        p1 = Float32(fmax_f32(acc1, Float32(0.0)) * w0)
+        p1 = Float32(p1 + fmax_f32(acc3, Float32(0.0)) * w1)
+        total0 = Float32(total0 + _reduce_column_pair_sum(p0))
+        total1 = Float32(total1 + _reduce_column_pair_sum(p1))
+    return total0, total1
+
+
+def _fused_indexer_state_nbytes(launch: _FusedLaunchConfig) -> int:
+    return launch.num_groups * _STATE_WORDS_PER_GROUP * 4
+
+
+def _fused_indexer_carry_nbytes(launch: _FusedLaunchConfig, topk: int) -> int:
+    # value f32 + index i32 = 8 bytes per (group, cta, topk) slot.
+    return launch.num_groups * launch.ctas_per_group * int(topk) * 8
+
+
+def fused_indexer_workspace_nbytes(
+    num_rows: int,
+    width: int,
+    topk: int,
+    *,
+    device: torch.device | str | None = None,
+) -> int:
+    if device is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    device = torch.device(device)
+    if device.type != "cuda":
+        # CPU planning fallback: assume 1 CTA/group worst case.
+        return max(int(num_rows), 1) * (_STATE_WORDS_PER_GROUP * 4 + int(topk) * 8)
+    launch = _resolve_fused_launch_config(int(num_rows), int(width), device)
+    return _fused_indexer_state_nbytes(launch) + _fused_indexer_carry_nbytes(
+        launch, int(topk)
+    )
+
+
+def _fused_indexer_capacity_nbytes(
+    max_rows: int, max_width: int, topk: int, *, device: torch.device
+) -> int:
+    max_rows = max(int(max_rows), 1)
+    max_width = max(int(max_width), 1)
+    if device.type != "cuda":
+        return fused_indexer_workspace_nbytes(max_rows, max_width, topk, device=device)
+    # Worst case over the strides that change ctas_per_group / num_groups.
+    candidate_widths = {1, max_width}
+    if max_width > FUSED_MIN_WIDTH:
+        candidate_widths.add(FUSED_MIN_WIDTH + 1)
+    return max(
+        fused_indexer_workspace_nbytes(max_rows, w, topk, device=device)
+        for w in candidate_widths
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XFusedIndexerScratchCaps:
+    device: torch.device | str
+    max_rows: int
+    max_width: int
+    topk: int
+
+    def __post_init__(self) -> None:
+        if int(self.topk) not in _SUPPORTED_TOPK:
+            raise ValueError(
+                f"fused indexer supports topk {_SUPPORTED_TOPK}, got {self.topk}"
+            )
+
+
+# --- dispatch gates -----------------------------------------------------------
+def supports_fused_indexer(
+    *,
+    topk: int,
+    num_rows: int,
+    width: int,
+) -> bool:
+    """Whether the fused kernel is applicable (capability gate)."""
+    if int(topk) not in _SUPPORTED_TOPK:
+        return False
+    if int(width) <= 0 or int(num_rows) <= 0:
+        return False
+    return True
+
+
+def resolve_fused_indexer_path(
+    *,
+    topk: int,
+    num_rows: int,
+    width: int,
+    num_heads: int | None = None,
+    compute_capability: tuple[int, int] | None = None,
+) -> bool:
+    """Route to the fused kernel only for small decode batches (rows <= N).
+
+    Row count, head count, top-k, and width here are all capture-time workspace
+    metadata; live seqlen is deliberately absent, so the selected route is stable
+    across vLLM CUDA-graph replays. The general small-decode gate remains six
+    rows. C4's 64-head/top-k-512 shape uses fused through B16 on SM120 and
+    SM121. GLM's 32-head/top-k-2048 shape uses fused through B16 and the
+    streamed tiled route beyond. Prefill is selected before this decode-only
+    resolver and remains packed-contiguous.
+    """
+    if not supports_fused_indexer(topk=topk, num_rows=num_rows, width=width):
+        return False
+    if int(topk) == 512 and num_heads is not None and int(num_heads) == 64:
+        # C4 (DSV4, heads=64/topk=512): both RTX-class SM120 and GB10/SM121
+        # favor the single-launch fused path through the measured B16 bucket.
+        return (
+            compute_capability in {(12, 0), (12, 1)}
+            and int(num_rows) <= _C4_SM12X_FUSED_MAX_ROWS
+        )
+    if int(topk) == 2048 and num_heads is not None and int(num_heads) == 32:
+        return int(num_rows) <= _GLM32_FUSED_MAX_ROWS
+    return int(num_rows) <= FUSED_MAX_ROWS
+
+
+def fused_indexer_scratch_max_rows(
+    *,
+    topk: int,
+    num_heads: int,
+    compute_capability: tuple[int, int] | None = None,
+) -> int:
+    """Return the fixed row capacity needed by fused decode scratch."""
+
+    if (
+        int(topk) == 512
+        and int(num_heads) == 64
+        and compute_capability in {(12, 0), (12, 1)}
+    ):
+        return _C4_SM12X_FUSED_MAX_ROWS
+    if int(topk) == 2048 and int(num_heads) == 32:
+        return _GLM32_FUSED_MAX_ROWS
+    return FUSED_MAX_ROWS
+
+
+def _resolve_default_ctas_per_group(
+    *,
+    num_rows: int,
+    max_pages: int,
+    device: torch.device,
+) -> int:
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    # Target a single CTA wave (rows * ctas_per_group ~ num_sms): more CTAs
+    # only add last-CTA merge work + a second wave. Never split below 1 page.
+    return max(1, min(int(max_pages), num_sms // max(1, int(num_rows))))
+
+
+def _resolve_default_merge_threshold(
+    *,
+    ctas_per_group: int,
+    num_heads: int,
+    topk: int,
+) -> int:
+    # Cross-CTA merge auto-switch, candidate-count model (sm120, graph; refit after
+    # the last-CTA select was unrolled/de-branched to match tiled_topk). The
+    # per-group merge sees min(seq_len, ctas_per_group*topk) candidates -- each CTA
+    # trims its local top-k to topk, so ctas_per_group*topk caps the count. Coop's
+    # grid-barrier radix only amortizes its fixed barrier cost (which GROWS with
+    # ctas_per_group) above a crossover candidate count C; below it the now-fast
+    # serial last-CTA select wins. Measured crossover (rows 1/2 -> ctas_pg 188/94,
+    # topk 512/1024/2048): C ~= 22000 + 117*ctas_per_group - 13*(topk-512). When the
+    # cap ctas_per_group*topk <= C (small ctas_pg, i.e. rows>=4) coop can never reach
+    # the crossover, so force last-CTA. The kernel branches seq_len > merge_threshold;
+    # since cap > C in the coop-reachable case, seq_len > C <=> min(seq,cap) > C.
+    ctas_per_group = max(1, int(ctas_per_group))
+    topk = int(topk)
+    crossover = max(4096, 22000 + 117 * ctas_per_group - 13 * (topk - 512))
+    # The original fit was dominated by the 64-head kernel. After vectorized
+    # query staging, GLM's 32-head/top-k-2048 path still favors the serial
+    # last-CTA reducer through 16k for B2-B5; cooperative merge only wins
+    # beyond that point. This floor is runtime-seqlen dispatch inside a
+    # capture-static kernel variant, and both arms self-reset for replay.
+    if int(num_heads) == 32 and topk == 2048:
+        crossover = max(crossover, 16384)
+    cap = ctas_per_group * topk
+    return crossover if cap > crossover else _FORCE_LAST_CTA
+
+
+def fused_indexer_decode_warmup_rows(
+    *,
+    topk: int,
+    num_heads: int,
+    max_pages: int,
+    device: torch.device,
+) -> tuple[int, ...]:
+    """Return one safe launch row count per compiled decode policy.
+
+    The default fused planner specializes ``ctas_per_group`` and its merge
+    threshold by row count. Each returned row count selects a distinct policy
+    while preserving the planner's one-machine-wave launch bound. Callers can
+    launch these shapes before graph capture to populate every runtime variant.
+    """
+    props = torch.cuda.get_device_properties(device)
+    compute_capability = (
+        (int(props.major), int(props.minor))
+        if hasattr(props, "major") and hasattr(props, "minor")
+        else None
+    )
+    max_rows = fused_indexer_scratch_max_rows(
+        topk=int(topk),
+        num_heads=int(num_heads),
+        compute_capability=compute_capability,
+    )
+
+    width = int(max_pages) * _PAGE_SIZE
+    rows_by_policy: list[int] = []
+    seen_policies: set[tuple[int, int]] = set()
+    for rows in range(1, max_rows + 1):
+        if not resolve_fused_indexer_path(
+            topk=int(topk),
+            num_rows=rows,
+            width=width,
+            num_heads=int(num_heads),
+            compute_capability=compute_capability,
+        ):
+            continue
+        ctas_per_group = _resolve_default_ctas_per_group(
+            num_rows=rows,
+            max_pages=int(max_pages),
+            device=device,
+        )
+        merge_threshold = _resolve_default_merge_threshold(
+            ctas_per_group=ctas_per_group,
+            num_heads=int(num_heads),
+            topk=int(topk),
+        )
+        policy = (ctas_per_group, merge_threshold)
+        if policy not in seen_policies:
+            seen_policies.add(policy)
+            rows_by_policy.append(rows)
+    return tuple(rows_by_policy)
+
+
+# --- scratch plan trio (layout-agnostic: sizes only) --------------------------
+@dataclass(frozen=True)
+class SM12XFusedIndexerScratchPlan:
+    caps: SM12XFusedIndexerScratchCaps
+    workspace_nbytes: int
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def workspace_view(
+        self,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+    ) -> torch.Tensor:
+        """Materialize the int32 workspace view from a bound arena slice."""
+        arena = scratch_tensor(scratch, self._scratch_specs, owner="fused indexer")
+        return arena[: self.workspace_nbytes].view(torch.int32)
+
+
+def plan_fused_indexer_scratch(
+    caps: SM12XFusedIndexerScratchCaps,
+) -> SM12XFusedIndexerScratchPlan:
+    device = torch.device(caps.device)
+    workspace_nbytes = _fused_indexer_capacity_nbytes(
+        caps.max_rows, caps.max_width, caps.topk, device=device
+    )
+    return SM12XFusedIndexerScratchPlan(
+        caps=caps,
+        workspace_nbytes=workspace_nbytes,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "fused_indexer.state",
+                nbytes=workspace_nbytes,
+                device=device,
+            ),
+        ),
+    )
+
+
+# --- fused kernel SharedStorage -----------------------------------------------
+# 1024-thread CTA. Score phase: warps 0-3 (tx < _PAGED_THREADS_PER_CTA) run the
+# scorer MMA over a K-sub-tile into the logit staging (s_stage_*); all 1024
+# threads then run the tiled_topk radix folding {staging ∪ carry} -> carry.
+# Layout = scorer fields (q/weights/k_page/perm/scales/partial_logits) + radix
+# scratch (hist0/1, out_idx, counters, cand0/1) + the SMEM running-topk carry
+# (double-buffered value+gindex) + the per-sub-tile logit staging (value+gindex).
+# Batching: score directly into an over-sized carry (topk + slack); run the radix
+# only to "trim" carry back to topk when it would overflow -> one radix per
+# ~slack/page pages instead of one per page (the dominant cost). Slack is a
+# perf/SMEM knob.
+# The fused scorer is synchronization/instruction limited rather than HBM
+# limited on SM120 (the 64-head DSV4 B32/128K production launch reaches only
+# ~45% DRAM throughput).  Spend the otherwise-idle one-block-per-SM shared-memory
+# headroom on a larger DSV4 carry, batching fifty-two 64-token pages between
+# exact radix trims.  DSV4 serving graphs always have a large static context
+# capacity, so do not create capacity-dependent variants that are unreachable
+# in production.  Other contracts retain the smaller footprint, notably GLM's
+# top-k-2048 specialization, which cannot fit the larger carry.
+# 448 (not 512): the deferred-reduce pipeline's third K stage + partials/scales
+# rings cost ~10KB of SMEM; topk-2048 (GLM) needs 64 fewer carry entries to fit
+# the 101376B SM120 carveout. One trim per ~7 pages instead of 8.
+_BATCH_SLACK = 448
+_DSV4_BATCH_SLACK = 2816
+
+
+def _resolve_fused_batch_slack(
+    *,
+    kv_layout: int,
+    num_heads: int,
+    topk: int,
+) -> int:
+    """Select the capture-static carry batching size for one fused variant."""
+
+    if int(kv_layout) == KV_LAYOUT_PAGED and int(num_heads) == 64 and int(topk) == 512:
+        return _DSV4_BATCH_SLACK
+    return _BATCH_SLACK
+
+
+@lru_cache(maxsize=64)
+def _fused_indexer_shared_storage_cls(
+    padded_q_heads: int,
+    tokens_per_work: int,
+    num_q_head_tiles: int,
+    topk: int,
+    carry_cap: int,
+    cands: int,
+):
+    class SharedStorage:
+        pass
+
+    def _u8_page():
+        return cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, _PAGE_SIZE * _INDEX_HEAD_DIM], 1024
+        ]
+
+    def _i32(n):
+        return cute.struct.Align[cute.struct.MemRange[cutlass.Int32, int(n)], 128]
+
+    def _f32(n):
+        return cute.struct.Align[cute.struct.MemRange[cutlass.Float32, int(n)], 128]
+
+    annotations = {
+        # --- scorer fields (mirror _paged_indexer_shared_storage_cls) ---
+        "mbar_ptr_k": cute.struct.MemRange[cutlass.Int64, 1],
+        "q_bytes": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, int(padded_q_heads) * _INDEX_HEAD_DIM],
+            16,
+        ],
+        "weights": _f32(int(padded_q_heads)),
+        "k_page": _u8_page(),
+        "k_page_perm": _u8_page(),
+        "k_page3": _u8_page(),
+        "scales": _f32(4 * _PAGE_SIZE),
+        # Second per-page scale slot: the paged branch ping-pongs K between
+        # k_page_perm (stage 0) and k_page (stage 1, otherwise unused there),
+        # so the scale staging needs a matching second buffer.
+        "partial_logits": _f32(int(tokens_per_work) * int(num_q_head_tiles)),
+        "partial_logits2": _f32(int(tokens_per_work) * int(num_q_head_tiles)),
+        # --- radix scratch (mirror tiled_topk SharedStorage) ---
+        "hist0": _i32(384),
+        "hist1": _i32(384),
+        "out_idx": _i32(int(topk)),
+        "counter": _i32(1),
+        "thr_id": _i32(1),
+        "ni0": _i32(1),
+        "ni1": _i32(1),
+        "last_rem": _i32(1),
+        # relay[0]=pack offset, relay[1]=arrival-old (last-CTA broadcast scalars)
+        "relay": _i32(2),
+        # cooperative-merge SMEM: suffix-scan of the global histogram + per-CTA
+        # scalars (prefix/remaining_k/pivot_bin/rem) + counters (gt-count/base).
+        "coop_suffix": _i32(int(_RADIX)),
+        "coop_scalars": cute.struct.Align[cute.struct.MemRange[cutlass.Uint32, 4], 128],
+        "coop_counters": _i32(2),
+        "cand0": _i32(cands),
+        "cand1": _i32(cands),
+        # --- running accumulator: scored tokens append here; over-sized to topk+slack ---
+        "carry0_values": _f32(int(carry_cap)),
+        "carry0_gindex": _i32(int(carry_cap)),
+        # --- trim output (exactly topk) ---
+        "carry1_values": _f32(int(topk)),
+        "carry1_gindex": _i32(int(topk)),
+    }
+    SharedStorage.__annotations__ = annotations
+    return cute.struct(SharedStorage)
+
+
+@cute.jit
+def _fused_radix_select(
+    vin_v: cute.Tensor,
+    vin_g: cute.Tensor,
+    vout_v: cute.Tensor,
+    vout_g: cute.Tensor,
+    n_total: Int32,
+    topk_static: Int32,
+    cands: cutlass.Constexpr[int],
+    tx: Int32,
+    s_hist0: cute.Tensor,
+    s_hist1: cute.Tensor,
+    s_out: cute.Tensor,
+    s_cand0: cute.Tensor,
+    s_cand1: cute.Tensor,
+    h0: Int32,
+    ctr: Int32,
+    thr: Int32,
+    ni0: Int32,
+    ni1: Int32,
+    lr: Int32,
+):
+    """Exact radix top-k of vin[0:n_total] -> vout[0:topk_static] (single source).
+
+    Assumes n_total > topk_static (callers only trim when over capacity). Reuses the
+    tiled_topk coarse-8-bit-histogram + byte-refine. All 1024 threads must call this.
+    """
+    topk = topk_static
+    if tx < Int32(257):
+        s_hist0[tx] = Int32(0)
+    cute.arch.sync_threads()
+    # Single contiguous source: read vin_v[idx] directly (no virtual-index branch)
+    # and unroll the full-length scan by _SCAN_UNROLL for memory-level parallelism,
+    # mirroring tiled_topk's select (this is the rows=1 last-CTA merge hot loop).
+    idx_base = Int32(tx)
+    full_scan_limit = n_total - Int32((_SCAN_UNROLL - 1) * _RADIX_THREADS)
+    while idx_base < full_scan_limit:
+        for scan_u in cutlass.range_constexpr(_SCAN_UNROLL):
+            sidx = idx_base + Int32(scan_u * _RADIX_THREADS)
+            bin8 = _convert_to_uint8(Float32(vin_v[sidx]))
+            _smem_red_add(h0, Int32(bin8), Int32(1))
+        idx_base += Int32(_RADIX_THREADS * _SCAN_UNROLL)
+    while idx_base < n_total:
+        bin8 = _convert_to_uint8(Float32(vin_v[idx_base]))
+        _smem_red_add(h0, Int32(bin8), Int32(1))
+        idx_base += Int32(_RADIX_THREADS)
+    cute.arch.sync_threads()
+    for stage in cutlass.range_constexpr(8):
+        j = Int32(1 << stage)
+        if tx < Int32(256):
+            if (stage & 1) == 0:
+                value = Int32(s_hist0[tx])
+                if tx < Int32(256) - j:
+                    value = value + Int32(s_hist0[tx + j])
+                s_hist1[tx] = value
+            else:
+                value = Int32(s_hist1[tx])
+                if tx < Int32(256) - j:
+                    value = value + Int32(s_hist1[tx + j])
+                s_hist0[tx] = value
+        cute.arch.sync_threads()
+    if tx < Int32(256):
+        val_tx = Int32(s_hist0[tx])
+        val_tx1 = Int32(s_hist0[tx + Int32(1)])
+        if val_tx > topk:
+            if val_tx1 <= topk:
+                _smem_st(thr, Int32(0), Int32(tx))
+                _smem_st(ni0, Int32(0), Int32(0))
+                _smem_st(ctr, Int32(0), Int32(0))
+    cute.arch.sync_threads()
+    threshold_bin = _smem_ld(thr, Int32(0))
+    topk = topk - Int32(s_hist0[threshold_bin + Int32(1)])
+    # Captured below (refine-setup) = true #candidates in the coarse threshold bin; used
+    # to detect candidate-buffer overflow and fall back to an exact re-scan radix.
+    bin_count = Int32(0)
+
+    if topk == Int32(0):
+        idx_base = Int32(tx)
+        while idx_base < n_total:
+            bin8 = _convert_to_uint8(Float32(vin_v[idx_base]))
+            if Int32(bin8) > threshold_bin:
+                pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                s_out[pos] = idx_base
+            idx_base += Int32(_RADIX_THREADS)
+
+    if topk != Int32(0):
+        cute.arch.sync_threads()
+        if tx < Int32(257):
+            s_hist0[tx] = Int32(0)
+        cute.arch.sync_threads()
+        idx_base = Int32(tx)
+        full_scan_limit = n_total - Int32((_SCAN_UNROLL - 1) * _RADIX_THREADS)
+        while idx_base < full_scan_limit:
+            for scan_u in cutlass.range_constexpr(_SCAN_UNROLL):
+                sidx = idx_base + Int32(scan_u * _RADIX_THREADS)
+                raw_input = Float32(vin_v[sidx])
+                bin8 = _convert_to_uint8(raw_input)
+                if Int32(bin8) > threshold_bin:
+                    pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                    s_out[pos] = sidx
+                else:
+                    if Int32(bin8) == threshold_bin:
+                        cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
+                        if cand_pos < Int32(cands):
+                            s_cand0[cand_pos] = sidx
+                            key32 = _convert_to_uint32(raw_input)
+                            sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
+                            _smem_red_add(h0, Int32(sub_bin), Int32(1))
+            idx_base += Int32(_RADIX_THREADS * _SCAN_UNROLL)
+        while idx_base < n_total:
+            raw_input = Float32(vin_v[idx_base])
+            bin8 = _convert_to_uint8(raw_input)
+            if Int32(bin8) > threshold_bin:
+                pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                s_out[pos] = idx_base
+            else:
+                if Int32(bin8) == threshold_bin:
+                    cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
+                    if cand_pos < Int32(cands):
+                        s_cand0[cand_pos] = idx_base
+                        key32 = _convert_to_uint32(raw_input)
+                        sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
+                        _smem_red_add(h0, Int32(sub_bin), Int32(1))
+            idx_base += Int32(_RADIX_THREADS)
+        cute.arch.sync_threads()
+        # ni0 now holds the FULL threshold-bin candidate count: the xadd ran for every
+        # bin-matching key, even past `cands`. Capture it to detect refine overflow.
+        bin_count = Int32(_smem_ld(ni0, Int32(0)))
+
+        for round_idx in cutlass.range_constexpr(4):
+            if topk != Int32(-1):
+                r_idx_is_0 = (round_idx % 2) == 0
+                r_idx_next_is_0 = not r_idx_is_0
+                raw_num_input = (
+                    _smem_ld(ni0, Int32(0))
+                    if cutlass.const_expr(r_idx_is_0)
+                    else _smem_ld(ni1, Int32(0))
+                )
+                num_input = (
+                    raw_num_input if raw_num_input < Int32(cands) else Int32(cands)
+                )
+                for stage in cutlass.range_constexpr(8):
+                    j = Int32(1 << stage)
+                    if tx < Int32(256):
+                        if (stage & 1) == 0:
+                            value = Int32(s_hist0[tx])
+                            if tx < Int32(256) - j:
+                                value = value + Int32(s_hist0[tx + j])
+                            s_hist1[tx] = value
+                        else:
+                            value = Int32(s_hist1[tx])
+                            if tx < Int32(256) - j:
+                                value = value + Int32(s_hist1[tx + j])
+                            s_hist0[tx] = value
+                    cute.arch.sync_threads()
+                if tx < Int32(256):
+                    val_tx = Int32(s_hist0[tx])
+                    val_tx1 = Int32(s_hist0[tx + Int32(1)])
+                    if val_tx > topk:
+                        if val_tx1 <= topk:
+                            _smem_st(thr, Int32(0), Int32(tx))
+                            if cutlass.const_expr(r_idx_next_is_0):
+                                _smem_st(ni0, Int32(0), Int32(0))
+                            else:
+                                _smem_st(ni1, Int32(0), Int32(0))
+                            _smem_st(lr, Int32(0), topk - val_tx1)
+                cute.arch.sync_threads()
+                sub_threshold = _smem_ld(thr, Int32(0))
+                topk = topk - Int32(s_hist0[sub_threshold + Int32(1)])
+
+                if topk == Int32(0):
+                    i = Int32(tx)
+                    while i < num_input:
+                        c_idx = (
+                            Int32(s_cand0[i])
+                            if cutlass.const_expr(r_idx_is_0)
+                            else Int32(s_cand1[i])
+                        )
+                        offset = Int32(24 - round_idx * 8)
+                        raw_val = Float32(vin_v[c_idx])
+                        key32 = _convert_to_uint32(raw_val)
+                        bin = (key32 >> Uint32(offset)) & Uint32(0xFF)
+                        if Int32(bin) > sub_threshold:
+                            pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                            s_out[pos] = c_idx
+                        i += Int32(_RADIX_THREADS)
+                    topk = Int32(-1)
+
+                if topk != Int32(-1):
+                    cute.arch.sync_threads()
+                    if tx < Int32(257):
+                        s_hist0[tx] = Int32(0)
+                    cute.arch.sync_threads()
+                    i = Int32(tx)
+                    while i < num_input:
+                        c_idx = (
+                            Int32(s_cand0[i])
+                            if cutlass.const_expr(r_idx_is_0)
+                            else Int32(s_cand1[i])
+                        )
+                        raw_val = Float32(vin_v[c_idx])
+                        offset = Int32(24 - round_idx * 8)
+                        key32 = _convert_to_uint32(raw_val)
+                        bin = (key32 >> Uint32(offset)) & Uint32(0xFF)
+                        if Int32(bin) > sub_threshold:
+                            pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                            s_out[pos] = c_idx
+                        else:
+                            if Int32(bin) == sub_threshold:
+                                if cutlass.const_expr(round_idx == 3):
+                                    old_rem = _smem_xadd(lr, Int32(0), Int32(-1))
+                                    if old_rem > Int32(0):
+                                        s_out[topk_static - old_rem] = c_idx
+                                else:
+                                    cand_pos = (
+                                        _smem_xadd(ni0, Int32(0), Int32(1))
+                                        if cutlass.const_expr(r_idx_next_is_0)
+                                        else _smem_xadd(ni1, Int32(0), Int32(1))
+                                    )
+                                    if cand_pos < Int32(cands):
+                                        if cutlass.const_expr(r_idx_next_is_0):
+                                            s_cand0[cand_pos] = c_idx
+                                        else:
+                                            s_cand1[cand_pos] = c_idx
+                                        sub_bin = (
+                                            key32 >> Uint32(24 - (round_idx + 1) * 8)
+                                        ) & Uint32(0xFF)
+                                        _smem_red_add(h0, Int32(sub_bin), Int32(1))
+                        i += Int32(_RADIX_THREADS)
+                    cute.arch.sync_threads()
+
+    # ---- exact overflow fallback ----
+    # The buffered coarse+refine above drops winners when more than `cands` candidates
+    # share the coarse threshold bucket (clustered scores; the cross-CTA merge can pack
+    # up to ctas_per_group*topk candidates). When that happens, redo the selection
+    # EXACTLY with a 4-round 8-bit MSD radix that RE-SCANS vin each round filtered by the
+    # locked key prefix -- no candidate buffer, so no overflow. Same convention as the
+    # cooperative arm (_convert_to_uint32 monotone key, byte=(key>>shift)&0xFF). Slower
+    # (re-scans n_total per round on one CTA) but only taken on the rare clustered case;
+    # it overwrites s_out[0:topk]. Scalars: ni0=prefix, thr=remaining_k, ni1=bucket,
+    # lr=next remaining_k, ctr=output counter.
+    if bin_count > Int32(cands):
+        if tx == Int32(0):
+            _smem_st(ni0, Int32(0), Int32(0))
+            _smem_st(thr, Int32(0), topk_static)
+        cute.arch.sync_threads()
+        for ex_round in cutlass.range_constexpr(4):
+            ex_shift = Uint32(24 - ex_round * 8)
+            ex_prefix = Uint32(_smem_ld(ni0, Int32(0)))
+            ex_remaining = Int32(_smem_ld(thr, Int32(0)))
+            if tx < Int32(256):
+                s_hist0[tx] = Int32(0)
+            cute.arch.sync_threads()
+            idx_base = Int32(tx)
+            while idx_base < n_total:
+                ex_key = _convert_to_uint32(Float32(vin_v[idx_base]))
+                if cutlass.const_expr(ex_round == 0):
+                    _smem_red_add(
+                        h0, Int32((ex_key >> ex_shift) & Uint32(0xFF)), Int32(1)
+                    )
+                else:
+                    ex_mask = Uint32(0xFFFFFFFF) << Uint32(32 - ex_round * 8)
+                    if (ex_key & ex_mask) == ex_prefix:
+                        _smem_red_add(
+                            h0, Int32((ex_key >> ex_shift) & Uint32(0xFF)), Int32(1)
+                        )
+                idx_base += Int32(_RADIX_THREADS)
+            cute.arch.sync_threads()
+            for ex_stage in cutlass.range_constexpr(8):
+                ex_j = Int32(1 << ex_stage)
+                if tx < Int32(256):
+                    if (ex_stage & 1) == 0:
+                        ex_v = Int32(s_hist0[tx])
+                        if tx < Int32(256) - ex_j:
+                            ex_v = ex_v + Int32(s_hist0[tx + ex_j])
+                        s_hist1[tx] = ex_v
+                    else:
+                        ex_v = Int32(s_hist1[tx])
+                        if tx < Int32(256) - ex_j:
+                            ex_v = ex_v + Int32(s_hist1[tx + ex_j])
+                        s_hist0[tx] = ex_v
+                cute.arch.sync_threads()
+            if tx == Int32(0):
+                _smem_st(ni1, Int32(0), Int32(0))
+                _smem_st(lr, Int32(0), ex_remaining)
+            cute.arch.sync_threads()
+            if tx < Int32(256):
+                ex_cge = Int32(s_hist0[tx])
+                ex_cgt = Int32(0)
+                if tx + Int32(1) < Int32(256):
+                    ex_cgt = Int32(s_hist0[tx + Int32(1)])
+                if (ex_cge >= ex_remaining) & (ex_cgt < ex_remaining):
+                    _smem_st(ni1, Int32(0), Int32(tx))
+                    _smem_st(lr, Int32(0), ex_remaining - ex_cgt)
+            cute.arch.sync_threads()
+            if tx == Int32(0):
+                ex_bucket = Uint32(_smem_ld(ni1, Int32(0)))
+                _smem_st(ni0, Int32(0), Int32(ex_prefix | (ex_bucket << ex_shift)))
+                _smem_st(thr, Int32(0), _smem_ld(lr, Int32(0)))
+            cute.arch.sync_threads()
+        ex_pivot = Uint32(_smem_ld(ni0, Int32(0)))
+        if tx == Int32(0):
+            _smem_st(ctr, Int32(0), Int32(0))
+        cute.arch.sync_threads()
+        idx_base = Int32(tx)
+        while idx_base < n_total:
+            ex_key = _convert_to_uint32(Float32(vin_v[idx_base]))
+            if ex_key > ex_pivot:
+                ex_pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                if ex_pos < topk_static:
+                    s_out[ex_pos] = idx_base
+            idx_base += Int32(_RADIX_THREADS)
+        cute.arch.sync_threads()
+        idx_base = Int32(tx)
+        while idx_base < n_total:
+            ex_key = _convert_to_uint32(Float32(vin_v[idx_base]))
+            if ex_key == ex_pivot:
+                ex_pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                if ex_pos < topk_static:
+                    s_out[ex_pos] = idx_base
+            idx_base += Int32(_RADIX_THREADS)
+        cute.arch.sync_threads()
+    cute.arch.sync_threads()
+    i = Int32(tx)
+    while i < topk_static:
+        sel = Int32(s_out[i])
+        vout_v[i] = Float32(vin_v[sel])
+        vout_g[i] = Int32(vin_g[sel])
+        i += Int32(_RADIX_THREADS)
+
+
+class SparseNSAFusedIndexerKernel:
+    """paged fused score+top-k, v1: single-CTA-per-row, scalar K-load, 1024 threads.
+
+    Score phase: warps 0-3 (tx < _PAGED_THREADS_PER_CTA) reuse the paged scorer's
+    page-load + mxfp8 MMA (m=heads) into the SMEM logit staging; barriers are
+    unconditional so all 1024 threads stay in lock-step. Fold phase: all 1024
+    threads run the tiled_topk radix over {staging ∪ carry0} → carry1, then copy
+    carry1 → carry0 (running top-k). After all pages, carry0 is the row's top-k.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_heads_static: int,
+        topk: int,
+        kv_layout: int = KV_LAYOUT_PAGED,
+        paged_output: bool = False,
+        ctas_per_group: int = 1,
+        merge_threshold: int = _LAST_CTA_MERGE_MAX,
+        k_quant_page_stride: int = _PAGE_SIZE * _INDEX_HEAD_DIM,
+        k_scales_row_stride: int = _PAGE_SIZE,
+        max_seq_capacity: int = 1 << 30,
+        vectorized_q_load: bool = False,
+        q_row_stride_bytes: int = 0,
+    ):
+        self.num_heads_static = int(num_heads_static)
+        self.topk = int(topk)
+        self.kv_layout = int(kv_layout)
+        self.ctas_per_group = max(1, int(ctas_per_group))
+        self.merge_threshold = int(merge_threshold)
+        self.max_seq_capacity = max(0, int(max_seq_capacity))
+        self.vectorized_q_load = bool(vectorized_q_load)
+        self.q_row_stride_bytes = int(q_row_stride_bytes)
+        # dim-0 byte stride of k_quant_bytes for the PAGED wide load. Defaults to
+        # the contiguous 8192 (64*128); the packed paged cache interleaves per-page
+        # scales so its real page stride is 8448 -- run_fused_paged_indexer passes
+        # k_quant_bytes.stride(0) so the load reads the correct page.
+        self.k_quant_page_stride = int(k_quant_page_stride)
+        # dim-0 ELEMENT stride of the (pages, 64) f32 scales view: the packed
+        # cache interleaves per-page scales, while standalone scale tensors are
+        # normally contiguous.  Keep this independent from the quant-page byte
+        # stride so both layouts obey their actual tensor contracts.
+        self.k_scales_row_stride = int(k_scales_row_stride)
+        if self.kv_layout not in (KV_LAYOUT_CONTIGUOUS_MLA, KV_LAYOUT_PAGED):
+            raise ValueError(f"bad kv_layout {self.kv_layout}")
+        self.paged_output = bool(paged_output)
+        if self.paged_output and self.kv_layout != KV_LAYOUT_PAGED:
+            raise ValueError("physical-slot output requires the paged K/V layout")
+        if self.topk not in _SUPPORTED_TOPK:
+            raise ValueError(
+                f"fused indexer supports topk {_SUPPORTED_TOPK}, got {self.topk}"
+            )
+        self.num_q_head_tiles = _num_q_head_tiles(self.num_heads_static)
+        if self.num_q_head_tiles not in (1, 2, 4):
+            raise ValueError(
+                f"fused indexer supports 1/2/4 head tiles, got {self.num_q_head_tiles}"
+            )
+        self.padded_q_heads = self.num_q_head_tiles * _PAGED_Q_HEAD_TILE
+        # All-warp scoring: spread the page's 64 tokens across as many warps as the
+        # head-tiling leaves free, scoring the whole page in ONE pass instead of the
+        # 4-warp / page_splits-deep sequential loop. token_groups covers the page
+        # (8 tokens/group => 8 groups) bounded by warps available after head-tiling.
+        # heads=16 (tiles=1): 8 warps; heads=32 (tiles=2): 16; heads=64 (tiles=4): 32.
+        total_warps = _RADIX_THREADS // _WARP_THREADS
+        self.token_groups = min(
+            _PAGE_SIZE // _PAGED_TOKENS_PER_GROUP,  # 8 => one pass over the page
+            total_warps // self.num_q_head_tiles,  # warps free after head-tiling
+        )
+        self.tokens_per_work = _PAGED_TOKENS_PER_GROUP * self.token_groups
+        self.page_splits = _PAGE_SIZE // self.tokens_per_work
+        # Warp-owns-tokens direct-L2 score: no K staging, no page barriers.
+        # Gated to the 4-head-tile paged decode contract (DSV4 64-head) at
+        # rows >= 3 (ctas_per_group <= 16): those rows re-read an L2-resident
+        # K where 16B fragment loads are free. rows 1-2 stream mostly-cold K
+        # from DRAM, where the staged pipeline's contiguous 128B page loads
+        # win (measured +25% at rows=1, +3.5% at rows=2); they keep the
+        # historical path.
+        self.direct_k_score = (
+            self.kv_layout == KV_LAYOUT_PAGED
+            and self.num_q_head_tiles == 4
+            and self.ctas_per_group <= 16
+        )
+        self.score_warps = self.token_groups * self.num_q_head_tiles
+        self.score_threads = self.score_warps * _WARP_THREADS
+        # Over-sized accumulator: scored tokens append until topk+slack, then
+        # trim.  Keep the large measured slack specific to the paged DSV4
+        # contract so top-k-2048 and contiguous contracts retain their existing
+        # shared-memory residency.
+        batch_slack = _resolve_fused_batch_slack(
+            kv_layout=self.kv_layout,
+            num_heads=self.num_heads_static,
+            topk=self.topk,
+        )
+        self.carry_cap = int(self.topk) + int(batch_slack)
+        # The trim radix runs over <= carry_cap elements, so its threshold-bin
+        # candidate set is bounded by carry_cap -> size cand0/cand1 to that.
+        self.cands = self.carry_cap
+        # In-kernel cross-CTA merge (ctas_per_group > 1): each CTA atomically
+        # packs its REAL local candidates into a per-group global slab of
+        # capacity ctas_per_group * topk; the last-arriving CTA radix-selects the
+        # final top-k over the packed reals (no host merge launch).
+        self.merge_in_kernel = self.ctas_per_group > 1
+        self.coop_merge_possible = (
+            self.merge_in_kernel and self.max_seq_capacity > self.merge_threshold
+        )
+        self.pack_cap = self.ctas_per_group * int(self.topk)
+        # Both cross-CTA merge arms are compiled and chosen at runtime per group by
+        # seq_len vs merge_threshold (see the merge dispatch). Both index the
+        # per-group _COOP_STATE_WORDS state block, and the last-CTA arm also needs
+        # the global pack slab, so size state at _COOP_STATE_WORDS whenever the
+        # in-kernel merge is active.
+        self.state_words_per_group = _COOP_STATE_WORDS if self.merge_in_kernel else 2
+
+    def _get_shared_storage_cls(self):
+        return _fused_indexer_shared_storage_cls(
+            self.padded_q_heads,
+            self.tokens_per_work,
+            self.num_q_head_tiles,
+            self.topk,
+            self.carry_cap,
+            self.cands,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        out_indices: cute.Tensor,
+        out_values: cute.Tensor,
+        pack_values: cute.Tensor,
+        pack_indices: cute.Tensor,
+        merge_state: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            q_bytes,
+            weights,
+            k_quant_bytes,
+            k_scales,
+            real_page_table,
+            seqlens_per_query,
+            k_start,
+            k_end,
+            out_indices,
+            out_values,
+            pack_values,
+            pack_indices,
+            merge_state,
+        ).launch(
+            grid=(q_bytes.shape[0] * self.ctas_per_group, 1, 1),
+            block=[_RADIX_THREADS, 1, 1],
+            # The 1024-thread radix CTA is architecturally limited to one
+            # resident block on SM120 (1536 threads/SM).  The cooperative
+            # planner also caps the default launch to one machine-wide wave.
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        k_start: cute.Tensor,
+        k_end: cute.Tensor,
+        out_indices: cute.Tensor,
+        out_values: cute.Tensor,
+        pack_values: cute.Tensor,
+        pack_indices: cute.Tensor,
+        merge_state: cute.Tensor,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        bid, _, _ = cute.arch.block_idx()
+        bid = Int32(bid)
+        # Relay: ctas_per_group CTAs cooperate on one row (group). Each owns a
+        # page-slice and emits a LOCAL top-k into candidate[cta_in_group, group, :];
+        # the host merges the per-CTA partials. ctas_per_group==1 => single-CTA.
+        ctas_pg = Int32(self.ctas_per_group)
+        group_id = bid // ctas_pg
+        cta_in_group = bid - group_id * ctas_pg
+        q_idx = group_id
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+        topk_static = Int32(self.topk)
+        num_heads = Int32(self.num_heads_static)
+        # All-warp scoring: warps [0, score_warps) run the MMA + reduce (the page
+        # is covered in one pass). K-load / repack stay at _PAGED_THREADS_PER_CTA.
+        score_threads = Int32(self.score_threads)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self._get_shared_storage_cls())
+
+        s_w = storage.weights.get_tensor(
+            cute.make_layout((self.padded_q_heads,), stride=(1,))
+        )
+        q_smem_base_addr = shared_ptr_to_u32(storage.q_bytes.data_ptr())
+        k_page_base_addr = shared_ptr_to_u32(storage.k_page.data_ptr())
+        k_page_perm_base_addr = shared_ptr_to_u32(storage.k_page_perm.data_ptr())
+        k_page3_base_addr = shared_ptr_to_u32(storage.k_page3.data_ptr())
+        s_k_page_stage = storage.k_page.get_tensor(
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM, 1),
+                stride=(_INDEX_HEAD_DIM, 1, _PAGE_SIZE * _INDEX_HEAD_DIM),
+            )
+        )
+        s_scale = storage.scales.get_tensor(
+            cute.make_layout((_PAGE_SIZE,), stride=(1,))
+        )
+        s_partial_logits = storage.partial_logits.get_tensor(
+            cute.make_layout(
+                (self.tokens_per_work, self.num_q_head_tiles),
+                stride=(self.num_q_head_tiles, 1),
+            )
+        )
+        s_partial_logits2 = storage.partial_logits2.get_tensor(
+            cute.make_layout(
+                (self.tokens_per_work, self.num_q_head_tiles),
+                stride=(self.num_q_head_tiles, 1),
+            )
+        )
+        s_c0_values = storage.carry0_values.get_tensor(
+            cute.make_layout((self.carry_cap,), stride=(1,))
+        )
+        s_c0_gindex = storage.carry0_gindex.get_tensor(
+            cute.make_layout((self.carry_cap,), stride=(1,))
+        )
+        s_c1_values = storage.carry1_values.get_tensor(
+            cute.make_layout((self.topk,), stride=(1,))
+        )
+        s_c1_gindex = storage.carry1_gindex.get_tensor(
+            cute.make_layout((self.topk,), stride=(1,))
+        )
+        s_hist0 = storage.hist0.get_tensor(cute.make_layout((384,), stride=(1,)))
+        s_hist1 = storage.hist1.get_tensor(cute.make_layout((384,), stride=(1,)))
+        s_out = storage.out_idx.get_tensor(cute.make_layout((self.topk,), stride=(1,)))
+        s_cand0 = storage.cand0.get_tensor(cute.make_layout((self.cands,), stride=(1,)))
+        s_cand1 = storage.cand1.get_tensor(cute.make_layout((self.cands,), stride=(1,)))
+        s_relay = storage.relay.get_tensor(cute.make_layout((2,), stride=(1,)))
+        s_coop_suffix = storage.coop_suffix.get_tensor(
+            cute.make_layout((_RADIX,), stride=(1,))
+        )
+        s_coop_scalars = storage.coop_scalars.get_tensor(
+            cute.make_layout((4,), stride=(1,))
+        )
+        s_coop_counters = storage.coop_counters.get_tensor(
+            cute.make_layout((2,), stride=(1,))
+        )
+        # coop local histogram reuses hist0 (>=256); its u32 base address for atomics:
+        coop_hist_addr = shared_ptr_to_u32(storage.hist0.data_ptr())
+        coop_ctr_addr = shared_ptr_to_u32(storage.coop_counters.data_ptr())
+        h0 = shared_ptr_to_u32(storage.hist0.data_ptr())
+        ctr = shared_ptr_to_u32(storage.counter.data_ptr())
+        thr = shared_ptr_to_u32(storage.thr_id.data_ptr())
+        ni0 = shared_ptr_to_u32(storage.ni0.data_ptr())
+        ni1 = shared_ptr_to_u32(storage.ni1.data_ptr())
+        lr = shared_ptr_to_u32(storage.last_rem.data_ptr())
+
+        # PAGED: valid k = [0, seqlen) via page table. CONTIGUOUS_MLA: contiguous k =
+        # [k_start, k_end) with abs_start = k_start (no page table).
+        abs_start = Int32(0)
+        if cutlass.const_expr(self.kv_layout == KV_LAYOUT_PAGED):
+            seq_len = Int32(seqlens_per_query[q_idx])
+        else:
+            abs_start = Int32(k_start[q_idx])
+            seq_len = Int32(k_end[q_idx]) - abs_start
+        if seq_len < Int32(0):
+            seq_len = Int32(0)
+        total_pages = (seq_len + Int32(_PAGE_SIZE - 1)) // Int32(_PAGE_SIZE)
+        # This CTA's page-slice of the row (balanced split across ctas_pg CTAs).
+        pages_per_cta = (total_pages + ctas_pg - Int32(1)) // ctas_pg
+        page_start = cta_in_group * pages_per_cta
+        page_end = page_start + pages_per_cta
+        if page_end > total_pages:
+            page_end = total_pages
+        if page_start > total_pages:
+            page_start = total_pages
+
+        # Stage q + weights with all 1024 threads (paid once per CTA; the
+        # 128-thread version was 64 sequential byte rounds, costly at short K
+        # where per-CTA work is small and CTAs are many).
+        # Q staged straight into the ldmatrix-permuted per-head-tile layout so
+        # the score core consumes raw fragments on BOTH operands (no byte
+        # packs, no 16b->8b fragment swizzles).
+        if cutlass.const_expr(self.vectorized_q_load):
+            _stage_q_permuted(
+                q_bytes,
+                q_idx,
+                num_heads,
+                q_smem_base_addr,
+                tx,
+                Int64(self.q_row_stride_bytes),
+                padded_q_heads=self.padded_q_heads,
+                stage_threads=_RADIX_THREADS,
+            )
+        else:
+            # Preserve arbitrary tensor head/row strides.  Each thread moves
+            # individual bytes directly into the same XOR-permuted granules as
+            # the vectorized loader; this is the correctness fallback for views
+            # whose 128-byte head rows are not 16-byte vector-load compatible.
+            q_linear = tx
+            total_q_bytes = Int32(self.padded_q_heads * _INDEX_HEAD_DIM)
+            while q_linear < total_q_bytes:
+                head_idx = q_linear // Int32(_INDEX_HEAD_DIM)
+                col_idx = q_linear - head_idx * Int32(_INDEX_HEAD_DIM)
+                vec_idx = col_idx // Int32(16)
+                byte_idx = col_idx - vec_idx * Int32(16)
+                tile_idx = head_idx // Int32(_PAGED_Q_HEAD_TILE)
+                row_in_tile = head_idx - tile_idx * Int32(_PAGED_Q_HEAD_TILE)
+                tile_base = q_smem_base_addr + tile_idx * Int32(
+                    _PAGED_Q_HEAD_TILE * _INDEX_HEAD_DIM
+                )
+                dst_addr = (
+                    _smem_addr_from_b128_offset(
+                        tile_base,
+                        _permuted_offset_128b(
+                            row_in_tile, vec_idx, Int32(_INDEX_HEAD_DIM // 16)
+                        ),
+                    )
+                    + byte_idx
+                )
+                q_byte = cutlass.Uint8(0)
+                if head_idx < num_heads:
+                    q_byte = q_bytes[q_idx, head_idx, col_idx]
+                st_shared_u8(dst_addr, q_byte)
+                q_linear += Int32(_RADIX_THREADS)
+        w_linear = tx
+        while w_linear < Int32(self.padded_q_heads):
+            s_w[w_linear] = (
+                Float32(weights[q_idx, w_linear])
+                if w_linear < num_heads
+                else Float32(0.0)
+            )
+            w_linear += Int32(_RADIX_THREADS)
+        cute.arch.sync_threads()
+
+        head_tile_slot = warp_idx % Int32(self.num_q_head_tiles)
+        token_group = warp_idx // Int32(self.num_q_head_tiles)
+
+        if cutlass.const_expr(self.direct_k_score):
+            # Warp-owns-tokens score: every warp streams 8 consecutive tokens
+            # per round with K fragments read straight from L2 (no staging,
+            # no producer pipeline, no per-page barrier). Slot bookkeeping is
+            # uniform register arithmetic, so different rounds write disjoint
+            # carry regions and the only CTA rendezvous are trims.
+            carry_count = Int32(0)
+            span_first = page_start * Int32(_PAGE_SIZE)
+            span_end_tok = page_end * Int32(_PAGE_SIZE)
+            if span_end_tok > seq_len:
+                span_end_tok = seq_len
+            span = span_end_tok - span_first
+            if span < Int32(0):
+                span = Int32(0)
+            lane4 = lane % Int32(4)
+            round_base = Int32(0)
+            while round_base < span:
+                round_valid = span - round_base
+                if round_valid > Int32(256):
+                    round_valid = Int32(256)
+                if carry_count + Int32(256) > Int32(self.carry_cap):
+                    cute.arch.sync_threads()
+                    _fused_radix_select(
+                        s_c0_values,
+                        s_c0_gindex,
+                        s_c1_values,
+                        s_c1_gindex,
+                        carry_count,
+                        topk_static,
+                        self.cands,
+                        tx,
+                        s_hist0,
+                        s_hist1,
+                        s_out,
+                        s_cand0,
+                        s_cand1,
+                        h0,
+                        ctr,
+                        thr,
+                        ni0,
+                        ni1,
+                        lr,
+                    )
+                    cute.arch.sync_threads()
+                    ti = Int32(tx)
+                    while ti < topk_static:
+                        s_c0_values[ti] = Float32(s_c1_values[ti])
+                        s_c0_gindex[ti] = Int32(s_c1_gindex[ti])
+                        ti += Int32(_RADIX_THREADS)
+                    cute.arch.sync_threads()
+                    carry_count = topk_static
+                my_rel = round_base + warp_idx * Int32(8)
+                pid = Int32(-1)
+                tip0 = Int32(0)
+                if my_rel < span:
+                    my_page = my_rel // Int32(_PAGE_SIZE)
+                    tip0 = my_rel - my_page * Int32(_PAGE_SIZE)
+                    pcol = page_start + my_page
+                    if pcol < Int32(real_page_table.shape[1]):
+                        pid = Int32(real_page_table[q_idx, pcol])
+                t0 = Float32(0.0)
+                t1 = Float32(0.0)
+                if pid >= Int32(0):
+                    k_off = (
+                        pid * Int32(self.k_quant_page_stride)
+                        + (tip0 + lane // Int32(4)) * Int32(_INDEX_HEAD_DIM)
+                        + lane4 * Int32(4)
+                    )
+                    t0, t1 = _score_tokens_direct_k(
+                        q_smem_base_addr,
+                        s_w,
+                        num_heads,
+                        k_quant_bytes,
+                        k_off,
+                        lane,
+                        self.num_q_head_tiles,
+                    )
+                if lane < Int32(4):
+                    for cc in cutlass.range_constexpr(2):
+                        col = Int32(2) * lane4 + Int32(cc)
+                        tok_rel = my_rel + col
+                        if tok_rel < span:
+                            val = Float32(-3.4028235e38)
+                            gidx = Int32(-1)
+                            if pid >= Int32(0):
+                                if cutlass.const_expr(cc == 0):
+                                    tsel = t0
+                                else:
+                                    tsel = t1
+                                val = Float32(tsel * Float32(k_scales[pid, tip0 + col]))
+                                if cutlass.const_expr(self.paged_output):
+                                    gidx = pid * Int32(_PAGE_SIZE) + tip0 + col
+                                else:
+                                    gidx = span_first + tok_rel
+                            s_c0_values[carry_count + tok_rel - round_base] = val
+                            s_c0_gindex[carry_count + tok_rel - round_base] = gidx
+                carry_count = carry_count + round_valid
+                round_base += Int32(256)
+            cute.arch.sync_threads()
+            if carry_count > topk_static:
+                _fused_radix_select(
+                    s_c0_values,
+                    s_c0_gindex,
+                    s_c1_values,
+                    s_c1_gindex,
+                    carry_count,
+                    topk_static,
+                    self.cands,
+                    tx,
+                    s_hist0,
+                    s_hist1,
+                    s_out,
+                    s_cand0,
+                    s_cand1,
+                    h0,
+                    ctr,
+                    thr,
+                    ni0,
+                    ni1,
+                    lr,
+                )
+                cute.arch.sync_threads()
+                ti = Int32(tx)
+                while ti < topk_static:
+                    s_c0_values[ti] = Float32(s_c1_values[ti])
+                    s_c0_gindex[ti] = Int32(s_c1_gindex[ti])
+                    ti += Int32(_RADIX_THREADS)
+                cute.arch.sync_threads()
+                carry_count = topk_static
+        else:
+            carry_count = Int32(0)
+            # Paged-branch cp.async ping-pong: K alternates between k_page_perm
+            # (stage 0) and k_page (stage 1 -- unused as linear staging on the
+            # paged path); scales alternate scales/scales2. One page of lookahead.
+            scales_base_addr = shared_ptr_to_u32(storage.scales.data_ptr())
+            scales_ring_last = scales_base_addr + Int32(3 * _PAGE_SIZE * 4)
+            pipe_stage = Int32(0)
+            # Deferred-reduce pipeline (page_splits==1 paged flow): page p's reduce
+            # and carry append run at iteration p+1 BEHIND the pipeline barrier, so
+            # one barrier per page orders both the K stage and the partials handoff
+            # (the per-page reduce barrier disappears). Scales need a 3-deep ring
+            # because page p-1's scales are still live when p+1's are issued.
+            cur_scale_addr = scales_base_addr
+            prev_do = Int32(0)
+            prev_valid = Int32(0)
+            prev_out_base = Int32(0)
+            prev_scale_addr = scales_base_addr
+            prev_pl2 = Int32(0)
+            cur_pl2 = Int32(0)
+            if cutlass.const_expr(self.kv_layout == KV_LAYOUT_PAGED):
+                if page_start < page_end:
+                    pid0 = Int32(-1)
+                    if page_start < Int32(real_page_table.shape[1]):
+                        pid0 = Int32(real_page_table[q_idx, page_start])
+                    if pid0 >= Int32(0):
+                        _stream_issue_k_page_cp_async(
+                            k_quant_bytes,
+                            k_scales,
+                            pid0,
+                            k_page_perm_base_addr,
+                            scales_base_addr,
+                            Int32(0),
+                            tx,
+                            k_quant_page_stride=int(self.k_quant_page_stride),
+                            k_scales_row_stride=int(self.k_scales_row_stride),
+                            issue_threads=_RADIX_THREADS,
+                        )
+                cute.arch.cp_async_commit_group()
+            page_col = page_start
+            while page_col < page_end:
+                page_base = page_col * Int32(_PAGE_SIZE)
+                valid_slots = seq_len - page_base
+                if valid_slots > Int32(_PAGE_SIZE):
+                    valid_slots = Int32(_PAGE_SIZE)
+                n_new = Int32(0)
+                do_page = Int32(0)
+                page_id = Int32(0)
+                if cutlass.const_expr(self.kv_layout == KV_LAYOUT_PAGED):
+                    page_id = Int32(-1)
+                    if page_col < Int32(real_page_table.shape[1]):
+                        page_id = Int32(real_page_table[q_idx, page_col])
+                    if (page_id >= Int32(0)) & (valid_slots > Int32(0)):
+                        do_page = Int32(1)
+                else:
+                    if valid_slots > Int32(0):
+                        do_page = Int32(1)
+
+                cur_k_base = k_page_perm_base_addr
+                cur_scale_base = scales_base_addr
+                nsc_ring = cur_scale_addr + Int32(_PAGE_SIZE * 4)
+                if nsc_ring > scales_ring_last:
+                    nsc_ring = scales_base_addr
+                if cutlass.const_expr(self.kv_layout == KV_LAYOUT_PAGED):
+                    # Issue the NEXT page into the K ring stage of page p-2. In the
+                    # warp-specialized flow the producer first waits that stage's
+                    # EMPTY barrier (all score warps released it), so no CTA
+                    # barrier is needed; in the fallback flow the CTA barrier
+                    # provides the same ordering.
+                    nxt = page_col + Int32(1)
+                    nxt_valid = Int32(0)
+                    pid_n = Int32(-1)
+                    if nxt < page_end:
+                        if nxt < Int32(real_page_table.shape[1]):
+                            pid_n = Int32(real_page_table[q_idx, nxt])
+                        if (pid_n >= Int32(0)) & (nxt * Int32(_PAGE_SIZE) < seq_len):
+                            nxt_valid = Int32(1)
+                    # stage((p+1) % 3): perm -> k_page -> k_page3 -> perm
+                    nk = k_page_base_addr
+                    if pipe_stage == Int32(1):
+                        nk = k_page3_base_addr
+                    if pipe_stage == Int32(2):
+                        nk = k_page_perm_base_addr
+                    if nxt_valid != Int32(0):
+                        _stream_issue_k_page_cp_async(
+                            k_quant_bytes,
+                            k_scales,
+                            pid_n,
+                            nk,
+                            nsc_ring,
+                            Int32(0),
+                            tx,
+                            k_quant_page_stride=int(self.k_quant_page_stride),
+                            k_scales_row_stride=int(self.k_scales_row_stride),
+                            issue_threads=_RADIX_THREADS,
+                        )
+                    cute.arch.cp_async_commit_group()
+                    cute.arch.cp_async_wait_group(1)
+                    cute.arch.sync_threads()
+                    cur_scale_base = cur_scale_addr
+                    if pipe_stage == Int32(1):
+                        cur_k_base = k_page_base_addr
+                    if pipe_stage == Int32(2):
+                        cur_k_base = k_page3_base_addr
+                    if cutlass.const_expr(self.page_splits == 1):
+                        # Reduce + append the PREVIOUS page: its partials (all
+                        # head tiles) and its scales are ordered by the pipeline
+                        # barrier above; the score of the current page then runs
+                        # into the other partials buffer with no trailing barrier.
+                        if prev_do != Int32(0):
+                            if tx < score_threads:
+                                if (head_tile_slot == Int32(0)) & (
+                                    lane < Int32(_PAGED_TOKENS_PER_GROUP)
+                                ):
+                                    slot_idx = (
+                                        token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                                        + lane
+                                    )
+                                    if slot_idx < prev_valid:
+                                        logit = Float32(0.0)
+                                        h_i = Int32(0)
+                                        if prev_pl2 == Int32(0):
+                                            while h_i < Int32(self.num_q_head_tiles):
+                                                logit = Float32(
+                                                    logit
+                                                    + s_partial_logits[slot_idx, h_i]
+                                                )
+                                                h_i += Int32(1)
+                                        else:
+                                            while h_i < Int32(self.num_q_head_tiles):
+                                                logit = Float32(
+                                                    logit
+                                                    + s_partial_logits2[slot_idx, h_i]
+                                                )
+                                                h_i += Int32(1)
+                                        s_c0_values[carry_count + slot_idx] = Float32(
+                                            logit
+                                            * ld_shared_f32(
+                                                prev_scale_addr + slot_idx * Int32(4)
+                                            )
+                                        )
+                                        s_c0_gindex[carry_count + slot_idx] = (
+                                            prev_out_base + slot_idx
+                                        )
+                            carry_count = carry_count + prev_valid
+                            prev_do = Int32(0)
+                if do_page != Int32(0):
+                    n_new = valid_slots
+                    if cutlass.const_expr(self.kv_layout == KV_LAYOUT_PAGED):
+                        pass
+                    else:
+                        # CONTIGUOUS_MLA: masked wide scalar load into linear staging, then repack.
+                        _load_flat_k_tile_wide(
+                            k_quant_bytes,
+                            abs_start + page_base,
+                            valid_slots,
+                            s_k_page_stage,
+                            tx,
+                            Int32(_RADIX_THREADS),
+                        )
+                        scale_idx = tx
+                        while scale_idx < Int32(_PAGE_SIZE):
+                            sv = Float32(0.0)
+                            if scale_idx < valid_slots:
+                                sv = Float32(
+                                    k_scales[abs_start + page_base + scale_idx]
+                                )
+                            s_scale[scale_idx] = sv
+                            scale_idx += Int32(_RADIX_THREADS)
+                        cute.arch.sync_threads()
+                        _repack_k_page_wide(
+                            k_page_base_addr,
+                            k_page_perm_base_addr,
+                            tx,
+                            Int32(_RADIX_THREADS),
+                        )
+                        cute.arch.sync_threads()
+
+                    if cutlass.const_expr(
+                        self.kv_layout == KV_LAYOUT_PAGED and self.page_splits == 1
+                    ):
+                        tb_defer = token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                        if tx < score_threads:
+                            if tb_defer < valid_slots:
+                                htb_defer = head_tile_slot * Int32(_PAGED_Q_HEAD_TILE)
+                                if cur_pl2 == Int32(0):
+                                    _compute_mxfp8_tile_partials_qldm(
+                                        q_smem_base_addr,
+                                        s_w,
+                                        num_heads,
+                                        cur_k_base,
+                                        tb_defer,
+                                        htb_defer,
+                                        head_tile_slot,
+                                        lane,
+                                        s_partial_logits,
+                                        token_group * Int32(_PAGED_TOKENS_PER_GROUP),
+                                        head_tile_slot,
+                                    )
+                                else:
+                                    _compute_mxfp8_tile_partials_qldm(
+                                        q_smem_base_addr,
+                                        s_w,
+                                        num_heads,
+                                        cur_k_base,
+                                        tb_defer,
+                                        htb_defer,
+                                        head_tile_slot,
+                                        lane,
+                                        s_partial_logits2,
+                                        token_group * Int32(_PAGED_TOKENS_PER_GROUP),
+                                        head_tile_slot,
+                                    )
+                        prev_do = Int32(1)
+                        prev_valid = valid_slots
+                        prev_scale_addr = cur_scale_addr
+                        prev_pl2 = cur_pl2
+                        cur_pl2 = cur_pl2 ^ Int32(1)
+                        prev_out_base = abs_start + page_base
+                        if cutlass.const_expr(self.paged_output):
+                            prev_out_base = page_id * Int32(_PAGE_SIZE)
+                    else:
+                        split_idx = Int32(0)
+                        while split_idx < Int32(self.page_splits):
+                            # No partial-logits pre-zero: every group with token_base <
+                            # valid_slots runs the MMA (writing all its token columns for
+                            # all head tiles), and the reduce only reads slot_idx <
+                            # valid_slots -> it never consumes a stale (unwritten) partial.
+                            token_base = split_idx * Int32(
+                                self.tokens_per_work
+                            ) + token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                            if tx < score_threads:
+                                if token_base < valid_slots:
+                                    head_tile_base = head_tile_slot * Int32(
+                                        _PAGED_Q_HEAD_TILE
+                                    )
+                                    _compute_mxfp8_tile_partials_qldm(
+                                        q_smem_base_addr,
+                                        s_w,
+                                        num_heads,
+                                        cur_k_base,
+                                        token_base,
+                                        head_tile_base,
+                                        head_tile_slot,
+                                        lane,
+                                        s_partial_logits,
+                                        token_group * Int32(_PAGED_TOKENS_PER_GROUP),
+                                        head_tile_slot,
+                                    )
+                            cute.arch.sync_threads()
+                            if tx < score_threads:
+                                if (head_tile_slot == Int32(0)) & (
+                                    lane < Int32(_PAGED_TOKENS_PER_GROUP)
+                                ):
+                                    slot_idx = token_base + lane
+                                    if slot_idx < valid_slots:
+                                        logit = Float32(0.0)
+                                        partial_row = (
+                                            token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                                            + lane
+                                        )
+                                        h_i = Int32(0)
+                                        while h_i < Int32(self.num_q_head_tiles):
+                                            logit = Float32(
+                                                logit
+                                                + s_partial_logits[partial_row, h_i]
+                                            )
+                                            h_i += Int32(1)
+                                        s_c0_values[carry_count + slot_idx] = Float32(
+                                            logit
+                                            * ld_shared_f32(
+                                                cur_scale_base + slot_idx * Int32(4)
+                                            )
+                                        )
+                                        output_idx = abs_start + page_base + slot_idx
+                                        if cutlass.const_expr(
+                                            self.kv_layout == KV_LAYOUT_PAGED
+                                            and self.paged_output
+                                        ):
+                                            output_idx = (
+                                                page_id * Int32(_PAGE_SIZE) + slot_idx
+                                            )
+                                        s_c0_gindex[carry_count + slot_idx] = output_idx
+                            # page_splits==1 (always for 1/2/4 head tiles): no post-reduce
+                            # barrier — the next page's load barrier (or the trim's leading
+                            # sync, or the pre-output sync) orders this reduce before any
+                            # later writer of s_partial_logits / reader of the carry. Multi-
+                            # split would need the barrier between splits, so keep it then.
+                            if cutlass.const_expr(self.page_splits > 1):
+                                cute.arch.sync_threads()
+                            split_idx += Int32(1)
+                # ---- accumulate + conditional trim ----
+                is_last = page_col == (page_end - Int32(1))
+                need_trim = Int32(0) != Int32(0)
+                if cutlass.const_expr(
+                    self.kv_layout == KV_LAYOUT_PAGED and self.page_splits == 1
+                ):
+                    # Deferred flow: the count already advanced at the deferred
+                    # append; the current page appends next iteration (or in the
+                    # post-loop tail), so only capacity pressure trims here -- the
+                    # final trim runs after the loop.
+                    need_trim = carry_count + Int32(_PAGE_SIZE) > Int32(self.carry_cap)
+                else:
+                    # This page's n_new scored tokens were written into carry0[carry_count:].
+                    if do_page != Int32(0):
+                        carry_count = carry_count + n_new
+                    # Trim carry0 back to topk only when the next page would overflow the
+                    # over-sized accumulator, or at the very end. This runs the radix once
+                    # per ~(_BATCH_SLACK/_PAGE_SIZE) pages instead of every page.
+                    need_trim = (
+                        carry_count + Int32(_PAGE_SIZE) > Int32(self.carry_cap)
+                    ) | (is_last & (carry_count > topk_static))
+                if cutlass.const_expr(self.kv_layout == KV_LAYOUT_PAGED):
+                    pipe_stage = pipe_stage + Int32(1)
+                    if pipe_stage == Int32(3):
+                        pipe_stage = Int32(0)
+                    cur_scale_addr = nsc_ring
+                if need_trim:
+                    cute.arch.sync_threads()
+                    _fused_radix_select(
+                        s_c0_values,
+                        s_c0_gindex,
+                        s_c1_values,
+                        s_c1_gindex,
+                        carry_count,
+                        topk_static,
+                        self.cands,
+                        tx,
+                        s_hist0,
+                        s_hist1,
+                        s_out,
+                        s_cand0,
+                        s_cand1,
+                        h0,
+                        ctr,
+                        thr,
+                        ni0,
+                        ni1,
+                        lr,
+                    )
+                    cute.arch.sync_threads()
+                    i = Int32(tx)
+                    while i < topk_static:
+                        s_c0_values[i] = Float32(s_c1_values[i])
+                        s_c0_gindex[i] = Int32(s_c1_gindex[i])
+                        i += Int32(_RADIX_THREADS)
+                    cute.arch.sync_threads()
+                    carry_count = topk_static
+                page_col += Int32(1)
+
+            cute.arch.sync_threads()
+            if cutlass.const_expr(
+                self.kv_layout == KV_LAYOUT_PAGED and self.page_splits == 1
+            ):
+                # Drain the deferred pipeline: the last page's partials are ordered
+                # by the barrier above; append it, then run the final trim the
+                # in-loop path no longer performs.
+                if prev_do != Int32(0):
+                    if tx < score_threads:
+                        if (head_tile_slot == Int32(0)) & (
+                            lane < Int32(_PAGED_TOKENS_PER_GROUP)
+                        ):
+                            slot_idx = (
+                                token_group * Int32(_PAGED_TOKENS_PER_GROUP) + lane
+                            )
+                            if slot_idx < prev_valid:
+                                logit = Float32(0.0)
+                                h_i = Int32(0)
+                                if prev_pl2 == Int32(0):
+                                    while h_i < Int32(self.num_q_head_tiles):
+                                        logit = Float32(
+                                            logit + s_partial_logits[slot_idx, h_i]
+                                        )
+                                        h_i += Int32(1)
+                                else:
+                                    while h_i < Int32(self.num_q_head_tiles):
+                                        logit = Float32(
+                                            logit + s_partial_logits2[slot_idx, h_i]
+                                        )
+                                        h_i += Int32(1)
+                                s_c0_values[carry_count + slot_idx] = Float32(
+                                    logit
+                                    * ld_shared_f32(
+                                        prev_scale_addr + slot_idx * Int32(4)
+                                    )
+                                )
+                                s_c0_gindex[carry_count + slot_idx] = (
+                                    prev_out_base + slot_idx
+                                )
+                    carry_count = carry_count + prev_valid
+                if carry_count > topk_static:
+                    cute.arch.sync_threads()
+                    _fused_radix_select(
+                        s_c0_values,
+                        s_c0_gindex,
+                        s_c1_values,
+                        s_c1_gindex,
+                        carry_count,
+                        topk_static,
+                        self.cands,
+                        tx,
+                        s_hist0,
+                        s_hist1,
+                        s_out,
+                        s_cand0,
+                        s_cand1,
+                        h0,
+                        ctr,
+                        thr,
+                        ni0,
+                        ni1,
+                        lr,
+                    )
+                    cute.arch.sync_threads()
+                    i = Int32(tx)
+                    while i < topk_static:
+                        s_c0_values[i] = Float32(s_c1_values[i])
+                        s_c0_gindex[i] = Int32(s_c1_gindex[i])
+                        i += Int32(_RADIX_THREADS)
+                    cute.arch.sync_threads()
+                    carry_count = topk_static
+        if cutlass.const_expr(not self.merge_in_kernel):
+            # ---- single CTA per row: carry0 is already the final top-k ----
+            i = Int32(tx)
+            while i < topk_static:
+                is_valid = i < carry_count
+                out_values[group_id, i] = (
+                    Float32(s_c0_values[i]) if is_valid else Float32(float("-inf"))
+                )
+                out_indices[group_id, i] = (
+                    Int32(s_c0_gindex[i]) if is_valid else Int32(-1)
+                )
+                i += Int32(_RADIX_THREADS)
+        else:
+            # ---- in-kernel cross-CTA merge: runtime-selected strategy ----
+            # All CTAs in a group share the row's live K length (seq_len, from
+            # metadata), so they pick the SAME arm with no extra barrier:
+            #   seq_len >  merge_threshold -> cooperative grid-barrier radix over
+            #     the SMEM carries (parallel; amortizes the barriers at long K);
+            #   seq_len <= merge_threshold -> serial last-CTA reduction over a
+            #     packed slab (no grid barriers; cheaper for few-row/short-K).
+            # Both arms index the per-group _COOP_STATE_WORDS state block via
+            # _state_offset, so groups taking different arms never collide.
+            ctas_pg = Int32(self.ctas_per_group)
+            barrier_phase = Int32(0)
+            cap = Int32(self.pack_cap)
+            slab_base = group_id * cap
+            pack_v_row = cute.make_tensor(
+                pack_values.iterator + slab_base,
+                cute.make_layout((self.pack_cap,), stride=(1,)),
+            )
+            pack_i_row = cute.make_tensor(
+                pack_indices.iterator + slab_base,
+                cute.make_layout((self.pack_cap,), stride=(1,)),
+            )
+            # Pre-declare every variable assigned inside the dynamic arms below;
+            # cute forbids a None->typed transition inside a dynamic `if`.
+            i = Int32(0)
+            base = Int32(0)
+            off = Int32(0)
+            total = Int32(0)
+            key = Uint32(0)
+            byte = Int32(0)
+            mask = Uint32(0)
+            count_ge = Int32(0)
+            count_gt = Int32(0)
+            scan_val = Int32(0)
+            stride_s = Int32(0)
+            local_gt = Int32(0)
+            gt_base = Int32(0)
+            lp = Int32(0)
+            pos = Int32(0)
+            prefix = Uint32(0)
+            remaining_k = Int32(0)
+            shift = Uint32(0)
+            ordered_pivot = Uint32(0)
+            bucket_u32 = Uint32(0)
+            c = Int32(0)
+            coop_possible = Int32(1 if self.coop_merge_possible else 0)
+            if (seq_len > Int32(self.merge_threshold)) & (coop_possible != Int32(0)):
+                # group total candidate count (for the degenerate total <= topk path)
+                if tx == Int32(0):
+                    atomic_add_global_i32(
+                        _global_state_ptr(
+                            merge_state, group_id, Int32(_FUSED_STATE_TOTAL)
+                        ),
+                        carry_count,
+                    )
+                barrier_phase = _group_barrier(
+                    merge_state, group_id, barrier_phase, ctas_pg, tx
+                )
+                total = Int32(
+                    merge_state[_state_offset(group_id, Int32(_FUSED_STATE_TOTAL))]
+                )
+                if total <= topk_static:
+                    # every candidate survives: pack contiguously (atomic base) + pad -1
+                    if tx == Int32(0):
+                        s_coop_counters[1] = atomic_add_global_i32(
+                            _global_state_ptr(
+                                merge_state, group_id, Int32(_STATE_OUTPUT_COUNTER)
+                            ),
+                            carry_count,
+                        )
+                    cute.arch.sync_threads()
+                    base = Int32(s_coop_counters[1])
+                    i = Int32(tx)
+                    while i < carry_count:
+                        out_values[group_id, base + i] = Float32(s_c0_values[i])
+                        out_indices[group_id, base + i] = Int32(s_c0_gindex[i])
+                        i += Int32(_RADIX_THREADS)
+                    barrier_phase = _group_barrier(
+                        merge_state, group_id, barrier_phase, ctas_pg, tx
+                    )
+                    # pad [total, topk) with -1 (cta0 only, to avoid duplicate writes)
+                    i = Int32(tx)
+                    while i < topk_static:
+                        if (i >= total) & (cta_in_group == Int32(0)):
+                            out_values[group_id, i] = Float32(float("-inf"))
+                            out_indices[group_id, i] = Int32(-1)
+                        i += Int32(_RADIX_THREADS)
+                else:
+                    if tx == Int32(0):
+                        s_coop_scalars[0] = Uint32(0)  # prefix
+                        s_coop_scalars[1] = Uint32(topk_static)  # remaining_k
+                    cute.arch.sync_threads()
+                    for round_idx in cutlass.range_constexpr(4):
+                        shift = Uint32(24 - round_idx * 8)
+                        prefix = Uint32(s_coop_scalars[0])
+                        remaining_k = Int32(s_coop_scalars[1])
+                        # cta0 zeros the per-group global histogram for this round
+                        if cta_in_group == Int32(0):
+                            i = Int32(tx)
+                            while i < Int32(_RADIX):
+                                merge_state[_state_offset(group_id, i)] = Int32(0)
+                                i += Int32(_RADIX_THREADS)
+                        i = Int32(tx)
+                        while i < Int32(_RADIX):
+                            s_hist0[i] = Int32(0)  # local histogram (reuses hist0)
+                            i += Int32(_RADIX_THREADS)
+                        cute.arch.sync_threads()
+                        barrier_phase = _group_barrier(
+                            merge_state, group_id, barrier_phase, ctas_pg, tx
+                        )
+                        # histogram this CTA's carry entries matching the running prefix
+                        i = Int32(tx)
+                        while i < carry_count:
+                            key = _convert_to_uint32(Float32(s_c0_values[i]))
+                            if cutlass.const_expr(round_idx == 0):
+                                byte = Int32((key >> shift) & Uint32(0xFF))
+                                _smem_red_add(coop_hist_addr, byte, Int32(1))
+                            else:
+                                mask = Uint32(0xFFFFFFFF) << Uint32(32 - round_idx * 8)
+                                if (key & mask) == prefix:
+                                    byte = Int32((key >> shift) & Uint32(0xFF))
+                                    _smem_red_add(coop_hist_addr, byte, Int32(1))
+                            i += Int32(_RADIX_THREADS)
+                        cute.arch.sync_threads()
+                        # local histogram -> per-group global histogram (atomics)
+                        i = Int32(tx)
+                        while i < Int32(_RADIX):
+                            c = Int32(s_hist0[i])
+                            if c > Int32(0):
+                                atomic_add_global_i32(
+                                    _global_state_ptr(merge_state, group_id, i), c
+                                )
+                            i += Int32(_RADIX_THREADS)
+                        barrier_phase = _group_barrier(
+                            merge_state, group_id, barrier_phase, ctas_pg, tx
+                        )
+                        # read global histogram -> suffix sum (count_ge per bin)
+                        i = Int32(tx)
+                        while i < Int32(_RADIX):
+                            s_coop_suffix[i] = Int32(
+                                merge_state[_state_offset(group_id, i)]
+                            )
+                            i += Int32(_RADIX_THREADS)
+                        cute.arch.sync_threads()
+                        for stage in cutlass.range_constexpr(8):
+                            stride_s = Int32(1 << stage)
+                            scan_val = Int32(0)
+                            if tx < Int32(_RADIX):
+                                scan_val = Int32(s_coop_suffix[tx])
+                                if tx < Int32(_RADIX) - stride_s:
+                                    scan_val = scan_val + Int32(
+                                        s_coop_suffix[tx + stride_s]
+                                    )
+                            cute.arch.sync_threads()
+                            if tx < Int32(_RADIX):
+                                s_coop_suffix[tx] = scan_val
+                            cute.arch.sync_threads()
+                        # pivot bin: count_ge >= remaining_k and count_gt < remaining_k
+                        if tx == Int32(0):
+                            s_coop_scalars[2] = Uint32(0)
+                            s_coop_scalars[3] = Uint32(remaining_k)
+                        cute.arch.sync_threads()
+                        if tx < Int32(_RADIX):
+                            count_ge = Int32(s_coop_suffix[tx])
+                            count_gt = Int32(0)
+                            if tx + Int32(1) < Int32(_RADIX):
+                                count_gt = Int32(s_coop_suffix[tx + Int32(1)])
+                            if (count_ge >= remaining_k) & (count_gt < remaining_k):
+                                s_coop_scalars[2] = Uint32(tx)
+                                s_coop_scalars[3] = Uint32(remaining_k - count_gt)
+                        cute.arch.sync_threads()
+                        if tx == Int32(0):
+                            bucket_u32 = Uint32(s_coop_scalars[2])
+                            s_coop_scalars[0] = prefix | (bucket_u32 << shift)
+                            s_coop_scalars[1] = Uint32(s_coop_scalars[3])
+                        cute.arch.sync_threads()
+                        barrier_phase = _group_barrier(
+                            merge_state, group_id, barrier_phase, ctas_pg, tx
+                        )
+                    ordered_pivot = Uint32(s_coop_scalars[0])
+                    # > pivot: definite winners, written at a per-CTA atomic base
+                    if tx == Int32(0):
+                        s_coop_counters[0] = Int32(0)
+                    cute.arch.sync_threads()
+                    i = Int32(tx)
+                    while i < carry_count:
+                        key = _convert_to_uint32(Float32(s_c0_values[i]))
+                        if key > ordered_pivot:
+                            _smem_xadd(coop_ctr_addr, Int32(0), Int32(1))
+                        i += Int32(_RADIX_THREADS)
+                    cute.arch.sync_threads()
+                    local_gt = Int32(s_coop_counters[0])
+                    if tx == Int32(0):
+                        gt_base = Int32(0)
+                        if local_gt > Int32(0):
+                            gt_base = atomic_add_global_i32(
+                                _global_state_ptr(
+                                    merge_state, group_id, Int32(_STATE_OUTPUT_COUNTER)
+                                ),
+                                local_gt,
+                            )
+                        s_coop_counters[0] = Int32(0)
+                        s_coop_counters[1] = gt_base
+                    cute.arch.sync_threads()
+                    i = Int32(tx)
+                    while i < carry_count:
+                        key = _convert_to_uint32(Float32(s_c0_values[i]))
+                        if key > ordered_pivot:
+                            lp = _smem_xadd(coop_ctr_addr, Int32(0), Int32(1))
+                            pos = Int32(s_coop_counters[1]) + lp
+                            out_values[group_id, pos] = Float32(s_c0_values[i])
+                            out_indices[group_id, pos] = Int32(s_c0_gindex[i])
+                        i += Int32(_RADIX_THREADS)
+                    barrier_phase = _group_barrier(
+                        merge_state, group_id, barrier_phase, ctas_pg, tx
+                    )
+                    # == pivot: fill the remaining slots up to topk (ties at the boundary)
+                    i = Int32(tx)
+                    while i < carry_count:
+                        key = _convert_to_uint32(Float32(s_c0_values[i]))
+                        if key == ordered_pivot:
+                            pos = atomic_add_global_i32(
+                                _global_state_ptr(
+                                    merge_state, group_id, Int32(_STATE_OUTPUT_COUNTER)
+                                ),
+                                Int32(1),
+                            )
+                            if pos < topk_static:
+                                out_values[group_id, pos] = Float32(s_c0_values[i])
+                                out_indices[group_id, pos] = Int32(s_c0_gindex[i])
+                        i += Int32(_RADIX_THREADS)
+
+                # Self-reset the cooperative state without a second grid
+                # barrier.  Each CTA publishes departure only after its final
+                # output/state use; the last departing CTA can therefore reset
+                # every cross-launch scalar safely.  This also permits graph
+                # replays to switch between cooperative and serial merge as the
+                # live seqlen changes, without a captured memset on every replay.
+                cute.arch.sync_threads()
+                if tx == Int32(0):
+                    cleanup_ptr = _global_state_ptr(
+                        merge_state, group_id, Int32(_FUSED_STATE_CLEANUP)
+                    )
+                    s_relay[0] = atomic_add_global_i32(cleanup_ptr, Int32(1))
+                cute.arch.sync_threads()
+                if Int32(s_relay[0]) == (ctas_pg - Int32(1)):
+                    if tx == Int32(0):
+                        merge_state[
+                            _state_offset(group_id, Int32(_STATE_OUTPUT_COUNTER))
+                        ] = Int32(0)
+                        merge_state[
+                            _state_offset(group_id, Int32(_STATE_ARRIVAL_COUNTER))
+                        ] = Int32(0)
+                        merge_state[
+                            _state_offset(group_id, Int32(_FUSED_STATE_TOTAL))
+                        ] = Int32(0)
+                        merge_state[
+                            _state_offset(group_id, Int32(_FUSED_STATE_CLEANUP))
+                        ] = Int32(0)
+            else:
+                # ---- in-kernel cross-CTA merge (relay) ----
+                # Each CTA atomically packs its carry_count REAL candidates into the
+                # per-group global slab; the last-arriving CTA radix-selects the final
+                # top-k over the packed reals and writes the row (no host merge launch).
+                # 1. reserve a contiguous slab slot for this CTA's real candidates.
+                #    woff/arrival live in this group's coop-state block (via
+                #    _STATE_OUTPUT_COUNTER / _STATE_ARRIVAL_COUNTER), so a group on
+                #    this arm never collides with a sibling group on the coop arm.
+                if tx == Int32(0):
+                    woff_ptr = _global_state_ptr(
+                        merge_state, group_id, Int32(_STATE_OUTPUT_COUNTER)
+                    )
+                    s_relay[0] = atomic_add_global_i32(woff_ptr, carry_count)
+                cute.arch.sync_threads()
+                off = Int32(s_relay[0])
+                # 2. publish carry0[0:carry_count] into slab[slab_base+off : +count]
+                i = Int32(tx)
+                while i < carry_count:
+                    pack_values[slab_base + off + i] = Float32(s_c0_values[i])
+                    pack_indices[slab_base + off + i] = Int32(s_c0_gindex[i])
+                    i += Int32(_RADIX_THREADS)
+                cute.arch.sync_threads()
+                # 3. release the writes, then bump arrival; old==ctas-1 => I am last
+                if tx == Int32(0):
+                    threadfence()
+                    arr_ptr = _global_state_ptr(
+                        merge_state, group_id, Int32(_STATE_ARRIVAL_COUNTER)
+                    )
+                    s_relay[1] = atomic_add_global_i32(arr_ptr, Int32(1))
+                cute.arch.sync_threads()
+                if Int32(s_relay[1]) == (ctas_pg - Int32(1)):
+                    threadfence()  # acquire: observe every producer's packed writes
+                    total = Int32(
+                        merge_state[
+                            _state_offset(group_id, Int32(_STATE_OUTPUT_COUNTER))
+                        ]
+                    )
+                    if total > topk_static:
+                        _fused_radix_select(
+                            pack_v_row,
+                            pack_i_row,
+                            s_c1_values,
+                            s_c1_gindex,
+                            total,
+                            topk_static,
+                            self.cands,
+                            tx,
+                            s_hist0,
+                            s_hist1,
+                            s_out,
+                            s_cand0,
+                            s_cand1,
+                            h0,
+                            ctr,
+                            thr,
+                            ni0,
+                            ni1,
+                            lr,
+                        )
+                        cute.arch.sync_threads()
+                        i = Int32(tx)
+                        while i < topk_static:
+                            out_values[group_id, i] = Float32(s_c1_values[i])
+                            out_indices[group_id, i] = Int32(s_c1_gindex[i])
+                            i += Int32(_RADIX_THREADS)
+                    else:
+                        i = Int32(tx)
+                        while i < topk_static:
+                            if i < total:
+                                out_values[group_id, i] = Float32(pack_v_row[i])
+                                out_indices[group_id, i] = Int32(pack_i_row[i])
+                            else:
+                                out_values[group_id, i] = Float32(float("-inf"))
+                                out_indices[group_id, i] = Int32(-1)
+                            i += Int32(_RADIX_THREADS)
+                    # reset the group's counters so the next launch / graph replay starts clean
+                    cute.arch.sync_threads()
+                    if tx == Int32(0):
+                        merge_state[
+                            _state_offset(group_id, Int32(_STATE_OUTPUT_COUNTER))
+                        ] = Int32(0)
+                        merge_state[
+                            _state_offset(group_id, Int32(_STATE_ARRIVAL_COUNTER))
+                        ] = Int32(0)
+
+
+@lru_cache(maxsize=64)
+def _build_fused_indexer_kernel(
+    kv_layout: int,
+    num_heads_static: int,
+    topk: int,
+    paged_output: bool,
+    ctas_per_group: int,
+    merge_threshold: int = _LAST_CTA_MERGE_MAX,
+    k_quant_page_stride: int = _PAGE_SIZE * _INDEX_HEAD_DIM,
+    k_scales_row_stride: int = _PAGE_SIZE,
+    max_seq_capacity: int = 1 << 30,
+    vectorized_q_load: bool = False,
+    q_row_stride_bytes: int = 0,
+):
+    return SparseNSAFusedIndexerKernel(
+        num_heads_static=num_heads_static,
+        topk=topk,
+        kv_layout=kv_layout,
+        paged_output=paged_output,
+        ctas_per_group=ctas_per_group,
+        merge_threshold=merge_threshold,
+        k_quant_page_stride=k_quant_page_stride,
+        k_scales_row_stride=k_scales_row_stride,
+        max_seq_capacity=max_seq_capacity,
+        vectorized_q_load=vectorized_q_load,
+        q_row_stride_bytes=q_row_stride_bytes,
+    )
+
+
+def _arg_sig(*tensors: torch.Tensor):
+    return tuple((tuple(t.shape), str(t.dtype)) for t in tensors)
+
+
+def _fused_indexer_tensor_key(name: str, tensor: torch.Tensor) -> tuple[object, ...]:
+    dynamic_row_names = {
+        "q",
+        "w",
+        "pt",
+        "sl",
+        "kstart",
+        "kend",
+        "oi",
+        "ov",
+        "pv",
+        "pi",
+        "st",
+    }
+    dynamic_dims = (0,) if name in dynamic_row_names and int(tensor.ndim) >= 1 else ()
+    return tensor_compile_fact(name, tensor, dynamic_dims=dynamic_dims)
+
+
+def _launch_fused(kernel, cute_args, key_tensors, policy):
+    """Graph-safe launch via sm12x_launch (compile-once + replayable run_compiled).
+
+    Unlike a bare cute.compile()+call, the sm12x_launch path is CUDA-graph-capturable
+    (the existing indexer kernels rely on it). Row-bearing key tensors use dynamic
+    row dimensions; policy distinguishes the constexpr variant.
+    """
+    # Variants that do not take the direct-K path trace byte-identical code to
+    # the v2 kernel, so they keep their v2 cache keys: the heavy legacy
+    # variants (e.g. heads=16/topk=2048/ctas=96) have pathologically long cold
+    # compiles and their warm cubins are load-bearing.
+    variant = (
+        "fused_indexer_v3_directk" if kernel.direct_k_score else "fused_indexer_v2_coop"
+    )
+    cache_key = tuple(_fused_indexer_tensor_key(name, t) for name, t in key_tensors) + (
+        (variant,) + tuple(policy),
+    )
+    labels = tuple(name for name, _ in key_tensors) + ("policy",)
+    compile_spec = KernelCompileSpec.from_key(
+        "attention.indexer.fused_indexer", 1, cache_key, labels=labels
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=cute_args,
+        runtime_args=cute_args,
+    )
+
+
+def _alloc_merge_scratch(rows: int, topk: int, ctas_per_group: int, dev):
+    """Per-group merge state + pack slab for the in-kernel cross-CTA merge.
+
+    ctas_per_group == 1 takes no merge path -> minimal dummies. Otherwise the
+    runtime auto-switch can take either arm per group, so allocate BOTH: the
+    per-group state at _COOP_STATE_WORDS int32 (cooperative histogram/barrier/
+    output/total counters, which the last-CTA arm reuses for its woff/arrival
+    words) and the global pack slab (rows * ctas_per_group * topk) the last-CTA
+    arm packs into. State is zeroed each call; under CUDA-graph capture the memset
+    is captured and replays clean (the per-launch reset).
+    """
+    if ctas_per_group <= 1:
+        pack_v = torch.empty((1,), dtype=torch.float32, device=dev)
+        pack_i = torch.empty((1,), dtype=torch.int32, device=dev)
+        state = torch.zeros((2,), dtype=torch.int32, device=dev)
+    else:
+        cap = rows * ctas_per_group * int(topk)
+        pack_v = torch.empty((cap,), dtype=torch.float32, device=dev)
+        pack_i = torch.empty((cap,), dtype=torch.int32, device=dev)
+        state = torch.zeros((rows * _COOP_STATE_WORDS,), dtype=torch.int32, device=dev)
+    return pack_v, pack_i, state
+
+
+def fused_indexer_scratch_capacity(
+    max_rows: int, topk: int, num_sms: int
+) -> tuple[int, int]:
+    """Frugal FIXED capacity for the fused cross-CTA merge scratch -- for a workspace to
+    allocate ONCE and reuse, never grow.
+
+    The merge packs each cooperating CTA's local top-k (already trimmed to `topk`) into a
+    per-group slab slot. With ctas_per_group = num_sms // rows, the total packed
+    candidates = rows * ctas_per_group * topk <= num_sms * topk for ANY rows in
+    [1, num_sms]. So the pack slab is bounded by num_sms * topk -- INDEPENDENT of batch
+    size AND sequence length (the candidate count is capped by per-CTA top-k trimming,
+    not seq_len). This is the whole point: unlike a per-seq gather buffer, the fused merge
+    scratch never scales with context/max_model_len, so the frugal constant cap is exact.
+
+    Returns (pack_elems, state_words): pack_values and pack_indices each need pack_elems
+    (f32 / i32); merge_state needs state_words int32.
+    """
+    pack_elems = max(1, int(num_sms)) * int(topk)
+    state_words = max(1, int(max_rows)) * _COOP_STATE_WORDS
+    return pack_elems, state_words
+
+
+def _to_kernel_tensor(tensor: torch.Tensor, dtype, *, assumed_align: int = 16):
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = dtype
+    leading_dim = next((i for i, s in enumerate(tensor.stride()) if s == 1), None)
+    if leading_dim is not None and tensor.ndim >= 2:
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+    return cute_tensor
+
+
+def run_fused_paged_indexer(
+    *,
+    q_bytes: torch.Tensor,  # uint8 view of fp8 q, [rows, heads, 128]
+    weights: torch.Tensor,  # f32, [rows, heads]
+    k_quant_bytes: torch.Tensor,  # uint8, [pages, 64, 128]
+    k_scales: torch.Tensor,  # f32, [pages, 64]
+    real_page_table: torch.Tensor,  # i32, [rows, max_pages]
+    seqlens: torch.Tensor,  # i32, [rows]
+    num_heads: int,
+    topk: int,
+    out_indices: torch.Tensor | None = None,
+    out_values: torch.Tensor | None = None,
+    ctas_per_group: int | None = None,
+    merge_threshold: int | None = None,
+    pack_values: torch.Tensor | None = None,
+    pack_indices: torch.Tensor | None = None,
+    merge_state: torch.Tensor | None = None,
+    merge_state_preinitialized: bool = False,
+    output_physical_slots: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paged fused indexer. ctas_per_group>1 splits the row's K across cooperating CTAs.
+    Returns (indices, values).
+
+    pack_values/pack_indices/merge_state: optional caller-owned (workspace) scratch for
+    serving. Size them with fused_indexer_scratch_capacity(max_rows, topk, num_sms) ONCE
+    (fixed capacity, never grows -- the merge scratch is seq-independent). When omitted,
+    scratch is allocated per call (benchmarks/tests). A caller-owned merge_state must
+    either be zero-initialized once and pass merge_state_preinitialized=True, or it is
+    zeroed here for backwards compatibility. Both merge arms self-reset every scalar
+    they carry across launches, so a preinitialized state needs no replay-time memset.
+
+    merge_threshold drives the per-group runtime cross-CTA merge auto-switch: a row
+    whose live seq_len <= merge_threshold uses the serial last-CTA reduction (no grid
+    barriers; faster for few-row/short-K); larger rows use the cooperative
+    grid-barrier radix. 0 forces cooperative; a very large value forces last-CTA."""
+    rows = int(q_bytes.shape[0])
+    dev = q_bytes.device
+    max_pages = int(real_page_table.shape[1])
+    if ctas_per_group is None:
+        ctas_per_group = _resolve_default_ctas_per_group(
+            num_rows=rows,
+            max_pages=max_pages,
+            device=dev,
+        )
+    ctas_per_group = max(1, int(ctas_per_group))
+    if merge_threshold is None:
+        merge_threshold = _resolve_default_merge_threshold(
+            ctas_per_group=ctas_per_group,
+            num_heads=int(num_heads),
+            topk=int(topk),
+        )
+
+    out_i = (
+        torch.empty((rows, topk), dtype=torch.int32, device=dev)
+        if out_indices is None
+        else out_indices
+    )
+    out_v = (
+        torch.empty((rows, topk), dtype=torch.float32, device=dev)
+        if out_values is None
+        else out_values
+    )
+    if pack_values is not None and pack_indices is not None and merge_state is not None:
+        # Workspace-owned fixed-capacity scratch. Capacity is validated against
+        # fused_indexer_scratch_capacity by the workspace at allocation time.
+        pack_need = rows * ctas_per_group * int(topk)
+        state_need = rows * _COOP_STATE_WORDS
+        if pack_values.numel() < pack_need or pack_indices.numel() < pack_need:
+            raise ValueError(
+                f"fused indexer pack scratch too small: need {pack_need}, have "
+                f"{min(pack_values.numel(), pack_indices.numel())} "
+                f"(size via fused_indexer_scratch_capacity)"
+            )
+        if merge_state.numel() < state_need:
+            raise ValueError(
+                f"fused indexer merge_state too small: need {state_need}, have "
+                f"{merge_state.numel()} (size via fused_indexer_scratch_capacity)"
+            )
+        pack_v = pack_values[:pack_need]
+        pack_i = pack_indices[:pack_need]
+        state = merge_state[:state_need]
+        if not bool(merge_state_preinitialized):
+            state.zero_()
+    else:
+        pack_v, pack_i, state = _alloc_merge_scratch(rows, topk, ctas_per_group, dev)
+    # Real dim-0 byte stride of the K-quant tensor: the packed paged cache interleaves
+    # per-page scales (stride 8448), a plain [pages,64,128] view is contiguous (8192).
+    # The wide g2s load must use this, not a hardcoded stride, to read the right page.
+    k_quant_page_stride = int(k_quant_bytes.stride(0))
+    k_scales_row_stride = int(k_scales.stride(0))
+    vectorized_q_load = (
+        int(q_bytes.data_ptr()) % 16 == 0
+        and int(q_bytes.stride(2)) == 1
+        and int(q_bytes.stride(1)) == _INDEX_HEAD_DIM
+        and int(q_bytes.stride(0)) % 16 == 0
+    )
+    q_row_stride_bytes = int(q_bytes.stride(0)) if vectorized_q_load else 0
+    kernel = _build_fused_indexer_kernel(
+        KV_LAYOUT_PAGED,
+        int(num_heads),
+        int(topk),
+        bool(output_physical_slots),
+        ctas_per_group,
+        merge_threshold=int(merge_threshold),
+        k_quant_page_stride=k_quant_page_stride,
+        k_scales_row_stride=k_scales_row_stride,
+        max_seq_capacity=max_pages * _PAGE_SIZE,
+        vectorized_q_load=vectorized_q_load,
+        q_row_stride_bytes=q_row_stride_bytes,
+    )
+    # k_start/k_end are constexpr-dead in the PAGED kernel. Reuse the existing
+    # int32 row metadata instead of capturing a pointless zero-fill kernel.
+    unused_k_bounds = seqlens
+    args = (
+        _to_kernel_tensor(q_bytes, cutlass.Uint8, assumed_align=4),
+        _to_kernel_tensor(weights, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(k_quant_bytes, cutlass.Uint8, assumed_align=4),
+        _to_kernel_tensor(k_scales, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(real_page_table, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(seqlens, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(unused_k_bounds, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(unused_k_bounds, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(out_i, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(out_v, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(pack_v, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(pack_i, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(state, cutlass.Int32, assumed_align=4),
+        current_cuda_stream(),
+    )
+    key_tensors = [
+        ("q", q_bytes),
+        ("w", weights),
+        ("kq", k_quant_bytes),
+        ("ks", k_scales),
+        ("pt", real_page_table),
+        ("sl", seqlens),
+        ("kstart", unused_k_bounds),
+        ("kend", unused_k_bounds),
+        ("oi", out_i),
+        ("ov", out_v),
+        ("pv", pack_v),
+        ("pi", pack_i),
+        ("st", state),
+    ]
+    _launch_fused(
+        kernel,
+        args,
+        key_tensors,
+        (
+            KV_LAYOUT_PAGED,
+            int(num_heads),
+            int(topk),
+            bool(output_physical_slots),
+            int(ctas_per_group),
+            int(merge_threshold),
+            k_quant_page_stride,
+            max_pages * _PAGE_SIZE,
+            k_scales_row_stride,
+            bool(vectorized_q_load),
+            q_row_stride_bytes,
+        ),
+    )
+    return out_i, out_v
+
+
+def run_fused_indexer_mla(
+    *,
+    q_bytes: torch.Tensor,  # uint8 view of fp8 q, [rows, heads, 128]
+    weights: torch.Tensor,  # f32, [rows, heads]
+    k_quant_bytes: torch.Tensor,  # uint8, [k_rows, 128] (contiguous MLA K)
+    k_scales: torch.Tensor,  # f32, [k_rows]
+    k_start: torch.Tensor,  # i32, [rows]
+    k_end: torch.Tensor,  # i32, [rows]
+    num_heads: int,
+    topk: int,
+    out_indices: torch.Tensor | None = None,
+    out_values: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """v1 FLAT/MLA fused indexer over contiguous K with per-row [k_start, k_end). ctas=1."""
+    rows = int(q_bytes.shape[0])
+    dev = q_bytes.device
+    out_i = (
+        torch.empty((rows, topk), dtype=torch.int32, device=dev)
+        if out_indices is None
+        else out_indices
+    )
+    out_v = (
+        torch.empty((rows, topk), dtype=torch.float32, device=dev)
+        if out_values is None
+        else out_values
+    )
+    pack_v, pack_i, state = _alloc_merge_scratch(rows, topk, 1, dev)
+    vectorized_q_load = (
+        int(q_bytes.data_ptr()) % 16 == 0
+        and int(q_bytes.stride(2)) == 1
+        and int(q_bytes.stride(1)) == _INDEX_HEAD_DIM
+        and int(q_bytes.stride(0)) % 16 == 0
+    )
+    q_row_stride_bytes = int(q_bytes.stride(0)) if vectorized_q_load else 0
+    kernel = _build_fused_indexer_kernel(
+        KV_LAYOUT_CONTIGUOUS_MLA,
+        int(num_heads),
+        int(topk),
+        False,
+        1,
+        vectorized_q_load=vectorized_q_load,
+        q_row_stride_bytes=q_row_stride_bytes,
+    )
+    # page table / seqlens unused for FLAT; pass minimal dummies.
+    dummy_pt = torch.zeros((rows, 1), dtype=torch.int32, device=dev)
+    dummy_sl = torch.zeros((rows,), dtype=torch.int32, device=dev)
+    args = (
+        _to_kernel_tensor(q_bytes, cutlass.Uint8, assumed_align=4),
+        _to_kernel_tensor(weights, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(k_quant_bytes, cutlass.Uint8, assumed_align=4),
+        _to_kernel_tensor(k_scales, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(dummy_pt, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(dummy_sl, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(k_start, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(k_end, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(out_i, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(out_v, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(pack_v, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(pack_i, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(state, cutlass.Int32, assumed_align=4),
+        current_cuda_stream(),
+    )
+    key_tensors = [
+        ("q", q_bytes),
+        ("w", weights),
+        ("kq", k_quant_bytes),
+        ("ks", k_scales),
+        ("pt", dummy_pt),
+        ("sl", dummy_sl),
+        ("kstart", k_start),
+        ("kend", k_end),
+        ("oi", out_i),
+        ("ov", out_v),
+        ("pv", pack_v),
+        ("pi", pack_i),
+        ("st", state),
+    ]
+    _launch_fused(
+        kernel,
+        args,
+        key_tensors,
+        (
+            KV_LAYOUT_CONTIGUOUS_MLA,
+            int(num_heads),
+            int(topk),
+            1,
+            bool(vectorized_q_load),
+            q_row_stride_bytes,
+        ),
+    )
+    return out_i, out_v

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/kernel.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/kernel.py
@@ -1,0 +1,3678 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/kernel.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""CuTeDSL paged decode score kernel for the paged NSA contract."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+import cutlass
+import cutlass.cute as cute
+import cuda.bindings.driver as cuda
+import torch
+from cutlass import Float32, Int32, Uint32
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.experimental.sm12x.attention._shared.cute import copy as cute_copy
+from flashinfer.experimental.sm12x.attention._shared.cute import (
+    pipeline as cute_pipeline,
+)
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as attention_ops
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    launch as sm12x_launch,
+    tensor_compile_fact,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import get_sm_version
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    cp_async4_shared_global,
+    cp_async_u32_shared_global,
+    frag_layout_swizzle_16b_to_8b,
+    get_ptr_as_int64,
+    ld_global_v4_u32,
+    ld_shared_v4_u32,
+    ldmatrix_m8n8x2_b16,
+    ldmatrix_m8n8x4_b16,
+    ldmatrix_m8n8x4_left_half_b16,
+    ldmatrix_m8n8x4_right_half_b16,
+    mxfp8_mma_m16n8k32_f32_e4m3,
+    shared_ptr_to_u32,
+    st_shared_v4_u32,
+)
+from cutlass import Int64
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+
+
+_INDEX_HEAD_DIM = 128
+_PAGE_SIZE = 64
+_SCALE_BYTES = 4
+_WARP_THREADS = 32
+_PAGED_WARPS_PER_CTA = 4
+_PAGED_THREADS_PER_CTA = _WARP_THREADS * _PAGED_WARPS_PER_CTA
+_PAGED_TOKENS_PER_GROUP = 8
+PAGED_MQA_LOGITS_SCHEDULE_PAGES_PER_SPLIT = 4
+_SCHEDULE_MIN_PAGES = 1024
+_ENABLE_MULTI_ROW_SCHEDULE = True
+_SCHEDULE_SINGLE_ROW_PARALLEL_CTAS = 4
+_SCHEDULE_MULTI_ROW_PARALLEL_CTAS = 4
+_SCHEDULE_MULTI_ROW_MAX_Q_ROWS = 8
+_MAX_SUPPORTED_Q_HEADS = 64
+_PAGED_TILED_BLOCK_Q = 32
+_PAGED_TILED_BLOCK_K = 512
+_PAGED_Q_HEAD_TILE = 16
+_BLACKWELL_TINY_STRIDED_TMA_MAX_BACKING_BYTES = 128 * 1024
+
+
+class IndexerScoreMode:
+    NSA_RELU_SUM = 0
+    MSA_BILINEAR = 1
+
+
+class IndexerOutputMode:
+    TOKEN_LOGITS = 0
+    PAGE_HEAD_MAX = 1
+
+
+def _raise_binding_extras(api_name: str, extras: list[str]) -> None:
+    raise ValueError(
+        f"{api_name} binding owns runtime tensors and kernel options; "
+        f"do not also pass {', '.join(extras)}"
+    )
+
+
+def _require_bound_arg(value, *, api_name: str, name: str):
+    if value is None:
+        raise TypeError(f"{api_name} requires {name} or binding")
+    return value
+
+
+@dataclass(frozen=True, kw_only=True)
+class IndexerPagedLogitsKernelBinding:
+    q_fp8: torch.Tensor
+    weights: torch.Tensor
+    index_k_cache: torch.Tensor
+    real_page_table: torch.Tensor
+    seqlens_per_query: torch.Tensor
+    schedule_metadata: torch.Tensor | None = None
+    active_width: torch.Tensor | None = None
+    page_size: int = _PAGE_SIZE
+    preinitialize_invalid_logits: bool = True
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM
+    output_mode: int = IndexerOutputMode.TOKEN_LOGITS
+    page_scores: torch.Tensor | None = None
+
+    def run(self) -> torch.Tensor:
+        return run_paged_logits_kernel(binding=self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class IndexerPagedTiledLogitsKernelBinding:
+    q_fp8: torch.Tensor
+    weights: torch.Tensor
+    index_k_cache: torch.Tensor
+    real_page_table: torch.Tensor
+    seqlens_per_query: torch.Tensor
+    active_width: torch.Tensor
+    tile_logits: torch.Tensor
+    page_size: int = _PAGE_SIZE
+    tile_block_q: int = _PAGED_TILED_BLOCK_Q
+    tile_block_k: int = _PAGED_TILED_BLOCK_K
+    preinitialize_tile_logits: bool = True
+
+    def run(self) -> torch.Tensor:
+        return run_paged_tiled_logits_kernel(binding=self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class IndexerPagedSupertileLogitsKernelBinding:
+    q_fp8: torch.Tensor
+    weights: torch.Tensor
+    index_k_cache: torch.Tensor
+    real_page_table: torch.Tensor
+    seqlens_per_query: torch.Tensor
+    active_width: torch.Tensor
+    tile_logits: torch.Tensor
+    source_page_offset: int
+    output_width_tokens: int
+    page_size: int = _PAGE_SIZE
+    tile_block_q: int = _PAGED_TILED_BLOCK_Q
+    tile_block_k: int = _PAGED_TILED_BLOCK_K
+    preinitialize_tile_logits: bool = True
+
+    def run(self) -> torch.Tensor:
+        return run_paged_supertile_logits_kernel(binding=self)
+
+
+def build_indexer_paged_logits_kernel_binding(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+    schedule_metadata: torch.Tensor | None = None,
+    active_width: torch.Tensor | None = None,
+    page_size: int = _PAGE_SIZE,
+    preinitialize_invalid_logits: bool = True,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    output_mode: int = IndexerOutputMode.TOKEN_LOGITS,
+    page_scores: torch.Tensor | None = None,
+) -> IndexerPagedLogitsKernelBinding:
+    return IndexerPagedLogitsKernelBinding(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens_per_query=seqlens_per_query,
+        schedule_metadata=schedule_metadata,
+        active_width=active_width,
+        page_size=int(page_size),
+        preinitialize_invalid_logits=bool(preinitialize_invalid_logits),
+        score_mode=int(score_mode),
+        output_mode=int(output_mode),
+        page_scores=page_scores,
+    )
+
+
+def build_indexer_paged_tiled_logits_kernel_binding(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+    active_width: torch.Tensor,
+    tile_logits: torch.Tensor,
+    page_size: int = _PAGE_SIZE,
+    tile_block_q: int = _PAGED_TILED_BLOCK_Q,
+    tile_block_k: int = _PAGED_TILED_BLOCK_K,
+    preinitialize_tile_logits: bool = True,
+) -> IndexerPagedTiledLogitsKernelBinding:
+    return IndexerPagedTiledLogitsKernelBinding(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens_per_query=seqlens_per_query,
+        active_width=active_width,
+        tile_logits=tile_logits,
+        page_size=int(page_size),
+        tile_block_q=int(tile_block_q),
+        tile_block_k=int(tile_block_k),
+        preinitialize_tile_logits=bool(preinitialize_tile_logits),
+    )
+
+
+def build_indexer_paged_supertile_logits_kernel_binding(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+    active_width: torch.Tensor,
+    tile_logits: torch.Tensor,
+    source_page_offset: int,
+    output_width_tokens: int,
+    page_size: int = _PAGE_SIZE,
+    tile_block_q: int = _PAGED_TILED_BLOCK_Q,
+    tile_block_k: int = _PAGED_TILED_BLOCK_K,
+    preinitialize_tile_logits: bool = True,
+) -> IndexerPagedSupertileLogitsKernelBinding:
+    return IndexerPagedSupertileLogitsKernelBinding(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens_per_query=seqlens_per_query,
+        active_width=active_width,
+        tile_logits=tile_logits,
+        source_page_offset=int(source_page_offset),
+        output_width_tokens=int(output_width_tokens),
+        page_size=int(page_size),
+        tile_block_q=int(tile_block_q),
+        tile_block_k=int(tile_block_k),
+        preinitialize_tile_logits=bool(preinitialize_tile_logits),
+    )
+
+
+def _num_q_head_tiles(num_heads: int) -> int:
+    return max((num_heads + _PAGED_Q_HEAD_TILE - 1) // _PAGED_Q_HEAD_TILE, 1)
+
+
+def _page_splits_for_num_heads(num_heads: int) -> int:
+    num_q_head_tiles = _num_q_head_tiles(num_heads)
+    token_groups = _PAGED_WARPS_PER_CTA // num_q_head_tiles
+    tokens_per_work = _PAGED_TOKENS_PER_GROUP * token_groups
+    return _PAGE_SIZE // tokens_per_work
+
+
+@lru_cache(maxsize=16)
+def _paged_indexer_shared_storage_cls(
+    padded_q_heads: int,
+    tokens_per_work: int,
+    num_q_head_tiles: int,
+):
+    class SharedStorage:
+        pass
+
+    def k_page_storage():
+        return cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, _PAGE_SIZE * _INDEX_HEAD_DIM],
+            1024,
+        ]
+
+    annotations = {
+        "mbar_ptr_k": cute.struct.MemRange[cutlass.Int64, 1],
+        "q_bytes": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, int(padded_q_heads) * _INDEX_HEAD_DIM],
+            16,
+        ],
+        "weights": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, int(padded_q_heads)],
+            16,
+        ],
+    }
+    annotations["k_page"] = k_page_storage()
+    annotations.update(
+        {
+            "k_page_perm": k_page_storage(),
+            "scales": cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, _PAGE_SIZE],
+                16,
+            ],
+            "partial_logits": cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32,
+                    max(
+                        int(tokens_per_work) * int(num_q_head_tiles),
+                        _PAGED_WARPS_PER_CTA * _PAGED_Q_HEAD_TILE,
+                    ),
+                ],
+                16,
+            ],
+        }
+    )
+    SharedStorage.__annotations__ = annotations
+    return cute.struct(SharedStorage)
+
+
+def _to_kernel_tensor(
+    tensor: torch.Tensor,
+    dtype: type[cutlass.Numeric],
+    *,
+    assumed_align: int = 16,
+) -> cutlass.cute.Tensor:
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = dtype
+    leading_dim = next(
+        (idx for idx, stride in enumerate(tensor.stride()) if stride == 1), None
+    )
+    if leading_dim is not None and tensor.ndim >= 2:
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+    return cute_tensor
+
+
+def _is_row_shared_i32_matrix(tensor: torch.Tensor) -> bool:
+    return (
+        tensor.ndim == 2
+        and tensor.dtype == torch.int32
+        and int(tensor.stride(0)) == 0
+        and int(tensor.stride(1)) == 1
+    )
+
+
+def _tensor_meta_key(
+    tensor: torch.Tensor,
+) -> tuple[tuple[int, ...], tuple[int, ...], str, tuple[str, int | None]]:
+    return (
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        str(tensor.dtype),
+        (tensor.device.type, tensor.device.index),
+    )
+
+
+def _tensor_compile_key(
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    dynamic_dims: tuple[int, ...] = (),
+) -> tuple[object, ...]:
+    return tensor_compile_fact(name, tensor, dynamic_dims=dynamic_dims)
+
+
+def _assume_paged_k_tma_source_aligned(t: cute.Tensor):
+    divby = 128 // t.element_type.width
+    strides = []
+    for dim, stride in enumerate(t.stride):
+        if dim == 1 or isinstance(stride, int):
+            strides.append(stride)
+        else:
+            strides.append(cute.assume(stride, divby=divby))
+    return cute.make_tensor(
+        t.iterator, cute.make_layout(t.shape, stride=tuple(strides))
+    )
+
+
+def _make_paged_index_k_tma_source(
+    k_quant_bytes: cutlass.cute.Tensor,
+) -> cutlass.cute.Tensor:
+    t_pages = cute.make_tensor(
+        k_quant_bytes.iterator, cute.select(k_quant_bytes.layout, mode=[1, 2, 0])
+    )
+    return _assume_paged_k_tma_source_aligned(t_pages)
+
+
+@lru_cache(maxsize=16)
+def _default_sparse_nsa_persistent_ctas(device_index: int) -> int:
+    num_sms = int(torch.cuda.get_device_properties(device_index).multi_processor_count)
+    return max(num_sms * 4, 1)
+
+
+def _resolve_sparse_nsa_persistent_ctas(
+    *,
+    device_index: int,
+    q_rows: int,
+) -> int:
+    persistent_ctas = _default_sparse_nsa_persistent_ctas(device_index)
+    if q_rows >= 4:
+        persistent_ctas = max(persistent_ctas // 2, 1)
+    return persistent_ctas
+
+
+def _tensor_storage_nbytes(tensor: torch.Tensor) -> int:
+    storage = (
+        tensor.untyped_storage()
+        if hasattr(tensor, "untyped_storage")
+        else tensor.storage()
+    )
+    if hasattr(storage, "nbytes"):
+        return int(storage.nbytes())
+    return int(storage.size()) * tensor.element_size()
+
+
+def _is_dense_non_overlapping(tensor: torch.Tensor) -> bool:
+    expected_stride = 1
+    strides_and_sizes = []
+    for size, stride in zip(tensor.shape, tensor.stride(), strict=True):
+        if int(size) <= 1:
+            continue
+        strides_and_sizes.append((abs(int(stride)), int(size)))
+    for stride, size in sorted(strides_and_sizes):
+        if stride != expected_stride:
+            return False
+        expected_stride *= size
+    return True
+
+
+def _needs_paged_index_k_scalar_load(
+    index_k_cache: torch.Tensor,
+    k_quant_bytes: torch.Tensor,
+) -> bool:
+    # Real serving caches are large enough for the normal TMA path. Tiny
+    # strided caches appear in fake/warmup runs and should still be valid, so
+    # load those pages cooperatively instead of depending on tiny strided TMA
+    # descriptor behavior.
+    if get_sm_version(index_k_cache.device) // 10 != 12:
+        return False
+    if (
+        _tensor_storage_nbytes(index_k_cache)
+        >= _BLACKWELL_TINY_STRIDED_TMA_MAX_BACKING_BYTES
+    ):
+        return False
+    return not _is_dense_non_overlapping(k_quant_bytes)
+
+
+@lru_cache(maxsize=16)
+def _dummy_paged_index_k_tma_desc_ptrs(device_index: int) -> torch.Tensor:
+    return torch.zeros(
+        (1,), dtype=torch.int64, device=torch.device("cuda", device_index)
+    )
+
+
+@lru_cache(maxsize=32)
+def _cached_int32_scalar(value: int, device_index: int) -> torch.Tensor:
+    return torch.tensor(
+        [value], dtype=torch.int32, device=torch.device("cuda", device_index)
+    )
+
+
+@cute.jit
+def _permuted_offset_128b(row_idx, vec_idx, row_stride_128b):
+    return row_idx * row_stride_128b + (vec_idx ^ (row_idx % 8))
+
+
+@cute.jit
+def _smem_addr_from_b128_offset(base_addr: Int32, offset_128b):
+    return base_addr + Int32(offset_128b * 16)
+
+
+@cute.jit
+def _advance_offset_by_row_128b(offset_128b, step_size, row_stride_128b):
+    return offset_128b + step_size * row_stride_128b
+
+
+@cute.jit
+def _advance_offset_by_column_128b_2(offset_128b, step_idx):
+    xor_term = Int32(0x2) + (Int32(0x4) if step_idx % 2 == 1 else Int32(0))
+    extra = Int32(8) if step_idx % 4 == 3 else Int32(0)
+    return (offset_128b ^ xor_term) + extra
+
+
+@cute.jit
+def _pack_q_mxfp8_reg(
+    s_q_bytes: cute.Tensor,
+    row: Int32,
+    col_pair_base: Int32,
+) -> Uint32:
+    b0 = Uint32(s_q_bytes[row, col_pair_base + Int32(0)])
+    b1 = Uint32(s_q_bytes[row, col_pair_base + Int32(1)])
+    b2 = Uint32(s_q_bytes[row, col_pair_base + Int32(8)])
+    b3 = Uint32(s_q_bytes[row, col_pair_base + Int32(9)])
+    return b0 | (b1 << Int32(8)) | (b2 << Int32(16)) | (b3 << Int32(24))
+
+
+@cute.jit
+def _repack_k_page_to_permuted(
+    k_linear_base_addr: Int32,
+    k_perm_base_addr: Int32,
+    lane_linear: Int32,
+):
+    linear = lane_linear
+    total = Int32(_PAGE_SIZE * (_INDEX_HEAD_DIM // 16))
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM // 16)
+        vec_idx = linear - row * Int32(_INDEX_HEAD_DIM // 16)
+        src_addr = k_linear_base_addr + Int32(row * _INDEX_HEAD_DIM + vec_idx * 16)
+        dst_addr = _smem_addr_from_b128_offset(
+            k_perm_base_addr,
+            _permuted_offset_128b(row, vec_idx, Int32(_INDEX_HEAD_DIM // 16)),
+        )
+        v0, v1, v2, v3 = ld_shared_v4_u32(src_addr)
+        st_shared_v4_u32(dst_addr, v0, v1, v2, v3)
+        linear += Int32(_PAGED_THREADS_PER_CTA)
+
+
+@cute.jit
+def _load_index_k_page_scalar(
+    k_quant_bytes: cute.Tensor,
+    page_id: Int32,
+    s_k_page_stage: cute.Tensor,
+    lane_linear: Int32,
+):
+    linear = lane_linear
+    total = Int32(_PAGE_SIZE * _INDEX_HEAD_DIM)
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM)
+        col = linear - row * Int32(_INDEX_HEAD_DIM)
+        s_k_page_stage[row, col, Int32(0)] = k_quant_bytes[page_id, row, col]
+        linear += Int32(_PAGED_THREADS_PER_CTA)
+
+
+@cute.jit
+def _reduce_column_pair_sum(value: Float32) -> Float32:
+    value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=4))
+    value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=8))
+    value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=16))
+    return value
+
+
+@cute.jit
+def _reduce_quad_max(value: Float32) -> Float32:
+    value = attention_ops.fmax(value, cute.arch.shuffle_sync_bfly(value, offset=1))
+    value = attention_ops.fmax(value, cute.arch.shuffle_sync_bfly(value, offset=2))
+    return value
+
+
+@cute.jit
+def _compute_mxfp8_tile_partials(
+    s_q_bytes: cute.Tensor,
+    s_w: cute.Tensor,
+    num_heads: Int32,
+    k_perm_base_addr: Int32,
+    token_base: Int32,
+    head_tile_base: Int32,
+    lane: Int32,
+    s_partial_logits: cute.Tensor,
+    partial_row_base: Int32,
+    head_tile_slot: Int32,
+    score_mode: cutlass.Constexpr[int] = IndexerScoreMode.NSA_RELU_SUM,
+):
+    group_id = lane // Int32(4)
+    thread_id_in_group = lane % Int32(4)
+    col_pair_base = thread_id_in_group * Int32(2)
+    q0_acc = Float32(0.0)
+    q1_acc = Float32(0.0)
+    q2_acc = Float32(0.0)
+    q3_acc = Float32(0.0)
+    k_offset = _permuted_offset_128b(
+        token_base + Int32(8) * (lane // Int32(16)) + lane % Int32(8),
+        (lane % Int32(16)) // Int32(8),
+        Int32(_INDEX_HEAD_DIM // 16),
+    )
+    for mma_pair in cutlass.range_constexpr(_INDEX_HEAD_DIM // 32):
+        pair_base = Int32(mma_pair * 32) + col_pair_base
+        q0 = _pack_q_mxfp8_reg(s_q_bytes, head_tile_base + group_id, pair_base)
+        q1 = _pack_q_mxfp8_reg(
+            s_q_bytes, head_tile_base + group_id + Int32(8), pair_base
+        )
+        q2 = _pack_q_mxfp8_reg(
+            s_q_bytes, head_tile_base + group_id, pair_base + Int32(16)
+        )
+        q3 = _pack_q_mxfp8_reg(
+            s_q_bytes,
+            head_tile_base + group_id + Int32(8),
+            pair_base + Int32(16),
+        )
+        b0_k0, _ = ldmatrix_m8n8x4_left_half_b16(
+            _smem_addr_from_b128_offset(k_perm_base_addr, k_offset)
+        )
+        b0_k1, _ = ldmatrix_m8n8x4_right_half_b16(
+            _smem_addr_from_b128_offset(k_perm_base_addr, k_offset)
+        )
+        b0_k0 = frag_layout_swizzle_16b_to_8b(b0_k0)
+        b0_k1 = frag_layout_swizzle_16b_to_8b(b0_k1)
+        k_offset_cur = _advance_offset_by_row_128b(
+            k_offset,
+            Int32(16),
+            Int32(_INDEX_HEAD_DIM // 16),
+        )
+        d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+            q0_acc,
+            q1_acc,
+            q2_acc,
+            q3_acc,
+            q0,
+            q1,
+            q2,
+            q3,
+            b0_k0,
+            b0_k1,
+            Uint32(0x7F7F7F7F),
+            Uint32(0x7F7F7F7F),
+        )
+        q0_acc = d0
+        q1_acc = d1
+        q2_acc = d2
+        q3_acc = d3
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            16 * (_INDEX_HEAD_DIM // 16)
+        )
+
+    head0 = head_tile_base + group_id
+    head1 = head0 + Int32(8)
+    w0 = Float32(0.0)
+    w1 = Float32(0.0)
+    if head0 < num_heads:
+        w0 = Float32(s_w[head0])
+    if head1 < num_heads:
+        w1 = Float32(s_w[head1])
+    col0 = col_pair_base
+    col1 = col_pair_base + Int32(1)
+    if cutlass.const_expr(score_mode == IndexerScoreMode.MSA_BILINEAR):
+        partial0 = Float32(q0_acc * w0)
+        partial0 = Float32(partial0 + q2_acc * w1)
+        partial1 = Float32(q1_acc * w0)
+        partial1 = Float32(partial1 + q3_acc * w1)
+    else:
+        partial0 = Float32(attention_ops.fmax(q0_acc, Float32(0.0)) * w0)
+        partial0 = Float32(partial0 + attention_ops.fmax(q2_acc, Float32(0.0)) * w1)
+        partial1 = Float32(attention_ops.fmax(q1_acc, Float32(0.0)) * w0)
+        partial1 = Float32(partial1 + attention_ops.fmax(q3_acc, Float32(0.0)) * w1)
+    partial0 = _reduce_column_pair_sum(partial0)
+    partial1 = _reduce_column_pair_sum(partial1)
+    if group_id == Int32(0):
+        s_partial_logits[partial_row_base + col0, head_tile_slot] = partial0
+        s_partial_logits[partial_row_base + col1, head_tile_slot] = partial1
+
+
+@cute.jit
+def _compute_mxfp8_tile_head_token_max(
+    s_q_bytes: cute.Tensor,
+    s_w: cute.Tensor,
+    num_heads: Int32,
+    k_perm_base_addr: Int32,
+    token_base: Int32,
+    head_tile_base: Int32,
+    lane: Int32,
+    s_scale: cute.Tensor,
+    valid_slots: Int32,
+    s_page_partials: cute.Tensor,
+    token_group: Int32,
+):
+    group_id = lane // Int32(4)
+    thread_id_in_group = lane % Int32(4)
+    col_pair_base = thread_id_in_group * Int32(2)
+    q0_acc = Float32(0.0)
+    q1_acc = Float32(0.0)
+    q2_acc = Float32(0.0)
+    q3_acc = Float32(0.0)
+    k_offset = _permuted_offset_128b(
+        token_base + Int32(8) * (lane // Int32(16)) + lane % Int32(8),
+        (lane % Int32(16)) // Int32(8),
+        Int32(_INDEX_HEAD_DIM // 16),
+    )
+    for mma_pair in cutlass.range_constexpr(_INDEX_HEAD_DIM // 32):
+        pair_base = Int32(mma_pair * 32) + col_pair_base
+        q0 = _pack_q_mxfp8_reg(s_q_bytes, head_tile_base + group_id, pair_base)
+        q1 = _pack_q_mxfp8_reg(
+            s_q_bytes, head_tile_base + group_id + Int32(8), pair_base
+        )
+        q2 = _pack_q_mxfp8_reg(
+            s_q_bytes, head_tile_base + group_id, pair_base + Int32(16)
+        )
+        q3 = _pack_q_mxfp8_reg(
+            s_q_bytes,
+            head_tile_base + group_id + Int32(8),
+            pair_base + Int32(16),
+        )
+        b0_k0, _ = ldmatrix_m8n8x4_left_half_b16(
+            _smem_addr_from_b128_offset(k_perm_base_addr, k_offset)
+        )
+        b0_k1, _ = ldmatrix_m8n8x4_right_half_b16(
+            _smem_addr_from_b128_offset(k_perm_base_addr, k_offset)
+        )
+        b0_k0 = frag_layout_swizzle_16b_to_8b(b0_k0)
+        b0_k1 = frag_layout_swizzle_16b_to_8b(b0_k1)
+        k_offset_cur = _advance_offset_by_row_128b(
+            k_offset,
+            Int32(16),
+            Int32(_INDEX_HEAD_DIM // 16),
+        )
+        d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+            q0_acc,
+            q1_acc,
+            q2_acc,
+            q3_acc,
+            q0,
+            q1,
+            q2,
+            q3,
+            b0_k0,
+            b0_k1,
+            Uint32(0x7F7F7F7F),
+            Uint32(0x7F7F7F7F),
+        )
+        q0_acc = d0
+        q1_acc = d1
+        q2_acc = d2
+        q3_acc = d3
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            16 * (_INDEX_HEAD_DIM // 16)
+        )
+
+    head0 = head_tile_base + group_id
+    head1 = head0 + Int32(8)
+    w0 = Float32(0.0)
+    w1 = Float32(0.0)
+    if head0 < num_heads:
+        w0 = Float32(s_w[head0])
+    if head1 < num_heads:
+        w1 = Float32(s_w[head1])
+
+    col0 = token_base + col_pair_base
+    col1 = col0 + Int32(1)
+    max0 = Float32(-Float32.inf)
+    max1 = Float32(-Float32.inf)
+    if (head0 < num_heads) and (col0 < valid_slots):
+        max0 = attention_ops.fmax(max0, Float32(q0_acc * w0 * s_scale[col0]))
+    if (head0 < num_heads) and (col1 < valid_slots):
+        max0 = attention_ops.fmax(max0, Float32(q1_acc * w0 * s_scale[col1]))
+    if (head1 < num_heads) and (col0 < valid_slots):
+        max1 = attention_ops.fmax(max1, Float32(q2_acc * w1 * s_scale[col0]))
+    if (head1 < num_heads) and (col1 < valid_slots):
+        max1 = attention_ops.fmax(max1, Float32(q3_acc * w1 * s_scale[col1]))
+
+    max0 = _reduce_quad_max(max0)
+    max1 = _reduce_quad_max(max1)
+    if thread_id_in_group == Int32(0):
+        if head0 < num_heads:
+            s_page_partials[token_group, head0] = attention_ops.fmax(
+                s_page_partials[token_group, head0],
+                max0,
+            )
+        if head1 < num_heads:
+            s_page_partials[token_group, head1] = attention_ops.fmax(
+                s_page_partials[token_group, head1],
+                max1,
+            )
+
+
+@cute.jit
+def _issue_index_k_tma_copy(
+    load_tma,
+    producer_state,
+    mbar_ptr,
+    expected_bytes,
+    page_id,
+):
+    full_mbar_ptr = mbar_ptr + producer_state.index
+    with cute.arch.elect_one():
+        cute.arch.mbarrier_arrive_and_expect_tx(full_mbar_ptr, expected_bytes)
+    load_tma(src_idx=page_id, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr)
+
+
+class SparseNSAPagedLogitsKernel:
+    """One CTA reuses a query row across a small tile of paged candidate positions."""
+
+    def __init__(
+        self,
+        persistent_ctas: int,
+        num_heads_static: int,
+        *,
+        tiled_output: bool = False,
+        tile_block_q: int = _PAGED_TILED_BLOCK_Q,
+        tile_block_k: int = _PAGED_TILED_BLOCK_K,
+        score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    ):
+        self.persistent_ctas = int(persistent_ctas)
+        self.num_heads_static = int(num_heads_static)
+        self.tiled_output = bool(tiled_output)
+        self.tile_block_q = int(tile_block_q)
+        self.tile_block_k = int(tile_block_k)
+        self.score_mode = int(score_mode)
+        if self.tiled_output and self.tile_block_k != _PAGED_TILED_BLOCK_K:
+            raise ValueError(
+                f"paged tiled logits currently require block_k={_PAGED_TILED_BLOCK_K}, "
+                f"got {self.tile_block_k}"
+            )
+        self.num_q_head_tiles = _num_q_head_tiles(self.num_heads_static)
+        if self.num_q_head_tiles not in (1, 2, 4):
+            raise ValueError(
+                f"paged logits kernel only supports 1/2/4 head tiles, got {self.num_q_head_tiles}"
+            )
+        self.padded_q_heads = self.num_q_head_tiles * _PAGED_Q_HEAD_TILE
+        self.token_groups = _PAGED_WARPS_PER_CTA // self.num_q_head_tiles
+        self.tokens_per_work = _PAGED_TOKENS_PER_GROUP * self.token_groups
+        self.page_splits = _PAGE_SIZE // self.tokens_per_work
+
+    def _get_shared_storage_cls(self):
+        return _paged_indexer_shared_storage_cls(
+            self.padded_q_heads,
+            self.tokens_per_work,
+            self.num_q_head_tiles,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        use_scalar_k_load: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        active_width: cute.Tensor,
+        logits_out: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        k_tma_source = _make_paged_index_k_tma_source(k_quant_bytes)
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            k_tma_source,
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM), stride=(_INDEX_HEAD_DIM, 1)
+            ),
+            (_PAGE_SIZE, _INDEX_HEAD_DIM),
+            1,
+        )
+        self.kernel(
+            q_bytes,
+            weights,
+            k_quant_bytes,
+            tma_tensor_k,
+            k_tma_desc_ptrs,
+            use_scalar_k_load,
+            k_scales,
+            real_page_table,
+            seqlens_per_query,
+            active_width,
+            Int32(0),
+            Int32(0),
+            logits_out,
+            tma_atom_k,
+        ).launch(
+            grid=(
+                q_bytes.shape[0],
+                self.persistent_ctas,
+                1,
+            ),
+            block=[_PAGED_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_tensor: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        use_scalar_k_load: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        active_width: cute.Tensor,
+        source_page_offset: Int32,
+        output_width_tokens: Int32,
+        logits_out: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        q_idx, cta_idx, _ = cute.arch.block_idx()
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+
+        smem = cutlass.utils.SmemAllocator()
+        SharedStorage = self._get_shared_storage_cls()
+
+        source_width_tokens = Int32(real_page_table.shape[1]) * Int32(_PAGE_SIZE)
+        source_offset_pages = source_page_offset
+        if source_offset_pages < Int32(0):
+            source_offset_pages = Int32(0)
+        source_offset_tokens = source_offset_pages * Int32(_PAGE_SIZE)
+        remaining_width_tokens = source_width_tokens - source_offset_tokens
+        if remaining_width_tokens < Int32(0):
+            remaining_width_tokens = Int32(0)
+
+        width_tokens = output_width_tokens
+        if width_tokens <= Int32(0):
+            width_tokens = remaining_width_tokens
+        valid_width_tokens = width_tokens
+        if valid_width_tokens > remaining_width_tokens:
+            valid_width_tokens = remaining_width_tokens
+
+        live_width = Int32(active_width[Int32(0)])
+        if live_width > source_width_tokens:
+            live_width = source_width_tokens
+        live_width = live_width - source_offset_tokens
+        if live_width < Int32(0):
+            live_width = Int32(0)
+        if live_width > valid_width_tokens:
+            live_width = valid_width_tokens
+
+        seq_len = Int32(seqlens_per_query[q_idx]) - source_offset_tokens
+        if seq_len < Int32(0):
+            seq_len = Int32(0)
+        if seq_len > live_width:
+            seq_len = live_width
+        total_work = (seq_len + Int32(_PAGE_SIZE - 1)) // Int32(_PAGE_SIZE)
+
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_k = storage.mbar_ptr_k.data_ptr()
+        s_q = storage.q_bytes.get_tensor(
+            cute.make_layout(
+                (self.padded_q_heads, _INDEX_HEAD_DIM), stride=(_INDEX_HEAD_DIM, 1)
+            )
+        )
+        s_w = storage.weights.get_tensor(
+            cute.make_layout((self.padded_q_heads,), stride=(1,))
+        )
+        k_page_base_addr = shared_ptr_to_u32(storage.k_page.data_ptr())
+        k_page_perm_base_addr = shared_ptr_to_u32(storage.k_page_perm.data_ptr())
+        s_k_page_stage = storage.k_page.get_tensor(
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM, 1),
+                stride=(_INDEX_HEAD_DIM, 1, _PAGE_SIZE * _INDEX_HEAD_DIM),
+            )
+        )
+        s_scale = storage.scales.get_tensor(
+            cute.make_layout((_PAGE_SIZE,), stride=(1,))
+        )
+        s_partial_logits = storage.partial_logits.get_tensor(
+            cute.make_layout(
+                (self.tokens_per_work, self.num_q_head_tiles),
+                stride=(self.num_q_head_tiles, 1),
+            )
+        )
+        load_k_tma, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.local_tile(k_tma_tensor, (_PAGE_SIZE, _INDEX_HEAD_DIM), (0, 0, None)),
+            s_k_page_stage,
+        )
+        use_scalar_k_load_flag = Int32(use_scalar_k_load[Int32(0)])
+        if cta_idx < total_work:
+            if tx == 0:
+                cute.arch.mbarrier_init(mbar_ptr_k, Int32(1))
+            if (warp_idx == Int32(0)) & (use_scalar_k_load_flag == Int32(0)):
+                cpasync.prefetch_descriptor(tma_atom_k)
+
+            num_heads = Int32(self.num_heads_static)
+            q_linear = tx
+            total_q_bytes = Int32(self.padded_q_heads * _INDEX_HEAD_DIM)
+            while q_linear < total_q_bytes:
+                head_idx = q_linear // Int32(_INDEX_HEAD_DIM)
+                col_idx = q_linear - head_idx * Int32(_INDEX_HEAD_DIM)
+                s_q[head_idx, col_idx] = (
+                    q_bytes[q_idx, head_idx, col_idx]
+                    if head_idx < num_heads
+                    else cutlass.Uint8(0)
+                )
+                q_linear += Int32(_PAGED_THREADS_PER_CTA)
+
+            w_linear = tx
+            while w_linear < Int32(self.padded_q_heads):
+                s_w[w_linear] = (
+                    Float32(weights[q_idx, w_linear])
+                    if w_linear < num_heads
+                    else Float32(0.0)
+                )
+                w_linear += Int32(_PAGED_THREADS_PER_CTA)
+            cute.arch.sync_threads()
+
+            producer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            consumer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            head_tile_slot = warp_idx % Int32(self.num_q_head_tiles)
+            token_group = warp_idx // Int32(self.num_q_head_tiles)
+            work_idx = cta_idx
+            while work_idx < total_work:
+                page_col = work_idx
+                source_page_col = source_offset_pages + page_col
+                page_base = page_col * Int32(_PAGE_SIZE)
+                if (page_base < seq_len) & (
+                    source_page_col < Int32(real_page_table.shape[1])
+                ):
+                    page_id = Int32(real_page_table[q_idx, source_page_col])
+                    if page_id >= Int32(0):
+                        if use_scalar_k_load_flag != Int32(0):
+                            _load_index_k_page_scalar(
+                                k_quant_bytes,
+                                page_id,
+                                s_k_page_stage,
+                                tx,
+                            )
+                        else:
+                            if warp_idx == Int32(0):
+                                _issue_index_k_tma_copy(
+                                    load_k_tma,
+                                    producer_state,
+                                    mbar_ptr_k,
+                                    Int32(_PAGE_SIZE * _INDEX_HEAD_DIM),
+                                    page_id,
+                                )
+                        scale_idx = tx
+                        while scale_idx < Int32(_PAGE_SIZE):
+                            s_scale[scale_idx] = Float32(k_scales[page_id, scale_idx])
+                            scale_idx += Int32(_PAGED_THREADS_PER_CTA)
+                        if use_scalar_k_load_flag == Int32(0):
+                            cute.arch.mbarrier_wait(
+                                mbar_ptr_k + consumer_state.index,
+                                phase=consumer_state.phase,
+                            )
+                        cute.arch.sync_threads()
+                        _repack_k_page_to_permuted(
+                            k_page_base_addr, k_page_perm_base_addr, tx
+                        )
+                        cute.arch.sync_threads()
+
+                        valid_slots = seq_len - page_base
+                        if valid_slots > Int32(_PAGE_SIZE):
+                            valid_slots = Int32(_PAGE_SIZE)
+                        split_idx = Int32(0)
+                        while split_idx < Int32(self.page_splits):
+                            token_base = split_idx * Int32(
+                                self.tokens_per_work
+                            ) + token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                            zero_idx = tx
+                            while zero_idx < Int32(
+                                self.tokens_per_work * self.num_q_head_tiles
+                            ):
+                                token_idx = zero_idx // Int32(self.num_q_head_tiles)
+                                head_tile_idx = zero_idx - token_idx * Int32(
+                                    self.num_q_head_tiles
+                                )
+                                s_partial_logits[token_idx, head_tile_idx] = Float32(
+                                    0.0
+                                )
+                                zero_idx += Int32(_PAGED_THREADS_PER_CTA)
+                            cute.arch.sync_threads()
+                            if token_base < valid_slots:
+                                head_tile_base = head_tile_slot * Int32(
+                                    _PAGED_Q_HEAD_TILE
+                                )
+                                _compute_mxfp8_tile_partials(
+                                    s_q,
+                                    s_w,
+                                    num_heads,
+                                    k_page_perm_base_addr,
+                                    token_base,
+                                    head_tile_base,
+                                    lane,
+                                    s_partial_logits,
+                                    token_group * Int32(_PAGED_TOKENS_PER_GROUP),
+                                    head_tile_slot,
+                                    self.score_mode,
+                                )
+                            cute.arch.sync_threads()
+                            if (head_tile_slot == Int32(0)) & (
+                                lane < Int32(_PAGED_TOKENS_PER_GROUP)
+                            ):
+                                slot_idx = token_base + lane
+                                if slot_idx < valid_slots:
+                                    logit = Float32(0.0)
+                                    head_tile_idx = Int32(0)
+                                    partial_row = (
+                                        token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                                        + lane
+                                    )
+                                    while head_tile_idx < Int32(self.num_q_head_tiles):
+                                        logit = Float32(
+                                            logit
+                                            + s_partial_logits[
+                                                partial_row, head_tile_idx
+                                            ]
+                                        )
+                                        head_tile_idx += Int32(1)
+                                    value = Float32(logit * s_scale[slot_idx])
+                                    if cutlass.const_expr(self.tiled_output):
+                                        tile_block_q = Int32(self.tile_block_q)
+                                        tile_block_k = Int32(self.tile_block_k)
+                                        tile_size = Int32(
+                                            self.tile_block_q * self.tile_block_k
+                                        )
+                                        num_k_tiles = (
+                                            width_tokens + tile_block_k - Int32(1)
+                                        ) // tile_block_k
+                                        q_tile_idx = q_idx // tile_block_q
+                                        q_local = q_idx - q_tile_idx * tile_block_q
+                                        k_tile_idx = page_base // tile_block_k
+                                        k_local = (
+                                            page_base
+                                            - k_tile_idx * tile_block_k
+                                            + slot_idx
+                                        )
+                                        flat_offset = (
+                                            q_tile_idx * num_k_tiles * tile_size
+                                            + k_tile_idx * tile_size
+                                            + q_local * tile_block_k
+                                            + k_local
+                                        )
+                                        logits_out[flat_offset] = value
+                                    else:
+                                        logits_out[q_idx, page_base + slot_idx] = value
+                            cute.arch.sync_threads()
+                            split_idx += Int32(1)
+                        producer_state.advance()
+                        consumer_state.advance()
+                        cute.arch.sync_threads()
+
+                work_idx += Int32(self.persistent_ctas)
+
+
+class SparseNSAPagedSupertileLogitsKernel(SparseNSAPagedLogitsKernel):
+    """Paged supertile adapter over a full paged table.
+
+    The shared paged NSA scorer keeps its historical public ABI. This wrapper
+    exposes the extra page offset and width scalars only to paged supertile
+    callers.
+    """
+
+    @cute.jit
+    def __call__(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        use_scalar_k_load: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        active_width: cute.Tensor,
+        source_page_offset: Int32,
+        output_width_tokens: Int32,
+        logits_out: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        k_tma_source = _make_paged_index_k_tma_source(k_quant_bytes)
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            k_tma_source,
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM), stride=(_INDEX_HEAD_DIM, 1)
+            ),
+            (_PAGE_SIZE, _INDEX_HEAD_DIM),
+            1,
+        )
+        self.kernel(
+            q_bytes,
+            weights,
+            k_quant_bytes,
+            tma_tensor_k,
+            k_tma_desc_ptrs,
+            use_scalar_k_load,
+            k_scales,
+            real_page_table,
+            seqlens_per_query,
+            active_width,
+            source_page_offset,
+            output_width_tokens,
+            logits_out,
+            tma_atom_k,
+        ).launch(
+            grid=(
+                q_bytes.shape[0],
+                self.persistent_ctas,
+                1,
+            ),
+            block=[_PAGED_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+
+def _should_use_schedule_kernel(
+    *,
+    q_rows: int,
+    max_pages: int,
+) -> bool:
+    return q_rows > 0 and max_pages >= _SCHEDULE_MIN_PAGES
+
+
+def _should_use_schedule_single_row_kernel(
+    *,
+    q_rows: int,
+    max_pages: int,
+) -> bool:
+    return q_rows == 1 and _should_use_schedule_kernel(
+        q_rows=q_rows, max_pages=max_pages
+    )
+
+
+def _should_use_schedule_multi_row_kernel(
+    *,
+    q_rows: int,
+    max_pages: int,
+) -> bool:
+    return (
+        _ENABLE_MULTI_ROW_SCHEDULE
+        and q_rows > 1
+        and q_rows <= _SCHEDULE_MULTI_ROW_MAX_Q_ROWS
+        and _should_use_schedule_kernel(q_rows=q_rows, max_pages=max_pages)
+    )
+
+
+class SparseNSAScheduledSingleRowLogitsKernel:
+    """Schedule-driven scorer for the long single-row decode case."""
+
+    def __init__(
+        self,
+        parallel_ctas: int,
+        num_heads_static: int,
+        score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+        output_mode: int = IndexerOutputMode.TOKEN_LOGITS,
+    ):
+        self.parallel_ctas = int(parallel_ctas)
+        self.num_heads_static = int(num_heads_static)
+        self.score_mode = int(score_mode)
+        self.output_mode = int(output_mode)
+        self.num_q_head_tiles = _num_q_head_tiles(self.num_heads_static)
+        if self.num_q_head_tiles not in (1, 2, 4):
+            raise ValueError(
+                f"paged logits kernel only supports 1/2/4 head tiles, got {self.num_q_head_tiles}"
+            )
+        if (
+            self.output_mode == IndexerOutputMode.PAGE_HEAD_MAX
+            and self.num_heads_static > _PAGED_Q_HEAD_TILE
+        ):
+            raise ValueError("scheduled page-head-max output supports at most 16 heads")
+        self.padded_q_heads = self.num_q_head_tiles * _PAGED_Q_HEAD_TILE
+        self.token_groups = _PAGED_WARPS_PER_CTA // self.num_q_head_tiles
+        self.tokens_per_work = _PAGED_TOKENS_PER_GROUP * self.token_groups
+        self.page_splits = _PAGE_SIZE // self.tokens_per_work
+        self.schedule_pages_per_split = int(PAGED_MQA_LOGITS_SCHEDULE_PAGES_PER_SPLIT)
+
+    def _get_shared_storage_cls(self):
+        return _paged_indexer_shared_storage_cls(
+            self.padded_q_heads,
+            self.tokens_per_work,
+            self.num_q_head_tiles,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        use_scalar_k_load: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        schedule_metadata: cute.Tensor,
+        active_width: cute.Tensor,
+        logits_out: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        k_tma_source = _make_paged_index_k_tma_source(k_quant_bytes)
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            k_tma_source,
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM), stride=(_INDEX_HEAD_DIM, 1)
+            ),
+            (_PAGE_SIZE, _INDEX_HEAD_DIM),
+            1,
+        )
+        self.kernel(
+            q_bytes,
+            weights,
+            k_quant_bytes,
+            tma_tensor_k,
+            k_tma_desc_ptrs,
+            use_scalar_k_load,
+            k_scales,
+            real_page_table,
+            seqlens_per_query,
+            schedule_metadata,
+            active_width,
+            logits_out,
+            tma_atom_k,
+        ).launch(
+            grid=(
+                schedule_metadata.shape[0] - 1,
+                self.parallel_ctas,
+                1,
+            ),
+            block=[_PAGED_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_tensor: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        use_scalar_k_load: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        schedule_metadata: cute.Tensor,
+        active_width: cute.Tensor,
+        logits_out: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        interval_idx, cta_lane_idx, _ = cute.arch.block_idx()
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+
+        smem = cutlass.utils.SmemAllocator()
+        SharedStorage = self._get_shared_storage_cls()
+
+        width_tokens = Int32(real_page_table.shape[1]) * Int32(_PAGE_SIZE)
+        live_width = Int32(active_width[Int32(0)])
+        if live_width > width_tokens:
+            live_width = width_tokens
+        seq_len = Int32(seqlens_per_query[Int32(0)])
+        if seq_len > live_width:
+            seq_len = live_width
+        live_pages = (seq_len + Int32(_PAGE_SIZE - 1)) // Int32(_PAGE_SIZE)
+
+        start_q_idx = Int32(schedule_metadata[interval_idx, Int32(0)])
+        start_split_idx = Int32(schedule_metadata[interval_idx, Int32(1)])
+        end_q_idx = Int32(schedule_metadata[interval_idx + Int32(1), Int32(0)])
+        end_split_idx = Int32(schedule_metadata[interval_idx + Int32(1), Int32(1)])
+
+        interval_page_start = start_split_idx * Int32(self.schedule_pages_per_split)
+        interval_page_end = live_pages
+        if end_q_idx == Int32(0):
+            interval_page_end = end_split_idx * Int32(self.schedule_pages_per_split)
+            if interval_page_end > live_pages:
+                interval_page_end = live_pages
+
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_k = storage.mbar_ptr_k.data_ptr()
+        s_q = storage.q_bytes.get_tensor(
+            cute.make_layout(
+                (self.padded_q_heads, _INDEX_HEAD_DIM), stride=(_INDEX_HEAD_DIM, 1)
+            )
+        )
+        s_w = storage.weights.get_tensor(
+            cute.make_layout((self.padded_q_heads,), stride=(1,))
+        )
+        k_page_base_addr = shared_ptr_to_u32(storage.k_page.data_ptr())
+        k_page_perm_base_addr = shared_ptr_to_u32(storage.k_page_perm.data_ptr())
+        s_k_page_stage = storage.k_page.get_tensor(
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM, 1),
+                stride=(_INDEX_HEAD_DIM, 1, _PAGE_SIZE * _INDEX_HEAD_DIM),
+            )
+        )
+        s_scale = storage.scales.get_tensor(
+            cute.make_layout((_PAGE_SIZE,), stride=(1,))
+        )
+        s_partial_logits = storage.partial_logits.get_tensor(
+            cute.make_layout(
+                (self.tokens_per_work, self.num_q_head_tiles),
+                stride=(self.num_q_head_tiles, 1),
+            )
+        )
+        s_page_partials = storage.partial_logits.get_tensor(
+            cute.make_layout(
+                (_PAGED_WARPS_PER_CTA, _PAGED_Q_HEAD_TILE),
+                stride=(_PAGED_Q_HEAD_TILE, 1),
+            )
+        )
+        load_k_tma, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.local_tile(k_tma_tensor, (_PAGE_SIZE, _INDEX_HEAD_DIM), (0, 0, None)),
+            s_k_page_stage,
+        )
+        use_scalar_k_load_flag = Int32(use_scalar_k_load[Int32(0)])
+        PAGE_HEAD_MAX = cutlass.const_expr(
+            self.output_mode == IndexerOutputMode.PAGE_HEAD_MAX
+        )
+
+        if (
+            (start_q_idx == Int32(0))
+            & (interval_page_start < interval_page_end)
+            & (cta_lane_idx < Int32(self.parallel_ctas))
+        ):
+            if tx == 0:
+                cute.arch.mbarrier_init(mbar_ptr_k, Int32(1))
+            if (warp_idx == Int32(0)) & (use_scalar_k_load_flag == Int32(0)):
+                cpasync.prefetch_descriptor(tma_atom_k)
+
+            num_heads = Int32(self.num_heads_static)
+            q_linear = tx
+            total_q_bytes = Int32(self.padded_q_heads * _INDEX_HEAD_DIM)
+            while q_linear < total_q_bytes:
+                head_idx = q_linear // Int32(_INDEX_HEAD_DIM)
+                col_idx = q_linear - head_idx * Int32(_INDEX_HEAD_DIM)
+                s_q[head_idx, col_idx] = (
+                    q_bytes[Int32(0), head_idx, col_idx]
+                    if head_idx < num_heads
+                    else cutlass.Uint8(0)
+                )
+                q_linear += Int32(_PAGED_THREADS_PER_CTA)
+
+            w_linear = tx
+            while w_linear < Int32(self.padded_q_heads):
+                s_w[w_linear] = (
+                    Float32(weights[Int32(0), w_linear])
+                    if w_linear < num_heads
+                    else Float32(0.0)
+                )
+                w_linear += Int32(_PAGED_THREADS_PER_CTA)
+            cute.arch.sync_threads()
+
+            producer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            consumer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            head_tile_slot = warp_idx % Int32(self.num_q_head_tiles)
+            token_group = warp_idx // Int32(self.num_q_head_tiles)
+            page_col = interval_page_start + cta_lane_idx
+            while page_col < interval_page_end:
+                page_base = page_col * Int32(_PAGE_SIZE)
+                if page_base < seq_len:
+                    page_id = Int32(real_page_table[Int32(0), page_col])
+                    if page_id >= Int32(0):
+                        if use_scalar_k_load_flag != Int32(0):
+                            _load_index_k_page_scalar(
+                                k_quant_bytes,
+                                page_id,
+                                s_k_page_stage,
+                                tx,
+                            )
+                        else:
+                            if warp_idx == Int32(0):
+                                _issue_index_k_tma_copy(
+                                    load_k_tma,
+                                    producer_state,
+                                    mbar_ptr_k,
+                                    Int32(_PAGE_SIZE * _INDEX_HEAD_DIM),
+                                    page_id,
+                                )
+                        scale_idx = tx
+                        while scale_idx < Int32(_PAGE_SIZE):
+                            s_scale[scale_idx] = Float32(k_scales[page_id, scale_idx])
+                            scale_idx += Int32(_PAGED_THREADS_PER_CTA)
+                        if use_scalar_k_load_flag == Int32(0):
+                            cute.arch.mbarrier_wait(
+                                mbar_ptr_k + consumer_state.index,
+                                phase=consumer_state.phase,
+                            )
+                        cute.arch.sync_threads()
+                        _repack_k_page_to_permuted(
+                            k_page_base_addr, k_page_perm_base_addr, tx
+                        )
+                        cute.arch.sync_threads()
+
+                        valid_slots = seq_len - page_base
+                        if valid_slots > Int32(_PAGE_SIZE):
+                            valid_slots = Int32(_PAGE_SIZE)
+                        zero_idx = Int32(0)
+                        if cutlass.const_expr(PAGE_HEAD_MAX):
+                            zero_idx = tx
+                            while zero_idx < Int32(
+                                _PAGED_WARPS_PER_CTA * _PAGED_Q_HEAD_TILE
+                            ):
+                                group_idx = zero_idx // Int32(_PAGED_Q_HEAD_TILE)
+                                head_idx = zero_idx - group_idx * Int32(
+                                    _PAGED_Q_HEAD_TILE
+                                )
+                                s_page_partials[group_idx, head_idx] = Float32(
+                                    -Float32.inf
+                                )
+                                zero_idx += Int32(_PAGED_THREADS_PER_CTA)
+                            cute.arch.sync_threads()
+                        split_idx = Int32(0)
+                        while split_idx < Int32(self.page_splits):
+                            token_base = split_idx * Int32(
+                                self.tokens_per_work
+                            ) + token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                            if cutlass.const_expr(not PAGE_HEAD_MAX):
+                                zero_idx = tx
+                                while zero_idx < Int32(
+                                    self.tokens_per_work * self.num_q_head_tiles
+                                ):
+                                    token_idx = zero_idx // Int32(self.num_q_head_tiles)
+                                    head_tile_idx = zero_idx - token_idx * Int32(
+                                        self.num_q_head_tiles
+                                    )
+                                    s_partial_logits[token_idx, head_tile_idx] = (
+                                        Float32(0.0)
+                                    )
+                                    zero_idx += Int32(_PAGED_THREADS_PER_CTA)
+                                cute.arch.sync_threads()
+                            if token_base < valid_slots:
+                                head_tile_base = head_tile_slot * Int32(
+                                    _PAGED_Q_HEAD_TILE
+                                )
+                                if cutlass.const_expr(PAGE_HEAD_MAX):
+                                    _compute_mxfp8_tile_head_token_max(
+                                        s_q,
+                                        s_w,
+                                        num_heads,
+                                        k_page_perm_base_addr,
+                                        token_base,
+                                        head_tile_base,
+                                        lane,
+                                        s_scale,
+                                        valid_slots,
+                                        s_page_partials,
+                                        token_group,
+                                    )
+                                else:
+                                    _compute_mxfp8_tile_partials(
+                                        s_q,
+                                        s_w,
+                                        num_heads,
+                                        k_page_perm_base_addr,
+                                        token_base,
+                                        head_tile_base,
+                                        lane,
+                                        s_partial_logits,
+                                        token_group * Int32(_PAGED_TOKENS_PER_GROUP),
+                                        head_tile_slot,
+                                        self.score_mode,
+                                    )
+                            cute.arch.sync_threads()
+                            if cutlass.const_expr(not PAGE_HEAD_MAX):
+                                if (head_tile_slot == Int32(0)) & (
+                                    lane < Int32(_PAGED_TOKENS_PER_GROUP)
+                                ):
+                                    slot_idx = token_base + lane
+                                    if slot_idx < valid_slots:
+                                        logit = Float32(0.0)
+                                        head_tile_idx = Int32(0)
+                                        partial_row = (
+                                            token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                                            + lane
+                                        )
+                                        while head_tile_idx < Int32(
+                                            self.num_q_head_tiles
+                                        ):
+                                            logit = Float32(
+                                                logit
+                                                + s_partial_logits[
+                                                    partial_row, head_tile_idx
+                                                ]
+                                            )
+                                            head_tile_idx += Int32(1)
+                                        logits_out[Int32(0), page_base + slot_idx] = (
+                                            Float32(logit * s_scale[slot_idx])
+                                        )
+                            cute.arch.sync_threads()
+                            split_idx += Int32(1)
+                        if cutlass.const_expr(PAGE_HEAD_MAX):
+                            if tx < Int32(_PAGED_Q_HEAD_TILE):
+                                head_idx = tx
+                                if head_idx < num_heads:
+                                    page_max = Float32(-Float32.inf)
+                                    group_idx = Int32(0)
+                                    while group_idx < Int32(_PAGED_WARPS_PER_CTA):
+                                        page_max = attention_ops.fmax(
+                                            page_max,
+                                            s_page_partials[group_idx, head_idx],
+                                        )
+                                        group_idx += Int32(1)
+                                    logits_out[head_idx, Int32(0), page_col] = page_max
+                            cute.arch.sync_threads()
+                        producer_state.advance()
+                        consumer_state.advance()
+                        cute.arch.sync_threads()
+
+                page_col += Int32(self.parallel_ctas)
+
+
+class SparseNSAScheduledMultiRowLogitsKernel:
+    """Schedule-driven scorer for long multi-row decode."""
+
+    def __init__(
+        self,
+        parallel_ctas: int,
+        num_heads_static: int,
+        score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+        output_mode: int = IndexerOutputMode.TOKEN_LOGITS,
+    ):
+        self.parallel_ctas = int(parallel_ctas)
+        self.num_heads_static = int(num_heads_static)
+        self.score_mode = int(score_mode)
+        self.output_mode = int(output_mode)
+        self.num_q_head_tiles = _num_q_head_tiles(self.num_heads_static)
+        if self.num_q_head_tiles not in (1, 2, 4):
+            raise ValueError(
+                f"paged logits kernel only supports 1/2/4 head tiles, got {self.num_q_head_tiles}"
+            )
+        if (
+            self.output_mode == IndexerOutputMode.PAGE_HEAD_MAX
+            and self.num_heads_static > _PAGED_Q_HEAD_TILE
+        ):
+            raise ValueError("scheduled page-head-max output supports at most 16 heads")
+        self.padded_q_heads = self.num_q_head_tiles * _PAGED_Q_HEAD_TILE
+        self.token_groups = _PAGED_WARPS_PER_CTA // self.num_q_head_tiles
+        self.tokens_per_work = _PAGED_TOKENS_PER_GROUP * self.token_groups
+        self.page_splits = _PAGE_SIZE // self.tokens_per_work
+        self.schedule_pages_per_split = int(PAGED_MQA_LOGITS_SCHEDULE_PAGES_PER_SPLIT)
+
+    def _get_shared_storage_cls(self):
+        return _paged_indexer_shared_storage_cls(
+            self.padded_q_heads,
+            self.tokens_per_work,
+            self.num_q_head_tiles,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        use_scalar_k_load: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        schedule_metadata: cute.Tensor,
+        active_width: cute.Tensor,
+        logits_out: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        k_tma_source = _make_paged_index_k_tma_source(k_quant_bytes)
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            k_tma_source,
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM), stride=(_INDEX_HEAD_DIM, 1)
+            ),
+            (_PAGE_SIZE, _INDEX_HEAD_DIM),
+            1,
+        )
+        self.kernel(
+            q_bytes,
+            weights,
+            k_quant_bytes,
+            tma_tensor_k,
+            k_tma_desc_ptrs,
+            use_scalar_k_load,
+            k_scales,
+            real_page_table,
+            seqlens_per_query,
+            schedule_metadata,
+            active_width,
+            logits_out,
+            tma_atom_k,
+        ).launch(
+            grid=(
+                schedule_metadata.shape[0] - 1,
+                self.parallel_ctas,
+                1,
+            ),
+            block=[_PAGED_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_tensor: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,
+        use_scalar_k_load: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        schedule_metadata: cute.Tensor,
+        active_width: cute.Tensor,
+        logits_out: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        interval_idx, cta_lane_idx, _ = cute.arch.block_idx()
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+
+        smem = cutlass.utils.SmemAllocator()
+        SharedStorage = self._get_shared_storage_cls()
+
+        width_tokens = Int32(real_page_table.shape[1]) * Int32(_PAGE_SIZE)
+        live_width = Int32(active_width[Int32(0)])
+        if live_width > width_tokens:
+            live_width = width_tokens
+        q_rows = Int32(seqlens_per_query.shape[0])
+        total_schedule_intervals = Int32(schedule_metadata.shape[0] - 1)
+        start_q_idx = Int32(schedule_metadata[interval_idx, Int32(0)])
+        start_split_idx = Int32(schedule_metadata[interval_idx, Int32(1)])
+        end_q_idx = Int32(schedule_metadata[interval_idx + Int32(1), Int32(0)])
+        end_split_idx = Int32(schedule_metadata[interval_idx + Int32(1), Int32(1)])
+
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_k = storage.mbar_ptr_k.data_ptr()
+        s_q = storage.q_bytes.get_tensor(
+            cute.make_layout(
+                (self.padded_q_heads, _INDEX_HEAD_DIM), stride=(_INDEX_HEAD_DIM, 1)
+            )
+        )
+        s_w = storage.weights.get_tensor(
+            cute.make_layout((self.padded_q_heads,), stride=(1,))
+        )
+        k_page_base_addr = shared_ptr_to_u32(storage.k_page.data_ptr())
+        k_page_perm_base_addr = shared_ptr_to_u32(storage.k_page_perm.data_ptr())
+        s_k_page_stage = storage.k_page.get_tensor(
+            cute.make_layout(
+                (_PAGE_SIZE, _INDEX_HEAD_DIM, 1),
+                stride=(_INDEX_HEAD_DIM, 1, _PAGE_SIZE * _INDEX_HEAD_DIM),
+            )
+        )
+        s_scale = storage.scales.get_tensor(
+            cute.make_layout((_PAGE_SIZE,), stride=(1,))
+        )
+        s_partial_logits = storage.partial_logits.get_tensor(
+            cute.make_layout(
+                (self.tokens_per_work, self.num_q_head_tiles),
+                stride=(self.num_q_head_tiles, 1),
+            )
+        )
+        s_page_partials = storage.partial_logits.get_tensor(
+            cute.make_layout(
+                (_PAGED_WARPS_PER_CTA, _PAGED_Q_HEAD_TILE),
+                stride=(_PAGED_Q_HEAD_TILE, 1),
+            )
+        )
+        load_k_tma, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.local_tile(k_tma_tensor, (_PAGE_SIZE, _INDEX_HEAD_DIM), (0, 0, None)),
+            s_k_page_stage,
+        )
+        use_scalar_k_load_flag = Int32(use_scalar_k_load[Int32(0)])
+        PAGE_HEAD_MAX = cutlass.const_expr(
+            self.output_mode == IndexerOutputMode.PAGE_HEAD_MAX
+        )
+
+        if (interval_idx < total_schedule_intervals) & (
+            cta_lane_idx < Int32(self.parallel_ctas)
+        ):
+            if tx == 0:
+                cute.arch.mbarrier_init(mbar_ptr_k, Int32(1))
+            if (warp_idx == Int32(0)) & (use_scalar_k_load_flag == Int32(0)):
+                cpasync.prefetch_descriptor(tma_atom_k)
+
+            num_heads = Int32(self.num_heads_static)
+            producer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            consumer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+            head_tile_slot = warp_idx % Int32(self.num_q_head_tiles)
+            token_group = warp_idx // Int32(self.num_q_head_tiles)
+            current_q_idx = start_q_idx
+            current_split_idx = start_split_idx
+
+            while (current_q_idx < q_rows) & (
+                (current_q_idx < end_q_idx)
+                | ((current_q_idx == end_q_idx) & (end_split_idx > Int32(0)))
+            ):
+                seq_len = Int32(seqlens_per_query[current_q_idx])
+                if seq_len > live_width:
+                    seq_len = live_width
+                live_pages = (seq_len + Int32(_PAGE_SIZE - 1)) // Int32(_PAGE_SIZE)
+                row_total_splits = (
+                    live_pages + Int32(self.schedule_pages_per_split - 1)
+                ) // Int32(self.schedule_pages_per_split)
+                row_split_start = (
+                    current_split_idx if current_q_idx == start_q_idx else Int32(0)
+                )
+                row_split_end = row_total_splits
+                if current_q_idx == end_q_idx:
+                    row_split_end = end_split_idx
+                    if row_split_end > row_total_splits:
+                        row_split_end = row_total_splits
+
+                if row_split_start < row_split_end:
+                    q_linear = tx
+                    total_q_bytes = Int32(self.padded_q_heads * _INDEX_HEAD_DIM)
+                    while q_linear < total_q_bytes:
+                        head_idx = q_linear // Int32(_INDEX_HEAD_DIM)
+                        col_idx = q_linear - head_idx * Int32(_INDEX_HEAD_DIM)
+                        s_q[head_idx, col_idx] = (
+                            q_bytes[current_q_idx, head_idx, col_idx]
+                            if head_idx < num_heads
+                            else cutlass.Uint8(0)
+                        )
+                        q_linear += Int32(_PAGED_THREADS_PER_CTA)
+
+                    w_linear = tx
+                    while w_linear < Int32(self.padded_q_heads):
+                        s_w[w_linear] = (
+                            Float32(weights[current_q_idx, w_linear])
+                            if w_linear < num_heads
+                            else Float32(0.0)
+                        )
+                        w_linear += Int32(_PAGED_THREADS_PER_CTA)
+                    cute.arch.sync_threads()
+
+                    row_page_end = row_split_end * Int32(self.schedule_pages_per_split)
+                    if row_page_end > live_pages:
+                        row_page_end = live_pages
+                    page_col = (
+                        row_split_start * Int32(self.schedule_pages_per_split)
+                        + cta_lane_idx
+                    )
+                    while page_col < row_page_end:
+                        page_base = page_col * Int32(_PAGE_SIZE)
+                        if page_base < seq_len:
+                            page_id = Int32(real_page_table[current_q_idx, page_col])
+                            if page_id >= Int32(0):
+                                if use_scalar_k_load_flag != Int32(0):
+                                    _load_index_k_page_scalar(
+                                        k_quant_bytes,
+                                        page_id,
+                                        s_k_page_stage,
+                                        tx,
+                                    )
+                                else:
+                                    if warp_idx == Int32(0):
+                                        _issue_index_k_tma_copy(
+                                            load_k_tma,
+                                            producer_state,
+                                            mbar_ptr_k,
+                                            Int32(_PAGE_SIZE * _INDEX_HEAD_DIM),
+                                            page_id,
+                                        )
+                                scale_idx = tx
+                                while scale_idx < Int32(_PAGE_SIZE):
+                                    s_scale[scale_idx] = Float32(
+                                        k_scales[page_id, scale_idx]
+                                    )
+                                    scale_idx += Int32(_PAGED_THREADS_PER_CTA)
+                                if use_scalar_k_load_flag == Int32(0):
+                                    cute.arch.mbarrier_wait(
+                                        mbar_ptr_k + consumer_state.index,
+                                        phase=consumer_state.phase,
+                                    )
+                                cute.arch.sync_threads()
+                                _repack_k_page_to_permuted(
+                                    k_page_base_addr, k_page_perm_base_addr, tx
+                                )
+                                cute.arch.sync_threads()
+
+                                valid_slots = seq_len - page_base
+                                if valid_slots > Int32(_PAGE_SIZE):
+                                    valid_slots = Int32(_PAGE_SIZE)
+                                zero_idx = Int32(0)
+                                if cutlass.const_expr(PAGE_HEAD_MAX):
+                                    zero_idx = tx
+                                    while zero_idx < Int32(
+                                        _PAGED_WARPS_PER_CTA * _PAGED_Q_HEAD_TILE
+                                    ):
+                                        group_idx = zero_idx // Int32(
+                                            _PAGED_Q_HEAD_TILE
+                                        )
+                                        head_idx = zero_idx - group_idx * Int32(
+                                            _PAGED_Q_HEAD_TILE
+                                        )
+                                        s_page_partials[group_idx, head_idx] = Float32(
+                                            -Float32.inf
+                                        )
+                                        zero_idx += Int32(_PAGED_THREADS_PER_CTA)
+                                    cute.arch.sync_threads()
+                                split_idx = Int32(0)
+                                while split_idx < Int32(self.page_splits):
+                                    token_base = split_idx * Int32(
+                                        self.tokens_per_work
+                                    ) + token_group * Int32(_PAGED_TOKENS_PER_GROUP)
+                                    if cutlass.const_expr(not PAGE_HEAD_MAX):
+                                        zero_idx = tx
+                                        while zero_idx < Int32(
+                                            self.tokens_per_work * self.num_q_head_tiles
+                                        ):
+                                            token_idx = zero_idx // Int32(
+                                                self.num_q_head_tiles
+                                            )
+                                            head_tile_idx = (
+                                                zero_idx
+                                                - token_idx
+                                                * Int32(self.num_q_head_tiles)
+                                            )
+                                            s_partial_logits[
+                                                token_idx, head_tile_idx
+                                            ] = Float32(0.0)
+                                            zero_idx += Int32(_PAGED_THREADS_PER_CTA)
+                                        cute.arch.sync_threads()
+                                    if token_base < valid_slots:
+                                        head_tile_base = head_tile_slot * Int32(
+                                            _PAGED_Q_HEAD_TILE
+                                        )
+                                        if cutlass.const_expr(PAGE_HEAD_MAX):
+                                            _compute_mxfp8_tile_head_token_max(
+                                                s_q,
+                                                s_w,
+                                                num_heads,
+                                                k_page_perm_base_addr,
+                                                token_base,
+                                                head_tile_base,
+                                                lane,
+                                                s_scale,
+                                                valid_slots,
+                                                s_page_partials,
+                                                token_group,
+                                            )
+                                        else:
+                                            _compute_mxfp8_tile_partials(
+                                                s_q,
+                                                s_w,
+                                                num_heads,
+                                                k_page_perm_base_addr,
+                                                token_base,
+                                                head_tile_base,
+                                                lane,
+                                                s_partial_logits,
+                                                token_group
+                                                * Int32(_PAGED_TOKENS_PER_GROUP),
+                                                head_tile_slot,
+                                                self.score_mode,
+                                            )
+                                    cute.arch.sync_threads()
+                                    if cutlass.const_expr(not PAGE_HEAD_MAX):
+                                        if head_tile_slot == Int32(0) and lane < Int32(
+                                            _PAGED_TOKENS_PER_GROUP
+                                        ):
+                                            slot_idx = token_base + lane
+                                            if slot_idx < valid_slots:
+                                                logit = Float32(0.0)
+                                                head_tile_idx = Int32(0)
+                                                partial_row = (
+                                                    token_group
+                                                    * Int32(_PAGED_TOKENS_PER_GROUP)
+                                                    + lane
+                                                )
+                                                while head_tile_idx < Int32(
+                                                    self.num_q_head_tiles
+                                                ):
+                                                    logit = Float32(
+                                                        logit
+                                                        + s_partial_logits[
+                                                            partial_row, head_tile_idx
+                                                        ]
+                                                    )
+                                                    head_tile_idx += Int32(1)
+                                                logits_out[
+                                                    current_q_idx, page_base + slot_idx
+                                                ] = Float32(logit * s_scale[slot_idx])
+                                    cute.arch.sync_threads()
+                                    split_idx += Int32(1)
+                                if cutlass.const_expr(PAGE_HEAD_MAX):
+                                    if tx < Int32(_PAGED_Q_HEAD_TILE):
+                                        head_idx = tx
+                                        if head_idx < num_heads:
+                                            page_max = Float32(-Float32.inf)
+                                            group_idx = Int32(0)
+                                            while group_idx < Int32(
+                                                _PAGED_WARPS_PER_CTA
+                                            ):
+                                                page_max = attention_ops.fmax(
+                                                    page_max,
+                                                    s_page_partials[
+                                                        group_idx, head_idx
+                                                    ],
+                                                )
+                                                group_idx += Int32(1)
+                                            logits_out[
+                                                head_idx, current_q_idx, page_col
+                                            ] = page_max
+                                    cute.arch.sync_threads()
+                                producer_state.advance()
+                                consumer_state.advance()
+                                cute.arch.sync_threads()
+
+                        page_col += Int32(self.parallel_ctas)
+
+                current_q_idx += Int32(1)
+                current_split_idx = Int32(0)
+
+
+@lru_cache(maxsize=32)
+def _build_sparse_nsa_paged_kernel(
+    persistent_ctas: int,
+    num_heads_static: int,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+) -> SparseNSAPagedLogitsKernel:
+    return SparseNSAPagedLogitsKernel(
+        persistent_ctas, num_heads_static, score_mode=score_mode
+    )
+
+
+@lru_cache(maxsize=32)
+def _build_sparse_nsa_paged_tiled_kernel(
+    persistent_ctas: int,
+    num_heads_static: int,
+    tile_block_q: int,
+    tile_block_k: int,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+) -> SparseNSAPagedLogitsKernel:
+    return SparseNSAPagedLogitsKernel(
+        persistent_ctas,
+        num_heads_static,
+        tiled_output=True,
+        tile_block_q=tile_block_q,
+        tile_block_k=tile_block_k,
+        score_mode=score_mode,
+    )
+
+
+@lru_cache(maxsize=32)
+def _build_sparse_nsa_paged_supertile_kernel(
+    persistent_ctas: int,
+    num_heads_static: int,
+    tile_block_q: int,
+    tile_block_k: int,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+) -> SparseNSAPagedSupertileLogitsKernel:
+    return SparseNSAPagedSupertileLogitsKernel(
+        persistent_ctas,
+        num_heads_static,
+        tiled_output=True,
+        tile_block_q=tile_block_q,
+        tile_block_k=tile_block_k,
+        score_mode=score_mode,
+    )
+
+
+@lru_cache(maxsize=16)
+def _build_sparse_nsa_schedule_single_row_kernel(
+    parallel_ctas: int,
+    num_heads_static: int,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    output_mode: int = IndexerOutputMode.TOKEN_LOGITS,
+) -> SparseNSAScheduledSingleRowLogitsKernel:
+    return SparseNSAScheduledSingleRowLogitsKernel(
+        parallel_ctas,
+        num_heads_static,
+        score_mode,
+        output_mode,
+    )
+
+
+@lru_cache(maxsize=16)
+def _build_sparse_nsa_schedule_multi_row_kernel(
+    parallel_ctas: int,
+    num_heads_static: int,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+    output_mode: int = IndexerOutputMode.TOKEN_LOGITS,
+) -> SparseNSAScheduledMultiRowLogitsKernel:
+    return SparseNSAScheduledMultiRowLogitsKernel(
+        parallel_ctas,
+        num_heads_static,
+        score_mode,
+        output_mode,
+    )
+
+
+def _split_index_k_cache_runtime_views(
+    index_k_cache: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if index_k_cache.stride(-1) != 1:
+        raise ValueError(
+            f"index_k_cache must have a contiguous last dimension, got stride={index_k_cache.stride()}"
+        )
+    num_pages = index_k_cache.shape[0]
+    data_bytes = _PAGE_SIZE * _INDEX_HEAD_DIM
+    k_quant_bytes = index_k_cache[:, :data_bytes].view(
+        num_pages, _PAGE_SIZE, _INDEX_HEAD_DIM
+    )
+    k_scales = (
+        index_k_cache[:, data_bytes : data_bytes + _PAGE_SIZE * _SCALE_BYTES]
+        .view(num_pages, _PAGE_SIZE, _SCALE_BYTES)
+        .view(torch.float32)
+        .squeeze(-1)
+    )
+    return k_quant_bytes, k_scales
+
+
+def clear_indexer_kernel_cache() -> None:
+    _build_sparse_nsa_paged_kernel.cache_clear()
+    _build_sparse_nsa_paged_tiled_kernel.cache_clear()
+    _build_sparse_nsa_paged_supertile_kernel.cache_clear()
+    _build_sparse_nsa_schedule_single_row_kernel.cache_clear()
+    _build_sparse_nsa_schedule_multi_row_kernel.cache_clear()
+
+
+def supports_paged_logits_kernel(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+    page_size: int,
+) -> bool:
+    if page_size != _PAGE_SIZE:
+        return False
+    if q_fp8.device.type != "cuda":
+        return False
+    if not (
+        weights.device
+        == index_k_cache.device
+        == real_page_table.device
+        == seqlens_per_query.device
+        == q_fp8.device
+    ):
+        return False
+    if q_fp8.ndim != 3 or q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        return False
+    if q_fp8.shape[1] > _MAX_SUPPORTED_Q_HEADS:
+        return False
+    if _num_q_head_tiles(q_fp8.shape[1]) not in (1, 2, 4):
+        return False
+    if weights.ndim != 2 or weights.shape != q_fp8.shape[:2]:
+        return False
+    if real_page_table.ndim != 2:
+        return False
+    if seqlens_per_query.ndim != 1 or seqlens_per_query.shape[0] != q_fp8.shape[0]:
+        return False
+    if index_k_cache.ndim != 2 or index_k_cache.shape[1] != _PAGE_SIZE * (
+        _INDEX_HEAD_DIM + _SCALE_BYTES
+    ):
+        return False
+    if q_fp8.dtype != torch.float8_e4m3fn:
+        return False
+    if weights.dtype != torch.float32:
+        return False
+    if index_k_cache.dtype != torch.uint8:
+        return False
+    if index_k_cache.stride(-1) != 1:
+        return False
+    if real_page_table.dtype != torch.int32 or seqlens_per_query.dtype != torch.int32:
+        return False
+    return True
+
+
+def run_paged_logits_kernel(
+    *,
+    q_fp8: torch.Tensor | None = None,
+    weights: torch.Tensor | None = None,
+    index_k_cache: torch.Tensor | None = None,
+    real_page_table: torch.Tensor | None = None,
+    seqlens_per_query: torch.Tensor | None = None,
+    schedule_metadata: torch.Tensor | None = None,
+    active_width: torch.Tensor | None = None,
+    page_size: int | None = None,
+    preinitialize_invalid_logits: bool | None = None,
+    score_mode: int | None = None,
+    output_mode: int | None = None,
+    page_scores: torch.Tensor | None = None,
+    binding: IndexerPagedLogitsKernelBinding | None = None,
+) -> torch.Tensor:
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("q_fp8", q_fp8),
+                ("weights", weights),
+                ("index_k_cache", index_k_cache),
+                ("real_page_table", real_page_table),
+                ("seqlens_per_query", seqlens_per_query),
+                ("schedule_metadata", schedule_metadata),
+                ("active_width", active_width),
+                ("page_size", page_size),
+                ("preinitialize_invalid_logits", preinitialize_invalid_logits),
+                ("score_mode", score_mode),
+                ("output_mode", output_mode),
+                ("page_scores", page_scores),
+            )
+            if value is not None
+        ]
+        if extras:
+            _raise_binding_extras("run_paged_logits_kernel", extras)
+        q_fp8 = binding.q_fp8
+        weights = binding.weights
+        index_k_cache = binding.index_k_cache
+        real_page_table = binding.real_page_table
+        seqlens_per_query = binding.seqlens_per_query
+        schedule_metadata = binding.schedule_metadata
+        active_width = binding.active_width
+        page_size = binding.page_size
+        preinitialize_invalid_logits = binding.preinitialize_invalid_logits
+        score_mode = binding.score_mode
+        output_mode = binding.output_mode
+        page_scores = binding.page_scores
+
+    q_fp8 = _require_bound_arg(q_fp8, api_name="run_paged_logits_kernel", name="q_fp8")
+    weights = _require_bound_arg(
+        weights, api_name="run_paged_logits_kernel", name="weights"
+    )
+    index_k_cache = _require_bound_arg(
+        index_k_cache,
+        api_name="run_paged_logits_kernel",
+        name="index_k_cache",
+    )
+    real_page_table = _require_bound_arg(
+        real_page_table,
+        api_name="run_paged_logits_kernel",
+        name="real_page_table",
+    )
+    seqlens_per_query = _require_bound_arg(
+        seqlens_per_query,
+        api_name="run_paged_logits_kernel",
+        name="seqlens_per_query",
+    )
+    page_size = _PAGE_SIZE if page_size is None else int(page_size)
+    preinitialize_invalid_logits = (
+        True
+        if preinitialize_invalid_logits is None
+        else bool(preinitialize_invalid_logits)
+    )
+    score_mode = (
+        IndexerScoreMode.NSA_RELU_SUM if score_mode is None else int(score_mode)
+    )
+    if score_mode not in (IndexerScoreMode.NSA_RELU_SUM, IndexerScoreMode.MSA_BILINEAR):
+        raise ValueError(f"unsupported indexer score_mode {score_mode}")
+    output_mode = (
+        IndexerOutputMode.TOKEN_LOGITS if output_mode is None else int(output_mode)
+    )
+    if output_mode not in (
+        IndexerOutputMode.TOKEN_LOGITS,
+        IndexerOutputMode.PAGE_HEAD_MAX,
+    ):
+        raise ValueError(f"unsupported indexer output_mode {output_mode}")
+    if output_mode == IndexerOutputMode.PAGE_HEAD_MAX:
+        if score_mode != IndexerScoreMode.MSA_BILINEAR:
+            raise ValueError("PAGE_HEAD_MAX output requires MSA_BILINEAR score mode")
+        if int(q_fp8.shape[1]) > _PAGED_Q_HEAD_TILE:
+            raise ValueError("PAGE_HEAD_MAX output supports at most 16 heads")
+
+    if not supports_paged_logits_kernel(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens_per_query=seqlens_per_query,
+        page_size=page_size,
+    ):
+        raise ValueError(
+            "sparse NSA paged logits kernel only supports the exact CUDA page_size=64 FP8 contract"
+        )
+
+    rows = q_fp8.shape[0]
+    width_tokens = real_page_table.shape[1] * page_size
+    if rows == 0 or width_tokens == 0:
+        if output_mode == IndexerOutputMode.PAGE_HEAD_MAX:
+            max_pages = int(real_page_table.shape[1])
+            even_pages = max_pages if max_pages % 2 == 0 else max_pages + 1
+            return torch.empty(
+                (int(q_fp8.shape[1]), rows, even_pages),
+                dtype=torch.float32,
+                device=q_fp8.device,
+            )
+        return torch.empty(
+            (rows, width_tokens), dtype=torch.float32, device=q_fp8.device
+        )
+    if active_width is None:
+        active_width = torch.tensor(
+            [width_tokens], dtype=torch.int32, device=q_fp8.device
+        )
+    if active_width.shape != (1,):
+        raise ValueError(
+            f"active_width must have shape (1,), got {tuple(active_width.shape)}"
+        )
+    if active_width.dtype != torch.int32:
+        raise ValueError(
+            f"active_width must have dtype torch.int32, got {active_width.dtype}"
+        )
+    if active_width.device != q_fp8.device:
+        raise ValueError(
+            f"active_width device {active_width.device} does not match q_fp8 device {q_fp8.device}"
+        )
+
+    k_quant_bytes, k_scales = _split_index_k_cache_runtime_views(index_k_cache)
+    use_scalar_k_load = _needs_paged_index_k_scalar_load(
+        index_k_cache,
+        k_quant_bytes,
+    )
+    device_index = q_fp8.device.index or 0
+    k_tma_desc_ptrs = _dummy_paged_index_k_tma_desc_ptrs(device_index)
+    use_scalar_k_load_tensor = _cached_int32_scalar(
+        int(use_scalar_k_load),
+        device_index,
+    )
+    q_bytes = q_fp8.contiguous().view(torch.uint8)
+    weights_kernel = weights.contiguous()
+    real_page_table_kernel = real_page_table.contiguous()
+    seqlens_per_query_kernel = seqlens_per_query.contiguous()
+    active_width_kernel = active_width.contiguous()
+    schedule_metadata_kernel = None
+    max_pages = int(real_page_table.shape[1])
+    if output_mode == IndexerOutputMode.PAGE_HEAD_MAX:
+        even_pages = max_pages if max_pages % 2 == 0 else max_pages + 1
+        if page_scores is None:
+            logits = torch.full(
+                (int(q_fp8.shape[1]), rows, even_pages),
+                float("-inf"),
+                dtype=torch.float32,
+                device=q_fp8.device,
+            )
+        else:
+            if page_scores.dtype != torch.float32:
+                raise ValueError(
+                    f"page_scores must have dtype torch.float32, got {page_scores.dtype}"
+                )
+            if page_scores.device != q_fp8.device:
+                raise ValueError("page_scores device must match q_fp8")
+            if (
+                page_scores.ndim != 3
+                or int(page_scores.shape[0]) < int(q_fp8.shape[1])
+                or int(page_scores.shape[1]) < rows
+                or int(page_scores.shape[2]) < even_pages
+            ):
+                raise ValueError(
+                    "page_scores must have shape at least "
+                    f"({int(q_fp8.shape[1])}, {rows}, {even_pages}), got "
+                    f"{tuple(page_scores.shape)}"
+                )
+            logits = page_scores[: int(q_fp8.shape[1]), :rows, :even_pages]
+            if preinitialize_invalid_logits:
+                logits.fill_(float("-inf"))
+        logits_view = logits
+    else:
+        if page_scores is not None:
+            raise ValueError("page_scores is only valid with PAGE_HEAD_MAX output")
+        if preinitialize_invalid_logits:
+            logits = torch.full(
+                (rows, width_tokens),
+                float("-inf"),
+                dtype=torch.float32,
+                device=q_fp8.device,
+            )
+        else:
+            logits = torch.empty(
+                (rows, width_tokens), dtype=torch.float32, device=q_fp8.device
+            )
+        logits_view = logits
+    common_args = (
+        _to_kernel_tensor(q_bytes, cutlass.Uint8),
+        _to_kernel_tensor(weights_kernel, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(k_quant_bytes, cutlass.Uint8),
+        _to_kernel_tensor(k_tma_desc_ptrs, cutlass.Int64, assumed_align=8),
+        _to_kernel_tensor(use_scalar_k_load_tensor, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(k_scales, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(real_page_table_kernel, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(seqlens_per_query_kernel, cutlass.Int32, assumed_align=4),
+    )
+    common_cache_key = (
+        q_fp8.shape[1],
+        score_mode,
+        output_mode,
+        _tensor_compile_key(
+            "q_bytes",
+            q_bytes,
+            dynamic_dims=(0,),
+        ),
+        _tensor_compile_key(
+            "weights",
+            weights_kernel,
+            dynamic_dims=(0,),
+        ),
+        _tensor_meta_key(k_quant_bytes),
+        _tensor_meta_key(k_tma_desc_ptrs),
+        _tensor_meta_key(use_scalar_k_load_tensor),
+        _tensor_meta_key(k_scales),
+        _tensor_compile_key(
+            "real_page_table",
+            real_page_table_kernel,
+            dynamic_dims=(0,),
+        ),
+        _tensor_compile_key(
+            "seqlens_per_query",
+            seqlens_per_query_kernel,
+            dynamic_dims=(0,),
+        ),
+        _tensor_meta_key(active_width_kernel),
+        (
+            _tensor_compile_key(
+                "page_scores",
+                logits,
+                dynamic_dims=(1,),
+            )
+            if output_mode == IndexerOutputMode.PAGE_HEAD_MAX
+            else _tensor_compile_key(
+                "logits",
+                logits,
+                dynamic_dims=(0,),
+            )
+        ),
+    )
+    if schedule_metadata is not None and schedule_metadata_kernel is None:
+        schedule_metadata_kernel = (
+            schedule_metadata
+            if schedule_metadata.is_contiguous()
+            else schedule_metadata.contiguous()
+        )
+    if _should_use_schedule_single_row_kernel(q_rows=rows, max_pages=max_pages):
+        if schedule_metadata is None:
+            raise ValueError(
+                "schedule_metadata is required for the scheduled single-row decode path"
+            )
+        kernel = _build_sparse_nsa_schedule_single_row_kernel(
+            _SCHEDULE_SINGLE_ROW_PARALLEL_CTAS,
+            q_fp8.shape[1],
+            score_mode,
+            output_mode,
+        )
+        args = (
+            *common_args,
+            _to_kernel_tensor(schedule_metadata_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(active_width_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(logits, cutlass.Float32, assumed_align=4),
+            current_cuda_stream(),
+        )
+        cache_key = (
+            "schedule_single_row",
+            _SCHEDULE_SINGLE_ROW_PARALLEL_CTAS,
+            *common_cache_key,
+            _tensor_compile_key(
+                "schedule_metadata",
+                schedule_metadata_kernel,
+                dynamic_dims=(0,),
+            ),
+        )
+    elif _should_use_schedule_multi_row_kernel(q_rows=rows, max_pages=max_pages):
+        if schedule_metadata is None:
+            raise ValueError(
+                "schedule_metadata is required for the scheduled multi-row decode path"
+            )
+        kernel = _build_sparse_nsa_schedule_multi_row_kernel(
+            _SCHEDULE_MULTI_ROW_PARALLEL_CTAS,
+            q_fp8.shape[1],
+            score_mode,
+            output_mode,
+        )
+        args = (
+            *common_args,
+            _to_kernel_tensor(schedule_metadata_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(active_width_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(logits, cutlass.Float32, assumed_align=4),
+            current_cuda_stream(),
+        )
+        cache_key = (
+            "schedule_multi_row",
+            _SCHEDULE_MULTI_ROW_PARALLEL_CTAS,
+            *common_cache_key,
+            _tensor_compile_key(
+                "schedule_metadata",
+                schedule_metadata_kernel,
+                dynamic_dims=(0,),
+            ),
+        )
+    else:
+        if output_mode == IndexerOutputMode.PAGE_HEAD_MAX:
+            raise NotImplementedError(
+                "PAGE_HEAD_MAX output is only implemented for scheduled paged decode routes"
+            )
+        persistent_ctas = _resolve_sparse_nsa_persistent_ctas(
+            device_index=device_index,
+            q_rows=rows,
+        )
+        kernel = _build_sparse_nsa_paged_kernel(
+            persistent_ctas,
+            q_fp8.shape[1],
+            score_mode,
+        )
+        args = (
+            *common_args,
+            _to_kernel_tensor(active_width_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(logits, cutlass.Float32, assumed_align=4),
+            current_cuda_stream(),
+        )
+        cache_key = (
+            "persistent",
+            persistent_ctas,
+            *common_cache_key,
+        )
+    compile_spec = KernelCompileSpec.from_key(
+        "attention.indexer.paged_logits",
+        2,
+        cache_key,
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+    return logits_view
+
+
+def run_paged_tiled_logits_kernel(
+    *,
+    q_fp8: torch.Tensor | None = None,
+    weights: torch.Tensor | None = None,
+    index_k_cache: torch.Tensor | None = None,
+    real_page_table: torch.Tensor | None = None,
+    seqlens_per_query: torch.Tensor | None = None,
+    active_width: torch.Tensor | None = None,
+    tile_logits: torch.Tensor | None = None,
+    page_size: int | None = None,
+    tile_block_q: int | None = None,
+    tile_block_k: int | None = None,
+    preinitialize_tile_logits: bool | None = None,
+    binding: IndexerPagedTiledLogitsKernelBinding | None = None,
+) -> torch.Tensor:
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("q_fp8", q_fp8),
+                ("weights", weights),
+                ("index_k_cache", index_k_cache),
+                ("real_page_table", real_page_table),
+                ("seqlens_per_query", seqlens_per_query),
+                ("active_width", active_width),
+                ("tile_logits", tile_logits),
+                ("page_size", page_size),
+                ("tile_block_q", tile_block_q),
+                ("tile_block_k", tile_block_k),
+                ("preinitialize_tile_logits", preinitialize_tile_logits),
+            )
+            if value is not None
+        ]
+        if extras:
+            _raise_binding_extras("run_paged_tiled_logits_kernel", extras)
+        q_fp8 = binding.q_fp8
+        weights = binding.weights
+        index_k_cache = binding.index_k_cache
+        real_page_table = binding.real_page_table
+        seqlens_per_query = binding.seqlens_per_query
+        active_width = binding.active_width
+        tile_logits = binding.tile_logits
+        page_size = binding.page_size
+        tile_block_q = binding.tile_block_q
+        tile_block_k = binding.tile_block_k
+        preinitialize_tile_logits = binding.preinitialize_tile_logits
+
+    q_fp8 = _require_bound_arg(
+        q_fp8, api_name="run_paged_tiled_logits_kernel", name="q_fp8"
+    )
+    weights = _require_bound_arg(
+        weights, api_name="run_paged_tiled_logits_kernel", name="weights"
+    )
+    index_k_cache = _require_bound_arg(
+        index_k_cache,
+        api_name="run_paged_tiled_logits_kernel",
+        name="index_k_cache",
+    )
+    real_page_table = _require_bound_arg(
+        real_page_table,
+        api_name="run_paged_tiled_logits_kernel",
+        name="real_page_table",
+    )
+    seqlens_per_query = _require_bound_arg(
+        seqlens_per_query,
+        api_name="run_paged_tiled_logits_kernel",
+        name="seqlens_per_query",
+    )
+    active_width = _require_bound_arg(
+        active_width,
+        api_name="run_paged_tiled_logits_kernel",
+        name="active_width",
+    )
+    tile_logits = _require_bound_arg(
+        tile_logits,
+        api_name="run_paged_tiled_logits_kernel",
+        name="tile_logits",
+    )
+    page_size = _PAGE_SIZE if page_size is None else int(page_size)
+    tile_block_q = _PAGED_TILED_BLOCK_Q if tile_block_q is None else int(tile_block_q)
+    tile_block_k = _PAGED_TILED_BLOCK_K if tile_block_k is None else int(tile_block_k)
+    preinitialize_tile_logits = (
+        True if preinitialize_tile_logits is None else bool(preinitialize_tile_logits)
+    )
+
+    return _run_paged_tiled_logits_kernel_common(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens_per_query=seqlens_per_query,
+        active_width=active_width,
+        tile_logits=tile_logits,
+        page_size=page_size,
+        tile_block_q=tile_block_q,
+        tile_block_k=tile_block_k,
+        preinitialize_tile_logits=preinitialize_tile_logits,
+        source_page_offset=0,
+        output_width_tokens=None,
+        supertile=False,
+    )
+
+
+def run_paged_supertile_logits_kernel(
+    *,
+    q_fp8: torch.Tensor | None = None,
+    weights: torch.Tensor | None = None,
+    index_k_cache: torch.Tensor | None = None,
+    real_page_table: torch.Tensor | None = None,
+    seqlens_per_query: torch.Tensor | None = None,
+    active_width: torch.Tensor | None = None,
+    tile_logits: torch.Tensor | None = None,
+    source_page_offset: int | None = None,
+    output_width_tokens: int | None = None,
+    page_size: int | None = None,
+    tile_block_q: int | None = None,
+    tile_block_k: int | None = None,
+    preinitialize_tile_logits: bool | None = None,
+    binding: IndexerPagedSupertileLogitsKernelBinding | None = None,
+) -> torch.Tensor:
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("q_fp8", q_fp8),
+                ("weights", weights),
+                ("index_k_cache", index_k_cache),
+                ("real_page_table", real_page_table),
+                ("seqlens_per_query", seqlens_per_query),
+                ("active_width", active_width),
+                ("tile_logits", tile_logits),
+                ("source_page_offset", source_page_offset),
+                ("output_width_tokens", output_width_tokens),
+                ("page_size", page_size),
+                ("tile_block_q", tile_block_q),
+                ("tile_block_k", tile_block_k),
+                ("preinitialize_tile_logits", preinitialize_tile_logits),
+            )
+            if value is not None
+        ]
+        if extras:
+            _raise_binding_extras("run_paged_supertile_logits_kernel", extras)
+        q_fp8 = binding.q_fp8
+        weights = binding.weights
+        index_k_cache = binding.index_k_cache
+        real_page_table = binding.real_page_table
+        seqlens_per_query = binding.seqlens_per_query
+        active_width = binding.active_width
+        tile_logits = binding.tile_logits
+        source_page_offset = binding.source_page_offset
+        output_width_tokens = binding.output_width_tokens
+        page_size = binding.page_size
+        tile_block_q = binding.tile_block_q
+        tile_block_k = binding.tile_block_k
+        preinitialize_tile_logits = binding.preinitialize_tile_logits
+
+    q_fp8 = _require_bound_arg(
+        q_fp8,
+        api_name="run_paged_supertile_logits_kernel",
+        name="q_fp8",
+    )
+    weights = _require_bound_arg(
+        weights,
+        api_name="run_paged_supertile_logits_kernel",
+        name="weights",
+    )
+    index_k_cache = _require_bound_arg(
+        index_k_cache,
+        api_name="run_paged_supertile_logits_kernel",
+        name="index_k_cache",
+    )
+    real_page_table = _require_bound_arg(
+        real_page_table,
+        api_name="run_paged_supertile_logits_kernel",
+        name="real_page_table",
+    )
+    seqlens_per_query = _require_bound_arg(
+        seqlens_per_query,
+        api_name="run_paged_supertile_logits_kernel",
+        name="seqlens_per_query",
+    )
+    active_width = _require_bound_arg(
+        active_width,
+        api_name="run_paged_supertile_logits_kernel",
+        name="active_width",
+    )
+    tile_logits = _require_bound_arg(
+        tile_logits,
+        api_name="run_paged_supertile_logits_kernel",
+        name="tile_logits",
+    )
+    source_page_offset = _require_bound_arg(
+        source_page_offset,
+        api_name="run_paged_supertile_logits_kernel",
+        name="source_page_offset",
+    )
+    output_width_tokens = _require_bound_arg(
+        output_width_tokens,
+        api_name="run_paged_supertile_logits_kernel",
+        name="output_width_tokens",
+    )
+    page_size = _PAGE_SIZE if page_size is None else int(page_size)
+    tile_block_q = _PAGED_TILED_BLOCK_Q if tile_block_q is None else int(tile_block_q)
+    tile_block_k = _PAGED_TILED_BLOCK_K if tile_block_k is None else int(tile_block_k)
+    preinitialize_tile_logits = (
+        True if preinitialize_tile_logits is None else bool(preinitialize_tile_logits)
+    )
+    return _run_paged_tiled_logits_kernel_common(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens_per_query=seqlens_per_query,
+        active_width=active_width,
+        tile_logits=tile_logits,
+        page_size=page_size,
+        tile_block_q=tile_block_q,
+        tile_block_k=tile_block_k,
+        preinitialize_tile_logits=preinitialize_tile_logits,
+        source_page_offset=source_page_offset,
+        output_width_tokens=output_width_tokens,
+        supertile=True,
+    )
+
+
+def _run_paged_tiled_logits_kernel_common(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+    active_width: torch.Tensor,
+    tile_logits: torch.Tensor,
+    page_size: int,
+    tile_block_q: int,
+    tile_block_k: int,
+    preinitialize_tile_logits: bool,
+    source_page_offset: int = 0,
+    output_width_tokens: int | None = None,
+    supertile: bool,
+) -> torch.Tensor:
+    if page_size != _PAGE_SIZE:
+        raise ValueError(
+            f"paged tiled logits kernel requires page_size={_PAGE_SIZE}, got {page_size}"
+        )
+    if int(tile_block_k) != _PAGED_TILED_BLOCK_K:
+        raise ValueError(
+            f"paged tiled logits kernel requires tile_block_k={_PAGED_TILED_BLOCK_K}, got {tile_block_k}"
+        )
+    if not supports_paged_logits_kernel(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens_per_query=seqlens_per_query,
+        page_size=page_size,
+    ):
+        raise ValueError(
+            "sparse NSA paged tiled logits kernel only supports the exact CUDA page_size=64 FP8 contract"
+        )
+    if active_width.shape != (1,):
+        raise ValueError(
+            f"active_width must have shape (1,), got {tuple(active_width.shape)}"
+        )
+    if active_width.dtype != torch.int32:
+        raise ValueError(
+            f"active_width must have dtype torch.int32, got {active_width.dtype}"
+        )
+    if active_width.device != q_fp8.device:
+        raise ValueError(
+            f"active_width device {active_width.device} does not match q_fp8 device {q_fp8.device}"
+        )
+    if tile_logits.dtype != torch.float32 or tile_logits.device != q_fp8.device:
+        raise ValueError(
+            "tile_logits must be a CUDA torch.float32 tensor on the q_fp8 device"
+        )
+    if not tile_logits.is_contiguous():
+        raise ValueError("tile_logits must be contiguous")
+
+    rows = int(q_fp8.shape[0])
+    source_width_tokens = int(real_page_table.shape[1]) * int(page_size)
+    source_page_offset = int(source_page_offset)
+    if source_page_offset < 0:
+        raise ValueError(
+            f"source_page_offset must be non-negative, got {source_page_offset}"
+        )
+    if source_page_offset > int(real_page_table.shape[1]):
+        raise ValueError(
+            "source_page_offset exceeds real_page_table width: "
+            f"offset={source_page_offset}, width={int(real_page_table.shape[1])}"
+        )
+    if supertile:
+        if output_width_tokens is None:
+            raise ValueError("paged supertile logits require output_width_tokens")
+        width_tokens = int(output_width_tokens)
+    else:
+        width_tokens = source_width_tokens
+    if rows == 0 or width_tokens == 0:
+        return tile_logits
+    if width_tokens < 0:
+        raise ValueError(
+            f"output_width_tokens must be non-negative, got {width_tokens}"
+        )
+    if width_tokens % int(tile_block_k) != 0:
+        raise ValueError(
+            f"paged tiled logits width {width_tokens} must be divisible by tile_block_k={tile_block_k}"
+        )
+    num_q_tiles = (rows + int(tile_block_q) - 1) // int(tile_block_q)
+    num_k_tiles = width_tokens // int(tile_block_k)
+    required_elements = (
+        num_q_tiles * num_k_tiles * int(tile_block_q) * int(tile_block_k)
+    )
+    if int(tile_logits.numel()) < required_elements:
+        raise ValueError(
+            f"tile_logits has {int(tile_logits.numel())} elements, expected at least {required_elements}"
+        )
+
+    k_quant_bytes, k_scales = _split_index_k_cache_runtime_views(index_k_cache)
+    use_scalar_k_load = _needs_paged_index_k_scalar_load(
+        index_k_cache,
+        k_quant_bytes,
+    )
+    device_index = q_fp8.device.index or 0
+    k_tma_desc_ptrs = _dummy_paged_index_k_tma_desc_ptrs(device_index)
+    use_scalar_k_load_tensor = _cached_int32_scalar(
+        int(use_scalar_k_load),
+        device_index,
+    )
+    if not q_fp8.is_contiguous():
+        raise ValueError("paged tiled logits requires contiguous q_fp8")
+    if not weights.is_contiguous():
+        raise ValueError("paged tiled logits requires contiguous weights")
+    if not real_page_table.is_contiguous() and not _is_row_shared_i32_matrix(
+        real_page_table
+    ):
+        raise ValueError("paged tiled logits requires contiguous real_page_table")
+    if not seqlens_per_query.is_contiguous():
+        raise ValueError("paged tiled logits requires contiguous seqlens_per_query")
+    if not active_width.is_contiguous():
+        raise ValueError("paged tiled logits requires contiguous active_width")
+    q_bytes = q_fp8.view(torch.uint8)
+    weights_kernel = weights
+    real_page_table_kernel = real_page_table
+    seqlens_per_query_kernel = seqlens_per_query
+    active_width_kernel = active_width
+    logits = tile_logits
+    logits_view = tile_logits[:required_elements]
+    if preinitialize_tile_logits:
+        logits_view.fill_(float("-inf"))
+
+    common_args = (
+        _to_kernel_tensor(q_bytes, cutlass.Uint8),
+        _to_kernel_tensor(weights_kernel, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(k_quant_bytes, cutlass.Uint8),
+        _to_kernel_tensor(k_tma_desc_ptrs, cutlass.Int64, assumed_align=8),
+        _to_kernel_tensor(use_scalar_k_load_tensor, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(k_scales, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(real_page_table_kernel, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(seqlens_per_query_kernel, cutlass.Int32, assumed_align=4),
+    )
+    common_cache_key = (
+        q_fp8.shape[1],
+        _tensor_compile_key(
+            "q_bytes",
+            q_bytes,
+            dynamic_dims=(0,),
+        ),
+        _tensor_compile_key(
+            "weights",
+            weights_kernel,
+            dynamic_dims=(0,),
+        ),
+        _tensor_meta_key(k_quant_bytes),
+        _tensor_meta_key(k_tma_desc_ptrs),
+        _tensor_meta_key(use_scalar_k_load_tensor),
+        _tensor_meta_key(k_scales),
+        _tensor_compile_key(
+            "real_page_table",
+            real_page_table_kernel,
+            dynamic_dims=(0,),
+        ),
+        _tensor_compile_key(
+            "seqlens_per_query",
+            seqlens_per_query_kernel,
+            dynamic_dims=(0,),
+        ),
+        _tensor_meta_key(active_width_kernel),
+        _tensor_compile_key(
+            "tile_logits",
+            logits,
+            dynamic_dims=(0,),
+        ),
+    )
+    persistent_ctas = _resolve_sparse_nsa_persistent_ctas(
+        device_index=device_index,
+        q_rows=rows,
+    )
+    if supertile and _env_indexer_stream_scorer_enabled():
+        stream_ctas = _resolve_stream_scorer_ctas(
+            device_index=device_index,
+            q_rows=rows,
+        )
+        kernel = _build_sparse_nsa_paged_stream_supertile_kernel(
+            stream_ctas,
+            q_fp8.shape[1],
+            int(tile_block_q),
+            int(tile_block_k),
+            int(k_quant_bytes.stride(0)),
+            int(k_scales.stride(0)),
+        )
+        args = (
+            *common_args,
+            _to_kernel_tensor(active_width_kernel, cutlass.Int32, assumed_align=4),
+            Int32(source_page_offset),
+            Int32(width_tokens),
+            _to_kernel_tensor(logits, cutlass.Float32, assumed_align=4),
+            current_cuda_stream(),
+        )
+        cache_key = (
+            "stream_supertile",
+            stream_ctas,
+            int(tile_block_q),
+            int(tile_block_k),
+            int(k_quant_bytes.stride(0)),
+            int(k_scales.stride(0)),
+            *common_cache_key,
+        )
+    elif supertile:
+        kernel = _build_sparse_nsa_paged_supertile_kernel(
+            persistent_ctas,
+            q_fp8.shape[1],
+            int(tile_block_q),
+            int(tile_block_k),
+        )
+        args = (
+            *common_args,
+            _to_kernel_tensor(active_width_kernel, cutlass.Int32, assumed_align=4),
+            Int32(source_page_offset),
+            Int32(width_tokens),
+            _to_kernel_tensor(logits, cutlass.Float32, assumed_align=4),
+            current_cuda_stream(),
+        )
+        cache_key = (
+            "persistent_supertile",
+            persistent_ctas,
+            int(tile_block_q),
+            int(tile_block_k),
+            *common_cache_key,
+        )
+    else:
+        kernel = _build_sparse_nsa_paged_tiled_kernel(
+            persistent_ctas,
+            q_fp8.shape[1],
+            int(tile_block_q),
+            int(tile_block_k),
+        )
+        args = (
+            *common_args,
+            _to_kernel_tensor(active_width_kernel, cutlass.Int32, assumed_align=4),
+            _to_kernel_tensor(logits, cutlass.Float32, assumed_align=4),
+            current_cuda_stream(),
+        )
+        cache_key = (
+            "persistent_tiled",
+            persistent_ctas,
+            int(tile_block_q),
+            int(tile_block_k),
+            *common_cache_key,
+        )
+    compile_spec = KernelCompileSpec.from_key(
+        "attention.indexer.paged_tiled_logits",
+        2,
+        cache_key,
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+    logits_view._sm12x_num_q_tiles = num_q_tiles
+    logits_view._sm12x_num_k_tiles = num_k_tiles
+    logits_view._sm12x_block_q = int(tile_block_q)
+    logits_view._sm12x_block_k = int(tile_block_k)
+    return logits_view
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Streamed paged scorer (v2): persistent right-sized grid + multi-stage
+# cp.async K ring loaded straight into the ldmatrix-permuted layout.
+#
+# Replaces, for the production tiled route, the historical per-row 4xSM grid
+# whose single-stage TMA pipeline (issue -> wait -> compute per 8.4KB page)
+# and SMEM->SMEM repack left DRAM at ~15% of SOL while saturating L1TEX. The
+# ring keeps _STREAM_KV_STAGES-1 page fetches in flight (DeepGEMM
+# sm120_fp8_paged_mqa_logits idiom) and the 32-warp CTA covers a full
+# 64-token page in ONE MMA pass (the fused kernel's proven score shape), so
+# the steady state is wait_group -> MMA -> reduce with three barriers per
+# page instead of ~24.
+# ═════════════════════════════════════════════════════════════════════════════
+_STREAM_WARPS_PER_CTA = 16
+_STREAM_THREADS_PER_CTA = _WARP_THREADS * _STREAM_WARPS_PER_CTA
+_STREAM_KV_STAGES = 8
+# Four warps cooperate on one 64-token page (16 tokens per warp, DeepGEMM's
+# A=KV geometry); a 512-thread CTA therefore consumes four pages per
+# iteration, each quad ping-ponging two ring stages independently.
+_STREAM_WARPS_PER_PAGE = 4
+_STREAM_PAGES_PER_ITER = _STREAM_WARPS_PER_CTA // _STREAM_WARPS_PER_PAGE
+_STREAM_TOKENS_PER_WARP = _PAGE_SIZE // _STREAM_WARPS_PER_PAGE
+_INDEXER_STREAM_SCORER_ENV = "FLASHINFER_EXP_SM12X_INDEXER_STREAM_SCORER"
+
+
+def _env_indexer_stream_scorer_enabled() -> bool:
+    raw = os.environ.get(_INDEXER_STREAM_SCORER_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() in {"1", "true", "on", "yes"}
+
+
+def _resolve_stream_scorer_ctas(*, device_index: int, q_rows: int) -> int:
+    """One wave of 1024-thread CTAs (1 CTA/SM) split evenly across rows."""
+    num_sms = int(torch.cuda.get_device_properties(device_index).multi_processor_count)
+    rows = max(1, int(q_rows))
+    return max(1, (num_sms + rows - 1) // rows)
+
+
+@lru_cache(maxsize=None)
+def _paged_stream_indexer_shared_storage_cls(
+    padded_q_heads: int,
+    tokens_per_work: int,
+    num_q_head_tiles: int,
+):
+    class SharedStorage:
+        pass
+
+    SharedStorage.__annotations__ = {
+        "q_bytes": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, int(padded_q_heads) * _INDEX_HEAD_DIM],
+            16,
+        ],
+        "weights": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, int(padded_q_heads)],
+            16,
+        ],
+        # _STREAM_KV_STAGES ldmatrix-permuted K pages (cp.async ring).
+        "k_perm_ring": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.Uint8, _STREAM_KV_STAGES * _PAGE_SIZE * _INDEX_HEAD_DIM
+            ],
+            1024,
+        ],
+        "scales_ring": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _STREAM_KV_STAGES * _PAGE_SIZE],
+            16,
+        ],
+    }
+    return cute.struct(SharedStorage)
+
+
+@cute.jit
+def _stage_q_permuted(
+    q_bytes: cute.Tensor,  # (rows, heads, 128) uint8
+    q_idx: Int32,
+    num_heads: Int32,
+    q_perm_base_addr: Int32,
+    tx: Int32,
+    q_row_stride_bytes: Int64,
+    *,
+    padded_q_heads: cutlass.Constexpr,
+    stage_threads: cutlass.Constexpr = _STREAM_THREADS_PER_CTA,
+):
+    """Stage Q into per-head-tile XOR-permuted 16B granules (ldmatrix layout).
+
+    Head-tile t occupies a 2KB block (16 head rows x 8 vec16), swizzled with
+    the same `_permuted_offset_128b` pattern as the K pages, so the score core
+    can ldmatrix.x4 the Q operand instead of gathering 64 bytes per fragment.
+    Heads past num_heads stage zeros (same padding contract as the linear
+    staging).
+    """
+    linear = tx
+    total = Int32(int(padded_q_heads) * (_INDEX_HEAD_DIM // 16))
+    while linear < total:
+        head_idx = linear // Int32(_INDEX_HEAD_DIM // 16)
+        vec_idx = linear - head_idx * Int32(_INDEX_HEAD_DIM // 16)
+        v0 = Uint32(0)
+        v1 = Uint32(0)
+        v2 = Uint32(0)
+        v3 = Uint32(0)
+        if head_idx < num_heads:
+            v0, v1, v2, v3 = ld_global_v4_u32(
+                get_ptr_as_int64(
+                    q_bytes,
+                    Int64(q_idx) * q_row_stride_bytes
+                    + Int64(head_idx) * Int64(_INDEX_HEAD_DIM)
+                    + Int64(vec_idx) * Int64(16),
+                )
+            )
+        tile_idx = head_idx // Int32(_PAGED_Q_HEAD_TILE)
+        row_in_tile = head_idx - tile_idx * Int32(_PAGED_Q_HEAD_TILE)
+        tile_base = q_perm_base_addr + tile_idx * Int32(
+            _PAGED_Q_HEAD_TILE * _INDEX_HEAD_DIM
+        )
+        dst_addr = _smem_addr_from_b128_offset(
+            tile_base,
+            _permuted_offset_128b(row_in_tile, vec_idx, Int32(_INDEX_HEAD_DIM // 16)),
+        )
+        st_shared_v4_u32(dst_addr, v0, v1, v2, v3)
+        linear += Int32(stage_threads)
+
+
+@cute.jit
+def _compute_mxfp8_tile_partials_qldm(
+    q_perm_base_addr: Int32,
+    s_w: cute.Tensor,
+    num_heads: Int32,
+    k_perm_base_addr: Int32,
+    token_base: Int32,
+    head_tile_base: Int32,
+    head_tile_slot: Int32,
+    lane: Int32,
+    s_partial_logits: cute.Tensor,
+    partial_row_base: Int32,
+    partial_col: Int32,
+    score_mode: cutlass.Constexpr[int] = IndexerScoreMode.NSA_RELU_SUM,
+):
+    """Score core with BOTH operands ldmatrix-loaded from permuted smem.
+
+    Byte-identical math to `_compute_mxfp8_tile_partials`: the manual
+    `_pack_q_mxfp8_reg` byte gather (64 single-byte smem loads + shifts per
+    warp per page) is replaced by one ldmatrix.x4 + the standard 16b->8b
+    fragment swizzle per 32-dim step, which reproduces exactly the
+    {2t, 2t+1, 2t+8, 2t+9} per-lane byte pattern the MMA expects.
+    """
+    group_id = lane // Int32(4)
+    thread_id_in_group = lane % Int32(4)
+    q0_acc = Float32(0.0)
+    q1_acc = Float32(0.0)
+    q2_acc = Float32(0.0)
+    q3_acc = Float32(0.0)
+    q_tile_base = q_perm_base_addr + head_tile_slot * Int32(
+        _PAGED_Q_HEAD_TILE * _INDEX_HEAD_DIM
+    )
+    q_row = lane & Int32(15)
+    q_half = lane >> Int32(4)
+    k_offset = _permuted_offset_128b(
+        token_base + Int32(8) * (lane // Int32(16)) + lane % Int32(8),
+        (lane % Int32(16)) // Int32(8),
+        Int32(_INDEX_HEAD_DIM // 16),
+    )
+    for mma_pair in cutlass.range_constexpr(_INDEX_HEAD_DIM // 32):
+        q_vec = Int32(2 * mma_pair) + q_half
+        q_addr = _smem_addr_from_b128_offset(
+            q_tile_base,
+            _permuted_offset_128b(q_row, q_vec, Int32(_INDEX_HEAD_DIM // 16)),
+        )
+        # RAW b16 ldmatrix order on BOTH operands: the fp8 MMA's K reduction is
+        # permutation-invariant as long as A and B agree, so the historical
+        # 16b->8b fragment swizzles (2 shuffles + 2 byte-perms each, x6 per
+        # pair) are unnecessary. DeepGEMM's sm120 fp8_mma uses the same raw
+        # convention.
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(q_addr)
+        # One x4 yields both K halves for this warp's 8 tokens as matrices
+        # 0 and 1 (lanes 0-7 / 8-15 address token rows 0-7 at halves 0/1);
+        # the historical left+right pair issued TWO x4 loads and kept one
+        # matrix from each.
+        b0_k0, b0_k1, _bk2, _bk3 = ldmatrix_m8n8x4_b16(
+            _smem_addr_from_b128_offset(k_perm_base_addr, k_offset)
+        )
+        k_offset_cur = _advance_offset_by_row_128b(
+            k_offset,
+            Int32(16),
+            Int32(_INDEX_HEAD_DIM // 16),
+        )
+        d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+            q0_acc,
+            q1_acc,
+            q2_acc,
+            q3_acc,
+            a0,
+            a1,
+            a2,
+            a3,
+            b0_k0,
+            b0_k1,
+            Uint32(0x7F7F7F7F),
+            Uint32(0x7F7F7F7F),
+        )
+        q0_acc = d0
+        q1_acc = d1
+        q2_acc = d2
+        q3_acc = d3
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            16 * (_INDEX_HEAD_DIM // 16)
+        )
+
+    head0 = head_tile_base + group_id
+    head1 = head0 + Int32(8)
+    w0 = Float32(0.0)
+    w1 = Float32(0.0)
+    if head0 < num_heads:
+        w0 = Float32(s_w[head0])
+    if head1 < num_heads:
+        w1 = Float32(s_w[head1])
+    col0 = thread_id_in_group * Int32(2)
+    col1 = col0 + Int32(1)
+    if cutlass.const_expr(score_mode == IndexerScoreMode.MSA_BILINEAR):
+        partial0 = Float32(q0_acc * w0)
+        partial0 = Float32(partial0 + q2_acc * w1)
+        partial1 = Float32(q1_acc * w0)
+        partial1 = Float32(partial1 + q3_acc * w1)
+    else:
+        partial0 = Float32(attention_ops.fmax(q0_acc, Float32(0.0)) * w0)
+        partial0 = Float32(partial0 + attention_ops.fmax(q2_acc, Float32(0.0)) * w1)
+        partial1 = Float32(attention_ops.fmax(q1_acc, Float32(0.0)) * w0)
+        partial1 = Float32(partial1 + attention_ops.fmax(q3_acc, Float32(0.0)) * w1)
+    partial0 = _reduce_column_pair_sum(partial0)
+    partial1 = _reduce_column_pair_sum(partial1)
+    if group_id == Int32(0):
+        s_partial_logits[partial_row_base + col0, partial_col] = partial0
+        s_partial_logits[partial_row_base + col1, partial_col] = partial1
+
+
+@cute.jit
+def _stream_issue_k_page_cp_async(
+    k_quant_bytes: cute.Tensor,  # (pages, 64, 128) uint8 view of the packed cache
+    k_scales: cute.Tensor,  # (pages, 64) float32 view of the packed cache
+    page_id: Int32,
+    k_ring_base_addr: Int32,
+    scales_ring_base_addr: Int32,
+    stage: Int32,
+    tx: Int32,
+    *,
+    k_quant_page_stride: cutlass.Constexpr,  # dim-0 BYTE stride (8448 packed)
+    k_scales_row_stride: cutlass.Constexpr,  # dim-0 ELEMENT stride (2112 packed)
+    issue_threads: cutlass.Constexpr = _STREAM_THREADS_PER_CTA,
+):
+    """Async global->shared page fetch straight into the permuted layout.
+
+    16B `cp.async.cg` granules use the same XOR-swizzled destination as the
+    fused kernel's synchronous `_load_permute_k_page_g2s`, so the MMA-side
+    addressing is unchanged; the copy is simply asynchronous and ring-staged.
+    The caller commits the group.
+    """
+    stage_k_base = k_ring_base_addr + stage * Int32(_PAGE_SIZE * _INDEX_HEAD_DIM)
+    page_elem_base = Int64(page_id) * Int64(k_quant_page_stride)
+    linear = tx
+    total = Int32(_PAGE_SIZE * (_INDEX_HEAD_DIM // 16))
+    while linear < total:
+        row = linear // Int32(_INDEX_HEAD_DIM // 16)
+        vec_idx = linear - row * Int32(_INDEX_HEAD_DIM // 16)
+        g_addr = get_ptr_as_int64(
+            k_quant_bytes,
+            page_elem_base
+            + Int64(row) * Int64(_INDEX_HEAD_DIM)
+            + Int64(vec_idx) * Int64(16),
+        )
+        dst_addr = _smem_addr_from_b128_offset(
+            stage_k_base,
+            _permuted_offset_128b(row, vec_idx, Int32(_INDEX_HEAD_DIM // 16)),
+        )
+        cp_async4_shared_global(dst_addr, g_addr)
+        linear += Int32(issue_threads)
+    if tx < Int32(_PAGE_SIZE):
+        s_addr = scales_ring_base_addr + (stage * Int32(_PAGE_SIZE) + tx) * Int32(4)
+        g_addr = get_ptr_as_int64(
+            k_scales,
+            Int64(page_id) * Int64(k_scales_row_stride) + Int64(tx),
+        )
+        cp_async_u32_shared_global(s_addr, g_addr)
+
+
+class SparseNSAPagedStreamLogitsKernel:
+    """Persistent streamed paged scorer (tiled-output supertile contract)."""
+
+    def __init__(
+        self,
+        persistent_ctas: int,
+        num_heads_static: int,
+        *,
+        tile_block_q: int = _PAGED_TILED_BLOCK_Q,
+        tile_block_k: int = _PAGED_TILED_BLOCK_K,
+        score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+        k_quant_page_stride: int,
+        k_scales_row_stride: int,
+    ):
+        self.persistent_ctas = int(persistent_ctas)
+        self.num_heads_static = int(num_heads_static)
+        self.tile_block_q = int(tile_block_q)
+        self.tile_block_k = int(tile_block_k)
+        self.score_mode = int(score_mode)
+        self.k_quant_page_stride = int(k_quant_page_stride)
+        self.k_scales_row_stride = int(k_scales_row_stride)
+        if self.tile_block_k != _PAGED_TILED_BLOCK_K:
+            raise ValueError(
+                f"stream paged logits require block_k={_PAGED_TILED_BLOCK_K}, "
+                f"got {self.tile_block_k}"
+            )
+        self.num_q_head_tiles = _num_q_head_tiles(self.num_heads_static)
+        if self.num_q_head_tiles not in (1, 2, 4):
+            raise ValueError(
+                "stream paged logits kernel only supports 1/2/4 head tiles, "
+                f"got {self.num_q_head_tiles}"
+            )
+        self.padded_q_heads = self.num_q_head_tiles * _PAGED_Q_HEAD_TILE
+        # DeepGEMM A=KV geometry: a warp owns 16 tokens and loops every 8-head
+        # B tile in registers, so a warp quad covers one 64-token page and the
+        # CTA consumes _STREAM_PAGES_PER_ITER pages per iteration.
+        self.tokens_per_work = _PAGE_SIZE
+        self.num_b_head_tiles = (self.num_heads_static + 7) // 8
+
+    def _get_shared_storage_cls(self):
+        return _paged_stream_indexer_shared_storage_cls(
+            self.padded_q_heads,
+            self.tokens_per_work,
+            self.num_q_head_tiles,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_tma_desc_ptrs: cute.Tensor,  # unused (ABI parity, kept)
+        use_scalar_k_load: cute.Tensor,  # unused (single cp.async path)
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        active_width: cute.Tensor,
+        source_page_offset: Int32,
+        output_width_tokens: Int32,
+        logits_out: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            q_bytes,
+            weights,
+            k_quant_bytes,
+            k_scales,
+            real_page_table,
+            seqlens_per_query,
+            active_width,
+            source_page_offset,
+            output_width_tokens,
+            logits_out,
+        ).launch(
+            grid=(q_bytes.shape[0], self.persistent_ctas, 1),
+            block=[_STREAM_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_bytes: cute.Tensor,
+        weights: cute.Tensor,
+        k_quant_bytes: cute.Tensor,
+        k_scales: cute.Tensor,
+        real_page_table: cute.Tensor,
+        seqlens_per_query: cute.Tensor,
+        active_width: cute.Tensor,
+        source_page_offset: Int32,
+        output_width_tokens: Int32,
+        logits_out: cute.Tensor,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        q_idx, cta_idx, _ = cute.arch.block_idx()
+        lane = tx % Int32(_WARP_THREADS)
+        warp_idx = tx // Int32(_WARP_THREADS)
+
+        smem = cutlass.utils.SmemAllocator()
+        SharedStorage = self._get_shared_storage_cls()
+
+        # ── live width / seqlen clamps (identical to the historical scorer) ──
+        source_width_tokens = Int32(real_page_table.shape[1]) * Int32(_PAGE_SIZE)
+        source_offset_pages = source_page_offset
+        if source_offset_pages < Int32(0):
+            source_offset_pages = Int32(0)
+        source_offset_tokens = source_offset_pages * Int32(_PAGE_SIZE)
+        remaining_width_tokens = source_width_tokens - source_offset_tokens
+        if remaining_width_tokens < Int32(0):
+            remaining_width_tokens = Int32(0)
+
+        width_tokens = output_width_tokens
+        if width_tokens <= Int32(0):
+            width_tokens = remaining_width_tokens
+        valid_width_tokens = width_tokens
+        if valid_width_tokens > remaining_width_tokens:
+            valid_width_tokens = remaining_width_tokens
+
+        live_width = Int32(active_width[Int32(0)])
+        if live_width > source_width_tokens:
+            live_width = source_width_tokens
+        live_width = live_width - source_offset_tokens
+        if live_width < Int32(0):
+            live_width = Int32(0)
+        if live_width > valid_width_tokens:
+            live_width = valid_width_tokens
+
+        seq_len = Int32(seqlens_per_query[q_idx]) - source_offset_tokens
+        if seq_len < Int32(0):
+            seq_len = Int32(0)
+        if seq_len > live_width:
+            seq_len = live_width
+        total_work = (seq_len + Int32(_PAGE_SIZE - 1)) // Int32(_PAGE_SIZE)
+
+        storage = smem.allocate(SharedStorage)
+        s_w = storage.weights.get_tensor(
+            cute.make_layout((self.padded_q_heads,), stride=(1,))
+        )
+        k_ring_base_addr = shared_ptr_to_u32(storage.k_perm_ring.data_ptr())
+        scales_ring_base_addr = shared_ptr_to_u32(storage.scales_ring.data_ptr())
+        q_perm_base_addr = shared_ptr_to_u32(storage.q_bytes.data_ptr())
+        s_scales_ring = storage.scales_ring.get_tensor(
+            cute.make_layout((_STREAM_KV_STAGES * _PAGE_SIZE,), stride=(1,))
+        )
+
+        if cta_idx < total_work:
+            num_heads = Int32(self.num_heads_static)
+            _stage_q_permuted(
+                q_bytes,
+                q_idx,
+                num_heads,
+                q_perm_base_addr,
+                tx,
+                Int64(q_bytes.shape[1]) * Int64(_INDEX_HEAD_DIM),
+                padded_q_heads=self.padded_q_heads,
+            )
+            w_linear = tx
+            while w_linear < Int32(self.padded_q_heads):
+                s_w[w_linear] = (
+                    Float32(weights[q_idx, w_linear])
+                    if w_linear < num_heads
+                    else Float32(0.0)
+                )
+                w_linear += Int32(_STREAM_THREADS_PER_CTA)
+
+            # ── v3 geometry: warp quad per page, warp per 16 tokens ──
+            quad = warp_idx // Int32(_STREAM_WARPS_PER_PAGE)
+            warp_in_quad = warp_idx % Int32(_STREAM_WARPS_PER_PAGE)
+            tx_in_quad = tx % Int32(_WARP_THREADS * _STREAM_WARPS_PER_PAGE)
+            token_base_w = warp_in_quad * Int32(_STREAM_TOKENS_PER_WARP)
+            g = lane // Int32(4)
+            t = lane % Int32(4)
+
+            ctas_stride = Int32(self.persistent_ctas)
+            # This CTA's page count and iteration count (uniform across CTA).
+            n_pages_cta = (
+                total_work - Int32(cta_idx) + ctas_stride - Int32(1)
+            ) // ctas_stride
+            n_iters = (n_pages_cta + Int32(_STREAM_PAGES_PER_ITER - 1)) // Int32(
+                _STREAM_PAGES_PER_ITER
+            )
+
+            # Q staging must be visible before B-fragment loads.
+            cute.arch.sync_threads()
+
+            # ── prologue: each quad prefetches its first page (stage=quad) ──
+            j0 = quad
+            if j0 < n_pages_cta:
+                work0 = Int32(cta_idx) + j0 * ctas_stride
+                src_col0 = source_offset_pages + work0
+                if (work0 * Int32(_PAGE_SIZE) < seq_len) & (
+                    src_col0 < Int32(real_page_table.shape[1])
+                ):
+                    page_id0 = Int32(real_page_table[q_idx, src_col0])
+                    if page_id0 >= Int32(0):
+                        _stream_issue_k_page_cp_async(
+                            k_quant_bytes,
+                            k_scales,
+                            page_id0,
+                            k_ring_base_addr,
+                            scales_ring_base_addr,
+                            quad,
+                            tx_in_quad,
+                            k_quant_page_stride=self.k_quant_page_stride,
+                            k_scales_row_stride=self.k_scales_row_stride,
+                            issue_threads=_WARP_THREADS * _STREAM_WARPS_PER_PAGE,
+                        )
+            cute.arch.cp_async_commit_group()
+
+            it = Int32(0)
+            while it < n_iters:
+                j = it * Int32(_STREAM_PAGES_PER_ITER) + quad
+                # ping-pong stage for this quad: quad or quad + PAGES_PER_ITER
+                stage = quad + (it % Int32(2)) * Int32(_STREAM_PAGES_PER_ITER)
+                next_stage = quad + ((it + Int32(1)) % Int32(2)) * Int32(
+                    _STREAM_PAGES_PER_ITER
+                )
+
+                # Issue the quad's NEXT page into the other stage, then wait
+                # for the current one (1 group lookahead per quad).
+                j_next = j + Int32(_STREAM_PAGES_PER_ITER)
+                if j_next < n_pages_cta:
+                    work_n = Int32(cta_idx) + j_next * ctas_stride
+                    src_col_n = source_offset_pages + work_n
+                    if (work_n * Int32(_PAGE_SIZE) < seq_len) & (
+                        src_col_n < Int32(real_page_table.shape[1])
+                    ):
+                        page_id_n = Int32(real_page_table[q_idx, src_col_n])
+                        if page_id_n >= Int32(0):
+                            _stream_issue_k_page_cp_async(
+                                k_quant_bytes,
+                                k_scales,
+                                page_id_n,
+                                k_ring_base_addr,
+                                scales_ring_base_addr,
+                                next_stage,
+                                tx_in_quad,
+                                k_quant_page_stride=self.k_quant_page_stride,
+                                k_scales_row_stride=self.k_scales_row_stride,
+                                issue_threads=_WARP_THREADS * _STREAM_WARPS_PER_PAGE,
+                            )
+                cute.arch.cp_async_commit_group()
+                # Current page landed (own-thread groups: <=1 pending).
+                cute.arch.cp_async_wait_group(1)
+                cute.arch.sync_threads()
+
+                consume = Int32(0)
+                work = Int32(cta_idx) + j * ctas_stride
+                page_base = work * Int32(_PAGE_SIZE)
+                if j < n_pages_cta:
+                    src_col = source_offset_pages + work
+                    if (page_base < seq_len) & (
+                        src_col < Int32(real_page_table.shape[1])
+                    ):
+                        if Int32(real_page_table[q_idx, src_col]) >= Int32(0):
+                            consume = Int32(1)
+                if consume != Int32(0):
+                    valid_slots = seq_len - page_base
+                    if valid_slots > Int32(_PAGE_SIZE):
+                        valid_slots = Int32(_PAGE_SIZE)
+                    stage_k_base = k_ring_base_addr + stage * Int32(
+                        _PAGE_SIZE * _INDEX_HEAD_DIM
+                    )
+
+                    # Hoist the warp's A (K-token) fragments: 16 tokens x 128
+                    # dims as 4 k-step x4 fragments, reused across all B head
+                    # tiles.
+                    a_row = token_base_w + (lane & Int32(15))
+                    a_half = lane >> Int32(4)
+                    ak = cute.make_rmem_tensor(16, Uint32)
+                    for kk in cutlass.range_constexpr(4):
+                        a_addr = _smem_addr_from_b128_offset(
+                            stage_k_base,
+                            _permuted_offset_128b(
+                                a_row,
+                                Int32(2 * kk) + a_half,
+                                Int32(_INDEX_HEAD_DIM // 16),
+                            ),
+                        )
+                        aa0, aa1, aa2, aa3 = ldmatrix_m8n8x4_b16(a_addr)
+                        ak[kk * 4 + 0] = aa0
+                        ak[kk * 4 + 1] = aa1
+                        ak[kk * 4 + 2] = aa2
+                        ak[kk * 4 + 3] = aa3
+
+                    partial0 = Float32(0.0)
+                    partial1 = Float32(0.0)
+                    b_row = lane & Int32(7)
+                    b_half = (lane >> Int32(3)) & Int32(1)
+                    for nt in cutlass.range_constexpr(2 * self.num_q_head_tiles):
+                        if cutlass.const_expr(True):
+                            d0 = Float32(0.0)
+                            d1 = Float32(0.0)
+                            d2 = Float32(0.0)
+                            d3 = Float32(0.0)
+                            tile16 = nt // 2
+                            row_in_tile = Int32((nt % 2) * 8) + b_row
+                            q_tile_base = q_perm_base_addr + Int32(
+                                tile16 * _PAGED_Q_HEAD_TILE * _INDEX_HEAD_DIM
+                            )
+                            for kk in cutlass.range_constexpr(4):
+                                b_addr = _smem_addr_from_b128_offset(
+                                    q_tile_base,
+                                    _permuted_offset_128b(
+                                        row_in_tile,
+                                        Int32(2 * kk) + b_half,
+                                        Int32(_INDEX_HEAD_DIM // 16),
+                                    ),
+                                )
+                                b0, b1 = ldmatrix_m8n8x2_b16(b_addr)
+                                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                                    d0,
+                                    d1,
+                                    d2,
+                                    d3,
+                                    ak[kk * 4 + 0],
+                                    ak[kk * 4 + 1],
+                                    ak[kk * 4 + 2],
+                                    ak[kk * 4 + 3],
+                                    b0,
+                                    b1,
+                                    Uint32(0x7F7F7F7F),
+                                    Uint32(0x7F7F7F7F),
+                                )
+                            h0 = Int32(nt * 8) + t * Int32(2)
+                            h1 = h0 + Int32(1)
+                            w0 = Float32(0.0)
+                            w1 = Float32(0.0)
+                            if h0 < num_heads:
+                                w0 = Float32(s_w[h0])
+                            if h1 < num_heads:
+                                w1 = Float32(s_w[h1])
+                            if cutlass.const_expr(
+                                self.score_mode == IndexerScoreMode.MSA_BILINEAR
+                            ):
+                                partial0 = Float32(partial0 + d0 * w0 + d1 * w1)
+                                partial1 = Float32(partial1 + d2 * w0 + d3 * w1)
+                            else:
+                                partial0 = Float32(
+                                    partial0
+                                    + attention_ops.fmax(d0, Float32(0.0)) * w0
+                                    + attention_ops.fmax(d1, Float32(0.0)) * w1
+                                )
+                                partial1 = Float32(
+                                    partial1
+                                    + attention_ops.fmax(d2, Float32(0.0)) * w0
+                                    + attention_ops.fmax(d3, Float32(0.0)) * w1
+                                )
+
+                    # Quad-lane (t) reduction: sum head-column pairs.
+                    for off in cutlass.range_constexpr(2):
+                        partial0 = partial0 + cute.arch.shuffle_sync_bfly(
+                            partial0, offset=1 << off
+                        )
+                        partial1 = partial1 + cute.arch.shuffle_sync_bfly(
+                            partial1, offset=1 << off
+                        )
+
+                    if t == Int32(0):
+                        tile_block_q = Int32(self.tile_block_q)
+                        tile_block_k = Int32(self.tile_block_k)
+                        tile_size = Int32(self.tile_block_q * self.tile_block_k)
+                        num_k_tiles = (
+                            width_tokens + tile_block_k - Int32(1)
+                        ) // tile_block_k
+                        q_tile_idx = q_idx // tile_block_q
+                        q_local = q_idx - q_tile_idx * tile_block_q
+                        k_tile_idx = page_base // tile_block_k
+                        row_flat_base = (
+                            q_tile_idx * num_k_tiles * tile_size
+                            + k_tile_idx * tile_size
+                            + q_local * tile_block_k
+                            + page_base
+                            - k_tile_idx * tile_block_k
+                        )
+                        slot0 = token_base_w + g
+                        if slot0 < valid_slots:
+                            logits_out[row_flat_base + slot0] = Float32(
+                                partial0
+                                * s_scales_ring[stage * Int32(_PAGE_SIZE) + slot0]
+                            )
+                        slot1 = slot0 + Int32(8)
+                        if slot1 < valid_slots:
+                            logits_out[row_flat_base + slot1] = Float32(
+                                partial1
+                                * s_scales_ring[stage * Int32(_PAGE_SIZE) + slot1]
+                            )
+                # Ring safety: all quad threads finished reading this stage
+                # before the NEXT iteration's issue targets it again (the
+                # next issue writes next_stage of it+1 == stage of it).
+                cute.arch.sync_threads()
+                it += Int32(1)
+
+
+@lru_cache(maxsize=None)
+def _build_sparse_nsa_paged_stream_supertile_kernel(
+    persistent_ctas: int,
+    num_heads_static: int,
+    tile_block_q: int,
+    tile_block_k: int,
+    k_quant_page_stride: int,
+    k_scales_row_stride: int,
+    score_mode: int = IndexerScoreMode.NSA_RELU_SUM,
+) -> SparseNSAPagedStreamLogitsKernel:
+    return SparseNSAPagedStreamLogitsKernel(
+        persistent_ctas,
+        num_heads_static,
+        tile_block_q=tile_block_q,
+        tile_block_k=tile_block_k,
+        score_mode=score_mode,
+        k_quant_page_stride=k_quant_page_stride,
+        k_scales_row_stride=k_scales_row_stride,
+    )

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/msa_reference.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/msa_reference.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/msa_reference.py @ 118a3b70 (2026-06-12) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""PyTorch references for MiniMax-M3 sparse-attention indexer contracts."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from .reference import _split_index_k_cache_reference
+
+
+MSA_BLOCK_TOKENS = 128
+MSA_TOPK_BLOCKS = 16
+MSA_SM_SCALE = 1.0 / math.sqrt(128.0)
+
+_FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+_INDEX_HEAD_DIM = 128
+_INT32_MAX = torch.iinfo(torch.int32).max
+
+
+def _validate_q_fp8_and_scale(
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+) -> tuple[int, int]:
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"q_fp8 head_dim must be {_INDEX_HEAD_DIM}, got {q_fp8.shape[2]}"
+        )
+    if q_fp8.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            f"q_fp8 must have dtype torch.float8_e4m3fn, got {q_fp8.dtype}"
+        )
+    if q_scale.ndim != 2 or q_scale.shape != q_fp8.shape[:2]:
+        raise ValueError(
+            f"q_scale must have shape {tuple(q_fp8.shape[:2])}, got {tuple(q_scale.shape)}"
+        )
+    if q_scale.dtype != torch.float32:
+        raise ValueError(f"q_scale must have dtype torch.float32, got {q_scale.dtype}")
+    if q_scale.device != q_fp8.device:
+        raise ValueError("q_scale must be on the same device as q_fp8")
+    return int(q_fp8.shape[0]), int(q_fp8.shape[1])
+
+
+def quantize_msa_q_fp8_reference(q: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize MSA index-Q rows with one positive FP32 scale per (token, head)."""
+
+    if q.ndim != 3:
+        raise ValueError(f"q must be rank-3, got {tuple(q.shape)}")
+    if q.shape[2] != _INDEX_HEAD_DIM:
+        raise ValueError(f"q head_dim must be {_INDEX_HEAD_DIM}, got {q.shape[2]}")
+    if not q.dtype.is_floating_point:
+        raise ValueError(f"q must be floating point, got {q.dtype}")
+    q_f32 = q.to(torch.float32)
+    scale = q_f32.abs().amax(dim=2) / _FP8_E4M3_MAX
+    scale = torch.where(scale > 0, scale, torch.ones_like(scale)).to(torch.float32)
+    quant = (q_f32 / scale.unsqueeze(2)).clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX)
+    return quant.to(torch.float8_e4m3fn).contiguous(), scale.contiguous()
+
+
+def _validate_kv_fp8(
+    kv_fp8: tuple[torch.Tensor, torch.Tensor], device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    k_quant, k_scale = kv_fp8
+    if k_quant.ndim != 2 or k_quant.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k_quant must have shape (K, {_INDEX_HEAD_DIM}), got {tuple(k_quant.shape)}"
+        )
+    if k_quant.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            f"k_quant must have dtype torch.float8_e4m3fn, got {k_quant.dtype}"
+        )
+    if k_scale.ndim == 2 and k_scale.shape[1] == 1:
+        k_scale = k_scale.squeeze(1)
+    if k_scale.ndim != 1 or k_scale.shape[0] != k_quant.shape[0]:
+        raise ValueError(
+            f"k_scale must have shape ({k_quant.shape[0]},), got {tuple(k_scale.shape)}"
+        )
+    if k_scale.dtype != torch.float32:
+        raise ValueError(f"k_scale must have dtype torch.float32, got {k_scale.dtype}")
+    if k_quant.device != device or k_scale.device != device:
+        raise ValueError("kv_fp8 tensors must be on the same device as q_fp8")
+    return k_quant.contiguous(), k_scale.contiguous()
+
+
+def _validate_row_bounds(
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+    *,
+    q_rows: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k_start.ndim != 1 or k_end.ndim != 1:
+        raise ValueError(
+            f"k_start and k_end must be rank-1, got {tuple(k_start.shape)} and {tuple(k_end.shape)}"
+        )
+    if k_start.shape != k_end.shape:
+        raise ValueError(
+            f"k_start and k_end must have the same shape, got {tuple(k_start.shape)} vs {tuple(k_end.shape)}"
+        )
+    if k_start.shape[0] > q_rows:
+        raise ValueError(
+            f"metadata describes {k_start.shape[0]} query rows, but q has {q_rows}"
+        )
+    if k_start.dtype != torch.int32 or k_end.dtype != torch.int32:
+        raise ValueError("k_start and k_end must have dtype torch.int32")
+    if k_start.device != device or k_end.device != device:
+        raise ValueError("k_start and k_end must be on the same device as q_fp8")
+    return k_start.contiguous(), k_end.contiguous()
+
+
+def _block_max_from_token_scores(
+    token_scores: torch.Tensor,
+    *,
+    num_blocks: int,
+) -> torch.Tensor:
+    heads = int(token_scores.shape[0])
+    out = torch.full(
+        (heads, num_blocks),
+        float("-inf"),
+        dtype=torch.float32,
+        device=token_scores.device,
+    )
+    for block_idx in range(num_blocks):
+        begin = block_idx * MSA_BLOCK_TOKENS
+        end = min(begin + MSA_BLOCK_TOKENS, int(token_scores.shape[1]))
+        if end > begin:
+            out[:, block_idx] = token_scores[:, begin:end].amax(dim=1)
+    return out
+
+
+def msa_contiguous_block_scores_reference(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+) -> torch.Tensor:
+    """Return MSA column-max block scores for contiguous packed K rows.
+
+    The block axis is global over the packed K matrix. Token masking is applied
+    before the block max, so empty/future/padded rows remain ``-inf``.
+    """
+
+    q_rows, num_heads = _validate_q_fp8_and_scale(q_fp8, q_scale)
+    k_quant, k_scale = _validate_kv_fp8(kv_fp8, q_fp8.device)
+    k_start, k_end = _validate_row_bounds(
+        k_start, k_end, q_rows=q_rows, device=q_fp8.device
+    )
+
+    k_rows = int(k_quant.shape[0])
+    num_blocks = math.ceil(k_rows / MSA_BLOCK_TOKENS)
+    out = torch.full(
+        (num_heads, q_rows, num_blocks),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    if k_rows == 0 or k_start.numel() == 0:
+        return out
+
+    q_f32 = q_fp8.to(torch.float32)
+    k_f32 = k_quant.to(torch.float32)
+    token_pos = torch.arange(k_rows, dtype=torch.long, device=q_fp8.device)
+    neg_inf = torch.full(
+        (num_heads, k_rows), float("-inf"), dtype=torch.float32, device=q_fp8.device
+    )
+    for q_idx in range(int(k_start.numel())):
+        ks = k_start[q_idx].to(torch.long).clamp(min=0, max=k_rows)
+        ke = k_end[q_idx].to(torch.long).clamp(min=0, max=k_rows)
+        valid = (token_pos >= ks) & (token_pos < ke)
+        scores = torch.matmul(q_f32[q_idx], k_f32.transpose(0, 1))
+        scores = (
+            scores * q_scale[q_idx].unsqueeze(1) * k_scale.unsqueeze(0) * MSA_SM_SCALE
+        )
+        scores = torch.where(valid.unsqueeze(0), scores, neg_inf)
+        out[:, q_idx, :] = _block_max_from_token_scores(scores, num_blocks=num_blocks)
+    return out
+
+
+def msa_paged_decode_block_scores_reference(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    page_size: int = 64,
+) -> torch.Tensor:
+    """Return MSA block scores for decode over the paged index-K cache."""
+
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    q_rows, num_heads = _validate_q_fp8_and_scale(q_fp8, q_scale)
+    if real_page_table.ndim != 2:
+        raise ValueError(
+            f"real_page_table must be rank-2, got {tuple(real_page_table.shape)}"
+        )
+    if real_page_table.dtype != torch.int32:
+        raise ValueError(
+            f"real_page_table must have dtype torch.int32, got {real_page_table.dtype}"
+        )
+    if cache_seqlens_int32.ndim != 1:
+        raise ValueError(
+            f"cache_seqlens_int32 must be rank-1, got {tuple(cache_seqlens_int32.shape)}"
+        )
+    if cache_seqlens_int32.dtype != torch.int32:
+        raise ValueError(
+            f"cache_seqlens_int32 must have dtype torch.int32, got {cache_seqlens_int32.dtype}"
+        )
+    if real_page_table.shape[0] != cache_seqlens_int32.shape[0]:
+        raise ValueError(
+            "real_page_table and cache_seqlens_int32 must describe the same rows"
+        )
+    if real_page_table.shape[0] > q_rows:
+        raise ValueError(
+            f"real_page_table rows {real_page_table.shape[0]} exceed q rows {q_rows}"
+        )
+    if (
+        real_page_table.device != q_fp8.device
+        or cache_seqlens_int32.device != q_fp8.device
+    ):
+        raise ValueError("paged metadata tensors must be on the same device as q_fp8")
+
+    k_quant, k_scale = _split_index_k_cache_reference(
+        index_k_cache, page_size=page_size
+    )
+    width_tokens = int(real_page_table.shape[1]) * int(page_size)
+    num_blocks = math.ceil(width_tokens / MSA_BLOCK_TOKENS)
+    out = torch.full(
+        (num_heads, q_rows, num_blocks),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    if width_tokens == 0 or real_page_table.shape[0] == 0:
+        return out
+
+    max_pages = int(k_quant.shape[0])
+    q_f32 = q_fp8.to(torch.float32)
+    token_pos = torch.arange(width_tokens, dtype=torch.long, device=q_fp8.device)
+    page_col = torch.div(token_pos, page_size, rounding_mode="floor")
+    slot_idx = token_pos % page_size
+    neg_inf = torch.full(
+        (num_heads, width_tokens),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    for q_idx in range(int(real_page_table.shape[0])):
+        page_ids = real_page_table[q_idx, page_col].to(torch.long)
+        seq_len = (
+            cache_seqlens_int32[q_idx].to(torch.long).clamp(min=0, max=width_tokens)
+        )
+        valid = (token_pos < seq_len) & (page_ids >= 0) & (page_ids < max_pages)
+        safe_page_ids = page_ids.clamp(0, max(max_pages - 1, 0))
+        k_selected = k_quant[safe_page_ids, slot_idx]
+        scale_selected = k_scale[safe_page_ids, slot_idx]
+        scores = torch.matmul(q_f32[q_idx], k_selected.transpose(0, 1))
+        scores = (
+            scores
+            * q_scale[q_idx].unsqueeze(1)
+            * scale_selected.unsqueeze(0)
+            * MSA_SM_SCALE
+        )
+        scores = torch.where(valid.unsqueeze(0), scores, neg_inf)
+        out[:, q_idx, :] = _block_max_from_token_scores(scores, num_blocks=num_blocks)
+    return out
+
+
+def msa_select_blocks_reference(
+    *,
+    block_scores: torch.Tensor,
+    query_positions: torch.Tensor,
+    block_base: torch.Tensor | None = None,
+    topk: int = MSA_TOPK_BLOCKS,
+) -> torch.Tensor:
+    """Select ascending block ids from raw MSA block scores with local forcing."""
+
+    if block_scores.ndim != 3:
+        raise ValueError(
+            f"block_scores must be rank-3, got {tuple(block_scores.shape)}"
+        )
+    if block_scores.dtype != torch.float32:
+        raise ValueError(
+            f"block_scores must have dtype torch.float32, got {block_scores.dtype}"
+        )
+    if query_positions.ndim != 1 or query_positions.shape[0] != block_scores.shape[1]:
+        raise ValueError(
+            f"query_positions must have shape ({block_scores.shape[1]},), got {tuple(query_positions.shape)}"
+        )
+    if query_positions.dtype != torch.int32:
+        raise ValueError(
+            f"query_positions must have dtype torch.int32, got {query_positions.dtype}"
+        )
+    if query_positions.device != block_scores.device:
+        raise ValueError("query_positions must be on the same device as block_scores")
+    if block_base is not None:
+        if block_base.ndim != 1 or block_base.shape != query_positions.shape:
+            raise ValueError(
+                f"block_base must have shape {tuple(query_positions.shape)}, got {tuple(block_base.shape)}"
+            )
+        if block_base.dtype != torch.int32:
+            raise ValueError(
+                f"block_base must have dtype torch.int32, got {block_base.dtype}"
+            )
+        if block_base.device != block_scores.device:
+            raise ValueError("block_base must be on the same device as block_scores")
+    topk = int(topk)
+    if topk < 0:
+        raise ValueError(f"topk must be non-negative, got {topk}")
+
+    heads, q_rows, num_blocks = map(int, block_scores.shape)
+    result = torch.full(
+        (heads, q_rows, topk), -1, dtype=torch.int32, device=block_scores.device
+    )
+    if topk == 0 or num_blocks == 0:
+        return result
+
+    scores = block_scores.clone()
+    local_blocks = torch.div(query_positions, MSA_BLOCK_TOKENS, rounding_mode="floor")
+    valid_local = (local_blocks >= 0) & (local_blocks < num_blocks)
+    scatter_idx = (
+        local_blocks.clamp(min=0, max=num_blocks - 1)
+        .to(torch.long)
+        .view(1, q_rows, 1)
+        .expand(heads, q_rows, 1)
+    )
+    current_local = torch.gather(scores, 2, scatter_idx)
+    force_values = torch.where(
+        valid_local.view(1, q_rows, 1),
+        torch.full_like(current_local, float("inf")),
+        current_local,
+    )
+    scores.scatter_(2, scatter_idx, force_values)
+
+    gather_k = min(topk, num_blocks)
+    top_values, top_indices = torch.topk(
+        scores, k=gather_k, dim=2, largest=True, sorted=False
+    )
+    base = torch.zeros_like(query_positions) if block_base is None else block_base
+    local_indices = top_indices.to(torch.int32) - base.view(1, q_rows, 1)
+    valid = top_values > float("-inf")
+    valid = valid & (local_indices >= 0)
+    masked = torch.where(
+        valid,
+        local_indices,
+        torch.full_like(local_indices, _INT32_MAX),
+    )
+    sorted_indices = torch.sort(masked, dim=2).values
+    sorted_indices = torch.where(
+        sorted_indices == _INT32_MAX,
+        torch.full_like(sorted_indices, -1),
+        sorted_indices,
+    )
+    result[:, :, :gather_k].copy_(sorted_indices.to(torch.int32))
+    return result
+
+
+def msa_q2k_indices_reference(
+    *,
+    q_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    query_positions: torch.Tensor,
+    topk: int = MSA_TOPK_BLOCKS,
+    block_base: torch.Tensor | None = None,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor] | None = None,
+    k_start: torch.Tensor | None = None,
+    k_end: torch.Tensor | None = None,
+    index_k_cache: torch.Tensor | None = None,
+    real_page_table: torch.Tensor | None = None,
+    cache_seqlens_int32: torch.Tensor | None = None,
+    page_size: int = 64,
+) -> torch.Tensor:
+    """End-to-end MSA reference for either contiguous prefill or paged decode."""
+
+    has_contiguous = kv_fp8 is not None or k_start is not None or k_end is not None
+    has_paged = (
+        index_k_cache is not None
+        or real_page_table is not None
+        or cache_seqlens_int32 is not None
+    )
+    if has_contiguous == has_paged:
+        raise ValueError(
+            "provide exactly one of contiguous kv_fp8/k_start/k_end or paged cache metadata"
+        )
+    if has_contiguous:
+        if kv_fp8 is None or k_start is None or k_end is None:
+            raise ValueError("contiguous reference requires kv_fp8, k_start, and k_end")
+        block_scores = msa_contiguous_block_scores_reference(
+            q_fp8=q_fp8,
+            q_scale=q_scale,
+            kv_fp8=kv_fp8,
+            k_start=k_start,
+            k_end=k_end,
+        )
+    else:
+        if (
+            index_k_cache is None
+            or real_page_table is None
+            or cache_seqlens_int32 is None
+        ):
+            raise ValueError(
+                "paged reference requires index_k_cache, real_page_table, and cache_seqlens_int32"
+            )
+        block_scores = msa_paged_decode_block_scores_reference(
+            q_fp8=q_fp8,
+            q_scale=q_scale,
+            index_k_cache=index_k_cache,
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            page_size=page_size,
+        )
+    return msa_select_blocks_reference(
+        block_scores=block_scores,
+        query_positions=query_positions,
+        block_base=block_base,
+        topk=topk,
+    )

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/paged.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/paged.py
@@ -1,0 +1,1045 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/paged.py @ 77bd50eb (2026-07-01) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Paged sparse-indexer integration surface.
+
+This module adapts the generic indexer scorer/top-k kernels to the DSV4/GLM
+paged index-cache layout.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import torch
+import triton
+import triton.language as tl
+
+from flashinfer.experimental.sm12x.attention.nsa_indexer._impl import (
+    build_paged_mqa_schedule_metadata,
+    uses_paged_mqa_schedule,
+)
+from flashinfer.experimental.sm12x.attention.nsa_indexer.contiguous_kernel import (
+    run_contiguous_logits_kernel,
+)
+from flashinfer.experimental.sm12x.attention.nsa_indexer.kernel import (
+    _env_indexer_stream_scorer_enabled,
+    _split_index_k_cache_runtime_views,
+    run_paged_supertile_logits_kernel,
+)
+from flashinfer.experimental.sm12x.attention.nsa_indexer.tiled_topk import (
+    run_row_topk,
+    run_tiled_topk,
+)
+
+# Two-level fold: target slice width for level-1 pseudo-row parallelism and the
+# cap that keeps the candidate buffers capacity-independent (~topk*8B*cap per
+# row) at very long contexts.
+_TWO_LEVEL_SLICE_TOKENS = 16384
+_TWO_LEVEL_MAX_SLICES = 32
+from flashinfer.experimental.sm12x.attention.nsa_indexer.reference import (
+    pack_index_k_cache_reference,
+    paged_decode_logits_reference,
+    unpack_index_k_cache_reference,
+)
+
+
+INDEX_HEAD_DIM = 128
+PAGED_INDEX_PAGE_SIZE = 64
+_PAGED_INDEX_SUPERTILE_K_ENV = "FLASHINFER_EXP_SM12X_PAGED_INDEX_SUPERTILE_K"
+_PAGED_INDEX_SUPERTILE_K_DEFAULT = 32768
+_PAGED_INDEX_TILE_BLOCK_Q = 32
+_PAGED_INDEX_TILE_BLOCK_K = 512
+_PAGED_INDEX_CACHE_DATA_BYTES = PAGED_INDEX_PAGE_SIZE * INDEX_HEAD_DIM
+
+
+@triton.jit(
+    do_not_specialize=[
+        "q_rows",
+        "page_table_width",
+        "source_page_offset",
+        "cache_row_stride_bytes",
+    ]
+)
+def _gather_shared_paged_supertile_kernel(
+    index_k_cache,
+    real_page_table,
+    seqlens_per_query,
+    k_quant_out,
+    k_scale_bytes_out,
+    k_start_out,
+    k_end_out,
+    q_rows,
+    page_table_width,
+    source_page_offset,
+    supertile_tokens: tl.constexpr,
+    block_tokens: tl.constexpr,
+    page_size: tl.constexpr,
+    index_head_dim: tl.constexpr,
+    cache_row_stride_bytes,
+    cache_data_bytes: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    token_offsets = pid * block_tokens + tl.arange(0, block_tokens)
+    token_mask = token_offsets < supertile_tokens
+
+    page_cols = source_page_offset + token_offsets // page_size
+    slot_offsets = token_offsets % page_size
+    page_ids = tl.load(
+        real_page_table + page_cols,
+        mask=token_mask & (page_cols < page_table_width),
+        other=-1,
+    )
+    valid_tokens = token_mask & (page_ids >= 0)
+    # Packed multi-group allocations can span more than 4 GiB. Keep address
+    # math 64-bit even though the logical page IDs themselves are int32.
+    page_byte_offsets = page_ids.to(tl.int64) * cache_row_stride_bytes
+
+    byte_offsets = tl.arange(0, index_head_dim)
+    k_bytes = tl.load(
+        index_k_cache
+        + page_byte_offsets[:, None]
+        + slot_offsets[:, None] * index_head_dim
+        + byte_offsets[None, :],
+        mask=valid_tokens[:, None],
+        other=0,
+    )
+    tl.store(
+        k_quant_out + token_offsets[:, None] * index_head_dim + byte_offsets[None, :],
+        k_bytes,
+        mask=token_mask[:, None],
+    )
+
+    scale_byte_offsets = tl.arange(0, 4)
+    scale_bytes = tl.load(
+        index_k_cache
+        + page_byte_offsets[:, None]
+        + cache_data_bytes
+        + slot_offsets[:, None] * 4
+        + scale_byte_offsets[None, :],
+        mask=valid_tokens[:, None],
+        other=0,
+    )
+    tl.store(
+        k_scale_bytes_out + token_offsets[:, None] * 4 + scale_byte_offsets[None, :],
+        scale_bytes,
+        mask=token_mask[:, None],
+    )
+
+    row_offsets = token_offsets
+    row_mask = row_offsets < q_rows
+    row_lengths = tl.load(seqlens_per_query + row_offsets, mask=row_mask, other=0)
+    local_ends = row_lengths - source_page_offset * page_size
+    local_ends = tl.minimum(tl.maximum(local_ends, 0), supertile_tokens)
+    tl.store(
+        k_start_out + row_offsets, tl.zeros((block_tokens,), tl.int32), mask=row_mask
+    )
+    tl.store(k_end_out + row_offsets, local_ends, mask=row_mask)
+
+
+@dataclass(frozen=True)
+class IndexerPagedMetadata:
+    """Metadata for paged FP8 MQA indexer logits.
+
+    ``expected_num_q_heads`` is optional for the generic path, but integrations
+    should set it to the exact indexer-head count they pass to sm12x. Replicated
+    selector paths such as paged use the full model-global selector-head count on
+    every attention TP rank.
+    """
+
+    real_page_table: torch.Tensor
+    cache_seqlens_int32: torch.Tensor
+    schedule_metadata: torch.Tensor | None = None
+    expected_num_q_heads: int | None = None
+    shared_page_table: bool = False
+
+
+def resolve_replicated_num_q_heads(
+    *,
+    global_num_q_heads: int,
+    tensor_parallel_size: int | None = None,
+) -> int:
+    """Return the replicated query/index head count used on every TP rank."""
+
+    global_num_q_heads = int(global_num_q_heads)
+    if global_num_q_heads <= 0:
+        raise ValueError(
+            f"global_num_q_heads must be positive, got {global_num_q_heads}"
+        )
+    if tensor_parallel_size is not None and int(tensor_parallel_size) <= 0:
+        raise ValueError(
+            f"tensor_parallel_size must be positive, got {int(tensor_parallel_size)}"
+        )
+    return global_num_q_heads
+
+
+def resolve_local_num_q_heads(
+    *,
+    global_num_q_heads: int,
+    tensor_parallel_size: int,
+) -> int:
+    """Return a TP-local head count for legacy sharded-indexer callers."""
+
+    global_num_q_heads = int(global_num_q_heads)
+    tensor_parallel_size = int(tensor_parallel_size)
+    if global_num_q_heads <= 0:
+        raise ValueError(
+            f"global_num_q_heads must be positive, got {global_num_q_heads}"
+        )
+    if tensor_parallel_size <= 0:
+        raise ValueError(
+            f"tensor_parallel_size must be positive, got {tensor_parallel_size}"
+        )
+    if global_num_q_heads % tensor_parallel_size != 0:
+        raise ValueError(
+            f"global_num_q_heads={global_num_q_heads} is not divisible by "
+            f"tensor_parallel_size={tensor_parallel_size}"
+        )
+    return global_num_q_heads // tensor_parallel_size
+
+
+def _is_cuda_graph_capture_active(device: torch.device) -> bool:
+    return device.type == "cuda" and torch.cuda.is_current_stream_capturing()
+
+
+def _validate_i32_contiguous(
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    ndim: int,
+) -> None:
+    if tensor.ndim != ndim:
+        raise ValueError(f"{name} must be rank-{ndim}, got {tuple(tensor.shape)}")
+    if tensor.dtype != torch.int32:
+        raise ValueError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _is_row_shared_i32_matrix(tensor: torch.Tensor) -> bool:
+    return (
+        tensor.ndim == 2
+        and tensor.dtype == torch.int32
+        and int(tensor.stride(0)) == 0
+        and int(tensor.stride(1)) == 1
+    )
+
+
+def _validate_raw_page_lengths(
+    *,
+    real_page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    page_size: int,
+) -> None:
+    """Reject positive lengths whose active page-table entries are missing."""
+
+    if _is_cuda_graph_capture_active(real_page_table.device):
+        raise RuntimeError(
+            "paged-index metadata prep must run outside CUDA graph capture"
+        )
+    if (
+        real_page_table.device.type == "cuda"
+        and os.getenv("FLASHINFER_EXP_SM12X_VALIDATE_PAGED_INDEXER_CUDA_VALUES", "0")
+        != "1"
+    ):
+        return
+    if cache_seqlens_int32.numel() == 0:
+        return
+    if torch.any(cache_seqlens_int32 < 0).item():
+        raise ValueError("cache_seqlens_int32 must be non-negative")
+
+    max_width_tokens = int(real_page_table.shape[1]) * int(page_size)
+    if torch.any(cache_seqlens_int32 > max_width_tokens).item():
+        max_len = int(cache_seqlens_int32.max().item())
+        raise ValueError(
+            f"cache_seqlens_int32 contains length {max_len}, but page-table capacity "
+            f"is {max_width_tokens} tokens"
+        )
+
+    required_pages = torch.div(
+        cache_seqlens_int32.to(torch.int64) + int(page_size) - 1,
+        int(page_size),
+        rounding_mode="floor",
+    )
+    if real_page_table.shape[1] == 0:
+        return
+    cols = torch.arange(
+        int(real_page_table.shape[1]),
+        dtype=torch.int64,
+        device=real_page_table.device,
+    ).unsqueeze(0)
+    active_page_mask = cols < required_pages.unsqueeze(1)
+    if torch.any(active_page_mask & (real_page_table.to(torch.int64) < 0)).item():
+        raise ValueError(
+            "cache_seqlens_int32 marks page-table slots active, but real_page_table "
+            "contains -1 in those slots; pass raw unclamped paged-index lengths"
+        )
+
+
+def _validate_schedule_metadata(
+    schedule_metadata: torch.Tensor,
+    *,
+    device: torch.device,
+) -> None:
+    _validate_i32_contiguous(
+        schedule_metadata,
+        name="schedule_metadata",
+        ndim=2,
+    )
+    if schedule_metadata.shape[1] != 2:
+        raise ValueError(
+            "schedule_metadata must have trailing dimension 2, got "
+            f"{tuple(schedule_metadata.shape)}"
+        )
+    if schedule_metadata.device != device:
+        raise ValueError(
+            "schedule_metadata device "
+            f"{schedule_metadata.device} does not match real_page_table device {device}"
+        )
+
+
+def prepare_paged_indexer_metadata(
+    *,
+    real_page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    page_size: int = PAGED_INDEX_PAGE_SIZE,
+    expected_num_q_heads: int | None = None,
+    schedule_metadata: torch.Tensor | None = None,
+    schedule_out: torch.Tensor | None = None,
+    schedule_num_sms: int | None = None,
+    build_schedule: bool | None = None,
+    validate_raw_lengths: bool = True,
+    shared_page_table: bool = False,
+) -> IndexerPagedMetadata:
+    """Validate and optionally build metadata for paged indexer logits.
+
+    ``cache_seqlens_int32`` must be the raw token length for the paged indexer
+    layout. Do not pass attention-kernel clamp-to-1 lengths here.
+    """
+
+    page_size = int(page_size)
+    if page_size != PAGED_INDEX_PAGE_SIZE:
+        raise ValueError(
+            f"paged indexer currently supports page_size={PAGED_INDEX_PAGE_SIZE}, "
+            f"got {page_size}"
+        )
+    if bool(shared_page_table) and _is_row_shared_i32_matrix(real_page_table):
+        pass
+    else:
+        _validate_i32_contiguous(real_page_table, name="real_page_table", ndim=2)
+    _validate_i32_contiguous(cache_seqlens_int32, name="cache_seqlens_int32", ndim=1)
+    if real_page_table.shape[0] != cache_seqlens_int32.shape[0]:
+        raise ValueError(
+            f"real_page_table rows {real_page_table.shape[0]} do not match "
+            f"cache_seqlens_int32 rows {cache_seqlens_int32.shape[0]}"
+        )
+    if real_page_table.device != cache_seqlens_int32.device:
+        raise ValueError(
+            f"real_page_table device {real_page_table.device} does not match "
+            f"cache_seqlens_int32 device {cache_seqlens_int32.device}"
+        )
+    if expected_num_q_heads is not None:
+        expected_num_q_heads = int(expected_num_q_heads)
+        if expected_num_q_heads <= 0:
+            raise ValueError(
+                f"expected_num_q_heads must be positive, got {expected_num_q_heads}"
+            )
+    if validate_raw_lengths:
+        _validate_raw_page_lengths(
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            page_size=page_size,
+        )
+
+    if build_schedule is None:
+        build_schedule = uses_paged_mqa_schedule(
+            q_rows=int(real_page_table.shape[0]),
+            max_pages=int(real_page_table.shape[1]),
+        )
+    if build_schedule:
+        if schedule_metadata is not None and schedule_out is not None:
+            raise ValueError("pass only one of schedule_metadata or schedule_out")
+        if schedule_metadata is None:
+            if _is_cuda_graph_capture_active(real_page_table.device):
+                raise RuntimeError(
+                    "paged-indexer schedule metadata must be built before CUDA graph capture"
+                )
+            schedule_metadata = build_paged_mqa_schedule_metadata(
+                cache_seqlens_int32,
+                page_size,
+                schedule_num_sms,
+                out=schedule_out,
+            )
+        else:
+            _validate_schedule_metadata(
+                schedule_metadata,
+                device=real_page_table.device,
+            )
+    elif schedule_metadata is not None:
+        _validate_schedule_metadata(
+            schedule_metadata,
+            device=real_page_table.device,
+        )
+    elif schedule_out is not None:
+        raise ValueError("schedule_out was provided, but build_schedule is false")
+
+    return IndexerPagedMetadata(
+        real_page_table=real_page_table,
+        cache_seqlens_int32=cache_seqlens_int32,
+        schedule_metadata=schedule_metadata,
+        expected_num_q_heads=expected_num_q_heads,
+        shared_page_table=bool(shared_page_table),
+    )
+
+
+def _resolve_binding_metadata(
+    *,
+    binding,
+    metadata: IndexerPagedMetadata | None,
+    active_width_override: torch.Tensor | None = None,
+) -> tuple[IndexerPagedMetadata, object, torch.Tensor | None]:
+    if binding is None:
+        raise TypeError("paged indexer launch requires a plan binding")
+
+    binding_scratch = getattr(binding, "scratch", None)
+    if binding_scratch is None:
+        raise TypeError("paged indexer binding is missing scratch")
+    if metadata is not None:
+        raise ValueError("pass either metadata or binding, not both")
+    metadata = IndexerPagedMetadata(
+        real_page_table=getattr(binding, "real_page_table"),
+        cache_seqlens_int32=getattr(binding, "cache_seqlens_int32"),
+        schedule_metadata=getattr(binding, "schedule_metadata", None),
+        expected_num_q_heads=getattr(binding, "expected_num_q_heads", None),
+        shared_page_table=bool(getattr(binding, "shared_page_table", False)),
+    )
+    if active_width_override is None:
+        active_width_override = getattr(binding, "active_width", None)
+    return metadata, binding_scratch, active_width_override
+
+
+def _prepare_shared_paged_supertile(
+    *,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+    scratch,
+    q_rows: int,
+    page_table_width: int,
+    page_begin: int,
+    supertile_tokens: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    if index_k_cache.ndim != 2 or index_k_cache.dtype != torch.uint8:
+        raise ValueError(
+            "shared paged-index supertile gather requires uint8 index_k_cache with "
+            f"rank 2, got shape={tuple(index_k_cache.shape)} dtype={index_k_cache.dtype}"
+        )
+    if int(index_k_cache.stride(1)) != 1:
+        raise ValueError(
+            "shared paged-index supertile gather requires unit inner stride, "
+            f"got stride={tuple(index_k_cache.stride())}"
+        )
+    expected_width = PAGED_INDEX_PAGE_SIZE * (INDEX_HEAD_DIM + 4)
+    if int(index_k_cache.shape[1]) != expected_width:
+        raise ValueError(
+            f"index_k_cache width must be {expected_width}, got {int(index_k_cache.shape[1])}"
+        )
+
+    k_quant_bytes, k_scale_bytes = scratch.get_indexer_gather_outputs(
+        row_count=supertile_tokens,
+    )
+    k_start = scratch.get_indexer_contiguous_lengths(row_count=q_rows)
+    get_end = getattr(scratch, "get_paged_indexer_runtime_lengths", None)
+    if get_end is None:
+        raise RuntimeError("paged indexer scratch is missing runtime length scratch")
+    k_end = get_end(row_count=q_rows)
+
+    block_tokens = 128
+    grid_elems = max(int(supertile_tokens), int(q_rows))
+    grid = (triton.cdiv(grid_elems, block_tokens),)
+    _gather_shared_paged_supertile_kernel[grid](
+        index_k_cache,
+        real_page_table,
+        seqlens_per_query,
+        k_quant_bytes,
+        k_scale_bytes,
+        k_start,
+        k_end,
+        q_rows,
+        int(page_table_width),
+        int(page_begin),
+        int(supertile_tokens),
+        block_tokens,
+        PAGED_INDEX_PAGE_SIZE,
+        INDEX_HEAD_DIM,
+        int(index_k_cache.stride(0)),
+        _PAGED_INDEX_CACHE_DATA_BYTES,
+        num_warps=4,
+    )
+
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    if fp8_dtype is None:
+        raise RuntimeError(
+            "torch.float8_e4m3fn is required for shared paged-index scoring"
+        )
+    return (
+        k_quant_bytes.view(fp8_dtype),
+        k_scale_bytes.view(torch.float32).view(-1),
+        k_start,
+        k_end,
+    )
+
+
+def _validate_q_head_contract(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    metadata: IndexerPagedMetadata,
+    expected_num_q_heads: int | None,
+    allow_partial_rows: bool,
+) -> int:
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if q_fp8.shape[2] != INDEX_HEAD_DIM:
+        raise ValueError(
+            f"q_fp8 head_dim must be {INDEX_HEAD_DIM}, got {q_fp8.shape[2]}"
+        )
+    if expected_num_q_heads is not None and metadata.expected_num_q_heads is not None:
+        if int(expected_num_q_heads) != int(metadata.expected_num_q_heads):
+            raise ValueError(
+                "expected_num_q_heads argument does not match metadata "
+                f"({expected_num_q_heads} vs {metadata.expected_num_q_heads})"
+            )
+    expected_heads = (
+        int(expected_num_q_heads)
+        if expected_num_q_heads is not None
+        else metadata.expected_num_q_heads
+    )
+    if expected_heads is not None and q_fp8.shape[1] != int(expected_heads):
+        raise ValueError(
+            f"q_fp8 must use expected indexer head count {int(expected_heads)}, got "
+            f"{q_fp8.shape[1]}"
+        )
+    if weights.ndim == 3:
+        if weights.shape[2] != 1:
+            raise ValueError(
+                f"weights rank-3 input must have trailing dimension 1, got {tuple(weights.shape)}"
+            )
+        weight_shape = (weights.shape[0], weights.shape[1])
+    elif weights.ndim == 2:
+        weight_shape = tuple(weights.shape)
+    else:
+        raise ValueError(
+            f"weights must be rank-2 or rank-3, got {tuple(weights.shape)}"
+        )
+    if weight_shape != (q_fp8.shape[0], q_fp8.shape[1]):
+        raise ValueError(
+            f"weights must have shape {(q_fp8.shape[0], q_fp8.shape[1])}, got "
+            f"{tuple(weights.shape)}"
+        )
+    metadata_rows = int(metadata.real_page_table.shape[0])
+    if allow_partial_rows:
+        if metadata_rows > q_fp8.shape[0]:
+            raise ValueError(
+                f"metadata rows {metadata_rows} exceed q rows {q_fp8.shape[0]}"
+            )
+    elif metadata_rows != q_fp8.shape[0]:
+        raise ValueError(
+            f"metadata rows {metadata_rows} must match q rows {q_fp8.shape[0]}"
+        )
+    return int(expected_heads) if expected_heads is not None else int(q_fp8.shape[1])
+
+
+def _weights_as_2d(weights: torch.Tensor) -> torch.Tensor:
+    if weights.ndim == 3:
+        return weights.squeeze(-1)
+    return weights
+
+
+def _resolve_supertile_k(supertile_k: int | None, *, page_size: int) -> int:
+    if supertile_k is None:
+        raw = os.environ.get(_PAGED_INDEX_SUPERTILE_K_ENV)
+        if raw is None:
+            supertile_k = _PAGED_INDEX_SUPERTILE_K_DEFAULT
+        else:
+            try:
+                supertile_k = int(raw)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{_PAGED_INDEX_SUPERTILE_K_ENV} must be an integer, got {raw!r}"
+                ) from exc
+    alignment = _PAGED_INDEX_TILE_BLOCK_K
+    if alignment % int(page_size) != 0:
+        raise ValueError(
+            f"internal paged supertile alignment {alignment} must be divisible by page_size={page_size}"
+        )
+    supertile_k = max(int(supertile_k), alignment)
+    return ((supertile_k + alignment - 1) // alignment) * alignment
+
+
+def index_topk_fp8(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    metadata: IndexerPagedMetadata | None = None,
+    binding=None,
+    page_size: int = PAGED_INDEX_PAGE_SIZE,
+    topk: int | None = None,
+    expected_num_q_heads: int | None = None,
+    out_indices: torch.Tensor | None = None,
+    out_scores: torch.Tensor | None = None,
+    supertile_k: int | None = None,
+) -> torch.Tensor:
+    """Indexer top-k selection over the paged FP8 index cache.
+
+    Phase-agnostic and model-agnostic: serves DSV4 and GLM because the byte
+    layout the kernel reads is identical, and spans both the few-row decode
+    regime and the large-row shared-prefill regime (q_rows>=1024 via
+    run_contiguous_logits_kernel). Routes the few-row decode case onto the fused
+    score+select kernel (no external top-k blob) and otherwise scores into a
+    tiled-logits supertile and folds the shared `run_tiled_topk` selector.
+    Returns top-k indices per query row. When ``out_scores`` is provided, it is
+    filled with the float32 top-k scores corresponding position-for-position to
+    the returned indices. A binding with ``output_physical_slots=True`` makes the
+    producer emit flat physical cache slots directly; no post-selection remap is
+    performed or supported by this entrypoint.
+    """
+
+    metadata, scratch, binding_active_width = _resolve_binding_metadata(
+        binding=binding,
+        metadata=metadata,
+    )
+    page_size = int(page_size)
+    if page_size != PAGED_INDEX_PAGE_SIZE:
+        raise ValueError(
+            f"paged indexer currently supports page_size={PAGED_INDEX_PAGE_SIZE}, "
+            f"got {page_size}"
+        )
+    _validate_q_head_contract(
+        q_fp8=q_fp8,
+        weights=weights,
+        metadata=metadata,
+        expected_num_q_heads=expected_num_q_heads,
+        allow_partial_rows=False,
+    )
+    weights = _weights_as_2d(weights)
+    if q_fp8.device.type != "cuda":
+        raise NotImplementedError("paged index supertile top-k requires CUDA")
+    if metadata.real_page_table.device != q_fp8.device:
+        raise ValueError("real_page_table must be on the same device as q_fp8")
+    if not metadata.real_page_table.is_contiguous() and not (
+        metadata.shared_page_table
+        and _is_row_shared_i32_matrix(metadata.real_page_table)
+    ):
+        raise ValueError("metadata.real_page_table must be contiguous")
+
+    q_rows = int(q_fp8.shape[0])
+    if topk is None:
+        if out_indices is not None:
+            topk = int(out_indices.shape[1])
+        elif out_scores is not None:
+            topk = int(out_scores.shape[1])
+        else:
+            topk = int(getattr(scratch, "topk", 0))
+            if topk <= 0:
+                raise RuntimeError(
+                    "paged index supertile top-k requires topk, out_indices, "
+                    "out_scores, or a bound scratch with topk capacity"
+                )
+    topk = int(topk)
+    if out_indices is not None:
+        if out_indices.shape != (q_rows, topk):
+            raise ValueError(
+                f"out_indices must have shape {(q_rows, topk)}, got "
+                f"{tuple(out_indices.shape)}"
+            )
+        if out_indices.dtype != torch.int32 or not out_indices.is_contiguous():
+            raise ValueError("out_indices must be contiguous torch.int32")
+    if out_scores is not None:
+        if out_scores.shape != (q_rows, topk):
+            raise ValueError(
+                f"out_scores must have shape {(q_rows, topk)}, got "
+                f"{tuple(out_scores.shape)}"
+            )
+        if out_scores.dtype != torch.float32 or not out_scores.is_contiguous():
+            raise ValueError("out_scores must be contiguous torch.float32")
+        if out_scores.device != q_fp8.device:
+            raise ValueError("out_scores device must match q_fp8")
+
+    page_table_width = int(metadata.real_page_table.shape[1])
+
+    route = str(getattr(binding, "route", getattr(scratch, "route", "paged_tiled")))
+    output_physical_slots = bool(getattr(binding, "output_physical_slots", False))
+    # Fused score+top-k route: single launch, no logits blob. Route selection is
+    # owned by the scratch plan; launch only carries it out.
+    from flashinfer.experimental.sm12x.attention.nsa_indexer.fused_indexer import (
+        run_fused_paged_indexer,
+    )
+
+    indexer_heads = int(q_fp8.shape[1])
+    if route == "paged_fused":
+        if bool(metadata.shared_page_table):
+            raise RuntimeError(
+                "fused paged indexer route cannot consume a shared page table"
+            )
+        cache = scratch.get_fused_indexer_scratch(topk=topk)
+        quant, scales = _split_index_k_cache_runtime_views(index_k_cache)
+        idx, _ = run_fused_paged_indexer(
+            q_bytes=q_fp8.view(torch.uint8),
+            weights=weights,
+            k_quant_bytes=quant,
+            k_scales=scales,
+            real_page_table=metadata.real_page_table,
+            seqlens=metadata.cache_seqlens_int32,
+            num_heads=indexer_heads,
+            topk=topk,
+            out_indices=out_indices,
+            out_values=out_scores,
+            pack_values=cache[0],
+            pack_indices=cache[1],
+            merge_state=cache[2],
+            merge_state_preinitialized=bool(
+                getattr(scratch, "fused_indexer_merge_state_preinitialized", False)
+            ),
+            output_physical_slots=output_physical_slots,
+        )
+        return idx
+
+    if supertile_k is None:
+        supertile_k = getattr(binding, "supertile_k", None)
+    if supertile_k is None:
+        supertile_k = getattr(scratch, "paged_tile_logits_k_rows", None)
+    supertile_tokens = _resolve_supertile_k(supertile_k, page_size=page_size)
+    supertile_pages = max(1, supertile_tokens // page_size)
+    num_chunks = max(1, (page_table_width + supertile_pages - 1) // supertile_pages)
+    if int(getattr(scratch, "max_page_table_width", 0)) < page_table_width:
+        raise RuntimeError(
+            "paged index supertile top-k scratch page-table capacity is too small: "
+            f"need={page_table_width}, have={getattr(scratch, 'max_page_table_width', None)}"
+        )
+    use_shared_prefill_scorer = route == "packed_contiguous"
+    topk_block_k = (
+        int(
+            getattr(binding, "prefill_block_k", 0)
+            or getattr(scratch, "prefill_block_k", 0)
+        )
+        if use_shared_prefill_scorer
+        else _PAGED_INDEX_TILE_BLOCK_K
+    )
+    if topk_block_k <= 0:
+        raise RuntimeError(
+            "packed-contiguous paged indexer binding is missing prefill_block_k"
+        )
+    if supertile_tokens % topk_block_k != 0:
+        raise RuntimeError(
+            "paged indexer supertile width must be divisible by route block_k: "
+            f"supertile_tokens={supertile_tokens}, block_k={topk_block_k}"
+        )
+    supertile_k_tiles = supertile_tokens // topk_block_k
+    if route not in ("paged_tiled", "packed_contiguous"):
+        raise RuntimeError(f"unsupported paged indexer route {route!r}")
+    tile_logits = scratch.get_indexer_contiguous_tile_logits()
+    if tile_logits is None:
+        raise RuntimeError(
+            "paged index supertile top-k scratch is missing tiled logits"
+        )
+
+    scratch_values, scratch_raw_indices = scratch.get_indexer_contiguous_topk_buffers(
+        row_count=q_rows,
+    )
+    final_values = out_scores if out_scores is not None else scratch_values[:, :topk]
+    final_raw_indices = (
+        out_indices if out_indices is not None else scratch_raw_indices[:, :topk]
+    )
+    if final_values.shape != (q_rows, topk) or final_raw_indices.shape != (
+        q_rows,
+        topk,
+    ):
+        raise ValueError(
+            f"paged indexer scratch buffers are smaller than requested paged top-k {topk}"
+        )
+    if final_values.dtype != torch.float32 or final_values.device != q_fp8.device:
+        raise ValueError(
+            "paged indexer top-k values must be a CUDA torch.float32 tensor "
+            "on the q_fp8 device"
+        )
+    if (
+        final_raw_indices.dtype != torch.int32
+        or final_raw_indices.device != q_fp8.device
+    ):
+        raise ValueError(
+            "out_indices must be a CUDA torch.int32 tensor on the q_fp8 device"
+        )
+    if not final_values.is_contiguous() or not final_raw_indices.is_contiguous():
+        raise ValueError("paged indexer top-k buffers must be contiguous")
+    # Streaming-fold carry double-buffer (2, M, topk): chunk j reads the running top-k
+    # written by chunk j-1 and writes the next half; the final chunk writes the user
+    # Two-level cross-chunk fold: each chunk's slices are top-k'd by parallel
+    # pseudo-row CTAs straight into a shared candidate buffer (bounded by the
+    # slice cap, NOT the context capacity); one linear pass folds them after
+    # the last chunk. The per-chunk tile-logits scratch stays at the supertile
+    # ceiling. Physical-slot output keeps the legacy carry chain (the fold
+    # gather emits logical indices).
+    width_tokens = page_table_width * page_size
+    two_level_slices: list[tuple[int, int]] = []
+    total_slices = 0
+    fold_values = None
+    fold_indices = None
+    fold_lengths = None
+    if not output_physical_slots and width_tokens >= 2 * _TWO_LEVEL_SLICE_TOKENS:
+        slice_tokens = _TWO_LEVEL_SLICE_TOKENS
+        min_slice = -(-width_tokens // _TWO_LEVEL_MAX_SLICES)
+        if min_slice > slice_tokens:
+            slice_tokens = -(-min_slice // page_size) * page_size
+        base = 0
+        for c in range(num_chunks):
+            c_pages = (
+                min((c + 1) * supertile_pages, page_table_width) - c * supertile_pages
+            )
+            c_tokens = c_pages * page_size
+            splits_c = max(1, -(-c_tokens // slice_tokens))
+            two_level_slices.append((splits_c, base))
+            base += splits_c
+        total_slices = base
+        fold_values = torch.empty(
+            (q_rows * total_slices, topk), dtype=torch.float32, device=q_fp8.device
+        )
+        fold_indices = torch.empty(
+            (q_rows * total_slices, topk), dtype=torch.int32, device=q_fp8.device
+        )
+        fold_lengths = torch.full(
+            (q_rows,), total_slices * topk, dtype=torch.int32, device=q_fp8.device
+        )
+    # output. Only needed when there is more than one supertile chunk.
+    carry_buf_values = None
+    carry_buf_indices = None
+    if num_chunks > 1 and not two_level_slices:
+        carry_buf_values, carry_buf_indices = (
+            scratch.get_indexer_contiguous_candidate_buffers()
+        )
+        if carry_buf_values.shape[0] < 2 or carry_buf_indices.shape[0] < 2:
+            raise RuntimeError(
+                "paged indexer scratch carry buffers need a first dim of at least 2: "
+                f"have={carry_buf_values.shape[0]}"
+            )
+        carry_buf_values = carry_buf_values[:2, :q_rows, :topk]
+        carry_buf_indices = carry_buf_indices[:2, :q_rows, :topk]
+        if (
+            carry_buf_values.dtype != torch.float32
+            or carry_buf_values.device != q_fp8.device
+        ):
+            raise ValueError(
+                "paged indexer carry values must be a CUDA torch.float32 "
+                "tensor on the q_fp8 device"
+            )
+        if (
+            carry_buf_indices.dtype != torch.int32
+            or carry_buf_indices.device != q_fp8.device
+        ):
+            raise ValueError(
+                "paged indexer carry indices must be a CUDA torch.int32 "
+                "tensor on the q_fp8 device"
+            )
+        if (
+            not carry_buf_values.is_contiguous()
+            or not carry_buf_indices.is_contiguous()
+        ):
+            raise ValueError("paged indexer carry buffers must be contiguous")
+
+    active_width = (
+        binding_active_width
+        if binding_active_width is not None
+        else scratch.get_paged_indexer_active_width_cap()
+    )
+    page_table_for_kernel = metadata.real_page_table
+    lengths_for_kernel = metadata.cache_seqlens_int32
+    if use_shared_prefill_scorer:
+        if not bool(metadata.shared_page_table):
+            raise RuntimeError(
+                "packed-contiguous paged indexer route requires a shared page table"
+            )
+        indexer_q_capacity = max(
+            int(getattr(scratch, "max_total_q", 0)),
+            int(getattr(scratch, "max_paged_q_rows", 0)),
+        )
+        if indexer_q_capacity < q_rows:
+            raise RuntimeError(
+                "packed-contiguous paged-index route scratch capacity is too small: "
+                f"q_rows={q_rows}, capacity={indexer_q_capacity}"
+            )
+
+    for chunk_idx in range(num_chunks):
+        page_begin = chunk_idx * supertile_pages
+        page_end = min(page_begin + supertile_pages, page_table_width)
+        chunk_pages = page_end - page_begin
+        chunk_width_tokens = chunk_pages * page_size
+        chunk_start_token = page_begin * page_size
+        if not _env_indexer_stream_scorer_enabled() and uses_paged_mqa_schedule(
+            q_rows=q_rows, max_pages=chunk_pages
+        ):
+            # The streamed scorer schedules its own persistent grid over the
+            # whole supertile; only the legacy tiled scorer needs the
+            # unscheduled-tile contract.
+            raise RuntimeError(
+                "paged supertile top-k requires an unscheduled paged scorer tile; "
+                f"reduce {_PAGED_INDEX_SUPERTILE_K_ENV} below "
+                f"{chunk_width_tokens} tokens"
+            )
+
+        if use_shared_prefill_scorer:
+            k_quant, k_scale, k_start, k_end = _prepare_shared_paged_supertile(
+                index_k_cache=index_k_cache,
+                real_page_table=page_table_for_kernel,
+                seqlens_per_query=lengths_for_kernel,
+                scratch=scratch,
+                q_rows=q_rows,
+                page_table_width=page_table_width,
+                page_begin=page_begin,
+                supertile_tokens=supertile_tokens,
+            )
+            logits = run_contiguous_logits_kernel(
+                q_fp8=q_fp8,
+                weights=weights,
+                k_quant=k_quant,
+                k_scale=k_scale,
+                k_start=k_start,
+                k_end=k_end,
+                tile_logits=tile_logits,
+                tile_k_offset=0,
+                tile_num_k_tiles=supertile_k_tiles,
+                prefill_block_k=topk_block_k,
+            )
+            # The shared scorer consumes local supertile K bounds, but tiled
+            # top-k clips against global raw-token offsets below.
+            topk_lengths = lengths_for_kernel
+        else:
+            logits = run_paged_supertile_logits_kernel(
+                q_fp8=q_fp8,
+                weights=weights,
+                index_k_cache=index_k_cache,
+                real_page_table=page_table_for_kernel,
+                seqlens_per_query=lengths_for_kernel,
+                active_width=active_width,
+                tile_logits=tile_logits,
+                source_page_offset=page_begin,
+                output_width_tokens=supertile_tokens,
+                page_size=page_size,
+                tile_block_q=_PAGED_INDEX_TILE_BLOCK_Q,
+                tile_block_k=_PAGED_INDEX_TILE_BLOCK_K,
+                preinitialize_tile_logits=False,
+            )
+            topk_lengths = lengths_for_kernel
+        if not logits.is_contiguous():
+            raise RuntimeError(
+                "paged supertile scorer returned non-contiguous tiled logits"
+            )
+
+        is_first = chunk_idx == 0
+        is_last = chunk_idx == num_chunks - 1
+        if carry_buf_values is not None:
+            carry_values = carry_buf_values[(chunk_idx - 1) % 2]
+            carry_indices = carry_buf_indices[(chunk_idx - 1) % 2]
+            out_values = final_values if is_last else carry_buf_values[chunk_idx % 2]
+            out_indices = (
+                final_raw_indices if is_last else carry_buf_indices[chunk_idx % 2]
+            )
+        else:
+            # Single chunk: is_first folds nothing and writes straight to the output.
+            carry_values = None
+            carry_indices = None
+            out_values = final_values
+            out_indices = final_raw_indices
+        if two_level_slices:
+            chunk_splits, chunk_slice_base = two_level_slices[chunk_idx]
+            split_extent = -(-chunk_width_tokens // chunk_splits)
+            split_extent = -(-split_extent // topk_block_k) * topk_block_k
+            run_tiled_topk(
+                tile_logits=tile_logits,
+                k_start=None,
+                lengths=topk_lengths,
+                topk=topk,
+                block_q=_PAGED_INDEX_TILE_BLOCK_Q,
+                block_k=topk_block_k,
+                output_values=fold_values,
+                output_indices=fold_indices,
+                num_k_tiles=supertile_k_tiles,
+                input_index_offset=chunk_start_token,
+                input_extent=split_extent,
+                output_index_offset=chunk_start_token,
+                zero_row_start=True,
+                is_first=True,
+                extent_splits=chunk_splits,
+                output_row_stride=total_slices,
+                output_row_base=chunk_slice_base,
+            )
+            if is_last:
+                run_row_topk(
+                    row_logits=fold_values.view(q_rows, total_slices * topk),
+                    lengths=fold_lengths,
+                    topk=topk,
+                    output_values=final_values,
+                    output_indices=final_raw_indices,
+                    output_gather_table=fold_indices.view(q_rows, total_slices * topk),
+                )
+        else:
+            run_tiled_topk(
+                tile_logits=tile_logits,
+                k_start=None,
+                lengths=topk_lengths,
+                topk=topk,
+                block_q=_PAGED_INDEX_TILE_BLOCK_Q,
+                block_k=topk_block_k,
+                output_values=out_values,
+                output_indices=out_indices,
+                num_k_tiles=supertile_k_tiles,
+                input_index_offset=chunk_start_token,
+                input_extent=chunk_width_tokens,
+                output_index_offset=chunk_start_token,
+                zero_row_start=True,
+                carry_values=carry_values,
+                carry_indices=carry_indices,
+                is_first=is_first,
+                output_page_table=(
+                    metadata.real_page_table
+                    if is_last and output_physical_slots
+                    else None
+                ),
+                output_page_size=page_size,
+            )
+
+    return final_raw_indices
+
+
+pack_paged_index_k_cache_reference = pack_index_k_cache_reference
+unpack_paged_index_k_cache_reference = unpack_index_k_cache_reference
+paged_index_logits_reference = paged_decode_logits_reference
+
+from .scratch import (
+    SM12XIndexerPagedBinding,
+    SM12XIndexerPagedScratch,
+    SM12XIndexerPagedScratchCaps,
+    SM12XIndexerPagedScratchPlan,
+    plan_indexer_paged_scratch,
+)
+
+
+__all__ = [
+    "SM12XIndexerPagedBinding",
+    "SM12XIndexerPagedScratch",
+    "SM12XIndexerPagedScratchCaps",
+    "SM12XIndexerPagedScratchPlan",
+    "INDEX_HEAD_DIM",
+    "PAGED_INDEX_PAGE_SIZE",
+    "IndexerPagedMetadata",
+    "pack_paged_index_k_cache_reference",
+    "paged_index_logits_reference",
+    "index_topk_fp8",
+    "prepare_paged_indexer_metadata",
+    "plan_indexer_paged_scratch",
+    "resolve_local_num_q_heads",
+    "resolve_replicated_num_q_heads",
+    "unpack_paged_index_k_cache_reference",
+]

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/persistent_topk.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/persistent_topk.py
@@ -1,0 +1,990 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/persistent_topk.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Persistent large-N TopK=2048 selector for NSA decode logits."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Float32, Int32, Uint32
+
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_add_global_i32,
+    get_ptr_as_int64,
+    red_add_global_release_i32,
+    shared_ptr_to_u32,
+    spin_wait_global_ge_i32,
+    st_global_release_i32,
+)
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    launch as sm12x_launch,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+from .tiled_topk import (
+    _convert_to_uint32,
+    _tensor_meta_key,
+    _to_kernel_tensor,
+    _smem_red_add,
+    _smem_xadd,
+)
+
+_TOPK = 2048
+_RADIX = 256
+_THREADS_PER_CTA = 1024
+_RADIX_THRESHOLD = 32768
+_MAX_CHUNK_ELEMENTS = 8192
+_STATE_WORDS = 3 * _RADIX + 4
+_STATE_HIST0 = 0
+_STATE_HIST1 = _RADIX
+_STATE_HIST2 = 2 * _RADIX
+_STATE_REMAINING_K = 3 * _RADIX
+_STATE_PREFIX = _STATE_REMAINING_K + 1
+_STATE_ARRIVAL_COUNTER = _STATE_REMAINING_K + 2
+_STATE_OUTPUT_COUNTER = _STATE_REMAINING_K + 3
+
+
+@dataclass(frozen=True)
+class _LaunchConfig:
+    chunk_size: int
+    ctas_per_group: int
+    num_groups: int
+    total_ctas: int
+
+
+def _align_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _resolve_vec_size(stride: int) -> int:
+    if stride % 4 == 0:
+        return 4
+    if stride % 2 == 0:
+        return 2
+    return 1
+
+
+def _resolve_launch_config(
+    num_rows: int, stride: int, device: torch.device
+) -> _LaunchConfig:
+    vec_size = _resolve_vec_size(stride)
+    max_chunk = (_MAX_CHUNK_ELEMENTS // vec_size) * vec_size
+    max_chunk = max(max_chunk, vec_size * _THREADS_PER_CTA)
+    ctas_per_group = max(1, (stride + max_chunk - 1) // max_chunk)
+    chunk_size = _align_up((stride + ctas_per_group - 1) // ctas_per_group, vec_size)
+    chunk_size = min(chunk_size, max_chunk)
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    num_groups = min(num_rows, max(1, num_sms // ctas_per_group))
+    total_ctas = max(1, num_groups * ctas_per_group)
+    return _LaunchConfig(
+        chunk_size=chunk_size,
+        ctas_per_group=ctas_per_group,
+        num_groups=num_groups,
+        total_ctas=total_ctas,
+    )
+
+
+def persistent_topk2048_scratch_nbytes(
+    num_rows: int,
+    stride: int,
+    *,
+    device: torch.device | str | None = None,
+) -> int:
+    if device is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    device = torch.device(device)
+    if device.type != "cuda":
+        return (
+            max(int(num_rows), 1)
+            * _STATE_WORDS
+            * torch.empty((), dtype=torch.int32).element_size()
+        )
+    launch = _resolve_launch_config(int(num_rows), int(stride), device)
+    return (
+        launch.num_groups
+        * _STATE_WORDS
+        * torch.empty((), dtype=torch.int32).element_size()
+    )
+
+
+def _persistent_topk2048_capacity_nbytes(
+    max_rows: int,
+    max_stride: int,
+    *,
+    device: torch.device,
+) -> int:
+    max_rows = max(int(max_rows), 1)
+    max_stride = max(int(max_stride), 1)
+    if device.type != "cuda":
+        return persistent_topk2048_scratch_nbytes(max_rows, max_stride, device=device)
+    candidate_strides = {1, max_stride}
+    if max_stride > _RADIX_THRESHOLD:
+        candidate_strides.add(_RADIX_THRESHOLD + 1)
+    return max(
+        persistent_topk2048_scratch_nbytes(max_rows, stride, device=device)
+        for stride in candidate_strides
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XPersistentTopK2048ScratchCaps:
+    device: torch.device | str
+    max_rows: int
+    max_stride: int
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "max_rows", max(int(self.max_rows), 1))
+        object.__setattr__(self, "max_stride", max(int(self.max_stride), 1))
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XPersistentTopK2048Binding:
+    logits: torch.Tensor
+    lengths: torch.Tensor
+    scratch: torch.Tensor
+    page_table_1: torch.Tensor | None = None
+    output_indices: torch.Tensor | None = None
+    max_seq_len: int | None = None
+
+    def run(self) -> torch.Tensor:
+        return run_persistent_topk2048(binding=self)
+
+
+@dataclass(frozen=True)
+class SM12XPersistentTopK2048ScratchPlan:
+    caps: SM12XPersistentTopK2048ScratchCaps
+    scratch_nbytes: int
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        logits: torch.Tensor,
+        lengths: torch.Tensor,
+        page_table_1: torch.Tensor | None = None,
+        output_indices: torch.Tensor | None = None,
+        max_seq_len: int | None = None,
+    ) -> SM12XPersistentTopK2048Binding:
+        if logits.ndim != 2:
+            raise ValueError(f"logits must be rank-2, got {tuple(logits.shape)}")
+        rows, stride = int(logits.shape[0]), int(logits.shape[1])
+        if rows > int(self.caps.max_rows):
+            raise ValueError(
+                f"logits rows {rows} exceed persistent top-k capacity {self.caps.max_rows}"
+            )
+        if stride > int(self.caps.max_stride):
+            raise ValueError(
+                f"logits stride {stride} exceeds persistent top-k capacity {self.caps.max_stride}"
+            )
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="persistent top-k 2048",
+        )
+        state = scratch_storage[: self.scratch_nbytes].view(torch.int32)
+        return build_persistent_topk2048_binding(
+            logits=logits,
+            lengths=lengths,
+            scratch=state,
+            page_table_1=page_table_1,
+            output_indices=output_indices,
+            max_seq_len=max_seq_len,
+        )
+
+
+def plan_persistent_topk2048_scratch(
+    caps: SM12XPersistentTopK2048ScratchCaps,
+) -> SM12XPersistentTopK2048ScratchPlan:
+    scratch_nbytes = _persistent_topk2048_capacity_nbytes(
+        caps.max_rows,
+        caps.max_stride,
+        device=caps.device,
+    )
+    return SM12XPersistentTopK2048ScratchPlan(
+        caps=caps,
+        scratch_nbytes=scratch_nbytes,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "persistent_topk2048.state",
+                nbytes=scratch_nbytes,
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+def build_persistent_topk2048_binding(
+    *,
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    scratch: torch.Tensor,
+    page_table_1: torch.Tensor | None = None,
+    output_indices: torch.Tensor | None = None,
+    max_seq_len: int | None = None,
+) -> SM12XPersistentTopK2048Binding:
+    if logits.ndim != 2:
+        raise ValueError(f"logits must be rank-2, got {tuple(logits.shape)}")
+    if lengths.ndim != 1:
+        lengths = lengths.reshape(-1)
+    if lengths.shape[0] != logits.shape[0]:
+        raise ValueError(
+            f"lengths rows {int(lengths.shape[0])} do not match logits rows {int(logits.shape[0])}"
+        )
+    if lengths.dtype != torch.int32:
+        raise ValueError(f"lengths must have dtype torch.int32, got {lengths.dtype}")
+    if lengths.device != logits.device:
+        raise ValueError("lengths must be on the logits device")
+    if scratch.dtype != torch.int32 or scratch.device != logits.device:
+        raise ValueError("scratch must be an int32 tensor on the logits device")
+    if not scratch.is_contiguous():
+        raise ValueError("scratch must be contiguous")
+    return SM12XPersistentTopK2048Binding(
+        logits=logits,
+        lengths=lengths,
+        scratch=scratch,
+        page_table_1=page_table_1,
+        output_indices=output_indices,
+        max_seq_len=max_seq_len,
+    )
+
+
+@cute.jit
+def _state_offset(group_id: Int32, word: Int32) -> Int32:
+    return group_id * Int32(_STATE_WORDS) + word
+
+
+@cute.jit
+def _global_state_ptr(state: cute.Tensor, group_id: Int32, word: Int32):
+    return get_ptr_as_int64(state, _state_offset(group_id, word))
+
+
+@cute.jit
+def _group_barrier(
+    state: cute.Tensor, group_id: Int32, phase: Int32, ctas_per_group: Int32, tx: Int32
+) -> Int32:
+    arrival_ptr = _global_state_ptr(state, group_id, Int32(_STATE_ARRIVAL_COUNTER))
+    if tx == Int32(0):
+        red_add_global_release_i32(arrival_ptr, Int32(1))
+        spin_wait_global_ge_i32(arrival_ptr, (phase + Int32(1)) * ctas_per_group)
+    cute.arch.sync_threads()
+    return phase + Int32(1)
+
+
+@cute.jit
+def _store_output_index(
+    output: cute.Tensor,
+    page_table: cute.Tensor,
+    row_idx: Int32,
+    output_pos: Int32,
+    logical_idx: Int32,
+    page_table_stride: Int32,
+    output_stride: Int32,
+    paged_output: cutlass.Constexpr[bool],
+):
+    out_val = logical_idx
+    if cutlass.const_expr(paged_output):
+        out_val = Int32(page_table[row_idx * page_table_stride + logical_idx])
+    output[row_idx * output_stride + output_pos] = out_val
+
+
+class SparseNSAPersistentTopK2048Kernel:
+    def __init__(self, *, paged_output: bool, topk: int = _TOPK):
+        self.paged_output = bool(paged_output)
+        self.topk_static = int(topk)
+
+    @cute.jit
+    def __call__(
+        self,
+        logits,
+        lengths,
+        page_table,
+        output,
+        state,
+        num_rows,
+        stride,
+        chunk_size,
+        ctas_per_group,
+        num_groups,
+        page_table_stride,
+        stream,
+    ):
+        self.kernel(
+            logits,
+            lengths,
+            page_table,
+            output,
+            state,
+            num_rows,
+            stride,
+            chunk_size,
+            ctas_per_group,
+            num_groups,
+            page_table_stride,
+        ).launch(
+            grid=(num_groups * ctas_per_group, 1, 1),
+            block=[_THREADS_PER_CTA, 1, 1],
+            # 1024 threads make this a one-resident-CTA kernel on SM120; expose
+            # that fact to ptxas instead of targeting unattainable occupancy.
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        logits: cute.Tensor,
+        lengths: cute.Tensor,
+        page_table: cute.Tensor,
+        output: cute.Tensor,
+        state: cute.Tensor,
+        num_rows: Int32,
+        stride: Int32,
+        chunk_size: Int32,
+        ctas_per_group: Int32,
+        num_groups: Int32,
+        page_table_stride: Int32,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        bid, _, _ = cute.arch.block_idx()
+        tx = Int32(tx)
+        bid = Int32(bid)
+        group_id = bid // ctas_per_group
+        cta_in_group = bid - group_id * ctas_per_group
+
+        smem_alloc = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class SharedStorage:
+            local_histogram: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, _RADIX], 128
+            ]
+            suffix_sum: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, _RADIX], 128
+            ]
+            scalars: cute.struct.Align[cute.struct.MemRange[cutlass.Uint32, 4], 128]
+            counters: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 2], 128]
+            ordered: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, _MAX_CHUNK_ELEMENTS], 128
+            ]
+
+        storage = smem_alloc.allocate(SharedStorage)
+        s_hist = storage.local_histogram.get_tensor(
+            cute.make_layout((_RADIX,), stride=(1,))
+        )
+        s_suffix = storage.suffix_sum.get_tensor(
+            cute.make_layout((_RADIX,), stride=(1,))
+        )
+        s_scalars = storage.scalars.get_tensor(cute.make_layout((4,), stride=(1,)))
+        s_counters = storage.counters.get_tensor(cute.make_layout((2,), stride=(1,)))
+        s_ordered = storage.ordered.get_tensor(
+            cute.make_layout((_MAX_CHUNK_ELEMENTS,), stride=(1,))
+        )
+        hist_ptr = shared_ptr_to_u32(storage.local_histogram.data_ptr())
+        counter_ptr = shared_ptr_to_u32(storage.counters.data_ptr())
+
+        if cta_in_group == Int32(0):
+            i = tx
+            while i < Int32(_STATE_WORDS):
+                state[_state_offset(group_id, i)] = Int32(0)
+                i = i + Int32(_THREADS_PER_CTA)
+        cute.arch.sync_threads()
+
+        barrier_phase = Int32(0)
+        total_iters = (num_rows + num_groups - Int32(1)) // num_groups
+        iter_idx = Int32(0)
+        row_idx = Int32(0)
+        seq_len = Int32(0)
+        row_base = Int32(0)
+        row_out_base = Int32(0)
+        chunk_start = Int32(0)
+        chunk_end = Int32(0)
+        actual_chunk_size = Int32(0)
+        val = Float32(0.0)
+        ordered = Uint32(0)
+        mask = Uint32(0)
+        bucket = Int32(0)
+        local_count = Int32(0)
+        global_round = Int32(0)
+        hist_buf = Int32(0)
+        next_hist_buf = Int32(0)
+        current_hist_word = Int32(0)
+        next_hist_word = Int32(0)
+        shift = Uint32(0)
+        prefix = Uint32(0)
+        remaining_k = Int32(0)
+        stride_scan = Int32(0)
+        scan_val = Int32(0)
+        count_ge = Int32(0)
+        count_gt = Int32(0)
+        bucket_u32 = Uint32(0)
+        ordered_pivot = Uint32(0)
+        local_gt_count = Int32(0)
+        base = Int32(0)
+        local_pos = Int32(0)
+        pos = Int32(0)
+        while iter_idx < total_iters:
+            row_idx = group_id + iter_idx * num_groups
+            seq_len = Int32(0)
+            row_base = Int32(0)
+            row_out_base = Int32(0)
+            chunk_start = Int32(0)
+            chunk_end = Int32(0)
+            actual_chunk_size = Int32(0)
+            val = Float32(0.0)
+            ordered = Uint32(0)
+            mask = Uint32(0)
+            bucket = Int32(0)
+            local_count = Int32(0)
+            global_round = Int32(0)
+            hist_buf = Int32(0)
+            next_hist_buf = Int32(0)
+            current_hist_word = Int32(0)
+            next_hist_word = Int32(0)
+            shift = Uint32(0)
+            prefix = Uint32(0)
+            remaining_k = Int32(0)
+            stride_scan = Int32(0)
+            scan_val = Int32(0)
+            count_ge = Int32(0)
+            count_gt = Int32(0)
+            bucket_u32 = Uint32(0)
+            ordered_pivot = Uint32(0)
+            local_gt_count = Int32(0)
+            base = Int32(0)
+            local_pos = Int32(0)
+            pos = Int32(0)
+            if row_idx < num_rows:
+                seq_len = Int32(lengths[row_idx])
+                row_base = row_idx * stride
+                row_out_base = row_idx * Int32(self.topk_static)
+
+                chunk_start = Int32(0)
+                chunk_end = Int32(0)
+                actual_chunk_size = Int32(0)
+                val = Float32(0.0)
+                ordered = Uint32(0)
+                mask = Uint32(0)
+                bucket = Int32(0)
+                local_count = Int32(0)
+                global_round = Int32(0)
+                hist_buf = Int32(0)
+                next_hist_buf = Int32(0)
+                current_hist_word = Int32(0)
+                next_hist_word = Int32(0)
+                shift = Uint32(0)
+                prefix = Uint32(0)
+                remaining_k = Int32(0)
+                stride_scan = Int32(0)
+                scan_val = Int32(0)
+                count_ge = Int32(0)
+                count_gt = Int32(0)
+                bucket_u32 = Uint32(0)
+                ordered_pivot = Uint32(0)
+                local_gt_count = Int32(0)
+                base = Int32(0)
+                local_pos = Int32(0)
+                pos = Int32(0)
+
+                if seq_len <= Int32(self.topk_static):
+                    if cta_in_group == Int32(0):
+                        i = tx
+                        while i < Int32(self.topk_static):
+                            if i < seq_len:
+                                _store_output_index(
+                                    output,
+                                    page_table,
+                                    row_idx,
+                                    i,
+                                    i,
+                                    page_table_stride,
+                                    Int32(self.topk_static),
+                                    self.paged_output,
+                                )
+                            else:
+                                output[row_out_base + i] = Int32(-1)
+                            i = i + Int32(_THREADS_PER_CTA)
+
+                if seq_len > Int32(self.topk_static):
+                    chunk_start = cta_in_group * chunk_size
+                    chunk_end = chunk_start + chunk_size
+                    if chunk_end > seq_len:
+                        chunk_end = seq_len
+                    actual_chunk_size = Int32(0)
+                    if chunk_start < seq_len:
+                        actual_chunk_size = chunk_end - chunk_start
+
+                    i = tx
+                    while i < actual_chunk_size:
+                        val = Float32(logits[row_base + chunk_start + i])
+                        s_ordered[i] = _convert_to_uint32(val)
+                        i = i + Int32(_THREADS_PER_CTA)
+                    cute.arch.sync_threads()
+
+                    if tx == Int32(0):
+                        s_scalars[0] = Uint32(0)
+                        s_scalars[1] = Uint32(self.topk_static)
+                    cute.arch.sync_threads()
+
+                    barrier_phase = _group_barrier(
+                        state, group_id, barrier_phase, ctas_per_group, tx
+                    )
+
+                    if cta_in_group == Int32(0) and tx == Int32(0):
+                        st_global_release_i32(
+                            _global_state_ptr(
+                                state, group_id, Int32(_STATE_OUTPUT_COUNTER)
+                            ),
+                            Int32(0),
+                        )
+                    cute.arch.sync_threads()
+
+                    for round_idx in cutlass.range_constexpr(4):
+                        global_round = iter_idx * Int32(4) + Int32(round_idx)
+                        hist_buf = global_round % Int32(3)
+                        next_hist_buf = (global_round + Int32(1)) % Int32(3)
+                        current_hist_word = hist_buf * Int32(_RADIX)
+                        next_hist_word = next_hist_buf * Int32(_RADIX)
+                        shift = Uint32(24 - round_idx * 8)
+                        prefix = Uint32(s_scalars[0])
+                        remaining_k = Int32(s_scalars[1])
+
+                        i = tx
+                        while i < Int32(_RADIX):
+                            s_hist[i] = Int32(0)
+                            i = i + Int32(_THREADS_PER_CTA)
+                        cute.arch.sync_threads()
+
+                        i = tx
+                        ordered = Uint32(0)
+                        mask = Uint32(0)
+                        bucket = Int32(0)
+                        while i < actual_chunk_size:
+                            ordered = Uint32(s_ordered[i])
+                            mask = Uint32(0)
+                            if cutlass.const_expr(round_idx != 0):
+                                mask = Uint32(0xFFFFFFFF) << Uint32(32 - round_idx * 8)
+                            if (ordered & mask) == prefix:
+                                bucket = Int32((ordered >> shift) & Uint32(0xFF))
+                                _smem_red_add(hist_ptr, bucket, Int32(1))
+                            i = i + Int32(_THREADS_PER_CTA)
+                        cute.arch.sync_threads()
+
+                        i = tx
+                        local_count = Int32(0)
+                        while i < Int32(_RADIX):
+                            local_count = Int32(s_hist[i])
+                            if local_count > Int32(0):
+                                atomic_add_global_i32(
+                                    _global_state_ptr(
+                                        state, group_id, current_hist_word + i
+                                    ),
+                                    local_count,
+                                )
+                            i = i + Int32(_THREADS_PER_CTA)
+
+                        if cta_in_group == Int32(0):
+                            i = tx
+                            while i < Int32(_RADIX):
+                                state[_state_offset(group_id, next_hist_word + i)] = (
+                                    Int32(0)
+                                )
+                                i = i + Int32(_THREADS_PER_CTA)
+
+                        barrier_phase = _group_barrier(
+                            state, group_id, barrier_phase, ctas_per_group, tx
+                        )
+
+                        i = tx
+                        while i < Int32(_RADIX):
+                            s_suffix[i] = Int32(
+                                state[_state_offset(group_id, current_hist_word + i)]
+                            )
+                            i = i + Int32(_THREADS_PER_CTA)
+                        cute.arch.sync_threads()
+
+                        for stage in cutlass.range_constexpr(8):
+                            stride_scan = Int32(1 << stage)
+                            scan_val = Int32(0)
+                            if tx < Int32(_RADIX):
+                                scan_val = Int32(s_suffix[tx])
+                                if tx < Int32(_RADIX) - stride_scan:
+                                    scan_val = scan_val + Int32(
+                                        s_suffix[tx + stride_scan]
+                                    )
+                            cute.arch.sync_threads()
+                            if tx < Int32(_RADIX):
+                                s_suffix[tx] = scan_val
+                            cute.arch.sync_threads()
+
+                        if tx == Int32(0):
+                            s_scalars[2] = Uint32(0)
+                            s_scalars[3] = Uint32(remaining_k)
+                        cute.arch.sync_threads()
+
+                        if tx < Int32(_RADIX):
+                            count_ge = Int32(s_suffix[tx])
+                            count_gt = Int32(0)
+                            if tx + Int32(1) < Int32(_RADIX):
+                                count_gt = Int32(s_suffix[tx + Int32(1)])
+                            if count_ge >= remaining_k and count_gt < remaining_k:
+                                s_scalars[2] = Uint32(tx)
+                                s_scalars[3] = Uint32(remaining_k - count_gt)
+                        cute.arch.sync_threads()
+
+                        if tx == Int32(0):
+                            bucket_u32 = Uint32(s_scalars[2])
+                            s_scalars[0] = prefix | (bucket_u32 << shift)
+                            s_scalars[1] = s_scalars[3]
+                        cute.arch.sync_threads()
+
+                    ordered_pivot = Uint32(s_scalars[0])
+
+                    if tx == Int32(0):
+                        s_counters[0] = Int32(0)
+                    cute.arch.sync_threads()
+
+                    i = tx
+                    while i < actual_chunk_size:
+                        if Uint32(s_ordered[i]) > ordered_pivot:
+                            _smem_red_add(counter_ptr, Int32(0), Int32(1))
+                        i = i + Int32(_THREADS_PER_CTA)
+                    cute.arch.sync_threads()
+
+                    local_gt_count = Int32(s_counters[0])
+                    if tx == Int32(0):
+                        s_counters[0] = Int32(0)
+                        base = Int32(0)
+                        if local_gt_count > Int32(0):
+                            base = atomic_add_global_i32(
+                                _global_state_ptr(
+                                    state, group_id, Int32(_STATE_OUTPUT_COUNTER)
+                                ),
+                                local_gt_count,
+                            )
+                        s_counters[1] = base
+                    cute.arch.sync_threads()
+
+                    i = tx
+                    local_pos = Int32(0)
+                    pos = Int32(0)
+                    while i < actual_chunk_size:
+                        if Uint32(s_ordered[i]) > ordered_pivot:
+                            local_pos = _smem_xadd(counter_ptr, Int32(0), Int32(1))
+                            pos = Int32(s_counters[1]) + local_pos
+                            _store_output_index(
+                                output,
+                                page_table,
+                                row_idx,
+                                pos,
+                                chunk_start + i,
+                                page_table_stride,
+                                Int32(self.topk_static),
+                                self.paged_output,
+                            )
+                        i = i + Int32(_THREADS_PER_CTA)
+
+                    barrier_phase = _group_barrier(
+                        state, group_id, barrier_phase, ctas_per_group, tx
+                    )
+
+                    i = tx
+                    pos = Int32(0)
+                    while i < actual_chunk_size:
+                        if Uint32(s_ordered[i]) == ordered_pivot:
+                            pos = atomic_add_global_i32(
+                                _global_state_ptr(
+                                    state, group_id, Int32(_STATE_OUTPUT_COUNTER)
+                                ),
+                                Int32(1),
+                            )
+                            if pos < Int32(self.topk_static):
+                                _store_output_index(
+                                    output,
+                                    page_table,
+                                    row_idx,
+                                    pos,
+                                    chunk_start + i,
+                                    page_table_stride,
+                                    Int32(self.topk_static),
+                                    self.paged_output,
+                                )
+                        i = i + Int32(_THREADS_PER_CTA)
+
+            iter_idx = iter_idx + Int32(1)
+
+
+@lru_cache(maxsize=16)
+def _build_persistent_topk_kernel(*, paged_output: bool, topk: int = _TOPK):
+    return SparseNSAPersistentTopK2048Kernel(paged_output=paged_output, topk=topk)
+
+
+def clear_persistent_topk2048_kernel_cache() -> None:
+    _build_persistent_topk_kernel.cache_clear()
+
+
+def supports_persistent_topk2048(
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    *,
+    topk: int = _TOPK,
+    page_table_1: torch.Tensor | None = None,
+) -> bool:
+    if int(topk) not in (512, 1024, 2048):
+        return False
+    if not logits.is_cuda or logits.dtype != torch.float32 or logits.ndim != 2:
+        return False
+    if not logits.is_contiguous():
+        return False
+    if lengths.device != logits.device or lengths.dtype != torch.int32:
+        return False
+    if lengths.numel() != logits.shape[0] or not lengths.is_contiguous():
+        return False
+    if logits.shape[1] <= _RADIX_THRESHOLD:
+        return False
+    if page_table_1 is not None:
+        if page_table_1.device != logits.device or page_table_1.dtype != torch.int32:
+            return False
+        if page_table_1.ndim != 2 or page_table_1.shape[0] < logits.shape[0]:
+            return False
+        if page_table_1.shape[1] < logits.shape[1] or not page_table_1.is_contiguous():
+            return False
+    return True
+
+
+def _fallback_topk2048(
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    *,
+    page_table_1: torch.Tensor | None,
+    output_indices: torch.Tensor | None,
+    topk: int = _TOPK,
+) -> torch.Tensor:
+    rows, cols = logits.shape
+    if output_indices is None:
+        output = torch.full((rows, topk), -1, dtype=torch.int32, device=logits.device)
+    else:
+        if output_indices.shape != (rows, topk) or output_indices.dtype != torch.int32:
+            raise ValueError(
+                f"output_indices must have shape {(rows, topk)} and dtype int32, "
+                f"got {tuple(output_indices.shape)} {output_indices.dtype}"
+            )
+        if output_indices.device != logits.device:
+            raise ValueError("output_indices must be on the logits device")
+        if not output_indices.is_contiguous():
+            raise ValueError("output_indices must be contiguous")
+        output = output_indices
+        output.fill_(-1)
+    gather_k = min(topk, cols)
+    if gather_k == 0:
+        return output
+    mask = torch.arange(cols, device=logits.device).unsqueeze(0) >= lengths.reshape(
+        -1, 1
+    )
+    masked_logits = torch.where(mask, torch.full_like(logits, float("-inf")), logits)
+    topk_values, topk_pos = torch.topk(
+        masked_logits, k=gather_k, dim=1, largest=True, sorted=False
+    )
+    if page_table_1 is None:
+        gathered = topk_pos.to(torch.int32)
+    else:
+        gathered = torch.gather(page_table_1, 1, topk_pos.to(torch.long))
+    output[:, :gather_k] = torch.where(
+        torch.isfinite(topk_values),
+        gathered,
+        torch.full_like(gathered, -1),
+    )
+    return output
+
+
+def run_persistent_topk2048(
+    logits: torch.Tensor | None = None,
+    lengths: torch.Tensor | None = None,
+    *,
+    page_table_1: torch.Tensor | None = None,
+    output_indices: torch.Tensor | None = None,
+    scratch: torch.Tensor | None = None,
+    max_seq_len: int | None = None,
+    topk: int = _TOPK,
+    binding: SM12XPersistentTopK2048Binding | None = None,
+) -> torch.Tensor:
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("logits", logits),
+                ("lengths", lengths),
+                ("page_table_1", page_table_1),
+                ("output_indices", output_indices),
+                ("scratch", scratch),
+                ("max_seq_len", max_seq_len),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "persistent top-k binding owns runtime tensors, scratch, and options; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        logits = binding.logits
+        lengths = binding.lengths
+        page_table_1 = binding.page_table_1
+        output_indices = binding.output_indices
+        scratch = binding.scratch
+        max_seq_len = binding.max_seq_len
+    if logits is None or lengths is None:
+        raise TypeError("run_persistent_topk2048 requires logits/lengths or binding")
+    if lengths.ndim != 1:
+        lengths = lengths.reshape(-1)
+    if max_seq_len is None:
+        max_seq_len = int(logits.shape[1])
+    if not supports_persistent_topk2048(
+        logits, lengths, topk=topk, page_table_1=page_table_1
+    ):
+        return _fallback_topk2048(
+            logits,
+            lengths,
+            page_table_1=page_table_1,
+            output_indices=output_indices,
+            topk=topk,
+        )
+    if int(max_seq_len) <= _RADIX_THRESHOLD:
+        return _fallback_topk2048(
+            logits,
+            lengths,
+            page_table_1=page_table_1,
+            output_indices=output_indices,
+            topk=topk,
+        )
+
+    rows, stride = logits.shape
+    launch = _resolve_launch_config(rows, stride, logits.device)
+    if launch.chunk_size > _MAX_CHUNK_ELEMENTS:
+        return _fallback_topk2048(
+            logits,
+            lengths,
+            page_table_1=page_table_1,
+            output_indices=output_indices,
+            topk=topk,
+        )
+
+    if output_indices is None:
+        output_indices = torch.empty(
+            (rows, topk), dtype=torch.int32, device=logits.device
+        )
+    elif output_indices.shape != (rows, topk) or output_indices.dtype != torch.int32:
+        raise ValueError(
+            f"output_indices must have shape {(rows, topk)} and dtype int32, "
+            f"got {tuple(output_indices.shape)} {output_indices.dtype}"
+        )
+    elif output_indices.device != logits.device:
+        raise ValueError("output_indices must be on the logits device")
+    elif not output_indices.is_contiguous():
+        raise ValueError("output_indices must be contiguous")
+
+    state_words = launch.num_groups * _STATE_WORDS
+    if scratch is None:
+        state = torch.empty((state_words,), dtype=torch.int32, device=logits.device)
+    else:
+        if scratch.dtype != torch.int32 or scratch.device != logits.device:
+            raise ValueError("scratch must be an int32 tensor on the logits device")
+        if scratch.numel() < state_words:
+            raise ValueError(
+                f"scratch too small: need {state_words * 4} bytes, "
+                f"got {scratch.numel() * scratch.element_size()} bytes"
+            )
+        state = scratch.reshape(-1)[:state_words]
+        if not state.is_contiguous():
+            raise ValueError("scratch must be contiguous")
+
+    paged_output = page_table_1 is not None
+    if page_table_1 is None:
+        page_table = output_indices
+        page_table_stride = int(topk)
+    else:
+        page_table = page_table_1
+        page_table_stride = int(page_table_1.shape[1])
+
+    # The kernel intentionally addresses these row-major matrices with flat
+    # scalar offsets.  CUTLASS DSL 4.6 preserves the rank-2 CuTe layout for a
+    # one-coordinate access instead of implicitly flattening it as 4.5 did,
+    # which aliases rows when rows > 1.  Keep the public tensors (and their
+    # semantic compile facts) rank-2, but make the launch ABI explicitly 1-D.
+    logits_runtime = logits.view(-1)
+    page_table_runtime = page_table.view(-1)
+    output_indices_runtime = output_indices.view(-1)
+
+    kernel = _build_persistent_topk_kernel(paged_output=paged_output, topk=int(topk))
+    args = (
+        _to_kernel_tensor(logits_runtime, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(lengths, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(page_table_runtime, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(output_indices_runtime, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(state, cutlass.Int32, assumed_align=4),
+        Int32(rows),
+        Int32(stride),
+        Int32(launch.chunk_size),
+        Int32(launch.ctas_per_group),
+        Int32(launch.num_groups),
+        Int32(page_table_stride),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        _tensor_meta_key(logits, dynamic_dims=(0,)),
+        _tensor_meta_key(lengths, dynamic_dims=(0,)),
+        _tensor_meta_key(page_table, dynamic_dims=(0,)),
+        _tensor_meta_key(output_indices, dynamic_dims=(0,)),
+        _tensor_meta_key(state, dynamic_dims=(0,)),
+        (
+            "persistent_topk2048_v2",
+            int(topk),
+            launch.chunk_size,
+            launch.ctas_per_group,
+            launch.num_groups,
+            paged_output,
+            ("runtime_layout", "flat_1d"),
+        ),
+    )
+    compile_spec = KernelCompileSpec.from_key(
+        "attention.indexer.persistent_topk",
+        2,
+        cache_key,
+        labels=(
+            "logits",
+            "lengths",
+            "page_table",
+            "output_indices",
+            "state",
+            "policy",
+        ),
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+    return output_indices

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/reference.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/reference.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/reference.py @ 99c2a475 (2026-07-01) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""PyTorch references for NSA indexer logits contracts."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+_FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+_INDEX_HEAD_DIM = 128
+_SCALE_BYTES = 4
+
+
+def _as_2d_index_k_cache(
+    index_k_cache: torch.Tensor, *, page_size: int
+) -> torch.Tensor:
+    if index_k_cache.ndim != 2:
+        raise ValueError(
+            f"index_k_cache must be rank-2, got {tuple(index_k_cache.shape)}"
+        )
+    expected_width = page_size * (_INDEX_HEAD_DIM + _SCALE_BYTES)
+    if index_k_cache.shape[1] != expected_width:
+        raise ValueError(
+            f"index_k_cache width must be {expected_width} for page_size={page_size}, "
+            f"got {index_k_cache.shape[1]}"
+        )
+    if index_k_cache.dtype != torch.uint8:
+        raise ValueError(
+            f"index_k_cache must have dtype torch.uint8, got {index_k_cache.dtype}"
+        )
+    return index_k_cache.contiguous()
+
+
+def _as_k_matrix(k: torch.Tensor) -> torch.Tensor:
+    if k.ndim == 3:
+        if k.shape[1] != 1:
+            raise ValueError(f"k must have middle dimension 1, got {tuple(k.shape)}")
+        k = k[:, 0, :]
+    if k.ndim != 2:
+        raise ValueError(f"k must be rank-2 or rank-3, got {tuple(k.shape)}")
+    if k.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k last dimension must be {_INDEX_HEAD_DIM}, got {k.shape[1]}"
+        )
+    return k.contiguous()
+
+
+def _normalize_weights(
+    weights: torch.Tensor, *, q_rows: int, num_heads: int
+) -> torch.Tensor:
+    if weights.ndim == 3:
+        if weights.shape[2] != 1:
+            raise ValueError(
+                f"weights rank-3 input must have trailing dimension 1, got {tuple(weights.shape)}"
+            )
+        weights = weights.squeeze(2)
+    if weights.ndim != 2:
+        raise ValueError(
+            f"weights must be rank-2 or rank-3, got {tuple(weights.shape)}"
+        )
+    if weights.shape != (q_rows, num_heads):
+        raise ValueError(
+            f"weights shape must be {(q_rows, num_heads)}, got {tuple(weights.shape)}"
+        )
+    return weights.to(torch.float32)
+
+
+def _split_index_k_cache_reference(
+    index_k_cache: torch.Tensor,
+    *,
+    page_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cache = _as_2d_index_k_cache(index_k_cache, page_size=page_size)
+    num_pages = cache.shape[0]
+    data_bytes = page_size * _INDEX_HEAD_DIM
+    k_quant = (
+        cache[:, :data_bytes]
+        .contiguous()
+        .view(num_pages, page_size, _INDEX_HEAD_DIM)
+        .view(torch.float8_e4m3fn)
+        .to(torch.float32)
+    )
+    k_scale = (
+        cache[:, data_bytes : data_bytes + page_size * _SCALE_BYTES]
+        .contiguous()
+        .view(torch.float32)
+        .view(num_pages, page_size)
+    )
+    return k_quant, k_scale
+
+
+def pack_index_k_cache_reference(
+    k: torch.Tensor,
+    *,
+    page_size: int = 64,
+) -> torch.Tensor:
+    """Pack dequantized index-K rows into the paged FP8+scale cache layout."""
+
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+
+    k_matrix = _as_k_matrix(k).to(torch.float32)
+    num_tokens = k_matrix.shape[0]
+    num_pages = max(1, math.ceil(num_tokens / page_size))
+    cache = torch.zeros(
+        (num_pages, page_size * (_INDEX_HEAD_DIM + _SCALE_BYTES)),
+        dtype=torch.uint8,
+        device=k_matrix.device,
+    )
+
+    data_bytes = page_size * _INDEX_HEAD_DIM
+    scales = k_matrix.abs().amax(dim=1) / _FP8_E4M3_MAX
+    scales = torch.where(scales > 0, scales, torch.ones_like(scales))
+    quant = (
+        (k_matrix / scales.unsqueeze(1))
+        .clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX)
+        .to(torch.float8_e4m3fn)
+    )
+
+    # The packed page is planar: all 64 quantized 128-byte rows followed by
+    # all 64 FP32 scales.  Populate those two planes in bulk; the previous
+    # per-token Python loop launched several tiny CUDA operations per row and
+    # made production-capacity benchmark setup take minutes.
+    padded_tokens = num_pages * page_size
+    quant_padded = torch.zeros(
+        (padded_tokens, _INDEX_HEAD_DIM), dtype=torch.uint8, device=k_matrix.device
+    )
+    scale_padded = torch.zeros(
+        (padded_tokens,), dtype=torch.float32, device=k_matrix.device
+    )
+    quant_padded[:num_tokens].copy_(quant.view(torch.uint8))
+    scale_padded[:num_tokens].copy_(scales)
+    cache[:, :data_bytes].view(num_pages, page_size, _INDEX_HEAD_DIM).copy_(
+        quant_padded.view(num_pages, page_size, _INDEX_HEAD_DIM)
+    )
+    cache[:, data_bytes:].view(torch.float32).copy_(
+        scale_padded.view(num_pages, page_size)
+    )
+    return cache.contiguous()
+
+
+def unpack_index_k_cache_reference(
+    index_k_cache: torch.Tensor,
+    *,
+    num_tokens: int,
+    page_size: int = 64,
+) -> torch.Tensor:
+    """Unpack the paged FP8+scale cache layout back into dequantized rows."""
+
+    if num_tokens < 0:
+        raise ValueError(f"num_tokens must be non-negative, got {num_tokens}")
+    k_quant, k_scale = _split_index_k_cache_reference(
+        index_k_cache, page_size=page_size
+    )
+    max_tokens = k_quant.shape[0] * page_size
+    if num_tokens > max_tokens:
+        raise ValueError(f"num_tokens {num_tokens} exceeds cache capacity {max_tokens}")
+    if num_tokens == 0:
+        return torch.empty(
+            (0, _INDEX_HEAD_DIM), dtype=torch.float32, device=index_k_cache.device
+        )
+    token_ids = torch.arange(num_tokens, device=index_k_cache.device, dtype=torch.long)
+    page_idx = torch.div(token_ids, page_size, rounding_mode="floor")
+    slot_idx = token_ids % page_size
+    return k_quant[page_idx, slot_idx] * k_scale[page_idx, slot_idx].unsqueeze(1)
+
+
+def paged_decode_logits_reference(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    real_page_table: torch.Tensor,
+    query_row_to_batch: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+    page_size: int = 64,
+) -> torch.Tensor:
+    """Return dense token-position logits from the paged/block-table contract."""
+
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"q_fp8 head_dim must be {_INDEX_HEAD_DIM}, got {q_fp8.shape[2]}"
+        )
+    if real_page_table.ndim != 2:
+        raise ValueError(
+            f"real_page_table must be rank-2, got {tuple(real_page_table.shape)}"
+        )
+    if real_page_table.dtype != torch.int32:
+        raise ValueError(
+            f"real_page_table must have dtype torch.int32, got {real_page_table.dtype}"
+        )
+    if real_page_table.device != q_fp8.device:
+        raise ValueError(
+            f"real_page_table device {real_page_table.device} does not match q_fp8 device {q_fp8.device}"
+        )
+    if query_row_to_batch.ndim != 1:
+        raise ValueError(
+            f"query_row_to_batch must be rank-1, got {tuple(query_row_to_batch.shape)}"
+        )
+    if seqlens_per_query.ndim != 1:
+        raise ValueError(
+            f"seqlens_per_query must be rank-1, got {tuple(seqlens_per_query.shape)}"
+        )
+    if query_row_to_batch.shape != seqlens_per_query.shape:
+        raise ValueError(
+            "query_row_to_batch and seqlens_per_query must have the same shape, got "
+            f"{tuple(query_row_to_batch.shape)} vs {tuple(seqlens_per_query.shape)}"
+        )
+    if query_row_to_batch.device != q_fp8.device:
+        raise ValueError(
+            f"query_row_to_batch device {query_row_to_batch.device} does not match "
+            f"q_fp8 device {q_fp8.device}"
+        )
+    if seqlens_per_query.device != q_fp8.device:
+        raise ValueError(
+            f"seqlens_per_query device {seqlens_per_query.device} does not match "
+            f"q_fp8 device {q_fp8.device}"
+        )
+
+    num_queries, num_heads, _ = q_fp8.shape
+    weights_f = _normalize_weights(weights, q_rows=num_queries, num_heads=num_heads)
+    k_quant, k_scale = _split_index_k_cache_reference(
+        index_k_cache, page_size=page_size
+    )
+    valid_q_rows = int(query_row_to_batch.numel())
+    if valid_q_rows > num_queries:
+        raise ValueError(
+            f"metadata describes {valid_q_rows} query rows, but q_fp8 has {num_queries}"
+        )
+
+    width_tokens = real_page_table.shape[1] * page_size
+    logits_out = torch.full(
+        (num_queries, width_tokens),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    q_fp32 = q_fp8.to(torch.float32)
+    max_page_capacity = k_quant.shape[0]
+    if real_page_table.shape[0] == 0 or max_page_capacity == 0:
+        return logits_out
+
+    token_pos = torch.arange(width_tokens, device=q_fp8.device, dtype=torch.long)
+    page_col = torch.div(token_pos, page_size, rounding_mode="floor")
+    slot_idx = token_pos % page_size
+    neg_inf = torch.full(
+        (width_tokens,), float("-inf"), dtype=torch.float32, device=q_fp8.device
+    )
+    for query_row in range(valid_q_rows):
+        batch_row = query_row_to_batch[query_row].to(torch.long)
+        batch_valid = (batch_row >= 0) & (batch_row < real_page_table.shape[0])
+        safe_batch_row = batch_row.clamp(0, real_page_table.shape[0] - 1).reshape(1)
+        page_ids = real_page_table.index_select(0, safe_batch_row)[0, page_col].to(
+            torch.long
+        )
+        seq_len = (
+            seqlens_per_query[query_row].to(torch.long).clamp(min=0, max=width_tokens)
+        )
+        valid_mask = (
+            batch_valid
+            & (token_pos < seq_len)
+            & (page_ids >= 0)
+            & (page_ids < max_page_capacity)
+        )
+        safe_page_ids = page_ids.clamp(0, max_page_capacity - 1)
+        k_selected = k_quant[safe_page_ids, slot_idx]
+        scale_selected = k_scale[safe_page_ids, slot_idx]
+        score = torch.matmul(q_fp32[query_row], k_selected.transpose(0, 1))
+        logits = (torch.relu(score) * weights_f[query_row].unsqueeze(1)).sum(dim=0)
+        logits_out[query_row].copy_(
+            torch.where(valid_mask, logits * scale_selected, neg_inf)
+        )
+
+    return logits_out
+
+
+def contiguous_logits_reference(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+) -> torch.Tensor:
+    """Return dense ragged logits from the contiguous non-paged contract."""
+
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must be rank-3, got {tuple(q_fp8.shape)}")
+    if q_fp8.shape[2] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"q_fp8 head_dim must be {_INDEX_HEAD_DIM}, got {q_fp8.shape[2]}"
+        )
+    if k_start.ndim != 1 or k_end.ndim != 1:
+        raise ValueError(
+            f"k_start and k_end must be rank-1, got {tuple(k_start.shape)} and {tuple(k_end.shape)}"
+        )
+    if k_start.shape != k_end.shape:
+        raise ValueError(
+            f"k_start and k_end must have the same shape, got {tuple(k_start.shape)} vs {tuple(k_end.shape)}"
+        )
+    if k_start.device != q_fp8.device or k_end.device != q_fp8.device:
+        raise ValueError("k_start and k_end must be on the same device as q_fp8")
+
+    k_quant, k_scale = kv_fp8
+    if k_quant.ndim != 2 or k_quant.shape[1] != _INDEX_HEAD_DIM:
+        raise ValueError(
+            f"k_quant must have shape (K, {_INDEX_HEAD_DIM}), got {tuple(k_quant.shape)}"
+        )
+    if k_scale.ndim == 2 and k_scale.shape[1] == 1:
+        k_scale = k_scale.squeeze(1)
+    if k_scale.ndim != 1 or k_scale.shape[0] != k_quant.shape[0]:
+        raise ValueError(
+            f"k_scale must have shape ({k_quant.shape[0]},), got {tuple(k_scale.shape)}"
+        )
+    if k_quant.device != q_fp8.device or k_scale.device != q_fp8.device:
+        raise ValueError("kv_fp8 tensors must be on the same device as q_fp8")
+    if k_scale.dtype != torch.float32:
+        raise ValueError(f"k_scale must have dtype torch.float32, got {k_scale.dtype}")
+
+    num_queries, num_heads, _ = q_fp8.shape
+    weights_f = _normalize_weights(weights, q_rows=num_queries, num_heads=num_heads)
+    valid_q_rows = int(k_start.numel())
+    if valid_q_rows > num_queries:
+        raise ValueError(
+            f"metadata describes {valid_q_rows} query rows, but q_fp8 has {num_queries}"
+        )
+
+    q_fp32 = q_fp8.to(torch.float32)
+    k_fp32 = k_quant.to(torch.float32)
+    logits_out = torch.full(
+        (num_queries, k_quant.shape[0]),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    if k_quant.shape[0] == 0:
+        return logits_out
+    token_pos = torch.arange(k_quant.shape[0], dtype=torch.long, device=q_fp8.device)
+    for query_row in range(valid_q_rows):
+        ks = k_start[query_row].to(torch.long).clamp(min=0, max=k_quant.shape[0])
+        ke = k_end[query_row].to(torch.long).clamp(min=0, max=k_quant.shape[0])
+        valid_mask = (token_pos >= ks) & (token_pos < ke)
+        score = torch.matmul(q_fp32[query_row], k_fp32.transpose(0, 1))
+        logits = (torch.relu(score) * weights_f[query_row].unsqueeze(1)).sum(dim=0)
+        row_out = torch.where(
+            valid_mask,
+            logits * k_scale,
+            torch.full_like(logits, float("-inf")),
+        )
+        logits_out[query_row].copy_(row_out)
+
+    return logits_out

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/schedule_metadata.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/schedule_metadata.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/schedule_metadata.py @ 16aba799 (2026-05-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Paged-MQA schedule metadata helpers."""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+import torch
+
+
+_MAX_TRITON_BATCH = 256
+_MAX_TRITON_SMS = 512
+
+
+@triton.jit
+def _build_paged_mqa_schedule_triton(
+    context_lens_ptr,
+    schedule_ptr,
+    batch_size,
+    next_n,
+    num_sms,
+    context_lens_row_stride,
+    schedule_row_stride,
+    split_kv,
+    IS_CONTEXT_LENS_2D: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    BLOCK_SMS: tl.constexpr,
+):
+    q_offsets = tl.arange(0, BLOCK_BATCH)
+    if IS_CONTEXT_LENS_2D:
+        lens_ptrs = (
+            context_lens_ptr + q_offsets * context_lens_row_stride + (next_n - 1)
+        )
+    else:
+        lens_ptrs = context_lens_ptr + q_offsets
+
+    q_mask = q_offsets < batch_size
+    context_lens = tl.load(lens_ptrs, mask=q_mask, other=0).to(tl.int32)
+    context_lens = tl.maximum(context_lens, 0)
+    num_segments = (context_lens + split_kv - 1) // split_kv
+    prefix_sum = tl.cumsum(num_segments, axis=0)
+    total_segments = tl.sum(num_segments, axis=0)
+
+    sm_offsets = tl.arange(0, BLOCK_SMS)
+    sm_mask = sm_offsets <= num_sms
+    segments_per_sm = total_segments // num_sms
+    segment_remainder = total_segments % num_sms
+    segment_starts = sm_offsets * segments_per_sm + tl.minimum(
+        sm_offsets, segment_remainder
+    )
+
+    completed_rows = (prefix_sum[None, :] <= segment_starts[:, None]) & q_mask[None, :]
+    q_idx = tl.sum(completed_rows.to(tl.int32), axis=1)
+    prev_q_idx = tl.maximum(q_idx - 1, 0)
+    q_slots = tl.arange(0, BLOCK_BATCH)[None, :]
+    prev_prefix_mask = q_mask[None, :] & (q_slots == prev_q_idx[:, None])
+    prev_prefix_sum = tl.sum(tl.where(prev_prefix_mask, prefix_sum[None, :], 0), axis=1)
+    prev_prefix_sum = tl.where(q_idx > 0, prev_prefix_sum, 0)
+    kv_split_idx = segment_starts - prev_prefix_sum
+
+    tl.store(schedule_ptr + sm_offsets * schedule_row_stride, q_idx, mask=sm_mask)
+    tl.store(
+        schedule_ptr + sm_offsets * schedule_row_stride + 1, kv_split_idx, mask=sm_mask
+    )
+
+
+def supports_triton_paged_mqa_schedule_metadata(
+    context_lens: torch.Tensor,
+    *,
+    num_sms: int,
+) -> bool:
+    if context_lens.device.type != "cuda":
+        return False
+    batch_size = int(context_lens.shape[0]) if context_lens.ndim else 0
+    if batch_size > _MAX_TRITON_BATCH:
+        return False
+    if num_sms <= 0 or num_sms > _MAX_TRITON_SMS:
+        return False
+    return True
+
+
+def build_paged_mqa_schedule_metadata_torch(
+    context_lens: torch.Tensor,
+    *,
+    block_kv: int,
+    num_sms: int,
+    pages_per_split: int,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    schedule_lens = context_lens[:, -1] if context_lens.ndim == 2 else context_lens
+    schedule_lens = schedule_lens.to(torch.int64).clamp_min_(0)
+    if schedule_lens.numel() == 0:
+        out.zero_()
+        return out
+
+    split_kv = int(block_kv) * int(pages_per_split)
+    num_segments = torch.div(
+        schedule_lens + (split_kv - 1), split_kv, rounding_mode="floor"
+    )
+    prefix_sum = torch.cumsum(num_segments, dim=0, dtype=torch.int64)
+    total_segments = prefix_sum[-1]
+
+    sm_indices = torch.arange(
+        num_sms + 1, dtype=torch.int64, device=context_lens.device
+    )
+    segments_per_sm = torch.div(total_segments, num_sms, rounding_mode="floor")
+    segment_remainder = torch.remainder(total_segments, num_sms)
+    segment_starts = sm_indices * segments_per_sm + torch.minimum(
+        sm_indices,
+        segment_remainder.expand_as(sm_indices),
+    )
+    q_idx = torch.searchsorted(prefix_sum, segment_starts, right=True)
+    prev_q_idx = (q_idx - 1).clamp_min_(0)
+    prev_prefix = prefix_sum.gather(0, prev_q_idx.clamp_max_(prefix_sum.shape[0] - 1))
+    prev_prefix = torch.where(q_idx > 0, prev_prefix, torch.zeros_like(prev_prefix))
+    kv_split_idx = segment_starts - prev_prefix
+
+    out[:, 0].copy_(q_idx.to(torch.int32))
+    out[:, 1].copy_(kv_split_idx.to(torch.int32))
+    return out
+
+
+def build_paged_mqa_schedule_metadata_triton(
+    context_lens: torch.Tensor,
+    *,
+    block_kv: int,
+    num_sms: int,
+    pages_per_split: int,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    if not supports_triton_paged_mqa_schedule_metadata(context_lens, num_sms=num_sms):
+        return build_paged_mqa_schedule_metadata_torch(
+            context_lens,
+            block_kv=block_kv,
+            num_sms=num_sms,
+            pages_per_split=pages_per_split,
+            out=out,
+        )
+
+    batch_size = int(context_lens.shape[0])
+    block_batch = max(triton.next_power_of_2(max(batch_size, 1)), 1)
+    block_sms = max(triton.next_power_of_2(num_sms + 1), 1)
+    num_warps = 8 if block_sms > 256 else 4 if block_sms > 128 else 2
+
+    _build_paged_mqa_schedule_triton[(1,)](
+        context_lens,
+        out,
+        batch_size,
+        int(context_lens.shape[1]) if context_lens.ndim == 2 else 0,
+        num_sms,
+        int(context_lens.stride(0)) if context_lens.ndim == 2 else 0,
+        int(out.stride(0)),
+        int(block_kv) * int(pages_per_split),
+        IS_CONTEXT_LENS_2D=context_lens.ndim == 2,
+        BLOCK_BATCH=block_batch,
+        BLOCK_SMS=block_sms,
+        num_warps=num_warps,
+    )
+    return out

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/scratch.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/scratch.py
@@ -1,0 +1,2386 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/scratch.py @ c368a837 (2026-07-14) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Caller-owned scratch plans for indexer paths."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+
+from flashinfer.experimental.sm12x.attention.nsa_indexer._impl import (
+    IndexerContiguousMetadata,
+    IndexerPagedDecodeMetadata,
+)
+from flashinfer.experimental.sm12x.attention.nsa_indexer.msa_reference import (
+    MSA_BLOCK_TOKENS,
+)
+from flashinfer.experimental.sm12x._lib.scratch_layout import (
+    SCRATCH_ALIGN_BYTES,
+    align_up,
+    dtype_nbytes,
+    materialize_scratch_view,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+_PAGED_INDEX_SUPERTILE_K_ENV = "FLASHINFER_EXP_SM12X_PAGED_INDEX_SUPERTILE_K"
+_PAGED_INDEX_SUPERTILE_K_DEFAULT = 32768
+_PAGED_INDEX_TILE_BLOCK_Q = 32
+_PAGED_INDEX_TILE_BLOCK_K = 512
+_PAGED_INDEX_HEAD_DIM = 128
+_INDEXER_CONTIGUOUS_BLOCK_Q = 32
+_INDEXER_CONTIGUOUS_PREFILL_BLOCK_K = 256
+_INDEXER_CONTIGUOUS_DECODE_BLOCK_K = 64
+_INDEXER_CONTIGUOUS_HEAD_DIM = 128
+_INDEXER_CONTIGUOUS_SCALE_BYTES = 4
+_INDEXER_CONTIGUOUS_TMA_DESC_WORDS = 16
+INDEXER_PAGED_ROUTE_AUTO = "auto"
+INDEXER_PAGED_ROUTE_FUSED = "paged_fused"
+INDEXER_PAGED_ROUTE_TILED = "paged_tiled"
+INDEXER_PAGED_ROUTE_PACKED_CONTIGUOUS = "packed_contiguous"
+INDEXER_SOURCE_LAYOUT_PAGED = "paged"
+INDEXER_SOURCE_LAYOUT_CONTIGUOUS = "contiguous"
+_INDEXER_PAGED_ROUTES = frozenset(
+    {
+        INDEXER_PAGED_ROUTE_AUTO,
+        INDEXER_PAGED_ROUTE_FUSED,
+        INDEXER_PAGED_ROUTE_TILED,
+        INDEXER_PAGED_ROUTE_PACKED_CONTIGUOUS,
+    }
+)
+_INDEXER_SOURCE_LAYOUTS = frozenset(
+    {
+        INDEXER_SOURCE_LAYOUT_PAGED,
+        INDEXER_SOURCE_LAYOUT_CONTIGUOUS,
+    }
+)
+
+
+class SM12XIndexerTopKPositionBufferUnavailable(RuntimeError):
+    """Raised when scratch does not reserve reusable top-k merge positions."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XIndexerScratchCaps:
+    """Production-facing capacity inputs for indexer scratch planning.
+
+    `source_layout` describes the caller's K-cache contract, not the scratch
+    implementation. For paged sources, row/page capacities are measured in
+    indexer K-cache rows. C4 callers should therefore pass one K row per four
+    model-context tokens.
+    """
+
+    device: torch.device | str
+    source_layout: str
+    num_q_heads: int
+    max_q_rows: int
+    topk: int
+    mode: str = "decode"
+    max_k_rows: int | None = None
+    max_page_table_width: int | None = None
+    page_size: int = 64
+    supertile_k: int = 0
+    shared_page_table: bool = False
+    dtype: torch.dtype = torch.bfloat16
+    kv_dtype: torch.dtype = torch.uint8
+    k_dtype: torch.dtype = torch.float8_e4m3fn
+    max_batch: int | None = None
+    reserve_paged_logits: bool = False
+    paged_logits_k_rows: int = 0
+    route: str = INDEXER_PAGED_ROUTE_AUTO
+    prefill_block_k: int = _INDEXER_CONTIGUOUS_PREFILL_BLOCK_K
+    score_mode: str = "nsa"
+    num_idx_heads: int = 1
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+
+        source_layout = str(self.source_layout)
+        if source_layout not in _INDEXER_SOURCE_LAYOUTS:
+            raise ValueError(
+                "indexer source_layout must be one of "
+                f"{sorted(_INDEXER_SOURCE_LAYOUTS)}, got {source_layout!r}"
+            )
+        object.__setattr__(self, "source_layout", source_layout)
+
+        mode = str(self.mode)
+        if mode not in ("decode", "prefill"):
+            raise ValueError(
+                f"indexer scratch mode must be decode or prefill, got {mode!r}"
+            )
+        object.__setattr__(self, "mode", mode)
+
+        route = str(self.route)
+        if route not in _INDEXER_PAGED_ROUTES:
+            raise ValueError(
+                "indexer route must be one of "
+                f"{sorted(_INDEXER_PAGED_ROUTES)}, got {route!r}"
+            )
+        object.__setattr__(self, "route", route)
+        score_mode = str(self.score_mode).lower()
+        if score_mode not in ("nsa", "msa"):
+            raise ValueError(
+                f"indexer scratch score_mode must be nsa or msa, got {score_mode!r}"
+            )
+        object.__setattr__(self, "score_mode", score_mode)
+
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "num_idx_heads", max(int(self.num_idx_heads), 1))
+        object.__setattr__(self, "max_q_rows", max(int(self.max_q_rows), 1))
+        object.__setattr__(self, "topk", max(int(self.topk), 1))
+        object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+        object.__setattr__(self, "supertile_k", max(int(self.supertile_k), 0))
+        object.__setattr__(self, "shared_page_table", bool(self.shared_page_table))
+        object.__setattr__(
+            self, "reserve_paged_logits", bool(self.reserve_paged_logits)
+        )
+        object.__setattr__(
+            self, "paged_logits_k_rows", max(int(self.paged_logits_k_rows), 0)
+        )
+        object.__setattr__(self, "prefill_block_k", max(int(self.prefill_block_k), 1))
+        max_batch = self.max_q_rows if self.max_batch is None else self.max_batch
+        object.__setattr__(self, "max_batch", max(int(max_batch), 1))
+
+        max_k_rows = None if self.max_k_rows is None else max(int(self.max_k_rows), 1)
+        max_page_table_width = (
+            None
+            if self.max_page_table_width is None
+            else max(int(self.max_page_table_width), 1)
+        )
+        if source_layout == INDEXER_SOURCE_LAYOUT_PAGED:
+            if max_page_table_width is None:
+                if max_k_rows is None:
+                    raise ValueError(
+                        "paged indexer scratch planning requires max_page_table_width "
+                        "or max_k_rows"
+                    )
+                max_page_table_width = (max_k_rows + int(self.page_size) - 1) // int(
+                    self.page_size
+                )
+            object.__setattr__(self, "max_page_table_width", max_page_table_width)
+            object.__setattr__(self, "max_k_rows", max_k_rows)
+        else:
+            if max_k_rows is None:
+                raise ValueError(
+                    "contiguous indexer scratch planning requires max_k_rows"
+                )
+            object.__setattr__(self, "max_k_rows", max_k_rows)
+            object.__setattr__(self, "max_page_table_width", max_page_table_width)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XIndexerPagedScratchCaps:
+    """Capacity inputs for the paged indexer scratch planner.
+
+    `max_page_table_width` and `paged_tile_logits_k_rows` are measured in
+    indexer K-cache rows/pages, not original model-context tokens. For compressed
+    sources such as C4, callers must pass the compressed K-row capacity.
+    """
+
+    device: torch.device | str
+    num_q_heads: int
+    max_q_rows: int
+    max_page_table_width: int
+    topk: int
+    dtype: torch.dtype = torch.bfloat16
+    kv_dtype: torch.dtype = torch.uint8
+    max_batch: int | None = None
+    page_size: int = 64
+    max_k_rows: int = 0
+    reserve_paged_logits: bool = True
+    paged_logits_k_rows: int = 0
+    paged_tile_logits_k_rows: int = 0
+    mode: str = "decode"
+    shared_page_table: bool = False
+    route: str = INDEXER_PAGED_ROUTE_AUTO
+    score_mode: str = "nsa"
+    num_idx_heads: int = 1
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "num_idx_heads", max(int(self.num_idx_heads), 1))
+        object.__setattr__(self, "max_q_rows", max(int(self.max_q_rows), 1))
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            max(int(self.max_page_table_width), 1),
+        )
+        object.__setattr__(self, "topk", max(int(self.topk), 1))
+        max_batch = self.max_q_rows if self.max_batch is None else self.max_batch
+        object.__setattr__(self, "max_batch", max(int(max_batch), 1))
+        object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+        object.__setattr__(self, "max_k_rows", max(int(self.max_k_rows), 0))
+        object.__setattr__(
+            self, "reserve_paged_logits", bool(self.reserve_paged_logits)
+        )
+        object.__setattr__(
+            self, "paged_logits_k_rows", max(int(self.paged_logits_k_rows), 0)
+        )
+        object.__setattr__(
+            self,
+            "paged_tile_logits_k_rows",
+            max(int(self.paged_tile_logits_k_rows), 0),
+        )
+        mode = str(self.mode)
+        if mode not in ("decode", "prefill"):
+            raise ValueError(
+                f"indexer paged scratch mode must be decode or prefill, got {mode!r}"
+            )
+        route = str(self.route)
+        if route not in _INDEXER_PAGED_ROUTES:
+            raise ValueError(
+                "indexer paged scratch route must be one of "
+                f"{sorted(_INDEXER_PAGED_ROUTES)}, got {route!r}"
+            )
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "shared_page_table", bool(self.shared_page_table))
+        object.__setattr__(self, "route", route)
+        score_mode = str(self.score_mode).lower()
+        if score_mode not in ("nsa", "msa"):
+            raise ValueError(
+                f"indexer paged scratch score_mode must be nsa or msa, got {score_mode!r}"
+            )
+        object.__setattr__(self, "score_mode", score_mode)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XIndexerContiguousScratchCaps:
+    device: torch.device | str
+    num_q_heads: int
+    max_q_rows: int
+    max_k_rows: int
+    topk: int
+    k_dtype: torch.dtype = torch.float8_e4m3fn
+    supertile_k: int = 32768
+    prefill_block_k: int = _INDEXER_CONTIGUOUS_PREFILL_BLOCK_K
+    score_mode: str = "nsa"
+    num_idx_heads: int = 1
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "num_idx_heads", max(int(self.num_idx_heads), 1))
+        object.__setattr__(self, "max_q_rows", max(int(self.max_q_rows), 1))
+        max_k_rows = max(int(self.max_k_rows), 1)
+        max_k_rows = (
+            (max_k_rows + _INDEXER_CONTIGUOUS_DECODE_BLOCK_K - 1)
+            // _INDEXER_CONTIGUOUS_DECODE_BLOCK_K
+        ) * _INDEXER_CONTIGUOUS_DECODE_BLOCK_K
+        object.__setattr__(self, "max_k_rows", max_k_rows)
+        object.__setattr__(self, "topk", max(int(self.topk), 1))
+        supertile_k = max(int(self.supertile_k), int(self.prefill_block_k), 1)
+        prefill_block_k = int(self.prefill_block_k)
+        if prefill_block_k != _INDEXER_CONTIGUOUS_PREFILL_BLOCK_K:
+            raise ValueError(
+                "indexer contiguous scratch currently supports "
+                f"prefill_block_k={_INDEXER_CONTIGUOUS_PREFILL_BLOCK_K}, got "
+                f"{prefill_block_k}"
+            )
+        supertile_k = (
+            (supertile_k + prefill_block_k - 1) // prefill_block_k
+        ) * prefill_block_k
+        object.__setattr__(self, "supertile_k", supertile_k)
+        object.__setattr__(self, "prefill_block_k", prefill_block_k)
+        score_mode = str(self.score_mode).lower()
+        if score_mode not in ("nsa", "msa"):
+            raise ValueError(
+                f"indexer contiguous scratch score_mode must be nsa or msa, got {score_mode!r}"
+            )
+        object.__setattr__(self, "score_mode", score_mode)
+
+
+@dataclass(frozen=True, kw_only=True)
+class _SM12XIndexerPagedScratchLayout:
+    nbytes: int
+    supertile_tokens: int
+    max_chunks: int
+    route: str
+    prefill_block_k: int | None
+    tile_logits_elements: int
+    gather_k_rows: int
+    fused_pack_elements: int
+    fused_state_words: int
+    gather_k_quant_offset_bytes: int
+    gather_k_scale_offset_bytes: int
+    contiguous_lengths_offset_bytes: int
+    runtime_lengths_offset_bytes: int
+    tile_logits_offset_bytes: int
+    topk_values_offset_bytes: int
+    topk_indices_offset_bytes: int
+    candidate_values_offset_bytes: int
+    candidate_indices_offset_bytes: int
+    merge_positions_offset_bytes: int
+    active_width_offset_bytes: int
+    fused_pack_values_offset_bytes: int
+    fused_pack_indices_offset_bytes: int
+    fused_merge_state_offset_bytes: int
+    msa_page_scores_offset_bytes: int
+    msa_block_scores_offset_bytes: int
+    msa_q2k_indices_offset_bytes: int
+    msa_topk_score_scratch_offset_bytes: int
+    msa_topk_values_offset_bytes: int
+    msa_topk_indices_offset_bytes: int
+    msa_sort_values_offset_bytes: int
+    msa_sort_indices_offset_bytes: int
+    msa_expanded_page_table_offset_bytes: int
+    msa_expanded_seqlens_offset_bytes: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class _SM12XIndexerContiguousScratchLayout:
+    nbytes: int
+    max_k_rows: int
+    max_chunk_tiles: int
+    tile_logits_elements: int
+    k_quant_offset_bytes: int
+    k_scale_offset_bytes: int
+    dummy_logits_offset_bytes: int
+    tile_logits_offset_bytes: int
+    lengths_offset_bytes: int
+    topk_values_offset_bytes: int
+    topk_indices_offset_bytes: int
+    candidate_values_offset_bytes: int
+    candidate_indices_offset_bytes: int
+    metadata_k_start_offset_bytes: int
+    metadata_k_end_offset_bytes: int
+    k_tma_desc_offset_bytes: int
+    k_tma_desc_ptrs_offset_bytes: int
+    k_tma_prefill_desc_offset_bytes: int
+    k_tma_prefill_desc_ptrs_offset_bytes: int
+    msa_block_scores_offset_bytes: int
+    msa_q2k_indices_offset_bytes: int
+    msa_topk_score_scratch_offset_bytes: int
+    msa_topk_values_offset_bytes: int
+    msa_topk_indices_offset_bytes: int
+    msa_sort_values_offset_bytes: int
+    msa_sort_indices_offset_bytes: int
+
+
+@dataclass(kw_only=True)
+class SM12XIndexerPagedScratch:
+    """Paged indexer scratch views over caller-owned storage."""
+
+    shared_scratch: torch.Tensor
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    topk: int
+    max_page_table_width: int
+    max_total_q: int
+    max_paged_q_rows: int
+    max_batch: int
+    page_size: int
+    paged_tile_logits_k_rows: int
+    max_chunks: int
+    route: str
+    shared_page_table: bool = False
+    prefill_block_k: int | None = None
+    fixed_capacity: bool = True
+    use_cuda_graph: bool = False
+    indexer_k_quant_bytes: torch.Tensor | None = None
+    indexer_k_scales_bytes: torch.Tensor | None = None
+    indexer_contiguous_lengths: torch.Tensor | None = None
+    paged_indexer_runtime_lengths: torch.Tensor | None = None
+    indexer_contiguous_tile_logits: torch.Tensor | None = None
+    indexer_contiguous_topk_values: torch.Tensor | None = None
+    indexer_contiguous_topk_indices: torch.Tensor | None = None
+    indexer_contiguous_candidate_values: torch.Tensor | None = None
+    indexer_contiguous_candidate_indices: torch.Tensor | None = None
+    indexer_contiguous_topk_positions: torch.Tensor | None = None
+    paged_indexer_active_width_cap: torch.Tensor | None = None
+    fused_indexer_pack_values: torch.Tensor | None = None
+    fused_indexer_pack_indices: torch.Tensor | None = None
+    fused_indexer_merge_state: torch.Tensor | None = None
+    fused_indexer_merge_state_preinitialized: bool = False
+    msa_page_scores: torch.Tensor | None = None
+    msa_block_scores: torch.Tensor | None = None
+    msa_q2k_indices: torch.Tensor | None = None
+    msa_topk_score_scratch: torch.Tensor | None = None
+    msa_topk_values: torch.Tensor | None = None
+    msa_topk_indices: torch.Tensor | None = None
+    msa_sort_values: torch.Tensor | None = None
+    msa_sort_indices: torch.Tensor | None = None
+    msa_expanded_page_table: torch.Tensor | None = None
+    msa_expanded_seqlens: torch.Tensor | None = None
+
+    def bind(
+        self,
+        *,
+        real_page_table: torch.Tensor,
+        cache_seqlens_int32: torch.Tensor,
+        active_width: torch.Tensor | None = None,
+        schedule_metadata: torch.Tensor | None = None,
+        expected_num_q_heads: int | None = None,
+        shared_page_table: bool | None = None,
+        output_physical_slots: bool = False,
+    ) -> "SM12XIndexerPagedBinding":
+        if shared_page_table is None:
+            shared_page_table = bool(self.shared_page_table)
+        return build_indexer_paged_binding(
+            scratch=self,
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            active_width=active_width,
+            schedule_metadata=schedule_metadata,
+            expected_num_q_heads=expected_num_q_heads,
+            shared_page_table=shared_page_table,
+            output_physical_slots=output_physical_slots,
+        )
+
+    def bind_msa(
+        self,
+        *,
+        real_page_table: torch.Tensor,
+        cache_seqlens_int32: torch.Tensor,
+        active_width: torch.Tensor | None = None,
+        schedule_metadata: torch.Tensor | None = None,
+        topk: int | None = None,
+    ) -> "SM12XIndexerMSAPagedBinding":
+        return build_indexer_msa_paged_binding(
+            scratch=self,
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            active_width=active_width,
+            schedule_metadata=schedule_metadata,
+            topk=topk,
+        )
+
+    def get_indexer_contiguous_tile_logits(self) -> torch.Tensor:
+        if self.indexer_contiguous_tile_logits is None:
+            raise RuntimeError("paged indexer scratch is missing tiled logits")
+        return self.indexer_contiguous_tile_logits
+
+    def get_indexer_contiguous_topk_buffers(
+        self,
+        *,
+        row_count: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if (
+            self.indexer_contiguous_topk_values is None
+            or self.indexer_contiguous_topk_indices is None
+        ):
+            raise RuntimeError("paged indexer scratch is missing top-k buffers")
+        row_count = int(row_count)
+        if row_count < 0:
+            raise ValueError(f"row_count must be non-negative, got {row_count}")
+        if row_count > int(self.indexer_contiguous_topk_indices.shape[0]):
+            raise ValueError(
+                "row_count "
+                f"{row_count} exceeds paged indexer scratch top-k capacity "
+                f"{int(self.indexer_contiguous_topk_indices.shape[0])}"
+            )
+        return (
+            self.indexer_contiguous_topk_values[:row_count],
+            self.indexer_contiguous_topk_indices[:row_count],
+        )
+
+    def get_indexer_contiguous_candidate_buffers(
+        self,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if (
+            self.indexer_contiguous_candidate_values is None
+            or self.indexer_contiguous_candidate_indices is None
+        ):
+            raise RuntimeError("paged indexer scratch is missing candidate buffers")
+        return (
+            self.indexer_contiguous_candidate_values,
+            self.indexer_contiguous_candidate_indices,
+        )
+
+    def get_indexer_contiguous_topk_position_buffer(
+        self, *, row_count: int
+    ) -> torch.Tensor:
+        if self.indexer_contiguous_topk_positions is None:
+            raise SM12XIndexerTopKPositionBufferUnavailable(
+                "paged indexer scratch is missing top-k position buffer"
+            )
+        row_count = int(row_count)
+        if row_count < 0:
+            raise ValueError(f"row_count must be non-negative, got {row_count}")
+        if row_count > int(self.indexer_contiguous_topk_positions.shape[0]):
+            raise ValueError(
+                "row_count "
+                f"{row_count} exceeds paged indexer scratch position capacity "
+                f"{int(self.indexer_contiguous_topk_positions.shape[0])}"
+            )
+        return self.indexer_contiguous_topk_positions[:row_count]
+
+    def get_paged_indexer_active_width_cap(self) -> torch.Tensor:
+        if self.paged_indexer_active_width_cap is None:
+            raise RuntimeError("paged indexer scratch is missing active-width cap")
+        return self.paged_indexer_active_width_cap
+
+    def get_fused_indexer_scratch(
+        self,
+        *,
+        topk: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        topk = int(topk)
+        if topk <= 0 or topk > int(self.topk):
+            raise ValueError(
+                f"fused indexer topk must be in [1, {int(self.topk)}], got {topk}"
+            )
+        if (
+            self.fused_indexer_pack_values is None
+            or self.fused_indexer_pack_indices is None
+            or self.fused_indexer_merge_state is None
+        ):
+            raise RuntimeError("paged indexer scratch is missing fused buffers")
+        return (
+            self.fused_indexer_pack_values,
+            self.fused_indexer_pack_indices,
+            self.fused_indexer_merge_state,
+        )
+
+    def get_indexer_gather_outputs(
+        self,
+        *,
+        row_count: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.indexer_k_quant_bytes is None or self.indexer_k_scales_bytes is None:
+            raise RuntimeError(
+                "paged indexer scratch is missing packed-contiguous gather buffers"
+            )
+        row_count = int(row_count)
+        if row_count < 0:
+            raise ValueError(f"row_count must be non-negative, got {row_count}")
+        if row_count > int(self.indexer_k_quant_bytes.shape[0]):
+            raise ValueError(
+                f"row_count {row_count} exceeds paged indexer gather capacity "
+                f"{int(self.indexer_k_quant_bytes.shape[0])}"
+            )
+        return (
+            self.indexer_k_quant_bytes[:row_count],
+            self.indexer_k_scales_bytes[:row_count],
+        )
+
+    def get_indexer_contiguous_lengths(self, *, row_count: int) -> torch.Tensor:
+        if self.indexer_contiguous_lengths is None:
+            raise RuntimeError(
+                "paged indexer scratch is missing packed-contiguous k_start"
+            )
+        row_count = int(row_count)
+        if row_count < 0:
+            raise ValueError(f"row_count must be non-negative, got {row_count}")
+        if row_count > int(self.indexer_contiguous_lengths.shape[0]):
+            raise ValueError(
+                f"row_count {row_count} exceeds paged indexer metadata capacity "
+                f"{int(self.indexer_contiguous_lengths.shape[0])}"
+            )
+        return self.indexer_contiguous_lengths[:row_count]
+
+    def get_paged_indexer_runtime_lengths(self, *, row_count: int) -> torch.Tensor:
+        if self.paged_indexer_runtime_lengths is None:
+            raise RuntimeError(
+                "paged indexer scratch is missing packed-contiguous k_end"
+            )
+        row_count = int(row_count)
+        if row_count < 0:
+            raise ValueError(f"row_count must be non-negative, got {row_count}")
+        if row_count > int(self.paged_indexer_runtime_lengths.shape[0]):
+            raise ValueError(
+                f"row_count {row_count} exceeds paged indexer metadata capacity "
+                f"{int(self.paged_indexer_runtime_lengths.shape[0])}"
+            )
+        return self.paged_indexer_runtime_lengths[:row_count]
+
+
+@dataclass(kw_only=True)
+class SM12XIndexerContiguousScratch:
+    """Contiguous-indexer scratch views over caller-owned storage."""
+
+    shared_scratch: torch.Tensor
+    device: torch.device
+    num_q_heads: int
+    max_q_rows: int
+    max_k_rows: int
+    topk: int
+    supertile_k: int
+    prefill_block_k: int
+    k_quant: torch.Tensor
+    k_scale_bytes: torch.Tensor
+    k_scale: torch.Tensor
+    dummy_logits: torch.Tensor
+    tile_logits: torch.Tensor
+    lengths: torch.Tensor
+    topk_values: torch.Tensor
+    topk_indices: torch.Tensor
+    candidate_values: torch.Tensor
+    candidate_indices: torch.Tensor
+    metadata_k_start: torch.Tensor
+    metadata_k_end: torch.Tensor
+    k_tma_desc_ptrs: torch.Tensor
+    k_tma_prefill_desc_ptrs: torch.Tensor
+    msa_block_scores: torch.Tensor | None = None
+    msa_q2k_indices: torch.Tensor | None = None
+    msa_topk_score_scratch: torch.Tensor | None = None
+    msa_topk_values: torch.Tensor | None = None
+    msa_topk_indices: torch.Tensor | None = None
+    msa_sort_values: torch.Tensor | None = None
+    msa_sort_indices: torch.Tensor | None = None
+
+    def prepare_k_padding(self, *, k_rows: int) -> None:
+        k_rows = int(k_rows)
+        if k_rows < 0:
+            raise ValueError(f"k_rows must be non-negative, got {k_rows}")
+        if k_rows > int(self.max_k_rows):
+            raise ValueError(
+                f"k_rows {k_rows} exceed contiguous scratch capacity {self.max_k_rows}"
+            )
+        padded_rows = (
+            (max(k_rows, 1) + int(self.prefill_block_k) - 1)
+            // int(self.prefill_block_k)
+        ) * int(self.prefill_block_k)
+        padded_rows = min(padded_rows, int(self.max_k_rows))
+        if padded_rows > k_rows:
+            self.k_quant[k_rows:padded_rows].zero_()
+            self.k_scale_bytes[k_rows:padded_rows].zero_()
+
+    def bind_msa(
+        self,
+        *,
+        k_start: torch.Tensor,
+        k_end: torch.Tensor,
+        topk: int | None = None,
+    ) -> "SM12XIndexerMSAContiguousBinding":
+        return build_indexer_msa_contiguous_binding(
+            scratch=self,
+            k_start=k_start,
+            k_end=k_end,
+            topk=topk,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XIndexerPagedBinding:
+    scratch: object
+    metadata: IndexerPagedDecodeMetadata
+    real_page_table: torch.Tensor
+    cache_seqlens_int32: torch.Tensor
+    active_width: torch.Tensor
+    schedule_metadata: torch.Tensor | None = None
+    expected_num_q_heads: int | None = None
+    shared_page_table: bool = False
+    output_physical_slots: bool = False
+    route: str = INDEXER_PAGED_ROUTE_TILED
+    supertile_k: int | None = None
+    prefill_block_k: int | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XIndexerContiguousBinding:
+    scratch: object
+    metadata: IndexerContiguousMetadata
+    topk: int | None = None
+    tile_logits: torch.Tensor | None = None
+    lengths: torch.Tensor | None = None
+    output_values: torch.Tensor | None = None
+    output_indices: torch.Tensor | None = None
+    candidate_values: torch.Tensor | None = None
+    candidate_indices: torch.Tensor | None = None
+    merge_positions: torch.Tensor | None = None
+    prefill_block_k: int | None = None
+    supertile_k: int | None = None
+    strict: bool = False
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XIndexerMSAPagedBinding:
+    scratch: object
+    metadata: IndexerPagedDecodeMetadata
+    real_page_table: torch.Tensor
+    cache_seqlens_int32: torch.Tensor
+    active_width: torch.Tensor
+    schedule_metadata: torch.Tensor | None = None
+    page_scores: torch.Tensor | None = None
+    block_scores: torch.Tensor | None = None
+    q2k_indices: torch.Tensor | None = None
+    topk_score_scratch: torch.Tensor | None = None
+    topk_values: torch.Tensor | None = None
+    topk_indices: torch.Tensor | None = None
+    sort_values: torch.Tensor | None = None
+    sort_indices: torch.Tensor | None = None
+    expanded_page_table: torch.Tensor | None = None
+    expanded_seqlens: torch.Tensor | None = None
+    topk: int | None = None
+    num_idx_heads: int | None = None
+    strict: bool = True
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XIndexerMSAContiguousBinding:
+    scratch: object
+    metadata: IndexerContiguousMetadata
+    block_scores: torch.Tensor | None = None
+    q2k_indices: torch.Tensor | None = None
+    topk_score_scratch: torch.Tensor | None = None
+    topk_values: torch.Tensor | None = None
+    topk_indices: torch.Tensor | None = None
+    sort_values: torch.Tensor | None = None
+    sort_indices: torch.Tensor | None = None
+    topk: int | None = None
+    num_idx_heads: int | None = None
+    strict: bool = True
+
+
+def _resolve_indexer_paged_supertile_tokens(
+    raw_tokens: int,
+    *,
+    capacity_tokens: int | None = None,
+) -> int:
+    use_capacity_default = False
+    if int(raw_tokens) <= 0:
+        raw = os.environ.get(_PAGED_INDEX_SUPERTILE_K_ENV)
+        if raw is None:
+            raw_tokens = _PAGED_INDEX_SUPERTILE_K_DEFAULT
+            use_capacity_default = True
+        else:
+            try:
+                raw_tokens = int(raw)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{_PAGED_INDEX_SUPERTILE_K_ENV} must be an integer, got {raw!r}"
+                ) from exc
+    tokens = max(int(raw_tokens), _PAGED_INDEX_TILE_BLOCK_K)
+    tokens = (
+        (tokens + _PAGED_INDEX_TILE_BLOCK_K - 1) // _PAGED_INDEX_TILE_BLOCK_K
+    ) * _PAGED_INDEX_TILE_BLOCK_K
+    # The default is a chunk-size ceiling, not a request to reserve beyond the
+    # caller's fixed cache capacity. Keeping the explicit argument and env knob
+    # authoritative preserves tuning/debug behavior while making the normal
+    # vLLM plan proportional to its configured page-table width.
+    if use_capacity_default and capacity_tokens is not None:
+        capacity = max(int(capacity_tokens), 1)
+        capacity = (
+            (capacity + _PAGED_INDEX_TILE_BLOCK_K - 1) // _PAGED_INDEX_TILE_BLOCK_K
+        ) * _PAGED_INDEX_TILE_BLOCK_K
+        tokens = min(tokens, max(capacity, _PAGED_INDEX_TILE_BLOCK_K))
+    return tokens
+
+
+def _resolve_indexer_paged_route(
+    caps: SM12XIndexerPagedScratchCaps,
+    *,
+    supertile_tokens: int,
+) -> tuple[str, int | None]:
+    route = str(caps.route)
+    prefill_block_k: int | None = None
+    device = torch.device(caps.device)
+    compute_capability: tuple[int, int] | None = None
+    if device.type == "cuda":
+        props = torch.cuda.get_device_properties(device)
+        compute_capability = (int(props.major), int(props.minor))
+    if route == INDEXER_PAGED_ROUTE_AUTO:
+        if bool(caps.shared_page_table) or str(caps.mode) == "prefill":
+            route = INDEXER_PAGED_ROUTE_PACKED_CONTIGUOUS
+        else:
+            route = INDEXER_PAGED_ROUTE_TILED
+            if os.getenv("FLASHINFER_EXP_SM12X_FUSED_INDEXER", "1") != "0":
+                from flashinfer.experimental.sm12x.attention.nsa_indexer.fused_indexer import (
+                    resolve_fused_indexer_path,
+                )
+                from flashinfer.experimental.sm12x.attention.nsa_indexer.kernel import (
+                    _num_q_head_tiles,
+                )
+
+                width = int(caps.max_page_table_width) * int(caps.page_size)
+                if resolve_fused_indexer_path(
+                    topk=int(caps.topk),
+                    num_rows=int(caps.max_q_rows),
+                    width=int(width),
+                    num_heads=int(caps.num_q_heads),
+                    compute_capability=compute_capability,
+                ) and _num_q_head_tiles(int(caps.num_q_heads)) in (1, 2, 4):
+                    route = INDEXER_PAGED_ROUTE_FUSED
+    if route == INDEXER_PAGED_ROUTE_PACKED_CONTIGUOUS:
+        from flashinfer.experimental.sm12x.attention.nsa_indexer.contiguous_kernel import (
+            resolve_contiguous_prefill_block_k,
+        )
+
+        prefill_block_k = resolve_contiguous_prefill_block_k(
+            valid_q_rows=int(caps.max_q_rows),
+            k_rows=int(supertile_tokens),
+            num_heads=int(caps.num_q_heads),
+        )
+        if prefill_block_k is None:
+            prefill_block_k = _INDEXER_CONTIGUOUS_PREFILL_BLOCK_K
+        if int(supertile_tokens) % int(prefill_block_k) != 0:
+            raise ValueError(
+                "packed-contiguous paged indexer route requires supertile_tokens "
+                f"divisible by prefill_block_k, got supertile_tokens={supertile_tokens}, "
+                f"prefill_block_k={prefill_block_k}"
+            )
+    elif route == INDEXER_PAGED_ROUTE_FUSED:
+        if bool(caps.shared_page_table) or str(caps.mode) == "prefill":
+            raise ValueError("fused paged indexer route is decode-only")
+        from flashinfer.experimental.sm12x.attention.nsa_indexer.fused_indexer import (
+            resolve_fused_indexer_path,
+        )
+        from flashinfer.experimental.sm12x.attention.nsa_indexer.kernel import (
+            _num_q_head_tiles,
+        )
+
+        width = int(caps.max_page_table_width) * int(caps.page_size)
+        if not (
+            os.getenv("FLASHINFER_EXP_SM12X_FUSED_INDEXER", "1") != "0"
+            and resolve_fused_indexer_path(
+                topk=int(caps.topk),
+                num_rows=int(caps.max_q_rows),
+                width=int(width),
+                num_heads=int(caps.num_q_heads),
+                compute_capability=compute_capability,
+            )
+            and _num_q_head_tiles(int(caps.num_q_heads)) in (1, 2, 4)
+        ):
+            raise ValueError(
+                "fused paged indexer route is not available for the planned caps: "
+                f"max_q_rows={int(caps.max_q_rows)}, topk={int(caps.topk)}, "
+                f"width={width}, num_q_heads={int(caps.num_q_heads)}"
+            )
+    elif route != INDEXER_PAGED_ROUTE_TILED:
+        raise ValueError(f"unsupported indexer paged route {route!r}")
+    return route, prefill_block_k
+
+
+def _indexer_paged_scratch_layout(
+    caps: SM12XIndexerPagedScratchCaps,
+) -> _SM12XIndexerPagedScratchLayout:
+    max_q_rows = max(int(caps.max_q_rows), 1)
+    page_size = max(int(caps.page_size), 1)
+    supertile_tokens = _resolve_indexer_paged_supertile_tokens(
+        int(caps.paged_tile_logits_k_rows),
+        capacity_tokens=int(caps.max_page_table_width) * page_size,
+    )
+    if supertile_tokens % page_size != 0:
+        raise ValueError(
+            "paged indexer supertile width must be divisible by page_size, "
+            f"got supertile_tokens={supertile_tokens}, page_size={page_size}"
+        )
+    route, prefill_block_k = _resolve_indexer_paged_route(
+        caps,
+        supertile_tokens=supertile_tokens,
+    )
+    supertile_pages = max(1, supertile_tokens // page_size)
+    max_chunks = max(
+        1,
+        (int(caps.max_page_table_width) + supertile_pages - 1) // supertile_pages,
+    )
+    num_q_tiles = (
+        max_q_rows + _PAGED_INDEX_TILE_BLOCK_Q - 1
+    ) // _PAGED_INDEX_TILE_BLOCK_Q
+    num_k_tiles = supertile_tokens // _PAGED_INDEX_TILE_BLOCK_K
+    tile_logits_elements = max(
+        1,
+        num_q_tiles
+        * num_k_tiles
+        * _PAGED_INDEX_TILE_BLOCK_Q
+        * _PAGED_INDEX_TILE_BLOCK_K,
+    )
+    device = torch.device(caps.device)
+    if device.type == "cuda":
+        num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    else:
+        num_sms = 1
+    fused_pack_elements = 0
+    fused_state_words = 0
+    if route == INDEXER_PAGED_ROUTE_FUSED:
+        from flashinfer.experimental.sm12x.attention.nsa_indexer.fused_indexer import (
+            fused_indexer_scratch_capacity,
+        )
+
+        fused_pack_elements, fused_state_words = fused_indexer_scratch_capacity(
+            max_q_rows,
+            int(caps.topk),
+            int(num_sms),
+        )
+    gather_k_rows = (
+        int(supertile_tokens) if route == INDEXER_PAGED_ROUTE_PACKED_CONTIGUOUS else 0
+    )
+
+    cursor = 0
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+    gather_k_quant_offset_bytes = cursor
+    cursor += gather_k_rows * _PAGED_INDEX_HEAD_DIM * dtype_nbytes(torch.uint8)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    gather_k_scale_offset_bytes = cursor
+    cursor += (
+        gather_k_rows * _INDEXER_CONTIGUOUS_SCALE_BYTES * dtype_nbytes(torch.uint8)
+    )
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    contiguous_lengths_offset_bytes = cursor
+    cursor += max_q_rows * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    runtime_lengths_offset_bytes = cursor
+    cursor += max_q_rows * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+    tile_logits_offset_bytes = cursor
+    cursor += tile_logits_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    topk_values_offset_bytes = cursor
+    cursor += max_q_rows * int(caps.topk) * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    topk_indices_offset_bytes = cursor
+    cursor += max_q_rows * int(caps.topk) * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    # Streaming-fold carry double-buffer: two (M, topk) halves ping-pong across
+    # supertile chunks (replaces the old max_chunks-deep candidate slab and the
+    # merge_positions buffer, both of which the merge step required).
+    fold_carry_chunks = 2 if int(max_chunks) > 1 else 0
+
+    candidate_values_offset_bytes = cursor
+    cursor += (
+        fold_carry_chunks * max_q_rows * int(caps.topk) * dtype_nbytes(torch.float32)
+    )
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    candidate_indices_offset_bytes = cursor
+    cursor += (
+        fold_carry_chunks * max_q_rows * int(caps.topk) * dtype_nbytes(torch.int32)
+    )
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    # merge_positions is gone with the merge step; keep the offset for layout
+    # compatibility but reserve no bytes.
+    merge_positions_offset_bytes = cursor
+
+    active_width_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    fused_pack_values_offset_bytes = cursor
+    cursor += fused_pack_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    fused_pack_indices_offset_bytes = cursor
+    cursor += fused_pack_elements * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    fused_merge_state_offset_bytes = cursor
+    cursor += fused_state_words * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_enabled = str(caps.score_mode) == "msa"
+    num_idx_heads = max(int(caps.num_idx_heads), 1)
+    max_pages_even = int(caps.max_page_table_width)
+    if max_pages_even % 2 != 0:
+        max_pages_even += 1
+    max_blocks = max(
+        1,
+        (int(caps.max_page_table_width) * page_size + MSA_BLOCK_TOKENS - 1)
+        // MSA_BLOCK_TOKENS,
+    )
+    msa_page_score_elements = (
+        num_idx_heads * max_q_rows * max_pages_even if msa_enabled else 0
+    )
+    msa_block_score_elements = (
+        num_idx_heads * max_q_rows * max_blocks if msa_enabled else 0
+    )
+    msa_q2k_elements = num_idx_heads * max_q_rows * int(caps.topk) if msa_enabled else 0
+    msa_expanded_rows = num_idx_heads * max_q_rows if msa_enabled else 0
+
+    msa_page_scores_offset_bytes = cursor
+    cursor += msa_page_score_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_block_scores_offset_bytes = cursor
+    cursor += msa_block_score_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_q2k_indices_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_topk_score_scratch_offset_bytes = cursor
+    cursor += msa_block_score_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_topk_values_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_topk_indices_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_sort_values_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_sort_indices_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_expanded_page_table_offset_bytes = cursor
+    cursor += (
+        msa_expanded_rows * int(caps.max_page_table_width) * dtype_nbytes(torch.int32)
+    )
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_expanded_seqlens_offset_bytes = cursor
+    cursor += msa_expanded_rows * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    return _SM12XIndexerPagedScratchLayout(
+        nbytes=max(int(cursor), SCRATCH_ALIGN_BYTES),
+        supertile_tokens=supertile_tokens,
+        max_chunks=max_chunks,
+        route=route,
+        prefill_block_k=prefill_block_k,
+        tile_logits_elements=tile_logits_elements,
+        gather_k_rows=gather_k_rows,
+        fused_pack_elements=fused_pack_elements,
+        fused_state_words=fused_state_words,
+        gather_k_quant_offset_bytes=gather_k_quant_offset_bytes,
+        gather_k_scale_offset_bytes=gather_k_scale_offset_bytes,
+        contiguous_lengths_offset_bytes=contiguous_lengths_offset_bytes,
+        runtime_lengths_offset_bytes=runtime_lengths_offset_bytes,
+        tile_logits_offset_bytes=tile_logits_offset_bytes,
+        topk_values_offset_bytes=topk_values_offset_bytes,
+        topk_indices_offset_bytes=topk_indices_offset_bytes,
+        candidate_values_offset_bytes=candidate_values_offset_bytes,
+        candidate_indices_offset_bytes=candidate_indices_offset_bytes,
+        merge_positions_offset_bytes=merge_positions_offset_bytes,
+        active_width_offset_bytes=active_width_offset_bytes,
+        fused_pack_values_offset_bytes=fused_pack_values_offset_bytes,
+        fused_pack_indices_offset_bytes=fused_pack_indices_offset_bytes,
+        fused_merge_state_offset_bytes=fused_merge_state_offset_bytes,
+        msa_page_scores_offset_bytes=msa_page_scores_offset_bytes,
+        msa_block_scores_offset_bytes=msa_block_scores_offset_bytes,
+        msa_q2k_indices_offset_bytes=msa_q2k_indices_offset_bytes,
+        msa_topk_score_scratch_offset_bytes=msa_topk_score_scratch_offset_bytes,
+        msa_topk_values_offset_bytes=msa_topk_values_offset_bytes,
+        msa_topk_indices_offset_bytes=msa_topk_indices_offset_bytes,
+        msa_sort_values_offset_bytes=msa_sort_values_offset_bytes,
+        msa_sort_indices_offset_bytes=msa_sort_indices_offset_bytes,
+        msa_expanded_page_table_offset_bytes=msa_expanded_page_table_offset_bytes,
+        msa_expanded_seqlens_offset_bytes=msa_expanded_seqlens_offset_bytes,
+    )
+
+
+def _indexer_contiguous_scratch_layout(
+    caps: SM12XIndexerContiguousScratchCaps,
+) -> _SM12XIndexerContiguousScratchLayout:
+    max_q_rows = max(int(caps.max_q_rows), 1)
+    max_k_rows = max(int(caps.max_k_rows), 1)
+    topk = max(int(caps.topk), 1)
+    prefill_block_k = int(caps.prefill_block_k)
+    supertile_tiles = max(1, int(caps.supertile_k) // prefill_block_k)
+    num_q_tiles = (
+        max_q_rows + _INDEXER_CONTIGUOUS_BLOCK_Q - 1
+    ) // _INDEXER_CONTIGUOUS_BLOCK_Q
+    num_k_tiles = (max_k_rows + prefill_block_k - 1) // prefill_block_k
+    max_chunk_tiles = min(supertile_tiles, num_k_tiles)
+    tile_logits_elements = max(
+        1,
+        num_q_tiles * max_chunk_tiles * _INDEXER_CONTIGUOUS_BLOCK_Q * prefill_block_k,
+    )
+
+    cursor = 0
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+    k_quant_offset_bytes = cursor
+    cursor += max_k_rows * _INDEXER_CONTIGUOUS_HEAD_DIM * dtype_nbytes(caps.k_dtype)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    k_scale_offset_bytes = cursor
+    cursor += max_k_rows * _INDEXER_CONTIGUOUS_SCALE_BYTES * dtype_nbytes(torch.uint8)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    dummy_logits_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    tile_logits_offset_bytes = cursor
+    cursor += tile_logits_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    lengths_offset_bytes = cursor
+    cursor += max_q_rows * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    topk_values_offset_bytes = cursor
+    cursor += max_q_rows * topk * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    topk_indices_offset_bytes = cursor
+    cursor += max_q_rows * topk * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    candidate_values_offset_bytes = cursor
+    cursor += 2 * max_q_rows * topk * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    candidate_indices_offset_bytes = cursor
+    cursor += 2 * max_q_rows * topk * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    metadata_k_start_offset_bytes = cursor
+    cursor += max_q_rows * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    metadata_k_end_offset_bytes = cursor
+    cursor += max_q_rows * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    k_tma_desc_offset_bytes = cursor
+    cursor += _INDEXER_CONTIGUOUS_TMA_DESC_WORDS * dtype_nbytes(torch.uint64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    k_tma_desc_ptrs_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.int64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    k_tma_prefill_desc_offset_bytes = cursor
+    cursor += _INDEXER_CONTIGUOUS_TMA_DESC_WORDS * dtype_nbytes(torch.uint64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    k_tma_prefill_desc_ptrs_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.int64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_enabled = str(caps.score_mode) == "msa"
+    num_idx_heads = max(int(caps.num_idx_heads), 1)
+    max_blocks = max(1, (max_k_rows + MSA_BLOCK_TOKENS - 1) // MSA_BLOCK_TOKENS)
+    msa_block_score_elements = (
+        num_idx_heads * max_q_rows * max_blocks if msa_enabled else 0
+    )
+    msa_q2k_elements = num_idx_heads * max_q_rows * topk if msa_enabled else 0
+
+    msa_block_scores_offset_bytes = cursor
+    cursor += msa_block_score_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_q2k_indices_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_topk_score_scratch_offset_bytes = cursor
+    cursor += msa_block_score_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_topk_values_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_topk_indices_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_sort_values_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    msa_sort_indices_offset_bytes = cursor
+    cursor += msa_q2k_elements * dtype_nbytes(torch.int64)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    return _SM12XIndexerContiguousScratchLayout(
+        nbytes=max(int(cursor), SCRATCH_ALIGN_BYTES),
+        max_k_rows=max_k_rows,
+        max_chunk_tiles=max_chunk_tiles,
+        tile_logits_elements=tile_logits_elements,
+        k_quant_offset_bytes=k_quant_offset_bytes,
+        k_scale_offset_bytes=k_scale_offset_bytes,
+        dummy_logits_offset_bytes=dummy_logits_offset_bytes,
+        tile_logits_offset_bytes=tile_logits_offset_bytes,
+        lengths_offset_bytes=lengths_offset_bytes,
+        topk_values_offset_bytes=topk_values_offset_bytes,
+        topk_indices_offset_bytes=topk_indices_offset_bytes,
+        candidate_values_offset_bytes=candidate_values_offset_bytes,
+        candidate_indices_offset_bytes=candidate_indices_offset_bytes,
+        metadata_k_start_offset_bytes=metadata_k_start_offset_bytes,
+        metadata_k_end_offset_bytes=metadata_k_end_offset_bytes,
+        k_tma_desc_offset_bytes=k_tma_desc_offset_bytes,
+        k_tma_desc_ptrs_offset_bytes=k_tma_desc_ptrs_offset_bytes,
+        k_tma_prefill_desc_offset_bytes=k_tma_prefill_desc_offset_bytes,
+        k_tma_prefill_desc_ptrs_offset_bytes=k_tma_prefill_desc_ptrs_offset_bytes,
+        msa_block_scores_offset_bytes=msa_block_scores_offset_bytes,
+        msa_q2k_indices_offset_bytes=msa_q2k_indices_offset_bytes,
+        msa_topk_score_scratch_offset_bytes=msa_topk_score_scratch_offset_bytes,
+        msa_topk_values_offset_bytes=msa_topk_values_offset_bytes,
+        msa_topk_indices_offset_bytes=msa_topk_indices_offset_bytes,
+        msa_sort_values_offset_bytes=msa_sort_values_offset_bytes,
+        msa_sort_indices_offset_bytes=msa_sort_indices_offset_bytes,
+    )
+
+
+def _materialize_indexer_paged_scratch(
+    caps: SM12XIndexerPagedScratchCaps,
+    scratch_storage: torch.Tensor,
+    layout: _SM12XIndexerPagedScratchLayout,
+) -> SM12XIndexerPagedScratch:
+    max_q_rows = max(int(caps.max_q_rows), 1)
+    topk = max(int(caps.topk), 1)
+    gather_k_rows = int(layout.gather_k_rows)
+    if gather_k_rows > 0:
+        indexer_k_quant_bytes, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.gather_k_quant_offset_bytes,
+            shape=(gather_k_rows, _PAGED_INDEX_HEAD_DIM),
+            dtype=torch.uint8,
+        )
+        indexer_k_scales_bytes, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.gather_k_scale_offset_bytes,
+            shape=(gather_k_rows, _INDEXER_CONTIGUOUS_SCALE_BYTES),
+            dtype=torch.uint8,
+        )
+    else:
+        indexer_k_quant_bytes = None
+        indexer_k_scales_bytes = None
+    contiguous_lengths, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.contiguous_lengths_offset_bytes,
+        shape=(max_q_rows,),
+        dtype=torch.int32,
+    )
+    runtime_lengths, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.runtime_lengths_offset_bytes,
+        shape=(max_q_rows,),
+        dtype=torch.int32,
+    )
+    tile_logits, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.tile_logits_offset_bytes,
+        shape=(int(layout.tile_logits_elements),),
+        dtype=torch.float32,
+    )
+    topk_values, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.topk_values_offset_bytes,
+        shape=(max_q_rows, topk),
+        dtype=torch.float32,
+    )
+    topk_indices, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.topk_indices_offset_bytes,
+        shape=(max_q_rows, topk),
+        dtype=torch.int32,
+    )
+    # Streaming-fold carry double-buffer (two halves) when chunking is possible;
+    # otherwise no carry buffer. merge_positions is gone with the merge step.
+    fold_carry_chunks = 2 if int(layout.max_chunks) > 1 else 0
+    if fold_carry_chunks:
+        candidate_values, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.candidate_values_offset_bytes,
+            shape=(fold_carry_chunks, max_q_rows, topk),
+            dtype=torch.float32,
+        )
+        candidate_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.candidate_indices_offset_bytes,
+            shape=(fold_carry_chunks, max_q_rows, topk),
+            dtype=torch.int32,
+        )
+    else:
+        candidate_values = None
+        candidate_indices = None
+    merge_positions = None
+    active_width_cap, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.active_width_offset_bytes,
+        shape=(1,),
+        dtype=torch.int32,
+    )
+    width_cap = max(
+        int(caps.max_page_table_width) * int(caps.page_size),
+        int(layout.supertile_tokens),
+        1,
+    )
+    active_width_cap.fill_(int(width_cap))
+    if int(layout.fused_pack_elements) > 0 and int(layout.fused_state_words) > 0:
+        fused_pack_values, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.fused_pack_values_offset_bytes,
+            shape=(int(layout.fused_pack_elements),),
+            dtype=torch.float32,
+        )
+        fused_pack_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.fused_pack_indices_offset_bytes,
+            shape=(int(layout.fused_pack_elements),),
+            dtype=torch.int32,
+        )
+        fused_merge_state, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.fused_merge_state_offset_bytes,
+            shape=(int(layout.fused_state_words),),
+            dtype=torch.int32,
+        )
+        # One-time initialization at workspace bind/materialization.  Both fused
+        # merge strategies restore their cross-launch counters before returning,
+        # so serving graph replays do not need to capture a state memset.
+        fused_merge_state.zero_()
+    else:
+        fused_pack_values = None
+        fused_pack_indices = None
+        fused_merge_state = None
+
+    if str(caps.score_mode) == "msa":
+        num_idx_heads = max(int(caps.num_idx_heads), 1)
+        max_pages_even = int(caps.max_page_table_width)
+        if max_pages_even % 2 != 0:
+            max_pages_even += 1
+        max_blocks = max(
+            1,
+            (
+                int(caps.max_page_table_width) * int(caps.page_size)
+                + MSA_BLOCK_TOKENS
+                - 1
+            )
+            // MSA_BLOCK_TOKENS,
+        )
+        msa_page_scores, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_page_scores_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, max_pages_even),
+            dtype=torch.float32,
+        )
+        msa_block_scores, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_block_scores_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, max_blocks),
+            dtype=torch.float32,
+        )
+        msa_q2k_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_q2k_indices_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int32,
+        )
+        msa_topk_score_scratch, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_topk_score_scratch_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, max_blocks),
+            dtype=torch.float32,
+        )
+        msa_topk_values, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_topk_values_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.float32,
+        )
+        msa_topk_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_topk_indices_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int64,
+        )
+        msa_sort_values, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_sort_values_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int32,
+        )
+        msa_sort_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_sort_indices_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int64,
+        )
+        msa_expanded_page_table, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_expanded_page_table_offset_bytes,
+            shape=(num_idx_heads * max_q_rows, int(caps.max_page_table_width)),
+            dtype=torch.int32,
+        )
+        msa_expanded_seqlens, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_expanded_seqlens_offset_bytes,
+            shape=(num_idx_heads * max_q_rows,),
+            dtype=torch.int32,
+        )
+    else:
+        msa_page_scores = None
+        msa_block_scores = None
+        msa_q2k_indices = None
+        msa_topk_score_scratch = None
+        msa_topk_values = None
+        msa_topk_indices = None
+        msa_sort_values = None
+        msa_sort_indices = None
+        msa_expanded_page_table = None
+        msa_expanded_seqlens = None
+
+    scratch = SM12XIndexerPagedScratch(
+        shared_scratch=scratch_storage,
+        device=caps.device,
+        dtype=caps.dtype,
+        kv_dtype=caps.kv_dtype,
+        num_q_heads=caps.num_q_heads,
+        topk=caps.topk,
+        max_page_table_width=caps.max_page_table_width,
+        max_total_q=caps.max_q_rows,
+        max_paged_q_rows=caps.max_q_rows,
+        max_batch=caps.max_batch,
+        page_size=caps.page_size,
+        paged_tile_logits_k_rows=layout.supertile_tokens,
+        max_chunks=layout.max_chunks,
+        route=layout.route,
+        shared_page_table=bool(caps.shared_page_table),
+        prefill_block_k=layout.prefill_block_k,
+        indexer_k_quant_bytes=indexer_k_quant_bytes,
+        indexer_k_scales_bytes=indexer_k_scales_bytes,
+        indexer_contiguous_lengths=contiguous_lengths,
+        paged_indexer_runtime_lengths=runtime_lengths,
+        indexer_contiguous_tile_logits=tile_logits,
+        indexer_contiguous_topk_values=topk_values,
+        indexer_contiguous_topk_indices=topk_indices,
+        indexer_contiguous_candidate_values=candidate_values,
+        indexer_contiguous_candidate_indices=candidate_indices,
+        indexer_contiguous_topk_positions=merge_positions,
+        paged_indexer_active_width_cap=active_width_cap,
+        fused_indexer_pack_values=fused_pack_values,
+        fused_indexer_pack_indices=fused_pack_indices,
+        fused_indexer_merge_state=fused_merge_state,
+        fused_indexer_merge_state_preinitialized=fused_merge_state is not None,
+        msa_page_scores=msa_page_scores,
+        msa_block_scores=msa_block_scores,
+        msa_q2k_indices=msa_q2k_indices,
+        msa_topk_score_scratch=msa_topk_score_scratch,
+        msa_topk_values=msa_topk_values,
+        msa_topk_indices=msa_topk_indices,
+        msa_sort_values=msa_sort_values,
+        msa_sort_indices=msa_sort_indices,
+        msa_expanded_page_table=msa_expanded_page_table,
+        msa_expanded_seqlens=msa_expanded_seqlens,
+    )
+    return scratch
+
+
+def _materialize_indexer_contiguous_scratch(
+    caps: SM12XIndexerContiguousScratchCaps,
+    scratch_storage: torch.Tensor,
+    layout: _SM12XIndexerContiguousScratchLayout,
+) -> SM12XIndexerContiguousScratch:
+    max_q_rows = max(int(caps.max_q_rows), 1)
+    max_k_rows = max(int(layout.max_k_rows), 1)
+    topk = max(int(caps.topk), 1)
+    k_quant, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.k_quant_offset_bytes,
+        shape=(max_k_rows, _INDEXER_CONTIGUOUS_HEAD_DIM),
+        dtype=caps.k_dtype,
+    )
+    k_scale_bytes, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.k_scale_offset_bytes,
+        shape=(max_k_rows, _INDEXER_CONTIGUOUS_SCALE_BYTES),
+        dtype=torch.uint8,
+    )
+    k_scale = k_scale_bytes.view(torch.float32).flatten()
+    dummy_logits, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.dummy_logits_offset_bytes,
+        shape=(1, 1),
+        dtype=torch.float32,
+    )
+    tile_logits, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.tile_logits_offset_bytes,
+        shape=(int(layout.tile_logits_elements),),
+        dtype=torch.float32,
+    )
+    lengths, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.lengths_offset_bytes,
+        shape=(max_q_rows,),
+        dtype=torch.int32,
+    )
+    topk_values, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.topk_values_offset_bytes,
+        shape=(max_q_rows, topk),
+        dtype=torch.float32,
+    )
+    topk_indices, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.topk_indices_offset_bytes,
+        shape=(max_q_rows, topk),
+        dtype=torch.int32,
+    )
+    candidate_values, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.candidate_values_offset_bytes,
+        shape=(2, max_q_rows, topk),
+        dtype=torch.float32,
+    )
+    candidate_indices, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.candidate_indices_offset_bytes,
+        shape=(2, max_q_rows, topk),
+        dtype=torch.int32,
+    )
+    metadata_k_start, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.metadata_k_start_offset_bytes,
+        shape=(max_q_rows,),
+        dtype=torch.int32,
+    )
+    metadata_k_end, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.metadata_k_end_offset_bytes,
+        shape=(max_q_rows,),
+        dtype=torch.int32,
+    )
+    k_tma_desc, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.k_tma_desc_offset_bytes,
+        shape=(_INDEXER_CONTIGUOUS_TMA_DESC_WORDS,),
+        dtype=torch.uint64,
+    )
+    k_tma_desc_ptrs, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.k_tma_desc_ptrs_offset_bytes,
+        shape=(1,),
+        dtype=torch.int64,
+    )
+    k_tma_prefill_desc, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.k_tma_prefill_desc_offset_bytes,
+        shape=(_INDEXER_CONTIGUOUS_TMA_DESC_WORDS,),
+        dtype=torch.uint64,
+    )
+    k_tma_prefill_desc_ptrs, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.k_tma_prefill_desc_ptrs_offset_bytes,
+        shape=(1,),
+        dtype=torch.int64,
+    )
+    k_quant_bytes = k_quant.view(torch.uint8)
+    if k_quant.device.type == "cuda":
+        from flashinfer.experimental.sm12x.attention.nsa_indexer.contiguous_kernel import (
+            _encode_contiguous_k_tma_descriptor_into,
+        )
+
+        _encode_contiguous_k_tma_descriptor_into(
+            k_quant_bytes,
+            k_tma_desc,
+            k_tma_desc_ptrs,
+            block_k=_INDEXER_CONTIGUOUS_DECODE_BLOCK_K,
+        )
+        _encode_contiguous_k_tma_descriptor_into(
+            k_quant_bytes,
+            k_tma_prefill_desc,
+            k_tma_prefill_desc_ptrs,
+            block_k=_INDEXER_CONTIGUOUS_PREFILL_BLOCK_K,
+        )
+    else:
+        k_tma_desc_ptrs.fill_(int(k_tma_desc.data_ptr()))
+        k_tma_prefill_desc_ptrs.fill_(int(k_tma_prefill_desc.data_ptr()))
+
+    if str(caps.score_mode) == "msa":
+        num_idx_heads = max(int(caps.num_idx_heads), 1)
+        max_blocks = max(1, (max_k_rows + MSA_BLOCK_TOKENS - 1) // MSA_BLOCK_TOKENS)
+        msa_block_scores, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_block_scores_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, max_blocks),
+            dtype=torch.float32,
+        )
+        msa_q2k_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_q2k_indices_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int32,
+        )
+        msa_topk_score_scratch, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_topk_score_scratch_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, max_blocks),
+            dtype=torch.float32,
+        )
+        msa_topk_values, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_topk_values_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.float32,
+        )
+        msa_topk_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_topk_indices_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int64,
+        )
+        msa_sort_values, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_sort_values_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int32,
+        )
+        msa_sort_indices, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_sort_indices_offset_bytes,
+            shape=(num_idx_heads, max_q_rows, topk),
+            dtype=torch.int64,
+        )
+    else:
+        msa_block_scores = None
+        msa_q2k_indices = None
+        msa_topk_score_scratch = None
+        msa_topk_values = None
+        msa_topk_indices = None
+        msa_sort_values = None
+        msa_sort_indices = None
+
+    return SM12XIndexerContiguousScratch(
+        shared_scratch=scratch_storage,
+        device=caps.device,
+        num_q_heads=caps.num_q_heads,
+        max_q_rows=max_q_rows,
+        max_k_rows=max_k_rows,
+        topk=topk,
+        supertile_k=caps.supertile_k,
+        prefill_block_k=caps.prefill_block_k,
+        k_quant=k_quant,
+        k_scale_bytes=k_scale_bytes,
+        k_scale=k_scale,
+        dummy_logits=dummy_logits,
+        tile_logits=tile_logits,
+        lengths=lengths,
+        topk_values=topk_values,
+        topk_indices=topk_indices,
+        candidate_values=candidate_values,
+        candidate_indices=candidate_indices,
+        metadata_k_start=metadata_k_start,
+        metadata_k_end=metadata_k_end,
+        k_tma_desc_ptrs=k_tma_desc_ptrs,
+        k_tma_prefill_desc_ptrs=k_tma_prefill_desc_ptrs,
+        msa_block_scores=msa_block_scores,
+        msa_q2k_indices=msa_q2k_indices,
+        msa_topk_score_scratch=msa_topk_score_scratch,
+        msa_topk_values=msa_topk_values,
+        msa_topk_indices=msa_topk_indices,
+        msa_sort_values=msa_sort_values,
+        msa_sort_indices=msa_sort_indices,
+    )
+
+
+def _validate_device(
+    tensor: torch.Tensor,
+    *,
+    scratch: object | None = None,
+    name: str,
+) -> None:
+    if scratch is None:
+        raise TypeError("_validate_device requires scratch")
+    if tensor.device != scratch.device:
+        raise ValueError(
+            f"{name} device {tensor.device} does not match resource device {scratch.device}"
+        )
+
+
+def _is_row_shared_i32_matrix(tensor: torch.Tensor) -> bool:
+    return (
+        tensor.ndim == 2 and int(tensor.stride(0)) == 0 and int(tensor.stride(1)) == 1
+    )
+
+
+def _validate_i32_contiguous(
+    tensor: torch.Tensor,
+    *,
+    scratch: object | None = None,
+    name: str,
+    ndim: int,
+) -> None:
+    if tensor.ndim != ndim:
+        raise ValueError(f"{name} must be rank-{ndim}, got {tuple(tensor.shape)}")
+    if tensor.dtype != torch.int32:
+        raise ValueError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    _validate_device(tensor, scratch=scratch, name=name)
+
+
+def build_indexer_paged_binding(
+    *,
+    scratch: object,
+    real_page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    active_width: torch.Tensor | None = None,
+    schedule_metadata: torch.Tensor | None = None,
+    expected_num_q_heads: int | None = None,
+    shared_page_table: bool = False,
+    output_physical_slots: bool = False,
+) -> SM12XIndexerPagedBinding:
+    if scratch is None:
+        raise TypeError("build_indexer_paged_binding requires scratch")
+
+    if bool(shared_page_table) and _is_row_shared_i32_matrix(real_page_table):
+        if real_page_table.dtype != torch.int32:
+            raise ValueError(
+                f"real_page_table must have dtype torch.int32, got {real_page_table.dtype}"
+            )
+        _validate_device(real_page_table, scratch=scratch, name="real_page_table")
+    else:
+        _validate_i32_contiguous(
+            real_page_table,
+            scratch=scratch,
+            name="real_page_table",
+            ndim=2,
+        )
+    _validate_i32_contiguous(
+        cache_seqlens_int32,
+        scratch=scratch,
+        name="cache_seqlens_int32",
+        ndim=1,
+    )
+    if active_width is None:
+        active_width = scratch.get_paged_indexer_active_width_cap()
+    _validate_i32_contiguous(
+        active_width,
+        scratch=scratch,
+        name="active_width",
+        ndim=1,
+    )
+    if active_width.shape != (1,):
+        raise ValueError(
+            f"active_width must have shape (1,), got {tuple(active_width.shape)}"
+        )
+    if int(real_page_table.shape[0]) != int(cache_seqlens_int32.shape[0]):
+        raise ValueError(
+            f"real_page_table rows {int(real_page_table.shape[0])} do not match "
+            f"cache_seqlens_int32 rows {int(cache_seqlens_int32.shape[0])}"
+        )
+    if int(real_page_table.shape[0]) > int(scratch.max_paged_q_rows):
+        raise ValueError(
+            f"real_page_table rows {int(real_page_table.shape[0])} exceed paged indexer capacity "
+            f"{scratch.max_paged_q_rows}"
+        )
+    if int(real_page_table.shape[1]) > int(scratch.max_page_table_width):
+        raise ValueError(
+            f"real_page_table width {int(real_page_table.shape[1])} exceeds paged indexer capacity "
+            f"{scratch.max_page_table_width}"
+        )
+    if bool(shared_page_table) != bool(
+        getattr(scratch, "shared_page_table", bool(shared_page_table))
+    ):
+        raise ValueError(
+            "shared_page_table does not match the paged indexer scratch plan: "
+            f"launch={bool(shared_page_table)}, plan={bool(getattr(scratch, 'shared_page_table'))}"
+        )
+    if schedule_metadata is not None:
+        _validate_i32_contiguous(
+            schedule_metadata,
+            scratch=scratch,
+            name="schedule_metadata",
+            ndim=2,
+        )
+        if int(schedule_metadata.shape[1]) != 2:
+            raise ValueError(
+                f"schedule_metadata must have shape (num_sms + 1, 2), got {tuple(schedule_metadata.shape)}"
+            )
+    if expected_num_q_heads is not None:
+        expected_num_q_heads = int(expected_num_q_heads)
+        if expected_num_q_heads <= 0:
+            raise ValueError(
+                f"expected_num_q_heads must be positive, got {expected_num_q_heads}"
+            )
+    return SM12XIndexerPagedBinding(
+        scratch=scratch,
+        metadata=IndexerPagedDecodeMetadata(
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            paged_mqa_schedule_metadata=schedule_metadata,
+        ),
+        real_page_table=real_page_table,
+        cache_seqlens_int32=cache_seqlens_int32,
+        active_width=active_width,
+        schedule_metadata=schedule_metadata,
+        expected_num_q_heads=expected_num_q_heads,
+        shared_page_table=bool(shared_page_table),
+        output_physical_slots=bool(output_physical_slots),
+        route=str(getattr(scratch, "route", INDEXER_PAGED_ROUTE_TILED)),
+        supertile_k=int(getattr(scratch, "paged_tile_logits_k_rows", 0)) or None,
+        prefill_block_k=getattr(scratch, "prefill_block_k", None),
+    )
+
+
+def build_indexer_contiguous_binding(
+    *,
+    scratch: object,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+    gather_rows: int | None = None,
+    topk: int | None = None,
+    include_topk_buffers: bool = True,
+    include_candidate_buffers: bool = True,
+    include_lengths: bool = True,
+    include_merge_positions: bool = True,
+    strict: bool = False,
+) -> SM12XIndexerContiguousBinding:
+    if scratch is None:
+        raise TypeError("build_indexer_contiguous_binding requires scratch")
+
+    _validate_i32_contiguous(
+        k_start,
+        scratch=scratch,
+        name="k_start",
+        ndim=1,
+    )
+    _validate_i32_contiguous(
+        k_end,
+        scratch=scratch,
+        name="k_end",
+        ndim=1,
+    )
+    if k_start.shape != k_end.shape:
+        raise ValueError(
+            f"k_start and k_end must have the same shape, got "
+            f"{tuple(k_start.shape)} and {tuple(k_end.shape)}"
+        )
+    row_count = int(k_start.shape[0])
+    max_rows = int(
+        getattr(scratch, "max_q_rows", getattr(scratch, "max_total_q", row_count))
+    )
+    if row_count > max_rows:
+        raise ValueError(
+            f"k_start rows {row_count} exceed indexer contiguous capacity {max_rows}"
+        )
+    if gather_rows is not None:
+        gather_rows = int(gather_rows)
+        max_k_rows = int(getattr(scratch, "max_k_rows", gather_rows))
+        if gather_rows < 0:
+            raise ValueError(f"gather_rows must be non-negative, got {gather_rows}")
+        if gather_rows > max_k_rows:
+            raise ValueError(
+                f"gather_rows {gather_rows} exceed indexer contiguous K capacity "
+                f"{max_k_rows}"
+            )
+
+    if topk is None:
+        topk = int(getattr(scratch, "topk", getattr(scratch, "indexer_topk", 0)))
+    topk = int(topk)
+    if topk <= 0:
+        raise ValueError(f"topk must be positive, got {topk}")
+
+    tile_logits = getattr(scratch, "tile_logits", None)
+    if tile_logits is None and hasattr(scratch, "get_indexer_contiguous_tile_logits"):
+        tile_logits = scratch.get_indexer_contiguous_tile_logits()
+    if tile_logits is None:
+        tile_logits = getattr(scratch, "indexer_contiguous_tile_logits", None)
+
+    output_values = None
+    output_indices = None
+    if include_topk_buffers:
+        if hasattr(scratch, "topk_values") and hasattr(scratch, "topk_indices"):
+            output_values = scratch.topk_values[:row_count, :topk]
+            output_indices = scratch.topk_indices[:row_count, :topk]
+        else:
+            output_values, output_indices = scratch.get_indexer_contiguous_topk_buffers(
+                row_count=row_count
+            )
+            output_values = output_values[:, :topk]
+            output_indices = output_indices[:, :topk]
+
+    candidate_values = None
+    candidate_indices = None
+    if include_candidate_buffers:
+        if hasattr(scratch, "candidate_values") and hasattr(
+            scratch, "candidate_indices"
+        ):
+            candidate_values = scratch.candidate_values[:, :row_count, :topk]
+            candidate_indices = scratch.candidate_indices[:, :row_count, :topk]
+        else:
+            candidate_values, candidate_indices = (
+                scratch.get_indexer_contiguous_candidate_buffers()
+            )
+            candidate_values = candidate_values[:, :row_count, :topk]
+            candidate_indices = candidate_indices[:, :row_count, :topk]
+
+    lengths = None
+    if include_lengths:
+        if hasattr(scratch, "lengths"):
+            lengths = scratch.lengths[:row_count]
+        else:
+            lengths = scratch.get_indexer_contiguous_lengths(row_count=row_count)
+
+    merge_positions = None
+    if include_merge_positions and not strict:
+        try:
+            merge_positions = scratch.get_indexer_contiguous_topk_position_buffer(
+                row_count=row_count
+            )[:, :topk]
+        except SM12XIndexerTopKPositionBufferUnavailable:
+            merge_positions = None
+        except AttributeError:
+            merge_positions = getattr(
+                scratch, "indexer_contiguous_topk_positions", None
+            )
+            if merge_positions is not None:
+                merge_positions = merge_positions[:row_count, :topk]
+
+    return SM12XIndexerContiguousBinding(
+        scratch=scratch,
+        metadata=IndexerContiguousMetadata(k_start=k_start, k_end=k_end),
+        topk=topk,
+        tile_logits=tile_logits,
+        lengths=lengths,
+        output_values=output_values,
+        output_indices=output_indices,
+        candidate_values=candidate_values,
+        candidate_indices=candidate_indices,
+        merge_positions=merge_positions,
+        prefill_block_k=getattr(scratch, "prefill_block_k", None),
+        supertile_k=getattr(scratch, "supertile_k", None),
+        strict=bool(strict),
+    )
+
+
+def _require_msa_scratch_tensor(scratch: object, name: str) -> torch.Tensor:
+    tensor = getattr(scratch, name, None)
+    if tensor is None:
+        raise RuntimeError(
+            "MSA indexer binding requires scratch planned with score_mode='msa'; "
+            f"missing {name}"
+        )
+    return tensor
+
+
+def build_indexer_msa_paged_binding(
+    *,
+    scratch: object,
+    real_page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    active_width: torch.Tensor | None = None,
+    schedule_metadata: torch.Tensor | None = None,
+    topk: int | None = None,
+) -> SM12XIndexerMSAPagedBinding:
+    if scratch is None:
+        raise TypeError("build_indexer_msa_paged_binding requires scratch")
+    _validate_i32_contiguous(
+        real_page_table,
+        scratch=scratch,
+        name="real_page_table",
+        ndim=2,
+    )
+    _validate_i32_contiguous(
+        cache_seqlens_int32,
+        scratch=scratch,
+        name="cache_seqlens_int32",
+        ndim=1,
+    )
+    if int(real_page_table.shape[0]) != int(cache_seqlens_int32.shape[0]):
+        raise ValueError("real_page_table rows must match cache_seqlens_int32")
+    if active_width is None:
+        active_width = scratch.get_paged_indexer_active_width_cap()
+    _validate_i32_contiguous(active_width, scratch=scratch, name="active_width", ndim=1)
+    if active_width.shape != (1,):
+        raise ValueError(
+            f"active_width must have shape (1,), got {tuple(active_width.shape)}"
+        )
+    if schedule_metadata is not None:
+        _validate_i32_contiguous(
+            schedule_metadata,
+            scratch=scratch,
+            name="schedule_metadata",
+            ndim=2,
+        )
+        if int(schedule_metadata.shape[1]) != 2:
+            raise ValueError("schedule_metadata must have trailing dimension 2")
+    if int(real_page_table.shape[0]) > int(
+        getattr(scratch, "max_total_q", real_page_table.shape[0])
+    ):
+        raise ValueError("real_page_table rows exceed MSA paged scratch capacity")
+    if int(real_page_table.shape[1]) > int(
+        getattr(scratch, "max_page_table_width", real_page_table.shape[1])
+    ):
+        raise ValueError("real_page_table width exceeds MSA paged scratch capacity")
+
+    block_scores = _require_msa_scratch_tensor(scratch, "msa_block_scores")
+    q2k_indices = _require_msa_scratch_tensor(scratch, "msa_q2k_indices")
+    page_scores = _require_msa_scratch_tensor(scratch, "msa_page_scores")
+    topk = int(getattr(scratch, "topk", q2k_indices.shape[2]) if topk is None else topk)
+    if topk <= 0 or topk > int(q2k_indices.shape[2]):
+        raise ValueError(
+            f"topk must be in [1, {int(q2k_indices.shape[2])}], got {topk}"
+        )
+    num_idx_heads = int(block_scores.shape[0])
+    return SM12XIndexerMSAPagedBinding(
+        scratch=scratch,
+        metadata=IndexerPagedDecodeMetadata(
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            paged_mqa_schedule_metadata=schedule_metadata,
+        ),
+        real_page_table=real_page_table,
+        cache_seqlens_int32=cache_seqlens_int32,
+        active_width=active_width,
+        schedule_metadata=schedule_metadata,
+        page_scores=page_scores,
+        block_scores=block_scores,
+        q2k_indices=q2k_indices,
+        topk_score_scratch=_require_msa_scratch_tensor(
+            scratch, "msa_topk_score_scratch"
+        ),
+        topk_values=_require_msa_scratch_tensor(scratch, "msa_topk_values"),
+        topk_indices=_require_msa_scratch_tensor(scratch, "msa_topk_indices"),
+        sort_values=_require_msa_scratch_tensor(scratch, "msa_sort_values"),
+        sort_indices=_require_msa_scratch_tensor(scratch, "msa_sort_indices"),
+        expanded_page_table=_require_msa_scratch_tensor(
+            scratch, "msa_expanded_page_table"
+        ),
+        expanded_seqlens=_require_msa_scratch_tensor(scratch, "msa_expanded_seqlens"),
+        topk=topk,
+        num_idx_heads=num_idx_heads,
+        strict=True,
+    )
+
+
+def build_indexer_msa_contiguous_binding(
+    *,
+    scratch: object,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+    topk: int | None = None,
+) -> SM12XIndexerMSAContiguousBinding:
+    if scratch is None:
+        raise TypeError("build_indexer_msa_contiguous_binding requires scratch")
+    _validate_i32_contiguous(k_start, scratch=scratch, name="k_start", ndim=1)
+    _validate_i32_contiguous(k_end, scratch=scratch, name="k_end", ndim=1)
+    if k_start.shape != k_end.shape:
+        raise ValueError("k_start and k_end must have matching shapes")
+    if int(k_start.shape[0]) > int(getattr(scratch, "max_q_rows", k_start.shape[0])):
+        raise ValueError("k_start rows exceed MSA contiguous scratch capacity")
+    block_scores = _require_msa_scratch_tensor(scratch, "msa_block_scores")
+    q2k_indices = _require_msa_scratch_tensor(scratch, "msa_q2k_indices")
+    topk = int(getattr(scratch, "topk", q2k_indices.shape[2]) if topk is None else topk)
+    if topk <= 0 or topk > int(q2k_indices.shape[2]):
+        raise ValueError(
+            f"topk must be in [1, {int(q2k_indices.shape[2])}], got {topk}"
+        )
+    return SM12XIndexerMSAContiguousBinding(
+        scratch=scratch,
+        metadata=IndexerContiguousMetadata(k_start=k_start, k_end=k_end),
+        block_scores=block_scores,
+        q2k_indices=q2k_indices,
+        topk_score_scratch=_require_msa_scratch_tensor(
+            scratch, "msa_topk_score_scratch"
+        ),
+        topk_values=_require_msa_scratch_tensor(scratch, "msa_topk_values"),
+        topk_indices=_require_msa_scratch_tensor(scratch, "msa_topk_indices"),
+        sort_values=_require_msa_scratch_tensor(scratch, "msa_sort_values"),
+        sort_indices=_require_msa_scratch_tensor(scratch, "msa_sort_indices"),
+        topk=topk,
+        num_idx_heads=int(block_scores.shape[0]),
+        strict=True,
+    )
+
+
+@dataclass(frozen=True)
+class SM12XIndexerPagedScratchPlan:
+    caps: SM12XIndexerPagedScratchCaps
+    layout: _SM12XIndexerPagedScratchLayout
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        real_page_table: torch.Tensor,
+        cache_seqlens_int32: torch.Tensor,
+        active_width: torch.Tensor | None = None,
+        schedule_metadata: torch.Tensor | None = None,
+        expected_num_q_heads: int | None = None,
+        shared_page_table: bool | None = None,
+        output_physical_slots: bool = False,
+    ) -> SM12XIndexerPagedBinding:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="paged indexer",
+        )
+        scratch_views = _materialize_indexer_paged_scratch(
+            self.caps,
+            scratch_storage,
+            self.layout,
+        )
+        if shared_page_table is None:
+            shared_page_table = bool(self.caps.shared_page_table)
+        return build_indexer_paged_binding(
+            scratch=scratch_views,
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            active_width=active_width,
+            schedule_metadata=schedule_metadata,
+            expected_num_q_heads=expected_num_q_heads,
+            shared_page_table=shared_page_table,
+            output_physical_slots=output_physical_slots,
+        )
+
+    def bind_msa(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        real_page_table: torch.Tensor,
+        cache_seqlens_int32: torch.Tensor,
+        active_width: torch.Tensor | None = None,
+        schedule_metadata: torch.Tensor | None = None,
+        topk: int | None = None,
+    ) -> SM12XIndexerMSAPagedBinding:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="paged MSA indexer",
+        )
+        scratch_views = _materialize_indexer_paged_scratch(
+            self.caps,
+            scratch_storage,
+            self.layout,
+        )
+        return build_indexer_msa_paged_binding(
+            scratch=scratch_views,
+            real_page_table=real_page_table,
+            cache_seqlens_int32=cache_seqlens_int32,
+            active_width=active_width,
+            schedule_metadata=schedule_metadata,
+            topk=topk,
+        )
+
+
+@dataclass(frozen=True)
+class SM12XIndexerContiguousScratchPlan:
+    caps: SM12XIndexerContiguousScratchCaps
+    layout: _SM12XIndexerContiguousScratchLayout
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        k_start: torch.Tensor | None = None,
+        k_end: torch.Tensor | None = None,
+        gather_rows: int | None = None,
+        topk: int | None = None,
+    ) -> SM12XIndexerContiguousBinding:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="indexer contiguous",
+        )
+        scratch_views = _materialize_indexer_contiguous_scratch(
+            self.caps,
+            scratch_storage,
+            self.layout,
+        )
+        if k_start is None:
+            k_start = scratch_views.metadata_k_start
+        if k_end is None:
+            k_end = scratch_views.metadata_k_end
+        return build_indexer_contiguous_binding(
+            scratch=scratch_views,
+            k_start=k_start,
+            k_end=k_end,
+            gather_rows=gather_rows,
+            topk=self.caps.topk if topk is None else topk,
+            include_topk_buffers=True,
+            include_candidate_buffers=True,
+            include_lengths=True,
+            include_merge_positions=False,
+            strict=True,
+        )
+
+    def bind_msa(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        k_start: torch.Tensor | None = None,
+        k_end: torch.Tensor | None = None,
+        topk: int | None = None,
+    ) -> SM12XIndexerMSAContiguousBinding:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="indexer contiguous MSA",
+        )
+        scratch_views = _materialize_indexer_contiguous_scratch(
+            self.caps,
+            scratch_storage,
+            self.layout,
+        )
+        if k_start is None:
+            k_start = scratch_views.metadata_k_start
+        if k_end is None:
+            k_end = scratch_views.metadata_k_end
+        return build_indexer_msa_contiguous_binding(
+            scratch=scratch_views,
+            k_start=k_start,
+            k_end=k_end,
+            topk=self.caps.topk if topk is None else topk,
+        )
+
+
+def plan_indexer_paged_scratch(
+    caps: SM12XIndexerPagedScratchCaps,
+) -> SM12XIndexerPagedScratchPlan:
+    layout = _indexer_paged_scratch_layout(caps)
+    return SM12XIndexerPagedScratchPlan(
+        caps=caps,
+        layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "paged_indexer.scratch",
+                nbytes=int(layout.nbytes),
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+def plan_indexer_contiguous_scratch(
+    caps: SM12XIndexerContiguousScratchCaps,
+) -> SM12XIndexerContiguousScratchPlan:
+    layout = _indexer_contiguous_scratch_layout(caps)
+    return SM12XIndexerContiguousScratchPlan(
+        caps=caps,
+        layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "indexer_contiguous.arena",
+                nbytes=int(layout.nbytes),
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class SM12XIndexerScratchPlan:
+    caps: SM12XIndexerScratchCaps
+    inner: SM12XIndexerPagedScratchPlan | SM12XIndexerContiguousScratchPlan
+
+    @property
+    def layout(self):
+        return self.inner.layout
+
+    @property
+    def source_layout(self) -> str:
+        return self.caps.source_layout
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self.inner.scratch_specs()
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return self.inner.shapes_and_dtypes()
+
+    def bind(self, **kwargs):
+        return self.inner.bind(**kwargs)
+
+    def bind_msa(self, **kwargs):
+        return self.inner.bind_msa(**kwargs)
+
+
+def plan_indexer_scratch(
+    caps: SM12XIndexerScratchCaps,
+) -> SM12XIndexerScratchPlan:
+    if caps.source_layout == INDEXER_SOURCE_LAYOUT_PAGED:
+        assert caps.max_page_table_width is not None
+        inner = plan_indexer_paged_scratch(
+            SM12XIndexerPagedScratchCaps(
+                device=caps.device,
+                num_q_heads=caps.num_q_heads,
+                max_q_rows=caps.max_q_rows,
+                max_page_table_width=caps.max_page_table_width,
+                topk=caps.topk,
+                dtype=caps.dtype,
+                kv_dtype=caps.kv_dtype,
+                max_batch=caps.max_batch,
+                page_size=caps.page_size,
+                max_k_rows=0 if caps.max_k_rows is None else caps.max_k_rows,
+                reserve_paged_logits=caps.reserve_paged_logits,
+                paged_logits_k_rows=caps.paged_logits_k_rows,
+                paged_tile_logits_k_rows=caps.supertile_k,
+                mode=caps.mode,
+                shared_page_table=caps.shared_page_table,
+                route=caps.route,
+                score_mode=caps.score_mode,
+                num_idx_heads=caps.num_idx_heads,
+            )
+        )
+    elif caps.source_layout == INDEXER_SOURCE_LAYOUT_CONTIGUOUS:
+        assert caps.max_k_rows is not None
+        inner = plan_indexer_contiguous_scratch(
+            SM12XIndexerContiguousScratchCaps(
+                device=caps.device,
+                num_q_heads=caps.num_q_heads,
+                max_q_rows=caps.max_q_rows,
+                max_k_rows=caps.max_k_rows,
+                topk=caps.topk,
+                k_dtype=caps.k_dtype,
+                supertile_k=(
+                    caps.supertile_k if caps.supertile_k > 0 else caps.max_k_rows
+                ),
+                prefill_block_k=caps.prefill_block_k,
+                score_mode=caps.score_mode,
+                num_idx_heads=caps.num_idx_heads,
+            )
+        )
+    else:
+        raise ValueError(f"unsupported indexer source_layout {caps.source_layout!r}")
+    return SM12XIndexerScratchPlan(caps=caps, inner=inner)
+
+
+__all__ = [
+    "ScratchBufferSpec",
+    "SM12XIndexerScratchCaps",
+    "SM12XIndexerScratchPlan",
+    "SM12XIndexerPagedBinding",
+    "SM12XIndexerPagedScratch",
+    "SM12XIndexerPagedScratchCaps",
+    "SM12XIndexerPagedScratchPlan",
+    "SM12XIndexerContiguousBinding",
+    "SM12XIndexerMSAPagedBinding",
+    "SM12XIndexerMSAContiguousBinding",
+    "SM12XIndexerContiguousScratch",
+    "SM12XIndexerContiguousScratchCaps",
+    "SM12XIndexerContiguousScratchPlan",
+    "INDEXER_SOURCE_LAYOUT_CONTIGUOUS",
+    "INDEXER_SOURCE_LAYOUT_PAGED",
+    "build_indexer_paged_binding",
+    "build_indexer_contiguous_binding",
+    "build_indexer_msa_paged_binding",
+    "build_indexer_msa_contiguous_binding",
+    "plan_indexer_scratch",
+    "plan_indexer_paged_scratch",
+    "plan_indexer_contiguous_scratch",
+]

--- a/flashinfer/experimental/sm12x/attention/nsa_indexer/tiled_topk.py
+++ b/flashinfer/experimental/sm12x/attention/nsa_indexer/tiled_topk.py
@@ -1,0 +1,1665 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/indexer/tiled_topk.py @ c795c02a (2026-07-16) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Faithful CuTe DSL port of the sglang radix-select topk kernel.
+
+Ported from: sgl-kernel/csrc/elementwise/topk.cu :: fast_topk_cuda_tl
+
+Uses raw PTX shared memory loads/stores/atomics for the double-buffered
+histogram prefix sum, since CuTe DSL does not support dynamic selection
+between tensor objects. Variables in dynamic control flow require SSA-style
+initialization before use.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import os
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Float32, Int32, Uint32
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    DimKey,
+    KernelCompileSpec,
+    launch as sm12x_launch,
+    tensor_compile_fact,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_add_shared_i32,
+    ld_shared_i32,
+    ld_shared_i32_relaxed,
+    red_add_shared_i32,
+    shared_ptr_to_u32,
+    st_shared_i32,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+
+_THREADS_PER_CTA = 1024
+_DEFAULT_TOPK = 2048
+_SUPPORTED_TOPK = (512, 1024, 2048)
+_RADIX = 256
+_SMEM_CANDS = 4096
+_SCAN_UNROLL = 4
+_SUPERTILE_K_ENV = "FLASHINFER_EXP_SM12X_NSA_TOPK_SUPERTILE_K"
+_SUPERTILE_K_DEFAULT = 32768
+
+
+@dsl_user_op
+def _cvt_rn_f16_f32(val: Float32, *, loc=None, ip=None) -> Uint32:
+    result = llvm.inline_asm(
+        T.i32(),
+        [Float32(val).ir_value(loc=loc, ip=ip)],
+        "cvt.rn.f16.f32 $0, $1;",
+        "=h,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Uint32(result)
+
+
+@dsl_user_op
+def _float_as_uint32(val: Float32, *, loc=None, ip=None) -> Uint32:
+    result = llvm.inline_asm(
+        T.i32(),
+        [Float32(val).ir_value(loc=loc, ip=ip)],
+        "mov.b32 $0, $1;",
+        "=r,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Uint32(result)
+
+
+@cute.jit
+def _smem_ld(base: Int32, idx: Int32) -> Int32:
+    return ld_shared_i32(base + idx * Int32(4))
+
+
+@cute.jit
+def _smem_ld_relaxed(base: Int32, idx: Int32) -> Int32:
+    return ld_shared_i32_relaxed(base + idx * Int32(4))
+
+
+@cute.jit
+def _smem_st(base: Int32, idx: Int32, val: Int32):
+    st_shared_i32(base + idx * Int32(4), val)
+
+
+@cute.jit
+def _smem_xadd(base: Int32, idx: Int32, val: Int32) -> Int32:
+    return atomic_add_shared_i32(base + idx * Int32(4), val)
+
+
+@cute.jit
+def _smem_red_add(base: Int32, idx: Int32, val: Int32):
+    red_add_shared_i32(base + idx * Int32(4), val)
+
+
+@cute.jit
+def _load_topk_input_from_row_base(
+    input_tensor,
+    row_base: Int32,
+    logical_k: Int32,
+    block_q: cutlass.Constexpr[int],
+    block_k: cutlass.Constexpr[int],
+    is_tiled: cutlass.Constexpr[bool],
+) -> Float32:
+    value = Float32(0.0)
+    if cutlass.const_expr(is_tiled):
+        tile_size = Int32(block_q * block_k)
+        k_tile_idx = Int32(0)
+        k_local = Int32(0)
+        if cutlass.const_expr(block_k == 256):
+            k_tile_idx = logical_k >> Int32(8)
+            k_local = logical_k & Int32(255)
+        else:
+            k_tile_idx = logical_k >> Int32(9)
+            k_local = logical_k & Int32(511)
+        value = Float32(input_tensor[row_base + k_tile_idx * tile_size + k_local])
+    else:
+        value = Float32(input_tensor[row_base + logical_k])
+    return value
+
+
+@cute.jit
+def _load_value_virtual(
+    input_tensor,
+    carry_values,
+    row_base: Int32,
+    row_start: Int32,
+    carry_base: Int32,
+    chunk_len: Int32,
+    vidx: Int32,
+    block_q: cutlass.Constexpr[int],
+    block_k: cutlass.Constexpr[int],
+    is_tiled: cutlass.Constexpr[bool],
+    is_first: cutlass.Constexpr[bool],
+) -> Float32:
+    """Load a candidate's logit by virtual index.
+
+    vidx in [0, chunk_len) reads this chunk's tiled logits; vidx >= chunk_len reads
+    the carried running-topk value at slot (vidx - chunk_len). When is_first there is
+    no carry range, so the carry branch is compiled away.
+    """
+    value = Float32(0.0)
+    if cutlass.const_expr(is_first):
+        value = _load_topk_input_from_row_base(
+            input_tensor, row_base, row_start + vidx, block_q, block_k, is_tiled
+        )
+    else:
+        if vidx < chunk_len:
+            value = _load_topk_input_from_row_base(
+                input_tensor, row_base, row_start + vidx, block_q, block_k, is_tiled
+            )
+        else:
+            value = Float32(carry_values[carry_base + (vidx - chunk_len)])
+    return value
+
+
+@cute.jit
+def _emit_global_index_virtual(
+    carry_indices,
+    output_page_table,
+    row_start: Int32,
+    output_index_offset: Int32,
+    carry_base: Int32,
+    chunk_len: Int32,
+    vidx: Int32,
+    row_idx: Int32,
+    page_size: Int32,
+    is_first: cutlass.Constexpr[bool],
+    output_physical_slots: cutlass.Constexpr[bool],
+) -> Int32:
+    """Map a virtual index to its final logical or physical K-index.
+
+    Local elements reconstruct as row_start + vidx + output_index_offset; carried
+    elements pass their already-global logical index through verbatim (never
+    re-offset). The final paged-indexer chunk optionally translates that logical
+    request-relative position through the real page table in this same store.
+    """
+    gidx = Int32(0)
+    if cutlass.const_expr(is_first):
+        gidx = row_start + vidx + output_index_offset
+    else:
+        if vidx < chunk_len:
+            gidx = row_start + vidx + output_index_offset
+        else:
+            gidx = Int32(carry_indices[carry_base + (vidx - chunk_len)])
+    if cutlass.const_expr(output_physical_slots):
+        physical_idx = Int32(-1)
+        if gidx >= Int32(0):
+            page_col = gidx // page_size
+            page_offset = gidx - page_col * page_size
+            page_id = Int32(output_page_table[row_idx, page_col])
+            if page_id >= Int32(0):
+                physical_idx = page_id * page_size + page_offset
+        gidx = physical_idx
+    return gidx
+
+
+@cute.jit
+def _convert_to_uint8(x: Float32) -> Uint32:
+    h_bits = _cvt_rn_f16_f32(x)
+    bits16 = h_bits & Uint32(0xFFFF)
+    sign = bits16 & Uint32(0x8000)
+    key16 = Uint32(0)
+    if sign != Uint32(0):
+        key16 = Uint32(0xFFFF) ^ bits16
+    else:
+        key16 = bits16 | Uint32(0x8000)
+    return (key16 >> Uint32(8)) & Uint32(0xFF)
+
+
+@cute.jit
+def _convert_to_uint32(x: Float32) -> Uint32:
+    bits = _float_as_uint32(x)
+    sign = bits & Uint32(0x80000000)
+    result = Uint32(0)
+    if sign != Uint32(0):
+        result = ~bits
+    else:
+        result = bits | Uint32(0x80000000)
+    return result
+
+
+def _to_kernel_tensor(tensor, dtype, *, assumed_align=16):
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = dtype
+    if tensor.ndim >= 1:
+        leading_dim = next(
+            (idx for idx, stride in enumerate(tensor.stride()) if stride == 1), None
+        )
+        if leading_dim is not None:
+            cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+    return cute_tensor
+
+
+def _tensor_compile_key(name, tensor, *, dynamic_dims=()):
+    return tensor_compile_fact(name, tensor, dynamic_dims=dynamic_dims)
+
+
+def _flat_tensor_compile_key(name, tensor, *, dynamic=False):
+    flat = tensor.reshape(-1)
+    dims = (DimKey.dynamic() if dynamic else DimKey.exact(int(flat.shape[0])),)
+    return tensor_compile_fact(name, flat, dims=dims)
+
+
+def _tensor_meta_key(tensor, *, dynamic_dims=()):
+    dynamic_dim_set = set(dynamic_dims)
+    return (
+        tuple(
+            DimKey.dynamic() if idx in dynamic_dim_set else int(dim)
+            for idx, dim in enumerate(tensor.shape)
+        ),
+        tuple(tensor.stride()),
+        str(tensor.dtype),
+        (tensor.device.type, tensor.device.index),
+    )
+
+
+def _flat_tensor_meta_key(tensor):
+    return (
+        (int(tensor.numel()),),
+        (1,),
+        str(tensor.dtype),
+        (tensor.device.type, tensor.device.index),
+    )
+
+
+class SparseNSATiledTopkKernel:
+    def __init__(
+        self,
+        *,
+        is_tiled: bool = False,
+        block_q: int = 1,
+        block_k: int = 1,
+        topk: int = _DEFAULT_TOPK,
+        zero_row_start: bool = False,
+        is_first: bool = True,
+        output_physical_slots: bool = False,
+        extent_splits: int = 1,
+    ):
+        self.extent_splits = int(extent_splits)
+        self.is_tiled = is_tiled
+        self.block_q = int(block_q)
+        self.block_k = int(block_k)
+        self.topk = int(topk)
+        self.zero_row_start = bool(zero_row_start)
+        # When is_first the carry buffers are unread (the running-topk fold has no
+        # predecessor for the first supertile chunk). There is no `is_last`: the
+        # kernel always emits (value, global index) topk into values/indices; the
+        # orchestrator decides whether that tensor is the next chunk's carry buffer
+        # or the user's final output.
+        self.is_first = bool(is_first)
+        self.output_physical_slots = bool(output_physical_slots)
+
+    @cute.jit
+    def __call__(
+        self,
+        input_tensor,
+        row_starts,
+        lengths,
+        values,
+        indices,
+        carry_values,
+        carry_indices,
+        output_page_table,
+        batch_size,
+        input_stride,
+        num_k_tiles,
+        tile_k_offset,
+        block_q,
+        block_k,
+        topk_val,
+        input_index_offset,
+        input_extent,
+        output_index_offset,
+        output_page_size,
+        out_row_stride,
+        out_row_base,
+        stream,
+    ):
+        self.kernel(
+            input_tensor,
+            row_starts,
+            lengths,
+            values,
+            indices,
+            carry_values,
+            carry_indices,
+            output_page_table,
+            batch_size,
+            input_stride,
+            num_k_tiles,
+            tile_k_offset,
+            block_q,
+            block_k,
+            topk_val,
+            input_index_offset,
+            input_extent,
+            output_index_offset,
+            output_page_size,
+            out_row_stride,
+            out_row_base,
+        ).launch(
+            grid=(batch_size, 1, 1),
+            block=[_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        input_tensor: cute.Tensor,
+        row_starts: cute.Tensor,
+        lengths: cute.Tensor,
+        values: cute.Tensor,
+        indices: cute.Tensor,
+        carry_values: cute.Tensor,
+        carry_indices: cute.Tensor,
+        output_page_table: cute.Tensor,
+        batch_size: Int32,
+        input_stride: Int32,
+        num_k_tiles: Int32,
+        tile_k_offset: Int32,
+        block_q: Int32,
+        block_k: Int32,
+        topk_val: Int32,
+        input_index_offset: Int32,
+        input_extent: Int32,
+        output_index_offset: Int32,
+        output_page_size: Int32,
+        out_row_stride: Int32,
+        out_row_base: Int32,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        bid, _, _ = cute.arch.block_idx()
+        bid = Int32(bid)
+
+        # extent_splits > 1: pseudo-row decomposition. CTA `bid` selects the
+        # top-k of ONE extent slice of real row bid//splits: slice s covers
+        # [s*input_extent, (s+1)*input_extent) via the existing chunk-clip
+        # logic, so the emitted global indices stay correct. Outputs land at
+        # pseudo-row `bid`; a second (linear) pass folds the slices.
+        data_bid = bid
+        if cutlass.const_expr(self.extent_splits > 1):
+            splits_i = Int32(self.extent_splits)
+            data_bid = bid // splits_i
+            split_id = bid - data_bid * splits_i
+            input_index_offset = input_index_offset + split_id * input_extent
+            output_index_offset = output_index_offset + split_id * input_extent
+            tile_k_offset = tile_k_offset + split_id * (
+                input_extent // Int32(self.block_k)
+            )
+
+        row_start = Int32(0)
+        if not cutlass.const_expr(self.zero_row_start):
+            row_start = Int32(row_starts[data_bid])
+        length = Int32(lengths[data_bid])
+        if input_extent > Int32(0):
+            row_end = row_start + length
+            clipped_start = row_start
+            if clipped_start < input_index_offset:
+                clipped_start = input_index_offset
+            clipped_end = row_end
+            chunk_end = input_index_offset + input_extent
+            if cutlass.const_expr(self.is_tiled):
+                # A balanced extent split can round its final slice up by one
+                # tile. Clip that slice to the tiles actually present instead
+                # of reading the next scratch region as logits.
+                tiled_end = input_index_offset + (num_k_tiles - tile_k_offset) * block_k
+                if chunk_end > tiled_end:
+                    chunk_end = tiled_end
+            if clipped_end > chunk_end:
+                clipped_end = chunk_end
+            if clipped_end > clipped_start:
+                row_start = clipped_start - input_index_offset
+                length = clipped_end - clipped_start
+            else:
+                row_start = Int32(0)
+                length = Int32(0)
+        topk_capacity = self.topk
+        topk_static = Int32(self.topk)
+        out_row = data_bid * out_row_stride + out_row_base
+        if cutlass.const_expr(self.extent_splits > 1):
+            out_row = out_row + split_id
+        out_base = out_row * topk_static
+        row_base = data_bid * input_stride
+        if cutlass.const_expr(self.is_tiled):
+            block_q_i = Int32(self.block_q)
+            block_k_i = Int32(self.block_k)
+            tile_size = Int32(self.block_q * self.block_k)
+            q_tile_idx = data_bid // block_q_i
+            q_local = data_bid - q_tile_idx * block_q_i
+            row_base = (
+                q_tile_idx * num_k_tiles * tile_size
+                + tile_k_offset * tile_size
+                + q_local * block_k_i
+            )
+
+        smem_alloc = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class SharedStorage:
+            hist0: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 384], 128]
+            hist1: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 384], 128]
+            out_idx: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, topk_capacity], 128
+            ]
+            counter: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 1], 128]
+            thr_id: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 1], 128]
+            ni0: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 1], 128]
+            ni1: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 1], 128]
+            last_rem: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 1], 128]
+            cand0: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, _SMEM_CANDS], 128
+            ]
+            cand1: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, _SMEM_CANDS], 128
+            ]
+
+        storage = smem_alloc.allocate(SharedStorage)
+
+        s_hist0 = storage.hist0.get_tensor(cute.make_layout((384,), stride=(1,)))
+        s_hist1 = storage.hist1.get_tensor(cute.make_layout((384,), stride=(1,)))
+        s_out = storage.out_idx.get_tensor(
+            cute.make_layout((topk_capacity,), stride=(1,))
+        )
+        s_cand0 = storage.cand0.get_tensor(
+            cute.make_layout((_SMEM_CANDS,), stride=(1,))
+        )
+        s_cand1 = storage.cand1.get_tensor(
+            cute.make_layout((_SMEM_CANDS,), stride=(1,))
+        )
+
+        h0 = shared_ptr_to_u32(storage.hist0.data_ptr())
+        ctr = shared_ptr_to_u32(storage.counter.data_ptr())
+        thr = shared_ptr_to_u32(storage.thr_id.data_ptr())
+        ni0 = shared_ptr_to_u32(storage.ni0.data_ptr())
+        ni1 = shared_ptr_to_u32(storage.ni1.data_ptr())
+        lr = shared_ptr_to_u32(storage.last_rem.data_ptr())
+
+        # Virtual candidate range: local logits in [0, length) plus, for fold chunks
+        # (not is_first), the topk carried running-topk slots in [length, length+topk).
+        total_len = length
+        if not cutlass.const_expr(self.is_first):
+            total_len = length + topk_static
+
+        need_radix = total_len > topk_static
+
+        if not need_radix:
+            i = Int32(tx)
+            while i < topk_static:
+                is_valid = i < total_len
+                values[out_base + i] = (
+                    _load_value_virtual(
+                        input_tensor,
+                        carry_values,
+                        row_base,
+                        row_start,
+                        out_base,
+                        length,
+                        i,
+                        self.block_q,
+                        self.block_k,
+                        self.is_tiled,
+                        self.is_first,
+                    )
+                    if is_valid
+                    else Float32(float("-inf"))
+                )
+                indices[out_base + i] = (
+                    _emit_global_index_virtual(
+                        carry_indices,
+                        output_page_table,
+                        row_start,
+                        output_index_offset,
+                        out_base,
+                        length,
+                        i,
+                        bid,
+                        output_page_size,
+                        self.is_first,
+                        self.output_physical_slots,
+                    )
+                    if is_valid
+                    else Int32(-1)
+                )
+                i = i + Int32(_THREADS_PER_CTA)
+
+        if need_radix:
+            topk = topk_static
+
+            if tx < Int32(257):
+                s_hist0[tx] = Int32(0)
+            cute.arch.sync_threads()
+
+            idx_base = Int32(tx)
+            full_scan_limit = total_len - Int32((_SCAN_UNROLL - 1) * _THREADS_PER_CTA)
+            while idx_base < full_scan_limit:
+                for scan_u in cutlass.range_constexpr(_SCAN_UNROLL):
+                    idx = idx_base + Int32(scan_u * _THREADS_PER_CTA)
+                    val = _load_value_virtual(
+                        input_tensor,
+                        carry_values,
+                        row_base,
+                        row_start,
+                        out_base,
+                        length,
+                        idx,
+                        self.block_q,
+                        self.block_k,
+                        self.is_tiled,
+                        self.is_first,
+                    )
+                    bin8 = _convert_to_uint8(val)
+                    _smem_red_add(h0, Int32(bin8), Int32(1))
+                idx_base = idx_base + Int32(_THREADS_PER_CTA * _SCAN_UNROLL)
+            while idx_base < total_len:
+                val = _load_value_virtual(
+                    input_tensor,
+                    carry_values,
+                    row_base,
+                    row_start,
+                    out_base,
+                    length,
+                    idx_base,
+                    self.block_q,
+                    self.block_k,
+                    self.is_tiled,
+                    self.is_first,
+                )
+                bin8 = _convert_to_uint8(val)
+                _smem_red_add(h0, Int32(bin8), Int32(1))
+                idx_base = idx_base + Int32(_THREADS_PER_CTA)
+
+            cute.arch.sync_threads()
+
+            # Parallel prefix sum: 8 stages, double-buffer h0/h1
+            for stage in cutlass.range_constexpr(8):
+                j = Int32(1 << stage)
+                if tx < Int32(256):
+                    if (stage & 1) == 0:
+                        value = Int32(s_hist0[tx])
+                        if tx < Int32(256) - j:
+                            value = value + Int32(s_hist0[tx + j])
+                        s_hist1[tx] = value
+                    else:
+                        value = Int32(s_hist1[tx])
+                        if tx < Int32(256) - j:
+                            value = value + Int32(s_hist1[tx + j])
+                        s_hist0[tx] = value
+                cute.arch.sync_threads()
+
+            # Find threshold bin
+            if tx < Int32(256):
+                val_tx = Int32(s_hist0[tx])
+                val_tx1 = Int32(s_hist0[tx + Int32(1)])
+                if val_tx > topk:
+                    if val_tx1 <= topk:
+                        _smem_st(thr, Int32(0), Int32(tx))
+                        _smem_st(ni0, Int32(0), Int32(0))
+                        _smem_st(ctr, Int32(0), Int32(0))
+
+            cute.arch.sync_threads()
+            threshold_bin = _smem_ld(thr, Int32(0))
+            topk = topk - Int32(s_hist0[threshold_bin + Int32(1)])
+
+            if topk == Int32(0):
+                idx_base = Int32(tx)
+                full_scan_limit = total_len - Int32(
+                    (_SCAN_UNROLL - 1) * _THREADS_PER_CTA
+                )
+                while idx_base < full_scan_limit:
+                    for scan_u in cutlass.range_constexpr(_SCAN_UNROLL):
+                        idx = idx_base + Int32(scan_u * _THREADS_PER_CTA)
+                        val = _load_value_virtual(
+                            input_tensor,
+                            carry_values,
+                            row_base,
+                            row_start,
+                            out_base,
+                            length,
+                            idx,
+                            self.block_q,
+                            self.block_k,
+                            self.is_tiled,
+                            self.is_first,
+                        )
+                        bin8 = _convert_to_uint8(val)
+                        if Int32(bin8) > threshold_bin:
+                            pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                            s_out[pos] = idx
+                    idx_base = idx_base + Int32(_THREADS_PER_CTA * _SCAN_UNROLL)
+                while idx_base < total_len:
+                    val = _load_value_virtual(
+                        input_tensor,
+                        carry_values,
+                        row_base,
+                        row_start,
+                        out_base,
+                        length,
+                        idx_base,
+                        self.block_q,
+                        self.block_k,
+                        self.is_tiled,
+                        self.is_first,
+                    )
+                    bin8 = _convert_to_uint8(val)
+                    if Int32(bin8) > threshold_bin:
+                        pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                        s_out[pos] = idx_base
+                    idx_base = idx_base + Int32(_THREADS_PER_CTA)
+
+            if topk != Int32(0):
+                cute.arch.sync_threads()
+
+                if tx < Int32(257):
+                    s_hist0[tx] = Int32(0)
+                cute.arch.sync_threads()
+
+                idx_base = Int32(tx)
+                full_scan_limit = total_len - Int32(
+                    (_SCAN_UNROLL - 1) * _THREADS_PER_CTA
+                )
+                while idx_base < full_scan_limit:
+                    for scan_u in cutlass.range_constexpr(_SCAN_UNROLL):
+                        idx = idx_base + Int32(scan_u * _THREADS_PER_CTA)
+                        raw_input = _load_value_virtual(
+                            input_tensor,
+                            carry_values,
+                            row_base,
+                            row_start,
+                            out_base,
+                            length,
+                            idx,
+                            self.block_q,
+                            self.block_k,
+                            self.is_tiled,
+                            self.is_first,
+                        )
+                        bin8 = _convert_to_uint8(raw_input)
+                        if Int32(bin8) > threshold_bin:
+                            pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                            s_out[pos] = idx
+                        else:
+                            if Int32(bin8) == threshold_bin:
+                                cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
+                                if cand_pos < Int32(_SMEM_CANDS):
+                                    s_cand0[cand_pos] = idx
+                                    key32 = _convert_to_uint32(raw_input)
+                                    sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
+                                    _smem_red_add(h0, Int32(sub_bin), Int32(1))
+                    idx_base = idx_base + Int32(_THREADS_PER_CTA * _SCAN_UNROLL)
+                while idx_base < total_len:
+                    raw_input = _load_value_virtual(
+                        input_tensor,
+                        carry_values,
+                        row_base,
+                        row_start,
+                        out_base,
+                        length,
+                        idx_base,
+                        self.block_q,
+                        self.block_k,
+                        self.is_tiled,
+                        self.is_first,
+                    )
+                    bin8 = _convert_to_uint8(raw_input)
+                    if Int32(bin8) > threshold_bin:
+                        pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                        s_out[pos] = idx_base
+                    else:
+                        if Int32(bin8) == threshold_bin:
+                            cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
+                            if cand_pos < Int32(_SMEM_CANDS):
+                                s_cand0[cand_pos] = idx_base
+                                key32 = _convert_to_uint32(raw_input)
+                                sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
+                                _smem_red_add(h0, Int32(sub_bin), Int32(1))
+                    idx_base = idx_base + Int32(_THREADS_PER_CTA)
+
+                cute.arch.sync_threads()
+
+                # Stage 2: refine with 8-bit radix passes
+                for round_idx in cutlass.range_constexpr(4):
+                    if topk != Int32(-1):
+                        r_idx_is_0 = (round_idx % 2) == 0
+                        r_idx_next_is_0 = not r_idx_is_0
+
+                        raw_num_input = (
+                            _smem_ld(ni0, Int32(0))
+                            if cutlass.const_expr(r_idx_is_0)
+                            else _smem_ld(ni1, Int32(0))
+                        )
+                        num_input = (
+                            raw_num_input
+                            if raw_num_input < Int32(_SMEM_CANDS)
+                            else Int32(_SMEM_CANDS)
+                        )
+
+                        # Prefix sum
+                        for stage in cutlass.range_constexpr(8):
+                            j = Int32(1 << stage)
+                            if tx < Int32(256):
+                                if (stage & 1) == 0:
+                                    value = Int32(s_hist0[tx])
+                                    if tx < Int32(256) - j:
+                                        value = value + Int32(s_hist0[tx + j])
+                                    s_hist1[tx] = value
+                                else:
+                                    value = Int32(s_hist1[tx])
+                                    if tx < Int32(256) - j:
+                                        value = value + Int32(s_hist1[tx + j])
+                                    s_hist0[tx] = value
+                            cute.arch.sync_threads()
+
+                        if tx < Int32(256):
+                            val_tx = Int32(s_hist0[tx])
+                            val_tx1 = Int32(s_hist0[tx + Int32(1)])
+                            if val_tx > topk:
+                                if val_tx1 <= topk:
+                                    _smem_st(thr, Int32(0), Int32(tx))
+                                    if cutlass.const_expr(r_idx_next_is_0):
+                                        _smem_st(ni0, Int32(0), Int32(0))
+                                    else:
+                                        _smem_st(ni1, Int32(0), Int32(0))
+                                    _smem_st(lr, Int32(0), topk - val_tx1)
+
+                        cute.arch.sync_threads()
+
+                        sub_threshold = _smem_ld(thr, Int32(0))
+                        topk = topk - Int32(s_hist0[sub_threshold + Int32(1)])
+
+                        # Quick exit
+                        if topk == Int32(0):
+                            i = Int32(tx)
+                            while i < num_input:
+                                c_idx = (
+                                    Int32(s_cand0[i])
+                                    if cutlass.const_expr(r_idx_is_0)
+                                    else Int32(s_cand1[i])
+                                )
+                                offset = Int32(24 - round_idx * 8)
+                                raw_val = _load_value_virtual(
+                                    input_tensor,
+                                    carry_values,
+                                    row_base,
+                                    row_start,
+                                    out_base,
+                                    length,
+                                    c_idx,
+                                    self.block_q,
+                                    self.block_k,
+                                    self.is_tiled,
+                                    self.is_first,
+                                )
+                                key32 = _convert_to_uint32(raw_val)
+                                bin = (key32 >> Uint32(offset)) & Uint32(0xFF)
+                                if Int32(bin) > sub_threshold:
+                                    pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                                    s_out[pos] = c_idx
+                                i = i + Int32(_THREADS_PER_CTA)
+                            topk = Int32(-1)
+
+                        # Continue refinement
+                        if topk != Int32(-1):
+                            cute.arch.sync_threads()
+
+                            if tx < Int32(257):
+                                s_hist0[tx] = Int32(0)
+                            cute.arch.sync_threads()
+
+                            i = Int32(tx)
+                            while i < num_input:
+                                c_idx = (
+                                    Int32(s_cand0[i])
+                                    if cutlass.const_expr(r_idx_is_0)
+                                    else Int32(s_cand1[i])
+                                )
+                                raw_val = _load_value_virtual(
+                                    input_tensor,
+                                    carry_values,
+                                    row_base,
+                                    row_start,
+                                    out_base,
+                                    length,
+                                    c_idx,
+                                    self.block_q,
+                                    self.block_k,
+                                    self.is_tiled,
+                                    self.is_first,
+                                )
+                                offset = Int32(24 - round_idx * 8)
+                                key32 = _convert_to_uint32(raw_val)
+                                bin = (key32 >> Uint32(offset)) & Uint32(0xFF)
+
+                                if Int32(bin) > sub_threshold:
+                                    pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                                    s_out[pos] = c_idx
+                                else:
+                                    if Int32(bin) == sub_threshold:
+                                        if cutlass.const_expr(round_idx == 3):
+                                            old_rem = _smem_xadd(
+                                                lr, Int32(0), Int32(-1)
+                                            )
+                                            if old_rem > Int32(0):
+                                                s_out[topk_static - old_rem] = c_idx
+                                        else:
+                                            cand_pos = (
+                                                _smem_xadd(ni0, Int32(0), Int32(1))
+                                                if cutlass.const_expr(r_idx_next_is_0)
+                                                else _smem_xadd(ni1, Int32(0), Int32(1))
+                                            )
+                                            if cand_pos < Int32(_SMEM_CANDS):
+                                                if cutlass.const_expr(r_idx_next_is_0):
+                                                    s_cand0[cand_pos] = c_idx
+                                                else:
+                                                    s_cand1[cand_pos] = c_idx
+                                                sub_bin = (
+                                                    key32
+                                                    >> Uint32(24 - (round_idx + 1) * 8)
+                                                ) & Uint32(0xFF)
+                                                _smem_red_add(
+                                                    h0, Int32(sub_bin), Int32(1)
+                                                )
+
+                                i = i + Int32(_THREADS_PER_CTA)
+
+                            cute.arch.sync_threads()
+
+            cute.arch.sync_threads()
+            idx0 = Int32(tx)
+            if idx0 < topk_static:
+                selected0 = Int32(s_out[idx0])
+                values[out_base + idx0] = _load_value_virtual(
+                    input_tensor,
+                    carry_values,
+                    row_base,
+                    row_start,
+                    out_base,
+                    length,
+                    selected0,
+                    self.block_q,
+                    self.block_k,
+                    self.is_tiled,
+                    self.is_first,
+                )
+                indices[out_base + idx0] = _emit_global_index_virtual(
+                    carry_indices,
+                    output_page_table,
+                    row_start,
+                    output_index_offset,
+                    out_base,
+                    length,
+                    selected0,
+                    bid,
+                    output_page_size,
+                    self.is_first,
+                    self.output_physical_slots,
+                )
+            idx1 = idx0 + Int32(_THREADS_PER_CTA)
+            if idx1 < topk_static:
+                selected1 = Int32(s_out[idx1])
+                values[out_base + idx1] = _load_value_virtual(
+                    input_tensor,
+                    carry_values,
+                    row_base,
+                    row_start,
+                    out_base,
+                    length,
+                    selected1,
+                    self.block_q,
+                    self.block_k,
+                    self.is_tiled,
+                    self.is_first,
+                )
+                indices[out_base + idx1] = _emit_global_index_virtual(
+                    carry_indices,
+                    output_page_table,
+                    row_start,
+                    output_index_offset,
+                    out_base,
+                    length,
+                    selected1,
+                    bid,
+                    output_page_size,
+                    self.is_first,
+                    self.output_physical_slots,
+                )
+
+
+@lru_cache(maxsize=64)
+def _build_tiled_topk_kernel(
+    block_q: int,
+    block_k: int,
+    topk: int,
+    zero_row_start: bool = False,
+    is_first: bool = True,
+    output_physical_slots: bool = False,
+    extent_splits: int = 1,
+):
+    return SparseNSATiledTopkKernel(
+        is_tiled=True,
+        block_q=block_q,
+        block_k=block_k,
+        topk=topk,
+        zero_row_start=zero_row_start,
+        is_first=is_first,
+        output_physical_slots=output_physical_slots,
+        extent_splits=extent_splits,
+    )
+
+
+@lru_cache(maxsize=8)
+def _build_row_topk_kernel(topk: int, output_physical_slots: bool = False):
+    return SparseNSATiledTopkKernel(
+        is_tiled=False,
+        block_q=1,
+        block_k=1,
+        topk=topk,
+        zero_row_start=True,
+        output_physical_slots=output_physical_slots,
+    )
+
+
+def clear_tiled_topk_kernel_cache() -> None:
+    _build_tiled_topk_kernel.cache_clear()
+    _build_row_topk_kernel.cache_clear()
+
+
+def _validate_supported_topk(topk: int, *, caller: str) -> int:
+    topk = int(topk)
+    if topk not in _SUPPORTED_TOPK:
+        raise ValueError(
+            f"{caller} supports topk values {_SUPPORTED_TOPK}, got topk={topk}"
+        )
+    return topk
+
+
+def run_tiled_topk(
+    *,
+    tile_logits: torch.Tensor,
+    k_start: torch.Tensor | None,
+    k_end: torch.Tensor | None = None,
+    lengths: torch.Tensor | None = None,
+    topk: int,
+    block_q: int,
+    block_k: int,
+    output_values: torch.Tensor | None = None,
+    output_indices: torch.Tensor | None = None,
+    num_k_tiles: int | None = None,
+    tile_k_offset: int = 0,
+    input_index_offset: int = 0,
+    input_extent: int = 0,
+    output_index_offset: int = 0,
+    zero_row_start: bool = False,
+    carry_values: torch.Tensor | None = None,
+    carry_indices: torch.Tensor | None = None,
+    is_first: bool = True,
+    output_page_table: torch.Tensor | None = None,
+    output_page_size: int = 64,
+    extent_splits: int = 1,
+    output_row_stride: int | None = None,
+    output_row_base: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    topk = _validate_supported_topk(topk, caller="run_tiled_topk")
+    extent_splits = int(extent_splits)
+    if extent_splits > 1:
+        # Level-1 of the two-level fold: each pseudo-row selects one extent
+        # slice; slices are folded by a second linear pass. Slice windows ride
+        # the chunk-clip logic, so a per-slice input_extent is required.
+        if int(input_extent) <= 0:
+            raise ValueError("extent_splits > 1 requires a per-slice input_extent")
+        if not is_first or carry_values is not None or carry_indices is not None:
+            raise ValueError("extent_splits > 1 does not fold carries")
+        if output_page_table is not None:
+            raise ValueError("extent_splits > 1 emits logical indices only")
+    if k_end is None and lengths is None:
+        raise ValueError("run_tiled_topk requires either k_end or lengths")
+    if not tile_logits.is_contiguous():
+        raise ValueError("tile_logits must be contiguous")
+    if k_start is None:
+        if not zero_row_start:
+            raise ValueError(
+                "run_tiled_topk requires k_start unless zero_row_start is true"
+            )
+        if lengths is None:
+            raise ValueError("run_tiled_topk zero_row_start requires explicit lengths")
+        k_start = lengths
+    if not k_start.is_contiguous():
+        raise ValueError("k_start must be contiguous")
+    if lengths is None:
+        if k_end is None:
+            raise AssertionError("unreachable")
+        lengths = k_end - k_start
+    elif not lengths.is_contiguous():
+        raise ValueError("lengths must be contiguous")
+
+    num_q_rows = int(k_start.shape[0])
+    if output_row_stride is None:
+        output_row_stride = extent_splits
+    output_row_stride = int(output_row_stride)
+    output_row_base = int(output_row_base)
+    if output_row_base + extent_splits > output_row_stride:
+        raise ValueError(
+            "output_row_base + extent_splits must fit within output_row_stride, "
+            f"got {output_row_base} + {extent_splits} > {output_row_stride}"
+        )
+    out_rows = num_q_rows * output_row_stride
+    output_physical_slots = output_page_table is not None
+    if output_physical_slots:
+        assert output_page_table is not None
+        if output_page_table.ndim != 2:
+            raise ValueError(
+                "output_page_table must be rank-2, got "
+                f"{tuple(output_page_table.shape)}"
+            )
+        if int(output_page_table.shape[0]) != num_q_rows:
+            raise ValueError(
+                "output_page_table rows must match top-k rows, got "
+                f"{int(output_page_table.shape[0])} != {num_q_rows}"
+            )
+        if output_page_table.dtype != torch.int32:
+            raise ValueError(
+                "output_page_table must have dtype torch.int32, got "
+                f"{output_page_table.dtype}"
+            )
+        if output_page_table.device != tile_logits.device:
+            raise ValueError("output_page_table device must match tile_logits")
+        if int(output_page_table.stride(1)) != 1 or not (
+            output_page_table.is_contiguous() or int(output_page_table.stride(0)) == 0
+        ):
+            raise ValueError(
+                "output_page_table must be contiguous or a row-shared stride-0 view"
+            )
+        if int(output_page_size) <= 0:
+            raise ValueError(
+                f"output_page_size must be positive, got {output_page_size}"
+            )
+        output_page_table_for_kernel = output_page_table
+    else:
+        # The physical mapping branch is constexpr-elided. Reuse row metadata as
+        # its dummy tensor so ordinary tiled top-k remains allocation-free.
+        output_page_table_for_kernel = lengths
+        output_page_size = 1
+    num_q_tiles = (num_q_rows + block_q - 1) // block_q
+    tile_size = block_q * block_k
+    total_elements = int(tile_logits.shape[0])
+    if num_k_tiles is None:
+        num_k_tiles = total_elements // (num_q_tiles * tile_size)
+        if num_k_tiles == 0:
+            num_k_tiles = getattr(tile_logits, "_sm12x_num_k_tiles", None)
+            if num_k_tiles is None:
+                raise ValueError("Cannot determine num_k_tiles")
+    if int(num_k_tiles) <= 0:
+        raise ValueError("Cannot determine num_k_tiles")
+
+    if output_indices is None:
+        topk_indices = torch.empty(
+            (out_rows, topk),
+            dtype=torch.int32,
+            device=tile_logits.device,
+        )
+    else:
+        if output_indices.shape != (out_rows, topk):
+            raise ValueError(
+                f"output_indices must have shape {(out_rows, topk)}, got {tuple(output_indices.shape)}"
+            )
+        if not output_indices.is_contiguous():
+            raise ValueError("output_indices must be contiguous")
+        topk_indices = output_indices
+    if output_values is None:
+        topk_values = torch.empty(
+            (out_rows, topk),
+            dtype=torch.float32,
+            device=tile_logits.device,
+        )
+    else:
+        if output_values.shape != (out_rows, topk):
+            raise ValueError(
+                f"output_values must have shape {(out_rows, topk)}, got {tuple(output_values.shape)}"
+            )
+        if not output_values.is_contiguous():
+            raise ValueError("output_values must be contiguous")
+        topk_values = output_values
+
+    # Carry buffers hold the previous supertile chunk's running top-k (value, global
+    # index) that this launch folds in. When is_first there is no predecessor, so the
+    # kernel never reads them (the read path is constexpr-elided) — but a real tensor
+    # of the right shape must still be passed, so allocate a throwaway if none given.
+    if not is_first:
+        if carry_values is None or carry_indices is None:
+            raise ValueError(
+                "run_tiled_topk requires carry_values and carry_indices when is_first is False"
+            )
+        if carry_values.shape != (num_q_rows, topk):
+            raise ValueError(
+                f"carry_values must have shape {(num_q_rows, topk)}, got {tuple(carry_values.shape)}"
+            )
+        if carry_indices.shape != (num_q_rows, topk):
+            raise ValueError(
+                f"carry_indices must have shape {(num_q_rows, topk)}, got {tuple(carry_indices.shape)}"
+            )
+        if carry_values.dtype != torch.float32:
+            raise ValueError(f"carry_values must be float32, got {carry_values.dtype}")
+        if carry_indices.dtype != torch.int32:
+            raise ValueError(f"carry_indices must be int32, got {carry_indices.dtype}")
+        if not carry_values.is_contiguous() or not carry_indices.is_contiguous():
+            raise ValueError("carry_values and carry_indices must be contiguous")
+        if (
+            carry_values.device != tile_logits.device
+            or carry_indices.device != tile_logits.device
+        ):
+            raise ValueError("carry buffers must be on the tile_logits device")
+        # carry-IN is read throughout selection; the output (carry-OUT for non-final
+        # chunks) is written. They must be physically distinct to avoid an
+        # intra-launch read/write race — the orchestrator ping-pongs two buffers.
+        if carry_values.data_ptr() == topk_values.data_ptr():
+            raise ValueError("carry_values must not alias the output values buffer")
+        if carry_indices.data_ptr() == topk_indices.data_ptr():
+            raise ValueError("carry_indices must not alias the output indices buffer")
+    else:
+        # is_first: carry is never read (the read path is constexpr-elided). Reuse the
+        # output buffers as the throwaway carry tensors so the hot single-chunk /
+        # first-chunk path allocates nothing (safe under CUDA-graph capture). The
+        # kernel only writes `values`/`indices`, so aliasing them as the unread carry
+        # is harmless.
+        if carry_values is None:
+            carry_values = topk_values
+        if carry_indices is None:
+            carry_indices = topk_indices
+
+    input_stride = Int32(0)
+    flat_input = tile_logits.reshape(-1)
+    flat_values = topk_values.reshape(-1).contiguous()
+    flat_indices = topk_indices.reshape(-1).contiguous()
+    flat_carry_values = carry_values.reshape(-1).contiguous()
+    flat_carry_indices = carry_indices.reshape(-1).contiguous()
+
+    kernel = _build_tiled_topk_kernel(
+        block_q,
+        block_k,
+        topk,
+        bool(zero_row_start),
+        bool(is_first),
+        bool(output_physical_slots),
+        extent_splits,
+    )
+    input_key_tensor = tile_logits
+    lengths_key_tensor = lengths
+    row_start_key_tensor = k_start
+    if zero_row_start:
+        row_start_key_tensor = lengths_key_tensor
+    values_key_tensor = topk_values
+    indices_key_tensor = topk_indices
+    carry_values_key_tensor = carry_values
+    carry_indices_key_tensor = carry_indices
+    output_page_table_key_tensor = output_page_table_for_kernel
+    args = (
+        _to_kernel_tensor(flat_input, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(k_start, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(lengths, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(flat_values, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(flat_indices, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(flat_carry_values, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(flat_carry_indices, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(output_page_table_for_kernel, cutlass.Int32, assumed_align=4),
+        Int32(num_q_rows * extent_splits),
+        input_stride,
+        Int32(num_k_tiles),
+        Int32(tile_k_offset),
+        Int32(block_q),
+        Int32(block_k),
+        Int32(topk),
+        Int32(input_index_offset),
+        Int32(input_extent),
+        Int32(output_index_offset),
+        Int32(output_page_size),
+        Int32(output_row_stride),
+        Int32(output_row_base),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        _flat_tensor_compile_key("input", input_key_tensor, dynamic=True),
+        _tensor_compile_key("row_start", row_start_key_tensor, dynamic_dims=(0,)),
+        _tensor_compile_key("lengths", lengths_key_tensor, dynamic_dims=(0,)),
+        _flat_tensor_compile_key("topk_values", values_key_tensor, dynamic=True),
+        _flat_tensor_compile_key("topk_indices", indices_key_tensor, dynamic=True),
+        _flat_tensor_compile_key("carry_values", carry_values_key_tensor, dynamic=True),
+        _flat_tensor_compile_key(
+            "carry_indices", carry_indices_key_tensor, dynamic=True
+        ),
+        _tensor_compile_key(
+            "output_page_table",
+            output_page_table_key_tensor,
+            dynamic_dims=(0,),
+        ),
+        (
+            "tiled_topk_v21",
+            topk,
+            block_q,
+            block_k,
+            bool(zero_row_start),
+            bool(is_first),
+            bool(output_physical_slots),
+            extent_splits,
+        ),
+    )
+    compile_spec = KernelCompileSpec.from_key(
+        "attention.indexer.tiled_topk",
+        4,
+        cache_key,
+        labels=(
+            "input",
+            "row_start",
+            "lengths",
+            "topk_values",
+            "topk_indices",
+            "carry_values",
+            "carry_indices",
+            "output_page_table",
+            "policy",
+        ),
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+    return topk_values, topk_indices
+
+
+def run_row_topk(
+    *,
+    row_logits: torch.Tensor,
+    lengths: torch.Tensor,
+    topk: int,
+    output_values: torch.Tensor | None = None,
+    output_indices: torch.Tensor | None = None,
+    output_index_offset: int = 0,
+    output_gather_table: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Exact row-wise topk over a dense row-major logits tile.
+
+    output_gather_table: optional int32 (rows, width) table; selected logical
+    positions are remapped through it (out = table[row, pos]), turning the
+    pass into a fold over (value, index) candidate pairs. Padded candidates
+    (-inf value, -1 index) propagate -1 naturally.
+    """
+    topk = _validate_supported_topk(topk, caller="run_row_topk")
+    if row_logits.ndim != 2:
+        raise ValueError(f"row_logits must be rank-2, got {tuple(row_logits.shape)}")
+    if not row_logits.is_contiguous():
+        raise ValueError("row_logits must be contiguous")
+    if row_logits.dtype != torch.float32:
+        raise ValueError(
+            f"row_logits must have dtype torch.float32, got {row_logits.dtype}"
+        )
+    if lengths.ndim != 1:
+        raise ValueError(f"lengths must be rank-1, got {tuple(lengths.shape)}")
+    if lengths.dtype != torch.int32:
+        raise ValueError(f"lengths must have dtype torch.int32, got {lengths.dtype}")
+    if not lengths.is_contiguous():
+        raise ValueError("lengths must be contiguous")
+    num_q_rows = int(row_logits.shape[0])
+    width = int(row_logits.shape[1])
+    if lengths.shape[0] != num_q_rows:
+        raise ValueError(
+            f"lengths rows {lengths.shape[0]} do not match row_logits rows {num_q_rows}"
+        )
+
+    if output_indices is None:
+        topk_indices = torch.empty(
+            (num_q_rows, topk),
+            dtype=torch.int32,
+            device=row_logits.device,
+        )
+    else:
+        if output_indices.shape != (num_q_rows, topk):
+            raise ValueError(
+                f"output_indices must have shape {(num_q_rows, topk)}, got {tuple(output_indices.shape)}"
+            )
+        if not output_indices.is_contiguous():
+            raise ValueError("output_indices must be contiguous")
+        topk_indices = output_indices
+    if output_values is None:
+        topk_values = torch.empty(
+            (num_q_rows, topk),
+            dtype=torch.float32,
+            device=row_logits.device,
+        )
+    else:
+        if output_values.shape != (num_q_rows, topk):
+            raise ValueError(
+                f"output_values must have shape {(num_q_rows, topk)}, got {tuple(output_values.shape)}"
+            )
+        if not output_values.is_contiguous():
+            raise ValueError("output_values must be contiguous")
+        topk_values = output_values
+
+    flat_input = row_logits.reshape(-1)
+    flat_values = topk_values.reshape(-1).contiguous()
+    flat_indices = topk_indices.reshape(-1).contiguous()
+    # Row top-k is always a single-chunk (is_first) selection. The carry path is
+    # constexpr-elided, so alias the unread carry tensors to the outputs instead
+    # of allocating throwaways inside graph-captured serving paths.
+    if output_gather_table is not None:
+        if output_gather_table.shape != (num_q_rows, width):
+            raise ValueError(
+                f"output_gather_table must have shape {(num_q_rows, width)}, "
+                f"got {tuple(output_gather_table.shape)}"
+            )
+        if output_gather_table.dtype != torch.int32:
+            raise ValueError("output_gather_table must be int32")
+        if not output_gather_table.is_contiguous():
+            raise ValueError("output_gather_table must be contiguous")
+        if output_gather_table.device != row_logits.device:
+            raise ValueError("output_gather_table must be on the logits device")
+    carry_values = topk_values
+    carry_indices = topk_indices
+    flat_carry_values = carry_values.reshape(-1)
+    flat_carry_indices = carry_indices.reshape(-1)
+    kernel = _build_row_topk_kernel(topk, output_gather_table is not None)
+    input_key_tensor = row_logits
+    lengths_key_tensor = lengths
+    values_key_tensor = topk_values
+    indices_key_tensor = topk_indices
+    carry_values_key_tensor = carry_values
+    carry_indices_key_tensor = carry_indices
+    args = (
+        _to_kernel_tensor(flat_input, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(lengths, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(lengths, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(flat_values, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(flat_indices, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(flat_carry_values, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(flat_carry_indices, cutlass.Int32, assumed_align=4),
+        _to_kernel_tensor(
+            output_gather_table if output_gather_table is not None else lengths,
+            cutlass.Int32,
+            assumed_align=4,
+        ),
+        Int32(num_q_rows),
+        Int32(width),
+        Int32(0),
+        Int32(0),
+        Int32(1),
+        Int32(1),
+        Int32(topk),
+        Int32(0),
+        Int32(width),
+        Int32(output_index_offset),
+        Int32(1),
+        Int32(1),
+        Int32(0),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        _flat_tensor_compile_key("logits", input_key_tensor, dynamic=True),
+        _tensor_compile_key("lengths", lengths_key_tensor, dynamic_dims=(0,)),
+        _flat_tensor_compile_key("topk_values", values_key_tensor, dynamic=True),
+        _flat_tensor_compile_key("topk_indices", indices_key_tensor, dynamic=True),
+        _flat_tensor_compile_key("carry_values", carry_values_key_tensor, dynamic=True),
+        _flat_tensor_compile_key(
+            "carry_indices", carry_indices_key_tensor, dynamic=True
+        ),
+        (
+            "row_topk_v5",
+            topk,
+            output_gather_table is not None,
+        ),
+    )
+    compile_spec = KernelCompileSpec.from_key(
+        "attention.indexer.row_topk",
+        4,
+        cache_key,
+        labels=(
+            "logits",
+            "lengths",
+            "topk_values",
+            "topk_indices",
+            "carry_values",
+            "carry_indices",
+            "policy",
+        ),
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=compile_spec,
+        compile_args=args,
+        runtime_args=args,
+    )
+    return topk_values, topk_indices
+
+
+def _resolve_supertile_k(supertile_k: int | None, *, block_k: int) -> int:
+    if supertile_k is None:
+        raw = os.environ.get(_SUPERTILE_K_ENV)
+        if raw is None:
+            supertile_k = _SUPERTILE_K_DEFAULT
+        else:
+            try:
+                supertile_k = int(raw)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{_SUPERTILE_K_ENV} must be an integer, got {raw!r}"
+                ) from exc
+    supertile_k = max(int(supertile_k), int(block_k))
+    return ((supertile_k + block_k - 1) // block_k) * block_k
+
+
+def merge_tiled_topk_candidates(
+    *,
+    candidate_values: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    topk: int,
+    output_values: torch.Tensor | None = None,
+    output_indices: torch.Tensor | None = None,
+    merge_positions: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge per-supertile exact topk candidates into one row-wise topk."""
+    if candidate_values.shape != candidate_indices.shape:
+        raise ValueError(
+            "candidate_values and candidate_indices must have the same shape, got "
+            f"{tuple(candidate_values.shape)} vs {tuple(candidate_indices.shape)}"
+        )
+    if candidate_values.ndim != 3:
+        raise ValueError(
+            f"candidates must have shape (chunks, rows, topk), got {tuple(candidate_values.shape)}"
+        )
+    num_chunks, num_q_rows, local_topk = candidate_values.shape
+    if int(local_topk) != int(topk):
+        raise ValueError(
+            f"candidate local topk {local_topk} does not match requested topk {topk}"
+        )
+    candidate_cols = int(num_chunks) * int(topk)
+    candidate_values_2d = candidate_values.permute(1, 0, 2).reshape(
+        num_q_rows, candidate_cols
+    )
+    candidate_indices_2d = candidate_indices.permute(1, 0, 2).reshape(
+        num_q_rows, candidate_cols
+    )
+    if output_values is None:
+        topk_values = torch.empty(
+            (num_q_rows, topk),
+            dtype=candidate_values.dtype,
+            device=candidate_values.device,
+        )
+    else:
+        if (
+            output_values.ndim != 2
+            or output_values.shape[0] < num_q_rows
+            or output_values.shape[1] < topk
+        ):
+            raise ValueError(
+                "output_values must have shape at least "
+                f"({num_q_rows}, {topk}), got {tuple(output_values.shape)}"
+            )
+        if output_values.dtype != candidate_values.dtype:
+            raise ValueError(
+                f"output_values must have dtype {candidate_values.dtype}, got {output_values.dtype}"
+            )
+        if output_values.device != candidate_values.device:
+            raise ValueError("output_values device must match candidate_values")
+        topk_values = output_values[:num_q_rows, :topk]
+
+    if merge_positions is None:
+        merge_pos = torch.empty(
+            (num_q_rows, topk),
+            dtype=torch.int64,
+            device=candidate_values.device,
+        )
+    else:
+        if (
+            merge_positions.ndim != 2
+            or merge_positions.shape[0] < num_q_rows
+            or merge_positions.shape[1] < topk
+        ):
+            raise ValueError(
+                "merge_positions must have shape at least "
+                f"({num_q_rows}, {topk}), got {tuple(merge_positions.shape)}"
+            )
+        if merge_positions.dtype != torch.int64:
+            raise ValueError(
+                f"merge_positions must have dtype torch.int64, got {merge_positions.dtype}"
+            )
+        if merge_positions.device != candidate_values.device:
+            raise ValueError("merge_positions device must match candidate_values")
+        if not merge_positions.is_contiguous():
+            raise ValueError("merge_positions must be contiguous")
+        merge_pos = merge_positions[:num_q_rows, :topk]
+
+    torch.topk(
+        candidate_values_2d,
+        k=topk,
+        dim=1,
+        largest=True,
+        sorted=False,
+        out=(topk_values, merge_pos),
+    )
+
+    if output_indices is None:
+        topk_indices = torch.gather(candidate_indices_2d, 1, merge_pos).contiguous()
+    else:
+        if (
+            output_indices.ndim != 2
+            or output_indices.shape[0] < num_q_rows
+            or output_indices.shape[1] < topk
+        ):
+            raise ValueError(
+                "output_indices must have shape at least "
+                f"({num_q_rows}, {topk}), got {tuple(output_indices.shape)}"
+            )
+        if output_indices.dtype != candidate_indices.dtype:
+            raise ValueError(
+                f"output_indices must have dtype {candidate_indices.dtype}, got {output_indices.dtype}"
+            )
+        if output_indices.device != candidate_indices.device:
+            raise ValueError("output_indices device must match candidate_indices")
+        topk_indices = output_indices[:num_q_rows, :topk]
+        torch.gather(candidate_indices_2d, 1, merge_pos, out=topk_indices)
+    return topk_values, topk_indices
+
+
+def run_tiled_supertile_topk(
+    *,
+    tile_logits: torch.Tensor,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+    topk: int,
+    block_q: int,
+    block_k: int,
+    supertile_k: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Exact topk over tiled logits by local-selecting K supertiles then merging candidates."""
+    topk = _validate_supported_topk(topk, caller="run_tiled_supertile_topk")
+    if not tile_logits.is_contiguous():
+        raise ValueError("tile_logits must be contiguous")
+    if not k_start.is_contiguous() or not k_end.is_contiguous():
+        raise ValueError("k_start and k_end must be contiguous")
+
+    num_q_rows = int(k_start.shape[0])
+    num_q_tiles = (num_q_rows + block_q - 1) // block_q
+    tile_size = block_q * block_k
+    total_elements = int(tile_logits.shape[0])
+    num_k_tiles = total_elements // (num_q_tiles * tile_size)
+    if num_k_tiles == 0:
+        num_k_tiles = getattr(tile_logits, "_sm12x_num_k_tiles", None)
+        if num_k_tiles is None:
+            raise ValueError("Cannot determine num_k_tiles")
+    resolved_supertile_k = _resolve_supertile_k(supertile_k, block_k=block_k)
+    supertile_tiles = max(1, resolved_supertile_k // block_k)
+    num_chunks = (int(num_k_tiles) + supertile_tiles - 1) // supertile_tiles
+    if num_chunks <= 1:
+        return run_tiled_topk(
+            tile_logits=tile_logits,
+            k_start=k_start,
+            k_end=k_end,
+            topk=topk,
+            block_q=block_q,
+            block_k=block_k,
+        )
+
+    # Streaming fold: each chunk folds the previous chunk's running top-k (carry) into
+    # its own selection. Two (M, topk) carry halves ping-pong (read prev, write next);
+    # the final chunk writes the user output. No (num_chunks, ...) slab, no merge.
+    carry_buf_values = torch.empty(
+        (2, num_q_rows, topk), dtype=torch.float32, device=tile_logits.device
+    )
+    carry_buf_indices = torch.empty(
+        (2, num_q_rows, topk), dtype=torch.int32, device=tile_logits.device
+    )
+    out_values = torch.empty(
+        (num_q_rows, topk), dtype=torch.float32, device=tile_logits.device
+    )
+    out_indices = torch.empty(
+        (num_q_rows, topk), dtype=torch.int32, device=tile_logits.device
+    )
+    global_lengths = (k_end - k_start).contiguous()
+
+    for chunk_idx in range(num_chunks):
+        chunk_tile_begin = chunk_idx * supertile_tiles
+        chunk_tile_end = min(chunk_tile_begin + supertile_tiles, int(num_k_tiles))
+        chunk_start = chunk_tile_begin * block_k
+        chunk_rows = (chunk_tile_end - chunk_tile_begin) * block_k
+        is_first = chunk_idx == 0
+        is_last = chunk_idx == num_chunks - 1
+        carry_values = carry_buf_values[(chunk_idx - 1) % 2]
+        carry_indices = carry_buf_indices[(chunk_idx - 1) % 2]
+        out_v = out_values if is_last else carry_buf_values[chunk_idx % 2]
+        out_i = out_indices if is_last else carry_buf_indices[chunk_idx % 2]
+        run_tiled_topk(
+            tile_logits=tile_logits,
+            k_start=k_start,
+            lengths=global_lengths,
+            topk=topk,
+            block_q=block_q,
+            block_k=block_k,
+            output_values=out_v,
+            output_indices=out_i,
+            num_k_tiles=int(num_k_tiles),
+            tile_k_offset=chunk_tile_begin,
+            input_index_offset=chunk_start,
+            input_extent=chunk_rows,
+            output_index_offset=chunk_start,
+            carry_values=carry_values,
+            carry_indices=carry_indices,
+            is_first=is_first,
+        )
+
+    return out_values, out_indices

--- a/flashinfer/experimental/sm12x/attention/paged/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/paged/__init__.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Paged-KV self-attention for SM12x (decode + extend/prefill).
+
+FA2-style paged attention: BF16/FP16 queries, BF16/FP16/FP8-e4m3 KV cache
+(FP8 KV needs BF16 queries + k/v descales), any head_dim multiple of 16,
+attention sinks, sliding window, and an MSA block-sparse variant driven by
+``q2k_indices``. The planner owns tile/split-KV/chunk policy; integrations
+supply tensors, shape metadata, and capacity caps (``Budget``). Decode
+supports CUDA-graph replay with all metadata rebuilt on-device.
+
+Planned lifecycle: ``plan(Caps(...))`` sizes the caller-owned scratch;
+``bind`` maps allocation-free views; ``run`` launches (capture safe).
+``Workspace`` is the preplanned arena alternative for workspace-style
+serving.
+
+Example:
+    from flashinfer.experimental.sm12x.attention import paged
+
+    plan    = paged.plan(paged.Caps(mode="decode", dtype=torch.bfloat16, ...))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = paged.bind(plan, scratch=scratch, q=q, k_cache=k, v_cache=v,
+                         output=out, page_table=pt, cache_seqlens=lens,
+                         cu_seqlens_q=cu_q)
+    out, lse = paged.run(binding=binding)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="paged",
+    group="attention",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "Binding",
+        "Workspace",
+        "Budget",
+        "plan",
+        "bind",
+        "run",
+        "infer_mode",
+        "is_supported",
+        "clear_caches",
+    ),
+    dtypes=("bf16", "fp16", "fp8_e4m3"),
+    recipes=("dense", "msa_block_sparse"),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=(
+            "b12x/attention/paged/",
+            "b12x/integration/paged_attention_scratch.py",
+        ),
+    ),
+    test_path="tests/experimental/attention/test_paged.py",
+    since="0.7.0",
+    notes=(
+        "Decode CUDA-graph replay is implemented but currently untested "
+        "in-tree (b12x's replay tests are stale against the current planner); "
+        "graph coverage comes from compressed_mla until they are refreshed."
+    ),
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Binding,
+        Budget,
+        Caps,
+        Plan,
+        Workspace,
+        bind,
+        clear_caches,
+        infer_mode,
+        is_supported,
+        plan,
+        run,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/attention/paged/_forward.py
+++ b/flashinfer/experimental/sm12x/attention/paged/_forward.py
@@ -1,0 +1,1268 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/api.py @ 3044f545 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Public isolated API for the primary paged-attention backend."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import os
+
+import cuda.bindings.driver as cuda
+import cutlass
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    DimKey,
+    KernelCompileSpec,
+    launch as sm12x_launch,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+
+from .forward_paged import (
+    PagedForwardKernel,
+)
+from .forward_extend_generic import build_extend_forward_kernel
+from .graph_replay import build_msa_prefill_union_metadata
+from .merge import PagedPersistentMergeKernel, default_paged_persistent_ctas
+from .traits import PagedForwardTraits, select_paged_forward_traits_from_plan
+
+_DECODE_NATIVE_FP8_QKV_MAX_SMALL_BATCH = 2
+_DECODE_NATIVE_FP8_QKV_MIN_LONG_CHUNK_PAGES = 11
+
+
+def _turbo_attention_enabled() -> bool:
+    return os.environ.get("FLASHINFER_EXP_SM12X_TURBO_ATTN") == "1"
+
+
+def _torch_to_cutlass_dtype(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float16:
+        return cutlass.Float16
+    if dtype == torch.float8_e4m3fn:
+        return cutlass.Float8E4M3FN
+    if dtype == torch.float32:
+        return cutlass.Float32
+    raise TypeError(f"unsupported dtype {dtype}")
+
+
+def _torch_to_cutlass_storage_dtype(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.float8_e4m3fn:
+        return cutlass.Uint8
+    return _torch_to_cutlass_dtype(dtype)
+
+
+def _to_kernel_tensor(
+    tensor: torch.Tensor | None,
+    dtype: type[cutlass.Numeric],
+    *,
+    assumed_align: int = 16,
+) -> torch.Tensor | cutlass.cute.Tensor | None:
+    if tensor is None:
+        return None
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = dtype
+    leading_dim = next(
+        (idx for idx, stride in enumerate(tensor.stride()) if stride == 1), None
+    )
+    if leading_dim is not None and tensor.ndim >= 2:
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+    return cute_tensor
+
+
+def _as_int32_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor if tensor.dtype == torch.int32 else tensor.to(torch.int32)
+
+
+def _uses_native_fp8_attention_mma(
+    *,
+    plan,
+) -> bool:
+    return _turbo_attention_enabled() and plan.kv_dtype == torch.float8_e4m3fn
+
+
+def _resolve_native_fp8_attention_mma_flags(
+    *,
+    plan,
+) -> tuple[bool, bool, bool]:
+    if getattr(plan, "msa_block_sparse", False):
+        return False, False, False
+    use_native_fp8_qk = _uses_native_fp8_attention_mma(plan=plan)
+    decode_runtime_chunk_guard = False
+    if use_native_fp8_qk and plan.mode in ("decode", "verify"):
+        if (
+            plan.total_q > _DECODE_NATIVE_FP8_QKV_MAX_SMALL_BATCH
+            and plan.kv_chunk_size
+            < _DECODE_NATIVE_FP8_QKV_MIN_LONG_CHUNK_PAGES * plan.page_size
+        ):
+            # Mid-batch short-chunk decode sees the native FP8 QK loss without enough replay gain.
+            use_native_fp8_qk = False
+    use_native_fp8_pv = (
+        use_native_fp8_qk
+        and plan.mode in ("decode", "verify")
+        and plan.kv_chunk_size <= 384
+    )
+    return use_native_fp8_qk, use_native_fp8_pv, decode_runtime_chunk_guard
+
+
+@lru_cache(maxsize=16)
+def _dummy_plane_tma_desc_ptrs(device_index: int, num_heads: int) -> torch.Tensor:
+    return torch.zeros(
+        (num_heads,), dtype=torch.int64, device=torch.device("cuda", device_index)
+    )
+
+
+def _encode_plane_tma_descriptors(
+    cache: torch.Tensor,
+    *,
+    plane_cols: int,
+    tile_rows: int | None = None,
+) -> torch.Tensor:
+    if cache.ndim != 4:
+        raise ValueError(
+            "cache must have shape [num_pages, page_size, kv_heads, head_dim]"
+        )
+    num_pages, page_size, kv_heads, head_dim = [int(dim) for dim in cache.shape]
+    if plane_cols <= 0 or head_dim % plane_cols != 0:
+        raise ValueError(f"plane_cols={plane_cols} must divide head_dim={head_dim}")
+    if tile_rows is None:
+        tile_rows = page_size
+    if tile_rows <= 0 or page_size % tile_rows != 0:
+        raise ValueError(
+            f"tile_rows={tile_rows} must be positive and divide page_size={page_size}"
+        )
+
+    swizzle_name = os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_PLANE_SWIZZLE", "")
+    swizzle = (
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_NONE
+        if swizzle_name == "none"
+        else cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B
+    )
+    if cache.dtype == torch.float8_e4m3fn:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8
+        elem_bytes = 1
+    elif cache.dtype == torch.bfloat16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+        elem_bytes = 2
+    elif cache.dtype == torch.float16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT16
+        elem_bytes = 2
+    else:
+        raise TypeError(f"unsupported plane TMA cache dtype {cache.dtype}")
+    U64 = cuda.cuuint64_t
+    U32 = cuda.cuuint32_t
+    row_bytes = kv_heads * head_dim * elem_bytes
+    # The plane descriptors flatten the cache to rank-2 [head_dim, total_rows]
+    # with row pitch row_bytes; rows within a page must therefore be contiguous
+    # at exactly kv_heads * head_dim elements, and total_rows must be derived
+    # from the PAGE STRIDE (not the shape) so strided caches (e.g. vLLM's
+    # combined [N, 2, page, H, D] K/V slices) keep flat row coordinates
+    # `tile_idx * tile_rows` in-bounds.
+    if int(cache.stride(3)) != 1:
+        raise ValueError(
+            "plane TMA cache requires contiguous head_dim (stride(3) == 1)"
+        )
+    if int(cache.stride(2)) != head_dim:
+        raise ValueError(
+            "plane TMA cache requires contiguous kv-head rows (stride(2) == head_dim)"
+        )
+    row_stride_elems = int(cache.stride(1))
+    if row_stride_elems != kv_heads * head_dim:
+        raise ValueError(
+            "plane TMA cache requires rows-within-page contiguous: "
+            f"stride(1)={row_stride_elems} != kv_heads*head_dim={kv_heads * head_dim}"
+        )
+    page_stride_elems = int(cache.stride(0))
+    if page_stride_elems % row_stride_elems != 0:
+        raise ValueError(
+            "plane TMA cache page stride must be a whole number of rows: "
+            f"stride(0)={page_stride_elems}, stride(1)={row_stride_elems}"
+        )
+    page_stride_rows = page_stride_elems // row_stride_elems
+    if page_stride_rows % tile_rows != 0:
+        raise ValueError(
+            f"plane TMA cache page stride rows ({page_stride_rows}) must be a multiple of tile_rows={tile_rows}"
+        )
+    total_rows = num_pages * page_stride_rows
+    base_ptr = int(cache.view(torch.uint8).data_ptr())
+    head_stride_bytes = head_dim * elem_bytes
+
+    host_desc = torch.empty((kv_heads, 16), dtype=torch.uint64)
+    for kv_head_idx in range(kv_heads):
+        result, tensor_map = cuda.cuTensorMapEncodeTiled(
+            data_type,
+            2,
+            base_ptr + kv_head_idx * head_stride_bytes,
+            [U64(head_dim), U64(total_rows)],
+            [U64(row_bytes)],
+            [U32(plane_cols), U32(tile_rows)],
+            [U32(1), U32(1)],
+            cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+            swizzle,
+            cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+            cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+        )
+        if result != cuda.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"cuTensorMapEncodeTiled failed: {result}")
+        host_desc[kv_head_idx] = torch.tensor(
+            [int(word) for word in tensor_map.opaque],
+            dtype=torch.uint64,
+        )
+    return host_desc.to(device=cache.device, non_blocking=False)
+
+
+def _paged_kv_tiles_per_table_entry(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    tile_rows: int,
+    name: str,
+) -> int:
+    """Physical `tile_rows`-row tiles spanned by one page-table entry stride.
+
+    Derived from the CACHE STRIDE, not assumed contiguous: vLLM's combined
+    [num_blocks, 2, 128, H, D] cache exposes K/V as strided slices whose page
+    stride covers both planes; the off-plane rows appear as phantom tiles that
+    are never addressed.
+    """
+    if cache.ndim != 4:
+        raise ValueError(
+            f"{name} must be rank-4 [num_pages, page_size, kv_heads, head_dim]"
+        )
+    if int(cache.stride(3)) != 1:
+        raise ValueError(f"{name} requires contiguous head_dim (stride(3) == 1)")
+    row_stride_elems = int(cache.stride(1))
+    if row_stride_elems <= 0:
+        raise ValueError(f"{name} requires a positive token stride")
+    page_stride_elems = int(cache.stride(0))
+    if page_stride_elems % row_stride_elems != 0:
+        raise ValueError(
+            f"{name} page stride must be a whole number of token rows: "
+            f"stride(0)={page_stride_elems}, stride(1)={row_stride_elems}"
+        )
+    page_stride_rows = page_stride_elems // row_stride_elems
+    if page_stride_rows % tile_rows != 0:
+        raise ValueError(
+            f"{name} page stride rows ({page_stride_rows}) must be a multiple of {tile_rows}"
+        )
+    if page_stride_rows < int(page_size):
+        raise ValueError(
+            f"{name} page stride rows ({page_stride_rows}) are smaller than page_size={page_size}"
+        )
+    return page_stride_rows // tile_rows
+
+
+def _descriptor_row_ptrs(desc: torch.Tensor) -> torch.Tensor:
+    row_bytes = int(desc.stride(0)) * desc.element_size()
+    base_ptr = int(desc.data_ptr())
+    ptrs = [base_ptr + idx * row_bytes for idx in range(int(desc.shape[0]))]
+    return torch.tensor(ptrs, dtype=torch.int64, device=desc.device)
+
+
+def _get_cached_plane_tma_descs(
+    scratch: object,
+    *,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    plane_cols: int,
+    tile_rows: int,
+) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor, torch.Tensor] | None:
+    cached = getattr(scratch, "_live_plane_tma_desc_cache", None)
+    if cached is None:
+        return None
+    key = (
+        int(k_cache.data_ptr()),
+        int(v_cache.data_ptr()),
+        tuple(k_cache.shape),
+        tuple(v_cache.shape),
+        plane_cols,
+        tile_rows,
+    )
+    return cached.get(key)
+
+
+def _tensor_meta_key(
+    tensor: torch.Tensor | None,
+    *,
+    dynamic_dims: tuple[int, ...] = (),
+    dynamic_strides: tuple[int, ...] = (),
+) -> tuple[tuple[object, ...], tuple[object, ...], str, tuple[str, int | None]] | None:
+    if tensor is None:
+        return None
+    dynamic_dim_set = set(dynamic_dims)
+    dynamic_stride_set = set(dynamic_strides)
+    return (
+        tuple(
+            DimKey.dynamic() if idx in dynamic_dim_set else int(dim)
+            for idx, dim in enumerate(tensor.shape)
+        ),
+        tuple(
+            DimKey.dynamic() if idx in dynamic_stride_set else int(stride)
+            for idx, stride in enumerate(tensor.stride())
+        ),
+        str(tensor.dtype),
+        (tensor.device.type, tensor.device.index),
+    )
+
+
+def _paged_kv_cache_meta_key(
+    tensor: torch.Tensor | None,
+) -> tuple[tuple[object, ...], tuple[object, ...], str, tuple[str, int | None]] | None:
+    # K/V cache page capacity is runtime storage capacity. The selected kernel
+    # policy depends on page layout, dtype, heads, and strides, not total pages.
+    return _tensor_meta_key(tensor, dynamic_dims=(0,))
+
+
+def _traits_compile_key(traits: PagedForwardTraits) -> tuple[object, ...]:
+    return (
+        int(traits.cta_tile_q),
+        int(traits.cta_tile_kv),
+        int(traits.num_mma_q),
+        int(traits.num_mma_kv),
+        int(traits.num_mma_d_qk),
+        int(traits.num_mma_d_vo),
+        int(traits.num_warps_q),
+        int(traits.num_warps_kv),
+        int(traits.num_threads),
+        int(traits.head_dim_qk),
+        int(traits.head_dim_vo),
+        int(traits.upcast_stride_q),
+        int(traits.upcast_stride_k),
+        int(traits.upcast_stride_v),
+        int(traits.upcast_stride_o),
+        str(traits.q_dtype),
+        str(traits.kv_dtype),
+        str(traits.o_dtype),
+        int(traits.q_smem_bytes),
+        int(traits.shared_storage_bytes),
+        int(traits.num_ctas_per_sm),
+        int(traits.max_smem_per_threadblock),
+    )
+
+
+@lru_cache(maxsize=64)
+def _build_forward_kernel(
+    traits: PagedForwardTraits,
+    gqa_group_size: int,
+    split_kv: bool,
+    single_request_decode_graph: bool,
+    single_qtile_decode_graph: bool,
+    regularized_decode_graph: bool,
+    use_native_fp8_qk: bool,
+    use_native_fp8_pv: bool,
+    decode_only: bool,
+    decode_native_fp8_runtime_chunk_guard: bool,
+    window_left: int,
+    has_attention_sink_bias: bool,
+    has_relative_attention_bias: bool,
+    msa_block_sparse: bool,
+    page_size: int,
+    page_tiles_per_entry: int,
+) -> PagedForwardKernel:
+    return PagedForwardKernel(
+        _torch_to_cutlass_dtype(traits.q_dtype),
+        _torch_to_cutlass_dtype(traits.kv_dtype),
+        _torch_to_cutlass_storage_dtype(traits.kv_dtype),
+        _torch_to_cutlass_dtype(traits.o_dtype),
+        traits=traits,
+        gqa_group_size=gqa_group_size,
+        split_kv=split_kv,
+        single_request_decode_graph=single_request_decode_graph,
+        single_qtile_decode_graph=single_qtile_decode_graph,
+        regularized_decode_graph=regularized_decode_graph,
+        use_native_fp8_qk=use_native_fp8_qk,
+        use_native_fp8_pv=use_native_fp8_pv,
+        decode_only=decode_only,
+        decode_native_fp8_runtime_chunk_guard=decode_native_fp8_runtime_chunk_guard,
+        window_left=window_left,
+        has_attention_sink_bias=has_attention_sink_bias,
+        has_relative_attention_bias=has_relative_attention_bias,
+        msa_block_sparse=msa_block_sparse,
+        page_size=page_size,
+        page_tiles_per_entry=page_tiles_per_entry,
+    )
+
+
+@lru_cache(maxsize=32)
+def _build_extend_forward_kernel(
+    traits: PagedForwardTraits,
+    use_native_fp8_qk: bool,
+    use_native_fp8_pv: bool,
+    window_left: int,
+    has_attention_sink_bias: bool,
+    has_relative_attention_bias: bool,
+    msa_block_sparse: bool,
+    msa_union_tile: bool,
+    page_size: int,
+) -> object:
+    return build_extend_forward_kernel(
+        traits,
+        use_native_fp8_qk,
+        use_native_fp8_pv,
+        window_left=window_left,
+        has_attention_sink_bias=has_attention_sink_bias,
+        has_relative_attention_bias=has_relative_attention_bias,
+        msa_block_sparse=msa_block_sparse,
+        msa_union_tile=msa_union_tile,
+        page_size=page_size,
+    )
+
+
+@lru_cache(maxsize=16)
+def _build_merge_kernel(
+    dtype: torch.dtype,
+    head_dim: int,
+    total_q: int,
+    persistent_ctas: int,
+    direct_grid: bool,
+    regular_decode_graph: bool,
+    pair_bf16_partial_loads: bool,
+) -> PagedPersistentMergeKernel:
+    cutlass_dtype = _torch_to_cutlass_dtype(dtype)
+    merge_bdy = (
+        3 if dtype == torch.bfloat16 and head_dim == 128 and regular_decode_graph else 4
+    )
+    if (
+        dtype == torch.bfloat16
+        and head_dim == 128
+        and regular_decode_graph
+        and int(total_q) == 4
+    ):
+        merge_bdy = 4
+    return PagedPersistentMergeKernel(
+        cutlass_dtype,
+        cutlass_dtype,
+        head_dim=head_dim,
+        vec_size=head_dim // 32,
+        bdy=merge_bdy,
+        persistent_ctas=persistent_ctas,
+        direct_grid=direct_grid,
+        regular_decode_graph=regular_decode_graph,
+        pair_bf16_partial_loads=pair_bf16_partial_loads,
+    )
+
+
+def _resolve_paged_attention_binding(
+    *,
+    binding,
+    q: torch.Tensor | None,
+    k_cache: torch.Tensor | None,
+    v_cache: torch.Tensor | None,
+    output: torch.Tensor | None,
+    q2k_indices: torch.Tensor | None,
+    k_descale: torch.Tensor | None,
+    v_descale: torch.Tensor | None,
+    attention_sink_bias: torch.Tensor | None,
+    relative_attention_bias: torch.Tensor | None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    object,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    if binding is None:
+        raise TypeError("paged_attention_forward requires binding")
+
+    extras = [
+        name
+        for name, value in (
+            ("q", q),
+            ("k_cache", k_cache),
+            ("v_cache", v_cache),
+            ("output", output),
+            ("q2k_indices", q2k_indices),
+            ("k_descale", k_descale),
+            ("v_descale", v_descale),
+            ("attention_sink_bias", attention_sink_bias),
+            ("relative_attention_bias", relative_attention_bias),
+        )
+        if value is not None
+    ]
+    if extras:
+        raise ValueError(
+            "paged attention binding owns runtime tensors and scratch; "
+            f"do not also pass {', '.join(extras)}"
+        )
+    binding_scratch = getattr(binding, "scratch", None)
+    if binding_scratch is None:
+        raise TypeError("paged attention binding must expose scratch")
+    return (
+        binding.q,
+        binding.k_cache,
+        binding.v_cache,
+        binding_scratch,
+        binding.output,
+        getattr(binding, "q2k_indices", None),
+        binding.k_descale,
+        binding.v_descale,
+        binding.attention_sink_bias,
+        binding.relative_attention_bias,
+    )
+
+
+def _capture_decode_graph_replay_metadata_if_needed(
+    scratch: object,
+) -> None:
+    if not torch.cuda.is_current_stream_capturing():
+        return
+    if not (
+        getattr(scratch, "use_cuda_graph", False)
+        and getattr(scratch, "mode", None) == "decode"
+        and getattr(scratch, "_decode_graph_chunk_pages_lut", None) is not None
+        and getattr(scratch, "_plan", None) is not None
+    ):
+        return
+    if getattr(scratch, "_decode_graph_metadata_captured_in_graph", False):
+        return
+    update_metadata = getattr(
+        scratch,
+        "update_decode_graph_replay_metadata_from_runtime_cache_seqlens",
+        None,
+    )
+    if update_metadata is None:
+        return
+    update_metadata()
+    scratch._decode_graph_metadata_captured_in_graph = True
+
+
+def paged_attention_forward(
+    q: torch.Tensor | None = None,
+    k_cache: torch.Tensor | None = None,
+    v_cache: torch.Tensor | None = None,
+    *,
+    output: torch.Tensor | None = None,
+    q2k_indices: torch.Tensor | None = None,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    relative_attention_bias: torch.Tensor | None = None,
+    binding=None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    (
+        q,
+        k_cache,
+        v_cache,
+        workspace,
+        output,
+        q2k_indices,
+        k_descale,
+        v_descale,
+        attention_sink_bias,
+        relative_attention_bias,
+    ) = _resolve_paged_attention_binding(
+        binding=binding,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        q2k_indices=q2k_indices,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        attention_sink_bias=attention_sink_bias,
+        relative_attention_bias=relative_attention_bias,
+    )
+    plan = workspace.plan
+    page_table = workspace.page_table
+    cache_seqlens = workspace.cache_seqlens
+    cu_seqlens_q = workspace.cu_seqlens_q
+    if page_table is None or cache_seqlens is None or cu_seqlens_q is None:
+        raise RuntimeError("paged attention scratch metadata has not been prepared")
+    if plan.split_kv and (workspace.tmp_output is None or workspace.tmp_lse is None):
+        raise ValueError(
+            "split-kv plan requires tmp_output and tmp_lse in the scratch binding"
+        )
+    _capture_decode_graph_replay_metadata_if_needed(workspace)
+    if k_descale is not None and k_descale.ndim == 2 and int(k_descale.shape[1]) == 1:
+        k_descale = k_descale[:, 0].contiguous()
+    if v_descale is not None and v_descale.ndim == 2 and int(v_descale.shape[1]) == 1:
+        v_descale = v_descale[:, 0].contiguous()
+    if output.ndim != 3:
+        raise ValueError(
+            f"output must be rank-3 [total_q, heads, head_dim], got {tuple(output.shape)}"
+        )
+    if int(output.shape[0]) < int(plan.total_q):
+        raise ValueError(
+            f"output first dimension must be at least total_q={plan.total_q}, got {int(output.shape[0])}"
+        )
+    if tuple(output.shape[1:]) != (plan.num_q_heads, plan.head_dim_vo):
+        raise ValueError(
+            "output shape must match the prepared scratch contract: "
+            f"expected (*, {plan.num_q_heads}, {plan.head_dim_vo}), got {tuple(output.shape)}"
+        )
+
+    if (
+        k_cache.dtype == torch.float8_e4m3fn or v_cache.dtype == torch.float8_e4m3fn
+    ) and (k_descale is None or v_descale is None):
+        raise ValueError("fp8 paged caches require k_descale and v_descale")
+    if workspace.kv_window_start_tokens is None:
+        raise RuntimeError("paged attention scratch is missing kv_window_start_tokens")
+    if getattr(plan, "msa_block_sparse", False):
+        if attention_sink_bias is not None:
+            raise ValueError(
+                "MSA block-sparse paged attention does not support attention_sink_bias"
+            )
+        if relative_attention_bias is not None:
+            raise ValueError(
+                "MSA block-sparse paged attention does not support "
+                "relative_attention_bias"
+            )
+        if q2k_indices is None:
+            raise ValueError("MSA block-sparse paged attention requires q2k_indices")
+        if q2k_indices.ndim != 3:
+            raise ValueError(
+                "q2k_indices must have shape [kv_heads, total_q_capacity, 16]"
+            )
+        if q2k_indices.dtype != torch.int32:
+            raise TypeError("q2k_indices must be torch.int32")
+        if q2k_indices.device != q.device:
+            raise ValueError("q2k_indices must be on the same CUDA device as q")
+        if not q2k_indices.is_contiguous():
+            raise ValueError("q2k_indices must be contiguous")
+        expected_prefix = (plan.num_kv_heads, 16)
+        if (
+            int(q2k_indices.shape[0]) != expected_prefix[0]
+            or int(q2k_indices.shape[2]) != expected_prefix[1]
+        ):
+            raise ValueError(
+                "q2k_indices must have shape "
+                f"({plan.num_kv_heads}, >=total_q, 16), got {tuple(q2k_indices.shape)}"
+            )
+        if int(q2k_indices.shape[1]) < int(plan.total_q):
+            raise ValueError(
+                "q2k_indices total_q_capacity is smaller than active total_q"
+            )
+    elif q2k_indices is not None:
+        raise ValueError("q2k_indices can only be supplied for MSA block-sparse plans")
+    has_attention_sink_bias = attention_sink_bias is not None
+    if attention_sink_bias is None:
+        attention_sink_bias = torch.empty(0, dtype=torch.float32, device=q.device)
+    else:
+        if attention_sink_bias.ndim != 1:
+            raise ValueError(
+                f"attention_sink_bias must be rank-1 [num_q_heads], got {tuple(attention_sink_bias.shape)}"
+            )
+        if int(attention_sink_bias.shape[0]) != plan.num_q_heads:
+            raise ValueError(
+                f"attention_sink_bias must have {plan.num_q_heads} elements, got {int(attention_sink_bias.shape[0])}"
+            )
+        if attention_sink_bias.device != q.device:
+            raise ValueError("attention_sink_bias must be on the same CUDA device as q")
+        if attention_sink_bias.dtype != torch.float32:
+            attention_sink_bias = attention_sink_bias.to(torch.float32)
+        if not attention_sink_bias.is_contiguous():
+            attention_sink_bias = attention_sink_bias.contiguous()
+
+    has_relative_attention_bias = relative_attention_bias is not None
+    if relative_attention_bias is not None:
+        if relative_attention_bias.ndim != 3:
+            raise ValueError(
+                "relative_attention_bias must be rank-3 "
+                "[total_q_capacity, num_q_heads, relative_extent], got "
+                f"{tuple(relative_attention_bias.shape)}"
+            )
+        if int(relative_attention_bias.shape[0]) < int(plan.total_q):
+            raise ValueError(
+                "relative_attention_bias first dimension must be at least "
+                f"total_q={plan.total_q}, got "
+                f"{int(relative_attention_bias.shape[0])}"
+            )
+        if int(relative_attention_bias.shape[1]) != plan.num_q_heads:
+            raise ValueError(
+                "relative_attention_bias must have "
+                f"{plan.num_q_heads} query heads, got "
+                f"{int(relative_attention_bias.shape[1])}"
+            )
+        if int(relative_attention_bias.shape[2]) <= 0:
+            raise ValueError("relative_attention_bias extent must be positive")
+        if relative_attention_bias.device != q.device:
+            raise ValueError(
+                "relative_attention_bias must be on the same CUDA device as q"
+            )
+        if relative_attention_bias.dtype != q.dtype:
+            raise TypeError(
+                "relative_attention_bias must have the same dtype as q; "
+                f"got {relative_attention_bias.dtype} and {q.dtype}"
+            )
+        if not relative_attention_bias.is_contiguous():
+            raise ValueError("relative_attention_bias must be contiguous")
+
+    traits = select_paged_forward_traits_from_plan(plan)
+    use_native_fp8_qk, use_native_fp8_pv, decode_native_fp8_runtime_chunk_guard = (
+        _resolve_native_fp8_attention_mma_flags(plan=plan)
+    )
+    page_size = int(plan.page_size)
+    page_tiles_per_entry = 1
+    if page_size == 128:
+        if (
+            k_cache.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+            or v_cache.dtype != k_cache.dtype
+        ):
+            raise ValueError(
+                "page_size=128 paged attention requires matching fp16, bf16, or fp8 e4m3 K/V caches"
+            )
+        k_tiles_per_entry = _paged_kv_tiles_per_table_entry(
+            k_cache,
+            page_size=page_size,
+            tile_rows=64,
+            name="k_cache",
+        )
+        v_tiles_per_entry = _paged_kv_tiles_per_table_entry(
+            v_cache,
+            page_size=page_size,
+            tile_rows=64,
+            name="v_cache",
+        )
+        if k_tiles_per_entry != v_tiles_per_entry:
+            raise ValueError(
+                "page_size=128 paged attention requires K and V caches with equal "
+                f"page-stride tile counts, got {k_tiles_per_entry} vs {v_tiles_per_entry}"
+            )
+        page_tiles_per_entry = k_tiles_per_entry
+    single_request_decode_graph = False
+    single_qtile_decode_graph = False
+    regularized_decode_graph = False
+    if plan.mode == "extend":
+        if plan.split_kv:
+            raise ValueError("extend plans no longer support split-kv")
+        forward_kernel = _build_extend_forward_kernel(
+            traits,
+            use_native_fp8_qk,
+            use_native_fp8_pv,
+            plan.window_left,
+            has_attention_sink_bias,
+            has_relative_attention_bias,
+            bool(plan.msa_block_sparse),
+            bool(getattr(plan, "msa_union_tile", False)),
+            page_size,
+        )
+    else:
+        single_request_decode_graph = (
+            plan.mode == "decode"
+            and plan.enable_cuda_graph
+            and plan.split_kv
+            and not bool(plan.msa_block_sparse)
+            and plan.gqa_group_size <= plan.cta_tile_q
+            and workspace._decode_graph_chunk_pages_lut is not None
+            and plan.num_qo_tiles == 1
+            and plan.page_table_shape[0] == 1
+        )
+        single_qtile_decode_graph = (
+            plan.mode == "decode"
+            and plan.enable_cuda_graph
+            and plan.split_kv
+            and not bool(plan.msa_block_sparse)
+            and plan.gqa_group_size <= plan.cta_tile_q
+            and workspace._decode_graph_chunk_pages_lut is not None
+            and plan.page_table_shape[0] > 1
+            and max(plan.qo_tile_indices, default=0) == 0
+        )
+        regularized_decode_graph = (
+            single_qtile_decode_graph and workspace._use_regular_decode_graph_replay
+        )
+        forward_kernel = _build_forward_kernel(
+            traits,
+            plan.gqa_group_size,
+            plan.split_kv,
+            single_request_decode_graph,
+            single_qtile_decode_graph,
+            regularized_decode_graph,
+            use_native_fp8_qk,
+            use_native_fp8_pv,
+            plan.mode == "decode",
+            decode_native_fp8_runtime_chunk_guard,
+            plan.window_left,
+            has_attention_sink_bias,
+            has_relative_attention_bias,
+            bool(plan.msa_block_sparse),
+            page_size,
+            page_tiles_per_entry,
+        )
+    forward_output = workspace.tmp_output if plan.split_kv else output
+    forward_lse = workspace.tmp_lse if plan.split_kv else workspace.lse
+    assert forward_output is not None
+    assert forward_lse is not None
+    msa_union_blocks = None
+    msa_union_masks = None
+    msa_union_counts = None
+    if bool(getattr(plan, "msa_union_tile", False)):
+        msa_union_blocks = getattr(workspace, "msa_union_blocks", None)
+        msa_union_masks = getattr(workspace, "msa_union_masks", None)
+        msa_union_counts = getattr(workspace, "msa_union_counts", None)
+        if (
+            msa_union_blocks is None
+            or msa_union_masks is None
+            or msa_union_counts is None
+        ):
+            raise RuntimeError(
+                "MSA union-tile prefill requires union metadata scratch buffers"
+            )
+        assert q2k_indices is not None
+        build_msa_prefill_union_metadata(
+            q2k_indices=q2k_indices,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            request_indices=workspace.request_indices,
+            qo_tile_indices=workspace.qo_tile_indices,
+            block_valid_mask=workspace.block_valid_mask,
+            union_blocks=msa_union_blocks,
+            union_masks=msa_union_masks,
+            union_counts=msa_union_counts,
+        )
+
+    q_arg = _to_kernel_tensor(q, _torch_to_cutlass_dtype(q.dtype))
+    k_cache_arg = (
+        _to_kernel_tensor(k_cache.view(torch.uint8), cutlass.Uint8)
+        if k_cache.dtype == torch.float8_e4m3fn
+        else _to_kernel_tensor(k_cache, _torch_to_cutlass_dtype(k_cache.dtype))
+    )
+    v_cache_arg = (
+        _to_kernel_tensor(v_cache.view(torch.uint8), cutlass.Uint8)
+        if v_cache.dtype == torch.float8_e4m3fn
+        else _to_kernel_tensor(v_cache, _torch_to_cutlass_dtype(v_cache.dtype))
+    )
+    forward_output_arg = _to_kernel_tensor(
+        forward_output, _torch_to_cutlass_dtype(forward_output.dtype)
+    )
+    forward_lse_arg = _to_kernel_tensor(forward_lse, cutlass.Float32)
+    page_table_arg = _to_kernel_tensor(
+        _as_int32_tensor(page_table), cutlass.Int32, assumed_align=4
+    )
+    cache_seqlens_arg = _to_kernel_tensor(
+        _as_int32_tensor(cache_seqlens), cutlass.Int32, assumed_align=4
+    )
+    cu_seqlens_q_arg = _to_kernel_tensor(
+        _as_int32_tensor(cu_seqlens_q), cutlass.Int32, assumed_align=4
+    )
+    request_indices_arg = _to_kernel_tensor(
+        workspace.request_indices, cutlass.Int32, assumed_align=4
+    )
+    qo_tile_indices_arg = _to_kernel_tensor(
+        workspace.qo_tile_indices, cutlass.Int32, assumed_align=4
+    )
+    kv_tile_indices_arg = _to_kernel_tensor(
+        workspace.kv_tile_indices, cutlass.Int32, assumed_align=4
+    )
+    o_indptr_arg = _to_kernel_tensor(workspace.o_indptr, cutlass.Int32, assumed_align=4)
+    kv_chunk_size_arg = _to_kernel_tensor(
+        workspace.kv_chunk_size_ptr, cutlass.Int32, assumed_align=4
+    )
+    kv_window_start_arg = _to_kernel_tensor(
+        workspace.kv_window_start_tokens, cutlass.Int32, assumed_align=4
+    )
+    block_valid_mask_arg = _to_kernel_tensor(
+        workspace.block_valid_mask, cutlass.Int32, assumed_align=4
+    )
+    q2k_indices_arg = _to_kernel_tensor(q2k_indices, cutlass.Int32, assumed_align=4)
+    msa_union_blocks_arg = _to_kernel_tensor(
+        msa_union_blocks, cutlass.Int32, assumed_align=4
+    )
+    msa_union_masks_arg = _to_kernel_tensor(
+        msa_union_masks, cutlass.Int32, assumed_align=4
+    )
+    msa_union_counts_arg = _to_kernel_tensor(
+        msa_union_counts, cutlass.Int32, assumed_align=4
+    )
+    attention_sink_bias_arg = _to_kernel_tensor(
+        attention_sink_bias, cutlass.Float32, assumed_align=4
+    )
+    relative_attention_bias_arg = _to_kernel_tensor(
+        relative_attention_bias,
+        _torch_to_cutlass_dtype(q.dtype),
+    )
+    k_descale_arg = _to_kernel_tensor(k_descale, cutlass.Float32)
+    v_descale_arg = _to_kernel_tensor(v_descale, cutlass.Float32)
+    k_tma_desc_ptrs: torch.Tensor | None = None
+    v_tma_desc_ptrs: torch.Tensor | None = None
+    k_tma_desc: torch.Tensor | None = None
+    v_tma_desc: torch.Tensor | None = None
+    if plan.mode == "extend" and (
+        getattr(forward_kernel, "use_paged_kv_tma_raw_desc_issue", False)
+        or getattr(forward_kernel, "use_paged_kv_tma_fp8_raw_issue", False)
+    ):
+        cached_descs = _get_cached_plane_tma_descs(
+            workspace,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            plane_cols=forward_kernel.kv_tma_plane_head_dim,
+            tile_rows=forward_kernel.stage_tile_rows,
+        )
+        if cached_descs is not None:
+            k_tma_desc, v_tma_desc, k_tma_desc_ptrs, v_tma_desc_ptrs = cached_descs
+        else:
+            k_tma_desc = _encode_plane_tma_descriptors(
+                k_cache,
+                plane_cols=forward_kernel.kv_tma_plane_head_dim,
+                tile_rows=forward_kernel.stage_tile_rows,
+            )
+            v_tma_desc = _encode_plane_tma_descriptors(
+                v_cache,
+                plane_cols=forward_kernel.kv_tma_plane_head_dim,
+                tile_rows=forward_kernel.stage_tile_rows,
+            )
+            k_tma_desc_ptrs = _descriptor_row_ptrs(k_tma_desc)
+            v_tma_desc_ptrs = _descriptor_row_ptrs(v_tma_desc)
+            workspace._live_plane_tma_desc_cache[
+                (
+                    int(k_cache.data_ptr()),
+                    int(v_cache.data_ptr()),
+                    tuple(k_cache.shape),
+                    tuple(v_cache.shape),
+                    forward_kernel.kv_tma_plane_head_dim,
+                    forward_kernel.stage_tile_rows,
+                )
+            ] = (
+                k_tma_desc,
+                v_tma_desc,
+                k_tma_desc_ptrs,
+                v_tma_desc_ptrs,
+            )
+    if k_tma_desc_ptrs is None or v_tma_desc_ptrs is None:
+        dummy_desc_ptrs = _dummy_plane_tma_desc_ptrs(
+            torch.cuda.current_device(),
+            plan.num_kv_heads,
+        )
+        k_tma_desc_ptrs = dummy_desc_ptrs
+        v_tma_desc_ptrs = dummy_desc_ptrs
+    workspace._live_plane_tma_descs = (
+        k_tma_desc,
+        v_tma_desc,
+        k_tma_desc_ptrs,
+        v_tma_desc_ptrs,
+    )
+
+    stream = current_cuda_stream()
+    use_capacity_contract = (
+        plan.mode in ("extend", "verify") and workspace.fixed_capacity
+    )
+    q_cache_tensor = (
+        workspace._plan_q
+        if use_capacity_contract and workspace._plan_q is not None
+        else q
+    )
+    output_cache_tensor = (
+        workspace._plan_output
+        if use_capacity_contract and workspace._plan_output is not None
+        else forward_output
+    )
+    cuda_graph_decode = plan.mode == "decode" and plan.enable_cuda_graph
+    dynamic_first_dim = () if cuda_graph_decode else (0,)
+    # The worklist length determines the CUTE launch grid below:
+    # grid=(mBlockValidMask.shape[0], ...). Keep it static in the compile key
+    # so a kernel compiled for a smaller eager prefill bucket is not reused for
+    # a larger one with too few CTAs.
+    grid_worklist_dynamic_first_dim = ()
+    forward_lse_dynamic_dims = (
+        dynamic_first_dim if plan.split_kv else (() if cuda_graph_decode else (1,))
+    )
+    forward_lse_dynamic_strides = () if plan.split_kv or cuda_graph_decode else (0,)
+    forward_cache_key = [
+        _traits_compile_key(traits),
+        (
+            plan.mode,
+            bool(plan.split_kv),
+            bool(plan.enable_cuda_graph),
+            int(plan.gqa_group_size),
+            bool(single_request_decode_graph),
+            bool(single_qtile_decode_graph),
+            bool(regularized_decode_graph),
+            bool(plan.mode == "decode"),
+            bool(use_native_fp8_qk),
+            bool(use_native_fp8_pv),
+            bool(decode_native_fp8_runtime_chunk_guard),
+            int(plan.window_left),
+            bool(has_attention_sink_bias),
+            bool(has_relative_attention_bias),
+            bool(plan.msa_block_sparse),
+            bool(getattr(plan, "msa_union_tile", False)),
+            int(page_size),
+            int(page_tiles_per_entry),
+        ),
+        _tensor_meta_key(q_cache_tensor, dynamic_dims=dynamic_first_dim),
+        _paged_kv_cache_meta_key(k_cache),
+        _paged_kv_cache_meta_key(v_cache),
+        _tensor_meta_key(page_table, dynamic_dims=dynamic_first_dim),
+        _tensor_meta_key(cache_seqlens, dynamic_dims=dynamic_first_dim),
+        _tensor_meta_key(cu_seqlens_q, dynamic_dims=dynamic_first_dim),
+        _tensor_meta_key(
+            workspace.request_indices,
+            dynamic_dims=grid_worklist_dynamic_first_dim,
+        ),
+        _tensor_meta_key(
+            workspace.qo_tile_indices,
+            dynamic_dims=grid_worklist_dynamic_first_dim,
+        ),
+        _tensor_meta_key(
+            workspace.kv_tile_indices,
+            dynamic_dims=grid_worklist_dynamic_first_dim,
+        ),
+        _tensor_meta_key(workspace.o_indptr, dynamic_dims=dynamic_first_dim),
+        _tensor_meta_key(workspace.kv_chunk_size_ptr),
+        _tensor_meta_key(
+            workspace.kv_window_start_tokens, dynamic_dims=dynamic_first_dim
+        ),
+        _tensor_meta_key(
+            workspace.block_valid_mask,
+            dynamic_dims=grid_worklist_dynamic_first_dim,
+        ),
+        _tensor_meta_key(attention_sink_bias),
+        _tensor_meta_key(
+            relative_attention_bias,
+            dynamic_dims=dynamic_first_dim,
+        ),
+        _tensor_meta_key(output_cache_tensor, dynamic_dims=dynamic_first_dim),
+        _tensor_meta_key(
+            forward_lse,
+            dynamic_dims=forward_lse_dynamic_dims,
+            dynamic_strides=forward_lse_dynamic_strides,
+        ),
+        _tensor_meta_key(k_descale, dynamic_dims=dynamic_first_dim),
+        _tensor_meta_key(v_descale, dynamic_dims=dynamic_first_dim),
+    ]
+    cache_key_labels = [
+        "traits",
+        "kernel_policy",
+        "q_contract" if use_capacity_contract else "q",
+        "k_cache",
+        "v_cache",
+        "page_table",
+        "cache_seqlens",
+        "cu_seqlens_q",
+        "request_indices",
+        "qo_tile_indices",
+        "kv_tile_indices",
+        "o_indptr",
+        "kv_chunk_size_ptr",
+        "kv_window_start_tokens",
+        "block_valid_mask",
+        "attention_sink_bias",
+        "relative_attention_bias",
+        "output_contract" if use_capacity_contract else "forward_output",
+        "forward_lse",
+        "k_descale",
+        "v_descale",
+    ]
+    forward_args = [
+        q_arg,
+        k_cache_arg,
+        v_cache_arg,
+        page_table_arg,
+        cache_seqlens_arg,
+        cu_seqlens_q_arg,
+        request_indices_arg,
+        qo_tile_indices_arg,
+        kv_tile_indices_arg,
+        o_indptr_arg,
+        kv_chunk_size_arg,
+        kv_window_start_arg,
+        block_valid_mask_arg,
+    ]
+    forward_cache_key.append(
+        _tensor_meta_key(
+            q2k_indices,
+            dynamic_dims=(() if cuda_graph_decode else (1,)),
+            dynamic_strides=(
+                (0,)
+                if (
+                    not cuda_graph_decode
+                    and q2k_indices is not None
+                    and getattr(q2k_indices, "ndim", 0) >= 1
+                    and int(q2k_indices.shape[0]) == 1
+                )
+                else ()
+            ),
+        )
+    )
+    cache_key_labels.append("q2k_indices")
+    forward_args.append(q2k_indices_arg)
+    if plan.mode == "extend":
+        forward_cache_key.extend(
+            (
+                _tensor_meta_key(
+                    msa_union_blocks,
+                    dynamic_dims=grid_worklist_dynamic_first_dim,
+                ),
+                _tensor_meta_key(
+                    msa_union_masks,
+                    dynamic_dims=grid_worklist_dynamic_first_dim,
+                ),
+                _tensor_meta_key(
+                    msa_union_counts,
+                    dynamic_dims=grid_worklist_dynamic_first_dim,
+                ),
+            )
+        )
+        cache_key_labels.extend(
+            ("msa_union_blocks", "msa_union_masks", "msa_union_counts")
+        )
+        forward_args.extend(
+            (msa_union_blocks_arg, msa_union_masks_arg, msa_union_counts_arg)
+        )
+    forward_args.extend(
+        [
+            attention_sink_bias_arg,
+            relative_attention_bias_arg,
+            forward_output_arg,
+            forward_lse_arg,
+            k_descale_arg,
+            v_descale_arg,
+        ]
+    )
+    if plan.mode == "extend":
+        k_tma_desc_arg = _to_kernel_tensor(
+            k_tma_desc_ptrs, cutlass.Int64, assumed_align=8
+        )
+        v_tma_desc_arg = _to_kernel_tensor(
+            v_tma_desc_ptrs, cutlass.Int64, assumed_align=8
+        )
+        forward_args.extend((k_tma_desc_arg, v_tma_desc_arg))
+        forward_cache_key.extend(
+            (
+                _tensor_meta_key(k_tma_desc_ptrs),
+                _tensor_meta_key(v_tma_desc_ptrs),
+            )
+        )
+        cache_key_labels.extend(("k_tma_desc_ptrs", "v_tma_desc_ptrs"))
+    forward_args.append(stream)
+    forward_spec = KernelCompileSpec.from_key(
+        "attention.paged.forward",
+        5,
+        tuple(forward_cache_key),
+        labels=tuple(cache_key_labels),
+    )
+    sm12x_launch(
+        forward_kernel,
+        compile_spec=forward_spec,
+        compile_args=tuple(forward_args),
+        runtime_args=tuple(forward_args),
+    )
+
+    if plan.split_kv:
+        persistent_ctas = default_paged_persistent_ctas(
+            total_rows=plan.total_q,
+            num_heads=plan.num_q_heads,
+            device=output.device,
+        )
+        merge_regular_decode_graph = (
+            plan.mode == "decode"
+            and plan.enable_cuda_graph
+            and plan.gqa_group_size <= plan.cta_tile_q
+            and workspace._decode_graph_chunk_pages_lut is not None
+            and workspace._use_regular_decode_graph_replay
+            and max(plan.qo_tile_indices, default=0) == 0
+        )
+        merge_direct_grid = merge_regular_decode_graph
+        pair_bf16_merge_partial_loads = (
+            plan.mode == "decode"
+            and 2 <= int(plan.total_q) <= 4
+            and output.dtype == torch.bfloat16
+            and workspace.tmp_output is not None
+            and workspace.tmp_output.dtype == torch.bfloat16
+            and plan.head_dim_vo == 128
+            and plan.gqa_group_size == 6
+        )
+        merge_kernel = _build_merge_kernel(
+            output.dtype,
+            plan.head_dim_vo,
+            plan.total_q,
+            persistent_ctas,
+            merge_direct_grid,
+            merge_regular_decode_graph,
+            pair_bf16_merge_partial_loads,
+        )
+        tmp_output_arg = _to_kernel_tensor(
+            workspace.tmp_output, _torch_to_cutlass_dtype(workspace.tmp_output.dtype)
+        )
+        tmp_lse_arg = _to_kernel_tensor(workspace.tmp_lse, cutlass.Float32)
+        merge_indptr_arg = _to_kernel_tensor(
+            workspace.merge_indptr, cutlass.Int32, assumed_align=4
+        )
+        merge_cache_seqlens_arg = _to_kernel_tensor(
+            _as_int32_tensor(cache_seqlens), cutlass.Int32, assumed_align=4
+        )
+        output_arg = _to_kernel_tensor(output, _torch_to_cutlass_dtype(output.dtype))
+        lse_arg = _to_kernel_tensor(workspace.lse, cutlass.Float32)
+        total_num_rows_arg = (
+            None
+            if merge_regular_decode_graph
+            else _to_kernel_tensor(
+                workspace.total_num_rows_ptr, cutlass.Int32, assumed_align=4
+            )
+        )
+        merge_args = (
+            tmp_output_arg,
+            tmp_lse_arg,
+            merge_indptr_arg,
+            merge_cache_seqlens_arg,
+            kv_chunk_size_arg,
+            output_arg,
+            lse_arg,
+            total_num_rows_arg,
+        )
+        merge_dynamic_first_dim = () if cuda_graph_decode else (0,)
+        merge_cache_key = (
+            _tensor_meta_key(
+                workspace.tmp_output, dynamic_dims=merge_dynamic_first_dim
+            ),
+            _tensor_meta_key(workspace.tmp_lse, dynamic_dims=merge_dynamic_first_dim),
+            _tensor_meta_key(
+                workspace.merge_indptr, dynamic_dims=merge_dynamic_first_dim
+            ),
+            _tensor_meta_key(cache_seqlens, dynamic_dims=merge_dynamic_first_dim),
+            _tensor_meta_key(workspace.kv_chunk_size_ptr),
+            _tensor_meta_key(output, dynamic_dims=merge_dynamic_first_dim),
+            _tensor_meta_key(
+                workspace.lse,
+                dynamic_dims=(() if cuda_graph_decode else (1,)),
+                dynamic_strides=(() if cuda_graph_decode else (0,)),
+            ),
+            None
+            if merge_regular_decode_graph
+            else _tensor_meta_key(workspace.total_num_rows_ptr),
+            persistent_ctas,
+            merge_direct_grid,
+            merge_regular_decode_graph,
+            pair_bf16_merge_partial_loads,
+        )
+        merge_spec = KernelCompileSpec.from_key(
+            "attention.paged.merge",
+            2,
+            merge_cache_key,
+            labels=(
+                "tmp_output",
+                "tmp_lse",
+                "merge_indptr",
+                "cache_seqlens",
+                "kv_chunk_size_ptr",
+                "output",
+                "lse",
+                "total_num_rows_ptr",
+                "persistent_ctas",
+                "direct_grid",
+                "regular_decode_graph",
+                "pair_bf16_partial_loads",
+            ),
+        )
+        sm12x_launch(
+            merge_kernel,
+            compile_spec=merge_spec,
+            compile_args=(*merge_args, stream),
+            runtime_args=(*merge_args, stream),
+        )
+
+    return output[: plan.total_q], workspace.current_lse_view()
+
+
+def clear_paged_caches() -> None:
+    """Clear compiled-kernel caches for the primary paged backend."""
+    _build_forward_kernel.cache_clear()
+    _build_extend_forward_kernel.cache_clear()
+    _build_merge_kernel.cache_clear()

--- a/flashinfer/experimental/sm12x/attention/paged/_scratch.py
+++ b/flashinfer/experimental/sm12x/attention/paged/_scratch.py
@@ -1,0 +1,1892 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/paged_attention_scratch.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Caller-owned scratch plans for the primary paged-attention backend.
+
+Eager PLAN -> BIND -> KERNEL. The scratch plan owns only shape/capacity policy
+and tiny shape-only planning tensors. Each bind maps caller-owned uint8 scratch
+into plain tensor views, prepares/copies metadata into those views, and returns
+a binding consumed by ``flashinfer.experimental.sm12x.attention.paged._forward.paged_attention_forward``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import os
+from typing import Literal
+
+import torch
+from torch.profiler import record_function
+
+from flashinfer.experimental.sm12x.attention.paged.planner import (
+    PagedPlan,
+    PagedPlanBudget,
+    build_decode_chunk_pages_lut,
+    create_paged_plan,
+    decode_graph_max_chunks_per_request_budget,
+    infer_paged_mode,
+    resolve_decode_graph_ctas_per_sm,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+from flashinfer.experimental.sm12x._lib.scratch_layout import (
+    SCRATCH_ALIGN_BYTES,
+    align_up,
+    dtype_nbytes,
+    materialize_scratch_view,
+    shape_numel,
+)
+
+
+def _paged_lse_storage_shape(total_q: int, num_q_heads: int) -> tuple[int, int]:
+    return (num_q_heads, total_q)
+
+
+def _copy_int_metadata(
+    values: tuple[int, ...] | tuple[bool, ...],
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    return torch.tensor(values, dtype=torch.int32, device=device)
+
+
+def _canonical_device(device: torch.device | str) -> torch.device:
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None:
+        return torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
+def _page_table_width_for_scratch(caps: "SM12XPagedAttentionScratchCaps") -> int:
+    width = int(caps.max_page_table_width)
+    if (
+        caps.mode == "decode"
+        and caps.use_cuda_graph
+        and caps.copy_runtime_metadata
+        and caps.kv_dtype == torch.float8_e4m3fn
+        and width >= 16_384
+        and width & (width - 1) == 0
+    ):
+        return width + 1
+    return width
+
+
+def _shape_only_cuda_tensor(
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    if any(dim <= 0 for dim in shape):
+        raise ValueError(f"shape must be positive in every dimension, got {shape}")
+    base = torch.empty(1, dtype=dtype, device=device)
+    return base.as_strided(shape, (0,) * len(shape))
+
+
+def _infer_mode_from_host_total(
+    cu_seqlens_q: torch.Tensor,
+    active_total_q: int,
+) -> Literal["decode", "extend"]:
+    batch = max(int(cu_seqlens_q.shape[0]) - 1, 0)
+    return "decode" if batch > 0 and int(active_total_q) == batch else "extend"
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XPagedAttentionScratchCaps:
+    device: torch.device | str
+    mode: Literal["decode", "extend", "verify"]
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim_qk: int
+    head_dim_vo: int
+    page_size: int
+    max_total_q: int
+    max_batch: int
+    max_page_table_width: int
+    max_work_items: int
+    max_partial_rows: int
+    num_cache_pages: int
+    use_cuda_graph: bool = False
+    copy_runtime_metadata: bool = True
+    msa_block_sparse: bool = False
+    msa_union_tile: bool | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "msa_block_sparse", bool(self.msa_block_sparse))
+        if (
+            self.msa_block_sparse
+            and os.environ.get("FLASHINFER_EXP_SM12X_PAGED_MSA") == "0"
+        ):
+            raise RuntimeError(
+                "FLASHINFER_EXP_SM12X_PAGED_MSA=0 disables MSA block-sparse paged attention"
+            )
+        if self.msa_union_tile is None:
+            msa_union_tile = (
+                self.msa_block_sparse
+                and self.mode == "extend"
+                and os.environ.get("FLASHINFER_EXP_SM12X_PAGED_MSA_UNION_PREFILL", "1")
+                != "0"
+            )
+        else:
+            msa_union_tile = bool(self.msa_union_tile)
+        if msa_union_tile and not (self.msa_block_sparse and self.mode == "extend"):
+            raise ValueError(
+                "msa_union_tile requires mode='extend' and msa_block_sparse=True"
+            )
+        object.__setattr__(self, "msa_union_tile", msa_union_tile)
+        object.__setattr__(self, "device", _canonical_device(self.device))
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "num_kv_heads", max(int(self.num_kv_heads), 1))
+        object.__setattr__(self, "head_dim_qk", max(int(self.head_dim_qk), 1))
+        object.__setattr__(self, "head_dim_vo", max(int(self.head_dim_vo), 1))
+        object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+        object.__setattr__(self, "max_total_q", max(int(self.max_total_q), 1))
+        object.__setattr__(self, "max_batch", max(int(self.max_batch), 1))
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            max(int(self.max_page_table_width), 1),
+        )
+        object.__setattr__(self, "max_work_items", max(int(self.max_work_items), 0))
+        object.__setattr__(self, "max_partial_rows", max(int(self.max_partial_rows), 0))
+        object.__setattr__(self, "num_cache_pages", max(int(self.num_cache_pages), 1))
+        object.__setattr__(self, "use_cuda_graph", bool(self.use_cuda_graph))
+        object.__setattr__(
+            self, "copy_runtime_metadata", bool(self.copy_runtime_metadata)
+        )
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            _page_table_width_for_scratch(self),
+        )
+
+
+@dataclass(frozen=True)
+class _SM12XPagedAttentionScratchLayout:
+    nbytes: int
+    request_indices_offset_bytes: int
+    qo_tile_indices_offset_bytes: int
+    kv_tile_indices_offset_bytes: int
+    block_valid_mask_offset_bytes: int
+    page_table_offset_bytes: int | None
+    cache_seqlens_offset_bytes: int | None
+    cu_seqlens_q_offset_bytes: int | None
+    merge_indptr_offset_bytes: int
+    o_indptr_offset_bytes: int
+    kv_chunk_size_ptr_offset_bytes: int
+    kv_window_start_tokens_offset_bytes: int
+    total_num_rows_ptr_offset_bytes: int
+    lse_offset_bytes: int
+    tmp_output_offset_bytes: int
+    tmp_lse_offset_bytes: int
+    msa_union_blocks_offset_bytes: int | None
+    msa_union_masks_offset_bytes: int | None
+    msa_union_counts_offset_bytes: int | None
+
+
+def _paged_attention_scratch_layout(
+    caps: SM12XPagedAttentionScratchCaps,
+) -> _SM12XPagedAttentionScratchLayout:
+    offset = 0
+
+    def reserve(shape: tuple[int, ...], dtype: torch.dtype) -> int:
+        nonlocal offset
+        offset = align_up(offset, max(SCRATCH_ALIGN_BYTES, dtype_nbytes(dtype)))
+        current = offset
+        offset += shape_numel(shape) * dtype_nbytes(dtype)
+        return current
+
+    request_indices_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+    qo_tile_indices_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+    kv_tile_indices_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+    block_valid_mask_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+    if caps.copy_runtime_metadata:
+        page_table_offset_bytes = reserve(
+            (caps.max_batch, caps.max_page_table_width),
+            torch.int32,
+        )
+        cache_seqlens_offset_bytes = reserve((caps.max_batch,), torch.int32)
+        cu_seqlens_q_offset_bytes = reserve((caps.max_batch + 1,), torch.int32)
+    else:
+        page_table_offset_bytes = None
+        cache_seqlens_offset_bytes = None
+        cu_seqlens_q_offset_bytes = None
+    merge_indptr_offset_bytes = reserve((caps.max_total_q + 1,), torch.int32)
+    o_indptr_offset_bytes = reserve((caps.max_batch + 1,), torch.int32)
+    kv_chunk_size_ptr_offset_bytes = reserve((1,), torch.int32)
+    kv_window_start_tokens_offset_bytes = reserve((caps.max_batch,), torch.int32)
+    total_num_rows_ptr_offset_bytes = reserve((1,), torch.int32)
+    lse_offset_bytes = reserve(
+        _paged_lse_storage_shape(caps.max_total_q, caps.num_q_heads),
+        torch.float32,
+    )
+    tmp_output_offset_bytes = reserve(
+        (caps.max_partial_rows, caps.num_q_heads, caps.head_dim_vo),
+        caps.dtype,
+    )
+    tmp_lse_offset_bytes = reserve(
+        (caps.max_partial_rows, caps.num_q_heads),
+        torch.float32,
+    )
+    msa_union_blocks_offset_bytes = None
+    msa_union_masks_offset_bytes = None
+    msa_union_counts_offset_bytes = None
+    if caps.msa_union_tile:
+        msa_union_blocks_offset_bytes = reserve(
+            (caps.max_work_items, caps.num_kv_heads, 128),
+            torch.int32,
+        )
+        msa_union_masks_offset_bytes = reserve(
+            (caps.max_work_items, caps.num_kv_heads, 128),
+            torch.int32,
+        )
+        msa_union_counts_offset_bytes = reserve(
+            (caps.max_work_items, caps.num_kv_heads),
+            torch.int32,
+        )
+
+    return _SM12XPagedAttentionScratchLayout(
+        nbytes=max(int(offset), SCRATCH_ALIGN_BYTES),
+        request_indices_offset_bytes=request_indices_offset_bytes,
+        qo_tile_indices_offset_bytes=qo_tile_indices_offset_bytes,
+        kv_tile_indices_offset_bytes=kv_tile_indices_offset_bytes,
+        block_valid_mask_offset_bytes=block_valid_mask_offset_bytes,
+        page_table_offset_bytes=page_table_offset_bytes,
+        cache_seqlens_offset_bytes=cache_seqlens_offset_bytes,
+        cu_seqlens_q_offset_bytes=cu_seqlens_q_offset_bytes,
+        merge_indptr_offset_bytes=merge_indptr_offset_bytes,
+        o_indptr_offset_bytes=o_indptr_offset_bytes,
+        kv_chunk_size_ptr_offset_bytes=kv_chunk_size_ptr_offset_bytes,
+        kv_window_start_tokens_offset_bytes=kv_window_start_tokens_offset_bytes,
+        total_num_rows_ptr_offset_bytes=total_num_rows_ptr_offset_bytes,
+        lse_offset_bytes=lse_offset_bytes,
+        tmp_output_offset_bytes=tmp_output_offset_bytes,
+        tmp_lse_offset_bytes=tmp_lse_offset_bytes,
+        msa_union_blocks_offset_bytes=msa_union_blocks_offset_bytes,
+        msa_union_masks_offset_bytes=msa_union_masks_offset_bytes,
+        msa_union_counts_offset_bytes=msa_union_counts_offset_bytes,
+    )
+
+
+@dataclass(frozen=True)
+class _SM12XPagedPlanMetadataCache:
+    request_indices: torch.Tensor
+    qo_tile_indices: torch.Tensor
+    kv_tile_indices: torch.Tensor
+    merge_indptr: torch.Tensor
+    o_indptr: torch.Tensor
+    block_valid_mask: torch.Tensor
+    kv_window_start_tokens: torch.Tensor
+    kv_chunk_size: int
+    total_q: int
+
+
+def _make_plan_metadata_cache(
+    plan: PagedPlan,
+    *,
+    device: torch.device,
+) -> _SM12XPagedPlanMetadataCache:
+    return _SM12XPagedPlanMetadataCache(
+        request_indices=_copy_int_metadata(plan.request_indices, device=device),
+        qo_tile_indices=_copy_int_metadata(plan.qo_tile_indices, device=device),
+        kv_tile_indices=_copy_int_metadata(plan.kv_tile_indices, device=device),
+        merge_indptr=_copy_int_metadata(plan.merge_indptr, device=device),
+        o_indptr=_copy_int_metadata(plan.o_indptr, device=device),
+        block_valid_mask=_copy_int_metadata(plan.block_valid_mask, device=device),
+        kv_window_start_tokens=_copy_int_metadata(
+            plan.kv_window_start_tokens,
+            device=device,
+        ),
+        kv_chunk_size=int(plan.kv_chunk_size),
+        total_q=int(plan.total_q),
+    )
+
+
+@dataclass(kw_only=True)
+class SM12XPagedAttentionScratch:
+    """Paged-attention scratch views over caller-owned storage."""
+
+    shared_scratch: torch.Tensor
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    mode: Literal["decode", "extend", "verify"]
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim_qk: int
+    head_dim_vo: int
+    page_size: int
+    max_total_q: int
+    max_batch: int
+    max_page_table_width: int
+    max_work_items: int
+    max_partial_rows: int
+    num_cache_pages: int
+    use_cuda_graph: bool = False
+    copy_runtime_metadata: bool = True
+    fixed_capacity: bool = True
+    request_indices: torch.Tensor | None = None
+    qo_tile_indices: torch.Tensor | None = None
+    kv_tile_indices: torch.Tensor | None = None
+    merge_indptr: torch.Tensor | None = None
+    o_indptr: torch.Tensor | None = None
+    kv_chunk_size_ptr: torch.Tensor | None = None
+    kv_window_start_tokens: torch.Tensor | None = None
+    total_num_rows_ptr: torch.Tensor | None = None
+    block_valid_mask: torch.Tensor | None = None
+    page_table: torch.Tensor | None = None
+    cache_seqlens: torch.Tensor | None = None
+    cu_seqlens_q: torch.Tensor | None = None
+    lse: torch.Tensor | None = None
+    tmp_output: torch.Tensor | None = None
+    tmp_lse: torch.Tensor | None = None
+    msa_union_blocks: torch.Tensor | None = None
+    msa_union_masks: torch.Tensor | None = None
+    msa_union_counts: torch.Tensor | None = None
+    q2k_indices: torch.Tensor | None = None
+    _plan_q: torch.Tensor | None = None
+    _plan_output: torch.Tensor | None = None
+    _plan_k_cache: torch.Tensor | None = None
+    _plan_v_cache: torch.Tensor | None = None
+    _plan: PagedPlan | None = None
+    _plan_metadata_cache: _SM12XPagedPlanMetadataCache | None = None
+    _planner_budget: PagedPlanBudget | None = None
+    _decode_graph_chunk_pages_lut: torch.Tensor | None = None
+    _decode_graph_max_chunks_per_req: int | None = None
+    _use_regular_decode_graph_replay: bool = False
+    _decode_graph_metadata_captured_in_graph: bool = False
+    _prefill_graph_max_q_tiles_per_req: int | None = None
+    _prefill_graph_max_chunks_per_q_tile: int | None = None
+    _prefill_graph_max_q_rows_per_req: int | None = None
+    msa_block_sparse: bool = False
+    msa_union_tile: bool = False
+    _q2k_indices_data_ptr: int | None = None
+    _live_plane_tma_desc_cache: dict[
+        tuple[int, int, tuple[int, ...], tuple[int, ...], int, int],
+        tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor, torch.Tensor],
+    ] = field(default_factory=dict)
+
+    @property
+    def prepared(self) -> bool:
+        return self._plan is not None
+
+    @property
+    def plan(self) -> PagedPlan:
+        if self._plan is None:
+            raise RuntimeError("paged scratch has not been prepared")
+        return self._plan
+
+    @property
+    def active_total_q(self) -> int:
+        return self.plan.total_q
+
+    @property
+    def total_q_capacity(self) -> int:
+        if self._plan_q is None:
+            raise RuntimeError("paged scratch planning contract is not initialized")
+        return int(self._plan_q.shape[0])
+
+    @property
+    def planner_budget(self) -> PagedPlanBudget | None:
+        return self._planner_budget
+
+    def current_lse_view(self) -> torch.Tensor:
+        if self.lse is None:
+            raise RuntimeError("paged scratch has not been prepared")
+        return self.lse[:, : self.active_total_q].transpose(0, 1)
+
+    def bind(
+        self,
+        *,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        output: torch.Tensor,
+        page_table: torch.Tensor | None = None,
+        cache_seqlens: torch.Tensor | None = None,
+        cu_seqlens_q: torch.Tensor | None = None,
+        fixed_split_size: int | None = None,
+        disable_split_kv: bool = False,
+        window_left: int = -1,
+        active_total_q: int | None = None,
+        q2k_indices: torch.Tensor | None = None,
+        k_descale: torch.Tensor | None = None,
+        v_descale: torch.Tensor | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+        relative_attention_bias: torch.Tensor | None = None,
+    ) -> "SM12XPagedAttentionBinding":
+        return build_paged_attention_binding(
+            scratch=self,
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            fixed_split_size=fixed_split_size,
+            disable_split_kv=disable_split_kv,
+            window_left=window_left,
+            active_total_q=active_total_q,
+            q2k_indices=q2k_indices,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            attention_sink_bias=attention_sink_bias,
+            relative_attention_bias=relative_attention_bias,
+        )
+
+    @torch._dynamo.disable
+    def prepare(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        *,
+        fixed_split_size: int | None = None,
+        disable_split_kv: bool = False,
+        window_left: int = -1,
+        active_total_q: int | None = None,
+    ) -> "SM12XPagedAttentionScratch":
+        with record_function(f"paged_scratch.prepare.{self.mode}"):
+            if window_left < -1:
+                raise ValueError(
+                    "window_left must be -1 for full attention or a "
+                    "non-negative token count"
+                )
+            if self.use_cuda_graph and torch.cuda.is_current_stream_capturing():
+                if self._plan is None:
+                    raise RuntimeError(
+                        "graph-mode paged scratch must be prepared before "
+                        "CUDA graph capture"
+                    )
+                if int(window_left) != int(self._plan.window_left):
+                    raise ValueError(
+                        "captured paged attention graph was prepared with "
+                        f"window_left={self._plan.window_left}, got "
+                        f"window_left={int(window_left)}"
+                    )
+                if self._plan_metadata_cache is None:
+                    raise RuntimeError(
+                        "graph-mode paged scratch is missing cached plan metadata"
+                    )
+                self._bind_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+                self._copy_cached_plan_metadata(self._plan_metadata_cache)
+                if (
+                    self.mode == "decode"
+                    and self._decode_graph_chunk_pages_lut is not None
+                ):
+                    self.update_decode_graph_replay_metadata_from_runtime_cache_seqlens()
+                    self._decode_graph_metadata_captured_in_graph = True
+                return self
+
+            if (
+                self.use_cuda_graph
+                and self.mode == "decode"
+                and self._decode_graph_chunk_pages_lut is not None
+                and self._plan is not None
+            ):
+                if int(window_left) != int(self._plan.window_left):
+                    raise ValueError(
+                        "decode graph replay scratch was prepared with "
+                        f"window_left={self._plan.window_left}, got "
+                        f"window_left={int(window_left)}"
+                    )
+                self._bind_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+                if self._plan_metadata_cache is None:
+                    raise RuntimeError(
+                        "graph-mode paged scratch is missing cached plan metadata"
+                    )
+                self._copy_cached_plan_metadata(self._plan_metadata_cache)
+                if not self._decode_graph_metadata_captured_in_graph:
+                    self.update_decode_graph_replay_metadata_from_runtime_cache_seqlens()
+                    if torch.cuda.is_current_stream_capturing():
+                        self._decode_graph_metadata_captured_in_graph = True
+                return self
+
+            if active_total_q is None:
+                if torch.cuda.is_current_stream_capturing():
+                    raise RuntimeError(
+                        "paged attention scratch prepare() requires active_total_q "
+                        "to be supplied before CUDA graph capture; inferring it from "
+                        "a device cu_seqlens_q would require an illegal host sync"
+                    )
+                inferred_mode = infer_paged_mode(cu_seqlens_q)
+                active_total_q = int(cu_seqlens_q[-1].item())
+            else:
+                active_total_q = int(active_total_q)
+                inferred_mode = _infer_mode_from_host_total(
+                    cu_seqlens_q,
+                    active_total_q,
+                )
+            if (
+                inferred_mode != self.mode
+                and not (self.mode == "extend" and inferred_mode == "decode")
+                and not (self.mode == "verify" and inferred_mode == "extend")
+            ):
+                raise ValueError(
+                    f"scratch mode {self.mode} does not match prepared mode "
+                    f"{inferred_mode}"
+                )
+            self._ensure_plan_contract(active_total_q)
+            assert self._plan_q is not None
+            assert self._plan_k_cache is not None
+            assert self._plan_v_cache is not None
+            if active_total_q <= 0 or active_total_q > int(self._plan_q.shape[0]):
+                raise ValueError(
+                    f"cu_seqlens_q implies total_q={active_total_q}, but "
+                    f"scratch capacity is {int(self._plan_q.shape[0])}"
+                )
+
+            plan = create_paged_plan(
+                self._plan_q[:active_total_q],
+                self._plan_k_cache,
+                self._plan_v_cache,
+                page_table,
+                cache_seqlens,
+                cu_seqlens_q,
+                mode=self.mode,
+                fixed_split_size=(
+                    -1 if fixed_split_size is None else int(fixed_split_size)
+                ),
+                disable_split_kv=disable_split_kv,
+                window_left=int(window_left),
+                enable_cuda_graph=self.use_cuda_graph,
+                graph_chunk_policy=self.use_cuda_graph,
+                plan_budget=(
+                    self.planner_budget
+                    if self.mode in ("extend", "verify") and not self.use_cuda_graph
+                    else None
+                ),
+                msa_block_sparse=self.msa_block_sparse,
+                msa_union_tile=self.msa_union_tile,
+            )
+            self._ensure_capacity(plan)
+            self._bind_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+            self._plan_metadata_cache = self._copy_plan_metadata(plan)
+            self._plan = plan
+            return self
+
+    def _ensure_plan_contract(self, active_total_q: int) -> None:
+        if (
+            self._plan_q is None
+            or self._plan_k_cache is None
+            or self._plan_v_cache is None
+        ):
+            raise RuntimeError("paged scratch planning contract is not initialized")
+        if active_total_q <= int(self._plan_q.shape[0]):
+            return
+        raise ValueError(
+            "fixed-capacity paged scratch exceeded; construct a larger scratch "
+            f"plan for total_q={active_total_q}"
+        )
+
+    def _ensure_capacity(self, plan: PagedPlan) -> None:
+        work_items_needed = int(plan.new_batch_size)
+        block_valid_needed = int(plan.padded_batch_size)
+        total_q_needed = int(plan.total_q)
+        batch_needed = int(plan.page_table_shape[0])
+        page_table_width_needed = int(plan.page_table_shape[1])
+        partial_rows_needed = int(plan.total_num_partial_rows) if plan.split_kv else 0
+
+        if work_items_needed > self.max_work_items:
+            raise ValueError(
+                f"paged plan needs {work_items_needed} work items, scratch "
+                f"capacity is {self.max_work_items}"
+            )
+        if block_valid_needed > self.max_work_items:
+            raise ValueError(
+                f"paged plan needs {block_valid_needed} block-valid entries, "
+                f"scratch capacity is {self.max_work_items}"
+            )
+        if total_q_needed > self.max_total_q:
+            raise ValueError(
+                f"paged plan total_q={total_q_needed} exceeds scratch "
+                f"capacity {self.max_total_q}"
+            )
+        if batch_needed > self.max_batch:
+            raise ValueError(
+                f"paged plan batch={batch_needed} exceeds scratch capacity "
+                f"{self.max_batch}"
+            )
+        if page_table_width_needed > self.max_page_table_width:
+            raise ValueError(
+                "paged plan page table width="
+                f"{page_table_width_needed} exceeds scratch capacity "
+                f"{self.max_page_table_width}"
+            )
+        if partial_rows_needed > self.max_partial_rows:
+            raise ValueError(
+                f"paged plan needs {partial_rows_needed} partial rows, "
+                f"scratch capacity is {self.max_partial_rows}"
+            )
+
+    def _bind_runtime_metadata(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+    ) -> None:
+        if self.copy_runtime_metadata:
+            self._copy_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+            return
+        self._validate_runtime_metadata_reference(
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+        )
+        self.page_table = page_table
+        self.cache_seqlens = cache_seqlens
+        self.cu_seqlens_q = cu_seqlens_q
+
+    def _validate_runtime_metadata_reference(
+        self,
+        *,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+    ) -> None:
+        if (
+            page_table.device != self.device
+            or cache_seqlens.device != self.device
+            or cu_seqlens_q.device != self.device
+        ):
+            raise ValueError("paged scratch metadata references must stay on device")
+        if (
+            page_table.dtype != torch.int32
+            or cache_seqlens.dtype != torch.int32
+            or cu_seqlens_q.dtype != torch.int32
+        ):
+            raise TypeError("paged scratch metadata references must be int32 tensors")
+        if not (
+            page_table.is_contiguous()
+            and cache_seqlens.is_contiguous()
+            and cu_seqlens_q.is_contiguous()
+        ):
+            raise ValueError("paged scratch metadata references must be contiguous")
+        if page_table.ndim != 2:
+            raise ValueError("page_table must be rank-2")
+        if cache_seqlens.ndim != 1 or cu_seqlens_q.ndim != 1:
+            raise ValueError("cache_seqlens and cu_seqlens_q must be rank-1")
+        if int(page_table.shape[0]) > self.max_batch:
+            raise ValueError(
+                f"page_table batch={int(page_table.shape[0])} exceeds scratch "
+                f"capacity {self.max_batch}"
+            )
+        if int(page_table.shape[1]) > self.max_page_table_width:
+            raise ValueError(
+                f"page_table width={int(page_table.shape[1])} exceeds scratch "
+                f"capacity {self.max_page_table_width}"
+            )
+        if int(cache_seqlens.shape[0]) > self.max_batch:
+            raise ValueError(
+                f"cache_seqlens batch={int(cache_seqlens.shape[0])} exceeds "
+                f"scratch capacity {self.max_batch}"
+            )
+        if int(cu_seqlens_q.shape[0]) > self.max_batch + 1:
+            raise ValueError(
+                f"cu_seqlens_q length={int(cu_seqlens_q.shape[0])} exceeds "
+                f"scratch capacity {self.max_batch + 1}"
+            )
+
+    def _copy_runtime_metadata(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+    ) -> None:
+        assert self.page_table is not None
+        assert self.cache_seqlens is not None
+        assert self.cu_seqlens_q is not None
+
+        if (
+            page_table.dtype == torch.int32
+            and cache_seqlens.dtype == torch.int32
+            and cu_seqlens_q.dtype == torch.int32
+            and int(self.page_table.data_ptr()) == int(page_table.data_ptr())
+            and int(self.cache_seqlens.data_ptr()) == int(cache_seqlens.data_ptr())
+            and int(self.cu_seqlens_q.data_ptr()) == int(cu_seqlens_q.data_ptr())
+        ):
+            return
+
+        page_table_i32 = (
+            page_table
+            if page_table.dtype == torch.int32
+            else page_table.to(torch.int32)
+        )
+        cache_seqlens_i32 = (
+            cache_seqlens
+            if cache_seqlens.dtype == torch.int32
+            else cache_seqlens.to(torch.int32)
+        )
+        cu_seqlens_q_i32 = (
+            cu_seqlens_q
+            if cu_seqlens_q.dtype == torch.int32
+            else cu_seqlens_q.to(torch.int32)
+        )
+
+        self.page_table[: page_table_i32.shape[0], : page_table_i32.shape[1]].copy_(
+            page_table_i32
+        )
+        self.cache_seqlens[: cache_seqlens_i32.shape[0]].copy_(cache_seqlens_i32)
+        self.cu_seqlens_q[: cu_seqlens_q_i32.shape[0]].copy_(cu_seqlens_q_i32)
+
+    def _copy_cached_plan_metadata(
+        self,
+        cache: _SM12XPagedPlanMetadataCache,
+    ) -> None:
+        assert self.request_indices is not None
+        assert self.qo_tile_indices is not None
+        assert self.kv_tile_indices is not None
+        assert self.merge_indptr is not None
+        assert self.o_indptr is not None
+        assert self.kv_chunk_size_ptr is not None
+        assert self.kv_window_start_tokens is not None
+        assert self.total_num_rows_ptr is not None
+        assert self.block_valid_mask is not None
+
+        if self._decode_graph_chunk_pages_lut is None:
+            self._use_regular_decode_graph_replay = False
+        self._prefill_graph_max_q_tiles_per_req = None
+        self._prefill_graph_max_chunks_per_q_tile = None
+        self._prefill_graph_max_q_rows_per_req = None
+
+        self.request_indices.zero_()
+        self.qo_tile_indices.zero_()
+        self.kv_tile_indices.zero_()
+        self.block_valid_mask.zero_()
+        self.kv_window_start_tokens.zero_()
+        self.request_indices[: cache.request_indices.shape[0]].copy_(
+            cache.request_indices
+        )
+        self.qo_tile_indices[: cache.qo_tile_indices.shape[0]].copy_(
+            cache.qo_tile_indices
+        )
+        self.kv_tile_indices[: cache.kv_tile_indices.shape[0]].copy_(
+            cache.kv_tile_indices
+        )
+        self.merge_indptr[: cache.merge_indptr.shape[0]].copy_(cache.merge_indptr)
+        self.o_indptr[: cache.o_indptr.shape[0]].copy_(cache.o_indptr)
+        self.block_valid_mask[: cache.block_valid_mask.shape[0]].copy_(
+            cache.block_valid_mask
+        )
+        self.kv_window_start_tokens[: cache.kv_window_start_tokens.shape[0]].copy_(
+            cache.kv_window_start_tokens
+        )
+        self.kv_chunk_size_ptr.fill_(int(cache.kv_chunk_size))
+        self.total_num_rows_ptr.fill_(int(cache.total_q))
+
+    def _copy_plan_metadata(
+        self,
+        plan: PagedPlan,
+    ) -> _SM12XPagedPlanMetadataCache:
+        cache = _make_plan_metadata_cache(plan, device=self.device)
+        self._copy_cached_plan_metadata(cache)
+        return cache
+
+    def _validate_decode_graph_replay_capacity(self, *, batch: int) -> None:
+        if self._decode_graph_max_chunks_per_req is None:
+            raise RuntimeError("decode graph replay policy has not been prepared")
+        if self.request_indices is None:
+            raise RuntimeError("decode graph scratch is missing request indices")
+        if batch <= 0:
+            raise ValueError("decode graph replay requires bs > 0")
+        work_items_capacity = int(self.request_indices.shape[0])
+        if work_items_capacity % batch != 0:
+            raise RuntimeError(
+                "decode graph scratch request_indices shape is incompatible "
+                "with the batch bucket"
+            )
+        max_chunks_per_req = work_items_capacity // batch
+        if max_chunks_per_req <= 0:
+            raise RuntimeError(
+                "decode graph scratch must allocate at least one chunk per request"
+            )
+        if self._decode_graph_max_chunks_per_req > max_chunks_per_req:
+            raise RuntimeError(
+                "decode graph scratch capacity is too small for the current "
+                "chunking policy"
+            )
+
+    def _window_page_span_from_plan(self, plan: PagedPlan) -> int:
+        window_left = int(plan.window_left)
+        if window_left < 0:
+            return 0
+        return max(
+            (window_left + self.page_size + self.page_size - 1) // self.page_size,
+            1,
+        )
+
+    def update_decode_graph_replay_metadata_from_runtime_cache_seqlens(
+        self,
+    ) -> "SM12XPagedAttentionScratch":
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "update_decode_graph_replay_metadata_from_runtime_cache_seqlens "
+                "is only valid for graph-mode paged scratch"
+            )
+        if self.mode != "decode":
+            raise RuntimeError(
+                "update_decode_graph_replay_metadata_from_runtime_cache_seqlens "
+                "is only valid for decode scratch"
+            )
+        if self._decode_graph_chunk_pages_lut is None:
+            raise RuntimeError("decode graph replay policy has not been prepared")
+        if self.cache_seqlens is None:
+            raise RuntimeError("decode graph scratch is missing cache_seqlens")
+        if self.request_indices is None:
+            raise RuntimeError("decode graph scratch is missing request indices")
+        if self.qo_tile_indices is None or self.kv_tile_indices is None:
+            raise RuntimeError("decode graph scratch is missing tile indices")
+        if self.merge_indptr is None or self.o_indptr is None:
+            raise RuntimeError("decode graph scratch is missing indptr buffers")
+        if self.kv_chunk_size_ptr is None:
+            raise RuntimeError("decode graph scratch is missing kv_chunk_size_ptr")
+        if self.total_num_rows_ptr is None:
+            raise RuntimeError("decode graph scratch is missing total_num_rows_ptr")
+        if self.cu_seqlens_q is None:
+            raise RuntimeError("decode graph scratch is missing cu_seqlens_q")
+        if self.block_valid_mask is None:
+            raise RuntimeError("decode graph scratch is missing block_valid_mask")
+        if self.kv_window_start_tokens is None:
+            raise RuntimeError("decode graph scratch is missing kv_window_start_tokens")
+        if self._plan is None:
+            raise RuntimeError("decode graph scratch has not been prepared")
+
+        uses_compact_work_metadata = self._plan.split_kv and (
+            getattr(self._plan, "msa_block_sparse", False)
+            or not self._use_regular_decode_graph_replay
+        )
+        if uses_compact_work_metadata:
+            self._validate_decode_graph_replay_capacity(
+                batch=int(self.cache_seqlens.shape[0])
+            )
+        window_page_span = self._window_page_span_from_plan(self._plan)
+        if not self._plan.split_kv:
+            if int(self._plan.window_left) < 0:
+                return self
+            from flashinfer.experimental.sm12x.attention.paged.graph_replay import (
+                update_decode_graph_window_start_tokens,
+            )
+
+            update_decode_graph_window_start_tokens(
+                cache_seqlens=self.cache_seqlens,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                page_size=self.page_size,
+                window_left=int(self._plan.window_left),
+            )
+        elif getattr(self._plan, "msa_block_sparse", False):
+            from flashinfer.experimental.sm12x.attention.paged.graph_replay import (
+                update_msa_decode_graph_chunk_metadata,
+            )
+
+            update_msa_decode_graph_chunk_metadata(
+                cache_seqlens=self.cache_seqlens,
+                request_indices=self.request_indices,
+                qo_tile_indices=self.qo_tile_indices,
+                kv_tile_indices=self.kv_tile_indices,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                block_valid_mask=self.block_valid_mask,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                kv_chunk_size=int(self._plan.kv_chunk_size),
+                page_size=self.page_size,
+            )
+            batch = int(self.cache_seqlens.shape[0])
+            if int(self.cu_seqlens_q.shape[0]) < batch + 1:
+                raise RuntimeError(
+                    "decode graph cu_seqlens_q is smaller than the graph batch"
+                )
+            self.total_num_rows_ptr[:1].copy_(self.cu_seqlens_q[batch : batch + 1])
+        elif self._use_regular_decode_graph_replay:
+            from flashinfer.experimental.sm12x.attention.paged.graph_replay import (
+                update_regular_decode_graph_chunk_metadata_from_lut,
+            )
+
+            update_regular_decode_graph_chunk_metadata_from_lut(
+                cache_seqlens=self.cache_seqlens,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                decode_chunk_pages_lut=self._decode_graph_chunk_pages_lut,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        else:
+            from flashinfer.experimental.sm12x.attention.paged.graph_replay import (
+                update_decode_graph_chunk_metadata,
+            )
+
+            update_decode_graph_chunk_metadata(
+                cache_seqlens=self.cache_seqlens,
+                request_indices=self.request_indices,
+                qo_tile_indices=self.qo_tile_indices,
+                kv_tile_indices=self.kv_tile_indices,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                block_valid_mask=self.block_valid_mask,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                decode_chunk_pages_lut=self._decode_graph_chunk_pages_lut,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        if (
+            not getattr(self._plan, "msa_block_sparse", False)
+            and not torch.cuda.is_current_stream_capturing()
+        ):
+            self.total_num_rows_ptr[0] = int(self._plan.total_q)
+        return self
+
+    def _validate_static_shapes(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+    ) -> None:
+        if (
+            q.device != self.device
+            or k_cache.device != self.device
+            or v_cache.device != self.device
+        ):
+            raise ValueError("paged scratch inputs must stay on the scratch device")
+        if q.dtype != self.dtype:
+            raise TypeError(
+                f"paged scratch expects q dtype {self.dtype}, got {q.dtype}"
+            )
+        if k_cache.dtype != self.kv_dtype or v_cache.dtype != self.kv_dtype:
+            raise TypeError(
+                "paged scratch expects kv dtype "
+                f"{self.kv_dtype}, got {k_cache.dtype}/{v_cache.dtype}"
+            )
+        if tuple(q.shape[1:]) != (self.num_q_heads, self.head_dim_qk):
+            raise ValueError(
+                "q shape does not match the scratch contract: expected "
+                f"(*, {self.num_q_heads}, {self.head_dim_qk}), got {tuple(q.shape)}"
+            )
+        if (
+            int(k_cache.shape[1]) != self.page_size
+            or int(v_cache.shape[1]) != self.page_size
+        ):
+            raise ValueError(f"paged scratch expects page_size={self.page_size}")
+        if (
+            int(k_cache.shape[2]) != self.num_kv_heads
+            or int(v_cache.shape[2]) != self.num_kv_heads
+        ):
+            raise ValueError("kv head count does not match the scratch contract")
+        if int(k_cache.shape[3]) != self.head_dim_qk:
+            raise ValueError("k_cache head_dim does not match the scratch contract")
+        if int(v_cache.shape[3]) != self.head_dim_vo:
+            raise ValueError("v_cache head_dim does not match the scratch contract")
+
+    def _validate_q2k_indices_reference(
+        self,
+        q2k_indices: torch.Tensor | None,
+    ) -> None:
+        if not self.msa_block_sparse:
+            if q2k_indices is not None:
+                raise ValueError(
+                    "q2k_indices can only be bound when scratch caps set msa_block_sparse=True"
+                )
+            self.q2k_indices = None
+            return
+        if os.environ.get("FLASHINFER_EXP_SM12X_PAGED_MSA") == "0":
+            raise RuntimeError(
+                "FLASHINFER_EXP_SM12X_PAGED_MSA=0 disables MSA block-sparse paged attention"
+            )
+        if q2k_indices is None:
+            raise ValueError("MSA block-sparse paged attention requires q2k_indices")
+        if q2k_indices.device != self.device:
+            raise ValueError("q2k_indices must stay on the scratch device")
+        if q2k_indices.dtype != torch.int32:
+            raise TypeError("q2k_indices must be a torch.int32 tensor")
+        if q2k_indices.ndim != 3:
+            raise ValueError(
+                "q2k_indices must have shape [kv_heads, total_q_capacity, 16]"
+            )
+        if not q2k_indices.is_contiguous():
+            raise ValueError("q2k_indices must be contiguous")
+        if (
+            int(q2k_indices.shape[0]) != self.num_kv_heads
+            or int(q2k_indices.shape[2]) != 16
+        ):
+            raise ValueError(
+                "q2k_indices must have shape "
+                f"({self.num_kv_heads}, >=total_q_capacity, 16), got {tuple(q2k_indices.shape)}"
+            )
+        if int(q2k_indices.shape[1]) < self.total_q_capacity:
+            raise ValueError(
+                "q2k_indices total_q_capacity is smaller than scratch total_q_capacity"
+            )
+        data_ptr = int(q2k_indices.data_ptr())
+        if self._q2k_indices_data_ptr is None:
+            self._q2k_indices_data_ptr = data_ptr
+        elif self._q2k_indices_data_ptr != data_ptr:
+            raise ValueError(
+                "MSA q2k_indices data_ptr changed after prepare; graph-safe bindings "
+                "must rewrite the captured buffer in place"
+            )
+        self.q2k_indices = q2k_indices
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XPagedAttentionBinding:
+    scratch: object
+    q: torch.Tensor
+    k_cache: torch.Tensor
+    v_cache: torch.Tensor
+    output: torch.Tensor
+    q2k_indices: torch.Tensor | None = None
+    k_descale: torch.Tensor | None = None
+    v_descale: torch.Tensor | None = None
+    attention_sink_bias: torch.Tensor | None = None
+    relative_attention_bias: torch.Tensor | None = None
+
+    def run(self) -> tuple[torch.Tensor, torch.Tensor]:
+        from flashinfer.experimental.sm12x.attention.paged._forward import (
+            paged_attention_forward,
+        )
+
+        return paged_attention_forward(binding=self)
+
+
+def _validate_optional_tensor_device(
+    tensor: torch.Tensor | None,
+    *,
+    scratch: object,
+    name: str,
+) -> None:
+    if tensor is not None and tensor.device != scratch.device:
+        raise ValueError(
+            f"{name} device {tensor.device} does not match scratch device "
+            f"{scratch.device}"
+        )
+
+
+def _validate_output(
+    output: torch.Tensor,
+    *,
+    scratch: object,
+) -> None:
+    if output.device != scratch.device:
+        raise ValueError(
+            f"output device {output.device} does not match scratch device "
+            f"{scratch.device}"
+        )
+    if output.dtype != scratch.dtype:
+        raise TypeError(f"output must have dtype {scratch.dtype}, got {output.dtype}")
+    if output.ndim != 3:
+        raise ValueError(
+            f"output must be rank-3 [total_q, heads, head_dim], got "
+            f"{tuple(output.shape)}"
+        )
+    if tuple(output.shape[1:]) != (scratch.num_q_heads, scratch.head_dim_vo):
+        raise ValueError(
+            "output shape does not match the scratch contract: expected "
+            f"(*, {scratch.num_q_heads}, {scratch.head_dim_vo}), got "
+            f"{tuple(output.shape)}"
+        )
+
+
+def _metadata_tuple(
+    *,
+    page_table: torch.Tensor | None,
+    cache_seqlens: torch.Tensor | None,
+    cu_seqlens_q: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    values = (page_table, cache_seqlens, cu_seqlens_q)
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise ValueError(
+            "page_table, cache_seqlens, and cu_seqlens_q must be provided together"
+        )
+    return page_table, cache_seqlens, cu_seqlens_q
+
+
+def build_paged_attention_binding(
+    *,
+    scratch: object,
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    output: torch.Tensor,
+    page_table: torch.Tensor | None = None,
+    cache_seqlens: torch.Tensor | None = None,
+    cu_seqlens_q: torch.Tensor | None = None,
+    fixed_split_size: int | None = None,
+    disable_split_kv: bool = False,
+    window_left: int = -1,
+    active_total_q: int | None = None,
+    q2k_indices: torch.Tensor | None = None,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
+    attention_sink_bias: torch.Tensor | None = None,
+    relative_attention_bias: torch.Tensor | None = None,
+) -> SM12XPagedAttentionBinding:
+    scratch._validate_static_shapes(q, k_cache, v_cache)
+    _validate_output(output, scratch=scratch)
+    _validate_optional_tensor_device(k_descale, scratch=scratch, name="k_descale")
+    _validate_optional_tensor_device(v_descale, scratch=scratch, name="v_descale")
+    _validate_optional_tensor_device(
+        attention_sink_bias,
+        scratch=scratch,
+        name="attention_sink_bias",
+    )
+    _validate_optional_tensor_device(
+        relative_attention_bias,
+        scratch=scratch,
+        name="relative_attention_bias",
+    )
+
+    metadata = _metadata_tuple(
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    if metadata is not None:
+        scratch.prepare(
+            metadata[0],
+            metadata[1],
+            metadata[2],
+            fixed_split_size=fixed_split_size,
+            disable_split_kv=disable_split_kv,
+            window_left=window_left,
+            active_total_q=active_total_q,
+        )
+    elif not scratch.prepared:
+        raise RuntimeError("paged attention binding requires prepared scratch metadata")
+    scratch._validate_q2k_indices_reference(q2k_indices)
+
+    return SM12XPagedAttentionBinding(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        q2k_indices=q2k_indices,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        attention_sink_bias=attention_sink_bias,
+        relative_attention_bias=relative_attention_bias,
+    )
+
+
+def _materialize_paged_attention_scratch(
+    caps: SM12XPagedAttentionScratchCaps,
+    scratch_storage: torch.Tensor,
+    layout: _SM12XPagedAttentionScratchLayout,
+    *,
+    plan: PagedPlan | None,
+    plan_q: torch.Tensor,
+    plan_output: torch.Tensor,
+    plan_k_cache: torch.Tensor,
+    plan_v_cache: torch.Tensor,
+    planner_budget: PagedPlanBudget,
+    plan_metadata_cache: _SM12XPagedPlanMetadataCache | None,
+    decode_graph_chunk_pages_lut: torch.Tensor | None,
+    decode_graph_max_chunks_per_req: int | None,
+    use_regular_decode_graph_replay: bool,
+) -> SM12XPagedAttentionScratch:
+    request_indices, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.request_indices_offset_bytes,
+        shape=(caps.max_work_items,),
+        dtype=torch.int32,
+    )
+    qo_tile_indices, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.qo_tile_indices_offset_bytes,
+        shape=(caps.max_work_items,),
+        dtype=torch.int32,
+    )
+    kv_tile_indices, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.kv_tile_indices_offset_bytes,
+        shape=(caps.max_work_items,),
+        dtype=torch.int32,
+    )
+    block_valid_mask, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.block_valid_mask_offset_bytes,
+        shape=(caps.max_work_items,),
+        dtype=torch.int32,
+    )
+    page_table = None
+    if layout.page_table_offset_bytes is not None:
+        page_table, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.page_table_offset_bytes,
+            shape=(caps.max_batch, caps.max_page_table_width),
+            dtype=torch.int32,
+        )
+    cache_seqlens = None
+    if layout.cache_seqlens_offset_bytes is not None:
+        cache_seqlens, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.cache_seqlens_offset_bytes,
+            shape=(caps.max_batch,),
+            dtype=torch.int32,
+        )
+    cu_seqlens_q = None
+    if layout.cu_seqlens_q_offset_bytes is not None:
+        cu_seqlens_q, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.cu_seqlens_q_offset_bytes,
+            shape=(caps.max_batch + 1,),
+            dtype=torch.int32,
+        )
+    merge_indptr, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.merge_indptr_offset_bytes,
+        shape=(caps.max_total_q + 1,),
+        dtype=torch.int32,
+    )
+    o_indptr, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.o_indptr_offset_bytes,
+        shape=(caps.max_batch + 1,),
+        dtype=torch.int32,
+    )
+    kv_chunk_size_ptr, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.kv_chunk_size_ptr_offset_bytes,
+        shape=(1,),
+        dtype=torch.int32,
+    )
+    kv_window_start_tokens, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.kv_window_start_tokens_offset_bytes,
+        shape=(caps.max_batch,),
+        dtype=torch.int32,
+    )
+    total_num_rows_ptr, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.total_num_rows_ptr_offset_bytes,
+        shape=(1,),
+        dtype=torch.int32,
+    )
+    lse, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.lse_offset_bytes,
+        shape=_paged_lse_storage_shape(caps.max_total_q, caps.num_q_heads),
+        dtype=torch.float32,
+    )
+    tmp_output = None
+    tmp_lse = None
+    if caps.max_partial_rows > 0:
+        tmp_output, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.tmp_output_offset_bytes,
+            shape=(caps.max_partial_rows, caps.num_q_heads, caps.head_dim_vo),
+            dtype=caps.dtype,
+        )
+        tmp_lse, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.tmp_lse_offset_bytes,
+            shape=(caps.max_partial_rows, caps.num_q_heads),
+            dtype=torch.float32,
+        )
+    msa_union_blocks = None
+    msa_union_masks = None
+    msa_union_counts = None
+    if layout.msa_union_blocks_offset_bytes is not None:
+        msa_union_blocks, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_union_blocks_offset_bytes,
+            shape=(caps.max_work_items, caps.num_kv_heads, 128),
+            dtype=torch.int32,
+        )
+    if layout.msa_union_masks_offset_bytes is not None:
+        msa_union_masks, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_union_masks_offset_bytes,
+            shape=(caps.max_work_items, caps.num_kv_heads, 128),
+            dtype=torch.int32,
+        )
+    if layout.msa_union_counts_offset_bytes is not None:
+        msa_union_counts, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.msa_union_counts_offset_bytes,
+            shape=(caps.max_work_items, caps.num_kv_heads),
+            dtype=torch.int32,
+        )
+
+    return SM12XPagedAttentionScratch(
+        shared_scratch=scratch_storage,
+        device=caps.device,
+        dtype=caps.dtype,
+        kv_dtype=caps.kv_dtype,
+        mode=caps.mode,
+        num_q_heads=caps.num_q_heads,
+        num_kv_heads=caps.num_kv_heads,
+        head_dim_qk=caps.head_dim_qk,
+        head_dim_vo=caps.head_dim_vo,
+        page_size=caps.page_size,
+        max_total_q=caps.max_total_q,
+        max_batch=caps.max_batch,
+        max_page_table_width=caps.max_page_table_width,
+        max_work_items=caps.max_work_items,
+        max_partial_rows=caps.max_partial_rows,
+        num_cache_pages=caps.num_cache_pages,
+        use_cuda_graph=caps.use_cuda_graph,
+        copy_runtime_metadata=caps.copy_runtime_metadata,
+        request_indices=request_indices,
+        qo_tile_indices=qo_tile_indices,
+        kv_tile_indices=kv_tile_indices,
+        block_valid_mask=block_valid_mask,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        merge_indptr=merge_indptr,
+        o_indptr=o_indptr,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        kv_window_start_tokens=kv_window_start_tokens,
+        total_num_rows_ptr=total_num_rows_ptr,
+        lse=lse,
+        tmp_output=tmp_output,
+        tmp_lse=tmp_lse,
+        msa_union_blocks=msa_union_blocks,
+        msa_union_masks=msa_union_masks,
+        msa_union_counts=msa_union_counts,
+        msa_block_sparse=caps.msa_block_sparse,
+        msa_union_tile=bool(caps.msa_union_tile),
+        _plan_q=plan_q,
+        _plan_output=plan_output,
+        _plan_k_cache=plan_k_cache,
+        _plan_v_cache=plan_v_cache,
+        _plan=plan,
+        _plan_metadata_cache=plan_metadata_cache,
+        _planner_budget=planner_budget,
+        _decode_graph_chunk_pages_lut=decode_graph_chunk_pages_lut,
+        _decode_graph_max_chunks_per_req=decode_graph_max_chunks_per_req,
+        _use_regular_decode_graph_replay=use_regular_decode_graph_replay,
+    )
+
+
+@dataclass
+class SM12XPagedAttentionScratchPlan:
+    caps: SM12XPagedAttentionScratchCaps
+    layout: _SM12XPagedAttentionScratchLayout
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+    _plan_q: torch.Tensor
+    _plan_output: torch.Tensor
+    _plan_k_cache: torch.Tensor
+    _plan_v_cache: torch.Tensor
+    _planner_budget: PagedPlanBudget
+    _plan: PagedPlan | None = None
+    _plan_metadata_cache: _SM12XPagedPlanMetadataCache | None = None
+    _decode_graph_chunk_pages_lut: torch.Tensor | None = None
+    _decode_graph_max_chunks_per_req: int | None = None
+    _use_regular_decode_graph_replay: bool = False
+    _q2k_indices_data_ptr: int | None = None
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    @property
+    def prepared(self) -> bool:
+        return self._plan is not None
+
+    @property
+    def plan(self) -> PagedPlan:
+        if self._plan is None:
+            raise RuntimeError("paged scratch plan has not been prepared")
+        return self._plan
+
+    @property
+    def total_q_capacity(self) -> int:
+        return int(self._plan_q.shape[0])
+
+    @staticmethod
+    def _plan_has_regular_decode_graph_grid(plan: PagedPlan) -> bool:
+        batch = int(plan.page_table_shape[0])
+        if (
+            batch <= 0
+            or plan.mode != "decode"
+            or not plan.enable_cuda_graph
+            or not plan.split_kv
+        ):
+            return False
+        if int(plan.total_q) != batch:
+            return False
+        work_items = len(plan.request_indices)
+        if work_items <= 0 or work_items % batch != 0:
+            return False
+        max_chunks_per_req = work_items // batch
+        for req_idx in range(batch):
+            base = req_idx * max_chunks_per_req
+            for chunk_idx in range(max_chunks_per_req):
+                work_idx = base + chunk_idx
+                if plan.request_indices[work_idx] != req_idx:
+                    return False
+                if plan.qo_tile_indices[work_idx] != 0:
+                    return False
+                if plan.kv_tile_indices[work_idx] != chunk_idx:
+                    return False
+        return True
+
+    def _ensure_capacity(self, plan: PagedPlan) -> None:
+        work_items_needed = int(plan.new_batch_size)
+        block_valid_needed = int(plan.padded_batch_size)
+        total_q_needed = int(plan.total_q)
+        batch_needed = int(plan.page_table_shape[0])
+        page_table_width_needed = int(plan.page_table_shape[1])
+        partial_rows_needed = int(plan.total_num_partial_rows) if plan.split_kv else 0
+        if work_items_needed > self.caps.max_work_items:
+            raise ValueError(
+                f"paged plan needs {work_items_needed} work items, scratch "
+                f"capacity is {self.caps.max_work_items}"
+            )
+        if block_valid_needed > self.caps.max_work_items:
+            raise ValueError(
+                f"paged plan needs {block_valid_needed} block-valid entries, "
+                f"scratch capacity is {self.caps.max_work_items}"
+            )
+        if total_q_needed > self.caps.max_total_q:
+            raise ValueError(
+                f"paged plan total_q={total_q_needed} exceeds scratch "
+                f"capacity {self.caps.max_total_q}"
+            )
+        if batch_needed > self.caps.max_batch:
+            raise ValueError(
+                f"paged plan batch={batch_needed} exceeds scratch capacity "
+                f"{self.caps.max_batch}"
+            )
+        if page_table_width_needed > self.caps.max_page_table_width:
+            raise ValueError(
+                f"paged plan page table width={page_table_width_needed} exceeds "
+                f"scratch capacity {self.caps.max_page_table_width}"
+            )
+        if partial_rows_needed > self.caps.max_partial_rows:
+            raise ValueError(
+                f"paged plan needs {partial_rows_needed} partial rows, scratch "
+                f"capacity is {self.caps.max_partial_rows}"
+            )
+
+    @staticmethod
+    def _build_capacity_cu_seqlens_q(
+        *,
+        batch: int,
+        total_q_capacity: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        del total_q_capacity
+        return torch.arange(0, batch + 1, dtype=torch.int32, device=device)
+
+    def prepare_graph_replay_state(
+        self,
+        *,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        active_total_q: int | None = None,
+        fixed_split_size: int = -1,
+        disable_split_kv: bool = False,
+        window_left: int = -1,
+    ) -> "SM12XPagedAttentionScratchPlan":
+        """Prepare non-decode graph metadata before CUDA capture.
+
+        A scratch plan is rematerialized on every bind.  Installing the plan
+        and its device metadata cache on this caller-owned object ensures that
+        the first bind performed during capture starts from prepared state.
+        """
+        if not self.caps.use_cuda_graph:
+            raise RuntimeError(
+                "prepare_graph_replay_state is only valid for graph-mode "
+                "paged scratch plans"
+            )
+        if self.caps.mode == "decode":
+            raise RuntimeError("decode plans require prepare_decode_graph_replay_state")
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "prepare_graph_replay_state must be called before CUDA graph capture"
+            )
+        if window_left < -1:
+            raise ValueError(
+                "window_left must be -1 for full attention or a non-negative token count"
+            )
+        if active_total_q is None:
+            active_total_q = int(cu_seqlens_q[-1].item())
+        else:
+            active_total_q = int(active_total_q)
+        inferred_mode = _infer_mode_from_host_total(cu_seqlens_q, active_total_q)
+        if inferred_mode != self.caps.mode and not (
+            self.caps.mode == "verify" and inferred_mode == "extend"
+        ):
+            raise ValueError(
+                f"scratch mode {self.caps.mode} does not match prepared mode "
+                f"{inferred_mode}"
+            )
+        if active_total_q <= 0 or active_total_q > int(self._plan_q.shape[0]):
+            raise ValueError(
+                f"active_total_q={active_total_q} exceeds scratch capacity "
+                f"{int(self._plan_q.shape[0])}"
+            )
+
+        plan = create_paged_plan(
+            self._plan_q[:active_total_q],
+            self._plan_k_cache,
+            self._plan_v_cache,
+            page_table,
+            cache_seqlens,
+            cu_seqlens_q,
+            mode=self.caps.mode,
+            fixed_split_size=int(fixed_split_size),
+            disable_split_kv=bool(disable_split_kv),
+            window_left=int(window_left),
+            enable_cuda_graph=True,
+            graph_chunk_policy=True,
+            plan_budget=None,
+            msa_block_sparse=self.caps.msa_block_sparse,
+            msa_union_tile=bool(self.caps.msa_union_tile),
+        )
+        self._ensure_capacity(plan)
+        self._plan = plan
+        self._plan_metadata_cache = _make_plan_metadata_cache(
+            plan,
+            device=self.caps.device,
+        )
+        return self
+
+    def prepare_decode_graph_replay_state(
+        self,
+        *,
+        batch: int,
+        max_page_table_width: int,
+        total_q_capacity: int | None = None,
+        max_cache_page_count: int | None = None,
+        fixed_split_size: int = -1,
+        window_left: int = -1,
+        force_split_kv: bool = False,
+    ) -> "SM12XPagedAttentionScratchPlan":
+        if not self.caps.use_cuda_graph:
+            raise RuntimeError(
+                "prepare_decode_graph_replay_state is only valid for graph-mode "
+                "paged scratch plans"
+            )
+        if self.caps.mode != "decode":
+            raise RuntimeError(
+                "prepare_decode_graph_replay_state is only valid for decode plans"
+            )
+        if total_q_capacity is None:
+            total_q_capacity = int(self.caps.max_total_q)
+        else:
+            total_q_capacity = int(total_q_capacity)
+        if max_cache_page_count is None:
+            max_cache_page_count = int(max_page_table_width)
+        else:
+            max_cache_page_count = int(max_cache_page_count)
+        if batch <= 0:
+            raise ValueError("batch must be positive")
+        if total_q_capacity <= 0:
+            raise ValueError("total_q_capacity must be positive")
+        if max_page_table_width <= 0:
+            raise ValueError("max_page_table_width must be positive")
+        if max_cache_page_count <= 0:
+            raise ValueError("max_cache_page_count must be positive")
+        if window_left < -1:
+            raise ValueError(
+                "window_left must be -1 for full attention or a non-negative token count"
+            )
+
+        if self.caps.msa_block_sparse:
+            if window_left != -1:
+                raise ValueError(
+                    "MSA block-sparse decode graph replay does not support window_left/SWA"
+                )
+            if self.caps.page_size not in (64, 128):
+                raise ValueError(
+                    "MSA block-sparse decode graph replay requires page_size=64 or page_size=128"
+                )
+            if self.caps.head_dim_qk != 128 or self.caps.head_dim_vo != 128:
+                raise ValueError(
+                    "MSA block-sparse decode graph replay requires head_dim_qk=head_dim_vo=128"
+                )
+            if self.caps.num_q_heads // self.caps.num_kv_heads != 16:
+                raise ValueError(
+                    "MSA block-sparse decode graph replay requires gqa_group_size=16"
+                )
+            max_page_ids = torch.arange(
+                max_page_table_width, dtype=torch.int32, device=self.caps.device
+            )
+            max_page_table = (
+                (max_page_ids % self.caps.num_cache_pages)
+                .unsqueeze(0)
+                .expand(batch, -1)
+                .contiguous()
+            )
+            max_cache_seqlens = torch.full(
+                (batch,),
+                int(max_cache_page_count) * self.caps.page_size,
+                dtype=torch.int32,
+                device=self.caps.device,
+            )
+            max_cu_seqlens_q = self._build_capacity_cu_seqlens_q(
+                batch=batch,
+                total_q_capacity=total_q_capacity,
+                device=self.caps.device,
+            )
+            plan = create_paged_plan(
+                self._plan_q[:batch],
+                self._plan_k_cache,
+                self._plan_v_cache,
+                max_page_table,
+                max_cache_seqlens,
+                max_cu_seqlens_q,
+                mode="decode",
+                fixed_split_size=int(fixed_split_size),
+                force_split_kv=True,
+                window_left=-1,
+                enable_cuda_graph=True,
+                graph_chunk_policy=False,
+                max_batch_size_if_split=batch * 32,
+                msa_block_sparse=True,
+                plan_budget=None,
+            )
+            self._ensure_capacity(plan)
+            self._plan = plan
+            self._plan_metadata_cache = _make_plan_metadata_cache(
+                plan, device=self.caps.device
+            )
+            self._decode_graph_chunk_pages_lut = torch.empty(
+                (1,), dtype=torch.int32, device=self.caps.device
+            )
+            self._decode_graph_max_chunks_per_req = max(
+                int(plan.o_indptr[idx + 1] - plan.o_indptr[idx]) for idx in range(batch)
+            )
+            self._use_regular_decode_graph_replay = False
+            return self
+
+        from flashinfer.experimental.sm12x.attention.paged.graph_replay import (
+            make_decode_chunk_pages_lut_tensor,
+            summarize_decode_chunk_pages_lut,
+        )
+
+        max_effective_kv_pages = int(max_cache_page_count)
+        if window_left >= 0:
+            max_effective_kv_pages = min(
+                max_effective_kv_pages,
+                max(
+                    1,
+                    (int(window_left) + self.caps.page_size + self.caps.page_size - 1)
+                    // self.caps.page_size,
+                ),
+            )
+        graph_ctas_per_sm = resolve_decode_graph_ctas_per_sm(
+            kv_dtype=self.caps.kv_dtype,
+            batch=batch,
+            page_size=self.caps.page_size,
+            head_dim_qk=self.caps.head_dim_qk,
+            head_dim_vo=self.caps.head_dim_vo,
+            gqa_group_size=self.caps.num_q_heads // self.caps.num_kv_heads,
+        )
+        max_chunks_per_req_budget = decode_graph_max_chunks_per_request_budget(
+            device=self.caps.device,
+            num_kv_heads=self.caps.num_kv_heads,
+            batch=batch,
+            graph_ctas_per_sm=graph_ctas_per_sm,
+        )
+        decode_chunk_pages_lut = build_decode_chunk_pages_lut(
+            q_dtype=self.caps.dtype,
+            kv_dtype=self.caps.kv_dtype,
+            batch=batch,
+            page_size=self.caps.page_size,
+            head_dim_qk=self.caps.head_dim_qk,
+            head_dim_vo=self.caps.head_dim_vo,
+            gqa_group_size=self.caps.num_q_heads // self.caps.num_kv_heads,
+            max_effective_kv_pages=max_effective_kv_pages,
+            max_chunks_per_req=max_chunks_per_req_budget,
+        )
+        worst_page_count, max_chunks_per_req = summarize_decode_chunk_pages_lut(
+            decode_chunk_pages_lut
+        )
+        capacity_cache_seqlen = int(worst_page_count) * self.caps.page_size
+        if window_left >= 0:
+            capacity_cache_seqlen = int(max_cache_page_count) * self.caps.page_size - 1
+        max_cache_seqlens = torch.full(
+            (batch,),
+            int(capacity_cache_seqlen),
+            dtype=torch.int32,
+            device=self.caps.device,
+        )
+        max_page_ids = torch.arange(
+            max_page_table_width, dtype=torch.int32, device=self.caps.device
+        )
+        max_page_table = (
+            (max_page_ids % self.caps.num_cache_pages)
+            .unsqueeze(0)
+            .expand(batch, -1)
+            .contiguous()
+        )
+        max_cu_seqlens_q = self._build_capacity_cu_seqlens_q(
+            batch=batch,
+            total_q_capacity=total_q_capacity,
+            device=self.caps.device,
+        )
+        plan = create_paged_plan(
+            self._plan_q[:batch],
+            self._plan_k_cache,
+            self._plan_v_cache,
+            max_page_table,
+            max_cache_seqlens,
+            max_cu_seqlens_q,
+            mode="decode",
+            fixed_split_size=-1,
+            disable_split_kv=not force_split_kv,
+            force_split_kv=force_split_kv,
+            window_left=int(window_left),
+            enable_cuda_graph=True,
+            graph_chunk_policy=True,
+            plan_budget=None,
+        )
+        self._ensure_capacity(plan)
+        self._plan = plan
+        self._plan_metadata_cache = _make_plan_metadata_cache(
+            plan, device=self.caps.device
+        )
+        self._decode_graph_chunk_pages_lut = make_decode_chunk_pages_lut_tensor(
+            decode_chunk_pages_lut,
+            device=self.caps.device,
+        )
+        self._decode_graph_max_chunks_per_req = int(max_chunks_per_req)
+        self._use_regular_decode_graph_replay = int(plan.gqa_group_size) <= int(
+            plan.cta_tile_q
+        ) and self._plan_has_regular_decode_graph_grid(plan)
+        return self
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        output: torch.Tensor,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        fixed_split_size: int | None = None,
+        disable_split_kv: bool = False,
+        window_left: int = -1,
+        active_total_q: int | None = None,
+        k_descale: torch.Tensor | None = None,
+        v_descale: torch.Tensor | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+        relative_attention_bias: torch.Tensor | None = None,
+        q2k_indices: torch.Tensor | None = None,
+    ) -> SM12XPagedAttentionBinding:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="paged attention",
+        )
+        scratch_views = _materialize_paged_attention_scratch(
+            self.caps,
+            scratch_storage,
+            self.layout,
+            plan=self._plan,
+            plan_q=self._plan_q,
+            plan_output=self._plan_output,
+            plan_k_cache=self._plan_k_cache,
+            plan_v_cache=self._plan_v_cache,
+            planner_budget=self._planner_budget,
+            plan_metadata_cache=self._plan_metadata_cache,
+            decode_graph_chunk_pages_lut=self._decode_graph_chunk_pages_lut,
+            decode_graph_max_chunks_per_req=self._decode_graph_max_chunks_per_req,
+            use_regular_decode_graph_replay=self._use_regular_decode_graph_replay,
+        )
+        scratch_views._q2k_indices_data_ptr = self._q2k_indices_data_ptr
+        binding = build_paged_attention_binding(
+            scratch=scratch_views,
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            fixed_split_size=fixed_split_size,
+            disable_split_kv=disable_split_kv,
+            window_left=window_left,
+            active_total_q=active_total_q,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            attention_sink_bias=attention_sink_bias,
+            relative_attention_bias=relative_attention_bias,
+            q2k_indices=q2k_indices,
+        )
+        self._q2k_indices_data_ptr = scratch_views._q2k_indices_data_ptr
+        return binding
+
+
+def plan_paged_attention_scratch(
+    caps: SM12XPagedAttentionScratchCaps,
+) -> SM12XPagedAttentionScratchPlan:
+    layout = _paged_attention_scratch_layout(caps)
+    plan_q = _shape_only_cuda_tensor(
+        (caps.max_total_q, caps.num_q_heads, caps.head_dim_qk),
+        dtype=caps.dtype,
+        device=caps.device,
+    )
+    plan_output = _shape_only_cuda_tensor(
+        (caps.max_total_q, caps.num_q_heads, caps.head_dim_vo),
+        dtype=caps.dtype,
+        device=caps.device,
+    )
+    plan_k_cache = _shape_only_cuda_tensor(
+        (caps.num_cache_pages, caps.page_size, caps.num_kv_heads, caps.head_dim_qk),
+        dtype=caps.kv_dtype,
+        device=caps.device,
+    )
+    plan_v_cache = _shape_only_cuda_tensor(
+        (caps.num_cache_pages, caps.page_size, caps.num_kv_heads, caps.head_dim_vo),
+        dtype=caps.kv_dtype,
+        device=caps.device,
+    )
+    planner_budget = PagedPlanBudget(
+        max_total_q=caps.max_total_q,
+        max_batch=caps.max_batch,
+        max_page_table_width=caps.max_page_table_width,
+        max_work_items=caps.max_work_items,
+        max_partial_rows=caps.max_partial_rows,
+    )
+    return SM12XPagedAttentionScratchPlan(
+        caps=caps,
+        layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "paged_attention.scratch",
+                nbytes=int(layout.nbytes),
+                device=caps.device,
+            ),
+        ),
+        _plan_q=plan_q,
+        _plan_output=plan_output,
+        _plan_k_cache=plan_k_cache,
+        _plan_v_cache=plan_v_cache,
+        _planner_budget=planner_budget,
+    )
+
+
+__all__ = [
+    "SM12XPagedAttentionBinding",
+    "SM12XPagedAttentionScratch",
+    "SM12XPagedAttentionScratchCaps",
+    "SM12XPagedAttentionScratchPlan",
+    "build_paged_attention_binding",
+    "plan_paged_attention_scratch",
+]

--- a/flashinfer/experimental/sm12x/attention/paged/api.py
+++ b/flashinfer/experimental/sm12x/attention/paged/api.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for attention.paged (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from ._forward import (
+    clear_paged_caches as clear_caches,
+)
+from ._forward import (
+    paged_attention_forward as run,
+)
+from ._scratch import (
+    SM12XPagedAttentionBinding as Binding,
+)
+from ._scratch import (
+    SM12XPagedAttentionScratchCaps as Caps,
+)
+from ._scratch import (
+    SM12XPagedAttentionScratchPlan as Plan,
+)
+from ._scratch import (
+    plan_paged_attention_scratch as plan,
+)
+from .planner import (
+    PagedPlanBudget as Budget,
+)
+from .planner import (
+    infer_paged_mode as infer_mode,
+)
+from .workspace import (
+    PagedAttentionWorkspace as Workspace,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "Binding",
+    "Workspace",
+    "Budget",
+    "plan",
+    "bind",
+    "run",
+    "infer_mode",
+    "is_supported",
+    "clear_caches",
+]

--- a/flashinfer/experimental/sm12x/attention/paged/forward_extend_generic.py
+++ b/flashinfer/experimental/sm12x/attention/paged/forward_extend_generic.py
@@ -1,0 +1,6359 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/forward_extend_generic.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Historical generic paged extend kernels kept in a separate file.
+
+This uses the exact host planner worklists with the
+literal tensor-core inner path that we actually ship:
+- staged paged K/V ingress,
+- literal QK/PV MMA for BF16 and FP8 KV,
+- base-2 LSE storage for direct extend output.
+"""
+
+from __future__ import annotations
+import os
+from typing import Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.core import make_swizzle
+from cutlass.cute.nvgpu import cpasync, warpgroup
+from cutlass.utils import LayoutEnum
+import cutlass.utils.hopper_helpers as sm90_utils_basic
+
+from cutlass import Float32, Int32, Uint32, const_expr
+from cutlass.cutlass_dsl import Int64, T, dsl_user_op
+from flashinfer.experimental.sm12x.attention._shared.cute import copy as cute_copy
+from flashinfer.experimental.sm12x.attention._shared.cute import (
+    pipeline as cute_pipeline,
+)
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as attention_ops
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    get_ptr_as_int64,
+    shared_ptr_to_u32,
+)
+from flashinfer.experimental.sm12x._lib.smem import make_smem_memrange_alias
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    bf16_mma_m16n16k16_f32,
+    bf16_rowsum_m16k16_f32,
+    bfloat2_mul,
+    bfloat2_to_float2_scaled,
+    broadcast_f32_to_bfloat2,
+    cvt_bf16x2_to_e4m3x2,
+    fp8x4_e4m3_to_bfloat2x2,
+    ld_shared_v4_u32,
+    ldmatrix_m8n8x4_b16,
+    ldmatrix_m8n8x4_left_half_b16,
+    ldmatrix_m8n8x4_right_half_b16,
+    ldmatrix_m8n8x4_trans_b16,
+    ldmatrix_m8n8x4_trans_left_half_b16,
+    ldmatrix_m8n8x4_trans_right_half_b16,
+    mxfp8_mma_m16n8k32_f32_e4m3,
+    pack_f32x2_to_bfloat2,
+    frag_layout_swizzle_16b_to_8b,
+    frag_layout_swizzle_16b_to_8b_trans,
+    st_global_v4_u32,
+    st_shared_v4_u32,
+)
+
+from .traits import PagedForwardTraits
+
+
+def _assume_strides_aligned(t: cute.Tensor):
+    divby = 128 // t.element_type.width
+    strides = tuple(
+        s if isinstance(s, int) else cute.assume(s, divby=divby) for s in t.stride[:-1]
+    )
+    return (*strides, t.stride[-1])
+
+
+def _assume_tensor_aligned(t: cute.Tensor | None):
+    if t is None:
+        return None
+    return cute.make_tensor(
+        t.iterator, cute.make_layout(t.shape, stride=_assume_strides_aligned(t))
+    )
+
+
+def _assume_paged_kv_tma_source_aligned(t: cute.Tensor):
+    divby = 128 // t.element_type.width
+    strides = []
+    for dim, stride in enumerate(t.stride):
+        if dim == 1 or isinstance(stride, int):
+            strides.append(stride)
+        else:
+            strides.append(cute.assume(stride, divby=divby))
+    return cute.make_tensor(
+        t.iterator, cute.make_layout(t.shape, stride=tuple(strides))
+    )
+
+
+def _make_payload_ptr(payload_u8: cute.Tensor, dtype, offset_bytes: int = 0):
+    # Preserve 128-bit shared alignment when carving typed aliases out of the
+    # byte payload.
+    ptr = (
+        payload_u8.iterator if offset_bytes == 0 else payload_u8.iterator + offset_bytes
+    )
+    return cute.recast_ptr(ptr.align(16), dtype=dtype)
+
+
+def _make_payload_tensor(payload_u8: cute.Tensor, dtype, offset_bytes: int, layout):
+    return cute.make_tensor(_make_payload_ptr(payload_u8, dtype, offset_bytes), layout)
+
+
+def _make_payload_memrange(
+    payload_u8: cute.Tensor, dtype, offset_bytes: int, num_elems: int
+):
+    # Rebuild a MemRange alias over the payload slice so CuTe can lower swizzled
+    # shared-memory pointers the same way it does for typed struct fields.
+    return make_smem_memrange_alias(
+        dtype,
+        num_elems,
+        _make_payload_ptr(payload_u8, dtype, offset_bytes),
+    )
+
+
+def _get_memrange_tensor(memrange, layout):
+    if hasattr(layout, "outer") and hasattr(layout, "inner"):
+        return memrange.get_tensor(layout.outer, swizzle=layout.inner)
+    return memrange.get_tensor(layout)
+
+
+@dsl_user_op
+def _cp_async_bulk_tensor_2d(
+    dst_smem_addr: Int32,
+    tensor_map_ptr: Int64,
+    coord0: Int32,
+    coord1: Int32,
+    mbar_smem_addr: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    raise RuntimeError("raw tensor-map TMA issue is disabled; use CuTe atom TMA")
+
+
+@cute.jit
+def _dump_tma_stage_rows(
+    mDst: cute.Tensor,
+    sSrc: cute.Tensor,
+    tidx,
+    num_rows,
+    head_dim,
+    num_threads,
+    max_rows,
+):
+    dump_rows = cutlass.select_(max_rows < num_rows, max_rows, num_rows)
+    dst_rows = mDst.shape[0] * mDst.shape[1]
+    dump_rows = cutlass.select_(dump_rows < dst_rows, dump_rows, dst_rows)
+    linear = tidx
+    dump_elems = dump_rows * head_dim
+    while linear < dump_elems:
+        row = linear // head_dim
+        col = linear - row * head_dim
+        dst_q = row // mDst.shape[1]
+        dst_h = row - dst_q * mDst.shape[1]
+        mDst[dst_q, dst_h, col] = sSrc[row, col, 0]
+        linear += num_threads
+
+
+@cute.jit
+def _dump_s_frag_tile(
+    mDst: cute.Tensor,
+    s_frag: cute.Tensor,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    num_mma_q,
+    num_mma_kv,
+    packed_tile_rows,
+    tile_tokens,
+):
+    lane_group = lane // 4
+    lane_pair_base = 2 * (lane % 4)
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            for reg_id in cutlass.range_constexpr(8):
+                row_slot = (reg_id % 4) // 2
+                row = (
+                    warp_q_idx * num_mma_q * 16 + mma_q * 16 + lane_group + 8 * row_slot
+                )
+                col = (
+                    warp_kv_idx * num_mma_kv * 16
+                    + mma_kv * 16
+                    + lane_pair_base
+                    + 8 * (reg_id // 4)
+                    + (reg_id % 2)
+                )
+                if row < packed_tile_rows and col < tile_tokens:
+                    dst_linear = row * tile_tokens + col
+                    dst_q = dst_linear // (mDst.shape[1] * mDst.shape[2])
+                    dst_rem = dst_linear - dst_q * (mDst.shape[1] * mDst.shape[2])
+                    dst_h = dst_rem // mDst.shape[2]
+                    dst_col = dst_rem - dst_h * mDst.shape[2]
+                    mDst[dst_q, dst_h, dst_col] = cutlass.BFloat16(
+                        s_frag[mma_q, mma_kv, reg_id]
+                    )
+
+
+@cute.jit
+def _dump_pv_copyfrag_regs(
+    mDst: cute.Tensor,
+    tOrVt: cute.Tensor,
+    tOsVt: cute.Tensor,
+    smem_thr_copy_V: cute.TiledCopy,
+    lane,
+    num_mma_d_vo,
+):
+    tCrV_copy_view = smem_thr_copy_V.retile(tOrVt)
+    cute.copy(smem_thr_copy_V, tOsVt[None, None, 0], tCrV_copy_view[None, None, 0])
+    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+        if const_expr(mma_d < num_mma_d_vo - 1):
+            cute.copy(
+                smem_thr_copy_V,
+                tOsVt[None, None, mma_d + 1],
+                tCrV_copy_view[None, None, mma_d + 1],
+            )
+        b_regs = cute.flatten(cute.recast_tensor(tOrVt[None, None, mma_d], Uint32))
+        if lane == Int32(0):
+            for reg_id in cutlass.range_constexpr(cute.size(b_regs.shape)):
+                v0, v1 = bfloat2_to_float2_scaled(b_regs[reg_id], Float32(1.0))
+                mDst[mma_d * 8 + reg_id * 2 + 0] = cutlass.BFloat16(v0)
+                mDst[mma_d * 8 + reg_id * 2 + 1] = cutlass.BFloat16(v1)
+
+
+@cute.jit
+def _dump_pv_copyfrag_regs_raw(
+    mDst: cute.Tensor,
+    tOrVt: cute.Tensor,
+    tOsVt: cute.Tensor,
+    smem_thr_copy_V: cute.TiledCopy,
+    lane,
+    num_mma_d_vo,
+):
+    tCrV_copy_view = smem_thr_copy_V.retile(tOrVt)
+    cute.copy(smem_thr_copy_V, tOsVt[None, None, 0], tCrV_copy_view[None, None, 0])
+    lane_words = num_mma_d_vo * 4
+    dst_words = cute.size(mDst.shape)
+    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+        if const_expr(mma_d < num_mma_d_vo - 1):
+            cute.copy(
+                smem_thr_copy_V,
+                tOsVt[None, None, mma_d + 1],
+                tCrV_copy_view[None, None, mma_d + 1],
+            )
+        b_regs = cute.flatten(cute.recast_tensor(tOrVt[None, None, mma_d], Uint32))
+        dst_idx = lane * lane_words + mma_d * 4
+        if dst_idx + 0 < dst_words:
+            mDst[dst_idx + 0] = b_regs[0]
+        if dst_idx + 1 < dst_words:
+            mDst[dst_idx + 1] = b_regs[1]
+        if dst_idx + 2 < dst_words:
+            mDst[dst_idx + 2] = b_regs[2]
+        if dst_idx + 3 < dst_words:
+            mDst[dst_idx + 3] = b_regs[3]
+
+
+@cute.jit
+def _dump_flat_u32_words(
+    mDst: cute.Tensor,
+    sSrc: cute.Tensor,
+    tidx,
+    num_threads,
+):
+    flat = cute.flatten(sSrc)
+    dst_words = cute.size(mDst.shape)
+    src_words = cute.size(flat.shape)
+    dump_words = cutlass.select_(src_words < dst_words, src_words, dst_words)
+    linear = tidx
+    while linear < dump_words:
+        mDst[linear] = flat[linear]
+        linear += num_threads
+
+
+@cute.jit
+def _dump_flat_u32_words_offset(
+    mDst: cute.Tensor,
+    sSrc: cute.Tensor,
+    dst_word_offset,
+    tidx,
+    num_threads,
+):
+    flat = cute.flatten(sSrc)
+    dst_words = cute.size(mDst.shape)
+    src_words = cute.size(flat.shape)
+    dump_words = cutlass.select_(
+        src_words < (dst_words - dst_word_offset),
+        src_words,
+        (dst_words - dst_word_offset),
+    )
+    linear = tidx
+    while linear < dump_words:
+        mDst[dst_word_offset + linear] = flat[linear]
+        linear += num_threads
+
+
+@cute.jit
+def _issue_paged_kv_tma_copy_2planes_fp8_raw_impl(
+    mDescPtrsFlat: cute.Tensor,
+    kv_head_idx,
+    kv_tma_plane_head_dim,
+    sStageBytes: cute.Tensor,
+    stage_plane_offset,
+    kv_plane_total_bytes,
+    producer_state,
+    mbar_ptr,
+    expected_bytes,
+    mPageTable: cute.Tensor,
+    request_idx,
+    tile_token_base,
+    page_size,
+):
+    page_idx = tile_token_base // page_size
+    page_row_offset = tile_token_base - page_idx * page_size
+    page_id = (
+        Int32(0)
+        if const_expr(
+            os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0") == "1"
+        )
+        else mPageTable[request_idx, page_idx]
+    )
+    page_row_base = page_id * page_size + page_row_offset
+    desc_ptr = Int64(mDescPtrsFlat[kv_head_idx])
+    full_mbar_ptr = mbar_ptr + producer_state.index
+    with cute.arch.elect_one():
+        cute.arch.mbarrier_arrive_and_expect_tx(
+            full_mbar_ptr,
+            expected_bytes,
+        )
+        tma_bar_addr = shared_ptr_to_u32(full_mbar_ptr)
+        plane0_dst = shared_ptr_to_u32(
+            sStageBytes.iterator + stage_plane_offset + Int32(0 * kv_plane_total_bytes)
+        )
+        plane1_dst = shared_ptr_to_u32(
+            sStageBytes.iterator + stage_plane_offset + Int32(1 * kv_plane_total_bytes)
+        )
+        _cp_async_bulk_tensor_2d(
+            plane0_dst,
+            desc_ptr,
+            Int32(0),
+            page_row_base,
+            tma_bar_addr,
+        )
+        _cp_async_bulk_tensor_2d(
+            plane1_dst,
+            desc_ptr,
+            Int32(kv_tma_plane_head_dim),
+            page_row_base,
+            tma_bar_addr,
+        )
+
+
+@cute.jit
+def _async_copy_q_tile_permuted_128b_impl(
+    mQBytes: cute.Tensor,
+    q_start,
+    packed_tile_start,
+    packed_tile_rows,
+    kv_head_idx,
+    group_size,
+    num_q_heads,
+    row_bytes,
+    token_stride_bytes,
+    head_stride_bytes,
+    sQBytes: cute.Tensor,
+    lane,
+    warp_q_idx,
+    num_mma_q,
+    num_mma_d_qk,
+    upcast_stride_q,
+):
+    lane_row = lane // 8
+    lane_col = lane % 8
+    warp_row_base = Int32(warp_q_idx * num_mma_q * 16)
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for row_iter in cutlass.range_constexpr(4):
+            packed_q_idx = Int32(
+                packed_tile_start + warp_row_base + mma_q * 16 + lane_row + row_iter * 4
+            )
+            row_valid = packed_q_idx < (packed_tile_start + packed_tile_rows)
+            q_row_local = packed_q_idx // group_size
+            q_group_lane = packed_q_idx - q_row_local * group_size
+            q_head_idx = Int32(kv_head_idx * group_size + q_group_lane)
+            q_row_idx = Int32(q_start + q_row_local)
+            row_byte_base = Int64(q_row_idx) * Int64(token_stride_bytes) + Int64(
+                q_head_idx
+            ) * Int64(head_stride_bytes)
+            row_idx = Int32(warp_row_base + mma_q * 16 + lane_row + row_iter * 4)
+            for mma_do in cutlass.range_constexpr(num_mma_d_qk // 4):
+                vec_idx = Int32(lane_col + mma_do * 8)
+                src_byte_idx = row_byte_base + vec_idx * 16
+                dst_byte_idx = (
+                    _permuted_offset_128b(row_idx, vec_idx, upcast_stride_q) * 16
+                )
+                _cp_async_load_128b_pred(
+                    shared_ptr_to_u32(sQBytes.iterator + dst_byte_idx),
+                    get_ptr_as_int64(mQBytes, src_byte_idx),
+                    Int32(row_valid),
+                )
+
+
+@cute.jit
+def _dump_plane_stage_words_u32(
+    mDebugU32: cute.Tensor,
+    sStageBytes: cute.Tensor,
+    stage_idx,
+    kv_plane_stage_bytes,
+    kv_plane_total_bytes,
+    kv_tma_plane_count,
+    tidx,
+    num_threads,
+):
+    plane_words = kv_plane_stage_bytes // 4
+    plane0_u32 = cute.make_tensor(
+        cute.recast_tensor(
+            cute.make_tensor(
+                sStageBytes.iterator
+                + Int32(stage_idx * kv_plane_stage_bytes + 0 * kv_plane_total_bytes),
+                cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+            ),
+            cutlass.Uint32,
+        ).iterator,
+        cute.make_layout((plane_words,), stride=(1,)),
+    )
+    plane1_u32 = cute.make_tensor(
+        cute.recast_tensor(
+            cute.make_tensor(
+                sStageBytes.iterator
+                + Int32(stage_idx * kv_plane_stage_bytes + 1 * kv_plane_total_bytes),
+                cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+            ),
+            cutlass.Uint32,
+        ).iterator,
+        cute.make_layout((plane_words,), stride=(1,)),
+    )
+    _dump_flat_u32_words_offset(
+        mDebugU32,
+        plane0_u32,
+        Int32(0),
+        tidx,
+        num_threads,
+    )
+    _dump_flat_u32_words_offset(
+        mDebugU32,
+        plane1_u32,
+        Int32(plane_words),
+        tidx,
+        num_threads,
+    )
+    if const_expr(kv_tma_plane_count > 2):
+        plane2_u32 = cute.make_tensor(
+            cute.recast_tensor(
+                cute.make_tensor(
+                    sStageBytes.iterator
+                    + Int32(
+                        stage_idx * kv_plane_stage_bytes + 2 * kv_plane_total_bytes
+                    ),
+                    cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+                ),
+                cutlass.Uint32,
+            ).iterator,
+            cute.make_layout((plane_words,), stride=(1,)),
+        )
+        plane3_u32 = cute.make_tensor(
+            cute.recast_tensor(
+                cute.make_tensor(
+                    sStageBytes.iterator
+                    + Int32(
+                        stage_idx * kv_plane_stage_bytes + 3 * kv_plane_total_bytes
+                    ),
+                    cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+                ),
+                cutlass.Uint32,
+            ).iterator,
+            cute.make_layout((plane_words,), stride=(1,)),
+        )
+        _dump_flat_u32_words_offset(
+            mDebugU32,
+            plane2_u32,
+            Int32(plane_words * 2),
+            tidx,
+            num_threads,
+        )
+        _dump_flat_u32_words_offset(
+            mDebugU32,
+            plane3_u32,
+            Int32(plane_words * 3),
+            tidx,
+            num_threads,
+        )
+
+
+@cute.jit
+def _dump_p_frag_regs_raw(
+    mDst: cute.Tensor,
+    p_frag: cute.Tensor,
+    lane,
+):
+    p_regs = cute.flatten(p_frag)
+    dst_words = cute.size(mDst.shape)
+    lane_words = cute.size(p_regs.shape)
+    dst_idx = lane * lane_words
+    for reg_id in cutlass.range_constexpr(cute.size(p_regs.shape)):
+        if dst_idx + reg_id < dst_words:
+            mDst[dst_idx + reg_id] = p_regs[reg_id]
+
+
+@cute.jit
+def _dump_s_frag_regs_raw(
+    mDst: cute.Tensor,
+    s_frag: cute.Tensor,
+    lane,
+):
+    s_regs = cute.flatten(cute.recast_tensor(s_frag, cutlass.Uint32))
+    dst_words = cute.size(mDst.shape)
+    lane_words = cute.size(s_regs.shape)
+    dst_idx = lane * lane_words
+    for reg_id in cutlass.range_constexpr(cute.size(s_regs.shape)):
+        if dst_idx + reg_id < dst_words:
+            mDst[dst_idx + reg_id] = s_regs[reg_id]
+
+
+@cute.jit
+def _dump_s_frag_regs_raw_offset(
+    mDst: cute.Tensor,
+    s_frag: cute.Tensor,
+    lane,
+    dst_word_offset,
+):
+    s_regs = cute.flatten(cute.recast_tensor(s_frag, cutlass.Uint32))
+    dst_words = cute.size(mDst.shape)
+    lane_words = cute.size(s_regs.shape)
+    dst_idx = dst_word_offset + lane * lane_words
+    for reg_id in cutlass.range_constexpr(cute.size(s_regs.shape)):
+        if dst_idx + reg_id < dst_words:
+            mDst[dst_idx + reg_id] = s_regs[reg_id]
+
+
+@cute.jit
+def _permute_rowmajor_tile_in_place_to_permuted_128b(
+    sStageBytes: cute.Tensor,
+    stage_byte_offset,
+    lane,
+    warp_linear_idx,
+    valid_rows,
+    upcast_stride,
+    total_warps,
+):
+    stage_u32 = cute.make_tensor(
+        cute.recast_tensor(sStageBytes, cutlass.Uint32).iterator,
+        cute.make_layout((cute.size(sStageBytes.shape) // 4,), stride=(1,)),
+    )
+    lane_row = lane // 8
+    lane_col = lane % 8
+    stage_word_offset = stage_byte_offset // 4
+    for tile_iter in cutlass.range_constexpr(4):
+        row_idx = Int32(warp_linear_idx * 4 + lane_row + tile_iter * total_warps * 4)
+        row_word_base = stage_word_offset + row_idx * (upcast_stride * 4)
+        for vec_iter in cutlass.range_constexpr(upcast_stride // 8):
+            vec_idx = Int32(lane_col + vec_iter * 8)
+            word_idx = row_word_base + vec_idx * 4
+            if row_idx < valid_rows:
+                swap_mask = Int32(row_idx % 8)
+                partner_vec = vec_idx ^ swap_mask
+                if vec_idx < partner_vec:
+                    partner_word_idx = row_word_base + partner_vec * 4
+                    a0 = stage_u32[word_idx + 0]
+                    a1 = stage_u32[word_idx + 1]
+                    a2 = stage_u32[word_idx + 2]
+                    a3 = stage_u32[word_idx + 3]
+                    b0 = stage_u32[partner_word_idx + 0]
+                    b1 = stage_u32[partner_word_idx + 1]
+                    b2 = stage_u32[partner_word_idx + 2]
+                    b3 = stage_u32[partner_word_idx + 3]
+                    stage_u32[word_idx + 0] = b0
+                    stage_u32[word_idx + 1] = b1
+                    stage_u32[word_idx + 2] = b2
+                    stage_u32[word_idx + 3] = b3
+                    stage_u32[partner_word_idx + 0] = a0
+                    stage_u32[partner_word_idx + 1] = a1
+                    stage_u32[partner_word_idx + 2] = a2
+                    stage_u32[partner_word_idx + 3] = a3
+            else:
+                stage_u32[word_idx + 0] = Uint32(0)
+                stage_u32[word_idx + 1] = Uint32(0)
+                stage_u32[word_idx + 2] = Uint32(0)
+                stage_u32[word_idx + 3] = Uint32(0)
+
+
+@cute.jit
+def _permute_rowmajor_tile_in_place_to_permuted_128b_vec128(
+    sStageBytes: cute.Tensor,
+    stage_byte_offset,
+    lane,
+    warp_linear_idx,
+    valid_rows,
+    upcast_stride,
+    total_warps,
+):
+    lane_row = lane // 8
+    lane_col = lane % 8
+    for tile_iter in cutlass.range_constexpr(4):
+        row_idx = Int32(warp_linear_idx * 4 + lane_row + tile_iter * total_warps * 4)
+        for vec_iter in cutlass.range_constexpr(upcast_stride // 8):
+            vec_idx = Int32(lane_col + vec_iter * 8)
+            vec_byte_idx = stage_byte_offset + (row_idx * upcast_stride + vec_idx) * 16
+            vec_addr = shared_ptr_to_u32(sStageBytes.iterator + vec_byte_idx)
+            if row_idx < valid_rows:
+                swap_mask = Int32(row_idx % 8)
+                partner_vec = vec_idx ^ swap_mask
+                if vec_idx < partner_vec:
+                    partner_vec_byte_idx = (
+                        stage_byte_offset + (row_idx * upcast_stride + partner_vec) * 16
+                    )
+                    partner_vec_addr = shared_ptr_to_u32(
+                        sStageBytes.iterator + partner_vec_byte_idx
+                    )
+                    a0, a1, a2, a3 = ld_shared_v4_u32(vec_addr)
+                    b0, b1, b2, b3 = ld_shared_v4_u32(partner_vec_addr)
+                    st_shared_v4_u32(vec_addr, b0, b1, b2, b3)
+                    st_shared_v4_u32(partner_vec_addr, a0, a1, a2, a3)
+            else:
+                st_shared_v4_u32(vec_addr, Uint32(0), Uint32(0), Uint32(0), Uint32(0))
+
+
+@dsl_user_op
+def _cp_async_load_128b_pred(
+    smem_addr: Int32,
+    gmem_addr: Int64,
+    predicate: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    llvm.inline_asm(
+        None,
+        [
+            Int32(predicate).ir_value(loc=loc, ip=ip),
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        " .reg .pred p;\n"
+        " setp.ne.b32 p, $0, 0;\n"
+        " @p cp.async.cg.shared.global.L2::128B [$1], [$2], 16;\n"
+        "}",
+        "r,r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _cp_async_load_128b_zfill(
+    smem_addr: Int32,
+    gmem_addr: Int64,
+    src_bytes: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+            Int32(src_bytes).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.cg.shared.global.L2::128B [$0], [$1], 16, $2;",
+        "r,l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _exp2_approx_ftz_f32(a: Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "ex2.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def _apply_attention_sink_after_lse_scale(
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    mAttentionSinkBias: cute.Tensor,
+    mma_q,
+    row_slot,
+    q_head_idx: Int32,
+    row_valid: Int32,
+    causal_k_limit: Int32,
+    chunk_start: Int32,
+    chunk_end: Int32,
+    warp_kv_idx: Int32,
+    num_mma_d_vo,
+    softmax_scale_log2: Float32,
+    has_attention_sink_bias,
+    split_kv,
+):
+    if m_frag[mma_q, row_slot] != -Float32.inf:
+        m_frag[mma_q, row_slot] = Float32(m_frag[mma_q, row_slot] * softmax_scale_log2)
+    if const_expr(has_attention_sink_bias):
+        sink_owner = (row_valid != Int32(0)) and (warp_kv_idx == Int32(0))
+        if const_expr(split_kv):
+            if sink_owner:
+                sink_owner = (chunk_start <= causal_k_limit) and (
+                    causal_k_limit < chunk_end
+                )
+        if sink_owner:
+            old_m = m_frag[mma_q, row_slot]
+            sink_m = Float32(mAttentionSinkBias[q_head_idx] * attention_ops.LOG2_E)
+            new_m = attention_ops.fmax(old_m, sink_m)
+            old_scale = (
+                Float32(0.0)
+                if old_m == -Float32.inf
+                else _exp2_approx_ftz_f32(old_m - new_m)
+            )
+            sink_scale = _exp2_approx_ftz_f32(sink_m - new_m)
+            d_frag[mma_q, row_slot] = Float32(
+                d_frag[mma_q, row_slot] * old_scale + sink_scale
+            )
+            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                reg_base = row_slot * 2
+                o_frag[mma_q, mma_d, reg_base + 0] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 0] * old_scale
+                )
+                o_frag[mma_q, mma_d, reg_base + 1] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 1] * old_scale
+                )
+                o_frag[mma_q, mma_d, reg_base + 4] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 4] * old_scale
+                )
+                o_frag[mma_q, mma_d, reg_base + 5] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 5] * old_scale
+                )
+            m_frag[mma_q, row_slot] = Float32(new_m)
+
+
+@cute.jit
+def _apply_relative_attention_bias(
+    frag_s: cute.Tensor,
+    mRelativeAttentionBias: cute.Tensor,
+    q_row_idx_frag: cute.Tensor,
+    q_head_idx_frag: cute.Tensor,
+    causal_k_limit: cute.Tensor,
+    tile_key_base: Int32,
+    warp_kv_base: Int32,
+    lane_pair_base: Int32,
+    inverse_softmax_scale: Float32,
+    num_mma_q,
+    num_mma_kv,
+):
+    relative_extent = mRelativeAttentionBias.shape[2]
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            for reg_id in cutlass.range_constexpr(8):
+                row_slot = (reg_id % 4) // 2
+                if frag_s[mma_q, mma_kv, reg_id] != -Float32.inf:
+                    key_local = (
+                        warp_kv_base
+                        + mma_kv * 16
+                        + lane_pair_base
+                        + 8 * (reg_id // 4)
+                        + (reg_id % 2)
+                    )
+                    distance = (
+                        causal_k_limit[mma_q, row_slot] - tile_key_base - key_local
+                    )
+                    if distance >= Int32(0) and distance < relative_extent:
+                        bias = Float32(
+                            mRelativeAttentionBias[
+                                q_row_idx_frag[mma_q, row_slot],
+                                q_head_idx_frag[mma_q, row_slot],
+                                distance,
+                            ]
+                        )
+                        frag_s[mma_q, mma_kv, reg_id] += bias * inverse_softmax_scale
+
+
+@dsl_user_op
+def _exit_thread(
+    *,
+    loc=None,
+    ip=None,
+):
+    llvm.inline_asm(
+        None,
+        [],
+        "exit;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def _permuted_offset_128b(row_idx, vec_idx, stride_128b):
+    return row_idx * stride_128b + (vec_idx ^ (row_idx % 8))
+
+
+@cute.jit
+def _smem_addr_from_b128_offset(base_addr: Int32, offset_128b):
+    return base_addr + Int32(offset_128b * 16)
+
+
+@cute.jit
+def _advance_offset_by_row_128b(offset_128b, step_size, row_stride_128b):
+    return offset_128b + step_size * row_stride_128b
+
+
+@cute.jit
+def _advance_offset_by_column_128b_2(offset_128b, step_idx):
+    xor_term = Int32(0x2) + (Int32(0x4) if const_expr(step_idx % 2 == 1) else Int32(0))
+    extra = Int32(8) if const_expr(step_idx % 4 == 3) else Int32(0)
+    return (offset_128b ^ xor_term) + extra
+
+
+@cute.jit
+def _smem_addr_from_split_planes_128b(
+    plane0_base_addr: Int32,
+    plane1_base_addr: Int32,
+    full_offset_128b,
+    full_stride_128b,
+):
+    plane_stride_128b = full_stride_128b // Int32(2)
+    row = full_offset_128b // full_stride_128b
+    col = full_offset_128b - row * full_stride_128b
+    plane_idx = col // plane_stride_128b
+    local_col = col - plane_idx * plane_stride_128b
+    local_offset = row * plane_stride_128b + local_col
+    plane_base_addr = cutlass.select_(
+        plane_idx == Int32(0), plane0_base_addr, plane1_base_addr
+    )
+    return _smem_addr_from_b128_offset(plane_base_addr, local_offset)
+
+
+def _transpose_view(a: cute.Tensor) -> cute.Tensor:
+    shape = (a.shape[1], a.shape[0], *a.shape[2:])
+    order = (1, 0, *range(2, cute.rank(a)))
+    return cute.composition(a, cute.make_ordered_layout(shape, order=order))
+
+
+def _convert_layout_acc_mn(
+    acc_layout: cute.Layout, transpose: bool = False
+) -> cute.Layout:
+    acc_layout_col_major = cute.make_layout(acc_layout.shape)
+    shape = (
+        (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+        (
+            acc_layout_col_major.shape[0][0],
+            *acc_layout_col_major.shape[0][2:],
+            acc_layout_col_major.shape[2],
+        ),
+        *acc_layout_col_major.shape[3:],
+    )
+    stride = (
+        (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+        (
+            acc_layout_col_major.stride[0][0],
+            *acc_layout_col_major.stride[0][2:],
+            acc_layout_col_major.stride[2],
+        ),
+        *acc_layout_col_major.stride[3:],
+    )
+    if transpose:
+        shape = (shape[1], shape[0], *shape[2:])
+        stride = (stride[1], stride[0], *stride[2:])
+    return cute.composition(acc_layout, cute.make_layout(shape, stride=stride))
+
+
+def _reshape_acc_to_mn(acc: cute.Tensor, transpose: bool = False) -> cute.Tensor:
+    return cute.make_tensor(
+        acc.iterator, _convert_layout_acc_mn(acc.layout, transpose=transpose)
+    )
+
+
+@cute.jit
+def _convert_layout_acc_frgA(acc_layout: cute.Layout) -> cute.Layout:
+    if const_expr(cute.rank(acc_layout.shape[0]) == 3):
+        div = 2 if const_expr(acc_layout.shape[0][2] % 2 == 0) else 1
+        l = cute.logical_divide(acc_layout, ((None, None, div), None, None))
+        return cute.make_layout(
+            (
+                (l.shape[0][0], l.shape[0][1], l.shape[0][2][0]),
+                l.shape[1],
+                (l.shape[0][2][1], l.shape[2]),
+            ),
+            stride=(
+                (l.stride[0][0], l.stride[0][1], l.stride[0][2][0]),
+                l.stride[1],
+                (l.stride[0][2][1], l.stride[2]),
+            ),
+        )
+    l = cute.logical_divide(acc_layout, (None, None, 2))
+    return cute.make_layout(
+        (
+            (l.shape[0], l.shape[2][0]),
+            l.shape[1],
+            l.shape[2][1],
+        ),
+        stride=(
+            (l.stride[0], l.stride[2][0]),
+            l.stride[1],
+            l.stride[2][1],
+        ),
+    )
+
+
+def _reshape_acc_to_frgA(acc: cute.Tensor) -> cute.Tensor:
+    return cute.make_tensor(acc.iterator, _convert_layout_acc_frgA(acc.layout))
+
+
+@cute.jit
+def _mask_donor_acc_s_tma(
+    acc_S: cute.Tensor,
+    tScS_mn: cute.Tensor,
+    t0ScS_mn: cute.Tensor,
+    packed_tile_rows,
+    tile_tokens,
+    tile_base,
+    cache_len,
+    qo_len,
+    group_size,
+):
+    acc_S_mn = _reshape_acc_to_mn(acc_S)
+    thr_col_offset = tScS_mn[0][1]
+    for r in cutlass.range_constexpr(cute.size(tScS_mn.shape[0])):
+        row_idx = tScS_mn[r, 0][0]
+        for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+            col_idx = t0ScS_mn[0, c][1] + thr_col_offset
+            valid = row_idx < packed_tile_rows and col_idx < tile_tokens
+            if valid:
+                q_token_local = row_idx // group_size
+                causal_k_limit = q_token_local + cache_len - qo_len
+                valid = (tile_base + col_idx) <= causal_k_limit
+            if not valid:
+                acc_S_mn[r, c] = -Float32.inf
+
+
+@cute.jit
+def _donor_update_mdo_states_fp32_pack_p(
+    acc_S: cute.Tensor,
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    sm_scale_log2: Float32,
+    num_mma_d_vo,
+    dtype_p: cutlass.Constexpr,
+):
+    acc_S_mn = _reshape_acc_to_mn(acc_S)
+    for row_slot in cutlass.range_constexpr(cute.size(acc_S_mn.shape[0])):
+        m_prev = Float32(m_frag[0, row_slot])
+        m_new = Float32(m_prev)
+        for c in cutlass.range_constexpr(cute.size(acc_S_mn.shape[1])):
+            m_new = attention_ops.fmax(m_new, acc_S_mn[row_slot, c])
+        m_new = cute.arch.warp_reduction_max(m_new, threads_in_group=4)
+
+        scale_term = (
+            Float32(1.0)
+            if m_new == -Float32.inf
+            else _exp2_approx_ftz_f32((m_prev - m_new) * sm_scale_log2)
+        )
+        d_frag[0, row_slot] = Float32(d_frag[0, row_slot] * scale_term)
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            o_frag[0, mma_d, row_slot * 2 + 0] *= scale_term
+            o_frag[0, mma_d, row_slot * 2 + 1] *= scale_term
+            o_frag[0, mma_d, row_slot * 2 + 4] *= scale_term
+            o_frag[0, mma_d, row_slot * 2 + 5] *= scale_term
+
+        for c in cutlass.range_constexpr(cute.size(acc_S_mn.shape[1])):
+            acc_S_mn[row_slot, c] = (
+                Float32(0.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32(
+                    (acc_S_mn[row_slot, c] - m_new) * sm_scale_log2
+                )
+            )
+        m_frag[0, row_slot] = Float32(m_new)
+
+    rP = cute.make_fragment_like(acc_S, dtype_p)
+    rP.store(acc_S.load().to(dtype_p))
+    return cute.recast_tensor(_reshape_acc_to_frgA(rP), Uint32)
+
+
+@cute.jit
+def _acc_mn_to_frag_s(
+    frag_S: cute.Tensor,
+    acc_S_mn: cute.Tensor,
+    tScS_mn: cute.Tensor,
+    t0ScS_mn: cute.Tensor,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    num_mma_q,
+    num_mma_kv,
+):
+    lane_group = lane // 4
+    lane_pair_base = 2 * (lane % 4)
+    thr_col_offset = tScS_mn[0][1]
+    for r in cutlass.range_constexpr(cute.size(tScS_mn.shape[0])):
+        row = tScS_mn[r, 0][0]
+        for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+            col = t0ScS_mn[0, c][1] + thr_col_offset
+            val = acc_S_mn[r, c]
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                    for reg_id in cutlass.range_constexpr(8):
+                        row_slot = (reg_id % 4) // 2
+                        target_row = (
+                            warp_q_idx * num_mma_q * 16
+                            + mma_q * 16
+                            + lane_group
+                            + 8 * row_slot
+                        )
+                        target_col = (
+                            warp_kv_idx * num_mma_kv * 16
+                            + mma_kv * 16
+                            + lane_pair_base
+                            + 8 * (reg_id // 4)
+                            + (reg_id % 2)
+                        )
+                        if row == target_row and col == target_col:
+                            frag_S[mma_q, mma_kv, reg_id] = val
+
+
+@cute.jit
+def _warp_mma_gemm(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsA: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_A: cute.TiledCopy,
+    smem_thr_copy_B: cute.TiledCopy,
+    A_in_regs: cutlass.Constexpr = False,
+    B_in_regs: cutlass.Constexpr = False,
+):
+    tCrA_copy_view = smem_thr_copy_A.retile(tCrA)
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    if const_expr(not A_in_regs):
+        cute.copy(smem_thr_copy_A, tCsA[None, None, 0], tCrA_copy_view[None, None, 0])
+    if const_expr(not B_in_regs):
+        cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCsA.shape[2])):
+        if k < cute.size(tCsA.shape[2]) - 1:
+            if const_expr(not A_in_regs):
+                cute.copy(
+                    smem_thr_copy_A,
+                    tCsA[None, None, k + 1],
+                    tCrA_copy_view[None, None, k + 1],
+                )
+            if const_expr(not B_in_regs):
+                cute.copy(
+                    smem_thr_copy_B,
+                    tCsB[None, None, k + 1],
+                    tCrB_copy_view[None, None, k + 1],
+                )
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+@cute.jit
+def _warp_mma_gemm_rs(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_B: cute.TiledCopy,
+):
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
+        if const_expr(k < cute.size(tCrA.shape[2]) - 1):
+            cute.copy(
+                smem_thr_copy_B,
+                tCsB[None, None, k + 1],
+                tCrB_copy_view[None, None, k + 1],
+            )
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_k,
+):
+    for mma_d in cutlass.range_constexpr(num_mma_d_qk):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            q_row = warp_q_idx * num_mma_q * 16 + mma_q * 16 + lane % 16
+            q_col = mma_d * 2 + lane // 16
+            q_offset = _permuted_offset_128b(q_row, q_col, upcast_stride_q)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset)
+            )
+            a_regs[mma_q, 0] = a0
+            a_regs[mma_q, 1] = a1
+            a_regs[mma_q, 2] = a2
+            a_regs[mma_q, 3] = a3
+
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            k_row = (
+                row_base
+                + warp_kv_idx * num_mma_kv * 16
+                + mma_kv * 16
+                + 8 * (lane // 16)
+                + lane % 8
+            )
+            k_col = mma_d * 2 + (lane % 16) // 8
+            k_offset = _permuted_offset_128b(k_row, k_col, upcast_stride_k)
+            b0, b1, b2, b3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset)
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_plane_bf16(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_plane0_base_addr: Int32,
+    k_plane1_base_addr: Int32,
+    k_plane2_base_addr: Int32,
+    k_plane3_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_plane,
+):
+    for mma_d in cutlass.range_constexpr(num_mma_d_qk):
+        plane_idx = mma_d // 4
+        mma_d_local = mma_d - plane_idx * 4
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            q_row = warp_q_idx * num_mma_q * 16 + mma_q * 16 + lane % 16
+            q_col = mma_d * 2 + lane // 16
+            q_offset = _permuted_offset_128b(q_row, q_col, upcast_stride_q)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset)
+            )
+            a_regs[mma_q, 0] = a0
+            a_regs[mma_q, 1] = a1
+            a_regs[mma_q, 2] = a2
+            a_regs[mma_q, 3] = a3
+
+        if const_expr(plane_idx == 0):
+            k_plane_base_addr = k_plane0_base_addr
+        elif const_expr(plane_idx == 1):
+            k_plane_base_addr = k_plane1_base_addr
+        elif const_expr(plane_idx == 2):
+            k_plane_base_addr = k_plane2_base_addr
+        else:
+            k_plane_base_addr = k_plane3_base_addr
+
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            k_row = (
+                row_base
+                + warp_kv_idx * num_mma_kv * 16
+                + mma_kv * 16
+                + 8 * (lane // 16)
+                + lane % 8
+            )
+            k_col = mma_d_local * 2 + (lane % 16) // 8
+            k_offset = _permuted_offset_128b(k_row, k_col, upcast_stride_plane)
+            b0, b1, b2, b3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(k_plane_base_addr, k_offset)
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_fp8_raw(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_k,
+):
+    q_offset = _permuted_offset_128b(
+        warp_q_idx * num_mma_q * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_q,
+    )
+    k_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + 8 * (lane // 16) + lane % 8,
+        (lane % 16) // 8,
+        upcast_stride_k,
+    )
+    for mma_d in cutlass.range_constexpr(num_mma_d_qk):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        q_offset_cur = q_offset
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs[mma_q, 0] = a0
+            a_regs[mma_q, 1] = a1
+            a_regs[mma_q, 2] = a2
+            a_regs[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+        q_offset = _advance_offset_by_column_128b_2(q_offset_cur, mma_d) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            if const_expr(mma_d % 2 == 0):
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_left_half_b16(
+                    _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+                )
+            else:
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_right_half_b16(
+                    _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+                )
+            b_f8_0 = frag_layout_swizzle_16b_to_8b(b_f8_0)
+            b_f8_1 = frag_layout_swizzle_16b_to_8b(b_f8_1)
+            b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+            b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, 16, upcast_stride_k
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        if const_expr(mma_d % 2 == 1):
+            k_offset = _advance_offset_by_column_128b_2(
+                k_offset_cur, mma_d // 2
+            ) - Int32(num_mma_kv * 16 * upcast_stride_k)
+        else:
+            k_offset = k_offset_cur - Int32(num_mma_kv * 16 * upcast_stride_k)
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_fp8_raw_paired(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_k,
+):
+    q_offset = _permuted_offset_128b(
+        warp_q_idx * num_mma_q * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_q,
+    )
+    k_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + 8 * (lane // 16) + lane % 8,
+        (lane % 16) // 8,
+        upcast_stride_k,
+    )
+    for mma_pair in cutlass.range_constexpr(num_mma_d_qk // 2):
+        a_regs_k0 = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        a_regs_k1 = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+
+        q_offset_cur = q_offset
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs_k0[mma_q, 0] = a0
+            a_regs_k0[mma_q, 1] = a1
+            a_regs_k0[mma_q, 2] = a2
+            a_regs_k0[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+
+        mma_d0 = mma_pair * 2
+        q_offset_mid = _advance_offset_by_column_128b_2(q_offset_cur, mma_d0) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+        q_offset_cur = q_offset_mid
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs_k1[mma_q, 0] = a0
+            a_regs_k1[mma_q, 1] = a1
+            a_regs_k1[mma_q, 2] = a2
+            a_regs_k1[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+        q_offset = _advance_offset_by_column_128b_2(q_offset_cur, mma_d0 + 1) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            b_f8_0_l, b_f8_1_l = ldmatrix_m8n8x4_left_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            b_f8_0_r, b_f8_1_r = ldmatrix_m8n8x4_right_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            b_f8_0_l = frag_layout_swizzle_16b_to_8b(b_f8_0_l)
+            b_f8_1_l = frag_layout_swizzle_16b_to_8b(b_f8_1_l)
+            b_f8_0_r = frag_layout_swizzle_16b_to_8b(b_f8_0_r)
+            b_f8_1_r = frag_layout_swizzle_16b_to_8b(b_f8_1_r)
+            bl0, bl1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0_l)
+            bl2, bl3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1_l)
+            br0, br1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0_r)
+            br2, br3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1_r)
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, 16, upcast_stride_k
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    a_regs_k0[mma_q, 0],
+                    a_regs_k0[mma_q, 1],
+                    a_regs_k0[mma_q, 2],
+                    a_regs_k0[mma_q, 3],
+                    bl0,
+                    bl1,
+                    bl2,
+                    bl3,
+                )
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    d0,
+                    d1,
+                    d2,
+                    d3,
+                    d4,
+                    d5,
+                    d6,
+                    d7,
+                    a_regs_k1[mma_q, 0],
+                    a_regs_k1[mma_q, 1],
+                    a_regs_k1[mma_q, 2],
+                    a_regs_k1[mma_q, 3],
+                    br0,
+                    br1,
+                    br2,
+                    br3,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            num_mma_kv * 16 * upcast_stride_k
+        )
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_plane_fp8_raw(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_plane0_base_addr: Int32,
+    k_plane1_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_plane,
+):
+    upcast_stride_full = upcast_stride_plane * Int32(2)
+    q_offset = _permuted_offset_128b(
+        warp_q_idx * num_mma_q * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_q,
+    )
+    k_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + 8 * (lane // 16) + lane % 8,
+        (lane % 16) // 8,
+        upcast_stride_full,
+    )
+    for mma_d in cutlass.range_constexpr(num_mma_d_qk):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        q_offset_cur = q_offset
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs[mma_q, 0] = a0
+            a_regs[mma_q, 1] = a1
+            a_regs[mma_q, 2] = a2
+            a_regs[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+        q_offset = _advance_offset_by_column_128b_2(q_offset_cur, mma_d) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            k_addr = _smem_addr_from_split_planes_128b(
+                k_plane0_base_addr,
+                k_plane1_base_addr,
+                k_offset_cur,
+                upcast_stride_full,
+            )
+            if const_expr(mma_d % 2 == 0):
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_left_half_b16(k_addr)
+            else:
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_right_half_b16(k_addr)
+            b_f8_0 = frag_layout_swizzle_16b_to_8b(b_f8_0)
+            b_f8_1 = frag_layout_swizzle_16b_to_8b(b_f8_1)
+            b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+            b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, 16, upcast_stride_full
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        if const_expr(mma_d % 2 == 1):
+            k_offset = _advance_offset_by_column_128b_2(
+                k_offset_cur, mma_d // 2
+            ) - Int32(num_mma_kv * 16 * upcast_stride_full)
+        else:
+            k_offset = k_offset_cur - Int32(num_mma_kv * 16 * upcast_stride_full)
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_mxfp8_raw(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_k,
+):
+    unit_scale = Uint32(0x7F7F7F7F)
+    mask16 = Uint32(0xFFFF)
+    shift16 = Uint32(16)
+    q_offset = _permuted_offset_128b(
+        warp_q_idx * num_mma_q * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_q,
+    )
+    k_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + 8 * (lane // 16) + lane % 8,
+        (lane % 16) // 8,
+        upcast_stride_k,
+    )
+    for mma_pair in cutlass.range_constexpr(num_mma_d_qk // 2):
+        a_regs_k0 = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        a_regs_k1 = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+
+        q_offset_cur = q_offset
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs_k0[mma_q, 0] = a0
+            a_regs_k0[mma_q, 1] = a1
+            a_regs_k0[mma_q, 2] = a2
+            a_regs_k0[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+
+        mma_d0 = mma_pair * 2
+        q_offset_mid = _advance_offset_by_column_128b_2(q_offset_cur, mma_d0) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+        q_offset_cur = q_offset_mid
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs_k1[mma_q, 0] = a0
+            a_regs_k1[mma_q, 1] = a1
+            a_regs_k1[mma_q, 2] = a2
+            a_regs_k1[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+        q_offset = _advance_offset_by_column_128b_2(q_offset_cur, mma_d0 + 1) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            b0_k0, b1_k0 = ldmatrix_m8n8x4_left_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            b0_k1, b1_k1 = ldmatrix_m8n8x4_right_half_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            b0_k0 = frag_layout_swizzle_16b_to_8b(b0_k0)
+            b1_k0 = frag_layout_swizzle_16b_to_8b(b1_k0)
+            b0_k1 = frag_layout_swizzle_16b_to_8b(b0_k1)
+            b1_k1 = frag_layout_swizzle_16b_to_8b(b1_k1)
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, 16, upcast_stride_k
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                qa0 = (cvt_bf16x2_to_e4m3x2(a_regs_k0[mma_q, 0]) & mask16) | (
+                    (cvt_bf16x2_to_e4m3x2(a_regs_k1[mma_q, 0]) & mask16) << shift16
+                )
+                qa1 = (cvt_bf16x2_to_e4m3x2(a_regs_k0[mma_q, 1]) & mask16) | (
+                    (cvt_bf16x2_to_e4m3x2(a_regs_k1[mma_q, 1]) & mask16) << shift16
+                )
+                qa2 = (cvt_bf16x2_to_e4m3x2(a_regs_k0[mma_q, 2]) & mask16) | (
+                    (cvt_bf16x2_to_e4m3x2(a_regs_k1[mma_q, 2]) & mask16) << shift16
+                )
+                qa3 = (cvt_bf16x2_to_e4m3x2(a_regs_k0[mma_q, 3]) & mask16) | (
+                    (cvt_bf16x2_to_e4m3x2(a_regs_k1[mma_q, 3]) & mask16) << shift16
+                )
+
+                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    qa0,
+                    qa1,
+                    qa2,
+                    qa3,
+                    b0_k0,
+                    b0_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                d4, d5, d6, d7 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    qa0,
+                    qa1,
+                    qa2,
+                    qa3,
+                    b1_k0,
+                    b1_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            num_mma_kv * 16 * upcast_stride_k
+        )
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_bf16_packed(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_v,
+    v_scale,
+    debug_regs: cute.Tensor | None = None,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_v,
+    )
+    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = bfloat2_mul(p_frag[mma_q, mma_kv, 0], v_scale_bf2)
+            a_regs[mma_q, 1] = bfloat2_mul(p_frag[mma_q, mma_kv, 1], v_scale_bf2)
+            a_regs[mma_q, 2] = bfloat2_mul(p_frag[mma_q, mma_kv, 2], v_scale_bf2)
+            a_regs[mma_q, 3] = bfloat2_mul(p_frag[mma_q, mma_kv, 3], v_scale_bf2)
+
+        v_offset_cur = v_offset
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            b0, b1, b2, b3 = ldmatrix_m8n8x4_trans_b16(
+                _smem_addr_from_b128_offset(v_base_addr, v_offset_cur)
+            )
+            if const_expr(debug_regs is not None):
+                lane_words = num_mma_kv * num_mma_d_vo * 4
+                dst_words = cute.size(debug_regs.shape)
+                dst_idx = lane * lane_words + (mma_kv * num_mma_d_vo + mma_d) * 4
+                if dst_idx + 0 < dst_words:
+                    debug_regs[dst_idx + 0] = b0
+                if dst_idx + 1 < dst_words:
+                    debug_regs[dst_idx + 1] = b1
+                if dst_idx + 2 < dst_words:
+                    debug_regs[dst_idx + 2] = b2
+                if dst_idx + 3 < dst_words:
+                    debug_regs[dst_idx + 3] = b3
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+            v_offset_cur = _advance_offset_by_column_128b_2(v_offset_cur, mma_d)
+        v_offset = _advance_offset_by_row_128b(
+            v_offset_cur, 16, upcast_stride_v
+        ) - Int32(2 * num_mma_d_vo)
+    v_offset -= Int32(16 * num_mma_kv * upcast_stride_v)
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_plane_bf16_packed(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_plane0_base_addr: Int32,
+    v_plane1_base_addr: Int32,
+    v_plane2_base_addr: Int32,
+    v_plane3_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_plane,
+    v_scale,
+    debug_regs: cute.Tensor | None = None,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = bfloat2_mul(p_frag[mma_q, mma_kv, 0], v_scale_bf2)
+            a_regs[mma_q, 1] = bfloat2_mul(p_frag[mma_q, mma_kv, 1], v_scale_bf2)
+            a_regs[mma_q, 2] = bfloat2_mul(p_frag[mma_q, mma_kv, 2], v_scale_bf2)
+            a_regs[mma_q, 3] = bfloat2_mul(p_frag[mma_q, mma_kv, 3], v_scale_bf2)
+
+        v_row = row_base + warp_kv_idx * num_mma_kv * 16 + mma_kv * 16 + lane % 16
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            plane_idx = mma_d // 4
+            mma_d_local = mma_d - plane_idx * 4
+            if const_expr(plane_idx == 0):
+                v_plane_base_addr = v_plane0_base_addr
+            elif const_expr(plane_idx == 1):
+                v_plane_base_addr = v_plane1_base_addr
+            elif const_expr(plane_idx == 2):
+                v_plane_base_addr = v_plane2_base_addr
+            else:
+                v_plane_base_addr = v_plane3_base_addr
+            v_col = mma_d_local * 2 + lane // 16
+            v_offset = _permuted_offset_128b(v_row, v_col, upcast_stride_plane)
+            b0, b1, b2, b3 = ldmatrix_m8n8x4_trans_b16(
+                _smem_addr_from_b128_offset(v_plane_base_addr, v_offset)
+            )
+            if const_expr(debug_regs is not None):
+                lane_words = num_mma_kv * num_mma_d_vo * 4
+                dst_words = cute.size(debug_regs.shape)
+                dst_idx = lane * lane_words + (mma_kv * num_mma_d_vo + mma_d) * 4
+                if dst_idx + 0 < dst_words:
+                    debug_regs[dst_idx + 0] = b0
+                if dst_idx + 1 < dst_words:
+                    debug_regs[dst_idx + 1] = b1
+                if dst_idx + 2 < dst_words:
+                    debug_regs[dst_idx + 2] = b2
+                if dst_idx + 3 < dst_words:
+                    debug_regs[dst_idx + 3] = b3
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_tma_bf16_copyfrag(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    tOrVt: cute.Tensor,
+    tOsVt: cute.Tensor,
+    smem_thr_copy_V: cute.TiledCopy,
+    num_mma_q,
+    num_mma_d_vo,
+    v_scale,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    tCrV_copy_view = smem_thr_copy_V.retile(tOrVt)
+    cute.copy(smem_thr_copy_V, tOsVt[None, None, 0], tCrV_copy_view[None, None, 0])
+    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+        if const_expr(mma_d < num_mma_d_vo - 1):
+            cute.copy(
+                smem_thr_copy_V,
+                tOsVt[None, None, mma_d + 1],
+                tCrV_copy_view[None, None, mma_d + 1],
+            )
+        b_regs = cute.flatten(cute.recast_tensor(tOrVt[None, None, mma_d], Uint32))
+        b0 = b_regs[0]
+        b1 = b_regs[1]
+        b2 = b_regs[2]
+        b3 = b_regs[3]
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0 = bfloat2_mul(p_frag[mma_q, 0, 0], v_scale_bf2)
+            a1 = bfloat2_mul(p_frag[mma_q, 0, 1], v_scale_bf2)
+            a2 = bfloat2_mul(p_frag[mma_q, 0, 2], v_scale_bf2)
+            a3 = bfloat2_mul(p_frag[mma_q, 0, 3], v_scale_bf2)
+            d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                o_frag[mma_q, mma_d, 0],
+                o_frag[mma_q, mma_d, 1],
+                o_frag[mma_q, mma_d, 2],
+                o_frag[mma_q, mma_d, 3],
+                o_frag[mma_q, mma_d, 4],
+                o_frag[mma_q, mma_d, 5],
+                o_frag[mma_q, mma_d, 6],
+                o_frag[mma_q, mma_d, 7],
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+                b2,
+                b3,
+            )
+            o_frag[mma_q, mma_d, 0] = d0
+            o_frag[mma_q, mma_d, 1] = d1
+            o_frag[mma_q, mma_d, 2] = d2
+            o_frag[mma_q, mma_d, 3] = d3
+            o_frag[mma_q, mma_d, 4] = d4
+            o_frag[mma_q, mma_d, 5] = d5
+            o_frag[mma_q, mma_d, 6] = d6
+            o_frag[mma_q, mma_d, 7] = d7
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_fp8_raw(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_v,
+    v_scale,
+    debug_regs: cute.Tensor | None = None,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_v,
+    )
+    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = bfloat2_mul(p_frag[mma_q, mma_kv, 0], v_scale_bf2)
+            a_regs[mma_q, 1] = bfloat2_mul(p_frag[mma_q, mma_kv, 1], v_scale_bf2)
+            a_regs[mma_q, 2] = bfloat2_mul(p_frag[mma_q, mma_kv, 2], v_scale_bf2)
+            a_regs[mma_q, 3] = bfloat2_mul(p_frag[mma_q, mma_kv, 3], v_scale_bf2)
+
+        v_offset_cur = v_offset
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            if const_expr(mma_d % 2 == 0):
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_left_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_cur)
+                )
+            else:
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_right_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_cur)
+                )
+            b_f8_0 = frag_layout_swizzle_16b_to_8b_trans(b_f8_0)
+            b_f8_1 = frag_layout_swizzle_16b_to_8b_trans(b_f8_1)
+            b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+            b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+            tmp = b1
+            b1 = b2
+            b2 = tmp
+            if const_expr(debug_regs is not None):
+                lane_words = num_mma_kv * num_mma_d_vo * 4
+                dst_words = cute.size(debug_regs.shape)
+                dst_idx = lane * lane_words + (mma_kv * num_mma_d_vo + mma_d) * 4
+                if dst_idx + 0 < dst_words:
+                    debug_regs[dst_idx + 0] = b0
+                if dst_idx + 1 < dst_words:
+                    debug_regs[dst_idx + 1] = b1
+                if dst_idx + 2 < dst_words:
+                    debug_regs[dst_idx + 2] = b2
+                if dst_idx + 3 < dst_words:
+                    debug_regs[dst_idx + 3] = b3
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+            if const_expr(mma_d % 2 == 1):
+                v_offset_cur = _advance_offset_by_column_128b_2(
+                    v_offset_cur, mma_d // 2
+                )
+        v_offset = _advance_offset_by_row_128b(
+            v_offset_cur, 16, upcast_stride_v
+        ) - Int32(num_mma_d_vo)
+    v_offset -= Int32(16 * num_mma_kv * upcast_stride_v)
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_plane_fp8_raw(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_plane0_base_addr: Int32,
+    v_plane1_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_plane,
+    v_scale,
+    debug_regs: cute.Tensor | None = None,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    upcast_stride_full = upcast_stride_plane * Int32(2)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_full,
+    )
+    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = bfloat2_mul(p_frag[mma_q, mma_kv, 0], v_scale_bf2)
+            a_regs[mma_q, 1] = bfloat2_mul(p_frag[mma_q, mma_kv, 1], v_scale_bf2)
+            a_regs[mma_q, 2] = bfloat2_mul(p_frag[mma_q, mma_kv, 2], v_scale_bf2)
+            a_regs[mma_q, 3] = bfloat2_mul(p_frag[mma_q, mma_kv, 3], v_scale_bf2)
+
+        v_offset_cur = v_offset
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            v_addr = _smem_addr_from_split_planes_128b(
+                v_plane0_base_addr,
+                v_plane1_base_addr,
+                v_offset_cur,
+                upcast_stride_full,
+            )
+            if const_expr(mma_d % 2 == 0):
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_left_half_b16(v_addr)
+            else:
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_right_half_b16(v_addr)
+            b_f8_0 = frag_layout_swizzle_16b_to_8b_trans(b_f8_0)
+            b_f8_1 = frag_layout_swizzle_16b_to_8b_trans(b_f8_1)
+            b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+            b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+            tmp = b1
+            b1 = b2
+            b2 = tmp
+            if const_expr(debug_regs is not None):
+                lane_words = num_mma_kv * num_mma_d_vo * 4
+                dst_words = cute.size(debug_regs.shape)
+                dst_idx = lane * lane_words + (mma_kv * num_mma_d_vo + mma_d) * 4
+                if dst_idx + 0 < dst_words:
+                    debug_regs[dst_idx + 0] = b0
+                if dst_idx + 1 < dst_words:
+                    debug_regs[dst_idx + 1] = b1
+                if dst_idx + 2 < dst_words:
+                    debug_regs[dst_idx + 2] = b2
+                if dst_idx + 3 < dst_words:
+                    debug_regs[dst_idx + 3] = b3
+            if const_expr(mma_d % 2 == 1):
+                v_offset_cur = _advance_offset_by_column_128b_2(
+                    v_offset_cur, mma_d // 2
+                )
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+        v_offset = _advance_offset_by_row_128b(
+            v_offset_cur, 16, upcast_stride_full
+        ) - Int32(num_mma_d_vo)
+    v_offset -= Int32(16 * num_mma_kv * upcast_stride_full)
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_mxfp8_raw(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_v,
+    v_scale,
+):
+    unit_scale = Uint32(0x7F7F7F7F)
+    mask16 = Uint32(0xFFFF)
+    shift16 = Uint32(16)
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_v,
+    )
+    for mma_pair in cutlass.range_constexpr(num_mma_kv // 2):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        mma_kv0 = mma_pair * 2
+        mma_kv1 = mma_kv0 + 1
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 0], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 0], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+            a_regs[mma_q, 1] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 1], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 1], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+            a_regs[mma_q, 2] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 2], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 2], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+            a_regs[mma_q, 3] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 3], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 3], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+
+        v_offset_k0 = v_offset
+        v_offset_k1 = _advance_offset_by_row_128b(v_offset, 16, upcast_stride_v)
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            if const_expr(mma_d % 2 == 0):
+                b0_k0, b1_k0 = ldmatrix_m8n8x4_trans_left_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k0)
+                )
+                b0_k1, b1_k1 = ldmatrix_m8n8x4_trans_left_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k1)
+                )
+            else:
+                b0_k0, b1_k0 = ldmatrix_m8n8x4_trans_right_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k0)
+                )
+                b0_k1, b1_k1 = ldmatrix_m8n8x4_trans_right_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k1)
+                )
+            b0_k0 = frag_layout_swizzle_16b_to_8b_trans(b0_k0)
+            b1_k0 = frag_layout_swizzle_16b_to_8b_trans(b1_k0)
+            b0_k1 = frag_layout_swizzle_16b_to_8b_trans(b0_k1)
+            b1_k1 = frag_layout_swizzle_16b_to_8b_trans(b1_k1)
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0_k0,
+                    b0_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                d4, d5, d6, d7 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b1_k0,
+                    b1_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+            if const_expr(mma_d % 2 == 1):
+                v_offset_k0 = _advance_offset_by_column_128b_2(v_offset_k0, mma_d // 2)
+                v_offset_k1 = _advance_offset_by_column_128b_2(v_offset_k1, mma_d // 2)
+
+        v_offset = _advance_offset_by_row_128b(v_offset, 32, upcast_stride_v)
+
+
+@cute.jit
+def _literal_update_mdo_states_fp32_pack_p(
+    s_frag: cute.Tensor,
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    sm_scale_log2: Float32,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    p_frag_scalar: cute.Tensor | None = None,
+):
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for row_slot in cutlass.range_constexpr(2):
+            m_prev = Float32(m_frag[mma_q, row_slot])
+            m_new = Float32(m_prev)
+            for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                m_local = attention_ops.fmax(
+                    attention_ops.fmax(
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 0],
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 1],
+                    ),
+                    attention_ops.fmax(
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 4],
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 5],
+                    ),
+                )
+                m_new = attention_ops.fmax(m_new, m_local)
+            m_new = attention_ops.fmax(
+                m_new, cute.arch.shuffle_sync_bfly(m_new, offset=2)
+            )
+            m_new = attention_ops.fmax(
+                m_new, cute.arch.shuffle_sync_bfly(m_new, offset=1)
+            )
+
+            scale_term = (
+                Float32(1.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32((m_prev - m_new) * sm_scale_log2)
+            )
+            d_frag[mma_q, row_slot] = Float32(d_frag[mma_q, row_slot] * scale_term)
+            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                o_frag[mma_q, mma_d, row_slot * 2 + 0] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 1] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 4] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 5] *= scale_term
+
+            for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                p0 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 0] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p1 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 1] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p2 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 4] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p3 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 5] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p_frag[mma_q, mma_kv, row_slot + 0] = pack_f32x2_to_bfloat2(p0, p1)
+                p_frag[mma_q, mma_kv, row_slot + 2] = pack_f32x2_to_bfloat2(p2, p3)
+                if const_expr(p_frag_scalar is not None):
+                    p_frag_scalar[mma_q, mma_kv, row_slot * 2 + 0] = cutlass.BFloat16(
+                        p0
+                    )
+                    p_frag_scalar[mma_q, mma_kv, row_slot * 2 + 1] = cutlass.BFloat16(
+                        p1
+                    )
+                    p_frag_scalar[mma_q, mma_kv, row_slot * 2 + 4] = cutlass.BFloat16(
+                        p2
+                    )
+                    p_frag_scalar[mma_q, mma_kv, row_slot * 2 + 5] = cutlass.BFloat16(
+                        p3
+                    )
+
+            m_frag[mma_q, row_slot] = Float32(m_new)
+
+
+class PagedForwardKernel:
+    def __init__(
+        self,
+        dtype_q: Type[cutlass.Numeric],
+        dtype_kv: Type[cutlass.Numeric],
+        dtype_kv_storage: Type[cutlass.Numeric],
+        dtype_o: Type[cutlass.Numeric],
+        *,
+        traits: PagedForwardTraits,
+        use_native_fp8_qk: bool = False,
+        use_native_fp8_pv: bool = False,
+        enable_paged_kv_tma: bool = False,
+        window_left: int = -1,
+        has_attention_sink_bias: bool = False,
+        has_relative_attention_bias: bool = False,
+        msa_block_sparse: bool = False,
+        msa_union_tile: bool = False,
+        page_size: int = 64,
+    ):
+        self.dtype_q = dtype_q
+        self.dtype_kv = dtype_kv
+        self.dtype_kv_storage = dtype_kv_storage
+        self.dtype_o = dtype_o
+        self.traits = traits
+        self.split_kv = False
+        self.window_left = int(window_left)
+        self.has_attention_sink_bias = bool(has_attention_sink_bias)
+        self.has_relative_attention_bias = bool(has_relative_attention_bias)
+        self.msa_block_sparse = bool(msa_block_sparse)
+        self.msa_union_tile = bool(msa_union_tile)
+        self.MSA_BLOCK_TOKENS = 128
+        self.MSA_TOPK = 16
+        self.MSA_UNION_TOKENS_PER_TILE = 8
+        self.page_size = int(page_size)
+        if self.page_size not in (64, 128):
+            raise ValueError(
+                f"paged extend kernel supports page_size 64 or 128, got {self.page_size}"
+            )
+        # Number of page-table entries that span one 128-token MSA block.
+        self.entries_per_block = self.MSA_BLOCK_TOKENS // self.page_size
+        self.kv_is_fp8 = dtype_kv == cutlass.Float8E4M3FN
+        self.vec_size = traits.head_dim_vo // 32
+        self.total_warps = traits.num_warps_q * traits.num_warps_kv
+        self.stage_tile_rows = traits.cta_tile_kv
+        q_stage_bytes = traits.cta_tile_q * traits.head_dim_qk * (dtype_q.width // 8)
+        kv_stage_bytes = (
+            self.stage_tile_rows
+            * (traits.head_dim_qk + traits.head_dim_vo)
+            * (dtype_kv_storage.width // 8)
+        )
+        self.num_stages = (
+            1
+            if traits.num_warps_kv > 1 or self.kv_is_fp8
+            else (
+                2
+                if q_stage_bytes + 2 * kv_stage_bytes <= traits.max_smem_per_threadblock
+                else 1
+            )
+        )
+        # The extend TMA path indexes one 64-row source tile per page-table
+        # entry. Page-128 uses the byte-addressed copy path until extend TMA
+        # gets the decode kernel's page-entry flattening.
+        base_use_paged_kv_tma_extend = (
+            enable_paged_kv_tma
+            and os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA", "1") != "0"
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and traits.head_dim_qk == 256
+            and traits.head_dim_vo == 256
+            and self.num_stages == 1
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and self.stage_tile_rows == 64
+            and traits.cta_tile_q == 16
+            and traits.num_mma_q == 1
+            and traits.num_mma_kv == 1
+            and self.page_size == 64
+        )
+        self.use_paged_kv_tma_exact_plane_bf16_layout = base_use_paged_kv_tma_extend
+        self.use_paged_k_tma = self.use_paged_kv_tma_exact_plane_bf16_layout
+        self.use_paged_v_tma = self.use_paged_kv_tma_exact_plane_bf16_layout
+        self.use_paged_kv_tma = self.use_paged_kv_tma_exact_plane_bf16_layout
+        self.use_paged_kv_tma_fp8_raw_issue = False
+        tma_debug_dump = os.environ.get(
+            "FLASHINFER_EXP_SM12X_PAGED_KV_TMA_DEBUG_DUMP", ""
+        )
+        paged_debug_dump = os.environ.get(
+            "FLASHINFER_EXP_SM12X_PAGED_KV_DEBUG_DUMP", ""
+        )
+        self.debug_dump_paged_kv_tma_k = self.use_paged_kv_tma and tma_debug_dump == "K"
+        self.debug_dump_paged_kv_tma_s = self.use_paged_kv_tma and tma_debug_dump == "S"
+        self.debug_dump_paged_kv_tma_v = self.use_paged_kv_tma and tma_debug_dump == "V"
+        self.debug_dump_paged_kv_pvregs = (
+            paged_debug_dump == "PVREGS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_pregs = (
+            paged_debug_dump == "PREGS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_sregs = (
+            paged_debug_dump == "SREGS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_svwords = (
+            paged_debug_dump == "SVWORDS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and not self.kv_is_fp8
+        )
+        self.debug_dump_paged_kv_planewords = (
+            paged_debug_dump == "PLANEWORDS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and self.use_paged_v_tma
+            and self.use_paged_kv_tma_exact_plane_bf16_layout
+        )
+        self.debug_dump_paged_kv_extend_state = (
+            paged_debug_dump == "EXTEND_STATE"
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_extend_pregs = (
+            paged_debug_dump == "EXTEND_PREGS"
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_extend_pscalars = (
+            paged_debug_dump == "EXTEND_PSCALARS"
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_extend_partials = (
+            paged_debug_dump == "EXTEND_PARTIALS"
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and traits.num_warps_kv > 1
+        )
+        self.debug_dump_paged_kv_extend_sregs = (
+            paged_debug_dump == "EXTEND_SREGS"
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_extend_kwords = (
+            paged_debug_dump == "EXTEND_KWORDS"
+            and self.kv_is_fp8
+            and traits.num_warps_kv == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and self.use_paged_k_tma
+        )
+        self.debug_dump_paged_kv_extend_vwords = (
+            paged_debug_dump == "EXTEND_VWORDS"
+            and self.kv_is_fp8
+            and traits.num_warps_kv == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and self.use_paged_v_tma
+        )
+        self.kv_tma_plane_head_dim = 128 if self.kv_is_fp8 else 64
+        self.kv_tma_plane_mem_dtype = (
+            cutlass.Uint8 if self.kv_is_fp8 else self.dtype_kv_storage
+        )
+        self.kv_tma_internal_type = None
+        self.kv_tma_plane_count = (
+            (2 if self.kv_is_fp8 else 4)
+            if self.use_paged_kv_tma_exact_plane_bf16_layout
+            else 1
+        )
+        self.kv_tma_copy_bytes_k = (
+            self.stage_tile_rows * traits.head_dim_qk * (dtype_kv_storage.width // 8)
+        )
+        self.kv_tma_copy_bytes_v = (
+            self.stage_tile_rows * traits.head_dim_vo * (dtype_kv_storage.width // 8)
+        )
+        self.kv_tma_desc_words_per_head = 16
+        self.use_native_fp8_qk_mma = (
+            use_native_fp8_qk
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and traits.head_dim_qk % 32 == 0
+            and traits.num_mma_d_qk % 2 == 0
+        )
+        self.use_native_fp8_pv_mma = (
+            use_native_fp8_pv
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and traits.num_warps_kv == 1
+            and traits.num_mma_kv % 2 == 0
+        )
+        self.softmax_scale_log2 = Float32(
+            (traits.head_dim_qk**-0.5) * attention_ops.LOG2_E
+        )
+        self.inverse_softmax_scale = Float32(traits.head_dim_qk**0.5)
+
+    def _get_shared_storage_cls(self):
+        class SharedStorage:
+            pass
+
+        if self.traits.num_warps_kv > 1:
+            if self.use_paged_kv_tma:
+                mbar_struct = cute.struct.MemRange[cutlass.Int64, 2 * self.num_stages]
+                SharedStorage.__annotations__ = {
+                    "mbar_ptr_K": mbar_struct,
+                    "mbar_ptr_V": mbar_struct,
+                }
+            payload_alignment = (
+                1024 if self.use_paged_kv_tma_exact_plane_bf16_layout else 128
+            )
+            payload_struct = cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    int(self.traits.shared_storage_bytes),
+                ],
+                payload_alignment,
+            ]
+            SharedStorage.__annotations__["payload"] = payload_struct
+        else:
+            q_struct = cute.struct.Align[
+                cute.struct.MemRange[
+                    self.dtype_q,
+                    int(self.traits.cta_tile_q * self.traits.head_dim_qk),
+                ],
+                128,
+            ]
+            if self.use_paged_kv_tma:
+                payload_bytes = int(
+                    self.num_stages
+                    * self.stage_tile_rows
+                    * (self.traits.upcast_stride_k + self.traits.upcast_stride_v)
+                    * 16
+                )
+                SharedStorage.__annotations__ = {
+                    "mbar_ptr_K": cute.struct.MemRange[
+                        cutlass.Int64, 2 * self.num_stages
+                    ],
+                    "mbar_ptr_V": cute.struct.MemRange[
+                        cutlass.Int64, 2 * self.num_stages
+                    ],
+                    "sQ": q_struct,
+                    "payload": cute.struct.Align[
+                        cute.struct.MemRange[cutlass.Uint8, payload_bytes],
+                        1024,
+                    ],
+                }
+            else:
+                kv_storage_bytes = self.dtype_kv_storage.width // 8
+                k_smem_row_elems = self.traits.upcast_stride_k * 16 // kv_storage_bytes
+                v_smem_row_elems = self.traits.upcast_stride_v * 16 // kv_storage_bytes
+                k_struct = cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.dtype_kv_storage,
+                        int(self.num_stages * self.stage_tile_rows * k_smem_row_elems),
+                    ],
+                    128,
+                ]
+                v_struct = cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.dtype_kv_storage,
+                        int(self.num_stages * self.stage_tile_rows * v_smem_row_elems),
+                    ],
+                    128,
+                ]
+                SharedStorage.__annotations__ = {
+                    "sQ": q_struct,
+                    "sK": k_struct,
+                    "sV": v_struct,
+                }
+
+        return cute.struct(SharedStorage)
+
+    def _get_paged_kv_tma_plane_layout(self):
+        plane_swizzle = os.environ.get(
+            "FLASHINFER_EXP_SM12X_PAGED_KV_TMA_PLANE_SWIZZLE", ""
+        )
+        if plane_swizzle == "none":
+            return cute.make_layout(
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                stride=(self.kv_tma_plane_head_dim, 1),
+            )
+        if plane_swizzle:
+            mbase, bbits, sshift = [int(part) for part in plane_swizzle.split(",")]
+            swizzle = make_swizzle(mbase, bbits, sshift)
+        else:
+            swizzle = make_swizzle(3, 4, 3)
+        return cute.make_composed_layout(
+            swizzle,
+            0,
+            cute.make_layout(
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                stride=(self.kv_tma_plane_head_dim, 1),
+            ),
+        )
+
+    def _get_paged_kv_tma_plane_stage_layout(self):
+        return cute.tile_to_shape(
+            self._get_paged_kv_tma_plane_layout(),
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim, self.num_stages),
+            (0, 1, 2),
+        )
+
+    def _get_paged_kv_tma_layout(self, head_dim: int):
+        if self.dtype_kv_storage.width == 16:
+            layout_atom = warpgroup.make_smem_layout_atom(
+                sm90_utils_basic.get_smem_layout_atom(
+                    LayoutEnum.ROW_MAJOR,
+                    self.dtype_kv_storage,
+                    head_dim,
+                ),
+                self.dtype_kv_storage,
+            )
+            return cute.tile_to_shape(
+                layout_atom,
+                (self.stage_tile_rows, head_dim),
+                (0, 1),
+            )
+        swizzle = (
+            make_swizzle(3, 4, 4)
+            if self.dtype_kv_storage.width == 8
+            else make_swizzle(3, 3, 5)
+        )
+        return cute.make_composed_layout(
+            swizzle,
+            0,
+            cute.make_layout(
+                (self.stage_tile_rows, head_dim),
+                stride=(head_dim, 1),
+            ),
+        )
+
+    def _get_paged_kv_tma_stage_layout(self, head_dim: int):
+        return cute.tile_to_shape(
+            self._get_paged_kv_tma_layout(head_dim),
+            (self.stage_tile_rows, head_dim, self.num_stages),
+            (0, 1, 2),
+        )
+
+    @cute.jit
+    def _msa_selected_token_count(
+        self,
+        mQ2KIndices: cute.Tensor,
+        kv_head_idx,
+        q_row_idx,
+        visible_len,
+    ):
+        visible_len = cutlass.select_(visible_len > Int32(0), visible_len, Int32(1))
+        block_count = (visible_len + Int32(self.MSA_BLOCK_TOKENS - 1)) // Int32(
+            self.MSA_BLOCK_TOKENS
+        )
+        block_count = cutlass.select_(
+            block_count < Int32(self.MSA_TOPK), block_count, Int32(self.MSA_TOPK)
+        )
+        block_count = cutlass.select_(block_count > Int32(0), block_count, Int32(1))
+        if const_expr(self.page_size == 128):
+            # Whole-page walk at page_size=128: the planner counts full
+            # 128-token pages, so the kernel must not tail-compact.
+            return block_count * Int32(self.MSA_BLOCK_TOKENS)
+        last_j = block_count - Int32(1)
+        local_block_id = mQ2KIndices[kv_head_idx, q_row_idx, last_j]
+        tail_tokens = visible_len - local_block_id * Int32(self.MSA_BLOCK_TOKENS)
+        tail_pages = (tail_tokens + Int32(63)) // Int32(64)
+        tail_pages = cutlass.select_(tail_pages < Int32(1), Int32(1), tail_pages)
+        tail_pages = cutlass.select_(tail_pages > Int32(2), Int32(2), tail_pages)
+        return ((block_count - Int32(1)) * Int32(2) + tail_pages) * Int32(64)
+
+    @cute.jit
+    def _msa_union_selected_token_count(
+        self,
+        mMSAUnionBlocks: cute.Tensor,
+        mMSAUnionCounts: cute.Tensor,
+        work_idx,
+        kv_head_idx,
+        cache_len,
+        qo_len,
+        tile_first_token,
+        tile_token_count,
+    ):
+        block_count = mMSAUnionCounts[work_idx, kv_head_idx]
+        block_count = cutlass.select_(block_count > Int32(0), block_count, Int32(1))
+        if const_expr(self.page_size == 128):
+            # Whole-page walk at page_size=128 (no tail compaction).
+            return block_count * Int32(self.MSA_BLOCK_TOKENS)
+        last_block_id = mMSAUnionBlocks[work_idx, kv_head_idx, block_count - Int32(1)]
+        max_visible_len = cache_len - qo_len + tile_first_token + tile_token_count
+        max_visible_len = cutlass.select_(
+            max_visible_len > Int32(0), max_visible_len, Int32(1)
+        )
+        tail_tokens = max_visible_len - last_block_id * Int32(self.MSA_BLOCK_TOKENS)
+        tail_pages = (tail_tokens + Int32(63)) // Int32(64)
+        tail_pages = cutlass.select_(tail_pages < Int32(1), Int32(1), tail_pages)
+        tail_pages = cutlass.select_(tail_pages > Int32(2), Int32(2), tail_pages)
+        return ((block_count - Int32(1)) * Int32(2) + tail_pages) * Int32(64)
+
+    @cute.jit
+    def _tile_page_idx(
+        self,
+        mQ2KIndices: cute.Tensor | None,
+        mMSAUnionBlocks: cute.Tensor | None,
+        work_idx,
+        kv_head_idx,
+        q_row_idx,
+        tile_token_base,
+        page_size,
+    ):
+        if const_expr(self.msa_block_sparse):
+            block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
+            if const_expr(self.entries_per_block == 1):
+                block_id = (
+                    mMSAUnionBlocks[work_idx, kv_head_idx, block_j]
+                    if const_expr(self.msa_union_tile)
+                    else mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+                )
+                return cutlass.select_(
+                    block_id >= Int32(0),
+                    block_id,
+                    Int32(0),
+                )
+            block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
+            subpage = block_offset // page_size
+            block_id = (
+                mMSAUnionBlocks[work_idx, kv_head_idx, block_j]
+                if const_expr(self.msa_union_tile)
+                else mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+            )
+            return cutlass.select_(
+                block_id >= Int32(0),
+                block_id * Int32(self.entries_per_block) + subpage,
+                Int32(0),
+            )
+        return tile_token_base // page_size
+
+    @cute.jit
+    def _tile_key_base(
+        self,
+        mQ2KIndices: cute.Tensor | None,
+        mMSAUnionBlocks: cute.Tensor | None,
+        work_idx,
+        kv_head_idx,
+        q_row_idx,
+        tile_token_base,
+    ):
+        if const_expr(self.msa_block_sparse):
+            block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
+            block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
+            block_id = (
+                mMSAUnionBlocks[work_idx, kv_head_idx, block_j]
+                if const_expr(self.msa_union_tile)
+                else mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+            )
+            return cutlass.select_(
+                block_id >= Int32(0),
+                block_id * Int32(self.MSA_BLOCK_TOKENS) + block_offset,
+                Int32(0x7FFFFFFF),
+            )
+        return tile_token_base
+
+    @cute.jit
+    def _msa_union_row_has_block(
+        self,
+        mMSAUnionMasks: cute.Tensor | None,
+        work_idx,
+        kv_head_idx,
+        tile_token_base,
+        q_token_local,
+        tile_first_token,
+    ):
+        if const_expr(self.msa_union_tile):
+            block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
+            local_token = q_token_local - tile_first_token
+            mask_word = mMSAUnionMasks[work_idx, kv_head_idx, block_j]
+            return ((mask_word >> local_token) & Int32(1)) != Int32(0)
+        return True
+
+    @cute.jit
+    def _async_copy_paged_tile_permuted_128b(
+        self,
+        mCacheBytes: cute.Tensor,
+        mPageTable: cute.Tensor,
+        request_idx,
+        tile_token_base,
+        page_idx,
+        kv_head_idx,
+        num_kv_heads,
+        row_bytes,
+        page_stride_bytes,
+        token_stride_bytes,
+        head_stride_bytes,
+        sStageBytes: cute.Tensor,
+        stage_byte_offset,
+        lane,
+        warp_linear_idx,
+        valid_rows,
+        upcast_stride,
+        fill_zero: cutlass.Constexpr,
+    ):
+        page_size = Int32(self.page_size)
+        lane_row = lane // 8
+        lane_col = lane % 8
+        for tile_iter in cutlass.range_constexpr(
+            self.traits.num_mma_kv * 4 // self.traits.num_warps_q
+        ):
+            row_idx = Int32(
+                warp_linear_idx * 4 + lane_row + tile_iter * self.total_warps * 4
+            )
+            token_idx = Int32(tile_token_base + row_idx)
+            page_iter = (
+                page_idx
+                if const_expr(self.msa_block_sparse)
+                else token_idx // page_size
+            )
+            entry_idx = (
+                (tile_token_base - (tile_token_base // page_size) * page_size) + row_idx
+                if const_expr(self.msa_block_sparse)
+                else token_idx - page_iter * page_size
+            )
+            page_id = mPageTable[request_idx, page_iter]
+            row_valid = row_idx < valid_rows
+            row_byte_base = (
+                Int64(page_id) * Int64(page_stride_bytes)
+                + Int64(entry_idx) * Int64(token_stride_bytes)
+                + Int64(kv_head_idx) * Int64(head_stride_bytes)
+            )
+            for vec_iter in cutlass.range_constexpr((row_bytes + 127) // 128):
+                vec_idx = Int32(lane_col + vec_iter * 8)
+                src_byte_idx = row_byte_base + vec_idx * 16
+                dst_byte_idx = (
+                    stage_byte_offset
+                    + _permuted_offset_128b(row_idx, vec_idx, upcast_stride) * 16
+                )
+                vec_valid = row_valid and (vec_idx * Int32(16) < row_bytes)
+                if const_expr(fill_zero):
+                    _cp_async_load_128b_zfill(
+                        shared_ptr_to_u32(sStageBytes.iterator + dst_byte_idx),
+                        get_ptr_as_int64(mCacheBytes, src_byte_idx),
+                        cutlass.select_(vec_valid, Int32(16), Int32(0)),
+                    )
+                else:
+                    _cp_async_load_128b_pred(
+                        shared_ptr_to_u32(sStageBytes.iterator + dst_byte_idx),
+                        get_ptr_as_int64(mCacheBytes, src_byte_idx),
+                        Int32(vec_valid),
+                    )
+
+    @cute.jit
+    def _issue_paged_kv_tma_copy_planes(
+        self,
+        load_tma0,
+        load_tma1,
+        load_tma2,
+        load_tma3,
+        pipeline_tma,
+        producer_state,
+        mPageTable: cute.Tensor,
+        request_idx,
+        tile_token_base,
+        page_size,
+    ):
+        page_idx = tile_token_base // page_size
+        page_id = (
+            Int32(0)
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0")
+                == "1"
+            )
+            else mPageTable[request_idx, page_idx]
+        )
+        pipeline_tma.producer_acquire(producer_state)
+        load_tma0(src_idx=page_id, producer_state=producer_state)
+        load_tma1(src_idx=page_id, producer_state=producer_state)
+        load_tma2(src_idx=page_id, producer_state=producer_state)
+        load_tma3(src_idx=page_id, producer_state=producer_state)
+
+    @cute.jit
+    def _issue_paged_kv_tma_copy_2planes(
+        self,
+        load_tma0,
+        load_tma1,
+        pipeline_tma,
+        producer_state,
+        mPageTable: cute.Tensor,
+        request_idx,
+        tile_token_base,
+        page_size,
+    ):
+        page_idx = tile_token_base // page_size
+        page_id = (
+            Int32(0)
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0")
+                == "1"
+            )
+            else mPageTable[request_idx, page_idx]
+        )
+        pipeline_tma.producer_acquire(producer_state)
+        load_tma0(src_idx=page_id, producer_state=producer_state)
+        load_tma1(src_idx=page_id, producer_state=producer_state)
+
+    @cute.jit
+    def _issue_paged_kv_tma_copy_2planes_fp8_raw(
+        self,
+        mDescPtrsFlat: cute.Tensor,
+        kv_head_idx,
+        sStageBytes: cute.Tensor,
+        stage_plane_offset,
+        kv_plane_total_bytes,
+        producer_state,
+        mbar_ptr,
+        expected_bytes,
+        mPageTable: cute.Tensor,
+        request_idx,
+        tile_token_base,
+        page_size,
+    ):
+        _issue_paged_kv_tma_copy_2planes_fp8_raw_impl(
+            mDescPtrsFlat,
+            kv_head_idx,
+            Int32(self.kv_tma_plane_head_dim),
+            sStageBytes,
+            stage_plane_offset,
+            kv_plane_total_bytes,
+            producer_state,
+            mbar_ptr,
+            expected_bytes,
+            mPageTable,
+            request_idx,
+            tile_token_base,
+            page_size,
+        )
+
+    @cute.jit
+    def _async_copy_q_tile_permuted_128b(
+        self,
+        mQBytes: cute.Tensor,
+        q_start,
+        packed_tile_start,
+        packed_tile_rows,
+        kv_head_idx,
+        group_size,
+        num_q_heads,
+        row_bytes,
+        token_stride_bytes,
+        head_stride_bytes,
+        sQBytes: cute.Tensor,
+        lane,
+        warp_q_idx,
+    ):
+        lane_row = lane // 8
+        lane_col = lane % 8
+        warp_row_base = Int32(warp_q_idx * self.traits.num_mma_q * 16)
+        for mma_q in cutlass.range_constexpr(self.traits.num_mma_q):
+            for row_iter in cutlass.range_constexpr(4):
+                packed_q_idx = Int32(
+                    packed_tile_start
+                    + warp_row_base
+                    + mma_q * 16
+                    + lane_row
+                    + row_iter * 4
+                )
+                row_valid = packed_q_idx < (packed_tile_start + packed_tile_rows)
+                q_row_local = packed_q_idx // group_size
+                q_group_lane = packed_q_idx - q_row_local * group_size
+                q_head_idx = Int32(kv_head_idx * group_size + q_group_lane)
+                q_row_idx = Int32(q_start + q_row_local)
+                row_byte_base = Int64(q_row_idx) * Int64(token_stride_bytes) + Int64(
+                    q_head_idx
+                ) * Int64(head_stride_bytes)
+                row_idx = Int32(warp_row_base + mma_q * 16 + lane_row + row_iter * 4)
+                for mma_do in cutlass.range_constexpr(self.traits.num_mma_d_qk // 4):
+                    vec_idx = Int32(lane_col + mma_do * 8)
+                    src_byte_idx = row_byte_base + vec_idx * 16
+                    dst_byte_idx = (
+                        _permuted_offset_128b(
+                            row_idx, vec_idx, self.traits.upcast_stride_q
+                        )
+                        * 16
+                    )
+                    _cp_async_load_128b_pred(
+                        shared_ptr_to_u32(sQBytes.iterator + dst_byte_idx),
+                        get_ptr_as_int64(mQBytes, src_byte_idx),
+                        Int32(row_valid),
+                    )
+
+    @staticmethod
+    def can_implement(
+        dtype_q: Type[cutlass.Numeric],
+        dtype_kv: Type[cutlass.Numeric],
+        dtype_kv_storage: Type[cutlass.Numeric],
+        dtype_o: Type[cutlass.Numeric],
+        *,
+        traits: PagedForwardTraits,
+        split_kv: bool,
+    ) -> bool:
+        del split_kv
+        if dtype_q not in (cutlass.Float16, cutlass.BFloat16):
+            return False
+        if dtype_kv not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float8E4M3FN):
+            return False
+        if dtype_kv_storage not in (cutlass.Float16, cutlass.BFloat16, cutlass.Uint8):
+            return False
+        if dtype_o not in (cutlass.Float16, cutlass.BFloat16):
+            return False
+        if traits.head_dim_qk % 32 != 0 or traits.head_dim_vo % 32 != 0:
+            return False
+        if traits.num_threads != 128:
+            return False
+        if traits.cta_tile_q not in (16, 64, 128):
+            return False
+        return True
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mKCache: cute.Tensor,
+        mVCache: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mKvWindowStartTokens: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mQ2KIndices: cute.Tensor | None,
+        mMSAUnionBlocks: cute.Tensor | None,
+        mMSAUnionMasks: cute.Tensor | None,
+        mMSAUnionCounts: cute.Tensor | None,
+        mAttentionSinkBias: cute.Tensor,
+        mRelativeAttentionBias: cute.Tensor | None,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        mKTmaDescPtrs: cute.Tensor,
+        mVTmaDescPtrs: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(len(mQ.shape) != 3):
+            raise ValueError("mQ must have shape (total_q, q_heads, head_dim)")
+        if const_expr(len(mKCache.shape) != 4 or len(mVCache.shape) != 4):
+            raise ValueError(
+                "mKCache and mVCache must have shape (num_pages, page_size, kv_heads, head_dim)"
+            )
+        if const_expr(len(mPageTable.shape) != 2):
+            raise ValueError("mPageTable must have shape (batch, max_pages)")
+        if const_expr(len(mCacheSeqlens.shape) != 1 or len(mCuSeqlensQ.shape) != 1):
+            raise ValueError("mCacheSeqlens and mCuSeqlensQ must be rank-1")
+        if const_expr(
+            len(mRequestIndices.shape) != 1
+            or len(mQoTileIndices.shape) != 1
+            or len(mKvTileIndices.shape) != 1
+        ):
+            raise ValueError("worklist tensors must be rank-1")
+        if const_expr(
+            len(mOIndptr.shape) != 1
+            or len(mKvChunkSizePtr.shape) != 1
+            or len(mKvWindowStartTokens.shape) != 1
+            or len(mBlockValidMask.shape) != 1
+        ):
+            raise ValueError(
+                "mOIndptr, mKvChunkSizePtr, mKvWindowStartTokens, and mBlockValidMask must be rank-1"
+            )
+        if const_expr(len(mO.shape) != 3 or len(mLSE.shape) != 2):
+            raise ValueError("mO must be rank-3 and mLSE must be rank-2")
+        if const_expr(mKDescale is not None and len(mKDescale.shape) not in (1, 2)):
+            raise ValueError("mKDescale must have shape (batch,) or (batch, kv_heads)")
+        if const_expr(mVDescale is not None and len(mVDescale.shape) not in (1, 2)):
+            raise ValueError("mVDescale must have shape (batch,) or (batch, kv_heads)")
+        if const_expr(self.msa_block_sparse and mQ2KIndices is None):
+            raise ValueError("MSA block-sparse paged extend requires mQ2KIndices")
+        if const_expr(
+            self.has_relative_attention_bias and len(mRelativeAttentionBias.shape) != 3
+        ):
+            raise ValueError(
+                "mRelativeAttentionBias must have shape "
+                "(total_q_capacity, q_heads, relative_extent)"
+            )
+        if const_expr(
+            self.msa_union_tile
+            and (
+                mMSAUnionBlocks is None
+                or mMSAUnionMasks is None
+                or mMSAUnionCounts is None
+            )
+        ):
+            raise ValueError(
+                "MSA union-tile paged extend requires union metadata tensors"
+            )
+        if const_expr(self.msa_block_sparse and self.window_left >= 0):
+            raise ValueError(
+                "MSA block-sparse paged extend does not support window_left"
+            )
+        if const_expr(
+            self.msa_block_sparse
+            and (
+                self.traits.head_dim_qk != 128
+                or self.traits.head_dim_vo != 128
+                or (
+                    self.traits.cta_tile_q != 16
+                    and not (self.msa_union_tile and self.traits.cta_tile_q == 128)
+                )
+                or self.stage_tile_rows > 64
+                or 64 % self.stage_tile_rows != 0
+            )
+        ):
+            raise ValueError(
+                "MSA block-sparse extend requires cta_tile_q=16 or union cta_tile_q=128, page_size in (64, 128), cta_tile_kv dividing 64, and head_dim=128"
+            )
+        if const_expr(mQ.element_type != self.dtype_q):
+            raise TypeError("mQ dtype must match dtype_q")
+        if const_expr(
+            mKCache.element_type != self.dtype_kv_storage
+            or mVCache.element_type != self.dtype_kv_storage
+        ):
+            raise TypeError("mKCache/mVCache dtype must match dtype_kv_storage")
+        if const_expr(mO.element_type != self.dtype_o):
+            raise TypeError("mO dtype must match dtype_o")
+        if const_expr(mLSE.element_type != Float32):
+            raise TypeError("mLSE must be Float32")
+        if const_expr(
+            not self.can_implement(
+                self.dtype_q,
+                self.dtype_kv,
+                self.dtype_kv_storage,
+                self.dtype_o,
+                traits=self.traits,
+                split_kv=self.split_kv,
+            )
+        ):
+            raise TypeError("paged forward kernel configuration is not supported")
+
+        mQ = _assume_tensor_aligned(mQ)
+        mKCache = _assume_tensor_aligned(mKCache)
+        mVCache = _assume_tensor_aligned(mVCache)
+        mO = _assume_tensor_aligned(mO)
+
+        mKCacheT = cute.make_tensor(
+            mKCache.iterator, cute.select(mKCache.layout, mode=[1, 3, 2, 0])
+        )
+        mVCacheT = cute.make_tensor(
+            mVCache.iterator, cute.select(mVCache.layout, mode=[1, 3, 2, 0])
+        )
+        if const_expr(self.use_paged_k_tma):
+            mKCacheT = _assume_paged_kv_tma_source_aligned(mKCacheT)
+        if const_expr(self.use_paged_v_tma):
+            mVCacheT = _assume_paged_kv_tma_source_aligned(mVCacheT)
+        tma_tensor_K = mKCacheT
+        tma_tensor_V = mVCacheT
+        tma_atom_K = None
+        tma_atom_V = None
+        if const_expr(
+            (self.use_paged_k_tma or self.use_paged_v_tma)
+            and not self.use_paged_kv_tma_fp8_raw_issue
+        ):
+            gmem_tiled_copy_kv = cpasync.CopyBulkTensorTileG2SOp()
+            k_tma_source = (
+                cute.recast_tensor(mKCacheT, self.kv_tma_plane_mem_dtype)
+                if const_expr(self.kv_is_fp8)
+                else mKCacheT
+            )
+            v_tma_source = mVCacheT
+            if const_expr(self.kv_is_fp8):
+                v_tma_source = cute.recast_tensor(
+                    v_tma_source, self.kv_tma_plane_mem_dtype
+                )
+            if const_expr(self.use_paged_k_tma):
+                tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+                    gmem_tiled_copy_kv,
+                    k_tma_source,
+                    self._get_paged_kv_tma_plane_layout(),
+                    (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                    1,
+                    internal_type=self.kv_tma_internal_type,
+                )
+            if const_expr(self.use_paged_v_tma):
+                tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+                    gmem_tiled_copy_kv,
+                    v_tma_source,
+                    self._get_paged_kv_tma_plane_layout(),
+                    (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                    1,
+                    internal_type=self.kv_tma_internal_type,
+                )
+
+        self.kernel(
+            mQ,
+            mKCache,
+            mVCache,
+            tma_tensor_K,
+            tma_tensor_V,
+            mPageTable,
+            mCacheSeqlens,
+            mCuSeqlensQ,
+            mRequestIndices,
+            mQoTileIndices,
+            mKvTileIndices,
+            mOIndptr,
+            mKvChunkSizePtr,
+            mKvWindowStartTokens,
+            mBlockValidMask,
+            mQ2KIndices,
+            mMSAUnionBlocks,
+            mMSAUnionMasks,
+            mMSAUnionCounts,
+            mAttentionSinkBias,
+            mRelativeAttentionBias,
+            mO,
+            mLSE,
+            mKDescale,
+            mVDescale,
+            mKTmaDescPtrs,
+            mVTmaDescPtrs,
+            tma_atom_K,
+            tma_atom_V,
+        ).launch(
+            grid=(mBlockValidMask.shape[0], mKCache.shape[2], 1),
+            block=[32, self.traits.num_warps_q, self.traits.num_warps_kv],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mKCache: cute.Tensor,
+        mVCache: cute.Tensor,
+        mKCacheT: cute.Tensor,
+        mVCacheT: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mKvWindowStartTokens: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mQ2KIndices: cute.Tensor | None,
+        mMSAUnionBlocks: cute.Tensor | None,
+        mMSAUnionMasks: cute.Tensor | None,
+        mMSAUnionCounts: cute.Tensor | None,
+        mAttentionSinkBias: cute.Tensor,
+        mRelativeAttentionBias: cute.Tensor | None,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        mKTmaDescPtrs: cute.Tensor,
+        mVTmaDescPtrs: cute.Tensor,
+        tma_atom_K: cute.CopyAtom | None,
+        tma_atom_V: cute.CopyAtom | None,
+    ):
+        lane, warp_q_idx, warp_kv_idx = cute.arch.thread_idx()
+        work_idx, kv_head_idx, _ = cute.arch.block_idx()
+        block_valid = mBlockValidMask[work_idx]
+        if block_valid == Int32(0):
+            _exit_thread()
+        valid_work = True
+        request_idx = mRequestIndices[work_idx]
+        qo_tile_idx = mQoTileIndices[work_idx]
+        kv_tile_idx = mKvTileIndices[work_idx]
+        q_start = mCuSeqlensQ[request_idx]
+        q_end = mCuSeqlensQ[request_idx + 1]
+        qo_len = q_end - q_start
+        cache_len = mCacheSeqlens[request_idx]
+        group_size = mQ.shape[1] // mKCache.shape[2]
+        packed_qo_len = qo_len * group_size
+        packed_tile_start = qo_tile_idx * self.traits.cta_tile_q
+        packed_tile_limit = packed_tile_start + self.traits.cta_tile_q
+        packed_tile_end = cutlass.select_(
+            packed_tile_limit < packed_qo_len, packed_tile_limit, packed_qo_len
+        )
+        packed_tile_rows = packed_tile_end - packed_tile_start
+        kv_chunk_size = mKvChunkSizePtr[0]
+
+        if const_expr(self.msa_block_sparse):
+            kv_window_start = Int32(0)
+            msa_tile_first_token = packed_tile_start // group_size
+            msa_tile_token_count = (
+                packed_tile_rows + group_size - Int32(1)
+            ) // group_size
+            msa_q_row_idx = q_start + msa_tile_first_token
+            msa_visible_len = cache_len - qo_len + msa_tile_first_token + Int32(1)
+            msa_tile_max_visible_len = (
+                cache_len - qo_len + msa_tile_first_token + msa_tile_token_count
+            )
+            selected_token_count = (
+                self._msa_union_selected_token_count(
+                    mMSAUnionBlocks,
+                    mMSAUnionCounts,
+                    work_idx,
+                    kv_head_idx,
+                    cache_len,
+                    qo_len,
+                    msa_tile_first_token,
+                    msa_tile_token_count,
+                )
+                if const_expr(self.msa_union_tile)
+                else self._msa_selected_token_count(
+                    mQ2KIndices,
+                    kv_head_idx,
+                    msa_q_row_idx,
+                    msa_visible_len,
+                )
+            )
+            chunk_start = (
+                kv_tile_idx * kv_chunk_size if const_expr(self.split_kv) else Int32(0)
+            )
+            chunk_end = (
+                cutlass.select_(
+                    (kv_tile_idx + 1) * kv_chunk_size < selected_token_count,
+                    (kv_tile_idx + 1) * kv_chunk_size,
+                    selected_token_count,
+                )
+                if const_expr(self.split_kv)
+                else selected_token_count
+            )
+        else:
+            kv_window_start = (
+                mKvWindowStartTokens[request_idx]
+                if const_expr(self.window_left >= 0)
+                else Int32(0)
+            )
+            msa_q_row_idx = Int32(0)
+            msa_visible_len = Int32(0)
+            msa_tile_first_token = Int32(0)
+            msa_tile_token_count = Int32(0)
+            msa_tile_max_visible_len = Int32(0)
+            chunk_start = (
+                kv_window_start + kv_tile_idx * kv_chunk_size
+                if const_expr(self.split_kv)
+                else kv_window_start
+            )
+            chunk_end = (
+                cutlass.select_(
+                    kv_window_start + (kv_tile_idx + 1) * kv_chunk_size < cache_len,
+                    kv_window_start + (kv_tile_idx + 1) * kv_chunk_size,
+                    cache_len,
+                )
+                if const_expr(self.split_kv)
+                else cache_len
+            )
+        request_partial_start = mOIndptr[request_idx]
+        request_partial_end = mOIndptr[request_idx + 1]
+        num_chunks_kv = (
+            (request_partial_end - request_partial_start) // qo_len
+            if const_expr(self.split_kv)
+            else 1
+        )
+        page_size = mKCache.shape[1]
+        stage_tile_rows = self.stage_tile_rows
+        q_bytes = self.traits.q_smem_bytes
+        kv_storage_bytes = self.dtype_kv_storage.width // 8
+        k_smem_row_bytes = self.traits.upcast_stride_k * 16
+        v_smem_row_bytes = self.traits.upcast_stride_v * 16
+        k_smem_row_elems = k_smem_row_bytes // kv_storage_bytes
+        v_smem_row_elems = v_smem_row_bytes // kv_storage_bytes
+        k_bytes = self.num_stages * stage_tile_rows * k_smem_row_bytes
+        v_bytes = self.num_stages * stage_tile_rows * v_smem_row_bytes
+        kv_plane_stage_bytes = (
+            stage_tile_rows
+            * self.kv_tma_plane_head_dim
+            * (self.dtype_kv_storage.width // 8)
+        )
+        kv_plane_total_bytes = self.num_stages * kv_plane_stage_bytes
+        warp_linear_idx = warp_kv_idx * self.traits.num_warps_q + warp_q_idx
+        tidx = lane + 32 * (warp_q_idx + self.traits.num_warps_q * warp_kv_idx)
+
+        smem = cutlass.utils.SmemAllocator()
+        SharedStorage = self._get_shared_storage_cls()
+        storage = smem.allocate(SharedStorage)
+        if const_expr(
+            (self.use_paged_k_tma or self.use_paged_v_tma)
+            and not self.use_paged_kv_tma_fp8_raw_issue
+        ):
+            if warp_q_idx == Int32(0) and warp_kv_idx == Int32(0):
+                if const_expr(self.use_paged_k_tma):
+                    cpasync.prefetch_descriptor(tma_atom_K)
+                if const_expr(self.use_paged_v_tma):
+                    cpasync.prefetch_descriptor(tma_atom_V)
+        if const_expr(self.traits.num_warps_kv > 1):
+            if const_expr(self.use_paged_k_tma):
+                mbar_ptr_K = storage.mbar_ptr_K.data_ptr()
+            else:
+                mbar_ptr_K = None
+            if const_expr(self.use_paged_v_tma):
+                mbar_ptr_V = storage.mbar_ptr_V.data_ptr()
+            else:
+                mbar_ptr_V = None
+            if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                if tidx < self.num_stages:
+                    if const_expr(self.use_paged_k_tma):
+                        cute.arch.mbarrier_init(mbar_ptr_K + tidx, Int32(1))
+                    if const_expr(self.use_paged_v_tma):
+                        cute.arch.mbarrier_init(mbar_ptr_V + tidx, Int32(1))
+                cute.arch.sync_threads()
+            payload_u8 = storage.payload.get_tensor(
+                cute.make_layout((self.traits.shared_storage_bytes,), stride=(1,))
+            )
+            sQ = _make_payload_tensor(
+                payload_u8,
+                self.dtype_q,
+                0,
+                cute.make_layout(
+                    (self.traits.cta_tile_q, self.traits.head_dim_qk),
+                    stride=(self.traits.head_dim_qk, 1),
+                ),
+            )
+            sQTile = sQ
+            sK = _make_payload_tensor(
+                payload_u8,
+                self.dtype_kv_storage,
+                q_bytes,
+                cute.make_layout(
+                    (stage_tile_rows, self.traits.head_dim_qk, self.num_stages),
+                    stride=(k_smem_row_elems, 1, stage_tile_rows * k_smem_row_elems),
+                ),
+            )
+            sKStageBytes = _make_payload_tensor(
+                payload_u8,
+                cutlass.Uint8,
+                q_bytes,
+                cute.make_layout((k_bytes,), stride=(1,)),
+            )
+            sV = _make_payload_tensor(
+                payload_u8,
+                self.dtype_kv_storage,
+                q_bytes + k_bytes,
+                cute.make_layout(
+                    (stage_tile_rows, self.traits.head_dim_vo, self.num_stages),
+                    stride=(v_smem_row_elems, 1, stage_tile_rows * v_smem_row_elems),
+                ),
+            )
+            sVStageBytes = _make_payload_tensor(
+                payload_u8,
+                cutlass.Uint8,
+                q_bytes + k_bytes,
+                cute.make_layout((v_bytes,), stride=(1,)),
+            )
+            sKTma = None
+            sVTma = None
+            if const_expr(self.use_paged_kv_tma_exact_plane_bf16_layout):
+                sKPlane0 = _get_memrange_tensor(
+                    _make_payload_memrange(
+                        payload_u8,
+                        self.kv_tma_plane_mem_dtype,
+                        q_bytes + 0 * kv_plane_total_bytes,
+                        self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                    ),
+                    self._get_paged_kv_tma_plane_stage_layout(),
+                )
+                sKPlane1 = _get_memrange_tensor(
+                    _make_payload_memrange(
+                        payload_u8,
+                        self.kv_tma_plane_mem_dtype,
+                        q_bytes + 1 * kv_plane_total_bytes,
+                        self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                    ),
+                    self._get_paged_kv_tma_plane_stage_layout(),
+                )
+                sKPlane2 = (
+                    _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            q_bytes + 2 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                sKPlane3 = (
+                    _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            q_bytes + 3 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                sVPlane0 = _get_memrange_tensor(
+                    _make_payload_memrange(
+                        payload_u8,
+                        self.kv_tma_plane_mem_dtype,
+                        q_bytes + k_bytes + 0 * kv_plane_total_bytes,
+                        self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                    ),
+                    self._get_paged_kv_tma_plane_stage_layout(),
+                )
+                sVPlane1 = _get_memrange_tensor(
+                    _make_payload_memrange(
+                        payload_u8,
+                        self.kv_tma_plane_mem_dtype,
+                        q_bytes + k_bytes + 1 * kv_plane_total_bytes,
+                        self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                    ),
+                    self._get_paged_kv_tma_plane_stage_layout(),
+                )
+                sVPlane2 = (
+                    _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            q_bytes + k_bytes + 2 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                sVPlane3 = (
+                    _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            q_bytes + k_bytes + 3 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+            else:
+                sKPlane0 = None
+                sKPlane1 = None
+                sKPlane2 = None
+                sKPlane3 = None
+                sVPlane0 = None
+                sVPlane1 = None
+                sVPlane2 = None
+                sVPlane3 = None
+        else:
+            sQTile = None
+            if const_expr(self.use_paged_kv_tma):
+                if const_expr(self.use_paged_k_tma):
+                    mbar_ptr_K = storage.mbar_ptr_K.data_ptr()
+                else:
+                    mbar_ptr_K = None
+                if const_expr(self.use_paged_v_tma):
+                    mbar_ptr_V = storage.mbar_ptr_V.data_ptr()
+                else:
+                    mbar_ptr_V = None
+                if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                    if tidx < self.num_stages:
+                        if const_expr(self.use_paged_k_tma):
+                            cute.arch.mbarrier_init(mbar_ptr_K + tidx, Int32(1))
+                        if const_expr(self.use_paged_v_tma):
+                            cute.arch.mbarrier_init(mbar_ptr_V + tidx, Int32(1))
+                    cute.arch.sync_threads()
+                payload_u8 = storage.payload.get_tensor(
+                    cute.make_layout((k_bytes + v_bytes,), stride=(1,))
+                )
+                sKStageBytes = _make_payload_tensor(
+                    payload_u8,
+                    cutlass.Uint8,
+                    0,
+                    cute.make_layout((k_bytes,), stride=(1,)),
+                )
+                sVStageBytes = _make_payload_tensor(
+                    payload_u8,
+                    cutlass.Uint8,
+                    k_bytes,
+                    cute.make_layout((v_bytes,), stride=(1,)),
+                )
+                sK = cute.make_tensor(
+                    cute.recast_tensor(sKStageBytes, self.dtype_kv_storage).iterator,
+                    cute.make_layout(
+                        (stage_tile_rows, self.traits.head_dim_qk, self.num_stages),
+                        stride=(
+                            k_smem_row_elems,
+                            1,
+                            stage_tile_rows * k_smem_row_elems,
+                        ),
+                    ),
+                )
+                sV = cute.make_tensor(
+                    cute.recast_tensor(sVStageBytes, self.dtype_kv_storage).iterator,
+                    cute.make_layout(
+                        (stage_tile_rows, self.traits.head_dim_vo, self.num_stages),
+                        stride=(
+                            v_smem_row_elems,
+                            1,
+                            stage_tile_rows * v_smem_row_elems,
+                        ),
+                    ),
+                )
+                sKTma = None
+                sVTma = None
+                if const_expr(self.use_paged_kv_tma_exact_plane_bf16_layout):
+                    sKPlane0 = _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            0 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    sKPlane1 = _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            1 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    sKPlane2 = None
+                    sKPlane3 = None
+                    sVPlane0 = _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            k_bytes + 0 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    sVPlane1 = _get_memrange_tensor(
+                        _make_payload_memrange(
+                            payload_u8,
+                            self.kv_tma_plane_mem_dtype,
+                            k_bytes + 1 * kv_plane_total_bytes,
+                            self.num_stages
+                            * stage_tile_rows
+                            * self.kv_tma_plane_head_dim,
+                        ),
+                        self._get_paged_kv_tma_plane_stage_layout(),
+                    )
+                    sVPlane2 = None
+                    sVPlane3 = None
+                else:
+                    sKPlane0 = None
+                    sKPlane1 = None
+                    sKPlane2 = None
+                    sKPlane3 = None
+                    sVPlane0 = None
+                    sVPlane1 = None
+                    sVPlane2 = None
+                    sVPlane3 = None
+            else:
+                mbar_ptr_K = None
+                mbar_ptr_V = None
+                sK = storage.sK.get_tensor(
+                    cute.make_layout(
+                        (stage_tile_rows, self.traits.head_dim_qk, self.num_stages),
+                        stride=(
+                            k_smem_row_elems,
+                            1,
+                            stage_tile_rows * k_smem_row_elems,
+                        ),
+                    )
+                )
+                sV = storage.sV.get_tensor(
+                    cute.make_layout(
+                        (stage_tile_rows, self.traits.head_dim_vo, self.num_stages),
+                        stride=(
+                            v_smem_row_elems,
+                            1,
+                            stage_tile_rows * v_smem_row_elems,
+                        ),
+                    )
+                )
+                sKStageBytes = cute.make_tensor(
+                    cute.recast_tensor(sK, cutlass.Uint8).iterator,
+                    cute.make_layout((k_bytes,), stride=(1,)),
+                )
+                sVStageBytes = cute.make_tensor(
+                    cute.recast_tensor(sV, cutlass.Uint8).iterator,
+                    cute.make_layout((v_bytes,), stride=(1,)),
+                )
+                sKTma = None
+                sVTma = None
+                sKPlane0 = None
+                sKPlane1 = None
+                sKPlane2 = None
+                sKPlane3 = None
+                sVPlane0 = None
+                sVPlane1 = None
+                sVPlane2 = None
+                sVPlane3 = None
+        if const_expr(
+            (self.use_paged_k_tma or self.use_paged_v_tma)
+            and not self.use_paged_kv_tma_fp8_raw_issue
+        ):
+            pipeline_kv_consumer_group = cutlass.pipeline.CooperativeGroup(
+                cutlass.pipeline.Agent.Thread, self.total_warps
+            )
+            pipeline_kv_producer_group = cutlass.pipeline.CooperativeGroup(
+                cutlass.pipeline.Agent.Thread
+            )
+            pipeline_k = (
+                cute_pipeline.PipelineTmaAsync.create(
+                    barrier_storage=mbar_ptr_K,
+                    num_stages=self.num_stages,
+                    producer_group=pipeline_kv_producer_group,
+                    consumer_group=pipeline_kv_consumer_group,
+                    tx_count=self.kv_tma_copy_bytes_k,
+                    defer_sync=True,
+                )
+                if const_expr(self.use_paged_k_tma)
+                else None
+            )
+            pipeline_v = (
+                cute_pipeline.PipelineTmaAsync.create(
+                    barrier_storage=mbar_ptr_V,
+                    num_stages=self.num_stages,
+                    producer_group=pipeline_kv_producer_group,
+                    consumer_group=pipeline_kv_consumer_group,
+                    tx_count=self.kv_tma_copy_bytes_v,
+                    defer_sync=False,
+                )
+                if const_expr(self.use_paged_v_tma)
+                else None
+            )
+        else:
+            pipeline_k = None
+            pipeline_v = None
+        if const_expr(self.traits.num_warps_kv > 1):
+            sQ = cute.make_tensor(
+                cute.recast_tensor(
+                    cute.make_tensor(
+                        payload_u8.iterator,
+                        cute.make_layout((q_bytes,), stride=(1,)),
+                    ),
+                    self.dtype_q,
+                ).iterator,
+                cute.make_layout(
+                    (self.traits.cta_tile_q * self.traits.head_dim_qk,), stride=(1,)
+                ),
+            )
+            sKTC = None
+            sVTC = None
+        else:
+            sQ = storage.sQ.get_tensor(
+                cute.make_layout(
+                    (self.traits.cta_tile_q * self.traits.head_dim_qk,), stride=(1,)
+                )
+            )
+            sKTC = None
+            sVTC = None
+        k_row_bytes = self.traits.head_dim_qk * (self.dtype_kv_storage.width // 8)
+        v_row_bytes = self.traits.head_dim_vo * (self.dtype_kv_storage.width // 8)
+        k_page_stride_bytes = mKCache.stride[0] * kv_storage_bytes
+        k_token_stride_bytes = mKCache.stride[1] * kv_storage_bytes
+        k_head_stride_bytes = mKCache.stride[2] * kv_storage_bytes
+        v_page_stride_bytes = mVCache.stride[0] * kv_storage_bytes
+        v_token_stride_bytes = mVCache.stride[1] * kv_storage_bytes
+        v_head_stride_bytes = mVCache.stride[2] * kv_storage_bytes
+        q_storage_bytes = self.dtype_q.width // 8
+        q_token_stride_bytes = mQ.stride[0] * q_storage_bytes
+        q_head_stride_bytes = mQ.stride[1] * q_storage_bytes
+        k_stage_bytes = stage_tile_rows * k_smem_row_bytes
+        v_stage_bytes = stage_tile_rows * v_smem_row_bytes
+        mQBytes = cute.flatten(cute.recast_tensor(mQ, cutlass.Uint8))
+        mKBytes = cute.flatten(cute.recast_tensor(mKCache, cutlass.Uint8))
+        mVBytes = cute.flatten(cute.recast_tensor(mVCache, cutlass.Uint8))
+        mKTmaDescFlat = cute.flatten(mKTmaDescPtrs)
+        mVTmaDescFlat = cute.flatten(mVTmaDescPtrs)
+        if const_expr(self.use_paged_k_tma or self.use_paged_v_tma):
+            mKCacheTHead = (
+                mKCacheT[None, None, kv_head_idx, None]
+                if const_expr(not self.use_paged_kv_tma_fp8_raw_issue)
+                else None
+            )
+            mVCacheTHead = (
+                mVCacheT[None, None, kv_head_idx, None]
+                if const_expr(not self.use_paged_kv_tma_fp8_raw_issue)
+                else None
+            )
+            if const_expr(
+                self.use_paged_k_tma and not self.use_paged_kv_tma_fp8_raw_issue
+            ):
+                gKTma0 = cute.local_tile(
+                    mKCacheTHead,
+                    (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                    (0, 0, None),
+                )
+                gKTma1 = cute.local_tile(
+                    mKCacheTHead,
+                    (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                    (0, 1, None),
+                )
+                gKTma2 = (
+                    cute.local_tile(
+                        mKCacheTHead,
+                        (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                        (0, 2, None),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                gKTma3 = (
+                    cute.local_tile(
+                        mKCacheTHead,
+                        (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                        (0, 3, None),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                load_K_tma0, _, _ = cute_copy.tma_get_copy_fn(
+                    tma_atom_K, 0, cute.make_layout(1), gKTma0, sKPlane0
+                )
+                load_K_tma1, _, _ = cute_copy.tma_get_copy_fn(
+                    tma_atom_K, 0, cute.make_layout(1), gKTma1, sKPlane1
+                )
+                load_K_tma2, _, _ = (
+                    cute_copy.tma_get_copy_fn(
+                        tma_atom_K, 0, cute.make_layout(1), gKTma2, sKPlane2
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else (None, None, None)
+                )
+                load_K_tma3, _, _ = (
+                    cute_copy.tma_get_copy_fn(
+                        tma_atom_K, 0, cute.make_layout(1), gKTma3, sKPlane3
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else (None, None, None)
+                )
+                load_K_tma0 = cute_copy.tma_producer_copy_fn(load_K_tma0, pipeline_k)
+                load_K_tma1 = cute_copy.tma_producer_copy_fn(load_K_tma1, pipeline_k)
+                load_K_tma2 = (
+                    cute_copy.tma_producer_copy_fn(load_K_tma2, pipeline_k)
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                load_K_tma3 = (
+                    cute_copy.tma_producer_copy_fn(load_K_tma3, pipeline_k)
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                load_K_tma = None
+            else:
+                load_K_tma = None
+                load_K_tma0 = None
+                load_K_tma1 = None
+                load_K_tma2 = None
+                load_K_tma3 = None
+            if const_expr(
+                self.use_paged_v_tma and not self.use_paged_kv_tma_fp8_raw_issue
+            ):
+                gVTma0 = cute.local_tile(
+                    mVCacheTHead,
+                    (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                    (0, 0, None),
+                )
+                gVTma1 = cute.local_tile(
+                    mVCacheTHead,
+                    (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                    (0, 1, None),
+                )
+                gVTma2 = (
+                    cute.local_tile(
+                        mVCacheTHead,
+                        (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                        (0, 2, None),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                gVTma3 = (
+                    cute.local_tile(
+                        mVCacheTHead,
+                        (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                        (0, 3, None),
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                load_V_tma0, _, _ = cute_copy.tma_get_copy_fn(
+                    tma_atom_V, 0, cute.make_layout(1), gVTma0, sVPlane0
+                )
+                load_V_tma1, _, _ = cute_copy.tma_get_copy_fn(
+                    tma_atom_V, 0, cute.make_layout(1), gVTma1, sVPlane1
+                )
+                load_V_tma2, _, _ = (
+                    cute_copy.tma_get_copy_fn(
+                        tma_atom_V, 0, cute.make_layout(1), gVTma2, sVPlane2
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else (None, None, None)
+                )
+                load_V_tma3, _, _ = (
+                    cute_copy.tma_get_copy_fn(
+                        tma_atom_V, 0, cute.make_layout(1), gVTma3, sVPlane3
+                    )
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else (None, None, None)
+                )
+                load_V_tma0 = cute_copy.tma_producer_copy_fn(load_V_tma0, pipeline_v)
+                load_V_tma1 = cute_copy.tma_producer_copy_fn(load_V_tma1, pipeline_v)
+                load_V_tma2 = (
+                    cute_copy.tma_producer_copy_fn(load_V_tma2, pipeline_v)
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                load_V_tma3 = (
+                    cute_copy.tma_producer_copy_fn(load_V_tma3, pipeline_v)
+                    if const_expr(self.kv_tma_plane_count > 2)
+                    else None
+                )
+                load_V_tma = None
+            else:
+                load_V_tma = None
+                load_V_tma0 = None
+                load_V_tma1 = None
+                load_V_tma2 = None
+                load_V_tma3 = None
+        sKU8 = (
+            sK
+            if const_expr(self.kv_is_fp8 and self.dtype_kv_storage == cutlass.Uint8)
+            else (
+                cute.recast_tensor(sK, cutlass.Uint8)
+                if const_expr(self.kv_is_fp8)
+                else None
+            )
+        )
+        sVU8 = (
+            sV
+            if const_expr(self.kv_is_fp8 and self.dtype_kv_storage == cutlass.Uint8)
+            else (
+                cute.recast_tensor(sV, cutlass.Uint8)
+                if const_expr(self.kv_is_fp8)
+                else None
+            )
+        )
+        if const_expr(self.traits.num_warps_kv > 1):
+            sync_payload = cute.recast_tensor(
+                payload_u8,
+                Float32,
+            )
+            sync_o_elems = (
+                self.traits.num_warps_kv
+                * self.traits.cta_tile_q
+                * self.traits.head_dim_vo
+            )
+            sSyncO = cute.make_tensor(
+                sync_payload.iterator,
+                cute.make_layout(
+                    (
+                        self.traits.num_warps_kv,
+                        self.traits.cta_tile_q,
+                        self.traits.head_dim_vo,
+                    ),
+                    stride=(
+                        self.traits.cta_tile_q * self.traits.head_dim_vo,
+                        self.traits.head_dim_vo,
+                        1,
+                    ),
+                ),
+            )
+            sSyncMD = cute.make_tensor(
+                sync_payload.iterator + Int32(sync_o_elems),
+                cute.make_layout(
+                    (self.traits.num_warps_kv, self.traits.cta_tile_q, 2),
+                    stride=(self.traits.cta_tile_q * 2, 2, 1),
+                ),
+            )
+            sFinalStage = cute.make_tensor(
+                cute.recast_tensor(sync_payload, self.dtype_o).iterator,
+                cute.make_layout(
+                    (
+                        self.traits.num_warps_kv,
+                        self.traits.cta_tile_q,
+                        self.traits.head_dim_vo * 2,
+                    ),
+                    stride=(
+                        self.traits.cta_tile_q * self.traits.head_dim_vo * 2,
+                        self.traits.head_dim_vo * 2,
+                        1,
+                    ),
+                ),
+            )
+            sFinalStageU32 = cute.recast_tensor(sFinalStage, cutlass.Uint32)
+        else:
+            sync_payload = cute.make_tensor(
+                cute.recast_tensor(cute.flatten(sQ), Float32).iterator,
+                cute.make_layout((4,), stride=(1,)),
+            )
+            sSyncO = cute.make_tensor(
+                sync_payload.iterator,
+                cute.make_layout((1, 1, 1), stride=(1, 1, 1)),
+            )
+            sSyncMD = cute.make_tensor(
+                sync_payload.iterator,
+                cute.make_layout((1, 1, 2), stride=(2, 2, 1)),
+            )
+        merged_store_v128 = const_expr(
+            self.traits.num_warps_kv > 1 and self.dtype_o == cutlass.BFloat16
+        )
+        split_store_v128 = const_expr(
+            self.split_kv
+            and self.traits.num_warps_kv == 1
+            and self.dtype_o == cutlass.BFloat16
+        )
+        final_store_v128 = const_expr(
+            not self.split_kv
+            and self.traits.num_warps_kv == 1
+            and self.dtype_o == cutlass.BFloat16
+        )
+        sOStage = cute.make_tensor(
+            sQ.iterator,
+            cute.make_layout(
+                (self.traits.cta_tile_q, self.traits.head_dim_vo),
+                stride=(self.traits.head_dim_vo, 1),
+            ),
+        )
+        sOStageU32 = cute.recast_tensor(sOStage, cutlass.Uint32)
+        mOFlat = cute.flatten(mO)
+
+        tc_upcast_elems_qk = 16 // (self.dtype_q.width // 8)
+        tc_upcast_stride_qk = self.traits.head_dim_qk // tc_upcast_elems_qk
+        tc_upcast_elems_vo = 16 // (self.dtype_q.width // 8)
+        tc_upcast_elems_plane = 16 // (self.dtype_kv_storage.width // 8)
+        tc_upcast_stride_vo = self.traits.head_dim_vo // tc_upcast_elems_vo
+        tc_upcast_stride_plane = self.kv_tma_plane_head_dim // tc_upcast_elems_plane
+        if const_expr(self.traits.num_warps_kv > 1):
+            sQBytes = cute.flatten(cute.recast_tensor(sQ, cutlass.Uint8))
+            if warp_kv_idx == Int32(0):
+                self._async_copy_q_tile_permuted_128b(
+                    mQBytes,
+                    q_start,
+                    packed_tile_start,
+                    packed_tile_rows,
+                    kv_head_idx,
+                    group_size,
+                    mQ.shape[1],
+                    self.traits.head_dim_qk * (self.dtype_q.width // 8),
+                    q_token_stride_bytes,
+                    q_head_stride_bytes,
+                    sQBytes,
+                    lane,
+                    warp_q_idx,
+                )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+            cute.arch.sync_threads()
+        else:
+            sQBytes = cute.flatten(cute.recast_tensor(sQ, cutlass.Uint8))
+            self._async_copy_q_tile_permuted_128b(
+                mQBytes,
+                q_start,
+                packed_tile_start,
+                packed_tile_rows,
+                kv_head_idx,
+                group_size,
+                mQ.shape[1],
+                self.traits.head_dim_qk * (self.dtype_q.width // 8),
+                q_token_stride_bytes,
+                q_head_stride_bytes,
+                sQBytes,
+                lane,
+                warp_q_idx,
+            )
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.sync_threads()
+
+        k_scale = (
+            mKDescale[request_idx]
+            if const_expr(mKDescale is not None and len(mKDescale.shape) == 1)
+            else (
+                mKDescale[request_idx, kv_head_idx]
+                if const_expr(mKDescale is not None)
+                else Float32(1.0)
+            )
+        )
+        v_scale = (
+            mVDescale[request_idx]
+            if const_expr(mVDescale is not None and len(mVDescale.shape) == 1)
+            else (
+                mVDescale[request_idx, kv_head_idx]
+                if const_expr(mVDescale is not None)
+                else Float32(1.0)
+            )
+        )
+        num_mma_q = self.traits.num_mma_q
+        num_mma_kv = self.traits.num_mma_kv
+        num_mma_d_vo = self.traits.num_mma_d_vo
+        warp_row_base = warp_q_idx * num_mma_q * 16
+        warp_kv_base = warp_kv_idx * num_mma_kv * 16
+        lane_group = lane // 4
+        lane_pair_base = 2 * (lane % 4)
+        row_local_idx = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        row_valid = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_token_local = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_head_idx_frag = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_row_idx_frag = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        causal_k_limit = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        frag_s_layout = cute.make_layout(
+            (num_mma_q, num_mma_kv, 8), stride=(num_mma_kv * 8, 8, 1)
+        )
+        frag_p_layout = cute.make_layout(
+            (num_mma_q, num_mma_kv, 4), stride=(num_mma_kv * 4, 4, 1)
+        )
+        frag_o_layout = cute.make_layout(
+            (num_mma_q, num_mma_d_vo, 8), stride=(num_mma_d_vo * 8, 8, 1)
+        )
+        s_frag = cute.make_rmem_tensor(
+            frag_s_layout,
+            Float32,
+        )
+        tSsQ_tma = None
+        tSrQ_tma = None
+        acc_shape_S_tma = None
+        tiled_mma_qk_tma = None
+        tiled_mma_pv_tma = None
+        thr_mma_qk_tma = None
+        thr_mma_pv_tma = None
+        smem_thr_copy_K_tma = None
+        smem_thr_copy_V_tma = None
+        tScS_mn_tma = None
+        t0ScS_mn_tma = None
+        o_frag = cute.make_rmem_tensor(
+            frag_o_layout,
+            Float32,
+        )
+        m_frag = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        d_frag = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        p_frag = cute.make_rmem_tensor(
+            frag_p_layout,
+            Uint32,
+        )
+        p_frag_scalar_debug = cute.make_rmem_tensor(
+            frag_s_layout,
+            cutlass.BFloat16,
+        )
+        q_smem_base_addr = shared_ptr_to_u32(sQ.iterator)
+
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                packed_row_local = (
+                    warp_row_base + mma_q * 16 + lane_group + 8 * row_slot
+                )
+                row_local_idx[mma_q, row_slot] = Int32(packed_row_local)
+                valid_row = packed_row_local < packed_tile_rows
+                row_valid[mma_q, row_slot] = Int32(valid_row)
+                if valid_row:
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_token_local[mma_q, row_slot] = Int32(token_local)
+                    q_head_idx_frag[mma_q, row_slot] = Int32(
+                        kv_head_idx * group_size + q_group_lane
+                    )
+                    q_row_idx_frag[mma_q, row_slot] = Int32(q_start + token_local)
+                    causal_k_limit[mma_q, row_slot] = Int32(
+                        token_local + cache_len - qo_len
+                    )
+                else:
+                    q_token_local[mma_q, row_slot] = Int32(0)
+                    q_head_idx_frag[mma_q, row_slot] = Int32(0)
+                    q_row_idx_frag[mma_q, row_slot] = Int32(0)
+                    causal_k_limit[mma_q, row_slot] = Int32(-1)
+
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                for reg_id in cutlass.range_constexpr(8):
+                    o_frag[mma_q, mma_d, reg_id] = Float32(0.0)
+            for row_slot in cutlass.range_constexpr(2):
+                m_frag[mma_q, row_slot] = Float32(-Float32.inf)
+                d_frag[mma_q, row_slot] = Float32(1.0)
+
+        prefetch_base = chunk_start
+        preload_count = 0
+        preload_stage_idx = Int32(0)
+        if const_expr(self.use_paged_k_tma or self.use_paged_v_tma):
+            kv_producer_state = cute_pipeline.make_pipeline_state(
+                cutlass.pipeline.PipelineUserType.Producer, self.num_stages
+            )
+            kv_consumer_state = cute_pipeline.make_pipeline_state(
+                cutlass.pipeline.PipelineUserType.Consumer, self.num_stages
+            )
+        else:
+            kv_producer_state = None
+            kv_consumer_state = None
+        if const_expr(self.use_paged_k_tma or self.use_paged_v_tma):
+            if prefetch_base < chunk_end:
+                tile_limit = cutlass.select_(
+                    prefetch_base + stage_tile_rows < chunk_end,
+                    prefetch_base + stage_tile_rows,
+                    chunk_end,
+                )
+                tile_tokens = tile_limit - prefetch_base
+                prefetch_page_idx = self._tile_page_idx(
+                    mQ2KIndices,
+                    mMSAUnionBlocks,
+                    work_idx,
+                    kv_head_idx,
+                    msa_q_row_idx,
+                    prefetch_base,
+                    page_size,
+                )
+                if warp_linear_idx == Int32(0):
+                    if const_expr(self.use_paged_k_tma):
+                        if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                            self._issue_paged_kv_tma_copy_2planes_fp8_raw(
+                                mKTmaDescFlat,
+                                kv_head_idx,
+                                sKStageBytes,
+                                Int32(preload_stage_idx * kv_plane_stage_bytes),
+                                kv_plane_total_bytes,
+                                kv_producer_state,
+                                mbar_ptr_K,
+                                self.kv_tma_copy_bytes_k,
+                                mPageTable,
+                                request_idx,
+                                prefetch_base,
+                                page_size,
+                            )
+                        elif const_expr(self.kv_tma_plane_count > 2):
+                            self._issue_paged_kv_tma_copy_planes(
+                                load_K_tma0,
+                                load_K_tma1,
+                                load_K_tma2,
+                                load_K_tma3,
+                                pipeline_k,
+                                kv_producer_state,
+                                mPageTable,
+                                request_idx,
+                                prefetch_base,
+                                page_size,
+                            )
+                        else:
+                            self._issue_paged_kv_tma_copy_2planes(
+                                load_K_tma0,
+                                load_K_tma1,
+                                pipeline_k,
+                                kv_producer_state,
+                                mPageTable,
+                                request_idx,
+                                prefetch_base,
+                                page_size,
+                            )
+                    if const_expr(self.use_paged_v_tma):
+                        if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                            self._issue_paged_kv_tma_copy_2planes_fp8_raw(
+                                mVTmaDescFlat,
+                                kv_head_idx,
+                                sVStageBytes,
+                                Int32(preload_stage_idx * kv_plane_stage_bytes),
+                                kv_plane_total_bytes,
+                                kv_producer_state,
+                                mbar_ptr_V,
+                                self.kv_tma_copy_bytes_v,
+                                mPageTable,
+                                request_idx,
+                                prefetch_base,
+                                page_size,
+                            )
+                        elif const_expr(self.kv_tma_plane_count > 2):
+                            self._issue_paged_kv_tma_copy_planes(
+                                load_V_tma0,
+                                load_V_tma1,
+                                load_V_tma2,
+                                load_V_tma3,
+                                pipeline_v,
+                                kv_producer_state,
+                                mPageTable,
+                                request_idx,
+                                prefetch_base,
+                                page_size,
+                            )
+                        else:
+                            self._issue_paged_kv_tma_copy_2planes(
+                                load_V_tma0,
+                                load_V_tma1,
+                                pipeline_v,
+                                kv_producer_state,
+                                mPageTable,
+                                request_idx,
+                                prefetch_base,
+                                page_size,
+                            )
+                if const_expr(not self.use_paged_k_tma):
+                    self._async_copy_paged_tile_permuted_128b(
+                        mKBytes,
+                        mPageTable,
+                        request_idx,
+                        prefetch_base,
+                        prefetch_page_idx,
+                        kv_head_idx,
+                        mKCache.shape[2],
+                        k_row_bytes,
+                        k_page_stride_bytes,
+                        k_token_stride_bytes,
+                        k_head_stride_bytes,
+                        sKStageBytes,
+                        Int32(preload_stage_idx * k_stage_bytes),
+                        lane,
+                        warp_linear_idx,
+                        tile_tokens,
+                        self.traits.upcast_stride_k,
+                        False,
+                    )
+                    cute.arch.cp_async_commit_group()
+                if const_expr(not self.use_paged_v_tma):
+                    self._async_copy_paged_tile_permuted_128b(
+                        mVBytes,
+                        mPageTable,
+                        request_idx,
+                        prefetch_base,
+                        prefetch_page_idx,
+                        kv_head_idx,
+                        mVCache.shape[2],
+                        v_row_bytes,
+                        v_page_stride_bytes,
+                        v_token_stride_bytes,
+                        v_head_stride_bytes,
+                        sVStageBytes,
+                        Int32(preload_stage_idx * v_stage_bytes),
+                        lane,
+                        warp_linear_idx,
+                        tile_tokens,
+                        self.traits.upcast_stride_v,
+                        True,
+                    )
+                    cute.arch.cp_async_commit_group()
+                kv_producer_state.advance()
+                prefetch_base += stage_tile_rows
+                preload_count = 1
+        else:
+            while preload_count < self.num_stages and prefetch_base < chunk_end:
+                tile_limit = cutlass.select_(
+                    prefetch_base + stage_tile_rows < chunk_end,
+                    prefetch_base + stage_tile_rows,
+                    chunk_end,
+                )
+                tile_tokens = tile_limit - prefetch_base
+                prefetch_page_idx = self._tile_page_idx(
+                    mQ2KIndices,
+                    mMSAUnionBlocks,
+                    work_idx,
+                    kv_head_idx,
+                    msa_q_row_idx,
+                    prefetch_base,
+                    page_size,
+                )
+                self._async_copy_paged_tile_permuted_128b(
+                    mKBytes,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    prefetch_page_idx,
+                    kv_head_idx,
+                    mKCache.shape[2],
+                    k_row_bytes,
+                    k_page_stride_bytes,
+                    k_token_stride_bytes,
+                    k_head_stride_bytes,
+                    sKStageBytes,
+                    Int32(preload_stage_idx * k_stage_bytes),
+                    lane,
+                    warp_linear_idx,
+                    tile_tokens,
+                    self.traits.upcast_stride_k,
+                    False,
+                )
+                cute.arch.cp_async_commit_group()
+                self._async_copy_paged_tile_permuted_128b(
+                    mVBytes,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    prefetch_page_idx,
+                    kv_head_idx,
+                    mVCache.shape[2],
+                    v_row_bytes,
+                    v_page_stride_bytes,
+                    v_token_stride_bytes,
+                    v_head_stride_bytes,
+                    sVStageBytes,
+                    Int32(preload_stage_idx * v_stage_bytes),
+                    lane,
+                    warp_linear_idx,
+                    tile_tokens,
+                    self.traits.upcast_stride_v,
+                    True,
+                )
+                cute.arch.cp_async_commit_group()
+                prefetch_base += stage_tile_rows
+                preload_count += 1
+                if const_expr(self.num_stages == 2):
+                    preload_stage_idx = Int32(1) - preload_stage_idx
+
+        if const_expr(
+            self.debug_dump_paged_kv_planewords
+            and self.kv_is_fp8
+            and not self.use_paged_k_tma
+            and self.use_paged_v_tma
+        ):
+            if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                cute.arch.mbarrier_wait(mbar_ptr_V + Int32(0), phase=Int32(0))
+            else:
+                pipeline_v.consumer_wait(
+                    kv_consumer_state,
+                    pipeline_v.consumer_try_wait(kv_consumer_state),
+                )
+            cute.arch.sync_threads()
+            if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                _dump_plane_stage_words_u32(
+                    mDebugU32,
+                    sVStageBytes,
+                    Int32(0),
+                    kv_plane_stage_bytes,
+                    kv_plane_total_bytes,
+                    self.kv_tma_plane_count,
+                    tidx,
+                    self.traits.num_threads,
+                )
+            _exit_thread()
+
+        consume_stage_idx = Int32(0)
+        tile_base = chunk_start
+        while tile_base < chunk_end:
+            tile_limit = cutlass.select_(
+                tile_base + stage_tile_rows < chunk_end,
+                tile_base + stage_tile_rows,
+                chunk_end,
+            )
+            tile_key_base = self._tile_key_base(
+                mQ2KIndices,
+                mMSAUnionBlocks,
+                work_idx,
+                kv_head_idx,
+                msa_q_row_idx,
+                tile_base,
+            )
+            tile_tokens = tile_limit - tile_base
+            if const_expr(self.msa_block_sparse):
+                live_limit = (
+                    msa_tile_max_visible_len
+                    if const_expr(self.msa_union_tile)
+                    else msa_visible_len
+                )
+                live_tokens = live_limit - tile_key_base
+                live_tokens = cutlass.select_(
+                    live_tokens < Int32(0), Int32(0), live_tokens
+                )
+                tile_tokens = cutlass.select_(
+                    live_tokens < tile_tokens, live_tokens, tile_tokens
+                )
+            if const_expr(self.use_paged_k_tma):
+                if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                    cute.arch.mbarrier_wait(
+                        mbar_ptr_K + kv_consumer_state.index,
+                        phase=kv_consumer_state.phase,
+                    )
+                else:
+                    pipeline_k.consumer_wait(
+                        kv_consumer_state,
+                        pipeline_k.consumer_try_wait(kv_consumer_state),
+                    )
+            elif const_expr(self.traits.num_warps_kv > 1):
+                cute.arch.cp_async_wait_group(1 if self.kv_is_fp8 else 0)
+            else:
+                cute.arch.cp_async_wait_group(1)
+            cute.arch.sync_threads()
+
+            if const_expr(
+                self.debug_dump_paged_kv_tma_k or self.debug_dump_paged_kv_tma_v
+            ):
+                if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                    _dump_tma_stage_rows(
+                        mO,
+                        sKTma if const_expr(self.debug_dump_paged_kv_tma_k) else sVTma,
+                        tidx,
+                        stage_tile_rows,
+                        self.traits.head_dim_qk
+                        if const_expr(self.debug_dump_paged_kv_tma_k)
+                        else self.traits.head_dim_vo,
+                        self.traits.num_threads,
+                        Int32(24),
+                    )
+                _exit_thread()
+
+            if const_expr(
+                self.debug_dump_paged_kv_extend_kwords
+                or self.debug_dump_paged_kv_extend_vwords
+            ):
+                if (
+                    work_idx == Int32(0)
+                    and kv_head_idx == Int32(0)
+                    and tile_base == chunk_start
+                ):
+                    mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                    _dump_plane_stage_words_u32(
+                        mDebugU32,
+                        sKStageBytes
+                        if const_expr(self.debug_dump_paged_kv_extend_kwords)
+                        else sVStageBytes,
+                        consume_stage_idx,
+                        kv_plane_stage_bytes,
+                        kv_plane_total_bytes,
+                        self.kv_tma_plane_count,
+                        tidx,
+                        self.traits.num_threads,
+                    )
+                _exit_thread()
+
+            subtile_base = (
+                Int32(0) if const_expr(self.traits.num_warps_kv == 1) else warp_kv_base
+            )
+            for _ in cutlass.range_constexpr(1):
+                p_frag.fill(Uint32(0))
+                if const_expr(self.use_native_fp8_qk_mma):
+                    k_smem_base_addr = shared_ptr_to_u32(
+                        sKStageBytes.iterator + Int32(consume_stage_idx * k_stage_bytes)
+                    )
+                    frag_S = cute.make_rmem_tensor(
+                        cute.make_layout(
+                            (num_mma_q, num_mma_kv, 8),
+                            stride=(num_mma_kv * 8, 8, 1),
+                        ),
+                        Float32,
+                    )
+                    frag_S.fill(0.0)
+                    _literal_qk_mma_into_sfrag_mxfp8_raw(
+                        frag_S,
+                        q_smem_base_addr,
+                        k_smem_base_addr,
+                        lane,
+                        warp_q_idx,
+                        warp_kv_idx,
+                        Int32(0)
+                        if const_expr(self.traits.num_warps_kv > 1)
+                        else subtile_base,
+                        num_mma_q,
+                        num_mma_kv,
+                        self.traits.num_mma_d_qk,
+                        tc_upcast_stride_qk,
+                        self.traits.upcast_stride_k,
+                    )
+                    for mma_q in cutlass.range_constexpr(num_mma_q):
+                        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                            for reg_id in cutlass.range_constexpr(8):
+                                row_slot = (reg_id % 4) // 2
+                                key_local = (
+                                    warp_kv_base
+                                    + mma_kv * 16
+                                    + lane_pair_base
+                                    + 8 * (reg_id // 4)
+                                    + (reg_id % 2)
+                                )
+                                valid = row_valid[mma_q, row_slot] != 0
+                                if valid:
+                                    valid = valid and key_local < tile_tokens
+                                if valid:
+                                    key_pos = tile_key_base + key_local
+                                    if const_expr(self.msa_union_tile):
+                                        valid = valid and self._msa_union_row_has_block(
+                                            mMSAUnionMasks,
+                                            work_idx,
+                                            kv_head_idx,
+                                            tile_base,
+                                            q_token_local[mma_q, row_slot],
+                                            msa_tile_first_token,
+                                        )
+                                    valid = (
+                                        valid
+                                        and key_pos <= causal_k_limit[mma_q, row_slot]
+                                    )
+                                    if const_expr(self.window_left >= 0):
+                                        window_start = causal_k_limit[
+                                            mma_q, row_slot
+                                        ] - Int32(self.window_left)
+                                        window_start = cutlass.select_(
+                                            window_start > Int32(0),
+                                            window_start,
+                                            Int32(0),
+                                        )
+                                        valid = valid and key_pos >= window_start
+                                if valid:
+                                    frag_S[mma_q, mma_kv, reg_id] = (
+                                        frag_S[mma_q, mma_kv, reg_id] * k_scale
+                                    )
+                                else:
+                                    frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                        -Float32.inf
+                                    )
+                    if const_expr(self.has_relative_attention_bias):
+                        _apply_relative_attention_bias(
+                            frag_S,
+                            mRelativeAttentionBias,
+                            q_row_idx_frag,
+                            q_head_idx_frag,
+                            causal_k_limit,
+                            tile_key_base,
+                            warp_kv_base,
+                            lane_pair_base,
+                            self.inverse_softmax_scale,
+                            num_mma_q,
+                            num_mma_kv,
+                        )
+                    p_frag_scalar = (
+                        p_frag_scalar_debug
+                        if const_expr(self.debug_dump_paged_kv_extend_pscalars)
+                        else None
+                    )
+                    if const_expr(self.debug_dump_paged_kv_extend_pscalars):
+                        p_frag_scalar.fill(cutlass.BFloat16(0.0))
+                    if (
+                        const_expr(self.traits.num_warps_kv == 1)
+                        or warp_kv_base < tile_tokens
+                    ):
+                        _literal_update_mdo_states_fp32_pack_p(
+                            frag_S,
+                            o_frag,
+                            m_frag,
+                            d_frag,
+                            p_frag,
+                            self.softmax_scale_log2,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            p_frag_scalar,
+                        )
+                elif const_expr(self.kv_is_fp8):
+                    k_smem_base_addr = shared_ptr_to_u32(
+                        sKStageBytes.iterator + Int32(consume_stage_idx * k_stage_bytes)
+                    )
+                    frag_S = cute.make_rmem_tensor(
+                        cute.make_layout(
+                            (num_mma_q, num_mma_kv, 8),
+                            stride=(num_mma_kv * 8, 8, 1),
+                        ),
+                        Float32,
+                    )
+                    frag_S.fill(0.0)
+                    if const_expr(self.use_paged_k_tma):
+                        k_stage_plane_offset = Int32(
+                            consume_stage_idx * kv_plane_stage_bytes
+                        )
+                        _literal_qk_mma_into_sfrag_plane_fp8_raw(
+                            frag_S,
+                            q_smem_base_addr,
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(1 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_q_idx,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            self.traits.num_mma_d_qk,
+                            tc_upcast_stride_qk,
+                            tc_upcast_stride_plane,
+                        )
+                    else:
+                        _literal_qk_mma_into_sfrag_fp8_raw_paired(
+                            frag_S,
+                            q_smem_base_addr,
+                            k_smem_base_addr,
+                            lane,
+                            warp_q_idx,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            self.traits.num_mma_d_qk,
+                            tc_upcast_stride_qk,
+                            self.traits.upcast_stride_k,
+                        )
+                    for mma_q in cutlass.range_constexpr(num_mma_q):
+                        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                            for reg_id in cutlass.range_constexpr(8):
+                                row_slot = (reg_id % 4) // 2
+                                key_local = (
+                                    warp_kv_base
+                                    + mma_kv * 16
+                                    + lane_pair_base
+                                    + 8 * (reg_id // 4)
+                                    + (reg_id % 2)
+                                )
+                                valid = row_valid[mma_q, row_slot] != 0
+                                if valid:
+                                    valid = valid and key_local < tile_tokens
+                                if valid:
+                                    key_pos = tile_key_base + key_local
+                                    if const_expr(self.msa_union_tile):
+                                        valid = valid and self._msa_union_row_has_block(
+                                            mMSAUnionMasks,
+                                            work_idx,
+                                            kv_head_idx,
+                                            tile_base,
+                                            q_token_local[mma_q, row_slot],
+                                            msa_tile_first_token,
+                                        )
+                                    valid = (
+                                        valid
+                                        and key_pos <= causal_k_limit[mma_q, row_slot]
+                                    )
+                                    if const_expr(self.window_left >= 0):
+                                        window_start = causal_k_limit[
+                                            mma_q, row_slot
+                                        ] - Int32(self.window_left)
+                                        window_start = cutlass.select_(
+                                            window_start > Int32(0),
+                                            window_start,
+                                            Int32(0),
+                                        )
+                                        valid = valid and key_pos >= window_start
+                                if valid:
+                                    frag_S[mma_q, mma_kv, reg_id] = (
+                                        frag_S[mma_q, mma_kv, reg_id] * k_scale
+                                    )
+                                else:
+                                    frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                        -Float32.inf
+                                    )
+                    if const_expr(self.has_relative_attention_bias):
+                        _apply_relative_attention_bias(
+                            frag_S,
+                            mRelativeAttentionBias,
+                            q_row_idx_frag,
+                            q_head_idx_frag,
+                            causal_k_limit,
+                            tile_key_base,
+                            warp_kv_base,
+                            lane_pair_base,
+                            self.inverse_softmax_scale,
+                            num_mma_q,
+                            num_mma_kv,
+                        )
+                    p_frag_scalar = (
+                        p_frag_scalar_debug
+                        if const_expr(self.debug_dump_paged_kv_extend_pscalars)
+                        else None
+                    )
+                    if const_expr(self.debug_dump_paged_kv_extend_pscalars):
+                        p_frag_scalar.fill(cutlass.BFloat16(0.0))
+                    if (
+                        const_expr(self.traits.num_warps_kv == 1)
+                        or warp_kv_base < tile_tokens
+                    ):
+                        _literal_update_mdo_states_fp32_pack_p(
+                            frag_S,
+                            o_frag,
+                            m_frag,
+                            d_frag,
+                            p_frag,
+                            self.softmax_scale_log2,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            p_frag_scalar,
+                        )
+                else:
+                    literal_key_base = (
+                        Int32(0)
+                        if const_expr(self.traits.num_warps_kv > 1)
+                        else subtile_base
+                    )
+                    k_smem_base_addr = shared_ptr_to_u32(
+                        sKStageBytes.iterator + Int32(consume_stage_idx * k_stage_bytes)
+                    )
+                    p_frag_scalar = None
+                    if const_expr(self.use_paged_k_tma):
+                        frag_S = cute.make_rmem_tensor(
+                            frag_s_layout,
+                            Float32,
+                        )
+                        frag_S.fill(0.0)
+                        k_stage_plane_offset = Int32(
+                            consume_stage_idx * kv_plane_stage_bytes
+                        )
+                        _literal_qk_mma_into_sfrag_plane_bf16(
+                            frag_S,
+                            q_smem_base_addr,
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(1 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(2 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(3 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_q_idx,
+                            warp_kv_idx,
+                            literal_key_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            self.traits.num_mma_d_qk,
+                            tc_upcast_stride_qk,
+                            tc_upcast_stride_plane,
+                        )
+                    else:
+                        frag_S = cute.make_rmem_tensor(
+                            frag_s_layout,
+                            Float32,
+                        )
+                        frag_S.fill(0.0)
+                        _literal_qk_mma_into_sfrag(
+                            frag_S,
+                            q_smem_base_addr,
+                            k_smem_base_addr,
+                            lane,
+                            warp_q_idx,
+                            warp_kv_idx,
+                            literal_key_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            self.traits.num_mma_d_qk,
+                            tc_upcast_stride_qk,
+                            tc_upcast_stride_qk,
+                        )
+                    for mma_q in cutlass.range_constexpr(num_mma_q):
+                        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                            for reg_id in cutlass.range_constexpr(8):
+                                row_slot = (reg_id % 4) // 2
+                                key_local = (
+                                    warp_kv_base
+                                    + mma_kv * 16
+                                    + lane_pair_base
+                                    + 8 * (reg_id // 4)
+                                    + (reg_id % 2)
+                                )
+                                valid = row_valid[mma_q, row_slot] != 0
+                                if valid:
+                                    valid = valid and key_local < tile_tokens
+                                if valid:
+                                    key_pos = tile_key_base + key_local
+                                    if const_expr(self.msa_union_tile):
+                                        valid = valid and self._msa_union_row_has_block(
+                                            mMSAUnionMasks,
+                                            work_idx,
+                                            kv_head_idx,
+                                            tile_base,
+                                            q_token_local[mma_q, row_slot],
+                                            msa_tile_first_token,
+                                        )
+                                    valid = (
+                                        valid
+                                        and key_pos <= causal_k_limit[mma_q, row_slot]
+                                    )
+                                    if const_expr(self.window_left >= 0):
+                                        window_start = causal_k_limit[
+                                            mma_q, row_slot
+                                        ] - Int32(self.window_left)
+                                        window_start = cutlass.select_(
+                                            window_start > Int32(0),
+                                            window_start,
+                                            Int32(0),
+                                        )
+                                        valid = valid and key_pos >= window_start
+                                # Keep each score selection scalar.  CUTLASS DSL 4.6
+                                # otherwise combines the unrolled branches into b64
+                                # selects, extending pair lifetimes and adding three
+                                # registers to this prefill specialization.
+                                frag_S[mma_q, mma_kv, reg_id] = cutlass.select_(
+                                    valid,
+                                    frag_S[mma_q, mma_kv, reg_id],
+                                    Float32(-Float32.inf),
+                                )
+
+                    if const_expr(self.debug_dump_paged_kv_tma_s):
+                        if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                            _dump_s_frag_tile(
+                                mO,
+                                frag_S,
+                                lane,
+                                warp_q_idx,
+                                warp_kv_idx,
+                                num_mma_q,
+                                num_mma_kv,
+                                packed_tile_rows,
+                                tile_tokens,
+                            )
+                        _exit_thread()
+
+                    if const_expr(self.has_relative_attention_bias):
+                        _apply_relative_attention_bias(
+                            frag_S,
+                            mRelativeAttentionBias,
+                            q_row_idx_frag,
+                            q_head_idx_frag,
+                            causal_k_limit,
+                            tile_key_base,
+                            warp_kv_base,
+                            lane_pair_base,
+                            self.inverse_softmax_scale,
+                            num_mma_q,
+                            num_mma_kv,
+                        )
+                    p_frag_scalar = (
+                        p_frag_scalar_debug
+                        if const_expr(self.debug_dump_paged_kv_extend_pscalars)
+                        else None
+                    )
+                    if const_expr(self.debug_dump_paged_kv_extend_pscalars):
+                        p_frag_scalar.fill(cutlass.BFloat16(0.0))
+                    _literal_update_mdo_states_fp32_pack_p(
+                        frag_S,
+                        o_frag,
+                        m_frag,
+                        d_frag,
+                        p_frag,
+                        self.softmax_scale_log2,
+                        num_mma_q,
+                        num_mma_kv,
+                        num_mma_d_vo,
+                        p_frag_scalar,
+                    )
+                if const_expr(self.debug_dump_paged_kv_pregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and warp_q_idx == Int32(0)
+                        and warp_kv_idx == Int32(0)
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        _dump_p_frag_regs_raw(
+                            mDebugU32,
+                            p_frag,
+                            lane,
+                        )
+                    _exit_thread()
+                if const_expr(self.debug_dump_paged_kv_sregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and warp_q_idx == Int32(0)
+                        and warp_kv_idx == Int32(0)
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        _dump_s_frag_regs_raw(
+                            mDebugU32,
+                            frag_S,
+                            lane,
+                        )
+                    _exit_thread()
+                if const_expr(self.debug_dump_paged_kv_extend_sregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and tile_base == chunk_start
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        lane_words = num_mma_q * num_mma_kv * 8
+                        dst_word_offset = (
+                            (warp_q_idx * Int32(self.traits.num_warps_kv) + warp_kv_idx)
+                            * Int32(32)
+                            * lane_words
+                        )
+                        _dump_s_frag_regs_raw_offset(
+                            mDebugU32,
+                            frag_S,
+                            lane,
+                            dst_word_offset,
+                        )
+                    _exit_thread()
+                for mma_q in cutlass.range_constexpr(num_mma_q):
+                    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                        d0, d1 = bf16_rowsum_m16k16_f32(
+                            d_frag[mma_q, 0],
+                            d_frag[mma_q, 1],
+                            p_frag[mma_q, mma_kv, 0],
+                            p_frag[mma_q, mma_kv, 1],
+                            p_frag[mma_q, mma_kv, 2],
+                            p_frag[mma_q, mma_kv, 3],
+                        )
+                        d_frag[mma_q, 0] = d0
+                        d_frag[mma_q, 1] = d1
+                if const_expr(self.kv_is_fp8 and self.traits.num_warps_kv > 1):
+                    if warp_kv_base >= tile_tokens:
+                        for mma_q in cutlass.range_constexpr(num_mma_q):
+                            for row_slot in cutlass.range_constexpr(2):
+                                m_frag[mma_q, row_slot] = Float32(-Float32.inf)
+                                d_frag[mma_q, row_slot] = Float32(1.0)
+                            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                                for reg_id in cutlass.range_constexpr(8):
+                                    o_frag[mma_q, mma_d, reg_id] = Float32(0.0)
+
+                if const_expr(self.debug_dump_paged_kv_extend_state):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and tile_base == chunk_start
+                    ):
+                        dump_base = (
+                            warp_q_idx * Int32(self.traits.num_warps_kv) + warp_kv_idx
+                        ) * Int32(4)
+                        if lane == Int32(0):
+                            mLSE[dump_base + 0, 0] = m_frag[0, 0]
+                            mLSE[dump_base + 1, 0] = d_frag[0, 0]
+                            mLSE[dump_base + 2, 0] = m_frag[0, 1]
+                            mLSE[dump_base + 3, 0] = d_frag[0, 1]
+                    _exit_thread()
+                if const_expr(self.debug_dump_paged_kv_extend_pregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and tile_base == chunk_start
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        lane_words = num_mma_kv * 4
+                        dst_idx = (
+                            (warp_q_idx * Int32(self.traits.num_warps_kv) + warp_kv_idx)
+                            * Int32(32)
+                            + lane
+                        ) * lane_words
+                        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                            word_base = dst_idx + mma_kv * 4
+                            mDebugU32[word_base + 0] = p_frag[0, mma_kv, 0]
+                            mDebugU32[word_base + 1] = p_frag[0, mma_kv, 1]
+                            mDebugU32[word_base + 2] = p_frag[0, mma_kv, 2]
+                            mDebugU32[word_base + 3] = p_frag[0, mma_kv, 3]
+                    _exit_thread()
+                if const_expr(self.debug_dump_paged_kv_extend_pscalars):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and tile_base == chunk_start
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        lane_words = num_mma_q * num_mma_kv * 4
+                        dst_word_offset = (
+                            (warp_q_idx * Int32(self.traits.num_warps_kv) + warp_kv_idx)
+                            * Int32(32)
+                            * lane_words
+                        )
+                        _dump_flat_u32_words_offset(
+                            mDebugU32,
+                            cute.flatten(
+                                cute.recast_tensor(p_frag_scalar_debug, cutlass.Uint32)
+                            ),
+                            dst_word_offset,
+                            lane,
+                            Int32(32),
+                        )
+                    _exit_thread()
+
+                if const_expr(
+                    self.use_paged_k_tma and not self.use_paged_kv_tma_fp8_raw_issue
+                ):
+                    pipeline_k.consumer_release(kv_consumer_state)
+
+                next_tile_base = prefetch_base
+                next_tile_tokens = Int32(0)
+                next_page_idx = Int32(0)
+                if const_expr(not self.use_paged_k_tma):
+                    if const_expr(self.traits.num_warps_kv > 1):
+                        if next_tile_base < chunk_end:
+                            next_tile_limit = cutlass.select_(
+                                next_tile_base + stage_tile_rows < chunk_end,
+                                next_tile_base + stage_tile_rows,
+                                chunk_end,
+                            )
+                            next_tile_tokens = next_tile_limit - next_tile_base
+                            next_page_idx = self._tile_page_idx(
+                                mQ2KIndices,
+                                mMSAUnionBlocks,
+                                work_idx,
+                                kv_head_idx,
+                                msa_q_row_idx,
+                                next_tile_base,
+                                page_size,
+                            )
+                            self._async_copy_paged_tile_permuted_128b(
+                                mKBytes,
+                                mPageTable,
+                                request_idx,
+                                next_tile_base,
+                                next_page_idx,
+                                kv_head_idx,
+                                mKCache.shape[2],
+                                k_row_bytes,
+                                k_page_stride_bytes,
+                                k_token_stride_bytes,
+                                k_head_stride_bytes,
+                                sKStageBytes,
+                                Int32(consume_stage_idx * k_stage_bytes),
+                                lane,
+                                warp_linear_idx,
+                                next_tile_tokens,
+                                self.traits.upcast_stride_k,
+                                False,
+                            )
+                            cute.arch.cp_async_commit_group()
+                        cute.arch.cp_async_wait_group(1)
+                        cute.arch.sync_threads()
+                    elif const_expr(self.traits.num_warps_kv == 1):
+                        if next_tile_base < chunk_end:
+                            next_tile_limit = cutlass.select_(
+                                next_tile_base + stage_tile_rows < chunk_end,
+                                next_tile_base + stage_tile_rows,
+                                chunk_end,
+                            )
+                            next_tile_tokens = next_tile_limit - next_tile_base
+                            next_page_idx = self._tile_page_idx(
+                                mQ2KIndices,
+                                mMSAUnionBlocks,
+                                work_idx,
+                                kv_head_idx,
+                                msa_q_row_idx,
+                                next_tile_base,
+                                page_size,
+                            )
+                            self._async_copy_paged_tile_permuted_128b(
+                                mKBytes,
+                                mPageTable,
+                                request_idx,
+                                next_tile_base,
+                                next_page_idx,
+                                kv_head_idx,
+                                mKCache.shape[2],
+                                k_row_bytes,
+                                k_page_stride_bytes,
+                                k_token_stride_bytes,
+                                k_head_stride_bytes,
+                                sKStageBytes,
+                                Int32(consume_stage_idx * k_stage_bytes),
+                                lane,
+                                warp_linear_idx,
+                                next_tile_tokens,
+                                self.traits.upcast_stride_k,
+                                False,
+                            )
+                            cute.arch.cp_async_commit_group()
+                        cute.arch.cp_async_wait_group(1)
+                        cute.arch.sync_threads()
+
+                if const_expr(self.use_paged_v_tma):
+                    if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                        cute.arch.mbarrier_wait(
+                            mbar_ptr_V + kv_consumer_state.index,
+                            phase=kv_consumer_state.phase,
+                        )
+                    else:
+                        pipeline_v.consumer_wait(
+                            kv_consumer_state,
+                            pipeline_v.consumer_try_wait(kv_consumer_state),
+                        )
+                elif const_expr(self.use_paged_k_tma):
+                    cute.arch.cp_async_wait_group(0)
+                    cute.arch.sync_threads()
+
+                if const_expr(self.debug_dump_paged_kv_pvregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and warp_q_idx == Int32(0)
+                        and warp_kv_idx == Int32(0)
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        pv_row_base = (
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base
+                        )
+                        if const_expr(self.kv_is_fp8):
+                            if const_expr(self.use_paged_v_tma):
+                                v_stage_plane_offset = Int32(
+                                    consume_stage_idx * kv_plane_stage_bytes
+                                )
+                                _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                                    o_frag,
+                                    p_frag,
+                                    shared_ptr_to_u32(
+                                        sVStageBytes.iterator
+                                        + v_stage_plane_offset
+                                        + Int32(0 * kv_plane_total_bytes)
+                                    ),
+                                    shared_ptr_to_u32(
+                                        sVStageBytes.iterator
+                                        + v_stage_plane_offset
+                                        + Int32(1 * kv_plane_total_bytes)
+                                    ),
+                                    lane,
+                                    warp_kv_idx,
+                                    pv_row_base,
+                                    num_mma_q,
+                                    num_mma_kv,
+                                    num_mma_d_vo,
+                                    tc_upcast_stride_plane,
+                                    v_scale,
+                                    mDebugU32,
+                                )
+                            else:
+                                _literal_pv_mma_into_ofrag_fp8_raw(
+                                    o_frag,
+                                    p_frag,
+                                    shared_ptr_to_u32(
+                                        sVStageBytes.iterator
+                                        + Int32(consume_stage_idx * v_stage_bytes)
+                                    ),
+                                    lane,
+                                    warp_kv_idx,
+                                    pv_row_base,
+                                    num_mma_q,
+                                    num_mma_kv,
+                                    num_mma_d_vo,
+                                    tc_upcast_stride_vo,
+                                    v_scale,
+                                    mDebugU32,
+                                )
+                        elif const_expr(self.use_paged_v_tma):
+                            v_stage_plane_offset = Int32(
+                                consume_stage_idx * kv_plane_stage_bytes
+                            )
+                            _literal_pv_mma_into_ofrag_plane_bf16_packed(
+                                o_frag,
+                                p_frag,
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(0 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(1 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(2 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(3 * kv_plane_total_bytes)
+                                ),
+                                lane,
+                                warp_kv_idx,
+                                pv_row_base,
+                                num_mma_q,
+                                num_mma_kv,
+                                num_mma_d_vo,
+                                tc_upcast_stride_plane,
+                                v_scale,
+                                mDebugU32,
+                            )
+                        else:
+                            _literal_pv_mma_into_ofrag_bf16_packed(
+                                o_frag,
+                                p_frag,
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + Int32(consume_stage_idx * v_stage_bytes)
+                                ),
+                                lane,
+                                warp_kv_idx,
+                                pv_row_base,
+                                num_mma_q,
+                                num_mma_kv,
+                                num_mma_d_vo,
+                                tc_upcast_stride_vo,
+                                v_scale,
+                                mDebugU32,
+                            )
+                    _exit_thread()
+
+                if const_expr(self.debug_dump_paged_kv_svwords):
+                    if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        _dump_flat_u32_words(
+                            mDebugU32,
+                            cute.recast_tensor(
+                                sV[None, None, consume_stage_idx],
+                                cutlass.Uint32,
+                            ),
+                            tidx,
+                            self.traits.num_threads,
+                        )
+                    _exit_thread()
+
+                if const_expr(self.debug_dump_paged_kv_planewords):
+                    if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        _dump_plane_stage_words_u32(
+                            mDebugU32,
+                            sVStageBytes,
+                            consume_stage_idx,
+                            kv_plane_stage_bytes,
+                            kv_plane_total_bytes,
+                            self.kv_tma_plane_count,
+                            tidx,
+                            self.traits.num_threads,
+                        )
+                    _exit_thread()
+
+                if const_expr(self.use_native_fp8_pv_mma):
+                    v_smem_base_addr = shared_ptr_to_u32(
+                        sVStageBytes.iterator + Int32(consume_stage_idx * v_stage_bytes)
+                    )
+                    _literal_pv_mma_into_ofrag_mxfp8_raw(
+                        o_frag,
+                        p_frag,
+                        v_smem_base_addr,
+                        lane,
+                        warp_kv_idx,
+                        Int32(0)
+                        if const_expr(self.traits.num_warps_kv > 1)
+                        else subtile_base,
+                        num_mma_q,
+                        num_mma_kv,
+                        num_mma_d_vo,
+                        self.traits.upcast_stride_v,
+                        v_scale,
+                    )
+                elif const_expr(self.kv_is_fp8):
+                    v_smem_base_addr = shared_ptr_to_u32(
+                        sVStageBytes.iterator + Int32(consume_stage_idx * v_stage_bytes)
+                    )
+                    if const_expr(self.use_paged_v_tma):
+                        v_stage_plane_offset = Int32(
+                            consume_stage_idx * kv_plane_stage_bytes
+                        )
+                        _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                            o_frag,
+                            p_frag,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(1 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+                    else:
+                        _literal_pv_mma_into_ofrag_fp8_raw(
+                            o_frag,
+                            p_frag,
+                            v_smem_base_addr,
+                            lane,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            self.traits.upcast_stride_v,
+                            v_scale,
+                        )
+                else:
+                    v_smem_base_addr = shared_ptr_to_u32(
+                        sVStageBytes.iterator + Int32(consume_stage_idx * v_stage_bytes)
+                    )
+                    if const_expr(self.use_paged_v_tma):
+                        v_stage_plane_offset = Int32(
+                            consume_stage_idx * kv_plane_stage_bytes
+                        )
+                        _literal_pv_mma_into_ofrag_plane_bf16_packed(
+                            o_frag,
+                            p_frag,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(1 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(2 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(3 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+                    else:
+                        _literal_pv_mma_into_ofrag_bf16_packed(
+                            o_frag,
+                            p_frag,
+                            v_smem_base_addr,
+                            lane,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            tc_upcast_stride_vo,
+                            v_scale,
+                        )
+
+                if const_expr(
+                    self.use_paged_v_tma and not self.use_paged_kv_tma_fp8_raw_issue
+                ):
+                    pipeline_v.consumer_release(kv_consumer_state)
+                if const_expr(self.use_paged_k_tma or self.use_paged_v_tma):
+                    kv_consumer_state.advance()
+                    if next_tile_base < chunk_end:
+                        if warp_linear_idx == Int32(0):
+                            if const_expr(self.use_paged_k_tma):
+                                if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                                    self._issue_paged_kv_tma_copy_2planes_fp8_raw(
+                                        mKTmaDescFlat,
+                                        kv_head_idx,
+                                        sKStageBytes,
+                                        Int32(consume_stage_idx * kv_plane_stage_bytes),
+                                        kv_plane_total_bytes,
+                                        kv_producer_state,
+                                        mbar_ptr_K,
+                                        self.kv_tma_copy_bytes_k,
+                                        mPageTable,
+                                        request_idx,
+                                        next_tile_base,
+                                        page_size,
+                                    )
+                                elif const_expr(self.kv_tma_plane_count > 2):
+                                    self._issue_paged_kv_tma_copy_planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        load_K_tma2,
+                                        load_K_tma3,
+                                        pipeline_k,
+                                        kv_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_tile_base,
+                                        page_size,
+                                    )
+                                else:
+                                    self._issue_paged_kv_tma_copy_2planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        pipeline_k,
+                                        kv_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_tile_base,
+                                        page_size,
+                                    )
+                            if const_expr(self.use_paged_v_tma):
+                                if const_expr(self.use_paged_kv_tma_fp8_raw_issue):
+                                    self._issue_paged_kv_tma_copy_2planes_fp8_raw(
+                                        mVTmaDescFlat,
+                                        kv_head_idx,
+                                        sVStageBytes,
+                                        Int32(consume_stage_idx * kv_plane_stage_bytes),
+                                        kv_plane_total_bytes,
+                                        kv_producer_state,
+                                        mbar_ptr_V,
+                                        self.kv_tma_copy_bytes_v,
+                                        mPageTable,
+                                        request_idx,
+                                        next_tile_base,
+                                        page_size,
+                                    )
+                                elif const_expr(self.kv_tma_plane_count > 2):
+                                    self._issue_paged_kv_tma_copy_planes(
+                                        load_V_tma0,
+                                        load_V_tma1,
+                                        load_V_tma2,
+                                        load_V_tma3,
+                                        pipeline_v,
+                                        kv_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_tile_base,
+                                        page_size,
+                                    )
+                                else:
+                                    self._issue_paged_kv_tma_copy_2planes(
+                                        load_V_tma0,
+                                        load_V_tma1,
+                                        pipeline_v,
+                                        kv_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_tile_base,
+                                        page_size,
+                                    )
+                        if const_expr(not self.use_paged_k_tma):
+                            self._async_copy_paged_tile_permuted_128b(
+                                mKBytes,
+                                mPageTable,
+                                request_idx,
+                                next_tile_base,
+                                next_page_idx,
+                                kv_head_idx,
+                                mKCache.shape[2],
+                                k_row_bytes,
+                                k_page_stride_bytes,
+                                k_token_stride_bytes,
+                                k_head_stride_bytes,
+                                sKStageBytes,
+                                Int32(consume_stage_idx * k_stage_bytes),
+                                lane,
+                                warp_linear_idx,
+                                next_tile_tokens,
+                                self.traits.upcast_stride_k,
+                                False,
+                            )
+                            cute.arch.cp_async_commit_group()
+                        if const_expr(not self.use_paged_v_tma):
+                            self._async_copy_paged_tile_permuted_128b(
+                                mVBytes,
+                                mPageTable,
+                                request_idx,
+                                next_tile_base,
+                                next_page_idx,
+                                kv_head_idx,
+                                mVCache.shape[2],
+                                v_row_bytes,
+                                v_page_stride_bytes,
+                                v_token_stride_bytes,
+                                v_head_stride_bytes,
+                                sVStageBytes,
+                                Int32(consume_stage_idx * v_stage_bytes),
+                                lane,
+                                warp_linear_idx,
+                                next_tile_tokens,
+                                self.traits.upcast_stride_v,
+                                True,
+                            )
+                            cute.arch.cp_async_commit_group()
+                        kv_producer_state.advance()
+                        prefetch_base += stage_tile_rows
+                elif const_expr(self.traits.num_warps_kv > 1):
+                    if next_tile_base < chunk_end:
+                        self._async_copy_paged_tile_permuted_128b(
+                            mVBytes,
+                            mPageTable,
+                            request_idx,
+                            next_tile_base,
+                            next_page_idx,
+                            kv_head_idx,
+                            mVCache.shape[2],
+                            v_row_bytes,
+                            v_page_stride_bytes,
+                            v_token_stride_bytes,
+                            v_head_stride_bytes,
+                            sVStageBytes,
+                            Int32(consume_stage_idx * v_stage_bytes),
+                            lane,
+                            warp_linear_idx,
+                            next_tile_tokens,
+                            self.traits.upcast_stride_v,
+                            True,
+                        )
+                        cute.arch.cp_async_commit_group()
+                        prefetch_base += stage_tile_rows
+                elif const_expr(self.traits.num_warps_kv == 1):
+                    if next_tile_base < chunk_end:
+                        self._async_copy_paged_tile_permuted_128b(
+                            mVBytes,
+                            mPageTable,
+                            request_idx,
+                            next_tile_base,
+                            next_page_idx,
+                            kv_head_idx,
+                            mVCache.shape[2],
+                            v_row_bytes,
+                            v_page_stride_bytes,
+                            v_token_stride_bytes,
+                            v_head_stride_bytes,
+                            sVStageBytes,
+                            Int32(consume_stage_idx * v_stage_bytes),
+                            lane,
+                            warp_linear_idx,
+                            next_tile_tokens,
+                            self.traits.upcast_stride_v,
+                            True,
+                        )
+                        cute.arch.cp_async_commit_group()
+                        prefetch_base += stage_tile_rows
+
+            cute.arch.sync_threads()
+            if const_expr(self.num_stages == 2):
+                consume_stage_idx = Int32(1) - consume_stage_idx
+            tile_base += stage_tile_rows
+
+        if const_expr(self.use_paged_k_tma or self.use_paged_v_tma):
+            if warp_linear_idx == Int32(0):
+                if const_expr(
+                    self.use_paged_k_tma and not self.use_paged_kv_tma_fp8_raw_issue
+                ):
+                    pipeline_k.producer_tail(kv_producer_state.clone())
+                if const_expr(
+                    self.use_paged_v_tma and not self.use_paged_kv_tma_fp8_raw_issue
+                ):
+                    pipeline_v.producer_tail(kv_producer_state.clone())
+
+        if const_expr(not self.has_attention_sink_bias):
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                for row_slot in cutlass.range_constexpr(2):
+                    if m_frag[mma_q, row_slot] != -Float32.inf:
+                        m_frag[mma_q, row_slot] = Float32(
+                            m_frag[mma_q, row_slot] * self.softmax_scale_log2
+                        )
+        else:
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                for row_slot in cutlass.range_constexpr(2):
+                    _apply_attention_sink_after_lse_scale(
+                        o_frag,
+                        m_frag,
+                        d_frag,
+                        mAttentionSinkBias,
+                        mma_q,
+                        row_slot,
+                        q_head_idx_frag[mma_q, row_slot],
+                        row_valid[mma_q, row_slot],
+                        causal_k_limit[mma_q, row_slot],
+                        chunk_start,
+                        chunk_end,
+                        warp_kv_idx,
+                        num_mma_d_vo,
+                        self.softmax_scale_log2,
+                        self.has_attention_sink_bias,
+                        self.split_kv,
+                    )
+
+        if const_expr(self.traits.num_warps_kv > 1):
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                for row_slot in cutlass.range_constexpr(2):
+                    packed_row_local = row_local_idx[mma_q, row_slot]
+                    if row_valid[mma_q, row_slot] != 0 and lane_pair_base == 0:
+                        sSyncMD[warp_kv_idx, packed_row_local, 0] = m_frag[
+                            mma_q, row_slot
+                        ]
+                        sSyncMD[warp_kv_idx, packed_row_local, 1] = d_frag[
+                            mma_q, row_slot
+                        ]
+                    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                        dim_low = mma_d * 16 + lane_pair_base
+                        dim_high = dim_low + 8
+                        reg_base = row_slot * 2
+                        if row_valid[mma_q, row_slot] != 0:
+                            sSyncO[warp_kv_idx, packed_row_local, dim_low + 0] = o_frag[
+                                mma_q, mma_d, reg_base + 0
+                            ]
+                            sSyncO[warp_kv_idx, packed_row_local, dim_low + 1] = o_frag[
+                                mma_q, mma_d, reg_base + 1
+                            ]
+                            sSyncO[warp_kv_idx, packed_row_local, dim_high + 0] = (
+                                o_frag[mma_q, mma_d, reg_base + 4]
+                            )
+                            sSyncO[warp_kv_idx, packed_row_local, dim_high + 1] = (
+                                o_frag[mma_q, mma_d, reg_base + 5]
+                            )
+            cute.arch.sync_threads()
+            if const_expr(self.debug_dump_paged_kv_extend_partials):
+                if (
+                    work_idx == Int32(0)
+                    and kv_head_idx == Int32(0)
+                    and warp_q_idx == Int32(0)
+                    and warp_kv_idx == Int32(0)
+                    and lane == Int32(0)
+                ):
+                    debug_idx = Int32(0)
+                    for packed_row_local_dump in cutlass.range_constexpr(
+                        self.traits.cta_tile_q
+                    ):
+                        packed_q_idx = packed_tile_start + Int32(packed_row_local_dump)
+                        token_local_dump = packed_q_idx // group_size
+                        q_group_lane_dump = packed_q_idx - token_local_dump * group_size
+                        q_head_idx_dump = kv_head_idx * group_size + q_group_lane_dump
+                        q_row_idx_dump = q_start + token_local_dump
+                        valid_row_dump = packed_row_local_dump < packed_tile_rows
+                        mOFlat[debug_idx + 0] = (
+                            Float32(q_row_idx_dump).to(self.dtype_o)
+                            if valid_row_dump
+                            else self.dtype_o(0.0)
+                        )
+                        mOFlat[debug_idx + 1] = (
+                            Float32(q_head_idx_dump).to(self.dtype_o)
+                            if valid_row_dump
+                            else self.dtype_o(0.0)
+                        )
+                        debug_idx += 2
+                        for kv_warp_dump in cutlass.range_constexpr(
+                            self.traits.num_warps_kv
+                        ):
+                            part_m = sSyncMD[kv_warp_dump, packed_row_local_dump, 0]
+                            part_d = sSyncMD[kv_warp_dump, packed_row_local_dump, 1]
+                            mOFlat[debug_idx + 0] = (
+                                part_m.to(self.dtype_o)
+                                if valid_row_dump
+                                else self.dtype_o(0.0)
+                            )
+                            mOFlat[debug_idx + 1] = (
+                                part_d.to(self.dtype_o)
+                                if valid_row_dump
+                                else self.dtype_o(0.0)
+                            )
+                            debug_idx += 2
+                            for dim_dump in cutlass.range_constexpr(8):
+                                part_o = sSyncO[
+                                    kv_warp_dump, packed_row_local_dump, dim_dump
+                                ]
+                                mOFlat[debug_idx + dim_dump] = (
+                                    part_o.to(self.dtype_o)
+                                    if valid_row_dump
+                                    else self.dtype_o(0.0)
+                                )
+                            debug_idx += 8
+                _exit_thread()
+
+        store_enabled = valid_work and warp_kv_idx == 0
+        packed_row_local = Int32(0)
+        q_head_idx = Int32(0)
+        q_row_idx = Int32(0)
+        token_local = Int32(0)
+        partial_row_idx = Int32(0)
+        if const_expr(self.traits.num_warps_kv > 1):
+            if store_enabled:
+                for mma_q in cutlass.range_constexpr(num_mma_q):
+                    for row_slot in cutlass.range_constexpr(2):
+                        packed_row_local = row_local_idx[mma_q, row_slot]
+                        q_head_idx = q_head_idx_frag[mma_q, row_slot]
+                        q_row_idx = q_row_idx_frag[mma_q, row_slot]
+                        token_local = q_token_local[mma_q, row_slot]
+                        valid_row_store = row_valid[mma_q, row_slot] != 0
+                        merged_m = Float32(-Float32.inf)
+                        merged_d = Float32(1.0)
+                        inv_d = Float32(0.0)
+                        merge_scale = cute.make_rmem_tensor(
+                            cute.make_layout((self.traits.num_warps_kv,), stride=(1,)),
+                            Float32,
+                        )
+                        merge_scale.fill(0.0)
+                        if valid_row_store:
+                            for kv_warp in cutlass.range_constexpr(
+                                self.traits.num_warps_kv
+                            ):
+                                part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                                part_d = sSyncMD[kv_warp, packed_row_local, 1]
+                                if merged_m == -Float32.inf:
+                                    merged_m = part_m
+                                    merged_d = part_d
+                                elif part_m != -Float32.inf:
+                                    new_m = attention_ops.fmax(merged_m, part_m)
+                                    merged_d = Float32(
+                                        merged_d
+                                        * _exp2_approx_ftz_f32(merged_m - new_m)
+                                        + part_d * _exp2_approx_ftz_f32(part_m - new_m)
+                                    )
+                                    merged_m = new_m
+                            if merged_m != -Float32.inf:
+                                inv_d = cute.arch.rcp_approx(merged_d)
+                                for kv_warp in cutlass.range_constexpr(
+                                    self.traits.num_warps_kv
+                                ):
+                                    part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                                    merge_scale[kv_warp] = (
+                                        Float32(0.0)
+                                        if part_m == -Float32.inf
+                                        else _exp2_approx_ftz_f32(part_m - merged_m)
+                                    )
+
+                        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                            dim_low = mma_d * 16 + lane_pair_base
+                            dim_high = dim_low + 8
+                            out_low0 = Float32(0.0)
+                            out_low1 = Float32(0.0)
+                            out_high0 = Float32(0.0)
+                            out_high1 = Float32(0.0)
+                            if valid_row_store and merged_m != -Float32.inf:
+                                acc_low0 = Float32(0.0)
+                                acc_low1 = Float32(0.0)
+                                acc_high0 = Float32(0.0)
+                                acc_high1 = Float32(0.0)
+                                for kv_warp in cutlass.range_constexpr(
+                                    self.traits.num_warps_kv
+                                ):
+                                    scale = merge_scale[kv_warp]
+                                    acc_low0 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_low + 0]
+                                        * scale
+                                    )
+                                    acc_low1 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_low + 1]
+                                        * scale
+                                    )
+                                    acc_high0 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_high + 0]
+                                        * scale
+                                    )
+                                    acc_high1 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_high + 1]
+                                        * scale
+                                    )
+                                out_low0 = acc_low0 * inv_d
+                                out_low1 = acc_low1 * inv_d
+                                out_high0 = acc_high0 * inv_d
+                                out_high1 = acc_high1 * inv_d
+
+                            if valid_row_store:
+                                if const_expr(self.dtype_o == cutlass.BFloat16):
+                                    sFinalStageU32[
+                                        0, packed_row_local, dim_low // 2
+                                    ] = pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                    sFinalStageU32[
+                                        0, packed_row_local, dim_high // 2
+                                    ] = pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                elif split_store_v128:
+                                    sOStageU32[packed_row_local, dim_low // 2] = (
+                                        pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                    )
+                                    sOStageU32[packed_row_local, dim_high // 2] = (
+                                        pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                    )
+                                elif final_store_v128:
+                                    sOStageU32[packed_row_local, dim_low // 2] = (
+                                        pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                    )
+                                    sOStageU32[packed_row_local, dim_high // 2] = (
+                                        pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                    )
+                                elif const_expr(self.split_kv):
+                                    partial_row_idx = (
+                                        request_partial_start
+                                        + token_local * num_chunks_kv
+                                        + kv_tile_idx
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                        out_low0.to(self.dtype_o)
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                        out_low1.to(self.dtype_o)
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                        out_high0.to(self.dtype_o)
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                        out_high1.to(self.dtype_o)
+                                    )
+                                else:
+                                    mO[q_row_idx, q_head_idx, dim_low + 0] = (
+                                        out_low0.to(self.dtype_o)
+                                    )
+                                    mO[q_row_idx, q_head_idx, dim_low + 1] = (
+                                        out_low1.to(self.dtype_o)
+                                    )
+                                    mO[q_row_idx, q_head_idx, dim_high + 0] = (
+                                        out_high0.to(self.dtype_o)
+                                    )
+                                    mO[q_row_idx, q_head_idx, dim_high + 1] = (
+                                        out_high1.to(self.dtype_o)
+                                    )
+                        if valid_row_store and (lane_pair_base == 0 or self.kv_is_fp8):
+                            row_lse = (
+                                Float32(-Float32.inf)
+                                if merged_m == -Float32.inf
+                                else Float32(
+                                    merged_m + cute.math.log2(merged_d, fastmath=True)
+                                )
+                            )
+                            if const_expr(self.split_kv):
+                                partial_row_idx = (
+                                    request_partial_start
+                                    + token_local * num_chunks_kv
+                                    + kv_tile_idx
+                                )
+                                mLSE[partial_row_idx, q_head_idx] = row_lse
+                            else:
+                                mLSE[q_head_idx, q_row_idx] = row_lse
+        else:
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                for row_slot in cutlass.range_constexpr(2):
+                    packed_row_local = row_local_idx[mma_q, row_slot]
+                    q_head_idx = q_head_idx_frag[mma_q, row_slot]
+                    q_row_idx = q_row_idx_frag[mma_q, row_slot]
+                    token_local = q_token_local[mma_q, row_slot]
+                    valid_row_store = row_valid[mma_q, row_slot] != 0
+                    merged_m = Float32(-Float32.inf)
+                    merged_d = Float32(1.0)
+                    inv_d = Float32(0.0)
+                    if store_enabled and valid_row_store:
+                        merged_m = m_frag[mma_q, row_slot]
+                        merged_d = d_frag[mma_q, row_slot]
+                        if merged_m != -Float32.inf:
+                            inv_d = cute.arch.rcp_approx(merged_d)
+
+                    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                        dim_low = mma_d * 16 + lane_pair_base
+                        dim_high = dim_low + 8
+                        reg_base = row_slot * 2
+                        out_low0 = Float32(0.0)
+                        out_low1 = Float32(0.0)
+                        out_high0 = Float32(0.0)
+                        out_high1 = Float32(0.0)
+                        if (
+                            store_enabled
+                            and valid_row_store
+                            and merged_m != -Float32.inf
+                        ):
+                            out_low0 = o_frag[mma_q, mma_d, reg_base + 0] * inv_d
+                            out_low1 = o_frag[mma_q, mma_d, reg_base + 1] * inv_d
+                            out_high0 = o_frag[mma_q, mma_d, reg_base + 4] * inv_d
+                            out_high1 = o_frag[mma_q, mma_d, reg_base + 5] * inv_d
+
+                        if store_enabled and valid_row_store:
+                            if split_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif final_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif const_expr(self.split_kv):
+                                partial_row_idx = (
+                                    request_partial_start
+                                    + token_local * num_chunks_kv
+                                    + kv_tile_idx
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                    out_low0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                    out_low1.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                    out_high0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                    out_high1.to(self.dtype_o)
+                                )
+                            else:
+                                mO[q_row_idx, q_head_idx, dim_low + 0] = out_low0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_low + 1] = out_low1.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 0] = out_high0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 1] = out_high1.to(
+                                    self.dtype_o
+                                )
+                    if (
+                        store_enabled
+                        and valid_row_store
+                        and (lane_pair_base == 0 or self.kv_is_fp8)
+                    ):
+                        row_lse = (
+                            Float32(-Float32.inf)
+                            if merged_m == -Float32.inf
+                            else Float32(
+                                merged_m + cute.math.log2(merged_d, fastmath=True)
+                            )
+                        )
+                        if const_expr(self.split_kv):
+                            partial_row_idx = (
+                                request_partial_start
+                                + token_local * num_chunks_kv
+                                + kv_tile_idx
+                            )
+                            mLSE[partial_row_idx, q_head_idx] = row_lse
+                        else:
+                            mLSE[q_head_idx, q_row_idx] = row_lse
+
+        if const_expr(merged_store_v128):
+            if valid_work:
+                cute.arch.sync_threads()
+                merged_chunks_per_row = self.traits.head_dim_vo // 8
+                merged_chunk_linear_idx = tidx
+                merged_total_chunks = packed_tile_rows * merged_chunks_per_row
+                while merged_chunk_linear_idx < merged_total_chunks:
+                    packed_row_local = merged_chunk_linear_idx // merged_chunks_per_row
+                    chunk_idx = (
+                        merged_chunk_linear_idx
+                        - packed_row_local * merged_chunks_per_row
+                    )
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_head_idx = kv_head_idx * group_size + q_group_lane
+                    q_row_idx = q_start + token_local
+                    u32_idx = chunk_idx * 4
+                    if const_expr(self.split_kv):
+                        partial_row_idx = (
+                            request_partial_start
+                            + token_local * num_chunks_kv
+                            + kv_tile_idx
+                        )
+                        gmem_elem_offset = (
+                            (partial_row_idx * mO.shape[1] + q_head_idx)
+                            * self.traits.head_dim_vo
+                        ) + chunk_idx * 8
+                    else:
+                        gmem_elem_offset = (
+                            (q_row_idx * mO.shape[1] + q_head_idx)
+                            * self.traits.head_dim_vo
+                        ) + chunk_idx * 8
+                    st_global_v4_u32(
+                        get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                        sFinalStageU32[0, packed_row_local, u32_idx + 0],
+                        sFinalStageU32[0, packed_row_local, u32_idx + 1],
+                        sFinalStageU32[0, packed_row_local, u32_idx + 2],
+                        sFinalStageU32[0, packed_row_local, u32_idx + 3],
+                    )
+                    merged_chunk_linear_idx += self.traits.num_threads
+
+        if split_store_v128:
+            if valid_work:
+                cute.arch.sync_threads()
+                split_chunks_per_row = self.traits.head_dim_vo // 8
+                split_chunk_linear_idx = tidx
+                split_total_chunks = packed_tile_rows * split_chunks_per_row
+                while split_chunk_linear_idx < split_total_chunks:
+                    packed_row_local = split_chunk_linear_idx // split_chunks_per_row
+                    chunk_idx = (
+                        split_chunk_linear_idx - packed_row_local * split_chunks_per_row
+                    )
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_head_idx = kv_head_idx * group_size + q_group_lane
+                    partial_row_idx = (
+                        request_partial_start
+                        + token_local * num_chunks_kv
+                        + kv_tile_idx
+                    )
+                    u32_idx = chunk_idx * 4
+                    gmem_elem_offset = (
+                        (partial_row_idx * mO.shape[1] + q_head_idx)
+                        * self.traits.head_dim_vo
+                    ) + chunk_idx * 8
+                    st_global_v4_u32(
+                        get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                        sOStageU32[packed_row_local, u32_idx + 0],
+                        sOStageU32[packed_row_local, u32_idx + 1],
+                        sOStageU32[packed_row_local, u32_idx + 2],
+                        sOStageU32[packed_row_local, u32_idx + 3],
+                    )
+                    split_chunk_linear_idx += self.traits.num_threads
+
+        if final_store_v128:
+            if valid_work:
+                cute.arch.sync_threads()
+                final_chunks_per_row = self.traits.head_dim_vo // 8
+                final_chunk_linear_idx = tidx
+                final_total_chunks = packed_tile_rows * final_chunks_per_row
+                while final_chunk_linear_idx < final_total_chunks:
+                    packed_row_local = final_chunk_linear_idx // final_chunks_per_row
+                    chunk_idx = (
+                        final_chunk_linear_idx - packed_row_local * final_chunks_per_row
+                    )
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_head_idx = kv_head_idx * group_size + q_group_lane
+                    q_row_idx = q_start + token_local
+                    u32_idx = chunk_idx * 4
+                    gmem_elem_offset = (
+                        (q_row_idx * mO.shape[1] + q_head_idx) * self.traits.head_dim_vo
+                    ) + chunk_idx * 8
+                    st_global_v4_u32(
+                        get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                        sOStageU32[packed_row_local, u32_idx + 0],
+                        sOStageU32[packed_row_local, u32_idx + 1],
+                        sOStageU32[packed_row_local, u32_idx + 2],
+                        sOStageU32[packed_row_local, u32_idx + 3],
+                    )
+                    final_chunk_linear_idx += self.traits.num_threads
+
+
+PagedExtendForwardKernel = PagedForwardKernel
+
+
+def _torch_to_cutlass_dtype(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float16:
+        return cutlass.Float16
+    if dtype == torch.float8_e4m3fn:
+        return cutlass.Float8E4M3FN
+    raise TypeError(f"unsupported extend dtype {dtype}")
+
+
+def _torch_to_cutlass_storage_dtype(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.float8_e4m3fn:
+        return cutlass.Uint8
+    return _torch_to_cutlass_dtype(dtype)
+
+
+def build_extend_forward_kernel(
+    traits: PagedForwardTraits,
+    use_native_fp8_qk: bool,
+    use_native_fp8_pv: bool,
+    *,
+    window_left: int = -1,
+    has_attention_sink_bias: bool = False,
+    has_relative_attention_bias: bool = False,
+    msa_block_sparse: bool = False,
+    msa_union_tile: bool = False,
+    page_size: int = 64,
+):
+    enable_paged_kv_tma = (
+        os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA", "1") != "0"
+    )
+    return PagedExtendForwardKernel(
+        _torch_to_cutlass_dtype(traits.q_dtype),
+        _torch_to_cutlass_dtype(traits.kv_dtype),
+        _torch_to_cutlass_storage_dtype(traits.kv_dtype),
+        _torch_to_cutlass_dtype(traits.o_dtype),
+        traits=traits,
+        use_native_fp8_qk=use_native_fp8_qk,
+        use_native_fp8_pv=use_native_fp8_pv,
+        enable_paged_kv_tma=enable_paged_kv_tma,
+        window_left=window_left,
+        has_attention_sink_bias=has_attention_sink_bias,
+        has_relative_attention_bias=has_relative_attention_bias,
+        msa_block_sparse=msa_block_sparse,
+        msa_union_tile=msa_union_tile,
+        page_size=page_size,
+    )

--- a/flashinfer/experimental/sm12x/attention/paged/forward_paged.py
+++ b/flashinfer/experimental/sm12x/attention/paged/forward_paged.py
@@ -1,0 +1,9621 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/forward_paged.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Standalone paged forward kernel for the primary paged backend.
+
+This uses the exact host planner worklists and split scratch layout with the
+literal tensor-core inner path that we actually ship:
+- staged paged K/V ingress,
+- literal QK/PV MMA for BF16 and FP8 KV,
+- base-2 LSE storage compatible with the paged merge kernel.
+"""
+
+from __future__ import annotations
+import os
+from typing import Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.core import make_swizzle
+from cutlass.cute.nvgpu import cpasync, warpgroup
+from cutlass.utils import LayoutEnum
+import cutlass.utils.hopper_helpers as sm90_utils_basic
+
+from cutlass import Float32, Int32, Uint32, const_expr
+from cutlass.cutlass_dsl import Int64, T, dsl_user_op
+from flashinfer.experimental.sm12x.attention._shared.cute import copy as cute_copy
+from flashinfer.experimental.sm12x.attention._shared.cute import (
+    pipeline as cute_pipeline,
+)
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as attention_ops
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    get_ptr_as_int64,
+    shared_ptr_to_u32,
+)
+from flashinfer.experimental.sm12x._lib.smem import (
+    make_smem_memrange_alias,
+    make_tma_aligned_payload_storage,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    bf16_mma_m16n16k16_f32,
+    bf16_rowsum_m16k16_f32,
+    bfloat2_mul,
+    broadcast_f32_to_bfloat2,
+    cvt_bf16x2x2_to_e4m3x4,
+    cvt_bf16x2_to_e4m3x2,
+    fp8x4_e4m3_to_bfloat2x2,
+    ld_shared_v4_u32,
+    ldmatrix_m8n8x4_b16,
+    ldmatrix_m8n8x4_left_half_b16,
+    ldmatrix_m8n8x4_right_half_b16,
+    ldmatrix_m8n8x4_trans_b16,
+    ldmatrix_m8n8x4_trans_left_half_b16,
+    ldmatrix_m8n8x4_trans_right_half_b16,
+    mxfp8_mma_m16n8k32_f32_e4m3,
+    pack_f32x2_to_bfloat2,
+    frag_layout_swizzle_16b_to_8b,
+    frag_layout_swizzle_16b_to_8b_trans,
+    st_global_v4_u32,
+    st_shared_v4_u32,
+)
+
+from .traits import PagedForwardTraits
+
+
+def _assume_strides_aligned(t: cute.Tensor):
+    divby = 128 // t.element_type.width
+    strides = tuple(
+        s if isinstance(s, int) else cute.assume(s, divby=divby) for s in t.stride[:-1]
+    )
+    return (*strides, t.stride[-1])
+
+
+def _assume_tensor_aligned(t: cute.Tensor | None):
+    if t is None:
+        return None
+    return cute.make_tensor(
+        t.iterator, cute.make_layout(t.shape, stride=_assume_strides_aligned(t))
+    )
+
+
+def _assume_paged_kv_tma_source_aligned(t: cute.Tensor):
+    divby = 128 // t.element_type.width
+    strides = []
+    for dim, stride in enumerate(t.stride):
+        if dim == 1 or isinstance(stride, int):
+            strides.append(stride)
+        else:
+            strides.append(cute.assume(stride, divby=divby))
+    return cute.make_tensor(
+        t.iterator, cute.make_layout(t.shape, stride=tuple(strides))
+    )
+
+
+def _make_paged_kv_tma_source_tensor(t: cute.Tensor, stage_tile_rows: int):
+    t_pages = cute.make_tensor(t.iterator, cute.select(t.layout, mode=[1, 3, 2, 0]))
+    t_pages = _assume_paged_kv_tma_source_aligned(t_pages)
+    tile_stride = stage_tile_rows * t_pages.stride[0]
+    page_tiles_per_page = t_pages.stride[3] // tile_stride
+    total_page_tiles = page_tiles_per_page * t_pages.shape[3]
+    return cute.make_tensor(
+        t_pages.iterator,
+        cute.make_layout(
+            (stage_tile_rows, t_pages.shape[1], t_pages.shape[2], total_page_tiles),
+            stride=(
+                t_pages.stride[0],
+                t_pages.stride[1],
+                t_pages.stride[2],
+                tile_stride,
+            ),
+        ),
+    )
+
+
+def _make_paged_kv_tile_source_tensor(
+    t: cute.Tensor, stage_tile_rows: int, page_tiles_per_entry: int
+):
+    """Flatten a [num_pages, page_size, kv_heads, head_dim] cache into 64-row tiles.
+
+    `page_tiles_per_entry` is the host-validated number of `stage_tile_rows`-row
+    tiles spanned by one page-table entry stride (derived from the CACHE STRIDE,
+    so strided slices such as vLLM's combined [N, 2, 128, H, D] cache produce
+    phantom tiles for the unrelated plane which are never addressed).
+    """
+    t_pages = cute.make_tensor(t.iterator, cute.select(t.layout, mode=[1, 3, 2, 0]))
+    t_pages = _assume_paged_kv_tma_source_aligned(t_pages)
+    tile_stride = stage_tile_rows * t_pages.stride[0]
+    total_page_tiles = page_tiles_per_entry * t_pages.shape[3]
+    return cute.make_tensor(
+        t_pages.iterator,
+        cute.make_layout(
+            (stage_tile_rows, t_pages.shape[1], t_pages.shape[2], total_page_tiles),
+            stride=(
+                t_pages.stride[0],
+                t_pages.stride[1],
+                t_pages.stride[2],
+                tile_stride,
+            ),
+        ),
+    )
+
+
+def _make_payload_ptr(payload_u8: cute.Tensor, dtype, offset_bytes: int = 0):
+    ptr = (
+        payload_u8.iterator if offset_bytes == 0 else payload_u8.iterator + offset_bytes
+    )
+    return cute.recast_ptr(ptr.align(16), dtype=dtype)
+
+
+def _make_payload_tensor(payload_u8: cute.Tensor, dtype, offset_bytes: int, layout):
+    return cute.make_tensor(_make_payload_ptr(payload_u8, dtype, offset_bytes), layout)
+
+
+def _make_payload_memrange(
+    payload_u8: cute.Tensor, dtype, offset_bytes: int, num_elems: int
+):
+    return make_smem_memrange_alias(
+        dtype,
+        num_elems,
+        _make_payload_ptr(payload_u8, dtype, offset_bytes),
+    )
+
+
+def _get_memrange_tensor(memrange, layout):
+    if hasattr(layout, "outer") and hasattr(layout, "inner"):
+        return memrange.get_tensor(layout.outer, swizzle=layout.inner)
+    return memrange.get_tensor(layout)
+
+
+def _paged_kv_tma_plane_layout(stage_tile_rows: int, kv_tma_plane_head_dim: int):
+    plane_swizzle = os.environ.get(
+        "FLASHINFER_EXP_SM12X_PAGED_KV_TMA_PLANE_SWIZZLE", ""
+    )
+    if plane_swizzle == "none":
+        return cute.make_layout(
+            (stage_tile_rows, kv_tma_plane_head_dim),
+            stride=(kv_tma_plane_head_dim, 1),
+        )
+    if plane_swizzle:
+        mbase, bbits, sshift = [int(part) for part in plane_swizzle.split(",")]
+        swizzle = make_swizzle(mbase, bbits, sshift)
+    else:
+        swizzle = make_swizzle(3, 4, 3)
+    return cute.make_composed_layout(
+        swizzle,
+        0,
+        cute.make_layout(
+            (stage_tile_rows, kv_tma_plane_head_dim),
+            stride=(kv_tma_plane_head_dim, 1),
+        ),
+    )
+
+
+def _paged_kv_tma_plane_stage_layout(
+    stage_tile_rows: int, kv_tma_plane_head_dim: int, num_stages: int
+):
+    return cute.tile_to_shape(
+        _paged_kv_tma_plane_layout(stage_tile_rows, kv_tma_plane_head_dim),
+        (stage_tile_rows, kv_tma_plane_head_dim, num_stages),
+        (0, 1, 2),
+    )
+
+
+@cute.jit
+def _issue_paged_kv_tma_copy_planes_tma(
+    load_tma0,
+    load_tma1,
+    load_tma2,
+    load_tma3,
+    pipeline_tma,
+    producer_state,
+    mPageTable: cute.Tensor,
+    request_idx,
+    tile_token_base,
+    page_size,
+):
+    page_idx = tile_token_base // page_size
+    page_id = (
+        Int32(0)
+        if const_expr(
+            os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0") == "1"
+        )
+        else mPageTable[request_idx, page_idx]
+    )
+    pipeline_tma.producer_acquire(producer_state)
+    load_tma0(src_idx=page_id, producer_state=producer_state)
+    load_tma1(src_idx=page_id, producer_state=producer_state)
+    load_tma2(src_idx=page_id, producer_state=producer_state)
+    load_tma3(src_idx=page_id, producer_state=producer_state)
+
+
+@cute.jit
+def _issue_paged_kv_tma_copy_2planes_tma(
+    load_tma0,
+    load_tma1,
+    pipeline_tma,
+    producer_state,
+    mPageTable: cute.Tensor,
+    request_idx,
+    tile_token_base,
+    page_size,
+):
+    page_idx = tile_token_base // page_size
+    page_id = (
+        Int32(0)
+        if const_expr(
+            os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0") == "1"
+        )
+        else mPageTable[request_idx, page_idx]
+    )
+    pipeline_tma.producer_acquire(producer_state)
+    load_tma0(src_idx=page_id, producer_state=producer_state)
+    load_tma1(src_idx=page_id, producer_state=producer_state)
+
+
+@cute.jit
+def _issue_paged_kv_tma_copy_2planes_tma_single_stage(
+    load_tma0,
+    load_tma1,
+    producer_state,
+    mbar_ptr,
+    expected_bytes,
+    mPageTable: cute.Tensor,
+    request_idx,
+    tile_token_base,
+    page_size,
+    stage_tile_rows,
+):
+    _issue_paged_kv_tma_copy_2planes_tma_manual(
+        load_tma0,
+        load_tma1,
+        producer_state,
+        mbar_ptr,
+        expected_bytes,
+        mPageTable,
+        request_idx,
+        tile_token_base,
+        page_size,
+        stage_tile_rows,
+    )
+
+
+@cute.jit
+def _issue_paged_kv_tma_copy_2planes_tma_manual(
+    load_tma0,
+    load_tma1,
+    producer_state,
+    mbar_ptr,
+    expected_bytes,
+    mPageTable: cute.Tensor,
+    request_idx,
+    tile_token_base,
+    page_size,
+    stage_tile_rows,
+):
+    page_idx = tile_token_base // page_size
+    page_row_offset = tile_token_base - page_idx * page_size
+    page_tile_idx = page_row_offset // stage_tile_rows
+    page_tiles_per_page = page_size // stage_tile_rows
+    page_id = (
+        Int32(0)
+        if const_expr(
+            os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0") == "1"
+        )
+        else mPageTable[request_idx, page_idx]
+    )
+    full_mbar_ptr = mbar_ptr + producer_state.index
+    with cute.arch.elect_one():
+        cute.arch.mbarrier_arrive_and_expect_tx(
+            full_mbar_ptr,
+            expected_bytes,
+        )
+    src_idx = page_id * page_tiles_per_page + page_tile_idx
+    load_tma0(src_idx=src_idx, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr)
+    load_tma1(src_idx=src_idx, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr)
+
+
+@cute.jit
+def _issue_paged_kv_tma_copy_4planes_tma_manual(
+    load_tma0,
+    load_tma1,
+    load_tma2,
+    load_tma3,
+    producer_state,
+    mbar_ptr,
+    expected_bytes,
+    mPageTable: cute.Tensor,
+    request_idx,
+    tile_token_base,
+    page_size,
+    stage_tile_rows,
+):
+    page_idx = tile_token_base // page_size
+    page_row_offset = tile_token_base - page_idx * page_size
+    page_tile_idx = page_row_offset // stage_tile_rows
+    page_tiles_per_page = page_size // stage_tile_rows
+    page_id = (
+        Int32(0)
+        if const_expr(
+            os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0") == "1"
+        )
+        else mPageTable[request_idx, page_idx]
+    )
+    full_mbar_ptr = mbar_ptr + producer_state.index
+    with cute.arch.elect_one():
+        cute.arch.mbarrier_arrive_and_expect_tx(
+            full_mbar_ptr,
+            expected_bytes,
+        )
+    src_idx = page_id * page_tiles_per_page + page_tile_idx
+    load_tma0(src_idx=src_idx, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr)
+    load_tma1(src_idx=src_idx, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr)
+    load_tma2(src_idx=src_idx, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr)
+    load_tma3(src_idx=src_idx, dst_idx=producer_state.index, tma_bar_ptr=full_mbar_ptr)
+
+
+@dsl_user_op
+def _cp_async_bulk_tensor_2d(
+    dst_smem_addr: Int32,
+    tensor_map_ptr: Int64,
+    coord0: Int32,
+    coord1: Int32,
+    mbar_smem_addr: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    raise RuntimeError("raw tensor-map TMA issue is disabled; use CuTe atom TMA")
+
+
+@cute.jit
+def _dump_tma_stage_rows(
+    mDst: cute.Tensor,
+    sSrc: cute.Tensor,
+    tidx,
+    num_rows,
+    head_dim,
+    num_threads,
+    max_rows,
+):
+    dump_rows = cutlass.select_(max_rows < num_rows, max_rows, num_rows)
+    dst_rows = mDst.shape[0] * mDst.shape[1]
+    dump_rows = cutlass.select_(dump_rows < dst_rows, dump_rows, dst_rows)
+    linear = tidx
+    dump_elems = dump_rows * head_dim
+    while linear < dump_elems:
+        row = linear // head_dim
+        col = linear - row * head_dim
+        dst_q = row // mDst.shape[1]
+        dst_h = row - dst_q * mDst.shape[1]
+        mDst[dst_q, dst_h, col] = sSrc[row, col, 0]
+        linear += num_threads
+
+
+@cute.jit
+def _dump_s_frag_tile(
+    mDst: cute.Tensor,
+    s_frag: cute.Tensor,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    num_mma_q,
+    num_mma_kv,
+    packed_tile_rows,
+    tile_tokens,
+):
+    lane_group = lane // 4
+    lane_pair_base = 2 * (lane % 4)
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            for reg_id in cutlass.range_constexpr(8):
+                row_slot = (reg_id % 4) // 2
+                row = (
+                    warp_q_idx * num_mma_q * 16 + mma_q * 16 + lane_group + 8 * row_slot
+                )
+                col = (
+                    warp_kv_idx * num_mma_kv * 16
+                    + mma_kv * 16
+                    + lane_pair_base
+                    + 8 * (reg_id // 4)
+                    + (reg_id % 2)
+                )
+                if row < packed_tile_rows and col < tile_tokens:
+                    dst_linear = row * tile_tokens + col
+                    dst_q = dst_linear // (mDst.shape[1] * mDst.shape[2])
+                    dst_rem = dst_linear - dst_q * (mDst.shape[1] * mDst.shape[2])
+                    dst_h = dst_rem // mDst.shape[2]
+                    dst_col = dst_rem - dst_h * mDst.shape[2]
+                    mDst[dst_q, dst_h, dst_col] = cutlass.BFloat16(
+                        s_frag[mma_q, mma_kv, reg_id]
+                    )
+
+
+@cute.jit
+def _dump_flat_u32_words(
+    mDst: cute.Tensor,
+    sSrc: cute.Tensor,
+    tidx,
+    num_threads,
+):
+    flat = cute.flatten(sSrc)
+    dst_words = cute.size(mDst.shape)
+    src_words = cute.size(flat.shape)
+    dump_words = cutlass.select_(src_words < dst_words, src_words, dst_words)
+    linear = tidx
+    while linear < dump_words:
+        mDst[linear] = flat[linear]
+        linear += num_threads
+
+
+@cute.jit
+def _dump_flat_u32_words_offset(
+    mDst: cute.Tensor,
+    sSrc: cute.Tensor,
+    dst_word_offset,
+    tidx,
+    num_threads,
+):
+    flat = cute.flatten(sSrc)
+    dst_words = cute.size(mDst.shape)
+    src_words = cute.size(flat.shape)
+    dump_words = cutlass.select_(
+        src_words < (dst_words - dst_word_offset),
+        src_words,
+        (dst_words - dst_word_offset),
+    )
+    linear = tidx
+    while linear < dump_words:
+        mDst[dst_word_offset + linear] = flat[linear]
+        linear += num_threads
+
+
+@cute.jit
+def _async_copy_q_tile_permuted_128b_fp8_decode_impl(
+    mQBytes: cute.Tensor,
+    q_start,
+    packed_tile_start,
+    packed_tile_rows,
+    kv_head_idx,
+    group_size,
+    num_q_heads,
+    row_bytes,
+    token_stride_bytes,
+    head_stride_bytes,
+    sQBytes: cute.Tensor,
+    lane,
+    upcast_stride_q,
+):
+    lane_row = lane // 8
+    lane_col = lane % 8
+    if group_size == Int32(8) or group_size == Int32(6):
+        q_row_idx = Int32(q_start)
+        q_head_base = Int32(kv_head_idx * group_size + packed_tile_start)
+        for row_iter in cutlass.range_constexpr(2):
+            row_idx = Int32(lane_row + row_iter * 4)
+            row_valid = row_idx < packed_tile_rows
+            q_head_idx = Int32(q_head_base + row_idx)
+            row_byte_base = Int64(q_row_idx) * Int64(token_stride_bytes) + Int64(
+                q_head_idx
+            ) * Int64(head_stride_bytes)
+            for mma_do in cutlass.range_constexpr(4):
+                vec_idx = Int32(lane_col + mma_do * 8)
+                src_byte_idx = row_byte_base + vec_idx * 16
+                dst_byte_idx = (
+                    _permuted_offset_128b(row_idx, vec_idx, upcast_stride_q) * 16
+                )
+                _cp_async_load_128b_pred(
+                    shared_ptr_to_u32(sQBytes.iterator + dst_byte_idx),
+                    get_ptr_as_int64(mQBytes, src_byte_idx),
+                    Int32(row_valid),
+                )
+    else:
+        for row_iter in cutlass.range_constexpr(4):
+            packed_q_idx = Int32(packed_tile_start + lane_row + row_iter * 4)
+            row_valid = packed_q_idx < (packed_tile_start + packed_tile_rows)
+            q_row_local = packed_q_idx // group_size
+            q_group_lane = packed_q_idx - q_row_local * group_size
+            q_head_idx = Int32(kv_head_idx * group_size + q_group_lane)
+            q_row_idx = Int32(q_start + q_row_local)
+            row_byte_base = Int64(q_row_idx) * Int64(token_stride_bytes) + Int64(
+                q_head_idx
+            ) * Int64(head_stride_bytes)
+            row_idx = Int32(lane_row + row_iter * 4)
+            for mma_do in cutlass.range_constexpr(4):
+                vec_idx = Int32(lane_col + mma_do * 8)
+                src_byte_idx = row_byte_base + vec_idx * 16
+                dst_byte_idx = (
+                    _permuted_offset_128b(row_idx, vec_idx, upcast_stride_q) * 16
+                )
+                _cp_async_load_128b_pred(
+                    shared_ptr_to_u32(sQBytes.iterator + dst_byte_idx),
+                    get_ptr_as_int64(mQBytes, src_byte_idx),
+                    Int32(row_valid),
+                )
+
+
+@cute.jit
+def _async_copy_q_tile_permuted_128b_impl(
+    mQBytes: cute.Tensor,
+    q_start,
+    packed_tile_start,
+    packed_tile_rows,
+    kv_head_idx,
+    group_size,
+    num_q_heads,
+    row_bytes,
+    token_stride_bytes,
+    head_stride_bytes,
+    sQBytes: cute.Tensor,
+    lane,
+    warp_q_idx,
+    num_mma_q,
+    num_mma_d_qk,
+    upcast_stride_q,
+):
+    lane_row = lane // 8
+    lane_col = lane % 8
+    warp_row_base = Int32(warp_q_idx * num_mma_q * 16)
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for row_iter in cutlass.range_constexpr(4):
+            packed_q_idx = Int32(
+                packed_tile_start + warp_row_base + mma_q * 16 + lane_row + row_iter * 4
+            )
+            row_valid = packed_q_idx < (packed_tile_start + packed_tile_rows)
+            q_row_local = packed_q_idx // group_size
+            q_group_lane = packed_q_idx - q_row_local * group_size
+            q_head_idx = Int32(kv_head_idx * group_size + q_group_lane)
+            q_row_idx = Int32(q_start + q_row_local)
+            row_byte_base = Int64(q_row_idx) * Int64(token_stride_bytes) + Int64(
+                q_head_idx
+            ) * Int64(head_stride_bytes)
+            row_idx = Int32(warp_row_base + mma_q * 16 + lane_row + row_iter * 4)
+            for mma_do in cutlass.range_constexpr(num_mma_d_qk // 4):
+                vec_idx = Int32(lane_col + mma_do * 8)
+                src_byte_idx = row_byte_base + vec_idx * 16
+                dst_byte_idx = (
+                    _permuted_offset_128b(row_idx, vec_idx, upcast_stride_q) * 16
+                )
+                _cp_async_load_128b_pred(
+                    shared_ptr_to_u32(sQBytes.iterator + dst_byte_idx),
+                    get_ptr_as_int64(mQBytes, src_byte_idx),
+                    Int32(row_valid),
+                )
+
+
+@cute.jit
+def _dump_plane_stage_words_u32(
+    mDebugU32: cute.Tensor,
+    sStageBytes: cute.Tensor,
+    stage_idx,
+    kv_plane_stage_bytes,
+    kv_plane_total_bytes,
+    kv_tma_plane_count,
+    tidx,
+    num_threads,
+):
+    plane_words = kv_plane_stage_bytes // 4
+    plane0_u32 = cute.make_tensor(
+        cute.recast_tensor(
+            cute.make_tensor(
+                sStageBytes.iterator
+                + Int32(stage_idx * kv_plane_stage_bytes + 0 * kv_plane_total_bytes),
+                cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+            ),
+            cutlass.Uint32,
+        ).iterator,
+        cute.make_layout((plane_words,), stride=(1,)),
+    )
+    plane1_u32 = cute.make_tensor(
+        cute.recast_tensor(
+            cute.make_tensor(
+                sStageBytes.iterator
+                + Int32(stage_idx * kv_plane_stage_bytes + 1 * kv_plane_total_bytes),
+                cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+            ),
+            cutlass.Uint32,
+        ).iterator,
+        cute.make_layout((plane_words,), stride=(1,)),
+    )
+    _dump_flat_u32_words_offset(
+        mDebugU32,
+        plane0_u32,
+        Int32(0),
+        tidx,
+        num_threads,
+    )
+    _dump_flat_u32_words_offset(
+        mDebugU32,
+        plane1_u32,
+        Int32(plane_words),
+        tidx,
+        num_threads,
+    )
+    if const_expr(kv_tma_plane_count > 2):
+        plane2_u32 = cute.make_tensor(
+            cute.recast_tensor(
+                cute.make_tensor(
+                    sStageBytes.iterator
+                    + Int32(
+                        stage_idx * kv_plane_stage_bytes + 2 * kv_plane_total_bytes
+                    ),
+                    cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+                ),
+                cutlass.Uint32,
+            ).iterator,
+            cute.make_layout((plane_words,), stride=(1,)),
+        )
+        plane3_u32 = cute.make_tensor(
+            cute.recast_tensor(
+                cute.make_tensor(
+                    sStageBytes.iterator
+                    + Int32(
+                        stage_idx * kv_plane_stage_bytes + 3 * kv_plane_total_bytes
+                    ),
+                    cute.make_layout((kv_plane_stage_bytes,), stride=(1,)),
+                ),
+                cutlass.Uint32,
+            ).iterator,
+            cute.make_layout((plane_words,), stride=(1,)),
+        )
+        _dump_flat_u32_words_offset(
+            mDebugU32,
+            plane2_u32,
+            Int32(plane_words * 2),
+            tidx,
+            num_threads,
+        )
+        _dump_flat_u32_words_offset(
+            mDebugU32,
+            plane3_u32,
+            Int32(plane_words * 3),
+            tidx,
+            num_threads,
+        )
+
+
+@cute.jit
+def _dump_p_frag_regs_raw(
+    mDst: cute.Tensor,
+    p_frag: cute.Tensor,
+    lane,
+):
+    p_regs = cute.flatten(p_frag)
+    dst_words = cute.size(mDst.shape)
+    lane_words = cute.size(p_regs.shape)
+    dst_idx = lane * lane_words
+    for reg_id in cutlass.range_constexpr(cute.size(p_regs.shape)):
+        if dst_idx + reg_id < dst_words:
+            mDst[dst_idx + reg_id] = p_regs[reg_id]
+
+
+@cute.jit
+def _dump_s_frag_regs_raw(
+    mDst: cute.Tensor,
+    s_frag: cute.Tensor,
+    lane,
+):
+    s_regs = cute.flatten(cute.recast_tensor(s_frag, cutlass.Uint32))
+    dst_words = cute.size(mDst.shape)
+    lane_words = cute.size(s_regs.shape)
+    dst_idx = lane * lane_words
+    for reg_id in cutlass.range_constexpr(cute.size(s_regs.shape)):
+        if dst_idx + reg_id < dst_words:
+            mDst[dst_idx + reg_id] = s_regs[reg_id]
+
+
+@cute.jit
+def _permute_rowmajor_tile_in_place_to_permuted_128b(
+    sStageBytes: cute.Tensor,
+    stage_byte_offset,
+    lane,
+    warp_linear_idx,
+    valid_rows,
+    upcast_stride,
+    total_warps,
+):
+    stage_u32 = cute.make_tensor(
+        cute.recast_tensor(sStageBytes, cutlass.Uint32).iterator,
+        cute.make_layout((cute.size(sStageBytes.shape) // 4,), stride=(1,)),
+    )
+    lane_row = lane // 8
+    lane_col = lane % 8
+    stage_word_offset = stage_byte_offset // 4
+    for tile_iter in cutlass.range_constexpr(4):
+        row_idx = Int32(warp_linear_idx * 4 + lane_row + tile_iter * total_warps * 4)
+        row_word_base = stage_word_offset + row_idx * (upcast_stride * 4)
+        for vec_iter in cutlass.range_constexpr(upcast_stride // 8):
+            vec_idx = Int32(lane_col + vec_iter * 8)
+            word_idx = row_word_base + vec_idx * 4
+            if row_idx < valid_rows:
+                swap_mask = Int32(row_idx % 8)
+                partner_vec = vec_idx ^ swap_mask
+                if vec_idx < partner_vec:
+                    partner_word_idx = row_word_base + partner_vec * 4
+                    a0 = stage_u32[word_idx + 0]
+                    a1 = stage_u32[word_idx + 1]
+                    a2 = stage_u32[word_idx + 2]
+                    a3 = stage_u32[word_idx + 3]
+                    b0 = stage_u32[partner_word_idx + 0]
+                    b1 = stage_u32[partner_word_idx + 1]
+                    b2 = stage_u32[partner_word_idx + 2]
+                    b3 = stage_u32[partner_word_idx + 3]
+                    stage_u32[word_idx + 0] = b0
+                    stage_u32[word_idx + 1] = b1
+                    stage_u32[word_idx + 2] = b2
+                    stage_u32[word_idx + 3] = b3
+                    stage_u32[partner_word_idx + 0] = a0
+                    stage_u32[partner_word_idx + 1] = a1
+                    stage_u32[partner_word_idx + 2] = a2
+                    stage_u32[partner_word_idx + 3] = a3
+            else:
+                stage_u32[word_idx + 0] = Uint32(0)
+                stage_u32[word_idx + 1] = Uint32(0)
+                stage_u32[word_idx + 2] = Uint32(0)
+                stage_u32[word_idx + 3] = Uint32(0)
+
+
+@cute.jit
+def _permute_rowmajor_tile_in_place_to_permuted_128b_vec128(
+    sStageBytes: cute.Tensor,
+    stage_byte_offset,
+    lane,
+    warp_linear_idx,
+    valid_rows,
+    upcast_stride,
+    total_warps,
+):
+    lane_row = lane // 8
+    lane_col = lane % 8
+    for tile_iter in cutlass.range_constexpr(4):
+        row_idx = Int32(warp_linear_idx * 4 + lane_row + tile_iter * total_warps * 4)
+        for vec_iter in cutlass.range_constexpr(upcast_stride // 8):
+            vec_idx = Int32(lane_col + vec_iter * 8)
+            vec_byte_idx = stage_byte_offset + (row_idx * upcast_stride + vec_idx) * 16
+            vec_addr = shared_ptr_to_u32(sStageBytes.iterator + vec_byte_idx)
+            if row_idx < valid_rows:
+                swap_mask = Int32(row_idx % 8)
+                partner_vec = vec_idx ^ swap_mask
+                if vec_idx < partner_vec:
+                    partner_vec_byte_idx = (
+                        stage_byte_offset + (row_idx * upcast_stride + partner_vec) * 16
+                    )
+                    partner_vec_addr = shared_ptr_to_u32(
+                        sStageBytes.iterator + partner_vec_byte_idx
+                    )
+                    a0, a1, a2, a3 = ld_shared_v4_u32(vec_addr)
+                    b0, b1, b2, b3 = ld_shared_v4_u32(partner_vec_addr)
+                    st_shared_v4_u32(vec_addr, b0, b1, b2, b3)
+                    st_shared_v4_u32(partner_vec_addr, a0, a1, a2, a3)
+            else:
+                st_shared_v4_u32(vec_addr, Uint32(0), Uint32(0), Uint32(0), Uint32(0))
+
+
+@dsl_user_op
+def _cp_async_load_128b_pred(
+    smem_addr: Int32,
+    gmem_addr: Int64,
+    predicate: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    llvm.inline_asm(
+        None,
+        [
+            Int32(predicate).ir_value(loc=loc, ip=ip),
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        " .reg .pred p;\n"
+        " setp.ne.b32 p, $0, 0;\n"
+        " @p cp.async.cg.shared.global.L2::128B [$1], [$2], 16;\n"
+        "}",
+        "r,r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _cp_async_load_128b_zfill(
+    smem_addr: Int32,
+    gmem_addr: Int64,
+    src_bytes: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+            Int32(src_bytes).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.cg.shared.global.L2::128B [$0], [$1], 16, $2;",
+        "r,l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _exp2_approx_ftz_f32(a: Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "ex2.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def _apply_attention_sink_after_lse_scale(
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    mAttentionSinkBias: cute.Tensor,
+    mma_q,
+    row_slot,
+    q_head_idx: Int32,
+    row_valid: Int32,
+    causal_k_limit: Int32,
+    chunk_start: Int32,
+    chunk_end: Int32,
+    warp_kv_idx: Int32,
+    num_mma_d_vo,
+    softmax_scale_log2: Float32,
+    has_attention_sink_bias,
+    split_kv,
+):
+    if m_frag[mma_q, row_slot] != -Float32.inf:
+        m_frag[mma_q, row_slot] = Float32(m_frag[mma_q, row_slot] * softmax_scale_log2)
+    if const_expr(has_attention_sink_bias):
+        sink_owner = (row_valid != Int32(0)) and (warp_kv_idx == Int32(0))
+        if const_expr(split_kv):
+            if sink_owner:
+                sink_owner = (chunk_start <= causal_k_limit) and (
+                    causal_k_limit < chunk_end
+                )
+        if sink_owner:
+            old_m = m_frag[mma_q, row_slot]
+            sink_m = Float32(mAttentionSinkBias[q_head_idx] * attention_ops.LOG2_E)
+            new_m = attention_ops.fmax(old_m, sink_m)
+            old_scale = (
+                Float32(0.0)
+                if old_m == -Float32.inf
+                else _exp2_approx_ftz_f32(old_m - new_m)
+            )
+            sink_scale = _exp2_approx_ftz_f32(sink_m - new_m)
+            d_frag[mma_q, row_slot] = Float32(
+                d_frag[mma_q, row_slot] * old_scale + sink_scale
+            )
+            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                reg_base = row_slot * 2
+                o_frag[mma_q, mma_d, reg_base + 0] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 0] * old_scale
+                )
+                o_frag[mma_q, mma_d, reg_base + 1] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 1] * old_scale
+                )
+                o_frag[mma_q, mma_d, reg_base + 4] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 4] * old_scale
+                )
+                o_frag[mma_q, mma_d, reg_base + 5] = Float32(
+                    o_frag[mma_q, mma_d, reg_base + 5] * old_scale
+                )
+            m_frag[mma_q, row_slot] = Float32(new_m)
+
+
+@cute.jit
+def _apply_relative_attention_bias(
+    frag_s: cute.Tensor,
+    mRelativeAttentionBias: cute.Tensor,
+    q_row_idx_frag: cute.Tensor,
+    q_head_idx_frag: cute.Tensor,
+    causal_k_limit: cute.Tensor,
+    tile_key_base: Int32,
+    warp_kv_base: Int32,
+    lane_pair_base: Int32,
+    inverse_softmax_scale: Float32,
+    num_mma_q,
+    num_mma_kv,
+):
+    relative_extent = mRelativeAttentionBias.shape[2]
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            for reg_id in cutlass.range_constexpr(8):
+                row_slot = (reg_id % 4) // 2
+                if frag_s[mma_q, mma_kv, reg_id] != -Float32.inf:
+                    key_local = (
+                        warp_kv_base
+                        + mma_kv * 16
+                        + lane_pair_base
+                        + 8 * (reg_id // 4)
+                        + (reg_id % 2)
+                    )
+                    distance = (
+                        causal_k_limit[mma_q, row_slot] - tile_key_base - key_local
+                    )
+                    if distance >= Int32(0) and distance < relative_extent:
+                        bias = Float32(
+                            mRelativeAttentionBias[
+                                q_row_idx_frag[mma_q, row_slot],
+                                q_head_idx_frag[mma_q, row_slot],
+                                distance,
+                            ]
+                        )
+                        frag_s[mma_q, mma_kv, reg_id] += bias * inverse_softmax_scale
+
+
+@dsl_user_op
+def _exit_thread(
+    *,
+    loc=None,
+    ip=None,
+):
+    llvm.inline_asm(
+        None,
+        [],
+        "exit;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def _permuted_offset_128b(row_idx, vec_idx, stride_128b):
+    return row_idx * stride_128b + (vec_idx ^ (row_idx % 8))
+
+
+@cute.jit
+def _smem_addr_from_b128_offset(base_addr: Int32, offset_128b):
+    return base_addr + Int32(offset_128b * 16)
+
+
+@cute.jit
+def _advance_offset_by_row_128b(offset_128b, step_size, row_stride_128b):
+    return offset_128b + step_size * row_stride_128b
+
+
+@cute.jit
+def _advance_offset_by_column_128b_2(offset_128b, step_idx):
+    xor_term = Int32(0x2) + (Int32(0x4) if const_expr(step_idx % 2 == 1) else Int32(0))
+    extra = Int32(8) if const_expr(step_idx % 4 == 3) else Int32(0)
+    return (offset_128b ^ xor_term) + extra
+
+
+@cute.jit
+def _smem_addr_from_split_planes_128b(
+    plane0_base_addr: Int32,
+    plane1_base_addr: Int32,
+    full_offset_128b,
+    full_stride_128b,
+):
+    plane_stride_128b = full_stride_128b // Int32(2)
+    row = full_offset_128b // full_stride_128b
+    col = full_offset_128b - row * full_stride_128b
+    plane_idx = col // plane_stride_128b
+    local_col = col - plane_idx * plane_stride_128b
+    local_offset = row * plane_stride_128b + local_col
+    plane_base_addr = cutlass.select_(
+        plane_idx == Int32(0), plane0_base_addr, plane1_base_addr
+    )
+    return _smem_addr_from_b128_offset(plane_base_addr, local_offset)
+
+
+def _transpose_view(a: cute.Tensor) -> cute.Tensor:
+    shape = (a.shape[1], a.shape[0], *a.shape[2:])
+    order = (1, 0, *range(2, cute.rank(a)))
+    return cute.composition(a, cute.make_ordered_layout(shape, order=order))
+
+
+def _convert_layout_acc_mn(
+    acc_layout: cute.Layout, transpose: bool = False
+) -> cute.Layout:
+    acc_layout_col_major = cute.make_layout(acc_layout.shape)
+    shape = (
+        (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+        (
+            acc_layout_col_major.shape[0][0],
+            *acc_layout_col_major.shape[0][2:],
+            acc_layout_col_major.shape[2],
+        ),
+        *acc_layout_col_major.shape[3:],
+    )
+    stride = (
+        (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+        (
+            acc_layout_col_major.stride[0][0],
+            *acc_layout_col_major.stride[0][2:],
+            acc_layout_col_major.stride[2],
+        ),
+        *acc_layout_col_major.stride[3:],
+    )
+    if transpose:
+        shape = (shape[1], shape[0], *shape[2:])
+        stride = (stride[1], stride[0], *stride[2:])
+    return cute.composition(acc_layout, cute.make_layout(shape, stride=stride))
+
+
+def _reshape_acc_to_mn(acc: cute.Tensor, transpose: bool = False) -> cute.Tensor:
+    return cute.make_tensor(
+        acc.iterator, _convert_layout_acc_mn(acc.layout, transpose=transpose)
+    )
+
+
+@cute.jit
+def _convert_layout_acc_frgA(acc_layout: cute.Layout) -> cute.Layout:
+    if const_expr(cute.rank(acc_layout.shape[0]) == 3):
+        div = 2 if const_expr(acc_layout.shape[0][2] % 2 == 0) else 1
+        l = cute.logical_divide(acc_layout, ((None, None, div), None, None))
+        return cute.make_layout(
+            (
+                (l.shape[0][0], l.shape[0][1], l.shape[0][2][0]),
+                l.shape[1],
+                (l.shape[0][2][1], l.shape[2]),
+            ),
+            stride=(
+                (l.stride[0][0], l.stride[0][1], l.stride[0][2][0]),
+                l.stride[1],
+                (l.stride[0][2][1], l.stride[2]),
+            ),
+        )
+    l = cute.logical_divide(acc_layout, (None, None, 2))
+    return cute.make_layout(
+        (
+            (l.shape[0], l.shape[2][0]),
+            l.shape[1],
+            l.shape[2][1],
+        ),
+        stride=(
+            (l.stride[0], l.stride[2][0]),
+            l.stride[1],
+            l.stride[2][1],
+        ),
+    )
+
+
+def _reshape_acc_to_frgA(acc: cute.Tensor) -> cute.Tensor:
+    return cute.make_tensor(acc.iterator, _convert_layout_acc_frgA(acc.layout))
+
+
+@cute.jit
+def _warp_mma_gemm(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsA: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_A: cute.TiledCopy,
+    smem_thr_copy_B: cute.TiledCopy,
+    A_in_regs: cutlass.Constexpr = False,
+    B_in_regs: cutlass.Constexpr = False,
+):
+    tCrA_copy_view = smem_thr_copy_A.retile(tCrA)
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    if const_expr(not A_in_regs):
+        cute.copy(smem_thr_copy_A, tCsA[None, None, 0], tCrA_copy_view[None, None, 0])
+    if const_expr(not B_in_regs):
+        cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCsA.shape[2])):
+        if k < cute.size(tCsA.shape[2]) - 1:
+            if const_expr(not A_in_regs):
+                cute.copy(
+                    smem_thr_copy_A,
+                    tCsA[None, None, k + 1],
+                    tCrA_copy_view[None, None, k + 1],
+                )
+            if const_expr(not B_in_regs):
+                cute.copy(
+                    smem_thr_copy_B,
+                    tCsB[None, None, k + 1],
+                    tCrB_copy_view[None, None, k + 1],
+                )
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+@cute.jit
+def _warp_mma_gemm_rs(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_B: cute.TiledCopy,
+):
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
+        if const_expr(k < cute.size(tCrA.shape[2]) - 1):
+            cute.copy(
+                smem_thr_copy_B,
+                tCsB[None, None, k + 1],
+                tCrB_copy_view[None, None, k + 1],
+            )
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_plane_bf16(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_plane0_base_addr: Int32,
+    k_plane1_base_addr: Int32,
+    k_plane2_base_addr: Int32,
+    k_plane3_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_plane,
+):
+    for mma_d in cutlass.range_constexpr(num_mma_d_qk):
+        plane_idx = mma_d // 4
+        mma_d_local = mma_d - plane_idx * 4
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            q_row = warp_q_idx * num_mma_q * 16 + mma_q * 16 + lane % 16
+            q_col = mma_d * 2 + lane // 16
+            q_offset = _permuted_offset_128b(q_row, q_col, upcast_stride_q)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset)
+            )
+            a_regs[mma_q, 0] = a0
+            a_regs[mma_q, 1] = a1
+            a_regs[mma_q, 2] = a2
+            a_regs[mma_q, 3] = a3
+
+        if const_expr(plane_idx == 0):
+            k_plane_base_addr = k_plane0_base_addr
+        elif const_expr(plane_idx == 1):
+            k_plane_base_addr = k_plane1_base_addr
+        elif const_expr(plane_idx == 2):
+            k_plane_base_addr = k_plane2_base_addr
+        else:
+            k_plane_base_addr = k_plane3_base_addr
+
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            k_row = (
+                row_base
+                + warp_kv_idx * num_mma_kv * 16
+                + mma_kv * 16
+                + 8 * (lane // 16)
+                + lane % 8
+            )
+            k_col = mma_d_local * 2 + (lane % 16) // 8
+            k_offset = _permuted_offset_128b(k_row, k_col, upcast_stride_plane)
+            b0, b1, b2, b3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(k_plane_base_addr, k_offset)
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_plane_bf16_row0_1x1(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_plane0_base_addr: Int32,
+    k_plane1_base_addr: Int32,
+    k_plane2_base_addr: Int32,
+    k_plane3_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_plane,
+):
+    q_row = warp_q_idx * 16 + lane % 16
+    k_row = row_base + warp_kv_idx * 16 + 8 * (lane // 16) + lane % 8
+    for mma_pair in cutlass.range_constexpr(num_mma_d_qk // 2):
+        mma_d0 = mma_pair * 2
+        mma_d1 = mma_d0 + 1
+
+        q_col0 = mma_d0 * 2 + lane // 16
+        q_offset0 = _permuted_offset_128b(q_row, q_col0, upcast_stride_q)
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+            _smem_addr_from_b128_offset(q_base_addr, q_offset0)
+        )
+        q_col1 = mma_d1 * 2 + lane // 16
+        q_offset1 = _permuted_offset_128b(q_row, q_col1, upcast_stride_q)
+        a4, a5, a6, a7 = ldmatrix_m8n8x4_b16(
+            _smem_addr_from_b128_offset(q_base_addr, q_offset1)
+        )
+
+        plane_idx0 = mma_d0 // 4
+        mma_d0_local = mma_d0 - plane_idx0 * 4
+        if const_expr(plane_idx0 == 0):
+            k_plane_base_addr = k_plane0_base_addr
+        elif const_expr(plane_idx0 == 1):
+            k_plane_base_addr = k_plane1_base_addr
+        elif const_expr(plane_idx0 == 2):
+            k_plane_base_addr = k_plane2_base_addr
+        else:
+            k_plane_base_addr = k_plane3_base_addr
+
+        k_col0 = mma_d0_local * 2 + (lane % 16) // 8
+        k_offset0 = _permuted_offset_128b(k_row, k_col0, upcast_stride_plane)
+        b0, b1, b2, b3 = ldmatrix_m8n8x4_b16(
+            _smem_addr_from_b128_offset(k_plane_base_addr, k_offset0)
+        )
+
+        d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+            s_frag[0, 0, 0],
+            s_frag[0, 0, 1],
+            s_frag[0, 0, 2],
+            s_frag[0, 0, 3],
+            s_frag[0, 0, 4],
+            s_frag[0, 0, 5],
+            s_frag[0, 0, 6],
+            s_frag[0, 0, 7],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+            b2,
+            b3,
+        )
+        s_frag[0, 0, 0] = d0
+        s_frag[0, 0, 1] = d1
+        s_frag[0, 0, 2] = d2
+        s_frag[0, 0, 3] = d3
+        s_frag[0, 0, 4] = d4
+        s_frag[0, 0, 5] = d5
+        s_frag[0, 0, 6] = d6
+        s_frag[0, 0, 7] = d7
+
+        plane_idx1 = mma_d1 // 4
+        mma_d1_local = mma_d1 - plane_idx1 * 4
+        if const_expr(plane_idx1 == 0):
+            k_plane_base_addr = k_plane0_base_addr
+        elif const_expr(plane_idx1 == 1):
+            k_plane_base_addr = k_plane1_base_addr
+        elif const_expr(plane_idx1 == 2):
+            k_plane_base_addr = k_plane2_base_addr
+        else:
+            k_plane_base_addr = k_plane3_base_addr
+
+        k_col1 = mma_d1_local * 2 + (lane % 16) // 8
+        k_offset1 = _permuted_offset_128b(k_row, k_col1, upcast_stride_plane)
+        b0, b1, b2, b3 = ldmatrix_m8n8x4_b16(
+            _smem_addr_from_b128_offset(k_plane_base_addr, k_offset1)
+        )
+
+        d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+            s_frag[0, 0, 0],
+            s_frag[0, 0, 1],
+            s_frag[0, 0, 2],
+            s_frag[0, 0, 3],
+            s_frag[0, 0, 4],
+            s_frag[0, 0, 5],
+            s_frag[0, 0, 6],
+            s_frag[0, 0, 7],
+            a4,
+            a5,
+            a6,
+            a7,
+            b0,
+            b1,
+            b2,
+            b3,
+        )
+        s_frag[0, 0, 0] = d0
+        s_frag[0, 0, 1] = d1
+        s_frag[0, 0, 2] = d2
+        s_frag[0, 0, 3] = d3
+        s_frag[0, 0, 4] = d4
+        s_frag[0, 0, 5] = d5
+        s_frag[0, 0, 6] = d6
+        s_frag[0, 0, 7] = d7
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_plane_fp8_raw(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_plane0_base_addr: Int32,
+    k_plane1_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_plane,
+):
+    upcast_stride_full = upcast_stride_plane * Int32(2)
+    q_offset = _permuted_offset_128b(
+        warp_q_idx * num_mma_q * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_q,
+    )
+    k_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + 8 * (lane // 16) + lane % 8,
+        (lane % 16) // 8,
+        upcast_stride_full,
+    )
+    for mma_d in cutlass.range_constexpr(num_mma_d_qk):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        q_offset_cur = q_offset
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs[mma_q, 0] = a0
+            a_regs[mma_q, 1] = a1
+            a_regs[mma_q, 2] = a2
+            a_regs[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+        q_offset = _advance_offset_by_column_128b_2(q_offset_cur, mma_d) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            k_addr = _smem_addr_from_split_planes_128b(
+                k_plane0_base_addr,
+                k_plane1_base_addr,
+                k_offset_cur,
+                upcast_stride_full,
+            )
+            if const_expr(mma_d % 2 == 0):
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_left_half_b16(k_addr)
+            else:
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_right_half_b16(k_addr)
+            b_f8_0 = frag_layout_swizzle_16b_to_8b(b_f8_0)
+            b_f8_1 = frag_layout_swizzle_16b_to_8b(b_f8_1)
+            b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+            b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, 16, upcast_stride_full
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        if const_expr(mma_d % 2 == 1):
+            k_offset = _advance_offset_by_column_128b_2(
+                k_offset_cur, mma_d // 2
+            ) - Int32(num_mma_kv * 16 * upcast_stride_full)
+        else:
+            k_offset = k_offset_cur - Int32(num_mma_kv * 16 * upcast_stride_full)
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_plane_fp8_raw_row0_1x1(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_plane0_base_addr: Int32,
+    k_plane1_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_plane,
+):
+    upcast_stride_full = upcast_stride_plane * Int32(2)
+    q_offset = _permuted_offset_128b(
+        warp_q_idx * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_q,
+    )
+    k_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * 16 + 8 * (lane // 16) + lane % 8,
+        (lane % 16) // 8,
+        upcast_stride_full,
+    )
+    for mma_pair in cutlass.range_constexpr(num_mma_d_qk // 2):
+        mma_d0 = mma_pair * 2
+        mma_d1 = mma_d0 + 1
+
+        q_offset_cur = q_offset
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+            _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+        )
+        q_offset_mid = _advance_offset_by_column_128b_2(
+            _advance_offset_by_row_128b(q_offset_cur, 16, upcast_stride_q),
+            mma_d0,
+        ) - Int32(16 * upcast_stride_q)
+
+        k_addr = _smem_addr_from_split_planes_128b(
+            k_plane0_base_addr,
+            k_plane1_base_addr,
+            k_offset,
+            upcast_stride_full,
+        )
+        b_f8_0, b_f8_1, b_f8_2, b_f8_3 = ldmatrix_m8n8x4_b16(k_addr)
+        b_f8_left0 = frag_layout_swizzle_16b_to_8b(b_f8_0)
+        b_f8_left1 = frag_layout_swizzle_16b_to_8b(b_f8_2)
+        b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_left0)
+        b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_left1)
+        d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+            s_frag[0, 0, 0],
+            s_frag[0, 0, 1],
+            s_frag[0, 0, 2],
+            s_frag[0, 0, 3],
+            s_frag[0, 0, 4],
+            s_frag[0, 0, 5],
+            s_frag[0, 0, 6],
+            s_frag[0, 0, 7],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+            b2,
+            b3,
+        )
+        s_frag[0, 0, 0] = d0
+        s_frag[0, 0, 1] = d1
+        s_frag[0, 0, 2] = d2
+        s_frag[0, 0, 3] = d3
+        s_frag[0, 0, 4] = d4
+        s_frag[0, 0, 5] = d5
+        s_frag[0, 0, 6] = d6
+        s_frag[0, 0, 7] = d7
+
+        q_offset_cur = q_offset_mid
+        a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+            _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+        )
+        q_offset = _advance_offset_by_column_128b_2(
+            _advance_offset_by_row_128b(q_offset_cur, 16, upcast_stride_q),
+            mma_d1,
+        ) - Int32(16 * upcast_stride_q)
+        b_f8_right0 = frag_layout_swizzle_16b_to_8b(b_f8_1)
+        b_f8_right1 = frag_layout_swizzle_16b_to_8b(b_f8_3)
+        b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_right0)
+        b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_right1)
+        d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+            s_frag[0, 0, 0],
+            s_frag[0, 0, 1],
+            s_frag[0, 0, 2],
+            s_frag[0, 0, 3],
+            s_frag[0, 0, 4],
+            s_frag[0, 0, 5],
+            s_frag[0, 0, 6],
+            s_frag[0, 0, 7],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+            b2,
+            b3,
+        )
+        s_frag[0, 0, 0] = d0
+        s_frag[0, 0, 1] = d1
+        s_frag[0, 0, 2] = d2
+        s_frag[0, 0, 3] = d3
+        s_frag[0, 0, 4] = d4
+        s_frag[0, 0, 5] = d5
+        s_frag[0, 0, 6] = d6
+        s_frag[0, 0, 7] = d7
+
+        k_offset = _advance_offset_by_column_128b_2(
+            _advance_offset_by_row_128b(k_offset, 16, upcast_stride_full),
+            mma_pair,
+        ) - Int32(16 * upcast_stride_full)
+
+
+@cute.jit
+def _literal_qk_mma_into_sfrag_mxfp8_raw(
+    s_frag: cute.Tensor,
+    q_base_addr: Int32,
+    k_base_addr: Int32,
+    lane,
+    warp_q_idx,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_qk,
+    upcast_stride_q,
+    upcast_stride_k,
+):
+    unit_scale = Uint32(0x7F7F7F7F)
+    shift16 = Uint32(16)
+    q_offset = _permuted_offset_128b(
+        warp_q_idx * num_mma_q * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_q,
+    )
+    k_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + 8 * (lane // 16) + lane % 8,
+        (lane % 16) // 8,
+        upcast_stride_k,
+    )
+    for mma_pair in cutlass.range_constexpr(num_mma_d_qk // 2):
+        a_regs_k0 = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        q_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+
+        q_offset_cur = q_offset
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            a_regs_k0[mma_q, 0] = a0
+            a_regs_k0[mma_q, 1] = a1
+            a_regs_k0[mma_q, 2] = a2
+            a_regs_k0[mma_q, 3] = a3
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+
+        mma_d0 = mma_pair * 2
+        q_offset_mid = _advance_offset_by_column_128b_2(q_offset_cur, mma_d0) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+        q_offset_cur = q_offset_mid
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(q_base_addr, q_offset_cur)
+            )
+            q_regs[mma_q, 0] = cvt_bf16x2x2_to_e4m3x4(a_regs_k0[mma_q, 0], a0)
+            q_regs[mma_q, 1] = cvt_bf16x2x2_to_e4m3x4(a_regs_k0[mma_q, 1], a1)
+            q_regs[mma_q, 2] = cvt_bf16x2x2_to_e4m3x4(a_regs_k0[mma_q, 2], a2)
+            q_regs[mma_q, 3] = cvt_bf16x2x2_to_e4m3x4(a_regs_k0[mma_q, 3], a3)
+            q_offset_cur = _advance_offset_by_row_128b(
+                q_offset_cur, 16, upcast_stride_q
+            )
+        q_offset = _advance_offset_by_column_128b_2(q_offset_cur, mma_d0 + 1) - Int32(
+            num_mma_q * 16 * upcast_stride_q
+        )
+
+        k_offset_cur = k_offset
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            b0_k0, b0_k1, b1_k0, b1_k1 = ldmatrix_m8n8x4_b16(
+                _smem_addr_from_b128_offset(k_base_addr, k_offset_cur)
+            )
+            b0_k0 = frag_layout_swizzle_16b_to_8b(b0_k0)
+            b1_k0 = frag_layout_swizzle_16b_to_8b(b1_k0)
+            b0_k1 = frag_layout_swizzle_16b_to_8b(b0_k1)
+            b1_k1 = frag_layout_swizzle_16b_to_8b(b1_k1)
+            k_offset_cur = _advance_offset_by_row_128b(
+                k_offset_cur, 16, upcast_stride_k
+            )
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                qa0 = q_regs[mma_q, 0]
+                qa1 = q_regs[mma_q, 1]
+                qa2 = q_regs[mma_q, 2]
+                qa3 = q_regs[mma_q, 3]
+
+                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                    s_frag[mma_q, mma_kv, 2],
+                    s_frag[mma_q, mma_kv, 3],
+                    qa0,
+                    qa1,
+                    qa2,
+                    qa3,
+                    b0_k0,
+                    b0_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                d4, d5, d6, d7 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                    s_frag[mma_q, mma_kv, 6],
+                    s_frag[mma_q, mma_kv, 7],
+                    qa0,
+                    qa1,
+                    qa2,
+                    qa3,
+                    b1_k0,
+                    b1_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                s_frag[mma_q, mma_kv, 0] = d0
+                s_frag[mma_q, mma_kv, 1] = d1
+                s_frag[mma_q, mma_kv, 2] = d2
+                s_frag[mma_q, mma_kv, 3] = d3
+                s_frag[mma_q, mma_kv, 4] = d4
+                s_frag[mma_q, mma_kv, 5] = d5
+                s_frag[mma_q, mma_kv, 6] = d6
+                s_frag[mma_q, mma_kv, 7] = d7
+
+        k_offset = _advance_offset_by_column_128b_2(k_offset_cur, mma_pair) - Int32(
+            num_mma_kv * 16 * upcast_stride_k
+        )
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_plane_bf16_packed(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_plane0_base_addr: Int32,
+    v_plane1_base_addr: Int32,
+    v_plane2_base_addr: Int32,
+    v_plane3_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_plane,
+    v_scale,
+    debug_regs: cute.Tensor | None = None,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = bfloat2_mul(p_frag[mma_q, mma_kv, 0], v_scale_bf2)
+            a_regs[mma_q, 1] = bfloat2_mul(p_frag[mma_q, mma_kv, 1], v_scale_bf2)
+            a_regs[mma_q, 2] = bfloat2_mul(p_frag[mma_q, mma_kv, 2], v_scale_bf2)
+            a_regs[mma_q, 3] = bfloat2_mul(p_frag[mma_q, mma_kv, 3], v_scale_bf2)
+
+        v_row = row_base + warp_kv_idx * num_mma_kv * 16 + mma_kv * 16 + lane % 16
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            plane_idx = mma_d // 4
+            mma_d_local = mma_d - plane_idx * 4
+            if const_expr(plane_idx == 0):
+                v_plane_base_addr = v_plane0_base_addr
+            elif const_expr(plane_idx == 1):
+                v_plane_base_addr = v_plane1_base_addr
+            elif const_expr(plane_idx == 2):
+                v_plane_base_addr = v_plane2_base_addr
+            else:
+                v_plane_base_addr = v_plane3_base_addr
+            v_col = mma_d_local * 2 + lane // 16
+            v_offset = _permuted_offset_128b(v_row, v_col, upcast_stride_plane)
+            b0, b1, b2, b3 = ldmatrix_m8n8x4_trans_b16(
+                _smem_addr_from_b128_offset(v_plane_base_addr, v_offset)
+            )
+            if const_expr(debug_regs is not None):
+                lane_words = num_mma_kv * num_mma_d_vo * 4
+                dst_words = cute.size(debug_regs.shape)
+                dst_idx = lane * lane_words + (mma_kv * num_mma_d_vo + mma_d) * 4
+                if dst_idx + 0 < dst_words:
+                    debug_regs[dst_idx + 0] = b0
+                if dst_idx + 1 < dst_words:
+                    debug_regs[dst_idx + 1] = b1
+                if dst_idx + 2 < dst_words:
+                    debug_regs[dst_idx + 2] = b2
+                if dst_idx + 3 < dst_words:
+                    debug_regs[dst_idx + 3] = b3
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_plane_bf16_row0_1x1(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_plane0_base_addr: Int32,
+    v_plane1_base_addr: Int32,
+    v_plane2_base_addr: Int32,
+    v_plane3_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_d_vo,
+    upcast_stride_plane,
+    v_scale,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    v_row = row_base + warp_kv_idx * 16 + lane % 16
+    a0 = bfloat2_mul(p_frag[0, 0, 0], v_scale_bf2)
+    a1 = Uint32(0)
+    a2 = bfloat2_mul(p_frag[0, 0, 2], v_scale_bf2)
+    a3 = Uint32(0)
+    for mma_pair in cutlass.range_constexpr(num_mma_d_vo // 2):
+        mma_d0 = mma_pair * 2
+        mma_d1 = mma_d0 + 1
+
+        plane_idx0 = mma_d0 // 4
+        mma_d0_local = mma_d0 - plane_idx0 * 4
+        if const_expr(plane_idx0 == 0):
+            v_plane_base_addr0 = v_plane0_base_addr
+        elif const_expr(plane_idx0 == 1):
+            v_plane_base_addr0 = v_plane1_base_addr
+        elif const_expr(plane_idx0 == 2):
+            v_plane_base_addr0 = v_plane2_base_addr
+        else:
+            v_plane_base_addr0 = v_plane3_base_addr
+        v_col0 = mma_d0_local * 2 + lane // 16
+        v_offset0 = _permuted_offset_128b(v_row, v_col0, upcast_stride_plane)
+        b0, b1, b2, b3 = ldmatrix_m8n8x4_trans_b16(
+            _smem_addr_from_b128_offset(v_plane_base_addr0, v_offset0)
+        )
+
+        plane_idx1 = mma_d1 // 4
+        mma_d1_local = mma_d1 - plane_idx1 * 4
+        if const_expr(plane_idx1 == 0):
+            v_plane_base_addr1 = v_plane0_base_addr
+        elif const_expr(plane_idx1 == 1):
+            v_plane_base_addr1 = v_plane1_base_addr
+        elif const_expr(plane_idx1 == 2):
+            v_plane_base_addr1 = v_plane2_base_addr
+        else:
+            v_plane_base_addr1 = v_plane3_base_addr
+        v_col1 = mma_d1_local * 2 + lane // 16
+        v_offset1 = _permuted_offset_128b(v_row, v_col1, upcast_stride_plane)
+        b4, b5, b6, b7 = ldmatrix_m8n8x4_trans_b16(
+            _smem_addr_from_b128_offset(v_plane_base_addr1, v_offset1)
+        )
+
+        d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+            o_frag[0, mma_d0, 0],
+            o_frag[0, mma_d0, 1],
+            o_frag[0, mma_d0, 2],
+            o_frag[0, mma_d0, 3],
+            o_frag[0, mma_d0, 4],
+            o_frag[0, mma_d0, 5],
+            o_frag[0, mma_d0, 6],
+            o_frag[0, mma_d0, 7],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+            b2,
+            b3,
+        )
+        o_frag[0, mma_d0, 0] = d0
+        o_frag[0, mma_d0, 1] = d1
+        o_frag[0, mma_d0, 2] = d2
+        o_frag[0, mma_d0, 3] = d3
+        o_frag[0, mma_d0, 4] = d4
+        o_frag[0, mma_d0, 5] = d5
+        o_frag[0, mma_d0, 6] = d6
+        o_frag[0, mma_d0, 7] = d7
+
+        d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+            o_frag[0, mma_d1, 0],
+            o_frag[0, mma_d1, 1],
+            o_frag[0, mma_d1, 2],
+            o_frag[0, mma_d1, 3],
+            o_frag[0, mma_d1, 4],
+            o_frag[0, mma_d1, 5],
+            o_frag[0, mma_d1, 6],
+            o_frag[0, mma_d1, 7],
+            a0,
+            a1,
+            a2,
+            a3,
+            b4,
+            b5,
+            b6,
+            b7,
+        )
+        o_frag[0, mma_d1, 0] = d0
+        o_frag[0, mma_d1, 1] = d1
+        o_frag[0, mma_d1, 2] = d2
+        o_frag[0, mma_d1, 3] = d3
+        o_frag[0, mma_d1, 4] = d4
+        o_frag[0, mma_d1, 5] = d5
+        o_frag[0, mma_d1, 6] = d6
+        o_frag[0, mma_d1, 7] = d7
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_plane_fp8_raw(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_plane0_base_addr: Int32,
+    v_plane1_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_plane,
+    v_scale,
+    debug_regs: cute.Tensor | None = None,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    upcast_stride_full = upcast_stride_plane * Int32(2)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_full,
+    )
+    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = bfloat2_mul(p_frag[mma_q, mma_kv, 0], v_scale_bf2)
+            a_regs[mma_q, 1] = bfloat2_mul(p_frag[mma_q, mma_kv, 1], v_scale_bf2)
+            a_regs[mma_q, 2] = bfloat2_mul(p_frag[mma_q, mma_kv, 2], v_scale_bf2)
+            a_regs[mma_q, 3] = bfloat2_mul(p_frag[mma_q, mma_kv, 3], v_scale_bf2)
+
+        v_offset_cur = v_offset
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            v_addr = _smem_addr_from_split_planes_128b(
+                v_plane0_base_addr,
+                v_plane1_base_addr,
+                v_offset_cur,
+                upcast_stride_full,
+            )
+            if const_expr(mma_d % 2 == 0):
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_left_half_b16(v_addr)
+            else:
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_right_half_b16(v_addr)
+            b_f8_0 = frag_layout_swizzle_16b_to_8b_trans(b_f8_0)
+            b_f8_1 = frag_layout_swizzle_16b_to_8b_trans(b_f8_1)
+            b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+            b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+            tmp = b1
+            b1 = b2
+            b2 = tmp
+            if const_expr(debug_regs is not None):
+                lane_words = num_mma_kv * num_mma_d_vo * 4
+                dst_words = cute.size(debug_regs.shape)
+                dst_idx = lane * lane_words + (mma_kv * num_mma_d_vo + mma_d) * 4
+                if dst_idx + 0 < dst_words:
+                    debug_regs[dst_idx + 0] = b0
+                if dst_idx + 1 < dst_words:
+                    debug_regs[dst_idx + 1] = b1
+                if dst_idx + 2 < dst_words:
+                    debug_regs[dst_idx + 2] = b2
+                if dst_idx + 3 < dst_words:
+                    debug_regs[dst_idx + 3] = b3
+            if const_expr(mma_d % 2 == 1):
+                v_offset_cur = _advance_offset_by_column_128b_2(
+                    v_offset_cur, mma_d // 2
+                )
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+        v_offset = _advance_offset_by_row_128b(
+            v_offset_cur, 16, upcast_stride_full
+        ) - Int32(num_mma_d_vo)
+    v_offset -= Int32(16 * num_mma_kv * upcast_stride_full)
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_plane_fp8_raw_row0(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_plane0_base_addr: Int32,
+    v_plane1_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_plane,
+    v_scale,
+    debug_regs: cute.Tensor | None = None,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    upcast_stride_full = upcast_stride_plane * Int32(2)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_full,
+    )
+    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = bfloat2_mul(p_frag[mma_q, mma_kv, 0], v_scale_bf2)
+            a_regs[mma_q, 1] = Uint32(0)
+            a_regs[mma_q, 2] = bfloat2_mul(p_frag[mma_q, mma_kv, 2], v_scale_bf2)
+            a_regs[mma_q, 3] = Uint32(0)
+
+        v_offset_cur = v_offset
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            v_addr = _smem_addr_from_split_planes_128b(
+                v_plane0_base_addr,
+                v_plane1_base_addr,
+                v_offset_cur,
+                upcast_stride_full,
+            )
+            if const_expr(mma_d % 2 == 0):
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_left_half_b16(v_addr)
+            else:
+                b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_right_half_b16(v_addr)
+            b_f8_0 = frag_layout_swizzle_16b_to_8b_trans(b_f8_0)
+            b_f8_1 = frag_layout_swizzle_16b_to_8b_trans(b_f8_1)
+            b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+            b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+            tmp = b1
+            b1 = b2
+            b2 = tmp
+            if const_expr(debug_regs is not None):
+                lane_words = num_mma_kv * num_mma_d_vo * 4
+                dst_words = cute.size(debug_regs.shape)
+                dst_idx = lane * lane_words + (mma_kv * num_mma_d_vo + mma_d) * 4
+                if dst_idx + 0 < dst_words:
+                    debug_regs[dst_idx + 0] = b0
+                if dst_idx + 1 < dst_words:
+                    debug_regs[dst_idx + 1] = b1
+                if dst_idx + 2 < dst_words:
+                    debug_regs[dst_idx + 2] = b2
+                if dst_idx + 3 < dst_words:
+                    debug_regs[dst_idx + 3] = b3
+            if const_expr(mma_d % 2 == 1):
+                v_offset_cur = _advance_offset_by_column_128b_2(
+                    v_offset_cur, mma_d // 2
+                )
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0,
+                    b1,
+                    b2,
+                    b3,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+        v_offset = _advance_offset_by_row_128b(
+            v_offset_cur, 16, upcast_stride_full
+        ) - Int32(num_mma_d_vo)
+    v_offset -= Int32(16 * num_mma_kv * upcast_stride_full)
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_plane_fp8_raw_row0_1x1(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_plane0_base_addr: Int32,
+    v_plane1_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_d_vo,
+    upcast_stride_plane,
+    v_scale,
+):
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    upcast_stride_full = upcast_stride_plane * Int32(2)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_full,
+    )
+    a0 = bfloat2_mul(p_frag[0, 0, 0], v_scale_bf2)
+    a1 = Uint32(0)
+    a2 = bfloat2_mul(p_frag[0, 0, 2], v_scale_bf2)
+    a3 = Uint32(0)
+    v_offset_cur = v_offset
+    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+        v_addr = _smem_addr_from_split_planes_128b(
+            v_plane0_base_addr,
+            v_plane1_base_addr,
+            v_offset_cur,
+            upcast_stride_full,
+        )
+        if const_expr(mma_d % 2 == 0):
+            b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_left_half_b16(v_addr)
+        else:
+            b_f8_0, b_f8_1 = ldmatrix_m8n8x4_trans_right_half_b16(v_addr)
+        b_f8_0 = frag_layout_swizzle_16b_to_8b_trans(b_f8_0)
+        b_f8_1 = frag_layout_swizzle_16b_to_8b_trans(b_f8_1)
+        b0, b1 = fp8x4_e4m3_to_bfloat2x2(b_f8_0)
+        b2, b3 = fp8x4_e4m3_to_bfloat2x2(b_f8_1)
+        tmp = b1
+        b1 = b2
+        b2 = tmp
+        if const_expr(mma_d % 2 == 1):
+            v_offset_cur = _advance_offset_by_column_128b_2(v_offset_cur, mma_d // 2)
+        d0, d1, d2, d3, d4, d5, d6, d7 = bf16_mma_m16n16k16_f32(
+            o_frag[0, mma_d, 0],
+            o_frag[0, mma_d, 1],
+            o_frag[0, mma_d, 2],
+            o_frag[0, mma_d, 3],
+            o_frag[0, mma_d, 4],
+            o_frag[0, mma_d, 5],
+            o_frag[0, mma_d, 6],
+            o_frag[0, mma_d, 7],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+            b2,
+            b3,
+        )
+        o_frag[0, mma_d, 0] = d0
+        o_frag[0, mma_d, 1] = d1
+        o_frag[0, mma_d, 2] = d2
+        o_frag[0, mma_d, 3] = d3
+        o_frag[0, mma_d, 4] = d4
+        o_frag[0, mma_d, 5] = d5
+        o_frag[0, mma_d, 6] = d6
+        o_frag[0, mma_d, 7] = d7
+
+
+@cute.jit
+def _literal_pv_mma_into_ofrag_mxfp8_raw(
+    o_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    v_base_addr: Int32,
+    lane,
+    warp_kv_idx,
+    row_base,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+    upcast_stride_v,
+    v_scale,
+):
+    unit_scale = Uint32(0x7F7F7F7F)
+    mask16 = Uint32(0xFFFF)
+    shift16 = Uint32(16)
+    v_scale_bf2 = broadcast_f32_to_bfloat2(v_scale)
+    v_offset = _permuted_offset_128b(
+        row_base + warp_kv_idx * num_mma_kv * 16 + lane % 16,
+        lane // 16,
+        upcast_stride_v,
+    )
+    for mma_pair in cutlass.range_constexpr(num_mma_kv // 2):
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 4), stride=(4, 1)),
+            Uint32,
+        )
+        mma_kv0 = mma_pair * 2
+        mma_kv1 = mma_kv0 + 1
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            a_regs[mma_q, 0] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 0], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 0], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+            a_regs[mma_q, 1] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 1], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 1], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+            a_regs[mma_q, 2] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 2], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 2], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+            a_regs[mma_q, 3] = (
+                cvt_bf16x2_to_e4m3x2(
+                    bfloat2_mul(p_frag[mma_q, mma_kv0, 3], v_scale_bf2)
+                )
+                & mask16
+            ) | (
+                (
+                    cvt_bf16x2_to_e4m3x2(
+                        bfloat2_mul(p_frag[mma_q, mma_kv1, 3], v_scale_bf2)
+                    )
+                    & mask16
+                )
+                << shift16
+            )
+
+        v_offset_k0 = v_offset
+        v_offset_k1 = _advance_offset_by_row_128b(v_offset, 16, upcast_stride_v)
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            if const_expr(mma_d % 2 == 0):
+                b0_k0, b1_k0 = ldmatrix_m8n8x4_trans_left_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k0)
+                )
+                b0_k1, b1_k1 = ldmatrix_m8n8x4_trans_left_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k1)
+                )
+            else:
+                b0_k0, b1_k0 = ldmatrix_m8n8x4_trans_right_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k0)
+                )
+                b0_k1, b1_k1 = ldmatrix_m8n8x4_trans_right_half_b16(
+                    _smem_addr_from_b128_offset(v_base_addr, v_offset_k1)
+                )
+            b0_k0 = frag_layout_swizzle_16b_to_8b_trans(b0_k0)
+            b1_k0 = frag_layout_swizzle_16b_to_8b_trans(b1_k0)
+            b0_k1 = frag_layout_swizzle_16b_to_8b_trans(b0_k1)
+            b1_k1 = frag_layout_swizzle_16b_to_8b_trans(b1_k1)
+
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    o_frag[mma_q, mma_d, 0],
+                    o_frag[mma_q, mma_d, 1],
+                    o_frag[mma_q, mma_d, 2],
+                    o_frag[mma_q, mma_d, 3],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b0_k0,
+                    b0_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                d4, d5, d6, d7 = mxfp8_mma_m16n8k32_f32_e4m3(
+                    o_frag[mma_q, mma_d, 4],
+                    o_frag[mma_q, mma_d, 5],
+                    o_frag[mma_q, mma_d, 6],
+                    o_frag[mma_q, mma_d, 7],
+                    a_regs[mma_q, 0],
+                    a_regs[mma_q, 1],
+                    a_regs[mma_q, 2],
+                    a_regs[mma_q, 3],
+                    b1_k0,
+                    b1_k1,
+                    unit_scale,
+                    unit_scale,
+                )
+                o_frag[mma_q, mma_d, 0] = d0
+                o_frag[mma_q, mma_d, 1] = d1
+                o_frag[mma_q, mma_d, 2] = d2
+                o_frag[mma_q, mma_d, 3] = d3
+                o_frag[mma_q, mma_d, 4] = d4
+                o_frag[mma_q, mma_d, 5] = d5
+                o_frag[mma_q, mma_d, 6] = d6
+                o_frag[mma_q, mma_d, 7] = d7
+            if const_expr(mma_d % 2 == 1):
+                v_offset_k0 = _advance_offset_by_column_128b_2(v_offset_k0, mma_d // 2)
+                v_offset_k1 = _advance_offset_by_column_128b_2(v_offset_k1, mma_d // 2)
+
+        v_offset = _advance_offset_by_row_128b(v_offset, 32, upcast_stride_v)
+
+
+@cute.jit
+def _literal_update_mdo_states_fp32_pack_p(
+    s_frag: cute.Tensor,
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    sm_scale_log2: Float32,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+):
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for row_slot in cutlass.range_constexpr(2):
+            m_prev = Float32(m_frag[mma_q, row_slot])
+            m_new = Float32(m_prev)
+            for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                m_local = attention_ops.fmax(
+                    attention_ops.fmax(
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 0],
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 1],
+                    ),
+                    attention_ops.fmax(
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 4],
+                        s_frag[mma_q, mma_kv, row_slot * 2 + 5],
+                    ),
+                )
+                m_new = attention_ops.fmax(m_new, m_local)
+            m_new = attention_ops.fmax(
+                m_new, cute.arch.shuffle_sync_bfly(m_new, offset=2)
+            )
+            m_new = attention_ops.fmax(
+                m_new, cute.arch.shuffle_sync_bfly(m_new, offset=1)
+            )
+
+            scale_term = (
+                Float32(1.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32((m_prev - m_new) * sm_scale_log2)
+            )
+            d_frag[mma_q, row_slot] = Float32(d_frag[mma_q, row_slot] * scale_term)
+            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                o_frag[mma_q, mma_d, row_slot * 2 + 0] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 1] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 4] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 5] *= scale_term
+
+            for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                p0 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 0] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p1 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 1] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p2 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 4] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p3 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag[mma_q, mma_kv, row_slot * 2 + 5] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p_frag[mma_q, mma_kv, row_slot + 0] = pack_f32x2_to_bfloat2(p0, p1)
+                p_frag[mma_q, mma_kv, row_slot + 2] = pack_f32x2_to_bfloat2(p2, p3)
+
+            m_frag[mma_q, row_slot] = Float32(m_new)
+
+
+@cute.jit
+def _literal_update_mdo_states_fp32_pack_p_row0(
+    s_frag: cute.Tensor,
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    sm_scale_log2: Float32,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+):
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        m_prev = Float32(m_frag[mma_q, 0])
+        m_new = Float32(m_prev)
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            m_local = attention_ops.fmax(
+                attention_ops.fmax(
+                    s_frag[mma_q, mma_kv, 0],
+                    s_frag[mma_q, mma_kv, 1],
+                ),
+                attention_ops.fmax(
+                    s_frag[mma_q, mma_kv, 4],
+                    s_frag[mma_q, mma_kv, 5],
+                ),
+            )
+            m_new = attention_ops.fmax(m_new, m_local)
+        m_new = attention_ops.fmax(m_new, cute.arch.shuffle_sync_bfly(m_new, offset=2))
+        m_new = attention_ops.fmax(m_new, cute.arch.shuffle_sync_bfly(m_new, offset=1))
+
+        scale_term = (
+            Float32(1.0)
+            if m_new == -Float32.inf
+            else _exp2_approx_ftz_f32((m_prev - m_new) * sm_scale_log2)
+        )
+        d_frag[mma_q, 0] = Float32(d_frag[mma_q, 0] * scale_term)
+        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+            o_frag[mma_q, mma_d, 0] *= scale_term
+            o_frag[mma_q, mma_d, 1] *= scale_term
+            o_frag[mma_q, mma_d, 4] *= scale_term
+            o_frag[mma_q, mma_d, 5] *= scale_term
+
+        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+            p0 = (
+                Float32(0.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32(
+                    (s_frag[mma_q, mma_kv, 0] - m_new) * sm_scale_log2
+                )
+            )
+            p1 = (
+                Float32(0.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32(
+                    (s_frag[mma_q, mma_kv, 1] - m_new) * sm_scale_log2
+                )
+            )
+            p2 = (
+                Float32(0.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32(
+                    (s_frag[mma_q, mma_kv, 4] - m_new) * sm_scale_log2
+                )
+            )
+            p3 = (
+                Float32(0.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32(
+                    (s_frag[mma_q, mma_kv, 5] - m_new) * sm_scale_log2
+                )
+            )
+            p_frag[mma_q, mma_kv, 0] = pack_f32x2_to_bfloat2(p0, p1)
+            p_frag[mma_q, mma_kv, 2] = pack_f32x2_to_bfloat2(p2, p3)
+            p_frag[mma_q, mma_kv, 1] = Uint32(0)
+            p_frag[mma_q, mma_kv, 3] = Uint32(0)
+
+        m_frag[mma_q, 0] = Float32(m_new)
+
+
+@cute.jit
+def _literal_update_mdo_states_fp32_pack_p_row0_1x1(
+    s_frag: cute.Tensor,
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    p_frag: cute.Tensor,
+    sm_scale_log2: Float32,
+    num_mma_d_vo,
+):
+    m_prev = Float32(m_frag[0, 0])
+    m_new = attention_ops.fmax(
+        attention_ops.fmax(s_frag[0, 0, 0], s_frag[0, 0, 1]),
+        attention_ops.fmax(s_frag[0, 0, 4], s_frag[0, 0, 5]),
+    )
+    m_new = attention_ops.fmax(m_prev, m_new)
+    m_new = attention_ops.fmax(m_new, cute.arch.shuffle_sync_bfly(m_new, offset=2))
+    m_new = attention_ops.fmax(m_new, cute.arch.shuffle_sync_bfly(m_new, offset=1))
+
+    scale_term = (
+        Float32(1.0)
+        if m_new == -Float32.inf
+        else _exp2_approx_ftz_f32((m_prev - m_new) * sm_scale_log2)
+    )
+    d_frag[0, 0] = Float32(d_frag[0, 0] * scale_term)
+    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+        o_frag[0, mma_d, 0] *= scale_term
+        o_frag[0, mma_d, 1] *= scale_term
+        o_frag[0, mma_d, 4] *= scale_term
+        o_frag[0, mma_d, 5] *= scale_term
+
+    p0 = (
+        Float32(0.0)
+        if m_new == -Float32.inf
+        else _exp2_approx_ftz_f32((s_frag[0, 0, 0] - m_new) * sm_scale_log2)
+    )
+    p1 = (
+        Float32(0.0)
+        if m_new == -Float32.inf
+        else _exp2_approx_ftz_f32((s_frag[0, 0, 1] - m_new) * sm_scale_log2)
+    )
+    p2 = (
+        Float32(0.0)
+        if m_new == -Float32.inf
+        else _exp2_approx_ftz_f32((s_frag[0, 0, 4] - m_new) * sm_scale_log2)
+    )
+    p3 = (
+        Float32(0.0)
+        if m_new == -Float32.inf
+        else _exp2_approx_ftz_f32((s_frag[0, 0, 5] - m_new) * sm_scale_log2)
+    )
+    p_frag[0, 0, 0] = pack_f32x2_to_bfloat2(p0, p1)
+    p_frag[0, 0, 2] = pack_f32x2_to_bfloat2(p2, p3)
+    p_frag[0, 0, 1] = Uint32(0)
+    p_frag[0, 0, 3] = Uint32(0)
+    m_frag[0, 0] = Float32(m_new)
+
+
+@cute.jit
+def _literal_update_mdo_states_fp32_pack_p_pairwise(
+    s_frag0: cute.Tensor,
+    s_frag1: cute.Tensor,
+    o_frag: cute.Tensor,
+    m_frag: cute.Tensor,
+    d_frag: cute.Tensor,
+    p_frag0: cute.Tensor,
+    p_frag1: cute.Tensor,
+    sm_scale_log2: Float32,
+    num_mma_q,
+    num_mma_kv,
+    num_mma_d_vo,
+):
+    for mma_q in cutlass.range_constexpr(num_mma_q):
+        for row_slot in cutlass.range_constexpr(2):
+            m_prev = Float32(m_frag[mma_q, row_slot])
+            m_new = Float32(m_prev)
+            for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                m_local0 = attention_ops.fmax(
+                    attention_ops.fmax(
+                        s_frag0[mma_q, mma_kv, row_slot * 2 + 0],
+                        s_frag0[mma_q, mma_kv, row_slot * 2 + 1],
+                    ),
+                    attention_ops.fmax(
+                        s_frag0[mma_q, mma_kv, row_slot * 2 + 4],
+                        s_frag0[mma_q, mma_kv, row_slot * 2 + 5],
+                    ),
+                )
+                m_local1 = attention_ops.fmax(
+                    attention_ops.fmax(
+                        s_frag1[mma_q, mma_kv, row_slot * 2 + 0],
+                        s_frag1[mma_q, mma_kv, row_slot * 2 + 1],
+                    ),
+                    attention_ops.fmax(
+                        s_frag1[mma_q, mma_kv, row_slot * 2 + 4],
+                        s_frag1[mma_q, mma_kv, row_slot * 2 + 5],
+                    ),
+                )
+                m_new = attention_ops.fmax(
+                    m_new, attention_ops.fmax(m_local0, m_local1)
+                )
+            m_new = attention_ops.fmax(
+                m_new, cute.arch.shuffle_sync_bfly(m_new, offset=2)
+            )
+            m_new = attention_ops.fmax(
+                m_new, cute.arch.shuffle_sync_bfly(m_new, offset=1)
+            )
+
+            scale_term = (
+                Float32(1.0)
+                if m_new == -Float32.inf
+                else _exp2_approx_ftz_f32((m_prev - m_new) * sm_scale_log2)
+            )
+            d_frag[mma_q, row_slot] = Float32(d_frag[mma_q, row_slot] * scale_term)
+            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                o_frag[mma_q, mma_d, row_slot * 2 + 0] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 1] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 4] *= scale_term
+                o_frag[mma_q, mma_d, row_slot * 2 + 5] *= scale_term
+
+            for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                p00 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag0[mma_q, mma_kv, row_slot * 2 + 0] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p01 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag0[mma_q, mma_kv, row_slot * 2 + 1] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p02 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag0[mma_q, mma_kv, row_slot * 2 + 4] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p03 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag0[mma_q, mma_kv, row_slot * 2 + 5] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p10 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag1[mma_q, mma_kv, row_slot * 2 + 0] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p11 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag1[mma_q, mma_kv, row_slot * 2 + 1] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p12 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag1[mma_q, mma_kv, row_slot * 2 + 4] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p13 = (
+                    Float32(0.0)
+                    if m_new == -Float32.inf
+                    else _exp2_approx_ftz_f32(
+                        (s_frag1[mma_q, mma_kv, row_slot * 2 + 5] - m_new)
+                        * sm_scale_log2
+                    )
+                )
+                p_frag0[mma_q, mma_kv, row_slot + 0] = pack_f32x2_to_bfloat2(p00, p01)
+                p_frag0[mma_q, mma_kv, row_slot + 2] = pack_f32x2_to_bfloat2(p02, p03)
+                p_frag1[mma_q, mma_kv, row_slot + 0] = pack_f32x2_to_bfloat2(p10, p11)
+                p_frag1[mma_q, mma_kv, row_slot + 2] = pack_f32x2_to_bfloat2(p12, p13)
+
+            m_frag[mma_q, row_slot] = Float32(m_new)
+
+
+class PagedForwardKernel:
+    DECODE_NATIVE_FP8_RUNTIME_CHUNK_THRESHOLD = 11 * 64
+
+    def __init__(
+        self,
+        dtype_q: Type[cutlass.Numeric],
+        dtype_kv: Type[cutlass.Numeric],
+        dtype_kv_storage: Type[cutlass.Numeric],
+        dtype_o: Type[cutlass.Numeric],
+        *,
+        traits: PagedForwardTraits,
+        gqa_group_size: int,
+        split_kv: bool,
+        single_request_decode_graph: bool = False,
+        single_qtile_decode_graph: bool = False,
+        regularized_decode_graph: bool = False,
+        use_native_fp8_qk: bool = False,
+        use_native_fp8_pv: bool = False,
+        decode_only: bool = False,
+        decode_native_fp8_runtime_chunk_guard: bool = False,
+        window_left: int = -1,
+        has_attention_sink_bias: bool = False,
+        has_relative_attention_bias: bool = False,
+        msa_block_sparse: bool = False,
+        page_size: int = 64,
+        page_tiles_per_entry: int = 1,
+    ):
+        self.dtype_q = dtype_q
+        self.dtype_kv = dtype_kv
+        self.dtype_kv_storage = dtype_kv_storage
+        self.dtype_o = dtype_o
+        self.traits = traits
+        self.gqa_group_size = int(gqa_group_size)
+        self.split_kv = split_kv
+        self.single_request_decode_graph = single_request_decode_graph
+        self.single_qtile_decode_graph = single_qtile_decode_graph
+        self.regularized_decode_graph = regularized_decode_graph
+        self.decode_only = decode_only
+        self.window_left = int(window_left)
+        self.has_attention_sink_bias = bool(has_attention_sink_bias)
+        self.has_relative_attention_bias = bool(has_relative_attention_bias)
+        self.msa_block_sparse = bool(msa_block_sparse)
+        self.MSA_BLOCK_TOKENS = 128
+        self.MSA_TOPK = 16
+        self.page_size = int(page_size)
+        self.page_tiles_per_entry = int(page_tiles_per_entry)
+        if self.page_size not in (64, 128):
+            raise ValueError(
+                f"paged decode kernel supports page_size 64 or 128, got {self.page_size}"
+            )
+        if self.page_size == 64 and self.page_tiles_per_entry != 1:
+            raise ValueError(
+                "page_size=64 paged decode requires page_tiles_per_entry=1"
+            )
+        if self.page_tiles_per_entry < self.page_size // 64:
+            raise ValueError(
+                "page_tiles_per_entry must cover at least the logical page rows: "
+                f"got {self.page_tiles_per_entry} for page_size={self.page_size}"
+            )
+        # Number of page-table entries that span one 128-token MSA block.
+        self.entries_per_block = self.MSA_BLOCK_TOKENS // self.page_size
+        self.kv_is_fp8 = dtype_kv == cutlass.Float8E4M3FN
+        self.vec_size = traits.head_dim_vo // 32
+        self.total_warps = traits.num_warps_q * traits.num_warps_kv
+        self.stage_tile_rows = traits.cta_tile_kv
+        q_stage_bytes = traits.cta_tile_q * traits.head_dim_qk * (dtype_q.width // 8)
+        kv_stage_bytes = (
+            self.stage_tile_rows
+            * (traits.head_dim_qk + traits.head_dim_vo)
+            * (dtype_kv_storage.width // 8)
+        )
+        bf16_minimax_head128_decode = (
+            decode_only
+            and not self.has_relative_attention_bias
+            and dtype_q == cutlass.BFloat16
+            and dtype_kv == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and traits.head_dim_qk == 128
+            and traits.head_dim_vo == 128
+            and traits.cta_tile_q == 16
+            and traits.cta_tile_kv == 64
+            and traits.num_mma_q == 1
+            and traits.num_mma_kv == 1
+            and traits.num_warps_q == 1
+            and traits.num_warps_kv == 4
+            and self.gqa_group_size == 6
+        )
+        self.bf16_minimax_head128_decode = bf16_minimax_head128_decode
+        self.bf16_minimax_role_specialized_decode = bf16_minimax_head128_decode
+        self.launch_warps_kv = traits.num_warps_kv + (
+            1 if self.bf16_minimax_role_specialized_decode else 0
+        )
+        self.num_stages = (
+            3
+            if (
+                bf16_minimax_head128_decode
+                and q_stage_bytes + 3 * kv_stage_bytes
+                <= traits.max_smem_per_threadblock
+            )
+            else 1
+            if traits.num_warps_kv > 1 or self.kv_is_fp8
+            else (
+                2
+                if q_stage_bytes + 2 * kv_stage_bytes <= traits.max_smem_per_threadblock
+                else 1
+            )
+        )
+        self.shared_storage_bytes = max(
+            int(traits.shared_storage_bytes),
+            q_stage_bytes + self.num_stages * kv_stage_bytes,
+        )
+        SharedStorage = self._get_shared_storage_cls()
+        self.launch_smem_bytes = int(SharedStorage.size_in_bytes())
+        if self.launch_smem_bytes > traits.max_smem_per_threadblock:
+            raise ValueError(
+                f"paged typed shared storage requires {self.launch_smem_bytes} B per CTA, "
+                f"but the selected residency permits {traits.max_smem_per_threadblock} B"
+            )
+        exact_num_ctas_per_sm = (
+            2 if 2 * self.launch_smem_bytes <= traits.max_smem_per_sm else 1
+        )
+        if exact_num_ctas_per_sm != traits.num_ctas_per_sm:
+            raise AssertionError(
+                "paged trait residency does not match its instantiated typed shared storage: "
+                f"traits={traits.num_ctas_per_sm}, exact={exact_num_ctas_per_sm}, "
+                f"bytes={self.launch_smem_bytes}"
+            )
+        if self.num_stages == 1 and self.launch_smem_bytes != traits.launch_smem_bytes:
+            raise AssertionError(
+                "paged trait launch bytes do not match the instantiated shared storage: "
+                f"traits={traits.launch_smem_bytes}, exact={self.launch_smem_bytes}"
+            )
+        self.num_ctas_per_sm = exact_num_ctas_per_sm
+        bf16_plane_decode_dims_supported = (
+            not self.kv_is_fp8
+            and traits.head_dim_qk % 64 == 0
+            and traits.head_dim_vo % 64 == 0
+            and traits.head_dim_qk <= 256
+            and traits.head_dim_vo <= 256
+        )
+        fp8_plane_decode_dims_supported = (
+            self.kv_is_fp8
+            and traits.head_dim_qk % 64 == 0
+            and traits.head_dim_vo % 128 == 0
+            and traits.head_dim_qk >= 128
+            and traits.head_dim_qk <= 256
+            and traits.head_dim_vo <= 256
+        )
+        base_use_paged_kv_tma_decode = (
+            dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and (bf16_plane_decode_dims_supported or fp8_plane_decode_dims_supported)
+            and (self.num_stages == 1 or bf16_minimax_head128_decode)
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and self.stage_tile_rows == 64
+            and traits.cta_tile_q == 16
+            and traits.num_mma_q == 1
+            and traits.num_mma_kv == 1
+        )
+        self.use_paged_kv_tma_exact_plane_bf16_layout = base_use_paged_kv_tma_decode
+        self.use_paged_kv_tma = self.use_paged_kv_tma_exact_plane_bf16_layout
+        if not self.use_paged_kv_tma:
+            raise NotImplementedError(
+                "PagedForwardKernel now only supports exact-plane paged K/V TMA decode; "
+                "extend and legacy non-TMA ingress use dedicated specialized kernels."
+            )
+        if self.num_stages != 1 and not bf16_minimax_head128_decode:
+            raise NotImplementedError(
+                "PagedForwardKernel cleanup assumes the single-stage decode TMA family."
+            )
+        if traits.num_warps_kv <= 1:
+            raise NotImplementedError(
+                "PagedForwardKernel is now decode-only; single-KV-warp extend paths use standalone raw kernels."
+            )
+        tma_debug_dump = os.environ.get(
+            "FLASHINFER_EXP_SM12X_PAGED_KV_TMA_DEBUG_DUMP", ""
+        )
+        paged_debug_dump = os.environ.get(
+            "FLASHINFER_EXP_SM12X_PAGED_KV_DEBUG_DUMP", ""
+        )
+        self.debug_dump_paged_kv_tma_k = self.use_paged_kv_tma and tma_debug_dump == "K"
+        self.debug_dump_paged_kv_tma_s = self.use_paged_kv_tma and tma_debug_dump == "S"
+        self.debug_dump_paged_kv_tma_v = self.use_paged_kv_tma and tma_debug_dump == "V"
+        self.debug_dump_paged_kv_pvregs = (
+            paged_debug_dump == "PVREGS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_pregs = (
+            paged_debug_dump == "PREGS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_sregs = (
+            paged_debug_dump == "SREGS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+        )
+        self.debug_dump_paged_kv_svwords = (
+            paged_debug_dump == "SVWORDS"
+            and traits.num_warps_kv > 1
+            and traits.num_warps_q == 1
+            and dtype_q == cutlass.BFloat16
+            and dtype_o == cutlass.BFloat16
+            and not self.kv_is_fp8
+        )
+        self.kv_tma_plane_head_dim = 128 if self.kv_is_fp8 else 64
+        self.kv_tma_plane_mem_dtype = (
+            cutlass.Uint8 if self.kv_is_fp8 else self.dtype_kv_storage
+        )
+        self.kv_tma_internal_type = None
+        self.k_tma_plane_count = (
+            (traits.head_dim_qk + self.kv_tma_plane_head_dim - 1)
+            // self.kv_tma_plane_head_dim
+            if self.use_paged_kv_tma_exact_plane_bf16_layout
+            else 1
+        )
+        self.v_tma_plane_count = (
+            (traits.head_dim_vo + self.kv_tma_plane_head_dim - 1)
+            // self.kv_tma_plane_head_dim
+            if self.use_paged_kv_tma_exact_plane_bf16_layout
+            else 1
+        )
+        self.kv_tma_plane_count = max(self.k_tma_plane_count, self.v_tma_plane_count)
+        kv_storage_bytes = dtype_kv_storage.width // 8
+        self.kv_tma_copy_bytes_k = (
+            self.stage_tile_rows
+            * self.k_tma_plane_count
+            * self.kv_tma_plane_head_dim
+            * kv_storage_bytes
+        )
+        self.kv_tma_copy_bytes_v = (
+            self.stage_tile_rows
+            * self.v_tma_plane_count
+            * self.kv_tma_plane_head_dim
+            * kv_storage_bytes
+        )
+        self.use_native_fp8_qk_mma = (
+            use_native_fp8_qk
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and traits.head_dim_qk % 32 == 0
+            and traits.num_mma_d_qk % 2 == 0
+        )
+        self.use_native_fp8_pv_mma = (
+            use_native_fp8_pv
+            and self.kv_is_fp8
+            and dtype_q == cutlass.BFloat16
+            and traits.num_warps_kv == 1
+            and traits.num_mma_kv % 2 == 0
+        )
+        self.decode_native_fp8_runtime_chunk_guard = (
+            self.use_native_fp8_qk_mma
+            and decode_only
+            and decode_native_fp8_runtime_chunk_guard
+        )
+        self.softmax_scale_log2 = Float32(
+            (traits.head_dim_qk**-0.5) * attention_ops.LOG2_E
+        )
+        self.inverse_softmax_scale = Float32(traits.head_dim_qk**0.5)
+
+    def _get_shared_storage_cls(self):
+        return make_tma_aligned_payload_storage(
+            payload_bytes=self.shared_storage_bytes,
+            num_stages=self.num_stages,
+        )
+
+    def _get_paged_kv_tma_plane_layout(self):
+        plane_swizzle = os.environ.get(
+            "FLASHINFER_EXP_SM12X_PAGED_KV_TMA_PLANE_SWIZZLE", ""
+        )
+        if plane_swizzle == "none":
+            return cute.make_layout(
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                stride=(self.kv_tma_plane_head_dim, 1),
+            )
+        if plane_swizzle:
+            mbase, bbits, sshift = [int(part) for part in plane_swizzle.split(",")]
+            swizzle = make_swizzle(mbase, bbits, sshift)
+        else:
+            swizzle = make_swizzle(3, 4, 3)
+        return cute.make_composed_layout(
+            swizzle,
+            0,
+            cute.make_layout(
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                stride=(self.kv_tma_plane_head_dim, 1),
+            ),
+        )
+
+    def _get_paged_kv_tma_plane_stage_layout(self):
+        return cute.tile_to_shape(
+            self._get_paged_kv_tma_plane_layout(),
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim, self.num_stages),
+            (0, 1, 2),
+        )
+
+    def _get_paged_kv_tma_layout(self, head_dim: int):
+        if self.dtype_kv_storage.width == 16:
+            layout_atom = warpgroup.make_smem_layout_atom(
+                sm90_utils_basic.get_smem_layout_atom(
+                    LayoutEnum.ROW_MAJOR,
+                    self.dtype_kv_storage,
+                    head_dim,
+                ),
+                self.dtype_kv_storage,
+            )
+            return cute.tile_to_shape(
+                layout_atom,
+                (self.stage_tile_rows, head_dim),
+                (0, 1),
+            )
+        swizzle = (
+            make_swizzle(3, 4, 4)
+            if self.dtype_kv_storage.width == 8
+            else make_swizzle(3, 3, 5)
+        )
+        return cute.make_composed_layout(
+            swizzle,
+            0,
+            cute.make_layout(
+                (self.stage_tile_rows, head_dim),
+                stride=(head_dim, 1),
+            ),
+        )
+
+    def _get_paged_kv_tma_stage_layout(self, head_dim: int):
+        return cute.tile_to_shape(
+            self._get_paged_kv_tma_layout(head_dim),
+            (self.stage_tile_rows, head_dim, self.num_stages),
+            (0, 1, 2),
+        )
+
+    @cute.jit
+    def _msa_selected_token_count(
+        self,
+        mQ2KIndices: cute.Tensor,
+        kv_head_idx,
+        q_row_idx,
+        cache_len,
+    ):
+        block_count = (cache_len + Int32(self.MSA_BLOCK_TOKENS - 1)) // Int32(
+            self.MSA_BLOCK_TOKENS
+        )
+        block_count = cutlass.select_(
+            block_count < Int32(self.MSA_TOPK), block_count, Int32(self.MSA_TOPK)
+        )
+        block_count = cutlass.select_(block_count > Int32(0), block_count, Int32(1))
+        if const_expr(self.page_size == 128):
+            # Whole-page walk: the host planner and the in-graph Triton updater
+            # count full 128-token pages at page_size=128, so the kernel must not
+            # tail-compact (tail clamp is min=2, max=2 in 64-token tiles).
+            return block_count * Int32(self.MSA_BLOCK_TOKENS)
+        last_j = block_count - Int32(1)
+        local_block_id = mQ2KIndices[kv_head_idx, q_row_idx, last_j]
+        tail_tokens = cache_len - local_block_id * Int32(self.MSA_BLOCK_TOKENS)
+        tail_pages = (tail_tokens + Int32(63)) // Int32(64)
+        tail_pages = cutlass.select_(tail_pages < Int32(1), Int32(1), tail_pages)
+        tail_pages = cutlass.select_(tail_pages > Int32(2), Int32(2), tail_pages)
+        return ((block_count - Int32(1)) * Int32(2) + tail_pages) * Int32(64)
+
+    @cute.jit
+    def _tile_page_idx(
+        self,
+        mQ2KIndices: cute.Tensor | None,
+        kv_head_idx,
+        q_row_idx,
+        tile_token_base,
+        page_size,
+    ):
+        if const_expr(self.msa_block_sparse):
+            block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
+            if const_expr(self.entries_per_block == 1):
+                block_id = mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+                return cutlass.select_(
+                    block_id >= Int32(0),
+                    block_id,
+                    Int32(0),
+                )
+            block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
+            subpage = block_offset // page_size
+            block_id = mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+            return cutlass.select_(
+                block_id >= Int32(0),
+                block_id * Int32(self.entries_per_block) + subpage,
+                Int32(0),
+            )
+        return tile_token_base // page_size
+
+    @cute.jit
+    def _tile_sub64_idx(self, tile_token_base):
+        """64-row tile index within one page-table entry (always 0 at page_size=64)."""
+        if const_expr(self.page_size == 64):
+            return Int32(0)
+        page_j = tile_token_base // Int32(self.page_size)
+        return (tile_token_base - page_j * Int32(self.page_size)) // Int32(64)
+
+    @cute.jit
+    def _tile_key_base(
+        self,
+        mQ2KIndices: cute.Tensor | None,
+        kv_head_idx,
+        q_row_idx,
+        tile_token_base,
+    ):
+        if const_expr(self.msa_block_sparse):
+            block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
+            block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
+            block_id = mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+            return cutlass.select_(
+                block_id >= Int32(0),
+                block_id * Int32(self.MSA_BLOCK_TOKENS) + block_offset,
+                Int32(0x7FFFFFFF),
+            )
+        return tile_token_base
+
+    @cute.jit
+    def _async_copy_paged_tile_permuted_128b(
+        self,
+        mCacheBytes: cute.Tensor,
+        mPageTable: cute.Tensor,
+        request_idx,
+        tile_token_base,
+        kv_head_idx,
+        num_kv_heads,
+        row_bytes,
+        page_stride_bytes,
+        token_stride_bytes,
+        head_stride_bytes,
+        sStageBytes: cute.Tensor,
+        stage_byte_offset,
+        lane,
+        warp_linear_idx,
+        valid_rows,
+        upcast_stride,
+        fill_zero: cutlass.Constexpr,
+    ):
+        page_size = Int32(self.page_size)
+        lane_row = lane // 8
+        lane_col = lane % 8
+        for tile_iter in cutlass.range_constexpr(
+            self.traits.num_mma_kv * 4 // self.traits.num_warps_q
+        ):
+            row_idx = Int32(
+                warp_linear_idx * 4 + lane_row + tile_iter * self.total_warps * 4
+            )
+            token_idx = Int32(tile_token_base + row_idx)
+            page_iter = token_idx // page_size
+            entry_idx = token_idx - page_iter * page_size
+            page_id = mPageTable[request_idx, page_iter]
+            row_valid = row_idx < valid_rows
+            row_byte_base = (
+                Int64(page_id) * Int64(page_stride_bytes)
+                + Int64(entry_idx) * Int64(token_stride_bytes)
+                + Int64(kv_head_idx) * Int64(head_stride_bytes)
+            )
+            for vec_iter in cutlass.range_constexpr((row_bytes + 127) // 128):
+                vec_idx = Int32(lane_col + vec_iter * 8)
+                src_byte_idx = row_byte_base + vec_idx * 16
+                dst_byte_idx = (
+                    stage_byte_offset
+                    + _permuted_offset_128b(row_idx, vec_idx, upcast_stride) * 16
+                )
+                vec_valid = row_valid and (vec_idx * Int32(16) < row_bytes)
+                if const_expr(fill_zero):
+                    _cp_async_load_128b_zfill(
+                        shared_ptr_to_u32(sStageBytes.iterator + dst_byte_idx),
+                        get_ptr_as_int64(mCacheBytes, src_byte_idx),
+                        cutlass.select_(vec_valid, Int32(16), Int32(0)),
+                    )
+                else:
+                    _cp_async_load_128b_pred(
+                        shared_ptr_to_u32(sStageBytes.iterator + dst_byte_idx),
+                        get_ptr_as_int64(mCacheBytes, src_byte_idx),
+                        Int32(vec_valid),
+                    )
+
+    @cute.jit
+    def _tile_src_idx_from_page_id(self, page_id, sub_tile):
+        if const_expr(self.page_size == 64):
+            return page_id
+        return page_id * Int32(self.page_tiles_per_entry) + sub_tile
+
+    @cute.jit
+    def _issue_paged_kv_tma_copy_planes(
+        self,
+        load_tma0,
+        load_tma1,
+        load_tma2,
+        load_tma3,
+        pipeline_tma,
+        producer_state,
+        mPageTable: cute.Tensor,
+        request_idx,
+        page_idx,
+        sub_tile,
+    ):
+        page_id = (
+            Int32(0)
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0")
+                == "1"
+            )
+            else mPageTable[request_idx, page_idx]
+        )
+        pipeline_tma.producer_acquire(producer_state)
+        src_idx = self._tile_src_idx_from_page_id(page_id, sub_tile)
+        load_tma0(src_idx=src_idx, producer_state=producer_state)
+        load_tma1(src_idx=src_idx, producer_state=producer_state)
+        load_tma2(src_idx=src_idx, producer_state=producer_state)
+        load_tma3(src_idx=src_idx, producer_state=producer_state)
+
+    @cute.jit
+    def _issue_paged_kv_tma_copy_3planes(
+        self,
+        load_tma0,
+        load_tma1,
+        load_tma2,
+        pipeline_tma,
+        producer_state,
+        mPageTable: cute.Tensor,
+        request_idx,
+        page_idx,
+        sub_tile,
+    ):
+        page_id = (
+            Int32(0)
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0")
+                == "1"
+            )
+            else mPageTable[request_idx, page_idx]
+        )
+        pipeline_tma.producer_acquire(producer_state)
+        src_idx = self._tile_src_idx_from_page_id(page_id, sub_tile)
+        load_tma0(src_idx=src_idx, producer_state=producer_state)
+        load_tma1(src_idx=src_idx, producer_state=producer_state)
+        load_tma2(src_idx=src_idx, producer_state=producer_state)
+
+    @cute.jit
+    def _issue_paged_kv_tma_copy_2planes(
+        self,
+        load_tma0,
+        load_tma1,
+        pipeline_tma,
+        producer_state,
+        mPageTable: cute.Tensor,
+        request_idx,
+        page_idx,
+        sub_tile,
+    ):
+        page_id = (
+            Int32(0)
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0")
+                == "1"
+            )
+            else mPageTable[request_idx, page_idx]
+        )
+        pipeline_tma.producer_acquire(producer_state)
+        src_idx = self._tile_src_idx_from_page_id(page_id, sub_tile)
+        load_tma0(src_idx=src_idx, producer_state=producer_state)
+        load_tma1(src_idx=src_idx, producer_state=producer_state)
+
+    @cute.jit
+    def _issue_paged_kv_tma_copy_1plane(
+        self,
+        load_tma0,
+        pipeline_tma,
+        producer_state,
+        mPageTable: cute.Tensor,
+        request_idx,
+        page_idx,
+        sub_tile,
+    ):
+        page_id = (
+            Int32(0)
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_TMA_FORCE_PAGE0", "0")
+                == "1"
+            )
+            else mPageTable[request_idx, page_idx]
+        )
+        pipeline_tma.producer_acquire(producer_state)
+        src_idx = self._tile_src_idx_from_page_id(page_id, sub_tile)
+        load_tma0(src_idx=src_idx, producer_state=producer_state)
+
+    @cute.jit
+    def _async_copy_q_tile_permuted_128b(
+        self,
+        mQBytes: cute.Tensor,
+        q_start,
+        packed_tile_start,
+        packed_tile_rows,
+        kv_head_idx,
+        group_size,
+        num_q_heads,
+        row_bytes,
+        token_stride_bytes,
+        head_stride_bytes,
+        sQBytes: cute.Tensor,
+        lane,
+        warp_q_idx,
+    ):
+        if const_expr(
+            self.decode_only
+            and self.kv_is_fp8
+            and self.traits.num_warps_q == 1
+            and self.traits.num_mma_q == 1
+            and self.traits.num_mma_d_qk == 16
+            and not self.single_request_decode_graph
+            and not self.single_qtile_decode_graph
+        ):
+            _async_copy_q_tile_permuted_128b_fp8_decode_impl(
+                mQBytes,
+                q_start,
+                packed_tile_start,
+                packed_tile_rows,
+                kv_head_idx,
+                group_size,
+                num_q_heads,
+                row_bytes,
+                token_stride_bytes,
+                head_stride_bytes,
+                sQBytes,
+                lane,
+                self.traits.upcast_stride_q,
+            )
+            return
+        lane_row = lane // 8
+        lane_col = lane % 8
+        warp_row_base = Int32(warp_q_idx * self.traits.num_mma_q * 16)
+        for mma_q in cutlass.range_constexpr(self.traits.num_mma_q):
+            for row_iter in cutlass.range_constexpr(4):
+                packed_q_idx = Int32(
+                    packed_tile_start
+                    + warp_row_base
+                    + mma_q * 16
+                    + lane_row
+                    + row_iter * 4
+                )
+                row_valid = packed_q_idx < (packed_tile_start + packed_tile_rows)
+                q_row_local = packed_q_idx // group_size
+                q_group_lane = packed_q_idx - q_row_local * group_size
+                q_head_idx = Int32(kv_head_idx * group_size + q_group_lane)
+                q_row_idx = Int32(q_start + q_row_local)
+                row_byte_base = Int64(q_row_idx) * Int64(token_stride_bytes) + Int64(
+                    q_head_idx
+                ) * Int64(head_stride_bytes)
+                row_idx = Int32(warp_row_base + mma_q * 16 + lane_row + row_iter * 4)
+                for mma_do in cutlass.range_constexpr(self.traits.num_mma_d_qk // 4):
+                    vec_idx = Int32(lane_col + mma_do * 8)
+                    src_byte_idx = row_byte_base + vec_idx * 16
+                    dst_byte_idx = (
+                        _permuted_offset_128b(
+                            row_idx, vec_idx, self.traits.upcast_stride_q
+                        )
+                        * 16
+                    )
+                    _cp_async_load_128b_pred(
+                        shared_ptr_to_u32(sQBytes.iterator + dst_byte_idx),
+                        get_ptr_as_int64(mQBytes, src_byte_idx),
+                        Int32(row_valid),
+                    )
+
+    @staticmethod
+    def can_implement(
+        dtype_q: Type[cutlass.Numeric],
+        dtype_kv: Type[cutlass.Numeric],
+        dtype_kv_storage: Type[cutlass.Numeric],
+        dtype_o: Type[cutlass.Numeric],
+        *,
+        traits: PagedForwardTraits,
+        split_kv: bool,
+    ) -> bool:
+        del split_kv
+        if dtype_q not in (cutlass.Float16, cutlass.BFloat16):
+            return False
+        if dtype_kv not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float8E4M3FN):
+            return False
+        if dtype_kv_storage not in (cutlass.Float16, cutlass.BFloat16, cutlass.Uint8):
+            return False
+        if dtype_o not in (cutlass.Float16, cutlass.BFloat16):
+            return False
+        if traits.head_dim_qk % 32 != 0 or traits.head_dim_vo % 32 != 0:
+            return False
+        if traits.num_threads != 128:
+            return False
+        if traits.cta_tile_q not in (16, 64, 128):
+            return False
+        return True
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mKCache: cute.Tensor,
+        mVCache: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mKvWindowStartTokens: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mQ2KIndices: cute.Tensor | None,
+        mAttentionSinkBias: cute.Tensor,
+        mRelativeAttentionBias: cute.Tensor | None,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(len(mQ.shape) != 3):
+            raise ValueError("mQ must have shape (total_q, q_heads, head_dim)")
+        if const_expr(len(mKCache.shape) != 4 or len(mVCache.shape) != 4):
+            raise ValueError(
+                "mKCache and mVCache must have shape (num_pages, page_size, kv_heads, head_dim)"
+            )
+        if const_expr(len(mPageTable.shape) != 2):
+            raise ValueError("mPageTable must have shape (batch, max_pages)")
+        if const_expr(len(mCacheSeqlens.shape) != 1 or len(mCuSeqlensQ.shape) != 1):
+            raise ValueError("mCacheSeqlens and mCuSeqlensQ must be rank-1")
+        if const_expr(
+            len(mRequestIndices.shape) != 1
+            or len(mQoTileIndices.shape) != 1
+            or len(mKvTileIndices.shape) != 1
+        ):
+            raise ValueError("worklist tensors must be rank-1")
+        if const_expr(
+            len(mOIndptr.shape) != 1
+            or len(mKvChunkSizePtr.shape) != 1
+            or len(mKvWindowStartTokens.shape) != 1
+            or len(mBlockValidMask.shape) != 1
+        ):
+            raise ValueError(
+                "mOIndptr, mKvChunkSizePtr, mKvWindowStartTokens, and mBlockValidMask must be rank-1"
+            )
+        if const_expr(len(mO.shape) != 3 or len(mLSE.shape) != 2):
+            raise ValueError("mO must be rank-3 and mLSE must be rank-2")
+        if const_expr(mKDescale is not None and len(mKDescale.shape) not in (1, 2)):
+            raise ValueError("mKDescale must have shape (batch,) or (batch, kv_heads)")
+        if const_expr(mVDescale is not None and len(mVDescale.shape) not in (1, 2)):
+            raise ValueError("mVDescale must have shape (batch,) or (batch, kv_heads)")
+        if const_expr(self.msa_block_sparse and mQ2KIndices is None):
+            raise ValueError("MSA block-sparse paged attention requires mQ2KIndices")
+        if const_expr(
+            self.has_relative_attention_bias and len(mRelativeAttentionBias.shape) != 3
+        ):
+            raise ValueError(
+                "mRelativeAttentionBias must have shape "
+                "(total_q_capacity, q_heads, relative_extent)"
+            )
+        if const_expr(self.msa_block_sparse and self.window_left >= 0):
+            raise ValueError(
+                "MSA block-sparse paged attention does not support window_left"
+            )
+        if const_expr(
+            self.msa_block_sparse
+            and (
+                self.traits.head_dim_qk != 128
+                or self.traits.head_dim_vo != 128
+                or self.gqa_group_size != 16
+                or self.stage_tile_rows != 64
+            )
+        ):
+            raise ValueError(
+                "MSA block-sparse decode requires page_size in (64, 128), gqa_group_size=16, and head_dim=128"
+            )
+        if const_expr(mQ.element_type != self.dtype_q):
+            raise TypeError("mQ dtype must match dtype_q")
+        if const_expr(
+            mKCache.element_type != self.dtype_kv_storage
+            or mVCache.element_type != self.dtype_kv_storage
+        ):
+            raise TypeError("mKCache/mVCache dtype must match dtype_kv_storage")
+        if const_expr(mO.element_type != self.dtype_o):
+            raise TypeError("mO dtype must match dtype_o")
+        if const_expr(mLSE.element_type != Float32):
+            raise TypeError("mLSE must be Float32")
+        if const_expr(
+            not self.can_implement(
+                self.dtype_q,
+                self.dtype_kv,
+                self.dtype_kv_storage,
+                self.dtype_o,
+                traits=self.traits,
+                split_kv=self.split_kv,
+            )
+        ):
+            raise TypeError("paged forward kernel configuration is not supported")
+
+        mQ = _assume_tensor_aligned(mQ)
+        mKCache = _assume_tensor_aligned(mKCache)
+        mVCache = _assume_tensor_aligned(mVCache)
+        mO = _assume_tensor_aligned(mO)
+
+        if const_expr(self.page_size == 64):
+            mKCacheT = cute.make_tensor(
+                mKCache.iterator, cute.select(mKCache.layout, mode=[1, 3, 2, 0])
+            )
+            mVCacheT = cute.make_tensor(
+                mVCache.iterator, cute.select(mVCache.layout, mode=[1, 3, 2, 0])
+            )
+            mKCacheT = _assume_paged_kv_tma_source_aligned(mKCacheT)
+            mVCacheT = _assume_paged_kv_tma_source_aligned(mVCacheT)
+        else:
+            # page_size=128: flatten each page-table entry into
+            # `page_tiles_per_entry` physical 64-row TMA tiles (stride-derived,
+            # so strided vLLM K/V slices keep their phantom-plane gap).
+            mKCacheT = _make_paged_kv_tile_source_tensor(
+                mKCache, self.stage_tile_rows, self.page_tiles_per_entry
+            )
+            mVCacheT = _make_paged_kv_tile_source_tensor(
+                mVCache, self.stage_tile_rows, self.page_tiles_per_entry
+            )
+        tma_tensor_K = mKCacheT
+        tma_tensor_V = mVCacheT
+        tma_atom_K = None
+        tma_atom_V = None
+        gmem_tiled_copy_kv = cpasync.CopyBulkTensorTileG2SOp()
+        k_tma_source = (
+            cute.recast_tensor(mKCacheT, self.kv_tma_plane_mem_dtype)
+            if const_expr(self.kv_is_fp8)
+            else mKCacheT
+        )
+        v_tma_source = mVCacheT
+        if const_expr(self.kv_is_fp8):
+            v_tma_source = cute.recast_tensor(v_tma_source, self.kv_tma_plane_mem_dtype)
+        tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            k_tma_source,
+            self._get_paged_kv_tma_plane_layout(),
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+            internal_type=self.kv_tma_internal_type,
+        )
+        tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            v_tma_source,
+            self._get_paged_kv_tma_plane_layout(),
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+            internal_type=self.kv_tma_internal_type,
+        )
+
+        grid = (
+            (
+                mO.shape[0] // mPageTable.shape[0],
+                mKCache.shape[2],
+                mPageTable.shape[0],
+            )
+            if self.regularized_decode_graph
+            else (mBlockValidMask.shape[0], mKCache.shape[2], 1)
+        )
+        self.kernel(
+            mQ,
+            mKCache,
+            tma_tensor_K,
+            tma_tensor_V,
+            mPageTable,
+            mCacheSeqlens,
+            mCuSeqlensQ,
+            mRequestIndices,
+            mQoTileIndices,
+            mKvTileIndices,
+            mOIndptr,
+            mKvChunkSizePtr,
+            mKvWindowStartTokens,
+            mBlockValidMask,
+            mQ2KIndices,
+            mAttentionSinkBias,
+            mRelativeAttentionBias,
+            mO,
+            mLSE,
+            mKDescale,
+            mVDescale,
+            tma_atom_K,
+            tma_atom_V,
+        ).launch(
+            grid=grid,
+            block=[32, self.traits.num_warps_q, self.launch_warps_kv],
+            # The instantiated typed CUTLASS allocation is the launch and
+            # residency authority; carry that same contract into ptxas.
+            min_blocks_per_mp=self.num_ctas_per_sm,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mKCache: cute.Tensor,
+        mKCacheT: cute.Tensor,
+        mVCacheT: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mKvWindowStartTokens: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mQ2KIndices: cute.Tensor | None,
+        mAttentionSinkBias: cute.Tensor,
+        mRelativeAttentionBias: cute.Tensor | None,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        tma_atom_K: cute.CopyAtom | None,
+        tma_atom_V: cute.CopyAtom | None,
+    ):
+        lane, warp_q_idx, warp_kv_idx = cute.arch.thread_idx()
+        block_x, kv_head_idx, block_z = cute.arch.block_idx()
+        group_size = mQ.shape[1] // mKCache.shape[2]
+        if const_expr(self.regularized_decode_graph):
+            max_chunks_per_req = Int32(mO.shape[0] // mPageTable.shape[0])
+            request_idx = Int32(block_z)
+            kv_tile_idx = Int32(block_x)
+            work_idx = request_idx * max_chunks_per_req + kv_tile_idx
+            q_start = request_idx
+            qo_len = Int32(1)
+            cache_len = mCacheSeqlens[request_idx]
+            kv_chunk_size = mKvChunkSizePtr[0]
+            num_chunks_kv = (
+                mOIndptr[request_idx + 1] - mOIndptr[request_idx]
+                if const_expr(self.split_kv)
+                else 1
+            )
+            if kv_tile_idx >= num_chunks_kv:
+                _exit_thread()
+            request_partial_start = request_idx * max_chunks_per_req
+            request_partial_end = request_partial_start + num_chunks_kv
+        else:
+            work_idx = Int32(block_x)
+            block_valid = mBlockValidMask[work_idx]
+            if block_valid == Int32(0):
+                _exit_thread()
+            if const_expr(self.single_request_decode_graph):
+                request_idx = Int32(0)
+                q_start = Int32(0)
+                q_end = Int32(1)
+                qo_len = Int32(1)
+                kv_tile_idx = work_idx
+                request_partial_start = Int32(0)
+                request_partial_end = mOIndptr[1]
+            elif const_expr(self.single_qtile_decode_graph):
+                request_idx = mRequestIndices[work_idx]
+                kv_tile_idx = mKvTileIndices[work_idx]
+                q_start = request_idx
+                q_end = request_idx + 1
+                qo_len = Int32(1)
+                request_partial_start = mOIndptr[request_idx]
+                request_partial_end = mOIndptr[request_idx + 1]
+            elif const_expr(self.decode_only):
+                request_idx = mRequestIndices[work_idx]
+                kv_tile_idx = mKvTileIndices[work_idx]
+                q_start = request_idx
+                qo_len = Int32(1)
+                request_partial_start = mOIndptr[request_idx]
+                request_partial_end = mOIndptr[request_idx + 1]
+            else:
+                request_idx = mRequestIndices[work_idx]
+                qo_tile_idx = mQoTileIndices[work_idx]
+                kv_tile_idx = mKvTileIndices[work_idx]
+                q_start = mCuSeqlensQ[request_idx]
+                q_end = mCuSeqlensQ[request_idx + 1]
+                qo_len = q_end - q_start
+                request_partial_start = mOIndptr[request_idx]
+                request_partial_end = mOIndptr[request_idx + 1]
+            cache_len = mCacheSeqlens[request_idx]
+        packed_qo_len = qo_len * group_size
+        if const_expr(
+            self.single_request_decode_graph or self.single_qtile_decode_graph
+        ):
+            packed_tile_start = Int32(0)
+            packed_tile_end = packed_qo_len
+        elif const_expr(self.decode_only):
+            packed_tile_start = Int32(0)
+            packed_tile_limit = self.traits.cta_tile_q
+            packed_tile_end = cutlass.select_(
+                packed_tile_limit < packed_qo_len,
+                packed_tile_limit,
+                packed_qo_len,
+            )
+        else:
+            packed_tile_start = qo_tile_idx * self.traits.cta_tile_q
+            packed_tile_limit = packed_tile_start + self.traits.cta_tile_q
+            packed_tile_end = cutlass.select_(
+                packed_tile_limit < packed_qo_len, packed_tile_limit, packed_qo_len
+            )
+        kv_chunk_size = mKvChunkSizePtr[0]
+
+        if const_expr(self.msa_block_sparse):
+            kv_window_start = Int32(0)
+            selected_token_count = self._msa_selected_token_count(
+                mQ2KIndices,
+                kv_head_idx,
+                q_start,
+                cache_len,
+            )
+            chunk_start = (
+                kv_tile_idx * kv_chunk_size if const_expr(self.split_kv) else Int32(0)
+            )
+            chunk_end = (
+                cutlass.select_(
+                    (kv_tile_idx + 1) * kv_chunk_size < selected_token_count,
+                    (kv_tile_idx + 1) * kv_chunk_size,
+                    selected_token_count,
+                )
+                if const_expr(self.split_kv)
+                else selected_token_count
+            )
+        else:
+            kv_window_start = (
+                mKvWindowStartTokens[request_idx]
+                if const_expr(self.window_left >= 0)
+                else Int32(0)
+            )
+            chunk_start = (
+                kv_window_start + kv_tile_idx * kv_chunk_size
+                if const_expr(self.split_kv)
+                else kv_window_start
+            )
+            chunk_end = (
+                cutlass.select_(
+                    kv_window_start + (kv_tile_idx + 1) * kv_chunk_size < cache_len,
+                    kv_window_start + (kv_tile_idx + 1) * kv_chunk_size,
+                    cache_len,
+                )
+                if const_expr(self.split_kv)
+                else cache_len
+            )
+        if const_expr(self.split_kv):
+            num_chunks_kv = (
+                num_chunks_kv
+                if const_expr(self.regularized_decode_graph)
+                else (
+                    request_partial_end - request_partial_start
+                    if const_expr(
+                        self.single_request_decode_graph
+                        or self.single_qtile_decode_graph
+                    )
+                    else (request_partial_end - request_partial_start) // qo_len
+                )
+            )
+        else:
+            num_chunks_kv = 1
+        page_size = mKCache.shape[1]
+        stage_tile_rows = self.stage_tile_rows
+        q_bytes = self.traits.q_smem_bytes
+        k_bytes = (
+            self.num_stages
+            * stage_tile_rows
+            * self.traits.head_dim_qk
+            * (self.dtype_kv_storage.width // 8)
+        )
+        v_bytes = (
+            self.num_stages
+            * stage_tile_rows
+            * self.traits.head_dim_vo
+            * (self.dtype_kv_storage.width // 8)
+        )
+        kv_plane_stage_bytes = (
+            stage_tile_rows
+            * self.kv_tma_plane_head_dim
+            * (self.dtype_kv_storage.width // 8)
+        )
+        kv_plane_total_bytes = self.num_stages * kv_plane_stage_bytes
+        k_payload_bytes = max(k_bytes, self.k_tma_plane_count * kv_plane_total_bytes)
+        v_payload_bytes = max(v_bytes, self.v_tma_plane_count * kv_plane_total_bytes)
+        v_payload_offset = q_bytes + k_payload_bytes
+        warp_linear_idx = warp_kv_idx * self.traits.num_warps_q + warp_q_idx
+        tidx = lane + 32 * (warp_q_idx + self.traits.num_warps_q * warp_kv_idx)
+        packed_tile_rows = packed_tile_end - packed_tile_start
+
+        smem = cutlass.utils.SmemAllocator()
+        SharedStorage = self._get_shared_storage_cls()
+        # CUTLASS DSL 4.6 uses the typed alloca below to infer the launch's
+        # dynamic-SMEM size.  Its lowered field pointers, however, are kept as
+        # per-thread address registers on SM120 instead of folding their static
+        # offsets into shared-memory instructions.  Keep the typed allocation
+        # for exact size/accounting, but form every view from one symbolic
+        # dynamic-SMEM root so those compile-time offsets remain foldable.
+        _smem_allocation = smem.allocate(SharedStorage)
+        smem_base = cute.arch.get_dyn_smem(
+            cutlass.Uint8, alignment=SharedStorage.__alignof__()
+        )
+        mbar_ptr_K = cute.recast_ptr(
+            smem_base + SharedStorage._offsets["mbar_ptr_K"],
+            dtype=cutlass.Int64,
+        )
+        mbar_ptr_V = cute.recast_ptr(
+            smem_base + SharedStorage._offsets["mbar_ptr_V"],
+            dtype=cutlass.Int64,
+        )
+        payload_ptr = smem_base + SharedStorage._offsets["payload"]
+        # TMA descriptor prefetch is a uniform, idempotent hint.  Issuing it
+        # without a warp-role branch matches the pre-4.6 lowering and avoids a
+        # new live uniform predicate in every warp.
+        cpasync.prefetch_descriptor(tma_atom_K)
+        cpasync.prefetch_descriptor(tma_atom_V)
+        payload_u8 = cute.make_tensor(
+            payload_ptr, cute.make_layout((self.shared_storage_bytes,), stride=(1,))
+        )
+        sQ = _make_payload_tensor(
+            payload_u8,
+            self.dtype_q,
+            0,
+            cute.make_layout(
+                (self.traits.cta_tile_q, self.traits.head_dim_qk),
+                stride=(self.traits.head_dim_qk, 1),
+            ),
+        )
+        sQTile = sQ
+        sK = _make_payload_tensor(
+            payload_u8,
+            self.dtype_kv_storage,
+            q_bytes,
+            cute.make_layout(
+                (stage_tile_rows, self.traits.head_dim_qk, self.num_stages),
+                stride=(
+                    self.traits.head_dim_qk,
+                    1,
+                    stage_tile_rows * self.traits.head_dim_qk,
+                ),
+            ),
+        )
+        sKStageBytes = _make_payload_tensor(
+            payload_u8,
+            cutlass.Uint8,
+            q_bytes,
+            cute.make_layout((k_payload_bytes,), stride=(1,)),
+        )
+        sV = _make_payload_tensor(
+            payload_u8,
+            self.dtype_kv_storage,
+            v_payload_offset,
+            cute.make_layout(
+                (stage_tile_rows, self.traits.head_dim_vo, self.num_stages),
+                stride=(
+                    self.traits.head_dim_vo,
+                    1,
+                    stage_tile_rows * self.traits.head_dim_vo,
+                ),
+            ),
+        )
+        sVStageBytes = _make_payload_tensor(
+            payload_u8,
+            cutlass.Uint8,
+            v_payload_offset,
+            cute.make_layout((v_payload_bytes,), stride=(1,)),
+        )
+        sKTma = None
+        sVTma = None
+        sKPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                self.kv_tma_plane_mem_dtype,
+                q_bytes + 0 * kv_plane_total_bytes,
+                self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+            ),
+            self._get_paged_kv_tma_plane_stage_layout(),
+        )
+        sKPlane1 = (
+            _get_memrange_tensor(
+                _make_payload_memrange(
+                    payload_u8,
+                    self.kv_tma_plane_mem_dtype,
+                    q_bytes + 1 * kv_plane_total_bytes,
+                    self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                ),
+                self._get_paged_kv_tma_plane_stage_layout(),
+            )
+            if const_expr(self.k_tma_plane_count > 1)
+            else None
+        )
+        sKPlane2 = (
+            _get_memrange_tensor(
+                _make_payload_memrange(
+                    payload_u8,
+                    self.kv_tma_plane_mem_dtype,
+                    q_bytes + 2 * kv_plane_total_bytes,
+                    self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                ),
+                self._get_paged_kv_tma_plane_stage_layout(),
+            )
+            if const_expr(self.k_tma_plane_count > 2)
+            else None
+        )
+        sKPlane3 = (
+            _get_memrange_tensor(
+                _make_payload_memrange(
+                    payload_u8,
+                    self.kv_tma_plane_mem_dtype,
+                    q_bytes + 3 * kv_plane_total_bytes,
+                    self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                ),
+                self._get_paged_kv_tma_plane_stage_layout(),
+            )
+            if const_expr(self.k_tma_plane_count > 3)
+            else None
+        )
+        sVPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                self.kv_tma_plane_mem_dtype,
+                v_payload_offset + 0 * kv_plane_total_bytes,
+                self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+            ),
+            self._get_paged_kv_tma_plane_stage_layout(),
+        )
+        sVPlane1 = (
+            _get_memrange_tensor(
+                _make_payload_memrange(
+                    payload_u8,
+                    self.kv_tma_plane_mem_dtype,
+                    v_payload_offset + 1 * kv_plane_total_bytes,
+                    self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                ),
+                self._get_paged_kv_tma_plane_stage_layout(),
+            )
+            if const_expr(self.v_tma_plane_count > 1)
+            else None
+        )
+        sVPlane2 = (
+            _get_memrange_tensor(
+                _make_payload_memrange(
+                    payload_u8,
+                    self.kv_tma_plane_mem_dtype,
+                    v_payload_offset + 2 * kv_plane_total_bytes,
+                    self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                ),
+                self._get_paged_kv_tma_plane_stage_layout(),
+            )
+            if const_expr(self.v_tma_plane_count > 2)
+            else None
+        )
+        sVPlane3 = (
+            _get_memrange_tensor(
+                _make_payload_memrange(
+                    payload_u8,
+                    self.kv_tma_plane_mem_dtype,
+                    v_payload_offset + 3 * kv_plane_total_bytes,
+                    self.num_stages * stage_tile_rows * self.kv_tma_plane_head_dim,
+                ),
+                self._get_paged_kv_tma_plane_stage_layout(),
+            )
+            if const_expr(self.v_tma_plane_count > 3)
+            else None
+        )
+        pipeline_kv_consumer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, self.total_warps
+        )
+        pipeline_kv_producer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread
+        )
+        pipeline_k = cute_pipeline.PipelineTmaAsync.create(
+            barrier_storage=mbar_ptr_K,
+            num_stages=self.num_stages,
+            producer_group=pipeline_kv_producer_group,
+            consumer_group=pipeline_kv_consumer_group,
+            tx_count=self.kv_tma_copy_bytes_k,
+            defer_sync=True,
+        )
+        pipeline_v = cute_pipeline.PipelineTmaAsync.create(
+            barrier_storage=mbar_ptr_V,
+            num_stages=self.num_stages,
+            producer_group=pipeline_kv_producer_group,
+            consumer_group=pipeline_kv_consumer_group,
+            tx_count=self.kv_tma_copy_bytes_v,
+            defer_sync=False,
+        )
+        sQ = cute.make_tensor(
+            cute.recast_tensor(
+                cute.make_tensor(
+                    payload_u8.iterator,
+                    cute.make_layout((q_bytes,), stride=(1,)),
+                ),
+                self.dtype_q,
+            ).iterator,
+            cute.make_layout(
+                (self.traits.cta_tile_q * self.traits.head_dim_qk,), stride=(1,)
+            ),
+        )
+        sKTC = None
+        sVTC = None
+        k_row_bytes = self.traits.head_dim_qk * (self.dtype_kv_storage.width // 8)
+        v_row_bytes = self.traits.head_dim_vo * (self.dtype_kv_storage.width // 8)
+        q_storage_bytes = self.dtype_q.width // 8
+        q_token_stride_bytes = mQ.stride[0] * q_storage_bytes
+        q_head_stride_bytes = mQ.stride[1] * q_storage_bytes
+        k_stage_bytes = stage_tile_rows * k_row_bytes
+        v_stage_bytes = stage_tile_rows * v_row_bytes
+        mQBytes = cute.flatten(cute.recast_tensor(mQ, cutlass.Uint8))
+        mKCacheTHead = mKCacheT[None, None, kv_head_idx, None]
+        mVCacheTHead = mVCacheT[None, None, kv_head_idx, None]
+        gKTma0 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gKTma1 = (
+            cute.local_tile(
+                mKCacheTHead,
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                (0, 1, None),
+            )
+            if const_expr(self.k_tma_plane_count > 1)
+            else None
+        )
+        gKTma2 = (
+            cute.local_tile(
+                mKCacheTHead,
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                (0, 2, None),
+            )
+            if const_expr(self.k_tma_plane_count > 2)
+            else None
+        )
+        gKTma3 = (
+            cute.local_tile(
+                mKCacheTHead,
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                (0, 3, None),
+            )
+            if const_expr(self.k_tma_plane_count > 3)
+            else None
+        )
+        load_K_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma0, sKPlane0
+        )
+        load_K_tma1, _, _ = (
+            cute_copy.tma_get_copy_fn(
+                tma_atom_K, 0, cute.make_layout(1), gKTma1, sKPlane1
+            )
+            if const_expr(self.k_tma_plane_count > 1)
+            else (None, None, None)
+        )
+        load_K_tma2, _, _ = (
+            cute_copy.tma_get_copy_fn(
+                tma_atom_K, 0, cute.make_layout(1), gKTma2, sKPlane2
+            )
+            if const_expr(self.k_tma_plane_count > 2)
+            else (None, None, None)
+        )
+        load_K_tma3, _, _ = (
+            cute_copy.tma_get_copy_fn(
+                tma_atom_K, 0, cute.make_layout(1), gKTma3, sKPlane3
+            )
+            if const_expr(self.k_tma_plane_count > 3)
+            else (None, None, None)
+        )
+        load_K_tma0 = cute_copy.tma_producer_copy_fn(load_K_tma0, pipeline_k)
+        load_K_tma1 = (
+            cute_copy.tma_producer_copy_fn(load_K_tma1, pipeline_k)
+            if const_expr(self.k_tma_plane_count > 1)
+            else None
+        )
+        load_K_tma2 = (
+            cute_copy.tma_producer_copy_fn(load_K_tma2, pipeline_k)
+            if const_expr(self.k_tma_plane_count > 2)
+            else None
+        )
+        load_K_tma3 = (
+            cute_copy.tma_producer_copy_fn(load_K_tma3, pipeline_k)
+            if const_expr(self.k_tma_plane_count > 3)
+            else None
+        )
+        gVTma0 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gVTma1 = (
+            cute.local_tile(
+                mVCacheTHead,
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                (0, 1, None),
+            )
+            if const_expr(self.v_tma_plane_count > 1)
+            else None
+        )
+        gVTma2 = (
+            cute.local_tile(
+                mVCacheTHead,
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                (0, 2, None),
+            )
+            if const_expr(self.v_tma_plane_count > 2)
+            else None
+        )
+        gVTma3 = (
+            cute.local_tile(
+                mVCacheTHead,
+                (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+                (0, 3, None),
+            )
+            if const_expr(self.v_tma_plane_count > 3)
+            else None
+        )
+        load_V_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma0, sVPlane0
+        )
+        load_V_tma1, _, _ = (
+            cute_copy.tma_get_copy_fn(
+                tma_atom_V, 0, cute.make_layout(1), gVTma1, sVPlane1
+            )
+            if const_expr(self.v_tma_plane_count > 1)
+            else (None, None, None)
+        )
+        load_V_tma2, _, _ = (
+            cute_copy.tma_get_copy_fn(
+                tma_atom_V, 0, cute.make_layout(1), gVTma2, sVPlane2
+            )
+            if const_expr(self.v_tma_plane_count > 2)
+            else (None, None, None)
+        )
+        load_V_tma3, _, _ = (
+            cute_copy.tma_get_copy_fn(
+                tma_atom_V, 0, cute.make_layout(1), gVTma3, sVPlane3
+            )
+            if const_expr(self.v_tma_plane_count > 3)
+            else (None, None, None)
+        )
+        load_V_tma0 = cute_copy.tma_producer_copy_fn(load_V_tma0, pipeline_v)
+        load_V_tma1 = (
+            cute_copy.tma_producer_copy_fn(load_V_tma1, pipeline_v)
+            if const_expr(self.v_tma_plane_count > 1)
+            else None
+        )
+        load_V_tma2 = (
+            cute_copy.tma_producer_copy_fn(load_V_tma2, pipeline_v)
+            if const_expr(self.v_tma_plane_count > 2)
+            else None
+        )
+        load_V_tma3 = (
+            cute_copy.tma_producer_copy_fn(load_V_tma3, pipeline_v)
+            if const_expr(self.v_tma_plane_count > 3)
+            else None
+        )
+        sKU8 = (
+            sK
+            if const_expr(self.kv_is_fp8 and self.dtype_kv_storage == cutlass.Uint8)
+            else (
+                cute.recast_tensor(sK, cutlass.Uint8)
+                if const_expr(self.kv_is_fp8)
+                else None
+            )
+        )
+        sVU8 = (
+            sV
+            if const_expr(self.kv_is_fp8 and self.dtype_kv_storage == cutlass.Uint8)
+            else (
+                cute.recast_tensor(sV, cutlass.Uint8)
+                if const_expr(self.kv_is_fp8)
+                else None
+            )
+        )
+        if const_expr(self.traits.num_warps_kv > 1):
+            sync_payload = cute.recast_tensor(
+                payload_u8,
+                Float32,
+            )
+            sync_o_row_stride = self.traits.head_dim_vo + (
+                24
+                if (
+                    not self.kv_is_fp8
+                    and self.dtype_o == cutlass.BFloat16
+                    and self.traits.cta_tile_q == 16
+                )
+                else 0
+            )
+            sync_o_elems = (
+                self.traits.num_warps_kv * self.traits.cta_tile_q * sync_o_row_stride
+            )
+            sSyncO = cute.make_tensor(
+                sync_payload.iterator,
+                cute.make_layout(
+                    (
+                        self.traits.num_warps_kv,
+                        self.traits.cta_tile_q,
+                        self.traits.head_dim_vo,
+                    ),
+                    stride=(
+                        self.traits.cta_tile_q * sync_o_row_stride,
+                        sync_o_row_stride,
+                        1,
+                    ),
+                ),
+            )
+            sSyncMD = cute.make_tensor(
+                sync_payload.iterator + Int32(sync_o_elems),
+                cute.make_layout(
+                    (self.traits.num_warps_kv, self.traits.cta_tile_q, 2),
+                    stride=(self.traits.cta_tile_q * 2, 2, 1),
+                ),
+            )
+            sDecodeStage = cute.make_tensor(
+                cute.recast_tensor(sync_payload, self.dtype_o).iterator,
+                cute.make_layout(
+                    (
+                        self.traits.num_warps_kv,
+                        self.traits.cta_tile_q,
+                        self.traits.head_dim_vo * 2,
+                    ),
+                    stride=(
+                        self.traits.cta_tile_q * sync_o_row_stride * 2,
+                        sync_o_row_stride * 2,
+                        1,
+                    ),
+                ),
+            )
+            sDecodeStageU32 = cute.recast_tensor(sDecodeStage, cutlass.Uint32)
+        else:
+            sync_payload = cute.make_tensor(
+                cute.recast_tensor(cute.flatten(sQ), Float32).iterator,
+                cute.make_layout((4,), stride=(1,)),
+            )
+            sSyncO = cute.make_tensor(
+                sync_payload.iterator,
+                cute.make_layout((1, 1, 1), stride=(1, 1, 1)),
+            )
+            sSyncMD = cute.make_tensor(
+                sync_payload.iterator,
+                cute.make_layout((1, 1, 2), stride=(2, 2, 1)),
+            )
+        decode_store_v128 = const_expr(
+            self.traits.num_warps_kv > 1
+            and self.dtype_o == cutlass.BFloat16
+            and not (self.msa_block_sparse and self.split_kv)
+        )
+        split_store_v128 = const_expr(
+            self.split_kv
+            and self.traits.num_warps_kv == 1
+            and self.dtype_o == cutlass.BFloat16
+        )
+        final_store_v128 = const_expr(
+            not self.split_kv
+            and self.traits.num_warps_kv == 1
+            and self.dtype_o == cutlass.BFloat16
+        )
+        decode_qwen_single_row_fastpath = const_expr(
+            self.decode_only
+            and not self.has_relative_attention_bias
+            and self.single_request_decode_graph
+            and self.split_kv
+            and self.traits.num_mma_q == 1
+            and self.traits.num_warps_q == 1
+            and self.traits.num_warps_kv == 4
+            and (self.gqa_group_size == 6 or self.gqa_group_size == 8)
+        )
+        decode_row_metadata_fastpath = const_expr(
+            self.decode_only
+            and not self.has_relative_attention_bias
+            and not self.single_request_decode_graph
+            and not self.single_qtile_decode_graph
+            and not self.regularized_decode_graph
+        )
+        decode_fp8_row0_metadata_fastpath = const_expr(
+            decode_row_metadata_fastpath
+            and self.kv_is_fp8
+            and self.traits.num_mma_q == 1
+            and self.traits.num_mma_kv == 1
+            and self.traits.num_warps_q == 1
+            and self.traits.num_warps_kv == 4
+            and (self.gqa_group_size == 6 or self.gqa_group_size == 8)
+        )
+        decode_bf16_row0_fastpath = const_expr(
+            decode_row_metadata_fastpath
+            and not self.kv_is_fp8
+            and self.traits.num_mma_q == 1
+            and self.traits.num_mma_kv == 1
+            and self.traits.num_warps_q == 1
+            and self.traits.num_warps_kv == 4
+            and (self.gqa_group_size == 6 or self.gqa_group_size == 8)
+        )
+        decode_bf16_row0_merge_fastpath = const_expr(decode_bf16_row0_fastpath)
+        decode_bf16_row0_qk_fastpath = const_expr(decode_bf16_row0_fastpath)
+        decode_bf16_row0_mask_fastpath = const_expr(decode_bf16_row0_fastpath)
+        decode_row0_merge_fastpath = const_expr(
+            decode_fp8_row0_metadata_fastpath or decode_bf16_row0_merge_fastpath
+        )
+        decode_row0_k_release_fastpath = const_expr(
+            decode_fp8_row0_metadata_fastpath
+            or decode_bf16_row0_fastpath
+            or self.bf16_minimax_role_specialized_decode
+        )
+        sOStage = cute.make_tensor(
+            sQ.iterator,
+            cute.make_layout(
+                (self.traits.cta_tile_q, self.traits.head_dim_vo),
+                stride=(self.traits.head_dim_vo, 1),
+            ),
+        )
+        sOStageU32 = cute.recast_tensor(sOStage, cutlass.Uint32)
+        mOFlat = cute.flatten(mO)
+
+        tc_upcast_elems_qk = 16 // (self.dtype_q.width // 8)
+        tc_upcast_stride_qk = self.traits.head_dim_qk // tc_upcast_elems_qk
+        tc_upcast_elems_vo = 16 // (self.dtype_q.width // 8)
+        tc_upcast_elems_plane = 16 // (self.dtype_kv_storage.width // 8)
+        tc_upcast_stride_vo = self.traits.head_dim_vo // tc_upcast_elems_vo
+        tc_upcast_stride_plane = self.kv_tma_plane_head_dim // tc_upcast_elems_plane
+
+        if const_expr(self.bf16_minimax_role_specialized_decode):
+            if warp_kv_idx == Int32(self.traits.num_warps_kv):
+                cute.arch.setmaxregister_decrease(80)
+                role_k_producer_state = cute_pipeline.make_pipeline_state(
+                    cutlass.pipeline.PipelineUserType.Producer, self.num_stages
+                )
+                role_v_producer_state = cute_pipeline.make_pipeline_state(
+                    cutlass.pipeline.PipelineUserType.Producer, self.num_stages
+                )
+                role_prefetch_base = chunk_start
+                while role_prefetch_base < chunk_end:
+                    role_page_idx = self._tile_page_idx(
+                        mQ2KIndices,
+                        kv_head_idx,
+                        q_start,
+                        role_prefetch_base,
+                        page_size,
+                    )
+                    role_sub_tile = self._tile_sub64_idx(role_prefetch_base)
+                    self._issue_paged_kv_tma_copy_2planes(
+                        load_K_tma0,
+                        load_K_tma1,
+                        pipeline_k,
+                        role_k_producer_state,
+                        mPageTable,
+                        request_idx,
+                        role_page_idx,
+                        role_sub_tile,
+                    )
+                    role_k_producer_state.advance()
+                    self._issue_paged_kv_tma_copy_2planes(
+                        load_V_tma0,
+                        load_V_tma1,
+                        pipeline_v,
+                        role_v_producer_state,
+                        mPageTable,
+                        request_idx,
+                        role_page_idx,
+                        role_sub_tile,
+                    )
+                    role_v_producer_state.advance()
+                    role_prefetch_base += stage_tile_rows
+                pipeline_k.producer_tail(role_k_producer_state)
+                pipeline_v.producer_tail(role_v_producer_state)
+                _exit_thread()
+            cute.arch.setmaxregister_increase(248)
+
+        if const_expr(self.traits.num_warps_kv > 1):
+            sQBytes = cute.flatten(cute.recast_tensor(sQ, cutlass.Uint8))
+            if warp_kv_idx == Int32(0):
+                self._async_copy_q_tile_permuted_128b(
+                    mQBytes,
+                    q_start,
+                    packed_tile_start,
+                    packed_tile_rows,
+                    kv_head_idx,
+                    group_size,
+                    mQ.shape[1],
+                    self.traits.head_dim_qk * (self.dtype_q.width // 8),
+                    q_token_stride_bytes,
+                    q_head_stride_bytes,
+                    sQBytes,
+                    lane,
+                    warp_q_idx,
+                )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+            if const_expr(self.bf16_minimax_role_specialized_decode):
+                cute.arch.barrier(
+                    barrier_id=1, number_of_threads=self.traits.num_threads
+                )
+            else:
+                cute.arch.sync_threads()
+        else:
+            sQBytes = cute.flatten(cute.recast_tensor(sQ, cutlass.Uint8))
+            self._async_copy_q_tile_permuted_128b(
+                mQBytes,
+                q_start,
+                packed_tile_start,
+                packed_tile_rows,
+                kv_head_idx,
+                group_size,
+                mQ.shape[1],
+                self.traits.head_dim_qk * (self.dtype_q.width // 8),
+                q_token_stride_bytes,
+                q_head_stride_bytes,
+                sQBytes,
+                lane,
+                warp_q_idx,
+            )
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.sync_threads()
+
+        k_scale = (
+            mKDescale[request_idx]
+            if const_expr(mKDescale is not None and len(mKDescale.shape) == 1)
+            else (
+                mKDescale[request_idx, kv_head_idx]
+                if const_expr(mKDescale is not None)
+                else Float32(1.0)
+            )
+        )
+        v_scale = (
+            mVDescale[request_idx]
+            if const_expr(mVDescale is not None and len(mVDescale.shape) == 1)
+            else (
+                mVDescale[request_idx, kv_head_idx]
+                if const_expr(mVDescale is not None)
+                else Float32(1.0)
+            )
+        )
+        num_mma_q = self.traits.num_mma_q
+        num_mma_kv = self.traits.num_mma_kv
+        num_mma_d_vo = self.traits.num_mma_d_vo
+        warp_row_base = warp_q_idx * num_mma_q * 16
+        warp_kv_base = warp_kv_idx * num_mma_kv * 16
+        lane_group = lane // 4
+        lane_pair_base = 2 * (lane % 4)
+        row_local_idx = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        row_valid = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_token_local = None
+        q_head_idx_frag = None
+        q_row_idx_frag = None
+        causal_k_limit = None
+        if const_expr(not decode_row_metadata_fastpath):
+            q_token_local = cute.make_rmem_tensor(
+                cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+            )
+            q_head_idx_frag = cute.make_rmem_tensor(
+                cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+            )
+            q_row_idx_frag = cute.make_rmem_tensor(
+                cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+            )
+            causal_k_limit = cute.make_rmem_tensor(
+                cute.make_layout((num_mma_q, 2), stride=(2, 1)), Int32
+            )
+        frag_s_layout = cute.make_layout(
+            (num_mma_q, num_mma_kv, 8), stride=(num_mma_kv * 8, 8, 1)
+        )
+        frag_p_layout = cute.make_layout(
+            (num_mma_q, num_mma_kv, 4), stride=(num_mma_kv * 4, 4, 1)
+        )
+        frag_o_layout = cute.make_layout(
+            (num_mma_q, num_mma_d_vo, 8), stride=(num_mma_d_vo * 8, 8, 1)
+        )
+        s_frag = cute.make_rmem_tensor(
+            frag_s_layout,
+            Float32,
+        )
+        tSsQ_tma = None
+        tSrQ_tma = None
+        acc_shape_S_tma = None
+        tiled_mma_qk_tma = None
+        tiled_mma_pv_tma = None
+        thr_mma_qk_tma = None
+        thr_mma_pv_tma = None
+        smem_thr_copy_K_tma = None
+        smem_thr_copy_V_tma = None
+        tScS_mn_tma = None
+        t0ScS_mn_tma = None
+        o_frag = cute.make_rmem_tensor(
+            frag_o_layout,
+            Float32,
+        )
+        m_frag = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        d_frag = cute.make_rmem_tensor(
+            cute.make_layout((num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        p_frag = cute.make_rmem_tensor(
+            frag_p_layout,
+            Uint32,
+        )
+        q_smem_base_addr = shared_ptr_to_u32(sQ.iterator)
+        decode_q_head_base = (
+            Int32(kv_head_idx * group_size)
+            if const_expr(decode_row_metadata_fastpath)
+            else Int32(0)
+        )
+        decode_q_row_idx = (
+            Int32(request_idx) if const_expr(decode_row_metadata_fastpath) else Int32(0)
+        )
+        decode_partial_row_idx = (
+            Int32(request_partial_start + kv_tile_idx)
+            if const_expr(decode_row_metadata_fastpath and self.split_kv)
+            else Int32(0)
+        )
+
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                packed_row_local = (
+                    warp_row_base + mma_q * 16 + lane_group + 8 * row_slot
+                )
+                row_local_idx[mma_q, row_slot] = Int32(packed_row_local)
+                if const_expr(decode_qwen_single_row_fastpath):
+                    if const_expr(row_slot == 0):
+                        valid_row = packed_row_local < packed_tile_rows
+                        row_valid[mma_q, row_slot] = Int32(valid_row)
+                        causal_k_limit[mma_q, row_slot] = cutlass.select_(
+                            valid_row,
+                            Int32(cache_len - 1),
+                            Int32(-1),
+                        )
+                    else:
+                        row_valid[mma_q, row_slot] = Int32(0)
+                        causal_k_limit[mma_q, row_slot] = Int32(-1)
+                else:
+                    valid_row = packed_row_local < packed_tile_rows
+                    row_valid[mma_q, row_slot] = Int32(valid_row)
+                    if valid_row:
+                        if const_expr(
+                            self.single_request_decode_graph
+                            or self.single_qtile_decode_graph
+                        ):
+                            q_token_local[mma_q, row_slot] = Int32(0)
+                            q_head_idx_frag[mma_q, row_slot] = Int32(
+                                kv_head_idx * group_size + packed_row_local
+                            )
+                            q_row_idx_frag[mma_q, row_slot] = Int32(q_start)
+                            causal_k_limit[mma_q, row_slot] = Int32(cache_len - qo_len)
+                        elif const_expr(not decode_row_metadata_fastpath):
+                            packed_q_idx = packed_tile_start + packed_row_local
+                            token_local = packed_q_idx // group_size
+                            q_group_lane = packed_q_idx - token_local * group_size
+                            q_token_local[mma_q, row_slot] = Int32(token_local)
+                            q_head_idx_frag[mma_q, row_slot] = Int32(
+                                kv_head_idx * group_size + q_group_lane
+                            )
+                            q_row_idx_frag[mma_q, row_slot] = Int32(
+                                q_start + token_local
+                            )
+                            causal_k_limit[mma_q, row_slot] = Int32(
+                                token_local + cache_len - qo_len
+                            )
+                        else:
+                            pass
+                    elif const_expr(not decode_row_metadata_fastpath):
+                        q_token_local[mma_q, row_slot] = Int32(0)
+                        q_head_idx_frag[mma_q, row_slot] = Int32(0)
+                        q_row_idx_frag[mma_q, row_slot] = Int32(0)
+                        causal_k_limit[mma_q, row_slot] = Int32(-1)
+
+        for mma_q in cutlass.range_constexpr(num_mma_q):
+            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                for reg_id in cutlass.range_constexpr(8):
+                    o_frag[mma_q, mma_d, reg_id] = Float32(0.0)
+            for row_slot in cutlass.range_constexpr(2):
+                m_frag[mma_q, row_slot] = Float32(-Float32.inf)
+                d_frag[mma_q, row_slot] = Float32(1.0)
+
+        prefetch_base = chunk_start
+        k_producer_state = cute_pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.num_stages
+        )
+        k_consumer_state = cute_pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.num_stages
+        )
+        v_producer_state = cute_pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.num_stages
+        )
+        v_consumer_state = cute_pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.num_stages
+        )
+        initial_prefetch_stages = (
+            0
+            if const_expr(self.bf16_minimax_role_specialized_decode)
+            else 3
+            if const_expr(self.num_stages == 3)
+            else 1
+        )
+        for _prefetch_stage in cutlass.range_constexpr(initial_prefetch_stages):
+            if prefetch_base < chunk_end:
+                tile_limit = cutlass.select_(
+                    prefetch_base + stage_tile_rows < chunk_end,
+                    prefetch_base + stage_tile_rows,
+                    chunk_end,
+                )
+                tile_tokens = tile_limit - prefetch_base
+                if warp_linear_idx == Int32(0):
+                    prefetch_page_idx = self._tile_page_idx(
+                        mQ2KIndices,
+                        kv_head_idx,
+                        q_start,
+                        prefetch_base,
+                        page_size,
+                    )
+                    prefetch_sub_tile = self._tile_sub64_idx(prefetch_base)
+                    if const_expr(self.k_tma_plane_count > 3):
+                        self._issue_paged_kv_tma_copy_planes(
+                            load_K_tma0,
+                            load_K_tma1,
+                            load_K_tma2,
+                            load_K_tma3,
+                            pipeline_k,
+                            k_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                    elif const_expr(self.k_tma_plane_count > 2):
+                        self._issue_paged_kv_tma_copy_3planes(
+                            load_K_tma0,
+                            load_K_tma1,
+                            load_K_tma2,
+                            pipeline_k,
+                            k_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                    elif const_expr(self.k_tma_plane_count > 1):
+                        self._issue_paged_kv_tma_copy_2planes(
+                            load_K_tma0,
+                            load_K_tma1,
+                            pipeline_k,
+                            k_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                    else:
+                        self._issue_paged_kv_tma_copy_1plane(
+                            load_K_tma0,
+                            pipeline_k,
+                            k_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                    if const_expr(self.v_tma_plane_count > 3):
+                        self._issue_paged_kv_tma_copy_planes(
+                            load_V_tma0,
+                            load_V_tma1,
+                            load_V_tma2,
+                            load_V_tma3,
+                            pipeline_v,
+                            v_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                    elif const_expr(self.v_tma_plane_count > 2):
+                        self._issue_paged_kv_tma_copy_3planes(
+                            load_V_tma0,
+                            load_V_tma1,
+                            load_V_tma2,
+                            pipeline_v,
+                            v_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                    elif const_expr(self.v_tma_plane_count > 1):
+                        self._issue_paged_kv_tma_copy_2planes(
+                            load_V_tma0,
+                            load_V_tma1,
+                            pipeline_v,
+                            v_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                    else:
+                        self._issue_paged_kv_tma_copy_1plane(
+                            load_V_tma0,
+                            pipeline_v,
+                            v_producer_state,
+                            mPageTable,
+                            request_idx,
+                            prefetch_page_idx,
+                            prefetch_sub_tile,
+                        )
+                k_producer_state.advance()
+                v_producer_state.advance()
+                prefetch_base += stage_tile_rows
+
+        consume_stage_idx = Int32(0)
+        tile_base = chunk_start
+        while tile_base < chunk_end:
+            tile_limit = cutlass.select_(
+                tile_base + stage_tile_rows < chunk_end,
+                tile_base + stage_tile_rows,
+                chunk_end,
+            )
+            tile_key_base = self._tile_key_base(
+                mQ2KIndices,
+                kv_head_idx,
+                q_start,
+                tile_base,
+            )
+            tile_tokens = tile_limit - tile_base
+            if const_expr(self.msa_block_sparse):
+                live_tokens = cache_len - tile_key_base
+                live_tokens = cutlass.select_(
+                    live_tokens < Int32(0), Int32(0), live_tokens
+                )
+                tile_tokens = cutlass.select_(
+                    live_tokens < tile_tokens, live_tokens, tile_tokens
+                )
+            pipeline_k.consumer_wait(
+                k_consumer_state,
+                pipeline_k.consumer_try_wait(k_consumer_state),
+            )
+            if const_expr(self.bf16_minimax_role_specialized_decode):
+                cute.arch.barrier(
+                    barrier_id=1, number_of_threads=self.traits.num_threads
+                )
+            else:
+                cute.arch.sync_threads()
+
+            if const_expr(
+                self.debug_dump_paged_kv_tma_k or self.debug_dump_paged_kv_tma_v
+            ):
+                if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                    _dump_tma_stage_rows(
+                        mO,
+                        sKTma if const_expr(self.debug_dump_paged_kv_tma_k) else sVTma,
+                        tidx,
+                        stage_tile_rows,
+                        self.traits.head_dim_qk
+                        if const_expr(self.debug_dump_paged_kv_tma_k)
+                        else self.traits.head_dim_vo,
+                        self.traits.num_threads,
+                        Int32(24),
+                    )
+                _exit_thread()
+
+            subtile_base = (
+                Int32(0) if const_expr(self.traits.num_warps_kv == 1) else warp_kv_base
+            )
+            for _ in cutlass.range_constexpr(1):
+                if const_expr(self.kv_is_fp8):
+                    frag_S = cute.make_rmem_tensor(
+                        cute.make_layout(
+                            (num_mma_q, num_mma_kv, 8),
+                            stride=(num_mma_kv * 8, 8, 1),
+                        ),
+                        Float32,
+                    )
+                    frag_S.fill(0.0)
+                    k_smem_base_addr = shared_ptr_to_u32(
+                        sKStageBytes.iterator + Int32(consume_stage_idx * k_stage_bytes)
+                    )
+                    k_stage_plane_offset = Int32(
+                        consume_stage_idx * kv_plane_stage_bytes
+                    )
+                    k_plane1_total_offset = Int32(
+                        kv_plane_total_bytes
+                        if const_expr(self.k_tma_plane_count > 1)
+                        else 0
+                    )
+                    if const_expr(
+                        self.use_native_fp8_qk_mma
+                        and not self.decode_native_fp8_runtime_chunk_guard
+                    ):
+                        _literal_qk_mma_into_sfrag_mxfp8_raw(
+                            frag_S,
+                            q_smem_base_addr,
+                            k_smem_base_addr,
+                            lane,
+                            warp_q_idx,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            self.traits.num_mma_d_qk,
+                            tc_upcast_stride_qk,
+                            self.traits.upcast_stride_k,
+                        )
+                    elif const_expr(
+                        self.use_native_fp8_qk_mma
+                        and self.decode_native_fp8_runtime_chunk_guard
+                    ):
+                        if kv_chunk_size >= Int32(
+                            self.DECODE_NATIVE_FP8_RUNTIME_CHUNK_THRESHOLD
+                        ):
+                            _literal_qk_mma_into_sfrag_mxfp8_raw(
+                                frag_S,
+                                q_smem_base_addr,
+                                k_smem_base_addr,
+                                lane,
+                                warp_q_idx,
+                                warp_kv_idx,
+                                Int32(0)
+                                if const_expr(self.traits.num_warps_kv > 1)
+                                else subtile_base,
+                                num_mma_q,
+                                num_mma_kv,
+                                self.traits.num_mma_d_qk,
+                                tc_upcast_stride_qk,
+                                self.traits.upcast_stride_k,
+                            )
+                        else:
+                            if const_expr(decode_fp8_row0_metadata_fastpath):
+                                _literal_qk_mma_into_sfrag_plane_fp8_raw_row0_1x1(
+                                    frag_S,
+                                    q_smem_base_addr,
+                                    shared_ptr_to_u32(
+                                        sKStageBytes.iterator
+                                        + k_stage_plane_offset
+                                        + Int32(0 * kv_plane_total_bytes)
+                                    ),
+                                    shared_ptr_to_u32(
+                                        sKStageBytes.iterator
+                                        + k_stage_plane_offset
+                                        + k_plane1_total_offset
+                                    ),
+                                    lane,
+                                    warp_q_idx,
+                                    warp_kv_idx,
+                                    Int32(0)
+                                    if const_expr(self.traits.num_warps_kv > 1)
+                                    else subtile_base,
+                                    self.traits.num_mma_d_qk,
+                                    tc_upcast_stride_qk,
+                                    tc_upcast_stride_plane,
+                                )
+                            else:
+                                _literal_qk_mma_into_sfrag_plane_fp8_raw(
+                                    frag_S,
+                                    q_smem_base_addr,
+                                    shared_ptr_to_u32(
+                                        sKStageBytes.iterator
+                                        + k_stage_plane_offset
+                                        + Int32(0 * kv_plane_total_bytes)
+                                    ),
+                                    shared_ptr_to_u32(
+                                        sKStageBytes.iterator
+                                        + k_stage_plane_offset
+                                        + k_plane1_total_offset
+                                    ),
+                                    lane,
+                                    warp_q_idx,
+                                    warp_kv_idx,
+                                    Int32(0)
+                                    if const_expr(self.traits.num_warps_kv > 1)
+                                    else subtile_base,
+                                    num_mma_q,
+                                    num_mma_kv,
+                                    self.traits.num_mma_d_qk,
+                                    tc_upcast_stride_qk,
+                                    tc_upcast_stride_plane,
+                                )
+                    else:
+                        if const_expr(decode_fp8_row0_metadata_fastpath):
+                            _literal_qk_mma_into_sfrag_plane_fp8_raw_row0_1x1(
+                                frag_S,
+                                q_smem_base_addr,
+                                shared_ptr_to_u32(
+                                    sKStageBytes.iterator
+                                    + k_stage_plane_offset
+                                    + Int32(0 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sKStageBytes.iterator
+                                    + k_stage_plane_offset
+                                    + k_plane1_total_offset
+                                ),
+                                lane,
+                                warp_q_idx,
+                                warp_kv_idx,
+                                Int32(0)
+                                if const_expr(self.traits.num_warps_kv > 1)
+                                else subtile_base,
+                                self.traits.num_mma_d_qk,
+                                tc_upcast_stride_qk,
+                                tc_upcast_stride_plane,
+                            )
+                        else:
+                            _literal_qk_mma_into_sfrag_plane_fp8_raw(
+                                frag_S,
+                                q_smem_base_addr,
+                                shared_ptr_to_u32(
+                                    sKStageBytes.iterator
+                                    + k_stage_plane_offset
+                                    + Int32(0 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sKStageBytes.iterator
+                                    + k_stage_plane_offset
+                                    + k_plane1_total_offset
+                                ),
+                                lane,
+                                warp_q_idx,
+                                warp_kv_idx,
+                                Int32(0)
+                                if const_expr(self.traits.num_warps_kv > 1)
+                                else subtile_base,
+                                num_mma_q,
+                                num_mma_kv,
+                                self.traits.num_mma_d_qk,
+                                tc_upcast_stride_qk,
+                                tc_upcast_stride_plane,
+                            )
+                    for mma_q in cutlass.range_constexpr(num_mma_q):
+                        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                            if const_expr(
+                                decode_row_metadata_fastpath
+                                and self.traits.num_warps_q == 1
+                                and num_mma_q == 1
+                            ):
+                                if group_size == Int32(8) or group_size == Int32(6):
+                                    for reg_id in cutlass.range_constexpr(8):
+                                        if const_expr(((reg_id % 4) // 2) == 0):
+                                            key_local = (
+                                                warp_kv_base
+                                                + mma_kv * 16
+                                                + lane_pair_base
+                                                + 8 * (reg_id // 4)
+                                                + (reg_id % 2)
+                                            )
+                                            valid = row_valid[mma_q, 0] != 0
+                                            if valid:
+                                                valid = (
+                                                    valid and key_local < tile_tokens
+                                                )
+                                            if const_expr(self.window_left >= 0):
+                                                if valid:
+                                                    key_pos = tile_key_base + key_local
+                                                    row_causal_k_limit = Int32(
+                                                        cache_len - qo_len
+                                                    )
+                                                    window_start = (
+                                                        row_causal_k_limit
+                                                        - Int32(self.window_left)
+                                                    )
+                                                    window_start = cutlass.select_(
+                                                        window_start > Int32(0),
+                                                        window_start,
+                                                        Int32(0),
+                                                    )
+                                                    valid = (
+                                                        valid
+                                                        and key_pos >= window_start
+                                                    )
+                                            if valid:
+                                                frag_S[mma_q, mma_kv, reg_id] = (
+                                                    frag_S[mma_q, mma_kv, reg_id]
+                                                    * k_scale
+                                                )
+                                            else:
+                                                frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                                    -Float32.inf
+                                                )
+                                        else:
+                                            frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                                -Float32.inf
+                                            )
+                                else:
+                                    for reg_id in cutlass.range_constexpr(8):
+                                        row_slot = (reg_id % 4) // 2
+                                        key_local = (
+                                            warp_kv_base
+                                            + mma_kv * 16
+                                            + lane_pair_base
+                                            + 8 * (reg_id // 4)
+                                            + (reg_id % 2)
+                                        )
+                                        valid = row_valid[mma_q, row_slot] != 0
+                                        if valid:
+                                            valid = valid and key_local < tile_tokens
+                                        if const_expr(self.window_left >= 0):
+                                            if valid:
+                                                key_pos = tile_key_base + key_local
+                                                row_causal_k_limit = Int32(
+                                                    cache_len - qo_len
+                                                )
+                                                window_start = (
+                                                    row_causal_k_limit
+                                                    - Int32(self.window_left)
+                                                )
+                                                window_start = cutlass.select_(
+                                                    window_start > Int32(0),
+                                                    window_start,
+                                                    Int32(0),
+                                                )
+                                                valid = (
+                                                    valid and key_pos >= window_start
+                                                )
+                                        if valid:
+                                            frag_S[mma_q, mma_kv, reg_id] = (
+                                                frag_S[mma_q, mma_kv, reg_id] * k_scale
+                                            )
+                                        else:
+                                            frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                                -Float32.inf
+                                            )
+                            else:
+                                for reg_id in cutlass.range_constexpr(8):
+                                    row_slot = (reg_id % 4) // 2
+                                    key_local = (
+                                        warp_kv_base
+                                        + mma_kv * 16
+                                        + lane_pair_base
+                                        + 8 * (reg_id // 4)
+                                        + (reg_id % 2)
+                                    )
+                                    valid = row_valid[mma_q, row_slot] != 0
+                                    if valid:
+                                        valid = valid and key_local < tile_tokens
+                                    if const_expr(not decode_row_metadata_fastpath):
+                                        if valid:
+                                            key_pos = tile_key_base + (
+                                                warp_kv_base
+                                                + mma_kv * 16
+                                                + lane_pair_base
+                                                + 8 * (reg_id // 4)
+                                                + (reg_id % 2)
+                                            )
+                                            valid = (
+                                                valid
+                                                and key_pos
+                                                <= causal_k_limit[mma_q, row_slot]
+                                            )
+                                            if const_expr(self.window_left >= 0):
+                                                window_start = causal_k_limit[
+                                                    mma_q, row_slot
+                                                ] - Int32(self.window_left)
+                                                window_start = cutlass.select_(
+                                                    window_start > Int32(0),
+                                                    window_start,
+                                                    Int32(0),
+                                                )
+                                                valid = (
+                                                    valid and key_pos >= window_start
+                                                )
+                                    elif const_expr(self.window_left >= 0):
+                                        if valid:
+                                            key_pos = tile_key_base + key_local
+                                            row_causal_k_limit = Int32(
+                                                cache_len - qo_len
+                                            )
+                                            window_start = row_causal_k_limit - Int32(
+                                                self.window_left
+                                            )
+                                            window_start = cutlass.select_(
+                                                window_start > Int32(0),
+                                                window_start,
+                                                Int32(0),
+                                            )
+                                            valid = valid and key_pos >= window_start
+                                    if valid:
+                                        frag_S[mma_q, mma_kv, reg_id] = (
+                                            frag_S[mma_q, mma_kv, reg_id] * k_scale
+                                        )
+                                    else:
+                                        frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                            -Float32.inf
+                                        )
+                else:
+                    literal_key_base = (
+                        Int32(0)
+                        if const_expr(self.traits.num_warps_kv > 1)
+                        else subtile_base
+                    )
+                    frag_S = cute.make_rmem_tensor(
+                        frag_s_layout,
+                        Float32,
+                    )
+                    frag_S.fill(0.0)
+                    k_stage_plane_offset = Int32(
+                        consume_stage_idx * kv_plane_stage_bytes
+                    )
+                    if const_expr(decode_bf16_row0_qk_fastpath):
+                        _literal_qk_mma_into_sfrag_plane_bf16_row0_1x1(
+                            frag_S,
+                            q_smem_base_addr,
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(1 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(2 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(3 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_q_idx,
+                            warp_kv_idx,
+                            literal_key_base,
+                            self.traits.num_mma_d_qk,
+                            tc_upcast_stride_qk,
+                            tc_upcast_stride_plane,
+                        )
+                    else:
+                        _literal_qk_mma_into_sfrag_plane_bf16(
+                            frag_S,
+                            q_smem_base_addr,
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(1 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(2 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + k_stage_plane_offset
+                                + Int32(3 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_q_idx,
+                            warp_kv_idx,
+                            literal_key_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            self.traits.num_mma_d_qk,
+                            tc_upcast_stride_qk,
+                            tc_upcast_stride_plane,
+                        )
+                    for mma_q in cutlass.range_constexpr(num_mma_q):
+                        for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                            if const_expr(decode_bf16_row0_mask_fastpath):
+                                for reg_id in cutlass.range_constexpr(8):
+                                    if const_expr(((reg_id % 4) // 2) == 0):
+                                        key_local = (
+                                            warp_kv_base
+                                            + mma_kv * 16
+                                            + lane_pair_base
+                                            + 8 * (reg_id // 4)
+                                            + (reg_id % 2)
+                                        )
+                                        valid = row_valid[mma_q, 0] != 0
+                                        if valid:
+                                            valid = valid and key_local < tile_tokens
+                                        if const_expr(self.window_left >= 0):
+                                            if valid:
+                                                key_pos = tile_key_base + key_local
+                                                row_causal_k_limit = Int32(
+                                                    cache_len - qo_len
+                                                )
+                                                window_start = (
+                                                    row_causal_k_limit
+                                                    - Int32(self.window_left)
+                                                )
+                                                window_start = cutlass.select_(
+                                                    window_start > Int32(0),
+                                                    window_start,
+                                                    Int32(0),
+                                                )
+                                                valid = (
+                                                    valid and key_pos >= window_start
+                                                )
+                                        # Keep each score selection scalar.  NVVM 23
+                                        # otherwise combines adjacent values into
+                                        # dependent b64 selects on SM120.
+                                        frag_S[mma_q, mma_kv, reg_id] = cutlass.select_(
+                                            valid,
+                                            frag_S[mma_q, mma_kv, reg_id],
+                                            Float32(-Float32.inf),
+                                        )
+                                    else:
+                                        frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                            -Float32.inf
+                                        )
+                            else:
+                                for reg_id in cutlass.range_constexpr(8):
+                                    row_slot = (reg_id % 4) // 2
+                                    key_local = (
+                                        warp_kv_base
+                                        + mma_kv * 16
+                                        + lane_pair_base
+                                        + 8 * (reg_id // 4)
+                                        + (reg_id % 2)
+                                    )
+                                    valid = row_valid[mma_q, row_slot] != 0
+                                    if valid:
+                                        valid = valid and key_local < tile_tokens
+                                    if const_expr(not decode_row_metadata_fastpath):
+                                        if valid:
+                                            key_pos = tile_key_base + key_local
+                                            valid = (
+                                                valid
+                                                and key_pos
+                                                <= causal_k_limit[mma_q, row_slot]
+                                            )
+                                            if const_expr(self.window_left >= 0):
+                                                window_start = causal_k_limit[
+                                                    mma_q, row_slot
+                                                ] - Int32(self.window_left)
+                                                window_start = cutlass.select_(
+                                                    window_start > Int32(0),
+                                                    window_start,
+                                                    Int32(0),
+                                                )
+                                                valid = (
+                                                    valid and key_pos >= window_start
+                                                )
+                                    elif const_expr(self.window_left >= 0):
+                                        if valid:
+                                            key_pos = tile_key_base + key_local
+                                            row_causal_k_limit = Int32(
+                                                cache_len - qo_len
+                                            )
+                                            window_start = row_causal_k_limit - Int32(
+                                                self.window_left
+                                            )
+                                            window_start = cutlass.select_(
+                                                window_start > Int32(0),
+                                                window_start,
+                                                Int32(0),
+                                            )
+                                            valid = valid and key_pos >= window_start
+                                    if not valid:
+                                        frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                            -Float32.inf
+                                        )
+
+                    if const_expr(self.debug_dump_paged_kv_tma_s):
+                        if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                            _dump_s_frag_tile(
+                                mO,
+                                frag_S,
+                                lane,
+                                warp_q_idx,
+                                warp_kv_idx,
+                                num_mma_q,
+                                num_mma_kv,
+                                packed_tile_rows,
+                                tile_tokens,
+                            )
+                        _exit_thread()
+
+                if const_expr(self.has_relative_attention_bias):
+                    _apply_relative_attention_bias(
+                        frag_S,
+                        mRelativeAttentionBias,
+                        q_row_idx_frag,
+                        q_head_idx_frag,
+                        causal_k_limit,
+                        tile_key_base,
+                        warp_kv_base,
+                        lane_pair_base,
+                        self.inverse_softmax_scale,
+                        num_mma_q,
+                        num_mma_kv,
+                    )
+
+                next_tile_base = prefetch_base
+                if const_expr(decode_row0_k_release_fastpath):
+                    pipeline_k.consumer_release(k_consumer_state)
+                    if const_expr(not self.bf16_minimax_role_specialized_decode):
+                        if next_tile_base < chunk_end:
+                            if warp_linear_idx == Int32(0):
+                                next_page_idx = self._tile_page_idx(
+                                    mQ2KIndices,
+                                    kv_head_idx,
+                                    q_start,
+                                    next_tile_base,
+                                    page_size,
+                                )
+                                next_sub_tile = self._tile_sub64_idx(next_tile_base)
+                                if const_expr(self.k_tma_plane_count > 3):
+                                    self._issue_paged_kv_tma_copy_planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        load_K_tma2,
+                                        load_K_tma3,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                                elif const_expr(self.k_tma_plane_count > 2):
+                                    self._issue_paged_kv_tma_copy_3planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        load_K_tma2,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                                elif const_expr(self.k_tma_plane_count > 1):
+                                    self._issue_paged_kv_tma_copy_2planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                                else:
+                                    self._issue_paged_kv_tma_copy_1plane(
+                                        load_K_tma0,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                            k_producer_state.advance()
+                    k_consumer_state.advance()
+
+                if const_expr(
+                    self.decode_only
+                    and self.kv_is_fp8
+                    and self.traits.num_warps_q == 1
+                    and num_mma_q == 1
+                ):
+                    if group_size == Int32(8) or group_size == Int32(6):
+                        if const_expr(num_mma_kv == 1):
+                            _literal_update_mdo_states_fp32_pack_p_row0_1x1(
+                                frag_S,
+                                o_frag,
+                                m_frag,
+                                d_frag,
+                                p_frag,
+                                self.softmax_scale_log2,
+                                num_mma_d_vo,
+                            )
+                        else:
+                            _literal_update_mdo_states_fp32_pack_p_row0(
+                                frag_S,
+                                o_frag,
+                                m_frag,
+                                d_frag,
+                                p_frag,
+                                self.softmax_scale_log2,
+                                num_mma_q,
+                                num_mma_kv,
+                                num_mma_d_vo,
+                            )
+                    else:
+                        _literal_update_mdo_states_fp32_pack_p(
+                            frag_S,
+                            o_frag,
+                            m_frag,
+                            d_frag,
+                            p_frag,
+                            self.softmax_scale_log2,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                        )
+                else:
+                    _literal_update_mdo_states_fp32_pack_p(
+                        frag_S,
+                        o_frag,
+                        m_frag,
+                        d_frag,
+                        p_frag,
+                        self.softmax_scale_log2,
+                        num_mma_q,
+                        num_mma_kv,
+                        num_mma_d_vo,
+                    )
+                if const_expr(self.debug_dump_paged_kv_pregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and warp_q_idx == Int32(0)
+                        and warp_kv_idx == Int32(0)
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        _dump_p_frag_regs_raw(
+                            mDebugU32,
+                            p_frag,
+                            lane,
+                        )
+                    _exit_thread()
+                if const_expr(self.debug_dump_paged_kv_sregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and warp_q_idx == Int32(0)
+                        and warp_kv_idx == Int32(0)
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        _dump_s_frag_regs_raw(
+                            mDebugU32,
+                            frag_S,
+                            lane,
+                        )
+                    _exit_thread()
+                for mma_q in cutlass.range_constexpr(num_mma_q):
+                    for mma_kv in cutlass.range_constexpr(num_mma_kv):
+                        d0, d1 = bf16_rowsum_m16k16_f32(
+                            d_frag[mma_q, 0],
+                            d_frag[mma_q, 1],
+                            p_frag[mma_q, mma_kv, 0],
+                            p_frag[mma_q, mma_kv, 1],
+                            p_frag[mma_q, mma_kv, 2],
+                            p_frag[mma_q, mma_kv, 3],
+                        )
+                        d_frag[mma_q, 0] = d0
+                        d_frag[mma_q, 1] = d1
+                if const_expr(not decode_row0_k_release_fastpath):
+                    pipeline_k.consumer_release(k_consumer_state)
+                    if const_expr(not self.bf16_minimax_role_specialized_decode):
+                        if next_tile_base < chunk_end:
+                            if warp_linear_idx == Int32(0):
+                                next_page_idx = self._tile_page_idx(
+                                    mQ2KIndices,
+                                    kv_head_idx,
+                                    q_start,
+                                    next_tile_base,
+                                    page_size,
+                                )
+                                next_sub_tile = self._tile_sub64_idx(next_tile_base)
+                                if const_expr(self.k_tma_plane_count > 3):
+                                    self._issue_paged_kv_tma_copy_planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        load_K_tma2,
+                                        load_K_tma3,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                                elif const_expr(self.k_tma_plane_count > 2):
+                                    self._issue_paged_kv_tma_copy_3planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        load_K_tma2,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                                elif const_expr(self.k_tma_plane_count > 1):
+                                    self._issue_paged_kv_tma_copy_2planes(
+                                        load_K_tma0,
+                                        load_K_tma1,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                                else:
+                                    self._issue_paged_kv_tma_copy_1plane(
+                                        load_K_tma0,
+                                        pipeline_k,
+                                        k_producer_state,
+                                        mPageTable,
+                                        request_idx,
+                                        next_page_idx,
+                                        next_sub_tile,
+                                    )
+                            k_producer_state.advance()
+                    k_consumer_state.advance()
+
+                pipeline_v.consumer_wait(
+                    v_consumer_state,
+                    pipeline_v.consumer_try_wait(v_consumer_state),
+                )
+
+                if const_expr(self.debug_dump_paged_kv_pvregs):
+                    if (
+                        work_idx == Int32(0)
+                        and kv_head_idx == Int32(0)
+                        and warp_q_idx == Int32(0)
+                        and warp_kv_idx == Int32(0)
+                    ):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        pv_row_base = (
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base
+                        )
+                        if const_expr(self.kv_is_fp8):
+                            v_stage_plane_offset = Int32(
+                                consume_stage_idx * kv_plane_stage_bytes
+                            )
+                            v_plane1_total_offset = Int32(
+                                kv_plane_total_bytes
+                                if const_expr(self.v_tma_plane_count > 1)
+                                else 0
+                            )
+                            _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                                o_frag,
+                                p_frag,
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(0 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + v_plane1_total_offset
+                                ),
+                                lane,
+                                warp_kv_idx,
+                                pv_row_base,
+                                num_mma_q,
+                                num_mma_kv,
+                                num_mma_d_vo,
+                                tc_upcast_stride_plane,
+                                v_scale,
+                                mDebugU32,
+                            )
+                        else:
+                            v_stage_plane_offset = Int32(
+                                consume_stage_idx * kv_plane_stage_bytes
+                            )
+                            v_plane1_total_offset = Int32(
+                                kv_plane_total_bytes
+                                if const_expr(self.v_tma_plane_count > 1)
+                                else 0
+                            )
+                            _literal_pv_mma_into_ofrag_plane_bf16_packed(
+                                o_frag,
+                                p_frag,
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(0 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + v_plane1_total_offset
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(2 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(3 * kv_plane_total_bytes)
+                                ),
+                                lane,
+                                warp_kv_idx,
+                                pv_row_base,
+                                num_mma_q,
+                                num_mma_kv,
+                                num_mma_d_vo,
+                                tc_upcast_stride_plane,
+                                v_scale,
+                                mDebugU32,
+                            )
+                    _exit_thread()
+
+                if const_expr(self.debug_dump_paged_kv_svwords):
+                    if work_idx == Int32(0) and kv_head_idx == Int32(0):
+                        mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                        _dump_flat_u32_words(
+                            mDebugU32,
+                            cute.recast_tensor(
+                                sV[None, None, consume_stage_idx],
+                                cutlass.Uint32,
+                            ),
+                            tidx,
+                            self.traits.num_threads,
+                        )
+                    _exit_thread()
+
+                if const_expr(self.use_native_fp8_pv_mma):
+                    v_smem_base_addr = shared_ptr_to_u32(
+                        sVStageBytes.iterator + Int32(consume_stage_idx * v_stage_bytes)
+                    )
+                    _literal_pv_mma_into_ofrag_mxfp8_raw(
+                        o_frag,
+                        p_frag,
+                        v_smem_base_addr,
+                        lane,
+                        warp_kv_idx,
+                        Int32(0)
+                        if const_expr(self.traits.num_warps_kv > 1)
+                        else subtile_base,
+                        num_mma_q,
+                        num_mma_kv,
+                        num_mma_d_vo,
+                        self.traits.upcast_stride_v,
+                        v_scale,
+                    )
+                elif const_expr(self.kv_is_fp8):
+                    v_stage_plane_offset = Int32(
+                        consume_stage_idx * kv_plane_stage_bytes
+                    )
+                    v_plane1_total_offset = Int32(
+                        kv_plane_total_bytes
+                        if const_expr(self.v_tma_plane_count > 1)
+                        else 0
+                    )
+                    if const_expr(
+                        self.decode_only
+                        and self.traits.num_warps_q == 1
+                        and num_mma_q == 1
+                    ):
+                        if group_size == Int32(8) or group_size == Int32(6):
+                            if const_expr(num_mma_kv == 1):
+                                _literal_pv_mma_into_ofrag_plane_fp8_raw_row0_1x1(
+                                    o_frag,
+                                    p_frag,
+                                    shared_ptr_to_u32(
+                                        sVStageBytes.iterator
+                                        + v_stage_plane_offset
+                                        + Int32(0 * kv_plane_total_bytes)
+                                    ),
+                                    shared_ptr_to_u32(
+                                        sVStageBytes.iterator
+                                        + v_stage_plane_offset
+                                        + v_plane1_total_offset
+                                    ),
+                                    lane,
+                                    warp_kv_idx,
+                                    Int32(0)
+                                    if const_expr(self.traits.num_warps_kv > 1)
+                                    else subtile_base,
+                                    num_mma_d_vo,
+                                    tc_upcast_stride_plane,
+                                    v_scale,
+                                )
+                            else:
+                                _literal_pv_mma_into_ofrag_plane_fp8_raw_row0(
+                                    o_frag,
+                                    p_frag,
+                                    shared_ptr_to_u32(
+                                        sVStageBytes.iterator
+                                        + v_stage_plane_offset
+                                        + Int32(0 * kv_plane_total_bytes)
+                                    ),
+                                    shared_ptr_to_u32(
+                                        sVStageBytes.iterator
+                                        + v_stage_plane_offset
+                                        + v_plane1_total_offset
+                                    ),
+                                    lane,
+                                    warp_kv_idx,
+                                    Int32(0)
+                                    if const_expr(self.traits.num_warps_kv > 1)
+                                    else subtile_base,
+                                    num_mma_q,
+                                    num_mma_kv,
+                                    num_mma_d_vo,
+                                    tc_upcast_stride_plane,
+                                    v_scale,
+                                )
+                        else:
+                            _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                                o_frag,
+                                p_frag,
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + Int32(0 * kv_plane_total_bytes)
+                                ),
+                                shared_ptr_to_u32(
+                                    sVStageBytes.iterator
+                                    + v_stage_plane_offset
+                                    + v_plane1_total_offset
+                                ),
+                                lane,
+                                warp_kv_idx,
+                                Int32(0)
+                                if const_expr(self.traits.num_warps_kv > 1)
+                                else subtile_base,
+                                num_mma_q,
+                                num_mma_kv,
+                                num_mma_d_vo,
+                                tc_upcast_stride_plane,
+                                v_scale,
+                            )
+                    else:
+                        _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                            o_frag,
+                            p_frag,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + v_plane1_total_offset
+                            ),
+                            lane,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+                else:
+                    v_stage_plane_offset = Int32(
+                        consume_stage_idx * kv_plane_stage_bytes
+                    )
+                    v_plane1_total_offset = Int32(
+                        kv_plane_total_bytes
+                        if const_expr(self.v_tma_plane_count > 1)
+                        else 0
+                    )
+                    if const_expr(decode_bf16_row0_fastpath):
+                        _literal_pv_mma_into_ofrag_plane_bf16_row0_1x1(
+                            o_frag,
+                            p_frag,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + v_plane1_total_offset
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(2 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(3 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+                    else:
+                        _literal_pv_mma_into_ofrag_plane_bf16_packed(
+                            o_frag,
+                            p_frag,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(0 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + v_plane1_total_offset
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(2 * kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + v_stage_plane_offset
+                                + Int32(3 * kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_kv_idx,
+                            Int32(0)
+                            if const_expr(self.traits.num_warps_kv > 1)
+                            else subtile_base,
+                            num_mma_q,
+                            num_mma_kv,
+                            num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+
+                pipeline_v.consumer_release(v_consumer_state)
+                v_consumer_state.advance()
+                if const_expr(not self.bf16_minimax_role_specialized_decode):
+                    if next_tile_base < chunk_end:
+                        if warp_linear_idx == Int32(0):
+                            next_page_idx = self._tile_page_idx(
+                                mQ2KIndices,
+                                kv_head_idx,
+                                q_start,
+                                next_tile_base,
+                                page_size,
+                            )
+                            next_sub_tile = self._tile_sub64_idx(next_tile_base)
+                            if const_expr(self.v_tma_plane_count > 3):
+                                self._issue_paged_kv_tma_copy_planes(
+                                    load_V_tma0,
+                                    load_V_tma1,
+                                    load_V_tma2,
+                                    load_V_tma3,
+                                    pipeline_v,
+                                    v_producer_state,
+                                    mPageTable,
+                                    request_idx,
+                                    next_page_idx,
+                                    next_sub_tile,
+                                )
+                            elif const_expr(self.v_tma_plane_count > 2):
+                                self._issue_paged_kv_tma_copy_3planes(
+                                    load_V_tma0,
+                                    load_V_tma1,
+                                    load_V_tma2,
+                                    pipeline_v,
+                                    v_producer_state,
+                                    mPageTable,
+                                    request_idx,
+                                    next_page_idx,
+                                    next_sub_tile,
+                                )
+                            elif const_expr(self.v_tma_plane_count > 1):
+                                self._issue_paged_kv_tma_copy_2planes(
+                                    load_V_tma0,
+                                    load_V_tma1,
+                                    pipeline_v,
+                                    v_producer_state,
+                                    mPageTable,
+                                    request_idx,
+                                    next_page_idx,
+                                    next_sub_tile,
+                                )
+                            else:
+                                self._issue_paged_kv_tma_copy_1plane(
+                                    load_V_tma0,
+                                    pipeline_v,
+                                    v_producer_state,
+                                    mPageTable,
+                                    request_idx,
+                                    next_page_idx,
+                                    next_sub_tile,
+                                )
+                        v_producer_state.advance()
+                        prefetch_base += stage_tile_rows
+
+            if const_expr(self.bf16_minimax_role_specialized_decode):
+                cute.arch.barrier(
+                    barrier_id=1, number_of_threads=self.traits.num_threads
+                )
+            else:
+                cute.arch.sync_threads()
+            if const_expr(self.num_stages == 2):
+                consume_stage_idx = Int32(1) - consume_stage_idx
+            elif const_expr(self.num_stages == 3):
+                consume_stage_idx = cutlass.select_(
+                    consume_stage_idx == Int32(2),
+                    Int32(0),
+                    consume_stage_idx + Int32(1),
+                )
+            tile_base += stage_tile_rows
+
+        if const_expr(not self.bf16_minimax_role_specialized_decode):
+            if warp_linear_idx == Int32(0):
+                pipeline_k.producer_tail(k_producer_state)
+                pipeline_v.producer_tail(v_producer_state)
+
+        if const_expr(not self.has_attention_sink_bias):
+            if const_expr(
+                (self.single_request_decode_graph or self.single_qtile_decode_graph)
+                and self.gqa_group_size <= 8
+            ):
+                for mma_q in cutlass.range_constexpr(num_mma_q):
+                    if m_frag[mma_q, 0] != -Float32.inf:
+                        m_frag[mma_q, 0] = Float32(
+                            m_frag[mma_q, 0] * self.softmax_scale_log2
+                        )
+            else:
+                for mma_q in cutlass.range_constexpr(num_mma_q):
+                    for row_slot in cutlass.range_constexpr(2):
+                        if m_frag[mma_q, row_slot] != -Float32.inf:
+                            m_frag[mma_q, row_slot] = Float32(
+                                m_frag[mma_q, row_slot] * self.softmax_scale_log2
+                            )
+        elif const_expr(
+            (self.single_request_decode_graph or self.single_qtile_decode_graph)
+            and self.gqa_group_size <= 8
+        ):
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                q_head_idx_sink = Int32(
+                    kv_head_idx * group_size + row_local_idx[mma_q, 0]
+                )
+                _apply_attention_sink_after_lse_scale(
+                    o_frag,
+                    m_frag,
+                    d_frag,
+                    mAttentionSinkBias,
+                    mma_q,
+                    0,
+                    q_head_idx_sink,
+                    row_valid[mma_q, 0],
+                    causal_k_limit[mma_q, 0],
+                    chunk_start,
+                    chunk_end,
+                    warp_kv_idx,
+                    num_mma_d_vo,
+                    self.softmax_scale_log2,
+                    self.has_attention_sink_bias,
+                    self.split_kv,
+                )
+        else:
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                for row_slot in cutlass.range_constexpr(2):
+                    q_head_idx_sink = (
+                        Int32(decode_q_head_base + row_local_idx[mma_q, row_slot])
+                        if const_expr(decode_row_metadata_fastpath)
+                        else q_head_idx_frag[mma_q, row_slot]
+                    )
+                    row_causal_k_limit = (
+                        Int32(cache_len - qo_len)
+                        if const_expr(decode_row_metadata_fastpath)
+                        else causal_k_limit[mma_q, row_slot]
+                    )
+                    _apply_attention_sink_after_lse_scale(
+                        o_frag,
+                        m_frag,
+                        d_frag,
+                        mAttentionSinkBias,
+                        mma_q,
+                        row_slot,
+                        q_head_idx_sink,
+                        row_valid[mma_q, row_slot],
+                        row_causal_k_limit,
+                        chunk_start,
+                        chunk_end,
+                        warp_kv_idx,
+                        num_mma_d_vo,
+                        self.softmax_scale_log2,
+                        self.has_attention_sink_bias,
+                        self.split_kv,
+                    )
+
+        if const_expr(self.traits.num_warps_kv > 1):
+            if const_expr(decode_qwen_single_row_fastpath):
+                packed_row_local = Int32(lane_group)
+                qwen_valid_row = packed_row_local < packed_tile_rows
+                spill_qwen_partial = qwen_valid_row and warp_kv_idx != 0
+                if lane_pair_base == 0 and spill_qwen_partial:
+                    sSyncMD[warp_kv_idx, packed_row_local, 0] = m_frag[0, 0]
+                    sSyncMD[warp_kv_idx, packed_row_local, 1] = d_frag[0, 0]
+                for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                    dim_low = mma_d * 16 + lane_pair_base
+                    dim_high = dim_low + 8
+                    if spill_qwen_partial:
+                        sSyncO[warp_kv_idx, packed_row_local, dim_low + 0] = o_frag[
+                            0, mma_d, 0
+                        ]
+                        sSyncO[warp_kv_idx, packed_row_local, dim_low + 1] = o_frag[
+                            0, mma_d, 1
+                        ]
+                        sSyncO[warp_kv_idx, packed_row_local, dim_high + 0] = o_frag[
+                            0, mma_d, 4
+                        ]
+                        sSyncO[warp_kv_idx, packed_row_local, dim_high + 1] = o_frag[
+                            0, mma_d, 5
+                        ]
+            elif const_expr(
+                (self.single_request_decode_graph or self.single_qtile_decode_graph)
+                and self.gqa_group_size <= 8
+            ):
+                for mma_q in cutlass.range_constexpr(num_mma_q):
+                    packed_row_local = row_local_idx[mma_q, 0]
+                    if row_valid[mma_q, 0] != 0 and lane_pair_base == 0:
+                        sSyncMD[warp_kv_idx, packed_row_local, 0] = m_frag[mma_q, 0]
+                        sSyncMD[warp_kv_idx, packed_row_local, 1] = d_frag[mma_q, 0]
+                    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                        dim_low = mma_d * 16 + lane_pair_base
+                        dim_high = dim_low + 8
+                        if row_valid[mma_q, 0] != 0:
+                            sSyncO[warp_kv_idx, packed_row_local, dim_low + 0] = o_frag[
+                                mma_q, mma_d, 0
+                            ]
+                            sSyncO[warp_kv_idx, packed_row_local, dim_low + 1] = o_frag[
+                                mma_q, mma_d, 1
+                            ]
+                            sSyncO[warp_kv_idx, packed_row_local, dim_high + 0] = (
+                                o_frag[mma_q, mma_d, 4]
+                            )
+                            sSyncO[warp_kv_idx, packed_row_local, dim_high + 1] = (
+                                o_frag[mma_q, mma_d, 5]
+                            )
+            elif const_expr(decode_row0_merge_fastpath):
+                packed_row_local = row_local_idx[0, 0]
+                spill_partial = warp_kv_idx != Int32(0)
+                if row_valid[0, 0] != 0 and lane_pair_base == 0 and spill_partial:
+                    sSyncMD[warp_kv_idx, packed_row_local, 0] = m_frag[0, 0]
+                    sSyncMD[warp_kv_idx, packed_row_local, 1] = d_frag[0, 0]
+                for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                    dim_low = mma_d * 16 + lane_pair_base
+                    dim_high = dim_low + 8
+                    if row_valid[0, 0] != 0 and spill_partial:
+                        sSyncO[warp_kv_idx, packed_row_local, dim_low + 0] = o_frag[
+                            0, mma_d, 0
+                        ]
+                        sSyncO[warp_kv_idx, packed_row_local, dim_low + 1] = o_frag[
+                            0, mma_d, 1
+                        ]
+                        sSyncO[warp_kv_idx, packed_row_local, dim_high + 0] = o_frag[
+                            0, mma_d, 4
+                        ]
+                        sSyncO[warp_kv_idx, packed_row_local, dim_high + 1] = o_frag[
+                            0, mma_d, 5
+                        ]
+            else:
+                for mma_q in cutlass.range_constexpr(num_mma_q):
+                    for row_slot in cutlass.range_constexpr(2):
+                        packed_row_local = row_local_idx[mma_q, row_slot]
+                        if row_valid[mma_q, row_slot] != 0 and lane_pair_base == 0:
+                            sSyncMD[warp_kv_idx, packed_row_local, 0] = m_frag[
+                                mma_q, row_slot
+                            ]
+                            sSyncMD[warp_kv_idx, packed_row_local, 1] = d_frag[
+                                mma_q, row_slot
+                            ]
+                        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                            dim_low = mma_d * 16 + lane_pair_base
+                            dim_high = dim_low + 8
+                            reg_base = row_slot * 2
+                            if row_valid[mma_q, row_slot] != 0:
+                                sSyncO[warp_kv_idx, packed_row_local, dim_low + 0] = (
+                                    o_frag[mma_q, mma_d, reg_base + 0]
+                                )
+                                sSyncO[warp_kv_idx, packed_row_local, dim_low + 1] = (
+                                    o_frag[mma_q, mma_d, reg_base + 1]
+                                )
+                                sSyncO[warp_kv_idx, packed_row_local, dim_high + 0] = (
+                                    o_frag[mma_q, mma_d, reg_base + 4]
+                                )
+                                sSyncO[warp_kv_idx, packed_row_local, dim_high + 1] = (
+                                    o_frag[mma_q, mma_d, reg_base + 5]
+                                )
+            if const_expr(self.bf16_minimax_role_specialized_decode):
+                cute.arch.barrier(
+                    barrier_id=1, number_of_threads=self.traits.num_threads
+                )
+            else:
+                cute.arch.sync_threads()
+
+        store_enabled = warp_kv_idx == 0
+        packed_row_local = Int32(0)
+        q_head_idx = Int32(0)
+        q_row_idx = Int32(0)
+        token_local = Int32(0)
+        partial_row_idx = Int32(0)
+        if const_expr(self.traits.num_warps_kv > 1):
+            if store_enabled:
+                if const_expr(decode_qwen_single_row_fastpath):
+                    packed_row_local = Int32(lane_group)
+                    valid_row_store = packed_row_local < packed_tile_rows
+                    q_head_idx = kv_head_idx * group_size + packed_row_local
+                    q_row_idx = q_start
+                    partial_row_idx = request_partial_start + kv_tile_idx
+                    merged_m = Float32(-Float32.inf)
+                    merged_d = Float32(1.0)
+                    inv_d = Float32(0.0)
+                    part_m0 = Float32(-Float32.inf)
+                    part_d0 = Float32(1.0)
+                    part_m1 = Float32(-Float32.inf)
+                    part_d1 = Float32(1.0)
+                    part_m2 = Float32(-Float32.inf)
+                    part_d2 = Float32(1.0)
+                    part_m3 = Float32(-Float32.inf)
+                    part_d3 = Float32(1.0)
+                    scale0 = Float32(0.0)
+                    scale1 = Float32(0.0)
+                    scale2 = Float32(0.0)
+                    scale3 = Float32(0.0)
+                    norm0 = Float32(0.0)
+                    norm1 = Float32(0.0)
+                    norm2 = Float32(0.0)
+                    norm3 = Float32(0.0)
+                    if valid_row_store:
+                        part_m0 = m_frag[0, 0]
+                        part_d0 = d_frag[0, 0]
+                        part_m1 = sSyncMD[1, packed_row_local, 0]
+                        part_d1 = sSyncMD[1, packed_row_local, 1]
+                        part_m2 = sSyncMD[2, packed_row_local, 0]
+                        part_d2 = sSyncMD[2, packed_row_local, 1]
+                        part_m3 = sSyncMD[3, packed_row_local, 0]
+                        part_d3 = sSyncMD[3, packed_row_local, 1]
+                        merged_m = attention_ops.fmax(
+                            attention_ops.fmax(part_m0, part_m1),
+                            attention_ops.fmax(part_m2, part_m3),
+                        )
+                        if merged_m != -Float32.inf:
+                            scale0 = (
+                                Float32(0.0)
+                                if part_m0 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m0 - merged_m)
+                            )
+                            scale1 = (
+                                Float32(0.0)
+                                if part_m1 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m1 - merged_m)
+                            )
+                            scale2 = (
+                                Float32(0.0)
+                                if part_m2 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m2 - merged_m)
+                            )
+                            scale3 = (
+                                Float32(0.0)
+                                if part_m3 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m3 - merged_m)
+                            )
+                            merged_d = Float32(
+                                part_d0 * scale0
+                                + part_d1 * scale1
+                                + part_d2 * scale2
+                                + part_d3 * scale3
+                            )
+                            inv_d = cute.arch.rcp_approx(merged_d)
+                            norm0 = scale0 * inv_d
+                            norm1 = scale1 * inv_d
+                            norm2 = scale2 * inv_d
+                            norm3 = scale3 * inv_d
+
+                    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                        dim_low = mma_d * 16 + lane_pair_base
+                        dim_high = dim_low + 8
+                        out_low0 = Float32(0.0)
+                        out_low1 = Float32(0.0)
+                        out_high0 = Float32(0.0)
+                        out_high1 = Float32(0.0)
+                        if valid_row_store and merged_m != -Float32.inf:
+                            out_low0 = Float32(
+                                o_frag[0, mma_d, 0] * norm0
+                                + sSyncO[1, packed_row_local, dim_low + 0] * norm1
+                                + sSyncO[2, packed_row_local, dim_low + 0] * norm2
+                                + sSyncO[3, packed_row_local, dim_low + 0] * norm3
+                            )
+                            out_low1 = Float32(
+                                o_frag[0, mma_d, 1] * norm0
+                                + sSyncO[1, packed_row_local, dim_low + 1] * norm1
+                                + sSyncO[2, packed_row_local, dim_low + 1] * norm2
+                                + sSyncO[3, packed_row_local, dim_low + 1] * norm3
+                            )
+                            out_high0 = Float32(
+                                o_frag[0, mma_d, 4] * norm0
+                                + sSyncO[1, packed_row_local, dim_high + 0] * norm1
+                                + sSyncO[2, packed_row_local, dim_high + 0] * norm2
+                                + sSyncO[3, packed_row_local, dim_high + 0] * norm3
+                            )
+                            out_high1 = Float32(
+                                o_frag[0, mma_d, 5] * norm0
+                                + sSyncO[1, packed_row_local, dim_high + 1] * norm1
+                                + sSyncO[2, packed_row_local, dim_high + 1] * norm2
+                                + sSyncO[3, packed_row_local, dim_high + 1] * norm3
+                            )
+
+                        if valid_row_store:
+                            if const_expr(decode_store_v128):
+                                sDecodeStageU32[0, packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sDecodeStageU32[0, packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif split_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif final_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif const_expr(self.split_kv):
+                                mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                    out_low0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                    out_low1.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                    out_high0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                    out_high1.to(self.dtype_o)
+                                )
+                            else:
+                                mO[q_row_idx, q_head_idx, dim_low + 0] = out_low0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_low + 1] = out_low1.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 0] = out_high0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 1] = out_high1.to(
+                                    self.dtype_o
+                                )
+                    if valid_row_store and lane_pair_base == 0:
+                        row_lse = (
+                            Float32(-Float32.inf)
+                            if merged_m == -Float32.inf
+                            else Float32(
+                                merged_m + cute.math.log2(merged_d, fastmath=True)
+                            )
+                        )
+                        if const_expr(self.split_kv):
+                            mLSE[partial_row_idx, q_head_idx] = row_lse
+                        else:
+                            mLSE[q_head_idx, q_row_idx] = row_lse
+                elif const_expr(decode_row0_merge_fastpath):
+                    packed_row_local = row_local_idx[0, 0]
+                    valid_row_store = row_valid[0, 0] != 0
+                    q_head_idx = decode_q_head_base + packed_row_local
+                    q_row_idx = decode_q_row_idx
+                    partial_row_idx = decode_partial_row_idx
+                    merged_m = Float32(-Float32.inf)
+                    merged_d = Float32(1.0)
+                    inv_d = Float32(0.0)
+                    part_m0 = Float32(-Float32.inf)
+                    part_d0 = Float32(1.0)
+                    part_m1 = Float32(-Float32.inf)
+                    part_d1 = Float32(1.0)
+                    part_m2 = Float32(-Float32.inf)
+                    part_d2 = Float32(1.0)
+                    part_m3 = Float32(-Float32.inf)
+                    part_d3 = Float32(1.0)
+                    scale0 = Float32(0.0)
+                    scale1 = Float32(0.0)
+                    scale2 = Float32(0.0)
+                    scale3 = Float32(0.0)
+                    norm0 = Float32(0.0)
+                    norm1 = Float32(0.0)
+                    norm2 = Float32(0.0)
+                    norm3 = Float32(0.0)
+                    if valid_row_store:
+                        part_m0 = m_frag[0, 0]
+                        part_d0 = d_frag[0, 0]
+                        part_m1 = sSyncMD[1, packed_row_local, 0]
+                        part_d1 = sSyncMD[1, packed_row_local, 1]
+                        part_m2 = sSyncMD[2, packed_row_local, 0]
+                        part_d2 = sSyncMD[2, packed_row_local, 1]
+                        part_m3 = sSyncMD[3, packed_row_local, 0]
+                        part_d3 = sSyncMD[3, packed_row_local, 1]
+                        merged_m = attention_ops.fmax(
+                            attention_ops.fmax(part_m0, part_m1),
+                            attention_ops.fmax(part_m2, part_m3),
+                        )
+                        if merged_m != -Float32.inf:
+                            scale0 = (
+                                Float32(0.0)
+                                if part_m0 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m0 - merged_m)
+                            )
+                            scale1 = (
+                                Float32(0.0)
+                                if part_m1 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m1 - merged_m)
+                            )
+                            scale2 = (
+                                Float32(0.0)
+                                if part_m2 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m2 - merged_m)
+                            )
+                            scale3 = (
+                                Float32(0.0)
+                                if part_m3 == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m3 - merged_m)
+                            )
+                            merged_d = Float32(
+                                part_d0 * scale0
+                                + part_d1 * scale1
+                                + part_d2 * scale2
+                                + part_d3 * scale3
+                            )
+                            inv_d = cute.arch.rcp_approx(merged_d)
+                            norm0 = scale0 * inv_d
+                            norm1 = scale1 * inv_d
+                            norm2 = scale2 * inv_d
+                            norm3 = scale3 * inv_d
+
+                    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                        dim_low = mma_d * 16 + lane_pair_base
+                        dim_high = dim_low + 8
+                        out_low0 = Float32(0.0)
+                        out_low1 = Float32(0.0)
+                        out_high0 = Float32(0.0)
+                        out_high1 = Float32(0.0)
+                        if valid_row_store and merged_m != -Float32.inf:
+                            out_low0 = Float32(
+                                o_frag[0, mma_d, 0] * norm0
+                                + sSyncO[1, packed_row_local, dim_low + 0] * norm1
+                                + sSyncO[2, packed_row_local, dim_low + 0] * norm2
+                                + sSyncO[3, packed_row_local, dim_low + 0] * norm3
+                            )
+                            out_low1 = Float32(
+                                o_frag[0, mma_d, 1] * norm0
+                                + sSyncO[1, packed_row_local, dim_low + 1] * norm1
+                                + sSyncO[2, packed_row_local, dim_low + 1] * norm2
+                                + sSyncO[3, packed_row_local, dim_low + 1] * norm3
+                            )
+                            out_high0 = Float32(
+                                o_frag[0, mma_d, 4] * norm0
+                                + sSyncO[1, packed_row_local, dim_high + 0] * norm1
+                                + sSyncO[2, packed_row_local, dim_high + 0] * norm2
+                                + sSyncO[3, packed_row_local, dim_high + 0] * norm3
+                            )
+                            out_high1 = Float32(
+                                o_frag[0, mma_d, 5] * norm0
+                                + sSyncO[1, packed_row_local, dim_high + 1] * norm1
+                                + sSyncO[2, packed_row_local, dim_high + 1] * norm2
+                                + sSyncO[3, packed_row_local, dim_high + 1] * norm3
+                            )
+
+                        if valid_row_store:
+                            if const_expr(decode_store_v128):
+                                sDecodeStageU32[0, packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sDecodeStageU32[0, packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif split_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif final_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif const_expr(self.split_kv):
+                                mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                    out_low0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                    out_low1.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                    out_high0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                    out_high1.to(self.dtype_o)
+                                )
+                            else:
+                                mO[q_row_idx, q_head_idx, dim_low + 0] = out_low0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_low + 1] = out_low1.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 0] = out_high0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 1] = out_high1.to(
+                                    self.dtype_o
+                                )
+                    if valid_row_store and lane_pair_base == 0:
+                        row_lse = (
+                            Float32(-Float32.inf)
+                            if merged_m == -Float32.inf
+                            else Float32(
+                                merged_m + cute.math.log2(merged_d, fastmath=True)
+                            )
+                        )
+                        if const_expr(self.split_kv):
+                            mLSE[partial_row_idx, q_head_idx] = row_lse
+                        else:
+                            mLSE[q_head_idx, q_row_idx] = row_lse
+                elif const_expr(
+                    (self.single_request_decode_graph or self.single_qtile_decode_graph)
+                    and self.gqa_group_size <= 8
+                ):
+                    for mma_q in cutlass.range_constexpr(num_mma_q):
+                        packed_row_local = row_local_idx[mma_q, 0]
+                        q_head_idx = q_head_idx_frag[mma_q, 0]
+                        q_row_idx = q_row_idx_frag[mma_q, 0]
+                        token_local = q_token_local[mma_q, 0]
+                        valid_row_store = row_valid[mma_q, 0] != 0
+                        merged_m = Float32(-Float32.inf)
+                        merged_d = Float32(1.0)
+                        inv_d = Float32(0.0)
+                        merge_scale = cute.make_rmem_tensor(
+                            cute.make_layout((self.traits.num_warps_kv,), stride=(1,)),
+                            Float32,
+                        )
+                        merge_scale.fill(0.0)
+                        if valid_row_store:
+                            for kv_warp in cutlass.range_constexpr(
+                                self.traits.num_warps_kv
+                            ):
+                                part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                                part_d = sSyncMD[kv_warp, packed_row_local, 1]
+                                if merged_m == -Float32.inf:
+                                    merged_m = part_m
+                                    merged_d = part_d
+                                elif part_m != -Float32.inf:
+                                    new_m = attention_ops.fmax(merged_m, part_m)
+                                    merged_d = Float32(
+                                        merged_d
+                                        * _exp2_approx_ftz_f32(merged_m - new_m)
+                                        + part_d * _exp2_approx_ftz_f32(part_m - new_m)
+                                    )
+                                    merged_m = new_m
+                            if merged_m != -Float32.inf:
+                                inv_d = cute.arch.rcp_approx(merged_d)
+                                for kv_warp in cutlass.range_constexpr(
+                                    self.traits.num_warps_kv
+                                ):
+                                    part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                                    merge_scale[kv_warp] = (
+                                        Float32(0.0)
+                                        if part_m == -Float32.inf
+                                        else _exp2_approx_ftz_f32(part_m - merged_m)
+                                    )
+
+                        for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                            dim_low = mma_d * 16 + lane_pair_base
+                            dim_high = dim_low + 8
+                            out_low0 = Float32(0.0)
+                            out_low1 = Float32(0.0)
+                            out_high0 = Float32(0.0)
+                            out_high1 = Float32(0.0)
+                            if valid_row_store and merged_m != -Float32.inf:
+                                acc_low0 = Float32(0.0)
+                                acc_low1 = Float32(0.0)
+                                acc_high0 = Float32(0.0)
+                                acc_high1 = Float32(0.0)
+                                for kv_warp in cutlass.range_constexpr(
+                                    self.traits.num_warps_kv
+                                ):
+                                    scale = merge_scale[kv_warp]
+                                    acc_low0 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_low + 0]
+                                        * scale
+                                    )
+                                    acc_low1 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_low + 1]
+                                        * scale
+                                    )
+                                    acc_high0 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_high + 0]
+                                        * scale
+                                    )
+                                    acc_high1 += (
+                                        sSyncO[kv_warp, packed_row_local, dim_high + 1]
+                                        * scale
+                                    )
+                                out_low0 = acc_low0 * inv_d
+                                out_low1 = acc_low1 * inv_d
+                                out_high0 = acc_high0 * inv_d
+                                out_high1 = acc_high1 * inv_d
+
+                            if valid_row_store:
+                                if const_expr(decode_store_v128):
+                                    sDecodeStageU32[
+                                        0, packed_row_local, dim_low // 2
+                                    ] = pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                    sDecodeStageU32[
+                                        0, packed_row_local, dim_high // 2
+                                    ] = pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                elif split_store_v128:
+                                    sOStageU32[packed_row_local, dim_low // 2] = (
+                                        pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                    )
+                                    sOStageU32[packed_row_local, dim_high // 2] = (
+                                        pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                    )
+                                elif final_store_v128:
+                                    sOStageU32[packed_row_local, dim_low // 2] = (
+                                        pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                    )
+                                    sOStageU32[packed_row_local, dim_high // 2] = (
+                                        pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                    )
+                                elif const_expr(self.split_kv):
+                                    partial_row_idx = (
+                                        decode_partial_row_idx
+                                        if const_expr(decode_row_metadata_fastpath)
+                                        else request_partial_start
+                                        + token_local * num_chunks_kv
+                                        + kv_tile_idx
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                        out_low0.to(self.dtype_o)
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                        out_low1.to(self.dtype_o)
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                        out_high0.to(self.dtype_o)
+                                    )
+                                    mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                        out_high1.to(self.dtype_o)
+                                    )
+                                else:
+                                    mO[q_row_idx, q_head_idx, dim_low + 0] = (
+                                        out_low0.to(self.dtype_o)
+                                    )
+                                    mO[q_row_idx, q_head_idx, dim_low + 1] = (
+                                        out_low1.to(self.dtype_o)
+                                    )
+                                    mO[q_row_idx, q_head_idx, dim_high + 0] = (
+                                        out_high0.to(self.dtype_o)
+                                    )
+                                    mO[q_row_idx, q_head_idx, dim_high + 1] = (
+                                        out_high1.to(self.dtype_o)
+                                    )
+                        if valid_row_store and lane_pair_base == 0:
+                            row_lse = (
+                                Float32(-Float32.inf)
+                                if merged_m == -Float32.inf
+                                else Float32(
+                                    merged_m + cute.math.log2(merged_d, fastmath=True)
+                                )
+                            )
+                            if const_expr(self.split_kv):
+                                partial_row_idx = (
+                                    decode_partial_row_idx
+                                    if const_expr(decode_row_metadata_fastpath)
+                                    else request_partial_start
+                                    + token_local * num_chunks_kv
+                                    + kv_tile_idx
+                                )
+                                mLSE[partial_row_idx, q_head_idx] = row_lse
+                            else:
+                                mLSE[q_head_idx, q_row_idx] = row_lse
+                else:
+                    for mma_q in cutlass.range_constexpr(num_mma_q):
+                        for row_slot in cutlass.range_constexpr(2):
+                            packed_row_local = row_local_idx[mma_q, row_slot]
+                            valid_row_store = row_valid[mma_q, row_slot] != 0
+                            if const_expr(decode_row_metadata_fastpath):
+                                q_head_idx = decode_q_head_base + packed_row_local
+                                q_row_idx = decode_q_row_idx
+                            else:
+                                q_head_idx = q_head_idx_frag[mma_q, row_slot]
+                                q_row_idx = q_row_idx_frag[mma_q, row_slot]
+                                token_local = q_token_local[mma_q, row_slot]
+                            merged_m = Float32(-Float32.inf)
+                            merged_d = Float32(1.0)
+                            inv_d = Float32(0.0)
+                            merge_scale = cute.make_rmem_tensor(
+                                cute.make_layout(
+                                    (self.traits.num_warps_kv,), stride=(1,)
+                                ),
+                                Float32,
+                            )
+                            merge_scale.fill(0.0)
+                            if valid_row_store:
+                                for kv_warp in cutlass.range_constexpr(
+                                    self.traits.num_warps_kv
+                                ):
+                                    part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                                    part_d = sSyncMD[kv_warp, packed_row_local, 1]
+                                    if merged_m == -Float32.inf:
+                                        merged_m = part_m
+                                        merged_d = part_d
+                                    elif part_m != -Float32.inf:
+                                        new_m = attention_ops.fmax(merged_m, part_m)
+                                        merged_d = Float32(
+                                            merged_d
+                                            * _exp2_approx_ftz_f32(merged_m - new_m)
+                                            + part_d
+                                            * _exp2_approx_ftz_f32(part_m - new_m)
+                                        )
+                                        merged_m = new_m
+                                if merged_m != -Float32.inf:
+                                    inv_d = cute.arch.rcp_approx(merged_d)
+                                    for kv_warp in cutlass.range_constexpr(
+                                        self.traits.num_warps_kv
+                                    ):
+                                        part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                                        merge_scale[kv_warp] = (
+                                            Float32(0.0)
+                                            if part_m == -Float32.inf
+                                            else _exp2_approx_ftz_f32(part_m - merged_m)
+                                        )
+
+                            for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                                dim_low = mma_d * 16 + lane_pair_base
+                                dim_high = dim_low + 8
+                                out_low0 = Float32(0.0)
+                                out_low1 = Float32(0.0)
+                                out_high0 = Float32(0.0)
+                                out_high1 = Float32(0.0)
+                                if valid_row_store and merged_m != -Float32.inf:
+                                    acc_low0 = Float32(0.0)
+                                    acc_low1 = Float32(0.0)
+                                    acc_high0 = Float32(0.0)
+                                    acc_high1 = Float32(0.0)
+                                    for kv_warp in cutlass.range_constexpr(
+                                        self.traits.num_warps_kv
+                                    ):
+                                        scale = merge_scale[kv_warp]
+                                        acc_low0 += (
+                                            sSyncO[
+                                                kv_warp, packed_row_local, dim_low + 0
+                                            ]
+                                            * scale
+                                        )
+                                        acc_low1 += (
+                                            sSyncO[
+                                                kv_warp, packed_row_local, dim_low + 1
+                                            ]
+                                            * scale
+                                        )
+                                        acc_high0 += (
+                                            sSyncO[
+                                                kv_warp, packed_row_local, dim_high + 0
+                                            ]
+                                            * scale
+                                        )
+                                        acc_high1 += (
+                                            sSyncO[
+                                                kv_warp, packed_row_local, dim_high + 1
+                                            ]
+                                            * scale
+                                        )
+                                    out_low0 = acc_low0 * inv_d
+                                    out_low1 = acc_low1 * inv_d
+                                    out_high0 = acc_high0 * inv_d
+                                    out_high1 = acc_high1 * inv_d
+
+                                if valid_row_store:
+                                    if const_expr(decode_store_v128):
+                                        sDecodeStageU32[
+                                            0, packed_row_local, dim_low // 2
+                                        ] = pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                        sDecodeStageU32[
+                                            0, packed_row_local, dim_high // 2
+                                        ] = pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                    elif split_store_v128:
+                                        sOStageU32[packed_row_local, dim_low // 2] = (
+                                            pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                        )
+                                        sOStageU32[packed_row_local, dim_high // 2] = (
+                                            pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                        )
+                                    elif final_store_v128:
+                                        sOStageU32[packed_row_local, dim_low // 2] = (
+                                            pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                        )
+                                        sOStageU32[packed_row_local, dim_high // 2] = (
+                                            pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                        )
+                                    elif const_expr(self.split_kv):
+                                        partial_row_idx = (
+                                            decode_partial_row_idx
+                                            if const_expr(decode_row_metadata_fastpath)
+                                            else request_partial_start
+                                            + token_local * num_chunks_kv
+                                            + kv_tile_idx
+                                        )
+                                        mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                            out_low0.to(self.dtype_o)
+                                        )
+                                        mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                            out_low1.to(self.dtype_o)
+                                        )
+                                        mO[
+                                            partial_row_idx, q_head_idx, dim_high + 0
+                                        ] = out_high0.to(self.dtype_o)
+                                        mO[
+                                            partial_row_idx, q_head_idx, dim_high + 1
+                                        ] = out_high1.to(self.dtype_o)
+                                    else:
+                                        mO[q_row_idx, q_head_idx, dim_low + 0] = (
+                                            out_low0.to(self.dtype_o)
+                                        )
+                                        mO[q_row_idx, q_head_idx, dim_low + 1] = (
+                                            out_low1.to(self.dtype_o)
+                                        )
+                                        mO[q_row_idx, q_head_idx, dim_high + 0] = (
+                                            out_high0.to(self.dtype_o)
+                                        )
+                                        mO[q_row_idx, q_head_idx, dim_high + 1] = (
+                                            out_high1.to(self.dtype_o)
+                                        )
+                            if valid_row_store and lane_pair_base == 0:
+                                row_lse = (
+                                    Float32(-Float32.inf)
+                                    if merged_m == -Float32.inf
+                                    else Float32(
+                                        merged_m
+                                        + cute.math.log2(merged_d, fastmath=True)
+                                    )
+                                )
+                                if const_expr(self.split_kv):
+                                    partial_row_idx = (
+                                        decode_partial_row_idx
+                                        if const_expr(decode_row_metadata_fastpath)
+                                        else request_partial_start
+                                        + token_local * num_chunks_kv
+                                        + kv_tile_idx
+                                    )
+                                    mLSE[partial_row_idx, q_head_idx] = row_lse
+                                else:
+                                    mLSE[q_head_idx, q_row_idx] = row_lse
+        else:
+            for mma_q in cutlass.range_constexpr(num_mma_q):
+                for row_slot in cutlass.range_constexpr(2):
+                    packed_row_local = row_local_idx[mma_q, row_slot]
+                    valid_row_store = row_valid[mma_q, row_slot] != 0
+                    if const_expr(decode_row_metadata_fastpath):
+                        q_head_idx = decode_q_head_base + packed_row_local
+                        q_row_idx = decode_q_row_idx
+                    else:
+                        q_head_idx = q_head_idx_frag[mma_q, row_slot]
+                        q_row_idx = q_row_idx_frag[mma_q, row_slot]
+                        token_local = q_token_local[mma_q, row_slot]
+                    merged_m = Float32(-Float32.inf)
+                    merged_d = Float32(1.0)
+                    inv_d = Float32(0.0)
+                    if store_enabled and valid_row_store:
+                        merged_m = m_frag[mma_q, row_slot]
+                        merged_d = d_frag[mma_q, row_slot]
+                        if merged_m != -Float32.inf:
+                            inv_d = cute.arch.rcp_approx(merged_d)
+
+                    for mma_d in cutlass.range_constexpr(num_mma_d_vo):
+                        dim_low = mma_d * 16 + lane_pair_base
+                        dim_high = dim_low + 8
+                        reg_base = row_slot * 2
+                        out_low0 = Float32(0.0)
+                        out_low1 = Float32(0.0)
+                        out_high0 = Float32(0.0)
+                        out_high1 = Float32(0.0)
+                        if (
+                            store_enabled
+                            and valid_row_store
+                            and merged_m != -Float32.inf
+                        ):
+                            out_low0 = o_frag[mma_q, mma_d, reg_base + 0] * inv_d
+                            out_low1 = o_frag[mma_q, mma_d, reg_base + 1] * inv_d
+                            out_high0 = o_frag[mma_q, mma_d, reg_base + 4] * inv_d
+                            out_high1 = o_frag[mma_q, mma_d, reg_base + 5] * inv_d
+
+                        if store_enabled and valid_row_store:
+                            if split_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif final_store_v128:
+                                sOStageU32[packed_row_local, dim_low // 2] = (
+                                    pack_f32x2_to_bfloat2(out_low0, out_low1)
+                                )
+                                sOStageU32[packed_row_local, dim_high // 2] = (
+                                    pack_f32x2_to_bfloat2(out_high0, out_high1)
+                                )
+                            elif const_expr(self.split_kv):
+                                partial_row_idx = (
+                                    decode_partial_row_idx
+                                    if const_expr(decode_row_metadata_fastpath)
+                                    else request_partial_start
+                                    + token_local * num_chunks_kv
+                                    + kv_tile_idx
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                    out_low0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                    out_low1.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                    out_high0.to(self.dtype_o)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                    out_high1.to(self.dtype_o)
+                                )
+                            else:
+                                mO[q_row_idx, q_head_idx, dim_low + 0] = out_low0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_low + 1] = out_low1.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 0] = out_high0.to(
+                                    self.dtype_o
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 1] = out_high1.to(
+                                    self.dtype_o
+                                )
+                    if store_enabled and valid_row_store and lane_pair_base == 0:
+                        row_lse = (
+                            Float32(-Float32.inf)
+                            if merged_m == -Float32.inf
+                            else Float32(
+                                merged_m + cute.math.log2(merged_d, fastmath=True)
+                            )
+                        )
+                        if const_expr(self.split_kv):
+                            partial_row_idx = (
+                                decode_partial_row_idx
+                                if const_expr(decode_row_metadata_fastpath)
+                                else request_partial_start
+                                + token_local * num_chunks_kv
+                                + kv_tile_idx
+                            )
+                            mLSE[partial_row_idx, q_head_idx] = row_lse
+                        else:
+                            mLSE[q_head_idx, q_row_idx] = row_lse
+
+        if const_expr(decode_store_v128):
+            if const_expr(self.bf16_minimax_role_specialized_decode):
+                cute.arch.barrier(
+                    barrier_id=1, number_of_threads=self.traits.num_threads
+                )
+            else:
+                cute.arch.sync_threads()
+            decode_chunks_per_row = self.traits.head_dim_vo // 8
+            decode_chunk_linear_idx = tidx
+            decode_total_chunks = packed_tile_rows * decode_chunks_per_row
+            while decode_chunk_linear_idx < decode_total_chunks:
+                packed_row_local = decode_chunk_linear_idx // decode_chunks_per_row
+                chunk_idx = (
+                    decode_chunk_linear_idx - packed_row_local * decode_chunks_per_row
+                )
+                if const_expr(decode_row_metadata_fastpath):
+                    q_head_idx = decode_q_head_base + packed_row_local
+                    q_row_idx = decode_q_row_idx
+                else:
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_head_idx = kv_head_idx * group_size + q_group_lane
+                    q_row_idx = q_start + token_local
+                u32_idx = chunk_idx * 4
+                if const_expr(self.split_kv):
+                    partial_row_idx = (
+                        decode_partial_row_idx
+                        if const_expr(decode_row_metadata_fastpath)
+                        else request_partial_start
+                        + token_local * num_chunks_kv
+                        + kv_tile_idx
+                    )
+                    gmem_elem_offset = (
+                        (partial_row_idx * mO.shape[1] + q_head_idx)
+                        * self.traits.head_dim_vo
+                    ) + chunk_idx * 8
+                else:
+                    gmem_elem_offset = (
+                        (q_row_idx * mO.shape[1] + q_head_idx) * self.traits.head_dim_vo
+                    ) + chunk_idx * 8
+                st_global_v4_u32(
+                    get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                    sDecodeStageU32[0, packed_row_local, u32_idx + 0],
+                    sDecodeStageU32[0, packed_row_local, u32_idx + 1],
+                    sDecodeStageU32[0, packed_row_local, u32_idx + 2],
+                    sDecodeStageU32[0, packed_row_local, u32_idx + 3],
+                )
+                decode_chunk_linear_idx += self.traits.num_threads
+
+        if split_store_v128:
+            cute.arch.sync_threads()
+            split_chunks_per_row = self.traits.head_dim_vo // 8
+            split_chunk_linear_idx = tidx
+            split_total_chunks = packed_tile_rows * split_chunks_per_row
+            while split_chunk_linear_idx < split_total_chunks:
+                packed_row_local = split_chunk_linear_idx // split_chunks_per_row
+                chunk_idx = (
+                    split_chunk_linear_idx - packed_row_local * split_chunks_per_row
+                )
+                if const_expr(decode_row_metadata_fastpath):
+                    q_head_idx = decode_q_head_base + packed_row_local
+                    partial_row_idx = decode_partial_row_idx
+                else:
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_head_idx = kv_head_idx * group_size + q_group_lane
+                    partial_row_idx = (
+                        request_partial_start
+                        + token_local * num_chunks_kv
+                        + kv_tile_idx
+                    )
+                u32_idx = chunk_idx * 4
+                gmem_elem_offset = (
+                    (partial_row_idx * mO.shape[1] + q_head_idx)
+                    * self.traits.head_dim_vo
+                ) + chunk_idx * 8
+                st_global_v4_u32(
+                    get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                    sOStageU32[packed_row_local, u32_idx + 0],
+                    sOStageU32[packed_row_local, u32_idx + 1],
+                    sOStageU32[packed_row_local, u32_idx + 2],
+                    sOStageU32[packed_row_local, u32_idx + 3],
+                )
+                split_chunk_linear_idx += self.traits.num_threads
+
+        if final_store_v128:
+            cute.arch.sync_threads()
+            final_chunks_per_row = self.traits.head_dim_vo // 8
+            final_chunk_linear_idx = tidx
+            final_total_chunks = packed_tile_rows * final_chunks_per_row
+            while final_chunk_linear_idx < final_total_chunks:
+                packed_row_local = final_chunk_linear_idx // final_chunks_per_row
+                chunk_idx = (
+                    final_chunk_linear_idx - packed_row_local * final_chunks_per_row
+                )
+                if const_expr(decode_row_metadata_fastpath):
+                    q_head_idx = decode_q_head_base + packed_row_local
+                    q_row_idx = decode_q_row_idx
+                else:
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_head_idx = kv_head_idx * group_size + q_group_lane
+                    q_row_idx = q_start + token_local
+                u32_idx = chunk_idx * 4
+                gmem_elem_offset = (
+                    (q_row_idx * mO.shape[1] + q_head_idx) * self.traits.head_dim_vo
+                ) + chunk_idx * 8
+                st_global_v4_u32(
+                    get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                    sOStageU32[packed_row_local, u32_idx + 0],
+                    sOStageU32[packed_row_local, u32_idx + 1],
+                    sOStageU32[packed_row_local, u32_idx + 2],
+                    sOStageU32[packed_row_local, u32_idx + 3],
+                )
+                final_chunk_linear_idx += self.traits.num_threads
+
+
+class PagedFp8DecodeRawForwardKernel:
+    def __init__(self):
+        self.cta_tile_q = 16
+        self.stage_tile_rows = 64
+        self.num_mma_q = 1
+        self.num_mma_kv = 1
+        self.num_mma_d_qk = 16
+        self.num_mma_d_vo = 16
+        self.num_warps_q = 1
+        self.num_warps_kv = 4
+        self.num_threads = 128
+        self.head_dim_qk = 256
+        self.head_dim_vo = 256
+        self.group_q_rows = 16
+        self.page_size = 64
+        self.q_dtype = cutlass.BFloat16
+        self.o_dtype = cutlass.BFloat16
+        self.kv_storage_dtype = cutlass.Uint8
+        self.kv_tma_plane_head_dim = 128
+        self.kv_tma_plane_count = 2
+        self.q_bytes = self.cta_tile_q * self.head_dim_qk * 2
+        self.k_bytes = self.stage_tile_rows * self.head_dim_qk
+        self.v_bytes = self.stage_tile_rows * self.head_dim_vo
+        qkv_storage_bytes = self.q_bytes + self.k_bytes + self.v_bytes
+        cta_sync_o_bytes = self.num_warps_kv * self.cta_tile_q * self.head_dim_vo * 4
+        cta_sync_md_bytes = self.num_warps_kv * self.cta_tile_q * 8
+        smem_o_bytes = self.cta_tile_q * self.head_dim_vo * 2
+        self.shared_storage_bytes = max(
+            qkv_storage_bytes, cta_sync_o_bytes + cta_sync_md_bytes, smem_o_bytes
+        )
+        self.kv_plane_stage_bytes = self.stage_tile_rows * self.kv_tma_plane_head_dim
+        self.kv_tma_copy_bytes_k = self.k_bytes
+        self.kv_tma_copy_bytes_v = self.v_bytes
+        self.softmax_scale_log2 = Float32(
+            (self.head_dim_qk**-0.5) * attention_ops.LOG2_E
+        )
+
+    def _get_shared_storage_cls(self):
+        class SharedStorage:
+            pass
+
+        SharedStorage.__annotations__ = {
+            "mbar_ptr_K": cute.struct.MemRange[cutlass.Int64, 2],
+            "mbar_ptr_V": cute.struct.MemRange[cutlass.Int64, 2],
+            "payload": cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    int(self.shared_storage_bytes),
+                ],
+                1024,
+            ],
+        }
+        return cute.struct(SharedStorage)
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mKCache: cute.Tensor,
+        mVCache: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ):
+        del mKvTileIndices, mOIndptr, mKvChunkSizePtr
+        mQ = _assume_tensor_aligned(mQ)
+        mKCache = _assume_tensor_aligned(mKCache)
+        mVCache = _assume_tensor_aligned(mVCache)
+        mO = _assume_tensor_aligned(mO)
+        mKCacheT = _make_paged_kv_tma_source_tensor(mKCache, self.stage_tile_rows)
+        mVCacheT = _make_paged_kv_tma_source_tensor(mVCache, self.stage_tile_rows)
+        plane_layout = _paged_kv_tma_plane_layout(
+            self.stage_tile_rows, self.kv_tma_plane_head_dim
+        )
+        gmem_tiled_copy_kv = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            mKCacheT,
+            plane_layout,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+        )
+        tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            mVCacheT,
+            plane_layout,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+        )
+        self.kernel(
+            mQ,
+            tma_tensor_K,
+            tma_tensor_V,
+            mPageTable,
+            mCacheSeqlens,
+            mCuSeqlensQ,
+            mRequestIndices,
+            mQoTileIndices,
+            mBlockValidMask,
+            mO,
+            mLSE,
+            mKDescale,
+            mVDescale,
+            tma_atom_K,
+            tma_atom_V,
+        ).launch(
+            grid=(mBlockValidMask.shape[0], mKCache.shape[2], 1),
+            block=[32, 1, 4],
+            # 67,584 B including barriers/alignment on SM120: one CTA/SM.
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mKCacheT: cute.Tensor,
+        mVCacheT: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+    ):
+        lane, warp_q_idx, warp_kv_idx = cute.arch.thread_idx()
+        work_idx, kv_head_idx, _ = cute.arch.block_idx()
+        if mBlockValidMask[work_idx] == Int32(0):
+            _exit_thread()
+
+        request_idx = mRequestIndices[work_idx]
+        qo_tile_idx = mQoTileIndices[work_idx]
+        q_start = mCuSeqlensQ[request_idx]
+        q_end = mCuSeqlensQ[request_idx + 1]
+        qo_len = q_end - q_start
+        cache_len = mCacheSeqlens[request_idx]
+        group_size = mQ.shape[1] // mKCacheT.shape[2]
+        packed_qo_len = qo_len * group_size
+        packed_tile_start = qo_tile_idx * self.cta_tile_q
+        packed_tile_end = cutlass.select_(
+            packed_tile_start + self.cta_tile_q < packed_qo_len,
+            packed_tile_start + self.cta_tile_q,
+            packed_qo_len,
+        )
+        packed_tile_rows = packed_tile_end - packed_tile_start
+        warp_linear_idx = warp_kv_idx
+        tidx = lane + 32 * warp_kv_idx
+
+        SharedStorage = self._get_shared_storage_cls()
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_K = storage.mbar_ptr_K.data_ptr()
+        mbar_ptr_V = storage.mbar_ptr_V.data_ptr()
+        if tidx == Int32(0):
+            cute.arch.mbarrier_init(mbar_ptr_K, Int32(1))
+            cute.arch.mbarrier_init(mbar_ptr_V, Int32(1))
+        cute.arch.sync_threads()
+
+        payload_u8 = storage.payload.get_tensor(
+            cute.make_layout((self.shared_storage_bytes,), stride=(1,))
+        )
+        sQ = cute.make_tensor(
+            cute.recast_ptr(payload_u8.iterator.align(16), dtype=self.q_dtype),
+            cute.make_layout(
+                (self.cta_tile_q, self.head_dim_qk), stride=(self.head_dim_qk, 1)
+            ),
+        )
+        sKStageBytes = cute.make_tensor(
+            payload_u8.iterator + Int32(self.q_bytes),
+            cute.make_layout((self.k_bytes,), stride=(1,)),
+        )
+        sVStageBytes = cute.make_tensor(
+            payload_u8.iterator + Int32(self.q_bytes + self.k_bytes),
+            cute.make_layout((self.v_bytes,), stride=(1,)),
+        )
+        plane_stage_layout = _paged_kv_tma_plane_stage_layout(
+            self.stage_tile_rows, self.kv_tma_plane_head_dim, 1
+        )
+        plane_num_elems = self.stage_tile_rows * self.kv_tma_plane_head_dim
+        sKPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + 0 * self.kv_plane_stage_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sKPlane1 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + 1 * self.kv_plane_stage_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + self.k_bytes + 0 * self.kv_plane_stage_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane1 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + self.k_bytes + 1 * self.kv_plane_stage_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        mKCacheTHead = mKCacheT[None, None, kv_head_idx, None]
+        mVCacheTHead = mVCacheT[None, None, kv_head_idx, None]
+        gKTma0 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gKTma1 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 1, None),
+        )
+        gVTma0 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gVTma1 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 1, None),
+        )
+        load_K_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma0, sKPlane0
+        )
+        load_K_tma1, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma1, sKPlane1
+        )
+        load_V_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma0, sVPlane0
+        )
+        load_V_tma1, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma1, sVPlane1
+        )
+        if warp_q_idx == Int32(0) and warp_kv_idx == Int32(0):
+            cpasync.prefetch_descriptor(tma_atom_K)
+            cpasync.prefetch_descriptor(tma_atom_V)
+
+        sQBytes = cute.flatten(cute.recast_tensor(sQ, cutlass.Uint8))
+        mQBytes = cute.flatten(cute.recast_tensor(mQ, cutlass.Uint8))
+        q_storage_bytes = self.q_dtype.width // 8
+        q_token_stride_bytes = mQ.stride[0] * q_storage_bytes
+        q_head_stride_bytes = mQ.stride[1] * q_storage_bytes
+        if warp_kv_idx == Int32(0):
+            _async_copy_q_tile_permuted_128b_fp8_decode_impl(
+                mQBytes,
+                q_start,
+                packed_tile_start,
+                packed_tile_rows,
+                kv_head_idx,
+                group_size,
+                mQ.shape[1],
+                Int32(self.head_dim_qk * 2),
+                q_token_stride_bytes,
+                q_head_stride_bytes,
+                sQBytes,
+                lane,
+                Int32(self.head_dim_qk // 8),
+            )
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+        sync_payload = cute.recast_tensor(payload_u8, Float32)
+        sync_o_elems = self.num_warps_kv * self.cta_tile_q * self.head_dim_vo
+        sSyncO = cute.make_tensor(
+            sync_payload.iterator,
+            cute.make_layout(
+                (self.num_warps_kv, self.cta_tile_q, self.head_dim_vo),
+                stride=(self.cta_tile_q * self.head_dim_vo, self.head_dim_vo, 1),
+            ),
+        )
+        sSyncMD = cute.make_tensor(
+            sync_payload.iterator + Int32(sync_o_elems),
+            cute.make_layout(
+                (self.num_warps_kv, self.cta_tile_q, 2),
+                stride=(self.cta_tile_q * 2, 2, 1),
+            ),
+        )
+        sDecodeStage = cute.make_tensor(
+            cute.recast_tensor(sync_payload, self.o_dtype).iterator,
+            cute.make_layout(
+                (self.num_warps_kv, self.cta_tile_q, self.head_dim_vo * 2),
+                stride=(
+                    self.cta_tile_q * self.head_dim_vo * 2,
+                    self.head_dim_vo * 2,
+                    1,
+                ),
+            ),
+        )
+        sDecodeStageU32 = cute.recast_tensor(sDecodeStage, cutlass.Uint32)
+        mOFlat = cute.flatten(mO)
+        tc_upcast_stride_qk = Int32(self.head_dim_qk // 8)
+        tc_upcast_elems_plane = Int32(16 // (self.kv_storage_dtype.width // 8))
+        tc_upcast_stride_plane = (
+            Int32(self.kv_tma_plane_head_dim) // tc_upcast_elems_plane
+        )
+        warp_kv_base = warp_kv_idx * 16
+        lane_group = lane // 4
+        lane_pair_base = 2 * (lane % 4)
+        row_local_idx = cute.make_rmem_tensor(
+            cute.make_layout((1, 2), stride=(2, 1)), Int32
+        )
+        row_valid = cute.make_rmem_tensor(
+            cute.make_layout((1, 2), stride=(2, 1)), Int32
+        )
+        q_token_local = cute.make_rmem_tensor(
+            cute.make_layout((1, 2), stride=(2, 1)), Int32
+        )
+        q_head_idx_frag = cute.make_rmem_tensor(
+            cute.make_layout((1, 2), stride=(2, 1)), Int32
+        )
+        q_row_idx_frag = cute.make_rmem_tensor(
+            cute.make_layout((1, 2), stride=(2, 1)), Int32
+        )
+        causal_k_limit = cute.make_rmem_tensor(
+            cute.make_layout((1, 2), stride=(2, 1)), Int32
+        )
+        frag_s_layout = cute.make_layout((1, 1, 8), stride=(8, 8, 1))
+        frag_p_layout = cute.make_layout((1, 1, 4), stride=(4, 4, 1))
+        frag_o_layout = cute.make_layout(
+            (1, self.num_mma_d_vo, 8), stride=(self.num_mma_d_vo * 8, 8, 1)
+        )
+        o_frag = cute.make_rmem_tensor(frag_o_layout, Float32)
+        m_frag = cute.make_rmem_tensor(cute.make_layout((1, 2), stride=(2, 1)), Float32)
+        d_frag = cute.make_rmem_tensor(cute.make_layout((1, 2), stride=(2, 1)), Float32)
+        p_frag = cute.make_rmem_tensor(frag_p_layout, Uint32)
+        for mma_d in cutlass.range_constexpr(self.num_mma_d_vo):
+            for reg_id in cutlass.range_constexpr(8):
+                o_frag[0, mma_d, reg_id] = Float32(0.0)
+        for row_slot in cutlass.range_constexpr(2):
+            m_frag[0, row_slot] = Float32(-Float32.inf)
+            d_frag[0, row_slot] = Float32(1.0)
+
+        producer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+        consumer_state = cute_pipeline.PipelineStateSimple(1, Int32(0))
+        tile_base = Int32(0)
+        if warp_linear_idx == Int32(0):
+            _issue_paged_kv_tma_copy_2planes_tma_single_stage(
+                load_K_tma0,
+                load_K_tma1,
+                producer_state,
+                mbar_ptr_K,
+                self.kv_tma_copy_bytes_k,
+                mPageTable,
+                request_idx,
+                tile_base,
+                Int32(self.page_size),
+                Int32(self.stage_tile_rows),
+            )
+            _issue_paged_kv_tma_copy_2planes_tma_single_stage(
+                load_V_tma0,
+                load_V_tma1,
+                producer_state,
+                mbar_ptr_V,
+                self.kv_tma_copy_bytes_v,
+                mPageTable,
+                request_idx,
+                tile_base,
+                Int32(self.page_size),
+                Int32(self.stage_tile_rows),
+            )
+            producer_state.advance()
+        cute.arch.sync_threads()
+        prefetch_base = tile_base + self.stage_tile_rows
+
+        while tile_base < cache_len:
+            tile_limit = cutlass.select_(
+                tile_base + self.stage_tile_rows < cache_len,
+                tile_base + self.stage_tile_rows,
+                cache_len,
+            )
+            tile_tokens = tile_limit - tile_base
+            if warp_linear_idx == Int32(0):
+                cute.arch.mbarrier_wait(
+                    mbar_ptr_K + consumer_state.index, phase=consumer_state.phase
+                )
+                cute.arch.mbarrier_wait(
+                    mbar_ptr_V + consumer_state.index, phase=consumer_state.phase
+                )
+            cute.arch.sync_threads()
+
+            k_scale = (
+                mKDescale[request_idx]
+                if const_expr(mKDescale is not None and len(mKDescale.shape) == 1)
+                else (
+                    mKDescale[request_idx, kv_head_idx]
+                    if const_expr(mKDescale is not None)
+                    else Float32(1.0)
+                )
+            )
+            v_scale = (
+                mVDescale[request_idx]
+                if const_expr(mVDescale is not None and len(mVDescale.shape) == 1)
+                else (
+                    mVDescale[request_idx, kv_head_idx]
+                    if const_expr(mVDescale is not None)
+                    else Float32(1.0)
+                )
+            )
+            q_smem_base_addr = shared_ptr_to_u32(sQ.iterator)
+
+            for row_slot in cutlass.range_constexpr(2):
+                packed_row_local = lane_group + 8 * row_slot
+                row_local_idx[0, row_slot] = Int32(packed_row_local)
+                valid_row = packed_row_local < packed_tile_rows
+                row_valid[0, row_slot] = Int32(valid_row)
+                if valid_row:
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_token_local[0, row_slot] = Int32(token_local)
+                    q_head_idx_frag[0, row_slot] = Int32(
+                        kv_head_idx * group_size + q_group_lane
+                    )
+                    q_row_idx_frag[0, row_slot] = Int32(q_start + token_local)
+                    causal_k_limit[0, row_slot] = Int32(
+                        token_local + cache_len - qo_len
+                    )
+                else:
+                    q_token_local[0, row_slot] = Int32(0)
+                    q_head_idx_frag[0, row_slot] = Int32(0)
+                    q_row_idx_frag[0, row_slot] = Int32(0)
+                    causal_k_limit[0, row_slot] = Int32(-1)
+
+            frag_S = cute.make_rmem_tensor(frag_s_layout, Float32)
+            frag_S.fill(0.0)
+            _literal_qk_mma_into_sfrag_plane_fp8_raw(
+                frag_S,
+                q_smem_base_addr,
+                shared_ptr_to_u32(
+                    sKStageBytes.iterator + Int32(0 * self.kv_plane_stage_bytes)
+                ),
+                shared_ptr_to_u32(
+                    sKStageBytes.iterator + Int32(1 * self.kv_plane_stage_bytes)
+                ),
+                lane,
+                warp_q_idx,
+                warp_kv_idx,
+                Int32(0),
+                1,
+                1,
+                self.num_mma_d_qk,
+                tc_upcast_stride_qk,
+                tc_upcast_stride_plane,
+            )
+            for reg_id in cutlass.range_constexpr(8):
+                row_slot = (reg_id % 4) // 2
+                key_local = (
+                    warp_kv_base + lane_pair_base + 8 * (reg_id // 4) + (reg_id % 2)
+                )
+                valid = row_valid[0, row_slot] != 0
+                if valid:
+                    valid = valid and key_local < tile_tokens
+                if valid:
+                    valid = (
+                        valid and (tile_base + key_local) <= causal_k_limit[0, row_slot]
+                    )
+                if valid:
+                    frag_S[0, 0, reg_id] = frag_S[0, 0, reg_id] * k_scale
+                else:
+                    frag_S[0, 0, reg_id] = Float32(-Float32.inf)
+
+            _literal_update_mdo_states_fp32_pack_p(
+                frag_S,
+                o_frag,
+                m_frag,
+                d_frag,
+                p_frag,
+                self.softmax_scale_log2,
+                1,
+                1,
+                self.num_mma_d_vo,
+            )
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_DEBUG_DUMP", "")
+                == "SREGS"
+            ):
+                if (
+                    kv_head_idx == Int32(0)
+                    and warp_q_idx == Int32(0)
+                    and warp_kv_idx == Int32(0)
+                ):
+                    mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                    _dump_s_frag_regs_raw(
+                        mDebugU32,
+                        frag_S,
+                        lane,
+                    )
+                _exit_thread()
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_DEBUG_DUMP", "")
+                == "PREGS"
+            ):
+                if (
+                    kv_head_idx == Int32(0)
+                    and warp_q_idx == Int32(0)
+                    and warp_kv_idx == Int32(0)
+                ):
+                    mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                    _dump_p_frag_regs_raw(
+                        mDebugU32,
+                        p_frag,
+                        lane,
+                    )
+                _exit_thread()
+            d0, d1 = bf16_rowsum_m16k16_f32(
+                d_frag[0, 0],
+                d_frag[0, 1],
+                p_frag[0, 0, 0],
+                p_frag[0, 0, 1],
+                p_frag[0, 0, 2],
+                p_frag[0, 0, 3],
+            )
+            d_frag[0, 0] = d0
+            d_frag[0, 1] = d1
+            if const_expr(
+                os.environ.get("FLASHINFER_EXP_SM12X_PAGED_KV_DEBUG_DUMP", "")
+                == "PVREGS"
+            ):
+                if (
+                    kv_head_idx == Int32(0)
+                    and warp_q_idx == Int32(0)
+                    and warp_kv_idx == Int32(0)
+                ):
+                    mDebugU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+                    _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                        o_frag,
+                        p_frag,
+                        shared_ptr_to_u32(
+                            sVStageBytes.iterator + Int32(0 * self.kv_plane_stage_bytes)
+                        ),
+                        shared_ptr_to_u32(
+                            sVStageBytes.iterator + Int32(1 * self.kv_plane_stage_bytes)
+                        ),
+                        lane,
+                        warp_kv_idx,
+                        warp_kv_base,
+                        1,
+                        1,
+                        self.num_mma_d_vo,
+                        tc_upcast_stride_plane,
+                        v_scale,
+                        mDebugU32,
+                    )
+                _exit_thread()
+            _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                o_frag,
+                p_frag,
+                shared_ptr_to_u32(
+                    sVStageBytes.iterator + Int32(0 * self.kv_plane_stage_bytes)
+                ),
+                shared_ptr_to_u32(
+                    sVStageBytes.iterator + Int32(1 * self.kv_plane_stage_bytes)
+                ),
+                lane,
+                warp_kv_idx,
+                Int32(0),
+                1,
+                1,
+                self.num_mma_d_vo,
+                tc_upcast_stride_plane,
+                v_scale,
+            )
+            consumer_state.advance()
+            tile_base += self.stage_tile_rows
+            if tile_base < cache_len:
+                if warp_linear_idx == Int32(0):
+                    _issue_paged_kv_tma_copy_2planes_tma_single_stage(
+                        load_K_tma0,
+                        load_K_tma1,
+                        producer_state,
+                        mbar_ptr_K,
+                        self.kv_tma_copy_bytes_k,
+                        mPageTable,
+                        request_idx,
+                        prefetch_base,
+                        Int32(self.page_size),
+                        Int32(self.stage_tile_rows),
+                    )
+                    _issue_paged_kv_tma_copy_2planes_tma_single_stage(
+                        load_V_tma0,
+                        load_V_tma1,
+                        producer_state,
+                        mbar_ptr_V,
+                        self.kv_tma_copy_bytes_v,
+                        mPageTable,
+                        request_idx,
+                        prefetch_base,
+                        Int32(self.page_size),
+                        Int32(self.stage_tile_rows),
+                    )
+                    producer_state.advance()
+                prefetch_base += self.stage_tile_rows
+            cute.arch.sync_threads()
+
+        for row_slot in cutlass.range_constexpr(2):
+            if m_frag[0, row_slot] != -Float32.inf:
+                m_frag[0, row_slot] = Float32(
+                    m_frag[0, row_slot] * self.softmax_scale_log2
+                )
+            packed_row_local = row_local_idx[0, row_slot]
+            if row_valid[0, row_slot] != 0 and lane_pair_base == 0:
+                sSyncMD[warp_kv_idx, packed_row_local, 0] = m_frag[0, row_slot]
+                sSyncMD[warp_kv_idx, packed_row_local, 1] = d_frag[0, row_slot]
+            for mma_d in cutlass.range_constexpr(self.num_mma_d_vo):
+                dim_low = mma_d * 16 + lane_pair_base
+                dim_high = dim_low + 8
+                reg_base = row_slot * 2
+                if row_valid[0, row_slot] != 0:
+                    sSyncO[warp_kv_idx, packed_row_local, dim_low + 0] = o_frag[
+                        0, mma_d, reg_base + 0
+                    ]
+                    sSyncO[warp_kv_idx, packed_row_local, dim_low + 1] = o_frag[
+                        0, mma_d, reg_base + 1
+                    ]
+                    sSyncO[warp_kv_idx, packed_row_local, dim_high + 0] = o_frag[
+                        0, mma_d, reg_base + 4
+                    ]
+                    sSyncO[warp_kv_idx, packed_row_local, dim_high + 1] = o_frag[
+                        0, mma_d, reg_base + 5
+                    ]
+        cute.arch.sync_threads()
+
+        if warp_kv_idx == 0:
+            for row_slot in cutlass.range_constexpr(2):
+                packed_row_local = row_local_idx[0, row_slot]
+                q_head_idx = q_head_idx_frag[0, row_slot]
+                q_row_idx = q_row_idx_frag[0, row_slot]
+                valid_row_store = row_valid[0, row_slot] != 0
+                merged_m = Float32(-Float32.inf)
+                merged_d = Float32(1.0)
+                inv_d = Float32(0.0)
+                merge_scale = cute.make_rmem_tensor(
+                    cute.make_layout((self.num_warps_kv,), stride=(1,)), Float32
+                )
+                merge_scale.fill(0.0)
+                if valid_row_store:
+                    for kv_warp in cutlass.range_constexpr(self.num_warps_kv):
+                        part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                        part_d = sSyncMD[kv_warp, packed_row_local, 1]
+                        if merged_m == -Float32.inf:
+                            merged_m = part_m
+                            merged_d = part_d
+                        elif part_m != -Float32.inf:
+                            new_m = attention_ops.fmax(merged_m, part_m)
+                            merged_d = Float32(
+                                merged_d * _exp2_approx_ftz_f32(merged_m - new_m)
+                                + part_d * _exp2_approx_ftz_f32(part_m - new_m)
+                            )
+                            merged_m = new_m
+                    if merged_m != -Float32.inf:
+                        inv_d = cute.arch.rcp_approx(merged_d)
+                        for kv_warp in cutlass.range_constexpr(self.num_warps_kv):
+                            part_m = sSyncMD[kv_warp, packed_row_local, 0]
+                            merge_scale[kv_warp] = (
+                                Float32(0.0)
+                                if part_m == -Float32.inf
+                                else _exp2_approx_ftz_f32(part_m - merged_m)
+                            )
+                for mma_d in cutlass.range_constexpr(self.num_mma_d_vo):
+                    dim_low = mma_d * 16 + lane_pair_base
+                    dim_high = dim_low + 8
+                    out_low0 = Float32(0.0)
+                    out_low1 = Float32(0.0)
+                    out_high0 = Float32(0.0)
+                    out_high1 = Float32(0.0)
+                    if valid_row_store and merged_m != -Float32.inf:
+                        acc_low0 = Float32(0.0)
+                        acc_low1 = Float32(0.0)
+                        acc_high0 = Float32(0.0)
+                        acc_high1 = Float32(0.0)
+                        for kv_warp in cutlass.range_constexpr(self.num_warps_kv):
+                            scale = merge_scale[kv_warp]
+                            acc_low0 += (
+                                sSyncO[kv_warp, packed_row_local, dim_low + 0] * scale
+                            )
+                            acc_low1 += (
+                                sSyncO[kv_warp, packed_row_local, dim_low + 1] * scale
+                            )
+                            acc_high0 += (
+                                sSyncO[kv_warp, packed_row_local, dim_high + 0] * scale
+                            )
+                            acc_high1 += (
+                                sSyncO[kv_warp, packed_row_local, dim_high + 1] * scale
+                            )
+                        out_low0 = acc_low0 * inv_d
+                        out_low1 = acc_low1 * inv_d
+                        out_high0 = acc_high0 * inv_d
+                        out_high1 = acc_high1 * inv_d
+                    if valid_row_store:
+                        sDecodeStageU32[0, packed_row_local, dim_low // 2] = (
+                            pack_f32x2_to_bfloat2(out_low0, out_low1)
+                        )
+                        sDecodeStageU32[0, packed_row_local, dim_high // 2] = (
+                            pack_f32x2_to_bfloat2(out_high0, out_high1)
+                        )
+                if valid_row_store and lane_pair_base == 0:
+                    mLSE[q_head_idx, q_row_idx] = (
+                        Float32(-Float32.inf)
+                        if merged_m == -Float32.inf
+                        else Float32(merged_m + cute.math.log2(merged_d, fastmath=True))
+                    )
+
+        cute.arch.sync_threads()
+        decode_chunks_per_row = self.head_dim_vo // 8
+        decode_chunk_linear_idx = tidx
+        decode_total_chunks = packed_tile_rows * decode_chunks_per_row
+        while decode_chunk_linear_idx < decode_total_chunks:
+            packed_row_local = decode_chunk_linear_idx // decode_chunks_per_row
+            chunk_idx = (
+                decode_chunk_linear_idx - packed_row_local * decode_chunks_per_row
+            )
+            packed_q_idx = packed_tile_start + packed_row_local
+            token_local = packed_q_idx // group_size
+            q_group_lane = packed_q_idx - token_local * group_size
+            q_head_idx = kv_head_idx * group_size + q_group_lane
+            q_row_idx = q_start + token_local
+            u32_idx = chunk_idx * 4
+            gmem_elem_offset = (
+                (q_row_idx * mO.shape[1] + q_head_idx) * self.head_dim_vo
+            ) + chunk_idx * 8
+            st_global_v4_u32(
+                get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                sDecodeStageU32[0, packed_row_local, u32_idx + 0],
+                sDecodeStageU32[0, packed_row_local, u32_idx + 1],
+                sDecodeStageU32[0, packed_row_local, u32_idx + 2],
+                sDecodeStageU32[0, packed_row_local, u32_idx + 3],
+            )
+            decode_chunk_linear_idx += self.num_threads
+
+
+class PagedBf16ExtendRawForwardKernel:
+    def __init__(self, *, split_kv: bool):
+        self.split_kv = split_kv
+        self.cta_tile_q = 64
+        self.stage_tile_rows = 32
+        self.compute_tile_rows = 16
+        self.num_mma_q = 1
+        self.num_mma_kv = 1
+        self.num_mma_d_qk = 16
+        self.num_mma_d_vo = 16
+        self.num_warps_q = 4
+        self.num_warps_kv = 1
+        self.num_threads = 128
+        self.head_dim_qk = 256
+        self.head_dim_vo = 256
+        self.page_size = 64
+        self.q_dtype = cutlass.BFloat16
+        self.o_dtype = cutlass.BFloat16
+        self.kv_storage_dtype = cutlass.BFloat16
+        self.use_paged_kv_tma = True
+        self.num_stages = 2
+        self.kv_tma_plane_head_dim = 64
+        self.kv_tma_plane_count = 4
+        self.q_bytes = self.cta_tile_q * self.head_dim_qk * 2
+        self.k_bytes = self.num_stages * self.stage_tile_rows * self.head_dim_qk * 2
+        self.v_bytes = self.num_stages * self.stage_tile_rows * self.head_dim_vo * 2
+        self.shared_storage_bytes = self.q_bytes + self.k_bytes + self.v_bytes
+        self.kv_plane_stage_bytes = (
+            self.stage_tile_rows * self.kv_tma_plane_head_dim * 2
+        )
+        self.kv_plane_total_bytes = self.num_stages * self.kv_plane_stage_bytes
+        self.kv_tma_copy_bytes_k = self.stage_tile_rows * self.head_dim_qk * 2
+        self.kv_tma_copy_bytes_v = self.stage_tile_rows * self.head_dim_vo * 2
+        self.softmax_scale_log2 = Float32(
+            (self.head_dim_qk**-0.5) * attention_ops.LOG2_E
+        )
+
+    def _get_shared_storage_cls(self):
+        class SharedStorage:
+            pass
+
+        SharedStorage.__annotations__ = {
+            "mbar_ptr_K": cute.struct.MemRange[cutlass.Int64, 2 * self.num_stages],
+            "mbar_ptr_V": cute.struct.MemRange[cutlass.Int64, 2 * self.num_stages],
+            "payload": cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    int(self.shared_storage_bytes),
+                ],
+                1024,
+            ],
+        }
+        return cute.struct(SharedStorage)
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mKCache: cute.Tensor,
+        mVCache: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ):
+        del mKDescale, mVDescale
+        mQ = _assume_tensor_aligned(mQ)
+        mKCache = _assume_tensor_aligned(mKCache)
+        mVCache = _assume_tensor_aligned(mVCache)
+        mO = _assume_tensor_aligned(mO)
+        mKCacheT = _make_paged_kv_tma_source_tensor(mKCache, self.stage_tile_rows)
+        mVCacheT = _make_paged_kv_tma_source_tensor(mVCache, self.stage_tile_rows)
+        plane_layout = _paged_kv_tma_plane_layout(
+            self.stage_tile_rows, self.kv_tma_plane_head_dim
+        )
+        gmem_tiled_copy_kv = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            mKCacheT,
+            plane_layout,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+        )
+        tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            mVCacheT,
+            plane_layout,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+        )
+        self.kernel(
+            mQ,
+            tma_tensor_K,
+            tma_tensor_V,
+            mPageTable,
+            mCacheSeqlens,
+            mCuSeqlensQ,
+            mRequestIndices,
+            mQoTileIndices,
+            mKvTileIndices,
+            mOIndptr,
+            mKvChunkSizePtr,
+            mBlockValidMask,
+            mO,
+            mLSE,
+            tma_atom_K,
+            tma_atom_V,
+        ).launch(
+            grid=(mBlockValidMask.shape[0], mKCache.shape[2], 1),
+            block=[32, 4, 1],
+            # 99,328 B including barriers/alignment on SM120: one CTA/SM.
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mKCacheT: cute.Tensor,
+        mVCacheT: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+    ):
+        lane, warp_q_idx, _ = cute.arch.thread_idx()
+        work_idx, kv_head_idx, _ = cute.arch.block_idx()
+        if mBlockValidMask[work_idx] == Int32(0):
+            _exit_thread()
+
+        request_idx = mRequestIndices[work_idx]
+        qo_tile_idx = mQoTileIndices[work_idx]
+        kv_tile_idx = mKvTileIndices[work_idx]
+        q_start = mCuSeqlensQ[request_idx]
+        q_end = mCuSeqlensQ[request_idx + 1]
+        qo_len = q_end - q_start
+        if qo_len <= Int32(0):
+            _exit_thread()
+        cache_len = mCacheSeqlens[request_idx]
+        group_size = mQ.shape[1] // mKCacheT.shape[2]
+        packed_qo_len = qo_len * group_size
+        packed_tile_start = qo_tile_idx * self.cta_tile_q
+        packed_tile_end = cutlass.select_(
+            packed_tile_start + self.cta_tile_q < packed_qo_len,
+            packed_tile_start + self.cta_tile_q,
+            packed_qo_len,
+        )
+        packed_tile_rows = packed_tile_end - packed_tile_start
+        if packed_tile_rows <= Int32(0):
+            _exit_thread()
+
+        kv_chunk_size = mKvChunkSizePtr[0]
+        chunk_start = (
+            kv_tile_idx * kv_chunk_size if const_expr(self.split_kv) else Int32(0)
+        )
+        chunk_end = (
+            cutlass.select_(
+                (kv_tile_idx + 1) * kv_chunk_size < cache_len,
+                (kv_tile_idx + 1) * kv_chunk_size,
+                cache_len,
+            )
+            if const_expr(self.split_kv)
+            else cache_len
+        )
+        request_partial_start = (
+            mOIndptr[request_idx] if const_expr(self.split_kv) else Int32(0)
+        )
+        request_partial_end = (
+            mOIndptr[request_idx + 1] if const_expr(self.split_kv) else Int32(0)
+        )
+        num_chunks_kv = (
+            (request_partial_end - request_partial_start) // qo_len
+            if const_expr(self.split_kv)
+            else Int32(1)
+        )
+        tidx = lane + warp_q_idx * Int32(32)
+
+        SharedStorage = self._get_shared_storage_cls()
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_K = storage.mbar_ptr_K.data_ptr()
+        mbar_ptr_V = storage.mbar_ptr_V.data_ptr()
+        if tidx < Int32(self.num_stages):
+            cute.arch.mbarrier_init(mbar_ptr_K + tidx, Int32(1))
+            cute.arch.mbarrier_init(mbar_ptr_V + tidx, Int32(1))
+        cute.arch.sync_threads()
+
+        payload_u8 = storage.payload.get_tensor(
+            cute.make_layout((self.shared_storage_bytes,), stride=(1,))
+        )
+        sQ = cute.make_tensor(
+            cute.recast_ptr(payload_u8.iterator.align(16), dtype=self.q_dtype),
+            cute.make_layout(
+                (self.cta_tile_q, self.head_dim_qk), stride=(self.head_dim_qk, 1)
+            ),
+        )
+        sOStageU32 = cute.recast_tensor(
+            cute.make_tensor(
+                cute.recast_ptr(payload_u8.iterator.align(16), dtype=cutlass.BFloat16),
+                cute.make_layout(
+                    (self.cta_tile_q, self.head_dim_vo), stride=(self.head_dim_vo, 1)
+                ),
+            ),
+            cutlass.Uint32,
+        )
+        sQBytes = cute.flatten(cute.recast_tensor(sQ, cutlass.Uint8))
+        sKStageBytes = cute.make_tensor(
+            payload_u8.iterator + Int32(self.q_bytes),
+            cute.make_layout((self.k_bytes,), stride=(1,)),
+        )
+        sVStageBytes = cute.make_tensor(
+            payload_u8.iterator + Int32(self.q_bytes + self.k_bytes),
+            cute.make_layout((self.v_bytes,), stride=(1,)),
+        )
+        plane_stage_layout = _paged_kv_tma_plane_stage_layout(
+            self.stage_tile_rows, self.kv_tma_plane_head_dim, self.num_stages
+        )
+        plane_num_elems = (
+            self.num_stages * self.stage_tile_rows * self.kv_tma_plane_head_dim
+        )
+        sKPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + 0 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sKPlane1 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + 1 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sKPlane2 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + 2 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sKPlane3 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + 3 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + self.k_bytes + 0 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane1 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + self.k_bytes + 1 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane2 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + self.k_bytes + 2 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane3 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.BFloat16,
+                self.q_bytes + self.k_bytes + 3 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        mKCacheTHead = mKCacheT[None, None, kv_head_idx, None]
+        mVCacheTHead = mVCacheT[None, None, kv_head_idx, None]
+        gKTma0 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gKTma1 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 1, None),
+        )
+        gKTma2 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 2, None),
+        )
+        gKTma3 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 3, None),
+        )
+        gVTma0 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gVTma1 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 1, None),
+        )
+        gVTma2 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 2, None),
+        )
+        gVTma3 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 3, None),
+        )
+        load_K_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma0, sKPlane0
+        )
+        load_K_tma1, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma1, sKPlane1
+        )
+        load_K_tma2, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma2, sKPlane2
+        )
+        load_K_tma3, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma3, sKPlane3
+        )
+        load_V_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma0, sVPlane0
+        )
+        load_V_tma1, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma1, sVPlane1
+        )
+        load_V_tma2, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma2, sVPlane2
+        )
+        load_V_tma3, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma3, sVPlane3
+        )
+        if warp_q_idx == Int32(0):
+            cpasync.prefetch_descriptor(tma_atom_K)
+            cpasync.prefetch_descriptor(tma_atom_V)
+        mOFlat = cute.flatten(mO)
+        mOFlatU32 = cute.flatten(cute.recast_tensor(mO, cutlass.Uint32))
+        mQBytes = cute.flatten(cute.recast_tensor(mQ, cutlass.Uint8))
+        q_storage_bytes = self.q_dtype.width // 8
+        q_token_stride_bytes = mQ.stride[0] * q_storage_bytes
+        q_head_stride_bytes = mQ.stride[1] * q_storage_bytes
+        _async_copy_q_tile_permuted_128b_impl(
+            mQBytes,
+            q_start,
+            packed_tile_start,
+            packed_tile_rows,
+            kv_head_idx,
+            group_size,
+            mQ.shape[1],
+            Int32(self.head_dim_qk * 2),
+            q_token_stride_bytes,
+            q_head_stride_bytes,
+            sQBytes,
+            lane,
+            warp_q_idx,
+            Int32(self.num_mma_q),
+            Int32(self.num_mma_d_qk),
+            Int32(self.head_dim_qk // 8),
+        )
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        tc_upcast_stride_q = Int32(self.head_dim_qk // 8)
+        tc_upcast_stride_plane = Int32(self.kv_tma_plane_head_dim // 8)
+        lane_group = lane // 4
+        lane_pair_base = Int32(2 * (lane % 4))
+        warp_row_base = Int32(warp_q_idx * self.num_mma_q * 16)
+        row_local_idx = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        row_valid = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_token_local = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_head_idx_frag = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_row_idx_frag = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        causal_k_limit = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        frag_s_layout = cute.make_layout(
+            (self.num_mma_q, self.num_mma_kv, 8), stride=(self.num_mma_kv * 8, 8, 1)
+        )
+        frag_p_layout = cute.make_layout(
+            (self.num_mma_q, self.num_mma_kv, 4), stride=(self.num_mma_kv * 4, 4, 1)
+        )
+        frag_o_layout = cute.make_layout(
+            (self.num_mma_q, self.num_mma_d_vo, 8), stride=(self.num_mma_d_vo * 8, 8, 1)
+        )
+        o_frag = cute.make_rmem_tensor(frag_o_layout, Float32)
+        m_frag = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        d_frag = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        p_frag = cute.make_rmem_tensor(frag_p_layout, Uint32)
+        p_frag_pair = cute.make_rmem_tensor(frag_p_layout, Uint32)
+        q_smem_base_addr = shared_ptr_to_u32(sQ.iterator)
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                packed_row_local = (
+                    warp_row_base + mma_q * 16 + lane_group + 8 * row_slot
+                )
+                row_local_idx[mma_q, row_slot] = Int32(packed_row_local)
+                valid_row = packed_row_local < packed_tile_rows
+                row_valid[mma_q, row_slot] = Int32(valid_row)
+                if valid_row:
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_group_lane = packed_q_idx - token_local * group_size
+                    q_token_local[mma_q, row_slot] = Int32(token_local)
+                    q_head_idx_frag[mma_q, row_slot] = Int32(
+                        kv_head_idx * group_size + q_group_lane
+                    )
+                    q_row_idx_frag[mma_q, row_slot] = Int32(q_start + token_local)
+                    causal_k_limit[mma_q, row_slot] = Int32(
+                        token_local + cache_len - qo_len
+                    )
+                else:
+                    q_token_local[mma_q, row_slot] = Int32(0)
+                    q_head_idx_frag[mma_q, row_slot] = Int32(0)
+                    q_row_idx_frag[mma_q, row_slot] = Int32(0)
+                    causal_k_limit[mma_q, row_slot] = Int32(-1)
+
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for mma_d in cutlass.range_constexpr(self.num_mma_d_vo):
+                for reg_id in cutlass.range_constexpr(8):
+                    o_frag[mma_q, mma_d, reg_id] = Float32(0.0)
+            for row_slot in cutlass.range_constexpr(2):
+                m_frag[mma_q, row_slot] = Float32(-Float32.inf)
+                d_frag[mma_q, row_slot] = Float32(1.0)
+
+        producer_state = cute_pipeline.PipelineStateSimple(self.num_stages, Int32(0))
+        consumer_state = cute_pipeline.PipelineStateSimple(self.num_stages, Int32(0))
+        tile_base = chunk_start
+        if tile_base < chunk_end and warp_q_idx == Int32(0):
+            _issue_paged_kv_tma_copy_4planes_tma_manual(
+                load_K_tma0,
+                load_K_tma1,
+                load_K_tma2,
+                load_K_tma3,
+                producer_state,
+                mbar_ptr_K,
+                self.kv_tma_copy_bytes_k,
+                mPageTable,
+                request_idx,
+                tile_base,
+                Int32(self.page_size),
+                Int32(self.stage_tile_rows),
+            )
+            _issue_paged_kv_tma_copy_4planes_tma_manual(
+                load_V_tma0,
+                load_V_tma1,
+                load_V_tma2,
+                load_V_tma3,
+                producer_state,
+                mbar_ptr_V,
+                self.kv_tma_copy_bytes_v,
+                mPageTable,
+                request_idx,
+                tile_base,
+                Int32(self.page_size),
+                Int32(self.stage_tile_rows),
+            )
+            producer_state.advance()
+        cute.arch.sync_threads()
+
+        prefetch_base = tile_base + Int32(self.stage_tile_rows)
+
+        while tile_base < chunk_end:
+            tile_limit = cutlass.select_(
+                tile_base + self.stage_tile_rows < chunk_end,
+                tile_base + self.stage_tile_rows,
+                chunk_end,
+            )
+            tile_tokens = tile_limit - tile_base
+            if warp_q_idx == Int32(0):
+                cute.arch.mbarrier_wait(
+                    mbar_ptr_K + consumer_state.index, phase=consumer_state.phase
+                )
+                cute.arch.mbarrier_wait(
+                    mbar_ptr_V + consumer_state.index, phase=consumer_state.phase
+                )
+            cute.arch.sync_threads()
+            if prefetch_base < chunk_end and warp_q_idx == Int32(0):
+                _issue_paged_kv_tma_copy_4planes_tma_manual(
+                    load_K_tma0,
+                    load_K_tma1,
+                    load_K_tma2,
+                    load_K_tma3,
+                    producer_state,
+                    mbar_ptr_K,
+                    self.kv_tma_copy_bytes_k,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    Int32(self.page_size),
+                    Int32(self.stage_tile_rows),
+                )
+                _issue_paged_kv_tma_copy_4planes_tma_manual(
+                    load_V_tma0,
+                    load_V_tma1,
+                    load_V_tma2,
+                    load_V_tma3,
+                    producer_state,
+                    mbar_ptr_V,
+                    self.kv_tma_copy_bytes_v,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    Int32(self.page_size),
+                    Int32(self.stage_tile_rows),
+                )
+                producer_state.advance()
+            stage_plane_offset = consumer_state.index * Int32(self.kv_plane_stage_bytes)
+            k_plane0_base_addr = shared_ptr_to_u32(
+                sKStageBytes.iterator
+                + stage_plane_offset
+                + Int32(0 * self.kv_plane_total_bytes)
+            )
+            k_plane1_base_addr = shared_ptr_to_u32(
+                sKStageBytes.iterator
+                + stage_plane_offset
+                + Int32(1 * self.kv_plane_total_bytes)
+            )
+            k_plane2_base_addr = shared_ptr_to_u32(
+                sKStageBytes.iterator
+                + stage_plane_offset
+                + Int32(2 * self.kv_plane_total_bytes)
+            )
+            k_plane3_base_addr = shared_ptr_to_u32(
+                sKStageBytes.iterator
+                + stage_plane_offset
+                + Int32(3 * self.kv_plane_total_bytes)
+            )
+            v_plane0_base_addr = shared_ptr_to_u32(
+                sVStageBytes.iterator
+                + stage_plane_offset
+                + Int32(0 * self.kv_plane_total_bytes)
+            )
+            v_plane1_base_addr = shared_ptr_to_u32(
+                sVStageBytes.iterator
+                + stage_plane_offset
+                + Int32(1 * self.kv_plane_total_bytes)
+            )
+            v_plane2_base_addr = shared_ptr_to_u32(
+                sVStageBytes.iterator
+                + stage_plane_offset
+                + Int32(2 * self.kv_plane_total_bytes)
+            )
+            v_plane3_base_addr = shared_ptr_to_u32(
+                sVStageBytes.iterator
+                + stage_plane_offset
+                + Int32(3 * self.kv_plane_total_bytes)
+            )
+
+            for subtile_pair_iter in cutlass.range_constexpr(2):
+                subtile_row_base = Int32(subtile_pair_iter * 2 * self.compute_tile_rows)
+                if subtile_row_base < tile_tokens:
+                    frag_S = cute.make_rmem_tensor(frag_s_layout, Float32)
+                    frag_S.fill(0.0)
+                    _literal_qk_mma_into_sfrag_plane_bf16(
+                        frag_S,
+                        q_smem_base_addr,
+                        k_plane0_base_addr,
+                        k_plane1_base_addr,
+                        k_plane2_base_addr,
+                        k_plane3_base_addr,
+                        lane,
+                        warp_q_idx,
+                        Int32(0),
+                        subtile_row_base,
+                        self.num_mma_q,
+                        self.num_mma_kv,
+                        self.num_mma_d_qk,
+                        tc_upcast_stride_q,
+                        tc_upcast_stride_plane,
+                    )
+                    for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                        for reg_id in cutlass.range_constexpr(8):
+                            row_slot = (reg_id % 4) // 2
+                            key_local = (
+                                subtile_row_base
+                                + lane_pair_base
+                                + 8 * (reg_id // 4)
+                                + (reg_id % 2)
+                            )
+                            valid = row_valid[mma_q, row_slot] != 0
+                            if valid:
+                                valid = valid and key_local < tile_tokens
+                            if valid:
+                                valid = (
+                                    valid
+                                    and (tile_base + key_local)
+                                    <= causal_k_limit[mma_q, row_slot]
+                                )
+                            if not valid:
+                                frag_S[mma_q, 0, reg_id] = Float32(-Float32.inf)
+
+                    next_subtile_row_base = subtile_row_base + Int32(
+                        self.compute_tile_rows
+                    )
+                    if next_subtile_row_base < tile_tokens:
+                        frag_S_pair = cute.make_rmem_tensor(frag_s_layout, Float32)
+                        frag_S_pair.fill(0.0)
+                        _literal_qk_mma_into_sfrag_plane_bf16(
+                            frag_S_pair,
+                            q_smem_base_addr,
+                            k_plane0_base_addr,
+                            k_plane1_base_addr,
+                            k_plane2_base_addr,
+                            k_plane3_base_addr,
+                            lane,
+                            warp_q_idx,
+                            Int32(0),
+                            next_subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_qk,
+                            tc_upcast_stride_q,
+                            tc_upcast_stride_plane,
+                        )
+                        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                            for reg_id in cutlass.range_constexpr(8):
+                                row_slot = (reg_id % 4) // 2
+                                key_local = (
+                                    next_subtile_row_base
+                                    + lane_pair_base
+                                    + 8 * (reg_id // 4)
+                                    + (reg_id % 2)
+                                )
+                                valid = row_valid[mma_q, row_slot] != 0
+                                if valid:
+                                    valid = valid and key_local < tile_tokens
+                                if valid:
+                                    valid = valid and (
+                                        (tile_base + key_local)
+                                        <= causal_k_limit[mma_q, row_slot]
+                                    )
+                                if not valid:
+                                    frag_S_pair[mma_q, 0, reg_id] = Float32(
+                                        -Float32.inf
+                                    )
+
+                        _literal_update_mdo_states_fp32_pack_p_pairwise(
+                            frag_S,
+                            frag_S_pair,
+                            o_frag,
+                            m_frag,
+                            d_frag,
+                            p_frag,
+                            p_frag_pair,
+                            self.softmax_scale_log2,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                        )
+                        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                            d0, d1 = bf16_rowsum_m16k16_f32(
+                                d_frag[mma_q, 0],
+                                d_frag[mma_q, 1],
+                                p_frag[mma_q, 0, 0],
+                                p_frag[mma_q, 0, 1],
+                                p_frag[mma_q, 0, 2],
+                                p_frag[mma_q, 0, 3],
+                            )
+                            d_frag[mma_q, 0] = d0
+                            d_frag[mma_q, 1] = d1
+                            d0, d1 = bf16_rowsum_m16k16_f32(
+                                d_frag[mma_q, 0],
+                                d_frag[mma_q, 1],
+                                p_frag_pair[mma_q, 0, 0],
+                                p_frag_pair[mma_q, 0, 1],
+                                p_frag_pair[mma_q, 0, 2],
+                                p_frag_pair[mma_q, 0, 3],
+                            )
+                            d_frag[mma_q, 0] = d0
+                            d_frag[mma_q, 1] = d1
+
+                        _literal_pv_mma_into_ofrag_plane_bf16_packed(
+                            o_frag,
+                            p_frag,
+                            v_plane0_base_addr,
+                            v_plane1_base_addr,
+                            v_plane2_base_addr,
+                            v_plane3_base_addr,
+                            lane,
+                            Int32(0),
+                            subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            Float32(1.0),
+                        )
+                        _literal_pv_mma_into_ofrag_plane_bf16_packed(
+                            o_frag,
+                            p_frag_pair,
+                            v_plane0_base_addr,
+                            v_plane1_base_addr,
+                            v_plane2_base_addr,
+                            v_plane3_base_addr,
+                            lane,
+                            Int32(0),
+                            next_subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            Float32(1.0),
+                        )
+                    else:
+                        _literal_update_mdo_states_fp32_pack_p(
+                            frag_S,
+                            o_frag,
+                            m_frag,
+                            d_frag,
+                            p_frag,
+                            self.softmax_scale_log2,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                        )
+                        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                            d0, d1 = bf16_rowsum_m16k16_f32(
+                                d_frag[mma_q, 0],
+                                d_frag[mma_q, 1],
+                                p_frag[mma_q, 0, 0],
+                                p_frag[mma_q, 0, 1],
+                                p_frag[mma_q, 0, 2],
+                                p_frag[mma_q, 0, 3],
+                            )
+                            d_frag[mma_q, 0] = d0
+                            d_frag[mma_q, 1] = d1
+
+                        _literal_pv_mma_into_ofrag_plane_bf16_packed(
+                            o_frag,
+                            p_frag,
+                            v_plane0_base_addr,
+                            v_plane1_base_addr,
+                            v_plane2_base_addr,
+                            v_plane3_base_addr,
+                            lane,
+                            Int32(0),
+                            subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            Float32(1.0),
+                        )
+
+            consumer_state.advance()
+            tile_base += Int32(self.stage_tile_rows)
+            prefetch_base += Int32(self.stage_tile_rows)
+            cute.arch.sync_threads()
+
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                if m_frag[mma_q, row_slot] != -Float32.inf:
+                    m_frag[mma_q, row_slot] = Float32(
+                        m_frag[mma_q, row_slot] * self.softmax_scale_log2
+                    )
+
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                q_head_idx = q_head_idx_frag[mma_q, row_slot]
+                q_row_idx = q_row_idx_frag[mma_q, row_slot]
+                token_local = q_token_local[mma_q, row_slot]
+                valid_row_store = row_valid[mma_q, row_slot] != 0
+                merged_m = m_frag[mma_q, row_slot]
+                merged_d = d_frag[mma_q, row_slot]
+                inv_d = Float32(0.0)
+                if valid_row_store and merged_m != -Float32.inf:
+                    inv_d = cute.arch.rcp_approx(merged_d)
+
+                for mma_d in cutlass.range_constexpr(self.num_mma_d_vo):
+                    dim_low = mma_d * 16 + lane_pair_base
+                    dim_high = dim_low + 8
+                    reg_base = row_slot * 2
+                    out_low0 = Float32(0.0)
+                    out_low1 = Float32(0.0)
+                    out_high0 = Float32(0.0)
+                    out_high1 = Float32(0.0)
+                    if valid_row_store and merged_m != -Float32.inf:
+                        out_low0 = o_frag[mma_q, mma_d, reg_base + 0] * inv_d
+                        out_low1 = o_frag[mma_q, mma_d, reg_base + 1] * inv_d
+                        out_high0 = o_frag[mma_q, mma_d, reg_base + 4] * inv_d
+                        out_high1 = o_frag[mma_q, mma_d, reg_base + 5] * inv_d
+                    if valid_row_store:
+                        if const_expr(
+                            self.split_kv
+                            and os.environ.get(
+                                "FLASHINFER_EXP_SM12X_DEBUG_BF16_EXTEND_DIRECT_STORE",
+                                "",
+                            )
+                            == "1"
+                        ):
+                            partial_row_idx = (
+                                request_partial_start
+                                + token_local * num_chunks_kv
+                                + kv_tile_idx
+                            )
+                            mO[partial_row_idx, q_head_idx, dim_low + 0] = out_low0.to(
+                                self.o_dtype
+                            )
+                            mO[partial_row_idx, q_head_idx, dim_low + 1] = out_low1.to(
+                                self.o_dtype
+                            )
+                            mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                out_high0.to(self.o_dtype)
+                            )
+                            mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                out_high1.to(self.o_dtype)
+                            )
+                        else:
+                            packed_row_local = row_local_idx[mma_q, row_slot]
+                            sOStageU32[packed_row_local, dim_low // 2] = (
+                                pack_f32x2_to_bfloat2(out_low0, out_low1)
+                            )
+                            sOStageU32[packed_row_local, dim_high // 2] = (
+                                pack_f32x2_to_bfloat2(out_high0, out_high1)
+                            )
+                if valid_row_store and lane_pair_base == 0:
+                    row_lse = (
+                        Float32(-Float32.inf)
+                        if merged_m == -Float32.inf
+                        else Float32(merged_m + cute.math.log2(merged_d, fastmath=True))
+                    )
+                    if const_expr(self.split_kv):
+                        partial_row_idx = (
+                            request_partial_start
+                            + token_local * num_chunks_kv
+                            + kv_tile_idx
+                        )
+                        mLSE[partial_row_idx, q_head_idx] = row_lse
+                    else:
+                        mLSE[q_head_idx, q_row_idx] = row_lse
+        if const_expr(
+            not (
+                self.split_kv
+                and os.environ.get(
+                    "FLASHINFER_EXP_SM12X_DEBUG_BF16_EXTEND_DIRECT_STORE", ""
+                )
+                == "1"
+            )
+        ):
+            cute.arch.sync_threads()
+            store_chunks_per_row = self.head_dim_vo // 8
+            store_chunk_linear_idx = tidx
+            store_total_chunks = packed_tile_rows * store_chunks_per_row
+            while store_chunk_linear_idx < store_total_chunks:
+                packed_row_local = store_chunk_linear_idx // store_chunks_per_row
+                chunk_idx = (
+                    store_chunk_linear_idx - packed_row_local * store_chunks_per_row
+                )
+                packed_q_idx = packed_tile_start + packed_row_local
+                token_local = packed_q_idx // group_size
+                q_group_lane = packed_q_idx - token_local * group_size
+                q_head_idx = kv_head_idx * group_size + q_group_lane
+                q_row_idx = q_start + token_local
+                if const_expr(not self.split_kv):
+                    gmem_elem_offset = Int64(
+                        (Int64(q_row_idx) * Int64(mO.shape[1]) + Int64(q_head_idx))
+                        * Int64(self.head_dim_vo)
+                        + Int64(chunk_idx * 8)
+                    )
+                    u32_idx = chunk_idx * 4
+                    st_global_v4_u32(
+                        get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                        sOStageU32[packed_row_local, u32_idx + 0],
+                        sOStageU32[packed_row_local, u32_idx + 1],
+                        sOStageU32[packed_row_local, u32_idx + 2],
+                        sOStageU32[packed_row_local, u32_idx + 3],
+                    )
+                else:
+                    partial_row_idx = (
+                        request_partial_start
+                        + token_local * num_chunks_kv
+                        + kv_tile_idx
+                    )
+                    u32_idx = chunk_idx * 4
+                    gmem_u32_offset = (
+                        (partial_row_idx * mO.shape[1] + q_head_idx)
+                        * (self.head_dim_vo // 2)
+                    ) + u32_idx
+                    st_global_v4_u32(
+                        get_ptr_as_int64(mOFlatU32, gmem_u32_offset),
+                        sOStageU32[packed_row_local, u32_idx + 0],
+                        sOStageU32[packed_row_local, u32_idx + 1],
+                        sOStageU32[packed_row_local, u32_idx + 2],
+                        sOStageU32[packed_row_local, u32_idx + 3],
+                    )
+                store_chunk_linear_idx += self.num_threads
+
+
+class PagedFp8ExtendRawForwardKernel:
+    def __init__(self, *, split_kv: bool, cta_tile_q: int):
+        self.split_kv = split_kv
+        self.cta_tile_q = cta_tile_q
+        self.use_q48_long_form = cta_tile_q == 48
+        self.stage_tile_rows = 32 if self.use_q48_long_form else 64
+        self.num_stages = 2 if self.use_q48_long_form else 1
+        self.compute_tile_rows = 16 if self.use_q48_long_form else 32
+        self.num_mma_q = 1
+        self.num_mma_kv = 1 if self.use_q48_long_form else 2
+        self.num_mma_d_qk = 16
+        self.num_mma_d_vo = 16
+        self.num_warps_q = 2 if cta_tile_q == 32 else 3
+        self.num_warps_kv = 1
+        self.num_threads = self.num_warps_q * 32
+        self.head_dim_qk = 256
+        self.head_dim_vo = 256
+        self.page_size = 64
+        self.q_dtype = cutlass.BFloat16
+        self.o_dtype = cutlass.BFloat16
+        self.kv_storage_dtype = cutlass.Uint8
+        self.use_paged_kv_tma = True
+        self.kv_tma_plane_head_dim = 128
+        self.kv_tma_plane_count = 2
+        self.q_bytes = self.cta_tile_q * self.head_dim_qk * 2
+        self.k_bytes = self.num_stages * self.stage_tile_rows * self.head_dim_qk
+        self.v_bytes = self.num_stages * self.stage_tile_rows * self.head_dim_vo
+        self.shared_storage_bytes = self.q_bytes + self.k_bytes + self.v_bytes
+        self.kv_plane_stage_bytes = self.stage_tile_rows * self.kv_tma_plane_head_dim
+        self.kv_plane_total_bytes = self.num_stages * self.kv_plane_stage_bytes
+        self.kv_tma_copy_bytes_k = self.stage_tile_rows * self.head_dim_qk
+        self.kv_tma_copy_bytes_v = self.stage_tile_rows * self.head_dim_vo
+        self.softmax_scale_log2 = Float32(
+            (self.head_dim_qk**-0.5) * attention_ops.LOG2_E
+        )
+
+    def _get_shared_storage_cls(self):
+        class SharedStorage:
+            pass
+
+        SharedStorage.__annotations__ = {
+            "mbar_ptr_K": cute.struct.MemRange[cutlass.Int64, 2 * self.num_stages],
+            "mbar_ptr_V": cute.struct.MemRange[cutlass.Int64, 2 * self.num_stages],
+            "payload": cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    int(self.shared_storage_bytes),
+                ],
+                1024,
+            ],
+        }
+        return cute.struct(SharedStorage)
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mKCache: cute.Tensor,
+        mVCache: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ):
+        mQ = _assume_tensor_aligned(mQ)
+        mKCache = _assume_tensor_aligned(mKCache)
+        mVCache = _assume_tensor_aligned(mVCache)
+        mO = _assume_tensor_aligned(mO)
+        mKCacheT = _make_paged_kv_tma_source_tensor(mKCache, self.stage_tile_rows)
+        mVCacheT = _make_paged_kv_tma_source_tensor(mVCache, self.stage_tile_rows)
+        plane_layout = _paged_kv_tma_plane_layout(
+            self.stage_tile_rows, self.kv_tma_plane_head_dim
+        )
+        gmem_tiled_copy_kv = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            mKCacheT,
+            plane_layout,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+        )
+        tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+            gmem_tiled_copy_kv,
+            mVCacheT,
+            plane_layout,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            1,
+        )
+        self.kernel(
+            mQ,
+            tma_tensor_K,
+            tma_tensor_V,
+            mPageTable,
+            mCacheSeqlens,
+            mCuSeqlensQ,
+            mRequestIndices,
+            mQoTileIndices,
+            mKvTileIndices,
+            mOIndptr,
+            mKvChunkSizePtr,
+            mBlockValidMask,
+            mO,
+            mLSE,
+            mKDescale,
+            mVDescale,
+            tma_atom_K,
+            tma_atom_V,
+        ).launch(
+            grid=(mBlockValidMask.shape[0], mKCache.shape[2], 1),
+            block=[32, self.num_warps_q, 1],
+            # Q48 consumes 58,368 B and is one-CTA; Q32 consumes 50,176 B
+            # and deliberately fits two CTAs in the 102,400-B SM budget.
+            min_blocks_per_mp=1 if self.use_q48_long_form else 2,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mKCacheT: cute.Tensor,
+        mVCacheT: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mCuSeqlensQ: cute.Tensor,
+        mRequestIndices: cute.Tensor,
+        mQoTileIndices: cute.Tensor,
+        mKvTileIndices: cute.Tensor,
+        mOIndptr: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mBlockValidMask: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mKDescale: cute.Tensor | None,
+        mVDescale: cute.Tensor | None,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+    ):
+        lane, warp_q_idx, _ = cute.arch.thread_idx()
+        work_idx, kv_head_idx, _ = cute.arch.block_idx()
+        if mBlockValidMask[work_idx] == Int32(0):
+            _exit_thread()
+
+        request_idx = mRequestIndices[work_idx]
+        qo_tile_idx = mQoTileIndices[work_idx]
+        kv_tile_idx = mKvTileIndices[work_idx]
+        q_start = mCuSeqlensQ[request_idx]
+        q_end = mCuSeqlensQ[request_idx + 1]
+        qo_len = q_end - q_start
+        if qo_len <= Int32(0):
+            _exit_thread()
+        cache_len = mCacheSeqlens[request_idx]
+        group_size = mQ.shape[1] // mKCacheT.shape[2]
+        packed_qo_len = qo_len * group_size
+        packed_tile_start = qo_tile_idx * self.cta_tile_q
+        packed_tile_end = cutlass.select_(
+            packed_tile_start + self.cta_tile_q < packed_qo_len,
+            packed_tile_start + self.cta_tile_q,
+            packed_qo_len,
+        )
+        packed_tile_rows = packed_tile_end - packed_tile_start
+        if packed_tile_rows <= Int32(0):
+            _exit_thread()
+
+        kv_chunk_size = mKvChunkSizePtr[0]
+        chunk_start = (
+            kv_tile_idx * kv_chunk_size if const_expr(self.split_kv) else Int32(0)
+        )
+        chunk_end = (
+            cutlass.select_(
+                (kv_tile_idx + 1) * kv_chunk_size < cache_len,
+                (kv_tile_idx + 1) * kv_chunk_size,
+                cache_len,
+            )
+            if const_expr(self.split_kv)
+            else cache_len
+        )
+        request_partial_start = (
+            mOIndptr[request_idx] if const_expr(self.split_kv) else Int32(0)
+        )
+        request_partial_end = (
+            mOIndptr[request_idx + 1] if const_expr(self.split_kv) else Int32(0)
+        )
+        num_chunks_kv = (
+            (request_partial_end - request_partial_start) // qo_len
+            if const_expr(self.split_kv)
+            else Int32(1)
+        )
+        tidx = lane + warp_q_idx * Int32(32)
+
+        SharedStorage = self._get_shared_storage_cls()
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr_K = storage.mbar_ptr_K.data_ptr()
+        mbar_ptr_V = storage.mbar_ptr_V.data_ptr()
+        if tidx < Int32(self.num_stages):
+            cute.arch.mbarrier_init(mbar_ptr_K + tidx, Int32(1))
+            cute.arch.mbarrier_init(mbar_ptr_V + tidx, Int32(1))
+        cute.arch.sync_threads()
+
+        payload_u8 = storage.payload.get_tensor(
+            cute.make_layout((self.shared_storage_bytes,), stride=(1,))
+        )
+        sQ = cute.make_tensor(
+            cute.recast_ptr(payload_u8.iterator.align(16), dtype=self.q_dtype),
+            cute.make_layout(
+                (self.cta_tile_q, self.head_dim_qk), stride=(self.head_dim_qk, 1)
+            ),
+        )
+        sOStageU32 = cute.recast_tensor(
+            cute.make_tensor(
+                cute.recast_ptr(payload_u8.iterator.align(16), dtype=cutlass.BFloat16),
+                cute.make_layout(
+                    (self.cta_tile_q, self.head_dim_vo), stride=(self.head_dim_vo, 1)
+                ),
+            ),
+            cutlass.Uint32,
+        )
+        sQBytes = cute.flatten(cute.recast_tensor(sQ, cutlass.Uint8))
+        sKStageBytes = cute.make_tensor(
+            payload_u8.iterator + Int32(self.q_bytes),
+            cute.make_layout((self.k_bytes,), stride=(1,)),
+        )
+        sVStageBytes = cute.make_tensor(
+            payload_u8.iterator + Int32(self.q_bytes + self.k_bytes),
+            cute.make_layout((self.v_bytes,), stride=(1,)),
+        )
+        plane_stage_layout = _paged_kv_tma_plane_stage_layout(
+            self.stage_tile_rows, self.kv_tma_plane_head_dim, self.num_stages
+        )
+        plane_num_elems = (
+            self.num_stages * self.stage_tile_rows * self.kv_tma_plane_head_dim
+        )
+        sKPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + 0 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sKPlane1 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + 1 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane0 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + self.k_bytes + 0 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        sVPlane1 = _get_memrange_tensor(
+            _make_payload_memrange(
+                payload_u8,
+                cutlass.Uint8,
+                self.q_bytes + self.k_bytes + 1 * self.kv_plane_total_bytes,
+                plane_num_elems,
+            ),
+            plane_stage_layout,
+        )
+        mKCacheTHead = mKCacheT[None, None, kv_head_idx, None]
+        mVCacheTHead = mVCacheT[None, None, kv_head_idx, None]
+        gKTma0 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gKTma1 = cute.local_tile(
+            mKCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 1, None),
+        )
+        gVTma0 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 0, None),
+        )
+        gVTma1 = cute.local_tile(
+            mVCacheTHead,
+            (self.stage_tile_rows, self.kv_tma_plane_head_dim),
+            (0, 1, None),
+        )
+        load_K_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma0, sKPlane0
+        )
+        load_K_tma1, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_K, 0, cute.make_layout(1), gKTma1, sKPlane1
+        )
+        load_V_tma0, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma0, sVPlane0
+        )
+        load_V_tma1, _, _ = cute_copy.tma_get_copy_fn(
+            tma_atom_V, 0, cute.make_layout(1), gVTma1, sVPlane1
+        )
+        if warp_q_idx == Int32(0):
+            cpasync.prefetch_descriptor(tma_atom_K)
+            cpasync.prefetch_descriptor(tma_atom_V)
+        mOFlat = cute.flatten(mO)
+        mQBytes = cute.flatten(cute.recast_tensor(mQ, cutlass.Uint8))
+        q_storage_bytes = self.q_dtype.width // 8
+        q_token_stride_bytes = mQ.stride[0] * q_storage_bytes
+        q_head_stride_bytes = mQ.stride[1] * q_storage_bytes
+        _async_copy_q_tile_permuted_128b_impl(
+            mQBytes,
+            q_start,
+            packed_tile_start,
+            packed_tile_rows,
+            kv_head_idx,
+            group_size,
+            mQ.shape[1],
+            Int32(self.head_dim_qk * 2),
+            q_token_stride_bytes,
+            q_head_stride_bytes,
+            sQBytes,
+            lane,
+            warp_q_idx,
+            Int32(self.num_mma_q),
+            Int32(self.num_mma_d_qk),
+            Int32(self.head_dim_qk // 8),
+        )
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+        tc_upcast_stride_q = Int32(self.head_dim_qk // 8)
+        tc_upcast_stride_plane = Int32(self.kv_tma_plane_head_dim // 16)
+        if const_expr(self.cta_tile_q == 48):
+            cute.arch.setmaxregister_increase(248)
+        lane_group = lane // 4
+        lane_pair_base = Int32(2 * (lane % 4))
+        warp_row_base = Int32(warp_q_idx * self.num_mma_q * 16)
+        row_local_idx = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        row_valid = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        q_token_local = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        causal_k_limit = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Int32
+        )
+        frag_s_layout = cute.make_layout(
+            (self.num_mma_q, self.num_mma_kv, 8), stride=(self.num_mma_kv * 8, 8, 1)
+        )
+        frag_p_layout = cute.make_layout(
+            (self.num_mma_q, self.num_mma_kv, 4), stride=(self.num_mma_kv * 4, 4, 1)
+        )
+        frag_o_layout = cute.make_layout(
+            (self.num_mma_q, self.num_mma_d_vo, 8), stride=(self.num_mma_d_vo * 8, 8, 1)
+        )
+        o_frag = cute.make_rmem_tensor(frag_o_layout, Float32)
+        m_frag = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        d_frag = cute.make_rmem_tensor(
+            cute.make_layout((self.num_mma_q, 2), stride=(2, 1)), Float32
+        )
+        p_frag = cute.make_rmem_tensor(frag_p_layout, Uint32)
+        p_frag_pair = cute.make_rmem_tensor(frag_p_layout, Uint32)
+        q_smem_base_addr = shared_ptr_to_u32(sQ.iterator)
+
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                packed_row_local = (
+                    warp_row_base + mma_q * 16 + lane_group + 8 * row_slot
+                )
+                row_local_idx[mma_q, row_slot] = Int32(packed_row_local)
+                valid_row = packed_row_local < packed_tile_rows
+                row_valid[mma_q, row_slot] = Int32(valid_row)
+                if valid_row:
+                    packed_q_idx = packed_tile_start + packed_row_local
+                    token_local = packed_q_idx // group_size
+                    q_token_local[mma_q, row_slot] = Int32(token_local)
+                    causal_k_limit[mma_q, row_slot] = Int32(
+                        token_local + cache_len - qo_len
+                    )
+                else:
+                    q_token_local[mma_q, row_slot] = Int32(0)
+                    causal_k_limit[mma_q, row_slot] = Int32(-1)
+
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for mma_d in cutlass.range_constexpr(self.num_mma_d_vo):
+                for reg_id in cutlass.range_constexpr(8):
+                    o_frag[mma_q, mma_d, reg_id] = Float32(0.0)
+            for row_slot in cutlass.range_constexpr(2):
+                m_frag[mma_q, row_slot] = Float32(-Float32.inf)
+                d_frag[mma_q, row_slot] = Float32(1.0)
+
+        k_scale = (
+            mKDescale[request_idx]
+            if const_expr(mKDescale is not None and len(mKDescale.shape) == 1)
+            else (
+                mKDescale[request_idx, kv_head_idx]
+                if const_expr(mKDescale is not None)
+                else Float32(1.0)
+            )
+        )
+        v_scale = (
+            mVDescale[request_idx]
+            if const_expr(mVDescale is not None and len(mVDescale.shape) == 1)
+            else (
+                mVDescale[request_idx, kv_head_idx]
+                if const_expr(mVDescale is not None)
+                else Float32(1.0)
+            )
+        )
+        producer_state = cute_pipeline.PipelineStateSimple(self.num_stages, Int32(0))
+        consumer_state = cute_pipeline.PipelineStateSimple(self.num_stages, Int32(0))
+        tile_base = chunk_start
+        if tile_base < chunk_end and warp_q_idx == Int32(0):
+            _issue_paged_kv_tma_copy_2planes_tma_manual(
+                load_K_tma0,
+                load_K_tma1,
+                producer_state,
+                mbar_ptr_K,
+                self.kv_tma_copy_bytes_k,
+                mPageTable,
+                request_idx,
+                tile_base,
+                Int32(self.page_size),
+                Int32(self.stage_tile_rows),
+            )
+            _issue_paged_kv_tma_copy_2planes_tma_manual(
+                load_V_tma0,
+                load_V_tma1,
+                producer_state,
+                mbar_ptr_V,
+                self.kv_tma_copy_bytes_v,
+                mPageTable,
+                request_idx,
+                tile_base,
+                Int32(self.page_size),
+                Int32(self.stage_tile_rows),
+            )
+            producer_state.advance()
+        cute.arch.sync_threads()
+        prefetch_base = tile_base + Int32(self.stage_tile_rows)
+
+        while tile_base < chunk_end:
+            tile_limit = cutlass.select_(
+                tile_base + self.stage_tile_rows < chunk_end,
+                tile_base + self.stage_tile_rows,
+                chunk_end,
+            )
+            tile_tokens = tile_limit - tile_base
+            cute.arch.mbarrier_wait(
+                mbar_ptr_K + consumer_state.index, phase=consumer_state.phase
+            )
+            cute.arch.mbarrier_wait(
+                mbar_ptr_V + consumer_state.index, phase=consumer_state.phase
+            )
+            cute.arch.sync_threads()
+            if (
+                const_expr(self.num_stages > 1)
+                and prefetch_base < chunk_end
+                and warp_q_idx == Int32(0)
+            ):
+                _issue_paged_kv_tma_copy_2planes_tma_manual(
+                    load_K_tma0,
+                    load_K_tma1,
+                    producer_state,
+                    mbar_ptr_K,
+                    self.kv_tma_copy_bytes_k,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    Int32(self.page_size),
+                    Int32(self.stage_tile_rows),
+                )
+                _issue_paged_kv_tma_copy_2planes_tma_manual(
+                    load_V_tma0,
+                    load_V_tma1,
+                    producer_state,
+                    mbar_ptr_V,
+                    self.kv_tma_copy_bytes_v,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    Int32(self.page_size),
+                    Int32(self.stage_tile_rows),
+                )
+                producer_state.advance()
+            stage_plane_offset = consumer_state.index * Int32(self.kv_plane_stage_bytes)
+
+            for subtile_iter in cutlass.range_constexpr(2):
+                subtile_row_base = Int32(subtile_iter * self.compute_tile_rows)
+                if subtile_row_base < tile_tokens:
+                    frag_S = cute.make_rmem_tensor(frag_s_layout, Float32)
+                    frag_S.fill(0.0)
+                    _literal_qk_mma_into_sfrag_plane_fp8_raw(
+                        frag_S,
+                        q_smem_base_addr,
+                        shared_ptr_to_u32(
+                            sKStageBytes.iterator
+                            + stage_plane_offset
+                            + Int32(0 * self.kv_plane_total_bytes)
+                        ),
+                        shared_ptr_to_u32(
+                            sKStageBytes.iterator
+                            + stage_plane_offset
+                            + Int32(1 * self.kv_plane_total_bytes)
+                        ),
+                        lane,
+                        warp_q_idx,
+                        Int32(0),
+                        subtile_row_base,
+                        self.num_mma_q,
+                        self.num_mma_kv,
+                        self.num_mma_d_qk,
+                        tc_upcast_stride_q,
+                        tc_upcast_stride_plane,
+                    )
+                    for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                        for mma_kv in cutlass.range_constexpr(self.num_mma_kv):
+                            for reg_id in cutlass.range_constexpr(8):
+                                row_slot = (reg_id % 4) // 2
+                                key_local = (
+                                    subtile_row_base
+                                    + mma_kv * 16
+                                    + lane_pair_base
+                                    + 8 * (reg_id // 4)
+                                    + (reg_id % 2)
+                                )
+                                valid = row_valid[mma_q, row_slot] != 0
+                                if valid:
+                                    valid = valid and key_local < tile_tokens
+                                if valid:
+                                    valid = (
+                                        valid
+                                        and (tile_base + key_local)
+                                        <= causal_k_limit[mma_q, row_slot]
+                                    )
+                                if valid:
+                                    frag_S[mma_q, mma_kv, reg_id] = (
+                                        frag_S[mma_q, mma_kv, reg_id] * k_scale
+                                    )
+                                else:
+                                    frag_S[mma_q, mma_kv, reg_id] = Float32(
+                                        -Float32.inf
+                                    )
+
+                    next_subtile_row_base = subtile_row_base + Int32(
+                        self.compute_tile_rows
+                    )
+                    if subtile_iter == 0 and next_subtile_row_base < tile_tokens:
+                        frag_S_pair = cute.make_rmem_tensor(frag_s_layout, Float32)
+                        frag_S_pair.fill(0.0)
+                        _literal_qk_mma_into_sfrag_plane_fp8_raw(
+                            frag_S_pair,
+                            q_smem_base_addr,
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(0 * self.kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sKStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(1 * self.kv_plane_total_bytes)
+                            ),
+                            lane,
+                            warp_q_idx,
+                            Int32(0),
+                            next_subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_qk,
+                            tc_upcast_stride_q,
+                            tc_upcast_stride_plane,
+                        )
+                        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                            for mma_kv in cutlass.range_constexpr(self.num_mma_kv):
+                                for reg_id in cutlass.range_constexpr(8):
+                                    row_slot = (reg_id % 4) // 2
+                                    key_local = (
+                                        next_subtile_row_base
+                                        + mma_kv * 16
+                                        + lane_pair_base
+                                        + 8 * (reg_id // 4)
+                                        + (reg_id % 2)
+                                    )
+                                    valid = row_valid[mma_q, row_slot] != 0
+                                    if valid:
+                                        valid = valid and key_local < tile_tokens
+                                    if valid:
+                                        valid = valid and (
+                                            (tile_base + key_local)
+                                            <= causal_k_limit[mma_q, row_slot]
+                                        )
+                                    if valid:
+                                        frag_S_pair[mma_q, mma_kv, reg_id] = (
+                                            frag_S_pair[mma_q, mma_kv, reg_id] * k_scale
+                                        )
+                                    else:
+                                        frag_S_pair[mma_q, mma_kv, reg_id] = Float32(
+                                            -Float32.inf
+                                        )
+
+                        _literal_update_mdo_states_fp32_pack_p_pairwise(
+                            frag_S,
+                            frag_S_pair,
+                            o_frag,
+                            m_frag,
+                            d_frag,
+                            p_frag,
+                            p_frag_pair,
+                            self.softmax_scale_log2,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                        )
+                        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                            for mma_kv in cutlass.range_constexpr(self.num_mma_kv):
+                                d0, d1 = bf16_rowsum_m16k16_f32(
+                                    d_frag[mma_q, 0],
+                                    d_frag[mma_q, 1],
+                                    p_frag[mma_q, mma_kv, 0],
+                                    p_frag[mma_q, mma_kv, 1],
+                                    p_frag[mma_q, mma_kv, 2],
+                                    p_frag[mma_q, mma_kv, 3],
+                                )
+                                d_frag[mma_q, 0] = d0
+                                d_frag[mma_q, 1] = d1
+                            for mma_kv in cutlass.range_constexpr(self.num_mma_kv):
+                                d0, d1 = bf16_rowsum_m16k16_f32(
+                                    d_frag[mma_q, 0],
+                                    d_frag[mma_q, 1],
+                                    p_frag_pair[mma_q, mma_kv, 0],
+                                    p_frag_pair[mma_q, mma_kv, 1],
+                                    p_frag_pair[mma_q, mma_kv, 2],
+                                    p_frag_pair[mma_q, mma_kv, 3],
+                                )
+                                d_frag[mma_q, 0] = d0
+                                d_frag[mma_q, 1] = d1
+
+                        _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                            o_frag,
+                            p_frag,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(0 * self.kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(1 * self.kv_plane_total_bytes)
+                            ),
+                            lane,
+                            Int32(0),
+                            subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+                        _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                            o_frag,
+                            p_frag_pair,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(0 * self.kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(1 * self.kv_plane_total_bytes)
+                            ),
+                            lane,
+                            Int32(0),
+                            next_subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+                    elif subtile_iter == 0:
+                        _literal_update_mdo_states_fp32_pack_p(
+                            frag_S,
+                            o_frag,
+                            m_frag,
+                            d_frag,
+                            p_frag,
+                            self.softmax_scale_log2,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                        )
+                        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+                            for mma_kv in cutlass.range_constexpr(self.num_mma_kv):
+                                d0, d1 = bf16_rowsum_m16k16_f32(
+                                    d_frag[mma_q, 0],
+                                    d_frag[mma_q, 1],
+                                    p_frag[mma_q, mma_kv, 0],
+                                    p_frag[mma_q, mma_kv, 1],
+                                    p_frag[mma_q, mma_kv, 2],
+                                    p_frag[mma_q, mma_kv, 3],
+                                )
+                                d_frag[mma_q, 0] = d0
+                                d_frag[mma_q, 1] = d1
+
+                        _literal_pv_mma_into_ofrag_plane_fp8_raw(
+                            o_frag,
+                            p_frag,
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(0 * self.kv_plane_total_bytes)
+                            ),
+                            shared_ptr_to_u32(
+                                sVStageBytes.iterator
+                                + stage_plane_offset
+                                + Int32(1 * self.kv_plane_total_bytes)
+                            ),
+                            lane,
+                            Int32(0),
+                            subtile_row_base,
+                            self.num_mma_q,
+                            self.num_mma_kv,
+                            self.num_mma_d_vo,
+                            tc_upcast_stride_plane,
+                            v_scale,
+                        )
+
+            consumer_state.advance()
+            tile_base += Int32(self.stage_tile_rows)
+            if (
+                const_expr(self.num_stages == 1)
+                and tile_base < chunk_end
+                and warp_q_idx == Int32(0)
+            ):
+                _issue_paged_kv_tma_copy_2planes_tma_manual(
+                    load_K_tma0,
+                    load_K_tma1,
+                    producer_state,
+                    mbar_ptr_K,
+                    self.kv_tma_copy_bytes_k,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    Int32(self.page_size),
+                    Int32(self.stage_tile_rows),
+                )
+                _issue_paged_kv_tma_copy_2planes_tma_manual(
+                    load_V_tma0,
+                    load_V_tma1,
+                    producer_state,
+                    mbar_ptr_V,
+                    self.kv_tma_copy_bytes_v,
+                    mPageTable,
+                    request_idx,
+                    prefetch_base,
+                    Int32(self.page_size),
+                    Int32(self.stage_tile_rows),
+                )
+                producer_state.advance()
+            prefetch_base += Int32(self.stage_tile_rows)
+            cute.arch.sync_threads()
+
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                if m_frag[mma_q, row_slot] != -Float32.inf:
+                    m_frag[mma_q, row_slot] = Float32(
+                        m_frag[mma_q, row_slot] * self.softmax_scale_log2
+                    )
+
+        for mma_q in cutlass.range_constexpr(self.num_mma_q):
+            for row_slot in cutlass.range_constexpr(2):
+                token_local = q_token_local[mma_q, row_slot]
+                packed_q_idx = packed_tile_start + row_local_idx[mma_q, row_slot]
+                q_group_lane = packed_q_idx - token_local * group_size
+                q_head_idx = Int32(kv_head_idx * group_size + q_group_lane)
+                q_row_idx = Int32(q_start + token_local)
+                valid_row_store = row_valid[mma_q, row_slot] != 0
+                merged_m = m_frag[mma_q, row_slot]
+                merged_d = d_frag[mma_q, row_slot]
+                inv_d = Float32(0.0)
+                if valid_row_store and merged_m != -Float32.inf:
+                    inv_d = cute.arch.rcp_approx(merged_d)
+
+                for mma_d in cutlass.range_constexpr(self.num_mma_d_vo):
+                    dim_low = mma_d * 16 + lane_pair_base
+                    dim_high = dim_low + 8
+                    reg_base = row_slot * 2
+                    out_low0 = Float32(0.0)
+                    out_low1 = Float32(0.0)
+                    out_high0 = Float32(0.0)
+                    out_high1 = Float32(0.0)
+                    if valid_row_store and merged_m != -Float32.inf:
+                        out_low0 = o_frag[mma_q, mma_d, reg_base + 0] * inv_d
+                        out_low1 = o_frag[mma_q, mma_d, reg_base + 1] * inv_d
+                        out_high0 = o_frag[mma_q, mma_d, reg_base + 4] * inv_d
+                        out_high1 = o_frag[mma_q, mma_d, reg_base + 5] * inv_d
+                    if valid_row_store:
+                        if const_expr(self.cta_tile_q == 48):
+                            packed_row_local = row_local_idx[mma_q, row_slot]
+                            sOStageU32[packed_row_local, dim_low // 2] = (
+                                pack_f32x2_to_bfloat2(out_low0, out_low1)
+                            )
+                            sOStageU32[packed_row_local, dim_high // 2] = (
+                                pack_f32x2_to_bfloat2(out_high0, out_high1)
+                            )
+                        else:
+                            if const_expr(self.split_kv):
+                                partial_row_idx = (
+                                    request_partial_start
+                                    + token_local * num_chunks_kv
+                                    + kv_tile_idx
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 0] = (
+                                    out_low0.to(self.o_dtype)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_low + 1] = (
+                                    out_low1.to(self.o_dtype)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 0] = (
+                                    out_high0.to(self.o_dtype)
+                                )
+                                mO[partial_row_idx, q_head_idx, dim_high + 1] = (
+                                    out_high1.to(self.o_dtype)
+                                )
+                            else:
+                                mO[q_row_idx, q_head_idx, dim_low + 0] = out_low0.to(
+                                    self.o_dtype
+                                )
+                                mO[q_row_idx, q_head_idx, dim_low + 1] = out_low1.to(
+                                    self.o_dtype
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 0] = out_high0.to(
+                                    self.o_dtype
+                                )
+                                mO[q_row_idx, q_head_idx, dim_high + 1] = out_high1.to(
+                                    self.o_dtype
+                                )
+                if valid_row_store and lane_pair_base == 0:
+                    row_lse = (
+                        Float32(-Float32.inf)
+                        if merged_m == -Float32.inf
+                        else Float32(merged_m + cute.math.log2(merged_d, fastmath=True))
+                    )
+                    if const_expr(self.split_kv):
+                        partial_row_idx = (
+                            request_partial_start
+                            + token_local * num_chunks_kv
+                            + kv_tile_idx
+                        )
+                        mLSE[partial_row_idx, q_head_idx] = row_lse
+                    else:
+                        mLSE[q_head_idx, q_row_idx] = row_lse
+        if const_expr(self.cta_tile_q == 48):
+            cute.arch.sync_threads()
+            store_chunks_per_row = self.head_dim_vo // 8
+            store_chunk_linear_idx = tidx
+            store_total_chunks = packed_tile_rows * store_chunks_per_row
+            while store_chunk_linear_idx < store_total_chunks:
+                packed_row_local = store_chunk_linear_idx // store_chunks_per_row
+                chunk_idx = (
+                    store_chunk_linear_idx - packed_row_local * store_chunks_per_row
+                )
+                packed_q_idx = packed_tile_start + packed_row_local
+                token_local = packed_q_idx // group_size
+                q_group_lane = packed_q_idx - token_local * group_size
+                q_head_idx = kv_head_idx * group_size + q_group_lane
+                q_row_idx = q_start + token_local
+                if const_expr(self.split_kv):
+                    partial_row_idx = (
+                        request_partial_start
+                        + token_local * num_chunks_kv
+                        + kv_tile_idx
+                    )
+                    gmem_elem_offset = Int64(
+                        (
+                            Int64(partial_row_idx) * Int64(mO.shape[1])
+                            + Int64(q_head_idx)
+                        )
+                        * Int64(self.head_dim_vo)
+                        + Int64(chunk_idx * 8)
+                    )
+                else:
+                    gmem_elem_offset = Int64(
+                        (Int64(q_row_idx) * Int64(mO.shape[1]) + Int64(q_head_idx))
+                        * Int64(self.head_dim_vo)
+                        + Int64(chunk_idx * 8)
+                    )
+                u32_idx = chunk_idx * 4
+                st_global_v4_u32(
+                    get_ptr_as_int64(mOFlat, gmem_elem_offset),
+                    sOStageU32[packed_row_local, u32_idx + 0],
+                    sOStageU32[packed_row_local, u32_idx + 1],
+                    sOStageU32[packed_row_local, u32_idx + 2],
+                    sOStageU32[packed_row_local, u32_idx + 3],
+                )
+                store_chunk_linear_idx += self.num_threads

--- a/flashinfer/experimental/sm12x/attention/paged/graph_replay.py
+++ b/flashinfer/experimental/sm12x/attention/paged/graph_replay.py
@@ -1,0 +1,1760 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/graph_replay.py @ 3a6c424b (2026-06-13) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Device-side decode graph replay helpers for the paged attention backend."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import triton
+import triton.language as tl
+
+_DECODE_BLOCK_CHUNKS = 128
+_DECODE_BLOCK_PAGES = 128
+_PREFILL_BLOCK_WORK_ITEMS = 128
+_PREFILL_BLOCK_ROWS = 128
+_MSA_UNION_TOPK = 16
+_MSA_UNION_TOKENS_PER_TILE = 8
+_MSA_UNION_MAX_BLOCKS = _MSA_UNION_TOPK * _MSA_UNION_TOKENS_PER_TILE
+
+
+@triton.jit
+def stage_decode_cuda_graph_metadata_triton(
+    req_to_token_ptr,
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    cache_seqlens_ptr,
+    cu_seqlens_q_ptr,
+    page_table_ptr,
+    swa_page_table_ptr,
+    swa_index_mapping_ptr,
+    req_to_token_row_stride,
+    req_to_token_numel,
+    page_table_row_stride,
+    swa_page_table_row_stride,
+    req_pool_indices_stride,
+    seq_lens_stride,
+    swa_index_mapping_size,
+    PAGE_SIZE: tl.constexpr,
+    BATCH: tl.constexpr,
+    MAX_PAGES: tl.constexpr,
+    HAS_SWA: tl.constexpr,
+    BLOCK_PAGES: tl.constexpr,
+):
+    req_idx = tl.program_id(axis=0)
+    page_block_idx = tl.program_id(axis=1)
+
+    if page_block_idx == 0:
+        seq_len = tl.load(seq_lens_ptr + req_idx * seq_lens_stride).to(tl.int32)
+        tl.store(cache_seqlens_ptr + req_idx, seq_len)
+        tl.store(cu_seqlens_q_ptr + req_idx, req_idx)
+        tl.store(cu_seqlens_q_ptr + BATCH, BATCH, mask=req_idx == 0)
+
+    page_offsets = page_block_idx * BLOCK_PAGES + tl.arange(0, BLOCK_PAGES)
+    page_mask = page_offsets < MAX_PAGES
+    req_pool_idx = tl.load(req_pool_indices_ptr + req_idx * req_pool_indices_stride).to(
+        tl.int64
+    )
+    flat_token_offsets = (
+        req_pool_idx * req_to_token_row_stride + page_offsets.to(tl.int64) * PAGE_SIZE
+    )
+    flat_token_offsets = tl.minimum(
+        tl.maximum(flat_token_offsets, 0),
+        req_to_token_numel - 1,
+    )
+    token_indices = tl.load(
+        req_to_token_ptr + flat_token_offsets, mask=page_mask, other=0
+    )
+    tl.store(
+        page_table_ptr + req_idx * page_table_row_stride + page_offsets,
+        (token_indices // PAGE_SIZE).to(tl.int32),
+        mask=page_mask,
+    )
+
+    if HAS_SWA:
+        swa_indices = tl.where(
+            token_indices < 0,
+            swa_index_mapping_size - 1,
+            token_indices,
+        )
+        swa_indices = tl.minimum(tl.maximum(swa_indices, 0), swa_index_mapping_size - 1)
+        swa_token_indices = tl.load(
+            swa_index_mapping_ptr + swa_indices,
+            mask=page_mask,
+            other=-1,
+        )
+        tl.store(
+            swa_page_table_ptr + req_idx * swa_page_table_row_stride + page_offsets,
+            (swa_token_indices // PAGE_SIZE).to(tl.int32),
+            mask=page_mask,
+        )
+
+
+@triton.jit
+def patch_decode_cuda_graph_current_pages_triton(
+    cache_seqlens_ptr,
+    page_table_ptr,
+    swa_page_table_ptr,
+    out_cache_loc_ptr,
+    out_cache_loc_swa_ptr,
+    swa_index_mapping_ptr,
+    page_table_row_stride,
+    swa_page_table_row_stride,
+    out_cache_loc_stride,
+    out_cache_loc_swa_stride,
+    swa_index_mapping_size,
+    PAGE_SIZE: tl.constexpr,
+    FILL_VALUE: tl.constexpr,
+    MAX_PAGES: tl.constexpr,
+    HAS_SWA: tl.constexpr,
+    HAS_OUT_CACHE_LOC_SWA: tl.constexpr,
+    BLOCK_PAGES: tl.constexpr,
+):
+    req_idx = tl.program_id(axis=0)
+    page_block_idx = tl.program_id(axis=1)
+
+    cache_len = tl.load(cache_seqlens_ptr + req_idx).to(tl.int32)
+    out_cache_loc = tl.load(out_cache_loc_ptr + req_idx * out_cache_loc_stride).to(
+        tl.int64
+    )
+    valid = (cache_len != FILL_VALUE) | (out_cache_loc != 0)
+    logical_page = tl.minimum(
+        tl.maximum((cache_len - 1) // PAGE_SIZE, 0),
+        MAX_PAGES - 1,
+    )
+
+    page_offsets = page_block_idx * BLOCK_PAGES + tl.arange(0, BLOCK_PAGES)
+    page_mask = page_offsets < MAX_PAGES
+    invalid_page_mask = page_mask & ~valid
+    tl.store(
+        page_table_ptr + req_idx * page_table_row_stride + page_offsets,
+        tl.zeros((BLOCK_PAGES,), tl.int32),
+        mask=invalid_page_mask,
+    )
+    if HAS_SWA:
+        tl.store(
+            swa_page_table_ptr + req_idx * swa_page_table_row_stride + page_offsets,
+            tl.zeros((BLOCK_PAGES,), tl.int32),
+            mask=invalid_page_mask,
+        )
+
+    if page_block_idx == 0:
+        tl.store(cache_seqlens_ptr + req_idx, tl.where(valid, cache_len, FILL_VALUE))
+        current_page = (out_cache_loc // PAGE_SIZE).to(tl.int32)
+        tl.store(
+            page_table_ptr + req_idx * page_table_row_stride + logical_page,
+            current_page,
+            mask=valid,
+        )
+        if HAS_SWA:
+            if HAS_OUT_CACHE_LOC_SWA:
+                out_cache_loc_swa = tl.load(
+                    out_cache_loc_swa_ptr + req_idx * out_cache_loc_swa_stride
+                ).to(tl.int64)
+            else:
+                swa_mapping_idx = tl.minimum(
+                    tl.maximum(out_cache_loc, 0),
+                    swa_index_mapping_size - 1,
+                )
+                out_cache_loc_swa = tl.load(swa_index_mapping_ptr + swa_mapping_idx).to(
+                    tl.int64
+                )
+            tl.store(
+                swa_page_table_ptr + req_idx * swa_page_table_row_stride + logical_page,
+                (out_cache_loc_swa // PAGE_SIZE).to(tl.int32),
+                mask=valid,
+            )
+
+
+@triton.jit
+def build_decode_graph_page_table_full_triton(
+    req_to_token_ptr,
+    req_pool_indices_ptr,
+    page_table_ptr,
+    req_to_token_row_stride,
+    req_to_token_numel,
+    page_table_row_stride,
+    PAGE_SIZE: tl.constexpr,
+    MAX_PAGES: tl.constexpr,
+    BLOCK_PAGES: tl.constexpr,
+):
+    req_idx = tl.program_id(axis=0)
+    page_block_idx = tl.program_id(axis=1)
+
+    req_pool_idx = tl.load(req_pool_indices_ptr + req_idx).to(tl.int64)
+    page_offsets = page_block_idx * BLOCK_PAGES + tl.arange(0, BLOCK_PAGES)
+    page_mask = page_offsets < MAX_PAGES
+    flat_token_offsets = (
+        req_pool_idx * req_to_token_row_stride + page_offsets.to(tl.int64) * PAGE_SIZE
+    )
+    flat_token_offsets = tl.minimum(
+        tl.maximum(flat_token_offsets, 0),
+        req_to_token_numel - 1,
+    )
+    token_indices = tl.load(
+        req_to_token_ptr + flat_token_offsets, mask=page_mask, other=0
+    )
+    tl.store(
+        page_table_ptr + req_idx * page_table_row_stride + page_offsets,
+        (token_indices // PAGE_SIZE).to(tl.int32),
+        mask=page_mask,
+    )
+
+
+@triton.jit
+def update_decode_graph_metadata_fused_triton(
+    cache_seqlens_ptr,
+    request_indices_ptr,
+    qo_tile_indices_ptr,
+    kv_tile_indices_ptr,
+    merge_indptr_ptr,
+    o_indptr_ptr,
+    block_valid_mask_ptr,
+    kv_chunk_size_ptr,
+    kv_window_start_tokens_ptr,
+    decode_chunk_pages_lut_ptr,
+    max_chunks_per_req,
+    block_valid_capacity,
+    lut_size,
+    PAGE_SIZE: tl.constexpr,
+    WINDOW_PAGE_SPAN: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    BATCH: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    BLOCK_WORK_ITEMS: tl.constexpr,
+):
+    batch_offsets = tl.arange(0, BLOCK_BATCH)
+    batch_mask = batch_offsets < BATCH
+    cache_len = tl.load(cache_seqlens_ptr + batch_offsets, mask=batch_mask, other=0).to(
+        tl.int32
+    )
+    num_pages = tl.maximum((cache_len + (PAGE_SIZE - 1)) // PAGE_SIZE, 1)
+    window_start_page = tl.full((BLOCK_BATCH,), 0, tl.int32)
+    if WINDOW_LEFT >= 0:
+        window_start_token = tl.maximum(cache_len - 1 - WINDOW_LEFT, 0)
+        window_start_page = window_start_token // PAGE_SIZE
+    effective_pages = tl.maximum(num_pages - window_start_page, 1)
+    policy_pages = tl.max(tl.where(batch_mask, effective_pages, 1), axis=0)
+    if WINDOW_PAGE_SPAN > 0:
+        policy_pages = tl.minimum(policy_pages, WINDOW_PAGE_SPAN)
+    policy_pages = tl.minimum(tl.maximum(policy_pages, 1), lut_size - 1)
+    chunk_pages = tl.load(decode_chunk_pages_lut_ptr + policy_pages).to(tl.int32)
+    num_chunks = tl.maximum((effective_pages + chunk_pages - 1) // chunk_pages, 1)
+    prefix = tl.cumsum(tl.where(batch_mask, num_chunks, 0), 0)
+
+    tl.store(merge_indptr_ptr, 0)
+    tl.store(o_indptr_ptr, 0)
+    tl.store(
+        merge_indptr_ptr + batch_offsets + 1,
+        prefix,
+        mask=batch_mask,
+    )
+    tl.store(
+        o_indptr_ptr + batch_offsets + 1,
+        prefix,
+        mask=batch_mask,
+    )
+    tl.store(
+        kv_window_start_tokens_ptr + batch_offsets,
+        window_start_page * PAGE_SIZE,
+        mask=batch_mask,
+    )
+    tl.store(kv_chunk_size_ptr, chunk_pages * PAGE_SIZE)
+
+    work_offsets = tl.arange(0, BLOCK_WORK_ITEMS)
+    block_valid_mask = work_offsets < block_valid_capacity
+    tl.store(
+        block_valid_mask_ptr + work_offsets,
+        tl.zeros((BLOCK_WORK_ITEMS,), tl.int32),
+        mask=block_valid_mask,
+    )
+
+
+@triton.jit
+def build_msa_prefill_union_metadata_triton(
+    q2k_indices_ptr,
+    cache_seqlens_ptr,
+    cu_seqlens_q_ptr,
+    request_indices_ptr,
+    qo_tile_indices_ptr,
+    block_valid_mask_ptr,
+    union_blocks_ptr,
+    union_masks_ptr,
+    union_counts_ptr,
+    total_q_capacity,
+    block_valid_capacity,
+    NUM_KV_HEADS: tl.constexpr,
+    BLOCK_TOKENS: tl.constexpr,
+    TOPK: tl.constexpr,
+    TOKENS_PER_TILE: tl.constexpr,
+    MAX_UNION_BLOCKS: tl.constexpr,
+):
+    work_idx = tl.program_id(axis=0)
+    kv_head_idx = tl.program_id(axis=1)
+    work_valid = work_idx < block_valid_capacity
+    block_valid = tl.load(block_valid_mask_ptr + work_idx, mask=work_valid, other=0).to(
+        tl.int32
+    )
+    active = work_valid & (block_valid != 0)
+    union_base = (work_idx * NUM_KV_HEADS + kv_head_idx) * MAX_UNION_BLOCKS
+    union_count_offset = work_idx * NUM_KV_HEADS + kv_head_idx
+    tl.store(union_counts_ptr + union_count_offset, 0, mask=work_valid)
+
+    request_idx = tl.load(request_indices_ptr + work_idx, mask=active, other=0).to(
+        tl.int32
+    )
+    qo_tile_idx = tl.load(qo_tile_indices_ptr + work_idx, mask=active, other=0).to(
+        tl.int32
+    )
+    q_start = tl.load(cu_seqlens_q_ptr + request_idx, mask=active, other=0).to(tl.int32)
+    q_end = tl.load(cu_seqlens_q_ptr + request_idx + 1, mask=active, other=0).to(
+        tl.int32
+    )
+    qo_len = q_end - q_start
+    cache_len = tl.load(cache_seqlens_ptr + request_idx, mask=active, other=0).to(
+        tl.int32
+    )
+    tile_first_token = qo_tile_idx * TOKENS_PER_TILE
+    tile_token_count = tl.minimum(
+        tl.maximum(qo_len - tile_first_token, 0), TOKENS_PER_TILE
+    )
+    union_count = tl.full((), 0, tl.int32)
+
+    for token_idx in tl.static_range(0, TOKENS_PER_TILE):
+        token_valid = active & (token_idx < tile_token_count)
+        q_row_idx = q_start + tile_first_token + token_idx
+        visible_len = cache_len - qo_len + tile_first_token + token_idx + 1
+        visible_len = tl.maximum(visible_len, 1)
+        bit = tl.full((), 1 << token_idx, tl.int32)
+        for list_idx in tl.static_range(0, TOPK):
+            q2k_offset = (kv_head_idx * total_q_capacity + q_row_idx) * TOPK + list_idx
+            block_id = tl.load(
+                q2k_indices_ptr + q2k_offset, mask=token_valid, other=-1
+            ).to(tl.int32)
+            valid_block = (
+                token_valid & (block_id >= 0) & (block_id * BLOCK_TOKENS < visible_len)
+            )
+            found = tl.full((), False, tl.int1)
+            found_slot = tl.full((), 0, tl.int32)
+            for union_idx in tl.static_range(0, MAX_UNION_BLOCKS):
+                probe = union_idx < union_count
+                existing = tl.load(
+                    union_blocks_ptr + union_base + union_idx,
+                    mask=valid_block & probe,
+                    other=-1,
+                ).to(tl.int32)
+                match = valid_block & probe & (existing == block_id)
+                found_slot = tl.where(match & ~found, union_idx, found_slot)
+                found = found | match
+
+            do_update = valid_block & found
+            old_mask = tl.load(
+                union_masks_ptr + union_base + found_slot,
+                mask=do_update,
+                other=0,
+            ).to(tl.int32)
+            tl.store(
+                union_masks_ptr + union_base + found_slot,
+                old_mask | bit,
+                mask=do_update,
+            )
+
+            do_store = valid_block & ~found & (union_count < MAX_UNION_BLOCKS)
+            tl.store(
+                union_blocks_ptr + union_base + union_count, block_id, mask=do_store
+            )
+            tl.store(union_masks_ptr + union_base + union_count, bit, mask=do_store)
+            union_count += tl.where(do_store, 1, 0)
+
+    tl.store(union_counts_ptr + union_count_offset, union_count, mask=work_valid)
+
+
+@triton.jit
+def update_decode_graph_compact_work_metadata_triton(
+    request_indices_ptr,
+    qo_tile_indices_ptr,
+    kv_tile_indices_ptr,
+    o_indptr_ptr,
+    block_valid_mask_ptr,
+    work_items_capacity,
+    block_valid_capacity,
+    BATCH: tl.constexpr,
+    BLOCK_CHUNKS: tl.constexpr,
+):
+    req_idx = tl.program_id(axis=0)
+    chunk_block_idx = tl.program_id(axis=1)
+    chunk_offsets = chunk_block_idx * BLOCK_CHUNKS + tl.arange(0, BLOCK_CHUNKS)
+    req_start = tl.load(o_indptr_ptr + req_idx).to(tl.int32)
+    req_end = tl.load(o_indptr_ptr + req_idx + 1).to(tl.int32)
+    num_chunks = req_end - req_start
+    work_offsets = req_start + chunk_offsets
+    active = (req_idx < BATCH) & (chunk_offsets < num_chunks)
+    work_mask = active & (work_offsets < work_items_capacity)
+    valid_mask = active & (work_offsets < block_valid_capacity)
+    tl.store(request_indices_ptr + work_offsets, req_idx, mask=work_mask)
+    tl.store(qo_tile_indices_ptr + work_offsets, 0, mask=work_mask)
+    tl.store(
+        kv_tile_indices_ptr + work_offsets, chunk_offsets.to(tl.int32), mask=work_mask
+    )
+    tl.store(block_valid_mask_ptr + work_offsets, 1, mask=valid_mask)
+
+
+@triton.jit
+def update_msa_decode_graph_metadata_fused_triton(
+    cache_seqlens_ptr,
+    merge_indptr_ptr,
+    o_indptr_ptr,
+    block_valid_mask_ptr,
+    kv_chunk_size_ptr,
+    kv_window_start_tokens_ptr,
+    kv_chunk_size,
+    block_valid_capacity,
+    PAGE_SIZE: tl.constexpr,
+    PAGES_PER_BLOCK: tl.constexpr,
+    BATCH: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    BLOCK_WORK_ITEMS: tl.constexpr,
+):
+    batch_offsets = tl.arange(0, BLOCK_BATCH)
+    batch_mask = batch_offsets < BATCH
+    cache_len = tl.load(cache_seqlens_ptr + batch_offsets, mask=batch_mask, other=0).to(
+        tl.int32
+    )
+    active = batch_mask & (cache_len > 0)
+    visible_blocks = tl.maximum((cache_len + 127) // 128, 1)
+    selected_blocks = tl.minimum(visible_blocks, 16)
+    tail_tokens = tl.maximum(cache_len - (visible_blocks - 1) * 128, 1)
+    tail_pages = tl.minimum(
+        tl.maximum((tail_tokens + PAGE_SIZE - 1) // PAGE_SIZE, 1), PAGES_PER_BLOCK
+    )
+    effective_pages = tl.maximum(
+        (selected_blocks - 1) * PAGES_PER_BLOCK + tail_pages, 1
+    )
+    selected_tokens = effective_pages * PAGE_SIZE
+    num_chunks = tl.maximum((selected_tokens + kv_chunk_size - 1) // kv_chunk_size, 1)
+    num_chunks = tl.where(active, num_chunks, 0)
+    prefix = tl.cumsum(tl.where(batch_mask, num_chunks, 0), 0)
+
+    tl.store(merge_indptr_ptr, 0)
+    tl.store(o_indptr_ptr, 0)
+    tl.store(merge_indptr_ptr + batch_offsets + 1, prefix, mask=batch_mask)
+    tl.store(o_indptr_ptr + batch_offsets + 1, prefix, mask=batch_mask)
+    tl.store(
+        kv_window_start_tokens_ptr + batch_offsets,
+        tl.zeros((BLOCK_BATCH,), tl.int32),
+        mask=batch_mask,
+    )
+    tl.store(kv_chunk_size_ptr, kv_chunk_size)
+
+    work_offsets = tl.arange(0, BLOCK_WORK_ITEMS)
+    tl.store(
+        block_valid_mask_ptr + work_offsets,
+        tl.zeros((BLOCK_WORK_ITEMS,), tl.int32),
+        mask=work_offsets < block_valid_capacity,
+    )
+
+
+@triton.jit
+def update_regular_decode_graph_metadata_fused_triton(
+    cache_seqlens_ptr,
+    merge_indptr_ptr,
+    o_indptr_ptr,
+    kv_chunk_size_ptr,
+    kv_window_start_tokens_ptr,
+    decode_chunk_pages_lut_ptr,
+    kv_chunk_size_tensor_ptr,
+    lut_size,
+    PAGE_SIZE: tl.constexpr,
+    WINDOW_PAGE_SPAN: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    BATCH: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    USE_LUT: tl.constexpr,
+    HAS_KV_CHUNK_SIZE_TENSOR: tl.constexpr,
+    FIXED_KV_CHUNK_SIZE: tl.constexpr,
+):
+    batch_offsets = tl.arange(0, BLOCK_BATCH)
+    batch_mask = batch_offsets < BATCH
+    cache_len = tl.load(cache_seqlens_ptr + batch_offsets, mask=batch_mask, other=0).to(
+        tl.int32
+    )
+    num_pages = tl.maximum((cache_len + (PAGE_SIZE - 1)) // PAGE_SIZE, 1)
+    window_start_page = tl.full((BLOCK_BATCH,), 0, tl.int32)
+    if WINDOW_LEFT >= 0:
+        window_start_token = tl.maximum(cache_len - 1 - WINDOW_LEFT, 0)
+        window_start_page = window_start_token // PAGE_SIZE
+    effective_pages = tl.maximum(num_pages - window_start_page, 1)
+
+    if USE_LUT:
+        policy_pages = tl.max(tl.where(batch_mask, effective_pages, 1), axis=0)
+        if WINDOW_PAGE_SPAN > 0:
+            policy_pages = tl.minimum(policy_pages, WINDOW_PAGE_SPAN)
+        policy_pages = tl.minimum(tl.maximum(policy_pages, 1), lut_size - 1)
+        chunk_pages = tl.load(decode_chunk_pages_lut_ptr + policy_pages).to(tl.int32)
+        kv_chunk_size = chunk_pages * PAGE_SIZE
+    elif HAS_KV_CHUNK_SIZE_TENSOR:
+        kv_chunk_size = tl.load(kv_chunk_size_tensor_ptr).to(tl.int32)
+    else:
+        kv_chunk_size = tl.full((), FIXED_KV_CHUNK_SIZE, tl.int32)
+
+    effective_tokens = effective_pages * PAGE_SIZE
+    num_chunks = tl.maximum((effective_tokens + kv_chunk_size - 1) // kv_chunk_size, 1)
+    prefix = tl.cumsum(tl.where(batch_mask, num_chunks, 0), 0)
+
+    tl.store(merge_indptr_ptr, 0)
+    tl.store(o_indptr_ptr, 0)
+    tl.store(
+        merge_indptr_ptr + batch_offsets + 1,
+        prefix,
+        mask=batch_mask,
+    )
+    tl.store(
+        o_indptr_ptr + batch_offsets + 1,
+        prefix,
+        mask=batch_mask,
+    )
+    tl.store(
+        kv_window_start_tokens_ptr + batch_offsets,
+        window_start_page * PAGE_SIZE,
+        mask=batch_mask,
+    )
+    tl.store(kv_chunk_size_ptr, kv_chunk_size)
+
+
+@triton.jit
+def update_decode_graph_window_start_tokens_triton(
+    cache_seqlens_ptr,
+    kv_window_start_tokens_ptr,
+    PAGE_SIZE: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    BATCH: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+):
+    batch_offsets = tl.arange(0, BLOCK_BATCH)
+    batch_mask = batch_offsets < BATCH
+    cache_len = tl.load(cache_seqlens_ptr + batch_offsets, mask=batch_mask, other=0).to(
+        tl.int32
+    )
+    window_start_token = tl.maximum(cache_len - 1 - WINDOW_LEFT, 0)
+    window_start_page = window_start_token // PAGE_SIZE
+    tl.store(
+        kv_window_start_tokens_ptr + batch_offsets,
+        window_start_page * PAGE_SIZE,
+        mask=batch_mask,
+    )
+
+
+@triton.jit
+def update_prefill_graph_work_metadata_triton(
+    cache_seqlens_ptr,
+    cu_seqlens_q_ptr,
+    request_indices_ptr,
+    qo_tile_indices_ptr,
+    kv_tile_indices_ptr,
+    o_indptr_ptr,
+    block_valid_mask_ptr,
+    kv_chunk_size_ptr,
+    kv_window_start_tokens_ptr,
+    work_items_capacity: tl.constexpr,
+    block_valid_capacity: tl.constexpr,
+    BATCH: tl.constexpr,
+    MAX_Q_TILES_PER_REQ: tl.constexpr,
+    MAX_CHUNKS_PER_Q_TILE: tl.constexpr,
+    CTA_TILE_Q: tl.constexpr,
+    GQA_GROUP_SIZE: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    SPLIT_KV: tl.constexpr,
+    BLOCK_WORK_ITEMS: tl.constexpr,
+):
+    block_idx = tl.program_id(axis=0)
+    offsets = block_idx * BLOCK_WORK_ITEMS + tl.arange(0, BLOCK_WORK_ITEMS)
+    slots_per_req = MAX_Q_TILES_PER_REQ * MAX_CHUNKS_PER_Q_TILE
+    req_idx = offsets // slots_per_req
+    req_local = offsets - req_idx * slots_per_req
+    q_tile_idx = req_local // MAX_CHUNKS_PER_Q_TILE
+    kv_tile_idx = req_local - q_tile_idx * MAX_CHUNKS_PER_Q_TILE
+
+    in_block_capacity = offsets < block_valid_capacity
+    in_work_capacity = offsets < work_items_capacity
+    in_batch = req_idx < BATCH
+    usable = in_block_capacity & in_work_capacity & in_batch
+
+    q_start = tl.load(cu_seqlens_q_ptr + req_idx, mask=usable, other=0).to(tl.int32)
+    q_end = tl.load(cu_seqlens_q_ptr + req_idx + 1, mask=usable, other=0).to(tl.int32)
+    q_len = tl.maximum(q_end - q_start, 0)
+    cache_len = tl.load(cache_seqlens_ptr + req_idx, mask=usable, other=0).to(tl.int32)
+
+    packed_q_len = q_len * GQA_GROUP_SIZE
+    num_q_tiles = (packed_q_len + CTA_TILE_Q - 1) // CTA_TILE_Q
+    num_pages = tl.maximum((cache_len + PAGE_SIZE - 1) // PAGE_SIZE, 1)
+
+    window_start_page = tl.full((BLOCK_WORK_ITEMS,), 0, tl.int32)
+    if WINDOW_LEFT >= 0:
+        first_causal_key = tl.maximum(cache_len - tl.maximum(q_len, 1), 0)
+        first_window_key = tl.maximum(first_causal_key - WINDOW_LEFT, 0)
+        window_start_page = first_window_key // PAGE_SIZE
+        window_start_page = tl.minimum(window_start_page, tl.maximum(num_pages - 1, 0))
+    effective_pages = tl.maximum(num_pages - window_start_page, 1)
+
+    kv_chunk_size = tl.load(kv_chunk_size_ptr).to(tl.int32)
+    chunk_pages = tl.maximum((kv_chunk_size + PAGE_SIZE - 1) // PAGE_SIZE, 1)
+    num_chunks = tl.full((BLOCK_WORK_ITEMS,), 1, tl.int32)
+    if SPLIT_KV:
+        num_chunks = tl.maximum((effective_pages + chunk_pages - 1) // chunk_pages, 1)
+
+    active = (
+        usable
+        & (q_tile_idx < num_q_tiles)
+        & (kv_tile_idx < num_chunks)
+        & (q_len > 0)
+        & (cache_len > 0)
+    )
+    tl.store(
+        block_valid_mask_ptr + offsets, active.to(tl.int32), mask=in_block_capacity
+    )
+    tl.store(request_indices_ptr + offsets, req_idx.to(tl.int32), mask=in_work_capacity)
+    tl.store(
+        qo_tile_indices_ptr + offsets, q_tile_idx.to(tl.int32), mask=in_work_capacity
+    )
+    tl.store(
+        kv_tile_indices_ptr + offsets, kv_tile_idx.to(tl.int32), mask=in_work_capacity
+    )
+
+    first_slot_for_req = usable & (req_local == 0)
+    tl.store(
+        kv_window_start_tokens_ptr + req_idx,
+        (window_start_page * PAGE_SIZE).to(tl.int32),
+        mask=first_slot_for_req,
+    )
+    tl.store(
+        o_indptr_ptr + req_idx + 1,
+        (q_len * num_chunks).to(tl.int32),
+        mask=first_slot_for_req,
+    )
+    tl.store(o_indptr_ptr + offsets, 0, mask=offsets == 0)
+
+
+@triton.jit
+def update_prefill_graph_row_indptr_triton(
+    cu_seqlens_q_ptr,
+    o_indptr_ptr,
+    merge_indptr_ptr,
+    BATCH: tl.constexpr,
+    MAX_Q_ROWS_PER_REQ: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+):
+    req_idx = tl.program_id(axis=0)
+    row_block_idx = tl.program_id(axis=1)
+    rows = row_block_idx * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+
+    q_start = tl.load(cu_seqlens_q_ptr + req_idx).to(tl.int32)
+    q_end = tl.load(cu_seqlens_q_ptr + req_idx + 1).to(tl.int32)
+    q_len = tl.maximum(q_end - q_start, 0)
+    request_partial_start = tl.load(o_indptr_ptr + req_idx).to(tl.int32)
+    request_partial_end = tl.load(o_indptr_ptr + req_idx + 1).to(tl.int32)
+    safe_q_len = tl.maximum(q_len, 1)
+    num_chunks = tl.maximum(
+        (request_partial_end - request_partial_start) // safe_q_len, 1
+    )
+
+    row_mask = rows < q_len
+    tl.store(
+        merge_indptr_ptr + q_start + rows + 1,
+        request_partial_start + (rows + 1) * num_chunks,
+        mask=row_mask,
+    )
+    if BATCH > 0:
+        tl.store(merge_indptr_ptr, 0, mask=(req_idx == 0) & (row_block_idx == 0))
+
+
+def make_decode_chunk_pages_lut_tensor(
+    decode_chunk_pages_lut: Sequence[int],
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    if not decode_chunk_pages_lut:
+        raise ValueError("decode chunk-pages LUT must be non-empty")
+    if any(int(chunk_pages) <= 0 for chunk_pages in decode_chunk_pages_lut):
+        raise ValueError("decode chunk-pages LUT must contain only positive values")
+    return torch.tensor(
+        (
+            int(decode_chunk_pages_lut[0]),
+            *(int(chunk_pages) for chunk_pages in decode_chunk_pages_lut),
+        ),
+        dtype=torch.int32,
+        device=device,
+    )
+
+
+def summarize_decode_chunk_pages_lut(
+    decode_chunk_pages_lut: Sequence[int],
+) -> tuple[int, int]:
+    if not decode_chunk_pages_lut:
+        raise ValueError("decode chunk-pages LUT must be non-empty")
+    worst_page_count = 1
+    max_chunks_per_req = 1
+    for page_count, chunk_pages in enumerate(decode_chunk_pages_lut, start=1):
+        num_chunks = (page_count + int(chunk_pages) - 1) // int(chunk_pages)
+        if num_chunks > max_chunks_per_req:
+            max_chunks_per_req = num_chunks
+            worst_page_count = page_count
+    return int(worst_page_count), int(max_chunks_per_req)
+
+
+def build_msa_prefill_union_metadata(
+    *,
+    q2k_indices: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    request_indices: torch.Tensor,
+    qo_tile_indices: torch.Tensor,
+    block_valid_mask: torch.Tensor,
+    union_blocks: torch.Tensor,
+    union_masks: torch.Tensor,
+    union_counts: torch.Tensor,
+) -> None:
+    if q2k_indices.ndim != 3 or int(q2k_indices.shape[2]) != _MSA_UNION_TOPK:
+        raise ValueError("q2k_indices must have shape [kv_heads, total_q_capacity, 16]")
+    if q2k_indices.dtype != torch.int32 or not q2k_indices.is_contiguous():
+        raise TypeError("q2k_indices must be contiguous torch.int32")
+    if union_blocks.dtype != torch.int32 or union_masks.dtype != torch.int32:
+        raise TypeError("MSA union block/mask buffers must be torch.int32")
+    if union_counts.dtype != torch.int32:
+        raise TypeError("MSA union count buffer must be torch.int32")
+    if union_blocks.ndim != 3 or union_masks.ndim != 3:
+        raise ValueError("MSA union block/mask buffers must be rank-3")
+    if union_counts.ndim != 2:
+        raise ValueError("MSA union count buffer must be rank-2")
+    if tuple(union_blocks.shape) != tuple(union_masks.shape):
+        raise ValueError("MSA union block and mask buffers must have matching shapes")
+    if int(union_blocks.shape[1]) != int(q2k_indices.shape[0]):
+        raise ValueError(
+            "MSA union buffers must use the same kv-head count as q2k_indices"
+        )
+    if int(union_blocks.shape[2]) < _MSA_UNION_MAX_BLOCKS:
+        raise ValueError("MSA union buffers need capacity for 128 blocks per tile")
+    if tuple(union_counts.shape) != tuple(union_blocks.shape[:2]):
+        raise ValueError("MSA union count buffer shape must match union_blocks[:2]")
+    work_capacity = int(block_valid_mask.shape[0])
+    if int(union_blocks.shape[0]) < work_capacity:
+        raise ValueError("MSA union buffers are smaller than block_valid_mask capacity")
+    if (
+        int(request_indices.shape[0]) < work_capacity
+        or int(qo_tile_indices.shape[0]) < work_capacity
+    ):
+        raise ValueError(
+            "MSA worklist buffers are smaller than block_valid_mask capacity"
+        )
+    device = q2k_indices.device
+    tensors = (
+        cache_seqlens,
+        cu_seqlens_q,
+        request_indices,
+        qo_tile_indices,
+        block_valid_mask,
+        union_blocks,
+        union_masks,
+        union_counts,
+    )
+    if any(t.device != device for t in tensors):
+        raise ValueError("MSA union metadata tensors must all be on the q2k device")
+    build_msa_prefill_union_metadata_triton[(work_capacity, int(q2k_indices.shape[0]))](
+        q2k_indices,
+        cache_seqlens,
+        cu_seqlens_q,
+        request_indices,
+        qo_tile_indices,
+        block_valid_mask,
+        union_blocks,
+        union_masks,
+        union_counts,
+        int(q2k_indices.shape[1]),
+        work_capacity,
+        NUM_KV_HEADS=int(q2k_indices.shape[0]),
+        BLOCK_TOKENS=128,
+        TOPK=_MSA_UNION_TOPK,
+        TOKENS_PER_TILE=_MSA_UNION_TOKENS_PER_TILE,
+        MAX_UNION_BLOCKS=_MSA_UNION_MAX_BLOCKS,
+        num_warps=1,
+    )
+
+
+def stage_decode_cuda_graph_metadata(
+    *,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    page_table: torch.Tensor,
+    page_size: int,
+    swa_page_table: torch.Tensor | None = None,
+    swa_index_mapping: torch.Tensor | None = None,
+) -> None:
+    device = page_table.device
+    if req_to_token.device != device:
+        raise ValueError("req_to_token and page_table must be on the same device")
+    if req_pool_indices.device != device:
+        raise ValueError("req_pool_indices and page_table must be on the same device")
+    if seq_lens.device != device or cache_seqlens.device != device:
+        raise ValueError(
+            "seq_lens/cache_seqlens and page_table must be on the same device"
+        )
+    if cu_seqlens_q.device != device:
+        raise ValueError("cu_seqlens_q and page_table must be on the same device")
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if page_table.ndim != 2:
+        raise ValueError("page_table must be rank-2")
+
+    bs = int(page_table.shape[0])
+    max_pages = int(page_table.shape[1])
+    if bs <= 0:
+        raise ValueError("decode graph staging requires bs > 0")
+    if max_pages <= 0:
+        raise ValueError("page_table must have at least one page column")
+    if int(req_pool_indices.shape[0]) < bs:
+        raise ValueError("req_pool_indices is smaller than the graph batch")
+    if int(seq_lens.shape[0]) < bs:
+        raise ValueError("seq_lens is smaller than the graph batch")
+    if int(cache_seqlens.shape[0]) < bs:
+        raise ValueError("cache_seqlens is smaller than the graph batch")
+    if int(cu_seqlens_q.shape[0]) < bs + 1:
+        raise ValueError("cu_seqlens_q is smaller than the graph batch")
+
+    has_swa = swa_page_table is not None
+    if has_swa != (swa_index_mapping is not None):
+        raise ValueError(
+            "swa_page_table and swa_index_mapping must be provided together"
+        )
+    if has_swa:
+        assert swa_page_table is not None
+        assert swa_index_mapping is not None
+        if swa_page_table.device != device or swa_index_mapping.device != device:
+            raise ValueError("SWA staging tensors must be on the page_table device")
+        if tuple(swa_page_table.shape) != tuple(page_table.shape):
+            raise ValueError("swa_page_table shape must match page_table shape")
+        if swa_index_mapping.numel() <= 0:
+            raise ValueError("swa_index_mapping must be non-empty")
+
+    page_blocks = triton.cdiv(max_pages, _DECODE_BLOCK_PAGES)
+    stage_decode_cuda_graph_metadata_triton[(bs, page_blocks)](
+        req_to_token,
+        req_pool_indices,
+        seq_lens,
+        cache_seqlens,
+        cu_seqlens_q,
+        page_table,
+        page_table if swa_page_table is None else swa_page_table,
+        req_to_token if swa_index_mapping is None else swa_index_mapping,
+        req_to_token.stride(0),
+        req_to_token.numel(),
+        page_table.stride(0),
+        page_table.stride(0) if swa_page_table is None else swa_page_table.stride(0),
+        req_pool_indices.stride(0),
+        seq_lens.stride(0),
+        1 if swa_index_mapping is None else swa_index_mapping.numel(),
+        PAGE_SIZE=page_size,
+        BATCH=bs,
+        MAX_PAGES=max_pages,
+        HAS_SWA=has_swa,
+        BLOCK_PAGES=_DECODE_BLOCK_PAGES,
+    )
+
+
+def patch_decode_cuda_graph_current_pages(
+    *,
+    cache_seqlens: torch.Tensor,
+    page_table: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    page_size: int,
+    fill_value: int = 1,
+    swa_page_table: torch.Tensor | None = None,
+    out_cache_loc_swa: torch.Tensor | None = None,
+    swa_index_mapping: torch.Tensor | None = None,
+) -> None:
+    device = page_table.device
+    if cache_seqlens.device != device or out_cache_loc.device != device:
+        raise ValueError(
+            "cache_seqlens/out_cache_loc and page_table must share a device"
+        )
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if page_table.ndim != 2:
+        raise ValueError("page_table must be rank-2")
+
+    bs = int(cache_seqlens.shape[0])
+    max_pages = int(page_table.shape[1])
+    if bs <= 0:
+        raise ValueError("decode graph current-page patch requires bs > 0")
+    if int(page_table.shape[0]) < bs:
+        raise ValueError("page_table is smaller than cache_seqlens")
+    if max_pages <= 0:
+        raise ValueError("page_table must have at least one page column")
+    if int(out_cache_loc.shape[0]) < bs:
+        raise ValueError("out_cache_loc is smaller than the graph batch")
+
+    has_swa = swa_page_table is not None
+    has_out_cache_loc_swa = out_cache_loc_swa is not None
+    if has_swa:
+        assert swa_page_table is not None
+        if swa_page_table.device != device:
+            raise ValueError("swa_page_table and page_table must share a device")
+        if tuple(swa_page_table.shape) != tuple(page_table.shape):
+            raise ValueError("swa_page_table shape must match page_table shape")
+        if has_out_cache_loc_swa:
+            assert out_cache_loc_swa is not None
+            if out_cache_loc_swa.device != device:
+                raise ValueError("out_cache_loc_swa and page_table must share a device")
+            if int(out_cache_loc_swa.shape[0]) < bs:
+                raise ValueError("out_cache_loc_swa is smaller than the graph batch")
+        elif swa_index_mapping is None:
+            raise ValueError(
+                "swa_index_mapping is required when out_cache_loc_swa is not provided"
+            )
+        else:
+            if swa_index_mapping.device != device:
+                raise ValueError("swa_index_mapping and page_table must share a device")
+            if swa_index_mapping.numel() <= 0:
+                raise ValueError("swa_index_mapping must be non-empty")
+
+    page_blocks = triton.cdiv(max_pages, _DECODE_BLOCK_PAGES)
+    patch_decode_cuda_graph_current_pages_triton[(bs, page_blocks)](
+        cache_seqlens,
+        page_table,
+        page_table if swa_page_table is None else swa_page_table,
+        out_cache_loc,
+        out_cache_loc if out_cache_loc_swa is None else out_cache_loc_swa,
+        page_table if swa_index_mapping is None else swa_index_mapping,
+        page_table.stride(0),
+        page_table.stride(0) if swa_page_table is None else swa_page_table.stride(0),
+        out_cache_loc.stride(0),
+        out_cache_loc.stride(0)
+        if out_cache_loc_swa is None
+        else out_cache_loc_swa.stride(0),
+        1 if swa_index_mapping is None else swa_index_mapping.numel(),
+        PAGE_SIZE=page_size,
+        FILL_VALUE=int(fill_value),
+        MAX_PAGES=max_pages,
+        HAS_SWA=has_swa,
+        HAS_OUT_CACHE_LOC_SWA=has_out_cache_loc_swa,
+        BLOCK_PAGES=_DECODE_BLOCK_PAGES,
+    )
+
+
+def update_decode_graph_chunk_metadata_fused(
+    *,
+    cache_seqlens: torch.Tensor,
+    request_indices: torch.Tensor,
+    qo_tile_indices: torch.Tensor,
+    kv_tile_indices: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    block_valid_mask: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    decode_chunk_pages_lut: torch.Tensor,
+    page_size: int,
+    window_page_span: int = 0,
+    window_left: int = -1,
+) -> None:
+    device = cache_seqlens.device
+    if request_indices.device != device:
+        raise ValueError("request_indices and cache_seqlens must be on the same device")
+    if qo_tile_indices.device != device or kv_tile_indices.device != device:
+        raise ValueError(
+            "tile index buffers and cache_seqlens must be on the same device"
+        )
+    if merge_indptr.device != device or o_indptr.device != device:
+        raise ValueError("indptr buffers and cache_seqlens must be on the same device")
+    if block_valid_mask.device != device or kv_chunk_size_ptr.device != device:
+        raise ValueError(
+            "decode graph buffers and cache_seqlens must be on the same device"
+        )
+    if kv_window_start_tokens.device != device:
+        raise ValueError(
+            "kv_window_start_tokens and cache_seqlens must be on the same device"
+        )
+    if decode_chunk_pages_lut.device != device:
+        raise ValueError(
+            "decode_chunk_pages_lut and cache_seqlens must be on the same device"
+        )
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if window_left < -1:
+        raise ValueError("window_left must be -1 or non-negative")
+
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("decode graph replay requires bs > 0")
+    work_items_capacity = int(request_indices.shape[0])
+    block_valid_capacity = int(block_valid_mask.shape[0])
+    if (
+        int(qo_tile_indices.shape[0]) != work_items_capacity
+        or int(kv_tile_indices.shape[0]) != work_items_capacity
+    ):
+        raise RuntimeError(
+            "decode graph tile index buffers must match request_indices shape"
+        )
+    if work_items_capacity % bs != 0:
+        raise RuntimeError(
+            "decode graph workspace request_indices shape is incompatible with the batch bucket"
+        )
+    max_chunks_per_req = work_items_capacity // bs
+    if max_chunks_per_req <= 0:
+        raise RuntimeError(
+            "decode graph workspace must allocate at least one chunk per request"
+        )
+    if int(merge_indptr.shape[0]) < bs + 1 or int(o_indptr.shape[0]) < bs + 1:
+        raise RuntimeError(
+            "decode graph indptr buffers are smaller than the graph batch"
+        )
+    if int(kv_window_start_tokens.shape[0]) < bs:
+        raise RuntimeError(
+            "decode graph kv_window_start_tokens is smaller than the graph batch"
+        )
+    if int(decode_chunk_pages_lut.shape[0]) < 2:
+        raise RuntimeError(
+            "decode graph chunk-pages LUT must contain at least two entries"
+        )
+
+    update_decode_graph_metadata_fused_triton[(1,)](
+        cache_seqlens,
+        request_indices,
+        qo_tile_indices,
+        kv_tile_indices,
+        merge_indptr,
+        o_indptr,
+        block_valid_mask,
+        kv_chunk_size_ptr,
+        kv_window_start_tokens,
+        decode_chunk_pages_lut,
+        max_chunks_per_req,
+        block_valid_capacity,
+        decode_chunk_pages_lut.shape[0],
+        PAGE_SIZE=page_size,
+        WINDOW_PAGE_SPAN=int(window_page_span),
+        WINDOW_LEFT=int(window_left),
+        BATCH=bs,
+        BLOCK_BATCH=triton.next_power_of_2(bs),
+        BLOCK_WORK_ITEMS=triton.next_power_of_2(
+            max(work_items_capacity, block_valid_capacity)
+        ),
+    )
+    update_decode_graph_compact_work_metadata_triton[
+        (bs, triton.cdiv(max_chunks_per_req, _DECODE_BLOCK_CHUNKS))
+    ](
+        request_indices,
+        qo_tile_indices,
+        kv_tile_indices,
+        o_indptr,
+        block_valid_mask,
+        work_items_capacity,
+        block_valid_capacity,
+        BATCH=bs,
+        BLOCK_CHUNKS=_DECODE_BLOCK_CHUNKS,
+    )
+
+
+def update_decode_graph_replay_metadata(
+    *,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    request_indices: torch.Tensor,
+    qo_tile_indices: torch.Tensor,
+    kv_tile_indices: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    block_valid_mask: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    decode_chunk_pages_lut: torch.Tensor,
+    page_size: int,
+    window_page_span: int = 0,
+    window_left: int = -1,
+) -> None:
+    if req_to_token.device != page_table.device:
+        raise ValueError("req_to_token and page_table must be on the same device")
+    if req_pool_indices.device != page_table.device:
+        raise ValueError("req_pool_indices and page_table must be on the same device")
+    if cache_seqlens.device != page_table.device:
+        raise ValueError("cache_seqlens and page_table must be on the same device")
+    if (
+        qo_tile_indices.device != page_table.device
+        or kv_tile_indices.device != page_table.device
+    ):
+        raise ValueError("tile index buffers and page_table must be on the same device")
+    if decode_chunk_pages_lut.device != page_table.device:
+        raise ValueError(
+            "decode_chunk_pages_lut and page_table must be on the same device"
+        )
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("decode graph replay requires bs > 0")
+    if int(req_pool_indices.shape[0]) != bs:
+        raise ValueError("req_pool_indices shape must match cache_seqlens batch")
+    work_items_capacity = int(request_indices.shape[0])
+    if (
+        int(qo_tile_indices.shape[0]) != work_items_capacity
+        or int(kv_tile_indices.shape[0]) != work_items_capacity
+    ):
+        raise RuntimeError(
+            "decode graph tile index buffers must match request_indices shape"
+        )
+    if work_items_capacity % bs != 0:
+        raise RuntimeError(
+            "decode graph workspace request_indices shape is incompatible with the batch bucket"
+        )
+    max_chunks_per_req = work_items_capacity // bs
+    if max_chunks_per_req <= 0:
+        raise RuntimeError(
+            "decode graph workspace must allocate at least one chunk per request"
+        )
+
+    page_blocks = triton.cdiv(int(page_table.shape[1]), _DECODE_BLOCK_PAGES)
+    build_decode_graph_page_table_full_triton[(bs, page_blocks)](
+        req_to_token,
+        req_pool_indices,
+        page_table,
+        req_to_token.stride(0),
+        req_to_token.numel(),
+        page_table.stride(0),
+        PAGE_SIZE=page_size,
+        MAX_PAGES=int(page_table.shape[1]),
+        BLOCK_PAGES=_DECODE_BLOCK_PAGES,
+    )
+
+    update_decode_graph_chunk_metadata_fused(
+        cache_seqlens=cache_seqlens,
+        request_indices=request_indices,
+        qo_tile_indices=qo_tile_indices,
+        kv_tile_indices=kv_tile_indices,
+        merge_indptr=merge_indptr,
+        o_indptr=o_indptr,
+        block_valid_mask=block_valid_mask,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        kv_window_start_tokens=kv_window_start_tokens,
+        decode_chunk_pages_lut=decode_chunk_pages_lut,
+        page_size=page_size,
+        window_page_span=window_page_span,
+        window_left=window_left,
+    )
+
+
+def update_msa_decode_graph_chunk_metadata(
+    *,
+    cache_seqlens: torch.Tensor,
+    request_indices: torch.Tensor,
+    qo_tile_indices: torch.Tensor,
+    kv_tile_indices: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    block_valid_mask: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    kv_chunk_size: int,
+    page_size: int,
+) -> None:
+    device = cache_seqlens.device
+    if request_indices.device != device:
+        raise ValueError("request_indices and cache_seqlens must be on the same device")
+    if qo_tile_indices.device != device or kv_tile_indices.device != device:
+        raise ValueError(
+            "tile index buffers and cache_seqlens must be on the same device"
+        )
+    if merge_indptr.device != device or o_indptr.device != device:
+        raise ValueError("indptr buffers and cache_seqlens must be on the same device")
+    if block_valid_mask.device != device or kv_chunk_size_ptr.device != device:
+        raise ValueError(
+            "MSA decode graph buffers and cache_seqlens must be on the same device"
+        )
+    if kv_window_start_tokens.device != device:
+        raise ValueError(
+            "kv_window_start_tokens and cache_seqlens must be on the same device"
+        )
+    if page_size not in (64, 128):
+        raise ValueError(
+            "MSA decode graph replay requires page_size=64 or page_size=128"
+        )
+    kv_chunk_size = int(kv_chunk_size)
+    # Chunk boundaries are 64-token-tile aligned in the compacted virtual key
+    # space regardless of the physical page size.
+    if kv_chunk_size <= 0 or kv_chunk_size % 64 != 0:
+        raise ValueError(
+            "MSA decode graph kv_chunk_size must be a positive multiple of 64 tokens"
+        )
+
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("MSA decode graph replay requires bs > 0")
+    work_items_capacity = int(request_indices.shape[0])
+    block_valid_capacity = int(block_valid_mask.shape[0])
+    if (
+        int(qo_tile_indices.shape[0]) != work_items_capacity
+        or int(kv_tile_indices.shape[0]) != work_items_capacity
+    ):
+        raise RuntimeError(
+            "MSA decode graph tile index buffers must match request_indices shape"
+        )
+    if work_items_capacity % bs != 0:
+        raise RuntimeError(
+            "MSA decode graph workspace request_indices shape is incompatible with the batch bucket"
+        )
+    max_chunks_per_req = work_items_capacity // bs
+    if max_chunks_per_req <= 0:
+        raise RuntimeError(
+            "MSA decode graph workspace must allocate at least one chunk per request"
+        )
+    max_required_chunks = triton.cdiv(16 * 128, kv_chunk_size)
+    if max_chunks_per_req < max_required_chunks:
+        raise RuntimeError(
+            "MSA decode graph workspace request_indices capacity is too small for the chunk size"
+        )
+    if int(merge_indptr.shape[0]) < bs + 1 or int(o_indptr.shape[0]) < bs + 1:
+        raise RuntimeError(
+            "MSA decode graph indptr buffers are smaller than the graph batch"
+        )
+    if int(kv_window_start_tokens.shape[0]) < bs:
+        raise RuntimeError(
+            "MSA decode graph kv_window_start_tokens is smaller than the graph batch"
+        )
+
+    update_msa_decode_graph_metadata_fused_triton[(1,)](
+        cache_seqlens,
+        merge_indptr,
+        o_indptr,
+        block_valid_mask,
+        kv_chunk_size_ptr,
+        kv_window_start_tokens,
+        kv_chunk_size,
+        block_valid_capacity,
+        PAGE_SIZE=page_size,
+        PAGES_PER_BLOCK=128 // int(page_size),
+        BATCH=bs,
+        BLOCK_BATCH=triton.next_power_of_2(bs),
+        BLOCK_WORK_ITEMS=triton.next_power_of_2(
+            max(work_items_capacity, block_valid_capacity)
+        ),
+    )
+    update_decode_graph_compact_work_metadata_triton[
+        (bs, triton.cdiv(max_chunks_per_req, _DECODE_BLOCK_CHUNKS))
+    ](
+        request_indices,
+        qo_tile_indices,
+        kv_tile_indices,
+        o_indptr,
+        block_valid_mask,
+        work_items_capacity,
+        block_valid_capacity,
+        BATCH=bs,
+        BLOCK_CHUNKS=_DECODE_BLOCK_CHUNKS,
+    )
+
+
+def update_msa_decode_graph_replay_metadata(
+    *,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    request_indices: torch.Tensor,
+    qo_tile_indices: torch.Tensor,
+    kv_tile_indices: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    block_valid_mask: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    kv_chunk_size: int,
+    page_size: int,
+) -> None:
+    if req_to_token.device != page_table.device:
+        raise ValueError("req_to_token and page_table must be on the same device")
+    if req_pool_indices.device != page_table.device:
+        raise ValueError("req_pool_indices and page_table must be on the same device")
+    if cache_seqlens.device != page_table.device:
+        raise ValueError("cache_seqlens and page_table must be on the same device")
+    if page_size not in (64, 128):
+        raise ValueError(
+            "MSA decode graph replay requires page_size=64 or page_size=128"
+        )
+
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("MSA decode graph replay requires bs > 0")
+    if int(req_pool_indices.shape[0]) != bs:
+        raise ValueError("req_pool_indices shape must match cache_seqlens batch")
+
+    page_blocks = triton.cdiv(int(page_table.shape[1]), _DECODE_BLOCK_PAGES)
+    build_decode_graph_page_table_full_triton[(bs, page_blocks)](
+        req_to_token,
+        req_pool_indices,
+        page_table,
+        req_to_token.stride(0),
+        req_to_token.numel(),
+        page_table.stride(0),
+        PAGE_SIZE=page_size,
+        MAX_PAGES=int(page_table.shape[1]),
+        BLOCK_PAGES=_DECODE_BLOCK_PAGES,
+    )
+    update_msa_decode_graph_chunk_metadata(
+        cache_seqlens=cache_seqlens,
+        request_indices=request_indices,
+        qo_tile_indices=qo_tile_indices,
+        kv_tile_indices=kv_tile_indices,
+        merge_indptr=merge_indptr,
+        o_indptr=o_indptr,
+        block_valid_mask=block_valid_mask,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        kv_window_start_tokens=kv_window_start_tokens,
+        kv_chunk_size=kv_chunk_size,
+        page_size=page_size,
+    )
+
+
+def update_regular_decode_graph_replay_metadata(
+    *,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    decode_chunk_pages_lut: torch.Tensor,
+    page_size: int,
+    window_page_span: int = 0,
+    window_left: int = -1,
+) -> None:
+    if req_to_token.device != page_table.device:
+        raise ValueError("req_to_token and page_table must be on the same device")
+    if req_pool_indices.device != page_table.device:
+        raise ValueError("req_pool_indices and page_table must be on the same device")
+    if cache_seqlens.device != page_table.device:
+        raise ValueError("cache_seqlens and page_table must be on the same device")
+    if decode_chunk_pages_lut.device != page_table.device:
+        raise ValueError(
+            "decode_chunk_pages_lut and page_table must be on the same device"
+        )
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("decode graph replay requires bs > 0")
+    if int(req_pool_indices.shape[0]) != bs:
+        raise ValueError("req_pool_indices shape must match cache_seqlens batch")
+
+    page_blocks = triton.cdiv(int(page_table.shape[1]), _DECODE_BLOCK_PAGES)
+    build_decode_graph_page_table_full_triton[(bs, page_blocks)](
+        req_to_token,
+        req_pool_indices,
+        page_table,
+        req_to_token.stride(0),
+        req_to_token.numel(),
+        page_table.stride(0),
+        PAGE_SIZE=page_size,
+        MAX_PAGES=int(page_table.shape[1]),
+        BLOCK_PAGES=_DECODE_BLOCK_PAGES,
+    )
+
+    update_regular_decode_graph_chunk_metadata_from_lut(
+        cache_seqlens=cache_seqlens,
+        merge_indptr=merge_indptr,
+        o_indptr=o_indptr,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        kv_window_start_tokens=kv_window_start_tokens,
+        decode_chunk_pages_lut=decode_chunk_pages_lut,
+        page_size=page_size,
+        window_page_span=window_page_span,
+        window_left=window_left,
+    )
+
+
+def _launch_regular_decode_graph_metadata_fused(
+    *,
+    cache_seqlens: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    page_size: int,
+    window_page_span: int,
+    window_left: int,
+    decode_chunk_pages_lut: torch.Tensor | None = None,
+    kv_chunk_size: int | torch.Tensor | None = None,
+) -> None:
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("decode graph replay requires bs > 0")
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if window_left < -1:
+        raise ValueError("window_left must be -1 or non-negative")
+
+    use_lut = decode_chunk_pages_lut is not None
+    has_kv_chunk_size_tensor = isinstance(kv_chunk_size, torch.Tensor)
+    fixed_kv_chunk_size = 1
+    kv_chunk_size_tensor = kv_chunk_size_ptr
+    if use_lut:
+        if decode_chunk_pages_lut.device != cache_seqlens.device:
+            raise ValueError(
+                "decode_chunk_pages_lut and cache_seqlens must be on the same device"
+            )
+        if int(decode_chunk_pages_lut.shape[0]) < 2:
+            raise RuntimeError(
+                "decode graph chunk-pages LUT must contain at least two entries"
+            )
+        lut_size = int(decode_chunk_pages_lut.shape[0])
+    else:
+        decode_chunk_pages_lut = kv_chunk_size_ptr
+        lut_size = 0
+        if has_kv_chunk_size_tensor:
+            assert isinstance(kv_chunk_size, torch.Tensor)
+            if kv_chunk_size.device != cache_seqlens.device:
+                raise ValueError(
+                    "kv_chunk_size tensor and cache_seqlens must be on the same device"
+                )
+            if kv_chunk_size.numel() != 1:
+                raise ValueError(
+                    "kv_chunk_size tensor must contain exactly one element"
+                )
+            kv_chunk_size_tensor = kv_chunk_size.reshape(1)
+        else:
+            if kv_chunk_size is None:
+                raise ValueError(
+                    "kv_chunk_size is required when decode_chunk_pages_lut is not provided"
+                )
+            fixed_kv_chunk_size = int(kv_chunk_size)
+            if fixed_kv_chunk_size <= 0:
+                raise ValueError("kv_chunk_size must be positive")
+
+    update_regular_decode_graph_metadata_fused_triton[(1,)](
+        cache_seqlens,
+        merge_indptr,
+        o_indptr,
+        kv_chunk_size_ptr,
+        kv_window_start_tokens,
+        decode_chunk_pages_lut,
+        kv_chunk_size_tensor,
+        lut_size,
+        PAGE_SIZE=page_size,
+        WINDOW_PAGE_SPAN=int(window_page_span),
+        WINDOW_LEFT=int(window_left),
+        BATCH=bs,
+        BLOCK_BATCH=triton.next_power_of_2(bs),
+        USE_LUT=use_lut,
+        HAS_KV_CHUNK_SIZE_TENSOR=has_kv_chunk_size_tensor,
+        FIXED_KV_CHUNK_SIZE=fixed_kv_chunk_size,
+    )
+
+
+def update_decode_graph_window_start_tokens(
+    *,
+    cache_seqlens: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    page_size: int,
+    window_left: int,
+) -> None:
+    device = cache_seqlens.device
+    if kv_window_start_tokens.device != device:
+        raise ValueError(
+            "kv_window_start_tokens and cache_seqlens must be on the same device"
+        )
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if window_left < 0:
+        raise ValueError("window_left must be non-negative")
+
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("decode graph replay requires bs > 0")
+    if int(kv_window_start_tokens.shape[0]) < bs:
+        raise RuntimeError(
+            "decode graph kv_window_start_tokens is smaller than the graph batch"
+        )
+
+    update_decode_graph_window_start_tokens_triton[(1,)](
+        cache_seqlens,
+        kv_window_start_tokens,
+        PAGE_SIZE=page_size,
+        WINDOW_LEFT=int(window_left),
+        BATCH=bs,
+        BLOCK_BATCH=triton.next_power_of_2(bs),
+    )
+
+
+def update_regular_decode_graph_chunk_metadata_from_lut(
+    *,
+    cache_seqlens: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    decode_chunk_pages_lut: torch.Tensor,
+    page_size: int,
+    window_page_span: int = 0,
+    window_left: int = -1,
+) -> None:
+    device = cache_seqlens.device
+    if merge_indptr.device != device or o_indptr.device != device:
+        raise ValueError("indptr buffers and cache_seqlens must be on the same device")
+    if kv_chunk_size_ptr.device != device:
+        raise ValueError(
+            "decode graph buffers and cache_seqlens must be on the same device"
+        )
+    if kv_window_start_tokens.device != device:
+        raise ValueError(
+            "kv_window_start_tokens and cache_seqlens must be on the same device"
+        )
+
+    _launch_regular_decode_graph_metadata_fused(
+        cache_seqlens=cache_seqlens,
+        merge_indptr=merge_indptr,
+        o_indptr=o_indptr,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        kv_window_start_tokens=kv_window_start_tokens,
+        decode_chunk_pages_lut=decode_chunk_pages_lut,
+        page_size=page_size,
+        window_page_span=window_page_span,
+        window_left=window_left,
+    )
+
+
+def update_regular_decode_graph_chunk_metadata(
+    *,
+    cache_seqlens: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_chunk_size: int | torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    max_chunks_per_req: int,
+    page_size: int,
+    window_page_span: int = 0,
+    window_left: int = -1,
+) -> None:
+    device = cache_seqlens.device
+    if merge_indptr.device != device or o_indptr.device != device:
+        raise ValueError("indptr buffers and cache_seqlens must be on the same device")
+    if kv_chunk_size_ptr.device != device:
+        raise ValueError(
+            "decode graph buffers and cache_seqlens must be on the same device"
+        )
+    if kv_window_start_tokens.device != device:
+        raise ValueError(
+            "kv_window_start_tokens and cache_seqlens must be on the same device"
+        )
+    if max_chunks_per_req <= 0:
+        raise ValueError("max_chunks_per_req must be positive")
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+
+    bs = int(cache_seqlens.shape[0])
+    if bs <= 0:
+        raise ValueError("decode graph replay requires bs > 0")
+
+    _launch_regular_decode_graph_metadata_fused(
+        cache_seqlens=cache_seqlens,
+        merge_indptr=merge_indptr,
+        o_indptr=o_indptr,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        kv_window_start_tokens=kv_window_start_tokens,
+        kv_chunk_size=kv_chunk_size,
+        page_size=page_size,
+        window_page_span=window_page_span,
+        window_left=window_left,
+    )
+
+
+def update_decode_graph_chunk_metadata(
+    *,
+    cache_seqlens: torch.Tensor,
+    request_indices: torch.Tensor,
+    qo_tile_indices: torch.Tensor,
+    kv_tile_indices: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    block_valid_mask: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    decode_chunk_pages_lut: torch.Tensor,
+    page_size: int,
+    window_page_span: int = 0,
+    window_left: int = -1,
+) -> None:
+    device = cache_seqlens.device
+    if request_indices.device != device:
+        raise ValueError("request_indices and cache_seqlens must be on the same device")
+    if qo_tile_indices.device != device or kv_tile_indices.device != device:
+        raise ValueError(
+            "tile index buffers and cache_seqlens must be on the same device"
+        )
+    if merge_indptr.device != device or o_indptr.device != device:
+        raise ValueError("indptr buffers and cache_seqlens must be on the same device")
+    if block_valid_mask.device != device or kv_chunk_size_ptr.device != device:
+        raise ValueError(
+            "decode graph buffers and cache_seqlens must be on the same device"
+        )
+    if decode_chunk_pages_lut.device != device:
+        raise ValueError(
+            "decode_chunk_pages_lut and cache_seqlens must be on the same device"
+        )
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+
+    update_decode_graph_chunk_metadata_fused(
+        cache_seqlens=cache_seqlens,
+        request_indices=request_indices,
+        qo_tile_indices=qo_tile_indices,
+        kv_tile_indices=kv_tile_indices,
+        merge_indptr=merge_indptr,
+        o_indptr=o_indptr,
+        block_valid_mask=block_valid_mask,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        kv_window_start_tokens=kv_window_start_tokens,
+        decode_chunk_pages_lut=decode_chunk_pages_lut,
+        page_size=page_size,
+        window_page_span=window_page_span,
+        window_left=window_left,
+    )
+
+
+def update_prefill_graph_chunk_metadata(
+    *,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    request_indices: torch.Tensor,
+    qo_tile_indices: torch.Tensor,
+    kv_tile_indices: torch.Tensor,
+    merge_indptr: torch.Tensor,
+    o_indptr: torch.Tensor,
+    block_valid_mask: torch.Tensor,
+    kv_chunk_size_ptr: torch.Tensor,
+    kv_window_start_tokens: torch.Tensor,
+    total_num_rows_ptr: torch.Tensor,
+    batch: int,
+    max_q_tiles_per_req: int,
+    max_chunks_per_q_tile: int,
+    max_q_rows_per_req: int,
+    cta_tile_q: int,
+    gqa_group_size: int,
+    page_size: int,
+    split_kv: bool,
+    window_left: int = -1,
+) -> None:
+    device = cache_seqlens.device
+    if cu_seqlens_q.device != device:
+        raise ValueError("cu_seqlens_q and cache_seqlens must be on the same device")
+    if request_indices.device != device:
+        raise ValueError("request_indices and cache_seqlens must be on the same device")
+    if qo_tile_indices.device != device or kv_tile_indices.device != device:
+        raise ValueError(
+            "tile index buffers and cache_seqlens must be on the same device"
+        )
+    if merge_indptr.device != device or o_indptr.device != device:
+        raise ValueError("indptr buffers and cache_seqlens must be on the same device")
+    if block_valid_mask.device != device or kv_chunk_size_ptr.device != device:
+        raise ValueError(
+            "prefill graph buffers and cache_seqlens must be on the same device"
+        )
+    if kv_window_start_tokens.device != device or total_num_rows_ptr.device != device:
+        raise ValueError(
+            "prefill graph scalar buffers and cache_seqlens must be on the same device"
+        )
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if cta_tile_q <= 0:
+        raise ValueError("cta_tile_q must be positive")
+    if gqa_group_size <= 0:
+        raise ValueError("gqa_group_size must be positive")
+    if window_left < -1:
+        raise ValueError("window_left must be -1 or non-negative")
+
+    bs = int(batch)
+    if bs <= 0:
+        raise ValueError("prefill graph replay requires batch > 0")
+    if int(cache_seqlens.shape[0]) < bs:
+        raise ValueError("cache_seqlens is smaller than the graph batch")
+    if int(cu_seqlens_q.shape[0]) < bs + 1:
+        raise ValueError("cu_seqlens_q is smaller than the graph batch")
+    work_items_capacity = int(request_indices.shape[0])
+    block_valid_capacity = int(block_valid_mask.shape[0])
+    if (
+        int(qo_tile_indices.shape[0]) != work_items_capacity
+        or int(kv_tile_indices.shape[0]) != work_items_capacity
+    ):
+        raise RuntimeError(
+            "prefill graph tile index buffers must match request_indices shape"
+        )
+    if max_q_tiles_per_req <= 0:
+        raise ValueError("max_q_tiles_per_req must be positive")
+    if max_chunks_per_q_tile <= 0:
+        raise ValueError("max_chunks_per_q_tile must be positive")
+    if max_q_rows_per_req <= 0:
+        raise ValueError("max_q_rows_per_req must be positive")
+    required_work_items = bs * int(max_q_tiles_per_req) * int(max_chunks_per_q_tile)
+    if required_work_items > work_items_capacity:
+        raise RuntimeError(
+            "prefill graph workspace request_indices capacity is too small for the graph plan"
+        )
+    if required_work_items > block_valid_capacity:
+        raise RuntimeError(
+            "prefill graph workspace block_valid capacity is too small for the graph plan"
+        )
+    if int(o_indptr.shape[0]) < bs + 1:
+        raise RuntimeError("prefill graph workspace o_indptr capacity is too small")
+    if int(kv_window_start_tokens.shape[0]) < bs:
+        raise RuntimeError(
+            "prefill graph workspace kv_window_start_tokens capacity is too small"
+        )
+
+    work_blocks = triton.cdiv(block_valid_capacity, _PREFILL_BLOCK_WORK_ITEMS)
+    update_prefill_graph_work_metadata_triton[(work_blocks,)](
+        cache_seqlens,
+        cu_seqlens_q,
+        request_indices,
+        qo_tile_indices,
+        kv_tile_indices,
+        o_indptr,
+        block_valid_mask,
+        kv_chunk_size_ptr,
+        kv_window_start_tokens,
+        work_items_capacity=work_items_capacity,
+        block_valid_capacity=block_valid_capacity,
+        BATCH=bs,
+        MAX_Q_TILES_PER_REQ=int(max_q_tiles_per_req),
+        MAX_CHUNKS_PER_Q_TILE=int(max_chunks_per_q_tile),
+        CTA_TILE_Q=int(cta_tile_q),
+        GQA_GROUP_SIZE=int(gqa_group_size),
+        PAGE_SIZE=int(page_size),
+        WINDOW_LEFT=int(window_left),
+        SPLIT_KV=bool(split_kv),
+        BLOCK_WORK_ITEMS=_PREFILL_BLOCK_WORK_ITEMS,
+    )
+    torch.cumsum(
+        o_indptr[1 : bs + 1],
+        dim=0,
+        out=o_indptr[1 : bs + 1],
+    )
+    total_num_rows_ptr[:1].copy_(cu_seqlens_q[bs : bs + 1])
+
+    row_blocks = triton.cdiv(int(max_q_rows_per_req), _PREFILL_BLOCK_ROWS)
+    update_prefill_graph_row_indptr_triton[(bs, row_blocks)](
+        cu_seqlens_q,
+        o_indptr,
+        merge_indptr,
+        BATCH=bs,
+        MAX_Q_ROWS_PER_REQ=int(max_q_rows_per_req),
+        BLOCK_ROWS=_PREFILL_BLOCK_ROWS,
+    )

--- a/flashinfer/experimental/sm12x/attention/paged/merge.py
+++ b/flashinfer/experimental/sm12x/attention/paged/merge.py
@@ -1,0 +1,831 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/merge.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Standalone persistent merge kernel for the primary paged backend.
+
+This module intentionally does not share implementation with the archived
+`PagedAttentionCombineKernel`. It follows FlashInfer's split-state merge model:
+
+- partial outputs are normalized attention outputs,
+- partial scores are base-2 log-sum-exp values,
+- CTAs walk `(row, head)` work persistently,
+- each CTA cooperatively folds multiple partial states into one final state.
+
+The first version here ports the control flow and state arithmetic faithfully
+but keeps the partial-vector loads direct from global memory. The cp.async
+staging layer can be added on top of this contract without changing the API.
+"""
+
+from __future__ import annotations
+
+from typing import Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass._mlir.dialects import llvm
+
+from cutlass import Float32, Int32, Uint32, const_expr
+from cutlass.cutlass_dsl import Int64, T, dsl_user_op
+
+from flashinfer.experimental.sm12x.attention._shared.cute import ops as attention_ops
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    get_ptr_as_int64,
+    pack_f32x2_to_bfloat2,
+    shared_ptr_to_u32,
+)
+
+
+@dsl_user_op
+def _cp_async_load_128b(smem_addr: Int32, gmem_addr: Int64, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            Int64(gmem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.cg.shared.global.L2::128B [$0], [$1], 16;",
+        "r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _st_global_v2_u32(
+    base_ptr: Int64,
+    v0: Uint32,
+    v1: Uint32,
+    *,
+    loc=None,
+    ip=None,
+):
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Uint32(v0).ir_value(loc=loc, ip=ip),
+            Uint32(v1).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.v2.u32 [$0], {$1, $2};",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _exp2_approx_ftz_f32(a: Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "ex2.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _log2_approx_ftz_f32(a: Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "lg2.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def default_paged_persistent_ctas(
+    *,
+    total_rows: int,
+    num_heads: int,
+    device: torch.device | int | None = None,
+) -> int:
+    if device is None:
+        device = torch.cuda.current_device()
+    num_sms = int(torch.cuda.get_device_properties(device).multi_processor_count)
+    total_work = max(int(total_rows) * int(num_heads), 1)
+    # Match FlashInfer's persistent merge launch shape more closely: size the
+    # resident grid by useful blocks-per-SM rather than pinning it to 1 CTA/SM.
+    blocks_per_sm = min(3, _ceil_div(total_work, num_sms))
+    persistent_ctas = int(num_sms * max(blocks_per_sm, 1))
+    if int(total_rows) == 8:
+        return int(min(persistent_ctas, total_work))
+    return persistent_ctas
+
+
+@cute.jit
+def _state_init(
+    state_o: cute.Tensor,
+):
+    state_o.fill(0.0)
+    return Float32(-Float32.inf), Float32(1.0)
+
+
+@cute.jit
+def _state_get_lse_base2(
+    state_m: Float32,
+    state_d: Float32,
+) -> Float32:
+    return Float32(state_m + _log2_approx_ftz_f32(Float32(state_d)))
+
+
+@cute.jit
+def _state_merge(
+    state_o: cute.Tensor,
+    state_m: Float32,
+    state_d: Float32,
+    other_o: cute.Tensor,
+    other_m: Float32,
+    other_d: Float32,
+) -> tuple[Float32, Float32]:
+    prev_m = state_m
+    prev_d = state_d
+    if prev_m == -Float32.inf:
+        if other_m == -Float32.inf:
+            state_m = Float32(prev_m)
+            state_d = Float32(prev_d)
+        else:
+            for vec_idx in cutlass.range_constexpr(cute.size(state_o.shape)):
+                state_o[vec_idx] = other_o[vec_idx]
+            state_m = Float32(other_m)
+            state_d = Float32(other_d)
+    elif other_m == -Float32.inf:
+        state_m = Float32(prev_m)
+        state_d = Float32(prev_d)
+    else:
+        state_m = attention_ops.fmax(prev_m, other_m)
+        prev_scale = _exp2_approx_ftz_f32(prev_m - state_m)
+        other_scale = _exp2_approx_ftz_f32(other_m - state_m)
+        state_d = Float32(prev_d * prev_scale + other_d * other_scale)
+        for vec_idx in cutlass.range_constexpr(cute.size(state_o.shape)):
+            state_o[vec_idx] = (
+                state_o[vec_idx] * prev_scale + other_o[vec_idx] * other_scale
+            )
+    return Float32(state_m), state_d
+
+
+@cute.jit
+def _state_merge_normalized_lse_base2(
+    state_o: cute.Tensor,
+    state_m: Float32,
+    state_d: Float32,
+    other_o: cute.Tensor,
+    other_lse: Float32,
+) -> tuple[Float32, Float32]:
+    return _state_merge(
+        state_o,
+        state_m,
+        state_d,
+        other_o,
+        other_lse,
+        Float32(1.0),
+    )
+
+
+@cute.jit
+def _state_normalize(
+    state_o: cute.Tensor,
+    state_d: Float32,
+):
+    inv_d = cute.arch.rcp_approx(Float32(state_d))
+    for vec_idx in cutlass.range_constexpr(cute.size(state_o.shape)):
+        state_o[vec_idx] = state_o[vec_idx] * inv_d
+
+
+@cute.jit
+def _threadblock_sync_state(
+    state_o: cute.Tensor,
+    state_m: Float32,
+    state_d: Float32,
+    s_partial: cute.Tensor,
+    s_lse: cute.Tensor,
+    *,
+    vec_size: cutlass.Constexpr[int],
+    bdy: cutlass.Constexpr[int],
+) -> tuple[Float32, Float32]:
+    tx, ty, _ = cute.arch.thread_idx()
+    base_k = tx * vec_size
+    _state_normalize(state_o, state_d)
+    for vec_idx in cutlass.range_constexpr(vec_size):
+        s_partial[ty, base_k + vec_idx] = state_o[vec_idx]
+    s_lse[ty] = _state_get_lse_base2(state_m, state_d)
+    state_m, state_d = _state_init(state_o)
+    cute.arch.sync_threads()
+
+    for iter_idx in cutlass.range_constexpr(bdy):
+        other_o = cute.make_rmem_tensor(
+            cute.make_layout((vec_size,), stride=(1,)), Float32
+        )
+        for vec_idx in cutlass.range_constexpr(vec_size):
+            other_o[vec_idx] = s_partial[iter_idx, base_k + vec_idx]
+        state_m, state_d = _state_merge_normalized_lse_base2(
+            state_o,
+            state_m,
+            state_d,
+            other_o,
+            s_lse[iter_idx],
+        )
+    return state_m, state_d
+
+
+@cute.jit
+def _merge_async_slot(
+    *,
+    iter_idx: Int32,
+    start_idx,
+    num_heads,
+    head_idx,
+    num_index_sets,
+    num_stage_iters,
+    base_k,
+    head_dim,
+    vec_size: cutlass.Constexpr[int],
+    bdx: cutlass.Constexpr[int],
+    bdy: cutlass.Constexpr[int],
+    bytes_per_vec: cutlass.Constexpr[int],
+    num_smem_stages: cutlass.Constexpr[int],
+    s_stage_partial: cute.Tensor,
+    s_stage_lse: cute.Tensor,
+    mV_partial: cute.Tensor,
+    mLSE_partial: cute.Tensor,
+    state_o: cute.Tensor,
+    state_m: Float32,
+    state_d: Float32,
+    slot: cutlass.Constexpr[int],
+) -> tuple[Float32, Float32]:
+    tx, ty, _ = cute.arch.thread_idx()
+    cur_iter = iter_idx + Int32(slot)
+    if cur_iter < num_stage_iters:
+        if cur_iter % bdx == 0:
+            lse_linear_idx = cur_iter * bdy + ty * bdx + tx
+            s_stage_lse[ty * bdx + tx] = (
+                mLSE_partial[start_idx + lse_linear_idx, head_idx]
+                if lse_linear_idx < num_index_sets
+                else Float32(0.0)
+            )
+            cute.arch.sync_threads()
+
+        cute.arch.cp_async_wait_group(num_smem_stages - 1)
+        cute.arch.sync_threads()
+
+        if cur_iter * bdy + ty < num_index_sets:
+            other_o = cute.make_rmem_tensor(
+                cute.make_layout((vec_size,), stride=(1,)),
+                Float32,
+            )
+            for vec_idx in cutlass.range_constexpr(vec_size):
+                other_o[vec_idx] = s_stage_partial[
+                    cur_iter % num_smem_stages, ty, base_k + vec_idx
+                ].to(Float32)
+            state_m, state_d = _state_merge_normalized_lse_base2(
+                state_o,
+                state_m,
+                state_d,
+                other_o,
+                s_stage_lse[(cur_iter % bdx) * bdy + ty],
+            )
+
+        cute.arch.sync_threads()
+        next_linear_idx = (cur_iter + num_smem_stages) * bdy + ty
+        if const_expr(bytes_per_vec == 8):
+            load_base_k = tx * (vec_size * 2)
+            smem_addr = shared_ptr_to_u32(
+                s_stage_partial.iterator
+                + Int32(
+                    ((cur_iter % num_smem_stages) * bdy + ty) * head_dim + load_base_k
+                )
+            )
+            if tx < bdx // 2 and next_linear_idx < num_index_sets:
+                partial_idx = start_idx + next_linear_idx
+                gmem_addr = get_ptr_as_int64(
+                    mV_partial,
+                    (Int64(partial_idx) * Int64(num_heads) + Int64(head_idx))
+                    * Int64(head_dim)
+                    + Int64(load_base_k),
+                )
+                _cp_async_load_128b(smem_addr, gmem_addr)
+        else:
+            smem_addr = shared_ptr_to_u32(
+                s_stage_partial.iterator
+                + Int32(((cur_iter % num_smem_stages) * bdy + ty) * head_dim + base_k)
+            )
+            if next_linear_idx < num_index_sets:
+                partial_idx = start_idx + next_linear_idx
+                gmem_addr = get_ptr_as_int64(
+                    mV_partial,
+                    (Int64(partial_idx) * Int64(num_heads) + Int64(head_idx))
+                    * Int64(head_dim)
+                    + Int64(base_k),
+                )
+                _cp_async_load_128b(smem_addr, gmem_addr)
+        cute.arch.cp_async_commit_group()
+    return state_m, state_d
+
+
+class PagedPersistentMergeKernel:
+    """Faithful row/head-persistent merge for the current paged backend path.
+
+    The kernel expects:
+    - `mV_partial`: `(nnz_partial_rows, num_heads, head_dim)`
+    - `mLSE_partial`: `(nnz_partial_rows, num_heads)` in base-2 log domain
+    - `mMergeIndptr`: `(max_total_rows + 1,)`
+    - `mO`: `(max_total_rows, num_heads, head_dim)`
+    - `mLSE`: `(num_heads, max_total_rows)` in base-2 log domain
+    - `mTotalRowsPtr`: optional `(1,)` dynamic sequence length for graph replay
+    """
+
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        dtype_partial: Type[cutlass.Numeric],
+        *,
+        head_dim: int,
+        vec_size: int = 8,
+        bdx: int = 32,
+        bdy: int = 4,
+        num_smem_stages: int = 4,
+        persistent_ctas: int | None = None,
+        direct_grid: bool = False,
+        regular_decode_graph: bool = False,
+        pair_bf16_partial_loads: bool = False,
+    ):
+        self.dtype = dtype
+        self.dtype_partial = dtype_partial
+        self.head_dim = head_dim
+        self.vec_size = vec_size
+        self.bdx = bdx
+        self.bdy = bdy
+        self.num_smem_stages = num_smem_stages
+        self.persistent_ctas = (
+            int(persistent_ctas) if persistent_ctas is not None else 0
+        )
+        self.direct_grid = bool(direct_grid)
+        self.regular_decode_graph = bool(regular_decode_graph)
+        self.pair_bf16_partial_loads = bool(pair_bf16_partial_loads)
+
+    @staticmethod
+    def can_implement(
+        dtype: Type[cutlass.Numeric],
+        dtype_partial: Type[cutlass.Numeric],
+        *,
+        head_dim: int,
+        vec_size: int,
+        bdx: int,
+        bdy: int,
+        num_smem_stages: int,
+        persistent_ctas: int,
+        direct_grid: bool,
+    ) -> bool:
+        if dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float32):
+            return False
+        if dtype_partial not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float32):
+            return False
+        if (
+            head_dim <= 0
+            or vec_size <= 0
+            or bdx <= 0
+            or bdy <= 0
+            or num_smem_stages <= 0
+        ):
+            return False
+        if head_dim != bdx * vec_size:
+            return False
+        if bdx % 32 != 0:
+            return False
+        if not direct_grid and persistent_ctas <= 0:
+            return False
+        return True
+
+    def _get_shared_storage_cls(self):
+        # The staged path issues 16-byte cp.async transactions into this field.
+        # Encode that requirement in the typed 4.6 allocation contract instead
+        # of relying only on the dynamic-SMEM root's implicit alignment.
+        stage_partial_storage = cute.struct.Align[
+            cute.struct.MemRange[
+                self.dtype_partial,
+                int(self.num_smem_stages * self.bdy * self.head_dim),
+            ],
+            16,
+        ]
+        stage_lse_storage = cute.struct.MemRange[
+            cutlass.Float32, int(self.bdx * self.bdy)
+        ]
+        partial_storage = cute.struct.MemRange[
+            cutlass.Float32, int(self.bdy * self.head_dim)
+        ]
+        lse_storage = cute.struct.MemRange[cutlass.Float32, int(self.bdy)]
+
+        class SharedStorage:
+            pass
+
+        SharedStorage.__annotations__ = {
+            "sStagePartial": stage_partial_storage,
+            "sStageLSE": stage_lse_storage,
+            "sPartial": partial_storage,
+            "sLSE": lse_storage,
+        }
+
+        return cute.struct(SharedStorage)
+
+    @cute.jit
+    def __call__(
+        self,
+        mV_partial: cute.Tensor,
+        mLSE_partial: cute.Tensor,
+        mMergeIndptr: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mTotalRowsPtr: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(len(mV_partial.shape) != 3):
+            raise ValueError(
+                "mV_partial must have shape (nnz_partial_rows, num_heads, head_dim)"
+            )
+        if const_expr(len(mLSE_partial.shape) != 2):
+            raise ValueError(
+                "mLSE_partial must have shape (nnz_partial_rows, num_heads)"
+            )
+        if const_expr(len(mMergeIndptr.shape) != 1):
+            raise ValueError("mMergeIndptr must have shape (max_total_rows + 1,)")
+        if const_expr(len(mCacheSeqlens.shape) != 1):
+            raise ValueError("mCacheSeqlens must have shape (total_rows,)")
+        if const_expr(len(mKvChunkSizePtr.shape) != 1):
+            raise ValueError("mKvChunkSizePtr must have shape (1,)")
+        if const_expr(len(mO.shape) != 3):
+            raise ValueError("mO must have shape (max_total_rows, num_heads, head_dim)")
+        if const_expr(len(mLSE.shape) != 2):
+            raise ValueError("mLSE must have shape (num_heads, max_total_rows)")
+        if const_expr(mTotalRowsPtr is not None and len(mTotalRowsPtr.shape) != 1):
+            raise ValueError("mTotalRowsPtr must have shape (1,)")
+        if const_expr(mV_partial.element_type != self.dtype_partial):
+            raise TypeError("mV_partial dtype must match dtype_partial")
+        if const_expr(mO.element_type != self.dtype):
+            raise TypeError("mO dtype must match dtype")
+        if const_expr(
+            mLSE_partial.element_type != Float32 or mLSE.element_type != Float32
+        ):
+            raise TypeError("mLSE tensors must be Float32")
+        if const_expr(
+            not self.can_implement(
+                self.dtype,
+                self.dtype_partial,
+                head_dim=self.head_dim,
+                vec_size=self.vec_size,
+                bdx=self.bdx,
+                bdy=self.bdy,
+                num_smem_stages=self.num_smem_stages,
+                persistent_ctas=self.persistent_ctas,
+                direct_grid=self.direct_grid,
+            )
+        ):
+            raise TypeError("paged merge kernel configuration is not supported")
+
+        self.kernel(
+            mV_partial,
+            mLSE_partial,
+            mMergeIndptr,
+            mCacheSeqlens,
+            mKvChunkSizePtr,
+            mO,
+            mLSE,
+            mTotalRowsPtr,
+        ).launch(
+            grid=(
+                (mO.shape[1], mO.shape[0], 1)
+                if self.direct_grid
+                else (self.persistent_ctas, 1, 1)
+            ),
+            block=[self.bdx, self.bdy, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mV_partial: cute.Tensor,
+        mLSE_partial: cute.Tensor,
+        mMergeIndptr: cute.Tensor,
+        mCacheSeqlens: cute.Tensor,
+        mKvChunkSizePtr: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mTotalRowsPtr: cute.Tensor | None,
+    ):
+        tx, ty, _ = cute.arch.thread_idx()
+        block_x, block_y, _ = cute.arch.block_idx()
+        if const_expr(not self.direct_grid):
+            num_ctas, _, _ = cute.arch.grid_dim()
+        max_total_rows = mO.shape[0]
+        num_heads = mO.shape[1]
+        head_dim = self.head_dim
+        total_rows = (
+            mTotalRowsPtr[0]
+            if const_expr(mTotalRowsPtr is not None)
+            else max_total_rows
+        )
+
+        smem = cutlass.utils.SmemAllocator()
+        SharedStorage = self._get_shared_storage_cls()
+        storage = smem.allocate(SharedStorage)
+        s_stage_partial = storage.sStagePartial.get_tensor(
+            cute.make_layout(
+                (self.num_smem_stages, self.bdy, head_dim),
+                stride=(self.bdy * head_dim, head_dim, 1),
+            )
+        )
+        s_stage_lse = storage.sStageLSE.get_tensor(
+            cute.make_layout((self.bdx * self.bdy,), stride=(1,))
+        )
+        s_partial = storage.sPartial.get_tensor(
+            cute.make_layout((self.bdy, head_dim), stride=(head_dim, 1))
+        )
+        s_lse = storage.sLSE.get_tensor(cute.make_layout((self.bdy,), stride=(1,)))
+
+        if const_expr(not self.direct_grid):
+            cute.arch.griddepcontrol_wait()
+
+        total_work = total_rows * num_heads
+        base_k = tx * self.vec_size
+        work_linear_idx = (
+            Int32(block_y * num_heads + block_x)
+            if const_expr(self.direct_grid)
+            else Int32(block_x)
+        )
+        max_chunks_per_req = Int32(0)
+        if const_expr(self.regular_decode_graph):
+            max_chunks_per_req = Int32(mV_partial.shape[0] // mO.shape[0])
+        while work_linear_idx < total_work:
+            cute.arch.sync_threads()
+
+            if const_expr(self.direct_grid):
+                row_idx = Int32(block_y)
+                head_idx = Int32(block_x)
+            else:
+                row_idx = work_linear_idx // num_heads
+                head_idx = work_linear_idx % num_heads
+            if const_expr(self.regular_decode_graph):
+                start_idx = row_idx * max_chunks_per_req
+                num_index_sets = mMergeIndptr[row_idx + 1] - mMergeIndptr[row_idx]
+                end_idx = start_idx + num_index_sets
+            else:
+                start_idx = mMergeIndptr[row_idx]
+                end_idx = mMergeIndptr[row_idx + 1]
+                num_index_sets = end_idx - start_idx
+
+            if num_index_sets == 0:
+                if const_expr(self.dtype is cutlass.BFloat16 and self.vec_size == 4):
+                    _st_global_v2_u32(
+                        get_ptr_as_int64(
+                            mO,
+                            (Int64(row_idx) * Int64(num_heads) + Int64(head_idx))
+                            * Int64(head_dim)
+                            + Int64(base_k),
+                        ),
+                        Uint32(0),
+                        Uint32(0),
+                    )
+                else:
+                    for vec_idx in cutlass.range_constexpr(self.vec_size):
+                        mO[row_idx, head_idx, base_k + vec_idx] = self.dtype(0.0)
+                if tx == 0 and ty == 0:
+                    mLSE[head_idx, row_idx] = -Float32.inf
+            elif num_index_sets == 1:
+                for vec_idx in cutlass.range_constexpr(self.vec_size):
+                    mO[row_idx, head_idx, base_k + vec_idx] = mV_partial[
+                        start_idx, head_idx, base_k + vec_idx
+                    ].to(self.dtype)
+                if tx == 0 and ty == 0:
+                    mLSE[head_idx, row_idx] = mLSE_partial[start_idx, head_idx]
+            else:
+                state_o = cute.make_rmem_tensor(
+                    cute.make_layout((self.vec_size,), stride=(1,)),
+                    Float32,
+                )
+                state_m, state_d = _state_init(state_o)
+                bytes_per_vec = self.vec_size * self.dtype_partial.width // 8
+                can_stage_async = bytes_per_vec == 16 or (
+                    bytes_per_vec == 8
+                    and self.dtype_partial is cutlass.BFloat16
+                    and self.pair_bf16_partial_loads
+                )
+                if can_stage_async and (
+                    bytes_per_vec == 16 or num_index_sets >= Int32(8)
+                ):
+                    for stage_idx in cutlass.range_constexpr(self.num_smem_stages):
+                        staged_linear_idx = stage_idx * self.bdy + ty
+                        if const_expr(bytes_per_vec == 8):
+                            load_base_k = tx * (self.vec_size * 2)
+                            smem_addr = shared_ptr_to_u32(
+                                s_stage_partial.iterator
+                                + Int32(
+                                    (stage_idx * self.bdy + ty) * head_dim + load_base_k
+                                )
+                            )
+                            if (
+                                tx < self.bdx // 2
+                                and staged_linear_idx < num_index_sets
+                            ):
+                                partial_idx = start_idx + staged_linear_idx
+                                gmem_addr = get_ptr_as_int64(
+                                    mV_partial,
+                                    (
+                                        Int64(partial_idx) * Int64(num_heads)
+                                        + Int64(head_idx)
+                                    )
+                                    * Int64(head_dim)
+                                    + Int64(load_base_k),
+                                )
+                                _cp_async_load_128b(smem_addr, gmem_addr)
+                        else:
+                            smem_addr = shared_ptr_to_u32(
+                                s_stage_partial.iterator
+                                + Int32((stage_idx * self.bdy + ty) * head_dim + base_k)
+                            )
+                            if staged_linear_idx < num_index_sets:
+                                partial_idx = start_idx + staged_linear_idx
+                                gmem_addr = get_ptr_as_int64(
+                                    mV_partial,
+                                    (
+                                        Int64(partial_idx) * Int64(num_heads)
+                                        + Int64(head_idx)
+                                    )
+                                    * Int64(head_dim)
+                                    + Int64(base_k),
+                                )
+                                _cp_async_load_128b(smem_addr, gmem_addr)
+                        cute.arch.cp_async_commit_group()
+
+                    num_stage_iters = (num_index_sets + self.bdy - 1) // self.bdy
+                    iter_idx = Int32(0)
+                    while iter_idx < num_stage_iters:
+                        state_m, state_d = _merge_async_slot(
+                            iter_idx=iter_idx,
+                            start_idx=start_idx,
+                            num_heads=num_heads,
+                            head_idx=head_idx,
+                            num_index_sets=num_index_sets,
+                            num_stage_iters=num_stage_iters,
+                            base_k=base_k,
+                            head_dim=head_dim,
+                            vec_size=self.vec_size,
+                            bdx=self.bdx,
+                            bdy=self.bdy,
+                            bytes_per_vec=bytes_per_vec,
+                            num_smem_stages=self.num_smem_stages,
+                            s_stage_partial=s_stage_partial,
+                            s_stage_lse=s_stage_lse,
+                            mV_partial=mV_partial,
+                            mLSE_partial=mLSE_partial,
+                            state_o=state_o,
+                            state_m=state_m,
+                            state_d=state_d,
+                            slot=0,
+                        )
+                        state_m, state_d = _merge_async_slot(
+                            iter_idx=iter_idx,
+                            start_idx=start_idx,
+                            num_heads=num_heads,
+                            head_idx=head_idx,
+                            num_index_sets=num_index_sets,
+                            num_stage_iters=num_stage_iters,
+                            base_k=base_k,
+                            head_dim=head_dim,
+                            vec_size=self.vec_size,
+                            bdx=self.bdx,
+                            bdy=self.bdy,
+                            bytes_per_vec=bytes_per_vec,
+                            num_smem_stages=self.num_smem_stages,
+                            s_stage_partial=s_stage_partial,
+                            s_stage_lse=s_stage_lse,
+                            mV_partial=mV_partial,
+                            mLSE_partial=mLSE_partial,
+                            state_o=state_o,
+                            state_m=state_m,
+                            state_d=state_d,
+                            slot=1,
+                        )
+                        state_m, state_d = _merge_async_slot(
+                            iter_idx=iter_idx,
+                            start_idx=start_idx,
+                            num_heads=num_heads,
+                            head_idx=head_idx,
+                            num_index_sets=num_index_sets,
+                            num_stage_iters=num_stage_iters,
+                            base_k=base_k,
+                            head_dim=head_dim,
+                            vec_size=self.vec_size,
+                            bdx=self.bdx,
+                            bdy=self.bdy,
+                            bytes_per_vec=bytes_per_vec,
+                            num_smem_stages=self.num_smem_stages,
+                            s_stage_partial=s_stage_partial,
+                            s_stage_lse=s_stage_lse,
+                            mV_partial=mV_partial,
+                            mLSE_partial=mLSE_partial,
+                            state_o=state_o,
+                            state_m=state_m,
+                            state_d=state_d,
+                            slot=2,
+                        )
+                        state_m, state_d = _merge_async_slot(
+                            iter_idx=iter_idx,
+                            start_idx=start_idx,
+                            num_heads=num_heads,
+                            head_idx=head_idx,
+                            num_index_sets=num_index_sets,
+                            num_stage_iters=num_stage_iters,
+                            base_k=base_k,
+                            head_dim=head_dim,
+                            vec_size=self.vec_size,
+                            bdx=self.bdx,
+                            bdy=self.bdy,
+                            bytes_per_vec=bytes_per_vec,
+                            num_smem_stages=self.num_smem_stages,
+                            s_stage_partial=s_stage_partial,
+                            s_stage_lse=s_stage_lse,
+                            mV_partial=mV_partial,
+                            mLSE_partial=mLSE_partial,
+                            state_o=state_o,
+                            state_m=state_m,
+                            state_d=state_d,
+                            slot=3,
+                        )
+                        iter_idx += Int32(4)
+
+                    cute.arch.cp_async_wait_group(0)
+                    cute.arch.sync_threads()
+                else:
+                    partial_idx = start_idx + ty
+                    while partial_idx < end_idx:
+                        other_o = cute.make_rmem_tensor(
+                            cute.make_layout((self.vec_size,), stride=(1,)),
+                            Float32,
+                        )
+                        for vec_idx in cutlass.range_constexpr(self.vec_size):
+                            other_o[vec_idx] = mV_partial[
+                                partial_idx, head_idx, base_k + vec_idx
+                            ].to(Float32)
+                        state_m, state_d = _state_merge_normalized_lse_base2(
+                            state_o,
+                            state_m,
+                            state_d,
+                            other_o,
+                            mLSE_partial[partial_idx, head_idx],
+                        )
+                        partial_idx += self.bdy
+
+                state_m, state_d = _threadblock_sync_state(
+                    state_o,
+                    state_m,
+                    state_d,
+                    s_partial,
+                    s_lse,
+                    vec_size=self.vec_size,
+                    bdy=self.bdy,
+                )
+                _state_normalize(state_o, state_d)
+                if const_expr(self.dtype is cutlass.BFloat16 and self.vec_size == 4):
+                    _st_global_v2_u32(
+                        get_ptr_as_int64(
+                            mO,
+                            (Int64(row_idx) * Int64(num_heads) + Int64(head_idx))
+                            * Int64(head_dim)
+                            + Int64(base_k),
+                        ),
+                        pack_f32x2_to_bfloat2(state_o[0], state_o[1]),
+                        pack_f32x2_to_bfloat2(state_o[2], state_o[3]),
+                    )
+                else:
+                    for vec_idx in cutlass.range_constexpr(self.vec_size):
+                        mO[row_idx, head_idx, base_k + vec_idx] = state_o[vec_idx].to(
+                            self.dtype
+                        )
+                if tx == 0 and ty == 0:
+                    mLSE[head_idx, row_idx] = _state_get_lse_base2(state_m, state_d)
+            if const_expr(self.direct_grid):
+                work_linear_idx = total_work
+            else:
+                work_linear_idx += num_ctas
+
+        cute.arch.griddepcontrol_launch_dependents()

--- a/flashinfer/experimental/sm12x/attention/paged/planner.py
+++ b/flashinfer/experimental/sm12x/attention/paged/planner.py
@@ -1,0 +1,1354 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/planner.py @ e44cb777 (2026-07-05) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Host planner for the primary paged-attention backend.
+
+This module models the host-side work decomposition used by FlashInfer's paged
+attention kernels:
+
+- choose `CTA_TILE_Q` from packed Q rows,
+- choose `kv_chunk_size` on the host,
+- emit exact `(request_idx, qo_tile_idx, kv_tile_idx)` worklists,
+- emit `merge_indptr` / `o_indptr` for split reduction.
+
+No kernel-side split LUT or legacy scheduler assumptions live here.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+
+_FP8_KV_DTYPE = torch.float8_e4m3fn
+_PAGED_EXTEND_FP8_CHUNK_TABLE_PAGES = (
+    (1, 1),
+    (2, 1),
+    (4, 1),
+    (8, 1),
+    (16, 1),
+    (32, 2),
+    (64, 3),
+    (128, 6),
+    (256, 6),
+    (512, 24),
+    (1024, 24),
+    (2048, 24),
+)
+_PAGED_EXTEND_BF16_CHUNK_TABLE_PAGES = (
+    (1, 1),
+    (2, 1),
+    (4, 1),
+    (8, 1),
+    (16, 1),
+    (32, 2),
+    (64, 3),
+    (128, 6),
+    (256, 6),
+    (512, 32),
+    (1024, 32),
+    (2048, 32),
+)
+
+_DEFAULT_GRAPH_CTAS_PER_SM = 2
+_MSA_TOPK = 16
+_MSA_BLOCK_TOKENS = 128
+_BF16_MINIMAX_DECODE_MAX_CHUNKS = (
+    (1, 512, 20),
+    (1, 1, 16),
+    (2, 513, 13),
+    (2, 1, 12),
+    (3, 512, 16),
+    (3, 1, 14),
+    (4, 1, 11),
+)
+_PagedMode = Literal["decode", "extend", "verify"]
+
+
+def _merge_backend_supports_split_kv(
+    *,
+    output_dtype: torch.dtype,
+    head_dim_vo: int,
+) -> bool:
+    return output_dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ) and head_dim_vo in (128, 256)
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def _align_up(x: int, y: int) -> int:
+    return _ceil_div(x, y) * y
+
+
+def _msa_decode_chunk_tokens(policy_batch: int) -> int:
+    if int(policy_batch) <= 2:
+        return 128
+    if int(policy_batch) <= 8:
+        return 256
+    return 512
+
+
+def _msa_decode_chunk_pages(policy_batch: int, page_size: int) -> int:
+    return _ceil_div(_msa_decode_chunk_tokens(policy_batch), int(page_size))
+
+
+def _msa_effective_pages(cache_len: int, page_size: int) -> int:
+    visible_blocks = max(_ceil_div(max(int(cache_len), 1), _MSA_BLOCK_TOKENS), 1)
+    selected_blocks = min(_MSA_TOPK, visible_blocks)
+    pages_per_block = _ceil_div(_MSA_BLOCK_TOKENS, int(page_size))
+    tail_tokens = max(int(cache_len) - (visible_blocks - 1) * _MSA_BLOCK_TOKENS, 1)
+    tail_pages = min(max(_ceil_div(tail_tokens, int(page_size)), 1), pages_per_block)
+    return max((selected_blocks - 1) * pages_per_block + tail_pages, 1)
+
+
+def _previous_power_of_two(x: int) -> int:
+    x = max(int(x), 1)
+    return 1 << (x.bit_length() - 1)
+
+
+def _decode_graph_chunk_pages_env(name: str) -> int | None:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return None
+    value = int(raw)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _apply_decode_graph_chunk_pages_debug_policy(chunk_pages: int) -> int:
+    forced = _decode_graph_chunk_pages_env(
+        "FLASHINFER_EXP_SM12X_PAGED_DECODE_GRAPH_CHUNK_PAGES"
+    )
+    if forced is not None:
+        return forced
+    minimum = _decode_graph_chunk_pages_env(
+        "FLASHINFER_EXP_SM12X_PAGED_DECODE_GRAPH_MIN_CHUNK_PAGES"
+    )
+    if minimum is not None:
+        return max(int(chunk_pages), minimum)
+    return int(chunk_pages)
+
+
+def _bf16_minimax_decode_max_chunks(
+    *,
+    batch: int,
+    max_effective_kv_pages: int,
+) -> int | None:
+    for tuned_batch, min_pages, max_chunks in _BF16_MINIMAX_DECODE_MAX_CHUNKS:
+        if batch == tuned_batch and max_effective_kv_pages >= min_pages:
+            return max_chunks
+    return None
+
+
+def _cap_decode_graph_chunk_pages(
+    *,
+    chunk_pages: int,
+    max_effective_kv_pages: int,
+    max_chunks_per_req: int | None,
+) -> int:
+    chunk_pages = max(int(chunk_pages), 1)
+    if max_chunks_per_req is None:
+        return chunk_pages
+    max_chunks_per_req = max(int(max_chunks_per_req), 1)
+    return max(
+        chunk_pages, _ceil_div(max(int(max_effective_kv_pages), 1), max_chunks_per_req)
+    )
+
+
+def _window_start_page(
+    *,
+    cache_len: int,
+    q_len: int,
+    window_left: int,
+    page_size: int,
+) -> int:
+    if window_left < 0:
+        return 0
+    # Paged attention uses the right-aligned causal convention.  For a request
+    # with cached length K and query length Q, the first query row can see up to
+    # key index K - Q.  Start from that earliest row so every later row remains
+    # covered by the request-level page span.
+    first_causal_key = max(int(cache_len) - max(int(q_len), 1), 0)
+    first_window_key = max(first_causal_key - int(window_left), 0)
+    return first_window_key // int(page_size)
+
+
+def _graph_max_batch_size_if_split(
+    *,
+    device: torch.device,
+    num_kv_heads: int,
+    graph_ctas_per_sm: int,
+) -> int:
+    blocks_per_sm = int(graph_ctas_per_sm)
+    if blocks_per_sm <= 0:
+        raise ValueError("graph_ctas_per_sm must be positive")
+    if num_kv_heads <= 0:
+        raise ValueError("num_kv_heads must be positive")
+    num_sms = int(torch.cuda.get_device_properties(device).multi_processor_count)
+    return max((num_sms * blocks_per_sm) // num_kv_heads, 1)
+
+
+def decode_graph_max_chunks_per_request_budget(
+    *,
+    device: torch.device,
+    num_kv_heads: int,
+    batch: int,
+    graph_ctas_per_sm: int,
+) -> int:
+    max_batch_size_if_split = _graph_max_batch_size_if_split(
+        device=device,
+        num_kv_heads=num_kv_heads,
+        graph_ctas_per_sm=graph_ctas_per_sm,
+    )
+    return max(max_batch_size_if_split // max(int(batch), 1), 1)
+
+
+def _heuristic_decode_graph_ctas_per_sm(
+    *,
+    kv_dtype: torch.dtype,
+    batch: int,
+    page_size: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+) -> int:
+    if page_size != 64:
+        return _DEFAULT_GRAPH_CTAS_PER_SM
+    if (
+        kv_dtype == torch.bfloat16
+        and page_size == 64
+        and head_dim_qk == 128
+        and head_dim_vo == 128
+        and gqa_group_size == 6
+        and batch == 2
+    ):
+        return 6
+    if (
+        kv_dtype == torch.bfloat16
+        and page_size == 64
+        and head_dim_qk == 128
+        and head_dim_vo == 128
+        and gqa_group_size == 6
+        and batch in (3, 4)
+    ):
+        return 4
+    if (
+        kv_dtype in (torch.bfloat16, _FP8_KV_DTYPE)
+        and page_size == 64
+        and head_dim_qk == 128
+        and head_dim_vo == 128
+        and gqa_group_size == 6
+        and batch <= 4
+    ):
+        return 1
+    if head_dim_qk >= 256 and head_dim_vo >= 256 and gqa_group_size <= 8:
+        if kv_dtype == torch.bfloat16 and batch <= 1:
+            return 6
+        if batch <= 8:
+            return 2
+        return 1
+    if (
+        kv_dtype == _FP8_KV_DTYPE
+        and batch == 1
+        and head_dim_qk <= 192
+        and head_dim_vo <= 128
+    ):
+        return 1
+    if head_dim_qk <= 192 and head_dim_vo <= 128:
+        return 2
+    if gqa_group_size > 8:
+        return 2
+    return _DEFAULT_GRAPH_CTAS_PER_SM
+
+
+def _resolve_graph_ctas_per_sm(
+    *,
+    mode: _PagedMode,
+    kv_dtype: torch.dtype,
+    policy_batch: int,
+    page_size: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+    graph_ctas_per_sm: int | None,
+) -> int:
+    if graph_ctas_per_sm is not None:
+        resolved_graph_ctas_per_sm = int(graph_ctas_per_sm)
+        if resolved_graph_ctas_per_sm <= 0:
+            raise ValueError("graph_ctas_per_sm must be positive")
+        return resolved_graph_ctas_per_sm
+
+    if mode not in ("decode", "verify"):
+        return _DEFAULT_GRAPH_CTAS_PER_SM
+    resolved_graph_ctas_per_sm = _heuristic_decode_graph_ctas_per_sm(
+        kv_dtype=kv_dtype,
+        batch=policy_batch,
+        page_size=page_size,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        gqa_group_size=gqa_group_size,
+    )
+
+    if resolved_graph_ctas_per_sm <= 0:
+        raise ValueError("resolved graph_ctas_per_sm must be positive")
+    return resolved_graph_ctas_per_sm
+
+
+def resolve_decode_graph_ctas_per_sm(
+    *,
+    kv_dtype: torch.dtype,
+    batch: int,
+    page_size: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+    graph_ctas_per_sm: int | None = None,
+) -> int:
+    return _resolve_graph_ctas_per_sm(
+        mode="decode",
+        kv_dtype=kv_dtype,
+        policy_batch=max(int(batch), 1),
+        page_size=page_size,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        gqa_group_size=gqa_group_size,
+        graph_ctas_per_sm=graph_ctas_per_sm,
+    )
+
+
+def _metadata_to_cpu_int_list(t: torch.Tensor, *, name: str) -> list[int]:
+    if t.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"{name} must be torch.int32 or torch.int64")
+    if not t.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    return [int(v) for v in t.detach().cpu().tolist()]
+
+
+def _estimate_new_batch_size(
+    *,
+    packed_qo_len_arr: list[int],
+    kv_len_arr: list[int],
+    qo_chunk_size: int,
+    kv_chunk_size_pages: int,
+) -> int:
+    new_batch_size = 0
+    for packed_qo_len, kv_len in zip(packed_qo_len_arr, kv_len_arr):
+        num_tiles_q = _ceil_div(packed_qo_len, qo_chunk_size)
+        num_chunks_kv = _ceil_div(max(kv_len, 1), kv_chunk_size_pages)
+        new_batch_size += num_tiles_q * num_chunks_kv
+    return int(new_batch_size)
+
+
+def _lookup_chunk_pages_from_table(
+    max_effective_kv_pages: int,
+    table: tuple[tuple[int, int | None], ...],
+) -> int | None:
+    for max_pages, chunk_pages in table:
+        if max_effective_kv_pages <= max_pages:
+            return chunk_pages
+    return None
+
+
+def _q_lengths_from_cu_seqlens(cu_seqlens_q: torch.Tensor) -> list[int]:
+    cu_seqlens_q_list = _metadata_to_cpu_int_list(cu_seqlens_q, name="cu_seqlens_q")
+    q_lengths: list[int] = []
+    for start, end in zip(cu_seqlens_q_list[:-1], cu_seqlens_q_list[1:]):
+        if end < start:
+            raise ValueError("cu_seqlens_q must be non-decreasing")
+        q_lengths.append(end - start)
+    return q_lengths
+
+
+def _graph_policy_batch(
+    *,
+    mode: _PagedMode,
+    batch: int,
+    total_q: int,
+) -> int:
+    if mode == "verify":
+        return max(int(total_q), 1)
+    return max(int(batch), 1)
+
+
+def _decode_graph_heuristic_max_chunks_per_req(
+    *,
+    kv_dtype: torch.dtype,
+    batch: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+) -> int:
+    batch = max(int(batch), 1)
+    head_dim_qk = max(int(head_dim_qk), 1)
+    head_dim_vo = max(int(head_dim_vo), 1)
+    gqa_group_size = max(int(gqa_group_size), 1)
+
+    if head_dim_qk >= 256 and head_dim_vo >= 256 and gqa_group_size <= 8:
+        total_chunk_budget = 192
+        divisor = batch
+        min_chunks = 1
+        max_chunks = 256
+    elif (
+        kv_dtype == _FP8_KV_DTYPE
+        and batch == 1
+        and head_dim_qk <= 192
+        and head_dim_vo <= 128
+    ):
+        total_chunk_budget = 48
+        divisor = 1
+        min_chunks = 4
+        max_chunks = 48
+    elif head_dim_qk <= 192 and head_dim_vo <= 128:
+        total_chunk_budget = 64
+        divisor = max(batch, 2)
+        min_chunks = 4
+        max_chunks = 32
+    elif gqa_group_size > 8:
+        total_chunk_budget = 64
+        divisor = max(batch, 2)
+        min_chunks = 4
+        max_chunks = 32
+    else:
+        total_chunk_budget = 128
+        divisor = batch
+        min_chunks = 2
+        max_chunks = 128
+
+    chunk_count = total_chunk_budget // max(divisor, 1)
+    chunk_count = min(max(chunk_count, min_chunks), max_chunks)
+    if max_chunks <= 32 and chunk_count >= 4:
+        chunk_count = _previous_power_of_two(chunk_count)
+    return max(chunk_count, 1)
+
+
+def heuristic_decode_graph_chunk_pages(
+    *,
+    kv_dtype: torch.dtype,
+    batch: int,
+    page_size: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+    max_effective_kv_pages: int,
+    max_chunks_per_req: int | None = None,
+) -> int:
+    del page_size
+    max_chunks = _decode_graph_heuristic_max_chunks_per_req(
+        kv_dtype=kv_dtype,
+        batch=batch,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        gqa_group_size=gqa_group_size,
+    )
+    if (
+        kv_dtype == torch.bfloat16
+        and head_dim_qk == 128
+        and head_dim_vo == 128
+        and gqa_group_size == 6
+    ):
+        bf16_max_chunks = _bf16_minimax_decode_max_chunks(
+            batch=batch,
+            max_effective_kv_pages=max_effective_kv_pages,
+        )
+        if bf16_max_chunks is not None:
+            max_chunks = min(max_chunks, bf16_max_chunks)
+    if max_chunks_per_req is not None:
+        max_chunks = min(max_chunks, max(int(max_chunks_per_req), 1))
+    return max(_ceil_div(max(int(max_effective_kv_pages), 1), max_chunks), 1)
+
+
+def infer_paged_mode(cu_seqlens_q: torch.Tensor) -> Literal["decode", "extend"]:
+    q_lengths = _q_lengths_from_cu_seqlens(cu_seqlens_q)
+    return (
+        "decode" if q_lengths and all(q_len == 1 for q_len in q_lengths) else "extend"
+    )
+
+
+def _fa2_determine_cta_tile_q(avg_packed_qo_len: int, head_dim: int) -> int:
+    # Faithful to FlashInfer's FA2DetermineCtaTileQ.
+    if avg_packed_qo_len > 64 and head_dim < 256:
+        return 128
+    if avg_packed_qo_len > 16:
+        return 64
+    return 16
+
+
+def _paged_determine_cta_tile_q(
+    *,
+    mode: _PagedMode,
+    kv_dtype: torch.dtype,
+    packed_qo_len: int,
+    head_dim: int,
+    max_effective_kv_pages: int,
+) -> int:
+    if mode == "verify":
+        del kv_dtype, head_dim, max_effective_kv_pages
+        return 16
+    if mode == "extend" and packed_qo_len <= 32:
+        del kv_dtype, head_dim, max_effective_kv_pages
+        return 16
+
+    cta_tile_q = _fa2_determine_cta_tile_q(packed_qo_len, head_dim)
+    del max_effective_kv_pages
+    del mode, kv_dtype
+    return cta_tile_q
+
+
+def chunk_pages_for_family(
+    *,
+    mode: _PagedMode,
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    policy_batch: int | None,
+    graph_chunk_policy: bool,
+    page_size: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+    max_effective_kv_pages: int,
+    max_chunks_per_req: int | None = None,
+) -> int | None:
+    if q_dtype != torch.bfloat16:
+        return None
+    is_default_geometry = (
+        page_size == 64
+        and head_dim_qk == 256
+        and head_dim_vo == 256
+        and gqa_group_size == 8
+    )
+    if (
+        mode == "extend"
+        and is_default_geometry
+        and not graph_chunk_policy
+        and kv_dtype == _FP8_KV_DTYPE
+    ):
+        return _lookup_chunk_pages_from_table(
+            max_effective_kv_pages, _PAGED_EXTEND_FP8_CHUNK_TABLE_PAGES
+        )
+    if (
+        mode == "extend"
+        and is_default_geometry
+        and not graph_chunk_policy
+        and kv_dtype == torch.bfloat16
+    ):
+        return _lookup_chunk_pages_from_table(
+            max_effective_kv_pages,
+            _PAGED_EXTEND_BF16_CHUNK_TABLE_PAGES,
+        )
+
+    if (
+        mode not in ("decode", "verify")
+        or not graph_chunk_policy
+        or policy_batch is None
+        or page_size not in (64, 128)
+    ):
+        return None
+
+    policy_page_size = 64 if page_size == 128 else page_size
+    chunk_pages = heuristic_decode_graph_chunk_pages(
+        kv_dtype=kv_dtype,
+        batch=int(policy_batch),
+        page_size=policy_page_size,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        gqa_group_size=gqa_group_size,
+        max_effective_kv_pages=max_effective_kv_pages,
+        max_chunks_per_req=max_chunks_per_req,
+    )
+
+    chunk_pages = _apply_decode_graph_chunk_pages_debug_policy(chunk_pages)
+    return _cap_decode_graph_chunk_pages(
+        chunk_pages=chunk_pages,
+        max_effective_kv_pages=max_effective_kv_pages,
+        max_chunks_per_req=max_chunks_per_req,
+    )
+
+
+@dataclass(frozen=True)
+class PagedPlanBudget:
+    max_total_q: int | None = None
+    max_batch: int | None = None
+    max_page_table_width: int | None = None
+    max_work_items: int | None = None
+    max_partial_rows: int | None = None
+
+
+def _estimate_prefill_plan_usage(
+    *,
+    packed_qo_len_arr: list[int],
+    q_lengths: list[int],
+    kv_len_arr: list[int],
+    qo_chunk_size: int,
+    kv_chunk_size_pages: int,
+    force_split_kv: bool,
+) -> tuple[int, int]:
+    new_batch_size = 0
+    total_num_partial_rows = 0
+    split_kv = False
+    for packed_qo_len, qo_len, kv_len in zip(packed_qo_len_arr, q_lengths, kv_len_arr):
+        num_tiles_q = _ceil_div(packed_qo_len, qo_chunk_size)
+        num_chunks_kv = _ceil_div(max(kv_len, 1), kv_chunk_size_pages)
+        split_kv = split_kv or num_chunks_kv > 1
+        new_batch_size += num_tiles_q * num_chunks_kv
+        total_num_partial_rows += qo_len * num_chunks_kv
+    if force_split_kv:
+        split_kv = True
+    return int(new_batch_size), int(total_num_partial_rows if split_kv else 0)
+
+
+def _prefill_usage_fits_budget(
+    *,
+    budget: PagedPlanBudget | None,
+    new_batch_size: int,
+    total_num_partial_rows: int,
+) -> bool:
+    if budget is None:
+        return True
+    if budget.max_work_items is not None and new_batch_size > int(
+        budget.max_work_items
+    ):
+        return False
+    if budget.max_partial_rows is not None and total_num_partial_rows > int(
+        budget.max_partial_rows
+    ):
+        return False
+    return True
+
+
+def _prefill_binary_search_kv_chunk_size(
+    *,
+    enable_cuda_graph: bool,
+    max_batch_size_if_split: int,
+    packed_qo_len_arr: list[int],
+    q_lengths: list[int],
+    kv_len_arr: list[int],
+    qo_chunk_size: int,
+    force_split_kv: bool,
+    plan_budget: PagedPlanBudget | None = None,
+    min_kv_chunk_size: int = 1,
+) -> tuple[bool, int]:
+    max_kv_len = max(max(kv_len_arr, default=1), 1)
+    low = min_kv_chunk_size
+    high = max_kv_len
+    while low < high:
+        mid = (low + high) // 2
+        new_batch_size, total_num_partial_rows = _estimate_prefill_plan_usage(
+            packed_qo_len_arr=packed_qo_len_arr,
+            q_lengths=q_lengths,
+            kv_len_arr=kv_len_arr,
+            qo_chunk_size=qo_chunk_size,
+            kv_chunk_size_pages=mid,
+            force_split_kv=force_split_kv,
+        )
+        if new_batch_size > max_batch_size_if_split or not _prefill_usage_fits_budget(
+            budget=plan_budget,
+            new_batch_size=new_batch_size,
+            total_num_partial_rows=total_num_partial_rows,
+        ):
+            low = mid + 1
+        else:
+            high = mid
+    final_new_batch_size, final_total_num_partial_rows = _estimate_prefill_plan_usage(
+        packed_qo_len_arr=packed_qo_len_arr,
+        q_lengths=q_lengths,
+        kv_len_arr=kv_len_arr,
+        qo_chunk_size=qo_chunk_size,
+        kv_chunk_size_pages=low,
+        force_split_kv=force_split_kv,
+    )
+    if final_new_batch_size > max_batch_size_if_split or not _prefill_usage_fits_budget(
+        budget=plan_budget,
+        new_batch_size=final_new_batch_size,
+        total_num_partial_rows=final_total_num_partial_rows,
+    ):
+        raise ValueError(
+            "paged prefill plan exceeds the configured eager workspace budget"
+        )
+    return (enable_cuda_graph or low < max_kv_len, low)
+
+
+def decode_chunk_pages_for_graph(
+    *,
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    batch: int | None = None,
+    page_size: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+    max_effective_kv_pages: int,
+    max_chunks_per_req: int | None = None,
+) -> int | None:
+    return chunk_pages_for_family(
+        mode="decode",
+        q_dtype=q_dtype,
+        kv_dtype=kv_dtype,
+        policy_batch=batch,
+        graph_chunk_policy=True,
+        page_size=page_size,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        gqa_group_size=gqa_group_size,
+        max_effective_kv_pages=max_effective_kv_pages,
+        max_chunks_per_req=max_chunks_per_req,
+    )
+
+
+def build_decode_chunk_pages_lut(
+    *,
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    batch: int | None = None,
+    page_size: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    gqa_group_size: int,
+    max_effective_kv_pages: int,
+    max_chunks_per_req: int | None = None,
+) -> tuple[int, ...]:
+    if batch is None:
+        raise ValueError("batch is required for decode graph chunk policy lookup")
+    max_effective_kv_pages = max(int(max_effective_kv_pages), 1)
+    lut: list[int] = []
+    for page_count in range(1, max_effective_kv_pages + 1):
+        chunk_pages = decode_chunk_pages_for_graph(
+            q_dtype=q_dtype,
+            kv_dtype=kv_dtype,
+            batch=batch,
+            page_size=page_size,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            gqa_group_size=gqa_group_size,
+            max_effective_kv_pages=page_count,
+            max_chunks_per_req=max_chunks_per_req,
+        )
+        if chunk_pages is None:
+            raise ValueError(
+                "decode graph chunk heuristic is unavailable for "
+                f"q_dtype={q_dtype}, kv_dtype={kv_dtype}, batch={batch}, page_size={page_size}"
+            )
+        lut.append(int(chunk_pages))
+    return tuple(lut)
+
+
+@dataclass(frozen=True)
+class PagedPlanKey:
+    total_q: int
+    num_q_heads: int
+    head_dim_qk: int
+    head_dim_vo: int
+    k_cache_shape: tuple[int, ...]
+    v_cache_shape: tuple[int, ...]
+    page_table_shape: tuple[int, ...]
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    mode: _PagedMode
+    cta_tile_q: int
+    kv_chunk_size: int
+    split_kv: bool
+    fixed_split_size: int
+    disable_split_kv: bool
+    enable_cuda_graph: bool
+    graph_chunk_policy: bool
+    graph_ctas_per_sm: int
+    window_left: int
+    max_batch_size_if_split: int
+    padded_batch_size: int
+    new_batch_size: int
+    num_qo_tiles: int
+    total_num_partial_rows: int
+    page_size: int
+    num_kv_heads: int
+    gqa_group_size: int
+    msa_block_sparse: bool
+    msa_union_tile: bool
+    msa_topk: int
+    msa_block_tokens: int
+    device_index: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class PagedPlan:
+    key: PagedPlanKey
+    request_indices: tuple[int, ...]
+    qo_tile_indices: tuple[int, ...]
+    kv_tile_indices: tuple[int, ...]
+    merge_indptr: tuple[int, ...]
+    o_indptr: tuple[int, ...]
+    block_valid_mask: tuple[bool, ...]
+    kv_window_start_tokens: tuple[int, ...]
+
+    def __getattr__(self, name: str):
+        return getattr(self.key, name)
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.device_index)
+
+
+def create_paged_plan(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    *,
+    mode: _PagedMode | None = None,
+    fixed_split_size: int = -1,
+    disable_split_kv: bool = False,
+    force_split_kv: bool | None = None,
+    enable_cuda_graph: bool = False,
+    graph_chunk_policy: bool = False,
+    max_batch_size_if_split: int | None = None,
+    graph_ctas_per_sm: int | None = None,
+    plan_budget: PagedPlanBudget | None = None,
+    window_left: int = -1,
+    msa_block_sparse: bool = False,
+    msa_union_tile: bool | None = None,
+) -> PagedPlan:
+    if q.ndim != 3:
+        raise ValueError(
+            f"q must be rank-3 [total_q, q_heads, head_dim], got {tuple(q.shape)}"
+        )
+    if k_cache.ndim != 4:
+        raise ValueError(
+            f"k_cache must be rank-4 [num_pages, page_size, kv_heads, head_dim], got {tuple(k_cache.shape)}"
+        )
+    if v_cache.ndim != 4:
+        raise ValueError(
+            f"v_cache must be rank-4 [num_pages, page_size, kv_heads, head_dim_v], got {tuple(v_cache.shape)}"
+        )
+    if page_table.ndim != 2:
+        raise ValueError(
+            f"page_table must be rank-2 [batch, max_pages], got {tuple(page_table.shape)}"
+        )
+    if cache_seqlens.ndim != 1:
+        raise ValueError(
+            f"cache_seqlens must be rank-1 [batch], got {tuple(cache_seqlens.shape)}"
+        )
+    if cu_seqlens_q.ndim != 1:
+        raise ValueError(
+            f"cu_seqlens_q must be rank-1 [batch+1], got {tuple(cu_seqlens_q.shape)}"
+        )
+    if q.device.type != "cuda":
+        raise ValueError("q must be on CUDA")
+    if not (
+        k_cache.device
+        == v_cache.device
+        == page_table.device
+        == cache_seqlens.device
+        == cu_seqlens_q.device
+        == q.device
+    ):
+        raise ValueError("all inputs must be on the same CUDA device")
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(f"unsupported q dtype {q.dtype}")
+    if k_cache.dtype != v_cache.dtype:
+        raise TypeError("k_cache and v_cache must have matching dtypes")
+    if k_cache.dtype not in (torch.float16, torch.bfloat16, _FP8_KV_DTYPE):
+        raise TypeError(f"unsupported kv dtype {k_cache.dtype}")
+    if window_left < -1:
+        raise ValueError(
+            "window_left must be -1 for full attention or a non-negative token count"
+        )
+    msa_block_sparse = bool(msa_block_sparse)
+    if msa_block_sparse and window_left >= 0:
+        raise ValueError(
+            "MSA block-sparse paged attention does not support window_left/SWA"
+        )
+
+    total_q, num_q_heads, head_dim_qk = [int(dim) for dim in q.shape]
+    num_pages, page_size, num_kv_heads, head_dim_k = [int(dim) for dim in k_cache.shape]
+    v_num_pages, v_page_size, v_num_kv_heads, head_dim_vo = [
+        int(dim) for dim in v_cache.shape
+    ]
+    batch, max_pages_per_request = [int(dim) for dim in page_table.shape]
+
+    if (
+        num_pages != v_num_pages
+        or page_size != v_page_size
+        or num_kv_heads != v_num_kv_heads
+    ):
+        raise ValueError(
+            "k_cache and v_cache structural shapes must match except head_dim"
+        )
+    if head_dim_k != head_dim_qk:
+        raise ValueError(
+            "primary paged backend expects head_dim_qk to match k_cache head_dim"
+        )
+    if page_size not in (64, 128):
+        raise ValueError(
+            f"primary paged backend expects page_size=64 or page_size=128, got {page_size}"
+        )
+    if num_q_heads % num_kv_heads != 0:
+        raise ValueError("num_q_heads must be divisible by num_kv_heads")
+    if tuple(cache_seqlens.shape) != (batch,):
+        raise ValueError("cache_seqlens shape must match page_table batch")
+    if tuple(cu_seqlens_q.shape) != (batch + 1,):
+        raise ValueError("cu_seqlens_q shape must be [batch + 1]")
+
+    q_lengths = _q_lengths_from_cu_seqlens(cu_seqlens_q)
+    cache_lengths = _metadata_to_cpu_int_list(cache_seqlens, name="cache_seqlens")
+    if any(cache_len <= 0 for cache_len in cache_lengths):
+        raise ValueError("primary paged backend requires cache_seqlens > 0")
+    cache_pages_arr = [_ceil_div(cache_len, page_size) for cache_len in cache_lengths]
+    if any(cache_pages > max_pages_per_request for cache_pages in cache_pages_arr):
+        raise ValueError("page_table width is smaller than required by cache_seqlens")
+
+    inferred_mode = infer_paged_mode(cu_seqlens_q)
+    mode = inferred_mode if mode is None else mode
+    if msa_union_tile is None:
+        msa_union_tile = (
+            msa_block_sparse
+            and mode == "extend"
+            and os.environ.get("FLASHINFER_EXP_SM12X_PAGED_MSA_UNION_PREFILL", "1")
+            != "0"
+        )
+    else:
+        msa_union_tile = bool(msa_union_tile)
+    if msa_union_tile and not (msa_block_sparse and mode == "extend"):
+        raise ValueError("MSA union-tile prefill requires an MSA extend plan")
+    if msa_block_sparse:
+        if mode not in ("decode", "extend"):
+            raise ValueError(
+                "MSA block-sparse paged attention currently supports decode and extend plans only"
+            )
+        if page_size not in (64, 128):
+            raise ValueError(
+                "MSA block-sparse paged attention requires page_size=64 or page_size=128"
+            )
+        if head_dim_qk != 128 or head_dim_vo != 128:
+            raise ValueError(
+                "MSA block-sparse paged attention requires head_dim_qk=head_dim_vo=128"
+            )
+        if k_cache.dtype not in (torch.bfloat16, _FP8_KV_DTYPE):
+            raise TypeError(
+                "MSA block-sparse paged attention supports bf16 or fp8 KV only"
+            )
+        if mode == "extend" and not msa_union_tile and k_cache.dtype == _FP8_KV_DTYPE:
+            # The per-token (cta_tile_q=16) extend dequant path produces wrong
+            # results with fp8 KV (pre-existing, never exercised before MSA;
+            # see .msaport plan follow-ups). Union-tile is the production
+            # prefill path and is fp8-correct.
+            raise TypeError(
+                "MSA fp8 extend requires union-tile prefill "
+                "(per-token fp8 extend is not supported)"
+            )
+    if mode == "verify" and inferred_mode != "extend":
+        raise ValueError(
+            f"verify mode requires q_len > 1, got inferred mode {inferred_mode}"
+        )
+    if force_split_kv is None:
+        force_split_kv = mode == "verify" or (msa_block_sparse and mode == "decode")
+    if mode == "extend" and force_split_kv:
+        raise ValueError("extend plans no longer support split-kv")
+    if plan_budget is not None:
+        if plan_budget.max_total_q is not None and total_q > int(
+            plan_budget.max_total_q
+        ):
+            raise ValueError(
+                f"paged plan total_q={total_q} exceeds workspace capacity {int(plan_budget.max_total_q)}"
+            )
+        if plan_budget.max_batch is not None and batch > int(plan_budget.max_batch):
+            raise ValueError(
+                f"paged plan batch={batch} exceeds workspace capacity {int(plan_budget.max_batch)}"
+            )
+        if plan_budget.max_page_table_width is not None and max_pages_per_request > int(
+            plan_budget.max_page_table_width
+        ):
+            raise ValueError(
+                "paged plan page_table width="
+                f"{max_pages_per_request} exceeds workspace capacity {int(plan_budget.max_page_table_width)}"
+            )
+
+    gqa_group_size = num_q_heads // num_kv_heads
+    if msa_block_sparse and gqa_group_size != 16:
+        raise ValueError("MSA block-sparse paged attention requires gqa_group_size=16")
+    packed_qo_len_arr = [q_len * gqa_group_size for q_len in q_lengths]
+    kv_len_arr = list(cache_pages_arr)
+    policy_batch = _graph_policy_batch(
+        mode=mode,
+        batch=batch,
+        total_q=total_q,
+    )
+
+    if window_left >= 0:
+        kv_window_start_pages = [
+            min(
+                _window_start_page(
+                    cache_len=cache_len,
+                    q_len=q_len,
+                    window_left=window_left,
+                    page_size=page_size,
+                ),
+                max(kv_pages - 1, 0),
+            )
+            for cache_len, q_len, kv_pages in zip(cache_lengths, q_lengths, kv_len_arr)
+        ]
+        effective_kv_len_arr = [
+            max(kv_pages - start_page, 1)
+            for kv_pages, start_page in zip(kv_len_arr, kv_window_start_pages)
+        ]
+    else:
+        kv_window_start_pages = [0 for _ in kv_len_arr]
+        effective_kv_len_arr = kv_len_arr
+
+    if msa_block_sparse:
+        if msa_union_tile and mode == "extend":
+            effective_kv_len_arr = [
+                _MSA_TOPK * 8 * (_MSA_BLOCK_TOKENS // page_size) for _ in cache_lengths
+            ]
+        else:
+            effective_kv_len_arr = [
+                _msa_effective_pages(cache_len, page_size)
+                for cache_len in cache_lengths
+            ]
+
+    if enable_cuda_graph and window_left >= 0:
+        max_graph_window_pages = max(1, _ceil_div(window_left + page_size, page_size))
+        effective_kv_len_arr = [
+            max(effective_pages, min(kv_pages, max_graph_window_pages))
+            for effective_pages, kv_pages in zip(effective_kv_len_arr, kv_len_arr)
+        ]
+        kv_window_start_pages = [
+            min(start_page, max(kv_pages - effective_pages, 0))
+            for start_page, kv_pages, effective_pages in zip(
+                kv_window_start_pages, kv_len_arr, effective_kv_len_arr
+            )
+        ]
+
+    if enable_cuda_graph:
+        total_num_rows = total_q
+        max_seq_len = total_num_rows - batch + 1
+        max_qo_len = max_seq_len * gqa_group_size
+        cta_tile_q = _paged_determine_cta_tile_q(
+            mode=mode,
+            kv_dtype=k_cache.dtype,
+            packed_qo_len=max_qo_len,
+            head_dim=head_dim_qk,
+            max_effective_kv_pages=max(max(effective_kv_len_arr), 1),
+        )
+        total_num_qo_tiles = (
+            _ceil_div(total_num_rows * gqa_group_size, cta_tile_q) + batch - 1
+        )
+    else:
+        avg_packed_qo_len = sum(packed_qo_len_arr) // max(batch, 1)
+        if (
+            mode in ("extend", "verify")
+            and plan_budget is not None
+            and plan_budget.max_total_q is not None
+        ):
+            avg_packed_qo_len = max(
+                avg_packed_qo_len,
+                int(plan_budget.max_total_q) * gqa_group_size // max(batch, 1),
+            )
+        cta_tile_q = _paged_determine_cta_tile_q(
+            mode=mode,
+            kv_dtype=k_cache.dtype,
+            packed_qo_len=avg_packed_qo_len,
+            head_dim=head_dim_qk,
+            max_effective_kv_pages=max(max(effective_kv_len_arr), 1),
+        )
+        total_num_qo_tiles = sum(
+            _ceil_div(packed_qo_len, cta_tile_q) for packed_qo_len in packed_qo_len_arr
+        )
+
+    if msa_block_sparse and mode == "extend":
+        cta_tile_q = gqa_group_size * (8 if msa_union_tile else 1)
+        if enable_cuda_graph:
+            total_num_qo_tiles = (
+                _ceil_div(total_q * gqa_group_size, cta_tile_q) + batch - 1
+            )
+        else:
+            total_num_qo_tiles = sum(
+                _ceil_div(packed_qo_len, cta_tile_q)
+                for packed_qo_len in packed_qo_len_arr
+            )
+
+    if msa_block_sparse and cta_tile_q not in (gqa_group_size, gqa_group_size * 8):
+        raise ValueError(
+            "MSA block-sparse paged attention requires one or eight tokens per query tile "
+            f"(gqa_group_size={gqa_group_size}, cta_tile_q={cta_tile_q})"
+        )
+
+    kv_window_start_tokens = tuple(
+        start_page * page_size for start_page in kv_window_start_pages
+    )
+    resolved_graph_ctas_per_sm = 0
+    if enable_cuda_graph:
+        resolved_graph_ctas_per_sm = _resolve_graph_ctas_per_sm(
+            mode=mode,
+            kv_dtype=k_cache.dtype,
+            policy_batch=policy_batch,
+            page_size=page_size,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            gqa_group_size=gqa_group_size,
+            graph_ctas_per_sm=graph_ctas_per_sm,
+        )
+    if max_batch_size_if_split is None:
+        if enable_cuda_graph:
+            max_batch_size_if_split = _graph_max_batch_size_if_split(
+                device=q.device,
+                num_kv_heads=num_kv_heads,
+                graph_ctas_per_sm=resolved_graph_ctas_per_sm,
+            )
+        else:
+            max_batch_size_if_split = max(total_num_qo_tiles, 1) * max(
+                max(effective_kv_len_arr), 1
+            )
+    # Keep decode graph replay on the metadata-driven single-qtile path for now.
+    regularized_decode_graph = False
+    padded_batch_size = (
+        max(max_batch_size_if_split, total_num_qo_tiles) if enable_cuda_graph else 0
+    )
+    if regularized_decode_graph:
+        padded_batch_size = _align_up(padded_batch_size, max(batch, 1))
+
+    if not msa_block_sparse and not _merge_backend_supports_split_kv(
+        output_dtype=q.dtype,
+        head_dim_vo=head_dim_vo,
+    ):
+        disable_split_kv = True
+    if mode == "decode" and not force_split_kv:
+        disable_split_kv = True
+
+    min_kv_chunk_size = max(128 // page_size, 1)
+    if mode == "extend":
+        split_kv = False
+        disable_split_kv = True
+        required_kv_chunk_size_pages = max(max(effective_kv_len_arr), 1)
+        if fixed_split_size > 0:
+            if fixed_split_size < required_kv_chunk_size_pages:
+                raise ValueError(
+                    "extend fixed_split_size must cover the full effective KV span when split-kv is disabled"
+                )
+            kv_chunk_size_pages = fixed_split_size
+        else:
+            kv_chunk_size_pages = required_kv_chunk_size_pages
+    elif msa_block_sparse and force_split_kv:
+        split_kv = False
+        kv_chunk_size_pages = (
+            int(fixed_split_size)
+            if fixed_split_size > 0
+            else _msa_decode_chunk_pages(policy_batch, page_size)
+        )
+        if kv_chunk_size_pages <= 0:
+            raise ValueError("MSA split chunk size must be positive")
+    elif disable_split_kv and not force_split_kv:
+        split_kv = False
+        kv_chunk_size_pages = (
+            _ceil_div(_MSA_TOPK * _MSA_BLOCK_TOKENS, page_size)
+            if msa_block_sparse
+            else max(max(effective_kv_len_arr), 1)
+        )
+    elif fixed_split_size > 0:
+        split_kv = False
+        kv_chunk_size_pages = fixed_split_size
+    else:
+        graph_max_chunks_per_req = None
+        if enable_cuda_graph and graph_chunk_policy:
+            graph_max_chunks_per_req = max(
+                max_batch_size_if_split // max(policy_batch, 1), 1
+            )
+        heuristic_kv_chunk_size_pages = chunk_pages_for_family(
+            mode=mode,
+            q_dtype=q.dtype,
+            kv_dtype=k_cache.dtype,
+            policy_batch=policy_batch,
+            graph_chunk_policy=bool(enable_cuda_graph and graph_chunk_policy),
+            page_size=page_size,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            gqa_group_size=gqa_group_size,
+            max_effective_kv_pages=max(max(effective_kv_len_arr), 1),
+            max_chunks_per_req=graph_max_chunks_per_req,
+        )
+        heuristic_fits_graph_budget = True
+        heuristic_fits_plan_budget = True
+        if heuristic_kv_chunk_size_pages is not None and enable_cuda_graph:
+            heuristic_new_batch_size = _estimate_new_batch_size(
+                packed_qo_len_arr=packed_qo_len_arr,
+                kv_len_arr=effective_kv_len_arr,
+                qo_chunk_size=cta_tile_q,
+                kv_chunk_size_pages=heuristic_kv_chunk_size_pages,
+            )
+            heuristic_fits_graph_budget = heuristic_new_batch_size <= padded_batch_size
+        if heuristic_kv_chunk_size_pages is not None:
+            heuristic_new_batch_size, heuristic_total_num_partial_rows = (
+                _estimate_prefill_plan_usage(
+                    packed_qo_len_arr=packed_qo_len_arr,
+                    q_lengths=q_lengths,
+                    kv_len_arr=effective_kv_len_arr,
+                    qo_chunk_size=cta_tile_q,
+                    kv_chunk_size_pages=heuristic_kv_chunk_size_pages,
+                    force_split_kv=bool(force_split_kv),
+                )
+            )
+            heuristic_fits_plan_budget = _prefill_usage_fits_budget(
+                budget=plan_budget,
+                new_batch_size=heuristic_new_batch_size,
+                total_num_partial_rows=heuristic_total_num_partial_rows,
+            )
+        if (
+            heuristic_kv_chunk_size_pages is not None
+            and heuristic_fits_graph_budget
+            and heuristic_fits_plan_budget
+        ):
+            split_kv = False
+            kv_chunk_size_pages = heuristic_kv_chunk_size_pages
+        else:
+            split_kv, kv_chunk_size_pages = _prefill_binary_search_kv_chunk_size(
+                enable_cuda_graph=enable_cuda_graph,
+                max_batch_size_if_split=max_batch_size_if_split,
+                packed_qo_len_arr=packed_qo_len_arr,
+                q_lengths=q_lengths,
+                kv_len_arr=effective_kv_len_arr,
+                qo_chunk_size=cta_tile_q,
+                force_split_kv=bool(force_split_kv),
+                plan_budget=plan_budget,
+                min_kv_chunk_size=min_kv_chunk_size,
+            )
+
+    request_indices: list[int] = []
+    qo_tile_indices: list[int] = []
+    kv_tile_indices: list[int] = []
+    merge_indptr: list[int] = [0]
+    o_indptr: list[int] = [0]
+    request_num_chunks_kv: list[int] = []
+    new_batch_size = 0
+
+    for request_idx, (packed_qo_len, qo_len, kv_len) in enumerate(
+        zip(packed_qo_len_arr, q_lengths, effective_kv_len_arr)
+    ):
+        num_tiles_q = _ceil_div(packed_qo_len, cta_tile_q)
+        num_chunks_kv = (
+            1
+            if disable_split_kv and not force_split_kv
+            else _ceil_div(max(kv_len, 1), kv_chunk_size_pages)
+        )
+        request_num_chunks_kv.append(int(num_chunks_kv))
+        if not disable_split_kv or force_split_kv:
+            split_kv = split_kv or num_chunks_kv > 1
+        for q_tile_idx in range(num_tiles_q):
+            for kv_tile_idx in range(num_chunks_kv):
+                new_batch_size += 1
+                request_indices.append(request_idx)
+                qo_tile_indices.append(q_tile_idx)
+                kv_tile_indices.append(kv_tile_idx)
+        for _ in range(qo_len):
+            merge_indptr.append(merge_indptr[-1] + num_chunks_kv)
+        o_indptr.append(o_indptr[-1] + qo_len * num_chunks_kv)
+
+    padded_batch_size = (
+        max(max_batch_size_if_split, total_num_qo_tiles)
+        if enable_cuda_graph
+        else new_batch_size
+    )
+    if msa_block_sparse and force_split_kv and not enable_cuda_graph:
+        padded_batch_size = max(padded_batch_size, 128)
+    if regularized_decode_graph:
+        padded_batch_size = _align_up(padded_batch_size, max(batch, 1))
+    if new_batch_size > padded_batch_size:
+        raise ValueError(
+            "new_batch_size exceeds padded_batch_size; fixed_split_size is incompatible with the chosen graph budget"
+        )
+    if force_split_kv:
+        split_kv = True
+    total_num_partial_rows = o_indptr[-1] if split_kv else 0
+    if not _prefill_usage_fits_budget(
+        budget=plan_budget,
+        new_batch_size=new_batch_size,
+        total_num_partial_rows=total_num_partial_rows,
+    ):
+        raise ValueError(
+            "paged prefill plan exceeds the configured eager workspace budget"
+        )
+
+    if regularized_decode_graph:
+        max_chunks_per_req = padded_batch_size // max(batch, 1)
+        block_valid_mask = [False for _ in range(padded_batch_size)]
+        for request_idx, num_chunks_kv in enumerate(request_num_chunks_kv):
+            base_idx = request_idx * max_chunks_per_req
+            for kv_tile_idx in range(num_chunks_kv):
+                block_valid_mask[base_idx + kv_tile_idx] = True
+    else:
+        block_valid_mask = [idx < new_batch_size for idx in range(padded_batch_size)]
+    kv_chunk_size = kv_chunk_size_pages * page_size
+
+    if (
+        os.environ.get("FLASHINFER_EXP_SM12X_DEBUG_PAGED_POLICY") == "1"
+        and enable_cuda_graph
+        and graph_chunk_policy
+        and mode == "decode"
+    ):
+        print(
+            "# sm12x_paged_policy"
+            f" batch={batch}"
+            f" pages={max(max(effective_kv_len_arr), 1)}"
+            f" graph_ctas_per_sm={resolved_graph_ctas_per_sm}"
+            f" chunk_pages={kv_chunk_size_pages}"
+            f" split_kv={int(split_kv)}"
+            f" padded_batch_size={padded_batch_size}"
+            f" new_batch_size={new_batch_size}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    key = PagedPlanKey(
+        total_q=total_q,
+        num_q_heads=num_q_heads,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        k_cache_shape=tuple(int(dim) for dim in k_cache.shape),
+        v_cache_shape=tuple(int(dim) for dim in v_cache.shape),
+        page_table_shape=tuple(int(dim) for dim in page_table.shape),
+        dtype=q.dtype,
+        kv_dtype=k_cache.dtype,
+        mode=mode,
+        cta_tile_q=cta_tile_q,
+        kv_chunk_size=kv_chunk_size,
+        split_kv=split_kv,
+        fixed_split_size=fixed_split_size,
+        disable_split_kv=disable_split_kv,
+        enable_cuda_graph=enable_cuda_graph,
+        graph_chunk_policy=graph_chunk_policy,
+        graph_ctas_per_sm=resolved_graph_ctas_per_sm,
+        window_left=window_left,
+        max_batch_size_if_split=max_batch_size_if_split,
+        padded_batch_size=padded_batch_size,
+        new_batch_size=new_batch_size,
+        num_qo_tiles=total_num_qo_tiles,
+        total_num_partial_rows=total_num_partial_rows,
+        page_size=page_size,
+        num_kv_heads=num_kv_heads,
+        gqa_group_size=gqa_group_size,
+        msa_block_sparse=msa_block_sparse,
+        msa_union_tile=bool(msa_union_tile),
+        msa_topk=(_MSA_TOPK if msa_block_sparse else 0),
+        msa_block_tokens=(_MSA_BLOCK_TOKENS if msa_block_sparse else 0),
+        device_index=q.device.index
+        if q.device.index is not None
+        else torch.cuda.current_device(),
+    )
+    return PagedPlan(
+        key=key,
+        request_indices=tuple(request_indices),
+        qo_tile_indices=tuple(qo_tile_indices),
+        kv_tile_indices=tuple(kv_tile_indices),
+        merge_indptr=tuple(merge_indptr),
+        o_indptr=tuple(o_indptr),
+        block_valid_mask=tuple(block_valid_mask),
+        kv_window_start_tokens=kv_window_start_tokens,
+    )

--- a/flashinfer/experimental/sm12x/attention/paged/reference.py
+++ b/flashinfer/experimental/sm12x/attention/paged/reference.py
@@ -1,0 +1,378 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/reference.py @ 3044f545 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Reference attention helpers for sm12x attention correctness checks."""
+
+from __future__ import annotations
+
+import torch
+
+
+def _causal_mask_right_aligned(
+    seqlen_q: int,
+    seqlen_k: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    q_idx = torch.arange(seqlen_q, device=device, dtype=torch.int32).view(seqlen_q, 1)
+    k_idx = torch.arange(seqlen_k, device=device, dtype=torch.int32).view(1, seqlen_k)
+    return k_idx > (q_idx + seqlen_k - seqlen_q)
+
+
+def attention_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    softmax_scale: float | None = None,
+    causal: bool = True,
+    window_left: int = -1,
+    attention_sink_bias: torch.Tensor | None = None,
+    relative_attention_bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute exact self-attention for contiguous rank-3 or rank-4 tensors.
+
+    Supported layouts:
+    - `q`: `[seqlen_q, q_heads, head_dim_qk]` or `[batch, seqlen_q, q_heads, head_dim_qk]`
+    - `k`: same rank, with `kv_heads` in place of `q_heads`
+    - `v`: same rank, with `kv_heads` in place of `q_heads` and `head_dim_vo`
+
+    Returns:
+    - `out` with shape `q.shape[:-1] + (head_dim_vo,)` and the same dtype as `q`
+    - `lse` with shape `[q_heads, seqlen_q]` or `[batch, q_heads, seqlen_q]`
+    """
+    if q.ndim not in (3, 4):
+        raise ValueError(f"expected rank-3 or rank-4 q tensor, got rank {q.ndim}")
+    if q.ndim != k.ndim or q.ndim != v.ndim:
+        raise ValueError("q, k, and v must have the same rank")
+
+    squeeze_batch = q.ndim == 3
+    if squeeze_batch:
+        q = q.unsqueeze(0)
+        k = k.unsqueeze(0)
+        v = v.unsqueeze(0)
+
+    batch, seqlen_q, q_heads, head_dim_qk = q.shape
+    _, seqlen_k, kv_heads, head_dim_k = k.shape
+    _, seqlen_v, kv_heads_v, head_dim_v = v.shape
+    if head_dim_qk != head_dim_k:
+        raise ValueError("q and k must have matching head dims")
+    if seqlen_k != seqlen_v or kv_heads != kv_heads_v:
+        raise ValueError("k and v must have the same sequence length and head count")
+    if q_heads % kv_heads != 0:
+        raise ValueError(f"q_heads={q_heads} must be divisible by kv_heads={kv_heads}")
+
+    if softmax_scale is None:
+        softmax_scale = head_dim_qk**-0.5
+
+    q_per_kv = q_heads // kv_heads
+    if q_per_kv != 1:
+        k = k.repeat_interleave(q_per_kv, dim=2)
+        v = v.repeat_interleave(q_per_kv, dim=2)
+
+    q_f = q.permute(0, 2, 1, 3).to(torch.float32)
+    k_f = k.permute(0, 2, 1, 3).to(torch.float32)
+    v_f = v.permute(0, 2, 1, 3).to(torch.float32)
+
+    scores = torch.matmul(q_f, k_f.transpose(-1, -2)) * float(softmax_scale)
+    if relative_attention_bias is not None:
+        if relative_attention_bias.ndim == 3:
+            relative_attention_bias = relative_attention_bias.unsqueeze(0)
+        expected_prefix = (batch, seqlen_q, q_heads)
+        if (
+            relative_attention_bias.ndim != 4
+            or tuple(relative_attention_bias.shape[:3]) != expected_prefix
+        ):
+            raise ValueError(
+                "relative_attention_bias must have shape "
+                f"{expected_prefix} + (relative_extent,), got "
+                f"{tuple(relative_attention_bias.shape)}"
+            )
+        relative_extent = int(relative_attention_bias.shape[3])
+        q_idx = torch.arange(seqlen_q, device=scores.device, dtype=torch.int64).view(
+            seqlen_q, 1
+        )
+        k_idx = torch.arange(seqlen_k, device=scores.device, dtype=torch.int64).view(
+            1, seqlen_k
+        )
+        distance = q_idx + seqlen_k - seqlen_q - k_idx
+        in_extent = (distance >= 0) & (distance < relative_extent)
+        distance = distance.clamp(min=0, max=relative_extent - 1)
+        bias = relative_attention_bias.to(
+            device=scores.device, dtype=scores.dtype
+        ).permute(0, 2, 1, 3)
+        gather_idx = distance.view(1, 1, seqlen_q, seqlen_k).expand(
+            batch, q_heads, -1, -1
+        )
+        bias = torch.gather(bias, dim=-1, index=gather_idx)
+        scores = scores + bias.masked_fill(
+            ~in_extent.view(1, 1, seqlen_q, seqlen_k), 0.0
+        )
+    if causal:
+        causal_mask = _causal_mask_right_aligned(
+            seqlen_q, seqlen_k, device=scores.device
+        )
+        scores = scores.masked_fill(
+            causal_mask.view(1, 1, seqlen_q, seqlen_k), float("-inf")
+        )
+    if window_left >= 0:
+        q_idx = torch.arange(seqlen_q, device=scores.device, dtype=torch.int32).view(
+            seqlen_q, 1
+        )
+        k_idx = torch.arange(seqlen_k, device=scores.device, dtype=torch.int32).view(
+            1, seqlen_k
+        )
+        causal_limit = q_idx + seqlen_k - seqlen_q
+        window_mask = k_idx < (causal_limit - int(window_left))
+        scores = scores.masked_fill(
+            window_mask.view(1, 1, seqlen_q, seqlen_k), float("-inf")
+        )
+    if attention_sink_bias is not None:
+        if (
+            attention_sink_bias.ndim != 1
+            or int(attention_sink_bias.shape[0]) != q_heads
+        ):
+            raise ValueError("attention_sink_bias must have shape [q_heads]")
+        sink = attention_sink_bias.to(device=scores.device, dtype=scores.dtype).view(
+            1, q_heads, 1, 1
+        )
+        scores_for_lse = torch.cat(
+            (scores, sink.expand(batch, q_heads, seqlen_q, 1)), dim=-1
+        )
+    else:
+        scores_for_lse = scores
+    probs = torch.softmax(scores, dim=-1)
+    out = torch.matmul(probs, v_f).permute(0, 2, 1, 3).to(q.dtype)
+    if attention_sink_bias is not None:
+        denom = torch.exp(
+            scores_for_lse - torch.logsumexp(scores_for_lse, dim=-1, keepdim=True)
+        )
+        value_probs = denom[..., :seqlen_k]
+        out = torch.matmul(value_probs, v_f).permute(0, 2, 1, 3).to(q.dtype)
+    lse = torch.logsumexp(scores_for_lse, dim=-1).to(torch.float32)
+
+    if squeeze_batch:
+        out = out.squeeze(0)
+        lse = lse.squeeze(0)
+    return out, lse
+
+
+def materialize_paged_kv_cache(
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    *,
+    request_idx: int,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k_cache.ndim != 4 or v_cache.ndim != 4:
+        raise ValueError(
+            "expected paged K/V caches with shape [num_pages, page_size, heads, dim]"
+        )
+    page_size = int(k_cache.shape[1])
+    cache_len = int(cache_seqlens[request_idx].item())
+    if cache_len == 0:
+        return k_cache[:0].reshape(0, k_cache.shape[2], k_cache.shape[3]), v_cache[
+            :0
+        ].reshape(0, v_cache.shape[2], v_cache.shape[3])
+    num_pages = (cache_len + page_size - 1) // page_size
+    page_ids = page_table[request_idx, :num_pages].to(torch.long)
+    k = k_cache.index_select(0, page_ids).reshape(
+        num_pages * page_size, k_cache.shape[2], k_cache.shape[3]
+    )
+    v = v_cache.index_select(0, page_ids).reshape(
+        num_pages * page_size, v_cache.shape[2], v_cache.shape[3]
+    )
+    k = k[:cache_len]
+    v = v[:cache_len]
+    if k.dtype == torch.float8_e4m3fn:
+        scale = 1.0 if k_descale is None else k_descale[request_idx].view(1, -1, 1)
+        k = (k.float() * scale).to(torch.bfloat16)
+    if v.dtype == torch.float8_e4m3fn:
+        scale = 1.0 if v_descale is None else v_descale[request_idx].view(1, -1, 1)
+        v = (v.float() * scale).to(torch.bfloat16)
+    return k, v
+
+
+def paged_attention_reference(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    *,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
+    softmax_scale: float | None = None,
+    causal: bool = True,
+    window_left: int = -1,
+    attention_sink_bias: torch.Tensor | None = None,
+    relative_attention_bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference paged self-attention for the SGLang serving contract.
+
+    Inputs:
+    - `q`: `[total_q, q_heads, head_dim]`
+    - `k_cache`, `v_cache`: `[num_pages, page_size, kv_heads, head_dim]`
+    - `page_table`: `[batch, max_pages]`
+    - `cache_seqlens`: `[batch]`
+    - `cu_seqlens_q`: `[batch + 1]`
+
+    Returns:
+    - `out`: `[total_q, q_heads, head_dim]`
+    - `lse`: `[total_q, q_heads]` token-major float32
+    """
+    if q.ndim != 3:
+        raise ValueError(f"expected rank-3 q tensor, got rank {q.ndim}")
+    if cu_seqlens_q.ndim != 1 or cache_seqlens.ndim != 1:
+        raise ValueError("cu_seqlens_q and cache_seqlens must be rank-1 tensors")
+    total_q, q_heads, head_dim_qk = q.shape
+    head_dim_vo = int(v_cache.shape[-1])
+    if softmax_scale is None:
+        softmax_scale = head_dim_qk**-0.5
+
+    out = torch.empty((total_q, q_heads, head_dim_vo), dtype=q.dtype, device=q.device)
+    lse = torch.empty((total_q, q_heads), dtype=torch.float32, device=q.device)
+    q_offsets = [int(v) for v in cu_seqlens_q.detach().cpu().tolist()]
+    for request_idx, (q_start, q_end) in enumerate(zip(q_offsets[:-1], q_offsets[1:])):
+        if q_end == q_start:
+            continue
+        k, v = materialize_paged_kv_cache(
+            k_cache,
+            v_cache,
+            page_table,
+            cache_seqlens,
+            request_idx=request_idx,
+            k_descale=k_descale,
+            v_descale=v_descale,
+        )
+        out_cur, lse_cur = attention_reference(
+            q[q_start:q_end],
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_left=window_left,
+            attention_sink_bias=attention_sink_bias,
+            relative_attention_bias=(
+                None
+                if relative_attention_bias is None
+                else relative_attention_bias[q_start:q_end]
+            ),
+        )
+        out[q_start:q_end].copy_(out_cur)
+        lse[q_start:q_end].copy_(lse_cur.transpose(0, 1))
+    return out, lse
+
+
+def msa_attention_reference(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    q2k_indices: torch.Tensor,
+    *,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
+    softmax_scale: float | None = None,
+    block_tokens: int = 128,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference MiniMax-MSA sparse block-list paged attention.
+
+    `q2k_indices` is `[kv_heads, total_q_capacity, topk]`, containing
+    batch-local 128-token block ids.  Each selected block maps to
+    `block_tokens // page_size` page-table entries (two logical 64-token pages
+    at page_size=64, one page at page_size=128).
+    """
+    if q.ndim != 3:
+        raise ValueError(f"expected rank-3 q tensor, got rank {q.ndim}")
+    if q2k_indices.ndim != 3:
+        raise ValueError(
+            f"q2k_indices must be rank-3 [kv_heads, total_q_capacity, topk], got {tuple(q2k_indices.shape)}"
+        )
+    if k_cache.ndim != 4 or v_cache.ndim != 4:
+        raise ValueError(
+            "expected paged K/V caches with shape [num_pages, page_size, heads, dim]"
+        )
+    if int(k_cache.shape[1]) not in (64, 128) or int(v_cache.shape[1]) != int(
+        k_cache.shape[1]
+    ):
+        raise ValueError("MSA reference expects matching page_size 64 or 128")
+    if int(block_tokens) != 128:
+        raise ValueError("MSA reference currently expects block_tokens=128")
+    if int(block_tokens) % int(k_cache.shape[1]) != 0:
+        raise ValueError("MSA reference expects page_size dividing block_tokens")
+    if k_cache.shape[:3] != v_cache.shape[:3]:
+        raise ValueError("k_cache and v_cache structural shapes must match")
+    if int(q2k_indices.shape[0]) != int(k_cache.shape[2]):
+        raise ValueError("q2k_indices first dimension must match kv heads")
+
+    total_q, q_heads, head_dim_qk = q.shape
+    kv_heads = int(k_cache.shape[2])
+    head_dim_vo = int(v_cache.shape[-1])
+    if q_heads % kv_heads != 0:
+        raise ValueError("q_heads must be divisible by kv_heads")
+    if int(q2k_indices.shape[1]) < total_q:
+        raise ValueError("q2k_indices total_q_capacity is smaller than q")
+    if softmax_scale is None:
+        softmax_scale = head_dim_qk**-0.5
+
+    out = torch.empty((total_q, q_heads, head_dim_vo), dtype=q.dtype, device=q.device)
+    lse = torch.empty((total_q, q_heads), dtype=torch.float32, device=q.device)
+    q_offsets = [int(v) for v in cu_seqlens_q.detach().cpu().tolist()]
+    q_per_kv = q_heads // kv_heads
+
+    for request_idx, (q_start, q_end) in enumerate(zip(q_offsets[:-1], q_offsets[1:])):
+        qo_len = q_end - q_start
+        if qo_len <= 0:
+            continue
+        cache_len = int(cache_seqlens[request_idx].item())
+        k_full, v_full = materialize_paged_kv_cache(
+            k_cache,
+            v_cache,
+            page_table,
+            cache_seqlens,
+            request_idx=request_idx,
+            k_descale=k_descale,
+            v_descale=v_descale,
+        )
+        for q_row in range(q_start, q_end):
+            token_local = q_row - q_start
+            causal_limit = token_local + cache_len - qo_len
+            visible_limit = max(min(causal_limit + 1, cache_len), 0)
+            for q_head in range(q_heads):
+                kv_head = q_head // q_per_kv
+                block_ids = q2k_indices[kv_head, q_row].detach().cpu().tolist()
+                key_chunks: list[torch.Tensor] = []
+                value_chunks: list[torch.Tensor] = []
+                for block_id_raw in block_ids:
+                    block_id = int(block_id_raw)
+                    if block_id < 0:
+                        continue
+                    block_start = block_id * block_tokens
+                    block_end = min(block_start + block_tokens, visible_limit)
+                    if block_end <= block_start:
+                        continue
+                    key_chunks.append(k_full[block_start:block_end, kv_head])
+                    value_chunks.append(v_full[block_start:block_end, kv_head])
+
+                if not key_chunks:
+                    out[q_row, q_head].zero_()
+                    lse[q_row, q_head] = float("-inf")
+                    continue
+
+                keys = torch.cat(key_chunks, dim=0).to(torch.float32)
+                values = torch.cat(value_chunks, dim=0).to(torch.float32)
+                scores = torch.matmul(keys, q[q_row, q_head].to(torch.float32)) * float(
+                    softmax_scale
+                )
+                probs = torch.softmax(scores, dim=0)
+                out[q_row, q_head].copy_(torch.matmul(probs, values).to(q.dtype))
+                lse[q_row, q_head] = torch.logsumexp(scores, dim=0).to(torch.float32)
+    return out, lse

--- a/flashinfer/experimental/sm12x/attention/paged/traits.py
+++ b/flashinfer/experimental/sm12x/attention/paged/traits.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/traits.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""FlashInfer-inspired forward trait selection for the primary paged backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import torch
+
+from flashinfer.experimental.sm12x._lib.smem import make_tma_aligned_payload_storage
+
+from .planner import PagedPlan
+
+_FP8_KV_DTYPE = torch.float8_e4m3fn
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def _dtype_num_bytes(dtype: torch.dtype) -> int:
+    if dtype in (torch.float16, torch.bfloat16):
+        return 2
+    if dtype == torch.float32:
+        return 4
+    if dtype == _FP8_KV_DTYPE:
+        return 1
+    raise TypeError(f"unsupported dtype {dtype}")
+
+
+def paged_get_num_warps_q(cta_tile_q: int) -> int:
+    return 4 if cta_tile_q > 16 else 1
+
+
+def paged_get_num_warps_kv(cta_tile_q: int) -> int:
+    return 4 // paged_get_num_warps_q(cta_tile_q)
+
+
+def paged_get_num_mma_q(cta_tile_q: int) -> int:
+    return 2 if cta_tile_q > 64 else 1
+
+
+@dataclass(frozen=True)
+class PagedForwardTraits:
+    cta_tile_q: int
+    cta_tile_kv: int
+    num_mma_q: int
+    num_mma_kv: int
+    num_mma_d_qk: int
+    num_mma_d_vo: int
+    num_warps_q: int
+    num_warps_kv: int
+    num_threads: int
+    head_dim_qk: int
+    head_dim_vo: int
+    upcast_stride_q: int
+    upcast_stride_k: int
+    upcast_stride_v: int
+    upcast_stride_o: int
+    q_dtype: torch.dtype
+    kv_dtype: torch.dtype
+    o_dtype: torch.dtype
+    q_smem_bytes: int
+    shared_storage_bytes: int
+    max_smem_per_sm: int
+    num_ctas_per_sm: int
+    max_smem_per_threadblock: int
+
+    @property
+    def uses_fp8_kv(self) -> bool:
+        return self.kv_dtype == _FP8_KV_DTYPE
+
+    @property
+    def launch_smem_bytes(self) -> int:
+        """Typed one-stage TMA allocation used by the primary decode kernel."""
+        return int(
+            make_tma_aligned_payload_storage(
+                payload_bytes=self.shared_storage_bytes,
+                num_stages=1,
+            ).size_in_bytes()
+        )
+
+
+def _paged_is_invalid(
+    *,
+    num_mma_q: int,
+    num_mma_kv: int,
+    num_mma_d_vo: int,
+    num_warps_q: int,
+    kv_dtype: torch.dtype,
+) -> bool:
+    kv_is_fp8 = kv_dtype == _FP8_KV_DTYPE
+    if num_mma_d_vo < 4:
+        return True
+    if num_mma_d_vo == 4 and num_mma_kv % 2 == 1:
+        return True
+    if num_mma_q * (8 * num_mma_d_vo + 8 * num_mma_kv) >= 256:
+        return True
+    if kv_is_fp8 and (num_mma_kv * 2) % num_warps_q != 0:
+        return True
+    return False
+
+
+def select_paged_forward_traits(
+    *,
+    cta_tile_q: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    o_dtype: torch.dtype | None = None,
+    device: torch.device | int | None = None,
+) -> PagedForwardTraits:
+    if head_dim_qk % 16 != 0 or head_dim_vo % 16 != 0:
+        raise ValueError("head_dim_qk and head_dim_vo must be multiples of 16")
+    if q_dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(f"unsupported q dtype {q_dtype}")
+    if kv_dtype not in (torch.float16, torch.bfloat16, _FP8_KV_DTYPE):
+        raise TypeError(f"unsupported kv dtype {kv_dtype}")
+    if kv_dtype == _FP8_KV_DTYPE and q_dtype != torch.bfloat16:
+        raise TypeError("primary paged backend only supports bf16 queries with fp8 kv")
+    o_dtype = q_dtype if o_dtype is None else o_dtype
+    if o_dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(f"unsupported output dtype {o_dtype}")
+
+    if kv_dtype == _FP8_KV_DTYPE and cta_tile_q == 48:
+        device_props = torch.cuda.get_device_properties(
+            torch.cuda.current_device() if device is None else device
+        )
+        max_smem_per_sm = int(device_props.shared_memory_per_multiprocessor)
+        max_smem_per_block = min(
+            max_smem_per_sm,
+            int(
+                getattr(device_props, "shared_memory_per_block_optin", max_smem_per_sm)
+            ),
+        )
+        kv_bytes = _dtype_num_bytes(kv_dtype)
+        upcast_stride_k = _align_up(head_dim_qk // (16 // kv_bytes), 8)
+        upcast_stride_v = _align_up(head_dim_vo // (16 // kv_bytes), 8)
+        shared_storage_bytes = 49152
+        launch_smem_bytes = int(
+            make_tma_aligned_payload_storage(
+                payload_bytes=shared_storage_bytes,
+                num_stages=1,
+            ).size_in_bytes()
+        )
+        if launch_smem_bytes > max_smem_per_block:
+            raise ValueError(
+                f"paged forward typed shared storage requires {launch_smem_bytes} B, "
+                f"but the device permits {max_smem_per_block} B per CTA"
+            )
+        num_ctas_per_sm = 2 if 2 * launch_smem_bytes <= max_smem_per_sm else 1
+        return PagedForwardTraits(
+            cta_tile_q=48,
+            cta_tile_kv=32,
+            num_mma_q=1,
+            num_mma_kv=2,
+            num_mma_d_qk=head_dim_qk // 16,
+            num_mma_d_vo=head_dim_vo // 16,
+            num_warps_q=3,
+            num_warps_kv=1,
+            num_threads=96,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            upcast_stride_q=head_dim_qk // 8,
+            upcast_stride_k=upcast_stride_k,
+            upcast_stride_v=upcast_stride_v,
+            upcast_stride_o=head_dim_vo // (16 // _dtype_num_bytes(o_dtype)),
+            q_dtype=q_dtype,
+            kv_dtype=kv_dtype,
+            o_dtype=o_dtype,
+            q_smem_bytes=48 * head_dim_qk * _dtype_num_bytes(q_dtype),
+            shared_storage_bytes=shared_storage_bytes,
+            max_smem_per_sm=max_smem_per_sm,
+            num_ctas_per_sm=num_ctas_per_sm,
+            max_smem_per_threadblock=min(
+                max_smem_per_block,
+                max_smem_per_sm // num_ctas_per_sm,
+            ),
+        )
+
+    num_mma_d_qk = head_dim_qk // 16
+    num_mma_d_vo = head_dim_vo // 16
+    num_warps_q = paged_get_num_warps_q(cta_tile_q)
+    num_warps_kv = paged_get_num_warps_kv(cta_tile_q)
+    num_mma_q = paged_get_num_mma_q(cta_tile_q)
+
+    device_props = torch.cuda.get_device_properties(
+        torch.cuda.current_device() if device is None else device
+    )
+    max_smem_per_sm = int(device_props.shared_memory_per_multiprocessor)
+    max_smem_per_block = min(
+        max_smem_per_sm,
+        int(getattr(device_props, "shared_memory_per_block_optin", max_smem_per_sm)),
+    )
+
+    q_bytes = _dtype_num_bytes(q_dtype)
+    kv_bytes = _dtype_num_bytes(kv_dtype)
+    o_bytes = _dtype_num_bytes(o_dtype)
+    upcast_stride_q = head_dim_qk // (16 // q_bytes)
+    upcast_stride_k = head_dim_qk // (16 // kv_bytes)
+    upcast_stride_v = head_dim_vo // (16 // kv_bytes)
+    if kv_dtype == _FP8_KV_DTYPE:
+        upcast_stride_k = _align_up(upcast_stride_k, 8)
+        upcast_stride_v = _align_up(upcast_stride_v, 8)
+    upcast_stride_o = head_dim_vo // (16 // o_bytes)
+    q_smem_bytes = cta_tile_q * head_dim_qk * q_bytes
+    kv_bytes_per_mma = (upcast_stride_k + upcast_stride_v) * 16 * 16 * num_warps_kv
+    max_num_mma_kv_reg = 8 // num_mma_q
+    sync_o_row_stride = head_dim_vo + (
+        24
+        if (
+            kv_dtype != _FP8_KV_DTYPE and o_dtype == torch.bfloat16 and cta_tile_q == 16
+        )
+        else 0
+    )
+    cta_sync_o_bytes = (
+        4 if num_warps_kv == 1 else num_warps_kv * cta_tile_q * sync_o_row_stride * 4
+    )
+    cta_sync_md_bytes = 8 if num_warps_kv == 1 else num_warps_kv * cta_tile_q * 8
+    cta_sync_storage_bytes = cta_sync_o_bytes + cta_sync_md_bytes
+    smem_o_bytes = cta_tile_q * head_dim_vo * o_bytes
+
+    # Choose the MMA tile and residency together from exact CUTLASS typed
+    # allocations. This preserves the occupancy-first policy without deriving
+    # a per-CTA budget from assumed residency and feeding it back into the tile.
+    # The primary cta_q=16 backend is the exact-plane 64-row decode family; a
+    # larger KV tile disables that ingress path, so it is not a valid candidate.
+    max_candidate_mma_kv = 1 if cta_tile_q == 16 else max_num_mma_kv_reg
+    candidates: list[tuple[int, int, int, int, int]] = []
+    for candidate_mma_kv in range(1, max_candidate_mma_kv + 1):
+        if _paged_is_invalid(
+            num_mma_q=num_mma_q,
+            num_mma_kv=candidate_mma_kv,
+            num_mma_d_vo=num_mma_d_vo,
+            num_warps_q=num_warps_q,
+            kv_dtype=kv_dtype,
+        ):
+            continue
+        candidate_cta_tile_kv = candidate_mma_kv * num_warps_kv * 16
+        candidate_qkv_bytes = q_smem_bytes + candidate_mma_kv * kv_bytes_per_mma
+        candidate_payload_bytes = _align_up(
+            max(candidate_qkv_bytes, cta_sync_storage_bytes, smem_o_bytes),
+            16,
+        )
+        candidate_launch_bytes = int(
+            make_tma_aligned_payload_storage(
+                payload_bytes=candidate_payload_bytes,
+                num_stages=1,
+            ).size_in_bytes()
+        )
+        if candidate_launch_bytes > max_smem_per_block:
+            continue
+        candidate_residency = 2 if 2 * candidate_launch_bytes <= max_smem_per_sm else 1
+        candidates.append(
+            (
+                candidate_residency,
+                candidate_mma_kv,
+                candidate_cta_tile_kv,
+                candidate_payload_bytes,
+                candidate_launch_bytes,
+            )
+        )
+
+    if not candidates:
+        raise ValueError(
+            "no valid NUM_MMA_KV typed shared-memory allocation fits the device"
+        )
+    (
+        num_ctas_per_sm,
+        num_mma_kv,
+        cta_tile_kv,
+        shared_storage_bytes,
+        launch_smem_bytes,
+    ) = max(candidates, key=lambda candidate: (candidate[0], candidate[1]))
+    max_smem_per_threadblock = min(
+        max_smem_per_block,
+        max_smem_per_sm // num_ctas_per_sm,
+    )
+    if launch_smem_bytes > max_smem_per_threadblock:
+        raise AssertionError(
+            "selected paged typed shared-memory allocation exceeds its residency budget"
+        )
+
+    return PagedForwardTraits(
+        cta_tile_q=cta_tile_q,
+        cta_tile_kv=cta_tile_kv,
+        num_mma_q=num_mma_q,
+        num_mma_kv=num_mma_kv,
+        num_mma_d_qk=num_mma_d_qk,
+        num_mma_d_vo=num_mma_d_vo,
+        num_warps_q=num_warps_q,
+        num_warps_kv=num_warps_kv,
+        num_threads=num_warps_q * num_warps_kv * 32,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        upcast_stride_q=upcast_stride_q,
+        upcast_stride_k=upcast_stride_k,
+        upcast_stride_v=upcast_stride_v,
+        upcast_stride_o=upcast_stride_o,
+        q_dtype=q_dtype,
+        kv_dtype=kv_dtype,
+        o_dtype=o_dtype,
+        q_smem_bytes=q_smem_bytes,
+        shared_storage_bytes=shared_storage_bytes,
+        max_smem_per_sm=max_smem_per_sm,
+        num_ctas_per_sm=num_ctas_per_sm,
+        max_smem_per_threadblock=max_smem_per_threadblock,
+    )
+
+
+def select_paged_forward_traits_from_plan(
+    plan: PagedPlan,
+    *,
+    o_dtype: torch.dtype | None = None,
+) -> PagedForwardTraits:
+    return select_paged_forward_traits(
+        cta_tile_q=plan.cta_tile_q,
+        head_dim_qk=plan.head_dim_qk,
+        head_dim_vo=plan.head_dim_vo,
+        q_dtype=plan.dtype,
+        kv_dtype=plan.kv_dtype,
+        o_dtype=o_dtype,
+        device=plan.device,
+    )

--- a/flashinfer/experimental/sm12x/attention/paged/tuning/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/paged/tuning/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/tuning/__init__.py @ 866ac1cd (2026-05-10) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+from .registry import (
+    DECODE_GRAPH_POLICY,
+    DecodeGraphPolicy,
+    get_decode_graph_policy,
+    lookup_decode_graph_chunk_pages,
+    register_decode_graph_policy,
+    normalize_kv_dtype_key,
+)
+
+__all__ = [
+    "DECODE_GRAPH_POLICY",
+    "DecodeGraphPolicy",
+    "get_decode_graph_policy",
+    "lookup_decode_graph_chunk_pages",
+    "register_decode_graph_policy",
+    "normalize_kv_dtype_key",
+]

--- a/flashinfer/experimental/sm12x/attention/paged/tuning/registry.py
+++ b/flashinfer/experimental/sm12x/attention/paged/tuning/registry.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/tuning/registry.py @ 7dc97259 (2026-03-31) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+Ladder = tuple[tuple[int, int], ...]
+
+DECODE_GRAPH_POLICY: Dict[tuple[str, str], Dict[int, "DecodeGraphPolicy"]] = {}
+
+
+@dataclass(frozen=True)
+class DecodeGraphPolicy:
+    graph_ctas_per_sm: int
+    chunk_ladder: Ladder
+    capture_fixed_split_pages: int | None = None
+    capture_page_count: int | None = None
+    page_size: int | None = None
+
+
+def _validate_ladder(
+    *,
+    ladder: Ladder,
+    value_name: str,
+) -> None:
+    if not ladder:
+        raise ValueError("ladder must be non-empty")
+    previous_end = 0
+    for end_page, value in ladder:
+        if end_page <= previous_end:
+            raise ValueError("ladder end_page values must be strictly increasing")
+        if value <= 0:
+            raise ValueError(f"{value_name} must be positive")
+        previous_end = end_page
+
+
+def normalize_kv_dtype_key(kv_dtype: str) -> str:
+    return {
+        "bf16": "bf16",
+        "bfloat16": "bf16",
+        "fp16": "fp16",
+        "float16": "fp16",
+        "fp8": "fp8",
+        "fp8_e4m3fn": "fp8",
+        "float8_e4m3fn": "fp8",
+    }.get(kv_dtype, kv_dtype)
+
+
+def register_decode_graph_policy(
+    *,
+    kv_dtype: str,
+    regime: str,
+    batch: int,
+    graph_ctas_per_sm: int,
+    chunk_ladder: Ladder,
+    capture_fixed_split_pages: int | None = None,
+    capture_page_count: int | None = None,
+    page_size: int | None = None,
+) -> None:
+    if batch <= 0:
+        raise ValueError("batch must be positive")
+    if graph_ctas_per_sm <= 0:
+        raise ValueError("graph_ctas_per_sm must be positive")
+    if capture_fixed_split_pages is not None and capture_fixed_split_pages <= 0:
+        raise ValueError("capture_fixed_split_pages must be positive when provided")
+    if capture_page_count is not None and capture_page_count <= 0:
+        raise ValueError("capture_page_count must be positive when provided")
+    if page_size is not None and page_size <= 0:
+        raise ValueError("page_size must be positive when provided")
+    _validate_ladder(ladder=chunk_ladder, value_name="chunk_pages")
+    DECODE_GRAPH_POLICY.setdefault((normalize_kv_dtype_key(kv_dtype), regime), {})[
+        batch
+    ] = DecodeGraphPolicy(
+        graph_ctas_per_sm=int(graph_ctas_per_sm),
+        chunk_ladder=tuple(chunk_ladder),
+        capture_fixed_split_pages=(
+            None
+            if capture_fixed_split_pages is None
+            else int(capture_fixed_split_pages)
+        ),
+        capture_page_count=None
+        if capture_page_count is None
+        else int(capture_page_count),
+        page_size=None if page_size is None else int(page_size),
+    )
+
+
+def get_decode_graph_policy(
+    *,
+    kv_dtype: str,
+    regime: str,
+    batch: int,
+) -> DecodeGraphPolicy:
+    family = DECODE_GRAPH_POLICY[(normalize_kv_dtype_key(kv_dtype), regime)]
+    available_batches = sorted(family)
+    snapped_batch = next(
+        (candidate for candidate in available_batches if candidate >= batch),
+        available_batches[-1],
+    )
+    return family[snapped_batch]
+
+
+def lookup_decode_graph_chunk_pages(
+    *,
+    kv_dtype: str,
+    regime: str,
+    batch: int,
+    page_count: int,
+) -> int:
+    if page_count <= 0:
+        raise ValueError("page_count must be positive")
+    ladder = get_decode_graph_policy(
+        kv_dtype=kv_dtype, regime=regime, batch=batch
+    ).chunk_ladder
+    for end_page, chunk_pages in ladder:
+        if page_count <= end_page:
+            return chunk_pages
+    return ladder[-1][1]

--- a/flashinfer/experimental/sm12x/attention/paged/workspace.py
+++ b/flashinfer/experimental/sm12x/attention/paged/workspace.py
@@ -1,0 +1,2115 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/attention/paged/workspace.py @ 3044f545 (2026-07-17) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Dynamic workspace state for the primary paged-attention backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+import torch
+from torch.profiler import record_function
+
+from .planner import (
+    PagedPlan,
+    PagedPlanBudget,
+    build_decode_chunk_pages_lut,
+    create_paged_plan,
+    decode_graph_max_chunks_per_request_budget,
+    infer_paged_mode,
+    resolve_decode_graph_ctas_per_sm,
+)
+
+_ARENA_ALIGN_BYTES = 1024
+
+
+def _paged_lse_storage_shape(total_q: int, num_q_heads: int) -> tuple[int, int]:
+    return (num_q_heads, total_q)
+
+
+def _copy_int_metadata(
+    values: tuple[int, ...], *, device: torch.device
+) -> torch.Tensor:
+    return torch.tensor(values, dtype=torch.int32, device=device)
+
+
+def _canonical_device(device: torch.device | str) -> torch.device:
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None:
+        return torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    return ((int(value) + alignment - 1) // alignment) * alignment
+
+
+def _infer_mode_from_host_total(
+    cu_seqlens_q: torch.Tensor, active_total_q: int
+) -> Literal["decode", "extend"]:
+    batch = max(int(cu_seqlens_q.shape[0]) - 1, 0)
+    return "decode" if batch > 0 and int(active_total_q) == batch else "extend"
+
+
+def _dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _shape_numel(shape: tuple[int, ...]) -> int:
+    numel = 1
+    for dim in shape:
+        numel *= int(dim)
+    return numel
+
+
+def _materialize_arena_view(
+    arena: torch.Tensor,
+    *,
+    offset_bytes: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int]:
+    offset_bytes = _align_up(
+        offset_bytes, max(_ARENA_ALIGN_BYTES, _dtype_nbytes(dtype))
+    )
+    nbytes = _shape_numel(shape) * _dtype_nbytes(dtype)
+    if nbytes == 0:
+        return arena.narrow(0, 0, 0).view(dtype).view(shape), offset_bytes
+    view_bytes = arena.narrow(0, offset_bytes, nbytes)
+    typed_view = view_bytes.view(dtype).view(shape)
+    return typed_view, offset_bytes + nbytes
+
+
+def _shape_only_cuda_tensor(
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a tiny CUDA tensor view with the requested logical shape.
+
+    The paged planner only inspects shape, dtype, and device for the
+    contract-side KV tensors; it never reads their data. Represent the
+    contract with a single-element zero-stride view so graph workspaces do
+    not allocate full shadow copies of the KV cache.
+    """
+
+    if any(dim <= 0 for dim in shape):
+        raise ValueError(f"shape must be positive in every dimension, got {shape}")
+    base = torch.empty(1, dtype=dtype, device=device)
+    return base.as_strided(shape, (0,) * len(shape))
+
+
+@dataclass(frozen=True, kw_only=True)
+class PagedAttentionArenaCaps:
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim_qk: int
+    max_head_dim_vo: int
+    page_size: int
+    max_total_q: int
+    max_batch: int
+    max_page_table_width: int
+    max_work_items: int
+    max_partial_rows: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "device", _canonical_device(self.device))
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "num_kv_heads", max(int(self.num_kv_heads), 1))
+        object.__setattr__(self, "head_dim_qk", max(int(self.head_dim_qk), 1))
+        object.__setattr__(self, "max_head_dim_vo", max(int(self.max_head_dim_vo), 1))
+        object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+        object.__setattr__(self, "max_total_q", max(int(self.max_total_q), 1))
+        object.__setattr__(self, "max_batch", max(int(self.max_batch), 1))
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            max(int(self.max_page_table_width), 1),
+        )
+        object.__setattr__(self, "max_work_items", max(int(self.max_work_items), 0))
+        object.__setattr__(self, "max_partial_rows", max(int(self.max_partial_rows), 0))
+
+
+@dataclass(frozen=True, kw_only=True)
+class PagedAttentionWorkspaceContract:
+    mode: Literal["decode", "extend", "verify"]
+    max_total_q: int
+    max_batch: int
+    max_page_table_width: int
+    max_work_items: int
+    max_partial_rows: int
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim_qk: int
+    head_dim_vo: int
+    num_cache_pages: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "max_total_q", max(int(self.max_total_q), 1))
+        object.__setattr__(self, "max_batch", max(int(self.max_batch), 1))
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            max(int(self.max_page_table_width), 1),
+        )
+        object.__setattr__(self, "max_work_items", max(int(self.max_work_items), 0))
+        object.__setattr__(self, "max_partial_rows", max(int(self.max_partial_rows), 0))
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "num_kv_heads", max(int(self.num_kv_heads), 1))
+        object.__setattr__(self, "head_dim_qk", max(int(self.head_dim_qk), 1))
+        object.__setattr__(self, "head_dim_vo", max(int(self.head_dim_vo), 1))
+        object.__setattr__(self, "num_cache_pages", max(int(self.num_cache_pages), 1))
+
+
+@dataclass(frozen=True, kw_only=True)
+class _PagedAttentionArenaLayout:
+    arena_nbytes: int
+    request_indices_offset_bytes: int
+    qo_tile_indices_offset_bytes: int
+    kv_tile_indices_offset_bytes: int
+    block_valid_mask_offset_bytes: int
+    page_table_offset_bytes: int
+    cache_seqlens_offset_bytes: int
+    cu_seqlens_q_offset_bytes: int
+    merge_indptr_offset_bytes: int
+    o_indptr_offset_bytes: int
+    kv_chunk_size_ptr_offset_bytes: int
+    kv_window_start_tokens_offset_bytes: int
+    total_num_rows_ptr_offset_bytes: int
+    lse_offset_bytes: int
+    tmp_output_offset_bytes: int
+    tmp_lse_offset_bytes: int
+
+
+@dataclass(kw_only=True)
+class PagedAttentionArena:
+    caps: PagedAttentionArenaCaps
+    shared_arena: torch.Tensor
+    shared_arena_nbytes: int
+    request_indices_offset_bytes: int
+    qo_tile_indices_offset_bytes: int
+    kv_tile_indices_offset_bytes: int
+    block_valid_mask_offset_bytes: int
+    page_table_offset_bytes: int
+    cache_seqlens_offset_bytes: int
+    cu_seqlens_q_offset_bytes: int
+    merge_indptr_offset_bytes: int
+    o_indptr_offset_bytes: int
+    kv_chunk_size_ptr_offset_bytes: int
+    kv_window_start_tokens_offset_bytes: int
+    total_num_rows_ptr_offset_bytes: int
+    lse_offset_bytes: int
+    tmp_output_offset_bytes: int
+    tmp_lse_offset_bytes: int
+
+    @classmethod
+    def _layout(cls, caps: PagedAttentionArenaCaps) -> _PagedAttentionArenaLayout:
+        offset = 0
+
+        def reserve(shape: tuple[int, ...], dtype: torch.dtype) -> int:
+            nonlocal offset
+            offset = _align_up(offset, max(_ARENA_ALIGN_BYTES, _dtype_nbytes(dtype)))
+            current = offset
+            offset += _shape_numel(shape) * _dtype_nbytes(dtype)
+            return current
+
+        request_indices_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+        qo_tile_indices_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+        kv_tile_indices_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+        block_valid_mask_offset_bytes = reserve((caps.max_work_items,), torch.int32)
+        page_table_offset_bytes = reserve(
+            (caps.max_batch, caps.max_page_table_width),
+            torch.int32,
+        )
+        cache_seqlens_offset_bytes = reserve((caps.max_batch,), torch.int32)
+        cu_seqlens_q_offset_bytes = reserve((caps.max_batch + 1,), torch.int32)
+        merge_indptr_offset_bytes = reserve((caps.max_total_q + 1,), torch.int32)
+        o_indptr_offset_bytes = reserve((caps.max_batch + 1,), torch.int32)
+        kv_chunk_size_ptr_offset_bytes = reserve((1,), torch.int32)
+        kv_window_start_tokens_offset_bytes = reserve((caps.max_batch,), torch.int32)
+        total_num_rows_ptr_offset_bytes = reserve((1,), torch.int32)
+        lse_offset_bytes = reserve(
+            _paged_lse_storage_shape(caps.max_total_q, caps.num_q_heads),
+            torch.float32,
+        )
+        tmp_output_offset_bytes = reserve(
+            (caps.max_partial_rows, caps.num_q_heads, caps.max_head_dim_vo),
+            caps.dtype,
+        )
+        tmp_lse_offset_bytes = reserve(
+            (caps.max_partial_rows, caps.num_q_heads),
+            torch.float32,
+        )
+        return _PagedAttentionArenaLayout(
+            arena_nbytes=max(int(offset), 1),
+            request_indices_offset_bytes=request_indices_offset_bytes,
+            qo_tile_indices_offset_bytes=qo_tile_indices_offset_bytes,
+            kv_tile_indices_offset_bytes=kv_tile_indices_offset_bytes,
+            block_valid_mask_offset_bytes=block_valid_mask_offset_bytes,
+            page_table_offset_bytes=page_table_offset_bytes,
+            cache_seqlens_offset_bytes=cache_seqlens_offset_bytes,
+            cu_seqlens_q_offset_bytes=cu_seqlens_q_offset_bytes,
+            merge_indptr_offset_bytes=merge_indptr_offset_bytes,
+            o_indptr_offset_bytes=o_indptr_offset_bytes,
+            kv_chunk_size_ptr_offset_bytes=kv_chunk_size_ptr_offset_bytes,
+            kv_window_start_tokens_offset_bytes=kv_window_start_tokens_offset_bytes,
+            total_num_rows_ptr_offset_bytes=total_num_rows_ptr_offset_bytes,
+            lse_offset_bytes=lse_offset_bytes,
+            tmp_output_offset_bytes=tmp_output_offset_bytes,
+            tmp_lse_offset_bytes=tmp_lse_offset_bytes,
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        caps: PagedAttentionArenaCaps,
+        *,
+        shared_arena: torch.Tensor | None,
+    ) -> "PagedAttentionArena":
+        layout = cls._layout(caps)
+        if shared_arena is None:
+            shared_arena = torch.empty(
+                layout.arena_nbytes,
+                dtype=torch.uint8,
+                device=caps.device,
+            )
+        elif shared_arena.dtype != torch.uint8:
+            raise TypeError(
+                f"shared_arena must have dtype torch.uint8, got {shared_arena.dtype}"
+            )
+        elif shared_arena.device != caps.device:
+            raise ValueError(
+                f"shared_arena device {shared_arena.device} does not match caps device {caps.device}"
+            )
+        elif shared_arena.numel() < layout.arena_nbytes:
+            raise ValueError(
+                f"shared_arena has {shared_arena.numel()} bytes, but paged attention arena requires {layout.arena_nbytes}"
+            )
+        return cls(
+            caps=caps,
+            shared_arena=shared_arena,
+            shared_arena_nbytes=layout.arena_nbytes,
+            request_indices_offset_bytes=layout.request_indices_offset_bytes,
+            qo_tile_indices_offset_bytes=layout.qo_tile_indices_offset_bytes,
+            kv_tile_indices_offset_bytes=layout.kv_tile_indices_offset_bytes,
+            block_valid_mask_offset_bytes=layout.block_valid_mask_offset_bytes,
+            page_table_offset_bytes=layout.page_table_offset_bytes,
+            cache_seqlens_offset_bytes=layout.cache_seqlens_offset_bytes,
+            cu_seqlens_q_offset_bytes=layout.cu_seqlens_q_offset_bytes,
+            merge_indptr_offset_bytes=layout.merge_indptr_offset_bytes,
+            o_indptr_offset_bytes=layout.o_indptr_offset_bytes,
+            kv_chunk_size_ptr_offset_bytes=layout.kv_chunk_size_ptr_offset_bytes,
+            kv_window_start_tokens_offset_bytes=layout.kv_window_start_tokens_offset_bytes,
+            total_num_rows_ptr_offset_bytes=layout.total_num_rows_ptr_offset_bytes,
+            lse_offset_bytes=layout.lse_offset_bytes,
+            tmp_output_offset_bytes=layout.tmp_output_offset_bytes,
+            tmp_lse_offset_bytes=layout.tmp_lse_offset_bytes,
+        )
+
+    @classmethod
+    def allocate(cls, caps: PagedAttentionArenaCaps) -> "PagedAttentionArena":
+        return cls._build(caps, shared_arena=None)
+
+    @classmethod
+    def from_shared_arena(
+        cls,
+        caps: PagedAttentionArenaCaps,
+        shared_arena: torch.Tensor,
+    ) -> "PagedAttentionArena":
+        return cls._build(caps, shared_arena=shared_arena)
+
+    @classmethod
+    def required_nbytes(cls, caps: PagedAttentionArenaCaps) -> int:
+        return cls._layout(caps).arena_nbytes
+
+    def _make_workspace_views(
+        self,
+        contract: PagedAttentionWorkspaceContract,
+        *,
+        use_cuda_graph: bool = False,
+    ) -> "PagedAttentionWorkspace":
+        if contract.max_total_q > self.caps.max_total_q:
+            raise ValueError(
+                f"workspace max_total_q {contract.max_total_q} exceeds arena max_total_q {self.caps.max_total_q}"
+            )
+        if contract.max_batch > self.caps.max_batch:
+            raise ValueError(
+                f"workspace max_batch {contract.max_batch} exceeds arena max_batch {self.caps.max_batch}"
+            )
+        if contract.max_page_table_width > self.caps.max_page_table_width:
+            raise ValueError(
+                "workspace max_page_table_width "
+                f"{contract.max_page_table_width} exceeds arena max_page_table_width {self.caps.max_page_table_width}"
+            )
+        if contract.max_work_items > self.caps.max_work_items:
+            raise ValueError(
+                f"workspace max_work_items {contract.max_work_items} exceeds arena max_work_items {self.caps.max_work_items}"
+            )
+        if contract.max_partial_rows > self.caps.max_partial_rows:
+            raise ValueError(
+                "workspace max_partial_rows "
+                f"{contract.max_partial_rows} exceeds arena max_partial_rows {self.caps.max_partial_rows}"
+            )
+        if contract.num_q_heads > self.caps.num_q_heads:
+            raise ValueError(
+                f"workspace num_q_heads {contract.num_q_heads} exceeds arena num_q_heads {self.caps.num_q_heads}"
+            )
+        if contract.num_kv_heads > self.caps.num_kv_heads:
+            raise ValueError(
+                f"workspace num_kv_heads {contract.num_kv_heads} exceeds arena num_kv_heads {self.caps.num_kv_heads}"
+            )
+        if contract.head_dim_qk > self.caps.head_dim_qk:
+            raise ValueError(
+                f"workspace head_dim_qk {contract.head_dim_qk} exceeds arena head_dim_qk {self.caps.head_dim_qk}"
+            )
+        if contract.head_dim_vo > self.caps.max_head_dim_vo:
+            raise ValueError(
+                f"workspace head_dim_vo {contract.head_dim_vo} exceeds arena max_head_dim_vo {self.caps.max_head_dim_vo}"
+            )
+
+        plan_q = _shape_only_cuda_tensor(
+            (contract.max_total_q, contract.num_q_heads, contract.head_dim_qk),
+            dtype=self.caps.dtype,
+            device=self.caps.device,
+        )
+        plan_output = _shape_only_cuda_tensor(
+            (contract.max_total_q, contract.num_q_heads, contract.head_dim_vo),
+            dtype=self.caps.dtype,
+            device=self.caps.device,
+        )
+        plan_k_cache = _shape_only_cuda_tensor(
+            (
+                contract.num_cache_pages,
+                self.caps.page_size,
+                contract.num_kv_heads,
+                contract.head_dim_qk,
+            ),
+            dtype=self.caps.kv_dtype,
+            device=self.caps.device,
+        )
+        plan_v_cache = _shape_only_cuda_tensor(
+            (
+                contract.num_cache_pages,
+                self.caps.page_size,
+                contract.num_kv_heads,
+                contract.head_dim_vo,
+            ),
+            dtype=self.caps.kv_dtype,
+            device=self.caps.device,
+        )
+        workspace = PagedAttentionWorkspace(
+            arena=self,
+            contract=contract,
+            mode=contract.mode,
+            device=self.caps.device,
+            dtype=self.caps.dtype,
+            kv_dtype=self.caps.kv_dtype,
+            num_q_heads=contract.num_q_heads,
+            num_kv_heads=contract.num_kv_heads,
+            head_dim_qk=contract.head_dim_qk,
+            head_dim_vo=contract.head_dim_vo,
+            page_size=self.caps.page_size,
+            use_cuda_graph=use_cuda_graph,
+            fixed_capacity=True,
+            _plan_q=plan_q,
+            _plan_output=plan_output,
+            _plan_k_cache=plan_k_cache,
+            _plan_v_cache=plan_v_cache,
+            _planner_budget=PagedPlanBudget(
+                max_total_q=contract.max_total_q,
+                max_batch=contract.max_batch,
+                max_page_table_width=contract.max_page_table_width,
+                max_work_items=contract.max_work_items,
+                max_partial_rows=contract.max_partial_rows,
+            ),
+        )
+        workspace._allocate_runtime_buffers(
+            work_items_capacity=contract.max_work_items,
+            block_valid_capacity=contract.max_work_items,
+            total_q_capacity=contract.max_total_q,
+            batch_capacity=contract.max_batch,
+            page_table_width_capacity=contract.max_page_table_width,
+            partial_rows_capacity=contract.max_partial_rows,
+        )
+        return workspace
+
+    def make_workspace(
+        self,
+        contract: PagedAttentionWorkspaceContract,
+        *,
+        use_cuda_graph: bool = False,
+    ) -> "PagedAttentionWorkspace":
+        return self._make_workspace_views(
+            contract,
+            use_cuda_graph=use_cuda_graph,
+        )
+
+
+@dataclass(kw_only=True)
+class PagedAttentionWorkspace:
+    arena: PagedAttentionArena | None = None
+    contract: PagedAttentionWorkspaceContract | None = None
+    mode: Literal["decode", "extend", "verify"]
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim_qk: int
+    head_dim_vo: int
+    page_size: int = 64
+    use_cuda_graph: bool = False
+    fixed_capacity: bool = False
+    request_indices: torch.Tensor | None = None
+    qo_tile_indices: torch.Tensor | None = None
+    kv_tile_indices: torch.Tensor | None = None
+    merge_indptr: torch.Tensor | None = None
+    o_indptr: torch.Tensor | None = None
+    kv_chunk_size_ptr: torch.Tensor | None = None
+    kv_window_start_tokens: torch.Tensor | None = None
+    total_num_rows_ptr: torch.Tensor | None = None
+    block_valid_mask: torch.Tensor | None = None
+    page_table: torch.Tensor | None = None
+    cache_seqlens: torch.Tensor | None = None
+    cu_seqlens_q: torch.Tensor | None = None
+    lse: torch.Tensor | None = None
+    tmp_output: torch.Tensor | None = None
+    tmp_lse: torch.Tensor | None = None
+    _plan_q: torch.Tensor | None = None
+    _plan_output: torch.Tensor | None = None
+    _plan_k_cache: torch.Tensor | None = None
+    _plan_v_cache: torch.Tensor | None = None
+    _plan: PagedPlan | None = None
+    _planner_budget: PagedPlanBudget | None = None
+    shared_arena: torch.Tensor | None = None
+    shared_arena_nbytes: int = 0
+
+    # Pre-compiled kernel state (set by compile_paged_kernels in api.py).
+    _compiled_forward: object | None = None
+    _compiled_merge: object | None = None
+    _compiled_forward_kernel: object | None = None
+    _compiled_key: tuple | None = None
+    _decode_graph_chunk_pages_lut: torch.Tensor | None = None
+    _decode_graph_max_chunks_per_req: int | None = None
+    _use_regular_decode_graph_replay: bool = False
+    _decode_graph_metadata_captured_in_graph: bool = False
+    _prefill_graph_max_q_tiles_per_req: int | None = None
+    _prefill_graph_max_chunks_per_q_tile: int | None = None
+    _prefill_graph_max_q_rows_per_req: int | None = None
+    _live_plane_tma_desc_cache: dict[
+        tuple[int, int, tuple[int, ...], tuple[int, ...], int, int],
+        tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor, torch.Tensor],
+    ] = field(default_factory=dict)
+
+    @staticmethod
+    def eager_extend_work_items_capacity(
+        *,
+        max_total_q: int,
+        num_q_heads: int,
+        num_kv_heads: int,
+    ) -> int:
+        if max_total_q <= 0:
+            raise ValueError("max_total_q must be positive")
+        if num_q_heads <= 0 or num_kv_heads <= 0:
+            raise ValueError("head counts must be positive")
+        gqa_group_size = num_q_heads // num_kv_heads
+        return max((int(max_total_q) * int(gqa_group_size) + 15) // 16, 1)
+
+    @classmethod
+    def for_contract(
+        cls,
+        *,
+        mode: Literal["decode", "extend", "verify"],
+        device: torch.device | str,
+        dtype: torch.dtype,
+        kv_dtype: torch.dtype,
+        num_q_heads: int,
+        num_kv_heads: int,
+        head_dim_qk: int,
+        head_dim_vo: int,
+        page_size: int,
+        max_total_q: int,
+        num_cache_pages: int,
+        use_cuda_graph: bool = False,
+    ) -> PagedAttentionWorkspace:
+        device = _canonical_device(device)
+        if max_total_q <= 0:
+            raise ValueError("max_total_q must be positive")
+        if num_cache_pages <= 0:
+            raise ValueError("num_cache_pages must be positive")
+        plan_q = _shape_only_cuda_tensor(
+            (max_total_q, num_q_heads, head_dim_qk),
+            dtype=dtype,
+            device=device,
+        )
+        plan_output = _shape_only_cuda_tensor(
+            (max_total_q, num_q_heads, head_dim_vo),
+            dtype=dtype,
+            device=device,
+        )
+        plan_k_cache = _shape_only_cuda_tensor(
+            (num_cache_pages, page_size, num_kv_heads, head_dim_qk),
+            dtype=kv_dtype,
+            device=device,
+        )
+        plan_v_cache = _shape_only_cuda_tensor(
+            (num_cache_pages, page_size, num_kv_heads, head_dim_vo),
+            dtype=kv_dtype,
+            device=device,
+        )
+        return cls(
+            mode=mode,
+            device=device,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            page_size=page_size,
+            use_cuda_graph=use_cuda_graph,
+            _plan_q=plan_q,
+            _plan_output=plan_output,
+            _plan_k_cache=plan_k_cache,
+            _plan_v_cache=plan_v_cache,
+        )
+
+    @classmethod
+    def for_fixed_capacity(
+        cls,
+        *,
+        mode: Literal["decode", "extend", "verify"],
+        device: torch.device | str,
+        dtype: torch.dtype,
+        kv_dtype: torch.dtype,
+        num_q_heads: int,
+        num_kv_heads: int,
+        head_dim_qk: int,
+        head_dim_vo: int,
+        page_size: int,
+        max_total_q: int,
+        max_batch: int,
+        max_page_table_width: int,
+        max_work_items: int,
+        max_partial_rows: int,
+        num_cache_pages: int,
+        use_cuda_graph: bool = False,
+    ) -> PagedAttentionWorkspace:
+        device = _canonical_device(device)
+        caps = PagedAttentionArenaCaps(
+            device=device,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim_qk,
+            max_head_dim_vo=head_dim_vo,
+            page_size=page_size,
+            max_total_q=max_total_q,
+            max_batch=max_batch,
+            max_page_table_width=max_page_table_width,
+            max_work_items=max_work_items,
+            max_partial_rows=max_partial_rows,
+        )
+        arena = PagedAttentionArena.allocate(caps)
+        contract = PagedAttentionWorkspaceContract(
+            mode=mode,
+            max_total_q=int(max_total_q),
+            max_batch=int(max_batch),
+            max_page_table_width=int(max_page_table_width),
+            max_work_items=int(max_work_items),
+            max_partial_rows=int(max_partial_rows),
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            num_cache_pages=num_cache_pages,
+        )
+        return arena.make_workspace(contract, use_cuda_graph=use_cuda_graph)
+
+    @classmethod
+    def for_eager_extend_capacity(
+        cls,
+        *,
+        mode: Literal["extend", "verify"] = "extend",
+        device: torch.device | str,
+        dtype: torch.dtype,
+        kv_dtype: torch.dtype,
+        num_q_heads: int,
+        num_kv_heads: int,
+        head_dim_qk: int,
+        head_dim_vo: int,
+        page_size: int,
+        max_total_q: int,
+        max_batch: int,
+        max_page_table_width: int,
+        num_cache_pages: int,
+        use_cuda_graph: bool = False,
+    ) -> PagedAttentionWorkspace:
+        return cls.for_fixed_capacity(
+            mode=mode,
+            device=device,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            page_size=page_size,
+            max_total_q=max_total_q,
+            max_batch=max_batch,
+            max_page_table_width=max_page_table_width,
+            max_work_items=cls.eager_extend_work_items_capacity(
+                max_total_q=max_total_q,
+                num_q_heads=num_q_heads,
+                num_kv_heads=num_kv_heads,
+            ),
+            max_partial_rows=0,
+            num_cache_pages=num_cache_pages,
+            use_cuda_graph=use_cuda_graph,
+        )
+
+    @classmethod
+    def for_tensors(
+        cls,
+        *,
+        mode: Literal["decode", "extend", "verify"],
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        use_cuda_graph: bool = False,
+    ) -> PagedAttentionWorkspace:
+        if q.ndim != 3:
+            raise ValueError(
+                f"q must have shape [total_q, q_heads, head_dim], got {tuple(q.shape)}"
+            )
+        if k_cache.ndim != 4 or v_cache.ndim != 4:
+            raise ValueError("k_cache and v_cache must be rank-4 paged tensors")
+        return cls.for_contract(
+            mode=mode,
+            device=q.device,
+            dtype=q.dtype,
+            kv_dtype=k_cache.dtype,
+            num_q_heads=int(q.shape[1]),
+            num_kv_heads=int(k_cache.shape[2]),
+            head_dim_qk=int(q.shape[2]),
+            head_dim_vo=int(v_cache.shape[3]),
+            page_size=int(k_cache.shape[1]),
+            max_total_q=int(q.shape[0]),
+            num_cache_pages=int(k_cache.shape[0]),
+            use_cuda_graph=use_cuda_graph,
+        )
+
+    @property
+    def prepared(self) -> bool:
+        return self._plan is not None
+
+    @property
+    def plan(self) -> PagedPlan:
+        if self._plan is None:
+            raise RuntimeError("paged workspace has not been prepared")
+        return self._plan
+
+    @property
+    def active_total_q(self) -> int:
+        return self.plan.total_q
+
+    @property
+    def active_batch(self) -> int:
+        return self.plan.page_table_shape[0]
+
+    @property
+    def total_q_capacity(self) -> int:
+        if self._plan_q is None:
+            raise RuntimeError("paged workspace planning contract is not initialized")
+        return int(self._plan_q.shape[0])
+
+    @property
+    def planner_budget(self) -> PagedPlanBudget | None:
+        return self._planner_budget
+
+    @staticmethod
+    def _plan_has_regular_decode_graph_grid(plan: PagedPlan) -> bool:
+        batch = int(plan.page_table_shape[0])
+        if (
+            batch <= 0
+            or plan.mode != "decode"
+            or not plan.enable_cuda_graph
+            or not plan.split_kv
+        ):
+            return False
+        if int(plan.total_q) != batch:
+            return False
+        work_items = len(plan.request_indices)
+        if work_items <= 0 or work_items % batch != 0:
+            return False
+        max_chunks_per_req = work_items // batch
+        for req_idx in range(batch):
+            base = req_idx * max_chunks_per_req
+            for chunk_idx in range(max_chunks_per_req):
+                work_idx = base + chunk_idx
+                if plan.request_indices[work_idx] != req_idx:
+                    return False
+                if plan.qo_tile_indices[work_idx] != 0:
+                    return False
+                if plan.kv_tile_indices[work_idx] != chunk_idx:
+                    return False
+        return True
+
+    @torch._dynamo.disable
+    def prepare(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        *,
+        fixed_split_size: int | None = None,
+        disable_split_kv: bool = False,
+        window_left: int = -1,
+        active_total_q: int | None = None,
+    ) -> PagedAttentionWorkspace:
+        with record_function(f"paged_workspace.prepare.{self.mode}"):
+            if window_left < -1:
+                raise ValueError(
+                    "window_left must be -1 for full attention or a non-negative token count"
+                )
+            if self.use_cuda_graph and torch.cuda.is_current_stream_capturing():
+                if self._plan is None:
+                    raise RuntimeError(
+                        "graph-mode paged workspace must be prepared before CUDA graph capture"
+                    )
+                if int(window_left) != int(self._plan.window_left):
+                    raise ValueError(
+                        f"captured paged attention graph was prepared with window_left={self._plan.window_left}, "
+                        f"got window_left={int(window_left)}"
+                    )
+                with record_function("paged_workspace.copy_runtime_metadata.capture"):
+                    self._copy_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+                return self
+
+            if (
+                self.use_cuda_graph
+                and self.mode == "decode"
+                and self._decode_graph_chunk_pages_lut is not None
+                and self._plan is not None
+            ):
+                if int(window_left) != int(self._plan.window_left):
+                    raise ValueError(
+                        f"decode graph replay workspace was prepared with window_left={self._plan.window_left}, "
+                        f"got window_left={int(window_left)}"
+                    )
+                with record_function("paged_workspace.copy_runtime_metadata"):
+                    self._copy_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+                if not self._decode_graph_metadata_captured_in_graph:
+                    with record_function(
+                        "paged_workspace.update_decode_graph_replay_metadata"
+                    ):
+                        self.update_decode_graph_replay_metadata_from_runtime_cache_seqlens()
+                    if torch.cuda.is_current_stream_capturing():
+                        self._decode_graph_metadata_captured_in_graph = True
+                return self
+
+            if active_total_q is None:
+                if torch.cuda.is_current_stream_capturing():
+                    raise RuntimeError(
+                        "paged workspace prepare() requires active_total_q to be "
+                        "supplied before CUDA graph capture; inferring it from a "
+                        "device cu_seqlens_q would require an illegal host sync"
+                    )
+                with record_function("paged_workspace.infer_mode"):
+                    inferred_mode = infer_paged_mode(cu_seqlens_q)
+                active_total_q = int(cu_seqlens_q[-1].item())
+            else:
+                active_total_q = int(active_total_q)
+                inferred_mode = _infer_mode_from_host_total(
+                    cu_seqlens_q, active_total_q
+                )
+            if (
+                inferred_mode != self.mode
+                and not (self.mode == "extend" and inferred_mode == "decode")
+                and not (self.mode == "verify" and inferred_mode == "extend")
+            ):
+                raise ValueError(
+                    f"workspace mode {self.mode} does not match prepared mode {inferred_mode}"
+                )
+            with record_function("paged_workspace.ensure_plan_contract"):
+                self._ensure_plan_contract(active_total_q)
+            assert self._plan_q is not None
+            assert self._plan_k_cache is not None
+            assert self._plan_v_cache is not None
+            if active_total_q <= 0 or active_total_q > int(self._plan_q.shape[0]):
+                raise ValueError(
+                    f"cu_seqlens_q implies total_q={active_total_q}, but workspace capacity is {int(self._plan_q.shape[0])}"
+                )
+
+            with record_function("paged_workspace.create_paged_plan"):
+                plan = create_paged_plan(
+                    self._plan_q[:active_total_q],
+                    self._plan_k_cache,
+                    self._plan_v_cache,
+                    page_table,
+                    cache_seqlens,
+                    cu_seqlens_q,
+                    mode=self.mode,
+                    fixed_split_size=-1
+                    if fixed_split_size is None
+                    else int(fixed_split_size),
+                    disable_split_kv=disable_split_kv,
+                    window_left=int(window_left),
+                    enable_cuda_graph=self.use_cuda_graph,
+                    graph_chunk_policy=self.use_cuda_graph,
+                    plan_budget=(
+                        self.planner_budget
+                        if self.mode in ("extend", "verify") and not self.use_cuda_graph
+                        else None
+                    ),
+                )
+            with record_function("paged_workspace.ensure_capacity"):
+                self._ensure_capacity(plan)
+            with record_function("paged_workspace.copy_runtime_metadata"):
+                self._copy_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+            with record_function("paged_workspace.copy_plan_metadata"):
+                self._copy_plan_metadata(plan)
+            self._plan = plan
+            return self
+
+    def update_decode_graph_replay_metadata_from_runtime_cache_seqlens(
+        self,
+    ) -> PagedAttentionWorkspace:
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "update_decode_graph_replay_metadata_from_runtime_cache_seqlens "
+                "is only valid for graph-mode workspaces"
+            )
+        if self.mode != "decode":
+            raise RuntimeError(
+                "update_decode_graph_replay_metadata_from_runtime_cache_seqlens "
+                "is only valid for decode workspaces"
+            )
+        if self._decode_graph_chunk_pages_lut is None:
+            raise RuntimeError("decode graph replay policy has not been prepared")
+        if self.cache_seqlens is None:
+            raise RuntimeError("decode graph workspace is missing cache_seqlens")
+        if self.request_indices is None:
+            raise RuntimeError("decode graph workspace is missing request indices")
+        if self.qo_tile_indices is None or self.kv_tile_indices is None:
+            raise RuntimeError("decode graph workspace is missing tile indices")
+        if self.merge_indptr is None or self.o_indptr is None:
+            raise RuntimeError("decode graph workspace is missing indptr buffers")
+        if self.kv_chunk_size_ptr is None:
+            raise RuntimeError("decode graph workspace is missing kv_chunk_size_ptr")
+        if self.total_num_rows_ptr is None:
+            raise RuntimeError("decode graph workspace is missing total_num_rows_ptr")
+        if self.block_valid_mask is None:
+            raise RuntimeError("decode graph workspace is missing block_valid_mask")
+        if self.kv_window_start_tokens is None:
+            raise RuntimeError(
+                "decode graph workspace is missing kv_window_start_tokens"
+            )
+        if self._plan is None:
+            raise RuntimeError("decode graph workspace has not been prepared")
+
+        batch = int(self.cache_seqlens.shape[0])
+        self._validate_decode_graph_replay_capacity(batch=batch)
+        window_page_span = self._window_page_span_from_plan(self._plan)
+
+        if not self._plan.split_kv:
+            from .graph_replay import update_regular_decode_graph_chunk_metadata
+
+            update_regular_decode_graph_chunk_metadata(
+                cache_seqlens=self.cache_seqlens,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_chunk_size=int(self._plan.kv_chunk_size),
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                max_chunks_per_req=1,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        elif self._use_regular_decode_graph_replay:
+            from .graph_replay import (
+                update_regular_decode_graph_chunk_metadata_from_lut,
+            )
+
+            update_regular_decode_graph_chunk_metadata_from_lut(
+                cache_seqlens=self.cache_seqlens,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                decode_chunk_pages_lut=self._decode_graph_chunk_pages_lut,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        else:
+            from .graph_replay import update_decode_graph_chunk_metadata
+
+            update_decode_graph_chunk_metadata(
+                cache_seqlens=self.cache_seqlens,
+                request_indices=self.request_indices,
+                qo_tile_indices=self.qo_tile_indices,
+                kv_tile_indices=self.kv_tile_indices,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                block_valid_mask=self.block_valid_mask,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                decode_chunk_pages_lut=self._decode_graph_chunk_pages_lut,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        return self
+
+    def update_prefill_graph_replay_metadata(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        *,
+        window_left: int = -1,
+    ) -> PagedAttentionWorkspace:
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "update_prefill_graph_replay_metadata is only valid for graph-mode workspaces"
+            )
+        if self.mode not in ("extend", "verify"):
+            raise RuntimeError(
+                "update_prefill_graph_replay_metadata is only valid for extend/verify workspaces"
+            )
+        if self._plan is None:
+            raise RuntimeError("prefill graph workspace has not been prepared")
+        if int(window_left) != int(self._plan.window_left):
+            raise ValueError(
+                f"prefill graph replay workspace was prepared with window_left={self._plan.window_left}, "
+                f"got window_left={int(window_left)}"
+            )
+        if self.page_table is None:
+            raise RuntimeError("prefill graph workspace is missing page_table")
+        if self.cache_seqlens is None:
+            raise RuntimeError("prefill graph workspace is missing cache_seqlens")
+        if self.cu_seqlens_q is None:
+            raise RuntimeError("prefill graph workspace is missing cu_seqlens_q")
+
+        with record_function("paged_workspace.copy_runtime_metadata"):
+            self._copy_runtime_metadata(page_table, cache_seqlens, cu_seqlens_q)
+        with record_function("paged_workspace.update_prefill_graph_replay_metadata"):
+            self._update_prefill_graph_replay_metadata_from_runtime()
+        return self
+
+    def prepare_for_cuda_graph_replay(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        *,
+        fixed_split_size: int | None = None,
+        disable_split_kv: bool = False,
+        active_total_q: int | None = None,
+    ) -> PagedAttentionWorkspace:
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "prepare_for_cuda_graph_replay is only valid for graph-mode workspaces"
+            )
+        return self.prepare(
+            page_table,
+            cache_seqlens,
+            cu_seqlens_q,
+            fixed_split_size=fixed_split_size,
+            disable_split_kv=disable_split_kv,
+            active_total_q=active_total_q,
+        )
+
+    def bind_cuda_graph_runtime_metadata(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+    ) -> PagedAttentionWorkspace:
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "bind_cuda_graph_runtime_metadata is only valid for graph-mode workspaces"
+            )
+        # Decode graph replay already selected the workspace by mode, so avoid
+        # re-reading cu_seqlens_q back to the CPU just to rediscover q_len=1.
+        inferred_mode = (
+            self.mode if self.mode == "decode" else infer_paged_mode(cu_seqlens_q)
+        )
+        if (
+            inferred_mode != self.mode
+            and not (self.mode == "extend" and inferred_mode == "decode")
+            and not (self.mode == "verify" and inferred_mode == "extend")
+        ):
+            raise ValueError(
+                f"workspace mode {self.mode} does not match bound mode {inferred_mode}"
+            )
+        if (
+            page_table.device != self.device
+            or cache_seqlens.device != self.device
+            or cu_seqlens_q.device != self.device
+        ):
+            raise ValueError("bound graph metadata must stay on the workspace device")
+        self.page_table = page_table
+        self.cache_seqlens = cache_seqlens
+        self.cu_seqlens_q = cu_seqlens_q
+        return self
+
+    def prepare_decode_graph_replay_state(
+        self,
+        *,
+        batch: int,
+        max_page_table_width: int,
+        total_q_capacity: int | None = None,
+        max_cache_page_count: int | None = None,
+        window_left: int = -1,
+    ) -> PagedAttentionWorkspace:
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "prepare_decode_graph_replay_state is only valid for graph-mode workspaces"
+            )
+        if self.mode != "decode":
+            raise RuntimeError(
+                "prepare_decode_graph_replay_state is only valid for decode workspaces"
+            )
+        if total_q_capacity is None:
+            total_q_capacity = (
+                int(self._plan_q.shape[0]) if self._plan_q is not None else int(batch)
+            )
+        else:
+            total_q_capacity = int(total_q_capacity)
+        if max_cache_page_count is None:
+            max_cache_page_count = int(max_page_table_width)
+        else:
+            max_cache_page_count = int(max_cache_page_count)
+        if batch <= 0:
+            raise ValueError("batch must be positive")
+        if total_q_capacity <= 0:
+            raise ValueError("total_q_capacity must be positive")
+        if max_page_table_width <= 0:
+            raise ValueError("max_page_table_width must be positive")
+        if max_cache_page_count <= 0:
+            raise ValueError("max_cache_page_count must be positive")
+        if window_left < -1:
+            raise ValueError(
+                "window_left must be -1 for full attention or a non-negative token count"
+            )
+
+        from .graph_replay import (
+            make_decode_chunk_pages_lut_tensor,
+            summarize_decode_chunk_pages_lut,
+        )
+
+        max_effective_kv_pages = int(max_cache_page_count)
+        if window_left >= 0:
+            max_effective_kv_pages = min(
+                max_effective_kv_pages,
+                max(
+                    1,
+                    (int(window_left) + self.page_size + self.page_size - 1)
+                    // self.page_size,
+                ),
+            )
+        gqa_group_size = self.num_q_heads // self.num_kv_heads
+        graph_ctas_per_sm = resolve_decode_graph_ctas_per_sm(
+            kv_dtype=self.kv_dtype,
+            batch=batch,
+            page_size=self.page_size,
+            head_dim_qk=self.head_dim_qk,
+            head_dim_vo=self.head_dim_vo,
+            gqa_group_size=gqa_group_size,
+        )
+        max_chunks_per_req_budget = decode_graph_max_chunks_per_request_budget(
+            device=self.device,
+            num_kv_heads=self.num_kv_heads,
+            batch=batch,
+            graph_ctas_per_sm=graph_ctas_per_sm,
+        )
+        decode_chunk_pages_lut = build_decode_chunk_pages_lut(
+            q_dtype=self.dtype,
+            kv_dtype=self.kv_dtype,
+            batch=batch,
+            page_size=self.page_size,
+            head_dim_qk=self.head_dim_qk,
+            head_dim_vo=self.head_dim_vo,
+            gqa_group_size=gqa_group_size,
+            max_effective_kv_pages=max_effective_kv_pages,
+            max_chunks_per_req=max_chunks_per_req_budget,
+        )
+        worst_page_count, max_chunks_per_req = summarize_decode_chunk_pages_lut(
+            decode_chunk_pages_lut
+        )
+        self._decode_graph_chunk_pages_lut = make_decode_chunk_pages_lut_tensor(
+            decode_chunk_pages_lut,
+            device=self.device,
+        )
+        self._decode_graph_max_chunks_per_req = int(max_chunks_per_req)
+        self._use_regular_decode_graph_replay = False
+        self._decode_graph_metadata_captured_in_graph = False
+        capacity_cache_seqlen = worst_page_count * self.page_size
+        if window_left >= 0:
+            capacity_cache_seqlen = max_cache_page_count * self.page_size - 1
+        self.prepare_for_capacity(
+            batch=batch,
+            total_q_capacity=total_q_capacity,
+            max_page_table_width=max_page_table_width,
+            max_cache_seqlen=capacity_cache_seqlen,
+            window_left=window_left,
+        )
+        self._use_regular_decode_graph_replay = (
+            self._plan is not None
+            and int(self._plan.gqa_group_size) <= int(self._plan.cta_tile_q)
+            and self._plan_has_regular_decode_graph_grid(self._plan)
+        )
+        self._validate_decode_graph_replay_capacity(batch=batch)
+        return self
+
+    def prepare_prefill_graph_replay_state(
+        self,
+        *,
+        batch: int,
+        total_q_capacity: int,
+        max_page_table_width: int,
+        max_cache_seqlen: int,
+        cu_seqlens_q: torch.Tensor,
+        window_left: int = -1,
+    ) -> PagedAttentionWorkspace:
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "prepare_prefill_graph_replay_state is only valid for graph-mode workspaces"
+            )
+        if self.mode not in ("extend", "verify"):
+            raise RuntimeError(
+                "prepare_prefill_graph_replay_state is only valid for extend/verify workspaces"
+            )
+        if batch <= 0:
+            raise ValueError("batch must be positive")
+        if total_q_capacity <= 0:
+            raise ValueError("total_q_capacity must be positive")
+        if max_page_table_width <= 0:
+            raise ValueError("max_page_table_width must be positive")
+        if max_cache_seqlen <= 0:
+            raise ValueError("max_cache_seqlen must be positive")
+        if window_left < -1:
+            raise ValueError(
+                "window_left must be -1 for full attention or a non-negative token count"
+            )
+        if tuple(cu_seqlens_q.shape) != (int(batch) + 1,):
+            raise ValueError("cu_seqlens_q shape must match the graph batch")
+
+        max_cache_seqlens = torch.full(
+            (batch,),
+            int(max_cache_seqlen),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        num_cache_pages = (
+            int(self._plan_k_cache.shape[0]) if self._plan_k_cache is not None else 0
+        )
+        if num_cache_pages <= 0:
+            raise RuntimeError("paged workspace planning contract is not initialized")
+        max_page_ids = torch.arange(
+            max_page_table_width, dtype=torch.int32, device=self.device
+        )
+        max_page_table = (
+            (max_page_ids % num_cache_pages).unsqueeze(0).expand(batch, -1).contiguous()
+        )
+        self.prepare(
+            max_page_table,
+            max_cache_seqlens,
+            cu_seqlens_q,
+            window_left=window_left,
+            active_total_q=total_q_capacity,
+        )
+        self._cache_prefill_graph_replay_shape_from_plan()
+        return self
+
+    def prepare_for_capacity(
+        self,
+        *,
+        batch: int,
+        total_q_capacity: int,
+        max_page_table_width: int,
+        max_cache_seqlen: int,
+        window_left: int = -1,
+    ) -> PagedAttentionWorkspace:
+        if batch <= 0:
+            raise ValueError("batch must be positive")
+        if total_q_capacity <= 0:
+            raise ValueError("total_q_capacity must be positive")
+        if max_page_table_width <= 0:
+            raise ValueError("max_page_table_width must be positive")
+        if max_cache_seqlen <= 0:
+            raise ValueError("max_cache_seqlen must be positive")
+
+        max_cache_seqlens = torch.full(
+            (batch,),
+            int(max_cache_seqlen),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        num_cache_pages = (
+            int(self._plan_k_cache.shape[0]) if self._plan_k_cache is not None else 0
+        )
+        if num_cache_pages <= 0:
+            raise RuntimeError("paged workspace planning contract is not initialized")
+        max_page_ids = torch.arange(
+            max_page_table_width, dtype=torch.int32, device=self.device
+        )
+        max_page_table = (
+            (max_page_ids % num_cache_pages).unsqueeze(0).expand(batch, -1).contiguous()
+        )
+        max_cu_seqlens_q = self._build_capacity_cu_seqlens_q(
+            batch=batch,
+            total_q_capacity=total_q_capacity,
+        )
+        return self.prepare(
+            max_page_table,
+            max_cache_seqlens,
+            max_cu_seqlens_q,
+            window_left=window_left,
+            active_total_q=batch if self.mode == "decode" else total_q_capacity,
+        )
+
+    def _build_capacity_cu_seqlens_q(
+        self,
+        *,
+        batch: int,
+        total_q_capacity: int,
+    ) -> torch.Tensor:
+        if self.mode == "decode":
+            return torch.arange(0, batch + 1, dtype=torch.int32, device=self.device)
+        if total_q_capacity < batch:
+            raise ValueError(
+                f"extend graph bucket requires total_q_capacity >= batch, got {total_q_capacity} < {batch}"
+            )
+        q_lens = torch.ones(batch, dtype=torch.int32, device=self.device)
+        q_lens[-1] = int(total_q_capacity - (batch - 1))
+        cu_seqlens_q = torch.zeros(batch + 1, dtype=torch.int32, device=self.device)
+        torch.cumsum(q_lens, dim=0, out=cu_seqlens_q[1:])
+        return cu_seqlens_q
+
+    def _ensure_plan_contract(self, active_total_q: int) -> None:
+        if (
+            self._plan_q is None
+            or self._plan_k_cache is None
+            or self._plan_v_cache is None
+        ):
+            raise RuntimeError("paged workspace planning contract is not initialized")
+        if active_total_q <= int(self._plan_q.shape[0]):
+            return
+        if self.use_cuda_graph:
+            raise ValueError(
+                "graph-mode paged workspace capacity exceeded; construct a larger workspace or capture a larger graph bucket"
+            )
+        if self.fixed_capacity:
+            raise ValueError(
+                "fixed-capacity paged workspace exceeded; construct a larger eager extend workspace"
+            )
+        self._plan_q = _shape_only_cuda_tensor(
+            (active_total_q, self.num_q_heads, self.head_dim_qk),
+            dtype=self.dtype,
+            device=self.device,
+        )
+
+    def update_decode_graph_replay_metadata(
+        self,
+        *,
+        req_to_token: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+    ) -> PagedAttentionWorkspace:
+        if not self.use_cuda_graph:
+            raise RuntimeError(
+                "update_decode_graph_replay_metadata is only valid for graph-mode workspaces"
+            )
+        if self.mode != "decode":
+            raise RuntimeError(
+                "update_decode_graph_replay_metadata is only valid for decode workspaces"
+            )
+        if self._decode_graph_chunk_pages_lut is None:
+            raise RuntimeError("decode graph replay policy has not been prepared")
+        if self.page_table is None:
+            raise RuntimeError("decode graph workspace is missing page_table")
+        if self.cache_seqlens is None:
+            raise RuntimeError("decode graph workspace is missing cache_seqlens")
+        if self.cu_seqlens_q is None:
+            raise RuntimeError("decode graph workspace is missing cu_seqlens_q")
+        if self.request_indices is None:
+            raise RuntimeError("decode graph workspace is missing request indices")
+        if self.qo_tile_indices is None or self.kv_tile_indices is None:
+            raise RuntimeError("decode graph workspace is missing tile indices")
+        if self.block_valid_mask is None:
+            raise RuntimeError("decode graph workspace is missing block_valid_mask")
+        if self.merge_indptr is None or self.o_indptr is None:
+            raise RuntimeError("decode graph workspace is missing indptr buffers")
+        if self.kv_chunk_size_ptr is None:
+            raise RuntimeError("decode graph workspace is missing kv_chunk_size_ptr")
+        if self.total_num_rows_ptr is None:
+            raise RuntimeError("decode graph workspace is missing total_num_rows_ptr")
+        if self.kv_window_start_tokens is None:
+            raise RuntimeError(
+                "decode graph workspace is missing kv_window_start_tokens"
+            )
+        if self._plan is None:
+            raise RuntimeError("decode graph workspace has not been prepared")
+
+        batch = int(self.cache_seqlens.shape[0])
+        self._validate_decode_graph_replay_capacity(batch=batch)
+        window_page_span = self._window_page_span_from_plan(self._plan)
+
+        if not self._plan.split_kv:
+            from .graph_replay import (
+                _DECODE_BLOCK_PAGES,
+                build_decode_graph_page_table_full_triton,
+                update_regular_decode_graph_chunk_metadata,
+            )
+
+            page_blocks = (
+                int(self.page_table.shape[1]) + _DECODE_BLOCK_PAGES - 1
+            ) // _DECODE_BLOCK_PAGES
+            build_decode_graph_page_table_full_triton[(batch, page_blocks)](
+                req_to_token,
+                req_pool_indices,
+                self.page_table,
+                req_to_token.stride(0),
+                req_to_token.numel(),
+                self.page_table.stride(0),
+                PAGE_SIZE=self.page_size,
+                MAX_PAGES=int(self.page_table.shape[1]),
+                BLOCK_PAGES=_DECODE_BLOCK_PAGES,
+            )
+            update_regular_decode_graph_chunk_metadata(
+                cache_seqlens=self.cache_seqlens,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_chunk_size=int(self._plan.kv_chunk_size),
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                max_chunks_per_req=1,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        elif self._use_regular_decode_graph_replay:
+            from .graph_replay import update_regular_decode_graph_replay_metadata
+
+            update_regular_decode_graph_replay_metadata(
+                req_to_token=req_to_token,
+                req_pool_indices=req_pool_indices,
+                page_table=self.page_table,
+                cache_seqlens=self.cache_seqlens,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                decode_chunk_pages_lut=self._decode_graph_chunk_pages_lut,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        else:
+            from .graph_replay import update_decode_graph_replay_metadata
+
+            update_decode_graph_replay_metadata(
+                req_to_token=req_to_token,
+                req_pool_indices=req_pool_indices,
+                page_table=self.page_table,
+                cache_seqlens=self.cache_seqlens,
+                request_indices=self.request_indices,
+                qo_tile_indices=self.qo_tile_indices,
+                kv_tile_indices=self.kv_tile_indices,
+                merge_indptr=self.merge_indptr,
+                o_indptr=self.o_indptr,
+                block_valid_mask=self.block_valid_mask,
+                kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+                kv_window_start_tokens=self.kv_window_start_tokens,
+                decode_chunk_pages_lut=self._decode_graph_chunk_pages_lut,
+                page_size=self.page_size,
+                window_page_span=window_page_span,
+                window_left=int(self._plan.window_left),
+            )
+        return self
+
+    def bind_paged_attention(
+        self,
+        *,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        output: torch.Tensor,
+        page_table: torch.Tensor | None = None,
+        cache_seqlens: torch.Tensor | None = None,
+        cu_seqlens_q: torch.Tensor | None = None,
+        fixed_split_size: int | None = None,
+        disable_split_kv: bool = False,
+        window_left: int = -1,
+        active_total_q: int | None = None,
+        k_descale: torch.Tensor | None = None,
+        v_descale: torch.Tensor | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+        relative_attention_bias: torch.Tensor | None = None,
+    ):
+        from flashinfer.experimental.sm12x.attention.paged._scratch import (
+            build_paged_attention_binding,
+        )
+
+        return build_paged_attention_binding(
+            workspace=self,
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            fixed_split_size=fixed_split_size,
+            disable_split_kv=disable_split_kv,
+            window_left=window_left,
+            active_total_q=active_total_q,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            attention_sink_bias=attention_sink_bias,
+            relative_attention_bias=relative_attention_bias,
+        )
+
+    def _validate_q2k_indices_reference(self, q2k_indices: torch.Tensor | None) -> None:
+        if q2k_indices is not None:
+            raise ValueError(
+                "q2k_indices are only supported by MSA block-sparse scratch bindings"
+            )
+
+    @torch._dynamo.disable
+    def run(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        *,
+        output: torch.Tensor,
+        k_descale: torch.Tensor | None = None,
+        v_descale: torch.Tensor | None = None,
+        attention_sink_bias: torch.Tensor | None = None,
+        relative_attention_bias: torch.Tensor | None = None,
+        prepare_decode_graph_metadata: bool | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from ._forward import paged_attention_forward
+        from flashinfer.experimental.sm12x.attention.paged._scratch import (
+            SM12XPagedAttentionBinding,
+        )
+
+        if prepare_decode_graph_metadata is None:
+            prepare_decode_graph_metadata = (
+                self.use_cuda_graph
+                and self.mode == "decode"
+                and self._decode_graph_chunk_pages_lut is not None
+                and self._plan is not None
+                and torch.cuda.is_current_stream_capturing()
+            )
+        if prepare_decode_graph_metadata:
+            if not self.use_cuda_graph:
+                raise RuntimeError(
+                    "prepare_decode_graph_metadata requires a graph-mode workspace"
+                )
+            if self.mode != "decode":
+                raise RuntimeError(
+                    "prepare_decode_graph_metadata is only valid for decode workspaces"
+                )
+            if self._decode_graph_chunk_pages_lut is None or self._plan is None:
+                raise RuntimeError(
+                    "prepare_decode_graph_metadata requires a decode replay-state workspace"
+                )
+            with record_function(
+                "paged_workspace.capture_decode_graph_replay_metadata"
+            ):
+                self.update_decode_graph_replay_metadata_from_runtime_cache_seqlens()
+            if torch.cuda.is_current_stream_capturing():
+                self._decode_graph_metadata_captured_in_graph = True
+
+        out, lse = paged_attention_forward(
+            binding=SM12XPagedAttentionBinding(
+                scratch=self,
+                q=q,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                output=output,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                attention_sink_bias=attention_sink_bias,
+                relative_attention_bias=relative_attention_bias,
+            )
+        )
+        return out, lse
+
+    def current_lse_view(self) -> torch.Tensor:
+        if self.lse is None:
+            raise RuntimeError("workspace has not been prepared")
+        return self.lse[:, : self.active_total_q].transpose(0, 1)
+
+    def _validate_static_shapes(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+    ) -> None:
+        if (
+            q.device != self.device
+            or k_cache.device != self.device
+            or v_cache.device != self.device
+        ):
+            raise ValueError("workspace inputs must stay on the workspace device")
+        if q.dtype != self.dtype:
+            raise TypeError(f"workspace expects q dtype {self.dtype}, got {q.dtype}")
+        if k_cache.dtype != self.kv_dtype or v_cache.dtype != self.kv_dtype:
+            raise TypeError(
+                f"workspace expects kv dtype {self.kv_dtype}, got {k_cache.dtype}/{v_cache.dtype}"
+            )
+        if tuple(q.shape[1:]) != (self.num_q_heads, self.head_dim_qk):
+            raise ValueError(
+                "q shape does not match the workspace contract: "
+                f"expected (*, {self.num_q_heads}, {self.head_dim_qk}), got {tuple(q.shape)}"
+            )
+        if (
+            int(k_cache.shape[1]) != self.page_size
+            or int(v_cache.shape[1]) != self.page_size
+        ):
+            raise ValueError(f"workspace expects page_size={self.page_size}")
+        if (
+            int(k_cache.shape[2]) != self.num_kv_heads
+            or int(v_cache.shape[2]) != self.num_kv_heads
+        ):
+            raise ValueError("kv head count does not match the workspace contract")
+        if int(k_cache.shape[3]) != self.head_dim_qk:
+            raise ValueError("k_cache head_dim does not match the workspace contract")
+        if int(v_cache.shape[3]) != self.head_dim_vo:
+            raise ValueError("v_cache head_dim does not match the workspace contract")
+
+    def _ensure_capacity(self, plan: PagedPlan) -> None:
+        work_items_needed = int(plan.new_batch_size)
+        block_valid_needed = int(plan.padded_batch_size)
+        total_q_needed = int(plan.total_q)
+        batch_needed = int(plan.page_table_shape[0])
+        page_table_width_needed = int(plan.page_table_shape[1])
+        partial_rows_needed = int(plan.total_num_partial_rows) if plan.split_kv else 0
+
+        work_items_capacity = (
+            0 if self.request_indices is None else int(self.request_indices.shape[0])
+        )
+        block_valid_capacity = (
+            0 if self.block_valid_mask is None else int(self.block_valid_mask.shape[0])
+        )
+        total_q_capacity = 0 if self.lse is None else int(self.lse.shape[1])
+        batch_capacity = 0 if self.o_indptr is None else int(self.o_indptr.shape[0] - 1)
+        page_table_width_capacity = (
+            0 if self.page_table is None else int(self.page_table.shape[1])
+        )
+        partial_rows_capacity = (
+            0 if self.tmp_output is None else int(self.tmp_output.shape[0])
+        )
+
+        needs_growth = (
+            work_items_needed > work_items_capacity
+            or block_valid_needed > block_valid_capacity
+            or total_q_needed > total_q_capacity
+            or batch_needed > batch_capacity
+            or page_table_width_needed > page_table_width_capacity
+            or partial_rows_needed > partial_rows_capacity
+        )
+        if not needs_growth:
+            return
+        if self.use_cuda_graph and self.request_indices is not None:
+            raise ValueError(
+                "graph-mode paged workspace capacity exceeded; "
+                f"needed work_items={work_items_needed}, block_valid={block_valid_needed}, "
+                f"total_q={total_q_needed}, batch={batch_needed}, "
+                f"page_table_width={page_table_width_needed}, partial_rows={partial_rows_needed}; "
+                f"capacity work_items={work_items_capacity}, block_valid={block_valid_capacity}, "
+                f"total_q={total_q_capacity}, batch={batch_capacity}, "
+                f"page_table_width={page_table_width_capacity}, partial_rows={partial_rows_capacity}; "
+                "construct a larger workspace or capture a larger graph bucket"
+            )
+        if self.fixed_capacity and self.request_indices is not None:
+            raise ValueError(
+                "fixed-capacity paged workspace exceeded; construct a larger eager extend workspace"
+            )
+
+        work_items_capacity = max(work_items_capacity, work_items_needed)
+        block_valid_capacity = max(block_valid_capacity, block_valid_needed)
+        total_q_capacity = max(total_q_capacity, total_q_needed)
+        batch_capacity = max(batch_capacity, batch_needed)
+        page_table_width_capacity = max(
+            page_table_width_capacity, page_table_width_needed
+        )
+        partial_rows_capacity = max(partial_rows_capacity, partial_rows_needed)
+
+        self._allocate_runtime_buffers(
+            work_items_capacity=work_items_capacity,
+            block_valid_capacity=block_valid_capacity,
+            total_q_capacity=total_q_capacity,
+            batch_capacity=batch_capacity,
+            page_table_width_capacity=page_table_width_capacity,
+            partial_rows_capacity=partial_rows_capacity,
+        )
+
+    def _allocate_runtime_buffers(
+        self,
+        *,
+        work_items_capacity: int,
+        block_valid_capacity: int,
+        total_q_capacity: int,
+        batch_capacity: int,
+        page_table_width_capacity: int,
+        partial_rows_capacity: int,
+    ) -> None:
+        if self.arena is not None:
+            if work_items_capacity > self.arena.caps.max_work_items:
+                raise ValueError("paged attention arena work-item capacity exceeded")
+            if block_valid_capacity > self.arena.caps.max_work_items:
+                raise ValueError("paged attention arena block-valid capacity exceeded")
+            if total_q_capacity > self.arena.caps.max_total_q:
+                raise ValueError("paged attention arena total-q capacity exceeded")
+            if batch_capacity > self.arena.caps.max_batch:
+                raise ValueError("paged attention arena batch capacity exceeded")
+            if page_table_width_capacity > self.arena.caps.max_page_table_width:
+                raise ValueError(
+                    "paged attention arena page-table width capacity exceeded"
+                )
+            if partial_rows_capacity > self.arena.caps.max_partial_rows:
+                raise ValueError("paged attention arena partial-row capacity exceeded")
+
+            self.shared_arena = self.arena.shared_arena
+            self.shared_arena_nbytes = self.arena.shared_arena_nbytes
+            assert self.shared_arena is not None
+            self.request_indices, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.request_indices_offset_bytes,
+                shape=(work_items_capacity,),
+                dtype=torch.int32,
+            )
+            self.qo_tile_indices, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.qo_tile_indices_offset_bytes,
+                shape=(work_items_capacity,),
+                dtype=torch.int32,
+            )
+            self.kv_tile_indices, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.kv_tile_indices_offset_bytes,
+                shape=(work_items_capacity,),
+                dtype=torch.int32,
+            )
+            self.block_valid_mask, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.block_valid_mask_offset_bytes,
+                shape=(block_valid_capacity,),
+                dtype=torch.int32,
+            )
+            self.page_table, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.page_table_offset_bytes,
+                shape=(batch_capacity, page_table_width_capacity),
+                dtype=torch.int32,
+            )
+            self.cache_seqlens, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.cache_seqlens_offset_bytes,
+                shape=(batch_capacity,),
+                dtype=torch.int32,
+            )
+            self.cu_seqlens_q, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.cu_seqlens_q_offset_bytes,
+                shape=(batch_capacity + 1,),
+                dtype=torch.int32,
+            )
+            self.merge_indptr, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.merge_indptr_offset_bytes,
+                shape=(total_q_capacity + 1,),
+                dtype=torch.int32,
+            )
+            self.o_indptr, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.o_indptr_offset_bytes,
+                shape=(batch_capacity + 1,),
+                dtype=torch.int32,
+            )
+            self.kv_chunk_size_ptr, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.kv_chunk_size_ptr_offset_bytes,
+                shape=(1,),
+                dtype=torch.int32,
+            )
+            self.kv_window_start_tokens, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.kv_window_start_tokens_offset_bytes,
+                shape=(batch_capacity,),
+                dtype=torch.int32,
+            )
+            self.total_num_rows_ptr, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.total_num_rows_ptr_offset_bytes,
+                shape=(1,),
+                dtype=torch.int32,
+            )
+            self.lse, _ = _materialize_arena_view(
+                self.shared_arena,
+                offset_bytes=self.arena.lse_offset_bytes,
+                shape=_paged_lse_storage_shape(total_q_capacity, self.num_q_heads),
+                dtype=torch.float32,
+            )
+            if partial_rows_capacity > 0:
+                self.tmp_output, _ = _materialize_arena_view(
+                    self.shared_arena,
+                    offset_bytes=self.arena.tmp_output_offset_bytes,
+                    shape=(partial_rows_capacity, self.num_q_heads, self.head_dim_vo),
+                    dtype=self.dtype,
+                )
+                self.tmp_lse, _ = _materialize_arena_view(
+                    self.shared_arena,
+                    offset_bytes=self.arena.tmp_lse_offset_bytes,
+                    shape=(partial_rows_capacity, self.num_q_heads),
+                    dtype=torch.float32,
+                )
+            else:
+                self.tmp_output = None
+                self.tmp_lse = None
+            return
+
+        self.request_indices = torch.empty(
+            work_items_capacity, dtype=torch.int32, device=self.device
+        )
+        self.qo_tile_indices = torch.empty(
+            work_items_capacity, dtype=torch.int32, device=self.device
+        )
+        self.kv_tile_indices = torch.empty(
+            work_items_capacity, dtype=torch.int32, device=self.device
+        )
+        self.block_valid_mask = torch.empty(
+            block_valid_capacity, dtype=torch.int32, device=self.device
+        )
+        self.page_table = torch.empty(
+            (batch_capacity, page_table_width_capacity),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.cache_seqlens = torch.empty(
+            batch_capacity, dtype=torch.int32, device=self.device
+        )
+        self.cu_seqlens_q = torch.empty(
+            batch_capacity + 1, dtype=torch.int32, device=self.device
+        )
+        self.merge_indptr = torch.empty(
+            total_q_capacity + 1, dtype=torch.int32, device=self.device
+        )
+        self.o_indptr = torch.empty(
+            batch_capacity + 1, dtype=torch.int32, device=self.device
+        )
+        self.kv_chunk_size_ptr = torch.empty(1, dtype=torch.int32, device=self.device)
+        self.kv_window_start_tokens = torch.empty(
+            batch_capacity, dtype=torch.int32, device=self.device
+        )
+        self.total_num_rows_ptr = torch.empty(1, dtype=torch.int32, device=self.device)
+        self.lse = torch.empty(
+            _paged_lse_storage_shape(total_q_capacity, self.num_q_heads),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        if partial_rows_capacity > 0:
+            self.tmp_output = torch.empty(
+                (partial_rows_capacity, self.num_q_heads, self.head_dim_vo),
+                dtype=self.dtype,
+                device=self.device,
+            )
+            self.tmp_lse = torch.empty(
+                (partial_rows_capacity, self.num_q_heads),
+                dtype=torch.float32,
+                device=self.device,
+            )
+        else:
+            self.tmp_output = None
+            self.tmp_lse = None
+
+    def _cache_prefill_graph_replay_shape_from_plan(self) -> None:
+        if self._plan is None:
+            raise RuntimeError("prefill graph replay plan has not been prepared")
+        if self.mode not in ("extend", "verify") or not self.use_cuda_graph:
+            raise RuntimeError(
+                "prefill graph replay shape is only valid for graph extend/verify"
+            )
+        active_work_items = [
+            (request_idx, q_tile_idx, kv_tile_idx)
+            for request_idx, q_tile_idx, kv_tile_idx, valid in zip(
+                self._plan.request_indices,
+                self._plan.qo_tile_indices,
+                self._plan.kv_tile_indices,
+                self._plan.block_valid_mask,
+                strict=False,
+            )
+            if valid
+        ]
+        if not active_work_items:
+            raise RuntimeError("prefill graph replay plan contains no active work")
+        max_q_tiles_per_req = (
+            max(q_tile_idx for _, q_tile_idx, _ in active_work_items) + 1
+        )
+        max_chunks_per_q_tile = (
+            max(kv_tile_idx for _, _, kv_tile_idx in active_work_items) + 1
+        )
+        max_q_rows_per_req = max(
+            1,
+            (
+                int(max_q_tiles_per_req) * int(self._plan.cta_tile_q)
+                + int(self._plan.gqa_group_size)
+                - 1
+            )
+            // int(self._plan.gqa_group_size),
+        )
+        self._prefill_graph_max_q_tiles_per_req = int(max_q_tiles_per_req)
+        self._prefill_graph_max_chunks_per_q_tile = int(max_chunks_per_q_tile)
+        self._prefill_graph_max_q_rows_per_req = int(max_q_rows_per_req)
+
+    def _update_prefill_graph_replay_metadata_from_runtime(self) -> None:
+        if self._plan is None:
+            raise RuntimeError("prefill graph workspace has not been prepared")
+        if self.cache_seqlens is None:
+            raise RuntimeError("prefill graph workspace is missing cache_seqlens")
+        if self.cu_seqlens_q is None:
+            raise RuntimeError("prefill graph workspace is missing cu_seqlens_q")
+        if self.request_indices is None:
+            raise RuntimeError("prefill graph workspace is missing request indices")
+        if self.qo_tile_indices is None or self.kv_tile_indices is None:
+            raise RuntimeError("prefill graph workspace is missing tile indices")
+        if self.merge_indptr is None or self.o_indptr is None:
+            raise RuntimeError("prefill graph workspace is missing indptr buffers")
+        if self.kv_chunk_size_ptr is None:
+            raise RuntimeError("prefill graph workspace is missing kv_chunk_size_ptr")
+        if self.total_num_rows_ptr is None:
+            raise RuntimeError("prefill graph workspace is missing total_num_rows_ptr")
+        if self.block_valid_mask is None:
+            raise RuntimeError("prefill graph workspace is missing block_valid_mask")
+        if self.kv_window_start_tokens is None:
+            raise RuntimeError(
+                "prefill graph workspace is missing kv_window_start_tokens"
+            )
+        if (
+            self._prefill_graph_max_q_tiles_per_req is None
+            or self._prefill_graph_max_chunks_per_q_tile is None
+            or self._prefill_graph_max_q_rows_per_req is None
+        ):
+            self._cache_prefill_graph_replay_shape_from_plan()
+
+        from .graph_replay import update_prefill_graph_chunk_metadata
+
+        update_prefill_graph_chunk_metadata(
+            cache_seqlens=self.cache_seqlens,
+            cu_seqlens_q=self.cu_seqlens_q,
+            request_indices=self.request_indices,
+            qo_tile_indices=self.qo_tile_indices,
+            kv_tile_indices=self.kv_tile_indices,
+            merge_indptr=self.merge_indptr,
+            o_indptr=self.o_indptr,
+            block_valid_mask=self.block_valid_mask,
+            kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+            kv_window_start_tokens=self.kv_window_start_tokens,
+            total_num_rows_ptr=self.total_num_rows_ptr,
+            batch=int(self._plan.page_table_shape[0]),
+            max_q_tiles_per_req=int(self._prefill_graph_max_q_tiles_per_req),
+            max_chunks_per_q_tile=int(self._prefill_graph_max_chunks_per_q_tile),
+            max_q_rows_per_req=int(self._prefill_graph_max_q_rows_per_req),
+            cta_tile_q=int(self._plan.cta_tile_q),
+            gqa_group_size=int(self._plan.gqa_group_size),
+            page_size=int(self.page_size),
+            split_kv=bool(self._plan.split_kv),
+            window_left=int(self._plan.window_left),
+        )
+
+    def _validate_decode_graph_replay_capacity(
+        self,
+        *,
+        batch: int,
+    ) -> None:
+        if self._decode_graph_max_chunks_per_req is None:
+            raise RuntimeError("decode graph replay policy has not been prepared")
+        if self.request_indices is None:
+            raise RuntimeError("decode graph workspace is missing request indices")
+        if batch <= 0:
+            raise ValueError("decode graph replay requires bs > 0")
+        work_items_capacity = int(self.request_indices.shape[0])
+        if work_items_capacity % batch != 0:
+            raise RuntimeError(
+                "decode graph workspace request_indices shape is incompatible with the batch bucket"
+            )
+        max_chunks_per_req = work_items_capacity // batch
+        if max_chunks_per_req <= 0:
+            raise RuntimeError(
+                "decode graph workspace must allocate at least one chunk per request"
+            )
+        if self._decode_graph_max_chunks_per_req > max_chunks_per_req:
+            raise RuntimeError(
+                "decode graph workspace capacity is too small for the current chunking policy"
+            )
+
+    def _copy_runtime_metadata(
+        self,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+    ) -> None:
+        assert self.page_table is not None
+        assert self.cache_seqlens is not None
+        assert self.cu_seqlens_q is not None
+
+        if (
+            page_table.dtype == torch.int32
+            and cache_seqlens.dtype == torch.int32
+            and cu_seqlens_q.dtype == torch.int32
+            and int(self.page_table.data_ptr()) == int(page_table.data_ptr())
+            and int(self.cache_seqlens.data_ptr()) == int(cache_seqlens.data_ptr())
+            and int(self.cu_seqlens_q.data_ptr()) == int(cu_seqlens_q.data_ptr())
+        ):
+            return
+
+        with record_function("paged_workspace.runtime_cast_metadata"):
+            page_table_i32 = (
+                page_table
+                if page_table.dtype == torch.int32
+                else page_table.to(torch.int32)
+            )
+            cache_seqlens_i32 = (
+                cache_seqlens
+                if cache_seqlens.dtype == torch.int32
+                else cache_seqlens.to(torch.int32)
+            )
+            cu_seqlens_q_i32 = (
+                cu_seqlens_q
+                if cu_seqlens_q.dtype == torch.int32
+                else cu_seqlens_q.to(torch.int32)
+            )
+
+        with record_function("paged_workspace.runtime_copy_page_table"):
+            self.page_table[: page_table_i32.shape[0], : page_table_i32.shape[1]].copy_(
+                page_table_i32
+            )
+        with record_function("paged_workspace.runtime_copy_cache_seqlens"):
+            self.cache_seqlens[: cache_seqlens_i32.shape[0]].copy_(cache_seqlens_i32)
+        with record_function("paged_workspace.runtime_copy_cu_seqlens_q"):
+            self.cu_seqlens_q[: cu_seqlens_q_i32.shape[0]].copy_(cu_seqlens_q_i32)
+
+    def _copy_regular_decode_graph_plan_metadata(self, plan: PagedPlan) -> None:
+        assert self.request_indices is not None
+        assert self.merge_indptr is not None
+        assert self.o_indptr is not None
+        assert self.kv_chunk_size_ptr is not None
+        assert self.kv_window_start_tokens is not None
+        assert self.total_num_rows_ptr is not None
+        assert self.cache_seqlens is not None
+
+        batch = int(plan.page_table_shape[0])
+        if batch <= 0:
+            raise RuntimeError("regular decode graph replay requires bs > 0")
+        work_items_capacity = int(self.request_indices.shape[0])
+        if work_items_capacity % batch != 0:
+            raise RuntimeError(
+                "decode graph workspace request_indices shape is incompatible with the batch bucket"
+            )
+        capture_max_chunks_per_req = work_items_capacity // batch
+        current_work_items = len(plan.request_indices)
+        if current_work_items % batch != 0:
+            raise RuntimeError(
+                "decode graph replay plan work-items are incompatible with the batch bucket"
+            )
+        current_max_chunks_per_req = current_work_items // batch
+        if current_max_chunks_per_req > capture_max_chunks_per_req:
+            raise RuntimeError(
+                "decode graph replay plan exceeds the captured fixed-grid capacity"
+            )
+
+        from .graph_replay import update_regular_decode_graph_chunk_metadata
+
+        update_regular_decode_graph_chunk_metadata(
+            cache_seqlens=self.cache_seqlens,
+            merge_indptr=self.merge_indptr,
+            o_indptr=self.o_indptr,
+            kv_chunk_size_ptr=self.kv_chunk_size_ptr,
+            kv_chunk_size=int(plan.kv_chunk_size),
+            kv_window_start_tokens=self.kv_window_start_tokens,
+            max_chunks_per_req=capture_max_chunks_per_req,
+            page_size=self.page_size,
+            window_page_span=self._window_page_span_from_plan(plan),
+            window_left=int(plan.window_left),
+        )
+        self.total_num_rows_ptr[0] = int(plan.total_q)
+
+    def _window_page_span_from_plan(self, plan: PagedPlan) -> int:
+        window_left = int(plan.window_left)
+        if window_left < 0:
+            return 0
+        return max(
+            (window_left + self.page_size + self.page_size - 1) // self.page_size,
+            1,
+        )
+
+    def _copy_plan_metadata(self, plan: PagedPlan) -> None:
+        assert self.request_indices is not None
+        assert self.qo_tile_indices is not None
+        assert self.kv_tile_indices is not None
+        assert self.merge_indptr is not None
+        assert self.o_indptr is not None
+        assert self.kv_chunk_size_ptr is not None
+        assert self.kv_window_start_tokens is not None
+        assert self.total_num_rows_ptr is not None
+        assert self.block_valid_mask is not None
+
+        self._use_regular_decode_graph_replay = False
+        self._prefill_graph_max_q_tiles_per_req = None
+        self._prefill_graph_max_chunks_per_q_tile = None
+        self._prefill_graph_max_q_rows_per_req = None
+
+        with record_function("paged_workspace.plan_metadata_to_device"):
+            request_indices = _copy_int_metadata(
+                plan.request_indices, device=self.device
+            )
+            qo_tile_indices = _copy_int_metadata(
+                plan.qo_tile_indices, device=self.device
+            )
+            kv_tile_indices = _copy_int_metadata(
+                plan.kv_tile_indices, device=self.device
+            )
+            merge_indptr = _copy_int_metadata(plan.merge_indptr, device=self.device)
+            o_indptr = _copy_int_metadata(plan.o_indptr, device=self.device)
+            block_valid_mask = torch.tensor(
+                plan.block_valid_mask, dtype=torch.int32, device=self.device
+            )
+            kv_window_start_tokens = _copy_int_metadata(
+                plan.kv_window_start_tokens, device=self.device
+            )
+
+        with record_function("paged_workspace.plan_metadata_zero_buffers"):
+            self.request_indices.zero_()
+            self.qo_tile_indices.zero_()
+            self.kv_tile_indices.zero_()
+            self.block_valid_mask.zero_()
+            self.kv_window_start_tokens.zero_()
+        with record_function("paged_workspace.plan_metadata_copy_buffers"):
+            self.request_indices[: request_indices.shape[0]].copy_(request_indices)
+            self.qo_tile_indices[: qo_tile_indices.shape[0]].copy_(qo_tile_indices)
+            self.kv_tile_indices[: kv_tile_indices.shape[0]].copy_(kv_tile_indices)
+            self.merge_indptr[: merge_indptr.shape[0]].copy_(merge_indptr)
+            self.o_indptr[: o_indptr.shape[0]].copy_(o_indptr)
+            self.block_valid_mask[: block_valid_mask.shape[0]].copy_(block_valid_mask)
+            self.kv_window_start_tokens[: kv_window_start_tokens.shape[0]].copy_(
+                kv_window_start_tokens
+            )
+        with record_function("paged_workspace.plan_metadata_scalar_updates"):
+            self.kv_chunk_size_ptr[0] = int(plan.kv_chunk_size)
+            self.total_num_rows_ptr[0] = int(plan.total_q)

--- a/flashinfer/experimental/sm12x/attention/sparse_mla/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/sparse_mla/__init__.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Sparse MLA decode/extend for SM12x (DeepSeek-V3.2 DSV4, GLM NSA).
+
+Multi-head latent attention over top-k-selected KV tokens from a paged
+cache (DSV4: head_dim 576 = 512 nope + 64 rope, v_head_dim 512), FP8-e4m3
+or BF16 compute, split-KV decode with on-device merge; a single-pass decode
+path is selected automatically on SM121. Selection indices typically come
+from ``attention.nsa_indexer``.
+
+Planned lifecycle: ``plan(Caps(...))`` -> ``bind`` (views only) ->
+``run_decode`` / ``run_extend`` (capture safe).
+
+Example:
+    from flashinfer.experimental.sm12x.attention import sparse_mla
+
+    plan    = sparse_mla.plan(sparse_mla.Caps(device="cuda", num_q_heads=16,
+                                              max_q_rows=64, max_width=2048))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = sparse_mla.bind(plan, scratch=scratch, q=q,
+                              selected_indices=topk_idx,
+                              cache_seqlens_int32=lens,
+                              nsa_cache_seqlens_int32=active)
+    out = sparse_mla.run_decode(binding=binding, kv_cache=kv, sm_scale=scale)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="sparse_mla",
+    group="attention",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "Binding",
+        "Scratch",
+        "DecodeMetadata",
+        "ExtendMetadata",
+        "plan",
+        "bind",
+        "run_decode",
+        "run_extend",
+        "is_supported",
+        "clear_caches",
+    ),
+    dtypes=("bf16", "fp8_e4m3"),
+    recipes=("dsv4", "glm_nsa"),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=(
+            "b12x/integration/sparse_mla_scratch.py",
+            "b12x/attention/mla/",
+        ),
+    ),
+    test_path="tests/experimental/attention/test_sparse_mla.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Binding,
+        Caps,
+        DecodeMetadata,
+        ExtendMetadata,
+        Plan,
+        Scratch,
+        bind,
+        clear_caches,
+        is_supported,
+        plan,
+        run_decode,
+        run_extend,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/attention/sparse_mla/_scratch.py
+++ b/flashinfer/experimental/sm12x/attention/sparse_mla/_scratch.py
@@ -1,0 +1,535 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/sparse_mla_scratch.py @ 17428af5 (2026-07-01) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Caller-owned scratch plans for sparse MLA paths.
+
+Eager PLAN -> BIND -> KERNEL, never a workspace/arena. bind() maps the
+caller-owned scratch tensor into per-spec kernel-argument VIEWS and returns a
+plain SM12XSparseMLAScratch views container (mirroring SM12XCompressedMLAScratch).
+It never constructs a SM12XAttentionWorkspace / arena, allocates, or init-writes.
+The unified SM120 sparse-MLA decode/extend kernels duck-type the workspace
+(tmp_output/tmp_lse/output_buffer/final_lse/num_chunks_ptr/kv_chunk_size_ptr/
+set_split_chunk_config/...), so the views container is a drop-in -- no kernel
+signature change.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+
+from flashinfer.experimental.sm12x.attention._shared.workspace import (
+    _split_output_buffer_from_tmp,
+    _split_tmp_output_stride,
+)
+from flashinfer.experimental.sm12x._lib.scratch_layout import (
+    SCRATCH_ALIGN_BYTES,
+    align_up,
+    dtype_nbytes,
+    materialize_scratch_strided_view,
+    materialize_scratch_view,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XSparseMLAScratchCaps:
+    device: torch.device | str
+    num_q_heads: int
+    max_q_rows: int
+    max_width: int
+    dtype: torch.dtype = torch.bfloat16
+    kv_dtype: torch.dtype = torch.bfloat16
+    head_dim: int = 576
+    v_head_dim: int = 512
+    mode: Literal["decode", "extend", "verify", "draft_extend"] = "decode"
+    max_batch: int | None = None
+    max_kv_rows: int = 0
+    max_page_table_width: int | None = None
+    max_chunks_per_row: int = 64
+    max_q_chunks: int | None = None
+    page_size: int = 64
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "num_q_heads", max(int(self.num_q_heads), 1))
+        object.__setattr__(self, "max_q_rows", max(int(self.max_q_rows), 1))
+        object.__setattr__(self, "max_width", max(int(self.max_width), 1))
+        object.__setattr__(self, "head_dim", max(int(self.head_dim), 1))
+        object.__setattr__(self, "v_head_dim", max(int(self.v_head_dim), 1))
+        max_batch = self.max_q_rows if self.max_batch is None else self.max_batch
+        object.__setattr__(self, "max_batch", max(int(max_batch), 1))
+        object.__setattr__(self, "max_kv_rows", max(int(self.max_kv_rows), 0))
+        max_page_table_width = (
+            self.max_width
+            if self.max_page_table_width is None
+            else self.max_page_table_width
+        )
+        object.__setattr__(
+            self,
+            "max_page_table_width",
+            max(int(max_page_table_width), 1),
+        )
+        object.__setattr__(
+            self,
+            "max_chunks_per_row",
+            max(int(self.max_chunks_per_row), 1),
+        )
+        if self.max_q_chunks is not None:
+            object.__setattr__(self, "max_q_chunks", max(int(self.max_q_chunks), 1))
+        object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+
+
+@dataclass(kw_only=True)
+class SM12XSparseMLAScratch:
+    """Component-owned sparse-MLA scratch VIEWS over caller-owned storage.
+
+    Exposes exactly the attributes the unified SM120 sparse-MLA decode/extend
+    kernels duck-type off the (former) workspace. NEVER a SM12XAttentionWorkspace.
+    """
+
+    shared_scratch: torch.Tensor
+    device: torch.device
+    dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_q_heads: int
+    head_dim: int
+    v_head_dim: int
+    topk: int
+    max_total_q: int
+    max_batch: int
+    max_chunks_per_row: int
+    page_size: int
+    mode: str = "decode"
+    fixed_capacity: bool = True
+    use_cuda_graph: bool = False
+    tmp_output: torch.Tensor | None = None
+    tmp_lse: torch.Tensor | None = None
+    output_buffer: torch.Tensor | None = None
+    final_lse: torch.Tensor | None = None
+    kv_chunk_size_ptr: torch.Tensor | None = None
+    num_chunks_ptr: torch.Tensor | None = None
+    sm_scale_tensor: torch.Tensor | None = None
+    kv_chunk_size_value: int | None = None
+    num_chunks_value: int | None = None
+    sm_scale_value: float | None = None
+
+    def set_split_chunk_config(self, *, kv_chunk_size: int, num_chunks: int) -> None:
+        if num_chunks <= 0 or num_chunks > self.max_chunks_per_row:
+            raise ValueError(
+                f"num_chunks must be in [1, {self.max_chunks_per_row}], got {num_chunks}"
+            )
+        if kv_chunk_size <= 0:
+            raise ValueError(f"kv_chunk_size must be positive, got {kv_chunk_size}")
+        if self.kv_chunk_size_ptr is None or self.num_chunks_ptr is None:
+            raise RuntimeError("sparse MLA scratch is missing split-control tensors")
+        if self.kv_chunk_size_value != int(kv_chunk_size):
+            self.kv_chunk_size_ptr.fill_(int(kv_chunk_size))
+            self.kv_chunk_size_value = int(kv_chunk_size)
+        if self.num_chunks_value != int(num_chunks):
+            self.num_chunks_ptr.fill_(int(num_chunks))
+            self.num_chunks_value = int(num_chunks)
+
+    def bind(
+        self,
+        *,
+        q: torch.Tensor,
+        selected_indices: torch.Tensor,
+        cache_seqlens_int32: torch.Tensor,
+        nsa_cache_seqlens_int32: torch.Tensor,
+    ) -> "SM12XSparseMLABinding":
+        return build_sparse_mla_binding(
+            scratch=self,
+            q=q,
+            selected_indices=selected_indices,
+            cache_seqlens_int32=cache_seqlens_int32,
+            nsa_cache_seqlens_int32=nsa_cache_seqlens_int32,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XSparseMLABinding:
+    scratch: object
+    q: torch.Tensor
+    selected_indices: torch.Tensor
+    cache_seqlens_int32: torch.Tensor
+    nsa_cache_seqlens_int32: torch.Tensor
+
+
+def _validate_device(
+    tensor: torch.Tensor,
+    *,
+    scratch: object,
+    name: str,
+) -> None:
+    if tensor.device != scratch.device:
+        raise ValueError(
+            f"{name} device {tensor.device} does not match scratch device {scratch.device}"
+        )
+
+
+def _validate_q(q: torch.Tensor, *, scratch: object) -> torch.Tensor:
+    if q.ndim != 3:
+        raise ValueError(f"q must be rank-3, got {tuple(q.shape)}")
+    if q.dtype != scratch.dtype:
+        raise TypeError(f"q must have dtype {scratch.dtype}, got {q.dtype}")
+    if not q.is_contiguous():
+        raise ValueError("q must be contiguous")
+    _validate_device(q, scratch=scratch, name="q")
+    if int(q.shape[0]) > int(scratch.max_total_q):
+        raise ValueError(
+            f"q rows {int(q.shape[0])} exceed scratch capacity {scratch.max_total_q}"
+        )
+    if int(q.shape[1]) != int(scratch.num_q_heads):
+        raise ValueError(
+            f"q heads {int(q.shape[1])} do not match scratch heads {scratch.num_q_heads}"
+        )
+    if int(q.shape[2]) != int(scratch.head_dim):
+        raise ValueError(
+            f"q head_dim {int(q.shape[2])} does not match scratch head_dim {scratch.head_dim}"
+        )
+    return q.detach()
+
+
+def _validate_selected_indices(
+    selected_indices: torch.Tensor,
+    *,
+    scratch: object,
+    rows: int,
+) -> torch.Tensor:
+    if selected_indices.ndim != 2:
+        raise ValueError(
+            f"selected_indices must be rank-2, got {tuple(selected_indices.shape)}"
+        )
+    if selected_indices.dtype != torch.int32:
+        raise TypeError(
+            f"selected_indices must have dtype torch.int32, got {selected_indices.dtype}"
+        )
+    if not selected_indices.is_contiguous():
+        raise ValueError("selected_indices must be contiguous")
+    _validate_device(selected_indices, scratch=scratch, name="selected_indices")
+    if int(selected_indices.shape[0]) != int(rows):
+        raise ValueError(
+            f"selected_indices rows {int(selected_indices.shape[0])} do not match q rows {rows}"
+        )
+    if int(selected_indices.shape[1]) > int(scratch.topk):
+        raise ValueError(
+            f"selected_indices width {int(selected_indices.shape[1])} exceeds scratch topk {scratch.topk}"
+        )
+    return selected_indices
+
+
+def _validate_i32_vector(
+    tensor: torch.Tensor,
+    *,
+    scratch: object,
+    name: str,
+    max_rows: int | None = None,
+    rows: int | None = None,
+) -> torch.Tensor:
+    if tensor.ndim != 1:
+        raise ValueError(f"{name} must be rank-1, got {tuple(tensor.shape)}")
+    if tensor.dtype != torch.int32:
+        raise TypeError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    _validate_device(tensor, scratch=scratch, name=name)
+    if rows is not None and int(tensor.shape[0]) != int(rows):
+        raise ValueError(
+            f"{name} rows {int(tensor.shape[0])} do not match q rows {rows}"
+        )
+    if max_rows is not None and int(tensor.shape[0]) > int(max_rows):
+        raise ValueError(
+            f"{name} rows {int(tensor.shape[0])} exceed capacity {max_rows}"
+        )
+    return tensor
+
+
+def build_sparse_mla_binding(
+    *,
+    scratch: object,
+    q: torch.Tensor,
+    selected_indices: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    nsa_cache_seqlens_int32: torch.Tensor,
+) -> SM12XSparseMLABinding:
+    q = _validate_q(q, scratch=scratch)
+    rows = int(q.shape[0])
+    selected_indices = _validate_selected_indices(
+        selected_indices,
+        scratch=scratch,
+        rows=rows,
+    )
+    cache_seqlens_int32 = _validate_i32_vector(
+        cache_seqlens_int32,
+        scratch=scratch,
+        name="cache_seqlens_int32",
+        max_rows=scratch.max_batch,
+    )
+    nsa_cache_seqlens_int32 = _validate_i32_vector(
+        nsa_cache_seqlens_int32,
+        scratch=scratch,
+        name="nsa_cache_seqlens_int32",
+        rows=rows,
+    )
+    return SM12XSparseMLABinding(
+        scratch=scratch,
+        q=q,
+        selected_indices=selected_indices,
+        cache_seqlens_int32=cache_seqlens_int32,
+        nsa_cache_seqlens_int32=nsa_cache_seqlens_int32,
+    )
+
+
+@dataclass(frozen=True)
+class _SM12XSparseMLAScratchLayout:
+    nbytes: int
+    split: bool
+    output_offset_bytes: int
+    tmp_output_offset_bytes: int
+    tmp_lse_offset_bytes: int
+    final_lse_offset_bytes: int
+    kv_chunk_size_offset_bytes: int
+    num_chunks_offset_bytes: int
+    sm_scale_offset_bytes: int
+
+
+def _sparse_mla_scratch_layout(
+    caps: SM12XSparseMLAScratchCaps,
+) -> _SM12XSparseMLAScratchLayout:
+    max_total_q = max(int(caps.max_q_rows), 1)
+    num_q_heads = int(caps.num_q_heads)
+    v_head_dim = int(caps.v_head_dim)
+    max_chunks_per_row = max(int(caps.max_chunks_per_row), 1)
+    # Only the split-K DECODE path needs tmp_output/tmp_lse/final_lse + split
+    # control. The single-pass prefill (extend/verify/draft_extend) only writes
+    # output_buffer, so it gets a standalone output view -- no multi-chunk scratch.
+    split = caps.mode == "decode"
+
+    cursor = 0
+    tmp_output_offset_bytes = 0
+    output_offset_bytes = 0
+    tmp_lse_offset_bytes = 0
+    final_lse_offset_bytes = 0
+    kv_chunk_size_offset_bytes = 0
+    num_chunks_offset_bytes = 0
+    if split:
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+        tmp_output_offset_bytes = cursor
+        # output_buffer aliases tmp_output[:, :, 0, :] (chunk-major stride), so no
+        # separate output allocation is needed for decode.
+        output_offset_bytes = cursor
+        cursor += (
+            max_total_q
+            * max_chunks_per_row
+            * num_q_heads
+            * v_head_dim
+            * dtype_nbytes(caps.dtype)
+        )
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+        tmp_lse_offset_bytes = cursor
+        cursor += (
+            max_total_q * max_chunks_per_row * num_q_heads * dtype_nbytes(torch.float32)
+        )
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+        final_lse_offset_bytes = cursor
+        cursor += max_total_q * num_q_heads * dtype_nbytes(torch.float32)
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+        kv_chunk_size_offset_bytes = cursor
+        cursor += dtype_nbytes(torch.int32)
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+        num_chunks_offset_bytes = cursor
+        cursor += dtype_nbytes(torch.int32)
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+    else:
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+        output_offset_bytes = cursor
+        cursor += max_total_q * num_q_heads * v_head_dim * dtype_nbytes(caps.dtype)
+        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    sm_scale_offset_bytes = cursor
+    cursor += dtype_nbytes(torch.float32)
+    cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+
+    return _SM12XSparseMLAScratchLayout(
+        nbytes=max(int(cursor), SCRATCH_ALIGN_BYTES),
+        split=split,
+        output_offset_bytes=output_offset_bytes,
+        tmp_output_offset_bytes=tmp_output_offset_bytes,
+        tmp_lse_offset_bytes=tmp_lse_offset_bytes,
+        final_lse_offset_bytes=final_lse_offset_bytes,
+        kv_chunk_size_offset_bytes=kv_chunk_size_offset_bytes,
+        num_chunks_offset_bytes=num_chunks_offset_bytes,
+        sm_scale_offset_bytes=sm_scale_offset_bytes,
+    )
+
+
+def _materialize_sparse_mla_scratch(
+    caps: SM12XSparseMLAScratchCaps,
+    scratch_storage: torch.Tensor,
+    layout: _SM12XSparseMLAScratchLayout,
+) -> SM12XSparseMLAScratch:
+    max_total_q = max(int(caps.max_q_rows), 1)
+    num_q_heads = int(caps.num_q_heads)
+    v_head_dim = int(caps.v_head_dim)
+    max_chunks_per_row = max(int(caps.max_chunks_per_row), 1)
+
+    tmp_output = None
+    tmp_lse = None
+    final_lse = None
+    kv_chunk_size_ptr = None
+    num_chunks_ptr = None
+    if layout.split:
+        tmp_output, _ = materialize_scratch_strided_view(
+            scratch_storage,
+            offset_bytes=layout.tmp_output_offset_bytes,
+            shape=(max_total_q, num_q_heads, max_chunks_per_row, v_head_dim),
+            stride=_split_tmp_output_stride(
+                max_total_q=max_total_q,
+                num_q_heads=num_q_heads,
+                max_chunks_per_row=max_chunks_per_row,
+                v_head_dim=v_head_dim,
+            ),
+            dtype=caps.dtype,
+        )
+        output_buffer = _split_output_buffer_from_tmp(tmp_output)
+        tmp_lse, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.tmp_lse_offset_bytes,
+            shape=(max_total_q, num_q_heads, max_chunks_per_row),
+            dtype=torch.float32,
+        )
+        final_lse, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.final_lse_offset_bytes,
+            shape=(max_total_q, num_q_heads),
+            dtype=torch.float32,
+        )
+        kv_chunk_size_ptr, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.kv_chunk_size_offset_bytes,
+            shape=(1,),
+            dtype=torch.int32,
+        )
+        num_chunks_ptr, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.num_chunks_offset_bytes,
+            shape=(1,),
+            dtype=torch.int32,
+        )
+    else:
+        output_buffer, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.output_offset_bytes,
+            shape=(max_total_q, num_q_heads, v_head_dim),
+            dtype=caps.dtype,
+        )
+
+    sm_scale_tensor, _ = materialize_scratch_view(
+        scratch_storage,
+        offset_bytes=layout.sm_scale_offset_bytes,
+        shape=(1,),
+        dtype=torch.float32,
+    )
+
+    scratch = SM12XSparseMLAScratch(
+        shared_scratch=scratch_storage,
+        device=caps.device,
+        dtype=caps.dtype,
+        kv_dtype=caps.kv_dtype,
+        num_q_heads=num_q_heads,
+        head_dim=caps.head_dim,
+        v_head_dim=v_head_dim,
+        topk=caps.max_width,
+        max_total_q=caps.max_q_rows,
+        max_batch=caps.max_batch,
+        max_chunks_per_row=max_chunks_per_row,
+        page_size=caps.page_size,
+        mode=caps.mode,
+        tmp_output=tmp_output,
+        tmp_lse=tmp_lse,
+        output_buffer=output_buffer,
+        final_lse=final_lse,
+        kv_chunk_size_ptr=kv_chunk_size_ptr,
+        num_chunks_ptr=num_chunks_ptr,
+        sm_scale_tensor=sm_scale_tensor,
+    )
+    return scratch
+
+
+@dataclass(frozen=True)
+class SM12XSparseMLAScratchPlan:
+    caps: SM12XSparseMLAScratchCaps
+    layout: _SM12XSparseMLAScratchLayout
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        q: torch.Tensor,
+        selected_indices: torch.Tensor,
+        cache_seqlens_int32: torch.Tensor,
+        nsa_cache_seqlens_int32: torch.Tensor,
+    ) -> SM12XSparseMLABinding:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="sparse MLA",
+        )
+        scratch_views = _materialize_sparse_mla_scratch(
+            self.caps,
+            scratch_storage,
+            self.layout,
+        )
+        return build_sparse_mla_binding(
+            scratch=scratch_views,
+            q=q,
+            selected_indices=selected_indices,
+            cache_seqlens_int32=cache_seqlens_int32,
+            nsa_cache_seqlens_int32=nsa_cache_seqlens_int32,
+        )
+
+
+def plan_sparse_mla_scratch(
+    caps: SM12XSparseMLAScratchCaps,
+) -> SM12XSparseMLAScratchPlan:
+    layout = _sparse_mla_scratch_layout(caps)
+    return SM12XSparseMLAScratchPlan(
+        caps=caps,
+        layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "sparse_mla.scratch",
+                nbytes=int(layout.nbytes),
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+__all__ = [
+    "SM12XSparseMLABinding",
+    "SM12XSparseMLAScratch",
+    "SM12XSparseMLAScratchCaps",
+    "SM12XSparseMLAScratchPlan",
+    "build_sparse_mla_binding",
+    "plan_sparse_mla_scratch",
+]

--- a/flashinfer/experimental/sm12x/attention/sparse_mla/api.py
+++ b/flashinfer/experimental/sm12x/attention/sparse_mla/api.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for attention.sparse_mla (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from .._shared.mla.api import (
+    MLASparseDecodeMetadata as DecodeMetadata,
+)
+from .._shared.mla.api import (
+    MLASparseExtendMetadata as ExtendMetadata,
+)
+from .._shared.mla.api import (
+    clear_mla_caches as clear_caches,
+)
+from .._shared.mla.api import (
+    sparse_mla_decode_forward as run_decode,
+)
+from .._shared.mla.api import (
+    sparse_mla_extend_forward as run_extend,
+)
+from ._scratch import (
+    SM12XSparseMLABinding as Binding,
+)
+from ._scratch import (
+    SM12XSparseMLAScratch as Scratch,
+)
+from ._scratch import (
+    SM12XSparseMLAScratchCaps as Caps,
+)
+from ._scratch import (
+    SM12XSparseMLAScratchPlan as Plan,
+)
+from ._scratch import (
+    plan_sparse_mla_scratch as plan,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "Binding",
+    "Scratch",
+    "DecodeMetadata",
+    "ExtendMetadata",
+    "plan",
+    "bind",
+    "run_decode",
+    "run_extend",
+    "is_supported",
+    "clear_caches",
+]

--- a/flashinfer/experimental/sm12x/attention/sparse_mla/reference.py
+++ b/flashinfer/experimental/sm12x/attention/sparse_mla/reference.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-torch sparse-MLA semantics (re-export; the implementation lives with
+the shared MLA core it describes)."""
+
+from .._shared.mla.reference import *  # noqa: F403

--- a/flashinfer/experimental/sm12x/attention/varlen/__init__.py
+++ b/flashinfer/experimental/sm12x/attention/varlen/__init__.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Contiguous (non-paged) attention for SM12x: batched and varlen forward.
+
+BF16/FP16 Q/K/V, causal + sliding-window + attention-sink; tile shapes
+auto-selected by head_dim/causality. ``run`` is the varlen (cu_seqlens)
+entry, ``run_batched`` the fixed-shape batched entry; each has its own
+plan/scratch/binding family (``create_plan*`` for the per-shape kernel plan,
+``plan*`` for scratch sizing).
+
+Example:
+    from flashinfer.experimental.sm12x.attention import varlen
+
+    kplan   = varlen.create_plan_batched(q, k, v, causal=True)
+    splan   = varlen.plan_batched(kplan)
+    spec    = splan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = splan.bind(scratch=scratch, q=q, k=k, v=v, softmax_scale=s)
+    out, lse = varlen.run_batched(binding=binding)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="varlen",
+    group="attention",
+    api_style="planned",
+    entry_points=(
+        "BatchedPlan",
+        "BatchedScratchPlan",
+        "BatchedBinding",
+        "VarlenPlan",
+        "VarlenScratchPlan",
+        "VarlenBinding",
+        "create_plan_batched",
+        "create_plan",
+        "plan_batched",
+        "plan",
+        "run_batched",
+        "run",
+        "is_supported",
+        "clear_caches",
+    ),
+    dtypes=("bf16", "fp16"),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/attention/contiguous/",),
+    ),
+    test_path="tests/experimental/attention/test_varlen.py",
+    since="0.7.0",
+    notes=(
+        "Reduced-assurance tier: correctness-tested against a torch "
+        "reference; performance not tracked; first candidate for removal."
+    ),
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import *  # noqa: F401,F403
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/attention/varlen/api.py
+++ b/flashinfer/experimental/sm12x/attention/varlen/api.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for attention.varlen (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from .._shared.contiguous.api import (
+    AttentionBinding as BatchedBinding,
+)
+from .._shared.contiguous.api import (
+    AttentionPlan as BatchedPlan,
+)
+from .._shared.contiguous.api import (
+    AttentionScratchPlan as BatchedScratchPlan,
+)
+from .._shared.contiguous.api import (
+    VarlenAttentionBinding as VarlenBinding,
+)
+from .._shared.contiguous.api import (
+    VarlenAttentionPlan as VarlenPlan,
+)
+from .._shared.contiguous.api import (
+    VarlenAttentionScratchPlan as VarlenScratchPlan,
+)
+from .._shared.contiguous.api import (
+    clear_attention_caches as clear_caches,
+)
+from .._shared.contiguous.api import (
+    create_attention_plan as create_plan_batched,
+)
+from .._shared.contiguous.api import (
+    create_varlen_attention_plan as create_plan,
+)
+from .._shared.contiguous.api import (
+    plan_attention_scratch as plan_batched,
+)
+from .._shared.contiguous.api import (
+    plan_varlen_attention_scratch as plan,
+)
+from .._shared.contiguous.api import (
+    sm12x_attention_forward as run_batched,
+)
+from .._shared.contiguous.api import (
+    sm12x_varlen_attention_forward as run,
+)
+from . import META
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = list(META.entry_points)

--- a/flashinfer/experimental/sm12x/comm/__init__.py
+++ b/flashinfer/experimental/sm12x/comm/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Communication ops for flashinfer.experimental.sm12x.
+
+- ``pcie``: collectives for consumer PCIe fabrics (no NVLink) — one-shot and
+  DMA/CE-ring all-reduce, FP8-transport two-shot reduce-scatter, and the DCP
+  attention all-to-all with fused LSE merge.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_OP_MODULES = ("pcie",)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _OP_MODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(_OP_MODULES)
+
+
+__all__ = list(_OP_MODULES)

--- a/flashinfer/experimental/sm12x/comm/pcie/__init__.py
+++ b/flashinfer/experimental/sm12x/comm/pcie/__init__.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""PCIe collectives for SM12x multi-GPU boxes (no NVLink).
+
+Stateful class API (collectives own CUDA-IPC handles, mapped peer buffers,
+and their JIT-built extension): kwargs-only constructors with the shared
+vocabulary (rank / world_size / device / ...), CUDA-graph-capturable methods,
+pools via ``<Class>Pool``.
+
+- ``OneshotAllReduce``: one-shot all-reduce (+ ``all_reduce_fused_add_rms_norm``).
+- ``DmaAllReduce``: CE-copy ring reduce-scatter + all-gather for prefill
+  sizes, with a runtime crossover autotuner (``autotune_dma_crossovers``).
+- ``TwoShotReduceScatter``: two-shot sequence-parallel collectives with
+  per-token FP8-e4m3 transport.
+- ``DcpAllToAll``: DCP attention exchange with fused LSE reduce-scatter.
+
+Raw CUDA (not CuTe): each class JIT-builds its colocated ``.cu`` via
+torch.utils.cpp_extension, so nvcc must be available at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="pcie",
+    group="comm",
+    api_style="stateful",
+    entry_points=(
+        "OneshotAllReduce",
+        "OneshotAllReducePool",
+        "DmaAllReduce",
+        "TwoShotReduceScatter",
+        "DcpAllToAll",
+        "DcpAllToAllPool",
+        "autotune_dma_crossovers",
+        "parse_oneshot_max_size",
+        "lse_reduce_scatter_reference",
+        "is_supported",
+    ),
+    dtypes=("bf16", "fp32", "fp8_e4m3"),
+    requires=("multi_gpu",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/distributed/",),
+    ),
+    test_path="tests/experimental/comm/test_pcie.py",
+    since="0.7.0",
+    notes="Raw CUDA JIT-built via torch cpp_extension; needs nvcc at runtime.",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        DcpAllToAll,
+        DcpAllToAllPool,
+        DmaAllReduce,
+        OneshotAllReduce,
+        OneshotAllReducePool,
+        TwoShotReduceScatter,
+        autotune_dma_crossovers,
+        is_supported,
+        lse_reduce_scatter_reference,
+        parse_oneshot_max_size,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/comm/pcie/_cuda_ipc.py
+++ b/flashinfer/experimental/sm12x/comm/pcie/_cuda_ipc.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/distributed/_cuda_ipc.py @ a51c4f3c (2026-04-12) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Minimal CUDA runtime IPC wrapper used by distributed integration code."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import torch  # noqa: F401
+
+
+cudaError_t = ctypes.c_int
+cudaMemcpyKind = ctypes.c_int
+cudaStream_t = ctypes.c_void_p
+
+
+class cudaIpcMemHandle_t(ctypes.Structure):
+    _fields_ = [("internal", ctypes.c_byte * 128)]
+
+
+@dataclass(frozen=True)
+class _Function:
+    name: str
+    restype: Any
+    argtypes: list[Any]
+
+
+def _find_loaded_library(lib_name: str) -> Optional[str]:
+    with open("/proc/self/maps") as f:
+        for line in f:
+            if lib_name in line:
+                start = line.index("/")
+                return line[start:].strip()
+    return None
+
+
+class CudaRTLibrary:
+    _FUNCTIONS = [
+        _Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
+        _Function("cudaSetDevice", cudaError_t, [ctypes.c_int]),
+        _Function(
+            "cudaMalloc",
+            cudaError_t,
+            [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t],
+        ),
+        _Function("cudaFree", cudaError_t, [ctypes.c_void_p]),
+        _Function(
+            "cudaMemset", cudaError_t, [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]
+        ),
+        _Function(
+            "cudaMemcpyAsync",
+            cudaError_t,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_size_t,
+                cudaMemcpyKind,
+                cudaStream_t,
+            ],
+        ),
+        _Function(
+            "cudaIpcGetMemHandle",
+            cudaError_t,
+            [ctypes.POINTER(cudaIpcMemHandle_t), ctypes.c_void_p],
+        ),
+        _Function(
+            "cudaIpcOpenMemHandle",
+            cudaError_t,
+            [ctypes.POINTER(ctypes.c_void_p), cudaIpcMemHandle_t, ctypes.c_uint],
+        ),
+        _Function("cudaIpcCloseMemHandle", cudaError_t, [ctypes.c_void_p]),
+    ]
+
+    _LIB_CACHE: Dict[str, Any] = {}
+    _FUNC_CACHE: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(self, so_file: Optional[str] = None):
+        if so_file is None:
+            so_file = _find_loaded_library("libcudart")
+            if so_file is None:
+                raise RuntimeError("libcudart is not loaded in the current process")
+        if so_file not in self._LIB_CACHE:
+            self._LIB_CACHE[so_file] = ctypes.CDLL(so_file)
+        self.lib = self._LIB_CACHE[so_file]
+        if so_file not in self._FUNC_CACHE:
+            funcs: Dict[str, Any] = {}
+            for spec in self._FUNCTIONS:
+                func = getattr(self.lib, spec.name)
+                func.restype = spec.restype
+                func.argtypes = spec.argtypes
+                funcs[spec.name] = func
+            self._FUNC_CACHE[so_file] = funcs
+        self.funcs = self._FUNC_CACHE[so_file]
+
+    def _check(self, result: int) -> None:
+        if result != 0:
+            error = self.funcs["cudaGetErrorString"](result).decode("utf-8")
+            raise RuntimeError(f"CUDART error: {error}")
+
+    @staticmethod
+    def _void_p(ptr: int | ctypes.c_void_p) -> ctypes.c_void_p:
+        if isinstance(ptr, ctypes.c_void_p):
+            return ptr
+        return ctypes.c_void_p(int(ptr))
+
+    def cudaSetDevice(self, device: int) -> None:
+        self._check(self.funcs["cudaSetDevice"](device))
+
+    def cudaMalloc(self, size: int) -> int:
+        ptr = ctypes.c_void_p()
+        self._check(self.funcs["cudaMalloc"](ctypes.byref(ptr), size))
+        return int(ptr.value)
+
+    def cudaFree(self, ptr: int | ctypes.c_void_p) -> None:
+        self._check(self.funcs["cudaFree"](self._void_p(ptr)))
+
+    def cudaMemset(self, ptr: int | ctypes.c_void_p, value: int, count: int) -> None:
+        self._check(self.funcs["cudaMemset"](self._void_p(ptr), value, count))
+
+    def cudaMemcpyAsync(self, dst: int, src: int, count: int, stream: int) -> None:
+        cudaMemcpyDefault = 4
+        self._check(
+            self.funcs["cudaMemcpyAsync"](
+                self._void_p(dst),
+                self._void_p(src),
+                count,
+                cudaMemcpyDefault,
+                cudaStream_t(int(stream)),
+            )
+        )
+
+    def cudaIpcGetMemHandleBytes(self, ptr: int | ctypes.c_void_p) -> bytes:
+        handle = cudaIpcMemHandle_t()
+        self._check(
+            self.funcs["cudaIpcGetMemHandle"](ctypes.byref(handle), self._void_p(ptr))
+        )
+        return bytes(handle)
+
+    def cudaIpcOpenMemHandleBytes(self, handle_bytes: bytes) -> int:
+        if len(handle_bytes) != ctypes.sizeof(cudaIpcMemHandle_t):
+            raise ValueError("invalid CUDA IPC handle size")
+        handle = cudaIpcMemHandle_t.from_buffer_copy(handle_bytes)
+        cudaIpcMemLazyEnablePeerAccess = 1
+        ptr = ctypes.c_void_p()
+        self._check(
+            self.funcs["cudaIpcOpenMemHandle"](
+                ctypes.byref(ptr), handle, cudaIpcMemLazyEnablePeerAccess
+            )
+        )
+        return int(ptr.value)
+
+    def cudaIpcCloseMemHandle(self, ptr: int | ctypes.c_void_p) -> None:
+        self._check(self.funcs["cudaIpcCloseMemHandle"](self._void_p(ptr)))

--- a/flashinfer/experimental/sm12x/comm/pcie/api.py
+++ b/flashinfer/experimental/sm12x/comm/pcie/api.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for comm.pcie (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import is_sm12x
+from .pcie_dcp_a2a import (
+    PCIeDCPA2A as DcpAllToAll,
+)
+from .pcie_dcp_a2a import (
+    PCIeDCPA2APool as DcpAllToAllPool,
+)
+from .pcie_dcp_a2a import (
+    lse_reduce_scatter_reference,
+)
+from .pcie_dma import (
+    PCIeDmaAllReduce as DmaAllReduce,
+)
+from .pcie_dma import (
+    autotune_crossovers as autotune_dma_crossovers,
+)
+from .pcie_oneshot import (
+    PCIeOneshotAllReduce as OneshotAllReduce,
+)
+from .pcie_oneshot import (
+    PCIeOneshotAllReducePool as OneshotAllReducePool,
+)
+from .pcie_oneshot import (
+    parse_pcie_oneshot_max_size as parse_oneshot_max_size,
+)
+from .pcie_twoshot import (
+    PCIeTwoShotSP as TwoShotReduceScatter,
+)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with >= 2 visible CUDA devices.
+
+    Raw CUDA op: unlike the CuTe-DSL ops, this does not require
+    nvidia-cutlass-dsl (it needs nvcc at runtime instead; see META.notes).
+    """
+    import torch
+
+    return is_sm12x(device) and torch.cuda.device_count() >= 2
+
+
+__all__ = [
+    "OneshotAllReduce",
+    "OneshotAllReducePool",
+    "DmaAllReduce",
+    "TwoShotReduceScatter",
+    "DcpAllToAll",
+    "DcpAllToAllPool",
+    "autotune_dma_crossovers",
+    "parse_oneshot_max_size",
+    "lse_reduce_scatter_reference",
+    "is_supported",
+]

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_dcp_a2a.cu
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_dcp_a2a.cu
@@ -1,0 +1,604 @@
+// Ported from b12x b12x/distributed/pcie_dcp_a2a.cu @ a394fd2e (2026-07-04) -- one-time curated port.
+// PCIe one-shot exchange for DCP attention output and LSE reduction.
+//
+// Each rank first copies its full partial output and FP32 LSE into one of two
+// IPC-visible staging slots. A single system-scope barrier makes those copies
+// visible, after which every rank pulls only its destination head shard from
+// all peers and performs the stable LSE-weighted reduction while storing the
+// final output. This deliberately follows the low-latency, one-barrier design
+// of pcie_oneshot.cu rather than implementing a generic NCCL-style all-to-all.
+
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <math_constants.h>
+#include <torch/all.h>
+#include <torch/extension.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#define CHECK_CUDA_SUCCESS(cmd)                                                \
+  do {                                                                         \
+    cudaError_t e = cmd;                                                       \
+    if (e != cudaSuccess) {                                                    \
+      std::stringstream _message;                                              \
+      _message << cudaGetErrorString(e) << "\n"                                \
+               << __FILE__ << ':' << __LINE__;                                 \
+      throw std::runtime_error(_message.str());                                \
+    }                                                                          \
+  } while (0)
+
+namespace pcie_dcp_a2a {
+
+constexpr int kMaxBlocks = 64;
+constexpr int kMaxRanks = 8;
+constexpr int kFlagStride = 32;
+using FlagType = uint32_t;
+
+static int env_int(const char *name, int fallback) {
+  const char *raw = std::getenv(name);
+  if (raw == nullptr || raw[0] == '\0') {
+    return fallback;
+  }
+  return std::atoi(raw);
+}
+
+// Launch-shape overrides for latency sweeps. Every rank must use identical
+// values: warp geometry decides which rows each block stages, and peer
+// block b only reads what writer block b staged.
+static int dcp_threads_override() {
+  static const int value = env_int("FLASHINFER_EXP_SM12X_PCIE_DCP_THREADS", 0);
+  return value;
+}
+
+static int dcp_block_limit_override() {
+  static const int value = env_int("FLASHINFER_EXP_SM12X_PCIE_DCP_BLOCK_LIMIT", 0);
+  return value;
+}
+
+struct Signal {
+  alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+};
+
+struct RankSignals {
+  Signal *signals[kMaxRanks];
+};
+
+struct RankStaging {
+  void *ptrs[kMaxRanks];
+};
+
+template <typename T> struct __align__(16) Pack {
+  T values[8];
+};
+
+#define DINLINE __device__ __forceinline__
+
+static DINLINE void store_flag(FlagType *address, FlagType value) {
+  asm volatile("st.relaxed.sys.global.u32 [%1], %0;" ::"r"(value),
+               "l"(address));
+}
+
+static DINLINE FlagType load_flag(FlagType *address) {
+  FlagType value;
+  asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+               : "=r"(value)
+               : "l"(address));
+  return value;
+}
+
+// pre_sync orders in-kernel staging stores (from every warp of the block)
+// before the flag post; without staging the flags can go out immediately.
+template <int world_size, bool pre_sync>
+DINLINE void start_barrier(const RankSignals &signals, Signal *self, int rank) {
+  if constexpr (pre_sync) __syncthreads();
+  if (threadIdx.x < world_size) {
+    __threadfence_system();
+    const auto value = self->self_counter[blockIdx.x][threadIdx.x] +=
+        FlagType{1};
+    auto *peer = &signals.signals[threadIdx.x]
+                      ->peer_counter[value % 2][blockIdx.x][rank * kFlagStride];
+    auto *mine =
+        &self->peer_counter[value % 2][blockIdx.x][threadIdx.x * kFlagStride];
+    store_flag(peer, value);
+    while (load_flag(mine) != value) {
+    }
+  }
+  __syncthreads();
+}
+
+DINLINE float to_float(half value) { return __half2float(value); }
+DINLINE float to_float(nv_bfloat16 value) { return __bfloat162float(value); }
+
+template <typename T> DINLINE T from_float(float value);
+
+template <> DINLINE half from_float<half>(float value) {
+  return __float2half(value);
+}
+
+template <> DINLINE nv_bfloat16 from_float<nv_bfloat16>(float value) {
+  return __float2bfloat16(value);
+}
+
+DINLINE float sanitize_lse(float value) {
+  return isfinite(value) ? value : -CUDART_INF_F;
+}
+
+// Warp-per-row LSE-weighted reduction with in-kernel staging.
+//
+// Reader rows are the (batch, local_head) pairs of this rank's head shard,
+// and every rank strides that identical row space with identical warp
+// geometry. The warp that owns reader row (b, h) also stages this rank's
+// contributions for (b, h) across all destination shards (packs and LSE),
+// so the block-pairwise barrier covers exactly what the matching reader
+// blocks pull. Each warp reads the LSE values once per row (one lane per
+// source, packs_per_head times fewer remote scalar reads than per-pack
+// loads), builds the softmax weights via shuffles in rotated source order,
+// and streams the row's packs with lane-parallel pulls.
+template <typename T, int world_size>
+__global__ void __launch_bounds__(512, 1)
+    dcp_lse_reduce_kernel(const T *__restrict__ local_output,
+                          const float *__restrict__ local_lse,
+                          RankStaging staging, int64_t lse_offset,
+                          RankSignals signals, Signal *self,
+                          T *__restrict__ output, int rank, int batch,
+                          int total_heads, int head_dim, bool natural_log) {
+  constexpr int kPackElems = 8;
+  const int heads_per_rank = total_heads / world_size;
+  const int packs_per_head = head_dim / kPackElems;
+  const int rows = batch * heads_per_rank;
+  const int lane = threadIdx.x & 31;
+  const int warps_per_block = blockDim.x >> 5;
+  const int warp_first = blockIdx.x * warps_per_block + (threadIdx.x >> 5);
+  const int warp_stride = gridDim.x * warps_per_block;
+
+  const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_output);
+  auto *output_packs = reinterpret_cast<Pack<T> *>(output);
+
+  auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
+  auto *staging_lse = reinterpret_cast<float *>(
+      reinterpret_cast<char *>(staging.ptrs[rank]) + lse_offset);
+  for (int row = warp_first; row < rows; row += warp_stride) {
+    const int batch_index = row / heads_per_rank;
+    const int local_head = row - batch_index * heads_per_rank;
+#pragma unroll
+    for (int dest = 0; dest < world_size; ++dest) {
+      const int64_t source_row = int64_t(batch_index) * total_heads +
+                                 dest * heads_per_rank + local_head;
+      const int64_t base = source_row * packs_per_head;
+      for (int pack = lane; pack < packs_per_head; pack += warpSize) {
+        staging_out[base + pack] = local_packs[base + pack];
+      }
+      if (lane == 0) {
+        staging_lse[source_row] = local_lse[source_row];
+      }
+    }
+  }
+  start_barrier<world_size, true>(signals, self, rank);
+
+  // Rotated source pointers so every later access uses a compile-time
+  // index; the self source reads the local tensors directly (still hot in
+  // L2 from staging).
+  const Pack<T> *rot_packs[world_size];
+#pragma unroll
+  for (int i = 0; i < world_size; ++i) {
+    const int src = (rank + i) % world_size;
+    rot_packs[i] = src == rank
+                       ? local_packs
+                       : reinterpret_cast<const Pack<T> *>(staging.ptrs[src]);
+  }
+
+  for (int row = warp_first; row < rows; row += warp_stride) {
+    const int batch_index = row / heads_per_rank;
+    const int local_head = row - batch_index * heads_per_rank;
+    const int global_head = rank * heads_per_rank + local_head;
+    const int64_t source_row = int64_t(batch_index) * total_heads + global_head;
+
+    // Lane i pulls rotated source i's LSE; shuffles then give every lane
+    // all sources in rotated order. The pointer is derived per lane from
+    // the kernel param block to avoid a runtime-indexed local array.
+    float lane_lse = -CUDART_INF_F;
+    if (lane < world_size) {
+      const int src = (rank + lane) % world_size;
+      const float *lse_ptr =
+          src == rank ? local_lse
+                      : reinterpret_cast<const float *>(
+                            reinterpret_cast<const char *>(staging.ptrs[src]) +
+                            lse_offset);
+      lane_lse = sanitize_lse(lse_ptr[source_row]);
+    }
+    float weights[world_size];
+    float max_lse = -CUDART_INF_F;
+#pragma unroll
+    for (int i = 0; i < world_size; ++i) {
+      const float value = __shfl_sync(0xffffffff, lane_lse, i);
+      weights[i] = value;
+      max_lse = fmaxf(max_lse, value);
+    }
+    if (!isfinite(max_lse)) {
+      max_lse = 0.0f;
+    }
+    float weight_sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < world_size; ++i) {
+      const float delta = weights[i] - max_lse;
+      const float weight = isfinite(weights[i])
+                               ? (natural_log ? expf(delta) : exp2f(delta))
+                               : 0.0f;
+      weights[i] = weight;
+      weight_sum += weight;
+    }
+    const float inv_weight_sum = 1.0f / fmaxf(weight_sum, 1.0e-10f);
+
+    const int64_t source_base = source_row * packs_per_head;
+    const int64_t output_base = int64_t(row) * packs_per_head;
+    for (int pack = lane; pack < packs_per_head; pack += warpSize) {
+      float accum[kPackElems] = {};
+#pragma unroll
+      for (int i = 0; i < world_size; ++i) {
+        const Pack<T> values = rot_packs[i][source_base + pack];
+        const float weight = weights[i] * inv_weight_sum;
+#pragma unroll
+        for (int element = 0; element < kPackElems; ++element) {
+          accum[element] += weight * to_float(values.values[element]);
+        }
+      }
+      Pack<T> result;
+#pragma unroll
+      for (int element = 0; element < kPackElems; ++element) {
+        result.values[element] = from_float<T>(accum[element]);
+      }
+      output_packs[output_base + pack] = result;
+    }
+  }
+}
+
+// Warp-per-output-row head gather with in-kernel staging. Every rank
+// strides the identical output row space with identical warp geometry, so
+// the writer warp that owns row (batch, global_head) with source == this
+// rank stages exactly the packs the matching reader blocks pull. Row-major
+// warps also hoist the head/source arithmetic out of the pack loop (the
+// pack-strided version paid six integer divisions per 16B pack).
+template <typename T, int world_size>
+__global__ void __launch_bounds__(512, 1)
+    all_gather_heads_kernel(const T *__restrict__ local_input,
+                            RankStaging staging, RankSignals signals,
+                            Signal *self, T *__restrict__ output, int rank,
+                            int batch, int local_heads, int head_dim) {
+  constexpr int kPackElems = 8;
+  const int packs_per_head = head_dim / kPackElems;
+  const int total_heads = local_heads * world_size;
+  const int rows = batch * total_heads;
+  const int lane = threadIdx.x & 31;
+  const int warps_per_block = blockDim.x >> 5;
+  const int warp_first = blockIdx.x * warps_per_block + (threadIdx.x >> 5);
+  const int warp_stride = gridDim.x * warps_per_block;
+  const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_input);
+
+  auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
+  for (int row = warp_first; row < rows; row += warp_stride) {
+    const int batch_index = row / total_heads;
+    const int global_head = row - batch_index * total_heads;
+    const int source_rank = global_head / local_heads;
+    if (source_rank != rank) continue;
+    const int local_head = global_head - source_rank * local_heads;
+    const int64_t base =
+        (int64_t(batch_index) * local_heads + local_head) * packs_per_head;
+    for (int pack = lane; pack < packs_per_head; pack += warpSize) {
+      staging_out[base + pack] = local_packs[base + pack];
+    }
+  }
+  start_barrier<world_size, true>(signals, self, rank);
+
+  auto *output_packs = reinterpret_cast<Pack<T> *>(output);
+  for (int row = warp_first; row < rows; row += warp_stride) {
+    const int batch_index = row / total_heads;
+    const int global_head = row - batch_index * total_heads;
+    const int source_rank = global_head / local_heads;
+    const int local_head = global_head - source_rank * local_heads;
+    const auto *source_packs =
+        source_rank == rank
+            ? local_packs
+            : reinterpret_cast<const Pack<T> *>(staging.ptrs[source_rank]);
+    const int64_t source_base =
+        (int64_t(batch_index) * local_heads + local_head) * packs_per_head;
+    const int64_t output_base = int64_t(row) * packs_per_head;
+    for (int pack = lane; pack < packs_per_head; pack += warpSize) {
+      output_packs[output_base + pack] = source_packs[source_base + pack];
+    }
+  }
+}
+
+class PCIeDCPA2A {
+public:
+  int rank_;
+  int world_size_;
+  RankSignals signals_{};
+  Signal *self_signal_;
+  RankStaging staging_[2]{};
+  int64_t output_capacity_elems_;
+  int64_t lse_offset_;
+  int64_t lse_capacity_;
+  int slot_ = 0;
+
+  PCIeDCPA2A(Signal **signals,
+             const std::vector<std::array<void *, 2>> &staging,
+             int64_t output_capacity_elems, int64_t lse_offset,
+             int64_t lse_capacity, int rank, int world_size)
+      : rank_(rank), world_size_(world_size), self_signal_(signals[rank]),
+        output_capacity_elems_(output_capacity_elems), lse_offset_(lse_offset),
+        lse_capacity_(lse_capacity) {
+    for (int peer = 0; peer < world_size_; ++peer) {
+      signals_.signals[peer] = signals[peer];
+      staging_[0].ptrs[peer] = staging[peer][0];
+      staging_[1].ptrs[peer] = staging[peer][1];
+    }
+  }
+
+  template <typename T>
+  void run(cudaStream_t stream, const T *partial_output,
+           const float *partial_lse, T *output, int batch, int total_heads,
+           int head_dim, bool natural_log, int threads, int block_limit) {
+    const int64_t output_elems = int64_t(batch) * total_heads * head_dim;
+    const int64_t lse_elems = int64_t(batch) * total_heads;
+    if (output_elems > output_capacity_elems_ || lse_elems > lse_capacity_) {
+      throw std::runtime_error("PCIe DCP A2A staging capacity exceeded");
+    }
+    if (head_dim % 8 != 0) {
+      throw std::runtime_error("head_dim must be a multiple of 8");
+    }
+    if (total_heads % world_size_ != 0) {
+      throw std::runtime_error("total_heads must be divisible by world size");
+    }
+    if (threads < world_size_ || threads > 1024) {
+      throw std::runtime_error("invalid thread count");
+    }
+    if (block_limit <= 0 || block_limit > kMaxBlocks) {
+      throw std::runtime_error("invalid block limit");
+    }
+
+    if (const int env_threads = dcp_threads_override(); env_threads > 0) {
+      threads = std::min(512, std::max(64, (env_threads / 32) * 32));
+    }
+    if (const int env_blocks = dcp_block_limit_override(); env_blocks > 0) {
+      block_limit = std::min(env_blocks, kMaxBlocks);
+    }
+    if (threads % 32 != 0) {
+      throw std::runtime_error("threads must be a multiple of 32");
+    }
+
+    // Staging happens inside the kernel (warp-per-row, before the start
+    // barrier); no host staging memcpys are issued.
+    const int slot = slot_++ % 2;
+    const int heads_per_rank = total_heads / world_size_;
+    const int rows = batch * heads_per_rank;
+    const int warps_per_block = threads / 32;
+    const int blocks = std::max(
+        1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
+
+#define LAUNCH(world)                                                          \
+  dcp_lse_reduce_kernel<T, world><<<blocks, threads, 0, stream>>>(             \
+      partial_output, partial_lse, staging_[slot], lse_offset_, signals_,      \
+      self_signal_, output, rank_, batch, total_heads, head_dim, natural_log)
+    switch (world_size_) {
+    case 2:
+      LAUNCH(2);
+      break;
+    case 4:
+      LAUNCH(4);
+      break;
+    case 8:
+      LAUNCH(8);
+      break;
+    default:
+      throw std::runtime_error("PCIe DCP A2A supports 2, 4, or 8 ranks");
+    }
+#undef LAUNCH
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
+  }
+
+  template <typename T>
+  void all_gather_heads(cudaStream_t stream, const T *local_input, T *output,
+                        int batch, int local_heads, int head_dim, int threads,
+                        int block_limit) {
+    const int total_heads = local_heads * world_size_;
+    const int64_t output_elems = int64_t(batch) * total_heads * head_dim;
+    if (output_elems > output_capacity_elems_) {
+      throw std::runtime_error("PCIe DCP all-gather staging capacity exceeded");
+    }
+    if (head_dim % 8 != 0) {
+      throw std::runtime_error("head_dim must be a multiple of 8");
+    }
+    if (threads < world_size_ || threads > 1024) {
+      throw std::runtime_error("invalid thread count");
+    }
+    if (block_limit <= 0 || block_limit > kMaxBlocks) {
+      throw std::runtime_error("invalid block limit");
+    }
+
+    if (const int env_threads = dcp_threads_override(); env_threads > 0) {
+      threads = std::min(512, std::max(64, (env_threads / 32) * 32));
+    }
+    if (const int env_blocks = dcp_block_limit_override(); env_blocks > 0) {
+      block_limit = std::min(env_blocks, kMaxBlocks);
+    }
+    if (threads % 32 != 0) {
+      throw std::runtime_error("threads must be a multiple of 32");
+    }
+
+    // Staging happens inside the kernel (warp-per-row, before the start
+    // barrier); no host staging memcpy is issued.
+    const int slot = slot_++ % 2;
+    const int rows = batch * total_heads;
+    const int warps_per_block = threads / 32;
+    const int blocks = std::max(
+        1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
+
+#define LAUNCH(world)                                                          \
+  all_gather_heads_kernel<T, world><<<blocks, threads, 0, stream>>>(           \
+      local_input, staging_[slot], signals_, self_signal_, output, rank_,      \
+      batch, local_heads, head_dim)
+    switch (world_size_) {
+    case 2:
+      LAUNCH(2);
+      break;
+    case 4:
+      LAUNCH(4);
+      break;
+    case 8:
+      LAUNCH(8);
+      break;
+    default:
+      throw std::runtime_error("PCIe DCP all-gather supports 2, 4, or 8 ranks");
+    }
+#undef LAUNCH
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
+  }
+};
+
+} // namespace pcie_dcp_a2a
+
+using fptr_t = int64_t;
+
+static fptr_t init_dcp_a2a(const std::vector<fptr_t> &signal_ptrs,
+                           const std::vector<fptr_t> &staging0_ptrs,
+                           const std::vector<fptr_t> &staging1_ptrs,
+                           int64_t output_capacity_elems, int64_t lse_offset,
+                           int64_t lse_capacity, int64_t rank) {
+  const int world_size = signal_ptrs.size();
+  TORCH_CHECK(world_size == 2 || world_size == 4 || world_size == 8);
+  TORCH_CHECK_EQ(staging0_ptrs.size(), signal_ptrs.size());
+  TORCH_CHECK_EQ(staging1_ptrs.size(), signal_ptrs.size());
+  TORCH_CHECK(rank >= 0 && rank < world_size);
+
+  pcie_dcp_a2a::Signal *signals[pcie_dcp_a2a::kMaxRanks];
+  std::vector<std::array<void *, 2>> staging(world_size);
+  for (int peer = 0; peer < world_size; ++peer) {
+    signals[peer] = reinterpret_cast<pcie_dcp_a2a::Signal *>(signal_ptrs[peer]);
+    staging[peer] = {reinterpret_cast<void *>(staging0_ptrs[peer]),
+                     reinterpret_cast<void *>(staging1_ptrs[peer])};
+  }
+  return reinterpret_cast<fptr_t>(
+      new pcie_dcp_a2a::PCIeDCPA2A(signals, staging, output_capacity_elems,
+                                   lse_offset, lse_capacity, rank, world_size));
+}
+
+static void lse_reduce_scatter(fptr_t pointer, torch::Tensor &partial_output,
+                               torch::Tensor &partial_lse,
+                               torch::Tensor &output, bool natural_log,
+                               int64_t threads, int64_t block_limit) {
+  auto *runtime = reinterpret_cast<pcie_dcp_a2a::PCIeDCPA2A *>(pointer);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(partial_output));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+
+  TORCH_CHECK(partial_output.is_cuda() && partial_lse.is_cuda() &&
+              output.is_cuda());
+  TORCH_CHECK(partial_output.is_contiguous() && partial_lse.is_contiguous() &&
+              output.is_contiguous());
+  TORCH_CHECK_EQ(partial_output.dim(), 3);
+  TORCH_CHECK_EQ(partial_lse.dim(), 2);
+  TORCH_CHECK_EQ(output.dim(), 3);
+  TORCH_CHECK_EQ(partial_lse.scalar_type(), at::ScalarType::Float);
+  TORCH_CHECK_EQ(partial_output.scalar_type(), output.scalar_type());
+
+  const int64_t batch = partial_output.size(0);
+  const int64_t total_heads = partial_output.size(1);
+  const int64_t head_dim = partial_output.size(2);
+  TORCH_CHECK_GT(batch, 0);
+  TORCH_CHECK_EQ(partial_lse.size(0), batch);
+  TORCH_CHECK_EQ(partial_lse.size(1), total_heads);
+  TORCH_CHECK_EQ(total_heads % runtime->world_size_, 0);
+  TORCH_CHECK_EQ(output.size(0), batch);
+  TORCH_CHECK_EQ(output.size(1), total_heads / runtime->world_size_);
+  TORCH_CHECK_EQ(output.size(2), head_dim);
+
+  switch (partial_output.scalar_type()) {
+  case at::ScalarType::Half:
+    runtime->run(stream,
+                 reinterpret_cast<const half *>(partial_output.data_ptr()),
+                 reinterpret_cast<const float *>(partial_lse.data_ptr()),
+                 reinterpret_cast<half *>(output.data_ptr()), int(batch),
+                 int(total_heads), int(head_dim), natural_log, int(threads),
+                 int(block_limit));
+    break;
+  case at::ScalarType::BFloat16:
+    runtime->run(
+        stream,
+        reinterpret_cast<const nv_bfloat16 *>(partial_output.data_ptr()),
+        reinterpret_cast<const float *>(partial_lse.data_ptr()),
+        reinterpret_cast<nv_bfloat16 *>(output.data_ptr()), int(batch),
+        int(total_heads), int(head_dim), natural_log, int(threads),
+        int(block_limit));
+    break;
+  default:
+    TORCH_CHECK(false, "partial_output must be float16 or bfloat16");
+  }
+}
+
+static void all_gather_heads(fptr_t pointer, torch::Tensor &local_input,
+                             torch::Tensor &output, int64_t threads,
+                             int64_t block_limit) {
+  auto *runtime = reinterpret_cast<pcie_dcp_a2a::PCIeDCPA2A *>(pointer);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(local_input));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+
+  TORCH_CHECK(local_input.is_cuda() && output.is_cuda());
+  TORCH_CHECK(local_input.is_contiguous() && output.is_contiguous());
+  TORCH_CHECK_EQ(local_input.dim(), 3);
+  TORCH_CHECK_EQ(output.dim(), 3);
+  TORCH_CHECK_EQ(local_input.scalar_type(), output.scalar_type());
+
+  const int64_t batch = local_input.size(0);
+  const int64_t local_heads = local_input.size(1);
+  const int64_t head_dim = local_input.size(2);
+  TORCH_CHECK_GT(batch, 0);
+  TORCH_CHECK_GT(local_heads, 0);
+  TORCH_CHECK_EQ(output.size(0), batch);
+  TORCH_CHECK_EQ(output.size(1), local_heads * runtime->world_size_);
+  TORCH_CHECK_EQ(output.size(2), head_dim);
+
+  switch (local_input.scalar_type()) {
+  case at::ScalarType::Half:
+    runtime->all_gather_heads(
+        stream, reinterpret_cast<const half *>(local_input.data_ptr()),
+        reinterpret_cast<half *>(output.data_ptr()), int(batch),
+        int(local_heads), int(head_dim), int(threads), int(block_limit));
+    break;
+  case at::ScalarType::BFloat16:
+    runtime->all_gather_heads(
+        stream,
+        reinterpret_cast<const nv_bfloat16 *>(local_input.data_ptr()),
+        reinterpret_cast<nv_bfloat16 *>(output.data_ptr()), int(batch),
+        int(local_heads), int(head_dim), int(threads), int(block_limit));
+    break;
+  default:
+    TORCH_CHECK(false, "local_input must be float16 or bfloat16");
+  }
+}
+
+static void dispose(fptr_t pointer) {
+  delete reinterpret_cast<pcie_dcp_a2a::PCIeDCPA2A *>(pointer);
+}
+
+static int64_t meta_size() { return sizeof(pcie_dcp_a2a::Signal); }
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  module.def("init_dcp_a2a", &init_dcp_a2a, "initialize PCIe DCP A2A");
+  module.def("lse_reduce_scatter", &lse_reduce_scatter,
+             "fused PCIe DCP LSE reduce-scatter");
+  module.def("all_gather_heads", &all_gather_heads,
+             "PCIe DCP head-dimension all-gather");
+  module.def("dispose", &dispose, "dispose PCIe DCP A2A");
+  module.def("meta_size", &meta_size, "signal metadata size");
+}

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_dcp_a2a.py
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_dcp_a2a.py
@@ -1,0 +1,713 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/distributed/pcie_dcp_a2a.py @ 00695ee8 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""PCIe one-shot DCP attention exchange with fused LSE reduction."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from torch.utils.cpp_extension import load
+
+from ._cuda_ipc import CudaRTLibrary
+from .pcie_oneshot import (
+    IPC_SLAB_ALIGNMENT,
+    PCIeOneshotAllReduce,
+    _align_up,
+    _current_stream_key,
+    _is_current_stream_capturing,
+    _normalize_device,
+    _OwnedSharedBuffer,
+)
+
+
+SUPPORTED_WORLD_SIZES = (2, 4, 8)
+SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
+
+
+@dataclass(frozen=True)
+class _StagingLayout:
+    signal_bytes: int
+    staging0_offset: int
+    staging1_offset: int
+    output_capacity_elems: int
+    lse_offset: int
+    lse_capacity: int
+    slot_bytes: int
+    slab_bytes: int
+
+
+def _staging_layout(
+    *,
+    signal_bytes: int,
+    world_size: int,
+    max_batch_size: int,
+    total_heads: int,
+    head_dim: int,
+    query_head_dim: Optional[int] = None,
+) -> _StagingLayout:
+    if signal_bytes <= 0:
+        raise ValueError("signal_bytes must be positive")
+    if world_size not in SUPPORTED_WORLD_SIZES:
+        raise ValueError(f"unsupported world size {world_size}")
+    if max_batch_size <= 0:
+        raise ValueError("max_batch_size must be positive")
+    if total_heads <= 0 or total_heads % world_size != 0:
+        raise ValueError("total_heads must be positive and divisible by world_size")
+    if head_dim <= 0 or head_dim % 8 != 0:
+        raise ValueError("head_dim must be a positive multiple of 8")
+    if query_head_dim is None:
+        query_head_dim = head_dim
+    if query_head_dim <= 0 or query_head_dim % 8 != 0:
+        raise ValueError("query_head_dim must be a positive multiple of 8")
+
+    output_elems = max_batch_size * total_heads * max(head_dim, query_head_dim)
+    output_bytes = _align_up(output_elems * 2, IPC_SLAB_ALIGNMENT)
+    output_capacity_elems = output_bytes // 2
+    lse_offset = output_bytes
+    lse_elems = max_batch_size * total_heads
+    lse_capacity = _align_up(lse_elems * 4, IPC_SLAB_ALIGNMENT) // 4
+    slot_bytes = _align_up(
+        lse_offset + lse_capacity * 4,
+        IPC_SLAB_ALIGNMENT,
+    )
+    staging0_offset = _align_up(signal_bytes, IPC_SLAB_ALIGNMENT)
+    staging1_offset = staging0_offset + slot_bytes
+    return _StagingLayout(
+        signal_bytes=signal_bytes,
+        staging0_offset=staging0_offset,
+        staging1_offset=staging1_offset,
+        output_capacity_elems=output_capacity_elems,
+        lse_offset=lse_offset,
+        lse_capacity=lse_capacity,
+        slot_bytes=slot_bytes,
+        slab_bytes=staging1_offset + slot_bytes,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_extension():
+    source = Path(__file__).with_name("pcie_dcp_a2a.cu")
+    verbose = os.getenv("FLASHINFER_EXP_SM12X_PCIE_DCP_A2A_VERBOSE_BUILD", "0") == "1"
+    return load(
+        name="sm12x_pcie_dcp_a2a_ext",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
+        extra_ldflags=["-lcuda"],
+        verbose=verbose,
+    )
+
+
+def lse_reduce_scatter_reference(
+    partial_outputs: torch.Tensor,
+    partial_lses: torch.Tensor,
+    rank: int,
+    *,
+    is_lse_base_on_e: bool = True,
+) -> torch.Tensor:
+    """Reference LSE-weighted reduction for stacked rank contributions.
+
+    Args:
+        partial_outputs: Tensor shaped ``[world, batch, heads, head_dim]``.
+        partial_lses: FP32 tensor shaped ``[world, batch, heads]``.
+        rank: Destination rank whose contiguous head shard is returned.
+        is_lse_base_on_e: Whether LSE values use natural logarithms.
+
+    Returns:
+        The reduced output shaped ``[batch, heads // world, head_dim]``.
+    """
+    if partial_outputs.ndim != 4:
+        raise ValueError("partial_outputs must have rank 4")
+    if partial_lses.shape != partial_outputs.shape[:-1]:
+        raise ValueError("partial_lses shape must match partial_outputs[:-1]")
+    world_size, _, total_heads, _ = partial_outputs.shape
+    if not 0 <= rank < world_size:
+        raise ValueError(f"invalid rank {rank} for world size {world_size}")
+    if total_heads % world_size != 0:
+        raise ValueError("total heads must be divisible by world size")
+
+    heads_per_rank = total_heads // world_size
+    head_slice = slice(rank * heads_per_rank, (rank + 1) * heads_per_rank)
+    outputs = partial_outputs[:, :, head_slice, :].float()
+    lses = partial_lses[:, :, head_slice].float()
+    valid = torch.isfinite(lses)
+    sanitized = torch.where(valid, lses, torch.full_like(lses, -torch.inf))
+    max_lse = sanitized.amax(dim=0)
+    max_lse = torch.where(torch.isfinite(max_lse), max_lse, 0.0)
+    if is_lse_base_on_e:
+        weights = torch.exp(sanitized - max_lse.unsqueeze(0))
+    else:
+        weights = torch.exp2(sanitized - max_lse.unsqueeze(0))
+    weights = torch.where(valid, weights, torch.zeros_like(weights))
+    weights /= weights.sum(dim=0, keepdim=True).clamp_min_(1e-10)
+    return (outputs * weights.unsqueeze(-1)).sum(dim=0).to(partial_outputs.dtype)
+
+
+class PCIeDCPA2A:
+    """One ordered IPC channel for DCP attention collectives."""
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device | int | str,
+        signal_ptrs: Sequence[int],
+        staging0_ptrs: Sequence[int],
+        staging1_ptrs: Sequence[int],
+        max_batch_size: int,
+        total_heads: int,
+        head_dim: int,
+        output_capacity_elems: int,
+        lse_offset: int,
+        lse_capacity: int,
+        query_head_dim: Optional[int] = None,
+        exchange_group: Optional[ProcessGroup] = None,
+        ipc: Optional[CudaRTLibrary] = None,
+        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]] = None,
+        ext_module=None,
+        stream_affine: bool = True,
+    ) -> None:
+        if world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(f"unsupported world size {world_size}")
+        if not 0 <= rank < world_size:
+            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+        if (
+            len(signal_ptrs) != world_size
+            or len(staging0_ptrs) != world_size
+            or len(staging1_ptrs) != world_size
+        ):
+            raise ValueError("signal and staging pointers must match world size")
+        if total_heads <= 0 or total_heads % world_size != 0:
+            raise ValueError("total_heads must be divisible by world_size")
+        if head_dim <= 0 or head_dim % 8 != 0:
+            raise ValueError("head_dim must be a positive multiple of 8")
+
+        self.rank = int(rank)
+        self.world_size = int(world_size)
+        self.device = _normalize_device(device)
+        self.exchange_group = exchange_group
+        self.max_batch_size = int(max_batch_size)
+        self.total_heads = int(total_heads)
+        self.head_dim = int(head_dim)
+        self.query_head_dim = int(query_head_dim or head_dim)
+        if self.query_head_dim <= 0 or self.query_head_dim % 8 != 0:
+            raise ValueError("query_head_dim must be a positive multiple of 8")
+        self.heads_per_rank = self.total_heads // self.world_size
+        self._ipc = ipc
+        self._owned_buffers = list(owned_buffers or ())
+        self._ext = ext_module or _load_extension()
+        self._stream_affine = bool(stream_affine)
+        self._owner_stream_key: Optional[int] = None
+        self._closed = False
+        self._ptr = self._ext.init_dcp_a2a(
+            list(signal_ptrs),
+            list(staging0_ptrs),
+            list(staging1_ptrs),
+            int(output_capacity_elems),
+            int(lse_offset),
+            int(lse_capacity),
+            self.rank,
+        )
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_batch_size: int,
+        total_heads: int,
+        head_dim: int,
+        query_head_dim: Optional[int] = None,
+        ext_module=None,
+        stream_affine: bool = True,
+    ) -> "PCIeDCPA2A":
+        rank = dist.get_rank(group=exchange_group)
+        world_size = dist.get_world_size(group=exchange_group)
+        device_obj = _normalize_device(device)
+        if device_obj.type != "cuda":
+            raise ValueError("PCIe DCP A2A requires a CUDA device")
+
+        ipc = CudaRTLibrary()
+        ipc.cudaSetDevice(device_obj.index or 0)
+        ext = ext_module or _load_extension()
+        layout = _staging_layout(
+            signal_bytes=int(ext.meta_size()),
+            world_size=world_size,
+            max_batch_size=max_batch_size,
+            total_heads=total_heads,
+            head_dim=head_dim,
+            query_head_dim=query_head_dim,
+        )
+        owned: list[_OwnedSharedBuffer] = []
+        try:
+            slab = PCIeOneshotAllReduce._allocate_shared_buffer(
+                exchange_group,
+                layout.slab_bytes,
+                zero_fill=True,
+                ipc=ipc,
+            )
+            owned.append(slab)
+            return cls(
+                rank=rank,
+                world_size=world_size,
+                device=device_obj,
+                signal_ptrs=slab.peer_ptrs,
+                staging0_ptrs=tuple(
+                    ptr + layout.staging0_offset for ptr in slab.peer_ptrs
+                ),
+                staging1_ptrs=tuple(
+                    ptr + layout.staging1_offset for ptr in slab.peer_ptrs
+                ),
+                max_batch_size=max_batch_size,
+                total_heads=total_heads,
+                head_dim=head_dim,
+                output_capacity_elems=layout.output_capacity_elems,
+                lse_offset=layout.lse_offset,
+                lse_capacity=layout.lse_capacity,
+                query_head_dim=query_head_dim,
+                exchange_group=exchange_group,
+                ipc=ipc,
+                owned_buffers=owned,
+                ext_module=ext,
+                stream_affine=stream_affine,
+            )
+        except Exception:
+            for shared in owned:
+                for ptr in shared.remote_ptrs:
+                    with suppress(Exception):
+                        ipc.cudaIpcCloseMemHandle(ptr)
+                with suppress(Exception):
+                    ipc.cudaFree(shared.local_ptr)
+            raise
+
+    @classmethod
+    def from_process_group(
+        cls,
+        *,
+        process_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_batch_size: int,
+        total_heads: int,
+        head_dim: int,
+        query_head_dim: Optional[int] = None,
+        ext_module=None,
+        stream_affine: bool = True,
+    ) -> "PCIeDCPA2A":
+        return cls.from_exchange_group(
+            exchange_group=process_group,
+            device=device,
+            max_batch_size=max_batch_size,
+            total_heads=total_heads,
+            head_dim=head_dim,
+            query_head_dim=query_head_dim,
+            ext_module=ext_module,
+            stream_affine=stream_affine,
+        )
+
+    def _bind_stream_key(self, stream_key: Optional[int]) -> None:
+        if not self._stream_affine or stream_key is None:
+            return
+        if self._owner_stream_key is None:
+            self._owner_stream_key = int(stream_key)
+            return
+        if self._owner_stream_key != int(stream_key):
+            raise RuntimeError(
+                "PCIe DCP A2A channels are stream-affine; use a separate "
+                "channel for each CUDA stream"
+            )
+
+    def _check_stream(self, stream: object = None) -> None:
+        if self.device.type != "cuda":
+            return
+        if stream is None and _is_current_stream_capturing(self.device):
+            return
+        self._bind_stream_key(_current_stream_key(self.device, stream))
+
+    def _validate(
+        self,
+        partial_output: torch.Tensor,
+        partial_lse: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        if self._closed:
+            raise RuntimeError("PCIeDCPA2A is closed")
+        if partial_output.device != self.device or partial_lse.device != self.device:
+            raise ValueError("inputs must be on the runtime device")
+        if out.device != self.device:
+            raise ValueError("output must be on the runtime device")
+        if partial_output.dtype not in SUPPORTED_DTYPES:
+            raise ValueError(f"unsupported output dtype {partial_output.dtype}")
+        if partial_lse.dtype != torch.float32:
+            raise ValueError("partial_lse must be float32")
+        if out.dtype != partial_output.dtype:
+            raise ValueError("output dtype must match partial_output")
+        if partial_output.ndim != 3:
+            raise ValueError("partial_output must have shape [batch, heads, head_dim]")
+        batch, heads, head_dim = partial_output.shape
+        if batch <= 0 or batch > self.max_batch_size:
+            raise ValueError(
+                f"batch size {batch} exceeds configured capacity {self.max_batch_size}"
+            )
+        if heads != self.total_heads or head_dim != self.head_dim:
+            raise ValueError(
+                "partial_output shape does not match configured heads/head_dim: "
+                f"{tuple(partial_output.shape)}"
+            )
+        if partial_lse.shape != (batch, heads):
+            raise ValueError("partial_lse must have shape [batch, heads]")
+        expected_out = (batch, self.heads_per_rank, self.head_dim)
+        if out.shape != expected_out:
+            raise ValueError(
+                f"output shape must be {expected_out}, got {tuple(out.shape)}"
+            )
+        if not partial_output.is_contiguous():
+            raise ValueError("partial_output must be contiguous")
+        if not partial_lse.is_contiguous():
+            raise ValueError("partial_lse must be contiguous")
+        if not out.is_contiguous():
+            raise ValueError("output must be contiguous")
+
+    def lse_reduce_scatter(
+        self,
+        partial_output: torch.Tensor,
+        partial_lse: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        *,
+        is_lse_base_on_e: bool = True,
+        threads: int = 256,
+        block_limit: int = 16,
+    ) -> torch.Tensor:
+        """Exchange rank contributions and return this rank's reduced heads."""
+        self._check_stream()
+        if out is None:
+            out = torch.empty(
+                partial_output.shape[0],
+                self.heads_per_rank,
+                self.head_dim,
+                device=partial_output.device,
+                dtype=partial_output.dtype,
+            )
+        self._validate(partial_output, partial_lse, out)
+        self._ext.lse_reduce_scatter(
+            self._ptr,
+            partial_output,
+            partial_lse,
+            out,
+            bool(is_lse_base_on_e),
+            int(threads),
+            int(block_limit),
+        )
+        return out
+
+    def all_gather_heads(
+        self,
+        local_input: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        *,
+        threads: int = 256,
+        block_limit: int = 16,
+    ) -> torch.Tensor:
+        """Gather rank-local heads into a rank-major head dimension."""
+        self._check_stream()
+        if self._closed:
+            raise RuntimeError("PCIeDCPA2A is closed")
+        if local_input.device != self.device:
+            raise ValueError("input must be on the runtime device")
+        if local_input.dtype not in SUPPORTED_DTYPES:
+            raise ValueError(f"unsupported input dtype {local_input.dtype}")
+        if local_input.ndim != 3:
+            raise ValueError("input must have shape [batch, local_heads, head_dim]")
+        batch, local_heads, head_dim = local_input.shape
+        if batch <= 0 or batch > self.max_batch_size:
+            raise ValueError(
+                f"batch size {batch} exceeds configured capacity {self.max_batch_size}"
+            )
+        if local_heads != self.heads_per_rank or head_dim != self.query_head_dim:
+            raise ValueError(
+                "input shape does not match configured local heads/head_dim: "
+                f"{tuple(local_input.shape)}"
+            )
+        if not local_input.is_contiguous():
+            raise ValueError("input must be contiguous")
+        expected_out = (batch, self.total_heads, self.query_head_dim)
+        if out is None:
+            out = torch.empty(
+                expected_out,
+                device=local_input.device,
+                dtype=local_input.dtype,
+            )
+        if out.device != self.device or out.dtype != local_input.dtype:
+            raise ValueError("output device and dtype must match input")
+        if out.shape != expected_out:
+            raise ValueError(
+                f"output shape must be {expected_out}, got {tuple(out.shape)}"
+            )
+        if not out.is_contiguous():
+            raise ValueError("output must be contiguous")
+        self._ext.all_gather_heads(
+            self._ptr,
+            local_input,
+            out,
+            int(threads),
+            int(block_limit),
+        )
+        return out
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        with suppress(Exception):
+            self._ext.dispose(self._ptr)
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
+                for ptr in shared.remote_ptrs:
+                    with suppress(Exception):
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                with suppress(Exception):
+                    self._ipc.cudaFree(shared.local_ptr)
+        self._owned_buffers.clear()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()
+
+
+class PCIeDCPA2APool:
+    """Create an independent DCP collective channel for each CUDA stream."""
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device | int | str,
+        max_batch_size: int,
+        total_heads: int,
+        head_dim: int,
+        query_head_dim: Optional[int] = None,
+        exchange_group: Optional[ProcessGroup] = None,
+        ext_module=None,
+        single_channel: bool = False,
+        channel_factory: Optional[Callable[[Optional[int]], PCIeDCPA2A]] = None,
+    ) -> None:
+        if world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(f"unsupported world size {world_size}")
+        self.rank = int(rank)
+        self.world_size = int(world_size)
+        self.device = _normalize_device(device)
+        self.max_batch_size = int(max_batch_size)
+        self.total_heads = int(total_heads)
+        self.head_dim = int(head_dim)
+        self.query_head_dim = int(query_head_dim or head_dim)
+        self.exchange_group = exchange_group
+        self._ext = ext_module
+        self.single_channel = bool(single_channel)
+        self._channel_factory = channel_factory
+        self._channels: dict[int, PCIeDCPA2A] = {}
+        self._capture_channel_stack: list[PCIeDCPA2A] = []
+        self._closed = False
+        if channel_factory is None and exchange_group is None:
+            raise ValueError("exchange_group is required unless channel_factory is set")
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_batch_size: int,
+        total_heads: int,
+        head_dim: int,
+        query_head_dim: Optional[int] = None,
+        ext_module=None,
+        single_channel: bool = False,
+    ) -> "PCIeDCPA2APool":
+        return cls(
+            rank=dist.get_rank(group=exchange_group),
+            world_size=dist.get_world_size(group=exchange_group),
+            device=device,
+            max_batch_size=max_batch_size,
+            total_heads=total_heads,
+            head_dim=head_dim,
+            query_head_dim=query_head_dim,
+            exchange_group=exchange_group,
+            ext_module=ext_module,
+            single_channel=single_channel,
+        )
+
+    @classmethod
+    def from_process_group(
+        cls,
+        *,
+        process_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_batch_size: int,
+        total_heads: int,
+        head_dim: int,
+        query_head_dim: Optional[int] = None,
+        ext_module=None,
+        single_channel: bool = False,
+    ) -> "PCIeDCPA2APool":
+        return cls.from_exchange_group(
+            exchange_group=process_group,
+            device=device,
+            max_batch_size=max_batch_size,
+            total_heads=total_heads,
+            head_dim=head_dim,
+            query_head_dim=query_head_dim,
+            ext_module=ext_module,
+            single_channel=single_channel,
+        )
+
+    def _new_channel(self, stream_key: Optional[int]) -> PCIeDCPA2A:
+        if self._channel_factory is not None:
+            channel = self._channel_factory(stream_key)
+        else:
+            assert self.exchange_group is not None
+            channel = PCIeDCPA2A.from_exchange_group(
+                exchange_group=self.exchange_group,
+                device=self.device,
+                max_batch_size=self.max_batch_size,
+                total_heads=self.total_heads,
+                head_dim=self.head_dim,
+                query_head_dim=self.query_head_dim,
+                ext_module=self._ext,
+                stream_affine=not self.single_channel,
+            )
+        channel._bind_stream_key(stream_key)
+        return channel
+
+    def for_stream(self, stream: object = None) -> PCIeDCPA2A:
+        if self._closed:
+            raise RuntimeError("PCIeDCPA2APool is closed")
+        if self.single_channel:
+            key = 0
+            stream_key = None
+        else:
+            stream_key = _current_stream_key(self.device, stream)
+            key = 0 if stream_key is None else int(stream_key)
+        channel = self._channels.get(key)
+        if channel is not None:
+            return channel
+        if _is_current_stream_capturing(self.device):
+            # Nested piecewise captures use a torch-owned stream key that is
+            # unavailable before capture begins. Reuse the channel selected by
+            # the enclosing graph manager, never one owned by another graph.
+            if self._capture_channel_stack:
+                channel = self._capture_channel_stack[-1]
+                self._channels[key] = channel
+                return channel
+            if self._channels:
+                channel = next(iter(self._channels.values()))
+                self._channels[key] = channel
+                return channel
+            raise RuntimeError(
+                "PCIe DCP A2A pool has no channel during CUDA graph capture; "
+                "create or warm a channel before capture"
+            )
+        channel = self._new_channel(stream_key)
+        self._channels[key] = channel
+        return channel
+
+    def lse_reduce_scatter(
+        self,
+        partial_output: torch.Tensor,
+        partial_lse: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        *,
+        is_lse_base_on_e: bool = True,
+        threads: int = 256,
+        block_limit: int = 16,
+        stream: object = None,
+    ) -> torch.Tensor:
+        channel = self.for_stream(stream)
+        if stream is not None and self.device.type == "cuda":
+            with torch.cuda.stream(stream):
+                return channel.lse_reduce_scatter(
+                    partial_output,
+                    partial_lse,
+                    out,
+                    is_lse_base_on_e=is_lse_base_on_e,
+                    threads=threads,
+                    block_limit=block_limit,
+                )
+        return channel.lse_reduce_scatter(
+            partial_output,
+            partial_lse,
+            out,
+            is_lse_base_on_e=is_lse_base_on_e,
+            threads=threads,
+            block_limit=block_limit,
+        )
+
+    def all_gather_heads(
+        self,
+        local_input: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        *,
+        threads: int = 256,
+        block_limit: int = 16,
+        stream: object = None,
+    ) -> torch.Tensor:
+        channel = self.for_stream(stream)
+        if stream is not None and self.device.type == "cuda":
+            with torch.cuda.stream(stream):
+                return channel.all_gather_heads(
+                    local_input,
+                    out,
+                    threads=threads,
+                    block_limit=block_limit,
+                )
+        return channel.all_gather_heads(
+            local_input,
+            out,
+            threads=threads,
+            block_limit=block_limit,
+        )
+
+    @contextmanager
+    def capture(self, stream: object = None):
+        """Bind nested CUDA captures to the enclosing stream's channel."""
+        channel = self.for_stream(stream)
+        self._capture_channel_stack.append(channel)
+        try:
+            yield channel
+        finally:
+            popped = self._capture_channel_stack.pop()
+            if popped is not channel:
+                raise RuntimeError("PCIe DCP A2A capture channel stack corrupted")
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        seen: set[int] = set()
+        for channel in self._channels.values():
+            if id(channel) not in seen:
+                seen.add(id(channel))
+                channel.close()
+        self._channels.clear()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()
+
+
+__all__ = [
+    "PCIeDCPA2A",
+    "PCIeDCPA2APool",
+    "SUPPORTED_WORLD_SIZES",
+    "lse_reduce_scatter_reference",
+]

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_dma.cu
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_dma.cu
@@ -1,0 +1,398 @@
+// Ported from b12x b12x/distributed/pcie_dma.cu @ 7bfc9455 (2026-07-04) -- one-time curated port.
+// PCIe ring allreduce transport primitives.
+//
+// Prefill-size allreduce is bandwidth-bound and the per-GPU x16 link is the
+// invariant bottleneck (2*(N-1)/N * S egress per rank for any algorithm).
+// On this fabric CE peer copies sustain ~56 GB/s while SM peer reads run at
+// ~27 GB/s and SM peer writes at ~3 GB/s, so the data plane is CE
+// (cudaMemcpyAsync peer copies) and the SM only synchronizes and reduces:
+//
+//   copy chunk -> peer scratch (CE, stream-ordered)
+//   set_flag   -> peer flag    (tiny SM kernel, monotonic device counter)
+//   wait_flag  -> local flag   (spin kernel, graph-replay safe)
+//   add        -> accumulate received chunk into the working buffer
+//
+// Flag values come from device-resident monotonic counters so captured
+// graphs replay without host-side value patching, mirroring the oneshot
+// barrier's self_counter scheme.
+
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <torch/all.h>
+#include <torch/extension.h>
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#define CHECK_CUDA_SUCCESS(cmd)                                         \
+  do {                                                                  \
+    cudaError_t e = cmd;                                                \
+    if (e != cudaSuccess) {                                             \
+      std::stringstream _message;                                       \
+      _message << cudaGetErrorString(e) << "\n"                         \
+               << __FILE__ << ':' << __LINE__;                          \
+      throw std::runtime_error(_message.str());                        \
+    }                                                                   \
+  } while (0)
+
+namespace pcie_dma {
+
+using FlagType = unsigned int;
+
+__device__ __forceinline__ float to_float(float v) { return v; }
+__device__ __forceinline__ float to_float(half v) { return __half2float(v); }
+__device__ __forceinline__ float to_float(nv_bfloat16 v) { return __bfloat162float(v); }
+
+template <typename T>
+__device__ __forceinline__ T from_float(float v);
+template <>
+__device__ __forceinline__ float from_float<float>(float v) { return v; }
+template <>
+__device__ __forceinline__ half from_float<half>(float v) { return __float2half(v); }
+template <>
+__device__ __forceinline__ nv_bfloat16 from_float<nv_bfloat16>(float v) {
+  return __float2bfloat16(v);
+}
+
+__global__ void set_flag_kernel(FlagType* peer_flag, FlagType* local_counter) {
+  const FlagType value = *local_counter + 1;
+  *local_counter = value;
+  // The CE copy this flag publishes completed in stream order before this
+  // kernel launched; the system fence orders any outstanding writes.
+  __threadfence_system();
+  asm volatile("st.relaxed.sys.global.u32 [%1], %0;" ::"r"(value), "l"(peer_flag));
+}
+
+__global__ void wait_flag_kernel(FlagType* flag, FlagType* expected_counter) {
+  const FlagType expected = *expected_counter + 1;
+  *expected_counter = expected;
+  FlagType observed;
+  do {
+    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(observed) : "l"(flag));
+  } while (static_cast<int>(observed - expected) < 0);
+}
+
+// dst = a + b; with a == dst this is the in-place accumulate, and with
+// a == the caller's input it doubles as the first-touch accumulate that
+// removes the upfront out.copy_(input) from the critical path.
+template <typename T>
+__global__ void __launch_bounds__(256, 1) add_kernel(T* __restrict__ dst,
+                                                     const T* __restrict__ a_src,
+                                                     const T* __restrict__ b_src,
+                                                     long long packs) {
+  using Pack = uint4;
+  Pack* dst_p = reinterpret_cast<Pack*>(dst);
+  const Pack* a_p = reinterpret_cast<const Pack*>(a_src);
+  const Pack* b_p = reinterpret_cast<const Pack*>(b_src);
+  constexpr int kElems = sizeof(Pack) / sizeof(T);
+  for (long long idx = blockIdx.x * blockDim.x + threadIdx.x; idx < packs;
+       idx += gridDim.x * blockDim.x) {
+    Pack a = a_p[idx];
+    Pack b = b_p[idx];
+    T* av = reinterpret_cast<T*>(&a);
+    const T* bv = reinterpret_cast<const T*>(&b);
+#pragma unroll
+    for (int e = 0; e < kElems; ++e) {
+      av[e] = from_float<T>(to_float(av[e]) + to_float(bv[e]));
+    }
+    dst_p[idx] = a;
+  }
+}
+
+// ---- FP8 wire path (quantize-once all-to-all) ----
+//
+// E4M3 payload with one fp32 amax scale per 128 elements, scales packed
+// contiguously after the payload so a single CE copy ships both. Values are
+// quantized exactly once on the way in (reduce-scatter) and once on the way
+// out (broadcast); accumulation runs in fp32, so wire precision drops while
+// summation precision rises versus the bf16 ring's per-hop bf16 adds.
+
+constexpr int kQuantBlock = 128;
+constexpr float kFp8Max = 448.0f;
+
+struct __align__(16) SrcPtrs {
+  const void* ptrs[8];
+};
+
+__device__ __forceinline__ float4 load_bf16x4(const nv_bfloat16* src) {
+  const auto* src2 = reinterpret_cast<const __nv_bfloat162*>(src);
+  const float2 lo = __bfloat1622float2(src2[0]);
+  const float2 hi = __bfloat1622float2(src2[1]);
+  return make_float4(lo.x, lo.y, hi.x, hi.y);
+}
+
+__device__ __forceinline__ void store_bf16x4(nv_bfloat16* dst, const float4 v) {
+  auto* dst2 = reinterpret_cast<__nv_bfloat162*>(dst);
+  dst2[0] = __float22bfloat162_rn(make_float2(v.x, v.y));
+  dst2[1] = __float22bfloat162_rn(make_float2(v.z, v.w));
+}
+
+__device__ __forceinline__ float4 load_fp8x4(const __nv_fp8_e4m3* src) {
+  return static_cast<float4>(
+      *reinterpret_cast<const __nv_fp8x4_e4m3*>(src));
+}
+
+__device__ __forceinline__ void store_fp8x4(
+    __nv_fp8_e4m3* dst, const float4 v) {
+  *reinterpret_cast<__nv_fp8x4_e4m3*>(dst) = __nv_fp8x4_e4m3(v);
+}
+
+// One warp per 128-element block: 4 elements per lane, warp amax, scale,
+// convert, store.
+__global__ void __launch_bounds__(256, 1) quant_kernel(
+    const nv_bfloat16* __restrict__ src,
+    __nv_fp8_e4m3* __restrict__ payload,
+    float* __restrict__ scales,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    const float4 v = load_bf16x4(src + elem0);
+    float amax = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                       fmaxf(fabsf(v.z), fabsf(v.w)));
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, offset));
+    }
+    const float scale = amax > 0.0f ? amax / kFp8Max : 1.0f;
+    if (lane == 0) scales[block] = scale;
+    const float inv_scale = 1.0f / scale;
+    store_fp8x4(
+        payload + elem0,
+        make_float4(v.x * inv_scale, v.y * inv_scale,
+                    v.z * inv_scale, v.w * inv_scale));
+  }
+}
+
+// out = inp + sum_j dequant(payload_j) in fp32, single pass over out.
+__global__ void __launch_bounds__(256, 1) dequant_accum_kernel(
+    nv_bfloat16* __restrict__ out,
+    const nv_bfloat16* __restrict__ inp,
+    SrcPtrs payloads,
+    SrcPtrs scales,
+    int nsrc,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    float4 acc = load_bf16x4(inp + elem0);
+    for (int j = 0; j < nsrc; ++j) {
+      const __nv_fp8_e4m3* p =
+          reinterpret_cast<const __nv_fp8_e4m3*>(payloads.ptrs[j]) + elem0;
+      const float scale = reinterpret_cast<const float*>(scales.ptrs[j])[block];
+      const float4 v = load_fp8x4(p);
+      acc.x += v.x * scale;
+      acc.y += v.y * scale;
+      acc.z += v.z * scale;
+      acc.w += v.w * scale;
+    }
+    store_bf16x4(out + elem0, acc);
+  }
+}
+
+__global__ void __launch_bounds__(256, 1) dequant_store_kernel(
+    nv_bfloat16* __restrict__ out,
+    const __nv_fp8_e4m3* __restrict__ payload,
+    const float* __restrict__ scales,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    const float scale = scales[block];
+    const float4 v = load_fp8x4(payload + elem0);
+    store_bf16x4(
+        out + elem0,
+        make_float4(v.x * scale, v.y * scale, v.z * scale, v.w * scale));
+  }
+}
+
+// Add this rank's BF16 contribution to an incoming FP8 partial and emit the
+// next hop's FP8 partial in one pass.  Only the final reduce-scatter hop also
+// materializes BF16; intermediate partials stay compressed between ranks.
+template <bool StoreBf16>
+__global__ void __launch_bounds__(256, 1) dequant_add_quant_kernel(
+    nv_bfloat16* __restrict__ out,
+    const nv_bfloat16* __restrict__ local,
+    const __nv_fp8_e4m3* __restrict__ payload_in,
+    const float* __restrict__ scales_in,
+    __nv_fp8_e4m3* __restrict__ payload_out,
+    float* __restrict__ scales_out,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    const float scale_in = scales_in[block];
+    const float4 a = load_bf16x4(local + elem0);
+    const float4 b = load_fp8x4(payload_in + elem0);
+    const float4 v = make_float4(
+        a.x + b.x * scale_in, a.y + b.y * scale_in,
+        a.z + b.z * scale_in, a.w + b.w * scale_in);
+    float amax = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                       fmaxf(fabsf(v.z), fabsf(v.w)));
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, offset));
+    }
+    const float scale_out = amax > 0.0f ? amax / kFp8Max : 1.0f;
+    if (lane == 0) scales_out[block] = scale_out;
+    const float inv_scale = 1.0f / scale_out;
+    store_fp8x4(
+        payload_out + elem0,
+        make_float4(v.x * inv_scale, v.y * inv_scale,
+                    v.z * inv_scale, v.w * inv_scale));
+    if constexpr (StoreBf16) store_bf16x4(out + elem0, v);
+  }
+}
+
+}  // namespace pcie_dma
+
+static void dma_copy(int64_t dst_ptr, int64_t src_ptr, int64_t bytes) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  CHECK_CUDA_SUCCESS(cudaMemcpyAsync(reinterpret_cast<void*>(dst_ptr),
+                                     reinterpret_cast<const void*>(src_ptr),
+                                     static_cast<size_t>(bytes),
+                                     cudaMemcpyDeviceToDevice, stream));
+}
+
+static void dma_set_flag(int64_t peer_flag_ptr, int64_t counter_ptr) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  pcie_dma::set_flag_kernel<<<1, 1, 0, stream>>>(
+      reinterpret_cast<pcie_dma::FlagType*>(peer_flag_ptr),
+      reinterpret_cast<pcie_dma::FlagType*>(counter_ptr));
+}
+
+static void dma_wait_flag(int64_t flag_ptr, int64_t counter_ptr) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  pcie_dma::wait_flag_kernel<<<1, 1, 0, stream>>>(
+      reinterpret_cast<pcie_dma::FlagType*>(flag_ptr),
+      reinterpret_cast<pcie_dma::FlagType*>(counter_ptr));
+}
+
+static void dma_add(int64_t dst_ptr, int64_t a_ptr, int64_t b_ptr,
+                    int64_t elems, int64_t dtype_code) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  const int threads = 256;
+  const long long packs16 = elems * (dtype_code == 2 ? 4 : 2) / 16;
+  const int blocks = static_cast<int>(
+      std::max<long long>(1, std::min<long long>(64, (packs16 + threads - 1) / threads)));
+  if (dtype_code == 0) {
+    const long long packs = elems / 8;
+    pcie_dma::add_kernel<nv_bfloat16><<<blocks, threads, 0, stream>>>(
+        reinterpret_cast<nv_bfloat16*>(dst_ptr),
+        reinterpret_cast<const nv_bfloat16*>(a_ptr),
+        reinterpret_cast<const nv_bfloat16*>(b_ptr), packs);
+  } else if (dtype_code == 1) {
+    const long long packs = elems / 8;
+    pcie_dma::add_kernel<half><<<blocks, threads, 0, stream>>>(
+        reinterpret_cast<half*>(dst_ptr), reinterpret_cast<const half*>(a_ptr),
+        reinterpret_cast<const half*>(b_ptr), packs);
+  } else {
+    const long long packs = elems / 4;
+    pcie_dma::add_kernel<float><<<blocks, threads, 0, stream>>>(
+        reinterpret_cast<float*>(dst_ptr), reinterpret_cast<const float*>(a_ptr),
+        reinterpret_cast<const float*>(b_ptr), packs);
+  }
+}
+
+static int _fp8_blocks_grid(long long blocks, int threads) {
+  const int warps = threads / 32;
+  return static_cast<int>(std::max<long long>(
+      1, std::min<long long>(64, (blocks + warps - 1) / warps)));
+}
+
+static void dma_quant(int64_t src_ptr, int64_t payload_ptr, int64_t scales_ptr,
+                      int64_t elems) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  pcie_dma::quant_kernel<<<_fp8_blocks_grid(blocks, threads), threads, 0, stream>>>(
+      reinterpret_cast<const nv_bfloat16*>(src_ptr),
+      reinterpret_cast<__nv_fp8_e4m3*>(payload_ptr),
+      reinterpret_cast<float*>(scales_ptr), blocks);
+}
+
+static void dma_dequant_accum(int64_t out_ptr, int64_t inp_ptr,
+                              const std::vector<int64_t>& payload_ptrs,
+                              const std::vector<int64_t>& scale_ptrs,
+                              int64_t elems) {
+  TORCH_CHECK(payload_ptrs.size() == scale_ptrs.size());
+  TORCH_CHECK(payload_ptrs.size() <= 8);
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  pcie_dma::SrcPtrs payloads{};
+  pcie_dma::SrcPtrs scales{};
+  for (size_t j = 0; j < payload_ptrs.size(); ++j) {
+    payloads.ptrs[j] = reinterpret_cast<const void*>(payload_ptrs[j]);
+    scales.ptrs[j] = reinterpret_cast<const void*>(scale_ptrs[j]);
+  }
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  pcie_dma::dequant_accum_kernel<<<_fp8_blocks_grid(blocks, threads), threads, 0,
+                                   stream>>>(
+      reinterpret_cast<nv_bfloat16*>(out_ptr),
+      reinterpret_cast<const nv_bfloat16*>(inp_ptr), payloads, scales,
+      static_cast<int>(payload_ptrs.size()), blocks);
+}
+
+static void dma_dequant_store(int64_t out_ptr, int64_t payload_ptr,
+                              int64_t scales_ptr, int64_t elems) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  pcie_dma::dequant_store_kernel<<<_fp8_blocks_grid(blocks, threads), threads, 0,
+                                   stream>>>(
+      reinterpret_cast<nv_bfloat16*>(out_ptr),
+      reinterpret_cast<const __nv_fp8_e4m3*>(payload_ptr),
+      reinterpret_cast<const float*>(scales_ptr), blocks);
+}
+
+static void dma_dequant_add_quant(
+    int64_t out_ptr, int64_t local_ptr, int64_t payload_in_ptr,
+    int64_t scales_in_ptr, int64_t payload_out_ptr, int64_t scales_out_ptr,
+    int64_t elems, bool store_bf16) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  const int grid = _fp8_blocks_grid(blocks, threads);
+#define LAUNCH_DEQUANT_ADD_QUANT(STORE)                                      \
+  pcie_dma::dequant_add_quant_kernel<STORE><<<grid, threads, 0, stream>>>(  \
+      reinterpret_cast<nv_bfloat16*>(out_ptr),                              \
+      reinterpret_cast<const nv_bfloat16*>(local_ptr),                      \
+      reinterpret_cast<const __nv_fp8_e4m3*>(payload_in_ptr),               \
+      reinterpret_cast<const float*>(scales_in_ptr),                        \
+      reinterpret_cast<__nv_fp8_e4m3*>(payload_out_ptr),                    \
+      reinterpret_cast<float*>(scales_out_ptr), blocks)
+  if (store_bf16) {
+    LAUNCH_DEQUANT_ADD_QUANT(true);
+  } else {
+    LAUNCH_DEQUANT_ADD_QUANT(false);
+  }
+#undef LAUNCH_DEQUANT_ADD_QUANT
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("dma_quant", &dma_quant, "quantize bf16 to e4m3 with per-128 scales");
+  m.def("dma_dequant_accum", &dma_dequant_accum,
+        "out = inp + sum of dequantized sources (fp32 accumulate)");
+  m.def("dma_dequant_store", &dma_dequant_store, "dequantize e4m3 to bf16");
+  m.def("dma_dequant_add_quant", &dma_dequant_add_quant,
+        "add a BF16 contribution to an FP8 partial and requantize");
+  m.def("dma_copy", &dma_copy, "CE peer copy on the current stream");
+  m.def("dma_set_flag", &dma_set_flag, "publish a monotonic flag to a peer");
+  m.def("dma_wait_flag", &dma_wait_flag, "wait for a monotonic peer flag");
+  m.def("dma_add", &dma_add, "elementwise add src into dst");
+}

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_dma.py
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_dma.py
@@ -1,0 +1,903 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/distributed/pcie_dma.py @ fb628056 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""CE-driven PCIe ring allreduce for prefill-size tensors.
+
+NCCL's SM-copy transport sustains ~34 GB/s bus bandwidth on this fabric
+while CE peer copies run at ~56 GB/s on every ring hop concurrently
+(including the two root-complex crossings, which each own a partition
+uplink per direction). This runtime drives a classic reduce-scatter +
+all-gather ring where the data plane is CE copies and the SM only
+synchronizes (monotonic flag kernels) and reduces, so captured graphs
+replay without host patching.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import suppress
+from functools import lru_cache
+from pathlib import Path
+from statistics import median
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from torch.utils.cpp_extension import load
+
+from ._cuda_ipc import CudaRTLibrary
+from .pcie_oneshot import PCIeOneshotAllReduce
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_DTYPES = {
+    torch.bfloat16: 0,
+    torch.float16: 1,
+    torch.float32: 2,
+}
+FLAG_STRIDE = 128
+FLAG_SLOTS = 256
+MAX_PIECES = 8
+SCRATCH_ALIGN = 256
+FP8_QUANT_BLOCK = 128
+
+
+def _fp8_mode() -> str:
+    """Opt-in E4M3 wire transport mode.
+
+    "ag" (also "1"): keep the saturated bf16 reduce-scatter ring and
+    quantize only the allgather phase. Final values quantize exactly once
+    at their owner and are forwarded verbatim around the ring, so the
+    error cost is a single rounding while AG wire bytes halve.
+
+    "ring": quantize every reduce-scatter hop and the allgather payload,
+    keeping the saturated neighbor-only topology while halving both phases.
+
+    "a2a": quantize-once all-to-all (two roundings, half the wire in both
+    phases).
+
+    Every FP8 mode materializes the locally owned reduced shard through the
+    same FP8 payload as its peers.  An all-reduce result must be rank-identical;
+    retaining a pre-wire BF16 owner shard while peers dequantize that shard
+    gives every TP rank a different replicated activation.
+    """
+
+    return _normalize_fp8_mode(os.getenv("FLASHINFER_EXP_SM12X_PCIE_DMA_FP8", "0"))
+
+
+def _normalize_fp8_mode(value: str | None) -> str:
+    raw = (value or "").strip().lower()
+    if raw in ("", "0", "false", "off", "no"):
+        return ""
+    if raw in ("a2a", "ring"):
+        return raw
+    return "ag"
+
+
+@lru_cache(maxsize=1)
+def _load_extension():
+    source = Path(__file__).with_name("pcie_dma.cu")
+    verbose = os.getenv("FLASHINFER_EXP_SM12X_PCIE_DMA_VERBOSE_BUILD", "0") == "1"
+    return load(
+        name="sm12x_pcie_dma_ext",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O2"],
+        extra_ldflags=["-lcuda"],
+        verbose=verbose,
+    )
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+class PCIeDmaAllReduce:
+    """Single-channel ring allreduce over IPC scratch buffers.
+
+    A channel is a single ordered stream context; concurrent use from
+    multiple CUDA streams needs separate channels (same contract as the
+    oneshot runtime).
+    """
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_bytes: int,
+        ext_module=None,
+        fp8: Optional[str] = None,
+    ) -> None:
+        self.group = exchange_group
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self.device = (
+            device
+            if isinstance(device, torch.device)
+            else torch.device(f"cuda:{device}" if isinstance(device, int) else device)
+        )
+        if self.device.type != "cuda":
+            raise ValueError("PCIe ring allreduce requires a CUDA device")
+        if self.world_size < 2:
+            raise ValueError("ring allreduce needs at least 2 ranks")
+        self.max_bytes = int(max_bytes)
+        self._ext = ext_module or _load_extension()
+        self._ipc = CudaRTLibrary()
+        self._ipc.cudaSetDevice(self.device.index or 0)
+        self._closed = False
+
+        self.shard_capacity = _align_up(
+            (self.max_bytes + self.world_size - 1) // self.world_size, SCRATCH_ALIGN
+        )
+        steps = 2 * (self.world_size - 1)
+        flags_bytes = FLAG_SLOTS * FLAG_STRIDE
+        slab_bytes = flags_bytes + steps * self.shard_capacity
+        self._slab = PCIeOneshotAllReduce._allocate_shared_buffer(
+            exchange_group, slab_bytes, zero_fill=True, ipc=self._ipc
+        )
+        self._flags_base = list(self._slab.peer_ptrs)
+        self._scratch_base = [ptr + flags_bytes for ptr in self._slab.peer_ptrs]
+        # Device-resident monotonic counters: one per flag slot for the
+        # publisher role and one for the waiter role.
+        self._send_counters = torch.zeros(
+            FLAG_SLOTS, dtype=torch.int32, device=self.device
+        )
+        self._wait_counters = torch.zeros(
+            FLAG_SLOTS, dtype=torch.int32, device=self.device
+        )
+        self._copy_stream = torch.cuda.Stream(device=self.device)
+        self._flag_stream = torch.cuda.Stream(device=self.device)
+        # Separate CE/flag streams for the a2a broadcast phase so allgather
+        # traffic overlaps reduce-scatter traffic instead of queueing
+        # behind it.
+        self._ag_copy_stream = torch.cuda.Stream(device=self.device)
+        self._ag_flag_stream = torch.cuda.Stream(device=self.device)
+        # Persistent cross-stream events: captured graphs keep references to
+        # recorded events, so per-call temporaries must not be destroyed.
+        self._piece_events = [torch.cuda.Event() for _ in range(MAX_PIECES)]
+        self._copied_events = [
+            torch.cuda.Event() for _ in range(2 * (self.world_size - 1) * MAX_PIECES)
+        ]
+        self._input_ready = torch.cuda.Event()
+        self._ag_ready = torch.cuda.Event()
+        self._a2a_qdone = [torch.cuda.Event() for _ in range(MAX_PIECES)]
+        self._a2a_ownq = [torch.cuda.Event() for _ in range(MAX_PIECES)]
+        # Explicit argument wins over the environment so integrations can
+        # plumb the mode through their own configuration.
+        self._fp8 = _normalize_fp8_mode(fp8) if fp8 is not None else _fp8_mode()
+        self._fp8_stage = None
+        self._fp8_stage_stride = 0
+        if self._fp8:
+            max_shard_elems = self.max_bytes // 2 // self.world_size
+            stride = _align_up(
+                max_shard_elems + max_shard_elems // FP8_QUANT_BLOCK * 4,
+                SCRATCH_ALIGN,
+            )
+            self._fp8_stage = torch.empty(
+                self.world_size * stride, dtype=torch.uint8, device=self.device
+            )
+            self._fp8_stage_stride = stride
+        self.min_bytes = 0
+        self.wire_mode = f"fp8-{self._fp8}" if self._fp8 else "bf16"
+        logger.debug("[PCIe DMA allreduce] wire mode: %s", self.wire_mode)
+        if logger.isEnabledFor(logging.DEBUG):
+            self._log_peer_copy_bandwidth()
+
+    def _log_peer_copy_bandwidth(self, iters: int = 20) -> None:
+        """One-time raw cudaMemcpyAsync bandwidth check, bypassing the ring
+        schedule and flag sync entirely, so a slow deployment environment
+        shows up here (bandwidth) rather than only in the full ring's
+        latency (which would also be sensitive to sync/launch overhead).
+
+        Every rank concurrently writes step 1 of its successor's scratch
+        from step 0 of its own; no rank's step 0 (read) or step 1 (write)
+        is touched by anyone else, so this measures true full-ring-style
+        concurrent peer bandwidth with no self-inflicted read/write race.
+        """
+
+        if self.world_size < 2 or 2 * (self.world_size - 1) < 2:
+            return
+        nxt = (self.rank + 1) % self.world_size
+        probe_bytes = min(self.shard_capacity, 4 << 20)
+        probe_bytes -= probe_bytes % 16
+        if probe_bytes <= 0:
+            return
+        stream = torch.cuda.Stream(device=self.device)
+        device_index = (
+            self.device.index
+            if self.device.index is not None
+            else torch.cuda.current_device()
+        )
+        dist.barrier(group=self.group, device_ids=[device_index])
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                self._ext.dma_copy(
+                    self._scratch_ptr(nxt, 1),
+                    self._scratch_ptr(self.rank, 0),
+                    probe_bytes,
+                )
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record(stream)
+            for _ in range(iters):
+                self._ext.dma_copy(
+                    self._scratch_ptr(nxt, 1),
+                    self._scratch_ptr(self.rank, 0),
+                    probe_bytes,
+                )
+            end.record(stream)
+        stream.synchronize()
+        ms = start.elapsed_time(end)
+        gbps = probe_bytes * iters / (ms * 1e-3) / 1e9
+        logger.debug(
+            "[PCIe DMA allreduce] rank %d -> %d raw peer copy: %.1f GB/s "
+            "(%d bytes x %d iters)",
+            self.rank,
+            nxt,
+            gbps,
+            probe_bytes,
+            iters,
+        )
+
+    def _flag_ptr(self, rank: int, slot: int) -> int:
+        return self._flags_base[rank] + slot * FLAG_STRIDE
+
+    def _counter_ptr(self, counters: torch.Tensor, slot: int) -> int:
+        return counters.data_ptr() + slot * 4
+
+    def _scratch_ptr(self, rank: int, step: int) -> int:
+        return self._scratch_base[rank] + step * self.shard_capacity
+
+    @staticmethod
+    def _pick_pieces(shard_elems: int, shard_bytes: int) -> int:
+        override = int(os.getenv("FLASHINFER_EXP_SM12X_PCIE_DMA_PIECES", "0"))
+        # pieces=2 measured best at every size (deeper chunking pays an
+        # extra wait+add launch chain per piece on the main stream).
+        candidates = (override,) if 1 <= override <= MAX_PIECES else (2,)
+        for pieces in candidates:
+            if shard_elems % (pieces * 8) == 0 and shard_bytes // pieces >= 512 << 10:
+                return pieces
+        return 1
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        if self._closed or inp.device != self.device:
+            return False
+        if inp.dtype not in SUPPORTED_DTYPES:
+            return False
+        numel = inp.numel()
+        if numel <= 0 or numel % (self.world_size * 8) != 0:
+            return False
+        size_bytes = numel * inp.element_size()
+        if size_bytes < self.min_bytes:
+            return False
+        return inp.is_contiguous() and size_bytes <= self.max_bytes
+
+    def all_reduce(
+        self, inp: torch.Tensor, *, out: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if not self.should_allreduce(inp):
+            raise ValueError(
+                "input does not satisfy ring allreduce requirements "
+                f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
+            )
+        if out is None:
+            out = torch.empty_like(inp)
+        elif (
+            out.shape != inp.shape or out.dtype != inp.dtype or not out.is_contiguous()
+        ):
+            raise ValueError("output must match input shape/dtype and be contiguous")
+        ext = self._ext
+        world = self.world_size
+        rank = self.rank
+        nxt = (rank + 1) % world
+        prv = (rank - 1) % world
+        dtype_code = SUPPORTED_DTYPES[inp.dtype]
+        elem = inp.element_size()
+        shard_elems = inp.numel() // world
+        shard_bytes = shard_elems * elem
+
+        fp8_eligible = (
+            bool(self._fp8)
+            and inp.dtype == torch.bfloat16
+            and shard_elems % FP8_QUANT_BLOCK == 0
+        )
+        if fp8_eligible and self._fp8 == "a2a":
+            return self._all_reduce_fp8(inp, out, shard_elems)
+        fp8_ring = fp8_eligible and self._fp8 == "ring"
+        fp8_ag = fp8_eligible and self._fp8 in ("ag", "ring")
+
+        base = out.data_ptr()
+
+        # Sub-chunking with a dedicated copy stream keeps the copy engine
+        # busy: the CE never waits for a flag round trip or an add because
+        # sub-chunk c+1's copy overlaps sub-chunk c's wait+reduce. Deeper
+        # chunking amortizes the flag round trip further as long as each
+        # piece's copy time dominates the ~5us sub-step overhead.
+        pieces = self._pick_pieces(shard_elems, shard_bytes)
+        if fp8_ag and (shard_elems // pieces) % FP8_QUANT_BLOCK != 0:
+            pieces = 1
+        piece_elems = shard_elems // pieces
+        piece_bytes = piece_elems * elem
+        # fp8 AG slices are piece-contiguous: [payload][scales] per piece.
+        piece_slice_bytes = piece_elems + piece_elems // FP8_QUANT_BLOCK * 4
+        steps = 2 * (world - 1)
+
+        main = torch.cuda.current_stream(self.device)
+        copy_stream = self._copy_stream
+
+        # No upfront out.copy_(inp): the first send of each chunk reads the
+        # caller's input directly and every reduce-scatter add is a first
+        # touch (out = inp + scratch), so the accumulation base folds into
+        # the add instead of a full-size copy on the critical path.
+        in_base = inp.data_ptr()
+        self._input_ready.record(main)
+        copy_stream.wait_event(self._input_ready)
+
+        def piece_ptr(chunk: int, piece: int) -> int:
+            return base + chunk * shard_bytes + piece * piece_bytes
+
+        def in_piece_ptr(chunk: int, piece: int) -> int:
+            return in_base + chunk * shard_bytes + piece * piece_bytes
+
+        def scratch_piece(owner: int, step: int, piece: int) -> int:
+            return self._scratch_ptr(owner, step) + piece * piece_bytes
+
+        def slot(step: int, piece: int) -> int:
+            return step * pieces + piece
+
+        # Events gating each step's send on the previous step's reduce of
+        # the same payload piece (persistent; re-recorded per step). Flag
+        # kernels run on their own stream, gated per copy by copied[] events,
+        # so the copy stream is pure back-to-back CE work: an SM kernel
+        # between CE ops stalls the engine for the launch round trip, which
+        # is what made deeper sub-chunking regress.
+        add_done = self._piece_events
+        flag_stream = self._flag_stream
+        copied = self._copied_events
+        flag_stream.wait_event(self._input_ready)
+
+        def fp8_scratch_piece(owner: int, step: int, piece: int) -> int:
+            return self._scratch_ptr(owner, step) + piece * piece_slice_bytes
+
+        stage = self._fp8_stage.data_ptr() if fp8_ag else 0
+
+        def fp8_stage_piece(chunk: int, piece: int) -> int:
+            return stage + chunk * self._fp8_stage_stride + piece * piece_slice_bytes
+
+        for k in range(steps):
+            reduce_phase = k < world - 1
+            if reduce_phase:
+                send_chunk = (rank - k) % world
+                recv_chunk = (rank - k - 1) % world
+            else:
+                send_chunk = (rank + 1 - (k - (world - 1))) % world
+                recv_chunk = (rank - (k - (world - 1))) % world
+            fp8_reduce = fp8_ring and reduce_phase
+            fp8_step = fp8_reduce or (fp8_ag and not reduce_phase)
+            if fp8_step and k == world - 1:
+                # The AG-only mode quantizes the fully reduced owner chunk
+                # here.  The FP8 ring's fused final reduce hop already
+                # emitted the same payload.  Both modes forward those bytes
+                # verbatim, with no additional all-gather rounding.
+                if not fp8_ring:
+                    for p in range(pieces):
+                        ag_stage = fp8_stage_piece(send_chunk, p)
+                        ext.dma_quant(
+                            piece_ptr(send_chunk, p),
+                            ag_stage,
+                            ag_stage + piece_elems,
+                            piece_elems,
+                        )
+                # Publish the payload before the local materialization so the
+                # CE broadcast can overlap this read-only dequant kernel.
+                self._ag_ready.record(main)
+                # The owner used to retain its pre-wire BF16 shard while the
+                # other ranks materialized this same shard from FP8.  That
+                # violates the replicated-output contract of all-reduce and
+                # lets the next TP layer consume rank-dependent activations.
+                # Round-trip the owner through the exact forwarded payload so
+                # all ranks receive bit-identical BF16 values for every shard.
+                for p in range(pieces):
+                    owner_stage = fp8_stage_piece(send_chunk, p)
+                    ext.dma_dequant_store(
+                        piece_ptr(send_chunk, p),
+                        owner_stage,
+                        owner_stage + piece_elems,
+                        piece_elems,
+                    )
+            for p in range(pieces):
+                if fp8_reduce:
+                    send_src = fp8_stage_piece(send_chunk, p)
+                    if k == 0:
+                        ext.dma_quant(
+                            in_piece_ptr(send_chunk, p),
+                            send_src,
+                            send_src + piece_elems,
+                            piece_elems,
+                        )
+                        self._a2a_qdone[p].record(main)
+                    send_bytes = piece_slice_bytes
+                    send_dst = fp8_scratch_piece(nxt, k, p)
+                elif not fp8_step:
+                    send_src = (
+                        in_piece_ptr(send_chunk, p)
+                        if k == 0
+                        else piece_ptr(send_chunk, p)
+                    )
+                    send_bytes = piece_bytes
+                    send_dst = scratch_piece(nxt, k, p)
+                elif k == world - 1:
+                    send_src = fp8_stage_piece(send_chunk, p)
+                    send_bytes = piece_slice_bytes
+                    send_dst = fp8_scratch_piece(nxt, k, p)
+                else:
+                    send_src = fp8_scratch_piece(rank, k - 1, p)
+                    send_bytes = piece_slice_bytes
+                    send_dst = fp8_scratch_piece(nxt, k, p)
+                with torch.cuda.stream(copy_stream):
+                    if fp8_reduce:
+                        copy_stream.wait_event(
+                            self._a2a_qdone[p] if k == 0 else add_done[p]
+                        )
+                    elif fp8_step and k == world - 1:
+                        copy_stream.wait_event(self._ag_ready)
+                    elif k > 0:
+                        copy_stream.wait_event(add_done[p])
+                    ext.dma_copy(send_dst, send_src, send_bytes)
+                    copied[slot(k, p)].record(copy_stream)
+                with torch.cuda.stream(flag_stream):
+                    flag_stream.wait_event(copied[slot(k, p)])
+                    ext.dma_set_flag(
+                        self._flag_ptr(nxt, slot(k, p)),
+                        self._counter_ptr(self._send_counters, slot(k, p)),
+                    )
+                ext.dma_wait_flag(
+                    self._flag_ptr(rank, slot(k, p)),
+                    self._counter_ptr(self._wait_counters, slot(k, p)),
+                )
+                if reduce_phase:
+                    if fp8_reduce:
+                        payload = fp8_scratch_piece(rank, k, p)
+                        reduced = fp8_stage_piece(recv_chunk, p)
+                        ext.dma_dequant_add_quant(
+                            piece_ptr(recv_chunk, p),
+                            in_piece_ptr(recv_chunk, p),
+                            payload,
+                            payload + piece_elems,
+                            reduced,
+                            reduced + piece_elems,
+                            piece_elems,
+                            k == world - 2,
+                        )
+                    else:
+                        ext.dma_add(
+                            piece_ptr(recv_chunk, p),
+                            in_piece_ptr(recv_chunk, p),
+                            scratch_piece(rank, k, p),
+                            piece_elems,
+                            dtype_code,
+                        )
+                elif fp8_step:
+                    payload = fp8_scratch_piece(rank, k, p)
+                    # Forwarding reads the received FP8 payload verbatim, so
+                    # it only depends on the receive flag, not on the local
+                    # BF16 materialization below.  Publish readiness before
+                    # dequantization to overlap the next hop's CE copy with
+                    # this rank's read-only dequant/store.
+                    add_done[p].record(main)
+                    ext.dma_dequant_store(
+                        piece_ptr(recv_chunk, p),
+                        payload,
+                        payload + piece_elems,
+                        piece_elems,
+                    )
+                else:
+                    ext.dma_copy(
+                        piece_ptr(recv_chunk, p),
+                        scratch_piece(rank, k, p),
+                        piece_bytes,
+                    )
+                if reduce_phase or not fp8_step:
+                    add_done[p].record(main)
+
+        # Neighbor handshake so the next call (or graph replay) cannot
+        # overwrite scratch a lagging neighbor still reads. The main stream
+        # must also drain the copy and flag streams before the op is done.
+        main.wait_stream(copy_stream)
+        main.wait_stream(flag_stream)
+        done = steps * pieces
+        ext.dma_set_flag(
+            self._flag_ptr(prv, done), self._counter_ptr(self._send_counters, done)
+        )
+        ext.dma_wait_flag(
+            self._flag_ptr(rank, done), self._counter_ptr(self._wait_counters, done)
+        )
+        return out
+
+    def _pick_a2a_chunks(self, shard_elems: int) -> int:
+        override = int(os.getenv("FLASHINFER_EXP_SM12X_PCIE_DMA_A2A_CHUNKS", "0"))
+        candidates = (override,) if 1 <= override <= MAX_PIECES else (4, 3, 2)
+        for chunks in candidates:
+            if (
+                shard_elems % (chunks * FP8_QUANT_BLOCK) == 0
+                and shard_elems // chunks >= 384 << 10
+            ):
+                return chunks
+        return 1
+
+    def _all_reduce_fp8(
+        self, inp: torch.Tensor, out: torch.Tensor, shard_elems: int
+    ) -> torch.Tensor:
+        """Pipelined quantize-once E4M3 all-to-all.
+
+        Slices are split into chunks; each chunk's quantize -> scatter ->
+        fp32 dequant-accumulate -> quantize-once broadcast wave overlaps the
+        next chunk's, with broadcast copies on their own CE stream so the
+        two phases' wire time overlaps rather than queues.
+
+        No end handshake is needed: a rank re-enters the op only after its
+        stream finished, which required every peer's broadcast of every
+        chunk and therefore every peer's accumulate and placement; peers'
+        next-call writes are stream-ordered after that.
+        """
+
+        ext = self._ext
+        world = self.world_size
+        rank = self.rank
+        shard_bytes = shard_elems * 2
+        chunks = self._pick_a2a_chunks(shard_elems)
+        chunk_elems = shard_elems // chunks
+        chunk_bytes = chunk_elems * 2
+        chunk_payload = chunk_elems
+        chunk_slice = chunk_payload + chunk_elems // FP8_QUANT_BLOCK * 4
+        in_base = inp.data_ptr()
+        out_base = out.data_ptr()
+        stage_base = self._fp8_stage.data_ptr()
+        stride = self._fp8_stage_stride
+
+        def stage_chunk(shard: int, c: int) -> int:
+            return stage_base + shard * stride + c * chunk_slice
+
+        def rs_chunk(owner: int, srcpos: int, c: int) -> int:
+            return self._scratch_ptr(owner, srcpos) + c * chunk_slice
+
+        def ag_chunk(owner: int, srcpos: int, c: int) -> int:
+            return self._scratch_ptr(owner, (world - 1) + srcpos) + c * chunk_slice
+
+        def rs_slot(srcpos: int, c: int) -> int:
+            return srcpos * chunks + c
+
+        def ag_slot(srcpos: int, c: int) -> int:
+            return (world - 1) * chunks + srcpos * chunks + c
+
+        main = torch.cuda.current_stream(self.device)
+        copy_stream = self._copy_stream
+        flag_stream = self._flag_stream
+        ag_copy = self._ag_copy_stream
+        ag_flag = self._ag_flag_stream
+        copied = self._copied_events
+        half = len(copied) // 2
+        peers = [(rank + 1 + i) % world for i in range(world - 1)]
+        pos_at = [(rank - j - 1) % world for j in peers]
+
+        # Quantize all outgoing chunks up front (cheap kernels on main);
+        # per-chunk events let the scatter start as soon as its chunk is
+        # ready while later quants still run.
+        for c in range(chunks):
+            for j in peers:
+                ext.dma_quant(
+                    in_base + j * shard_bytes + c * chunk_bytes,
+                    stage_chunk(j, c),
+                    stage_chunk(j, c) + chunk_payload,
+                    chunk_elems,
+                )
+            self._a2a_qdone[c].record(main)
+
+        # Scatter: reduce-scatter slices, chunk-pipelined.
+        for c in range(chunks):
+            with torch.cuda.stream(copy_stream):
+                copy_stream.wait_event(self._a2a_qdone[c])
+                for i, j in enumerate(peers):
+                    ext.dma_copy(
+                        rs_chunk(j, pos_at[i], c), stage_chunk(j, c), chunk_slice
+                    )
+                    copied[i * chunks + c].record(copy_stream)
+            with torch.cuda.stream(flag_stream):
+                for i, j in enumerate(peers):
+                    flag_stream.wait_event(copied[i * chunks + c])
+                    slot = rs_slot(pos_at[i], c)
+                    ext.dma_set_flag(
+                        self._flag_ptr(j, slot),
+                        self._counter_ptr(self._send_counters, slot),
+                    )
+
+        # Accumulate own shard chunk by chunk; broadcast each chunk as soon
+        # as it is reduced and quantized (once).
+        for c in range(chunks):
+            for i in range(world - 1):
+                slot = rs_slot(i, c)
+                ext.dma_wait_flag(
+                    self._flag_ptr(rank, slot),
+                    self._counter_ptr(self._wait_counters, slot),
+                )
+            payloads = [rs_chunk(rank, i, c) for i in range(world - 1)]
+            scales = [ptr + chunk_payload for ptr in payloads]
+            own = rank * shard_bytes + c * chunk_bytes
+            ext.dma_dequant_accum(
+                out_base + own, in_base + own, payloads, scales, chunk_elems
+            )
+            ext.dma_quant(
+                out_base + own,
+                stage_chunk(rank, c),
+                stage_chunk(rank, c) + chunk_payload,
+                chunk_elems,
+            )
+            # Publish the payload first so its CE broadcast can overlap the
+            # local read-only materialization below.
+            self._a2a_ownq[c].record(main)
+            # Peers materialize this reduced shard from the broadcast FP8
+            # payload.  The owner must do the same or every rank enters the
+            # next TP layer with a different replicated activation.
+            ext.dma_dequant_store(
+                out_base + own,
+                stage_chunk(rank, c),
+                stage_chunk(rank, c) + chunk_payload,
+                chunk_elems,
+            )
+            with torch.cuda.stream(ag_copy):
+                ag_copy.wait_event(self._a2a_ownq[c])
+                for i, j in enumerate(peers):
+                    ext.dma_copy(
+                        ag_chunk(j, pos_at[i], c), stage_chunk(rank, c), chunk_slice
+                    )
+                    copied[half + i * chunks + c].record(ag_copy)
+            with torch.cuda.stream(ag_flag):
+                for i, j in enumerate(peers):
+                    ag_flag.wait_event(copied[half + i * chunks + c])
+                    slot = ag_slot(pos_at[i], c)
+                    ext.dma_set_flag(
+                        self._flag_ptr(j, slot),
+                        self._counter_ptr(self._send_counters, slot),
+                    )
+
+        # Place incoming reduced shards.
+        for c in range(chunks):
+            for i in range(world - 1):
+                src = peers[i]
+                slot = ag_slot(i, c)
+                ext.dma_wait_flag(
+                    self._flag_ptr(rank, slot),
+                    self._counter_ptr(self._wait_counters, slot),
+                )
+                payload = ag_chunk(rank, i, c)
+                ext.dma_dequant_store(
+                    out_base + src * shard_bytes + c * chunk_bytes,
+                    payload,
+                    payload + chunk_payload,
+                    chunk_elems,
+                )
+        main.wait_stream(copy_stream)
+        main.wait_stream(flag_stream)
+        main.wait_stream(ag_copy)
+        main.wait_stream(ag_flag)
+        return out
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for ptr in self._slab.remote_ptrs:
+            with suppress(Exception):
+                self._ipc.cudaIpcCloseMemHandle(ptr)
+        with suppress(Exception):
+            self._ipc.cudaFree(self._slab.local_ptr)
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()
+
+
+def autotune_crossovers(
+    oneshot,
+    dma: Optional[PCIeDmaAllReduce],
+    nccl_group: ProcessGroup,
+    *,
+    hidden_size: int,
+    max_rows: int,
+    rms_norm_op=None,
+    epsilon: float = 1e-6,
+    warmup: int = 5,
+    iters: int = 50,
+    samples: int = 5,
+    win_margin: float = 0.02,
+) -> tuple[int, int]:
+    """Single sweep from 1 row to the prefill chunk size with the real
+    kernels: the oneshot channel (fused AR+RMSNorm when ``rms_norm_op`` is
+    given, plain otherwise), the CE ring, and NCCL (plus ``rms_norm_op``)
+    as the fallback. Returns (oneshot_max_bytes, dma_min_bytes) and sets
+    ``dma.min_bytes``. Each timing is the median of multiple CUDA-event
+    samples after MAX-reducing every sample across ranks. A backend must win
+    by ``win_margin`` and DMA must do so at two consecutive sizes before its
+    crossover is committed.
+    """
+
+    device = oneshot.device if oneshot is not None else dma.device
+    stream = torch.cuda.Stream(device=device)
+    dtype = torch.bfloat16
+    weight = torch.ones(hidden_size, dtype=dtype, device=device)
+    inf = float("inf")
+    oneshot_max = 0
+    dma_min = 0
+    if dma is not None:
+        original_dma_min = dma.min_bytes
+        dma.min_bytes = 0
+    wire = "bf16" if dma is None else dma.wire_mode
+    lines = [
+        f"[PCIe allreduce] Crossover sweep (dma wire={wire}, "
+        f"hidden={hidden_size}, fused={rms_norm_op is not None}):"
+    ]
+
+    def bench(build) -> float:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(stream):
+            replay = build()
+        with torch.cuda.stream(stream), torch.cuda.graph(graph, stream=stream):
+            replay()
+        device_index = (
+            device.index if device.index is not None else torch.cuda.current_device()
+        )
+        dist.barrier(group=nccl_group, device_ids=[device_index])
+        with torch.cuda.stream(stream):
+            for _ in range(warmup):
+                graph.replay()
+        stream.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        rank_max = torch.empty((), dtype=torch.float64, device=device)
+        timings = []
+        for _ in range(samples):
+            dist.barrier(group=nccl_group, device_ids=[device_index])
+            with torch.cuda.stream(stream):
+                start.record(stream)
+                for _ in range(iters):
+                    graph.replay()
+                end.record(stream)
+            end.synchronize()
+            rank_max.fill_(start.elapsed_time(end) * 1e3 / iters)
+            dist.all_reduce(rank_max, op=dist.ReduceOp.MAX, group=nccl_group)
+            timings.append(float(rank_max.item()))
+        return float(median(timings))
+
+    try:
+        # Fully dense through 8 rows (the decode regime, where every row
+        # count occurs), quarter steps through 32-128 rows (where the
+        # NCCL/DMA boundary lives), and powers of two with midpoints
+        # elsewhere. The sweep stops once the DMA allreduce has won twice
+        # in a row: the curves are monotone above the boundary and the
+        # large probes are the expensive ones.
+        ladder = list(range(1, min(8, max_rows) + 1))
+        step = 8
+        while step <= max_rows:
+            if step not in ladder:
+                ladder.append(step)
+            if 32 <= step <= 64:
+                extra = (step + step // 4, step + step // 2, step + 3 * step // 4)
+            else:
+                extra = (step + step // 2,)
+            ladder.extend(rows for rows in extra if rows <= max_rows)
+            step *= 2
+        oneshot_losses = 0
+        dma_wins = 0
+        dma_candidate = 0
+        rank0 = dist.get_rank(group=nccl_group) == 0
+        if rank0:
+            logger.debug(lines[0])
+        for rows in ladder:
+            point_start = time.perf_counter()
+            shape = (rows, hidden_size)
+            size_bytes = rows * hidden_size * dtype.itemsize
+
+            def build_nccl():
+                inp = torch.randn(shape, dtype=dtype, device=device) * 0.01
+                residual = torch.randn(shape, dtype=dtype, device=device)
+                if rms_norm_op is None:
+                    return lambda: dist.all_reduce(inp, group=nccl_group)
+                return lambda: (
+                    dist.all_reduce(inp, group=nccl_group),
+                    rms_norm_op(inp, residual, weight, epsilon),
+                )
+
+            nccl_us = bench(build_nccl)
+
+            # Stop probing the oneshot after it has clearly lost (its curve
+            # is monotone against NCCL); a probe the kernel refuses (row or
+            # capacity limits) counts as a loss. Every rank takes the same
+            # branch because verdicts come from MAX-reduced timings.
+            oneshot_us = inf
+            if (
+                oneshot is not None
+                and oneshot_losses < 2
+                and size_bytes <= oneshot.max_size
+            ):
+
+                def build_oneshot():
+                    inp = torch.randn(shape, dtype=dtype, device=device) * 0.01
+                    residual = torch.randn(shape, dtype=dtype, device=device)
+                    out = torch.empty_like(inp)
+                    residual_out = torch.empty_like(inp)
+                    if rms_norm_op is None:
+                        return lambda: oneshot.all_reduce(inp, out=out)
+                    return lambda: oneshot.all_reduce_fused_add_rms_norm(
+                        inp,
+                        residual,
+                        weight,
+                        epsilon,
+                        out=out,
+                        residual_out=residual_out,
+                    )
+
+                try:
+                    oneshot_us = bench(build_oneshot)
+                except Exception:
+                    oneshot_us = inf
+
+            dma_us = inf
+            probe = torch.empty(shape, dtype=dtype, device=device)
+            if dma is not None and dma.should_allreduce(probe):
+
+                def build_dma():
+                    inp = torch.randn(shape, dtype=dtype, device=device) * 0.01
+                    out = torch.empty_like(inp)
+                    return lambda: dma.all_reduce(inp, out=out)
+
+                dma_us = bench(build_dma)
+            del probe
+
+            stats = torch.tensor(
+                [nccl_us, oneshot_us, dma_us], dtype=torch.float64, device=device
+            )
+            dist.all_reduce(stats, op=dist.ReduceOp.MAX, group=nccl_group)
+            nccl_us, oneshot_us, dma_us = (float(v) for v in stats.tolist())
+            oneshot_limit = (1.0 + win_margin) * min(nccl_us, dma_us)
+            if oneshot_us < oneshot_limit:
+                oneshot_max = size_bytes
+                oneshot_losses = 0
+            else:
+                oneshot_losses += 1
+            dma_limit = (1.0 - win_margin) * min(nccl_us, oneshot_us)
+            if dma_us < dma_limit:
+                if dma_wins == 0:
+                    dma_candidate = size_bytes
+                dma_wins += 1
+            else:
+                dma_wins = 0
+                dma_candidate = 0
+            line = (
+                f"  rows={rows:5d} ({size_bytes >> 10:6d}KB): "
+                f"oneshot {oneshot_us:9.1f}  dma {dma_us:9.1f}  "
+                f"nccl {nccl_us:9.1f} us"
+                f"  [{time.perf_counter() - point_start:.2f}s]"
+            )
+            lines.append(line)
+            if rank0:
+                logger.debug(line)
+            if dma_wins >= 2:
+                dma_min = dma_candidate
+                break
+    except Exception:
+        if dma is not None:
+            dma.min_bytes = original_dma_min
+        raise
+
+    if dma is not None:
+        dma.min_bytes = dma_min if dma_min > 0 else dma.max_bytes + 1
+    if dist.get_rank(group=nccl_group) == 0:
+        logger.debug("  oneshot_max_bytes=%d dma_min_bytes=%d", oneshot_max, dma_min)
+    return oneshot_max, dma_min
+
+
+__all__ = ["PCIeDmaAllReduce", "autotune_crossovers"]

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_oneshot.cu
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_oneshot.cu
@@ -1,0 +1,1056 @@
+// Ported from b12x b12x/distributed/pcie_oneshot.cu @ 913ac7aa (2026-07-04) -- one-time curated port.
+// PCIe-only custom allreduce extension.
+// System-scope barriers for cross-GPU visibility over PCIe switch fabric.
+
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <torch/all.h>
+#include <torch/extension.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#define CHECK_CUDA_SUCCESS(cmd)                                         \
+  do {                                                                  \
+    cudaError_t e = cmd;                                                \
+    if (e != cudaSuccess) {                                             \
+      std::stringstream _message;                                       \
+      auto s = cudaGetErrorString(e);                                   \
+      _message << std::string(s) + "\n" << __FILE__ << ':' << __LINE__; \
+      throw std::runtime_error(_message.str());                         \
+    }                                                                   \
+  } while (0)
+
+namespace pcie_allreduce {
+
+constexpr int kMaxBlocks = 36;
+constexpr int kMaxRanks = 16;
+using FlagType = uint32_t;
+
+// 128B stride per rank to avoid PCIe false sharing.
+constexpr int kFlagStride = 32;
+
+static int env_int(const char* name, int fallback) {
+  const char* raw = std::getenv(name);
+  if (raw == nullptr || raw[0] == '\0') return fallback;
+  return std::atoi(raw);
+}
+
+// Fused kernel launch knobs, mainly for latency sweeps. Every rank must use
+// identical values: launch geometry decides which columns each block stages,
+// and peer block b only reads what writer block b staged. 256 threads beat
+// 512 measurably at rows >= 2 on Gen5 PCIe (three packs per thread give the
+// pull loop deeper memory-level parallelism than half-idle wider blocks).
+static int fused_threads() {
+  static const int value = [] {
+    int v = env_int("FLASHINFER_EXP_SM12X_PCIE_FUSED_THREADS", 256);
+    v = std::min(512, std::max(64, v));
+    return (v / 32) * 32;
+  }();
+  return value;
+}
+
+static int fused_ctas_per_row_override() {
+  static const int value = env_int("FLASHINFER_EXP_SM12X_PCIE_FUSED_CTAS_PER_ROW", 0);
+  return value;
+}
+
+// Push transport requires eager slots of world_size * max_size bytes; the
+// Python runtime scales the allocation when the same env toggle is set.
+static bool oneshot_push_enabled() {
+  static const bool value = env_int("FLASHINFER_EXP_SM12X_PCIE_ONESHOT_PUSH", 0) != 0;
+  return value;
+}
+
+struct Signal {
+  alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+  alignas(128) FlagType rms_arrive[kMaxBlocks];
+  alignas(128) FlagType rms_gen[kMaxBlocks];
+  alignas(128) float rms_partial[kMaxBlocks];
+};
+
+struct __align__(16) RankData {
+  const void* __restrict__ ptrs[kMaxRanks];
+};
+
+struct __align__(16) RankSignals {
+  Signal* signals[kMaxRanks];
+};
+
+template <typename T, int sz>
+struct __align__(alignof(T) * sz) array_t {
+  T data[sz];
+  using type = T;
+  static constexpr int size = sz;
+};
+
+template <typename T>
+struct packed_t {
+  using P = array_t<T, 16 / sizeof(T)>;
+  using A = array_t<float, 16 / sizeof(T)>;
+};
+
+#define DINLINE __device__ __forceinline__
+
+DINLINE float upcast_s(float val) { return val; }
+DINLINE float upcast_s(half val) { return __half2float(val); }
+
+template <typename T>
+DINLINE T downcast_s(float val);
+template <>
+DINLINE half downcast_s(float val) {
+  return __float2half(val);
+}
+
+DINLINE half& assign_add(half& a, half b) {
+  a = __hadd(a, b);
+  return a;
+}
+DINLINE float& assign_add(float& a, float b) {
+  return a += b;
+}
+
+#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
+DINLINE float upcast_s(nv_bfloat16 val) { return __bfloat162float(val); }
+template <>
+DINLINE nv_bfloat16 downcast_s(float val) {
+  return __float2bfloat16(val);
+}
+DINLINE nv_bfloat16& assign_add(nv_bfloat16& a, nv_bfloat16 b) {
+  a = __hadd(a, b);
+  return a;
+}
+#endif
+
+template <typename T, int N>
+DINLINE array_t<T, N>& packed_assign_add(array_t<T, N>& a, array_t<T, N> b) {
+#pragma unroll
+  for (int i = 0; i < N; i++) assign_add(a.data[i], b.data[i]);
+  return a;
+}
+
+template <typename T, int N>
+DINLINE array_t<float, N> upcast(array_t<T, N> val) {
+  if constexpr (std::is_same<T, float>::value) {
+    return val;
+  } else {
+    array_t<float, N> out;
+#pragma unroll
+    for (int i = 0; i < N; i++) out.data[i] = upcast_s(val.data[i]);
+    return out;
+  }
+}
+
+template <typename O>
+DINLINE O downcast(array_t<float, O::size> val) {
+  if constexpr (std::is_same<typename O::type, float>::value) {
+    return val;
+  } else {
+    O out;
+#pragma unroll
+    for (int i = 0; i < O::size; i++) out.data[i] = downcast_s<typename O::type>(val.data[i]);
+    return out;
+  }
+}
+
+static DINLINE void st_flag_relaxed(FlagType* flag_addr, FlagType flag) {
+  asm volatile("st.relaxed.sys.global.u32 [%1], %0;" ::"r"(flag), "l"(flag_addr));
+}
+
+static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
+  FlagType flag;
+  asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr));
+  return flag;
+}
+
+static DINLINE FlagType ld_flag_relaxed_gpu(FlagType* flag_addr) {
+  FlagType flag;
+  asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
+  return flag;
+}
+
+static DINLINE FlagType ld_flag_acquire_gpu(FlagType* flag_addr) {
+  FlagType flag;
+  asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
+  return flag;
+}
+
+template <int ngpus, bool is_start>
+DINLINE void multi_gpu_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+  if constexpr (!is_start) __syncthreads();
+  if (threadIdx.x < ngpus) {
+    __threadfence_system();
+    auto val = self_sg->self_counter[blockIdx.x][threadIdx.x] += 1;
+    auto peer_counter_ptr = &sg.signals[threadIdx.x]->peer_counter[val % 2][blockIdx.x][rank * kFlagStride];
+    auto self_counter_ptr = &self_sg->peer_counter[val % 2][blockIdx.x][threadIdx.x * kFlagStride];
+    st_flag_relaxed(peer_counter_ptr, val);
+    while (ld_flag_relaxed(self_counter_ptr) != val)
+      ;
+  }
+  __syncthreads();
+}
+
+template <typename P, int ngpus, typename A>
+DINLINE P packed_reduce(const P* ptrs[], int idx) {
+  A tmp = upcast(ptrs[0][idx]);
+#pragma unroll
+  for (int i = 1; i < ngpus; i++) packed_assign_add(tmp, upcast(ptrs[i][idx]));
+  return downcast<P>(tmp);
+}
+
+template <typename T, int N>
+DINLINE float packed_square_sum(array_t<T, N> value) {
+  auto value_f = upcast(value);
+  float sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < N; i++) sum += value_f.data[i] * value_f.data[i];
+  return sum;
+}
+
+DINLINE float warp_reduce_sum(float value) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset /= 2) {
+    value += __shfl_down_sync(0xffffffff, value, offset);
+  }
+  return value;
+}
+
+DINLINE float block_reduce_sum(float value, float* warp_sums) {
+  const int lane = threadIdx.x % warpSize;
+  const int warp = threadIdx.x / warpSize;
+  value = warp_reduce_sum(value);
+  if (lane == 0) warp_sums[warp] = value;
+  __syncthreads();
+
+  value = threadIdx.x < blockDim.x / warpSize ? warp_sums[lane] : 0.0f;
+  if (warp == 0) value = warp_reduce_sum(value);
+  return value;
+}
+
+// 1-stage allreduce with staggered peer reads and start-barrier-only. The end
+// barrier is avoided by alternating between eager IPC buffers in a single
+// ordered channel. Callers must not share a channel concurrently across CUDA
+// streams; multi-stream use needs separate signal and staging buffers.
+//
+// With stage_input the kernel copies its own grid-stride index set from the
+// local input into this channel's staging slot before the start barrier,
+// replacing the host staging memcpy. Writer block b covers exactly the packs
+// reader block b consumes on every rank, so the block-pairwise barrier is
+// sufficient for staging visibility.
+template <typename T, int ngpus, bool stage_input>
+__global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ input,
+    T* __restrict__ result,
+    T* __restrict__ self_staging,
+    int rank,
+    int size) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  auto dp = *_dp;
+  const P* rotated[ngpus];
+#pragma unroll
+  for (int i = 0; i < ngpus; i++) {
+    rotated[i] = (const P*)dp.ptrs[(rank + i) % ngpus];
+  }
+  if constexpr (stage_input) {
+    const P* input_p = reinterpret_cast<const P*>(input);
+    P* staging_p = reinterpret_cast<P*>(self_staging);
+    for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+      staging_p[idx] = input_p[idx];
+    }
+  }
+  multi_gpu_barrier<ngpus, !stage_input>(sg, self_sg, rank);
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+    ((P*)result)[idx] = packed_reduce<P, ngpus, A>(rotated, idx);
+  }
+}
+
+// Per-thread register budget for the fused kernel's normalize-from-registers
+// path, in 16B packs. Three packs cover hidden_size 6144 at the default
+// 256-thread block while staying inside the 128-register budget (four packs
+// plus prefetched operands spilled to the stack and the spill traffic
+// dominated the pull loop). Larger per-thread column counts fall back to
+// re-reading residual_output during normalization.
+constexpr int kRegPacks = 3;
+
+// Transport modes for the fused kernel.
+//  kModeRegistered: the input already lives in a peer-visible registered
+//    buffer; peers pull it after the start barrier.
+//  kModeStagePull: the kernel copies its columns into this rank's eager slot
+//    before the start barrier (replacing the host staging memcpy); peers
+//    pull staged data.
+//  kModeStagePush: the kernel writes its columns into a per-source shard of
+//    every peer's eager slot (PCIe posted writes run at link bandwidth while
+//    pulls are round-trip bound); after the barrier the reduction reads only
+//    local memory. Requires eager slots of world_size * max_size bytes.
+constexpr int kModeRegistered = 0;
+constexpr int kModeStagePull = 1;
+constexpr int kModeStagePush = 2;
+
+// Complete the allreduce, residual add, and RMSNorm in one launch.
+//
+// Geometry is uniform: gridDim.x == rows * ctas_per_row and block b serves
+// row b / ctas_per_row, owning columns {(b % ctas_per_row) * blockDim.x +
+// threadIdx.x + k * ctas_per_row * blockDim.x}. The same block index covers
+// the same columns on every rank, so the block-pairwise start barrier is
+// sufficient for staging visibility (writer block b stages exactly the
+// columns reader block b consumes, for every source/destination pair).
+//
+// Slot reuse stays safe without an end barrier in every mode: a rank enters
+// kernel k+2 only after its kernel k+1 retired, which required every rank to
+// have passed kernel k+1's start barrier and hence to have fully consumed
+// slot k % 2 inside kernel k.
+//
+// The reduction runs in fp32 registers straight through the residual add.
+// With single_cta each row is normalized with block-local synchronization
+// only. Otherwise each CTA publishes one fp32 square-sum partial, crosses a
+// sense-reversing per-row generation barrier, and normalizes its own columns
+// from registers, so no CTA re-reads the row it just wrote. All CTAs of a
+// row spin, which is safe for the same reason the cross-rank start barrier
+// is: the grid never exceeds kMaxBlocks <= SM count, so every block is
+// resident.
+template <typename T, int ngpus, bool single_cta, int mode>
+__global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kernel(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ input,
+    const T* __restrict__ residual,
+    const T* __restrict__ weight,
+    T* __restrict__ output,
+    T* __restrict__ residual_output,
+    T* __restrict__ self_staging,
+    int rank,
+    int hidden_packs,
+    int ctas_per_row,
+    int shard_packs,
+    float epsilon) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  __shared__ float warp_sums[32];
+  __shared__ float s_inv_rms;
+
+  const int row = single_cta ? blockIdx.x : blockIdx.x / ctas_per_row;
+  const int row_cta = single_cta ? 0 : blockIdx.x - row * ctas_per_row;
+  const int row_offset = row * hidden_packs;
+  const int col_stride = single_cta ? blockDim.x : ctas_per_row * blockDim.x;
+  const int col0 = row_cta * blockDim.x + threadIdx.x;
+  const int max_packs = (hidden_packs + col_stride - 1) / col_stride;
+  const bool reg_norm = max_packs <= kRegPacks;
+
+  auto dp = *_dp;
+  const P* rotated[ngpus];
+#pragma unroll
+  for (int i = 0; i < ngpus; i++) {
+    rotated[i] = (const P*)dp.ptrs[(rank + i) % ngpus];
+  }
+
+  const P* input_p = reinterpret_cast<const P*>(input);
+  const P* residual_p = reinterpret_cast<const P*>(residual);
+  const P* weight_p = reinterpret_cast<const P*>(weight);
+  P* output_p = reinterpret_cast<P*>(output);
+  P* residual_output_p = reinterpret_cast<P*>(residual_output);
+  P* staging_p = reinterpret_cast<P*>(self_staging);
+
+  // Sense-reversing row barrier: latch the generation before arriving.
+  // Launches are stream-serialized, so this read cannot race a peer CTA's
+  // increment for this launch (that increment needs this CTA's arrival).
+  FlagType row_gen = 0;
+  if (!single_cta && threadIdx.x == 0) {
+    row_gen = ld_flag_relaxed_gpu(&self_sg->rms_gen[row]);
+  }
+
+  // Stage this block's columns before the start barrier so the load/store
+  // latency hides behind the peer flag exchange. The self contribution is
+  // kept in registers instead of being re-read from staging. Residual and
+  // weight stay in-loop: their local loads overlap the peer pulls and the
+  // row barrier, and keeping them out of registers avoids spilling.
+  P self_pk[kRegPacks];
+  if (reg_norm) {
+#pragma unroll
+    for (int n = 0; n < kRegPacks; n++) {
+      const int col = col0 + n * col_stride;
+      if (col < hidden_packs) {
+        const int idx = row_offset + col;
+        self_pk[n] = mode == kModeRegistered ? rotated[0][idx] : input_p[idx];
+        if constexpr (mode == kModeStagePull) staging_p[idx] = self_pk[n];
+      }
+    }
+    if constexpr (mode == kModeStagePush) {
+      // Peer-major order keeps each warp's stores contiguous per target so
+      // they coalesce into large PCIe TLPs.
+#pragma unroll
+      for (int i = 1; i < ngpus; i++) {
+        P* peer_shard = (P*)rotated[i] + rank * shard_packs;
+#pragma unroll
+        for (int n = 0; n < kRegPacks; n++) {
+          const int col = col0 + n * col_stride;
+          if (col < hidden_packs) peer_shard[row_offset + col] = self_pk[n];
+        }
+      }
+    }
+  } else if constexpr (mode == kModeStagePull) {
+    for (int col = col0; col < hidden_packs; col += col_stride) {
+      const int idx = row_offset + col;
+      staging_p[idx] = input_p[idx];
+    }
+  } else if constexpr (mode == kModeStagePush) {
+    for (int col = col0; col < hidden_packs; col += col_stride) {
+      const int idx = row_offset + col;
+      const P value = input_p[idx];
+#pragma unroll
+      for (int i = 1; i < ngpus; i++) {
+        ((P*)rotated[i] + rank * shard_packs)[idx] = value;
+      }
+    }
+  }
+
+  // Staging modes need the pre-barrier __syncthreads (is_start == false) so
+  // every thread's staging stores are fenced before the flag post.
+  multi_gpu_barrier<ngpus, mode == kModeRegistered>(sg, self_sg, rank);
+
+  float square_sum = 0.0f;
+  A vals_f[kRegPacks];
+  if (reg_norm) {
+#pragma unroll
+    for (int n = 0; n < kRegPacks; n++) {
+      const int col = col0 + n * col_stride;
+      if (col < hidden_packs) {
+        const int idx = row_offset + col;
+        A acc = upcast(self_pk[n]);
+        if constexpr (mode == kModeStagePush) {
+#pragma unroll
+          for (int src = 0; src < ngpus; src++) {
+            if (src != rank) {
+              packed_assign_add(acc, upcast(rotated[0][src * shard_packs + idx]));
+            }
+          }
+        } else {
+#pragma unroll
+          for (int i = 1; i < ngpus; i++) {
+            packed_assign_add(acc, upcast(rotated[i][idx]));
+          }
+        }
+        packed_assign_add(acc, upcast(residual_p[idx]));
+        residual_output_p[idx] = downcast<P>(acc);
+#pragma unroll
+        for (int j = 0; j < A::size; j++) {
+          square_sum += acc.data[j] * acc.data[j];
+        }
+        vals_f[n] = acc;
+      }
+    }
+  } else {
+    for (int col = col0; col < hidden_packs; col += col_stride) {
+      const int idx = row_offset + col;
+      A acc = upcast(mode == kModeStagePush ? input_p[idx] : rotated[0][idx]);
+      if constexpr (mode == kModeStagePush) {
+#pragma unroll
+        for (int src = 0; src < ngpus; src++) {
+          if (src != rank) {
+            packed_assign_add(acc, upcast(rotated[0][src * shard_packs + idx]));
+          }
+        }
+      } else {
+#pragma unroll
+        for (int i = 1; i < ngpus; i++) {
+          packed_assign_add(acc, upcast(rotated[i][idx]));
+        }
+      }
+      packed_assign_add(acc, upcast(residual_p[idx]));
+      residual_output_p[idx] = downcast<P>(acc);
+#pragma unroll
+      for (int j = 0; j < A::size; j++) {
+        square_sum += acc.data[j] * acc.data[j];
+      }
+    }
+  }
+
+  square_sum = block_reduce_sum(square_sum, warp_sums);
+  const float hidden_size_f = static_cast<float>(hidden_packs * P::size);
+
+  if constexpr (single_cta) {
+    if (threadIdx.x == 0) {
+      s_inv_rms = rsqrtf(square_sum / hidden_size_f + epsilon);
+    }
+  } else {
+    if (threadIdx.x == 0) {
+      self_sg->rms_partial[blockIdx.x] = square_sum;
+      __threadfence();
+      const FlagType prior = atomicAdd(&self_sg->rms_arrive[row], 1u);
+      if (prior == static_cast<FlagType>(ctas_per_row - 1)) {
+        // Last arriver: reset the arrival count for the next launch, then
+        // release the generation. The fence orders the reset and every
+        // observed peer partial before the release.
+        self_sg->rms_arrive[row] = 0;
+        __threadfence();
+        atomicAdd(&self_sg->rms_gen[row], 1u);
+      } else {
+        while (ld_flag_acquire_gpu(&self_sg->rms_gen[row]) == row_gen) {
+        }
+      }
+    }
+    __syncthreads();
+    if (threadIdx.x < warpSize) {
+      float partial = 0.0f;
+      for (int i = threadIdx.x; i < ctas_per_row; i += warpSize) {
+        partial += self_sg->rms_partial[row * ctas_per_row + i];
+      }
+      partial = warp_reduce_sum(partial);
+      if (threadIdx.x == 0) {
+        s_inv_rms = rsqrtf(partial / hidden_size_f + epsilon);
+      }
+    }
+  }
+  __syncthreads();
+  const float inv_rms = s_inv_rms;
+
+  if (reg_norm) {
+#pragma unroll
+    for (int n = 0; n < kRegPacks; n++) {
+      const int col = col0 + n * col_stride;
+      if (col < hidden_packs) {
+        A scale = upcast(weight_p[col]);
+        A value = vals_f[n];
+#pragma unroll
+        for (int j = 0; j < A::size; j++) {
+          value.data[j] *= inv_rms * scale.data[j];
+        }
+        output_p[row_offset + col] = downcast<P>(value);
+      }
+    }
+  } else {
+    for (int col = col0; col < hidden_packs; col += col_stride) {
+      const int idx = row_offset + col;
+      A value = upcast(residual_output_p[idx]);
+      A scale = upcast(weight_p[col]);
+#pragma unroll
+      for (int j = 0; j < A::size; j++) {
+        value.data[j] *= inv_rms * scale.data[j];
+      }
+      output_p[idx] = downcast<P>(value);
+    }
+  }
+}
+
+using IPC_KEY = std::array<uint8_t, sizeof(cudaIpcMemHandle_t)>;
+
+class PCIeAllreduce {
+ public:
+  int rank_;
+  int world_size_;
+
+  RankSignals sg_;
+  std::unordered_map<void*, RankData*> buffers_;
+  Signal* self_sg_;
+
+  RankData *d_rank_data_base_, *d_rank_data_end_;
+  std::vector<void*> graph_unreg_buffers_;
+  std::map<IPC_KEY, char*> ipc_handles_;
+
+  bool dbuf_enabled_ = false;
+  int dbuf_slot_ = 0;
+  void* dbuf_raw_[2][kMaxRanks] = {};
+  RankData* dbuf_rd_[2] = {};
+
+  PCIeAllreduce(Signal** signals, void* rank_data, size_t rank_data_sz, int rank, int world_size)
+      : rank_(rank),
+        world_size_(world_size),
+        self_sg_(signals[rank]),
+        d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)) {
+    for (int i = 0; i < world_size_; i++) sg_.signals[i] = signals[i];
+  }
+
+  char* open_ipc_handle(const void* ipc_handle) {
+    auto [it, new_handle] = ipc_handles_.insert({*((IPC_KEY*)ipc_handle), nullptr});
+    if (new_handle) {
+      char* ipc_ptr;
+      CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
+          (void**)&ipc_ptr, *((const cudaIpcMemHandle_t*)ipc_handle), cudaIpcMemLazyEnablePeerAccess));
+      it->second = ipc_ptr;
+    }
+    return it->second;
+  }
+
+  std::pair<std::string, std::vector<int64_t>> get_graph_buffer_ipc_meta() {
+    auto num_buffers = graph_unreg_buffers_.size();
+    auto handle_sz = sizeof(cudaIpcMemHandle_t);
+    std::string handles(handle_sz * num_buffers, static_cast<char>(0));
+    std::vector<int64_t> offsets(num_buffers);
+    for (size_t i = 0; i < num_buffers; i++) {
+      auto ptr = graph_unreg_buffers_[i];
+      void* base_ptr;
+      if (cuPointerGetAttribute(&base_ptr, CU_POINTER_ATTRIBUTE_RANGE_START_ADDR, (CUdeviceptr)ptr) != CUDA_SUCCESS)
+        throw std::runtime_error("failed to get pointer attr");
+      CHECK_CUDA_SUCCESS(cudaIpcGetMemHandle((cudaIpcMemHandle_t*)&handles[i * handle_sz], base_ptr));
+      offsets[i] = ((char*)ptr) - ((char*)base_ptr);
+    }
+    return std::make_pair(handles, offsets);
+  }
+
+  void check_rank_data_capacity(size_t num = 1) {
+    if (d_rank_data_base_ + num > d_rank_data_end_)
+      throw std::runtime_error("Rank data buffer overflow");
+  }
+
+  void register_pcie_buffers(void** ptrs0, void** ptrs1) {
+    check_rank_data_capacity(2);
+    for (int s = 0; s < 2; s++) {
+      void** ptrs = s == 0 ? ptrs0 : ptrs1;
+      RankData data;
+      for (int i = 0; i < world_size_; i++) {
+        data.ptrs[i] = ptrs[i];
+        dbuf_raw_[s][i] = ptrs[i];
+      }
+      dbuf_rd_[s] = d_rank_data_base_++;
+      CHECK_CUDA_SUCCESS(cudaMemcpy(dbuf_rd_[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
+    }
+    buffers_[ptrs0[rank_]] = dbuf_rd_[0];
+    buffers_[ptrs1[rank_]] = dbuf_rd_[1];
+    dbuf_enabled_ = true;
+    dbuf_slot_ = 0;
+  }
+
+  void register_buffer(void** ptrs) {
+    check_rank_data_capacity();
+    RankData data;
+    for (int i = 0; i < world_size_; i++) data.ptrs[i] = ptrs[i];
+    auto d_data = d_rank_data_base_++;
+    CHECK_CUDA_SUCCESS(cudaMemcpy(d_data, &data, sizeof(RankData), cudaMemcpyHostToDevice));
+    buffers_[ptrs[rank_]] = d_data;
+  }
+
+  void register_graph_buffers(
+      const std::vector<std::string>& handles, const std::vector<std::vector<int64_t>>& offsets) {
+    auto num_buffers = graph_unreg_buffers_.size();
+    check_rank_data_capacity(num_buffers);
+    std::vector<RankData> rank_data(num_buffers);
+    for (size_t i = 0; i < num_buffers; i++) {
+      auto self_ptr = graph_unreg_buffers_[i];
+      auto& rd = rank_data[i];
+      for (int j = 0; j < world_size_; j++) {
+        if (j != rank_) {
+          char* handle = open_ipc_handle(&handles[j][i * sizeof(cudaIpcMemHandle_t)]);
+          handle += offsets[j][i];
+          rd.ptrs[j] = handle;
+        } else {
+          rd.ptrs[j] = self_ptr;
+        }
+      }
+    }
+    CHECK_CUDA_SUCCESS(
+        cudaMemcpy(d_rank_data_base_, rank_data.data(), sizeof(RankData) * num_buffers, cudaMemcpyHostToDevice));
+    d_rank_data_base_ += num_buffers;
+    graph_unreg_buffers_.clear();
+  }
+
+  // 256-thread blocks with a low block cap measurably beat 512x36 on Gen5
+  // PCIe pulls at 12KB-96KB (10.0 vs 11.8 us at 12KB, 31.9 vs 39.6 us at
+  // 96KB, 8 GPUs): fewer, narrower blocks give each thread ~3 packs of
+  // memory-level parallelism instead of oversubscribing the fabric.
+  template <typename T>
+  void allreduce(cudaStream_t stream, T* input, T* output, int size, int threads = 256, int block_limit = 8) {
+    auto d = packed_t<T>::P::size;
+    if (size % d != 0)
+      throw std::runtime_error("allreduce requires input length to be multiple of " + std::to_string(d));
+    static const int env_threads = env_int("FLASHINFER_EXP_SM12X_PCIE_ONESHOT_THREADS", 0);
+    static const int env_block_limit = env_int("FLASHINFER_EXP_SM12X_PCIE_ONESHOT_BLOCK_LIMIT", 0);
+    if (env_threads > 0) threads = std::min(512, std::max(64, (env_threads / 32) * 32));
+    if (env_block_limit > 0) block_limit = env_block_limit;
+    if (block_limit > kMaxBlocks)
+      throw std::runtime_error("max supported block limit is " + std::to_string(kMaxBlocks));
+
+    RankData* ptrs;
+    T* staging = nullptr;
+    cudaStreamCaptureStatus status;
+    CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
+
+    if (dbuf_enabled_) {
+      // The kernel stages the input into the eager slot itself; no host
+      // staging memcpy is issued.
+      int slot = dbuf_slot_ % 2;
+      dbuf_slot_++;
+      ptrs = dbuf_rd_[slot];
+      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
+    } else if (status == cudaStreamCaptureStatusActive) {
+      throw std::runtime_error(
+          "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
+          "PCIeOneshotAllReducePool");
+    } else {
+      auto it = buffers_.find(input);
+      if (it == buffers_.end())
+        throw std::runtime_error(
+            "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
+      ptrs = it->second;
+    }
+
+    size /= d;
+    int blocks = std::min(block_limit, (size + threads - 1) / threads);
+    blocks = std::max(blocks, 1);
+
+#define KL(ngpus)                                                                                                     \
+  do {                                                                                                               \
+    if (staging != nullptr) {                                                                                        \
+      pcie_allreduce_kernel<T, ngpus, true>                                                                          \
+          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
+    } else {                                                                                                         \
+      pcie_allreduce_kernel<T, ngpus, false>                                                                         \
+          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
+    }                                                                                                                 \
+  } while (0)
+    switch (world_size_) {
+      case 2:
+        KL(2);
+        break;
+      case 4:
+        KL(4);
+        break;
+      case 6:
+        KL(6);
+        break;
+      case 8:
+        KL(8);
+        break;
+      case 10:
+        KL(10);
+        break;
+      default:
+        throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
+    }
+#undef KL
+  }
+
+  template <typename T>
+  void allreduce_fused_add_rms_norm(
+      cudaStream_t stream,
+      T* input,
+      const T* residual,
+      const T* weight,
+      T* output,
+      T* residual_output,
+      int size,
+      int hidden_size,
+      float epsilon) {
+    using P = typename packed_t<T>::P;
+    const int pack_size = P::size;
+    if (hidden_size <= 0 || size <= 0 || size % hidden_size != 0)
+      throw std::runtime_error("fused allreduce RMSNorm requires complete non-empty rows");
+    if (hidden_size % pack_size != 0)
+      throw std::runtime_error(
+          "fused allreduce RMSNorm requires hidden size to be a multiple of " + std::to_string(pack_size));
+
+    RankData* ptrs;
+    T* staging = nullptr;
+    cudaStreamCaptureStatus status;
+    CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
+    if (dbuf_enabled_) {
+      // The kernel stages the input into the eager slot itself; no host
+      // staging memcpy is issued.
+      int slot = dbuf_slot_ % 2;
+      dbuf_slot_++;
+      ptrs = dbuf_rd_[slot];
+      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
+    } else if (status == cudaStreamCaptureStatusActive) {
+      throw std::runtime_error(
+          "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
+          "PCIeOneshotAllReducePool");
+    } else {
+      auto it = buffers_.find(input);
+      if (it == buffers_.end())
+        throw std::runtime_error(
+            "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
+      ptrs = it->second;
+    }
+
+    int rows = size / hidden_size;
+    int hidden_packs = hidden_size / pack_size;
+    if (rows > kMaxBlocks)
+      throw std::runtime_error(
+          "fused allreduce RMSNorm supports at most " + std::to_string(kMaxBlocks) + " rows");
+    const int threads = fused_threads();
+    int ctas_per_row = fused_ctas_per_row_override();
+    if (ctas_per_row <= 0) {
+      // Measured on 8x Gen5 PCIe: the pull phase wants ~3 blocks in flight
+      // (12.3 vs 13.3 us at rows=1), while extra CTAs per row only add row
+      // barrier cost once rows supply that concurrency. Large hidden sizes
+      // additionally need enough CTAs to keep the normalize path in
+      // registers (kRegPacks packs per thread).
+      const int min_ctas = (hidden_packs + threads * kRegPacks - 1) / (threads * kRegPacks);
+      ctas_per_row = std::max(std::max(1, 3 / rows), min_ctas);
+    }
+    ctas_per_row = std::max(1, std::min(ctas_per_row, kMaxBlocks / rows));
+    const int blocks = rows * ctas_per_row;
+    const bool single = ctas_per_row == 1;
+    const int shard_packs = size / pack_size;
+    const int mode = staging == nullptr ? kModeRegistered
+                     : oneshot_push_enabled() ? kModeStagePush
+                                              : kModeStagePull;
+
+#define KL(ngpus, SINGLE, MODE)                                                                                       \
+  pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE><<<blocks, threads, 0, stream>>>(                   \
+      ptrs, sg_, self_sg_, input, residual, weight, output, residual_output, staging, rank_, hidden_packs,            \
+      ctas_per_row, shard_packs, epsilon);
+#define DISPATCH_MODE(ngpus, SINGLE)                                                                                  \
+  do {                                                                                                               \
+    if (mode == kModeStagePush) {                                                                                    \
+      KL(ngpus, SINGLE, kModeStagePush);                                                                             \
+    } else if (mode == kModeStagePull) {                                                                             \
+      KL(ngpus, SINGLE, kModeStagePull);                                                                             \
+    } else {                                                                                                         \
+      KL(ngpus, SINGLE, kModeRegistered);                                                                            \
+    }                                                                                                                 \
+  } while (0)
+#define DISPATCH(ngpus)                                                                                              \
+  do {                                                                                                               \
+    if (single) {                                                                                                    \
+      DISPATCH_MODE(ngpus, true);                                                                                    \
+    } else {                                                                                                         \
+      DISPATCH_MODE(ngpus, false);                                                                                   \
+    }                                                                                                                 \
+  } while (0)
+    switch (world_size_) {
+      case 2:
+        DISPATCH(2);
+        break;
+      case 4:
+        DISPATCH(4);
+        break;
+      case 6:
+        DISPATCH(6);
+        break;
+      case 8:
+        DISPATCH(8);
+        break;
+      case 10:
+        DISPATCH(10);
+        break;
+      default:
+        throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
+    }
+#undef DISPATCH
+#undef DISPATCH_MODE
+#undef KL
+  }
+
+  ~PCIeAllreduce() {
+    for (auto [_, ptr] : ipc_handles_) CHECK_CUDA_SUCCESS(cudaIpcCloseMemHandle(ptr));
+  }
+};
+
+}  // namespace pcie_allreduce
+
+using fptr_t = int64_t;
+
+static fptr_t init_custom_ar(const std::vector<fptr_t>& fake_ipc_ptrs, torch::Tensor& rank_data, int64_t rank) {
+  int world_size = fake_ipc_ptrs.size();
+  if (world_size > pcie_allreduce::kMaxRanks)
+    throw std::invalid_argument("world size > " + std::to_string(pcie_allreduce::kMaxRanks) + " is not supported");
+  if (world_size % 2 != 0) throw std::invalid_argument("Odd num gpus is not supported");
+  if (rank < 0 || rank >= world_size) throw std::invalid_argument("invalid rank");
+
+  pcie_allreduce::Signal* ipc_ptrs[pcie_allreduce::kMaxRanks];
+  for (int i = 0; i < world_size; i++) ipc_ptrs[i] = reinterpret_cast<pcie_allreduce::Signal*>(fake_ipc_ptrs[i]);
+  return (fptr_t) new pcie_allreduce::PCIeAllreduce(ipc_ptrs, rank_data.data_ptr(), rank_data.numel(), rank, world_size);
+}
+
+static bool _is_weak_contiguous(torch::Tensor& t) {
+  return t.is_contiguous() ||
+         (t.storage().nbytes() - t.storage_offset() * t.element_size() == t.numel() * t.element_size());
+}
+
+static void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out, fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes) {
+  auto fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+
+  TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
+  TORCH_CHECK_EQ(inp.numel(), out.numel());
+  TORCH_CHECK(_is_weak_contiguous(out));
+  TORCH_CHECK(_is_weak_contiguous(inp));
+  auto input_size = inp.numel() * inp.element_size();
+
+  // When double-buffer is active, allreduce handles the memcpy and slot
+  // alternation internally, including under CUDA graph capture.
+  void* reg_buffer;
+  if (fa->dbuf_enabled_) {
+    reg_buffer = inp.data_ptr();
+  } else if (_reg_buffer) {
+    reg_buffer = reinterpret_cast<void*>(_reg_buffer);
+    TORCH_CHECK_LE(input_size, reg_buffer_sz_bytes);
+    AT_CUDA_CHECK(cudaMemcpyAsync(reg_buffer, inp.data_ptr(), input_size, cudaMemcpyDeviceToDevice, stream));
+  } else {
+    reg_buffer = inp.data_ptr();
+  }
+
+  switch (out.scalar_type()) {
+    case at::ScalarType::Float:
+      fa->allreduce<float>(stream, (float*)reg_buffer, (float*)out.data_ptr(), out.numel());
+      break;
+    case at::ScalarType::Half:
+      fa->allreduce<half>(stream, (half*)reg_buffer, (half*)out.data_ptr(), out.numel());
+      break;
+#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
+    case at::ScalarType::BFloat16:
+      fa->allreduce<nv_bfloat16>(stream, (nv_bfloat16*)reg_buffer, (nv_bfloat16*)out.data_ptr(), out.numel());
+      break;
+#endif
+    default:
+      throw std::runtime_error("only supports float32, float16 and bfloat16");
+  }
+}
+
+static void all_reduce_fused_add_rms_norm(
+    fptr_t _fa,
+    torch::Tensor& inp,
+    torch::Tensor& residual,
+    torch::Tensor& weight,
+    torch::Tensor& out,
+    torch::Tensor& residual_out,
+    double epsilon,
+    fptr_t _reg_buffer,
+    int64_t reg_buffer_sz_bytes) {
+  auto fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+
+  TORCH_CHECK_GE(inp.dim(), 1);
+  TORCH_CHECK_EQ(inp.scalar_type(), residual.scalar_type());
+  TORCH_CHECK_EQ(inp.scalar_type(), weight.scalar_type());
+  TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
+  TORCH_CHECK_EQ(inp.scalar_type(), residual_out.scalar_type());
+  TORCH_CHECK_EQ(inp.device(), residual.device());
+  TORCH_CHECK_EQ(inp.device(), weight.device());
+  TORCH_CHECK_EQ(inp.device(), out.device());
+  TORCH_CHECK_EQ(inp.device(), residual_out.device());
+  TORCH_CHECK_EQ(inp.numel(), residual.numel());
+  TORCH_CHECK_EQ(inp.numel(), out.numel());
+  TORCH_CHECK_EQ(inp.numel(), residual_out.numel());
+  TORCH_CHECK_EQ(weight.dim(), 1);
+  TORCH_CHECK_EQ(weight.numel(), inp.size(-1));
+  TORCH_CHECK_GE(epsilon, 0.0);
+  TORCH_CHECK(_is_weak_contiguous(inp));
+  TORCH_CHECK(_is_weak_contiguous(residual));
+  TORCH_CHECK(weight.is_contiguous());
+  TORCH_CHECK(_is_weak_contiguous(out));
+  TORCH_CHECK(_is_weak_contiguous(residual_out));
+  TORCH_CHECK_NE(out.data_ptr(), residual_out.data_ptr());
+
+  auto input_size = inp.numel() * inp.element_size();
+  void* reg_buffer;
+  if (fa->dbuf_enabled_) {
+    reg_buffer = inp.data_ptr();
+  } else if (_reg_buffer) {
+    reg_buffer = reinterpret_cast<void*>(_reg_buffer);
+    TORCH_CHECK_LE(input_size, reg_buffer_sz_bytes);
+    AT_CUDA_CHECK(cudaMemcpyAsync(reg_buffer, inp.data_ptr(), input_size, cudaMemcpyDeviceToDevice, stream));
+  } else {
+    reg_buffer = inp.data_ptr();
+  }
+
+#define CALL_FUSED(T)                                                                                              \
+  fa->allreduce_fused_add_rms_norm<T>(                                                                             \
+      stream,                                                                                                      \
+      reinterpret_cast<T*>(reg_buffer),                                                                           \
+      reinterpret_cast<const T*>(residual.data_ptr()),                                                             \
+      reinterpret_cast<const T*>(weight.data_ptr()),                                                               \
+      reinterpret_cast<T*>(out.data_ptr()),                                                                        \
+      reinterpret_cast<T*>(residual_out.data_ptr()),                                                               \
+      inp.numel(),                                                                                                  \
+      inp.size(-1),                                                                                                 \
+      static_cast<float>(epsilon));
+  switch (inp.scalar_type()) {
+    case at::ScalarType::Float:
+      CALL_FUSED(float);
+      break;
+    case at::ScalarType::Half:
+      CALL_FUSED(half);
+      break;
+#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
+    case at::ScalarType::BFloat16:
+      CALL_FUSED(nv_bfloat16);
+      break;
+#endif
+    default:
+      throw std::runtime_error("only supports float32, float16 and bfloat16");
+  }
+#undef CALL_FUSED
+}
+
+static void dispose(fptr_t _fa) {
+  delete reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+}
+
+static int64_t meta_size() {
+  return sizeof(pcie_allreduce::Signal);
+}
+
+static void register_buffer(fptr_t _fa, const std::vector<fptr_t>& fake_ipc_ptrs) {
+  auto fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  TORCH_CHECK(fake_ipc_ptrs.size() == (size_t)fa->world_size_);
+  void* ipc_ptrs[pcie_allreduce::kMaxRanks];
+  for (size_t i = 0; i < fake_ipc_ptrs.size(); i++) ipc_ptrs[i] = reinterpret_cast<void*>(fake_ipc_ptrs[i]);
+  fa->register_buffer(ipc_ptrs);
+}
+
+static void register_pcie_buffers(fptr_t _fa, const std::vector<fptr_t>& ptrs0, const std::vector<fptr_t>& ptrs1) {
+  auto fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  TORCH_CHECK(ptrs0.size() == (size_t)fa->world_size_);
+  TORCH_CHECK(ptrs1.size() == (size_t)fa->world_size_);
+  void* p0[pcie_allreduce::kMaxRanks];
+  void* p1[pcie_allreduce::kMaxRanks];
+  for (size_t i = 0; i < ptrs0.size(); i++) {
+    p0[i] = reinterpret_cast<void*>(ptrs0[i]);
+    p1[i] = reinterpret_cast<void*>(ptrs1[i]);
+  }
+  fa->register_pcie_buffers(p0, p1);
+}
+
+static std::tuple<std::vector<int64_t>, std::vector<int64_t>> get_graph_buffer_ipc_meta(fptr_t _fa) {
+  auto fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  auto [handle, offsets] = fa->get_graph_buffer_ipc_meta();
+  std::vector<int64_t> bytes(handle.begin(), handle.end());
+  return std::make_tuple(bytes, offsets);
+}
+
+static void register_graph_buffers(
+    fptr_t _fa, const std::vector<std::vector<int64_t>>& handles, const std::vector<std::vector<int64_t>>& offsets) {
+  auto fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  std::vector<std::string> bytes;
+  bytes.reserve(handles.size());
+  for (size_t i = 0; i < handles.size(); i++) bytes.emplace_back(handles[i].begin(), handles[i].end());
+  fa->register_graph_buffers(bytes, offsets);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("init_custom_ar", &init_custom_ar, "init PCIe allreduce");
+  m.def("all_reduce", &all_reduce, "PCIe allreduce");
+  m.def(
+      "all_reduce_fused_add_rms_norm",
+      &all_reduce_fused_add_rms_norm,
+      "PCIe allreduce fused with residual add and RMSNorm");
+  m.def("dispose", &dispose, "dispose PCIe allreduce");
+  m.def("meta_size", &meta_size, "signal metadata size");
+  m.def("register_buffer", &register_buffer, "register IPC buffer");
+  m.def("register_pcie_buffers", &register_pcie_buffers, "register double-buffered IPC buffers");
+  m.def("get_graph_buffer_ipc_meta", &get_graph_buffer_ipc_meta, "get graph buffer IPC meta");
+  m.def("register_graph_buffers", &register_graph_buffers, "register graph buffers");
+}

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_oneshot.py
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_oneshot.py
@@ -1,0 +1,1186 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/distributed/pcie_oneshot.py @ 00695ee8 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""PCIe oneshot allreduce runtime with optional crossover autotuning."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from torch.utils.cpp_extension import load
+
+from ._cuda_ipc import CudaRTLibrary
+
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_WORLD_SIZES = (2, 4, 6, 8, 10)
+SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+DEFAULT_MAX_SIZE = 8 * 1024 * 1024
+DEFAULT_RANK_DATA_BYTES = 8 * 1024 * 1024
+AUTOTUNE_CEILING = 1 * 1024 * 1024
+AUTOTUNE_FINE_STEP = 8 * 1024
+IPC_SLAB_ALIGNMENT = 256
+
+
+def parse_pcie_oneshot_max_size(value: str | int | None) -> Optional[int]:
+    """Parse a byte-size string, or return ``None`` for ``auto``."""
+
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if value.lower() == "auto":
+        return None
+    normalized = value.upper().strip()
+    suffixes = {
+        "KB": 1024,
+        "K": 1024,
+        "MB": 1024 * 1024,
+        "M": 1024 * 1024,
+    }
+    for suffix, multiplier in sorted(suffixes.items(), key=lambda item: -len(item[0])):
+        if normalized.endswith(suffix):
+            return int(normalized[: -len(suffix)]) * multiplier
+    return int(value)
+
+
+def _normalize_device(device: torch.device | int | str) -> torch.device:
+    if isinstance(device, torch.device):
+        return device
+    if isinstance(device, int):
+        return torch.device(f"cuda:{device}")
+    return torch.device(device)
+
+
+def _current_stream_key(
+    device: torch.device | int | str, stream: object = None
+) -> Optional[int]:
+    device_obj = _normalize_device(device)
+    if device_obj.type != "cuda":
+        return None
+    if stream is None:
+        stream = torch.cuda.current_stream(device_obj)
+    if hasattr(stream, "cuda_stream"):
+        return int(stream.cuda_stream)
+    return int(stream)
+
+
+def _push_mode_enabled() -> bool:
+    """Match the extension's FLASHINFER_EXP_SM12X_PCIE_ONESHOT_PUSH transport toggle.
+
+    Push transport writes each rank's input into a per-source shard of every
+    peer's eager slot, so each slot must hold world_size * max_size bytes.
+    """
+
+    return os.getenv("FLASHINFER_EXP_SM12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0")
+
+
+def _is_weak_contiguous(inp: torch.Tensor) -> bool:
+    if inp.is_contiguous():
+        return True
+    storage = inp.untyped_storage()
+    return (
+        storage.nbytes() - inp.storage_offset() * inp.element_size()
+        == inp.numel() * inp.element_size()
+    )
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((int(value) + int(alignment) - 1) // int(alignment)) * int(alignment)
+
+
+def _resolve_exchange_group(
+    exchange_group: Optional[ProcessGroup],
+    process_group: Optional[ProcessGroup],
+) -> Optional[ProcessGroup]:
+    if (
+        exchange_group is not None
+        and process_group is not None
+        and exchange_group is not process_group
+    ):
+        raise ValueError("pass only one of exchange_group or process_group")
+    return exchange_group if exchange_group is not None else process_group
+
+
+def _group_ranks(group: ProcessGroup) -> list[int]:
+    world_size = dist.get_world_size(group=group)
+    if hasattr(dist, "get_process_group_ranks"):
+        ranks = sorted(dist.get_process_group_ranks(group=group))
+        if len(ranks) != world_size:
+            raise RuntimeError("process-group rank list does not match world size")
+        return ranks
+    return list(range(world_size))
+
+
+def _object_broadcast_device(group: ProcessGroup) -> torch.device | str:
+    try:
+        try:
+            backend = dist.get_backend(group=group)
+        except TypeError:
+            backend = dist.get_backend(group)
+    except Exception as exc:
+        raise RuntimeError(
+            "PCIe oneshot IPC exchange requires a CUDA/NCCL process group"
+        ) from exc
+    backend_name = str(backend).lower()
+    if "nccl" not in backend_name:
+        raise RuntimeError(
+            f"PCIe oneshot IPC exchange requires an NCCL process group, got {backend}"
+        )
+    if not torch.cuda.is_available():
+        raise RuntimeError("PCIe oneshot IPC exchange requires CUDA")
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _broadcast_gather_object(local_object: object, group: ProcessGroup) -> list[object]:
+    # `broadcast_object_list` is more robust than `all_gather_object` for
+    # the host-side exchange that happens around IPC setup and graph capture.
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+    all_objects: list[list[object | None]] = [[None] for _ in range(world_size)]
+    all_objects[rank][0] = local_object
+    device = _object_broadcast_device(group)
+    for index, src_rank in enumerate(_group_ranks(group)):
+        dist.broadcast_object_list(
+            all_objects[index], src=src_rank, group=group, device=device
+        )
+    return [entry[0] for entry in all_objects]
+
+
+@dataclass(frozen=True)
+class _OwnedSharedBuffer:
+    local_ptr: int
+    peer_ptrs: tuple[int, ...]
+    remote_ptrs: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _ChannelSharedBuffers:
+    owned_buffer: _OwnedSharedBuffer
+    signal_ptrs: tuple[int, ...]
+    eager0_ptrs: tuple[int, ...]
+    eager1_ptrs: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _BenchmarkResult:
+    size_bytes: int
+    custom_us: float
+    nccl_us: float
+    winner: str
+
+
+@lru_cache(maxsize=1)
+def _load_extension():
+    source = Path(__file__).with_name("pcie_oneshot.cu")
+    verbose = os.getenv("FLASHINFER_EXP_SM12X_PCIE_ONESHOT_VERBOSE_BUILD", "0") == "1"
+    return load(
+        name="sm12x_pcie_oneshot_ext",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O2", "--expt-relaxed-constexpr"],
+        extra_ldflags=["-lcuda"],
+        verbose=verbose,
+    )
+
+
+def _compute_crossover_size(
+    benchmark: Callable[[int], tuple[float, float]],
+    *,
+    ceiling_bytes: int = AUTOTUNE_CEILING,
+    fine_step_bytes: int = AUTOTUNE_FINE_STEP,
+) -> tuple[int, list[_BenchmarkResult]]:
+    coarse_sizes = []
+    current = 1024
+    while current <= ceiling_bytes:
+        coarse_sizes.append(current)
+        current *= 2
+
+    results: list[_BenchmarkResult] = []
+    seen_sizes: set[int] = set()
+    first_nccl_win: Optional[int] = None
+    last_custom_win = 0
+
+    def record(size_bytes: int) -> None:
+        nonlocal first_nccl_win, last_custom_win
+        custom_us, nccl_us = benchmark(size_bytes)
+        winner = "custom" if custom_us < nccl_us else "NCCL"
+        results.append(_BenchmarkResult(size_bytes, custom_us, nccl_us, winner))
+        seen_sizes.add(size_bytes)
+        if winner == "custom":
+            last_custom_win = max(last_custom_win, size_bytes)
+        elif first_nccl_win is None:
+            first_nccl_win = size_bytes
+
+    for size_bytes in coarse_sizes:
+        record(size_bytes)
+
+    if last_custom_win > 0 and first_nccl_win is not None:
+        fine_start = last_custom_win
+        fine_end = min(first_nccl_win, last_custom_win * 4)
+        fine_size = fine_start + fine_step_bytes
+        while fine_size < fine_end:
+            aligned = (fine_size // 16) * 16
+            if aligned not in seen_sizes:
+                record(aligned)
+            fine_size += fine_step_bytes
+
+    results.sort(key=lambda item: item.size_bytes)
+    crossover = 1024
+    for result in results:
+        if result.winner == "custom":
+            crossover = result.size_bytes
+    return crossover, results
+
+
+class PCIeOneshotAllReduce:
+    """Standalone unfused PCIe oneshot allreduce runtime."""
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device | int | str,
+        signal_ptrs: Sequence[int],
+        eager_buffer_ptrs0: Optional[Sequence[int]] = None,
+        eager_buffer_ptrs1: Optional[Sequence[int]] = None,
+        exchange_group: Optional[ProcessGroup] = None,
+        process_group: Optional[ProcessGroup] = None,
+        ipc: Optional[CudaRTLibrary] = None,
+        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]] = None,
+        max_size: int = DEFAULT_MAX_SIZE,
+        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+        ext_module=None,
+        stream_affine: bool = True,
+    ):
+        if world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(f"unsupported world size {world_size}")
+        if rank < 0 or rank >= world_size:
+            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+        if len(signal_ptrs) != world_size:
+            raise ValueError("signal_ptrs must match world size")
+        if (eager_buffer_ptrs0 is None) != (eager_buffer_ptrs1 is None):
+            raise ValueError("eager buffers must be provided as a pair")
+        if eager_buffer_ptrs0 is not None and len(eager_buffer_ptrs0) != world_size:
+            raise ValueError("eager_buffer_ptrs0 must match world size")
+        if eager_buffer_ptrs1 is not None and len(eager_buffer_ptrs1) != world_size:
+            raise ValueError("eager_buffer_ptrs1 must match world size")
+
+        self.rank = int(rank)
+        self.world_size = int(world_size)
+        self.device = _normalize_device(device)
+        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
+        # Compatibility alias for older callers that still refer to this as
+        # `process_group`.
+        self.process_group = self.exchange_group
+        self.max_size = int(max_size)
+        self._ipc = ipc
+        if self._ipc is None and (ext_module is None or owned_buffers):
+            self._ipc = CudaRTLibrary()
+        self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
+        self._owned_buffers = list(owned_buffers or [])
+        self._registered_input_ptrs: dict[int, tuple[int, ...]] = {}
+        self._stream_affine = bool(stream_affine)
+        self._owner_stream_key: Optional[int] = None
+        self._closed = False
+        self._ext = ext_module or _load_extension()
+
+        if ext_module is None and self.device.type != "cuda":
+            raise ValueError("PCIe oneshot allreduce requires a CUDA device")
+
+        self.rank_data = torch.empty(
+            rank_data_bytes, dtype=torch.uint8, device=self.device
+        )
+        self._ptr = self._ext.init_custom_ar(
+            list(self._signal_ptrs), self.rank_data, self.rank
+        )
+
+        self._eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
+        if eager_buffer_ptrs0 is not None and eager_buffer_ptrs1 is not None:
+            self._eager_ptrs = (
+                tuple(int(ptr) for ptr in eager_buffer_ptrs0),
+                tuple(int(ptr) for ptr in eager_buffer_ptrs1),
+            )
+            self._ext.register_pcie_buffers(
+                self._ptr,
+                list(self._eager_ptrs[0]),
+                list(self._eager_ptrs[1]),
+            )
+
+    @classmethod
+    def from_ipc(
+        cls,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device | int | str,
+        signal_ptrs: Sequence[int],
+        eager_buffer_ptrs0: Optional[Sequence[int]] = None,
+        eager_buffer_ptrs1: Optional[Sequence[int]] = None,
+        exchange_group: Optional[ProcessGroup] = None,
+        process_group: Optional[ProcessGroup] = None,
+        max_size: int = DEFAULT_MAX_SIZE,
+        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+        ext_module=None,
+        stream_affine: bool = True,
+    ) -> "PCIeOneshotAllReduce":
+        return cls(
+            rank=rank,
+            world_size=world_size,
+            device=device,
+            signal_ptrs=signal_ptrs,
+            eager_buffer_ptrs0=eager_buffer_ptrs0,
+            eager_buffer_ptrs1=eager_buffer_ptrs1,
+            exchange_group=exchange_group,
+            process_group=process_group,
+            max_size=max_size,
+            rank_data_bytes=rank_data_bytes,
+            ext_module=ext_module,
+            stream_affine=stream_affine,
+        )
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        eager_buffer_bytes: int = DEFAULT_MAX_SIZE,
+        max_size: int = DEFAULT_MAX_SIZE,
+        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+        ext_module=None,
+        stream_affine: bool = True,
+    ) -> "PCIeOneshotAllReduce":
+        rank = dist.get_rank(group=exchange_group)
+        world_size = dist.get_world_size(group=exchange_group)
+        if world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(f"unsupported world size {world_size}")
+
+        device_obj = _normalize_device(device)
+        if device_obj.type != "cuda":
+            raise ValueError("PCIe oneshot requires a CUDA device")
+
+        ipc = CudaRTLibrary()
+        ipc.cudaSetDevice(device_obj.index or 0)
+        ext = ext_module or _load_extension()
+
+        owned_buffers: list[_OwnedSharedBuffer] = []
+        try:
+            channel_buffers = cls._allocate_eager_channel_buffers(
+                exchange_group,
+                signal_bytes=ext.meta_size(),
+                eager_buffer_bytes=eager_buffer_bytes,
+                ipc=ipc,
+            )
+            owned_buffers.append(channel_buffers.owned_buffer)
+
+            return cls(
+                rank=rank,
+                world_size=world_size,
+                device=device_obj,
+                signal_ptrs=channel_buffers.signal_ptrs,
+                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+                exchange_group=exchange_group,
+                ipc=ipc,
+                owned_buffers=owned_buffers,
+                max_size=max_size,
+                rank_data_bytes=rank_data_bytes,
+                ext_module=ext,
+                stream_affine=stream_affine,
+            )
+        except Exception:
+            for shared in owned_buffers:
+                for ptr in shared.remote_ptrs:
+                    with suppress(Exception):
+                        ipc.cudaIpcCloseMemHandle(ptr)
+                with suppress(Exception):
+                    ipc.cudaFree(shared.local_ptr)
+            raise
+
+    @classmethod
+    def from_process_group(
+        cls,
+        *,
+        process_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_input_bytes: int = DEFAULT_MAX_SIZE,
+        eager_buffer_bytes: Optional[int] = None,
+        max_size: int = DEFAULT_MAX_SIZE,
+        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+        ext_module=None,
+        stream_affine: bool = True,
+    ) -> "PCIeOneshotAllReduce":
+        return cls.from_exchange_group(
+            exchange_group=process_group,
+            device=device,
+            eager_buffer_bytes=max_input_bytes
+            if eager_buffer_bytes is None
+            else eager_buffer_bytes,
+            max_size=max_size,
+            rank_data_bytes=rank_data_bytes,
+            ext_module=ext_module,
+            stream_affine=stream_affine,
+        )
+
+    @staticmethod
+    def _allocate_shared_buffer(
+        exchange_group: ProcessGroup,
+        size_in_bytes: int,
+        *,
+        zero_fill: bool,
+        ipc: CudaRTLibrary,
+    ) -> _OwnedSharedBuffer:
+        local_ptr = ipc.cudaMalloc(size_in_bytes)
+        peer_ptrs: list[int] = []
+        remote_ptrs: list[int] = []
+        try:
+            if zero_fill:
+                ipc.cudaMemset(local_ptr, 0, size_in_bytes)
+            local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
+            world_size = dist.get_world_size(group=exchange_group)
+            rank = dist.get_rank(group=exchange_group)
+            handles = _broadcast_gather_object(local_handle, exchange_group)
+            for idx, handle in enumerate(handles):
+                if idx == rank:
+                    peer_ptrs.append(local_ptr)
+                else:
+                    try:
+                        remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+                    except Exception as exc:
+                        raise RuntimeError(
+                            f"failed to open CUDA IPC handle for peer rank {idx}"
+                        ) from exc
+                    peer_ptrs.append(remote_ptr)
+                    remote_ptrs.append(remote_ptr)
+            if len(peer_ptrs) != world_size:
+                raise RuntimeError("failed to gather IPC handles for all ranks")
+            return _OwnedSharedBuffer(
+                local_ptr=local_ptr,
+                peer_ptrs=tuple(peer_ptrs),
+                remote_ptrs=tuple(remote_ptrs),
+            )
+        except Exception:
+            for ptr in remote_ptrs:
+                with suppress(Exception):
+                    ipc.cudaIpcCloseMemHandle(ptr)
+            with suppress(Exception):
+                ipc.cudaFree(local_ptr)
+            raise
+
+    @classmethod
+    def _allocate_eager_channel_buffers(
+        cls,
+        exchange_group: ProcessGroup,
+        *,
+        signal_bytes: int,
+        eager_buffer_bytes: int,
+        ipc: CudaRTLibrary,
+    ) -> _ChannelSharedBuffers:
+        signal_bytes = int(signal_bytes)
+        eager_buffer_bytes = int(eager_buffer_bytes)
+        if signal_bytes <= 0:
+            raise ValueError("signal_bytes must be positive")
+        if eager_buffer_bytes <= 0:
+            raise ValueError("eager_buffer_bytes must be positive")
+        if _push_mode_enabled():
+            eager_buffer_bytes *= dist.get_world_size(group=exchange_group)
+
+        signal_offset = 0
+        eager0_offset = _align_up(signal_bytes, IPC_SLAB_ALIGNMENT)
+        eager1_offset = eager0_offset + _align_up(
+            eager_buffer_bytes, IPC_SLAB_ALIGNMENT
+        )
+        slab_bytes = eager1_offset + eager_buffer_bytes
+        slab = cls._allocate_shared_buffer(
+            exchange_group,
+            slab_bytes,
+            # Clear signals before publishing the IPC handle so a peer cannot
+            # post an arrival that a later local memset would erase.
+            zero_fill=True,
+            ipc=ipc,
+        )
+        return _ChannelSharedBuffers(
+            owned_buffer=slab,
+            signal_ptrs=tuple(ptr + signal_offset for ptr in slab.peer_ptrs),
+            eager0_ptrs=tuple(ptr + eager0_offset for ptr in slab.peer_ptrs),
+            eager1_ptrs=tuple(ptr + eager1_offset for ptr in slab.peer_ptrs),
+        )
+
+    @property
+    def signal_ptrs(self) -> tuple[int, ...]:
+        return self._signal_ptrs
+
+    def _bind_stream_key(self, stream_key: Optional[int]) -> None:
+        if not self._stream_affine:
+            return
+        if stream_key is None:
+            return
+        if self._owner_stream_key is None:
+            self._owner_stream_key = int(stream_key)
+            return
+        if self._owner_stream_key != int(stream_key):
+            raise RuntimeError(
+                "PCIe oneshot allreduce channels are stream-affine; "
+                "create or use a separate channel for each CUDA stream"
+            )
+
+    def _check_stream(self, stream: object = None) -> None:
+        if stream is None and _is_current_stream_capturing(self.device):
+            # During CUDA graph capture the current stream is a torch-owned,
+            # ephemeral capture stream (true for piecewise/inductor graphs used
+            # by MTP and spec-decode). Stream affinity does not apply: the
+            # captured kernel replays on the caller's stream, not this one, so
+            # skip the affinity guard instead of rejecting the capture stream.
+            return
+        self._bind_stream_key(_current_stream_key(self.device, stream))
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        if self._closed:
+            return False
+        if inp.device != self.device:
+            return False
+        if inp.dtype not in SUPPORTED_DTYPES:
+            return False
+        inp_bytes = inp.numel() * inp.element_size()
+        if inp_bytes > self.max_size:
+            return False
+        if inp_bytes % 16 != 0:
+            return False
+        return _is_weak_contiguous(inp)
+
+    def register_buffer(self, peer_input_ptrs: Sequence[int]) -> None:
+        if self._closed:
+            raise RuntimeError("runtime is closed")
+        if len(peer_input_ptrs) != self.world_size:
+            raise ValueError("peer_input_ptrs must match world size")
+        ptrs = tuple(int(ptr) for ptr in peer_input_ptrs)
+        local_ptr = ptrs[self.rank]
+        existing = self._registered_input_ptrs.get(local_ptr)
+        if existing is not None:
+            if existing != ptrs:
+                raise ValueError(
+                    "input pointer is already registered with different peer_input_ptrs"
+                )
+            return
+        self._ext.register_buffer(self._ptr, list(ptrs))
+        self._registered_input_ptrs[local_ptr] = ptrs
+
+    def _prepare_input(
+        self,
+        inp: torch.Tensor,
+        peer_input_ptrs: Optional[Sequence[int]],
+    ) -> None:
+        local_ptr = int(inp.data_ptr())
+        if peer_input_ptrs is not None:
+            if len(peer_input_ptrs) != self.world_size:
+                raise ValueError("peer_input_ptrs must match world size")
+            ptrs = tuple(int(ptr) for ptr in peer_input_ptrs)
+            if ptrs[self.rank] != local_ptr:
+                raise ValueError("peer_input_ptrs[self.rank] must match inp.data_ptr()")
+            self.register_buffer(ptrs)
+        elif self._eager_ptrs is None and local_ptr not in self._registered_input_ptrs:
+            raise ValueError(
+                "peer_input_ptrs are required unless eager IPC buffers are configured "
+                "or this input was already registered"
+            )
+
+    def get_graph_buffer_ipc_meta(self) -> tuple[list[int], list[int]]:
+        if self._closed:
+            raise RuntimeError("runtime is closed")
+        handle, offsets = self._ext.get_graph_buffer_ipc_meta(self._ptr)
+        return list(handle), list(offsets)
+
+    def register_graph_buffers_from_ranks(
+        self,
+        handles: Sequence[Sequence[int]],
+        offsets: Sequence[Sequence[int]],
+    ) -> None:
+        if self._closed:
+            raise RuntimeError("runtime is closed")
+        if len(handles) != self.world_size:
+            raise ValueError("handles must match world size")
+        if len(offsets) != self.world_size:
+            raise ValueError("offsets must match world size")
+        self._ext.register_graph_buffers(
+            self._ptr,
+            [list(map(int, handle)) for handle in handles],
+            [list(map(int, rank_offsets)) for rank_offsets in offsets],
+        )
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        out: Optional[torch.Tensor] = None,
+        peer_input_ptrs: Optional[Sequence[int]] = None,
+    ) -> torch.Tensor:
+        if self._closed:
+            raise RuntimeError("runtime is closed")
+        if inp.device != self.device:
+            raise ValueError(
+                f"input device {inp.device} does not match runtime device {self.device}"
+            )
+        self._check_stream()
+        if not self.should_allreduce(inp):
+            raise ValueError(
+                "input does not satisfy device/dtype/size/alignment/contiguity requirements "
+                f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
+            )
+
+        if out is None:
+            out = torch.empty_like(inp)
+        if out.device != inp.device:
+            raise ValueError("output tensor must be on the same device as the input")
+        if out.shape != inp.shape or out.dtype != inp.dtype:
+            raise ValueError("output tensor must match input shape and dtype")
+        if not _is_weak_contiguous(out):
+            raise ValueError("output tensor must be weak-contiguous")
+
+        self._prepare_input(inp, peer_input_ptrs)
+
+        self._ext.all_reduce(self._ptr, inp, out, 0, 0)
+        return out
+
+    def all_reduce_fused_add_rms_norm(
+        self,
+        inp: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+        *,
+        out: Optional[torch.Tensor] = None,
+        residual_out: Optional[torch.Tensor] = None,
+        peer_input_ptrs: Optional[Sequence[int]] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """All-reduce ``inp``, add ``residual``, and apply RMSNorm."""
+
+        if self._closed:
+            raise RuntimeError("runtime is closed")
+        if inp.device != self.device:
+            raise ValueError(
+                f"input device {inp.device} does not match runtime device {self.device}"
+            )
+        self._check_stream()
+        if not self.should_allreduce(inp):
+            raise ValueError(
+                "input does not satisfy device/dtype/size/alignment/contiguity "
+                f"requirements (shape={tuple(inp.shape)}, dtype={inp.dtype})"
+            )
+        if inp.ndim == 0:
+            raise ValueError("input must have at least one dimension")
+        hidden_size = inp.shape[-1]
+        if hidden_size * inp.element_size() % 16 != 0:
+            raise ValueError(
+                "the last input dimension must occupy a multiple of 16 bytes"
+            )
+        if residual.device != inp.device:
+            raise ValueError("residual tensor must be on the same device as the input")
+        if residual.shape != inp.shape or residual.dtype != inp.dtype:
+            raise ValueError("residual tensor must match input shape and dtype")
+        if not _is_weak_contiguous(residual):
+            raise ValueError("residual tensor must be weak-contiguous")
+        if weight.device != inp.device:
+            raise ValueError("weight tensor must be on the same device as the input")
+        if weight.shape != (hidden_size,) or weight.dtype != inp.dtype:
+            raise ValueError(
+                "weight tensor must match the input dtype and last dimension"
+            )
+        if not weight.is_contiguous():
+            raise ValueError("weight tensor must be contiguous")
+        if epsilon < 0:
+            raise ValueError("epsilon must be non-negative")
+
+        if out is None:
+            out = torch.empty_like(inp)
+        if residual_out is None:
+            residual_out = torch.empty_like(residual)
+        for name, tensor in (("output", out), ("residual output", residual_out)):
+            if tensor.device != inp.device:
+                raise ValueError(
+                    f"{name} tensor must be on the same device as the input"
+                )
+            if tensor.shape != inp.shape or tensor.dtype != inp.dtype:
+                raise ValueError(f"{name} tensor must match input shape and dtype")
+            if not _is_weak_contiguous(tensor):
+                raise ValueError(f"{name} tensor must be weak-contiguous")
+        if out.data_ptr() == residual_out.data_ptr():
+            raise ValueError("output and residual output must not alias")
+
+        self._prepare_input(inp, peer_input_ptrs)
+        self._ext.all_reduce_fused_add_rms_norm(
+            self._ptr,
+            inp,
+            residual,
+            weight,
+            out,
+            residual_out,
+            float(epsilon),
+            0,
+            0,
+        )
+        return out, residual_out
+
+    @contextmanager
+    def capture(self, stream: object = None):
+        if self.exchange_group is None and self._eager_ptrs is None:
+            raise ValueError(
+                "exchange_group is required for CUDA graph capture registration"
+            )
+        self._check_stream(stream)
+        try:
+            yield
+        finally:
+            if self.exchange_group is not None and self._eager_ptrs is None:
+                self.register_graph_buffers()
+
+    def register_graph_buffers(self) -> None:
+        if self.exchange_group is None:
+            raise ValueError("exchange_group is required to register graph buffers")
+        local_meta = self.get_graph_buffer_ipc_meta()
+        all_meta = _broadcast_gather_object(local_meta, self.exchange_group)
+        num_buffers = [len(entry[1]) for entry in all_meta]
+        if any(count != num_buffers[0] for count in num_buffers):
+            raise RuntimeError(
+                "graph capture registered a different number of buffers across ranks"
+            )
+        if num_buffers[0] == 0:
+            return
+        self.register_graph_buffers_from_ranks(
+            [entry[0] for entry in all_meta],
+            [entry[1] for entry in all_meta],
+        )
+
+    def _bench_graph_latency(
+        self,
+        size_bytes: int,
+        nccl_group: ProcessGroup,
+        stream: torch.cuda.Stream,
+        warmup: int,
+        iters: int,
+    ) -> tuple[float, float]:
+        if self.exchange_group is None:
+            raise ValueError("exchange_group is required for graph-based autotuning")
+        self._check_stream(stream)
+
+        numel = size_bytes // torch.tensor([], dtype=torch.bfloat16).element_size()
+        device = self.device
+
+        def run_custom() -> float:
+            with torch.cuda.stream(stream):
+                graph_inp = torch.ones(numel, dtype=torch.bfloat16, device=device)
+                graph_out = torch.zeros_like(graph_inp)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=stream):
+                self._ext.all_reduce(self._ptr, graph_inp, graph_out, 0, 0)
+            self.register_graph_buffers()
+            dist.barrier(group=nccl_group)
+            with torch.cuda.stream(stream):
+                for _ in range(warmup):
+                    graph.replay()
+            stream.synchronize()
+            start = time.perf_counter()
+            with torch.cuda.stream(stream):
+                for _ in range(iters):
+                    graph.replay()
+            stream.synchronize()
+            return (time.perf_counter() - start) / iters * 1e6
+
+        def run_nccl() -> float:
+            with torch.cuda.stream(stream):
+                graph_inp = torch.ones(numel, dtype=torch.bfloat16, device=device)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=stream):
+                dist.all_reduce(graph_inp, group=nccl_group)
+            with torch.cuda.stream(stream):
+                for _ in range(warmup):
+                    graph.replay()
+            stream.synchronize()
+            start = time.perf_counter()
+            with torch.cuda.stream(stream):
+                for _ in range(iters):
+                    graph.replay()
+            stream.synchronize()
+            return (time.perf_counter() - start) / iters * 1e6
+
+        custom_runs = sorted(run_custom() for _ in range(3))
+        nccl_runs = sorted(run_nccl() for _ in range(3))
+        # Reduce timings across ranks so every rank reaches the same
+        # crossover verdicts; divergent local verdicts would desynchronize
+        # the sweep's collective sequence and deadlock.
+        stats = torch.tensor(
+            [custom_runs[1], nccl_runs[1]], dtype=torch.float64, device=device
+        )
+        dist.all_reduce(stats, op=dist.ReduceOp.MAX, group=nccl_group)
+        return float(stats[0].item()), float(stats[1].item())
+
+    def find_crossover_size(
+        self,
+        nccl_group: ProcessGroup,
+        *,
+        ceiling_bytes: int = AUTOTUNE_CEILING,
+        fine_step_bytes: int = AUTOTUNE_FINE_STEP,
+        warmup: int = 100,
+        iters: int = 1000,
+    ) -> int:
+        if self.device.type != "cuda":
+            raise ValueError("autotune requires a CUDA device")
+        bench_stream = torch.cuda.Stream(device=self.device)
+        crossover, results = _compute_crossover_size(
+            lambda size_bytes: self._bench_graph_latency(
+                size_bytes,
+                nccl_group,
+                bench_stream,
+                warmup,
+                iters,
+            ),
+            ceiling_bytes=ceiling_bytes,
+            fine_step_bytes=fine_step_bytes,
+        )
+        self.max_size = crossover
+
+        if self.rank == 0:
+
+            def fmt_size(size_bytes: int) -> str:
+                if size_bytes >= 1024 * 1024:
+                    return f"{size_bytes // (1024 * 1024)}MB"
+                if size_bytes >= 1024:
+                    return f"{size_bytes // 1024}KB"
+                return f"{size_bytes}B"
+
+            lines = [
+                f"[PCIe oneshot allreduce] Crossover benchmark ({self.world_size} GPUs, bf16):"
+            ]
+            for result in results:
+                lines.append(
+                    f"  {fmt_size(result.size_bytes):>6s}:  custom {result.custom_us:6.1f} us  "
+                    f"vs  NCCL {result.nccl_us:6.1f} us  -> {result.winner} wins"
+                )
+            lines.append(
+                f"  Setting max_size = {fmt_size(crossover)} (last size where custom AR wins)"
+            )
+            logger.info("\n".join(lines))
+        return crossover
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if getattr(self, "_ptr", 0):
+            self._ext.dispose(self._ptr)
+            self._ptr = 0
+        for shared in self._owned_buffers:
+            for ptr in shared.remote_ptrs:
+                if self._ipc is not None:
+                    self._ipc.cudaIpcCloseMemHandle(ptr)
+            if self._ipc is not None:
+                self._ipc.cudaFree(shared.local_ptr)
+        self._owned_buffers.clear()
+        self._registered_input_ptrs.clear()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()
+
+
+def _is_current_stream_capturing(device: torch.device) -> bool:
+    if device.type != "cuda":
+        return False
+    is_capturing = getattr(torch.cuda, "is_current_stream_capturing", None)
+    if is_capturing is None:
+        return False
+    return bool(is_capturing())
+
+
+class PCIeOneshotAllReducePool:
+    """Stream-affine PCIe oneshot wrapper.
+
+    A ``PCIeOneshotAllReduce`` instance is a single ordered channel with one
+    signal buffer and one double-buffered staging pair. The pool creates a
+    separate channel for each CUDA stream key so multi-stream callers never
+    reuse those buffers concurrently.
+    """
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device | int | str,
+        exchange_group: Optional[ProcessGroup] = None,
+        process_group: Optional[ProcessGroup] = None,
+        eager_buffer_bytes: int = DEFAULT_MAX_SIZE,
+        max_size: int = DEFAULT_MAX_SIZE,
+        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+        ext_module=None,
+        ipc: Optional[CudaRTLibrary] = None,
+        single_channel: bool = False,
+        channel_factory: Optional[
+            Callable[[Optional[int]], PCIeOneshotAllReduce]
+        ] = None,
+    ):
+        if world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(f"unsupported world size {world_size}")
+        if rank < 0 or rank >= world_size:
+            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+
+        self.rank = int(rank)
+        self.world_size = int(world_size)
+        self.device = _normalize_device(device)
+        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
+        self.process_group = self.exchange_group
+        self.eager_buffer_bytes = int(eager_buffer_bytes)
+        self.max_size = int(max_size)
+        self.rank_data_bytes = int(rank_data_bytes)
+        self.single_channel = bool(single_channel)
+        self._channel_factory = channel_factory
+        self._channels: dict[int, PCIeOneshotAllReduce] = {}
+        self._capture_channel_stack: list[PCIeOneshotAllReduce] = []
+        self._closed = False
+
+        self._ipc = ipc
+        self._ext = ext_module
+        if self._channel_factory is None:
+            if self.exchange_group is None:
+                raise ValueError(
+                    "exchange_group is required unless channel_factory is provided"
+                )
+            if self.device.type != "cuda":
+                raise ValueError("PCIe oneshot pool requires a CUDA device")
+            self._ipc = self._ipc or CudaRTLibrary()
+            self._ipc.cudaSetDevice(self.device.index or 0)
+            self._ext = self._ext or _load_extension()
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        eager_buffer_bytes: int = DEFAULT_MAX_SIZE,
+        max_size: int = DEFAULT_MAX_SIZE,
+        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+        ext_module=None,
+        single_channel: bool = False,
+    ) -> "PCIeOneshotAllReducePool":
+        return cls(
+            rank=dist.get_rank(group=exchange_group),
+            world_size=dist.get_world_size(group=exchange_group),
+            device=device,
+            exchange_group=exchange_group,
+            eager_buffer_bytes=eager_buffer_bytes,
+            max_size=max_size,
+            rank_data_bytes=rank_data_bytes,
+            ext_module=ext_module,
+            single_channel=single_channel,
+        )
+
+    @classmethod
+    def from_process_group(
+        cls,
+        *,
+        process_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_input_bytes: int = DEFAULT_MAX_SIZE,
+        eager_buffer_bytes: Optional[int] = None,
+        max_size: int = DEFAULT_MAX_SIZE,
+        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+        ext_module=None,
+        single_channel: bool = False,
+    ) -> "PCIeOneshotAllReducePool":
+        return cls.from_exchange_group(
+            exchange_group=process_group,
+            device=device,
+            eager_buffer_bytes=max_input_bytes
+            if eager_buffer_bytes is None
+            else eager_buffer_bytes,
+            max_size=max_size,
+            rank_data_bytes=rank_data_bytes,
+            ext_module=ext_module,
+            single_channel=single_channel,
+        )
+
+    def _new_channel(self, stream_key: Optional[int]) -> PCIeOneshotAllReduce:
+        if self._channel_factory is not None:
+            channel = self._channel_factory(stream_key)
+            if self.single_channel:
+                channel._stream_affine = False
+            channel._bind_stream_key(stream_key)
+            return channel
+
+        if self.exchange_group is None or self._ipc is None or self._ext is None:
+            raise RuntimeError("pool is not configured to allocate channels")
+
+        owned_buffers: list[_OwnedSharedBuffer] = []
+        try:
+            channel_buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+                self.exchange_group,
+                signal_bytes=self._ext.meta_size(),
+                eager_buffer_bytes=self.eager_buffer_bytes,
+                ipc=self._ipc,
+            )
+            owned_buffers.append(channel_buffers.owned_buffer)
+
+            channel = PCIeOneshotAllReduce(
+                rank=self.rank,
+                world_size=self.world_size,
+                device=self.device,
+                signal_ptrs=channel_buffers.signal_ptrs,
+                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+                exchange_group=self.exchange_group,
+                ipc=self._ipc,
+                owned_buffers=owned_buffers,
+                max_size=self.max_size,
+                rank_data_bytes=self.rank_data_bytes,
+                ext_module=self._ext,
+                stream_affine=not self.single_channel,
+            )
+        except Exception:
+            for shared in owned_buffers:
+                for ptr in shared.remote_ptrs:
+                    with suppress(Exception):
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                with suppress(Exception):
+                    self._ipc.cudaFree(shared.local_ptr)
+            raise
+        channel._bind_stream_key(stream_key)
+        return channel
+
+    def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
+        if self._closed:
+            raise RuntimeError("pool is closed")
+        if self.single_channel:
+            channel = self._channels.get(0)
+            if channel is not None:
+                return channel
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIe oneshot pool has no channel to reuse during CUDA graph "
+                    "capture; perform an eager all-reduce (or call for_stream) "
+                    "before capture starts"
+                )
+            channel = self._new_channel(None)
+            self._channels[0] = channel
+            return channel
+
+        stream_key = _current_stream_key(self.device, stream)
+        channel_key = 0 if stream_key is None else int(stream_key)
+        channel = self._channels.get(channel_key)
+        if channel is not None:
+            return channel
+        if _is_current_stream_capturing(self.device):
+            # Piecewise / inductor CUDA graphs (MTP, spec-decode) capture on a
+            # torch-owned stream that we cannot pre-register before capture
+            # starts. Reuse the channel selected by the enclosing vLLM graph
+            # capture, not an arbitrary channel from another graph manager.
+            # Target and draft graph managers can replay independently; if
+            # their nested captures share signal/staging buffers, they race.
+            if self._capture_channel_stack:
+                channel = self._capture_channel_stack[-1]
+                self._channels[channel_key] = channel
+                return channel
+            # Preserve compatibility for callers that enter CUDA capture
+            # without the pool.capture() context. They must already have a
+            # channel because allocating CUDA IPC storage mid-capture is
+            # illegal.
+            if self._channels:
+                channel = next(iter(self._channels.values()))
+                self._channels[channel_key] = channel
+                return channel
+            raise RuntimeError(
+                "PCIe oneshot pool has no channel to reuse during CUDA graph "
+                "capture; perform an eager all-reduce (or call for_stream) "
+                "before capture starts"
+            )
+        channel = self._new_channel(stream_key)
+        self._channels[channel_key] = channel
+        return channel
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        out: Optional[torch.Tensor] = None,
+        peer_input_ptrs: Optional[Sequence[int]] = None,
+        stream: object = None,
+    ) -> torch.Tensor:
+        channel = self.for_stream(stream)
+        if stream is not None and self.device.type == "cuda":
+            with torch.cuda.stream(stream):
+                return channel.all_reduce(inp, out=out, peer_input_ptrs=peer_input_ptrs)
+        return channel.all_reduce(inp, out=out, peer_input_ptrs=peer_input_ptrs)
+
+    def all_reduce_fused_add_rms_norm(
+        self,
+        inp: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+        *,
+        out: Optional[torch.Tensor] = None,
+        residual_out: Optional[torch.Tensor] = None,
+        peer_input_ptrs: Optional[Sequence[int]] = None,
+        stream: object = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        channel = self.for_stream(stream)
+
+        def run() -> tuple[torch.Tensor, torch.Tensor]:
+            return channel.all_reduce_fused_add_rms_norm(
+                inp,
+                residual,
+                weight,
+                epsilon,
+                out=out,
+                residual_out=residual_out,
+                peer_input_ptrs=peer_input_ptrs,
+            )
+
+        if stream is not None and self.device.type == "cuda":
+            with torch.cuda.stream(stream):
+                return run()
+        return run()
+
+    @contextmanager
+    def capture(self, stream: object = None):
+        channel = self.for_stream(stream)
+        with channel.capture(stream=stream):
+            self._capture_channel_stack.append(channel)
+            try:
+                yield channel
+            finally:
+                popped = self._capture_channel_stack.pop()
+                if popped is not channel:
+                    raise RuntimeError("PCIe oneshot capture channel stack corrupted")
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for channel in self._channels.values():
+            channel.close()
+        self._channels.clear()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()
+
+
+__all__ = [
+    "PCIeOneshotAllReduce",
+    "PCIeOneshotAllReducePool",
+    "SUPPORTED_WORLD_SIZES",
+    "parse_pcie_oneshot_max_size",
+]

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_twoshot.cu
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_twoshot.cu
@@ -1,0 +1,421 @@
+// Ported from b12x b12x/distributed/pcie_twoshot.cu @ 7bfc9455 (2026-07-04) -- one-time curated port.
+// PCIe two-shot sequence-parallel collectives with fp8 transport.
+//
+// Push-based: PCIe P2P writes run at full link bandwidth while P2P reads
+// are latency-bound, so each rank WRITES its quantized slices into the
+// destination rank's IPC staging region, crosses a block-pairwise
+// system-scope barrier, then consumes staged data with LOCAL reads:
+//
+//   reduce_scatter_fp8: rank j pushes its per-token-quantized partials
+//   for shard r into rank r's staging[j]; the owner then does a fused
+//   dequant + fp32 accumulate (+ its own local contribution) + bf16
+//   store. Each value is quantized exactly once at the source.
+//
+//   all_gather_fp8: rank j pushes its quantized shard into every peer's
+//   staging[j]; each rank then dequantizes staged shards to bf16.
+//
+// Writer block b covers the same pack range that reader block b consumes
+// (for every src/dst pair), so the per-block-index pairwise barrier is
+// sufficient. Two staging slots alternate per channel so no end barrier
+// is needed (same scheme as pcie_oneshot.cu); a channel must not be
+// shared concurrently across CUDA streams. Sources are read directly
+// from the caller's tensors (no input staging copy), which keeps the
+// ops CUDA-graph-capturable given stable input allocations.
+
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <torch/all.h>
+#include <torch/extension.h>
+
+#include <array>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#define CHECK_CUDA_SUCCESS(cmd)                                         \
+  do {                                                                  \
+    cudaError_t e = cmd;                                                \
+    if (e != cudaSuccess) {                                             \
+      std::stringstream _message;                                       \
+      auto s = cudaGetErrorString(e);                                   \
+      _message << std::string(s) + "\n" << __FILE__ << ':' << __LINE__; \
+      throw std::runtime_error(_message.str());                         \
+    }                                                                   \
+  } while (0)
+
+namespace pcie_twoshot {
+
+constexpr int kMaxBlocks = 64;
+constexpr int kMaxRanks = 16;
+using FlagType = uint32_t;
+
+// 128B stride per rank to avoid PCIe false sharing.
+constexpr int kFlagStride = 32;
+
+struct Signal {
+  alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+};
+
+struct __align__(16) RankPtrs {
+  void* __restrict__ ptrs[kMaxRanks];
+};
+
+struct RankSignals {
+  Signal* signals[kMaxRanks];
+};
+
+#define DINLINE __device__ __forceinline__
+
+static DINLINE void st_flag_relaxed(FlagType* flag_addr, FlagType flag) {
+  asm volatile("st.relaxed.sys.global.u32 [%1], %0;" ::"r"(flag), "l"(flag_addr));
+}
+
+static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
+  FlagType flag;
+  asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr));
+  return flag;
+}
+
+// Block-pairwise barrier: after it returns, all prior writes from every
+// rank's block blockIdx.x are visible to this block.
+template <int ngpus>
+DINLINE void block_pair_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+  __syncthreads();
+  if (threadIdx.x < ngpus) {
+    __threadfence_system();
+    auto val = self_sg->self_counter[blockIdx.x][threadIdx.x] += 1;
+    auto peer_counter_ptr = &sg.signals[threadIdx.x]->peer_counter[val % 2][blockIdx.x][rank * kFlagStride];
+    auto self_counter_ptr = &self_sg->peer_counter[val % 2][blockIdx.x][threadIdx.x * kFlagStride];
+    st_flag_relaxed(peer_counter_ptr, val);
+    while (ld_flag_relaxed(self_counter_ptr) != val)
+      ;
+  }
+  __syncthreads();
+}
+
+// 16 fp8 values as one 16B vector.
+struct __align__(16) Fp8Pack {
+  __nv_fp8_e4m3 v[16];
+};
+
+struct __align__(16) Bf16Pack8 {
+  nv_bfloat16 v[8];
+};
+
+DINLINE void dequant_accum(const Fp8Pack& p, float scale, float* acc) {
+#pragma unroll
+  for (int k = 0; k < 16; k++) acc[k] += float(p.v[k]) * scale;
+}
+
+DINLINE void store_bf16x16(nv_bfloat16* dst, const float* acc) {
+  Bf16Pack8 lo, hi;
+#pragma unroll
+  for (int k = 0; k < 8; k++) {
+    lo.v[k] = __float2bfloat16(acc[k]);
+    hi.v[k] = __float2bfloat16(acc[k + 8]);
+  }
+  reinterpret_cast<Bf16Pack8*>(dst)[0] = lo;
+  reinterpret_cast<Bf16Pack8*>(dst)[1] = hi;
+}
+
+// Staging layout per rank per slot (all offsets 256B-aligned host-side):
+//   payload: [world][pack_stride] Fp8Pack, indexed by src rank
+//   scales : [world][scale_stride] fp32 at scale_offset, indexed by src
+
+DINLINE Fp8Pack* staged_payload(void* base, int64_t pack_stride, int src) {
+  return reinterpret_cast<Fp8Pack*>(base) + int64_t(src) * pack_stride;
+}
+
+DINLINE float* staged_scale(void* base, int64_t scale_offset, int64_t scale_stride, int src) {
+  return reinterpret_cast<float*>(reinterpret_cast<char*>(base) + scale_offset) +
+         int64_t(src) * scale_stride;
+}
+
+// Grid-partitioned range [begin, end) for this block over `total` packs.
+DINLINE void block_range(int64_t total, int64_t& begin, int64_t& end) {
+  const int64_t chunk = (total + gridDim.x - 1) / gridDim.x;
+  begin = int64_t(blockIdx.x) * chunk;
+  end = min(begin + chunk, total);
+}
+
+template <int ngpus>
+__global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
+    const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
+    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
+    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
+    int rows_per_rank, int row_elems) {
+  const int packs_per_row = row_elems / 16;
+  const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
+  int64_t begin, end;
+  block_range(shard_packs, begin, end);
+
+  // Phase 1: push my quantized partials for every remote shard into the
+  // owner's staging[rank], peers visited in rank-staggered order.
+#pragma unroll 1
+  for (int i = 1; i < ngpus; i++) {
+    const int dst = (rank + i) % ngpus;
+    void* dst_base = staging.ptrs[dst];
+    Fp8Pack* dst_payload = staged_payload(dst_base, pack_stride, rank);
+    float* dst_scale = staged_scale(dst_base, scale_offset, scale_stride, rank);
+    const Fp8Pack* src = src_payload + int64_t(dst) * shard_packs;
+    const float* src_s = src_scale + int64_t(dst) * rows_per_rank;
+    for (int64_t idx = begin + threadIdx.x; idx < end; idx += blockDim.x) {
+      dst_payload[idx] = src[idx];
+    }
+    // Scales for the rows covered by this block's pack range.
+    const int64_t row_begin = begin / packs_per_row;
+    const int64_t row_end = (end + packs_per_row - 1) / packs_per_row;
+    for (int64_t row = row_begin + threadIdx.x; row < row_end; row += blockDim.x) {
+      dst_scale[row] = src_s[row];
+    }
+  }
+
+  block_pair_barrier<ngpus>(sg, self_sg, rank);
+
+  // Phase 2: fused dequant + accumulate from local staging plus my own
+  // (unstaged) contribution, then bf16 store.
+  void* self_base = staging.ptrs[rank];
+  const Fp8Pack* self_src = src_payload + int64_t(rank) * shard_packs;
+  const float* self_scale_src = src_scale + int64_t(rank) * rows_per_rank;
+  for (int64_t idx = begin + threadIdx.x; idx < end; idx += blockDim.x) {
+    const int64_t row = idx / packs_per_row;
+    float acc[16] = {};
+    dequant_accum(self_src[idx], self_scale_src[row], acc);
+#pragma unroll 1
+    for (int i = 1; i < ngpus; i++) {
+      const int src_rank = (rank + i) % ngpus;
+      const Fp8Pack* p = staged_payload(self_base, pack_stride, src_rank);
+      const float* s = staged_scale(self_base, scale_offset, scale_stride, src_rank);
+      dequant_accum(p[idx], s[row], acc);
+    }
+    store_bf16x16(&out[idx * 16], acc);
+  }
+}
+
+template <int ngpus>
+__global__ void __launch_bounds__(512, 1) ag_fp8_kernel(
+    const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
+    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
+    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
+    int rows_per_rank, int row_elems) {
+  const int packs_per_row = row_elems / 16;
+  const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
+  int64_t begin, end;
+  block_range(shard_packs, begin, end);
+  const int64_t row_begin = begin / packs_per_row;
+  const int64_t row_end = (end + packs_per_row - 1) / packs_per_row;
+
+  // Phase 1: push my shard into every peer's staging[rank].
+#pragma unroll 1
+  for (int i = 1; i < ngpus; i++) {
+    const int dst = (rank + i) % ngpus;
+    void* dst_base = staging.ptrs[dst];
+    Fp8Pack* dst_payload = staged_payload(dst_base, pack_stride, rank);
+    float* dst_scale = staged_scale(dst_base, scale_offset, scale_stride, rank);
+    for (int64_t idx = begin + threadIdx.x; idx < end; idx += blockDim.x) {
+      dst_payload[idx] = src_payload[idx];
+    }
+    for (int64_t row = row_begin + threadIdx.x; row < row_end; row += blockDim.x) {
+      dst_scale[row] = src_scale[row];
+    }
+  }
+
+  block_pair_barrier<ngpus>(sg, self_sg, rank);
+
+  // Phase 2: dequantize every shard (peers from local staging, own shard
+  // straight from the source) into the full-width bf16 output.
+  void* self_base = staging.ptrs[rank];
+#pragma unroll 1
+  for (int i = 0; i < ngpus; i++) {
+    const int src_rank = (rank + i) % ngpus;
+    const Fp8Pack* p = (src_rank == rank)
+                           ? src_payload
+                           : staged_payload(self_base, pack_stride, src_rank);
+    const float* s = (src_rank == rank)
+                         ? src_scale
+                         : staged_scale(self_base, scale_offset, scale_stride, src_rank);
+    nv_bfloat16* dst = out + int64_t(src_rank) * rows_per_rank * row_elems;
+    for (int64_t idx = begin + threadIdx.x; idx < end; idx += blockDim.x) {
+      const int64_t row = idx / packs_per_row;
+      float acc[16] = {};
+      dequant_accum(p[idx], s[row], acc);
+      store_bf16x16(&dst[idx * 16], acc);
+    }
+  }
+}
+
+class PCIeTwoShot {
+ public:
+  int rank_;
+  int world_size_;
+  RankSignals sg_;
+  Signal* self_sg_;
+
+  RankPtrs staging_[2];
+  int64_t pack_stride_;   // Fp8Packs per src region
+  int64_t scale_offset_;  // bytes
+  int64_t scale_stride_;  // floats per src region
+  int64_t max_shard_packs_;
+  int slot_ = 0;
+
+  PCIeTwoShot(Signal** signals, const std::vector<std::array<void*, 2>>& staging,
+              int64_t pack_stride, int64_t scale_offset, int64_t scale_stride, int rank,
+              int world_size)
+      : rank_(rank),
+        world_size_(world_size),
+        self_sg_(signals[rank]),
+        pack_stride_(pack_stride),
+        scale_offset_(scale_offset),
+        scale_stride_(scale_stride),
+        max_shard_packs_(pack_stride) {
+    for (int i = 0; i < world_size_; i++) {
+      sg_.signals[i] = signals[i];
+      for (int s = 0; s < 2; s++) staging_[s].ptrs[i] = staging[i][s];
+    }
+  }
+
+  template <typename Fn>
+  void dispatch(Fn&& fn) {
+    switch (world_size_) {
+      case 2:
+        fn(std::integral_constant<int, 2>{});
+        break;
+      case 4:
+        fn(std::integral_constant<int, 4>{});
+        break;
+      case 8:
+        fn(std::integral_constant<int, 8>{});
+        break;
+      default:
+        throw std::runtime_error("pcie_twoshot supports 2, 4 or 8 gpus, got " +
+                                 std::to_string(world_size_));
+    }
+  }
+
+  void check_shard(int64_t rows_per_rank, int64_t row_elems) {
+    if (row_elems % 16 != 0) throw std::runtime_error("row_elems must be a multiple of 16");
+    const int64_t shard_packs = rows_per_rank * (row_elems / 16);
+    if (shard_packs > max_shard_packs_)
+      throw std::runtime_error("pcie_twoshot staging capacity exceeded");
+    if (rows_per_rank > scale_stride_)
+      throw std::runtime_error("pcie_twoshot scale capacity exceeded");
+  }
+
+  void reduce_scatter(cudaStream_t stream, const void* payload, const void* scale, void* out,
+                      int64_t num_rows, int64_t row_elems, int threads, int block_limit) {
+    if (num_rows % world_size_ != 0)
+      throw std::runtime_error("num_rows must be divisible by world size");
+    const int64_t rows_per_rank = num_rows / world_size_;
+    check_shard(rows_per_rank, row_elems);
+    const int s = slot_ % 2;
+    slot_++;
+    const int64_t shard_packs = rows_per_rank * (row_elems / 16);
+    int blocks =
+        std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
+    dispatch([&](auto ng) {
+      constexpr int ngpus = decltype(ng)::value;
+      rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
+          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
+          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
+    });
+  }
+
+  void all_gather(cudaStream_t stream, const void* payload, const void* scale, void* out,
+                  int64_t rows_per_rank, int64_t row_elems, int threads, int block_limit) {
+    check_shard(rows_per_rank, row_elems);
+    const int s = slot_ % 2;
+    slot_++;
+    const int64_t shard_packs = rows_per_rank * (row_elems / 16);
+    int blocks =
+        std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
+    dispatch([&](auto ng) {
+      constexpr int ngpus = decltype(ng)::value;
+      ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
+          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
+          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
+    });
+  }
+};
+
+}  // namespace pcie_twoshot
+
+using fptr_t = int64_t;
+
+static fptr_t init_twoshot(const std::vector<fptr_t>& signal_ptrs,
+                           const std::vector<fptr_t>& staging0, const std::vector<fptr_t>& staging1,
+                           int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
+                           int64_t rank) {
+  const int world_size = signal_ptrs.size();
+  if (world_size != 2 && world_size != 4 && world_size != 8)
+    throw std::invalid_argument("pcie_twoshot supports 2, 4 or 8 gpus");
+  if (rank < 0 || rank >= world_size) throw std::invalid_argument("invalid rank");
+
+  pcie_twoshot::Signal* signals[pcie_twoshot::kMaxRanks];
+  std::vector<std::array<void*, 2>> staging(world_size);
+  for (int i = 0; i < world_size; i++) {
+    signals[i] = reinterpret_cast<pcie_twoshot::Signal*>(signal_ptrs[i]);
+    staging[i] = {reinterpret_cast<void*>(staging0[i]), reinterpret_cast<void*>(staging1[i])};
+  }
+  return (fptr_t) new pcie_twoshot::PCIeTwoShot(signals, staging, pack_stride, scale_offset,
+                                                scale_stride, rank, world_size);
+}
+
+static void check_fp8_inputs(torch::Tensor& payload, torch::Tensor& scale, torch::Tensor& out) {
+  TORCH_CHECK(payload.is_contiguous() && scale.is_contiguous() && out.is_contiguous());
+  TORCH_CHECK(payload.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+              payload.scalar_type() == at::ScalarType::Byte);
+  TORCH_CHECK_EQ(scale.scalar_type(), at::ScalarType::Float);
+  TORCH_CHECK_EQ(out.scalar_type(), at::ScalarType::BFloat16);
+}
+
+static void reduce_scatter_fp8(fptr_t _fa, torch::Tensor& payload, torch::Tensor& scale,
+                               torch::Tensor& out, int64_t threads, int64_t block_limit) {
+  auto fa = reinterpret_cast<pcie_twoshot::PCIeTwoShot*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(payload));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  check_fp8_inputs(payload, scale, out);
+  const int64_t num_rows = payload.size(0);
+  const int64_t row_elems = payload.size(1);
+  TORCH_CHECK_EQ(scale.numel(), num_rows);
+  TORCH_CHECK_EQ(out.numel(), (num_rows / fa->world_size_) * row_elems);
+  fa->reduce_scatter(stream, payload.data_ptr(), scale.data_ptr(), out.data_ptr(), num_rows,
+                     row_elems, int(threads), int(block_limit));
+}
+
+static void all_gather_fp8(fptr_t _fa, torch::Tensor& payload, torch::Tensor& scale,
+                           torch::Tensor& out, int64_t threads, int64_t block_limit) {
+  auto fa = reinterpret_cast<pcie_twoshot::PCIeTwoShot*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(payload));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  check_fp8_inputs(payload, scale, out);
+  const int64_t rows_per_rank = payload.size(0);
+  const int64_t row_elems = payload.size(1);
+  TORCH_CHECK_EQ(scale.numel(), rows_per_rank);
+  TORCH_CHECK_EQ(out.numel(), rows_per_rank * fa->world_size_ * row_elems);
+  fa->all_gather(stream, payload.data_ptr(), scale.data_ptr(), out.data_ptr(), rows_per_rank,
+                 row_elems, int(threads), int(block_limit));
+}
+
+static void dispose(fptr_t _fa) {
+  delete reinterpret_cast<pcie_twoshot::PCIeTwoShot*>(_fa);
+}
+
+static int64_t meta_size() {
+  return sizeof(pcie_twoshot::Signal);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("init_twoshot", &init_twoshot, "init PCIe twoshot SP collectives");
+  m.def("reduce_scatter_fp8", &reduce_scatter_fp8, "fp8-transport reduce_scatter");
+  m.def("all_gather_fp8", &all_gather_fp8, "fp8-transport all_gather");
+  m.def("dispose", &dispose, "dispose");
+  m.def("meta_size", &meta_size, "signal metadata size");
+}

--- a/flashinfer/experimental/sm12x/comm/pcie/pcie_twoshot.py
+++ b/flashinfer/experimental/sm12x/comm/pcie/pcie_twoshot.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/distributed/pcie_twoshot.py @ 7bfc9455 (2026-07-04) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""PCIe two-shot sequence-parallel collectives with fp8 transport.
+
+Pull-based reduce_scatter / all_gather over IPC-mapped peer slabs for
+TP sequence parallelism: values are quantized exactly once at the
+source (per-token e4m3 scales), moved as fp8, and dequantized fused
+with the fp32 reduction (RS) or the bf16 store (AG). Staging goes
+through alternating eager slots so both ops are CUDA-graph-capturable;
+a runtime instance must not be shared concurrently across CUDA streams.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import suppress
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional, Sequence
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from torch.utils.cpp_extension import load
+
+from ._cuda_ipc import CudaRTLibrary
+from .pcie_oneshot import (
+    IPC_SLAB_ALIGNMENT,
+    _align_up,
+    _broadcast_gather_object,
+    _normalize_device,
+    _OwnedSharedBuffer,
+)
+
+SUPPORTED_WORLD_SIZES = (2, 4, 8)
+FP8_MAX = 448.0
+
+
+@lru_cache(maxsize=1)
+def _load_extension():
+    source = Path(__file__).with_name("pcie_twoshot.cu")
+    verbose = os.getenv("FLASHINFER_EXP_SM12X_PCIE_TWOSHOT_VERBOSE_BUILD", "0") == "1"
+    return load(
+        name="sm12x_pcie_twoshot_ext",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O2", "--expt-relaxed-constexpr"],
+        extra_ldflags=["-lcuda"],
+        verbose=verbose,
+    )
+
+
+def quantize_per_row(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference per-row e4m3 quantization (tests / non-fused callers)."""
+    assert x.dim() == 2
+    amax = x.abs().amax(dim=-1, keepdim=True).float().clamp_(min=1e-12)
+    scale = amax / FP8_MAX
+    payload = (x.float() / scale).clamp_(-FP8_MAX, FP8_MAX).to(torch.float8_e4m3fn)
+    return payload, scale.squeeze(-1).contiguous()
+
+
+class PCIeTwoShotSP:
+    """Two-shot fp8-transport reduce_scatter / all_gather runtime."""
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device,
+        ext_module,
+        fptr: int,
+        owned_buffers: Sequence[_OwnedSharedBuffer],
+        ipc: CudaRTLibrary,
+        max_rows: int,
+        row_elems: int,
+    ) -> None:
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self._ext = ext_module
+        self._fptr = fptr
+        self._owned_buffers = list(owned_buffers)
+        self._ipc = ipc
+        self.max_rows = max_rows
+        self.row_elems = row_elems
+        self._closed = False
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_rows: int,
+        row_elems: int,
+        ext_module=None,
+    ) -> "PCIeTwoShotSP":
+        rank = dist.get_rank(group=exchange_group)
+        world_size = dist.get_world_size(group=exchange_group)
+        if world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(f"unsupported world size {world_size}")
+        if row_elems % 16 != 0:
+            raise ValueError("row_elems must be a multiple of 16")
+        if max_rows % world_size != 0:
+            raise ValueError("max_rows must be divisible by world size")
+
+        device_obj = _normalize_device(device)
+        if device_obj.type != "cuda":
+            raise ValueError("PCIe twoshot requires a CUDA device")
+
+        ipc = CudaRTLibrary()
+        ipc.cudaSetDevice(device_obj.index or 0)
+        ext = ext_module or _load_extension()
+
+        # Per-slot staging: [world][pack_stride] Fp8Packs then
+        # [world][scale_stride] fp32 scales, regions 256B-aligned.
+        max_rows_per_rank = max_rows // world_size
+        packs_per_row = row_elems // 16
+        pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
+        payload_bytes = world_size * pack_stride * 16
+        scale_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
+        scale_stride = _align_up(max_rows_per_rank, 64)
+        slot_bytes = _align_up(
+            scale_offset + world_size * scale_stride * 4, IPC_SLAB_ALIGNMENT
+        )
+        signal_bytes = _align_up(int(ext.meta_size()), IPC_SLAB_ALIGNMENT)
+        slab_bytes = signal_bytes + 2 * slot_bytes
+
+        local_ptr = ipc.cudaMalloc(slab_bytes)
+        owned: list[_OwnedSharedBuffer] = []
+        try:
+            # Signals must start zeroed.
+            ipc.cudaMemset(local_ptr, 0, signal_bytes)
+            local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
+            handles = _broadcast_gather_object(local_handle, exchange_group)
+
+            peer_ptrs: list[int] = []
+            remote_ptrs: list[int] = []
+            for idx, handle in enumerate(handles):
+                if idx == rank:
+                    peer_ptrs.append(local_ptr)
+                else:
+                    remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+                    peer_ptrs.append(remote_ptr)
+                    remote_ptrs.append(remote_ptr)
+            owned.append(
+                _OwnedSharedBuffer(
+                    local_ptr=local_ptr,
+                    peer_ptrs=tuple(peer_ptrs),
+                    remote_ptrs=tuple(remote_ptrs),
+                )
+            )
+
+            signal_ptrs = [p for p in peer_ptrs]
+            staging0 = [p + signal_bytes for p in peer_ptrs]
+            staging1 = [p + signal_bytes + slot_bytes for p in peer_ptrs]
+
+            fptr = ext.init_twoshot(
+                signal_ptrs,
+                staging0,
+                staging1,
+                pack_stride,
+                scale_offset,
+                scale_stride,
+                rank,
+            )
+            return cls(
+                rank=rank,
+                world_size=world_size,
+                device=device_obj,
+                ext_module=ext,
+                fptr=fptr,
+                owned_buffers=owned,
+                ipc=ipc,
+                max_rows=max_rows,
+                row_elems=row_elems,
+            )
+        except Exception:
+            for shared in owned:
+                for ptr in shared.remote_ptrs:
+                    with suppress(Exception):
+                        ipc.cudaIpcCloseMemHandle(ptr)
+            with suppress(Exception):
+                ipc.cudaFree(local_ptr)
+            raise
+
+    def _check(self, payload: torch.Tensor, scale: torch.Tensor, rows: int) -> None:
+        if self._closed:
+            raise RuntimeError("PCIeTwoShotSP is closed")
+        if payload.shape != (rows, self.row_elems):
+            raise ValueError(
+                f"payload shape {tuple(payload.shape)} != ({rows}, {self.row_elems})"
+            )
+        if scale.numel() != rows:
+            raise ValueError(f"scale numel {scale.numel()} != {rows}")
+
+    def reduce_scatter_fp8(
+        self,
+        payload: torch.Tensor,
+        scale: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        *,
+        threads: int = 512,
+        block_limit: int = 64,
+    ) -> torch.Tensor:
+        """Sum per-token-quantized partials; return the local row shard."""
+        rows = payload.shape[0]
+        self._check(payload, scale, rows)
+        if rows % self.world_size != 0:
+            raise ValueError("rows must be divisible by world size")
+        if out is None:
+            out = torch.empty(
+                rows // self.world_size,
+                self.row_elems,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+        self._ext.reduce_scatter_fp8(
+            self._fptr, payload, scale, out, threads, block_limit
+        )
+        return out
+
+    def all_gather_fp8(
+        self,
+        payload: torch.Tensor,
+        scale: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        *,
+        threads: int = 512,
+        block_limit: int = 64,
+    ) -> torch.Tensor:
+        """Gather per-token-quantized shards; return bf16 full width."""
+        rows = payload.shape[0]
+        self._check(payload, scale, rows)
+        if out is None:
+            out = torch.empty(
+                rows * self.world_size,
+                self.row_elems,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+        self._ext.all_gather_fp8(self._fptr, payload, scale, out, threads, block_limit)
+        return out
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        with suppress(Exception):
+            self._ext.dispose(self._fptr)
+        for shared in self._owned_buffers:
+            for ptr in shared.remote_ptrs:
+                with suppress(Exception):
+                    self._ipc.cudaIpcCloseMemHandle(ptr)
+            with suppress(Exception):
+                self._ipc.cudaFree(shared.local_ptr)
+        self._owned_buffers.clear()

--- a/flashinfer/experimental/sm12x/gemm/__init__.py
+++ b/flashinfer/experimental/sm12x/gemm/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""GEMM ops for flashinfer.experimental.sm12x.
+
+- ``blockscaled``: one-shot dense block-scaled GEMM (NVFP4 / MXFP4 / MXFP8).
+- ``block_fp8_linear``: DeepSeek-style serialized block-FP8 linear via MXFP8.
+- ``mxfp8_linear``: ModelOpt MXFP8 linear (one-shot).
+- ``wo_projection``: fused MLA WO-A/WO-B projections (+ inverse-RoPE variant).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_OP_MODULES = ("blockscaled", "block_fp8_linear", "mxfp8_linear", "wo_projection")
+
+
+def __getattr__(name: str) -> Any:
+    if name in _OP_MODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(_OP_MODULES)
+
+
+__all__ = list(_OP_MODULES)

--- a/flashinfer/experimental/sm12x/gemm/_shared/__init__.py
+++ b/flashinfer/experimental/sm12x/gemm/_shared/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Lowering shared by gemm ops (imports only _lib and itself)."""

--- a/flashinfer/experimental/sm12x/gemm/_shared/block_fp8.py
+++ b/flashinfer/experimental/sm12x/gemm/_shared/block_fp8.py
@@ -1,0 +1,835 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/gemm/block_fp8_linear.py @ 8de17f19 (2026-07-02) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import math
+import logging
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import torch
+
+from flashinfer.experimental.sm12x._lib.utils import cuda_stream_to_int
+from flashinfer.experimental.sm12x._lib.dense_gemm import (
+    dense_gemm,
+    dense_gemm_fused_quant_a,
+)
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+    MXFP8Rows,
+    MXFP8_SCALE_K_TILE,
+    MXFP8_SCALE_ROW_TILE,
+    MXFP8_SCALE_VEC_SIZE,
+    _check_gpu_tensor,
+    _check_mxfp8_k,
+    _check_mxfp8_rows_storage,
+    empty_dense_gemm_mnl_view,
+    empty_mxfp8_rows_bases,
+    mxfp8_rows_from_bases,
+    pack_fp8_block_scaled_weight_mxfp8,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+from flashinfer.experimental.sm12x._lib.quant.mxfp8_rows import quantize_mxfp8_rows_cute
+
+logger = logging.getLogger(__name__)
+_FLASHINFER_EXP_SM12X_TIMING = (
+    os.getenv("FLASHINFER_EXP_SM12X_TIMING", "0") == "1"
+    or os.getenv("VLLM_FLASHINFER_EXP_SM12X_TIMING", "0") == "1"
+)
+_FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS = float(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS",
+        os.getenv("VLLM_FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS", "0"),
+    )
+)
+
+_SCRATCH_ALIGN_BYTES = 1024
+
+
+@dataclass(frozen=True)
+class BlockFP8LinearWeight:
+    weight: MXFP8Rows
+    in_features: int
+    out_features: int
+    block_size: tuple[int, int]
+
+
+@dataclass(frozen=True, kw_only=True)
+class BlockFP8LinearBinding:
+    source: torch.Tensor
+    packed_weight: BlockFP8LinearWeight
+    x_q: MXFP8Rows
+    output: torch.Tensor
+    bias: torch.Tensor | None = None
+    # DeepGEMM-style regime hint forwarded to dense_gemm (decode vs prefill tile).
+    # None keeps the M-independent default; set it at bind time so the warmed
+    # kernel matches the regime this binding serves.
+    expected_m: int | None = None
+
+    def run(self, *, stream: object = None) -> torch.Tensor:
+        return block_fp8_linear_mxfp8(binding=self, stream=stream)
+
+
+@dataclass(frozen=True, kw_only=True)
+class BlockFP8LinearScratchCaps:
+    device: torch.device | str
+    max_tokens: int
+    in_features: int
+    out_features: int
+    output_dtype: torch.dtype = torch.bfloat16
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "max_tokens", max(int(self.max_tokens), 1))
+        object.__setattr__(self, "in_features", max(int(self.in_features), 1))
+        object.__setattr__(self, "out_features", max(int(self.out_features), 1))
+        _check_mxfp8_k(self.in_features)
+        if self.output_dtype not in (torch.bfloat16, torch.float16):
+            raise ValueError(f"output_dtype must be bf16/fp16, got {self.output_dtype}")
+
+
+@dataclass(frozen=True)
+class BlockFP8LinearScratchPlan:
+    caps: BlockFP8LinearScratchCaps
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        source: torch.Tensor,
+        packed_weight: BlockFP8LinearWeight,
+        output: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        expected_m: int | None = None,
+    ) -> BlockFP8LinearBinding:
+        source_2d = _source_2d(source)
+        tokens, in_features = map(int, source_2d.shape)
+        if tokens > int(self.caps.max_tokens):
+            raise ValueError(
+                f"source tokens {tokens} exceed block-FP8 scratch capacity {self.caps.max_tokens}"
+            )
+        if in_features != int(self.caps.in_features):
+            raise ValueError(
+                f"source K={in_features} does not match scratch in_features={self.caps.in_features}"
+            )
+        if int(packed_weight.out_features) != int(self.caps.out_features):
+            raise ValueError(
+                "packed weight out_features "
+                f"{packed_weight.out_features} does not match scratch out_features={self.caps.out_features}"
+            )
+        if source_2d.dtype != self.caps.output_dtype:
+            raise ValueError(
+                f"source dtype {source_2d.dtype} does not match scratch output_dtype={self.caps.output_dtype}"
+            )
+        scratch = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="block FP8 linear",
+        )
+        x_q = _block_fp8_linear_x_q_from_scratch(
+            scratch,
+            tokens=tokens,
+            in_features=self.caps.in_features,
+            output_dtype=self.caps.output_dtype,
+        )
+        return build_block_fp8_linear_binding(
+            source=source,
+            packed_weight=packed_weight,
+            x_q=x_q,
+            output=output,
+            bias=bias,
+            expected_m=expected_m,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class _BlockFP8LinearScratchLayout:
+    nbytes: int
+    x_values_offset_bytes: int
+    x_scale_rows_offset_bytes: int
+    x_scale_mma_offset_bytes: int
+    x_scale_mma_physical_shape: tuple[int, int, int, int, int, int]
+
+
+def _check_block_size(block_size: Sequence[int]) -> tuple[int, int]:
+    if len(block_size) != 2:
+        raise ValueError(f"block_size must have two elements, got {block_size}")
+    block_n, block_k = int(block_size[0]), int(block_size[1])
+    if (block_n, block_k) != (128, 128):
+        raise ValueError(
+            f"sm12x block FP8 linear currently supports 128x128 weight blocks, got {block_size}"
+        )
+    return block_n, block_k
+
+
+def _c_dtype_name(dtype: torch.dtype) -> str:
+    if dtype == torch.bfloat16:
+        return "bfloat16"
+    if dtype == torch.float16:
+        return "float16"
+    raise ValueError(
+        f"sm12x block FP8 linear output dtype must be bf16/fp16, got {dtype}"
+    )
+
+
+def _dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((int(value) + int(alignment) - 1) // int(alignment)) * int(alignment)
+
+
+def _shape_numel(shape: Sequence[int]) -> int:
+    numel = 1
+    for dim in shape:
+        numel *= int(dim)
+    return numel
+
+
+def _block_fp8_linear_scratch_layout(
+    *,
+    tokens: int,
+    in_features: int,
+    out_features: int,
+    output_dtype: torch.dtype,
+) -> _BlockFP8LinearScratchLayout:
+    tokens = max(int(tokens), 1)
+    in_features = max(int(in_features), 1)
+    del out_features
+    _check_mxfp8_k(in_features)
+    _c_dtype_name(output_dtype)
+
+    offset = 0
+    offset = _align_up(offset, _SCRATCH_ALIGN_BYTES)
+    x_values_offset_bytes = offset
+    offset += tokens * in_features * _dtype_nbytes(torch.float8_e4m3fn)
+
+    offset = _align_up(offset, _SCRATCH_ALIGN_BYTES)
+    x_scale_rows_offset_bytes = offset
+    offset += (
+        tokens
+        * (in_features // MXFP8_SCALE_VEC_SIZE)
+        * _dtype_nbytes(torch.float8_e8m0fnu)
+    )
+
+    offset = _align_up(offset, _SCRATCH_ALIGN_BYTES)
+    x_scale_mma_offset_bytes = offset
+    sf_k = in_features // MXFP8_SCALE_VEC_SIZE
+    x_scale_mma_physical_shape = (
+        1,
+        math.ceil(tokens / MXFP8_SCALE_ROW_TILE),
+        math.ceil(sf_k / MXFP8_SCALE_K_TILE),
+        32,
+        4,
+        4,
+    )
+    offset += _shape_numel(x_scale_mma_physical_shape) * _dtype_nbytes(torch.uint8)
+
+    return _BlockFP8LinearScratchLayout(
+        nbytes=max(int(offset), 1),
+        x_values_offset_bytes=x_values_offset_bytes,
+        x_scale_rows_offset_bytes=x_scale_rows_offset_bytes,
+        x_scale_mma_offset_bytes=x_scale_mma_offset_bytes,
+        x_scale_mma_physical_shape=x_scale_mma_physical_shape,
+    )
+
+
+def _scratch_view(
+    scratch: torch.Tensor,
+    *,
+    offset_bytes: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    offset_bytes = _align_up(
+        offset_bytes, max(_SCRATCH_ALIGN_BYTES, _dtype_nbytes(dtype))
+    )
+    nbytes = _shape_numel(shape) * _dtype_nbytes(dtype)
+    return scratch.narrow(0, offset_bytes, nbytes).view(dtype).view(shape)
+
+
+def _block_fp8_linear_x_q_from_scratch(
+    scratch: torch.Tensor,
+    *,
+    tokens: int,
+    in_features: int,
+    output_dtype: torch.dtype,
+) -> MXFP8Rows:
+    layout = _block_fp8_linear_scratch_layout(
+        tokens=tokens,
+        in_features=in_features,
+        out_features=1,
+        output_dtype=output_dtype,
+    )
+    if scratch.dtype != torch.uint8:
+        raise TypeError(
+            f"block FP8 linear scratch must have dtype torch.uint8, got {scratch.dtype}"
+        )
+    if not scratch.is_contiguous():
+        raise ValueError("block FP8 linear scratch must be contiguous")
+    if int(scratch.numel()) < int(layout.nbytes):
+        raise ValueError(
+            f"block FP8 linear scratch has {int(scratch.numel())} bytes, requires {layout.nbytes}"
+        )
+    x_values = _scratch_view(
+        scratch,
+        offset_bytes=layout.x_values_offset_bytes,
+        shape=(int(tokens), int(in_features)),
+        dtype=torch.float8_e4m3fn,
+    )
+    x_scale_rows_u8 = _scratch_view(
+        scratch,
+        offset_bytes=layout.x_scale_rows_offset_bytes,
+        shape=(1, int(tokens), int(in_features) // MXFP8_SCALE_VEC_SIZE),
+        dtype=torch.uint8,
+    )
+    x_scale_mma_u8 = _scratch_view(
+        scratch,
+        offset_bytes=layout.x_scale_mma_offset_bytes,
+        shape=layout.x_scale_mma_physical_shape,
+        dtype=torch.uint8,
+    )
+    x_scale_rows_u8.fill_(127)
+    x_scale_mma_u8.fill_(127)
+    x_scale_mma = x_scale_mma_u8.view(torch.float8_e8m0fnu).permute(
+        3,
+        4,
+        1,
+        5,
+        2,
+        0,
+    )
+    return MXFP8Rows(
+        values=x_values,
+        scale_rows=x_scale_rows_u8.view(torch.float8_e8m0fnu),
+        scale_mma=x_scale_mma,
+    )
+
+
+def _source_2d(source: torch.Tensor) -> torch.Tensor:
+    if source.ndim == 0:
+        raise ValueError("source must have at least one dimension")
+    return source.view(-1, source.shape[-1])
+
+
+def _check_block_fp8_linear_tensors(
+    x_q: MXFP8Rows,
+    output: torch.Tensor,
+    *,
+    tokens: int,
+    packed_weight: BlockFP8LinearWeight,
+    output_dtype: torch.dtype,
+) -> None:
+    _check_mxfp8_rows_storage(
+        x_q,
+        m=tokens,
+        k=packed_weight.in_features,
+        num_groups=1,
+    )
+    if output.shape != (tokens, packed_weight.out_features, 1):
+        raise ValueError(
+            "output must have shape "
+            f"{(tokens, packed_weight.out_features, 1)}, got {tuple(output.shape)}"
+        )
+    if output.dtype != output_dtype:
+        raise ValueError(
+            f"output dtype {output.dtype} does not match input {output_dtype}"
+        )
+
+
+def build_block_fp8_linear_binding(
+    *,
+    source: torch.Tensor,
+    packed_weight: BlockFP8LinearWeight,
+    x_q: MXFP8Rows,
+    output: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    expected_m: int | None = None,
+) -> BlockFP8LinearBinding:
+    if not isinstance(packed_weight, BlockFP8LinearWeight):
+        raise TypeError("packed_weight must be a BlockFP8LinearWeight")
+    source_2d = _source_2d(source)
+    tokens, in_features = map(int, source_2d.shape)
+    if in_features != packed_weight.in_features:
+        raise ValueError(
+            f"input K={in_features} does not match packed weight K={packed_weight.in_features}"
+        )
+    if source_2d.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"source dtype must be bf16/fp16, got {source_2d.dtype}")
+    _check_block_fp8_linear_tensors(
+        x_q,
+        output,
+        tokens=tokens,
+        packed_weight=packed_weight,
+        output_dtype=source_2d.dtype,
+    )
+    return BlockFP8LinearBinding(
+        source=source,
+        packed_weight=packed_weight,
+        x_q=x_q,
+        output=output,
+        bias=bias,
+        expected_m=expected_m,
+    )
+
+
+def plan_block_fp8_linear_scratch(
+    caps: BlockFP8LinearScratchCaps,
+) -> BlockFP8LinearScratchPlan:
+    layout = _block_fp8_linear_scratch_layout(
+        tokens=caps.max_tokens,
+        in_features=caps.in_features,
+        out_features=caps.out_features,
+        output_dtype=caps.output_dtype,
+    )
+    return BlockFP8LinearScratchPlan(
+        caps=caps,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "block_fp8_linear.scratch",
+                nbytes=layout.nbytes,
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+def pack_block_fp8_linear_weight_mxfp8(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    *,
+    block_size: Sequence[int] = (128, 128),
+) -> BlockFP8LinearWeight:
+    """Pack serialized block-FP8 linear weights for the native sm12x MXFP8 GEMM.
+
+    The checkpoint weight stays in E4M3. The 128x128 DSV-style block scales are
+    expanded once to the row/32-column UE8M0 scale layout consumed by SM120 MMA.
+    """
+
+    _check_gpu_tensor("weight", weight)
+    _check_gpu_tensor("weight_scale", weight_scale)
+    _check_block_size(block_size)
+    if weight.ndim != 2:
+        raise ValueError(f"weight must have shape [N,K], got {tuple(weight.shape)}")
+    out_features, in_features = weight.shape
+    _check_mxfp8_k(in_features)
+    if out_features <= 0:
+        raise ValueError("out_features must be positive")
+    packed = pack_fp8_block_scaled_weight_mxfp8(
+        weight.detach(),
+        weight_scale.detach(),
+        m=out_features,
+        k=in_features,
+        num_groups=1,
+    )
+    return BlockFP8LinearWeight(
+        weight=packed,
+        in_features=in_features,
+        out_features=out_features,
+        block_size=(128, 128),
+    )
+
+
+def _run_block_fp8_quant_kernel(
+    source_tk: torch.Tensor,
+    out_values: torch.Tensor,
+    out_scale_rows: torch.Tensor,
+    out_scale_mma: torch.Tensor,
+    tokens: int,
+    in_features: int,
+) -> None:
+    del tokens, in_features
+    quantize_mxfp8_rows_cute(
+        source_tk,
+        out_values,
+        out_scale_rows,
+        out_scale_mma,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::quantize_block_fp8_linear_input_mxfp8_alloc",
+    mutates_args=(),
+)
+def _quantize_block_fp8_linear_input_mxfp8_alloc_op(
+    source_tk: torch.Tensor,
+    tokens: int,
+    in_features: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Functional (allocate + return) quantizer: the raw CuTe kernel writes the
+    # MXFP8 output views INSIDE this opaque op, so torch.compile never sees a
+    # low-level mutation on 3 caller-visible views. Returns the
+    # CONTIGUOUS bases (not the views) so no symbolic-shaped view output reaches a
+    # downstream subgraph (which trips AOT merge_view_inputs). Used on the no-`out`
+    # (compile) path.
+    values_base, scale_rows_base, scale_physical_base = empty_mxfp8_rows_bases(
+        tokens, in_features, num_groups=1, device=source_tk.device
+    )
+    out = mxfp8_rows_from_bases(
+        values_base,
+        scale_rows_base,
+        scale_physical_base,
+        tokens,
+        in_features,
+        num_groups=1,
+    )
+    _run_block_fp8_quant_kernel(
+        source_tk, out.values, out.scale_rows, out.scale_mma, tokens, in_features
+    )
+    return values_base, scale_rows_base, scale_physical_base
+
+
+@_quantize_block_fp8_linear_input_mxfp8_alloc_op.register_fake
+def _quantize_block_fp8_linear_input_mxfp8_alloc_fake(
+    source_tk: torch.Tensor,
+    tokens: int,
+    in_features: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return empty_mxfp8_rows_bases(
+        tokens, in_features, num_groups=1, device=source_tk.device
+    )
+
+
+def quantize_block_fp8_linear_input_mxfp8(
+    source_tk: torch.Tensor,
+    *,
+    out: MXFP8Rows | None = None,
+) -> MXFP8Rows:
+    """Quantize dense BF16/FP16 rows `[tokens, K]` to native MXFP8 rows."""
+
+    _check_gpu_tensor("source_tk", source_tk)
+    if source_tk.ndim != 2:
+        raise ValueError(
+            f"source_tk must have shape [tokens,K], got {tuple(source_tk.shape)}"
+        )
+    tokens, in_features = source_tk.shape
+    if tokens <= 0:
+        raise ValueError("tokens must be positive")
+    _check_mxfp8_k(in_features)
+    if out is None:
+        values_base, scale_rows_base, scale_physical_base = (
+            torch.ops.flashinfer_sm12x.quantize_block_fp8_linear_input_mxfp8_alloc(
+                source_tk, tokens, in_features
+            )
+        )
+        return mxfp8_rows_from_bases(
+            values_base,
+            scale_rows_base,
+            scale_physical_base,
+            tokens,
+            in_features,
+            num_groups=1,
+        )
+
+    _check_mxfp8_rows_storage(out, m=tokens, k=in_features, num_groups=1)
+    _run_block_fp8_quant_kernel(
+        source_tk, out.values, out.scale_rows, out.scale_mma, tokens, in_features
+    )
+    return out
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::block_fp8_linear_mxfp8_fused",
+    mutates_args=(),
+)
+def _block_fp8_linear_mxfp8_fused_op(
+    source_2d: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_rows: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    in_features: int,
+    out_features: int,
+    expected_m: int,
+    stream_int: int | None,
+) -> torch.Tensor:
+    # Fused, fully opaque block-FP8 linear: quantize + dense GEMM run INSIDE this
+    # one op, so the token-shaped activation MXFP8 views (x_q.values/scale_mma)
+    # are never graph values -- they can't become symbolic-shaped view inputs to
+    # a downstream subgraph (which trips torch AOT merge_view_inputs under dynamic
+    # shapes). The weight views passed in are static-shaped, so they don't hit
+    # that path. Returns a contiguous [tokens, out_features] base.
+    tokens = int(source_2d.shape[0])
+    if tokens <= 8 and source_2d.dtype == torch.bfloat16:
+        return dense_gemm_fused_quant_a(
+            source_2d,
+            weight_values.reshape(out_features, in_features, 1),
+            weight_scale_mma,
+            expected_m=None if expected_m == 0 else expected_m,
+            sfb_k_replicated=True,
+            stream=stream_int,
+        )[:, :, 0]
+    x_q = quantize_block_fp8_linear_input_mxfp8(source_2d)
+    return dense_gemm(
+        (x_q.values.reshape(tokens, in_features, 1), x_q.scale_mma),
+        (weight_values.reshape(out_features, in_features, 1), weight_scale_mma),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype=_c_dtype_name(source_2d.dtype),
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        expected_m=None if expected_m == 0 else expected_m,
+        # Weight scales come from 128x128 blocks expanded to per-32 rows, so
+        # the four SFB bytes per 128-wide k tile are identical by construction.
+        sfb_k_replicated=True,
+        stream=stream_int,
+    )[:, :, 0]
+
+
+@_block_fp8_linear_mxfp8_fused_op.register_fake
+def _block_fp8_linear_mxfp8_fused_fake(
+    source_2d: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_rows: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    in_features: int,
+    out_features: int,
+    expected_m: int,
+    stream_int: int | None,
+) -> torch.Tensor:
+    del stream_int
+    return torch.empty(
+        (source_2d.shape[0], out_features),
+        dtype=source_2d.dtype,
+        device=source_2d.device,
+    )
+
+
+def block_fp8_linear_mxfp8(
+    source: torch.Tensor | None = None,
+    packed_weight: BlockFP8LinearWeight | None = None,
+    *,
+    bias: torch.Tensor | None = None,
+    binding: BlockFP8LinearBinding | None = None,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run a serialized block-FP8 linear through the native sm12x MXFP8 GEMM.
+
+    expected_m forwards a DeepGEMM-style regime hint to dense_gemm (decode vs
+    prefill tile); None keeps the M-independent default. When a binding is given
+    its stored expected_m is used.
+    """
+
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("source", source),
+                ("packed_weight", packed_weight),
+                ("bias", bias),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "block FP8 linear binding owns source, packed weight, scratch tensors, and bias; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        source = binding.source
+        packed_weight = binding.packed_weight
+        x_q_storage = binding.x_q
+        output_storage = binding.output
+        bias = binding.bias
+        expected_m = binding.expected_m
+    else:
+        x_q_storage = None
+        output_storage = None
+    if source is None or packed_weight is None:
+        raise TypeError(
+            "block_fp8_linear_mxfp8 requires source and packed_weight or binding"
+        )
+    _check_gpu_tensor("source", source)
+    if not isinstance(packed_weight, BlockFP8LinearWeight):
+        raise TypeError("packed_weight must be a BlockFP8LinearWeight")
+    source_2d = _source_2d(source)
+    tokens, in_features = source_2d.shape
+    if in_features != packed_weight.in_features:
+        raise ValueError(
+            f"input K={in_features} does not match packed weight K={packed_weight.in_features}"
+        )
+    if source_2d.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"source dtype must be bf16/fp16, got {source_2d.dtype}")
+    stream_int = cuda_stream_to_int(stream)
+
+    if binding is None:
+        # No caller-owned buffers (e.g. the torch.compile path): one fully opaque
+        # fused op runs quantize + dense GEMM internally, so the token-shaped
+        # activation MXFP8 views stay inside the op and never reach the graph (see
+        # _block_fp8_linear_mxfp8_fused_op). No is_compiling -- purely caller-intent.
+        output = torch.ops.flashinfer_sm12x.block_fp8_linear_mxfp8_fused(
+            source_2d,
+            packed_weight.weight.values,
+            packed_weight.weight.scale_rows,
+            packed_weight.weight.scale_mma,
+            packed_weight.in_features,
+            packed_weight.out_features,
+            int(expected_m) if expected_m is not None else 0,
+            stream_int,
+        )
+        if bias is not None:
+            output = output + bias
+        return output.view(*source.shape[:-1], packed_weight.out_features)
+
+    if x_q_storage is None or output_storage is None:
+        raise TypeError(
+            "block_fp8_linear_mxfp8 requires binding for caller-owned scratch"
+        )
+    _check_block_fp8_linear_tensors(
+        x_q_storage,
+        output_storage,
+        tokens=tokens,
+        packed_weight=packed_weight,
+        output_dtype=source_2d.dtype,
+    )
+
+    assert x_q_storage is not None
+    assert output_storage is not None
+    t0 = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    if tokens <= 8 and source_2d.dtype == torch.bfloat16:
+        output = dense_gemm_fused_quant_a(
+            source_2d,
+            packed_weight.weight.values.reshape(
+                packed_weight.out_features,
+                packed_weight.in_features,
+                1,
+            ),
+            packed_weight.weight.scale_mma,
+            out=output_storage,
+            expected_m=expected_m,
+            sfb_k_replicated=True,
+            stream=stream,
+        )[:, :, 0]
+        if bias is not None:
+            output += bias
+        return output.view(*source.shape[:-1], packed_weight.out_features)
+    x_q = quantize_block_fp8_linear_input_mxfp8(source_2d, out=x_q_storage)
+    t_quant = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    output = dense_gemm(
+        (x_q.values.reshape(tokens, packed_weight.in_features, 1), x_q.scale_mma),
+        (
+            packed_weight.weight.values.reshape(
+                packed_weight.out_features,
+                packed_weight.in_features,
+                1,
+            ),
+            packed_weight.weight.scale_mma,
+        ),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype=_c_dtype_name(source_2d.dtype),
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        out=output_storage,
+        expected_m=expected_m,
+        sfb_k_replicated=True,
+        stream=stream,
+    )[:, :, 0]
+    t_gemm = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    if bias is not None:
+        output += bias
+    if _FLASHINFER_EXP_SM12X_TIMING:
+        t_done = time.perf_counter()
+        total_ms = (t_done - t0) * 1000.0
+        if total_ms >= _FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS:
+            logger.warning(
+                "sm12x_block_fp8_linear timing tokens=%d in=%d out=%d "
+                "quant_enqueue=%.3fms dense_gemm=%.3fms bias=%.3fms total=%.3fms",
+                int(tokens),
+                int(packed_weight.in_features),
+                int(packed_weight.out_features),
+                (t_quant - t0) * 1000.0,
+                (t_gemm - t_quant) * 1000.0,
+                (t_done - t_gemm) * 1000.0,
+                total_ms,
+            )
+    return output.view(*source.shape[:-1], packed_weight.out_features)
+
+
+def prewarm_block_fp8_linear_mxfp8(
+    packed_weight: BlockFP8LinearWeight,
+    token_counts: Iterable[int],
+    *,
+    output_dtype: torch.dtype = torch.bfloat16,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> None:
+    """Compile and warm the native block-FP8 linear kernels for planned M values.
+
+    Pass the same expected_m the serving path will use so the warmed tile matches
+    the regime kernel that live calls reuse under frozen resolution.
+    """
+
+    if not isinstance(packed_weight, BlockFP8LinearWeight):
+        raise TypeError("packed_weight must be a BlockFP8LinearWeight")
+    if output_dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"output_dtype must be bf16/fp16, got {output_dtype}")
+    device = packed_weight.weight.values.device
+    counts = sorted({int(tokens) for tokens in token_counts if int(tokens) > 0})
+    if not counts:
+        return
+
+    with torch.inference_mode():
+        for tokens in counts:
+            source = torch.zeros(
+                (tokens, packed_weight.in_features),
+                dtype=output_dtype,
+                device=device,
+            )
+            plan = plan_block_fp8_linear_scratch(
+                BlockFP8LinearScratchCaps(
+                    device=device,
+                    max_tokens=tokens,
+                    in_features=packed_weight.in_features,
+                    out_features=packed_weight.out_features,
+                    output_dtype=output_dtype,
+                )
+            )
+            spec = plan.scratch_specs()[0]
+            scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+            output = empty_dense_gemm_mnl_view(
+                tokens,
+                packed_weight.out_features,
+                1,
+                device=device,
+                dtype=output_dtype,
+            )
+            binding = plan.bind(
+                scratch=scratch,
+                source=source,
+                packed_weight=packed_weight,
+                output=output,
+                expected_m=expected_m,
+            )
+            block_fp8_linear_mxfp8(binding=binding, stream=stream)
+        torch.cuda.synchronize(device)
+
+
+__all__ = [
+    "BlockFP8LinearBinding",
+    "BlockFP8LinearScratchCaps",
+    "BlockFP8LinearScratchPlan",
+    "BlockFP8LinearWeight",
+    "build_block_fp8_linear_binding",
+    "block_fp8_linear_mxfp8",
+    "pack_block_fp8_linear_weight_mxfp8",
+    "plan_block_fp8_linear_scratch",
+    "prewarm_block_fp8_linear_mxfp8",
+    "quantize_block_fp8_linear_input_mxfp8",
+]

--- a/flashinfer/experimental/sm12x/gemm/_shared/wo_mxfp8.py
+++ b/flashinfer/experimental/sm12x/gemm/_shared/wo_mxfp8.py
@@ -1,0 +1,3027 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/gemm/wo_projection.py @ 32d189d4 (2026-07-18) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+import triton
+import triton.language as tl
+
+from ..._lib.scratch_layout import (
+    layout_wo_projection as _layout_wo_projection,
+    materialize_scratch_strided_view as _materialize_arena_strided_view,
+    materialize_scratch_view as _materialize_arena_view,
+    wo_mxfp8_scale_physical_shape as _wo_mxfp8_scale_physical_shape,
+)
+from flashinfer.experimental.sm12x._lib.utils import cuda_stream_to_int
+from flashinfer.experimental.sm12x._lib.dense_gemm import (
+    _WO_SPARK_MAX_SMS,
+    dense_gemm,
+    dense_gemm_fused_quant_a,
+    dense_gemm_fused_quant_a_grouped,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+MXFP8_SCALE_VEC_SIZE = 32
+MXFP8_SCALE_ROW_TILE = 128
+MXFP8_SCALE_K_TILE = 4
+WO_A_INPUT_QUANT_GROUP_SIZE = MXFP8_SCALE_VEC_SIZE
+_WO_QUANT_CHUNKS_PER_PROGRAM = int(
+    os.environ.get("FLASHINFER_EXP_SM12X_WO_QUANT_CHUNKS_PER_PROGRAM", "16")
+)
+if _WO_QUANT_CHUNKS_PER_PROGRAM not in (1, 2, 4, 8, 16, 32):
+    raise ValueError(
+        "FLASHINFER_EXP_SM12X_WO_QUANT_CHUNKS_PER_PROGRAM must be one of 1, 2, 4, 8, 16, or 32, got "
+        f"{_WO_QUANT_CHUNKS_PER_PROGRAM}"
+    )
+_ALPHA_ONE_CACHE: dict[tuple[str, int | None], torch.Tensor] = {}
+
+
+def _should_use_exact_b16_wo(*, tokens: int, sm_count: int) -> bool:
+    return int(tokens) == 16 and int(sm_count) <= _WO_SPARK_MAX_SMS
+
+
+@dataclass(frozen=True)
+class MXFP8Rows:
+    """Row-wise MXFP8 operand and scales for `dense_gemm`.
+
+    `values` has logical dense-GEMM shape `[M, K, L]`, but for `L > 1` it is a
+    strided view over physical `[L, M, K]` storage because the current CuTe
+    dense kernel consumes raw pointers and reconstructs its own K-major layout.
+    `scale_rows` is the compact row/chunk view `[L, M, K/32]`, and `scale_mma`
+    is the strided `[32, 4, ceil(M/128), 4, ceil(K/128), L]` view consumed by
+    the CuTe kernel. `values_tiled`, when present, is an additional load-time
+    packed copy for a specialized dense-GEMM RHS; `values` remains the logical
+    operand used by every fallback path.
+    """
+
+    values: torch.Tensor
+    scale_rows: torch.Tensor
+    scale_mma: torch.Tensor
+    values_tiled: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class WOProjectionMXFP8Weights:
+    """MXFP8 WO-A/WO-B weights in the layouts consumed by the two GEMMs.
+
+    `sfb_k_replicated` records scale provenance: True only when the per-32
+    UE8M0 rows were expanded from 128x128 block scales, so the four SFB bytes
+    per 128-wide k tile are identical by construction and the dense GEMM may
+    load one byte per stage (sfb_k_reuse). Natively per-32-quantized weights
+    (quantize_wo_projection_weights_mxfp8_torch) must leave this False.
+    """
+
+    wo_a: MXFP8Rows
+    wo_b: MXFP8Rows
+    groups: int
+    group_width: int
+    rank: int
+    hidden: int
+    sfb_k_replicated: bool = False
+
+
+@dataclass(frozen=True)
+class _WOProjectionScratchViews:
+    x_q: MXFP8Rows
+    tmp: torch.Tensor
+    tmp_q: MXFP8Rows
+    output: torch.Tensor
+
+
+@dataclass(frozen=True, kw_only=True)
+class WOProjectionBinding:
+    source_tgd: torch.Tensor
+    weights: WOProjectionMXFP8Weights
+    x_q: MXFP8Rows
+    tmp: torch.Tensor
+    tmp_q: MXFP8Rows
+    output: torch.Tensor
+    return_3d: bool = False
+    # DeepGEMM-style regime hint forwarded to the wo_b up-projection (N=hidden,
+    # the n>1536 path). None keeps the M-independent default tile.
+    expected_m: int | None = None
+
+    def run(self, *, stream: object = None) -> torch.Tensor:
+        return wo_projection_mxfp8(binding=self, stream=stream)
+
+
+@dataclass(frozen=True, kw_only=True)
+class WOProjectionInvRopeBinding:
+    o: torch.Tensor
+    positions: torch.Tensor
+    cos_sin_cache: torch.Tensor
+    weights: WOProjectionMXFP8Weights
+    x_q: MXFP8Rows
+    tmp: torch.Tensor
+    tmp_q: MXFP8Rows
+    output: torch.Tensor
+    heads_per_group: int
+    nope_dim: int = 448
+    rope_dim: int = 64
+    return_3d: bool = False
+    # DeepGEMM-style regime hint forwarded to the wo_b up-projection.
+    expected_m: int | None = None
+
+    def run(self, *, stream: object = None) -> torch.Tensor:
+        return wo_projection_inv_rope_mxfp8(binding=self, stream=stream)
+
+
+@dataclass(frozen=True, kw_only=True)
+class WOProjectionScratchCaps:
+    device: torch.device | str
+    max_tokens: int
+    groups: int
+    group_width: int
+    rank: int
+    hidden: int
+    dtype: torch.dtype = torch.bfloat16
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "max_tokens", max(int(self.max_tokens), 1))
+        object.__setattr__(self, "groups", max(int(self.groups), 1))
+        object.__setattr__(self, "group_width", max(int(self.group_width), 1))
+        object.__setattr__(self, "rank", max(int(self.rank), 1))
+        object.__setattr__(self, "hidden", max(int(self.hidden), 1))
+        if self.dtype != torch.bfloat16:
+            raise ValueError(
+                "WO projection scratch currently supports torch.bfloat16 outputs, "
+                f"got {self.dtype}"
+            )
+        _check_mxfp8_k(self.group_width)
+        _check_mxfp8_k(self.rank * self.groups)
+
+
+@dataclass(frozen=True)
+class WOProjectionScratchPlan:
+    caps: WOProjectionScratchCaps
+    layout: object
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        source_tgd: torch.Tensor,
+        weights: WOProjectionMXFP8Weights,
+        return_3d: bool = False,
+        expected_m: int | None = None,
+    ) -> WOProjectionBinding:
+        tokens = _validate_wo_projection_inputs(source_tgd, weights)
+        self._check_live_capacity(tokens=tokens, weights=weights)
+        views = self._views_from_scratch(scratch=scratch, tokens=tokens)
+        return _build_wo_projection_binding_from_views(
+            x_q=views.x_q,
+            tmp=views.tmp,
+            tmp_q=views.tmp_q,
+            output=views.output,
+            source_tgd=source_tgd,
+            weights=weights,
+            return_3d=return_3d,
+            expected_m=expected_m,
+        )
+
+    def bind_inv_rope(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        o: torch.Tensor,
+        positions: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+        weights: WOProjectionMXFP8Weights,
+        heads_per_group: int,
+        nope_dim: int = 448,
+        rope_dim: int = 64,
+        return_3d: bool = False,
+        expected_m: int | None = None,
+    ) -> WOProjectionInvRopeBinding:
+        tokens = _validate_wo_projection_inv_rope_inputs(
+            o=o,
+            weights=weights,
+            heads_per_group=heads_per_group,
+            nope_dim=nope_dim,
+            rope_dim=rope_dim,
+        )
+        self._check_live_capacity(tokens=tokens, weights=weights)
+        views = self._views_from_scratch(scratch=scratch, tokens=tokens)
+        return _build_wo_projection_inv_rope_binding_from_views(
+            x_q=views.x_q,
+            tmp=views.tmp,
+            tmp_q=views.tmp_q,
+            output=views.output,
+            o=o,
+            positions=positions,
+            cos_sin_cache=cos_sin_cache,
+            weights=weights,
+            heads_per_group=heads_per_group,
+            nope_dim=nope_dim,
+            rope_dim=rope_dim,
+            return_3d=return_3d,
+            expected_m=expected_m,
+        )
+
+    def _views_from_scratch(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        tokens: int | None = None,
+    ) -> _WOProjectionScratchViews:
+        max_tokens = int(self.caps.max_tokens)
+        tokens = max_tokens if tokens is None else int(tokens)
+        if tokens <= 0 or tokens > max_tokens:
+            raise ValueError(
+                f"WO projection tokens={tokens} exceeds scratch capacity {max_tokens}"
+            )
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="WO projection",
+        )
+        groups = int(self.caps.groups)
+        group_width = int(self.caps.group_width)
+        rank = int(self.caps.rank)
+        hidden = int(self.caps.hidden)
+        layout = _layout_wo_projection(
+            offset_bytes=0,
+            tokens=tokens,
+            groups=groups,
+            group_width=group_width,
+            rank=rank,
+            hidden=hidden,
+        )
+        if int(layout.nbytes) > int(self.layout.nbytes):
+            raise RuntimeError(
+                "WO projection scratch layout exceeds reserved scratch "
+                f"capacity: requested={layout.nbytes}, reserved={self.layout.nbytes}"
+            )
+
+        def mxfp8_rows(
+            *,
+            values_offset_bytes: int,
+            scale_rows_offset_bytes: int,
+            scale_mma_offset_bytes: int,
+            m: int,
+            k: int,
+            num_groups: int,
+        ) -> MXFP8Rows:
+            if num_groups == 1:
+                values, _ = _materialize_arena_view(
+                    scratch_storage,
+                    offset_bytes=values_offset_bytes,
+                    shape=(m, k),
+                    dtype=torch.float8_e4m3fn,
+                )
+            else:
+                values, _ = _materialize_arena_strided_view(
+                    scratch_storage,
+                    offset_bytes=values_offset_bytes,
+                    shape=(m, k, num_groups),
+                    stride=(k, 1, m * k),
+                    dtype=torch.float8_e4m3fn,
+                )
+            scale_rows, _ = _materialize_arena_view(
+                scratch_storage,
+                offset_bytes=scale_rows_offset_bytes,
+                shape=(num_groups, m, k // MXFP8_SCALE_VEC_SIZE),
+                dtype=torch.float8_e8m0fnu,
+            )
+            scale_physical_u8, _ = _materialize_arena_view(
+                scratch_storage,
+                offset_bytes=scale_mma_offset_bytes,
+                shape=_wo_mxfp8_scale_physical_shape(
+                    m=m,
+                    k=k,
+                    num_groups=num_groups,
+                ),
+                dtype=torch.uint8,
+            )
+            if m % MXFP8_SCALE_ROW_TILE:
+                scale_physical_u8.fill_(127)
+            scale_mma = scale_physical_u8.view(torch.float8_e8m0fnu).permute(
+                3,
+                4,
+                1,
+                5,
+                2,
+                0,
+            )
+            return MXFP8Rows(
+                values=values,
+                scale_rows=scale_rows,
+                scale_mma=scale_mma,
+            )
+
+        x_q = mxfp8_rows(
+            values_offset_bytes=layout.x_q_values_offset_bytes,
+            scale_rows_offset_bytes=layout.x_q_scale_rows_offset_bytes,
+            scale_mma_offset_bytes=layout.x_q_scale_mma_offset_bytes,
+            m=tokens,
+            k=group_width,
+            num_groups=groups,
+        )
+        tmp, _ = _materialize_arena_strided_view(
+            scratch_storage,
+            offset_bytes=layout.tmp_offset_bytes,
+            shape=(tokens, rank, groups),
+            stride=(rank, 1, tokens * rank),
+            dtype=torch.bfloat16,
+        )
+        tmp_q = mxfp8_rows(
+            values_offset_bytes=layout.tmp_q_values_offset_bytes,
+            scale_rows_offset_bytes=layout.tmp_q_scale_rows_offset_bytes,
+            scale_mma_offset_bytes=layout.tmp_q_scale_mma_offset_bytes,
+            m=tokens,
+            k=rank * groups,
+            num_groups=1,
+        )
+        output, _ = _materialize_arena_view(
+            scratch_storage,
+            offset_bytes=layout.output_offset_bytes,
+            shape=(tokens, hidden, 1),
+            dtype=torch.bfloat16,
+        )
+        return _WOProjectionScratchViews(
+            x_q=x_q,
+            tmp=tmp,
+            tmp_q=tmp_q,
+            output=output,
+        )
+
+    def _check_live_capacity(
+        self,
+        *,
+        tokens: int,
+        weights: WOProjectionMXFP8Weights,
+    ) -> None:
+        if tokens > int(self.caps.max_tokens):
+            raise ValueError(
+                f"WO projection tokens {tokens} exceed scratch capacity {self.caps.max_tokens}"
+            )
+        expected = (
+            int(self.caps.groups),
+            int(self.caps.group_width),
+            int(self.caps.rank),
+            int(self.caps.hidden),
+        )
+        actual = (
+            int(weights.groups),
+            int(weights.group_width),
+            int(weights.rank),
+            int(weights.hidden),
+        )
+        if actual != expected:
+            raise ValueError(
+                "WO projection weights do not match scratch caps: "
+                f"weights={actual}, caps={expected}"
+            )
+
+
+def _check_gpu_tensor(name: str, tensor: torch.Tensor) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if not tensor.is_cuda:
+        raise ValueError(f"{name} must be on CUDA")
+
+
+def _as_grouped_mkl(source: torch.Tensor) -> tuple[torch.Tensor, int, int, int]:
+    _check_gpu_tensor("source", source)
+    if source.ndim == 2:
+        m, k = source.shape
+        grouped = source.reshape(m, k, 1).permute(2, 0, 1).contiguous()
+        return grouped, m, k, 1
+    if source.ndim == 3:
+        m, k, groups = source.shape
+        grouped = source.permute(2, 0, 1).contiguous()
+        return grouped, m, k, groups
+    raise ValueError(
+        f"source must have shape [M,K] or [M,K,L], got {tuple(source.shape)}"
+    )
+
+
+def _check_mxfp8_k(k: int) -> None:
+    if k <= 0 or k % 128 != 0:
+        raise ValueError(
+            f"MXFP8 dense_gemm K must be a positive multiple of 128, got {k}"
+        )
+
+
+def _wo_quant_chunks_per_program(k: int) -> int:
+    chunks = k // MXFP8_SCALE_VEC_SIZE
+    # tl.arange requires a power-of-two extent. K is only required to be a
+    # multiple of 128, so first round down before finding a divisor (for
+    # example, K=384 has 12 scale chunks and must use four per program).
+    chunks_per_program = min(
+        _WO_QUANT_CHUNKS_PER_PROGRAM,
+        1 << (chunks.bit_length() - 1),
+    )
+    while chunks % chunks_per_program:
+        chunks_per_program //= 2
+    return chunks_per_program
+
+
+def _cached_alpha_one(device: torch.device | str) -> torch.Tensor:
+    resolved = torch.device(device)
+    if resolved.type == "cuda" and resolved.index is None:
+        resolved = torch.device("cuda", torch.cuda.current_device())
+    key = (resolved.type, resolved.index)
+    alpha = _ALPHA_ONE_CACHE.get(key)
+    if alpha is None or alpha.device != resolved:
+        alpha = torch.ones((1,), dtype=torch.float32, device=resolved)
+        _ALPHA_ONE_CACHE[key] = alpha
+    return alpha
+
+
+@triton.jit
+def _quantize_grouped_tgd_to_tdg_kernel(
+    source,
+    values,
+    scale_rows,
+    scale_mma,
+    tokens,
+    groups: tl.constexpr,
+    group_width: tl.constexpr,
+    source_stride_t,
+    source_stride_g,
+    source_stride_d,
+    values_stride_t,
+    values_stride_d,
+    values_stride_g,
+    scale_mma_s0,
+    scale_mma_s1,
+    scale_mma_s2,
+    scale_mma_s3,
+    scale_mma_s4,
+    scale_mma_s5,
+    CHUNKS_PER_PROGRAM: tl.constexpr,
+) -> None:
+    token = tl.program_id(0)
+    group = tl.program_id(1)
+    chunk_block = tl.program_id(2)
+    chunk = chunk_block * CHUNKS_PER_PROGRAM + tl.arange(0, CHUNKS_PER_PROGRAM)
+    d = chunk[:, None] * 32 + tl.arange(0, 32)[None, :]
+
+    src = tl.load(
+        source
+        + token * source_stride_t
+        + group * source_stride_g
+        + d * source_stride_d,
+    ).to(tl.float32)
+    max_abs = tl.max(tl.abs(src), axis=1)
+    quant_scale = tl.where(max_abs > 0.0, max_abs / 448.0, 1.0)
+    scale_exp = tl.minimum(tl.maximum(tl.ceil(tl.log2(quant_scale)), -127.0), 127.0)
+    scale = tl.exp2(scale_exp)
+    scale_u8 = (scale_exp + 127.0).to(tl.uint8)
+
+    tl.store(
+        values
+        + token * values_stride_t
+        + d * values_stride_d
+        + group * values_stride_g,
+        (src / scale[:, None]).to(tl.float8e4nv),
+    )
+
+    sf_cols = group_width // 32
+    tl.store(
+        scale_rows + group * tokens * sf_cols + token * sf_cols + chunk,
+        scale_u8,
+    )
+
+    row32 = token % 32
+    row4 = (token // 32) % 4
+    tile_m = token // 128
+    k4 = chunk % 4
+    tile_k = chunk // 4
+    tl.store(
+        scale_mma
+        + row32 * scale_mma_s0
+        + row4 * scale_mma_s1
+        + tile_m * scale_mma_s2
+        + k4 * scale_mma_s3
+        + tile_k * scale_mma_s4
+        + group * scale_mma_s5,
+        scale_u8,
+    )
+
+
+@triton.jit
+def _quantize_attention_inv_rope_to_tdg_kernel(
+    o,
+    positions,
+    cos_sin_cache,
+    values,
+    scale_rows,
+    scale_mma,
+    clear_output,
+    tokens,
+    groups: tl.constexpr,
+    heads_per_group: tl.constexpr,
+    group_width: tl.constexpr,
+    o_stride_t,
+    o_stride_h,
+    o_stride_d,
+    cos_sin_stride_pos,
+    values_stride_t,
+    values_stride_d,
+    values_stride_g,
+    scale_mma_s0,
+    scale_mma_s1,
+    scale_mma_s2,
+    scale_mma_s3,
+    scale_mma_s4,
+    scale_mma_s5,
+    clear_output_stride_t,
+    clear_output_stride_n,
+    HEAD_DIM: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    HALF_ROPE_DIM: tl.constexpr,
+    CHUNKS_PER_PROGRAM: tl.constexpr,
+    FAST_B16_SCALE: tl.constexpr,
+    CLEAR_OUTPUT: tl.constexpr,
+    CLEAR_HIDDEN: tl.constexpr,
+    CLEAR_BLOCK_SIZE: tl.constexpr,
+) -> None:
+    token = tl.program_id(0)
+    group = tl.program_id(1)
+    chunk_block = tl.program_id(2)
+    chunk = chunk_block * CHUNKS_PER_PROGRAM + tl.arange(0, CHUNKS_PER_PROGRAM)
+    d = chunk[:, None] * 32 + tl.arange(0, 32)[None, :]
+
+    if CLEAR_OUTPUT:
+        chunk_blocks = group_width // 32 // CHUNKS_PER_PROGRAM
+        clear_block = group * chunk_blocks + chunk_block
+        clear_n = clear_block * CLEAR_BLOCK_SIZE + tl.arange(0, CLEAR_BLOCK_SIZE)
+        tl.store(
+            clear_output
+            + token * clear_output_stride_t
+            + clear_n * clear_output_stride_n,
+            0.0,
+            mask=clear_n < CLEAR_HIDDEN,
+        )
+
+    head_in_group = d // HEAD_DIM
+    head_d = d - head_in_group * HEAD_DIM
+    head = group * heads_per_group + head_in_group
+
+    src = tl.load(o + token * o_stride_t + head * o_stride_h + head_d * o_stride_d).to(
+        tl.float32
+    )
+
+    is_rope = head_d >= NOPE_DIM
+    rope_local = head_d - NOPE_DIM
+    partner_d = NOPE_DIM + (rope_local ^ 1)
+    partner = tl.load(
+        o + token * o_stride_t + head * o_stride_h + partner_d * o_stride_d,
+        mask=is_rope,
+        other=0.0,
+    ).to(tl.float32)
+
+    pos = tl.load(positions + token)
+    cs_idx = tl.maximum(rope_local >> 1, 0)
+    cache_base = cos_sin_cache + pos * cos_sin_stride_pos
+    cos_v = tl.load(cache_base + cs_idx, mask=is_rope, other=1.0)
+    sin_v = tl.load(cache_base + HALF_ROPE_DIM + cs_idx, mask=is_rope, other=0.0)
+    x_add = src * cos_v + partner * sin_v
+    x_sub = src * cos_v - partner * sin_v
+    rotated = tl.where((rope_local & 1) == 0, x_add, x_sub)
+    src = tl.where(is_rope, rotated, src)
+
+    max_abs = tl.max(tl.abs(src), axis=1)
+    if FAST_B16_SCALE:
+        max_bits = max_abs.to(tl.uint32, bitcast=True)
+        biased_exp = (max_bits >> 23) & 0xFF
+        mantissa = max_bits & 0x7FFFFF
+        scale_exp = biased_exp.to(tl.int32) - 135 + (mantissa > 0x600000).to(tl.int32)
+        scale_exp = tl.minimum(tl.maximum(scale_exp, -127), 127)
+        scale_exp = tl.where(max_abs > 0.0, scale_exp, 0)
+        inv_scale_bits = tl.where(
+            scale_exp == 127,
+            max_bits * 0 + 0x00400000,
+            (127 - scale_exp).to(tl.uint32) << 23,
+        )
+        inv_scale = inv_scale_bits.to(tl.float32, bitcast=True)
+        scaled_src = src * inv_scale[:, None]
+    else:
+        quant_scale = tl.where(max_abs > 0.0, max_abs / 448.0, 1.0)
+        scale_exp = tl.minimum(tl.maximum(tl.ceil(tl.log2(quant_scale)), -127.0), 127.0)
+        scale = tl.exp2(scale_exp)
+        scaled_src = src / scale[:, None]
+    scale_u8 = (scale_exp + 127.0).to(tl.uint8)
+
+    tl.store(
+        values
+        + token * values_stride_t
+        + d * values_stride_d
+        + group * values_stride_g,
+        scaled_src.to(tl.float8e4nv),
+    )
+
+    sf_cols = group_width // 32
+    tl.store(
+        scale_rows + group * tokens * sf_cols + token * sf_cols + chunk,
+        scale_u8,
+    )
+
+    row32 = token % 32
+    row4 = (token // 32) % 4
+    tile_m = token // 128
+    k4 = chunk % 4
+    tile_k = chunk // 4
+    tl.store(
+        scale_mma
+        + row32 * scale_mma_s0
+        + row4 * scale_mma_s1
+        + tile_m * scale_mma_s2
+        + k4 * scale_mma_s3
+        + tile_k * scale_mma_s4
+        + group * scale_mma_s5,
+        scale_u8,
+    )
+
+
+@triton.jit
+def _quantize_group_major_trg_to_tk_kernel(
+    source,
+    values,
+    scale_rows,
+    scale_mma,
+    tokens,
+    rank: tl.constexpr,
+    groups: tl.constexpr,
+    source_stride_t,
+    source_stride_r,
+    source_stride_g,
+    scale_mma_s0,
+    scale_mma_s1,
+    scale_mma_s2,
+    scale_mma_s3,
+    scale_mma_s4,
+    scale_mma_s5,
+    CHUNKS_PER_PROGRAM: tl.constexpr,
+) -> None:
+    token = tl.program_id(0)
+    chunk_block = tl.program_id(1)
+    chunk = chunk_block * CHUNKS_PER_PROGRAM + tl.arange(0, CHUNKS_PER_PROGRAM)
+    cols = chunk[:, None] * 32 + tl.arange(0, 32)[None, :]
+    g = cols // rank
+    r = cols - g * rank
+
+    src = tl.load(
+        source + token * source_stride_t + r * source_stride_r + g * source_stride_g,
+    ).to(tl.float32)
+    max_abs = tl.max(tl.abs(src), axis=1)
+    safe = tl.where(max_abs > 0.0, max_abs / 448.0, 1.0)
+    scale_exp = tl.minimum(tl.maximum(tl.ceil(tl.log2(safe)), -127.0), 127.0)
+    scale = tl.exp2(scale_exp)
+    scale_u8 = (scale_exp + 127.0).to(tl.uint8)
+
+    width = rank * groups
+    tl.store(values + token * width + cols, (src / scale[:, None]).to(tl.float8e4nv))
+
+    sf_cols = width // 32
+    tl.store(scale_rows + token * sf_cols + chunk, scale_u8)
+
+    row32 = token % 32
+    row4 = (token // 32) % 4
+    tile_m = token // 128
+    k4 = chunk % 4
+    tile_k = chunk // 4
+    tl.store(
+        scale_mma
+        + row32 * scale_mma_s0
+        + row4 * scale_mma_s1
+        + tile_m * scale_mma_s2
+        + k4 * scale_mma_s3
+        + tile_k * scale_mma_s4
+        + scale_mma_s5 * 0,
+        scale_u8,
+    )
+
+
+def empty_dense_gemm_mnl_view(
+    m: int,
+    n: int,
+    l: int,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Allocate an `[M,N,L]` view backed by dense-GEMM physical `[L,M,N]` storage."""
+
+    if m <= 0 or n <= 0 or l <= 0:
+        raise ValueError("m, n, and l must be positive")
+    if l == 1:
+        return torch.empty((m, n, 1), device=device, dtype=dtype)
+    physical = torch.empty((l, m, n), device=device, dtype=dtype)
+    return physical.as_strided((m, n, l), (n, 1, m * n))
+
+
+def empty_mxfp8_rows_bases(
+    m: int,
+    k: int,
+    *,
+    num_groups: int,
+    device: torch.device | str,
+    initialize_scales: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Allocate the three CONTIGUOUS base buffers behind an MXFP8Rows.
+
+    Returns ``(values_base, scale_rows_base_u8, scale_physical_base_u8)`` -- all
+    contiguous. ``mxfp8_rows_from_bases`` rebuilds the (strided/permuted)
+    dense-GEMM views from them. Functional custom ops return these bases instead
+    of the views: an opaque op that *returns a view* surfaces a symbolic-shaped
+    view as a downstream graph input, which trips torch's AOT
+    `merge_view_inputs` synthetic-base path under dynamic shapes. Returning bases
+    keeps op outputs contiguous; the views are rebuilt in normal traced code.
+
+    ``initialize_scales=False`` is for an immediately following quantization
+    kernel that overwrites every logical row scale and every physical scale
+    entry consumed by dense GEMM. Physical M-padding remains unspecified; dense
+    GEMM must not observe it for logical output rows.
+    """
+    if m <= 0 or k <= 0 or num_groups <= 0:
+        raise ValueError("m, k, and num_groups must be positive")
+    _check_mxfp8_k(k)
+    if num_groups == 1:
+        values_base = torch.empty((m, k), device=device, dtype=torch.float8_e4m3fn)
+    else:
+        # Physical [L, M, K]; mxfp8_rows_from_bases views it as the [M,K,L] mnl layout.
+        values_base = torch.empty(
+            (num_groups, m, k), device=device, dtype=torch.float8_e4m3fn
+        )
+    scale_shape = (num_groups, m, k // MXFP8_SCALE_VEC_SIZE)
+    if initialize_scales:
+        scale_rows_base = torch.full(
+            scale_shape,
+            127,
+            dtype=torch.uint8,
+            device=device,
+        )
+    else:
+        scale_rows_base = torch.empty(scale_shape, dtype=torch.uint8, device=device)
+    m_tiles = math.ceil(m / MXFP8_SCALE_ROW_TILE)
+    k_tiles = math.ceil((k // MXFP8_SCALE_VEC_SIZE) / MXFP8_SCALE_K_TILE)
+    physical_shape = (num_groups, m_tiles, k_tiles, 32, 4, 4)
+    if initialize_scales:
+        scale_physical_base = torch.full(
+            physical_shape,
+            127,
+            dtype=torch.uint8,
+            device=device,
+        )
+    else:
+        scale_physical_base = torch.empty(
+            physical_shape, dtype=torch.uint8, device=device
+        )
+    return values_base, scale_rows_base, scale_physical_base
+
+
+def mxfp8_rows_from_bases(
+    values_base: torch.Tensor,
+    scale_rows_base: torch.Tensor,
+    scale_physical_base: torch.Tensor,
+    m: int,
+    k: int,
+    *,
+    num_groups: int,
+) -> MXFP8Rows:
+    """Rebuild the dense-GEMM MXFP8Rows views over contiguous bases (pure views)."""
+    if num_groups == 1:
+        values = values_base
+    else:
+        values = values_base.as_strided((m, k, num_groups), (k, 1, m * k))
+    scale_rows = scale_rows_base.view(torch.float8_e8m0fnu)
+    scale_mma = scale_physical_base.view(torch.float8_e8m0fnu).permute(3, 4, 1, 5, 2, 0)
+    return MXFP8Rows(values=values, scale_rows=scale_rows, scale_mma=scale_mma)
+
+
+def empty_mxfp8_rows_for_dense_gemm(
+    m: int,
+    k: int,
+    *,
+    num_groups: int = 1,
+    device: torch.device | str,
+) -> MXFP8Rows:
+    """Allocate MXFP8 row storage in the layout consumed by `dense_gemm`."""
+
+    values_base, scale_rows_base, scale_physical_base = empty_mxfp8_rows_bases(
+        m, k, num_groups=num_groups, device=device
+    )
+    return mxfp8_rows_from_bases(
+        values_base, scale_rows_base, scale_physical_base, m, k, num_groups=num_groups
+    )
+
+
+def _check_dense_gemm_mnl_view(name: str, tensor: torch.Tensor) -> None:
+    _check_gpu_tensor(name, tensor)
+    if tensor.ndim != 3:
+        raise ValueError(f"{name} must have shape [M,N,L], got {tuple(tensor.shape)}")
+    m, n, l = tensor.shape
+    expected_stride = (n, 1, m * n) if l > 1 else tensor.stride()
+    if l > 1 and tensor.stride() != expected_stride:
+        raise ValueError(
+            f"{name} must be backed by dense-GEMM physical [L,M,N] storage: "
+            f"expected stride {expected_stride}, got {tensor.stride()}"
+        )
+
+
+def _scale_u8_from_max_abs(max_abs: torch.Tensor) -> torch.Tensor:
+    safe = torch.where(
+        max_abs > 0,
+        max_abs.to(torch.float32) / FP8_E4M3_MAX,
+        torch.ones_like(max_abs, dtype=torch.float32),
+    )
+    exponent = torch.ceil(torch.log2(safe)).clamp(-127, 127)
+    return (exponent + 127).to(torch.uint8)
+
+
+def _scale_to_e8m0_u8(scale: torch.Tensor) -> torch.Tensor:
+    _check_gpu_tensor("scale", scale)
+    if scale.dtype == torch.float8_e8m0fnu:
+        return scale.view(torch.uint8)
+    if scale.dtype == torch.uint8:
+        return scale
+    if not scale.is_floating_point():
+        raise ValueError(
+            f"scale must be e8m0, uint8, or floating-point, got {scale.dtype}"
+        )
+    safe = torch.where(
+        scale > 0,
+        scale.to(torch.float32),
+        torch.ones_like(scale, dtype=torch.float32),
+    )
+    exponent = torch.round(torch.log2(safe)).clamp(-127, 127)
+    return (exponent + 127).to(torch.uint8)
+
+
+def _expand_block_scales_to_mxfp8_rows(
+    scale: torch.Tensor,
+    *,
+    m: int,
+    k: int,
+    num_groups: int,
+) -> torch.Tensor:
+    _check_gpu_tensor("scale", scale)
+    if m <= 0 or k <= 0 or num_groups <= 0:
+        raise ValueError("m, k, and num_groups must be positive")
+    _check_mxfp8_k(k)
+
+    m_tiles = math.ceil(m / MXFP8_SCALE_ROW_TILE)
+    k_tiles = math.ceil((k // MXFP8_SCALE_VEC_SIZE) / MXFP8_SCALE_K_TILE)
+    expected_2d = (num_groups * m_tiles, k_tiles)
+    expected_3d = (num_groups, m_tiles, k_tiles)
+    if scale.shape == expected_2d:
+        block_u8 = _scale_to_e8m0_u8(scale).reshape(num_groups, m_tiles, k_tiles)
+    elif scale.shape == expected_3d:
+        block_u8 = _scale_to_e8m0_u8(scale).reshape(expected_3d)
+    elif num_groups == 1 and scale.shape == (m_tiles, k_tiles):
+        block_u8 = _scale_to_e8m0_u8(scale).reshape(1, m_tiles, k_tiles)
+    else:
+        raise ValueError(
+            "block scale must have shape "
+            f"{expected_2d}, {expected_3d}"
+            + (f", or {(m_tiles, k_tiles)}" if num_groups == 1 else "")
+            + f"; got {tuple(scale.shape)}"
+        )
+
+    scale_rows_u8 = (
+        block_u8[:, :, None, :, None]
+        .expand(num_groups, m_tiles, MXFP8_SCALE_ROW_TILE, k_tiles, MXFP8_SCALE_K_TILE)
+        .reshape(
+            num_groups,
+            m_tiles * MXFP8_SCALE_ROW_TILE,
+            k_tiles * MXFP8_SCALE_K_TILE,
+        )[:, :m, : k // MXFP8_SCALE_VEC_SIZE]
+        .contiguous()
+    )
+    return scale_rows_u8.view(torch.float8_e8m0fnu)
+
+
+def pack_mxfp8_scales_for_dense_gemm(
+    scale_rows: torch.Tensor,
+    *,
+    m: int,
+    k: int,
+    num_groups: int = 1,
+) -> torch.Tensor:
+    """Pack compact MXFP8 row/chunk scales into sm12x dense-GEMM MMA layout.
+
+    `scale_rows` must be UE8M0 scales in either `[M, K/32]`,
+    `[num_groups, M, K/32]`, or `[num_groups * M, K/32]` form. Missing padded
+    rows/chunks are filled with UE8M0 1.0, so the kernel can safely read the
+    fixed 128-row scale tile for small-M contracts.
+    """
+
+    _check_gpu_tensor("scale_rows", scale_rows)
+    if scale_rows.dtype == torch.uint8:
+        scale_rows = scale_rows.view(torch.float8_e8m0fnu)
+    if scale_rows.dtype != torch.float8_e8m0fnu:
+        raise ValueError(f"scale_rows must be uint8/e8m0, got {scale_rows.dtype}")
+    if m <= 0 or k <= 0 or num_groups <= 0:
+        raise ValueError("m, k, and num_groups must be positive")
+    _check_mxfp8_k(k)
+
+    sf_k = k // MXFP8_SCALE_VEC_SIZE
+    if scale_rows.ndim == 2:
+        if scale_rows.shape == (m, sf_k):
+            grouped = scale_rows.reshape(1, m, sf_k)
+            if num_groups != 1:
+                raise ValueError(
+                    "2D scale_rows with shape [M,K/32] requires num_groups=1"
+                )
+        elif scale_rows.shape == (num_groups * m, sf_k):
+            grouped = scale_rows.reshape(num_groups, m, sf_k)
+        else:
+            raise ValueError(
+                "scale_rows must have shape [M,K/32] or [num_groups*M,K/32], "
+                f"got {tuple(scale_rows.shape)} for m={m}, k={k}, num_groups={num_groups}"
+            )
+    elif scale_rows.ndim == 3:
+        if scale_rows.shape != (num_groups, m, sf_k):
+            raise ValueError(
+                f"scale_rows must have shape {(num_groups, m, sf_k)}, "
+                f"got {tuple(scale_rows.shape)}"
+            )
+        grouped = scale_rows
+    else:
+        raise ValueError(
+            "scale_rows must have shape [M,K/32], [num_groups*M,K/32], "
+            f"or [num_groups,M,K/32], got {tuple(scale_rows.shape)}"
+        )
+
+    m_tiles = math.ceil(m / MXFP8_SCALE_ROW_TILE)
+    k_tiles = math.ceil(sf_k / MXFP8_SCALE_K_TILE)
+    padded_m = m_tiles * MXFP8_SCALE_ROW_TILE
+    padded_sf_k = k_tiles * MXFP8_SCALE_K_TILE
+
+    padded_u8 = torch.full(
+        (num_groups, padded_m, padded_sf_k),
+        127,
+        dtype=torch.uint8,
+        device=scale_rows.device,
+    )
+    padded = padded_u8.view(torch.float8_e8m0fnu)
+    padded[:, :m, :sf_k] = grouped
+
+    physical = (
+        padded.view(num_groups, m_tiles, 4, 32, k_tiles, 4)
+        .permute(0, 1, 4, 3, 2, 5)
+        .contiguous()
+    )
+    return physical.permute(3, 4, 1, 5, 2, 0)
+
+
+def _scale_is_exact_ue8m0(scale: torch.Tensor) -> bool:
+    """True if `scale` is already an exact UE8M0 scale (no re-quant needed).
+
+    UE8M0-typed tensors (`float8_e8m0fnu`/`uint8`) qualify by construction. A
+    floating-point tensor qualifies only if every entry is a positive power of
+    two (zero mantissa) — e.g. a previously-UE8M0 scale widened to fp32. Genuine
+    checkpoint scales (`weight_scale_inv = block_amax / 448`) are not powers of
+    two and fail this test, so they get re-quantized. Runs once at weight load.
+    """
+
+    if scale.dtype in (torch.uint8, torch.float8_e8m0fnu):
+        return True
+    if not scale.is_floating_point():
+        return False
+    bits = scale.detach().to(torch.float32).view(torch.int32)
+    mantissa = bits & 0x7FFFFF
+    positive = scale.detach().to(torch.float32) > 0
+    return bool(torch.all(positive & (mantissa == 0)).item())
+
+
+def _requantize_block_fp8_to_ue8m0(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    m: int,
+    k: int,
+    num_groups: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Re-quantize an FP8 checkpoint weight onto exact UE8M0 block scales.
+
+    DeepSeek-style checkpoints carry `(w_fp8, s_fp32)` where `s_fp32 =
+    block_amax / 448` is an *arbitrary* fp32 128x128 block scale. The sm12x MMA
+    can only apply power-of-two (UE8M0) scales. Rounding `s_fp32` to the nearest
+    power of two while keeping the original `w_fp8` values leaves the values
+    matched to the *unrounded* scale, baking in a per-block scale error up to
+    sqrt(2) (~10% weight RMS error, measured).
+
+    Parity with DeepGEMM's `per_block_cast_to_fp8(use_ue8m0=True)`: reconstruct
+    the recovered weight `w_fp8 * s_fp32` and re-cast it onto a fresh ceil-UE8M0
+    block scale, so the FP8 values are re-derived *consistently* with the
+    power-of-two scale (~3.7% RMS error, near the irreducible e4m3 floor). This
+    runs once at weight load, not in the serving path.
+
+    Returns `(weight_e4m3 [num_groups*m, k] or [m, k], block_scale_e8m0_u8
+    [num_groups, m_tiles, k_tiles])`.
+    """
+
+    gk = MXFP8_SCALE_ROW_TILE  # 128
+    m_tiles = math.ceil(m / gk)
+    k_tiles = math.ceil((k // MXFP8_SCALE_VEC_SIZE) / MXFP8_SCALE_K_TILE)
+
+    # Normalize the FP8 weight to per-group [num_groups, m, k].
+    if num_groups == 1:
+        w_g = weight.reshape(1, m, k)
+    elif tuple(weight.shape) == (num_groups * m, k):
+        w_g = weight.reshape(num_groups, m, k)
+    elif tuple(weight.shape) == (m, k, num_groups):
+        w_g = weight.permute(2, 0, 1)
+    else:
+        raise ValueError(
+            f"weight must have shape {(num_groups * m, k)} or {(m, k, num_groups)} "
+            f"or {(m, k)}, got {tuple(weight.shape)}"
+        )
+
+    # Normalize the arbitrary fp32 block scale to [num_groups, m_tiles, k_tiles].
+    s = scale.to(torch.float32)
+    if tuple(s.shape) == (num_groups * m_tiles, k_tiles):
+        s_g = s.reshape(num_groups, m_tiles, k_tiles)
+    elif tuple(s.shape) == (num_groups, m_tiles, k_tiles):
+        s_g = s
+    elif num_groups == 1 and tuple(s.shape) == (m_tiles, k_tiles):
+        s_g = s.reshape(1, m_tiles, k_tiles)
+    else:
+        raise ValueError(
+            f"block scale must have shape {(num_groups * m_tiles, k_tiles)}, "
+            f"{(num_groups, m_tiles, k_tiles)}"
+            + (f", or {(m_tiles, k_tiles)}" if num_groups == 1 else "")
+            + f"; got {tuple(scale.shape)}"
+        )
+
+    # Reconstruct the recovered weight: w_fp8 * (block scale broadcast to elems).
+    s_elem = s_g.repeat_interleave(gk, dim=1).repeat_interleave(gk, dim=2)[:, :m, :k]
+    w_rec = w_g.to(torch.float32) * s_elem
+
+    # Pad to whole 128x128 blocks, take per-block amax, ceil-UE8M0 cast.
+    m_pad, k_pad = m_tiles * gk, k_tiles * gk
+    w_pad = w_rec.new_zeros(num_groups, m_pad, k_pad)
+    w_pad[:, :m, :k] = w_rec
+    blocks = w_pad.view(num_groups, m_tiles, gk, k_tiles, gk)
+    amax = blocks.abs().amax(dim=(2, 4), keepdim=True)  # [g, m_tiles, 1, k_tiles, 1]
+    safe = torch.where(amax > 0, amax / FP8_E4M3_MAX, torch.ones_like(amax))
+    exponent = torch.clamp(torch.ceil(torch.log2(safe)), -127.0, 127.0)
+    sf = torch.exp2(exponent)
+    new_vals = (
+        (blocks / sf)
+        .to(torch.float8_e4m3fn)
+        .view(num_groups, m_pad, k_pad)[:, :m, :k]
+        .contiguous()
+    )
+    new_scale_u8 = (exponent.view(num_groups, m_tiles, k_tiles) + 127).to(torch.uint8)
+
+    if num_groups == 1:
+        new_weight = new_vals.reshape(m, k)
+    else:
+        new_weight = new_vals.reshape(num_groups * m, k)
+    return new_weight, new_scale_u8
+
+
+def pack_fp8_block_scaled_weight_mxfp8(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    m: int,
+    k: int,
+    num_groups: int = 1,
+) -> MXFP8Rows:
+    """Pack checkpoint FP8 block-scaled weights for native MXFP8 dense GEMM.
+
+    `weight` is FP8 E4M3 and `scale` is the DSV4-style 128x128 block scale.
+
+    When `scale` is an *arbitrary* fp32 block scale (the DeepSeek
+    `weight_scale_inv` checkpoint format), the weight is **re-quantized** onto an
+    exact ceil-UE8M0 block scale so the FP8 values stay consistent with the
+    power-of-two scale the MMA applies (parity with DeepGEMM
+    `per_block_cast_to_fp8`). When `scale` is already UE8M0 (e8m0/uint8), the
+    FP8 values are kept verbatim and the scale is expanded as-is.
+    """
+
+    _check_gpu_tensor("weight", weight)
+    if weight.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"weight must be float8_e4m3fn, got {weight.dtype}")
+    if m <= 0 or k <= 0 or num_groups <= 0:
+        raise ValueError("m, k, and num_groups must be positive")
+    _check_mxfp8_k(k)
+
+    # Arbitrary fp32 checkpoint scales (e.g. DeepSeek `weight_scale_inv`) are not
+    # powers of two; re-quantize onto exact UE8M0 instead of rounding the scale
+    # and leaving the FP8 values stale (which costs ~2.7x more error). Scales
+    # that are already exact UE8M0 (e8m0/uint8, or a float tensor holding only
+    # powers of two) keep their FP8 values verbatim.
+    if not _scale_is_exact_ue8m0(scale):
+        _check_gpu_tensor("scale", scale)
+        weight, scale = _requantize_block_fp8_to_ue8m0(
+            weight, scale, m=m, k=k, num_groups=num_groups
+        )
+
+    if num_groups == 1:
+        if weight.shape != (m, k):
+            raise ValueError(
+                f"weight must have shape {(m, k)}, got {tuple(weight.shape)}"
+            )
+        values = weight.contiguous()
+    else:
+        if weight.shape == (num_groups * m, k):
+            values = weight.contiguous().view(num_groups, m, k).permute(1, 2, 0)
+        elif weight.shape == (m, k, num_groups):
+            values = weight
+            _check_dense_gemm_mnl_view("weight", values)
+        else:
+            raise ValueError(
+                f"weight must have shape {(num_groups * m, k)} or {(m, k, num_groups)}, "
+                f"got {tuple(weight.shape)}"
+            )
+
+    scale_rows = _expand_block_scales_to_mxfp8_rows(
+        scale,
+        m=m,
+        k=k,
+        num_groups=num_groups,
+    )
+    scale_mma = pack_mxfp8_scales_for_dense_gemm(
+        scale_rows,
+        m=m,
+        k=k,
+        num_groups=num_groups,
+    )
+    values_tiled = None
+    tile_n = 0
+    if (num_groups, m, k) == (4, 1024, 4096):
+        tile_n = 64
+    elif (num_groups, m, k) == (1, 4096, 4096):
+        tile_n = 128
+    if tile_n:
+        # Physical [L, Ntile, Ktile, Ninner, Kinner], specialized for the
+        # production decode WO Ntile/BK128 GEMMs. Keep `values` in its logical
+        # layout for all other schedules and callers.
+        values_lnk = values.permute(2, 0, 1) if num_groups > 1 else values.unsqueeze(0)
+        values_tiled = (
+            values_lnk.reshape(num_groups, m // tile_n, tile_n, k // 128, 128)
+            .permute(0, 1, 3, 2, 4)
+            .contiguous()
+        )
+    return MXFP8Rows(
+        values=values,
+        scale_rows=scale_rows,
+        scale_mma=scale_mma,
+        values_tiled=values_tiled,
+    )
+
+
+def pack_wo_projection_fp8_block_scaled_weights_mxfp8(
+    wo_a_weight: torch.Tensor,
+    wo_a_scale: torch.Tensor,
+    wo_b_weight: torch.Tensor,
+    wo_b_scale: torch.Tensor,
+    *,
+    groups: int,
+    group_width: int,
+    rank: int,
+    hidden: int,
+) -> WOProjectionMXFP8Weights:
+    """Pack local DSV4 WO-A/WO-B checkpoint FP8 weights for the sm12x WO path."""
+
+    wo_a = pack_fp8_block_scaled_weight_mxfp8(
+        wo_a_weight,
+        wo_a_scale,
+        m=rank,
+        k=group_width,
+        num_groups=groups,
+    )
+    wo_b = pack_fp8_block_scaled_weight_mxfp8(
+        wo_b_weight,
+        wo_b_scale,
+        m=hidden,
+        k=groups * rank,
+        num_groups=1,
+    )
+    return WOProjectionMXFP8Weights(
+        wo_a=wo_a,
+        wo_b=wo_b,
+        groups=groups,
+        group_width=group_width,
+        rank=rank,
+        hidden=hidden,
+        sfb_k_replicated=True,
+    )
+
+
+def _check_mxfp8_rows_storage(
+    out: MXFP8Rows,
+    *,
+    m: int,
+    k: int,
+    num_groups: int,
+) -> None:
+    _check_gpu_tensor("out.values", out.values)
+    _check_gpu_tensor("out.scale_rows", out.scale_rows)
+    _check_gpu_tensor("out.scale_mma", out.scale_mma)
+    if out.values.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"out.values must be float8_e4m3fn, got {out.values.dtype}")
+    if out.scale_rows.dtype != torch.float8_e8m0fnu:
+        raise ValueError(
+            f"out.scale_rows must be float8_e8m0fnu, got {out.scale_rows.dtype}"
+        )
+    if out.scale_mma.dtype != torch.float8_e8m0fnu:
+        raise ValueError(
+            f"out.scale_mma must be float8_e8m0fnu, got {out.scale_mma.dtype}"
+        )
+    if out.values_tiled is not None:
+        _check_gpu_tensor("out.values_tiled", out.values_tiled)
+        if out.values_tiled.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                f"out.values_tiled must be float8_e4m3fn, got {out.values_tiled.dtype}"
+            )
+        expected_tiled_shapes = {
+            (4, 1024, 4096): (4, 16, 32, 64, 128),
+            (1, 4096, 4096): (1, 32, 32, 128, 128),
+        }
+        expected_tiled_shape = expected_tiled_shapes.get((num_groups, m, k))
+        if (
+            expected_tiled_shape is None
+            or tuple(out.values_tiled.shape) != expected_tiled_shape
+        ):
+            raise ValueError(
+                "out.values_tiled is only supported for production WO-A/WO-B; "
+                f"got dimensions {(num_groups, m, k)} and shape "
+                f"{tuple(out.values_tiled.shape)}, expected {expected_tiled_shape}"
+            )
+        if out.values_tiled.device != out.values.device:
+            raise ValueError(
+                "out.values_tiled and out.values must be on the same device"
+            )
+        if not out.values_tiled.is_contiguous():
+            raise ValueError("out.values_tiled must be contiguous")
+    if num_groups == 1:
+        if out.values.shape != (m, k):
+            raise ValueError(
+                f"out.values must have shape {(m, k)}, got {tuple(out.values.shape)}"
+            )
+    else:
+        if out.values.shape != (m, k, num_groups):
+            raise ValueError(
+                f"out.values must have shape {(m, k, num_groups)}, got {tuple(out.values.shape)}"
+            )
+        _check_dense_gemm_mnl_view("out.values", out.values)
+    sf_k = k // MXFP8_SCALE_VEC_SIZE
+    if out.scale_rows.shape != (num_groups, m, sf_k):
+        raise ValueError(
+            f"out.scale_rows must have shape {(num_groups, m, sf_k)}, "
+            f"got {tuple(out.scale_rows.shape)}"
+        )
+    expected_scale_mma = (
+        32,
+        4,
+        math.ceil(m / MXFP8_SCALE_ROW_TILE),
+        4,
+        math.ceil(sf_k / MXFP8_SCALE_K_TILE),
+        num_groups,
+    )
+    if out.scale_mma.shape != expected_scale_mma:
+        raise ValueError(
+            f"out.scale_mma must have shape {expected_scale_mma}, got {tuple(out.scale_mma.shape)}"
+        )
+
+
+def quantize_wo_a_input_mxfp8(
+    source_tgd: torch.Tensor,
+    *,
+    out: MXFP8Rows | None = None,
+) -> MXFP8Rows:
+    """Quantize grouped WO-A input into per-32-column MXFP8 rows."""
+
+    _check_gpu_tensor("source_tgd", source_tgd)
+    if source_tgd.ndim != 3:
+        raise ValueError(
+            f"source_tgd must have shape [tokens, groups, group_width], got {tuple(source_tgd.shape)}"
+        )
+    tokens, groups, group_width = source_tgd.shape
+    _check_mxfp8_k(group_width)
+    if out is None:
+        out = empty_mxfp8_rows_for_dense_gemm(
+            tokens,
+            group_width,
+            num_groups=groups,
+            device=source_tgd.device,
+        )
+    else:
+        _check_mxfp8_rows_storage(out, m=tokens, k=group_width, num_groups=groups)
+    # Measured on RTX PRO 6000 at M=8192, gw=4096, groups=4: this Triton
+    # kernel (232.8us) beats the CuTe grouped port (250.1us) -- unlike the old
+    # per-32-group dense quantizer, it is already tiled and bandwidth-bound.
+    # quantize_wo_grouped_rows_cute stays available but is not routed.
+    values_stride_g = out.values.stride(2) if out.values.ndim == 3 else 0
+    chunks_per_program = _wo_quant_chunks_per_program(group_width)
+    _quantize_grouped_tgd_to_tdg_kernel[
+        (
+            tokens,
+            groups,
+            group_width // MXFP8_SCALE_VEC_SIZE // chunks_per_program,
+        )
+    ](
+        source_tgd,
+        out.values,
+        out.scale_rows.view(torch.uint8),
+        out.scale_mma.view(torch.uint8),
+        tokens,
+        groups,
+        group_width,
+        source_tgd.stride(0),
+        source_tgd.stride(1),
+        source_tgd.stride(2),
+        out.values.stride(0),
+        out.values.stride(1),
+        values_stride_g,
+        out.scale_mma.stride(0),
+        out.scale_mma.stride(1),
+        out.scale_mma.stride(2),
+        out.scale_mma.stride(3),
+        out.scale_mma.stride(4),
+        out.scale_mma.stride(5),
+        CHUNKS_PER_PROGRAM=chunks_per_program,
+        num_warps=4,
+    )
+    return out
+
+
+def _run_wo_a_quant_kernel(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    out_values: torch.Tensor,
+    out_scale_rows: torch.Tensor,
+    out_scale_mma: torch.Tensor,
+    tokens: int,
+    groups: int,
+    heads_per_group: int,
+    group_width: int,
+    head_dim: int,
+    nope_dim: int,
+    rope_dim: int,
+    clear_output: torch.Tensor | None = None,
+) -> None:
+    # Measured on RTX PRO 6000 at the DS4-Flash TP2 prefill shape (M=8192):
+    # this Triton kernel (263us) beats the branchless CuTe inverse-RoPE port
+    # (279us); both are near the read+write roofline. The CuTe variant
+    # (quantize_wo_grouped_rows_cute with positions) stays available but is
+    # not routed.
+    out_scale_mma_u8 = out_scale_mma.view(torch.uint8)
+    values_stride_g = out_values.stride(2) if out_values.ndim == 3 else 0
+    chunks_per_program = _wo_quant_chunks_per_program(group_width)
+    fast_b16_scale = (
+        tokens == 16
+        and groups == 4
+        and heads_per_group == 8
+        and group_width == 4096
+        and head_dim == 512
+        and nope_dim == 448
+        and rope_dim == 64
+        and chunks_per_program == 16
+    )
+    clear_programs = groups * group_width // MXFP8_SCALE_VEC_SIZE // chunks_per_program
+    if clear_output is None:
+        clear_output_arg = out_values
+        clear_output_stride_t = 0
+        clear_output_stride_n = 0
+        clear_hidden = 0
+        clear_block_size = 1
+    else:
+        if (
+            clear_output.ndim != 3
+            or int(clear_output.shape[0]) != tokens
+            or int(clear_output.shape[2]) != 1
+            or clear_output.dtype != torch.bfloat16
+        ):
+            raise ValueError(
+                "quantizer clear output must be BF16 [tokens, hidden, 1], got "
+                f"{clear_output.dtype} {tuple(clear_output.shape)}"
+            )
+        clear_output_arg = clear_output
+        clear_output_stride_t = clear_output.stride(0)
+        clear_output_stride_n = clear_output.stride(1)
+        clear_hidden = int(clear_output.shape[1])
+        clear_block_size = triton.next_power_of_2(
+            math.ceil(clear_hidden / clear_programs)
+        )
+    _quantize_attention_inv_rope_to_tdg_kernel[
+        (
+            tokens,
+            groups,
+            group_width // MXFP8_SCALE_VEC_SIZE // chunks_per_program,
+        )
+    ](
+        o,
+        positions,
+        cos_sin_cache,
+        out_values,
+        out_scale_rows.view(torch.uint8),
+        out_scale_mma_u8,
+        clear_output_arg,
+        tokens,
+        groups,
+        heads_per_group,
+        group_width,
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        cos_sin_cache.stride(0),
+        out_values.stride(0),
+        out_values.stride(1),
+        values_stride_g,
+        out_scale_mma.stride(0),
+        out_scale_mma.stride(1),
+        out_scale_mma.stride(2),
+        out_scale_mma.stride(3),
+        out_scale_mma.stride(4),
+        out_scale_mma.stride(5),
+        clear_output_stride_t,
+        clear_output_stride_n,
+        HEAD_DIM=head_dim,
+        NOPE_DIM=nope_dim,
+        HALF_ROPE_DIM=rope_dim // 2,
+        CHUNKS_PER_PROGRAM=chunks_per_program,
+        FAST_B16_SCALE=fast_b16_scale,
+        CLEAR_OUTPUT=clear_output is not None,
+        CLEAR_HIDDEN=clear_hidden,
+        CLEAR_BLOCK_SIZE=clear_block_size,
+        num_warps=2 if tokens == 16 else 4,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::quantize_wo_a_input_inv_rope_mxfp8_alloc",
+    mutates_args=(),
+)
+def _quantize_wo_a_input_inv_rope_mxfp8_alloc_op(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    tokens: int,
+    groups: int,
+    heads_per_group: int,
+    group_width: int,
+    head_dim: int,
+    nope_dim: int,
+    rope_dim: int,
+    initialize_scales: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Functional (allocate + return) quantizer. The MXFP8 output views (notably
+    # the permuted scale_mma) are materialized and written INSIDE this opaque op,
+    # so torch.compile never sees a mutation of an as_strided/permute view (which
+    # it bans). Used whenever the caller does not pass a pre-owned `out`.
+    values_base, scale_rows_base, scale_physical_base = empty_mxfp8_rows_bases(
+        tokens,
+        group_width,
+        num_groups=groups,
+        device=o.device,
+        initialize_scales=initialize_scales,
+    )
+    out = mxfp8_rows_from_bases(
+        values_base,
+        scale_rows_base,
+        scale_physical_base,
+        tokens,
+        group_width,
+        num_groups=groups,
+    )
+    _run_wo_a_quant_kernel(
+        o,
+        positions,
+        cos_sin_cache,
+        out.values,
+        out.scale_rows,
+        out.scale_mma,
+        tokens,
+        groups,
+        heads_per_group,
+        group_width,
+        head_dim,
+        nope_dim,
+        rope_dim,
+    )
+    # Return the CONTIGUOUS bases (not the views) -- see empty_mxfp8_rows_bases.
+    return values_base, scale_rows_base, scale_physical_base
+
+
+@_quantize_wo_a_input_inv_rope_mxfp8_alloc_op.register_fake
+def _quantize_wo_a_input_inv_rope_mxfp8_alloc_fake(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    tokens: int,
+    groups: int,
+    heads_per_group: int,
+    group_width: int,
+    head_dim: int,
+    nope_dim: int,
+    rope_dim: int,
+    initialize_scales: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return empty_mxfp8_rows_bases(
+        tokens,
+        group_width,
+        num_groups=groups,
+        device=o.device,
+        initialize_scales=initialize_scales,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::quantize_wo_a_input_inv_rope_mxfp8_launch",
+    mutates_args=("out_values", "out_scale_rows", "out_scale_mma"),
+)
+def _quantize_wo_a_input_inv_rope_mxfp8_launch_op(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    out_values: torch.Tensor,
+    out_scale_rows: torch.Tensor,
+    out_scale_mma: torch.Tensor,
+    tokens: int,
+    groups: int,
+    heads_per_group: int,
+    group_width: int,
+    head_dim: int,
+    nope_dim: int,
+    rope_dim: int,
+) -> None:
+    # Mutating variant for the eager `out`-provided path (caller owns base
+    # buffers). NOT compile-safe when out_* are strided views; the torch.compile
+    # path uses the _alloc op above instead.
+    _run_wo_a_quant_kernel(
+        o,
+        positions,
+        cos_sin_cache,
+        out_values,
+        out_scale_rows,
+        out_scale_mma,
+        tokens,
+        groups,
+        heads_per_group,
+        group_width,
+        head_dim,
+        nope_dim,
+        rope_dim,
+    )
+
+
+@_quantize_wo_a_input_inv_rope_mxfp8_launch_op.register_fake
+def _quantize_wo_a_input_inv_rope_mxfp8_launch_fake(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    out_values: torch.Tensor,
+    out_scale_rows: torch.Tensor,
+    out_scale_mma: torch.Tensor,
+    tokens: int,
+    groups: int,
+    heads_per_group: int,
+    group_width: int,
+    head_dim: int,
+    nope_dim: int,
+    rope_dim: int,
+) -> None:
+    return None
+
+
+def quantize_wo_a_input_inv_rope_mxfp8(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    *,
+    groups: int,
+    heads_per_group: int,
+    nope_dim: int = 448,
+    rope_dim: int = 64,
+    out: MXFP8Rows | None = None,
+    _initialize_scales: bool = True,
+) -> MXFP8Rows:
+    """Inverse-RoPE attention output and quantize into per-32-column MXFP8 rows."""
+
+    _check_gpu_tensor("o", o)
+    _check_gpu_tensor("positions", positions)
+    _check_gpu_tensor("cos_sin_cache", cos_sin_cache)
+    if o.ndim != 3:
+        raise ValueError(
+            f"o must have shape [tokens, heads, head_dim], got {tuple(o.shape)}"
+        )
+    tokens, heads, head_dim = o.shape
+    if head_dim != nope_dim + rope_dim:
+        raise ValueError(
+            f"o head_dim must equal nope_dim + rope_dim ({nope_dim + rope_dim}), "
+            f"got {head_dim}"
+        )
+    if heads != groups * heads_per_group:
+        raise ValueError(
+            f"o heads must equal groups * heads_per_group ({groups * heads_per_group}), "
+            f"got {heads}"
+        )
+    if positions.shape != (tokens,):
+        raise ValueError(
+            f"positions must have shape {(tokens,)}, got {tuple(positions.shape)}"
+        )
+    if cos_sin_cache.ndim != 2 or cos_sin_cache.shape[-1] != rope_dim:
+        raise ValueError(
+            "cos_sin_cache must have shape [max_position, rope_dim], "
+            f"got {tuple(cos_sin_cache.shape)}"
+        )
+    if rope_dim % 2 != 0:
+        raise ValueError(f"rope_dim must be even, got {rope_dim}")
+
+    group_width = heads_per_group * head_dim
+    _check_mxfp8_k(group_width)
+    if out is None:
+        values_base, scale_rows_base, scale_physical_base = (
+            torch.ops.flashinfer_sm12x.quantize_wo_a_input_inv_rope_mxfp8_alloc(
+                o,
+                positions,
+                cos_sin_cache,
+                tokens,
+                groups,
+                heads_per_group,
+                group_width,
+                head_dim,
+                nope_dim,
+                rope_dim,
+                _initialize_scales,
+            )
+        )
+        return mxfp8_rows_from_bases(
+            values_base,
+            scale_rows_base,
+            scale_physical_base,
+            tokens,
+            group_width,
+            num_groups=groups,
+        )
+
+    _check_mxfp8_rows_storage(out, m=tokens, k=group_width, num_groups=groups)
+    torch.ops.flashinfer_sm12x.quantize_wo_a_input_inv_rope_mxfp8_launch(
+        o,
+        positions,
+        cos_sin_cache,
+        out.values,
+        out.scale_rows,
+        out.scale_mma,
+        tokens,
+        groups,
+        heads_per_group,
+        group_width,
+        head_dim,
+        nope_dim,
+        rope_dim,
+    )
+    return out
+
+
+def _run_wo_b_quant_kernel(
+    source_trg: torch.Tensor,
+    out_values: torch.Tensor,
+    out_scale_rows: torch.Tensor,
+    out_scale_mma: torch.Tensor,
+    tokens: int,
+    rank: int,
+    groups: int,
+    width: int,
+) -> None:
+    # Measured on RTX PRO 6000 at M=8192, rank=1024, groups=4: the CuTe
+    # group-major port wins isolated (37us vs 41us) but loses inside the live
+    # WO chain (62.5us vs 46.6us right after the WO-A GEMM), so this stays on
+    # Triton. quantize_wo_group_major_rows_cute remains available unrouted.
+    chunks_per_program = _wo_quant_chunks_per_program(width)
+    _quantize_group_major_trg_to_tk_kernel[
+        (
+            tokens,
+            width // MXFP8_SCALE_VEC_SIZE // chunks_per_program,
+        )
+    ](
+        source_trg,
+        out_values,
+        out_scale_rows.view(torch.uint8),
+        out_scale_mma.view(torch.uint8),
+        tokens,
+        rank,
+        groups,
+        source_trg.stride(0),
+        source_trg.stride(1),
+        source_trg.stride(2),
+        out_scale_mma.stride(0),
+        out_scale_mma.stride(1),
+        out_scale_mma.stride(2),
+        out_scale_mma.stride(3),
+        out_scale_mma.stride(4),
+        out_scale_mma.stride(5),
+        CHUNKS_PER_PROGRAM=chunks_per_program,
+        num_warps=4,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::quantize_wo_b_input_mxfp8_alloc",
+    mutates_args=(),
+)
+def _quantize_wo_b_input_mxfp8_alloc_op(
+    source_trg: torch.Tensor,
+    tokens: int,
+    rank: int,
+    groups: int,
+    width: int,
+    initialize_scales: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Functional (allocate + return) quantizer; materializes + writes the MXFP8
+    # output views INSIDE the op, returns the contiguous bases (see WO-A _alloc).
+    values_base, scale_rows_base, scale_physical_base = empty_mxfp8_rows_bases(
+        tokens,
+        width,
+        num_groups=1,
+        device=source_trg.device,
+        initialize_scales=initialize_scales,
+    )
+    out = mxfp8_rows_from_bases(
+        values_base, scale_rows_base, scale_physical_base, tokens, width, num_groups=1
+    )
+    _run_wo_b_quant_kernel(
+        source_trg,
+        out.values,
+        out.scale_rows,
+        out.scale_mma,
+        tokens,
+        rank,
+        groups,
+        width,
+    )
+    return values_base, scale_rows_base, scale_physical_base
+
+
+@_quantize_wo_b_input_mxfp8_alloc_op.register_fake
+def _quantize_wo_b_input_mxfp8_alloc_fake(
+    source_trg: torch.Tensor,
+    tokens: int,
+    rank: int,
+    groups: int,
+    width: int,
+    initialize_scales: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return empty_mxfp8_rows_bases(
+        tokens,
+        width,
+        num_groups=1,
+        device=source_trg.device,
+        initialize_scales=initialize_scales,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::quantize_wo_b_input_mxfp8_launch",
+    mutates_args=("out_values", "out_scale_rows", "out_scale_mma"),
+)
+def _quantize_wo_b_input_mxfp8_launch_op(
+    source_trg: torch.Tensor,
+    out_values: torch.Tensor,
+    out_scale_rows: torch.Tensor,
+    out_scale_mma: torch.Tensor,
+    tokens: int,
+    rank: int,
+    groups: int,
+    width: int,
+) -> None:
+    # Mutating variant for the eager `out`-provided path (see WO-A _launch).
+    _run_wo_b_quant_kernel(
+        source_trg,
+        out_values,
+        out_scale_rows,
+        out_scale_mma,
+        tokens,
+        rank,
+        groups,
+        width,
+    )
+
+
+@_quantize_wo_b_input_mxfp8_launch_op.register_fake
+def _quantize_wo_b_input_mxfp8_launch_fake(
+    source_trg: torch.Tensor,
+    out_values: torch.Tensor,
+    out_scale_rows: torch.Tensor,
+    out_scale_mma: torch.Tensor,
+    tokens: int,
+    rank: int,
+    groups: int,
+    width: int,
+) -> None:
+    return None
+
+
+def quantize_wo_b_input_mxfp8(
+    source_trg: torch.Tensor,
+    *,
+    out: MXFP8Rows | None = None,
+    _initialize_scales: bool = True,
+) -> MXFP8Rows:
+    """Quantize WO-A intermediate `[tokens, rank, groups]` into group-major `[tokens, groups * rank]`."""
+
+    _check_gpu_tensor("source_trg", source_trg)
+    if source_trg.ndim != 3:
+        raise ValueError(
+            f"source_trg must have shape [tokens, rank, groups], got {tuple(source_trg.shape)}"
+        )
+    tokens, rank, groups = source_trg.shape
+    width = rank * groups
+    _check_mxfp8_k(width)
+    if out is None:
+        values_base, scale_rows_base, scale_physical_base = (
+            torch.ops.flashinfer_sm12x.quantize_wo_b_input_mxfp8_alloc(
+                source_trg,
+                tokens,
+                rank,
+                groups,
+                width,
+                _initialize_scales,
+            )
+        )
+        return mxfp8_rows_from_bases(
+            values_base,
+            scale_rows_base,
+            scale_physical_base,
+            tokens,
+            width,
+            num_groups=1,
+        )
+
+    _check_mxfp8_rows_storage(out, m=tokens, k=width, num_groups=1)
+    torch.ops.flashinfer_sm12x.quantize_wo_b_input_mxfp8_launch(
+        source_trg,
+        out.values,
+        out.scale_rows,
+        out.scale_mma,
+        tokens,
+        rank,
+        groups,
+        width,
+    )
+    return out
+
+
+def quantize_mxfp8_rows_torch(source: torch.Tensor) -> MXFP8Rows:
+    """Quantize `[M,K]` or `[M,K,L]` rows to MXFP8 on GPU.
+
+    This is a graph-capturable GPU Torch prep/reference helper. It is not the
+    final production activation-quant kernel for WO-A/WO-B.
+    """
+
+    grouped, m, k, num_groups = _as_grouped_mkl(source)
+    _check_mxfp8_k(k)
+
+    chunks = k // MXFP8_SCALE_VEC_SIZE
+    grouped_f32 = grouped.to(torch.float32)
+    blocked = grouped_f32.reshape(num_groups, m, chunks, MXFP8_SCALE_VEC_SIZE)
+    max_abs = blocked.abs().amax(dim=-1)
+    scale_u8 = _scale_u8_from_max_abs(max_abs)
+    scale_rows = scale_u8.view(torch.float8_e8m0fnu)
+    scale = scale_rows.to(torch.float32)
+    quant_grouped = (
+        (blocked / scale[..., None])
+        .clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
+        .to(torch.float8_e4m3fn)
+        .reshape(num_groups, m, k)
+        .contiguous()
+    )
+    if source.ndim == 2:
+        values = quant_grouped.reshape(m, k).contiguous()
+    else:
+        values = quant_grouped.as_strided((m, k, num_groups), (k, 1, m * k))
+    scale_mma = pack_mxfp8_scales_for_dense_gemm(
+        scale_rows,
+        m=m,
+        k=k,
+        num_groups=num_groups,
+    )
+    return MXFP8Rows(values=values, scale_rows=scale_rows, scale_mma=scale_mma)
+
+
+def dequantize_mxfp8_rows_torch(
+    values: torch.Tensor, scale_rows: torch.Tensor
+) -> torch.Tensor:
+    """Dequantize compact row-wise MXFP8 values on GPU for tests/oracles."""
+
+    grouped, m, k, num_groups = _as_grouped_mkl(values)
+    _check_mxfp8_k(k)
+    sf_k = k // MXFP8_SCALE_VEC_SIZE
+    if scale_rows.dtype == torch.uint8:
+        scale_rows = scale_rows.view(torch.float8_e8m0fnu)
+    if scale_rows.shape != (num_groups, m, sf_k):
+        raise ValueError(
+            f"scale_rows must have shape {(num_groups, m, sf_k)}, got {tuple(scale_rows.shape)}"
+        )
+    scale = scale_rows.to(torch.float32)
+    out_grouped = (
+        grouped.to(torch.float32).reshape(num_groups, m, sf_k, MXFP8_SCALE_VEC_SIZE)
+        * scale[..., None]
+    ).reshape(num_groups, m, k)
+    out = out_grouped.permute(1, 2, 0).contiguous()
+    if values.ndim == 2:
+        out = out[:, :, 0].contiguous()
+    return out
+
+
+def quantize_wo_projection_weights_mxfp8_torch(
+    wo_a_grd: torch.Tensor,
+    wo_b_hgr: torch.Tensor,
+) -> WOProjectionMXFP8Weights:
+    """Quantize BF16 WO weights into the native MXFP8 two-GEMM layouts.
+
+    This is a GPU Torch setup helper for tests and benchmarks. Serving should
+    prepare the same layouts at model load from checkpoint FP8 weights/scales.
+    """
+
+    _check_gpu_tensor("wo_a_grd", wo_a_grd)
+    _check_gpu_tensor("wo_b_hgr", wo_b_hgr)
+    if wo_a_grd.ndim != 3:
+        raise ValueError(
+            f"wo_a_grd must have shape [groups, rank, group_width], got {tuple(wo_a_grd.shape)}"
+        )
+    if wo_b_hgr.ndim != 2:
+        raise ValueError(
+            f"wo_b_hgr must have shape [hidden, groups * rank], got {tuple(wo_b_hgr.shape)}"
+        )
+    groups, rank, group_width = wo_a_grd.shape
+    hidden, wo_b_width = wo_b_hgr.shape
+    if wo_b_width != groups * rank:
+        raise ValueError(
+            f"wo_b_hgr width must equal groups * rank, got {wo_b_width} vs {groups * rank}"
+        )
+    _check_mxfp8_k(group_width)
+    _check_mxfp8_k(groups * rank)
+
+    wo_a_source = wo_a_grd.permute(1, 2, 0).contiguous()
+    # MXFP8Rows intentionally stores singleton-L values as compact [M,K].
+    # Preserve that convention for the benchmark/test setup helper so TP8
+    # (o_groups=8 -> one local output group) matches checkpoint packing.
+    if groups == 1:
+        wo_a_source = wo_a_source[:, :, 0]
+    wo_a = quantize_mxfp8_rows_torch(wo_a_source)
+    wo_b = quantize_mxfp8_rows_torch(wo_b_hgr)
+    return WOProjectionMXFP8Weights(
+        wo_a=wo_a,
+        wo_b=wo_b,
+        groups=groups,
+        group_width=group_width,
+        rank=rank,
+        hidden=hidden,
+    )
+
+
+def _check_wo_projection_weights(weights: WOProjectionMXFP8Weights) -> None:
+    if not isinstance(weights, WOProjectionMXFP8Weights):
+        raise TypeError("weights must be a WOProjectionMXFP8Weights instance")
+    if (
+        weights.groups <= 0
+        or weights.group_width <= 0
+        or weights.rank <= 0
+        or weights.hidden <= 0
+    ):
+        raise ValueError("WO projection dimensions must be positive")
+    _check_mxfp8_rows_storage(
+        weights.wo_a,
+        m=weights.rank,
+        k=weights.group_width,
+        num_groups=weights.groups,
+    )
+    _check_mxfp8_rows_storage(
+        weights.wo_b,
+        m=weights.hidden,
+        k=weights.rank * weights.groups,
+        num_groups=1,
+    )
+
+
+def _check_wo_projection_views(
+    *,
+    x_q: MXFP8Rows,
+    tmp: torch.Tensor,
+    tmp_q: MXFP8Rows,
+    output: torch.Tensor,
+    tokens: int,
+    weights: WOProjectionMXFP8Weights,
+) -> None:
+    _check_mxfp8_rows_storage(
+        x_q,
+        m=tokens,
+        k=weights.group_width,
+        num_groups=weights.groups,
+    )
+    _check_dense_gemm_mnl_view("tmp", tmp)
+    if tmp.shape != (tokens, weights.rank, weights.groups):
+        raise ValueError(
+            "tmp must have shape "
+            f"{(tokens, weights.rank, weights.groups)}, got {tuple(tmp.shape)}"
+        )
+    if tmp.dtype != torch.bfloat16:
+        raise ValueError(f"tmp must be bfloat16, got {tmp.dtype}")
+    _check_mxfp8_rows_storage(
+        tmp_q,
+        m=tokens,
+        k=weights.rank * weights.groups,
+        num_groups=1,
+    )
+    _check_dense_gemm_mnl_view("output", output)
+    if output.shape != (tokens, weights.hidden, 1):
+        raise ValueError(
+            "output must have shape "
+            f"{(tokens, weights.hidden, 1)}, got {tuple(output.shape)}"
+        )
+    if output.dtype != torch.bfloat16:
+        raise ValueError(f"output must be bfloat16, got {output.dtype}")
+
+
+def _validate_wo_projection_inputs(
+    source_tgd: torch.Tensor,
+    weights: WOProjectionMXFP8Weights,
+) -> int:
+    _check_gpu_tensor("source_tgd", source_tgd)
+    _check_wo_projection_weights(weights)
+    if source_tgd.ndim != 3:
+        raise ValueError(
+            f"source_tgd must have shape [tokens, groups, group_width], got {tuple(source_tgd.shape)}"
+        )
+    tokens, groups, group_width = source_tgd.shape
+    if (groups, group_width) != (weights.groups, weights.group_width):
+        raise ValueError(
+            "source_tgd shape does not match weights: "
+            f"source={(groups, group_width)}, weights={(weights.groups, weights.group_width)}"
+        )
+    return int(tokens)
+
+
+def _validate_wo_projection_inv_rope_inputs(
+    *,
+    o: torch.Tensor,
+    weights: WOProjectionMXFP8Weights,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+) -> int:
+    _check_gpu_tensor("o", o)
+    _check_wo_projection_weights(weights)
+    heads_per_group = int(heads_per_group)
+    nope_dim = int(nope_dim)
+    rope_dim = int(rope_dim)
+    if heads_per_group <= 0 or nope_dim <= 0 or rope_dim <= 0:
+        raise ValueError("heads_per_group, nope_dim, and rope_dim must be positive")
+    if o.ndim != 3:
+        raise ValueError(
+            f"o must have shape [tokens, heads, head_dim], got {tuple(o.shape)}"
+        )
+    tokens, heads, head_dim = o.shape
+    if head_dim != nope_dim + rope_dim:
+        raise ValueError(
+            f"o head_dim must equal nope_dim + rope_dim ({nope_dim + rope_dim}), "
+            f"got {head_dim}"
+        )
+    if heads != weights.groups * heads_per_group:
+        raise ValueError(
+            f"o heads must equal weights.groups * heads_per_group "
+            f"({weights.groups * heads_per_group}), got {heads}"
+        )
+    if weights.group_width != heads_per_group * head_dim:
+        raise ValueError(
+            "weights.group_width does not match heads_per_group * head_dim: "
+            f"{weights.group_width} != {heads_per_group * head_dim}"
+        )
+    return int(tokens)
+
+
+def build_wo_projection_binding(
+    *,
+    x_q: MXFP8Rows,
+    tmp: torch.Tensor,
+    tmp_q: MXFP8Rows,
+    output: torch.Tensor,
+    source_tgd: torch.Tensor,
+    weights: WOProjectionMXFP8Weights,
+    return_3d: bool = False,
+    expected_m: int | None = None,
+) -> WOProjectionBinding:
+    return _build_wo_projection_binding_from_views(
+        x_q=x_q,
+        tmp=tmp,
+        tmp_q=tmp_q,
+        output=output,
+        source_tgd=source_tgd,
+        weights=weights,
+        return_3d=return_3d,
+        expected_m=expected_m,
+    )
+
+
+def _build_wo_projection_binding_from_views(
+    *,
+    x_q: MXFP8Rows,
+    tmp: torch.Tensor,
+    tmp_q: MXFP8Rows,
+    output: torch.Tensor,
+    source_tgd: torch.Tensor,
+    weights: WOProjectionMXFP8Weights,
+    return_3d: bool = False,
+    expected_m: int | None = None,
+) -> WOProjectionBinding:
+    tokens = _validate_wo_projection_inputs(source_tgd, weights)
+    _check_wo_projection_views(
+        x_q=x_q,
+        tmp=tmp,
+        tmp_q=tmp_q,
+        output=output,
+        tokens=tokens,
+        weights=weights,
+    )
+    return WOProjectionBinding(
+        source_tgd=source_tgd,
+        weights=weights,
+        x_q=x_q,
+        tmp=tmp,
+        tmp_q=tmp_q,
+        output=output,
+        return_3d=bool(return_3d),
+        expected_m=expected_m,
+    )
+
+
+def build_wo_projection_inv_rope_binding(
+    *,
+    x_q: MXFP8Rows,
+    tmp: torch.Tensor,
+    tmp_q: MXFP8Rows,
+    output: torch.Tensor,
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    weights: WOProjectionMXFP8Weights,
+    heads_per_group: int,
+    nope_dim: int = 448,
+    rope_dim: int = 64,
+    return_3d: bool = False,
+    expected_m: int | None = None,
+) -> WOProjectionInvRopeBinding:
+    tokens = _validate_wo_projection_inv_rope_inputs(
+        o=o,
+        weights=weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+    )
+    _check_gpu_tensor("positions", positions)
+    _check_gpu_tensor("cos_sin_cache", cos_sin_cache)
+    _check_wo_projection_views(
+        x_q=x_q,
+        tmp=tmp,
+        tmp_q=tmp_q,
+        output=output,
+        tokens=tokens,
+        weights=weights,
+    )
+    return _build_wo_projection_inv_rope_binding_from_views(
+        x_q=x_q,
+        tmp=tmp,
+        tmp_q=tmp_q,
+        output=output,
+        o=o,
+        positions=positions,
+        cos_sin_cache=cos_sin_cache,
+        weights=weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        return_3d=return_3d,
+        expected_m=expected_m,
+    )
+
+
+def _build_wo_projection_inv_rope_binding_from_views(
+    *,
+    x_q: MXFP8Rows,
+    tmp: torch.Tensor,
+    tmp_q: MXFP8Rows,
+    output: torch.Tensor,
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    weights: WOProjectionMXFP8Weights,
+    heads_per_group: int,
+    nope_dim: int = 448,
+    rope_dim: int = 64,
+    return_3d: bool = False,
+    expected_m: int | None = None,
+) -> WOProjectionInvRopeBinding:
+    tokens = _validate_wo_projection_inv_rope_inputs(
+        o=o,
+        weights=weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+    )
+    _check_gpu_tensor("positions", positions)
+    _check_gpu_tensor("cos_sin_cache", cos_sin_cache)
+    _check_wo_projection_views(
+        x_q=x_q,
+        tmp=tmp,
+        tmp_q=tmp_q,
+        output=output,
+        tokens=tokens,
+        weights=weights,
+    )
+    return WOProjectionInvRopeBinding(
+        o=o,
+        positions=positions,
+        cos_sin_cache=cos_sin_cache,
+        weights=weights,
+        x_q=x_q,
+        tmp=tmp,
+        tmp_q=tmp_q,
+        output=output,
+        heads_per_group=int(heads_per_group),
+        nope_dim=int(nope_dim),
+        rope_dim=int(rope_dim),
+        return_3d=bool(return_3d),
+        expected_m=expected_m,
+    )
+
+
+def plan_wo_projection_scratch(
+    caps: WOProjectionScratchCaps,
+) -> WOProjectionScratchPlan:
+    layout = _layout_wo_projection(
+        offset_bytes=0,
+        tokens=caps.max_tokens,
+        groups=caps.groups,
+        group_width=caps.group_width,
+        rank=caps.rank,
+        hidden=caps.hidden,
+    )
+    return WOProjectionScratchPlan(
+        caps=caps,
+        layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "wo_projection.scratch",
+                nbytes=layout.nbytes,
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+def wo_a_dense_gemm_mxfp8(
+    x_tdg: MXFP8Rows,
+    wo_a_rdg: MXFP8Rows,
+    *,
+    out: torch.Tensor | None = None,
+    quantized_out: MXFP8Rows | None = None,
+    alpha: torch.Tensor | None = None,
+    expected_m: int | None = None,
+    sfb_k_replicated: bool = False,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run WO-A as grouped MXFP8 dense GEMM.
+
+    Inputs are `x.values [tokens, group_width, groups]` and
+    `wo_a.values [rank, group_width, groups]`; singleton groups use compact
+    `[tokens, group_width]` / `[rank, group_width]` storage. Output is
+    `[tokens, rank, groups]`.
+    """
+
+    if x_tdg.values.ndim not in (2, 3) or wo_a_rdg.values.ndim != x_tdg.values.ndim:
+        raise ValueError(
+            "WO-A operands must both have shape [M,K] for one group or "
+            "[M,K,groups] for multiple groups"
+        )
+    if x_tdg.values.shape[1:] != wo_a_rdg.values.shape[1:]:
+        raise ValueError(
+            f"WO-A K/groups mismatch: x={tuple(x_tdg.values.shape)} "
+            f"wo_a={tuple(wo_a_rdg.values.shape)}"
+        )
+    if out is not None:
+        _check_dense_gemm_mnl_view("out", out)
+    tokens = int(x_tdg.values.shape[0])
+    rank = int(wo_a_rdg.values.shape[0])
+    groups = int(wo_a_rdg.values.shape[2]) if wo_a_rdg.values.ndim == 3 else 1
+    if quantized_out is not None:
+        _check_mxfp8_rows_storage(
+            quantized_out,
+            m=tokens,
+            k=rank * groups,
+            num_groups=1,
+        )
+    # When out is None, dense_gemm allocates + returns functionally (no caller
+    # view mutated in the compile graph). The returned [M,N,L] is read downstream
+    # via strides, so its physical layout does not matter.
+    mma_tiler_mn = None
+    if expected_m is not None and wo_a_rdg.values.shape[0] <= 1536:
+        if 1 <= expected_m <= 8:
+            mma_tiler_mn = (16, 64)
+        # B16 is the existing generic decode policy; the B9-15 extension is
+        # measured for the DSV4 TP2 WO-A shape only.
+        elif expected_m == 16 or (
+            9 <= expected_m <= 15
+            and rank == 1024
+            and int(x_tdg.values.shape[1]) == 512
+            and groups == 4
+        ):
+            mma_tiler_mn = (32, 64)
+    x_values = x_tdg.values
+    wo_a_values = wo_a_rdg.values
+    if x_values.ndim == 2:
+        x_values = x_values.unsqueeze(-1)
+        wo_a_values = wo_a_values.unsqueeze(-1)
+    return dense_gemm(
+        (x_values, x_tdg.scale_mma),
+        (wo_a_values, wo_a_rdg.scale_mma),
+        rhs_values_tiled=(
+            wo_a_rdg.values_tiled
+            if mma_tiler_mn in ((16, 64), (32, 64), (64, 64))
+            else None
+        ),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype="bfloat16",
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        out=out,
+        alpha=alpha,
+        mma_tiler_mn=mma_tiler_mn,
+        expected_m=expected_m,
+        sfb_k_replicated=sfb_k_replicated,
+        _quantized_c=(
+            (
+                quantized_out.values,
+                quantized_out.scale_rows.reshape(tokens, -1),
+                quantized_out.scale_mma,
+            )
+            if quantized_out is not None
+            else None
+        ),
+        stream=stream,
+    )
+
+
+def wo_b_dense_gemm_mxfp8(
+    tmp_tgr_group_major: MXFP8Rows,
+    wo_b_hgr: MXFP8Rows,
+    *,
+    out: torch.Tensor | None = None,
+    alpha: torch.Tensor | None = None,
+    expected_m: int | None = None,
+    sfb_k_replicated: bool = False,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run group-major WO-B as MXFP8 dense GEMM.
+
+    Inputs are `tmp.values [tokens, rank * groups]` and
+    `wo_b.values [hidden, rank * groups]`; output is `[tokens, hidden, 1]`.
+    """
+
+    if tmp_tgr_group_major.values.ndim != 2 or wo_b_hgr.values.ndim != 2:
+        raise ValueError("WO-B operands must have shape [M,K] and [N,K]")
+    if tmp_tgr_group_major.values.shape[1] != wo_b_hgr.values.shape[1]:
+        raise ValueError(
+            f"WO-B K mismatch: tmp={tuple(tmp_tgr_group_major.values.shape)} "
+            f"wo_b={tuple(wo_b_hgr.values.shape)}"
+        )
+    if out is not None:
+        _check_dense_gemm_mnl_view("out", out)
+    # Preserve the generic B16 policy while limiting the B9-15 packed tile to
+    # the measured DSV4 TP2 WO-B shape.
+    use_decode_tile = expected_m == 16 or (
+        expected_m is not None
+        and 9 <= expected_m <= 15
+        and tuple(wo_b_hgr.values.shape) == (4096, 4096)
+    )
+    mma_tiler_mn = (32, 64) if use_decode_tile else None
+    # out=None -> dense_gemm allocates + returns functionally (no caller view
+    # mutated in the compile graph).
+    return dense_gemm(
+        (
+            tmp_tgr_group_major.values.reshape(
+                tmp_tgr_group_major.values.shape[0],
+                tmp_tgr_group_major.values.shape[1],
+                1,
+            ),
+            tmp_tgr_group_major.scale_mma,
+        ),
+        (
+            wo_b_hgr.values.reshape(
+                wo_b_hgr.values.shape[0],
+                wo_b_hgr.values.shape[1],
+                1,
+            ),
+            wo_b_hgr.scale_mma,
+        ),
+        rhs_values_tiled=(wo_b_hgr.values_tiled if use_decode_tile else None),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype="bfloat16",
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        out=out,
+        alpha=alpha,
+        mma_tiler_mn=mma_tiler_mn,
+        expected_m=expected_m,
+        sfb_k_replicated=sfb_k_replicated,
+        stream=stream,
+    )
+
+
+def _wo_a_fused_mma_tiler(expected_m: int | None, rank: int) -> tuple[int, int] | None:
+    if expected_m is not None and 1 <= expected_m <= 8 and rank <= 1536:
+        return (16, 64)
+    return None
+
+
+def wo_a_dense_gemm_fused_quant_mxfp8(
+    source_tgd: torch.Tensor,
+    wo_a_rdg: MXFP8Rows,
+    *,
+    out: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
+    cos_sin_cache: torch.Tensor | None = None,
+    head_dim: int = 0,
+    nope_dim: int = 0,
+    rope_dim: int = 0,
+    expected_m: int | None = None,
+    sfb_k_replicated: bool = False,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run WO-A at small M with (optionally inverse-RoPE) activation
+    quantization fused into the grouped GEMM's DMA warp.
+
+    `source_tgd` is the BF16 `[tokens, groups, group_width]` view of the
+    attention output (rows may be strided; each `[groups, group_width]` row
+    must be contiguous). Output is `[tokens, rank, groups]`.
+    """
+
+    if source_tgd.ndim != 3:
+        raise ValueError(
+            f"source_tgd must have shape [tokens, groups, group_width], got {tuple(source_tgd.shape)}"
+        )
+    groups = int(source_tgd.shape[1])
+    wo_a_values = wo_a_rdg.values
+    if wo_a_values.ndim == 2:
+        wo_a_values = wo_a_values.unsqueeze(-1)
+    rank = int(wo_a_values.shape[0])
+    if out is not None:
+        _check_dense_gemm_mnl_view("out", out)
+    return dense_gemm_fused_quant_a_grouped(
+        source_tgd,
+        wo_a_values,
+        wo_a_rdg.scale_mma,
+        groups=groups,
+        out=out,
+        positions=positions,
+        cos_sin_cache=cos_sin_cache,
+        head_dim=head_dim,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        expected_m=expected_m,
+        sfb_k_replicated=sfb_k_replicated,
+        mma_tiler_mn=_wo_a_fused_mma_tiler(expected_m, rank),
+        stream=stream,
+    )
+
+
+def wo_b_dense_gemm_fused_quant_mxfp8(
+    tmp_trg: torch.Tensor,
+    wo_b_hgr: MXFP8Rows,
+    *,
+    out: torch.Tensor | None = None,
+    expected_m: int | None = None,
+    sfb_k_replicated: bool = False,
+    _atomic_output_precleared: bool = False,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run WO-B at small M with group-major quantization fused into the GEMM.
+
+    `tmp_trg` is the BF16 WO-A output `[tokens, rank, groups]` dense-GEMM mnl
+    view; the GEMM's DMA warp quantizes the group-major `[tokens, groups*rank]`
+    rows in-CTA, so no standalone quant kernel or MXFP8 scratch is needed.
+    """
+
+    if tmp_trg.ndim != 3:
+        raise ValueError(
+            f"tmp_trg must have shape [tokens, rank, groups], got {tuple(tmp_trg.shape)}"
+        )
+    tokens, rank, groups = map(int, tmp_trg.shape)
+    width = rank * groups
+    if wo_b_hgr.values.ndim != 2 or int(wo_b_hgr.values.shape[1]) != width:
+        raise ValueError(
+            f"WO-B weight must have shape [N,{width}], got {tuple(wo_b_hgr.values.shape)}"
+        )
+    hidden = int(wo_b_hgr.values.shape[0])
+    if out is not None:
+        _check_dense_gemm_mnl_view("out", out)
+    if groups == 1:
+        if tmp_trg.stride(0) != rank or tmp_trg.stride(1) != 1:
+            raise ValueError(
+                f"tmp_trg rows must be contiguous [tokens, rank], got strides {tmp_trg.stride()}"
+            )
+        source: torch.Tensor = tmp_trg.as_strided((tokens, rank), (rank, 1))
+        inner_span = 0
+    else:
+        source = tmp_trg
+        inner_span = rank
+    return dense_gemm_fused_quant_a(
+        source,
+        wo_b_hgr.values.reshape(hidden, width, 1),
+        wo_b_hgr.scale_mma,
+        out=out,
+        expected_m=expected_m,
+        sfb_k_replicated=sfb_k_replicated,
+        rhs_values_tiled=(
+            wo_b_hgr.values_tiled
+            if expected_m is not None and 1 <= expected_m <= 8
+            else None
+        ),
+        a_inner_span=inner_span,
+        _atomic_output_precleared=_atomic_output_precleared,
+        stream=stream,
+    )
+
+
+def wo_projection_mxfp8(
+    source_tgd: torch.Tensor | None = None,
+    weights: WOProjectionMXFP8Weights | None = None,
+    *,
+    return_3d: bool = False,
+    binding: WOProjectionBinding | None = None,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run the native MXFP8 WO-A/WO-B projection.
+
+    `source_tgd` is `[tokens, groups, group_width]`. The default return value
+    is the SGLang-friendly `[tokens, hidden]` view over the binding output.
+    """
+
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("source_tgd", source_tgd),
+                ("weights", weights),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "WO projection binding owns source_tgd, weights, and scratch tensors; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        if return_3d:
+            raise ValueError(
+                "WO projection binding owns return_3d; do not also pass return_3d=True"
+            )
+        source_tgd = binding.source_tgd
+        weights = binding.weights
+        x_q = binding.x_q
+        tmp = binding.tmp
+        tmp_q = binding.tmp_q
+        output = binding.output
+        return_3d = binding.return_3d
+        expected_m = binding.expected_m
+    else:
+        x_q = None
+        tmp = None
+        tmp_q = None
+        output = None
+    if source_tgd is None or weights is None:
+        raise TypeError(
+            "wo_projection_mxfp8 requires source_tgd and weights or binding"
+        )
+    tokens = _validate_wo_projection_inputs(source_tgd, weights)
+    # WO auto-defaults the regime hint to the (capture-fixed) token count so the
+    # wo_b up-projection (N=hidden>1536) picks the decode tile (32x128) at small
+    # M and the prefill tile (64x128) at large M, with no caller change.
+    # Freeze-safe: the binding is built per-forward / per-capture, so `tokens`
+    # is fixed per compiled kernel. Pass expected_m explicitly to override.
+    if expected_m is None:
+        expected_m = int(tokens)
+    if x_q is None or tmp is None or tmp_q is None or output is None:
+        raise TypeError("wo_projection_mxfp8 requires binding for caller-owned scratch")
+
+    alpha_one = _cached_alpha_one(source_tgd.device)
+    # WO-A stays on the standalone quantizer + GEMM; fusing quant into the
+    # WO-A GEMM measured ~2x slower at M=1 (small N, deep K, per-n-tile
+    # requantization) -- see wo_a_dense_gemm_fused_quant_mxfp8.
+    quantize_wo_a_input_mxfp8(source_tgd, out=x_q)
+    wo_a_dense_gemm_mxfp8(
+        x_q,
+        weights.wo_a,
+        out=tmp,
+        alpha=alpha_one,
+        expected_m=expected_m,
+        sfb_k_replicated=weights.sfb_k_replicated,
+        stream=stream,
+    )
+    if tokens <= 8 and tmp.dtype == torch.bfloat16:
+        # Decode band: group-major WO-B quantization runs inside the GEMM's
+        # DMA warp; the bound tmp_q scratch is intentionally unused here.
+        wo_b_dense_gemm_fused_quant_mxfp8(
+            tmp,
+            weights.wo_b,
+            out=output,
+            expected_m=expected_m,
+            sfb_k_replicated=weights.sfb_k_replicated,
+            stream=stream,
+        )
+    else:
+        quantize_wo_b_input_mxfp8(tmp, out=tmp_q)
+        wo_b_dense_gemm_mxfp8(
+            tmp_q,
+            weights.wo_b,
+            out=output,
+            alpha=alpha_one,
+            expected_m=expected_m,
+            sfb_k_replicated=weights.sfb_k_replicated,
+            stream=stream,
+        )
+    if return_3d:
+        return output
+    return output[:, :, 0]
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::wo_projection_inv_rope_mxfp8_fused",
+    mutates_args=(),
+)
+def _wo_projection_inv_rope_mxfp8_fused_op(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    wo_a_values: torch.Tensor,
+    wo_a_values_tiled: torch.Tensor | None,
+    wo_a_scale_rows: torch.Tensor,
+    wo_a_scale_mma: torch.Tensor,
+    wo_b_values: torch.Tensor,
+    wo_b_values_tiled: torch.Tensor | None,
+    wo_b_scale_rows: torch.Tensor,
+    wo_b_scale_mma: torch.Tensor,
+    groups: int,
+    group_width: int,
+    rank: int,
+    hidden: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    expected_m: int,
+    sfb_k_replicated: bool,
+    stream_int: int | None,
+) -> torch.Tensor:
+    # Fully opaque fused inv-rope WO: the entire quantize -> wo_a gemm -> quantize
+    # -> wo_b gemm chain runs INSIDE this one op, so every token-shaped activation
+    # MXFP8 view (x_q, tmp_q) stays internal and never becomes a symbolic-shaped
+    # view graph value (which trips torch AOT merge_view_inputs under dynamic
+    # shapes). Weight views passed in are static-shaped. Returns the contiguous
+    # [tokens, hidden, 1] base.
+    weights = WOProjectionMXFP8Weights(
+        wo_a=MXFP8Rows(
+            values=wo_a_values,
+            scale_rows=wo_a_scale_rows,
+            scale_mma=wo_a_scale_mma,
+            values_tiled=wo_a_values_tiled,
+        ),
+        wo_b=MXFP8Rows(
+            values=wo_b_values,
+            scale_rows=wo_b_scale_rows,
+            scale_mma=wo_b_scale_mma,
+            values_tiled=wo_b_values_tiled,
+        ),
+        groups=groups,
+        group_width=group_width,
+        rank=rank,
+        hidden=hidden,
+        sfb_k_replicated=sfb_k_replicated,
+    )
+    alpha_one = _cached_alpha_one(o.device)
+    tokens = int(o.shape[0])
+    # Tiny-M WO-B uses atomic split-K. Clear its output inside the initial
+    # inverse-RoPE quantizer so the decode graph does not need a fill launch.
+    # WO-A stays on the standalone quantizer + GEMM: fusing the quant into the
+    # WO-A GEMM's DMA warp measured ~2x slower at M=1 (N=rank is small, K is
+    # deep, and every n-tile CTA re-quantizes the row without a source
+    # prefetch pipeline) -- see wo_a_dense_gemm_fused_quant_mxfp8.
+    # Both quantizers overwrite every logical scale before either GEMM reads
+    # it. Leave physical M-padding unspecified to avoid four graph-replayed
+    # uint8 unity-fill launches; poisoned-padding tests pin that it cannot
+    # affect a logical output row. Standalone quantizers retain initialized
+    # padding.
+    atomic_output_precleared = tokens <= 8
+    output = None
+    if atomic_output_precleared:
+        output = torch.empty((tokens, hidden, 1), dtype=torch.bfloat16, device=o.device)
+        values_base, scale_rows_base, scale_physical_base = empty_mxfp8_rows_bases(
+            tokens,
+            group_width,
+            num_groups=groups,
+            device=o.device,
+            initialize_scales=False,
+        )
+        x_q = mxfp8_rows_from_bases(
+            values_base,
+            scale_rows_base,
+            scale_physical_base,
+            tokens,
+            group_width,
+            num_groups=groups,
+        )
+        _run_wo_a_quant_kernel(
+            o,
+            positions,
+            cos_sin_cache,
+            x_q.values,
+            x_q.scale_rows,
+            x_q.scale_mma,
+            tokens,
+            groups,
+            heads_per_group,
+            group_width,
+            nope_dim + rope_dim,
+            nope_dim,
+            rope_dim,
+            clear_output=output,
+        )
+    else:
+        x_q = quantize_wo_a_input_inv_rope_mxfp8(
+            o,
+            positions,
+            cos_sin_cache,
+            groups=groups,
+            heads_per_group=heads_per_group,
+            nope_dim=nope_dim,
+            rope_dim=rope_dim,
+            _initialize_scales=False,
+        )
+    sm_count = torch.cuda.get_device_properties(o.device).multi_processor_count
+    # Keep upstream's Spark-only B16 policy. The B9-15 extension is likewise
+    # retained only for the measured DSV4 TP2 inverse-RoPE contract.
+    use_quantized_intermediate = _should_use_exact_b16_wo(
+        tokens=tokens,
+        sm_count=sm_count,
+    ) or (
+        9 <= tokens <= 15
+        and sm_count <= _WO_SPARK_MAX_SMS
+        and groups == 4
+        and group_width == 512
+        and rank == 1024
+        and hidden == 4096
+        and heads_per_group == 1
+        and nope_dim == 448
+        and rope_dim == 64
+    )
+    if use_quantized_intermediate:
+        tmp_q_bases = empty_mxfp8_rows_bases(
+            tokens,
+            rank * groups,
+            num_groups=1,
+            device=o.device,
+            initialize_scales=False,
+        )
+        tmp_q = mxfp8_rows_from_bases(
+            *tmp_q_bases,
+            tokens,
+            rank * groups,
+            num_groups=1,
+        )
+        wo_a_dense_gemm_mxfp8(
+            x_q,
+            weights.wo_a,
+            quantized_out=tmp_q,
+            expected_m=expected_m,
+            sfb_k_replicated=weights.sfb_k_replicated,
+            stream=stream_int,
+        )
+        return wo_b_dense_gemm_mxfp8(
+            tmp_q,
+            weights.wo_b,
+            expected_m=expected_m,
+            sfb_k_replicated=weights.sfb_k_replicated,
+            stream=stream_int,
+        )
+    tmp = wo_a_dense_gemm_mxfp8(
+        x_q,
+        weights.wo_a,
+        alpha=alpha_one,
+        expected_m=expected_m,
+        sfb_k_replicated=weights.sfb_k_replicated,
+        stream=stream_int,
+    )
+    if tokens <= 8 and tmp.dtype == torch.bfloat16:
+        # Decode band: quantize the group-major WO-B input inside the GEMM's
+        # DMA warp instead of launching a standalone quant kernel.
+        return wo_b_dense_gemm_fused_quant_mxfp8(
+            tmp,
+            weights.wo_b,
+            out=output,
+            expected_m=expected_m,
+            sfb_k_replicated=weights.sfb_k_replicated,
+            _atomic_output_precleared=atomic_output_precleared,
+            stream=stream_int,
+        )
+    tmp_q = quantize_wo_b_input_mxfp8(tmp, _initialize_scales=False)
+    return wo_b_dense_gemm_mxfp8(
+        tmp_q,
+        weights.wo_b,
+        alpha=alpha_one,
+        expected_m=expected_m,
+        sfb_k_replicated=weights.sfb_k_replicated,
+        stream=stream_int,
+    )
+
+
+@_wo_projection_inv_rope_mxfp8_fused_op.register_fake
+def _wo_projection_inv_rope_mxfp8_fused_fake(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    wo_a_values: torch.Tensor,
+    wo_a_values_tiled: torch.Tensor | None,
+    wo_a_scale_rows: torch.Tensor,
+    wo_a_scale_mma: torch.Tensor,
+    wo_b_values: torch.Tensor,
+    wo_b_values_tiled: torch.Tensor | None,
+    wo_b_scale_rows: torch.Tensor,
+    wo_b_scale_mma: torch.Tensor,
+    groups: int,
+    group_width: int,
+    rank: int,
+    hidden: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    expected_m: int,
+    sfb_k_replicated: bool,
+    stream_int: int | None,
+) -> torch.Tensor:
+    del stream_int
+    return torch.empty((o.shape[0], hidden, 1), dtype=o.dtype, device=o.device)
+
+
+def wo_projection_inv_rope_mxfp8(
+    o: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
+    cos_sin_cache: torch.Tensor | None = None,
+    weights: WOProjectionMXFP8Weights | None = None,
+    *,
+    heads_per_group: int | None = None,
+    nope_dim: int = 448,
+    rope_dim: int = 64,
+    return_3d: bool = False,
+    binding: WOProjectionInvRopeBinding | None = None,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run WO projection from attention output without BF16 inverse-RoPE storage."""
+
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("o", o),
+                ("positions", positions),
+                ("cos_sin_cache", cos_sin_cache),
+                ("weights", weights),
+                ("heads_per_group", heads_per_group),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "WO projection inverse-RoPE binding owns runtime tensors, weights, "
+                f"scratch tensors, and heads_per_group; do not also pass {', '.join(extras)}"
+            )
+        extra_options = []
+        if nope_dim != 448:
+            extra_options.append("nope_dim")
+        if rope_dim != 64:
+            extra_options.append("rope_dim")
+        if return_3d:
+            extra_options.append("return_3d")
+        if extra_options:
+            raise ValueError(
+                "WO projection inverse-RoPE binding owns options; "
+                f"do not also pass {', '.join(extra_options)}"
+            )
+        o = binding.o
+        positions = binding.positions
+        cos_sin_cache = binding.cos_sin_cache
+        weights = binding.weights
+        heads_per_group = binding.heads_per_group
+        nope_dim = binding.nope_dim
+        rope_dim = binding.rope_dim
+        return_3d = binding.return_3d
+        expected_m = binding.expected_m
+    if (
+        o is None
+        or positions is None
+        or cos_sin_cache is None
+        or weights is None
+        or heads_per_group is None
+    ):
+        raise TypeError(
+            "wo_projection_inv_rope_mxfp8 requires o, positions, cos_sin_cache, "
+            "weights, and heads_per_group or binding"
+        )
+    tokens = _validate_wo_projection_inv_rope_inputs(
+        o=o,
+        weights=weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+    )
+    _check_gpu_tensor("positions", positions)
+    _check_gpu_tensor("cos_sin_cache", cos_sin_cache)
+    # Auto-default the regime hint to the (capture-fixed) token count (see
+    # wo_projection_mxfp8); decode -> 32x128, prefill -> 64x128, no caller change.
+    if expected_m is None:
+        expected_m = int(tokens)
+    # One fully opaque fused op runs the whole quantize -> gemm -> quantize ->
+    # gemm chain internally, so the token-shaped activation MXFP8 views never
+    # become graph values (see _wo_projection_inv_rope_mxfp8_fused_op). Any
+    # bound scratch is intentionally unused here.
+    output = torch.ops.flashinfer_sm12x.wo_projection_inv_rope_mxfp8_fused(
+        o,
+        positions,
+        cos_sin_cache,
+        weights.wo_a.values,
+        weights.wo_a.values_tiled,
+        weights.wo_a.scale_rows,
+        weights.wo_a.scale_mma,
+        weights.wo_b.values,
+        weights.wo_b.values_tiled,
+        weights.wo_b.scale_rows,
+        weights.wo_b.scale_mma,
+        weights.groups,
+        weights.group_width,
+        weights.rank,
+        weights.hidden,
+        heads_per_group,
+        nope_dim,
+        rope_dim,
+        expected_m,
+        weights.sfb_k_replicated,
+        cuda_stream_to_int(stream),
+    )
+    if return_3d:
+        return output
+    return output[:, :, 0]
+
+
+__all__ = [
+    "FP8_E4M3_MAX",
+    "MXFP8Rows",
+    "MXFP8_SCALE_VEC_SIZE",
+    "WO_A_INPUT_QUANT_GROUP_SIZE",
+    "WOProjectionBinding",
+    "WOProjectionInvRopeBinding",
+    "WOProjectionMXFP8Weights",
+    "WOProjectionScratchCaps",
+    "WOProjectionScratchPlan",
+    "build_wo_projection_binding",
+    "build_wo_projection_inv_rope_binding",
+    "dequantize_mxfp8_rows_torch",
+    "empty_dense_gemm_mnl_view",
+    "empty_mxfp8_rows_for_dense_gemm",
+    "pack_fp8_block_scaled_weight_mxfp8",
+    "pack_mxfp8_scales_for_dense_gemm",
+    "pack_wo_projection_fp8_block_scaled_weights_mxfp8",
+    "plan_wo_projection_scratch",
+    "quantize_mxfp8_rows_torch",
+    "quantize_wo_a_input_inv_rope_mxfp8",
+    "quantize_wo_a_input_mxfp8",
+    "quantize_wo_b_input_mxfp8",
+    "quantize_wo_projection_weights_mxfp8_torch",
+    "wo_a_dense_gemm_fused_quant_mxfp8",
+    "wo_a_dense_gemm_mxfp8",
+    "wo_b_dense_gemm_fused_quant_mxfp8",
+    "wo_b_dense_gemm_mxfp8",
+    "wo_projection_inv_rope_mxfp8",
+    "wo_projection_mxfp8",
+]

--- a/flashinfer/experimental/sm12x/gemm/block_fp8_linear/__init__.py
+++ b/flashinfer/experimental/sm12x/gemm/block_fp8_linear/__init__.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Serialized block-FP8 (DeepSeek-style) linear via native MXFP8 GEMM.
+
+Planned lifecycle: ``pack_weight`` requantizes a 128x128-block-scaled FP8
+weight into the dense-GEMM MXFP8 layout (host-side, one-time); ``plan(Caps)``
+sizes the caller-owned scratch; ``bind`` maps allocation-free views (CUDA
+graph capture safe); ``run`` quantizes the BF16/FP16 input to MXFP8 inline
+and launches the GEMM.  ``prewarm`` compiles the kernels for a capacity ahead
+of serving.
+
+Example:
+    from flashinfer.experimental.sm12x.gemm import block_fp8_linear as bfl
+
+    weight  = bfl.pack_weight(w_fp8, w_scale)                      # one-time
+    plan    = bfl.plan(bfl.Caps(device="cuda", max_tokens=M,
+                                in_features=K, out_features=N))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = bfl.bind(plan, scratch=scratch, source=x,
+                       packed_weight=weight, output=out, expected_m=M)
+    y       = bfl.run(binding=binding)     # one-shot form: bfl.run(x, weight)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="block_fp8_linear",
+    group="gemm",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "Binding",
+        "Weight",
+        "plan",
+        "bind",
+        "run",
+        "pack_weight",
+        "quantize_input",
+        "prewarm",
+        "is_supported",
+    ),
+    dtypes=("bf16", "fp16"),
+    recipes=("mxfp8",),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/gemm/block_fp8_linear.py",),
+    ),
+    test_path="tests/experimental/gemm/test_block_fp8_linear.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Binding,
+        Caps,
+        Plan,
+        Weight,
+        bind,
+        is_supported,
+        pack_weight,
+        plan,
+        prewarm,
+        quantize_input,
+        run,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/gemm/block_fp8_linear/api.py
+++ b/flashinfer/experimental/sm12x/gemm/block_fp8_linear/api.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for gemm.block_fp8_linear (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from .._shared.block_fp8 import (
+    BlockFP8LinearBinding as Binding,
+)
+from .._shared.block_fp8 import (
+    BlockFP8LinearScratchCaps as Caps,
+)
+from .._shared.block_fp8 import (
+    BlockFP8LinearScratchPlan as Plan,
+)
+from .._shared.block_fp8 import (
+    BlockFP8LinearWeight as Weight,
+)
+from .._shared.block_fp8 import (
+    block_fp8_linear_mxfp8 as run,
+)
+from .._shared.block_fp8 import (
+    pack_block_fp8_linear_weight_mxfp8 as pack_weight,
+)
+from .._shared.block_fp8 import (
+    plan_block_fp8_linear_scratch as plan,
+)
+from .._shared.block_fp8 import (
+    prewarm_block_fp8_linear_mxfp8 as prewarm,
+)
+from .._shared.block_fp8 import (
+    quantize_block_fp8_linear_input_mxfp8 as quantize_input,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "Binding",
+    "Weight",
+    "plan",
+    "bind",
+    "run",
+    "pack_weight",
+    "quantize_input",
+    "prewarm",
+    "is_supported",
+]

--- a/flashinfer/experimental/sm12x/gemm/blockscaled/__init__.py
+++ b/flashinfer/experimental/sm12x/gemm/blockscaled/__init__.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Dense block-scaled GEMM for SM12x: ``C = (A·SFA) @ (B·SFB)``.
+
+One-shot functional op over the shared SM120 warp-MMA engine (no TMEM, no
+tcgen05, no 2-CTA).  Recipes: NVFP4 (Float4E2M1 values, e4m3 scales, vec 16),
+MXFP4 (e8m0 scales, vec 32), MXFP8 (e4m3 values, e8m0 scales, vec 32).
+``expected_m`` is a DeepGEMM-style regime hint (decode vs prefill tiles).
+Fused variants quantize the A operand inline (optionally grouped).
+
+Example:
+    from flashinfer.experimental.sm12x.gemm import blockscaled
+
+    out = blockscaled.mm(
+        (a_fp4, a_sf), (b_fp4, b_sf),
+        ab_dtype="float4_e2m1fn", sf_dtype="float8_e4m3fn", sf_vec_size=16,
+        c_dtype="bfloat16", alpha=alpha, expected_m=m,
+    )
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="blockscaled",
+    group="gemm",
+    api_style="oneshot",
+    entry_points=(
+        "mm",
+        "mm_fused_quant_a",
+        "mm_fused_quant_a_grouped",
+        "is_supported",
+    ),
+    dtypes=("bf16", "fp16", "fp32", "fp8_e4m3", "fp4_e2m1"),
+    recipes=("nvfp4", "mxfp4", "mxfp8"),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/gemm/dense.py",),
+    ),
+    test_path="tests/experimental/gemm/test_blockscaled.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        is_supported,
+        mm,
+        mm_fused_quant_a,
+        mm_fused_quant_a_grouped,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/gemm/blockscaled/api.py
+++ b/flashinfer/experimental/sm12x/gemm/blockscaled/api.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for gemm.blockscaled (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.dense_gemm import (
+    dense_gemm as mm,
+)
+from ..._lib.dense_gemm import (
+    dense_gemm_fused_quant_a as mm_fused_quant_a,
+)
+from ..._lib.dense_gemm import (
+    dense_gemm_fused_quant_a_grouped as mm_fused_quant_a_grouped,
+)
+from ..._lib.gating import default_is_supported
+from . import META
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = ["mm", "mm_fused_quant_a", "mm_fused_quant_a_grouped", "is_supported"]

--- a/flashinfer/experimental/sm12x/gemm/mxfp8_linear/__init__.py
+++ b/flashinfer/experimental/sm12x/gemm/mxfp8_linear/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""ModelOpt MXFP8 linear for SM12x (one-shot).
+
+``pack_weight`` converts a ModelOpt MXFP8 checkpoint weight into the
+dense-GEMM layout (host-side, one-time); ``mm`` quantizes the BF16/FP16
+input inline and runs the native MXFP8 GEMM.  Dispatches through an opaque
+torch custom op, so it is torch.compile- and CUDA-graph-safe.
+
+Example:
+    from flashinfer.experimental.sm12x.gemm import mxfp8_linear
+
+    weight = mxfp8_linear.pack_weight(w_mxfp8, w_scale)   # one-time
+    out = mxfp8_linear.mm(x, weight, expected_m=x.shape[0])
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="mxfp8_linear",
+    group="gemm",
+    api_style="oneshot",
+    entry_points=("Weight", "mm", "pack_weight", "is_supported"),
+    dtypes=("bf16", "fp16"),
+    recipes=("mxfp8",),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/gemm/mxfp8_linear.py",),
+    ),
+    test_path="tests/experimental/gemm/test_mxfp8_linear.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import Weight, is_supported, mm, pack_weight  # noqa: F401
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/gemm/mxfp8_linear/_kernel.py
+++ b/flashinfer/experimental/sm12x/gemm/mxfp8_linear/_kernel.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/gemm/mxfp8_linear.py @ 2464f36e (2026-06-14) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cutlass.cute as cute
+import torch
+
+from flashinfer.experimental.sm12x._lib.utils import cuda_stream_to_int
+from flashinfer.experimental.sm12x.gemm._shared.block_fp8 import (
+    quantize_block_fp8_linear_input_mxfp8,
+)
+from flashinfer.experimental.sm12x._lib.dense_gemm import dense_gemm
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+    MXFP8Rows,
+    MXFP8_SCALE_VEC_SIZE,
+    _check_gpu_tensor,
+    pack_mxfp8_scales_for_dense_gemm,
+)
+
+
+@dataclass(frozen=True)
+class MXFP8LinearWeight:
+    """ModelOpt-style MXFP8 linear weight packed for sm12x dense GEMM."""
+
+    weight: MXFP8Rows
+    in_features: int
+    padded_in_features: int
+    out_features: int
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((int(value) + int(alignment) - 1) // int(alignment)) * int(alignment)
+
+
+def _c_dtype_name(dtype: torch.dtype) -> str:
+    if dtype == torch.bfloat16:
+        return "bfloat16"
+    if dtype == torch.float16:
+        return "float16"
+    raise ValueError(f"sm12x MXFP8 linear output dtype must be bf16/fp16, got {dtype}")
+
+
+def _source_2d(source: torch.Tensor) -> torch.Tensor:
+    if source.ndim < 2:
+        raise ValueError(f"source must have at least 2 dims, got {tuple(source.shape)}")
+    return source.reshape(-1, source.shape[-1]).contiguous()
+
+
+def _scale_rows_to_u8(scale_rows: torch.Tensor) -> torch.Tensor:
+    if scale_rows.dtype == torch.uint8:
+        return scale_rows.contiguous()
+    if scale_rows.dtype == torch.float8_e8m0fnu:
+        return scale_rows.view(torch.uint8).contiguous()
+    raise ValueError(f"weight_scale must be uint8/e8m0, got {scale_rows.dtype}")
+
+
+def _pad_weight_k(weight: torch.Tensor, padded_k: int) -> torch.Tensor:
+    n, k = map(int, weight.shape)
+    if k == padded_k:
+        return weight.contiguous()
+    padded = weight.new_zeros((n, padded_k))
+    padded[:, :k] = weight
+    return padded.contiguous()
+
+
+def _pad_scale_rows_k(scale_rows_u8: torch.Tensor, padded_sf_k: int) -> torch.Tensor:
+    n, sf_k = map(int, scale_rows_u8.shape)
+    if sf_k == padded_sf_k:
+        return scale_rows_u8.contiguous().view(torch.float8_e8m0fnu)
+    padded = torch.full(
+        (n, padded_sf_k),
+        127,
+        dtype=torch.uint8,
+        device=scale_rows_u8.device,
+    )
+    padded[:, :sf_k] = scale_rows_u8
+    return padded.contiguous().view(torch.float8_e8m0fnu)
+
+
+def _pad_source_2d_k(source_2d: torch.Tensor, padded_k: int) -> torch.Tensor:
+    tokens, k = map(int, source_2d.shape)
+    if k == padded_k:
+        return source_2d
+    padded = source_2d.new_zeros((tokens, padded_k))
+    padded[:, :k] = source_2d
+    return padded.contiguous()
+
+
+def _dense_gemm_kwargs_for_n(out_features: int) -> dict[str, object]:
+    if int(out_features) < 64:
+        return {"mma_tiler_mn": (64, 32), "swap_ab": True}
+    return {}
+
+
+def is_mxfp8_linear_supported() -> tuple[bool, str | None]:
+    if not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
+        return False, "CUTLASS DSL does not expose cute.nvgpu.warp.MmaMXF8Op"
+    return True, None
+
+
+def pack_mxfp8_linear_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> MXFP8LinearWeight:
+    """Pack ModelOpt MXFP8 weights `[N,K]` and scales `[N,K/32]`.
+
+    ModelOpt MXFP8 checkpoints require only `K % 32 == 0`. The underlying sm12x
+    dense MXFP8 GEMM consumes a 128-wide K tile, so this pads K to the next
+    multiple of 128 with zero weights and UE8M0 1.0 scales.
+    """
+
+    _check_gpu_tensor("weight", weight)
+    _check_gpu_tensor("weight_scale", weight_scale)
+    if weight.ndim != 2:
+        raise ValueError(f"weight must have shape [N,K], got {tuple(weight.shape)}")
+    if weight.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"weight must be float8_e4m3fn, got {weight.dtype}")
+    if weight_scale.ndim != 2:
+        raise ValueError(
+            f"weight_scale must have shape [N,K/32], got {tuple(weight_scale.shape)}"
+        )
+
+    out_features, in_features = map(int, weight.shape)
+    if out_features <= 0:
+        raise ValueError("out_features must be positive")
+    if in_features <= 0 or in_features % MXFP8_SCALE_VEC_SIZE != 0:
+        raise ValueError(
+            "ModelOpt MXFP8 weight K must be a positive multiple of "
+            f"{MXFP8_SCALE_VEC_SIZE}, got {in_features}"
+        )
+
+    scale_k = in_features // MXFP8_SCALE_VEC_SIZE
+    if (
+        int(weight_scale.shape[0]) < out_features
+        or int(weight_scale.shape[1]) < scale_k
+    ):
+        raise ValueError(
+            "weight_scale must have at least shape "
+            f"{(out_features, scale_k)}, got {tuple(weight_scale.shape)}"
+        )
+
+    padded_in_features = _align_up(in_features, 128)
+    padded_scale_k = padded_in_features // MXFP8_SCALE_VEC_SIZE
+    weight_values = _pad_weight_k(
+        weight[:out_features, :in_features],
+        padded_in_features,
+    )
+    scale_rows_u8 = _scale_rows_to_u8(weight_scale[:out_features, :scale_k])
+    scale_rows = _pad_scale_rows_k(scale_rows_u8, padded_scale_k)
+    scale_mma = pack_mxfp8_scales_for_dense_gemm(
+        scale_rows,
+        m=out_features,
+        k=padded_in_features,
+        num_groups=1,
+    )
+
+    return MXFP8LinearWeight(
+        weight=MXFP8Rows(
+            values=weight_values,
+            scale_rows=scale_rows.reshape(1, out_features, padded_scale_k),
+            scale_mma=scale_mma,
+        ),
+        in_features=in_features,
+        padded_in_features=padded_in_features,
+        out_features=out_features,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mxfp8_linear_fused",
+    mutates_args=(),
+)
+def _mxfp8_linear_fused_op(
+    source_2d: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_rows: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    in_features: int,
+    padded_in_features: int,
+    out_features: int,
+    expected_m: int,
+    stream_int: int | None,
+) -> torch.Tensor:
+    del weight_scale_rows
+    tokens = int(source_2d.shape[0])
+    source_for_quant = _pad_source_2d_k(source_2d, int(padded_in_features))
+    x_q = quantize_block_fp8_linear_input_mxfp8(source_for_quant)
+    return dense_gemm(
+        (x_q.values.reshape(tokens, padded_in_features, 1), x_q.scale_mma),
+        (
+            weight_values.reshape(out_features, padded_in_features, 1),
+            weight_scale_mma,
+        ),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype=_c_dtype_name(source_2d.dtype),
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        expected_m=expected_m,
+        stream=stream_int,
+        **_dense_gemm_kwargs_for_n(out_features),
+    )[:, :, 0]
+
+
+@_mxfp8_linear_fused_op.register_fake
+def _mxfp8_linear_fused_fake(
+    source_2d: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_rows: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    in_features: int,
+    padded_in_features: int,
+    out_features: int,
+    expected_m: int,
+    stream_int: int | None,
+) -> torch.Tensor:
+    del stream_int
+    del weight_values, weight_scale_rows, weight_scale_mma
+    del in_features, padded_in_features, expected_m
+    return torch.empty(
+        (source_2d.shape[0], out_features),
+        dtype=source_2d.dtype,
+        device=source_2d.device,
+    )
+
+
+def mxfp8_linear(
+    source: torch.Tensor,
+    packed_weight: MXFP8LinearWeight,
+    *,
+    bias: torch.Tensor | None = None,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run a ModelOpt MXFP8 linear through the native sm12x dense GEMM path."""
+
+    _check_gpu_tensor("source", source)
+    if not isinstance(packed_weight, MXFP8LinearWeight):
+        raise TypeError("packed_weight must be an MXFP8LinearWeight")
+    source_2d = _source_2d(source)
+    tokens, in_features = map(int, source_2d.shape)
+    if in_features != int(packed_weight.in_features):
+        raise ValueError(
+            f"input K={in_features} does not match packed weight K="
+            f"{packed_weight.in_features}"
+        )
+    if source_2d.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"source dtype must be bf16/fp16, got {source_2d.dtype}")
+
+    out_features = int(packed_weight.out_features)
+    if tokens == 0:
+        output = source_2d.new_empty((0, out_features))
+    else:
+        output = torch.ops.flashinfer_sm12x.mxfp8_linear_fused(
+            source_2d,
+            packed_weight.weight.values,
+            packed_weight.weight.scale_rows,
+            packed_weight.weight.scale_mma,
+            packed_weight.in_features,
+            packed_weight.padded_in_features,
+            packed_weight.out_features,
+            int(expected_m) if expected_m is not None else tokens,
+            cuda_stream_to_int(stream),
+        )
+    if bias is not None:
+        output = output + bias
+    return output.view(*source.shape[:-1], out_features)
+
+
+__all__ = [
+    "MXFP8LinearWeight",
+    "is_mxfp8_linear_supported",
+    "mxfp8_linear",
+    "pack_mxfp8_linear_weight",
+]

--- a/flashinfer/experimental/sm12x/gemm/mxfp8_linear/api.py
+++ b/flashinfer/experimental/sm12x/gemm/mxfp8_linear/api.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for gemm.mxfp8_linear (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from ._kernel import (
+    MXFP8LinearWeight as Weight,
+)
+from ._kernel import (
+    is_mxfp8_linear_supported as _kernel_is_supported,
+)
+from ._kernel import (
+    mxfp8_linear as mm,
+)
+from ._kernel import (
+    pack_mxfp8_linear_weight as pack_weight,
+)
+from . import META
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0, triton, and
+    the kernel's own capability checks."""
+    return default_is_supported(device, requires=META.requires) and bool(
+        _kernel_is_supported()
+    )
+
+
+__all__ = ["Weight", "mm", "pack_weight", "is_supported"]

--- a/flashinfer/experimental/sm12x/gemm/wo_projection/__init__.py
+++ b/flashinfer/experimental/sm12x/gemm/wo_projection/__init__.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Fused MLA WO-A / WO-B projections as native MXFP8 GEMMs.
+
+Grouped ``[tokens, groups, group_width]`` input, quantized to MXFP8 inline;
+the ``run_inv_rope`` variant fuses inverse-RoPE into the input quantization.
+Planned lifecycle: ``pack_weights`` (host-side, one-time) -> ``plan(Caps)``
+-> ``bind``/``bind_inv_rope`` (views only) -> ``run``/``run_inv_rope``
+(capture-safe).  Standalone quantizers (``quantize_input*``) expose the
+input-quant stage for split pipelines.
+
+Example:
+    from flashinfer.experimental.sm12x.gemm import wo_projection as wo
+
+    weights = wo.pack_weights(wa_fp8, wa_scale, wb_fp8, wb_scale,   # one-time
+                              groups=G, group_width=D, rank=R, hidden=H)
+    plan    = wo.plan(wo.Caps(device="cuda", max_tokens=M, groups=G,
+                              group_width=D, rank=R, hidden=H))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = wo.bind(plan, scratch=scratch, source_tgd=x_tgd,
+                      weights=weights, expected_m=M)
+    out     = wo.run(binding=binding)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="wo_projection",
+    group="gemm",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "Binding",
+        "InvRopeBinding",
+        "Weights",
+        "MXFP8Rows",
+        "plan",
+        "bind",
+        "bind_inv_rope",
+        "run",
+        "run_inv_rope",
+        "pack_weights",
+        "quantize_input",
+        "quantize_input_inv_rope",
+        "quantize_input_b",
+        "is_supported",
+    ),
+    dtypes=("bf16",),
+    recipes=("mxfp8",),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/gemm/wo_projection.py", "b12x/gemm/wo_quant_cute.py"),
+    ),
+    test_path="tests/experimental/gemm/test_wo_projection.py",
+    since="0.7.0",
+    notes=(
+        "The planned run path is BF16-only; the standalone quantize_input* "
+        "facet also compiles for fp16."
+    ),
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Binding,
+        Caps,
+        InvRopeBinding,
+        MXFP8Rows,
+        Plan,
+        Weights,
+        bind,
+        bind_inv_rope,
+        is_supported,
+        pack_weights,
+        plan,
+        quantize_input,
+        quantize_input_b,
+        quantize_input_inv_rope,
+        run,
+        run_inv_rope,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/gemm/wo_projection/_quant_cute.py
+++ b/flashinfer/experimental/sm12x/gemm/wo_projection/_quant_cute.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/gemm/wo_quant_cute.py @ 7183f674 (2026-07-02) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cutlass_dsl import Int32, Uint8, Uint32
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    compile as sm12x_compile,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    FLOAT8_E4M3_MAX,
+    bfloat2_to_float2_scaled,
+    cvt_f32x4_to_e4m3x4,
+    fabs_f32,
+    fmax_f32,
+    get_ptr_as_int64,
+    ld_global_nc_u32,
+    pow2_ceil_ue8m0,
+    ue8m0_to_output_scale,
+)
+from flashinfer.experimental.sm12x._lib.runtime_control import (
+    raise_if_kernel_resolution_frozen,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream, make_ptr
+
+_THREADS = 256
+_GRID_CTAS_PER_SM = 4
+
+
+class _WOQuantCuTeLaunch:
+    """Tiled MXFP8 quantizer for the WO activation layouts.
+
+    NOT ROUTED in serving: measured on RTX PRO 6000 at DS4-Flash TP2 prefill
+    shapes (M=8192), the already-tiled Triton WO quantizers win or tie every
+    layout in live context -- grouped 232.8us vs 250.1us, inverse-RoPE 263us
+    vs 279us (branchless), group-major 46.6us vs 62.5us inside the WO chain
+    (the CuTe group-major wins isolated, 37us vs 41us, but not E2E). Kept
+    bit-exact and tested as the starting point for a future fused/producer
+    prefetch rework.
+
+    Mirrors the dense `_MXFP8RowsQuantLaunch` subgroup scheme (four 8-lane
+    subgroups per warp, one 32-value scale block each, four adjacent values
+    per lane) over two WO-specific addressings:
+
+    - grouped (`mode="grouped"`): BF16 source rows `[m, groups * group_width]`
+      (flat contiguous attention output), optionally applying inverse RoPE to
+      the trailing `rope_dim` of every `head_dim` block; writes the grouped
+      dense-GEMM operand (values physical `[g, m, group_width]`, per-group
+      scale_rows / swizzled scale_mma).
+    - group-major (`mode="group_major"`): BF16 source physical
+      `[g, m, rank]` (the WO-A output) regathered as flat group-major rows
+      `[m, groups * rank]`; writes the singleton-group dense-GEMM operand.
+    """
+
+    def __init__(
+        self,
+        mode: str,
+        total_k: int,
+        span: int,
+        source_type: type[cutlass.Numeric],
+        inv_rope: bool,
+        head_dim: int,
+        nope_dim: int,
+        rope_dim: int,
+        positions_type: type[cutlass.Numeric],
+        cos_sin_type: type[cutlass.Numeric],
+        threads: int,
+    ) -> None:
+        if mode not in ("grouped", "group_major"):
+            raise ValueError(f"unsupported WO quant mode {mode!r}")
+        self._mode = mode
+        self._total_k = int(total_k)
+        # Per-group width: group_width for grouped, rank for group-major.
+        self._span = int(span)
+        self._groups = self._total_k // self._span
+        self._groups_k = self._total_k // 32
+        self._span_groups_k = self._span // 32
+        self._source_type = source_type
+        self._inv_rope = bool(inv_rope)
+        self._head_dim = int(head_dim)
+        self._nope_dim = int(nope_dim)
+        self._rope_dim = int(rope_dim)
+        self._positions_type = positions_type
+        self._cos_sin_type = cos_sin_type
+        self._threads = int(threads)
+        self._warps_per_cta = self._threads // 32
+
+    @cute.jit
+    def __call__(
+        self,
+        source_ptr: cute.Pointer,
+        positions_ptr: cute.Pointer,
+        cos_sin_ptr: cute.Pointer,
+        values_ptr: cute.Pointer,
+        scale_rows_ptr: cute.Pointer,
+        scale_mma_ptr: cute.Pointer,
+        m: Int32,
+        cos_sin_len: Int32,
+        grid_x: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        source = cute.make_tensor(
+            source_ptr,
+            cute.make_layout((m * self._total_k,)),
+        )
+        positions = cute.make_tensor(positions_ptr, cute.make_layout((m,)))
+        cos_sin = cute.make_tensor(cos_sin_ptr, cute.make_layout((cos_sin_len,)))
+        values_u32 = cute.make_tensor(
+            values_ptr,
+            cute.make_layout((m * (self._total_k // 4),)),
+        )
+        scale_rows = cute.make_tensor(
+            scale_rows_ptr,
+            cute.make_layout((m * self._groups_k,)),
+        )
+        scale_mma = cute.make_tensor(
+            scale_mma_ptr,
+            cute.make_layout((max(512, ((self._groups_k + 3) // 4) * 512),)),
+        )
+        self.kernel(
+            source, positions, cos_sin, values_u32, scale_rows, scale_mma, m
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=[self._threads, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        source: cute.Tensor,
+        positions: cute.Tensor,
+        cos_sin: cute.Tensor,
+        values_u32: cute.Tensor,
+        scale_rows: cute.Tensor,
+        scale_mma: cute.Tensor,
+        m: Int32,
+    ) -> None:
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        # Four 8-lane subgroups per warp each quantize one 32-value block;
+        # every lane owns four adjacent values. total_k % 128 == 0, so all
+        # four blocks of a task exist and the warp never diverges at the
+        # butterfly reductions.
+        warp = Int32(tidx) // Int32(32)
+        lane = Int32(tidx) % Int32(32)
+        subgroup = lane // Int32(8)
+        lane8 = lane % Int32(8)
+        group_tiles = Int32(self._groups_k // 4)
+        task = Int32(bidx) * Int32(self._warps_per_cta) + warp
+        total_tasks = m * group_tiles
+        while task < total_tasks:
+            row = task // group_tiles
+            block = (task % group_tiles) * Int32(4) + subgroup
+            k0 = block * Int32(32) + lane8 * Int32(4)
+            g = k0 // Int32(self._span)
+            inner0 = k0 - g * Int32(self._span)
+
+            if cutlass.const_expr(self._mode == "group_major"):
+                # Source physical [g, m, span]: regather group-major flat k.
+                src0 = g * (m * Int32(self._span)) + row * Int32(self._span) + inner0
+            else:
+                src0 = row * Int32(self._total_k) + k0
+
+            # Pure SSA scalars (no rmem array): divergent updates under the
+            # rope branch then merge in registers instead of spilling.
+            v0 = cutlass.Float32(source[src0 + Int32(0)])
+            v1 = cutlass.Float32(source[src0 + Int32(1)])
+            v2 = cutlass.Float32(source[src0 + Int32(2)])
+            v3 = cutlass.Float32(source[src0 + Int32(3)])
+
+            if cutlass.const_expr(self._inv_rope):
+                # Branchless: every lane loads (clamped) cos/sin and computes
+                # the rotation; a full-width bit mask selects rotated vs raw
+                # values, so no divergent path lengthens the task loop and
+                # -0.0 payloads survive untouched on nope lanes.
+                head_d0 = k0 % Int32(self._head_dim)
+                is_rope = head_d0 >= Int32(self._nope_dim)
+                pos = Int32(positions[row])
+                half_rope = Int32(self._rope_dim // 2)
+                cs_base = pos * Int32(self._rope_dim)
+                rl_half0 = (head_d0 - Int32(self._nope_dim)) // Int32(2)
+                if rl_half0 < Int32(0):
+                    rl_half0 = Int32(0)
+                if cutlass.const_expr(self._cos_sin_type == cutlass.BFloat16):
+                    # rl_half0 is even (head_d0 and nope_dim are multiples of
+                    # 4), so each cos/sin pair sits on one aligned 4B word.
+                    cos_w = ld_global_nc_u32(
+                        get_ptr_as_int64(cos_sin, cs_base + rl_half0)
+                    )
+                    sin_w = ld_global_nc_u32(
+                        get_ptr_as_int64(cos_sin, cs_base + rl_half0 + half_rope)
+                    )
+                    cos0, cos1 = bfloat2_to_float2_scaled(cos_w, cutlass.Float32(1.0))
+                    sin0, sin1 = bfloat2_to_float2_scaled(sin_w, cutlass.Float32(1.0))
+                else:
+                    cos0 = cutlass.Float32(cos_sin[cs_base + rl_half0])
+                    sin0 = cutlass.Float32(cos_sin[cs_base + rl_half0 + half_rope])
+                    cos1 = cutlass.Float32(cos_sin[cs_base + rl_half0 + Int32(1)])
+                    sin1 = cutlass.Float32(
+                        cos_sin[cs_base + rl_half0 + Int32(1) + half_rope]
+                    )
+                r0 = v0 * cos0 + v1 * sin0
+                r1 = v1 * cos0 - v0 * sin0
+                r2 = v2 * cos1 + v3 * sin1
+                r3 = v3 * cos1 - v2 * sin1
+                mask = Uint32(0) - Uint32(is_rope)
+                keep = mask ^ Uint32(0xFFFFFFFF)
+                v0 = cutlass.Uint32(
+                    (r0.bitcast(Uint32) & mask) | (v0.bitcast(Uint32) & keep)
+                ).bitcast(cutlass.Float32)
+                v1 = cutlass.Uint32(
+                    (r1.bitcast(Uint32) & mask) | (v1.bitcast(Uint32) & keep)
+                ).bitcast(cutlass.Float32)
+                v2 = cutlass.Uint32(
+                    (r2.bitcast(Uint32) & mask) | (v2.bitcast(Uint32) & keep)
+                ).bitcast(cutlass.Float32)
+                v3 = cutlass.Uint32(
+                    (r3.bitcast(Uint32) & mask) | (v3.bitcast(Uint32) & keep)
+                ).bitcast(cutlass.Float32)
+
+            max_abs = fabs_f32(v0)
+            max_abs = fmax_f32(max_abs, fabs_f32(v1))
+            max_abs = fmax_f32(max_abs, fabs_f32(v2))
+            max_abs = fmax_f32(max_abs, fabs_f32(v3))
+            for shift in cutlass.range_constexpr(3):
+                max_abs = fmax_f32(
+                    max_abs,
+                    cute.arch.shuffle_sync_bfly(max_abs, offset=1 << shift),
+                )
+
+            _, scale_byte = pow2_ceil_ue8m0(
+                max_abs * cutlass.Float32(1.0 / FLOAT8_E4M3_MAX)
+            )
+            if max_abs == cutlass.Float32(0.0):
+                scale_byte = Uint32(127)
+            inv_scale = ue8m0_to_output_scale(scale_byte)
+            payload = cvt_f32x4_to_e4m3x4(
+                v0 * inv_scale,
+                v1 * inv_scale,
+                v2 * inv_scale,
+                v3 * inv_scale,
+            )
+
+            if cutlass.const_expr(self._mode == "grouped"):
+                # Values physical [g, m, span]: transpose grouped rows.
+                word = (
+                    g * (m * Int32(self._span // 4))
+                    + row * Int32(self._span // 4)
+                    + inner0 // Int32(4)
+                )
+            else:
+                word = row * Int32(self._total_k // 4) + k0 // Int32(4)
+            values_u32[word] = payload
+
+            if lane8 == Int32(0):
+                if cutlass.const_expr(self._mode == "grouped"):
+                    chunk = inner0 // Int32(32)
+                    span_gk = Int32(self._span_groups_k)
+                    scale_rows[g * (m * span_gk) + row * span_gk + chunk] = Uint8(
+                        scale_byte
+                    )
+                    span_tiles_k = Int32((self._span_groups_k + 3) // 4)
+                    m_tiles = (m + Int32(127)) // Int32(128)
+                    self._store_scale_mma(
+                        scale_mma,
+                        g * (m_tiles * span_tiles_k * Int32(512)),
+                        span_tiles_k,
+                        row,
+                        chunk,
+                        scale_byte,
+                    )
+                else:
+                    chunk = block
+                    scale_rows[row * Int32(self._groups_k) + chunk] = Uint8(scale_byte)
+                    self._store_scale_mma(
+                        scale_mma,
+                        Int32(0),
+                        Int32((self._groups_k + 3) // 4),
+                        row,
+                        chunk,
+                        scale_byte,
+                    )
+            task += Int32(gdim) * Int32(self._warps_per_cta)
+
+    @cute.jit
+    def _store_scale_mma(
+        self,
+        scale_mma: cute.Tensor,
+        base: Int32,
+        tiles_k: Int32,
+        row: Int32,
+        chunk: Int32,
+        scale_byte: Uint32,
+    ) -> None:
+        row32 = row % Int32(32)
+        row4 = (row // Int32(32)) % Int32(4)
+        tile_m = row // Int32(128)
+        k4 = chunk % Int32(4)
+        tile_k = chunk // Int32(4)
+        offset = (
+            base
+            + row32 * Int32(16)
+            + row4 * Int32(4)
+            + tile_m * (tiles_k * Int32(512))
+            + k4
+            + tile_k * Int32(512)
+        )
+        scale_mma[offset] = Uint8(scale_byte)
+
+
+def _cutlass_source_type(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float16:
+        return cutlass.Float16
+    raise TypeError(f"WO CuTe quantizer requires BF16/FP16 input, got {dtype}")
+
+
+def _cutlass_positions_type(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.int64:
+        return cutlass.Int64
+    if dtype == torch.int32:
+        return cutlass.Int32
+    raise TypeError(f"WO CuTe quantizer positions must be int32/int64, got {dtype}")
+
+
+def _cutlass_cos_sin_type(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    if dtype == torch.bfloat16:
+        return cutlass.BFloat16
+    if dtype == torch.float32:
+        return cutlass.Float32
+    raise TypeError(f"WO CuTe quantizer cos/sin must be bf16/fp32, got {dtype}")
+
+
+@functools.cache
+def _get_compiled_wo_quant(
+    mode: str,
+    total_k: int,
+    span: int,
+    source_dtype: torch.dtype,
+    inv_rope: bool,
+    head_dim: int,
+    nope_dim: int,
+    rope_dim: int,
+    positions_dtype: torch.dtype,
+    cos_sin_dtype: torch.dtype,
+) -> Callable:
+    source_type = _cutlass_source_type(source_dtype)
+    positions_type = _cutlass_positions_type(positions_dtype)
+    cos_sin_type = _cutlass_cos_sin_type(cos_sin_dtype)
+    launch = _WOQuantCuTeLaunch(
+        mode,
+        total_k,
+        span,
+        source_type,
+        inv_rope,
+        head_dim,
+        nope_dim,
+        rope_dim,
+        positions_type,
+        cos_sin_type,
+        _THREADS,
+    )
+    cache_key = (
+        mode,
+        int(total_k),
+        int(span),
+        str(source_dtype),
+        bool(inv_rope),
+        int(head_dim),
+        int(nope_dim),
+        int(rope_dim),
+        str(positions_dtype),
+        str(cos_sin_dtype),
+        _THREADS,
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=launch,
+        cache_key=cache_key,
+    )
+    raw = sm12x_compile(
+        launch,
+        make_ptr(source_type, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(positions_type, 16, cute.AddressSpace.gmem, assumed_align=8),
+        make_ptr(cos_sin_type, 16, cute.AddressSpace.gmem, assumed_align=4),
+        make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+        1,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "gemm.wo_quant_cute",
+            2,
+            cache_key,
+        ),
+    )
+
+    def launch_tensors(
+        source: torch.Tensor,
+        positions: torch.Tensor,
+        cos_sin: torch.Tensor,
+        values: torch.Tensor,
+        scale_rows: torch.Tensor,
+        scale_mma: torch.Tensor,
+        m: int,
+    ) -> None:
+        groups_per_warp_tile = 4
+        total_tasks = m * (total_k // 32 // groups_per_warp_tile)
+        warps_per_cta = _THREADS // 32
+        natural_grid = max(1, (total_tasks + warps_per_cta - 1) // warps_per_cta)
+        sm_count = torch.cuda.get_device_properties(source.device).multi_processor_count
+        grid_x = min(natural_grid, sm_count * _GRID_CTAS_PER_SM)
+        raw(
+            make_ptr(
+                source_type,
+                source.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                positions_type,
+                positions.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            ),
+            make_ptr(
+                cos_sin_type,
+                cos_sin.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=4,
+            ),
+            make_ptr(
+                cutlass.Uint32,
+                values.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Uint8,
+                scale_rows.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Uint8,
+                scale_mma.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            int(m),
+            int(cos_sin.numel()),
+            grid_x,
+            current_cuda_stream(),
+        )
+
+    return launch_tensors
+
+
+def quantize_wo_grouped_rows_cute(
+    source_flat: torch.Tensor,
+    values: torch.Tensor,
+    scale_rows: torch.Tensor,
+    scale_mma: torch.Tensor,
+    *,
+    m: int,
+    groups: int,
+    group_width: int,
+    positions: torch.Tensor | None = None,
+    cos_sin_cache: torch.Tensor | None = None,
+    head_dim: int = 0,
+    nope_dim: int = 0,
+    rope_dim: int = 0,
+) -> None:
+    """Quantize flat `[m, groups*group_width]` rows into the grouped WO-A
+    MXFP8 operand, optionally applying inverse RoPE first."""
+
+    inv_rope = positions is not None
+    if inv_rope:
+        assert cos_sin_cache is not None
+        pos_t: torch.Tensor = positions
+        cs_t: torch.Tensor = cos_sin_cache
+    else:
+        pos_t = source_flat
+        cs_t = source_flat
+    _get_compiled_wo_quant(
+        "grouped",
+        groups * group_width,
+        group_width,
+        source_flat.dtype,
+        inv_rope,
+        head_dim if inv_rope else 0,
+        nope_dim if inv_rope else 0,
+        rope_dim if inv_rope else 0,
+        pos_t.dtype if inv_rope else torch.int64,
+        cs_t.dtype if inv_rope else torch.bfloat16,
+    )(source_flat, pos_t, cs_t, values, scale_rows, scale_mma, m)
+
+
+def quantize_wo_group_major_rows_cute(
+    source_gmr: torch.Tensor,
+    values: torch.Tensor,
+    scale_rows: torch.Tensor,
+    scale_mma: torch.Tensor,
+    *,
+    m: int,
+    groups: int,
+    rank: int,
+) -> None:
+    """Quantize the WO-A output (physical `[groups, m, rank]`) as group-major
+    flat `[m, groups*rank]` MXFP8 rows for WO-B."""
+
+    _get_compiled_wo_quant(
+        "group_major",
+        groups * rank,
+        rank,
+        source_gmr.dtype,
+        False,
+        0,
+        0,
+        0,
+        torch.int64,
+        torch.bfloat16,
+    )(source_gmr, source_gmr, source_gmr, values, scale_rows, scale_mma, m)
+
+
+__all__ = [
+    "quantize_wo_group_major_rows_cute",
+    "quantize_wo_grouped_rows_cute",
+]

--- a/flashinfer/experimental/sm12x/gemm/wo_projection/api.py
+++ b/flashinfer/experimental/sm12x/gemm/wo_projection/api.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for gemm.wo_projection (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from .._shared.wo_mxfp8 import (
+    MXFP8Rows,
+)
+from .._shared.wo_mxfp8 import (
+    WOProjectionBinding as Binding,
+)
+from .._shared.wo_mxfp8 import (
+    WOProjectionInvRopeBinding as InvRopeBinding,
+)
+from .._shared.wo_mxfp8 import (
+    WOProjectionMXFP8Weights as Weights,
+)
+from .._shared.wo_mxfp8 import (
+    WOProjectionScratchCaps as Caps,
+)
+from .._shared.wo_mxfp8 import (
+    WOProjectionScratchPlan as Plan,
+)
+from .._shared.wo_mxfp8 import (
+    pack_wo_projection_fp8_block_scaled_weights_mxfp8 as pack_weights,
+)
+from .._shared.wo_mxfp8 import (
+    plan_wo_projection_scratch as plan,
+)
+from .._shared.wo_mxfp8 import (
+    quantize_wo_a_input_inv_rope_mxfp8 as quantize_input_inv_rope,
+)
+from .._shared.wo_mxfp8 import (
+    quantize_wo_a_input_mxfp8 as quantize_input,
+)
+from .._shared.wo_mxfp8 import (
+    quantize_wo_b_input_mxfp8 as quantize_input_b,
+)
+from .._shared.wo_mxfp8 import (
+    wo_projection_inv_rope_mxfp8 as run_inv_rope,
+)
+from .._shared.wo_mxfp8 import (
+    wo_projection_mxfp8 as run,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def bind_inv_rope(plan: Plan, **kwargs) -> InvRopeBinding:
+    """Bind the inverse-RoPE variant (views only; capture safe)."""
+    return plan.bind_inv_rope(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "Binding",
+    "InvRopeBinding",
+    "Weights",
+    "MXFP8Rows",
+    "plan",
+    "bind",
+    "bind_inv_rope",
+    "run",
+    "run_inv_rope",
+    "pack_weights",
+    "quantize_input",
+    "quantize_input_inv_rope",
+    "quantize_input_b",
+    "is_supported",
+]

--- a/flashinfer/experimental/sm12x/moe/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""MoE ops for flashinfer.experimental.sm12x.
+
+- ``fused_moe``: fused tensor-parallel routed-expert FFN (route -> FC1 ->
+  activation -> FC2 -> scatter); recipes nvfp4/mxfp4/w4a8_mx/w4a8_nvfp4/w4a16.
+- ``ep_moe``: expert-parallel MoE (replicated input -> local partial;
+  cross-rank reduction is the caller's job, typically ``comm.pcie``).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_OP_MODULES = ("fused_moe", "ep_moe")
+
+
+def __getattr__(name: str) -> Any:
+    if name in _OP_MODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(_OP_MODULES)
+
+
+__all__ = list(_OP_MODULES)

--- a/flashinfer/experimental/sm12x/moe/_shared/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Lowering shared by moe ops: the declarative execution model
+(``execution``), fused expert kernels (``kernels``), offline tuning
+registries (``tuning``), and the triton top-k router (``routing``).
+Imports only _lib and itself.
+"""

--- a/flashinfer/experimental/sm12x/moe/_shared/execution.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/execution.py
@@ -1,0 +1,847 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/execution.py @ 7f72b398 (2026-07-07) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Canonical MoE semantics and execution-regime descriptors.
+
+The public ``quant_mode`` names in :mod:`flashinfer.experimental.sm12x.moe.fused_moe._impl` historically
+identify several independent choices at once: activation encoding, weight-scale
+encoding, route materialization, work scheduling, graph fusion, and prepared
+weight layout.  That makes genuinely orthogonal implementations look like
+unrelated kernels.
+
+This module names those axes independently.  It deliberately contains no CUDA,
+Torch, or CuTe code so that planning, diagnostics, and tests can reason about a
+MoE implementation without importing a kernel lowering.
+
+The central scheduling distinction is ``WorkAvailability``:
+
+* ``INLINE`` work is decoded directly from top-k routing by a tiny kernel.
+* ``PRECOMPUTED`` work has been materialized before its compute phase (either
+  by an earlier launch or by an earlier globally synchronized phase of the
+  same kernel) and can therefore use either arithmetic grid assignment or a
+  work-stealing queue without readiness checks.
+* ``STREAMING`` work is published while the compute kernel is already resident;
+  a readiness-aware source (currently the append-only ready queue) is required.
+
+Thus readiness, load balancing, and arithmetic precision are separate axes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+
+
+class _StringEnum(str, Enum):
+    def __str__(self) -> str:
+        return self.value
+
+
+class OperandEncoding(_StringEnum):
+    BF16 = "bf16"
+    FP4_E2M1 = "fp4_e2m1"
+    MXFP8_E4M3 = "mxfp8_e4m3"
+
+
+class ScaleEncoding(_StringEnum):
+    E4M3_K16 = "e4m3_k16"
+    E8M0_K32 = "e8m0_k32"
+    E8M0_K32_X_E4M3_K16_RESIDUAL = "e8m0_k32_x_e4m3_k16_residual"
+
+
+class MoERegime(_StringEnum):
+    """Graph-level implementation regime, intentionally precision-neutral."""
+
+    DIRECT = "direct"
+    STREAMING_FUSED = "streaming_fused"
+    MATERIALIZED_FUSED = "materialized_fused"
+    MATERIALIZED_PERSISTENT = "materialized_persistent"
+
+
+class RouteLayout(_StringEnum):
+    DIRECT_TOPK = "direct_topk"
+    APPEND_ONLY_EXPERT = "append_only_expert"
+    SORTED_PADDED_EXPERT = "sorted_padded_expert"
+
+
+class WorkAvailability(_StringEnum):
+    INLINE = "inline"
+    PRECOMPUTED = "precomputed"
+    STREAMING = "streaming"
+
+
+class WorkScheduler(_StringEnum):
+    DIRECT = "direct"
+    PERSISTENT_GRID = "persistent_grid"
+    ATOMIC_QUEUE = "atomic_queue"
+    READY_QUEUE = "ready_queue"
+
+
+class GraphPartition(_StringEnum):
+    """Partitioning of FC1 -> activation/quantization -> FC2.
+
+    Route materialization is represented independently by
+    :class:`WorkAvailability`.
+    """
+
+    FUSED = "fused"
+
+
+class GemmEngine(_StringEnum):
+    DIRECT_DOT = "direct_dot"
+    NVFP4_MMA = "nvfp4_mma"
+    MXFP8_QMMA = "mxfp8_qmma"
+    W4A16_MMA = "w4a16_mma"
+
+
+class PreparedWeightLayout(_StringEnum):
+    SOURCE_NATIVE = "source_native"
+    MMA_VIEW = "mma_view"
+    MMA_PACKED = "mma_packed"
+    QMMA_REPACKED = "qmma_repacked"
+
+
+class PreparedScaleLayout(_StringEnum):
+    """Physical scale/metadata forms made available at model load time."""
+
+    SOURCE_NATIVE = "source_native"
+    RUNTIME_ALPHA = "runtime_alpha"
+    MMA_PACKED = "mma_packed"
+    QMMA_SFB = "qmma_sfb"
+
+
+class WeightPreparationTransform(_StringEnum):
+    """Concrete one-time transforms executed by the tensor integration layer."""
+
+    RUNTIME_ALPHAS = "runtime_alphas"
+    W4A16_NATIVE = "w4a16_native"
+    W4A16_PACKED = "w4a16_packed"
+    W4A8_QMMA = "w4a8_qmma"
+
+
+class WeightStoragePolicy(_StringEnum):
+    """Ownership policy for checkpoint storage after preparation.
+
+    ``KEEP_SOURCE`` leaves source tensors as the canonical runtime storage.
+    ``TRANSFER_SOURCE`` keeps their bytes unchanged but transfers ownership to
+    a prepared representation, allowing checkpoint parameter handles to go
+    away. ``REUSE_SOURCE`` transforms those bytes in-place and also transfers
+    ownership. There is intentionally no policy that keeps a source allocation
+    plus a second model-sized repack: incompatible representation requests are
+    planning errors.
+    """
+
+    KEEP_SOURCE = "keep_source"
+    TRANSFER_SOURCE = "transfer_source"
+    REUSE_SOURCE = "reuse_source"
+
+
+class OutputReduction(_StringEnum):
+    FUSED_TOPK_SUM = "fused_topk_sum"
+    ATOMIC_SCATTER = "atomic_scatter"
+    ROUTE_BUFFER_TOPK_SUM = "route_buffer_topk_sum"
+    SEPARATE_TOPK_SUM = "separate_topk_sum"
+
+
+_QUANT_MODES = {"nvfp4", "w4a16", "w4a8_mx", "w4a8_nvfp4"}
+_SOURCE_FORMATS = {
+    "modelopt_nvfp4",
+    "fp4_e8m0_k32",
+    "compressed_tensors",
+}
+_SOURCES_BY_QUANT_MODE = {
+    "nvfp4": frozenset({"modelopt_nvfp4"}),
+    "w4a8_nvfp4": frozenset({"modelopt_nvfp4"}),
+    "w4a8_mx": frozenset({"fp4_e8m0_k32"}),
+    "w4a16": frozenset(_SOURCE_FORMATS),
+}
+
+
+def validate_moe_source_quant(*, source_format: str, quant_mode: str) -> None:
+    """Validate the canonical checkpoint-format/numeric-recipe pairing."""
+
+    quant_mode = str(quant_mode).lower()
+    source_format = str(source_format).lower()
+    if quant_mode not in _QUANT_MODES:
+        raise ValueError(f"unsupported quant_mode {quant_mode!r}")
+    if source_format not in _SOURCE_FORMATS:
+        raise ValueError(f"unsupported source_format {source_format!r}")
+    if source_format not in _SOURCES_BY_QUANT_MODE[quant_mode]:
+        raise ValueError(
+            f"source_format={source_format!r} is incompatible with "
+            f"quant_mode={quant_mode!r}"
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class MoESpec:
+    """Semantic/numeric contract before choosing a kernel regime.
+
+    ``source_weight_scale`` describes checkpoint storage.  ``weight_scale``
+    describes the representation consumed by the selected arithmetic recipe;
+    they differ for W4A8-on-NVFP4, whose K/16 E4M3 scales are decomposed into
+    a K/32 E8M0 grid and a K/16 residual.
+    """
+
+    quant_mode: str
+    source_format: str
+    activation: str
+    io_dtype: str
+    activation_encoding: OperandEncoding
+    activation_scale: ScaleEncoding | None
+    weight_encoding: OperandEncoding
+    source_weight_scale: ScaleEncoding
+    weight_scale: ScaleEncoding
+    w13_layout: str
+    apply_router_weight_on_input: bool = False
+    accumulator_dtype: str = "float32"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "quant_mode", str(self.quant_mode).lower())
+        object.__setattr__(self, "source_format", str(self.source_format).lower())
+        object.__setattr__(
+            self,
+            "activation_encoding",
+            OperandEncoding(self.activation_encoding),
+        )
+        object.__setattr__(
+            self,
+            "activation_scale",
+            None
+            if self.activation_scale is None
+            else ScaleEncoding(self.activation_scale),
+        )
+        object.__setattr__(
+            self,
+            "weight_encoding",
+            OperandEncoding(self.weight_encoding),
+        )
+        object.__setattr__(
+            self,
+            "source_weight_scale",
+            ScaleEncoding(self.source_weight_scale),
+        )
+        object.__setattr__(
+            self,
+            "weight_scale",
+            ScaleEncoding(self.weight_scale),
+        )
+        if self.quant_mode not in _QUANT_MODES:
+            raise ValueError(f"unsupported quant_mode {self.quant_mode!r}")
+        if self.source_format not in _SOURCE_FORMATS:
+            raise ValueError(f"unsupported source_format {self.source_format!r}")
+        validate_moe_source_quant(
+            source_format=self.source_format,
+            quant_mode=self.quant_mode,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class MoEWeightPreparationPlan:
+    """Load-time representations required by a set of runtime MoE recipes.
+
+    The plan is deliberately tensor-free.  Kernel planning owns the choice of
+    representation; an integration layer merely executes ``transforms`` and
+    applies ``storage_policy`` before CUDA graph capture.
+    """
+
+    specs: tuple[MoESpec, ...]
+    num_experts: int
+    hidden_size: int
+    intermediate_size: int
+    transforms: frozenset[WeightPreparationTransform]
+    weight_layouts: frozenset[PreparedWeightLayout]
+    scale_layouts: frozenset[PreparedScaleLayout]
+    storage_policy: WeightStoragePolicy
+
+    def __post_init__(self) -> None:
+        specs = tuple(self.specs)
+        if not specs:
+            raise ValueError("weight preparation requires at least one MoE spec")
+        object.__setattr__(self, "specs", specs)
+        object.__setattr__(self, "num_experts", int(self.num_experts))
+        object.__setattr__(self, "hidden_size", int(self.hidden_size))
+        object.__setattr__(self, "intermediate_size", int(self.intermediate_size))
+        object.__setattr__(
+            self,
+            "transforms",
+            frozenset(WeightPreparationTransform(value) for value in self.transforms),
+        )
+        object.__setattr__(
+            self,
+            "weight_layouts",
+            frozenset(PreparedWeightLayout(value) for value in self.weight_layouts),
+        )
+        object.__setattr__(
+            self,
+            "scale_layouts",
+            frozenset(PreparedScaleLayout(value) for value in self.scale_layouts),
+        )
+        object.__setattr__(
+            self, "storage_policy", WeightStoragePolicy(self.storage_policy)
+        )
+        for name in ("num_experts", "hidden_size", "intermediate_size"):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive, got {getattr(self, name)}")
+
+        contract = (
+            specs[0].source_format,
+            specs[0].activation,
+            specs[0].io_dtype,
+            specs[0].w13_layout,
+        )
+        seen_modes: set[str] = set()
+        for spec in specs:
+            actual = (
+                spec.source_format,
+                spec.activation,
+                spec.io_dtype,
+                spec.w13_layout,
+            )
+            if actual != contract:
+                raise ValueError(
+                    "all weight-preparation specs must share source format, "
+                    "activation, dtype, and W13 layout"
+                )
+            if spec.quant_mode in seen_modes:
+                raise ValueError(
+                    f"duplicate quant_mode in weight preparation: {spec.quant_mode!r}"
+                )
+            seen_modes.add(spec.quant_mode)
+        if not self.transforms:
+            raise ValueError("weight preparation plan has no transforms")
+        if not self.weight_layouts:
+            raise ValueError("weight preparation plan has no weight layouts")
+
+    @property
+    def source_format(self) -> str:
+        return self.specs[0].source_format
+
+    @property
+    def activation(self) -> str:
+        return self.specs[0].activation
+
+    @property
+    def io_dtype(self) -> str:
+        return self.specs[0].io_dtype
+
+    @property
+    def w13_layout(self) -> str:
+        return self.specs[0].w13_layout
+
+    @property
+    def quant_modes(self) -> frozenset[str]:
+        return frozenset(spec.quant_mode for spec in self.specs)
+
+    @property
+    def prepares_runtime_alphas(self) -> bool:
+        return WeightPreparationTransform.RUNTIME_ALPHAS in self.transforms
+
+    @property
+    def discards_source_parameters(self) -> bool:
+        return self.storage_policy in {
+            WeightStoragePolicy.TRANSFER_SOURCE,
+            WeightStoragePolicy.REUSE_SOURCE,
+        }
+
+    @property
+    def reuses_source_storage(self) -> bool:
+        return self.storage_policy is WeightStoragePolicy.REUSE_SOURCE
+
+    @property
+    def w4a16_weight_layout(self) -> str | None:
+        if WeightPreparationTransform.W4A16_NATIVE in self.transforms:
+            return "modelopt"
+        if WeightPreparationTransform.W4A16_PACKED in self.transforms:
+            return "packed"
+        return None
+
+    @property
+    def w4a16_scale_format(self) -> str | None:
+        if self.w4a16_weight_layout is None:
+            return None
+        return self.specs[0].source_weight_scale.value
+
+    def required_weight_layout(self, quant_mode: str) -> PreparedWeightLayout | None:
+        """Return a fixed load-time layout for ``quant_mode``, if it has one.
+
+        Source-native NVFP4 recipes deliberately return ``None`` because their
+        direct and tensor-core regimes consume two zero-copy views of the same
+        allocation.  The execution lowering chooses between those views.
+        """
+
+        quant_mode = str(quant_mode).lower()
+        if quant_mode not in self.quant_modes:
+            raise ValueError(
+                f"quant_mode={quant_mode!r} is absent from this preparation plan"
+            )
+        if quant_mode == "w4a16":
+            return (
+                PreparedWeightLayout.SOURCE_NATIVE
+                if WeightPreparationTransform.W4A16_NATIVE in self.transforms
+                else PreparedWeightLayout.MMA_PACKED
+            )
+        if quant_mode == "w4a8_mx":
+            return PreparedWeightLayout.QMMA_REPACKED
+        return None
+
+    def supports(
+        self,
+        *,
+        quant_mode: str,
+        execution: "MoEExecutionPlan",
+    ) -> bool:
+        quant_mode = str(quant_mode).lower()
+        if quant_mode not in self.quant_modes:
+            return False
+        required = self.required_weight_layout(quant_mode)
+        if required is not None:
+            return execution.weight_layout is required
+        return execution.weight_layout in {
+            PreparedWeightLayout.SOURCE_NATIVE,
+            PreparedWeightLayout.MMA_VIEW,
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class MoEExecutionPlan:
+    """A lowering of :class:`MoESpec` onto one concrete execution regime."""
+
+    regime: MoERegime
+    route_layout: RouteLayout
+    work_availability: WorkAvailability
+    scheduler: WorkScheduler
+    graph_partition: GraphPartition
+    gemm_engine: GemmEngine
+    weight_layout: PreparedWeightLayout
+    reduction: OutputReduction
+    tile_m: int | None = None
+    tile_n: int | None = None
+    route_block_rows: int | None = None
+
+    def __post_init__(self) -> None:
+        for name, enum_type in (
+            ("regime", MoERegime),
+            ("route_layout", RouteLayout),
+            ("work_availability", WorkAvailability),
+            ("scheduler", WorkScheduler),
+            ("graph_partition", GraphPartition),
+            ("gemm_engine", GemmEngine),
+            ("weight_layout", PreparedWeightLayout),
+            ("reduction", OutputReduction),
+        ):
+            object.__setattr__(self, name, enum_type(getattr(self, name)))
+        if self.work_availability is WorkAvailability.STREAMING:
+            if self.scheduler is not WorkScheduler.READY_QUEUE:
+                raise ValueError("streaming work requires a readiness-aware scheduler")
+        elif self.scheduler is WorkScheduler.READY_QUEUE:
+            raise ValueError("ready_queue is only valid for streaming work")
+        if self.scheduler is WorkScheduler.ATOMIC_QUEUE:
+            if self.work_availability is not WorkAvailability.PRECOMPUTED:
+                raise ValueError("atomic_queue is only valid for precomputed work")
+        if self.route_layout is RouteLayout.APPEND_ONLY_EXPERT:
+            if self.work_availability not in {
+                WorkAvailability.PRECOMPUTED,
+                WorkAvailability.STREAMING,
+            }:
+                raise ValueError(
+                    "append-only expert routing must materialize or stream work"
+                )
+        if self.route_layout is RouteLayout.SORTED_PADDED_EXPERT:
+            if self.work_availability is not WorkAvailability.PRECOMPUTED:
+                raise ValueError(
+                    "sorted/padded routes must be materialized before compute"
+                )
+        for name, value in (
+            ("tile_m", self.tile_m),
+            ("tile_n", self.tile_n),
+            ("route_block_rows", self.route_block_rows),
+        ):
+            if value is not None and int(value) <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+
+    @property
+    def work_is_streamed(self) -> bool:
+        return self.work_availability is WorkAvailability.STREAMING
+
+    @property
+    def grid_addressable(self) -> bool:
+        """Whether all compute work is knowable without waiting in-kernel."""
+
+        return self.work_availability in {
+            WorkAvailability.INLINE,
+            WorkAvailability.PRECOMPUTED,
+        }
+
+    @property
+    def uses_explicit_task_queue(self) -> bool:
+        return self.scheduler in {
+            WorkScheduler.ATOMIC_QUEUE,
+            WorkScheduler.READY_QUEUE,
+        }
+
+
+def make_moe_spec(
+    *,
+    quant_mode: str,
+    source_format: str,
+    activation: str,
+    io_dtype: str,
+    w13_layout: str,
+    apply_router_weight_on_input: bool = False,
+) -> MoESpec:
+    """Build the canonical numeric contract for a normalized public request."""
+
+    quant_mode = str(quant_mode).lower()
+    source_format = str(source_format).lower()
+    validate_moe_source_quant(
+        source_format=source_format,
+        quant_mode=quant_mode,
+    )
+
+    source_scale = (
+        ScaleEncoding.E8M0_K32
+        if source_format == "fp4_e8m0_k32"
+        else ScaleEncoding.E4M3_K16
+    )
+    if quant_mode == "w4a16":
+        activation_encoding = OperandEncoding.BF16
+        activation_scale = None
+        weight_scale = source_scale
+    elif quant_mode == "nvfp4":
+        activation_encoding = OperandEncoding.FP4_E2M1
+        activation_scale = ScaleEncoding.E4M3_K16
+        weight_scale = ScaleEncoding.E4M3_K16
+    elif quant_mode == "w4a8_mx":
+        activation_encoding = OperandEncoding.MXFP8_E4M3
+        activation_scale = ScaleEncoding.E8M0_K32
+        weight_scale = ScaleEncoding.E8M0_K32
+    else:
+        activation_encoding = OperandEncoding.MXFP8_E4M3
+        activation_scale = ScaleEncoding.E8M0_K32
+        weight_scale = ScaleEncoding.E8M0_K32_X_E4M3_K16_RESIDUAL
+
+    return MoESpec(
+        quant_mode=quant_mode,
+        source_format=source_format,
+        activation=str(activation),
+        io_dtype=str(io_dtype),
+        activation_encoding=activation_encoding,
+        activation_scale=activation_scale,
+        weight_encoding=OperandEncoding.FP4_E2M1,
+        source_weight_scale=source_scale,
+        weight_scale=weight_scale,
+        w13_layout=str(w13_layout),
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+    )
+
+
+def plan_moe_weight_preparation(
+    specs: MoESpec | Iterable[MoESpec],
+    *,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    w4a16_layout: PreparedWeightLayout | str | None = None,
+) -> MoEWeightPreparationPlan:
+    """Choose the minimal representation set for the requested recipes.
+
+    W4A16's automatic policy mirrors the production serving choices: native
+    ModelOpt storage avoids a second full copy, compact E8M0 K tails stay native,
+    and aligned E8M0/CompressedTensors sources use the packed MMA layout.  An
+    explicit ``w4a16_layout`` is a development/deployment override, not an
+    adapter-side reimplementation of the policy.
+    """
+
+    if isinstance(specs, MoESpec):
+        normalized_specs = (specs,)
+    else:
+        normalized_specs = tuple(specs)
+    if not normalized_specs:
+        raise ValueError("weight preparation requires at least one MoE spec")
+    num_experts = int(num_experts)
+    hidden_size = int(hidden_size)
+    intermediate_size = int(intermediate_size)
+    for name, value in (
+        ("num_experts", num_experts),
+        ("hidden_size", hidden_size),
+        ("intermediate_size", intermediate_size),
+    ):
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {value}")
+
+    source_format = normalized_specs[0].source_format
+    requested_w4a16_layout = (
+        None if w4a16_layout is None else PreparedWeightLayout(w4a16_layout)
+    )
+    if requested_w4a16_layout not in {
+        None,
+        PreparedWeightLayout.SOURCE_NATIVE,
+        PreparedWeightLayout.MMA_PACKED,
+    }:
+        raise ValueError(
+            "W4A16 preparation requires source_native or mma_packed layout"
+        )
+
+    transforms: set[WeightPreparationTransform] = set()
+    weight_layouts: set[PreparedWeightLayout] = set()
+    scale_layouts: set[PreparedScaleLayout] = set()
+    for spec in normalized_specs:
+        if spec.source_format != source_format:
+            raise ValueError("all preparation specs must share one source format")
+        if spec.quant_mode in {"nvfp4", "w4a8_nvfp4"}:
+            transforms.add(WeightPreparationTransform.RUNTIME_ALPHAS)
+            # One source allocation supplies both direct-micro and dynamic MMA
+            # views; these are execution contracts, not duplicate byte copies.
+            weight_layouts.update(
+                {PreparedWeightLayout.SOURCE_NATIVE, PreparedWeightLayout.MMA_VIEW}
+            )
+            scale_layouts.update(
+                {
+                    PreparedScaleLayout.SOURCE_NATIVE,
+                    PreparedScaleLayout.RUNTIME_ALPHA,
+                }
+            )
+            continue
+        if spec.quant_mode == "w4a8_mx":
+            if spec.activation != "silu":
+                raise ValueError("W4A8-MX preparation currently requires silu")
+            # The rp storage ceil-tiles partial 256/128 tiles (zero-filled),
+            # so 32-aligned shards (352 = 2048/TP6, 192 = 3072/TP16) prepare
+            # fine; consumers bound their reads by the logical sizes.
+            if hidden_size % 256 != 0 or intermediate_size % 32 != 0:
+                raise ValueError(
+                    "W4A8-MX QMMA layout requires hidden_size % 256 == 0 and "
+                    "intermediate_size % 32 == 0"
+                )
+            transforms.add(WeightPreparationTransform.W4A8_QMMA)
+            weight_layouts.add(PreparedWeightLayout.QMMA_REPACKED)
+            scale_layouts.add(PreparedScaleLayout.QMMA_SFB)
+            continue
+        if spec.quant_mode == "w4a16":
+            layout = requested_w4a16_layout
+            if layout is None:
+                # The packed MMA kernels only have tile configs for
+                # 128-aligned intermediate shards; the native path already
+                # supports compact sub-32 tails (see
+                # test_w4a16_e8m0_native_compact_tail_uses_ceil_scale_grid),
+                # so route every non-128-aligned e8m0 shard through it
+                # instead of failing at kernel-config time (e.g. 2048/TP6 =
+                # 352, 3072/TP16 = 192).
+                layout = (
+                    PreparedWeightLayout.SOURCE_NATIVE
+                    if source_format == "modelopt_nvfp4"
+                    or (
+                        source_format == "fp4_e8m0_k32" and intermediate_size % 128 != 0
+                    )
+                    else PreparedWeightLayout.MMA_PACKED
+                )
+            if (
+                source_format == "compressed_tensors"
+                and layout is not PreparedWeightLayout.MMA_PACKED
+            ):
+                raise ValueError(
+                    "CompressedTensors W4A16 requires the packed MMA layout"
+                )
+            transforms.add(
+                WeightPreparationTransform.W4A16_NATIVE
+                if layout is PreparedWeightLayout.SOURCE_NATIVE
+                else WeightPreparationTransform.W4A16_PACKED
+            )
+            weight_layouts.add(layout)
+            scale_layouts.add(PreparedScaleLayout.MMA_PACKED)
+            continue
+        raise ValueError(f"unsupported quant_mode {spec.quant_mode!r}")
+
+    mutating = transforms & {
+        WeightPreparationTransform.W4A16_PACKED,
+        WeightPreparationTransform.W4A8_QMMA,
+    }
+    source_recipe_selected = bool(
+        {"nvfp4", "w4a8_nvfp4"} & {spec.quant_mode for spec in normalized_specs}
+    )
+    native_representation = WeightPreparationTransform.W4A16_NATIVE in transforms
+    if len(mutating) > 1:
+        raise ValueError(
+            "requested MoE recipes require multiple incompatible model-sized "
+            "weight repacks; keeping both is not a supported serving policy"
+        )
+    if mutating and (source_recipe_selected or native_representation):
+        raise ValueError(
+            "requested MoE recipes require both source-native weights and a "
+            "model-sized repack; choose a shared/native regime instead"
+        )
+    if source_recipe_selected:
+        storage_policy = WeightStoragePolicy.KEEP_SOURCE
+    elif native_representation:
+        storage_policy = WeightStoragePolicy.TRANSFER_SOURCE
+    elif mutating:
+        storage_policy = WeightStoragePolicy.REUSE_SOURCE
+    else:
+        storage_policy = WeightStoragePolicy.KEEP_SOURCE
+
+    return MoEWeightPreparationPlan(
+        specs=normalized_specs,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        transforms=frozenset(transforms),
+        weight_layouts=frozenset(weight_layouts),
+        scale_layouts=frozenset(scale_layouts),
+        storage_policy=storage_policy,
+    )
+
+
+def _gemm_engine_for_spec(spec: MoESpec) -> GemmEngine:
+    if spec.activation_encoding is OperandEncoding.BF16:
+        return GemmEngine.W4A16_MMA
+    if spec.activation_encoding is OperandEncoding.MXFP8_E4M3:
+        return GemmEngine.MXFP8_QMMA
+    return GemmEngine.NVFP4_MMA
+
+
+def lower_moe_execution(
+    spec: MoESpec,
+    *,
+    regime: MoERegime,
+    tile_m: int | None = None,
+    tile_n: int | None = None,
+    route_block_rows: int | None = None,
+    direct_routes: bool = False,
+    deterministic_output: bool = False,
+    scheduler: WorkScheduler | None = None,
+    required_weight_layout: PreparedWeightLayout | str | None = None,
+) -> MoEExecutionPlan:
+    """Lower one semantic spec without coupling regime to precision.
+
+    Activation precision does not select the scheduler: an MXFP8 activation
+    spec can lower to either queue or persistent-grid ownership in the unified
+    materialized kernel.
+    """
+
+    regime = MoERegime(regime)
+    required_weight_layout = (
+        None
+        if required_weight_layout is None
+        else PreparedWeightLayout(required_weight_layout)
+    )
+    if regime is MoERegime.DIRECT:
+        return MoEExecutionPlan(
+            regime=regime,
+            route_layout=RouteLayout.DIRECT_TOPK,
+            work_availability=WorkAvailability.INLINE,
+            scheduler=WorkScheduler.DIRECT,
+            graph_partition=GraphPartition.FUSED,
+            gemm_engine=GemmEngine.DIRECT_DOT,
+            weight_layout=(
+                required_weight_layout or PreparedWeightLayout.SOURCE_NATIVE
+            ),
+            reduction=OutputReduction.FUSED_TOPK_SUM,
+            tile_m=tile_m,
+            tile_n=tile_n,
+        )
+
+    if regime is MoERegime.STREAMING_FUSED:
+        engine = _gemm_engine_for_spec(spec)
+        reduction = (
+            OutputReduction.ROUTE_BUFFER_TOPK_SUM
+            if deterministic_output
+            else OutputReduction.ATOMIC_SCATTER
+        )
+        return MoEExecutionPlan(
+            regime=regime,
+            route_layout=RouteLayout.APPEND_ONLY_EXPERT,
+            work_availability=WorkAvailability.STREAMING,
+            scheduler=WorkScheduler.READY_QUEUE,
+            graph_partition=GraphPartition.FUSED,
+            gemm_engine=engine,
+            weight_layout=required_weight_layout or PreparedWeightLayout.MMA_VIEW,
+            reduction=reduction,
+            tile_m=tile_m,
+            tile_n=tile_n,
+        )
+
+    if regime is MoERegime.MATERIALIZED_FUSED:
+        engine = _gemm_engine_for_spec(spec)
+        resolved_scheduler = (
+            WorkScheduler.ATOMIC_QUEUE
+            if scheduler is None
+            else WorkScheduler(scheduler)
+        )
+        if resolved_scheduler not in {
+            WorkScheduler.PERSISTENT_GRID,
+            WorkScheduler.ATOMIC_QUEUE,
+        }:
+            raise ValueError(
+                "materialized_fused requires persistent_grid or atomic_queue"
+            )
+        reduction = (
+            OutputReduction.ROUTE_BUFFER_TOPK_SUM
+            if deterministic_output
+            else OutputReduction.ATOMIC_SCATTER
+        )
+        weight_layout = required_weight_layout or (
+            PreparedWeightLayout.QMMA_REPACKED
+            if spec.quant_mode == "w4a8_mx"
+            else PreparedWeightLayout.MMA_VIEW
+        )
+        return MoEExecutionPlan(
+            regime=regime,
+            route_layout=RouteLayout.APPEND_ONLY_EXPERT,
+            work_availability=WorkAvailability.PRECOMPUTED,
+            scheduler=resolved_scheduler,
+            graph_partition=GraphPartition.FUSED,
+            gemm_engine=engine,
+            weight_layout=weight_layout,
+            reduction=reduction,
+            tile_m=tile_m,
+            tile_n=tile_n,
+        )
+
+    if regime is MoERegime.MATERIALIZED_PERSISTENT:
+        engine = _gemm_engine_for_spec(spec)
+        return MoEExecutionPlan(
+            regime=regime,
+            route_layout=(
+                RouteLayout.DIRECT_TOPK
+                if direct_routes
+                else RouteLayout.SORTED_PADDED_EXPERT
+            ),
+            work_availability=WorkAvailability.PRECOMPUTED,
+            scheduler=WorkScheduler.PERSISTENT_GRID,
+            graph_partition=GraphPartition.FUSED,
+            gemm_engine=engine,
+            weight_layout=required_weight_layout or PreparedWeightLayout.MMA_PACKED,
+            reduction=OutputReduction.SEPARATE_TOPK_SUM,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            route_block_rows=route_block_rows,
+        )
+
+    raise ValueError(f"unsupported MoE execution regime {regime!s}")
+
+
+__all__ = [
+    "GemmEngine",
+    "GraphPartition",
+    "MoEExecutionPlan",
+    "MoERegime",
+    "MoESpec",
+    "OperandEncoding",
+    "OutputReduction",
+    "PreparedScaleLayout",
+    "PreparedWeightLayout",
+    "RouteLayout",
+    "ScaleEncoding",
+    "WorkAvailability",
+    "WeightPreparationTransform",
+    "WeightStoragePolicy",
+    "WorkScheduler",
+    "lower_moe_execution",
+    "make_moe_spec",
+    "MoEWeightPreparationPlan",
+    "plan_moe_weight_preparation",
+    "validate_moe_source_quant",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/__init__.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/__init__.py @ 377083ec (2026-06-03) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from .dynamic import MoEDynamicKernelBackend
+from .micro import MoEMicroKernelBackend
+from .relu2 import MoEDynamicKernelRelu2, MoEMicroKernelRelu2
+from .silu import MoEDynamicKernelSilu, MoEMicroKernelSilu
+from .reference import (
+    MoERouteTrace,
+    OracleMetrics,
+    compare_to_reference,
+    moe_reference_f32,
+    moe_reference_nvfp4,
+    trace_moe_reference_nvfp4_route,
+)
+
+MoEDynamicKernel = MoEDynamicKernelSilu
+MoEMicroKernel = MoEMicroKernelSilu
+
+__all__ = [
+    "MoEDynamicKernelBackend",
+    "MoEDynamicKernel",
+    "MoEDynamicKernelRelu2",
+    "MoEDynamicKernelSilu",
+    "MoEMicroKernelBackend",
+    "MoEMicroKernel",
+    "MoEMicroKernelRelu2",
+    "MoEMicroKernelSilu",
+    "MoERouteTrace",
+    "OracleMetrics",
+    "compare_to_reference",
+    "moe_reference_f32",
+    "moe_reference_nvfp4",
+    "trace_moe_reference_nvfp4_route",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/activations.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/activations.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/activations.py @ 69ad7557 (2026-06-13) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Shared activation metadata for fused MoE paths."""
+
+from __future__ import annotations
+
+import math
+
+
+SWIGLUOAI_UNINTERLEAVE = "swigluoai_uninterleave"
+SWIGLUOAI_DEFAULT_LIMIT = 7.0
+SWIGLUOAI_DEFAULT_ALPHA = 1.702
+SWIGLUOAI_DEFAULT_BETA = 1.0
+
+SUPPORTED_MOE_ACTIVATIONS = frozenset({"silu", "relu2", SWIGLUOAI_UNINTERLEAVE})
+GATED_MOE_ACTIVATIONS = frozenset({"silu", SWIGLUOAI_UNINTERLEAVE})
+
+
+def normalize_moe_activation(activation: str) -> str:
+    activation = str(activation)
+    if activation not in SUPPORTED_MOE_ACTIVATIONS:
+        raise ValueError(f"unsupported activation {activation!r}")
+    return activation
+
+
+def is_gated_moe_activation(activation: str) -> bool:
+    return normalize_moe_activation(activation) in GATED_MOE_ACTIVATIONS
+
+
+def moe_activation_w1_rows(activation: str, n: int) -> int:
+    return (2 if is_gated_moe_activation(activation) else 1) * int(n)
+
+
+def normalize_swiglu_limit_for_activation(
+    activation: str,
+    swiglu_limit: float | None,
+) -> float | None:
+    activation = normalize_moe_activation(activation)
+    if swiglu_limit is None:
+        return SWIGLUOAI_DEFAULT_LIMIT if activation == SWIGLUOAI_UNINTERLEAVE else None
+    if activation not in GATED_MOE_ACTIVATIONS:
+        raise ValueError("swiglu_limit requires a gated MoE activation")
+    limit = float(swiglu_limit)
+    if not math.isfinite(limit) or limit <= 0.0:
+        raise ValueError(f"swiglu_limit must be positive and finite, got {limit}")
+    return limit
+
+
+def normalize_swiglu_alpha_for_activation(
+    activation: str,
+    swiglu_alpha: float | None,
+) -> float:
+    activation = normalize_moe_activation(activation)
+    if activation != SWIGLUOAI_UNINTERLEAVE:
+        if swiglu_alpha is not None and float(swiglu_alpha) != 1.0:
+            raise ValueError(
+                "swiglu_alpha is only configurable for swigluoai_uninterleave"
+            )
+        return 1.0
+    alpha = SWIGLUOAI_DEFAULT_ALPHA if swiglu_alpha is None else float(swiglu_alpha)
+    if not math.isfinite(alpha):
+        raise ValueError(f"swiglu_alpha must be finite, got {alpha}")
+    return alpha
+
+
+def normalize_swiglu_beta_for_activation(
+    activation: str,
+    swiglu_beta: float | None,
+) -> float:
+    activation = normalize_moe_activation(activation)
+    if activation != SWIGLUOAI_UNINTERLEAVE:
+        if swiglu_beta is not None and float(swiglu_beta) != 0.0:
+            raise ValueError(
+                "swiglu_beta is only configurable for swigluoai_uninterleave"
+            )
+        return 0.0
+    beta = SWIGLUOAI_DEFAULT_BETA if swiglu_beta is None else float(swiglu_beta)
+    if not math.isfinite(beta):
+        raise ValueError(f"swiglu_beta must be finite, got {beta}")
+    return beta

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/dynamic.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/dynamic.py
@@ -1,0 +1,7435 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/dynamic.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""
+MoEDynamicKernel — fused routed low-precision MoE kernel for SM120.
+
+The kernel has a route/activation-pack phase followed by the proven FC1 /
+activation / quant / FC2 / scatter compute body.  The boundary between those
+phases is expressed as a compile-time work-source policy instead of being
+embedded in the math pipeline.
+
+Execution model
+  Phase 0: cooperative init / clear scratch state
+  Phase 1: all CTAs start as producers
+           - claim routed (token, topk_slot) pairs from pair_head
+           - append expert rows
+           - write token_map + token_weights
+           - quantize each routed token row into expert-major packed A + scales
+           - materialize one compute item per (expert, m_tile, slice_group)
+  Phase 2: after the resident-grid publish barrier, CTAs consume those items
+           - the default materialized queue dynamically balances items
+           - MMA warps run FC1 -> SiLU -> quant -> FC2 -> scatter for that task
+           - producer warp(s) stream the corresponding FC1 / FC2 weights
+
+An arithmetic persistent-grid source remains available as a compile-time A/B
+policy.  An append-only ready source is also retained experimentally for true
+producer/consumer overlap.  Neither policy is a property of W4A4 or W4A8
+arithmetic.
+
+This is intentionally conservative:
+  - still one CTA per SM
+  - the per-slice microkernel runs sequentially for a small grouped slice task
+  - route/pack is warp-private instead of CTA-broadcast
+
+It spans the full M-tile set {16,32,64,128} x 128, so a single dynamic kernel
+covers the decode and prefill bands.
+
+Native W4A8 M=1 is a compile-time regime within that family: the resident grid
+quantizes one input row, derives FC1 and FC2 work arithmetically, and skips the
+route histogram and task queue while consuming the same prepared weights.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+from cutlass.cutlass_dsl import (
+    Int32,
+    Int64,
+    Uint8,
+    Uint32,
+    Uint64,
+    T,
+    dsl_user_op,
+    extract_mlir_values,
+    new_from_mlir_values,
+)
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_add_global_i32,
+    bfloat2_to_float2_scaled,
+    broadcast_f32_to_half2,
+    cp_async4_shared_global,
+    cp_async_u32_shared_global,
+    cp_async_u64_shared_global,
+    e2m1x8_mul_residual_to_e4m3x8,
+    e2m1x8_to_qmma_e2m1x8,
+    fabs_f32,
+    fmax_f32,
+    fp8_e4m3_to_f32,
+    ld_shared_f32,
+    ld_shared_i32_relaxed,
+    ld_shared_u32,
+    ld_shared_v2_u32,
+    ld_shared_v4_u32,
+    ld_global_v4_u32,
+    atomic_add_shared_i32,
+    mxfp8_mma_m16n8k32_f32_e4m3,
+    mxfp8_mma_m16n8k32_f32_e2m1,
+    quantize_block_fp4,
+    quantize_block_fp4_fast,
+    quantize_block_fp8_mx,
+    get_ptr_as_int64,
+    st_global_f32,
+    st_global_i32,
+    shared_ptr_to_u32,
+    st_shared_f32,
+    st_shared_u8,
+    st_shared_u32,
+    st_global_u64,
+    st_global_v4_u32,
+    warp_reduce,
+)
+from flashinfer.experimental.sm12x._lib.smem import make_smem_memrange_alias
+from flashinfer.experimental.sm12x._lib.dense_gemm import (
+    DenseGemmKernel,
+    _reshape_acc_to_mn,
+    sm120_make_smem_layout_sfa,
+    sm120_make_smem_layout_sfb,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    scatter_add_bf16x2,
+    scatter_add_v4_bf16x2,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    SWIGLUOAI_UNINTERLEAVE,
+    is_gated_moe_activation,
+    normalize_moe_activation,
+    normalize_swiglu_alpha_for_activation,
+    normalize_swiglu_beta_for_activation,
+    normalize_swiglu_limit_for_activation,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a8_phase1 import (
+    W4A8MaterializedPhase1Kernel,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a8_phase2 import (
+    W4A8MaterializedPhase2Kernel,
+)
+
+
+_SF_VEC_SIZE = 16
+_TASK_SLICE_CHUNK = 1
+_WORK_ITEM_FIELDS = 5
+_WORK_EXPERT = 0
+_WORK_M_TILE = 1
+_WORK_SLICE_BEGIN = 2
+_WORK_SLICE_COUNT = 3
+_WORK_VALID_ROWS = 4
+
+_CTRL_HAS_WORK = 0
+_CTRL_DONE = 1
+_CTRL_WORK_BEGIN = 2
+_CTRL_CLAIMED_SLOT = 7
+
+_WORK_SOURCE_PERSISTENT_GRID = "persistent_grid"
+_WORK_SOURCE_MATERIALIZED_QUEUE = "materialized_queue"
+_WORK_SOURCE_READY_QUEUE = "ready_queue"
+_WORK_SOURCES = {
+    _WORK_SOURCE_PERSISTENT_GRID,
+    _WORK_SOURCE_MATERIALIZED_QUEUE,
+    _WORK_SOURCE_READY_QUEUE,
+}
+# w4a8 smem staging geometry: one 128-row x 64-byte packed-FP4 B tile per
+# k-tile. Rows pad to 80 bytes: 16-aligned (cp.async.cg requires dst
+# alignment = copy size) and 20*g mod 32 spreads the eight g-rows a lane
+# quad touches across distinct bank groups.
+_W4A8_B_ROW_PAD = 80
+
+
+@cute.jit
+def _load_bf16x32_to_f32(
+    a_input: cute.Tensor,
+    linear_offset: Int32,
+) -> Tuple[cute.Tensor, cutlass.Float32]:
+    """Load one aligned BF16x32 quant block with four 128-bit operations.
+
+    Keeping the converted values in one rmem tensor gives the quantizer the
+    same convenient scalar view without emitting 32 independent ``ld.u16``
+    instructions.  Immediate conversion of each four-word vector also avoids
+    extending a second 16-register packed-input tensor across the reduction.
+    """
+
+    values = cute.make_rmem_tensor((32,), cutlass.Float32)
+    block_max = cutlass.Float32(0.0)
+    base = get_ptr_as_int64(a_input, linear_offset)
+    for vec in cutlass.range_constexpr(4):
+        w0, w1, w2, w3 = ld_global_v4_u32(base + Int64(vec * 16))
+        v0, v1 = bfloat2_to_float2_scaled(w0, cutlass.Float32(1.0))
+        v2, v3 = bfloat2_to_float2_scaled(w1, cutlass.Float32(1.0))
+        v4, v5 = bfloat2_to_float2_scaled(w2, cutlass.Float32(1.0))
+        v6, v7 = bfloat2_to_float2_scaled(w3, cutlass.Float32(1.0))
+        values[vec * 8 + 0] = v0
+        values[vec * 8 + 1] = v1
+        values[vec * 8 + 2] = v2
+        values[vec * 8 + 3] = v3
+        values[vec * 8 + 4] = v4
+        values[vec * 8 + 5] = v5
+        values[vec * 8 + 6] = v6
+        values[vec * 8 + 7] = v7
+        block_max = fmax_f32(block_max, fabs_f32(v0))
+        block_max = fmax_f32(block_max, fabs_f32(v1))
+        block_max = fmax_f32(block_max, fabs_f32(v2))
+        block_max = fmax_f32(block_max, fabs_f32(v3))
+        block_max = fmax_f32(block_max, fabs_f32(v4))
+        block_max = fmax_f32(block_max, fabs_f32(v5))
+        block_max = fmax_f32(block_max, fabs_f32(v6))
+        block_max = fmax_f32(block_max, fabs_f32(v7))
+    return values, block_max
+
+
+_W4A8_TMA_TILE_BYTES = 128 * 64  # one (128 n, 128 fp4-k) TMA box
+_W4A8_B_BUF_BYTES = 128 * _W4A8_B_ROW_PAD
+
+
+@cute.jit
+def _w4a8_stage_b_tile(
+    b_u32: cute.Tensor,
+    smem_base: Int32,
+    base_idx: Int64,
+    row_u32_stride: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+    row_pad: cutlass.Constexpr = _W4A8_B_ROW_PAD,
+):
+    """cp.async one 128x64B packed-FP4 tile into smem rows.
+
+    Unpadded (64B) rows XOR-swizzle the 16B chunk by the row's low bits —
+    without it every consumer B load is a 4-8 way bank conflict."""
+    for i in cutlass.range_constexpr((128 * 4 + tcnt - 1) // tcnt):
+        idx = tidx + Int32(i * tcnt)
+        if idx < Int32(128 * 4):
+            r = idx >> Int32(2)
+            ch = idx & Int32(3)
+            gaddr = get_ptr_as_int64(
+                b_u32,
+                base_idx + Int64(r) * Int64(row_u32_stride) + Int64(ch * 4),
+            )
+            cp_async4_shared_global(
+                smem_base + r * Int32(row_pad) + ch * Int32(16), gaddr
+            )
+
+
+@cute.jit
+def _w4a8_stage_repacked_b_half(
+    b_rp_u32: cute.Tensor,
+    smem_base: Int32,
+    tile_base: Int64,
+    half: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+):
+    """Stage one N128 half of an N256 repacked W4A8 B tile.
+
+    The source tile is ``[kb=4, chunk=8, lane=32, n8_in_chunk=4]``.
+    Selecting four chunks per ``kb`` leaves four discontiguous 2KB source
+    spans; compact them into an 8KB shared tile with the same inner layout.
+    Each copy is exactly the four n8 words consumed by one ``ld.shared.v4``.
+    """
+
+    transfers = 4 * 4 * 32
+    for i in cutlass.range_constexpr((transfers + tcnt - 1) // tcnt):
+        idx = tidx + Int32(i * tcnt)
+        if idx < Int32(transfers):
+            lane = idx & Int32(31)
+            kc = idx >> Int32(5)
+            chunk = kc & Int32(3)
+            kb = kc >> Int32(2)
+            src_word = (
+                tile_base
+                + Int64(kb * 8 * 32 * 4)
+                + Int64((half * Int32(4) + chunk) * Int32(32 * 4))
+                + Int64(lane * Int32(4))
+            )
+            cp_async4_shared_global(
+                smem_base + (idx << Int32(4)),
+                get_ptr_as_int64(b_rp_u32, src_word),
+            )
+
+
+@cute.jit
+def _w4a8_stage_repacked_b_full(
+    b_rp_u32: cute.Tensor,
+    smem_base: Int32,
+    tile_base: Int64,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+):
+    """Stage one contiguous N256 repacked W4A8 B tile (16KB)."""
+
+    transfers = 4 * 8 * 32
+    for i in cutlass.range_constexpr((transfers + tcnt - 1) // tcnt):
+        idx = tidx + Int32(i * tcnt)
+        if idx < Int32(transfers):
+            cp_async4_shared_global(
+                smem_base + (idx << Int32(4)),
+                get_ptr_as_int64(b_rp_u32, tile_base + Int64(idx * 4)),
+            )
+
+
+@cute.jit
+def _w4a8_stage_repacked_sfb_half(
+    sfb_rp_u32: cute.Tensor,
+    smem_base: Int32,
+    tile_base: Int64,
+    half: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+):
+    """Stage the 512B SFB half paired with an N128 B half."""
+
+    transfers = (16 * 8) // 4
+    for i in cutlass.range_constexpr((transfers + tcnt - 1) // tcnt):
+        idx = tidx + Int32(i * tcnt)
+        if idx < Int32(transfers):
+            src_word = tile_base + Int64(half * Int32(16 * 8) + idx * 4)
+            cp_async4_shared_global(
+                smem_base + (idx << Int32(4)),
+                get_ptr_as_int64(sfb_rp_u32, src_word),
+            )
+
+
+@cute.jit
+def _w4a8_stage_repacked_sfb_full(
+    sfb_rp_u32: cute.Tensor,
+    smem_base: Int32,
+    tile_base: Int64,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+):
+    """Stage one contiguous N256 repacked SFB tile (1KB)."""
+
+    transfers = (32 * 8) // 4
+    for i in cutlass.range_constexpr((transfers + tcnt - 1) // tcnt):
+        idx = tidx + Int32(i * tcnt)
+        if idx < Int32(transfers):
+            cp_async4_shared_global(
+                smem_base + (idx << Int32(4)),
+                get_ptr_as_int64(sfb_rp_u32, tile_base + Int64(idx * 4)),
+            )
+
+
+@cute.jit
+def _w4a8_stage_a_tile(
+    pa_u32: cute.Tensor,
+    smem_base: Int32,
+    base_idx: Int64,
+    row_u32_stride: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+    rows: cutlass.Constexpr,
+):
+    """cp.async one rows x 128B E4M3 A tile into smem rows.
+
+    The compact repacked path keeps rows plain here.  Its raw fragment loads
+    use two aligned 64-bit accesses; changing this layout requires changing
+    those addresses in lockstep."""
+    for i in cutlass.range_constexpr((rows * 8 + tcnt - 1) // tcnt):
+        idx = tidx + Int32(i * tcnt)
+        if idx < Int32(rows * 8):
+            r = idx >> Int32(3)
+            ch = idx & Int32(7)
+            gaddr = get_ptr_as_int64(
+                pa_u32,
+                base_idx + Int64(r) * Int64(row_u32_stride) + Int64(ch * 4),
+            )
+            cp_async4_shared_global(
+                smem_base + (r << Int32(7)) + (ch << Int32(4)), gaddr
+            )
+
+
+@cute.jit
+def _w4a8_stage_a_tile_gather(
+    pa_u32: cute.Tensor,
+    token_map: cute.Tensor,
+    smem_base: Int32,
+    physical_row_base: Int32,
+    valid_rows: Int32,
+    k_word_base: Int32,
+    row_u32_stride: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+    rows: cutlass.Constexpr,
+):
+    """Gather one rows x 128B E4M3 tile through physical-row token ids.
+
+    Materialized W4A8 stores each quantized input row once, indexed by token,
+    instead of fanning it out to every routed expert row.  FC1 pays the same
+    gather it would have paid in a separate grouped GEMM while retaining the
+    resident task scheduler and fused activation handoff.
+    """
+    for i in cutlass.range_constexpr((rows * 8 + tcnt - 1) // tcnt):
+        idx = tidx + Int32(i * tcnt)
+        if idx < Int32(rows * 8):
+            r = idx >> Int32(3)
+            ch = idx & Int32(7)
+            src_row = Int32(0)
+            if r < valid_rows:
+                src_row = token_map[physical_row_base + r].to(Int32)
+            gaddr = get_ptr_as_int64(
+                pa_u32,
+                src_row * row_u32_stride + k_word_base + (ch << Int32(2)),
+            )
+            cp_async4_shared_global(
+                smem_base + (r << Int32(7)) + (ch << Int32(4)), gaddr
+            )
+
+
+@cute.jit
+def _w4a8_stage_scale_tile_gather(
+    scale_u8: cute.Tensor,
+    token_map: cute.Tensor,
+    smem_base: Int32,
+    physical_row_base: Int32,
+    valid_rows: Int32,
+    k_byte_base: Int32,
+    row_stride: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+    rows: cutlass.Constexpr,
+):
+    """Gather four packed UE8M0 bytes per row through ``token_map``."""
+    for i in cutlass.range_constexpr((rows + tcnt - 1) // tcnt):
+        r = tidx + Int32(i * tcnt)
+        if r < Int32(rows):
+            src_row = Int32(0)
+            if r < valid_rows:
+                src_row = token_map[physical_row_base + r].to(Int32)
+            cp_async_u32_shared_global(
+                smem_base + (r << Int32(2)),
+                get_ptr_as_int64(scale_u8, src_row * row_stride + k_byte_base),
+            )
+
+
+@cute.jit
+def _w4a8_stage_bytes4(
+    t_u8: cute.Tensor,
+    smem_base: Int32,
+    base_idx: Int64,
+    row_stride: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+    rows: cutlass.Constexpr = 128,
+):
+    """cp.async 4 contiguous bytes per row (scale grids)."""
+    for i in cutlass.range_constexpr((rows + tcnt - 1) // tcnt):
+        r = tidx + Int32(i * tcnt)
+        if r < Int32(rows):
+            gaddr = get_ptr_as_int64(t_u8, base_idx + Int64(r) * Int64(row_stride))
+            cp_async_u32_shared_global(smem_base + (r << Int32(2)), gaddr)
+
+
+@cute.jit
+def _w4a8_stage_bytes8(
+    t_u8: cute.Tensor,
+    smem_base: Int32,
+    base_idx: Int64,
+    row_stride: Int32,
+    tidx: Int32,
+    tcnt: cutlass.Constexpr,
+):
+    """cp.async 8 contiguous bytes per row for 128 rows (residual grids)."""
+    for i in cutlass.range_constexpr((128 + tcnt - 1) // tcnt):
+        r = tidx + Int32(i * tcnt)
+        if r < Int32(128):
+            gaddr = get_ptr_as_int64(t_u8, base_idx + Int64(r) * Int64(row_stride))
+            cp_async_u64_shared_global(smem_base + (r << Int32(3)), gaddr)
+
+
+_PRODUCER_PAIRS_PER_WARP = 2
+_FC2_TILE_RECIP_GS_NUM = 6.0 * 448.0
+
+
+class DynamicLaunchParams:
+    """Minimal runtime launch state shared between host setup and kernel code."""
+
+    def __init__(
+        self,
+        row_counts: cute.Tensor,
+        gate_tile_cnt: Int32,
+        *,
+        loc=None,
+    ):
+        self.row_counts = row_counts
+        self.gate_tile_cnt = gate_tile_cnt
+        self._loc = loc
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.row_counts, self.gate_tile_cnt]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip(
+            [self.row_counts, self.gate_tile_cnt],
+            self._values_pos,
+            strict=True,
+        ):
+            obj_list.append(new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return DynamicLaunchParams(*(tuple(obj_list)), loc=self._loc)
+
+
+@dsl_user_op
+def _st_shared_i32(addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [Int32(addr).ir_value(loc=loc, ip=ip), Int32(val).ir_value(loc=loc, ip=ip)],
+        "st.shared.s32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _st_shared_release_i32(addr, val, *, loc=None, ip=None):
+    """CTA-scope release store: pairs with the consumers' acquire spin so
+    the producer's prior writes (including async-proxy writes it observed
+    via an mbarrier wait or cp.async drain) are visible before the flag."""
+    llvm.inline_asm(
+        None,
+        [Int32(addr).ir_value(loc=loc, ip=ip), Int32(val).ir_value(loc=loc, ip=ip)],
+        "st.release.cta.shared.s32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _ld_shared_i32(addr, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            # This helper is used for scheduler control and work-item broadcasts.
+            # Those locations are rewritten between loop iterations and phases;
+            # a relaxed side-effect-free asm load can be CSE'd across a CTA
+            # barrier and observe the previous phase's value indefinitely.
+            "ld.volatile.shared.s32 $0, [$1];",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_global_u64(addr, *, loc=None, ip=None):
+    return Uint64(
+        llvm.inline_asm(
+            T.i64(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.global.u64 $0, [$1];",
+            "=l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_global_acquire_i32(addr, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.global.acquire.gpu.s32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _st_global_release_i32(addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int32(val).ir_value(loc=loc, ip=ip)],
+        "st.global.release.gpu.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _spin_wait_global_eq_i32(addr, expected, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(expected).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        ".reg .pred %p0;\n"
+        ".reg .s32 %val;\n"
+        "spin_loop:\n"
+        "  ld.global.acquire.gpu.s32 %val, [$0];\n"
+        "  setp.eq.s32 %p0, %val, $1;\n"
+        "  @%p0 bra spin_loop;\n"
+        "}",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _spin_wait_shared_ge_i32(addr, value, *, loc=None, ip=None):
+    """Spin until the shared i32 at ``addr`` is >= ``value`` (acquire)."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Int32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        ".reg .pred %p0;\n"
+        ".reg .s32 %val;\n"
+        "spin_ge_loop:\n"
+        "  ld.acquire.cta.shared.s32 %val, [$0];\n"
+        "  setp.lt.s32 %p0, %val, $1;\n"
+        "  @%p0 bra spin_ge_loop;\n"
+        "}",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _threadfence(*, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [],
+        "membar.gl;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _atomic_cas_global_i32(addr, compare, value, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(addr).ir_value(loc=loc, ip=ip),
+                Int32(compare).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.cas.b32 $0, [$1], $2, $3;",
+            "=r,l,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+class MoEDynamicKernelBackend:
+    """Fused route/pack + expert-compute kernel with a pluggable work source."""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        *,
+        fast_math: bool = False,
+        activation: str = "silu",
+        dynamic_down_scale: bool = False,
+        share_input_across_experts: bool = False,
+        deterministic_output: bool = False,
+        num_topk: int = 1,
+        swap_ab: bool = False,
+        quant_recipe: str = "nvfp4",
+        w4a8_repacked: bool = False,
+        direct_routing: bool = False,
+        materialize_intermediate: bool = False,
+        work_source: str = _WORK_SOURCE_MATERIALIZED_QUEUE,
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+    ):
+        activation = normalize_moe_activation(activation)
+        if quant_recipe not in {"nvfp4", "w4a8_mx", "w4a8_nvfp4"}:
+            raise ValueError(f"unsupported quant_recipe {quant_recipe!r}")
+        if work_source not in _WORK_SOURCES:
+            raise ValueError(
+                f"unsupported work_source {work_source!r}; "
+                f"expected one of {sorted(_WORK_SOURCES)}"
+            )
+        if quant_recipe != "nvfp4" and activation == SWIGLUOAI_UNINTERLEAVE:
+            raise NotImplementedError(
+                "activation='swigluoai_uninterleave' is not supported by W4A8 MoE"
+            )
+        swiglu_limit = normalize_swiglu_limit_for_activation(activation, swiglu_limit)
+        swiglu_alpha = normalize_swiglu_alpha_for_activation(activation, swiglu_alpha)
+        swiglu_beta = normalize_swiglu_beta_for_activation(activation, swiglu_beta)
+        self._dense_cls = DenseGemmKernel
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.fast_math = fast_math
+        self.activation = activation
+        self.is_gated = is_gated_moe_activation(activation)
+        self.is_swigluoai = activation == SWIGLUOAI_UNINTERLEAVE
+        self.has_swiglu_limit = swiglu_limit is not None
+        self.swiglu_limit = 0.0 if swiglu_limit is None else float(swiglu_limit)
+        self.swiglu_alpha = float(swiglu_alpha)
+        self.swiglu_beta = float(swiglu_beta)
+        # w4a8 recipes: E4M3 activations (dynamic per-32 UE8M0 block scales)
+        # against the same packed-FP4 weight bytes, computed on the FP8
+        # m16n8k32 block-scale MMA. "w4a8_nvfp4" additionally applies the
+        # per-K/16 residual multipliers from the NVFP4 scale decomposition
+        # during nibble expansion. The control plane, epilogue, and scatter
+        # are shared with the nvfp4 recipe; operands are read directly from
+        # global/shared memory (no A/SF TMA staging) in this bring-up shape.
+        self.quant_recipe = quant_recipe
+        self.work_source = work_source
+        self.work_is_persistent_grid = work_source == _WORK_SOURCE_PERSISTENT_GRID
+        self.work_is_streaming = work_source == _WORK_SOURCE_READY_QUEUE
+        self.is_w4a8 = quant_recipe != "nvfp4"
+        self.w4a8_residual = quant_recipe == "w4a8_nvfp4"
+        self.w4a8_repacked = bool(w4a8_repacked)
+        self.direct_routing = bool(direct_routing)
+        self.materialize_intermediate = bool(materialize_intermediate)
+        self.w4a8_m1_materialized = bool(
+            self.w4a8_repacked
+            and self.direct_routing
+            and self.materialize_intermediate
+            and mma_tiler_mn == (16, 128)
+        )
+        self.w4a8_m128_materialized = bool(
+            self.w4a8_repacked
+            and self.materialize_intermediate
+            and mma_tiler_mn == (128, 128)
+        )
+        self.w4a8_m64_materialized = bool(
+            self.w4a8_repacked
+            and self.materialize_intermediate
+            and mma_tiler_mn == (64, 128)
+        )
+        self.w4a8_split_materialized = bool(
+            self.w4a8_m64_materialized or self.w4a8_m128_materialized
+        )
+        # Dense M64/M128 retains this kernel as a routing/input-quantization
+        # front-end. Compact stream-ordered M64xN128 kernels compute FC1/FC2
+        # through the existing caller-owned MXFP8 workspace.  The split
+        # removes both GEMM bodies from the routing kernel's register/shared
+        # union and is graph-safe: every grid is fixed from preplanned launch
+        # capacity and no host value is read between launches.
+        self.external_materialized_fc1 = self.w4a8_split_materialized
+        self.external_materialized_fc2 = self.w4a8_split_materialized
+        if int(num_topk) <= 0:
+            raise ValueError(f"num_topk must be positive, got {num_topk}")
+        self.num_topk = int(num_topk)
+        materialized_source_tile_m = (
+            mma_tiler_mn[0] if self.w4a8_split_materialized else 128
+        )
+        self.materialized_phase1_kernel = W4A8MaterializedPhase1Kernel(
+            fast_math=self.fast_math,
+            source_tile_m=materialized_source_tile_m,
+            deterministic_output=bool(deterministic_output),
+            num_topk=self.num_topk,
+        )
+        self.materialized_phase2_kernel = W4A8MaterializedPhase2Kernel(
+            source_tile_m=materialized_source_tile_m,
+            deterministic_output=bool(deterministic_output),
+        )
+        if self.w4a8_repacked and quant_recipe != "w4a8_mx":
+            raise ValueError("repacked W4A8 weights are only valid for w4a8_mx")
+        if self.materialize_intermediate and not (
+            self.w4a8_repacked
+            and quant_recipe == "w4a8_mx"
+            and mma_tiler_mn in {(16, 128), (32, 128), (64, 128), (128, 128)}
+            and work_source != _WORK_SOURCE_READY_QUEUE
+        ):
+            raise ValueError(
+                "materialized-intermediate execution currently requires the "
+                "repacked W4A8 MX M16/M32/M64/M128 non-streaming specialization"
+            )
+        if self.direct_routing and not (
+            (
+                quant_recipe == "nvfp4"
+                or (self.w4a8_repacked and quant_recipe == "w4a8_mx")
+            )
+            and work_source != _WORK_SOURCE_READY_QUEUE
+            and (
+                not self.materialize_intermediate
+                or (
+                    self.w4a8_repacked
+                    and quant_recipe == "w4a8_mx"
+                    and mma_tiler_mn == (16, 128)
+                )
+            )
+        ):
+            raise ValueError(
+                "direct routing requires non-streaming NVFP4 or repacked "
+                "W4A8 MX (materialized execution is M16-only)"
+            )
+        if self.is_w4a8 and swap_ab:
+            raise ValueError("w4a8 recipes do not support swap_ab yet")
+        if self.is_w4a8 and share_input_across_experts and not self.w4a8_repacked:
+            raise ValueError(
+                "the W4A8 shared-input producer currently requires repacked weights"
+            )
+        if self.is_w4a8 and dynamic_down_scale:
+            raise ValueError(
+                "w4a8 recipes are self-ranging; dynamic_down_scale does not apply"
+            )
+        self.dynamic_down_scale = dynamic_down_scale
+        self.share_input_across_experts = share_input_across_experts
+        # Small repacked W4A8 has six route warps.  Split them into three
+        # two-warp token groups: this matches the pair-owned producer's useful
+        # warp/CTA concurrency while every K/32 block is quantized once.
+        self.input_warps_per_token = (
+            2 if self.is_w4a8 and share_input_across_experts else 1
+        )
+        self.deterministic_output = bool(deterministic_output)
+        # swap_ab runs the gated FC1 with the intermediate (logical N) on the
+        # MMA M-role (mirrors dense.py), so a sub-64 tile_n that divides a
+        # non-128 per-shard n (e.g. 32 | 352) is legal and the gate-half base
+        # rides the sub-128 M-atom SF slice instead of straddling N SF atoms.
+        # FC2 stays in the normal orientation, so FC1 builds its own tiled_mma.
+        self.swap_ab = bool(swap_ab) and self.is_gated
+        # FC1 swap produce-tile width (intermediate cols per swapped MMA tile).
+        # 32: for any 32-aligned n the gate-half base n%128 in {0,32,64,96}, so
+        # offset+32 <= 128 always fits one 128-row SF atom; and tile_m=32 keeps
+        # the base atom_shape (2,2,1)/4-warps, so FC1 and FC2 share warp count.
+        self._fc1_int_tile = 32
+        tile_k = sf_vec_size * 8
+        self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        # Scale-factor tiles are 128-row atoms in hardware. For sub-128 MMA
+        # tiles (e.g. tile_m=64) one SF atom backs several MMA tiles, so the
+        # TMA atom + smem are built at max(128, tile) and the kernel offsets
+        # into the shared block by `*_tiles_per_block` (mirrors dense.py).
+        self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
+        self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.sfa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
+        self.sfa_tiles_per_block = self.sfa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.sfb_tile_shape_nk = (max(128, mma_tiler_mn[1]), tile_k)
+        self.sfb_tiles_per_block = self.sfb_tile_shape_nk[0] // mma_tiler_mn[1]
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.cluster_shape_mn = (1, 1)
+        self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
+        self.occupancy = 1
+        # Per-tile atom layout / MMA-warp count (dense's table). Keep dynamic's
+        # proven (2,2,1)/4-warp config for the 128 tile; smaller tiles need the
+        # matching atom shape so the SF smem layout + V-map are consistent.
+        _tm = mma_tiler_mn[0]
+        if _tm == 128:
+            if self.w4a8_m128_materialized:
+                # Large-prefill A8 divides M128xN128 over a 2x4 warp array.
+                # Phase B runs in a separate compact kernel, while eight FC1
+                # warps retain enough registers to avoid local-memory spills.
+                self.atom_shape = (2, 4, 1)
+                self.num_mma_warps = 8
+            else:
+                self.atom_shape = (2, 2, 1)
+                self.num_mma_warps = 4
+        elif _tm == 16:
+            # W4A8's raw-MMA path benefits from exposing more independent
+            # N fragments without enlarging M (and therefore without padding
+            # sparse expert runs).  Keep the proven two-warp atom for W4A4.
+            if self.is_w4a8:
+                self.atom_shape = (1, 4, 1)
+                self.num_mma_warps = 4
+            else:
+                self.atom_shape = (1, 2, 1)
+                self.num_mma_warps = 2
+        elif _tm == 32:
+            if self.is_w4a8:
+                # Keep the warp decomposition on N and let every warp carry
+                # two independent M16 fragments.
+                self.atom_shape = (1, 4, 1)
+                self.num_mma_warps = 4
+            else:
+                self.atom_shape = (2, 2, 1)
+                self.num_mma_warps = 4
+        else:  # 64
+            self.atom_shape = (4, 2, 1)
+            self.num_mma_warps = 8
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        # Give W4A8 two producer streams, with buffer epochs split by parity,
+        # so TMA/cp.async issue is not serialized through one warp.  The M128
+        # materialized path is one CTA/SM and needs the second producer to hide
+        # the same global staging latency that a second small-tile CTA covers.
+        self.num_dma_warps = 2 if self.is_w4a8 else 1
+        self.num_route_warps = self.num_mma_warps + self.num_dma_warps
+        self.threads_per_cta = self.num_route_warps * self.num_threads_per_warp
+        # Repacked small-W4A8 has exactly two buffers and one producer warp
+        # assigned to each parity.  A hardware named-barrier handoff avoids
+        # burning scheduler slots in the old shared-flag polling loops.  M128
+        # keeps the epoch protocol because all eight MMA warps participate in
+        # each buffer handoff.
+        self.w4a8_named_pipeline = (
+            self.w4a8_repacked and self.is_w4a8 and mma_tiler_mn[0] <= 32
+        )
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.buffer_align_bytes = 1024
+
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.pass_gate_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_cta,
+        )
+        self.pass_final_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=self.threads_per_cta,
+        )
+        # Repacked W4A8's token-owned producer assigns a compile-time group of
+        # warps per input token.  Disjoint named barriers let each group
+        # exchange its route cache without serializing the whole CTA.
+        self.input_pair_barrier_0 = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.input_warps_per_token * self.num_threads_per_warp,
+        )
+        self.input_pair_barrier_1 = pipeline.NamedBarrier(
+            barrier_id=5,
+            num_threads=self.input_warps_per_token * self.num_threads_per_warp,
+        )
+        self.input_pair_barrier_2 = pipeline.NamedBarrier(
+            barrier_id=6,
+            num_threads=self.input_warps_per_token * self.num_threads_per_warp,
+        )
+        w4a8_stage_threads = (self.num_mma_warps + 1) * self.num_threads_per_warp
+        self.w4a8_ready_barrier_0 = pipeline.NamedBarrier(
+            barrier_id=7,
+            num_threads=w4a8_stage_threads,
+        )
+        self.w4a8_ready_barrier_1 = pipeline.NamedBarrier(
+            barrier_id=8,
+            num_threads=w4a8_stage_threads,
+        )
+        self.w4a8_done_barrier_0 = pipeline.NamedBarrier(
+            barrier_id=9,
+            num_threads=w4a8_stage_threads,
+        )
+        self.w4a8_done_barrier_1 = pipeline.NamedBarrier(
+            barrier_id=10,
+            num_threads=w4a8_stage_threads,
+        )
+        self.load_register_requirement = 32
+        self.mma_register_requirement = 232
+
+    def _thrfrg_SFA(self, sfa_tensor, tiled_mma):
+        return self._dense_cls._thrfrg_SFA(self, sfa_tensor, tiled_mma)
+
+    def _thrfrg_SFB(self, sfb_tensor, tiled_mma):
+        return self._dense_cls._thrfrg_SFB(self, sfb_tensor, tiled_mma)
+
+    def _get_layoutSFA_TV(self, tiled_mma):
+        return self._dense_cls._get_layoutSFA_TV(self, tiled_mma)
+
+    def _get_layoutSFB_TV(self, tiled_mma):
+        return self._dense_cls._get_layoutSFB_TV(self, tiled_mma)
+
+    def _setup_attributes(self):
+        import cutlass.utils.blackwell_helpers as sm120_utils
+
+        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+            self.a_dtype,
+            self.acc_dtype,
+            self.sf_dtype,
+        )
+        atom_layout = cute.make_layout(self.atom_shape)
+        permutation_mnk = sm120_utils.get_permutation_mnk(
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            False,
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            atom_layout,
+            permutation_mnk=permutation_mnk,
+        )
+        self.mma_atom = cute.make_mma_atom(mma_op)
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * self.atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * self.atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+
+        if cutlass.const_expr(self.swap_ab):
+            # Swapped FC1: intermediate (self._fc1_int_tile wide) rides the MMA
+            # M-role, tokens the N-role -- so a sub-64 int tile is legal and the
+            # gate-half weight SF rides the sub-128 M-atom slice (dense.py
+            # pattern). Same atom_shape -> identical warp count, so the CTA
+            # thread/barrier structure is unchanged. FC2 keeps self.tiled_mma
+            # (normal orientation over the 128-wide K contraction).
+            #
+            # The token N-role must be a multiple of the fixed sm120 N
+            # permutation atom (8,2,2)=32; a smaller tile (tile_shape_mnk[0] is
+            # 16 here) makes the MMA address phantom N-positions and scrambles
+            # tokens. Round the token tile up to a 64 multiple (>=64, dense's FP4
+            # swap_ab floor) and mask the padding with valid_rows. The 128-row
+            # activation atom supplies the extra token slots.
+            self._fc1_tok_tile = max(64, ((self.tile_shape_mnk[0] + 63) // 64) * 64)
+            self.fc1_tile_shape_mnk = (
+                self._fc1_int_tile,
+                self._fc1_tok_tile,
+                self.tile_shape_mnk[2],
+            )
+            fc1_perm = sm120_utils.get_permutation_mnk(
+                self.fc1_tile_shape_mnk,
+                self.sf_vec_size,
+                False,
+            )
+            self.fc1_tiled_mma = cute.make_tiled_mma(
+                mma_op,
+                atom_layout,
+                permutation_mnk=fc1_perm,
+            )
+            self.fc1_num_m_tiles = self.fc1_tile_shape_mnk[0] // (
+                16 * self.atom_shape[0]
+            )
+            self.fc1_num_n_tiles = self.fc1_tile_shape_mnk[1] // (
+                8 * self.atom_shape[1]
+            )
+
+        sfa_smem = sm120_make_smem_layout_sfa(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+        sfb_smem = sm120_make_smem_layout_sfb(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        self.ab_stage, self.epi_stage = self._dense_cls._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.sf_dtype,
+            sfa_smem,
+            sfb_smem,
+            self.epi_tile,
+            cutlass.BFloat16,
+            self.smem_capacity,
+            self.occupancy,
+        )
+        # dense._compute_stages assumes a single B/SFB buffer, but the gated
+        # path keeps two (sB+sB_up, sSFB+sSFB_up) plus a third mbar pipeline.
+        # For sub-128 MMA tiles its smaller A inflates the suggested stage
+        # count past what dynamic's doubled buffers fit, so cap to the real
+        # per-stage footprint before rounding to a divisor of 32.
+        nb = 2 if self.is_gated else 1
+        n_pipe = 3 if self.is_gated else 2
+        # sA smem is the 128-row atom for sub-128 tiles, so size from
+        # sa_tile_shape_mk (= tile_m at tile_m>=128).
+        a_bytes = (
+            self.sa_tile_shape_mk[0]
+            * self.sa_tile_shape_mk[1]
+            * self.a_dtype.width
+            // 8
+        )
+        b_bytes = (
+            cute.size(cute.slice_(self.tile_shape_mnk, (0, None, None)))
+            * self.b_dtype.width
+            // 8
+        )
+        sfa_bytes = (
+            cute.size(cute.filter_zeros(sfa_smem).shape) * self.sf_dtype.width // 8
+        )
+        sfb_bytes = (
+            cute.size(cute.filter_zeros(sfb_smem).shape) * self.sf_dtype.width // 8
+        )
+        per_stage = a_bytes + nb * b_bytes + sfa_bytes + nb * sfb_bytes + n_pipe * 2 * 8
+        fixed = (
+            self.tile_shape_mnk[0] * self.tile_shape_mnk[1] * 2  # sC (bf16 epi)
+            + 2 * (self.num_mma_warps + 1) * 32 * 4  # route caches
+            + self.tile_shape_mnk[0] * 8  # scatter caches
+            + 8 * 8
+            + 1024
+            + 8 * 1024  # ctrl/mbar/align slack
+        )
+        max_fit = max(1, (self.smem_capacity - fixed) // per_stage)
+        self.ab_stage = min(self.ab_stage, max_fit)
+        # ab_stage must divide k_tile_cnt (K/tile_K = 4096/128 = 32) evenly;
+        # 32%3!=0 causes pipeline phase mismatch. Round down to nearest divisor.
+        while self.ab_stage > 1 and 32 % self.ab_stage != 0:
+            self.ab_stage -= 1
+        self.w4a8_fc2_compute_width = 1
+        if self.is_w4a8:
+            # w4a8 repurposes the staging regions as fixed double buffers; a
+            # larger ab_stage only inflates smem. Capping at 2 cuts the CTA
+            # footprint to ~88KB so two blocks co-reside per SM (the barrier-
+            # heavy mainloop needs the extra occupancy to hide latency).
+            if self.w4a8_repacked:
+                # The generic fit estimate above includes route caches and a
+                # full standalone sC allocation.  Repacked W4A8 aliases those
+                # lifetimes and replaces the route caches with one placeholder
+                # element below, so that estimate is deliberately too large.
+                # Its physical byte layout always requires and fits the two
+                # stages encoded by ``w4a8_depth``.
+                self.ab_stage = 2
+            else:
+                self.ab_stage = min(self.ab_stage, 2)
+            # Staging layout/depth (see the kernel hoist block): python ints
+            # must live on self so in-loop const_expr sees them as static.
+            # Small tiles: gated FC1 runs FUSED (one k sweep, both gate+up
+            # accumulators — 64 hot regs fit at tile_m<=32) with 16KB
+            # gate+up B granules at depth 2; non-gated small tiles use
+            # depth-4 single-pass staging. Tile 128 keeps two passes/depth 2.
+            self.w4a8_small = self.tile_shape_mnk[0] <= 32
+            self.w4a8_fused = self.w4a8_small and self.is_gated
+            self.w4a8_depth = 2 if self.w4a8_fused else (4 if self.w4a8_small else 2)
+            self.w4a8_b_pad = 64 if self.w4a8_small else _W4A8_B_ROW_PAD
+            self.w4a8_depth_log2 = self.w4a8_depth.bit_length() - 1
+            self.w4a8_fc1_windows_per_slice = (
+                1 if self.w4a8_fused else (2 if self.is_gated else 1)
+            )
+            # B staged through TMA (probe-pinned SW64 layout: read chunk =
+            # kb ^ ((n_in>>1)&3)) instead of cp.async; the flag/epoch
+            # protocol is unchanged. Small tiles only (the dispatched path).
+            self.w4a8_b_tma = self.w4a8_small and not self.w4a8_repacked
+            # Fused small tiles also stage FC2 B_down in PAIRS (one 16KB
+            # granule = two output tiles), halving the FC2 sync cadence.
+            self.w4a8_fc2_pair = self.w4a8_fused
+            # Consume the already-paired FC2 window as one compile-time N256
+            # unit as well.  The old consumer revisited the same epoch twice
+            # and carried only one N128 accumulator set, leaving half of the
+            # producer's window idle.  Two sets fit the small-tile register
+            # budget and expose eight-N8-per-warp ILP in the fused kernel.
+            self.w4a8_fc2_compute_width = 2 if self.w4a8_fc2_pair else 1
+            self.w4a8_fc2_hoist_a = self.w4a8_small
+            if (
+                self.w4a8_repacked
+                and not self.w4a8_fused
+                and not self.w4a8_split_materialized
+            ):
+                raise ValueError(
+                    "the first repacked W4A8 dynamic specialization requires "
+                    "the small gated or split materialized kernel"
+                )
+        self.epi_stage = 1
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._dense_cls._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            cutlass.BFloat16,
+            self.c_layout,
+            self.epi_stage,
+            self.sf_vec_size,
+            self.tiled_mma,
+        )
+        # The A operand needs the 128-major swizzle atom for sub-128 MMA tiles
+        # (the LdMatrix/MMA path); dense builds it at tile_m. Override with the
+        # 128-atom layout (see _make_a_smem_layout). Identity when
+        # tile_m>=128 (sa_tiles_per_block==1), so the 128 path is untouched.
+        if cutlass.const_expr(self.sa_tiles_per_block > 1):
+            self.a_smem_layout_staged = self._make_a_smem_layout(self.ab_stage)
+
+        # The repacked small-W4A8 path never consumes ``sA`` through the
+        # generic FP4 TMA layout.  It uses the region in two non-overlapping
+        # phases instead:
+        #
+        #   FC1: [quantized FC2 intermediate][double-buffered MXFP8 A]
+        #   FC2: [quantized FC2 intermediate]
+        #
+        # Size that physical region from those live ranges rather than from
+        # the 128-row FP4 staging atom.  At M32 this is 12 KiB instead of
+        # 16 KiB, which is the difference between one and two resident CTAs
+        # on SM120.  Keep the generic tensor view below: it is compile-time
+        # plumbing only in this specialization and no access escapes the
+        # compact byte range.
+        self.sA_storage_elems = cute.cosize(self.a_smem_layout_staged)
+        self.route_storage_entries = self.num_route_warps * 32
+        self.sSFA_storage_elems = cute.cosize(self.sfa_smem_layout_staged)
+        self.sSFB_up_storage_elems = cute.cosize(self.sfb_smem_layout_staged)
+        self.sC_storage_elems = cute.cosize(self.epi_smem_layout_staged)
+        self.aux_buffer_align_bytes = self.buffer_align_bytes
+        self.sC_storage_align_bytes = self.buffer_align_bytes
+        if cutlass.const_expr(self.w4a8_repacked):
+            w4a8_sA_bytes = (
+                (1 + self.w4a8_depth) * self.tile_shape_mnk[0] * self.tile_shape_mnk[2]
+            )
+            w4a8_sA_elems = (
+                w4a8_sA_bytes * 8 + self.a_dtype.width - 1
+            ) // self.a_dtype.width
+            # This specialization addresses the allocation as explicit byte
+            # regions; the generic FP4 tensor layout is compile-time plumbing
+            # only.
+            self.sA_storage_elems = w4a8_sA_elems
+            # Raw W4A8 addresses these scale regions as plain byte arrays.  A
+            # full generic 128-row SF atom is unnecessary: sSFA retains only
+            # the Mx(K/32) FC2-intermediate scales, while sSFB_up retains the
+            # double-buffered FC1-A scales.  This also gives M128 its required
+            # 2x512-byte scale staging without inflating the intermediate
+            # scale plane.  Likewise, routing caches are dead
+            # before compute starts and can temporarily occupy sA itself.
+            self.sSFA_storage_elems = self.tile_shape_mnk[0] * (
+                self.tile_shape_mnk[2] // 32
+            )
+            self.sSFB_up_storage_elems = (
+                self.w4a8_depth
+                * self.tile_shape_mnk[0]
+                * (self.tile_shape_mnk[2] // 32)
+            )
+            self.route_storage_entries = 1
+            self.aux_buffer_align_bytes = 16
+            # sC aliases the double-buffered FC1-A tail of sA after FC1.  Keep
+            # a one-element field so the common struct shape remains valid;
+            # the actual tensor view is rebound to that phase union below.
+            self.sC_storage_elems = 1
+            self.sC_storage_align_bytes = 1
+
+        if cutlass.const_expr(self.swap_ab):
+            # FC1 SF smem layouts built for the swapped 32-int tile MMA (the SF
+            # smem must match the tiled_mma that reads it; the base 128-tile
+            # layout does not, which is the 'Unexpected index' root cause). Only
+            # the SF layouts are needed (A=weight uses the 128-atom a_smem; B=act
+            # uses sA's layout). Same ab_stage/storage bytes as the base.
+            (
+                self.fc1_a_smem_layout_staged,
+                _fc1_b_unused,
+                self.fc1_sfa_smem_layout_staged,
+                self.fc1_sfb_smem_layout_staged,
+                _fc1_epi_unused,
+            ) = self._dense_cls._make_smem_layouts(
+                self.fc1_tile_shape_mnk,
+                (self.fc1_tile_shape_mnk[0], self.fc1_tile_shape_mnk[1]),
+                self.a_dtype,
+                self.a_layout,
+                self.b_dtype,
+                self.b_layout,
+                self.ab_stage,
+                cutlass.BFloat16,
+                self.c_layout,
+                self.epi_stage,
+                self.sf_vec_size,
+                self.fc1_tiled_mma,
+            )
+
+    def _make_a_smem_layout(self, ab_stage: int):
+        import cutlass.utils.hopper_helpers as sm90_utils
+
+        a_is_k_major = self.a_layout.is_k_major_a()
+        a_major_mode_size = self.sa_tile_shape_mk[1 if a_is_k_major else 0]
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                self.a_layout,
+                self.a_dtype,
+                a_major_mode_size,
+            ),
+            self.a_dtype,
+        )
+        return cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(self.sa_tile_shape_mk, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+    @cute.jit
+    def _gated_activation_value(self, gate: cutlass.Float32, up: cutlass.Float32):
+        if cutlass.const_expr(self.has_swiglu_limit):
+            limit = cutlass.Float32(self.swiglu_limit)
+            neg_limit = cutlass.Float32(-self.swiglu_limit)
+            if gate > limit:
+                gate = limit
+            if up > limit:
+                up = limit
+            if up < neg_limit:
+                up = neg_limit
+        sigmoid_arg = gate
+        up_term = up
+        if cutlass.const_expr(self.is_swigluoai):
+            sigmoid_arg = cutlass.Float32(self.swiglu_alpha) * gate
+            up_term = up + cutlass.Float32(self.swiglu_beta)
+        sigmoid = cute.arch.rcp_approx(
+            cutlass.Float32(1.0) + cute.math.exp(-sigmoid_arg, fastmath=self.fast_math)
+        )
+        return gate * sigmoid * up_term
+
+    @cute.jit
+    def _resident_grid_barrier(
+        self,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        grid_x: Int32,
+        is_cta_leader: Int32,
+    ):
+        cute.arch.sync_threads()
+        _threadfence()
+        if is_cta_leader > Int32(0):
+            barrier_count_addr = get_ptr_as_int64(barrier_count, Int32(0))
+            barrier_epoch_addr = get_ptr_as_int64(barrier_epoch, Int32(0))
+            old_epoch = _ld_global_acquire_i32(barrier_epoch_addr)
+            arrived = atomic_add_global_i32(barrier_count_addr, Int32(1))
+            if arrived == grid_x - Int32(1):
+                st_global_i32(barrier_count_addr, Int32(0))
+                _st_global_release_i32(barrier_epoch_addr, old_epoch + Int32(1))
+            else:
+                _spin_wait_global_eq_i32(barrier_epoch_addr, old_epoch)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _sync_input_warp_pair(self, pair_idx: Int32):
+        if pair_idx == Int32(0):
+            self.input_pair_barrier_0.arrive_and_wait()
+        elif pair_idx == Int32(1):
+            self.input_pair_barrier_1.arrive_and_wait()
+        else:
+            self.input_pair_barrier_2.arrive_and_wait()
+
+    @cute.jit
+    def _sync_w4a8_stage_ready(self, stage: Int32):
+        if stage == Int32(0):
+            self.w4a8_ready_barrier_0.arrive_and_wait()
+        else:
+            self.w4a8_ready_barrier_1.arrive_and_wait()
+
+    @cute.jit
+    def _arrive_w4a8_stage_ready(self, stage: Int32):
+        if stage == Int32(0):
+            self.w4a8_ready_barrier_0.arrive_unaligned()
+        else:
+            self.w4a8_ready_barrier_1.arrive_unaligned()
+
+    @cute.jit
+    def _sync_w4a8_stage_done(self, stage: Int32):
+        if stage == Int32(0):
+            self.w4a8_done_barrier_0.arrive_and_wait()
+        else:
+            self.w4a8_done_barrier_1.arrive_and_wait()
+
+    @cute.jit
+    def _arrive_w4a8_stage_done(self, stage: Int32):
+        if stage == Int32(0):
+            self.w4a8_done_barrier_0.arrive_unaligned()
+        else:
+            self.w4a8_done_barrier_1.arrive_unaligned()
+
+    @cute.jit
+    def _store_w4a8_materialized_intermediate(
+        self,
+        intermediate_u32: cute.Tensor,
+        sa_base: Int32,
+        sfa_base: Int32,
+        tid: Int32,
+        m_tile: Int32,
+        intermediate_slice: Int32,
+        valid_rows: Int32,
+        rows_capacity: Int32,
+        intermediate_tiles: Int32,
+    ):
+        """Persist one M-tile x K128 MXFP8 activation tile.
+
+        Payload rows remain plain E4M3 bytes.  The four UE8M0 bytes for a
+        K128 slice are stored as one u32.  Keeping the scale word intact is
+        useful both here and in the phase-B QMMA byte-selector operands.
+        """
+
+        words_per_row = intermediate_tiles * Int32(32)
+        physical_row_base = m_tile * Int32(self.tile_shape_mnk[0])
+        copy_idx = tid
+        while copy_idx < valid_rows * Int32(32):
+            row = copy_idx >> Int32(5)
+            word = copy_idx & Int32(31)
+            intermediate_u32[
+                (physical_row_base + row) * words_per_row
+                + intermediate_slice * Int32(32)
+                + word
+            ] = ld_shared_u32(sa_base + row * Int32(128) + (word << Int32(2)))
+            copy_idx += Int32(self.num_mma_warps * self.num_threads_per_warp)
+
+        if tid < valid_rows:
+            sf_base = rows_capacity * words_per_row
+            intermediate_u32[
+                sf_base + intermediate_slice * rows_capacity + physical_row_base + tid
+            ] = ld_shared_u32(sfa_base + (tid << Int32(2)))
+
+    @cute.jit
+    def _stage_w4a8_materialized_fc2(
+        self,
+        intermediate_u32: cute.Tensor,
+        down_rp: cute.Tensor,
+        down_sfb_rp: cute.Tensor,
+        sa_base: Int32,
+        sfa_base: Int32,
+        sb_base: Int32,
+        sfb_base: Int32,
+        copy_tid: Int32,
+        copy_threads: cutlass.Constexpr,
+        m_tile: Int32,
+        expert_idx: Int32,
+        output_tile: Int32,
+        intermediate_slice: Int32,
+        rows_capacity: Int32,
+        intermediate_tiles: Int32,
+        output_tiles: Int32,
+    ):
+        """Issue one phase-B K128 stage from the materialized activation."""
+
+        tile_m = self.tile_shape_mnk[0]
+        words_per_row = intermediate_tiles * Int32(32)
+        physical_row_base = m_tile * Int32(tile_m)
+
+        # A: M32 x 128B, xor-swizzled by the row's low three bits on the way
+        # into shared memory.  Phase B distributes these copies over all four
+        # compute warps, matching the dense W4A8 phase-B issue topology.
+        for i in cutlass.range_constexpr(
+            (tile_m * 8 + copy_threads - 1) // copy_threads
+        ):
+            idx = copy_tid + Int32(i * copy_threads)
+            if idx < Int32(tile_m * 8):
+                row = idx >> Int32(3)
+                vec = idx & Int32(7)
+                physical_vec = vec ^ (row & Int32(7))
+                src_word = (
+                    (physical_row_base + row) * words_per_row
+                    + intermediate_slice * Int32(32)
+                    + (vec << Int32(2))
+                )
+                cp_async4_shared_global(
+                    sa_base + row * Int32(128) + (physical_vec << Int32(4)),
+                    get_ptr_as_int64(intermediate_u32, src_word),
+                )
+
+        # A scales: one packed four-byte K128 word per row.  The materialized
+        # scale plane is [slice, physical_row], matching both this warp-wide
+        # load and phase A's warp-wide store.  The former [row, slice] layout
+        # made every lane skip ``intermediate_tiles`` words and accounted for
+        # the largest remaining uncoalesced global-load site in phase B.
+        sf_row = copy_tid
+        if sf_row < Int32(tile_m):
+            sf_src = (
+                rows_capacity * words_per_row
+                + intermediate_slice * rows_capacity
+                + physical_row_base
+                + sf_row
+            )
+            cp_async_u32_shared_global(
+                sfa_base + (sf_row << Int32(2)),
+                get_ptr_as_int64(intermediate_u32, sf_src),
+            )
+
+        # Repacked B: [kb=4, chunk=8, lane=32, n8-in-chunk=4] u32.
+        # M128 uses one N128 half per task to keep 64 accumulator registers;
+        # the prepared allocation remains N256-tile-major.
+        packed_output_tile = output_tile
+        packed_half = Int32(0)
+        if cutlass.const_expr(self.w4a8_m128_materialized):
+            packed_output_tile = output_tile >> Int32(1)
+            packed_half = output_tile & Int32(1)
+        b_tile = (
+            expert_idx * output_tiles + packed_output_tile
+        ) * intermediate_tiles + intermediate_slice
+        b_word_base = Int64(b_tile) * Int64(4096)
+        if cutlass.const_expr(self.w4a8_m128_materialized):
+            _w4a8_stage_repacked_b_half(
+                down_rp,
+                sb_base,
+                b_word_base,
+                packed_half,
+                copy_tid,
+                copy_threads,
+            )
+        else:
+            for i in cutlass.range_constexpr(
+                (4096 // 4 + copy_threads - 1) // copy_threads
+            ):
+                transfer = copy_tid + Int32(i * copy_threads)
+                if transfer < Int32(4096 // 4):
+                    cp_async4_shared_global(
+                        sb_base + (transfer << Int32(4)),
+                        get_ptr_as_int64(
+                            down_rp,
+                            b_word_base + Int64(transfer << Int32(2)),
+                        ),
+                    )
+
+        # Repacked SFB: [n8=32, col8=8] u32, 1 KiB per tile.
+        sfb_word_base = Int64(b_tile) * Int64(256)
+        if cutlass.const_expr(self.w4a8_m128_materialized):
+            _w4a8_stage_repacked_sfb_half(
+                down_sfb_rp,
+                sfb_base,
+                sfb_word_base,
+                packed_half,
+                copy_tid,
+                copy_threads,
+            )
+        else:
+            for i in cutlass.range_constexpr(
+                (256 // 4 + copy_threads - 1) // copy_threads
+            ):
+                transfer = copy_tid + Int32(i * copy_threads)
+                if transfer < Int32(256 // 4):
+                    cp_async4_shared_global(
+                        sfb_base + (transfer << Int32(4)),
+                        get_ptr_as_int64(
+                            down_sfb_rp,
+                            sfb_word_base + Int64(transfer << Int32(2)),
+                        ),
+                    )
+
+    @cute.jit
+    def _run_w4a8_materialized_fc2(
+        self,
+        intermediate_u32: cute.Tensor,
+        down_rp: cute.Tensor,
+        down_sfb_rp: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        sa_storage_base: Int32,
+        sb0_base: Int32,
+        sb1_base: Int32,
+        sfb_storage_base: Int32,
+        tid: Int32,
+        warp_idx: Int32,
+        m_tile: Int32,
+        expert_idx: Int32,
+        output_tile: Int32,
+        valid_rows: Int32,
+        rows_capacity: Int32,
+        intermediate_tiles: Int32,
+        output_tiles: Int32,
+    ):
+        """Full-K MxN256 phase-B task with direct weighted scatter."""
+
+        lane = tid & Int32(31)
+        stage_a_bytes = Int32(self.tile_shape_mnk[0] * (128 + 4))
+        a_payload_bytes = Int32(self.tile_shape_mnk[0] * 128)
+        copy_threads = self.threads_per_cta
+        m_blocks = 4 if self.w4a8_m128_materialized else self.tile_shape_mnk[0] // 16
+        warp_m_base = Int32(0)
+        warp_n_group = warp_idx
+        if cutlass.const_expr(self.w4a8_m128_materialized):
+            warp_m_base = (warp_idx >> Int32(2)) * Int32(64)
+            warp_n_group = warp_idx & Int32(3)
+        n_fragments = 4 if self.w4a8_m128_materialized else 8
+        chunks_per_k = 4 if self.w4a8_m128_materialized else 8
+        chunks_per_warp = 1 if self.w4a8_m128_materialized else 2
+
+        self._stage_w4a8_materialized_fc2(
+            intermediate_u32,
+            down_rp,
+            down_sfb_rp,
+            sa_storage_base,
+            sa_storage_base + a_payload_bytes,
+            sb0_base,
+            sfb_storage_base,
+            tid,
+            copy_threads,
+            m_tile,
+            expert_idx,
+            output_tile,
+            Int32(0),
+            rows_capacity,
+            intermediate_tiles,
+            output_tiles,
+        )
+        cute.arch.cp_async_commit_group()
+
+        if warp_idx < Int32(self.num_mma_warps):
+            # M/16 blocks x eight N8 fragments per warp.  This flat rmem
+            # shape is deliberately the register-friendly representation used
+            # throughout the dense W4A8 specialization.
+            facc = cute.make_rmem_tensor((m_blocks, n_fragments, 4), cutlass.Float32)
+            facc.fill(0.0)
+            q = lane >> Int32(2)
+            c = lane & Int32(3)
+
+            intermediate_slice = Int32(0)
+            while intermediate_slice < intermediate_tiles:
+                stage = intermediate_slice & Int32(1)
+                sa_base = sa_storage_base + stage * stage_a_bytes
+                sfa_base = sa_base + a_payload_bytes
+                sb_base = sb0_base + (sb1_base - sb0_base) * stage
+                sfb_base = sfb_storage_base + (stage << Int32(10))
+
+                next_slice = intermediate_slice + Int32(1)
+                if next_slice < intermediate_tiles:
+                    next_stage = next_slice & Int32(1)
+                    next_sa = sa_storage_base + next_stage * stage_a_bytes
+                    self._stage_w4a8_materialized_fc2(
+                        intermediate_u32,
+                        down_rp,
+                        down_sfb_rp,
+                        next_sa,
+                        next_sa + a_payload_bytes,
+                        sb0_base + (sb1_base - sb0_base) * next_stage,
+                        sfb_storage_base + (next_stage << Int32(10)),
+                        tid,
+                        copy_threads,
+                        m_tile,
+                        expert_idx,
+                        output_tile,
+                        next_slice,
+                        rows_capacity,
+                        intermediate_tiles,
+                        output_tiles,
+                    )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(1)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                cute.arch.sync_threads()
+
+                asc = cute.make_rmem_tensor((m_blocks,), Uint32)
+                for blk in cutlass.range_constexpr(m_blocks):
+                    sf_row = (
+                        warp_m_base
+                        + Int32(blk * 16)
+                        + q
+                        + ((lane & Int32(1)) << Int32(3))
+                    )
+                    asc[blk] = ld_shared_u32(sfa_base + (sf_row << Int32(2)))
+
+                for kb in cutlass.range_constexpr(4):
+                    u_phys = (Int32(kb * 2) + (c >> Int32(1))) ^ q
+                    a_frag = cute.make_rmem_tensor((m_blocks, 4), Uint32)
+                    for blk in cutlass.range_constexpr(m_blocks):
+                        a_lo = (
+                            sa_base
+                            + warp_m_base * Int32(128)
+                            + Int32(blk * 16 * 128)
+                            + (q << Int32(7))
+                            + (u_phys << Int32(4))
+                            + ((c & Int32(1)) << Int32(3))
+                        )
+                        a0, a2 = ld_shared_v2_u32(a_lo)
+                        a1, a3 = ld_shared_v2_u32(a_lo + Int32(8 * 128))
+                        a_frag[blk, 0] = a0
+                        a_frag[blk, 1] = a1
+                        a_frag[blk, 2] = a2
+                        a_frag[blk, 3] = a3
+
+                    for ch in cutlass.range_constexpr(chunks_per_warp):
+                        w0, w1, w2, w3 = ld_shared_v4_u32(
+                            sb_base
+                            + (
+                                (
+                                    (
+                                        Int32(kb * chunks_per_k)
+                                        + warp_n_group * Int32(chunks_per_warp)
+                                        + Int32(ch)
+                                    )
+                                    * Int32(32)
+                                    + lane
+                                )
+                                << Int32(4)
+                            )
+                        )
+                        words = cute.make_rmem_tensor((4,), Uint32)
+                        words[0] = w0
+                        words[1] = w1
+                        words[2] = w2
+                        words[3] = w3
+                        for i in cutlass.range_constexpr(4):
+                            nt = ch * 4 + i
+                            n8 = warp_n_group * Int32(n_fragments) + Int32(nt)
+                            b0, b1 = e2m1x8_to_qmma_e2m1x8(words[i])
+                            sfb_word = ld_shared_u32(
+                                sfb_base + ((n8 * Int32(8) + q) << Int32(2))
+                            )
+                            for blk in cutlass.range_constexpr(m_blocks):
+                                d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e2m1(
+                                    facc[blk, nt, 0],
+                                    facc[blk, nt, 1],
+                                    facc[blk, nt, 2],
+                                    facc[blk, nt, 3],
+                                    a_frag[blk, 0],
+                                    a_frag[blk, 1],
+                                    a_frag[blk, 2],
+                                    a_frag[blk, 3],
+                                    b0,
+                                    b1,
+                                    asc[blk],
+                                    sfb_word,
+                                    bid_a=kb,
+                                    bid_b=kb,
+                                )
+                                facc[blk, nt, 0] = d0
+                                facc[blk, nt, 1] = d1
+                                facc[blk, nt, 2] = d2
+                                facc[blk, nt, 3] = d3
+
+                cute.arch.sync_threads()
+                intermediate_slice += Int32(1)
+
+            scatter_n = Int32(scatter_output.shape[1])
+            physical_row_base = m_tile * Int32(self.tile_shape_mnk[0])
+            down_scale = down_alpha[expert_idx].to(cutlass.Float32) * global_scale[
+                expert_idx
+            ].to(cutlass.Float32)
+            output_tile_width = 128 if self.w4a8_m128_materialized else 256
+            warp_n_width = 32 if self.w4a8_m128_materialized else 64
+            col_base = (
+                output_tile * Int32(output_tile_width)
+                + warp_n_group * Int32(warp_n_width)
+                + (c << Int32(1))
+            )
+            for nt in cutlass.range_constexpr(n_fragments):
+                col = col_base + Int32(nt * 8)
+                for blk in cutlass.range_constexpr(m_blocks):
+                    row_lo = warp_m_base + Int32(blk * 16) + q
+                    row_hi = row_lo + Int32(8)
+                    if row_lo < valid_rows:
+                        physical_row = physical_row_base + row_lo
+                        tok = token_map[physical_row].to(Int32)
+                        scale = down_scale * token_weights[physical_row].to(
+                            cutlass.Float32
+                        )
+                        scatter_add_bf16x2(
+                            get_ptr_as_int64(scatter_output, tok * scatter_n + col),
+                            scale * facc[blk, nt, 0],
+                            scale * facc[blk, nt, 1],
+                        )
+                    if row_hi < valid_rows:
+                        physical_row = physical_row_base + row_hi
+                        tok = token_map[physical_row].to(Int32)
+                        scale = down_scale * token_weights[physical_row].to(
+                            cutlass.Float32
+                        )
+                        scatter_add_bf16x2(
+                            get_ptr_as_int64(scatter_output, tok * scatter_n + col),
+                            scale * facc[blk, nt, 2],
+                            scale * facc[blk, nt, 3],
+                        )
+        elif warp_idx < Int32(self.num_mma_warps + self.num_dma_warps):
+            # Mirror the compute-warps' group/barrier cadence while supplying
+            # this warp's disjoint portion of each CTA-wide next-stage copy.
+            intermediate_slice = Int32(0)
+            while intermediate_slice < intermediate_tiles:
+                next_slice = intermediate_slice + Int32(1)
+                if next_slice < intermediate_tiles:
+                    next_stage = next_slice & Int32(1)
+                    next_sa = sa_storage_base + next_stage * stage_a_bytes
+                    self._stage_w4a8_materialized_fc2(
+                        intermediate_u32,
+                        down_rp,
+                        down_sfb_rp,
+                        next_sa,
+                        next_sa + a_payload_bytes,
+                        sb0_base + (sb1_base - sb0_base) * next_stage,
+                        sfb_storage_base + (next_stage << Int32(10)),
+                        tid,
+                        copy_threads,
+                        m_tile,
+                        expert_idx,
+                        output_tile,
+                        next_slice,
+                        rows_capacity,
+                        intermediate_tiles,
+                        output_tiles,
+                    )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(1)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                cute.arch.sync_threads()
+                cute.arch.sync_threads()
+                intermediate_slice += Int32(1)
+
+    def _publish_ready_tasks(
+        self,
+        task_tail: cute.Tensor,
+        task_ready: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_m_tile: cute.Tensor,
+        task_slice_begin: cute.Tensor,
+        task_slice_count: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        gate_tile_cnt: Int32,
+        slice_chunk: Int32,
+        expert_idx: Int32,
+        m_tile_idx: Int32,
+        valid_rows: Int32,
+    ):
+        num_groups = (gate_tile_cnt + slice_chunk - Int32(1)) // slice_chunk
+        start = atomic_add_global_i32(get_ptr_as_int64(task_tail, Int32(0)), num_groups)
+
+        g = Int32(0)
+        while g < num_groups:
+            slot = start + g
+            slice_begin = g * slice_chunk
+            slice_count = gate_tile_cnt - slice_begin
+            if slice_count > slice_chunk:
+                slice_count = slice_chunk
+            task_expert[slot] = expert_idx
+            task_m_tile[slot] = m_tile_idx
+            task_slice_begin[slot] = slice_begin
+            task_slice_count[slot] = slice_count
+            task_valid_rows[slot] = valid_rows
+            g += Int32(1)
+
+        _threadfence()
+
+        g = Int32(0)
+        while g < num_groups:
+            slot = start + g
+            _st_global_release_i32(get_ptr_as_int64(task_ready, slot), Int32(1))
+            g += Int32(1)
+
+    @cute.jit
+    def _publish_deferred_tasks(
+        self,
+        task_expert: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        gate_tile_cnt: Int32,
+        slice_chunk: Int32,
+        expert_idx: Int32,
+        m_tile_idx: Int32,
+        valid_rows: Int32,
+    ):
+        num_groups = (gate_tile_cnt + slice_chunk - Int32(1)) // slice_chunk
+        start = m_tile_idx * num_groups
+
+        g = Int32(0)
+        while g < num_groups:
+            slot = start + g
+            task_expert[slot] = expert_idx
+            task_valid_rows[slot] = valid_rows
+            g += Int32(1)
+
+    @cute.jit
+    def _decode_materialized_work_item(
+        self,
+        work_item: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        slot: Int32,
+        num_groups: Int32,
+        slice_chunk: Int32,
+        gate_tile_cnt: Int32,
+    ):
+        """Decode the deterministic deferred-task layout arithmetically.
+
+        Deferred tasks are stored at ``m_tile * num_groups + group``.  Only
+        expert and valid-row metadata need global storage; tile and slice
+        coordinates are properties of the slot itself.
+        """
+
+        m_tile = slot // num_groups
+        group = slot - m_tile * num_groups
+        slice_begin = group * slice_chunk
+        slice_count = gate_tile_cnt - slice_begin
+        if slice_count > slice_chunk:
+            slice_count = slice_chunk
+        work_item[_WORK_EXPERT] = task_expert[slot].to(Int32)
+        work_item[_WORK_M_TILE] = m_tile
+        work_item[_WORK_SLICE_BEGIN] = slice_begin
+        work_item[_WORK_SLICE_COUNT] = slice_count
+        work_item[_WORK_VALID_ROWS] = task_valid_rows[slot].to(Int32)
+
+    @cute.jit
+    def _decode_ready_work_item(
+        self,
+        work_item: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_m_tile: cute.Tensor,
+        task_slice_begin: cute.Tensor,
+        task_slice_count: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        slot: Int32,
+    ):
+        """Load an append-only item whose publication order is non-arithmetic."""
+
+        work_item[_WORK_EXPERT] = task_expert[slot].to(Int32)
+        work_item[_WORK_M_TILE] = task_m_tile[slot].to(Int32)
+        work_item[_WORK_SLICE_BEGIN] = task_slice_begin[slot].to(Int32)
+        work_item[_WORK_SLICE_COUNT] = task_slice_count[slot].to(Int32)
+        work_item[_WORK_VALID_ROWS] = task_valid_rows[slot].to(Int32)
+
+    @cute.jit
+    def _store_shared_work_item(
+        self,
+        ctrl_base_addr: Int32,
+        work_item: cute.Tensor,
+    ):
+        for field in cutlass.range_constexpr(_WORK_ITEM_FIELDS):
+            _st_shared_i32(
+                ctrl_base_addr + Int32((_CTRL_WORK_BEGIN + field) * 4),
+                work_item[field],
+            )
+
+    @cute.jit
+    def _load_shared_work_item(
+        self,
+        work_item: cute.Tensor,
+        ctrl_base_addr: Int32,
+    ):
+        for field in cutlass.range_constexpr(_WORK_ITEM_FIELDS):
+            work_item[field] = _ld_shared_i32(
+                ctrl_base_addr + Int32((_CTRL_WORK_BEGIN + field) * 4)
+            )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_input: cute.Tensor,  # [num_tokens, K] bf16
+        topk_ids: cute.Tensor,  # [num_tokens * topk] int32
+        topk_weights: cute.Tensor,  # [num_tokens * topk] float32
+        packed_a: cute.Tensor,  # [rows_padded, K, 1] fp4x2 view for compute
+        sfa_ptr: cute.Pointer,
+        packed_a_storage: cute.Tensor,  # flat uint8 backing packed_a
+        scale_storage: cute.Tensor,  # flat uint8 backing sfa_ptr
+        intermediate_u32: cute.Tensor,  # materialized MXFP8 payload + scales
+        barrier_count: cute.Tensor,  # [1] int32 (host-zeroed)
+        barrier_epoch: cute.Tensor,  # [1] int32 (host-zeroed)
+        pair_head: cute.Tensor,  # [1] int32
+        producers_done_count: cute.Tensor,  # [1] int32
+        all_work_published: cute.Tensor,  # [1] int32
+        task_head: cute.Tensor,  # [1] int32
+        task_tail: cute.Tensor,  # [1] int32
+        task_ready: cute.Tensor,  # [max_tasks] int32
+        task_expert: cute.Tensor,  # [max_tasks] int32
+        task_m_tile: cute.Tensor,  # [max_tasks] int32
+        task_slice_begin: cute.Tensor,  # [max_tasks] int32
+        task_slice_count: cute.Tensor,  # [max_tasks] int32
+        task_valid_rows: cute.Tensor,  # [max_tasks] int32
+        tile_write_count: cute.Tensor,  # [E * max_m_tiles] int32
+        b_w13: cute.Tensor,  # [w1_n, K, E] — gated packs [up, gate], relu2 is single FC1
+        sfb_w13_ptr: cute.Pointer,  # scale factors for FC1 weights
+        b_down: cute.Tensor,  # [K, I_tp, E]
+        sfb_down_ptr: cute.Pointer,
+        row_counts: cute.Tensor,  # expert row histogram [E]
+        expert_write_rows: cute.Tensor,  # route/pack write cursors [E]
+        expert_tile_base: cute.Tensor,  # compact physical-tile prefix [E + 1]
+        input_global_scale: cute.Tensor,  # [E] per-expert FC1 input scale
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_output: cute.Tensor,  # [num_tokens, K]
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        max_active_clusters: cutlass.Int32,
+        stream: cuda.CUstream,
+        *,
+        # w4a8 recipe operands (placeholders under the nvfp4 recipe): plain
+        # (unswizzled) UE8M0 K/32 weight scale grids and, for w4a8_nvfp4, the
+        # per-K/16 E4M3 residual grids from the NVFP4 scale decomposition.
+        sfb_w13_mx: cute.Tensor | None = None,  # [w1_n, K//32, E] uint8
+        sfb_down_mx: cute.Tensor | None = None,  # [K, I_tp//32, E] uint8
+        w13_residual: cute.Tensor | None = None,  # [w1_n, K//16, E] uint8
+        down_residual: cute.Tensor | None = None,  # [K, I_tp//16, E] uint8
+        w13_rp: cute.Tensor | None = None,  # flat repacked u32 B
+        w13_sfb_rp: cute.Tensor | None = None,  # flat repacked u32 SFB
+        down_rp: cute.Tensor | None = None,  # flat repacked u32 B
+        down_sfb_rp: cute.Tensor | None = None,  # flat repacked u32 SFB
+    ):
+        self.a_dtype = packed_a.element_type
+        self.b_dtype = b_w13.element_type
+        self.sf_dtype = sfa_ptr.dtype
+        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        # Dynamic never materializes the intermediate C tensor. Preserve the
+        # original row-major epilogue layout without carrying a dead memref.
+        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+
+        self._setup_attributes()
+
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            packed_a.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa_ptr, sfa_layout)
+
+        # Single SF tensor for FC1 weights. Gated activation packs [up, gate]
+        # along the N dimension; relu2 uses a single FC1 pass.
+        sfb_w13_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_w13.shape, self.sf_vec_size
+        )
+        sfb_w13_tensor = cute.make_tensor(sfb_w13_ptr, sfb_w13_layout)
+
+        # TMA descriptors
+        tma_a, gA = self._dense_cls._make_tma_atoms_and_tensors(
+            packed_a,
+            self.a_smem_layout_staged,
+            self.sa_tile_shape_mk,
+            1,
+        )
+        tma_sfa, gSFA = self._dense_cls._make_tma_atoms_and_tensors(
+            sfa_tensor,
+            self.sfa_smem_layout_staged,
+            self.sfa_tile_shape_mk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+        # Single TMA descriptor over FC1 weights. Gated activation packs
+        # [up, gate] across N; relu2 uses a single FC1 slice.
+        tma_b_w13, gB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
+            b_w13,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+        )
+        tma_sfb_w13, gSFB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
+            sfb_w13_tensor,
+            self.sfb_smem_layout_staged,
+            self.sfb_tile_shape_nk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+        # B_down TMA
+        sfb_down_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_down.shape, self.sf_vec_size
+        )
+        sfb_down_tensor = cute.make_tensor(sfb_down_ptr, sfb_down_layout)
+        tma_b_down, gB_down = self._dense_cls._make_tma_atoms_and_tensors(
+            b_down,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+        )
+        tma_sfb_down, gSFB_down = self._dense_cls._make_tma_atoms_and_tensors(
+            sfb_down_tensor,
+            self.sfb_smem_layout_staged,
+            self.sfb_tile_shape_nk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+
+        if cutlass.const_expr(self.swap_ab):
+            # Non-128-aligned n: the scheduler's slice count must CEIL so the
+            # partial last intermediate slice is issued. The plain floor below
+            # (b_w13.shape[0] // tile_n // 2) drops it -- e.g. n=352 -> 704//128
+            # //2 = 2, but the kernel's internal tile count ceils to 3, so the
+            # last 96-col slice is never computed (it silently contributes 0).
+            n_int = Int32(b_w13.shape[0])
+            if self.is_gated:
+                n_int = n_int // Int32(2)
+            gate_tile_cnt = (n_int + Int32(self.tile_shape_mnk[1]) - Int32(1)) // Int32(
+                self.tile_shape_mnk[1]
+            )
+        else:
+            # Same ceil as the swap_ab branch: gate_tile_cnt is also the w2
+            # rp K-tile stride, so a floored count misaddresses every tile
+            # past nt=0 on non-128-aligned shards (e.g. 352).
+            n_int = Int32(b_w13.shape[0])
+            if self.is_gated:
+                n_int = n_int // Int32(2)
+            gate_tile_cnt = (n_int + Int32(self.tile_shape_mnk[1]) - Int32(1)) // Int32(
+                self.tile_shape_mnk[1]
+            )
+        launch_params = DynamicLaunchParams(row_counts, gate_tile_cnt)
+        if cutlass.const_expr(self.is_w4a8):
+            assert sfb_w13_mx is not None and sfb_down_mx is not None, (
+                "w4a8 recipes require sfb_w13_mx and sfb_down_mx"
+            )
+            assert not self.w4a8_residual or (
+                w13_residual is not None and down_residual is not None
+            ), "w4a8_nvfp4 requires w13_residual and down_residual"
+            assert self.ab_stage * self.sa_tile_shape_mk[0] * self.sa_tile_shape_mk[
+                1
+            ] // 2 >= (self.tile_shape_mnk[0] * self.tile_shape_mnk[2]), (
+                "w4a8 needs ab_stage >= 2 to repurpose the sA staging region"
+            )
+        if cutlass.const_expr(sfb_w13_mx is None):
+            sfb_w13_mx = row_counts  # unused placeholder under nvfp4
+        if cutlass.const_expr(sfb_down_mx is None):
+            sfb_down_mx = row_counts
+        if cutlass.const_expr(w13_residual is None):
+            w13_residual = sfb_w13_mx
+        if cutlass.const_expr(down_residual is None):
+            down_residual = sfb_down_mx
+        if cutlass.const_expr(w13_rp is None):
+            w13_rp = row_counts
+        if cutlass.const_expr(w13_sfb_rp is None):
+            w13_sfb_rp = row_counts
+        if cutlass.const_expr(down_rp is None):
+            down_rp = row_counts
+        if cutlass.const_expr(down_sfb_rp is None):
+            down_sfb_rp = row_counts
+        if cutlass.const_expr(self.w4a8_repacked):
+            assert (
+                w13_rp is not None
+                and w13_sfb_rp is not None
+                and down_rp is not None
+                and down_sfb_rp is not None
+            ), "repacked w4a8_mx requires all four prepared weight tensors"
+        # Raw u32 views over the packed-FP4 weight bytes for the w4a8 direct
+        # global-load path (the TMA-derived gB tensors are coordinate tensors
+        # and not byte-addressable).
+        b_w13_u32 = cute.recast_tensor(b_w13, cutlass.Uint32)
+        b_down_u32 = cute.recast_tensor(b_down, cutlass.Uint32)
+        grid = (*self.cluster_shape_mn, max_active_clusters)
+        self.kernel(
+            a_input,
+            topk_ids,
+            topk_weights,
+            packed_a_storage,
+            scale_storage,
+            intermediate_u32,
+            barrier_count,
+            barrier_epoch,
+            pair_head,
+            producers_done_count,
+            all_work_published,
+            task_head,
+            task_tail,
+            task_ready,
+            task_expert,
+            task_m_tile,
+            task_slice_begin,
+            task_slice_count,
+            task_valid_rows,
+            tile_write_count,
+            tma_a,
+            gA,
+            tma_sfa,
+            gSFA,
+            tma_b_w13,
+            gB_w13,
+            tma_sfb_w13,
+            gSFB_w13,
+            tma_b_down,
+            gB_down,
+            tma_sfb_down,
+            gSFB_down,
+            self.tiled_mma,
+            self.mma_atom,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            # swap_ab FC1 objects (placeholders when off; only used under the
+            # const_expr swap branch). cute requires region-local values, so the
+            # fc1 tiled_mma + SF layouts are passed as params, not via self.
+            self.fc1_tiled_mma if self.swap_ab else self.tiled_mma,
+            self.fc1_sfa_smem_layout_staged
+            if self.swap_ab
+            else self.sfa_smem_layout_staged,
+            self.fc1_sfb_smem_layout_staged
+            if self.swap_ab
+            else self.sfb_smem_layout_staged,
+            launch_params,
+            expert_write_rows,
+            expert_tile_base,
+            input_global_scale,
+            alpha,
+            down_alpha,
+            global_scale,
+            scatter_output,
+            token_map,
+            token_weights,
+            sfb_w13_mx,
+            sfb_down_mx,
+            w13_residual,
+            down_residual,
+            b_w13_u32,
+            b_down_u32,
+            w13_rp,
+            w13_sfb_rp,
+            down_rp,
+            down_sfb_rp,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            # The phase boundaries below use a software grid barrier.  A
+            # regular launch can admit only part of the grid while auxiliary
+            # stream work occupies the remaining SMs, leaving resident CTAs
+            # spinning and the unscheduled CTAs unable to arrive.  Cooperative
+            # launch makes the all-CTA residency contract explicit.
+            cooperative=True,
+            stream=stream,
+        )
+        if cutlass.const_expr(self.external_materialized_fc1):
+            self.materialized_phase1_kernel(
+                packed_a_storage,
+                scale_storage,
+                w13_rp,
+                w13_sfb_rp,
+                intermediate_u32,
+                token_map,
+                task_expert,
+                task_valid_rows,
+                expert_tile_base,
+                alpha,
+                input_global_scale,
+                Int32(a_input.shape[1]) // Int32(128),
+                gate_tile_cnt,
+                Int32(b_w13.shape[0]) // Int32(256),
+                max_active_clusters,
+                stream,
+            )
+        if cutlass.const_expr(self.external_materialized_fc2):
+            self.materialized_phase2_kernel(
+                intermediate_u32,
+                down_rp,
+                down_sfb_rp,
+                scatter_output,
+                token_map,
+                token_weights,
+                task_expert,
+                task_valid_rows,
+                expert_tile_base,
+                down_alpha,
+                global_scale,
+                gate_tile_cnt,
+                Int32(b_down.shape[0]) // Int32(256),
+                max_active_clusters,
+                stream,
+            )
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        packed_a_storage: cute.Tensor,
+        scale_storage: cute.Tensor,
+        intermediate_u32: cute.Tensor,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        pair_head: cute.Tensor,
+        producers_done_count: cute.Tensor,
+        all_work_published: cute.Tensor,
+        task_head: cute.Tensor,
+        task_tail: cute.Tensor,
+        task_ready: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_m_tile: cute.Tensor,
+        task_slice_begin: cute.Tensor,
+        task_slice_count: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        tile_write_count: cute.Tensor,
+        tma_a: cute.CopyAtom,
+        mA: cute.Tensor,
+        tma_sfa: cute.CopyAtom,
+        mSFA: cute.Tensor,
+        tma_b_w13: cute.CopyAtom,
+        mB_w13: cute.Tensor,
+        tma_sfb_w13: cute.CopyAtom,
+        mSFB_w13: cute.Tensor,
+        tma_b_down: cute.CopyAtom,
+        mB_down: cute.Tensor,
+        tma_sfb_down: cute.CopyAtom,
+        mSFB_down: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        mma_atom: cute.MmaAtom,
+        cta_layout_mnk: cute.Layout,
+        a_smem_staged: cute.ComposedLayout,
+        b_smem_staged: cute.ComposedLayout,
+        sfa_smem_staged: cute.Layout,
+        sfb_smem_staged: cute.Layout,
+        epi_smem_staged: cute.ComposedLayout,
+        fc1_tiled_mma: cute.TiledMma,
+        fc1_sfa_smem_staged: cute.Layout,
+        fc1_sfb_smem_staged: cute.Layout,
+        launch_params: DynamicLaunchParams,
+        expert_write_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        sfb_w13_mx: cute.Tensor,
+        sfb_down_mx: cute.Tensor,
+        w13_residual: cute.Tensor,
+        down_residual: cute.Tensor,
+        b_w13_u32: cute.Tensor,
+        b_down_u32: cute.Tensor,
+        w13_rp: cute.Tensor,
+        w13_sfb_rp: cute.Tensor,
+        down_rp: cute.Tensor,
+        down_sfb_rp: cute.Tensor,
+    ):
+        """Kernel entry point."""
+        from cutlass.cute.nvgpu.warp.mma import Field as WarpField
+
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, bidz = cute.arch.block_idx()
+        _, _, gdim_z = cute.arch.grid_dim()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        # Keep the predicate in DSL IR; a Python conditional would try to
+        # convert the dynamic device value to a host bool during compilation.
+        is_cta_leader = Int32(Int32(tidx) == Int32(0))
+
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_a)
+            cpasync.prefetch_descriptor(tma_sfa)
+            cpasync.prefetch_descriptor(tma_b_w13)
+            cpasync.prefetch_descriptor(tma_sfb_w13)
+            cpasync.prefetch_descriptor(tma_b_down)
+            cpasync.prefetch_descriptor(tma_sfb_down)
+
+        cta_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cluster_coord = cta_layout_mnk.get_flat_coord(cta_rank)
+
+        a_smem_one = cute.slice_(a_smem_staged, (None, None, 0))
+        b_smem_one = cute.slice_(b_smem_staged, (None, None, 0))
+        sfa_smem_one = cute.slice_(sfa_smem_staged, (None, None, 0))
+        sfb_smem_one = cute.slice_(sfb_smem_staged, (None, None, 0))
+        tma_copy_bytes = (
+            cute.size_in_bytes(self.a_dtype, a_smem_one)
+            + cute.size_in_bytes(self.b_dtype, b_smem_one)
+            + cute.size_in_bytes(self.sf_dtype, sfa_smem_one)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        )
+        phase2_tma_copy_bytes = cute.size_in_bytes(
+            self.b_dtype, b_smem_one
+        ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        # swap_ab with a mid-atom gate base loads a second weight atom (atom-hi)
+        # into sB_up/sSFB_up during the gate pass, so the gate mbarrier expects
+        # those extra bytes; the up/phase2 pipelines are unchanged.
+        ml_tx_count = tma_copy_bytes
+        if cutlass.const_expr(
+            self.swap_ab and ((mB_w13.shape[0] // 2) % self.tile_shape_mnk[1]) != 0
+        ):
+            ml_tx_count = (
+                tma_copy_bytes
+                + cute.size_in_bytes(self.b_dtype, b_smem_one)
+                + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+            )
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 8]
+            route_phys_rows: cute.struct.MemRange[
+                cutlass.Int32,
+                self.route_storage_entries,
+            ]
+            route_expert_ids: cute.struct.MemRange[
+                cutlass.Int32,
+                self.route_storage_entries,
+            ]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, self.tile_shape_mnk[0]
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, self.tile_shape_mnk[0]
+            ]
+            # w4a8 producer-consumer staging flags: [0..1] FC1 ready epoch per
+            # buffer, [2..3] FC1 done count per buffer, [4..5] FC2 ready,
+            # [6..7] FC2 done.
+            w4a8_pipe: cute.struct.MemRange[cutlass.Int32, 8]
+            # One mbarrier per staging-buffer parity for w4a8 TMA-B staging
+            # (arrive count 1; phases tracked in producer registers).
+            w4a8_tma_mbar: cute.struct.MemRange[
+                cutlass.Int64, self.w4a8_depth if self.is_w4a8 else 1
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, self.sA_storage_elems],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.aux_buffer_align_bytes,
+            ]
+            sB_up: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.aux_buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, self.sSFA_storage_elems],
+                self.aux_buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfb_smem_staged)],
+                self.aux_buffer_align_bytes,
+            ]
+            sSFB_up: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, self.sSFB_up_storage_elems],
+                self.aux_buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, self.sC_storage_elems],
+                self.sC_storage_align_bytes,
+            ]
+            reduce_scratch: cute.struct.MemRange[cutlass.Float32, 5]
+
+        storage = smem.allocate(Storage)
+
+        prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        cons_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps
+        )
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        ml_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=ml_tx_count,
+            barrier_storage=storage.pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+        up_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.up_pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+        phase2_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=phase2_tma_copy_bytes,
+            barrier_storage=storage.phase2_pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+
+        w4a8_tma_mbar_ptr = storage.w4a8_tma_mbar.data_ptr()
+        if cutlass.const_expr(self.is_w4a8 and self.w4a8_b_tma):
+            if Int32(tidx) == Int32(0):
+                for _mb in cutlass.range_constexpr(self.w4a8_depth):
+                    cute.arch.mbarrier_init(w4a8_tma_mbar_ptr + _mb, Int32(1))
+            cute.arch.mbarrier_init_fence()
+        cute.arch.sync_threads()
+
+        sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
+        sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+        sB_up = storage.sB_up.get_tensor(
+            b_smem_staged.outer, swizzle=b_smem_staged.inner
+        )
+        sSFA = storage.sSFA.get_tensor(sfa_smem_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_staged)
+        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged)
+        if cutlass.const_expr(self.w4a8_repacked):
+            # FC1-A occupies the tail of sA only until the activation
+            # epilogue.  Rebind the same bytes as the swizzled BF16 sC tile;
+            # its size is depth*M*K bytes, exactly 8 KiB at M32/depth2.
+            sA_u8_ptr = cute.recast_ptr(
+                storage.sA.data_ptr().align(16),
+                dtype=cutlass.Uint8,
+            )
+            sC_alias_ptr = cute.recast_ptr(
+                (sA_u8_ptr + self.tile_shape_mnk[0] * self.tile_shape_mnk[2]).align(16),
+                dtype=cutlass.BFloat16,
+            )
+            sC_alias = make_smem_memrange_alias(
+                cutlass.BFloat16,
+                cute.cosize(epi_smem_staged),
+                sC_alias_ptr,
+            )
+            sC = sC_alias.get_tensor(
+                epi_smem_staged.outer,
+                swizzle=epi_smem_staged.inner,
+            )
+        else:
+            sC = storage.sC.get_tensor(
+                epi_smem_staged.outer,
+                swizzle=epi_smem_staged.inner,
+            )
+        ctrl_base_addr = shared_ptr_to_u32(storage.ctrl.data_ptr())
+        if cutlass.const_expr(self.w4a8_repacked):
+            sC_base_addr = (
+                ctrl_base_addr
+                + Int32(Storage._offsets["sA"])
+                + Int32(self.tile_shape_mnk[0] * self.tile_shape_mnk[2])
+            )
+        sfa_base_addr = ctrl_base_addr + Int32(Storage._offsets["sSFA"])
+        reduce_scratch_addr = ctrl_base_addr + Int32(Storage._offsets["reduce_scratch"])
+        if cutlass.const_expr(self.w4a8_repacked):
+            route_phys_rows_addr = ctrl_base_addr + Int32(Storage._offsets["sA"])
+            route_expert_ids_addr = route_phys_rows_addr + Int32(
+                self.num_route_warps * 32 * 4
+            )
+        else:
+            route_phys_rows_addr = ctrl_base_addr + Int32(
+                Storage._offsets["route_phys_rows"]
+            )
+            route_expert_ids_addr = ctrl_base_addr + Int32(
+                Storage._offsets["route_expert_ids"]
+            )
+        scatter_tok_base_addr = ctrl_base_addr + Int32(
+            Storage._offsets["scatter_tok_cache"]
+        )
+        scatter_weight_base_addr = ctrl_base_addr + Int32(
+            Storage._offsets["scatter_weight_cache"]
+        )
+
+        num_tokens = Int32(a_input.shape[0])
+        cols = Int32(a_input.shape[1])
+        scatter_base = scatter_output.iterator.toint()
+        row_counts = launch_params.row_counts
+        num_experts = Int32(row_counts.shape[0])
+        sf_blocks_per_row = cols // Int32(16)
+        if cutlass.const_expr(self.is_w4a8):
+            # E4M3 payload: one byte per element; UE8M0 scales per 32 elements.
+            output_bytes_per_row = cols
+            mx_blocks_per_row = cols // Int32(32)
+        else:
+            output_bytes_per_row = cols // Int32(2)
+            mx_blocks_per_row = sf_blocks_per_row  # unused placeholder
+        cols_u32 = cols // Int32(2)
+        scatter_output_u32 = cute.recast_tensor(scatter_output, cutlass.Uint32)
+        total_pairs = Int32(topk_ids.shape[0])
+        num_topk = total_pairs // num_tokens
+        flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
+        flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
+        num_k_tiles = (cols + Int32(63)) // Int32(64)
+        route_gate_tile_cnt = launch_params.gate_tile_cnt
+        task_slice_chunk = Int32(_TASK_SLICE_CHUNK)
+        # Split materialized FC1 indexes deferred metadata as
+        # ``m_tile * gate_tile_cnt`` and therefore needs one metadata slot per
+        # intermediate tile.  Fused deterministic consumers can collapse the
+        # same domain to one all-slices slot per M tile.
+        if cutlass.const_expr(
+            self.deterministic_output and not self.external_materialized_fc1
+        ):
+            task_slice_chunk = route_gate_tile_cnt
+        materialized_num_groups = (
+            route_gate_tile_cnt + task_slice_chunk - Int32(1)
+        ) // task_slice_chunk
+
+        # Phase 0: cooperative init — zero routing state, queue state, and output.
+        task_capacity = Int32(task_ready.shape[0])
+        tile_write_slots = Int32(tile_write_count.shape[0])
+        if cutlass.const_expr(not self.direct_routing):
+            i = flat_tid
+            while i < num_experts:
+                row_counts[i] = Int32(0)
+                expert_write_rows[i] = Int32(0)
+                i += flat_stride
+            if flat_tid < num_experts + Int32(1):
+                expert_tile_base[flat_tid] = Int32(0)
+
+        # Atomic scatter accumulates into the caller output and must start at
+        # zero.  Deterministic split phase 2 instead has exactly one producer
+        # for every real (route, output-column) location, and the fixed-order
+        # top-k kernel overwrites every caller-output location afterward.  Its
+        # routed scratch therefore needs no 4x-output clear; poison/replay
+        # coverage verifies that phase 2 really overwrites the full domain.
+        if cutlass.const_expr(
+            not (self.deterministic_output and self.external_materialized_fc2)
+        ):
+            scatter_rows = Int32(scatter_output.shape[0])
+            scatter_total_u32 = scatter_rows * cols_u32
+            scatter_vecs = scatter_total_u32 // Int32(4)
+            zero_u32 = Uint32(0)
+            zv = flat_tid
+            while zv < scatter_vecs:
+                st_global_v4_u32(
+                    scatter_base + Int64(zv) * Int64(16),
+                    zero_u32,
+                    zero_u32,
+                    zero_u32,
+                    zero_u32,
+                )
+                zv += flat_stride
+
+            j = scatter_vecs * Int32(4) + flat_tid
+            while j < scatter_total_u32:
+                scatter_output_u32[j // cols_u32, j % cols_u32] = Uint32(0)
+                j += flat_stride
+
+        # Materialized slots are overwritten before the second grid barrier;
+        # only a true ready queue needs generation flags cleared up front.
+        if cutlass.const_expr(self.work_is_streaming):
+            k = flat_tid
+            while k < task_capacity:
+                task_ready[k] = Int32(0)
+                k += flat_stride
+
+            tw = flat_tid
+            while tw < tile_write_slots:
+                tile_write_count[tw] = Int32(0)
+                tw += flat_stride
+
+        if flat_tid == Int32(0):
+            pair_head[Int32(0)] = Int32(0)
+            producers_done_count[Int32(0)] = Int32(0)
+            all_work_published[Int32(0)] = Int32(0)
+            task_head[Int32(0)] = Int32(0)
+            task_tail[Int32(0)] = Int32(0)
+
+        if cutlass.const_expr(self.w4a8_m1_materialized):
+            # Fixed M=1 preparation is itself a grid-sized arithmetic domain:
+            # one thread per K32 quantization block, plus one thread per route.
+            # Fold it into phase 0 so the existing resident barrier publishes
+            # both the cleared output and the prepared input in one step.
+            m1_blk_idx = flat_tid
+            while m1_blk_idx < mx_blocks_per_row:
+                m1_block_start = m1_blk_idx * Int32(32)
+                m1_values, m1_block_max = _load_bf16x32_to_f32(
+                    a_input,
+                    m1_block_start,
+                )
+                m1_payload, m1_mx_scale_byte = quantize_block_fp8_mx(
+                    m1_values,
+                    m1_block_max,
+                )
+                for m1_payload_pair in cutlass.range_constexpr(4):
+                    m1_packed64 = (
+                        Uint64(m1_payload[m1_payload_pair * 2 + 1]) << Uint64(32)
+                    ) | Uint64(m1_payload[m1_payload_pair * 2])
+                    st_global_u64(
+                        get_ptr_as_int64(
+                            packed_a_storage,
+                            m1_block_start + Int32(m1_payload_pair * 8),
+                        ),
+                        m1_packed64,
+                    )
+                scale_storage[m1_blk_idx] = Uint8(m1_mx_scale_byte & Uint32(0xFF))
+                m1_blk_idx += flat_stride
+
+            if flat_tid < total_pairs:
+                m1_physical_row = flat_tid * Int32(self.tile_shape_mnk[0])
+                token_map[m1_physical_row] = Int32(0)
+                token_weights[m1_physical_row] = topk_weights[flat_tid].to(
+                    cutlass.Float32
+                )
+
+        cute.arch.sync_threads()
+        self._resident_grid_barrier(
+            barrier_count,
+            barrier_epoch,
+            Int32(gdim_z),
+            is_cta_leader,
+        )
+
+        # General grouped execution compacts routes by expert.  Tiny direct-
+        # routing decode instead gives every routed pair its own physical M tile:
+        # this removes the histogram, serial expert prefix, and two resident-
+        # grid barriers while retaining the exact same compute/task body.
+        if cutlass.const_expr(not self.direct_routing):
+            hist_idx = flat_tid
+            while hist_idx < total_pairs:
+                expert_id = topk_ids[hist_idx].to(Int32)
+                atomic_add_global_i32(get_ptr_as_int64(row_counts, expert_id), Int32(1))
+                hist_idx += flat_stride
+
+            self._resident_grid_barrier(
+                barrier_count,
+                barrier_epoch,
+                Int32(gdim_z),
+                is_cta_leader,
+            )
+
+            if flat_tid == Int32(0):
+                tile_acc = Int32(0)
+                expert_idx = Int32(0)
+                while expert_idx < num_experts:
+                    expert_tile_base[expert_idx] = tile_acc
+                    rows = row_counts[expert_idx]
+                    tile_acc += (
+                        rows + Int32(self.tile_shape_mnk[0]) - Int32(1)
+                    ) // Int32(self.tile_shape_mnk[0])
+                    expert_idx += Int32(1)
+                expert_tile_base[num_experts] = tile_acc
+
+            self._resident_grid_barrier(
+                barrier_count,
+                barrier_epoch,
+                Int32(gdim_z),
+                is_cta_leader,
+            )
+
+        # Phase 2: warp-private route/pack producers into compact physical tiles.
+        lane_id = Int32(tidx) & Int32(31)
+        num_cta_warps = Int32(self.num_route_warps)
+        input_active_warps = num_cta_warps
+        input_groups_per_cta = num_cta_warps
+        if cutlass.const_expr(self.is_w4a8 and self.share_input_across_experts):
+            # Shared-input A8 assigns a compile-time group of warps to each
+            # token.  Only complete groups may enter the per-token named
+            # barrier; otherwise a tail warp in any future non-divisible CTA
+            # role layout would wait forever for a partner that was not
+            # launched.
+            input_groups_per_cta = num_cta_warps // Int32(self.input_warps_per_token)
+            input_active_warps = input_groups_per_cta * Int32(
+                self.input_warps_per_token
+            )
+        producer_batch_pairs = num_cta_warps * Int32(_PRODUCER_PAIRS_PER_WARP)
+        shared_input_gs_value = cutlass.Float32(0.0)
+        if cutlass.const_expr(self.share_input_across_experts):
+            shared_input_gs_value = input_global_scale[Int32(0)].to(cutlass.Float32)
+        pair_idx = Int32(0)
+        expert_id = Int32(0)
+        token_idx = Int32(0)
+        weight = cutlass.Float32(0.0)
+        row = Int32(0)
+        phys_tile = Int32(0)
+        phys_row = Int32(0)
+        # CuTe rmem tensors must be declared outside runtime control-flow.
+        # Each cache is consumed by a compile-time recipe branch and eliminated
+        # from the other one.
+        shared_route_phys_rows = cute.make_rmem_tensor((8,), Int32)
+        route_output_base = cute.make_rmem_tensor((8,), Int32)
+        route_scale_base = cute.make_rmem_tensor((8,), Int32)
+        produce_active = (
+            Int32(0) if cutlass.const_expr(self.w4a8_m1_materialized) else Int32(1)
+        )
+        while produce_active > Int32(0):
+            batch_base = Int32(0)
+            if is_cta_leader > Int32(0):
+                claim_count = producer_batch_pairs
+                if cutlass.const_expr(self.share_input_across_experts):
+                    # A compile-time warp group cooperates on each token,
+                    # partitioning both routes and K/32 blocks under A8.
+                    claim_count = input_groups_per_cta
+                batch_base = atomic_add_global_i32(
+                    get_ptr_as_int64(pair_head, Int32(0)),
+                    claim_count,
+                )
+                _st_shared_i32(ctrl_base_addr + Int32(28), batch_base)
+            cute.arch.sync_threads()
+            batch_base = _ld_shared_i32(ctrl_base_addr + Int32(28))
+            producer_limit = total_pairs
+            if cutlass.const_expr(self.share_input_across_experts):
+                producer_limit = num_tokens
+            if batch_base >= producer_limit:
+                produce_active = Int32(0)
+            else:
+                if cutlass.const_expr(self.share_input_across_experts):
+                    token_owner_warp = warp_idx
+                    token_partition = Int32(0)
+                    if cutlass.const_expr(self.is_w4a8):
+                        token_owner_warp = warp_idx // Int32(self.input_warps_per_token)
+                        token_partition = warp_idx % Int32(self.input_warps_per_token)
+                    token_idx = batch_base + token_owner_warp
+                    if warp_idx < input_active_warps and token_idx < num_tokens:
+                        route_slot_base = token_owner_warp * Int32(32)
+                        if lane_id == Int32(0):
+                            topk_slot = Int32(0)
+                            topk_step = Int32(1)
+                            if cutlass.const_expr(self.is_w4a8):
+                                topk_slot = token_partition
+                                topk_step = Int32(self.input_warps_per_token)
+                            while topk_slot < num_topk:
+                                pair_idx = token_idx * num_topk + topk_slot
+                                expert_id = topk_ids[pair_idx].to(Int32)
+                                weight = topk_weights[pair_idx].to(cutlass.Float32)
+                                if cutlass.const_expr(self.direct_routing):
+                                    row = Int32(0)
+                                    phys_tile = pair_idx
+                                else:
+                                    row = atomic_add_global_i32(
+                                        get_ptr_as_int64(expert_write_rows, expert_id),
+                                        Int32(1),
+                                    )
+                                    phys_tile = expert_tile_base[
+                                        expert_id
+                                    ] + row // Int32(self.tile_shape_mnk[0])
+                                phys_row = phys_tile * Int32(
+                                    self.tile_shape_mnk[0]
+                                ) + row % Int32(self.tile_shape_mnk[0])
+                                map_value = token_idx
+                                if cutlass.const_expr(self.deterministic_output):
+                                    map_value = pair_idx
+                                st_global_i32(
+                                    get_ptr_as_int64(token_map, phys_row), map_value
+                                )
+                                st_global_f32(
+                                    get_ptr_as_int64(token_weights, phys_row), weight
+                                )
+                                slot = route_slot_base + topk_slot
+                                _st_shared_i32(
+                                    route_phys_rows_addr + slot * Int32(4), phys_row
+                                )
+                                _st_shared_i32(
+                                    route_expert_ids_addr + slot * Int32(4), expert_id
+                                )
+                                topk_slot += topk_step
+                        if cutlass.const_expr(self.is_w4a8):
+                            self._sync_input_warp_pair(token_owner_warp)
+                        else:
+                            cute.arch.sync_warp()
+
+                        if cutlass.const_expr(self.is_w4a8):
+                            # A token's BF16 row is identical for every routed
+                            # expert. The materialized specialization stores one
+                            # quantized row per token and gathers it in FC1; the
+                            # route-expanded path fans it out to each route.
+                            # That path keeps only physical rows in rmem here to
+                            # stay below the two-CTA register-residency limit.
+                            if num_topk == Int32(8):
+                                for cache_slot in cutlass.range_constexpr(8):
+                                    slot = route_slot_base + Int32(cache_slot)
+                                    shared_route_phys_rows[cache_slot] = _ld_shared_i32(
+                                        route_phys_rows_addr + slot * Int32(4)
+                                    )
+
+                                blk_idx = lane_id + token_partition * Int32(32)
+                                while blk_idx < mx_blocks_per_row:
+                                    block_start = blk_idx * Int32(32)
+                                    values, block_max = _load_bf16x32_to_f32(
+                                        a_input,
+                                        token_idx * Int32(a_input.shape[1])
+                                        + block_start,
+                                    )
+                                    payload, mx_scale_byte = quantize_block_fp8_mx(
+                                        values, block_max
+                                    )
+                                    for payload_pair in cutlass.range_constexpr(4):
+                                        packed64 = (
+                                            Uint64(payload[payload_pair * 2 + 1])
+                                            << Uint64(32)
+                                        ) | Uint64(payload[payload_pair * 2])
+                                        if cutlass.const_expr(
+                                            self.materialize_intermediate
+                                        ):
+                                            output_offset = (
+                                                token_idx * output_bytes_per_row
+                                                + block_start
+                                                + Int32(payload_pair * 8)
+                                            )
+                                            st_global_u64(
+                                                get_ptr_as_int64(
+                                                    packed_a_storage,
+                                                    output_offset,
+                                                ),
+                                                packed64,
+                                            )
+                                        else:
+                                            for cache_slot in cutlass.range_constexpr(
+                                                8
+                                            ):
+                                                phys_row = shared_route_phys_rows[
+                                                    cache_slot
+                                                ]
+                                                output_offset = (
+                                                    phys_row * output_bytes_per_row
+                                                    + block_start
+                                                    + Int32(payload_pair * 8)
+                                                )
+                                                st_global_u64(
+                                                    get_ptr_as_int64(
+                                                        packed_a_storage,
+                                                        output_offset,
+                                                    ),
+                                                    packed64,
+                                                )
+                                    if cutlass.const_expr(
+                                        self.materialize_intermediate
+                                    ):
+                                        scale_storage[
+                                            token_idx * mx_blocks_per_row + blk_idx
+                                        ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                    else:
+                                        for cache_slot in cutlass.range_constexpr(8):
+                                            phys_row = shared_route_phys_rows[
+                                                cache_slot
+                                            ]
+                                            scale_storage[
+                                                phys_row * mx_blocks_per_row + blk_idx
+                                            ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                    blk_idx += Int32(self.input_warps_per_token * 32)
+                            else:
+                                blk_idx = lane_id + token_partition * Int32(32)
+                                while blk_idx < mx_blocks_per_row:
+                                    block_start = blk_idx * Int32(32)
+                                    values, block_max = _load_bf16x32_to_f32(
+                                        a_input,
+                                        token_idx * Int32(a_input.shape[1])
+                                        + block_start,
+                                    )
+                                    payload, mx_scale_byte = quantize_block_fp8_mx(
+                                        values, block_max
+                                    )
+                                    for payload_pair in cutlass.range_constexpr(4):
+                                        packed64 = (
+                                            Uint64(payload[payload_pair * 2 + 1])
+                                            << Uint64(32)
+                                        ) | Uint64(payload[payload_pair * 2])
+                                        if cutlass.const_expr(
+                                            self.materialize_intermediate
+                                        ):
+                                            output_offset = (
+                                                token_idx * output_bytes_per_row
+                                                + block_start
+                                                + Int32(payload_pair * 8)
+                                            )
+                                            st_global_u64(
+                                                get_ptr_as_int64(
+                                                    packed_a_storage,
+                                                    output_offset,
+                                                ),
+                                                packed64,
+                                            )
+                                        else:
+                                            # CuTe loop-carried values must have
+                                            # a concrete type before entering a
+                                            # dynamic while.  Keep the address
+                                            # offset in rmem and update it for
+                                            # each routed copy below.
+                                            output_offset = Int32(0)
+                                            topk_slot = Int32(0)
+                                            while topk_slot < num_topk:
+                                                slot = route_slot_base + topk_slot
+                                                phys_row = _ld_shared_i32(
+                                                    route_phys_rows_addr
+                                                    + slot * Int32(4)
+                                                )
+                                                output_offset = (
+                                                    phys_row * output_bytes_per_row
+                                                    + block_start
+                                                    + Int32(payload_pair * 8)
+                                                )
+                                                st_global_u64(
+                                                    get_ptr_as_int64(
+                                                        packed_a_storage,
+                                                        output_offset,
+                                                    ),
+                                                    packed64,
+                                                )
+                                                topk_slot += Int32(1)
+                                    if cutlass.const_expr(
+                                        self.materialize_intermediate
+                                    ):
+                                        scale_storage[
+                                            token_idx * mx_blocks_per_row + blk_idx
+                                        ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                    else:
+                                        topk_slot = Int32(0)
+                                        while topk_slot < num_topk:
+                                            slot = route_slot_base + topk_slot
+                                            phys_row = _ld_shared_i32(
+                                                route_phys_rows_addr + slot * Int32(4)
+                                            )
+                                            scale_storage[
+                                                phys_row * mx_blocks_per_row + blk_idx
+                                            ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                            topk_slot += Int32(1)
+                                    blk_idx += Int32(self.input_warps_per_token * 32)
+                        else:
+                            gs_value = shared_input_gs_value
+                            if num_topk == Int32(8):
+                                for cache_slot in cutlass.range_constexpr(8):
+                                    slot = route_slot_base + Int32(cache_slot)
+                                    phys_row = _ld_shared_i32(
+                                        route_phys_rows_addr + slot * Int32(4)
+                                    )
+                                    route_output_base[cache_slot] = (
+                                        phys_row * output_bytes_per_row
+                                    )
+                                    # Scale storage is tiled in 128-row SF
+                                    # atoms, independently of the MMA tile.
+                                    sf_atom = phys_row >> Int32(7)
+                                    sf_row = phys_row & Int32(127)
+                                    route_scale_base[cache_slot] = (
+                                        sf_atom * num_k_tiles * Int32(32 * 4 * 4)
+                                        + (sf_row % Int32(32)) * Int32(4 * 4)
+                                        + (sf_row // Int32(32)) * Int32(4)
+                                    )
+
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(16)
+                                    values = cute.make_rmem_tensor(
+                                        (16,), cutlass.Float32
+                                    )
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(16):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed64 = Uint64(0)
+                                    scale_byte = Uint8(0)
+                                    if self.is_gated and self.fast_math:
+                                        packed64, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed64, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
+
+                                    k_tile_idx = sf_idx // Int32(4)
+                                    inner_k_idx = sf_idx % Int32(4)
+                                    scale_k_base = (
+                                        k_tile_idx * Int32(32 * 4 * 4) + inner_k_idx
+                                    )
+                                    for cache_slot in cutlass.range_constexpr(8):
+                                        output_offset = route_output_base[
+                                            cache_slot
+                                        ] + sf_idx * Int32(8)
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage, output_offset
+                                            ),
+                                            packed64,
+                                        )
+                                        scale_storage[
+                                            route_scale_base[cache_slot] + scale_k_base
+                                        ] = scale_byte
+                                    sf_idx += Int32(32)
+                            else:
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(16)
+                                    values = cute.make_rmem_tensor(
+                                        (16,), cutlass.Float32
+                                    )
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(16):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed64 = Uint64(0)
+                                    scale_byte = Uint8(0)
+                                    if self.is_gated and self.fast_math:
+                                        packed64, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed64, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
+
+                                    topk_slot = Int32(0)
+                                    while topk_slot < num_topk:
+                                        slot = route_slot_base + topk_slot
+                                        phys_row = _ld_shared_i32(
+                                            route_phys_rows_addr + slot * Int32(4)
+                                        )
+                                        output_offset = (
+                                            phys_row * output_bytes_per_row
+                                            + sf_idx * Int32(8)
+                                        )
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage, output_offset
+                                            ),
+                                            packed64,
+                                        )
+
+                                        # scale_storage uses 128-row SF atoms
+                                        # (tile_atom_to_shape_SF); index by the 128-atom
+                                        # (phys_row>>7) + row-within-atom, NOT the MMA
+                                        # tile (which may be 64). Identity at tile_m==128.
+                                        k_tile_idx = sf_idx // Int32(4)
+                                        sf_atom = phys_row >> Int32(7)
+                                        sf_row = phys_row & Int32(127)
+                                        outer_m_idx = sf_row % Int32(32)
+                                        inner_m_idx = sf_row // Int32(32)
+                                        inner_k_idx = sf_idx % Int32(4)
+                                        scale_offset = (
+                                            sf_atom * num_k_tiles * Int32(32 * 4 * 4)
+                                            + k_tile_idx * Int32(32 * 4 * 4)
+                                            + outer_m_idx * Int32(4 * 4)
+                                            + inner_m_idx * Int32(4)
+                                            + inner_k_idx
+                                        )
+                                        scale_storage[scale_offset] = scale_byte
+                                        topk_slot += Int32(1)
+                                    sf_idx += Int32(32)
+
+                        if cutlass.const_expr(self.work_is_streaming):
+                            cute.arch.sync_warp()
+                            _threadfence()
+                            cute.arch.sync_warp()
+
+                            publish_routes = Int32(1)
+                            if cutlass.const_expr(self.is_w4a8):
+                                self._sync_input_warp_pair(token_owner_warp)
+                                publish_routes = Int32(1) - token_partition
+
+                            if lane_id == Int32(0) and publish_routes > Int32(0):
+                                topk_slot = Int32(0)
+                                while topk_slot < num_topk:
+                                    slot = route_slot_base + topk_slot
+                                    phys_row = _ld_shared_i32(
+                                        route_phys_rows_addr + slot * Int32(4)
+                                    )
+                                    expert_id = _ld_shared_i32(
+                                        route_expert_ids_addr + slot * Int32(4)
+                                    )
+                                    phys_tile = phys_row // Int32(
+                                        self.tile_shape_mnk[0]
+                                    )
+                                    completed = atomic_add_global_i32(
+                                        get_ptr_as_int64(tile_write_count, phys_tile),
+                                        Int32(1),
+                                    ) + Int32(1)
+                                    if completed == Int32(self.tile_shape_mnk[0]):
+                                        self._publish_ready_tasks(
+                                            task_tail,
+                                            task_ready,
+                                            task_expert,
+                                            task_m_tile,
+                                            task_slice_begin,
+                                            task_slice_count,
+                                            task_valid_rows,
+                                            route_gate_tile_cnt,
+                                            task_slice_chunk,
+                                            expert_id,
+                                            phys_tile,
+                                            Int32(self.tile_shape_mnk[0]),
+                                        )
+                                    topk_slot += Int32(1)
+                else:
+                    warp_item = Int32(0)
+                    while warp_item < Int32(_PRODUCER_PAIRS_PER_WARP):
+                        pair_idx = batch_base + warp_idx + warp_item * num_cta_warps
+                        expert_id = Int32(0)
+                        token_idx = Int32(0)
+                        weight = cutlass.Float32(0.0)
+                        row = Int32(0)
+                        phys_tile = Int32(0)
+                        if pair_idx < total_pairs:
+                            expert_id = topk_ids[pair_idx].to(Int32)
+                            token_idx = pair_idx // num_topk
+                            weight = topk_weights[pair_idx].to(cutlass.Float32)
+
+                            if lane_id == Int32(0):
+                                if cutlass.const_expr(self.direct_routing):
+                                    row = Int32(0)
+                                    phys_tile = pair_idx
+                                else:
+                                    row = atomic_add_global_i32(
+                                        get_ptr_as_int64(expert_write_rows, expert_id),
+                                        Int32(1),
+                                    )
+                                    phys_tile = expert_tile_base[
+                                        expert_id
+                                    ] + row // Int32(self.tile_shape_mnk[0])
+                                phys_row = phys_tile * Int32(
+                                    self.tile_shape_mnk[0]
+                                ) + row % Int32(self.tile_shape_mnk[0])
+                                map_value = token_idx
+                                if cutlass.const_expr(self.deterministic_output):
+                                    map_value = pair_idx
+                                st_global_i32(
+                                    get_ptr_as_int64(token_map, phys_row), map_value
+                                )
+                                st_global_f32(
+                                    get_ptr_as_int64(token_weights, phys_row), weight
+                                )
+
+                            row = cute.arch.shuffle_sync(row, Int32(0))
+                            phys_tile = cute.arch.shuffle_sync(phys_tile, Int32(0))
+                            expert_id = cute.arch.shuffle_sync(expert_id, Int32(0))
+                            token_idx = cute.arch.shuffle_sync(token_idx, Int32(0))
+
+                            gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+                            if cutlass.const_expr(self.is_w4a8):
+                                # w4a8: per-32 dynamic UE8M0 + E4M3 payload, no
+                                # global scale. Payload stored plain row-major;
+                                # scales stored plain [row, cols//32].
+                                phys_row = phys_tile * Int32(
+                                    self.tile_shape_mnk[0]
+                                ) + row % Int32(self.tile_shape_mnk[0])
+                                blk_idx = lane_id
+                                while blk_idx < mx_blocks_per_row:
+                                    block_start = blk_idx * Int32(32)
+                                    values = cute.make_rmem_tensor(
+                                        (32,), cutlass.Float32
+                                    )
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(32):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    payload, mx_scale_byte = quantize_block_fp8_mx(
+                                        values, block_max
+                                    )
+                                    output_offset = (
+                                        phys_row * output_bytes_per_row + block_start
+                                    )
+                                    for pair_idx in cutlass.range_constexpr(4):
+                                        packed64 = (
+                                            Uint64(payload[pair_idx * 2 + 1])
+                                            << Uint64(32)
+                                        ) | Uint64(payload[pair_idx * 2])
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage,
+                                                output_offset + Int32(pair_idx * 8),
+                                            ),
+                                            packed64,
+                                        )
+                                    scale_storage[
+                                        phys_row * mx_blocks_per_row + blk_idx
+                                    ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                    blk_idx += Int32(32)
+                            else:
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(16)
+                                    values = cute.make_rmem_tensor(
+                                        (16,), cutlass.Float32
+                                    )
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(16):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed64 = Uint64(0)
+                                    scale_byte = Uint8(0)
+                                    if self.is_gated and self.fast_math:
+                                        packed64, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed64, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
+
+                                    output_offset = (
+                                        phys_tile * Int32(self.tile_shape_mnk[0])
+                                        + row % Int32(self.tile_shape_mnk[0])
+                                    ) * output_bytes_per_row + sf_idx * Int32(8)
+                                    st_global_u64(
+                                        get_ptr_as_int64(
+                                            packed_a_storage, output_offset
+                                        ),
+                                        packed64,
+                                    )
+
+                                    k_tile_idx = sf_idx // Int32(4)
+                                    inner_k_idx = sf_idx % Int32(4)
+                                    # scale_storage uses 128-row SF atoms: index by the
+                                    # 128-atom + row-within-atom, not the MMA tile.
+                                    # Identity at tile_m==128.
+                                    phys_row = phys_tile * Int32(
+                                        self.tile_shape_mnk[0]
+                                    ) + row % Int32(self.tile_shape_mnk[0])
+                                    sf_atom = phys_row >> Int32(7)
+                                    sf_row = phys_row & Int32(127)
+                                    scale_offset = (
+                                        sf_atom * num_k_tiles * Int32(32 * 4 * 4)
+                                        + k_tile_idx * Int32(32 * 4 * 4)
+                                        + (sf_row % Int32(32)) * Int32(4 * 4)
+                                        + (sf_row // Int32(32)) * Int32(4)
+                                        + inner_k_idx
+                                    )
+                                    scale_storage[scale_offset] = scale_byte
+                                    sf_idx += Int32(32)
+
+                            if cutlass.const_expr(self.work_is_streaming):
+                                cute.arch.sync_warp()
+                                # When the whole launch has fewer than one M-tile of routed
+                                # rows, only the final partial-tile flush can publish work.
+                                # Skip the per-row fence/counter path in that common micro case.
+                                _threadfence()
+                                cute.arch.sync_warp()
+
+                                if lane_id == Int32(0):
+                                    completed = atomic_add_global_i32(
+                                        get_ptr_as_int64(tile_write_count, phys_tile),
+                                        Int32(1),
+                                    ) + Int32(1)
+                                    if completed == Int32(self.tile_shape_mnk[0]):
+                                        self._publish_ready_tasks(
+                                            task_tail,
+                                            task_ready,
+                                            task_expert,
+                                            task_m_tile,
+                                            task_slice_begin,
+                                            task_slice_count,
+                                            task_valid_rows,
+                                            route_gate_tile_cnt,
+                                            task_slice_chunk,
+                                            expert_id,
+                                            phys_tile,
+                                            Int32(self.tile_shape_mnk[0]),
+                                        )
+                        warp_item += Int32(1)
+
+        if cutlass.const_expr(not self.w4a8_m1_materialized):
+            cute.arch.sync_threads()
+            # Conservative publish fence before the last-producer CTA flushes
+            # any partial tiles. All producer threads in the CTA must order
+            # their global writes before lane 0 can publish work.
+            _threadfence()
+            cute.arch.sync_threads()
+
+        if cutlass.const_expr(not self.work_is_streaming):
+            # The active materialized sources rendezvous once, publish every
+            # physical tile, then consume a fully addressable work domain.
+            if cutlass.const_expr(not self.w4a8_m1_materialized):
+                self._resident_grid_barrier(
+                    barrier_count,
+                    barrier_epoch,
+                    Int32(gdim_z),
+                    is_cta_leader,
+                )
+
+            if is_cta_leader > Int32(0) and cutlass.const_expr(
+                not self.w4a8_m1_materialized
+            ):
+                if cutlass.const_expr(self.direct_routing):
+                    pair_flush = Int32(bidz)
+                    while pair_flush < total_pairs:
+                        expert_flush = topk_ids[pair_flush].to(Int32)
+                        self._publish_deferred_tasks(
+                            task_expert,
+                            task_valid_rows,
+                            route_gate_tile_cnt,
+                            task_slice_chunk,
+                            expert_flush,
+                            pair_flush,
+                            Int32(1),
+                        )
+                        pair_flush += Int32(gdim_z)
+                else:
+                    expert_flush = Int32(bidz)
+                    while expert_flush < num_experts:
+                        rows_remaining = row_counts[expert_flush]
+                        m_tile_offset = Int32(0)
+                        while rows_remaining > Int32(0):
+                            valid_rows = rows_remaining
+                            if valid_rows > Int32(self.tile_shape_mnk[0]):
+                                valid_rows = Int32(self.tile_shape_mnk[0])
+                            self._publish_deferred_tasks(
+                                task_expert,
+                                task_valid_rows,
+                                route_gate_tile_cnt,
+                                task_slice_chunk,
+                                expert_flush,
+                                expert_tile_base[expert_flush] + m_tile_offset,
+                                valid_rows,
+                            )
+                            rows_remaining -= Int32(self.tile_shape_mnk[0])
+                            m_tile_offset += Int32(1)
+                        expert_flush += Int32(gdim_z)
+
+            if flat_tid == Int32(0) and cutlass.const_expr(
+                not self.w4a8_m1_materialized
+            ):
+                materialized_tail = expert_tile_base[num_experts]
+                if cutlass.const_expr(self.direct_routing):
+                    materialized_tail = total_pairs
+                st_global_i32(
+                    get_ptr_as_int64(task_tail, Int32(0)),
+                    materialized_tail * materialized_num_groups,
+                )
+
+            if cutlass.const_expr(not self.w4a8_m1_materialized):
+                self._resident_grid_barrier(
+                    barrier_count,
+                    barrier_epoch,
+                    Int32(gdim_z),
+                    is_cta_leader,
+                )
+                if flat_tid == Int32(0):
+                    _st_global_release_i32(
+                        get_ptr_as_int64(all_work_published, Int32(0)),
+                        Int32(1),
+                    )
+        elif is_cta_leader > Int32(0):
+            prev_done = atomic_add_global_i32(
+                get_ptr_as_int64(producers_done_count, Int32(0)),
+                Int32(1),
+            )
+            if prev_done == Int32(gdim_z) - Int32(1):
+                expert_flush = Int32(0)
+                while expert_flush < num_experts:
+                    rows = row_counts[expert_flush]
+                    rem = rows % Int32(self.tile_shape_mnk[0])
+                    if rem != Int32(0):
+                        partial_m_tile = expert_tile_base[expert_flush] + rows // Int32(
+                            self.tile_shape_mnk[0]
+                        )
+                        self._publish_ready_tasks(
+                            task_tail,
+                            task_ready,
+                            task_expert,
+                            task_m_tile,
+                            task_slice_begin,
+                            task_slice_count,
+                            task_valid_rows,
+                            route_gate_tile_cnt,
+                            task_slice_chunk,
+                            expert_flush,
+                            partial_m_tile,
+                            rem,
+                        )
+                    expert_flush += Int32(1)
+                _threadfence()
+                _st_global_release_i32(
+                    get_ptr_as_int64(all_work_published, Int32(0)),
+                    Int32(1),
+                )
+
+        gA = cute.local_tile(mA, self.sa_tile_shape_mk, (None, None, None))
+        # Single tiled view over concatenated w13 [2*I_tp, K, E].
+        # W13 is packed as [up, gate] across the concatenated N dimension.
+        # Up tiles: N-indices 0..gate_tile_cnt-1
+        # Gate tiles: N-indices gate_tile_cnt..2*gate_tile_cnt-1
+        gB_w13_tiled = cute.local_tile(
+            mB_w13,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        # SF tiles use the 128-row atom shape; for sub-128 MMA tiles one SF
+        # block backs `sfa_tiles_per_block` MMA tiles (offset applied below).
+        gSFA = cute.local_tile(mSFA, self.sfa_tile_shape_mk, (None, None, None))
+        gSFB_w13_tiled = cute.local_tile(
+            mSFB_w13, self.sfb_tile_shape_nk, (None, None, None)
+        )
+        # swap_ab gate feed: the gate half of w13 starts at row n, which for a
+        # 32-aligned non-128-aligned n is mid-SF-atom (n % 128 in {32,64,96}).
+        # A 128-row SF atom can only be TMA'd atom-aligned, so the gate's 128-int
+        # slice is sourced from TWO adjacent 128-row atoms: atom-lo (the atom
+        # holding row n, at within-atom 32-sub gate_lo_sub) and atom-hi (the
+        # next). atom-lo loads into sB/sSFB (the existing gate buffers); atom-hi
+        # loads into sB_up/sSFB_up (free during the gate pass; the up pass only
+        # overwrites them after pass_gate_barrier). The consumer picks each
+        # 32-int sub from lo/hi at the within-atom offset (const_expr below).
+        gate_lo_off = (mB_w13.shape[0] // 2) // self.tile_shape_mnk[1]
+        gate_lo_sub = (
+            (mB_w13.shape[0] // 2) % self.tile_shape_mnk[1]
+        ) // self._fc1_int_tile
+        thr_mma = tiled_mma.get_slice(tidx)
+
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord[1]
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord[0]
+
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_sfa,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sSFA, 0, 2),
+            cute.group_modes(gSFA, 0, 2),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # Single w13 TMA partition (gate+up concatenated)
+        tBsB_w13, tBgB_w13 = cpasync.tma_partition(
+            tma_b_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_w13_tiled, 0, 2),
+        )
+        tBsB_w13_up, _ = cpasync.tma_partition(
+            tma_b_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB_up, 0, 2),
+            cute.group_modes(gB_w13_tiled, 0, 2),
+        )
+        tBsSFB_w13, tBgSFB_w13 = cpasync.tma_partition(
+            tma_sfb_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB, 0, 2),
+            cute.group_modes(gSFB_w13_tiled, 0, 2),
+        )
+        tBsSFB_w13_up, _ = cpasync.tma_partition(
+            tma_sfb_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB_up, 0, 2),
+            cute.group_modes(gSFB_w13_tiled, 0, 2),
+        )
+        tBsB_w13_up = cute.filter_zeros(tBsB_w13_up)
+        tBsSFB_w13 = cute.filter_zeros(tBsSFB_w13)
+        tBgSFB_w13 = cute.filter_zeros(tBgSFB_w13)
+        tBsSFB_w13_up = cute.filter_zeros(tBsSFB_w13_up)
+
+        # B_down TMA partitions
+        gB_down = cute.local_tile(
+            mB_down,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        gSFB_down = cute.local_tile(
+            mSFB_down,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        tBsB_down, tBgB_down = cpasync.tma_partition(
+            tma_b_down,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_down, 0, 2),
+        )
+        tBsB_down_up, _ = cpasync.tma_partition(
+            tma_b_down,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB_up, 0, 2),
+            cute.group_modes(gB_down, 0, 2),
+        )
+        tBsSFB_down, tBgSFB_down = cpasync.tma_partition(
+            tma_sfb_down,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB, 0, 2),
+            cute.group_modes(gSFB_down, 0, 2),
+        )
+        tBsSFB_down = cute.filter_zeros(tBsSFB_down)
+        tBgSFB_down = cute.filter_zeros(tBgSFB_down)
+
+        # MMA fragment partitions
+        # sA is the 128-major atom for sub-128 tiles; slice to the tile_m sub-tile
+        # the V-map expects (offset applied per-task at consumption). Identity at
+        # tile_m>=128.
+        if cutlass.const_expr(self.sa_tiles_per_block > 1):
+            sA_part = cute.local_tile(
+                sA,
+                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                (Int32(0), 0, None),
+            )
+        else:
+            sA_part = sA
+        tCsA = thr_mma.partition_A(sA_part)
+        tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
+        # sSFA holds a full 128-row SF atom; for sub-128 MMA tiles slice it to the
+        # tile_m-row sub-tile the V-map expects. Identity when
+        # tile_m>=128 (sfa_tiles_per_block==1) so the 128 path is byte-identical.
+        if cutlass.const_expr(self.is_w4a8):
+            # Raw W4A8 loads scale bytes by row and never consumes the generic
+            # SFA fragment.  Specialize that unused copy/retile path away just
+            # as we do for SFB below; the raw operand contract is independent
+            # of the generic 128-row scale-factor atom.
+            sSFA_part = sSFA
+            tCrSFA = cute.make_rmem_tensor((1,), self.sf_dtype)
+        elif cutlass.const_expr(self.sfa_tiles_per_block > 1):
+            sSFA_part = cute.local_tile(
+                sSFA,
+                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                (Int32(0), 0, None),
+            )
+        else:
+            sSFA_part = sSFA
+        if cutlass.const_expr(not self.is_w4a8):
+            tCrSFA = self._dense_cls._partition_fragment_SFA(
+                self, sSFA_part[None, None, 0], thr_mma, tidx
+            )
+        tCsB = thr_mma.partition_B(sB)
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCrSFB = self._dense_cls._partition_fragment_SFB(
+            self, sSFB[None, None, 0], thr_mma, tidx
+        )
+
+        tCsC_for_shape = thr_mma.partition_C(sC[None, None, 0])
+        epi_m_scale = self.tile_shape_mnk[0] // self.epi_tile[0]
+        sub_shape = tCsC_for_shape.shape[:3]
+        acc_shape = (sub_shape[0], sub_shape[1] * epi_m_scale, sub_shape[2])
+        gate_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+        up_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        k_tile_cnt = cute.size(gA, mode=[3])
+        fc1_k_tile_cnt = k_tile_cnt
+        # Gated FC1 packs [up, gate] across N; relu2 has a single FC1 pass.
+        intermediate_tile_cnt = cute.size(gB_w13_tiled, mode=[2])
+        gate_tile_cnt = intermediate_tile_cnt
+        if self.is_gated:
+            gate_tile_cnt = intermediate_tile_cnt // Int32(2)
+        output_tile_cnt = cute.size(gB_down, mode=[2])
+        phase1_output_tile_cnt = output_tile_cnt
+        if cutlass.const_expr(self.materialize_intermediate):
+            # Phase A stops after activation quantization.  Phase B below owns
+            # the full-K FC2 contraction with a finer (M, N256) work domain.
+            phase1_output_tile_cnt = Int32(0)
+        rows_capacity = Int32(packed_a_storage.shape[0]) // cols
+
+        prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+        up_prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        up_cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+        phase2_prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        phase2_cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        num_k_blocks = cute.size(tCrA, mode=[2])
+
+        atom_ld_A = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+            self.a_dtype,
+        )
+        atom_ld_B = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+            self.b_dtype,
+        )
+        smem_copy_A = cute.make_tiled_copy_A(atom_ld_A, tiled_mma)
+        smem_copy_B = cute.make_tiled_copy_B(atom_ld_B, tiled_mma)
+        atom_ld_SF = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.sf_dtype)
+        smem_copy_SFA = cute.make_tiled_copy(
+            atom_ld_SF,
+            self._dense_cls._get_layoutSFA_TV(self, tiled_mma),
+            (
+                cute.size(tiled_mma.permutation_mnk[0]),
+                cute.size(tiled_mma.permutation_mnk[2]),
+            ),
+        )
+        smem_copy_SFB = cute.make_tiled_copy(
+            atom_ld_SF,
+            self._dense_cls._get_layoutSFB_TV(self, tiled_mma),
+            (
+                cute.size(tiled_mma.permutation_mnk[1]),
+                cute.size(tiled_mma.permutation_mnk[2]),
+            ),
+        )
+
+        thr_ld_A = smem_copy_A.get_slice(tidx)
+        thr_ld_B = smem_copy_B.get_slice(tidx)
+        csA = thr_ld_A.partition_S(sA_part)
+        crA = thr_ld_A.retile(tCrA)
+        csB = thr_ld_B.partition_S(sB)
+        csB_up = thr_ld_B.partition_S(sB_up)
+        crB = thr_ld_B.retile(tCrB)
+
+        thr_ld_SFA = smem_copy_SFA.get_slice(tidx)
+        thr_ld_SFB = smem_copy_SFB.get_slice(tidx)
+        if cutlass.const_expr(self.is_w4a8):
+            csSFA = sSFA_part
+            crSFA = tCrSFA
+        else:
+            csSFA = thr_ld_SFA.partition_S(sSFA_part)
+            crSFA = thr_ld_SFA.retile(tCrSFA)
+        csSFB = thr_ld_SFB.partition_S(sSFB)
+        csSFB_up = thr_ld_SFB.partition_S(sSFB_up)
+        # The W4A8 mainloop decodes its B scale bytes directly and never uses
+        # the generic SFB copy fragment.  With a four-warp N atom that generic
+        # copy cannot be retiled to the raw-MMA fragment, so avoid asking CuTe
+        # to form an unused (and invalid) mapping.
+        if cutlass.const_expr(self.is_w4a8):
+            crSFB = tCrSFB
+        else:
+            crSFB = thr_ld_SFB.retile(tCrSFB)
+
+        if cutlass.const_expr(self.swap_ab):
+            # Swapped FC1 (dense.py swap_ab pattern): the gate/up weight (sB /
+            # sB_up) feeds MMA-A on the 32-wide intermediate M-role; the
+            # activation (sA) feeds MMA-B on the token N-role. Fragment/copy
+            # templates are built at intermediate sub-tile 0 of the shared
+            # 128-row weight smem; the per-sub-tile 32-col slice + SF offset are
+            # applied inside the FC1 loop. FC2 keeps the unswapped fragments
+            # above. num_mma_warps matches, so warp partitioning is unchanged.
+            thr_mma_fc1 = fc1_tiled_mma.get_slice(tidx)
+            # Weight DATA: same fp4 dtype/atom as the activation, so re-view sB
+            # through the activation's 128-row atom layout (sub-32 sliceable).
+            sB_fc1 = storage.sB.get_tensor(
+                a_smem_staged.outer, swizzle=a_smem_staged.inner
+            )
+            # SF smem must match the tiled_mma that reads it. Under swap the
+            # weight SF takes the SFA role (FC1 SFA layout, 32-int) and the
+            # activation SF the SFB role (FC1 SFB layout, 128-token) -- using the
+            # base 128-tile SF layout here is the 'Unexpected index' root cause.
+            sSFB_fc1 = storage.sSFB.get_tensor(fc1_sfa_smem_staged)
+            # Activation SF keeps its ORIGINAL smem layout (as the producer wrote
+            # it); only the SFB thread-partition (swapped mma) re-roles it. Re-
+            # viewing it through fc1_sfb scrambles the token axis (dense partitions
+            # sSFA directly under swap_ab, it does not relayout it).
+            sSFA_fc1 = storage.sSFA.get_tensor(sfa_smem_staged)
+            sB_up_fc1 = storage.sB_up.get_tensor(
+                a_smem_staged.outer, swizzle=a_smem_staged.inner
+            )
+            sSFB_up_fc1 = storage.sSFB_up.get_tensor(fc1_sfa_smem_staged)
+            sB_sub0 = cute.local_tile(
+                sB_fc1,
+                cute.slice_(self.fc1_tile_shape_mnk, (None, 0, None)),
+                (Int32(0), 0, None),
+            )
+            sSFB_sub0 = cute.local_tile(
+                sSFB_fc1,
+                cute.slice_(self.fc1_tile_shape_mnk, (None, 0, None)),
+                (Int32(0), 0, None),
+            )
+            # Activation B-operand rides the padded token N-role; slice the
+            # 128-row activation atom to fc1_tok_tile tokens (offset 0 -- the one
+            # valid m-tile sits at the atom start, padding masked by valid_rows).
+            sA_part_sw = cute.local_tile(
+                sA,
+                cute.slice_(self.fc1_tile_shape_mnk, (0, None, None)),
+                (Int32(0), 0, None),
+            )
+            # MMA-A = weight sub-tile (data sB / SF sSFB->SFA);
+            # MMA-B = activation (data sA_part_sw / SF sSFA->SFB).
+            tCsA_sw = thr_mma_fc1.partition_A(sB_sub0)
+            tCrA_sw = fc1_tiled_mma.make_fragment_A(tCsA_sw[None, None, None, 0])
+            tCsB_sw = thr_mma_fc1.partition_B(sA_part_sw)
+            tCrB_sw = fc1_tiled_mma.make_fragment_B(tCsB_sw[None, None, None, 0])
+            tCrSFA_sw = self._dense_cls._partition_fragment_SFA(
+                self,
+                sSFB_sub0[None, None, 0],
+                thr_mma_fc1,
+                tidx,
+            )
+            # Activation SF rides the same fc1_tok_tile-wide N-slice as the
+            # activation data (sA_part_sw); slice the atom SF to match so the
+            # SFB fragment and the per-task copy (which re-slices at the task's
+            # token tile) agree in size.
+            _sSFA_fc1_n = cute.local_tile(
+                sSFA_fc1,
+                cute.slice_(self.fc1_tile_shape_mnk, (0, None, None)),
+                (Int32(0), 0, None),
+            )
+            tCrSFB_sw = self._dense_cls._partition_fragment_SFB(
+                self,
+                _sSFA_fc1_n[None, None, 0],
+                thr_mma_fc1,
+                tidx,
+            )
+            # swapped acc: [int-32 M-role, token N-role]
+            tCgC_sw = thr_mma_fc1.partition_C(
+                cute.make_identity_tensor(
+                    (self.fc1_tile_shape_mnk[0], self.fc1_tile_shape_mnk[1])
+                )
+            )
+            gate_acc_sw = cute.make_rmem_tensor(tCgC_sw.shape[:3], self.acc_dtype)
+            up_acc_sw = cute.make_rmem_tensor(tCgC_sw.shape[:3], self.acc_dtype)
+
+            # smem->rmem copy atoms for the swapped FC1 (A=weight uses b_dtype/
+            # b_layout, B=activation uses a_dtype/a_layout; SF TV-layouts from
+            # fc1_tiled_mma). Mirrors dense.py swap_ab (1118-1180).
+            atom_ld_A_sw = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                self.b_dtype,
+            )
+            atom_ld_B_sw = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                self.a_dtype,
+            )
+            smem_copy_A_sw = cute.make_tiled_copy_A(atom_ld_A_sw, fc1_tiled_mma)
+            smem_copy_B_sw = cute.make_tiled_copy_B(atom_ld_B_sw, fc1_tiled_mma)
+            smem_copy_SFA_sw = cute.make_tiled_copy(
+                atom_ld_SF,
+                self._dense_cls._get_layoutSFA_TV(self, fc1_tiled_mma),
+                (
+                    cute.size(fc1_tiled_mma.permutation_mnk[0]),
+                    cute.size(fc1_tiled_mma.permutation_mnk[2]),
+                ),
+            )
+            smem_copy_SFB_sw = cute.make_tiled_copy(
+                atom_ld_SF,
+                self._dense_cls._get_layoutSFB_TV(self, fc1_tiled_mma),
+                (
+                    cute.size(fc1_tiled_mma.permutation_mnk[1]),
+                    cute.size(fc1_tiled_mma.permutation_mnk[2]),
+                ),
+            )
+            thr_ld_A_sw = smem_copy_A_sw.get_slice(tidx)
+            thr_ld_B_sw = smem_copy_B_sw.get_slice(tidx)
+            thr_ld_SFA_sw = smem_copy_SFA_sw.get_slice(tidx)
+            thr_ld_SFB_sw = smem_copy_SFB_sw.get_slice(tidx)
+            crA_sw = thr_ld_A_sw.retile(tCrA_sw)
+            crB_sw = thr_ld_B_sw.retile(tCrB_sw)
+            crSFA_sw = thr_ld_SFA_sw.retile(tCrSFA_sw)
+            crSFB_sw = thr_ld_SFB_sw.retile(tCrSFB_sw)
+
+        # ===================================================================
+        # Per-warp setup for the consumer steady state
+        # ===================================================================
+        if warp_idx < self.num_mma_warps:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+        elif warp_idx < self.tma_load_warp_id + self.num_dma_warps:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+        # ===================================================================
+        # Consumer steady state: pop one ready task per CTA, then let
+        # the MMA and producer warps cooperate on that task.
+        # ===================================================================
+        if cutlass.const_expr(self.is_w4a8):
+            # w4a8 operand views and smem addresses, hoisted out of the
+            # consumer loop (loop state must be purely dynamic expressions).
+            lane_c = Int32(tidx) & Int32(3)
+            lane_g = (Int32(tidx) & Int32(31)) >> Int32(2)
+            # Pin the logical m16n8 fragment coordinates in closed form.  A
+            # layout-tensor implementation is tempting here, but carrying the
+            # identity tensor through both GEMMs makes ptxas materialize large
+            # amounts of address state (and caused local-memory spills under
+            # CUTLASS DSL 4.6).  These expressions are the measured CuTe MMA
+            # V-map for each atom shape used by this kernel.
+            w4a8_m_warp_offset = Int32(0)
+            w4a8_m_block_stride = Int32(16)
+            if cutlass.const_expr(self.w4a8_m128_materialized):
+                # atom (2,4,1): two M warps, four permuted N warps.
+                w4a8_n8_thread_base = (
+                    ((Int32(tidx) & Int32(64)) >> Int32(2))
+                    | ((Int32(tidx) & Int32(128)) >> Int32(4))
+                    | lane_g
+                )
+                w4a8_m_warp_offset = (warp_idx & Int32(1)) * Int32(16)
+                w4a8_m_block_stride = Int32(32)
+            elif cutlass.const_expr(self.w4a8_small):
+                # atom (1,4,1): one M warp, four permuted N warps.
+                w4a8_n8_thread_base = (
+                    ((Int32(tidx) & Int32(32)) >> Int32(1))
+                    | ((Int32(tidx) & Int32(64)) >> Int32(3))
+                    | lane_g
+                )
+            elif cutlass.const_expr(self.tile_shape_mnk[0] == 64):
+                # atom (4,2,1): four M warps, two N warps.
+                w4a8_n8_thread_base = ((Int32(tidx) & Int32(128)) >> Int32(3)) | lane_g
+                w4a8_m_warp_offset = (Int32(tidx) & Int32(96)) >> Int32(1)
+                w4a8_m_block_stride = Int32(64)
+            else:
+                # Generic M128 atom (2,2,1): two M warps, two N warps.
+                w4a8_n8_thread_base = ((Int32(tidx) & Int32(64)) >> Int32(2)) | lane_g
+                w4a8_m_warp_offset = (Int32(tidx) & Int32(32)) >> Int32(1)
+                w4a8_m_block_stride = Int32(32)
+            n_k32_per_tile = self.tile_shape_mnk[2] // 32
+            a_u32_per_row = cols // Int32(4)
+            a_mx_per_row = cols // Int32(32)
+            pa_u32 = cute.recast_tensor(packed_a_storage, cutlass.Uint32)
+            sa_flat_addr = ctrl_base_addr + Int32(Storage._offsets["sA"])
+            # Double-buffered staging regions (repurposed; TMA is off under
+            # w4a8): B tiles in sB/sB_up, SFB byte rows in sSFB, residual
+            # byte rows in sSFB_up, A-scale byte rows in sSFA.
+            w4a8_sb0 = ctrl_base_addr + Int32(Storage._offsets["sB"])
+            # FC1 A tiles double-buffer through the sC region (32KB, provably
+            # free during the FC1 mainloop: the epilogue writes it afterwards).
+            # Staging depth: 4 buffers for small tiles (the DRAM-bound bands
+            # need memory-level parallelism, and capacity allows it); 2 for
+            # tile 128. Depth-4 layout: B unpadded 64B rows, two bufs per sB
+            # region; A bufs in sA past the FC2-intermediate bytes; FC1
+            # residual bufs in sC (dead until the epilogue rendezvous); FC2
+            # residual bufs alias the (FC1-only) A-buf region.
+            if cutlass.const_expr(self.w4a8_repacked):
+                w4a8_sa0 = (
+                    ctrl_base_addr
+                    + Int32(Storage._offsets["sA"])
+                    + Int32(self.tile_shape_mnk[0] * self.tile_shape_mnk[2])
+                )
+                w4a8_res0 = ctrl_base_addr + Int32(Storage._offsets["sC"])
+                w4a8_res2 = w4a8_sa0
+            elif cutlass.const_expr(self.w4a8_small):
+                w4a8_sa0 = (
+                    ctrl_base_addr
+                    + Int32(Storage._offsets["sA"])
+                    + Int32(self.tile_shape_mnk[0] * self.tile_shape_mnk[2])
+                )
+                w4a8_res0 = ctrl_base_addr + Int32(Storage._offsets["sC"])
+                w4a8_res2 = w4a8_sa0
+            else:
+                w4a8_sa0 = ctrl_base_addr + Int32(Storage._offsets["sC"])
+                w4a8_res0 = ctrl_base_addr + Int32(Storage._offsets["sSFB_up"])
+                w4a8_res2 = ctrl_base_addr + Int32(Storage._offsets["sSFB_up"])
+            w4a8_pipe_addr = ctrl_base_addr + Int32(Storage._offsets["w4a8_pipe"])
+            w4a8_sb1 = ctrl_base_addr + Int32(Storage._offsets["sB_up"])
+            w4a8_sfbb = ctrl_base_addr + Int32(Storage._offsets["sSFB"])
+            w4a8_resb = ctrl_base_addr + Int32(Storage._offsets["sSFB_up"])
+
+        # w4a8 TMA-B: per-mbarrier phase bits, owned by producer warps.
+        # Persist across tasks (mbarriers are init'd once; epochs reset per
+        # task but phases must not).
+        w4a8_mbar_phase = Int32(0)
+
+        # One normalized item per thread.  The CTA leader decodes a source slot
+        # into this shape and broadcasts it through ``ctrl``; every role then
+        # loads the five fields once and keeps them in registers for the whole
+        # FC1/activation/FC2 pipeline.
+        work_item = cute.make_rmem_tensor((_WORK_ITEM_FIELDS,), Int32)
+        materialized_slot = Int32(bidz)
+        materialized_tail = Int32(0)
+        if cutlass.const_expr(self.w4a8_m1_materialized):
+            materialized_tail = total_pairs * route_gate_tile_cnt
+        elif cutlass.const_expr(self.work_is_persistent_grid):
+            materialized_tail = _ld_global_acquire_i32(
+                get_ptr_as_int64(task_tail, Int32(0))
+            )
+        consumer_live = (
+            Int32(0) if cutlass.const_expr(self.external_materialized_fc1) else Int32(1)
+        )
+        while consumer_live > Int32(0):
+            if cutlass.const_expr(self.w4a8_m1_materialized):
+                # Fixed M=1 domain: one item per (route, intermediate K128
+                # slice).  The slot itself is all the scheduling metadata.
+                cute.arch.sync_threads()
+                has_task = Int32(0)
+                is_done = Int32(0)
+                if materialized_slot < materialized_tail:
+                    route_idx = materialized_slot // route_gate_tile_cnt
+                    route_slice = materialized_slot - route_idx * route_gate_tile_cnt
+                    work_item[_WORK_EXPERT] = topk_ids[route_idx].to(Int32)
+                    work_item[_WORK_M_TILE] = route_idx
+                    work_item[_WORK_SLICE_BEGIN] = route_slice
+                    work_item[_WORK_SLICE_COUNT] = Int32(1)
+                    work_item[_WORK_VALID_ROWS] = Int32(1)
+                    has_task = Int32(1)
+                else:
+                    is_done = Int32(1)
+                materialized_slot += Int32(gdim_z)
+            elif cutlass.const_expr(self.work_is_persistent_grid):
+                # A real grid scheduler needs no queue-control emulation: all
+                # threads in a CTA share the arithmetic slot, decode it into
+                # registers, and use the rendezvous only to finish the prior
+                # task before reusing shared storage.
+                cute.arch.sync_threads()
+                has_task = Int32(0)
+                is_done = Int32(0)
+                if materialized_slot < materialized_tail:
+                    self._decode_materialized_work_item(
+                        work_item,
+                        task_expert,
+                        task_valid_rows,
+                        materialized_slot,
+                        materialized_num_groups,
+                        task_slice_chunk,
+                        route_gate_tile_cnt,
+                    )
+                    has_task = Int32(1)
+                else:
+                    is_done = Int32(1)
+                materialized_slot += Int32(gdim_z)
+            else:
+                if is_cta_leader > Int32(0):
+                    _st_shared_i32(ctrl_base_addr + Int32(_CTRL_HAS_WORK * 4), Int32(0))
+                    _st_shared_i32(ctrl_base_addr + Int32(_CTRL_DONE * 4), Int32(0))
+                    _st_shared_i32(
+                        ctrl_base_addr + Int32(_CTRL_CLAIMED_SLOT * 4), Int32(0)
+                    )
+                    if cutlass.const_expr(self.work_is_streaming):
+                        head = _ld_global_acquire_i32(
+                            get_ptr_as_int64(task_head, Int32(0))
+                        )
+                        tail = _ld_global_acquire_i32(
+                            get_ptr_as_int64(task_tail, Int32(0))
+                        )
+                        if head < tail:
+                            prev_head = _atomic_cas_global_i32(
+                                get_ptr_as_int64(task_head, Int32(0)),
+                                head,
+                                head + Int32(1),
+                            )
+                            if prev_head == head:
+                                _spin_wait_global_eq_i32(
+                                    get_ptr_as_int64(task_ready, head), Int32(0)
+                                )
+                                self._decode_ready_work_item(
+                                    work_item,
+                                    task_expert,
+                                    task_m_tile,
+                                    task_slice_begin,
+                                    task_slice_count,
+                                    task_valid_rows,
+                                    head,
+                                )
+                                self._store_shared_work_item(ctrl_base_addr, work_item)
+                                _st_shared_i32(
+                                    ctrl_base_addr + Int32(_CTRL_HAS_WORK * 4),
+                                    Int32(1),
+                                )
+                                _st_shared_i32(
+                                    ctrl_base_addr + Int32(_CTRL_CLAIMED_SLOT * 4),
+                                    head,
+                                )
+                        else:
+                            if _ld_global_acquire_i32(
+                                get_ptr_as_int64(all_work_published, Int32(0))
+                            ) > Int32(0):
+                                _st_shared_i32(
+                                    ctrl_base_addr + Int32(_CTRL_DONE * 4),
+                                    Int32(1),
+                                )
+                    else:
+                        slot = atomic_add_global_i32(
+                            get_ptr_as_int64(task_head, Int32(0)), Int32(1)
+                        )
+                        tail = _ld_global_acquire_i32(
+                            get_ptr_as_int64(task_tail, Int32(0))
+                        )
+                        if slot < tail:
+                            self._decode_materialized_work_item(
+                                work_item,
+                                task_expert,
+                                task_valid_rows,
+                                slot,
+                                materialized_num_groups,
+                                task_slice_chunk,
+                                route_gate_tile_cnt,
+                            )
+                            self._store_shared_work_item(ctrl_base_addr, work_item)
+                            _st_shared_i32(
+                                ctrl_base_addr + Int32(_CTRL_HAS_WORK * 4),
+                                Int32(1),
+                            )
+                            _st_shared_i32(
+                                ctrl_base_addr + Int32(_CTRL_CLAIMED_SLOT * 4),
+                                slot,
+                            )
+                        else:
+                            _st_shared_i32(
+                                ctrl_base_addr + Int32(_CTRL_DONE * 4), Int32(1)
+                            )
+                cute.arch.sync_threads()
+                has_task = _ld_shared_i32(ctrl_base_addr + Int32(_CTRL_HAS_WORK * 4))
+                is_done = _ld_shared_i32(ctrl_base_addr + Int32(_CTRL_DONE * 4))
+            if has_task > Int32(0) and cutlass.const_expr(self.work_is_streaming):
+                claimed_slot = _ld_shared_i32(
+                    ctrl_base_addr + Int32(_CTRL_CLAIMED_SLOT * 4)
+                )
+                _ld_global_acquire_i32(get_ptr_as_int64(task_ready, claimed_slot))
+            if has_task > Int32(0):
+                if cutlass.const_expr(
+                    not self.work_is_persistent_grid and not self.w4a8_m1_materialized
+                ):
+                    self._load_shared_work_item(work_item, ctrl_base_addr)
+                task_m_tile_idx_cache = work_item[_WORK_M_TILE]
+                task_valid_rows_cache = work_item[_WORK_VALID_ROWS]
+                tile_m_base_cache = task_m_tile_idx_cache * Int32(
+                    self.tile_shape_mnk[0]
+                )
+                cache_row = Int32(tidx)
+                while cache_row < Int32(self.tile_shape_mnk[0]):
+                    tok = Int32(0)
+                    wv = cutlass.Float32(0.0)
+                    if cache_row < task_valid_rows_cache:
+                        global_row_cache = tile_m_base_cache + cache_row
+                        tok = token_map[global_row_cache].to(Int32)
+                        wv = token_weights[global_row_cache].to(cutlass.Float32)
+                    _st_shared_i32(scatter_tok_base_addr + cache_row * Int32(4), tok)
+                    st_shared_f32(scatter_weight_base_addr + cache_row * Int32(4), wv)
+                    cache_row += Int32(self.threads_per_cta)
+                if cutlass.const_expr(self.is_w4a8):
+                    if Int32(tidx) < Int32(8):
+                        _st_shared_i32(
+                            w4a8_pipe_addr + Int32(tidx) * Int32(4), Int32(0)
+                        )
+                cute.arch.sync_threads()
+            if has_task == Int32(0):
+                if is_done > Int32(0):
+                    consumer_live = Int32(0)
+            elif warp_idx < self.num_mma_warps:
+                task_expert_idx = work_item[_WORK_EXPERT]
+                task_m_tile_idx = work_item[_WORK_M_TILE]
+                task_slice_begin_idx = work_item[_WORK_SLICE_BEGIN]
+                task_slice_count_val = work_item[_WORK_SLICE_COUNT]
+                task_valid_rows_val = work_item[_WORK_VALID_ROWS]
+
+                alpha_value = alpha[task_expert_idx].to(cutlass.Float32)
+                if cutlass.const_expr(self.is_w4a8):
+                    # w4a8 activations are self-ranging: the calibrated input
+                    # global scale is NOT applied at quantize time, so fold it
+                    # out of the combined nvfp4 alpha to leave the pure weight
+                    # dequant alpha (alpha_nvfp4 = 1/(gs_act * gs_w)).
+                    alpha_value = alpha_value * input_global_scale[task_expert_idx].to(
+                        cutlass.Float32
+                    )
+                valid_rows = task_valid_rows_val
+
+                # In-loop SFA partition for sub-128 tiles. FC1 reads the
+                # TMA-loaded activation SF, whose rows sit at offset
+                # (task_m_tile_idx % sfa_tiles_per_block) within the shared
+                # 128-row atom. (FC2 re-slices at offset 0 before phase B, since
+                # its intermediate SF is quant-written to the atom's first half.)
+                if cutlass.const_expr(
+                    (not self.is_w4a8) and self.sfa_tiles_per_block > 1
+                ):
+                    _fc1_off = task_m_tile_idx % Int32(self.sfa_tiles_per_block)
+                    _sA_il = cute.local_tile(
+                        sA,
+                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                        (_fc1_off, 0, None),
+                    )
+                    tCrA = tiled_mma.make_fragment_A(
+                        thr_mma.partition_A(_sA_il)[None, None, None, 0]
+                    )
+                    csA = thr_ld_A.partition_S(_sA_il)
+                    crA = thr_ld_A.retile(tCrA)
+                    _sSFA_il = cute.local_tile(
+                        sSFA,
+                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                        (_fc1_off, 0, None),
+                    )
+                    tCrSFA = self._dense_cls._partition_fragment_SFA(
+                        self,
+                        _sSFA_il[None, None, 0],
+                        thr_mma,
+                        tidx,
+                    )
+                    csSFA = thr_ld_SFA.partition_S(_sSFA_il)
+                    crSFA = thr_ld_SFA.retile(tCrSFA)
+
+                _is_m_major = self.c_layout.is_m_major_c()
+                copy_atom_r2s = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.BFloat16,
+                )
+                copy_atom_C = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
+                    cutlass.BFloat16,
+                )
+                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+                tiled_copy_r2s = cute.make_tiled_copy_S(
+                    copy_atom_r2s, tiled_copy_C_Atom
+                )
+
+                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                tRS_sD = thr_copy_r2s.partition_D(sC)
+                tRS_rGate = tiled_copy_r2s.retile(gate_acc)
+                tRS_rUp = tiled_copy_r2s.retile(up_acc)
+
+                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+                tRS_rD_out = cute.make_rmem_tensor(
+                    tRS_rD_layout.shape, cutlass.BFloat16
+                )
+
+                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rGate, mode=[1])
+                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rGate, mode=[2])
+                epi_buffer = Int32(0)
+
+                down_alpha_value = down_alpha[task_expert_idx].to(cutlass.Float32)
+                if cutlass.const_expr(self.is_w4a8):
+                    down_alpha_value = down_alpha_value * global_scale[
+                        task_expert_idx
+                    ].to(cutlass.Float32)
+                down_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+                epi_rest_m = self.tile_shape_mnk[0] // self.epi_tile[0]
+                MmaMPerEpiM = self.epi_tile[0] // mma_tile_m
+                MmaNPerEpiN = self.epi_tile[1] // mma_tile_n
+                fc2_m_tiles = cute.size(tCrA, mode=[1])
+                fc2_n_tiles = cute.size(tCrB, mode=[1])
+
+                fc1_m_tiles = cute.size(tCrA, mode=[1])
+                fc1_n_tiles = cute.size(tCrB, mode=[1])
+                slice_idx = Int32(0)
+                while slice_idx < task_slice_count_val:
+                    # FC2 rebinds A/SFA to the quantized intermediate at offset
+                    # zero. Restore FC1's routed-input slice before every
+                    # additional intermediate slice in a grouped task.
+                    if cutlass.const_expr(
+                        self.deterministic_output
+                        and (not self.is_w4a8)
+                        and self.sfa_tiles_per_block > 1
+                    ):
+                        _fc1_off = task_m_tile_idx % Int32(self.sfa_tiles_per_block)
+                        _sA_il = cute.local_tile(
+                            sA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (_fc1_off, 0, None),
+                        )
+                        tCrA = tiled_mma.make_fragment_A(
+                            thr_mma.partition_A(_sA_il)[None, None, None, 0]
+                        )
+                        csA = thr_ld_A.partition_S(_sA_il)
+                        crA = thr_ld_A.retile(tCrA)
+                        _sSFA_il = cute.local_tile(
+                            sSFA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (_fc1_off, 0, None),
+                        )
+                        tCrSFA = self._dense_cls._partition_fragment_SFA(
+                            self, _sSFA_il[None, None, 0], thr_mma, tidx
+                        )
+                        csSFA = thr_ld_SFA.partition_S(_sSFA_il)
+                        crSFA = thr_ld_SFA.retile(tCrSFA)
+
+                    # ============================================================
+                    # PHASE A: FC1 for this slice (gate/only pass, plus up for silu)
+                    # ============================================================
+
+                    if cutlass.const_expr(self.swap_ab):
+                        # === Swapped FC1: produce this 128-int slice as n_sub x
+                        # 32-int sub-tiles (weight on MMA M, tokens on N), then a
+                        # transposed silu-store into sC[token,int] so the shared
+                        # quant below packs it into sA exactly as the normal path.
+                        n_sub = self.tile_shape_mnk[1] // self._fc1_int_tile
+                        n_mt = gate_acc_sw.shape[1]
+                        fz_crSFA_sw = cute.filter_zeros(crSFA_sw)
+                        fz_crSFB_sw = cute.filter_zeros(crSFB_sw)
+                        _nnt = cute.size(tCrB_sw, mode=[1])
+                        # Accumulators carry the MMA m-tiles (a 32-int sub-tile
+                        # spans n_mt MMA m16-tiles), the token n-tiles, and the
+                        # n_sub index (which 32-int sub-tile of the 128-int slice).
+                        # A Python list of tensors can't be tree-flattened as
+                        # while-loop state, so use one rmem tensor each. n_sub is the
+                        # OUTERMOST mode so a per-sub slice [None,:,:,_s] is compact
+                        # ((atom),m_tile,n_tile) -- identical to dense's accumulator,
+                        # which _reshape_acc_to_mn expects for the transposed store.
+                        sw_gate = cute.make_rmem_tensor(
+                            (gate_acc_sw.shape[0], n_mt, gate_acc_sw.shape[2], n_sub),
+                            self.acc_dtype,
+                        )
+                        sw_up = cute.make_rmem_tensor(
+                            (up_acc_sw.shape[0], n_mt, up_acc_sw.shape[2], n_sub),
+                            self.acc_dtype,
+                        )
+                        sw_gate.fill(0.0)
+                        sw_up.fill(0.0)
+                        _int_k = (self._fc1_int_tile, self.tile_shape_mnk[2])
+                        _sf_slice = cute.slice_(
+                            self.fc1_tile_shape_mnk, (None, 0, None)
+                        )
+                        # task_m_tile_idx is a GLOBAL packed-tile index; this task's
+                        # valid tokens sit at token m-tile _fc1_off within the 128-row
+                        # activation atom. Select the fc1_tok_tile-wide N-slice that
+                        # holds that m-tile (offset 0 when the atom is one such slice),
+                        # and re-base the valid tokens to sC rows 0..valid_rows in the
+                        # store via _tok_sub_off (the shared quant/scatter expect that).
+                        _tiles_per_tok = self._fc1_tok_tile // self.tile_shape_mnk[0]
+                        if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                            _fc1_off_sw = task_m_tile_idx % Int32(
+                                self.sfa_tiles_per_block
+                            )
+                        else:
+                            _fc1_off_sw = Int32(0)
+                        _tok_tile_idx = _fc1_off_sw // Int32(_tiles_per_tok)
+                        _tok_sub_off = (
+                            _fc1_off_sw - _tok_tile_idx * Int32(_tiles_per_tok)
+                        ) * Int32(self.tile_shape_mnk[0])
+                        _tok_nslice = cute.slice_(
+                            self.fc1_tile_shape_mnk, (0, None, None)
+                        )
+                        sA_part_sw_t = cute.local_tile(
+                            sA, _tok_nslice, (_tok_tile_idx, 0, None)
+                        )
+                        sSFA_fc1_t = cute.local_tile(
+                            sSFA_fc1, _tok_nslice, (_tok_tile_idx, 0, None)
+                        )
+                        _csB = thr_ld_B_sw.partition_S(sA_part_sw_t)
+                        _fz_csSFB = cute.filter_zeros(
+                            thr_ld_SFB_sw.partition_S(sSFA_fc1_t)
+                        )
+
+                        cons_state.reset_count()
+                        for _kt in range(fc1_k_tile_cnt):
+                            _pk = ml_pipeline.consumer_try_wait(cons_state)
+                            ml_pipeline.consumer_wait(cons_state, _pk)
+                            _i = cons_state.index
+                            for _kb in cutlass.range_constexpr(num_k_blocks):
+                                cute.copy(
+                                    smem_copy_B_sw,
+                                    _csB[None, None, _kb, _i],
+                                    crB_sw[None, None, _kb],
+                                )
+                                cute.copy(
+                                    smem_copy_SFB_sw,
+                                    _fz_csSFB[None, None, _kb, _i],
+                                    fz_crSFB_sw[None, None, _kb],
+                                )
+                                for _s in cutlass.range_constexpr(n_sub):
+                                    # gate sub _s = atom-lo (sB/sSFB) at within-atom
+                                    # sub gate_lo_sub+_s while that stays < n_sub,
+                                    # else atom-hi (sB_up/sSFB_up). For a 128-aligned
+                                    # forced swap (gate_lo_sub==0) every sub is in
+                                    # atom-lo at offset _s (the verified n=384 path).
+                                    if cutlass.const_expr(_s < n_sub - gate_lo_sub):
+                                        _g_data = sB_fc1
+                                        _g_sf = sSFB_fc1
+                                        _g_sub = gate_lo_sub + _s
+                                    else:
+                                        _g_data = sB_up_fc1
+                                        _g_sf = sSFB_up_fc1
+                                        _g_sub = _s - (n_sub - gate_lo_sub)
+                                    _csA_s = thr_ld_A_sw.partition_S(
+                                        cute.local_tile(
+                                            _g_data, _int_k, (Int32(_g_sub), 0, None)
+                                        )
+                                    )
+                                    _csSFA_s = thr_ld_SFA_sw.partition_S(
+                                        cute.local_tile(
+                                            _g_sf, _sf_slice, (Int32(_g_sub), 0, None)
+                                        )
+                                    )
+                                    cute.copy(
+                                        smem_copy_A_sw,
+                                        _csA_s[None, None, _kb, _i],
+                                        crA_sw[None, None, _kb],
+                                    )
+                                    cute.copy(
+                                        smem_copy_SFA_sw,
+                                        cute.filter_zeros(_csSFA_s)[
+                                            None, None, _kb, _i
+                                        ],
+                                        fz_crSFA_sw[None, None, _kb],
+                                    )
+                                    for _mt in cutlass.range_constexpr(n_mt):
+                                        for _nt in cutlass.range_constexpr(_nnt):
+                                            mma_atom.set(
+                                                WarpField.SFA,
+                                                tCrSFA_sw[None, _mt, _kb].iterator,
+                                            )
+                                            mma_atom.set(
+                                                WarpField.SFB,
+                                                tCrSFB_sw[None, _nt, _kb].iterator,
+                                            )
+                                            cute.gemm(
+                                                mma_atom,
+                                                sw_gate[None, _mt, _nt, _s],
+                                                tCrA_sw[None, _mt, _kb],
+                                                tCrB_sw[None, _nt, _kb],
+                                                sw_gate[None, _mt, _nt, _s],
+                                            )
+                            ml_pipeline.consumer_release(cons_state)
+                            cons_state.advance()
+                        self.pass_gate_barrier.arrive_unaligned()
+
+                        up_cons_state.reset_count()
+                        for _kt in range(fc1_k_tile_cnt):
+                            _pk = up_pipeline.consumer_try_wait(up_cons_state)
+                            up_pipeline.consumer_wait(up_cons_state, _pk)
+                            _i = up_cons_state.index
+                            for _kb in cutlass.range_constexpr(num_k_blocks):
+                                cute.copy(
+                                    smem_copy_B_sw,
+                                    _csB[None, None, _kb, _i],
+                                    crB_sw[None, None, _kb],
+                                )
+                                cute.copy(
+                                    smem_copy_SFB_sw,
+                                    _fz_csSFB[None, None, _kb, _i],
+                                    fz_crSFB_sw[None, None, _kb],
+                                )
+                                for _s in cutlass.range_constexpr(n_sub):
+                                    _csA_s = thr_ld_A_sw.partition_S(
+                                        cute.local_tile(
+                                            sB_up_fc1, _int_k, (Int32(_s), 0, None)
+                                        )
+                                    )
+                                    _csSFA_s = thr_ld_SFA_sw.partition_S(
+                                        cute.local_tile(
+                                            sSFB_up_fc1, _sf_slice, (Int32(_s), 0, None)
+                                        )
+                                    )
+                                    cute.copy(
+                                        smem_copy_A_sw,
+                                        _csA_s[None, None, _kb, _i],
+                                        crA_sw[None, None, _kb],
+                                    )
+                                    cute.copy(
+                                        smem_copy_SFA_sw,
+                                        cute.filter_zeros(_csSFA_s)[
+                                            None, None, _kb, _i
+                                        ],
+                                        fz_crSFA_sw[None, None, _kb],
+                                    )
+                                    for _mt in cutlass.range_constexpr(n_mt):
+                                        for _nt in cutlass.range_constexpr(_nnt):
+                                            mma_atom.set(
+                                                WarpField.SFA,
+                                                tCrSFA_sw[None, _mt, _kb].iterator,
+                                            )
+                                            mma_atom.set(
+                                                WarpField.SFB,
+                                                tCrSFB_sw[None, _nt, _kb].iterator,
+                                            )
+                                            cute.gemm(
+                                                mma_atom,
+                                                sw_up[None, _mt, _nt, _s],
+                                                tCrA_sw[None, _mt, _kb],
+                                                tCrB_sw[None, _nt, _kb],
+                                                sw_up[None, _mt, _nt, _s],
+                                            )
+                            up_pipeline.consumer_release(up_cons_state)
+                            up_cons_state.advance()
+
+                        sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
+                        packed_cols = Int32(self.tile_shape_mnk[2] // 2)
+                        sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
+                        # transposed silu-store (dense.py swap_ab epilogue pattern):
+                        # reshape the swapped acc (M-role=int, N-role=token) and the
+                        # matching identity coords through _reshape_acc_to_mn so the
+                        # MMA fragment's value layout is regrouped into a logical
+                        # (M,N) grid -- a manual flat-element walk does NOT align the
+                        # compact acc with the native coord layout. coord[0]=int,
+                        # coord[1]=token; store sC[token, s*32+int].
+                        _coord_sw = thr_mma_fc1.partition_C(
+                            cute.make_identity_tensor(
+                                (self.fc1_tile_shape_mnk[0], self.fc1_tile_shape_mnk[1])
+                            )
+                        )
+                        _coord_mn = _reshape_acc_to_mn(_coord_sw, transpose=True)
+                        # For a non-128-aligned n the last slice is partial; zero
+                        # its tail int cols (global int >= n) so the FC2 (which
+                        # contracts a full 128-int tile against TMA-zero-filled
+                        # b_down) ignores them. global int base = slice*128.
+                        _n_total = mB_w13.shape[0] // 2
+                        _gslice = task_slice_begin_idx + slice_idx
+                        _int_base = _gslice * Int32(self.tile_shape_mnk[1])
+                        for _s in cutlass.range_constexpr(n_sub):
+                            _g_mn = _reshape_acc_to_mn(
+                                sw_gate[None, None, None, _s], transpose=True
+                            )
+                            _u_mn = _reshape_acc_to_mn(
+                                sw_up[None, None, None, _s], transpose=True
+                            )
+                            for _am in cutlass.range_constexpr(
+                                cute.size(_g_mn.shape[0])
+                            ):
+                                for _an in cutlass.range_constexpr(
+                                    cute.size(_g_mn.shape[1])
+                                ):
+                                    _c = _coord_mn[_am, _an]
+                                    _ir = _c[0]
+                                    _tk = _c[1]
+                                    _g = alpha_value * _g_mn[_am, _an]
+                                    _u = alpha_value * _u_mn[_am, _an]
+                                    _int_col = _s * self._fc1_int_tile + _ir
+                                    _val = self._gated_activation_value(_g, _u).to(
+                                        cutlass.BFloat16
+                                    )
+                                    if cutlass.const_expr(
+                                        _n_total % self.tile_shape_mnk[1] != 0
+                                    ):
+                                        if _int_base + _int_col >= Int32(_n_total):
+                                            _val = cutlass.BFloat16(0.0)
+                                    _local_tk = _tk - _tok_sub_off
+                                    if _local_tk >= Int32(0) and _local_tk < valid_rows:
+                                        sC[_local_tk, _int_col, 0] = _val
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        # quant sC[token,int] -> sA (same packing as the normal path)
+                        _epi_rows = valid_rows
+                        if _epi_rows > Int32(self.epi_tile[0]):
+                            _epi_rows = Int32(self.epi_tile[0])
+                        _qgs = global_scale[task_expert_idx].to(cutlass.Float32)
+                        _qi = Int32(tidx)
+                        while _qi < _epi_rows * sf_blocks_per_row:
+                            _lr = _qi // sf_blocks_per_row
+                            row = _lr
+                            _sfb = _qi - _lr * sf_blocks_per_row
+                            _bs = _sfb * Int32(16)
+                            values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                            block_max = cutlass.Float32(0.0)
+                            for elem_idx in cutlass.range_constexpr(16):
+                                value = cutlass.Float32(sC[_lr, _bs + elem_idx, 0])
+                                values[elem_idx] = value
+                                block_max = fmax_f32(block_max, fabs_f32(value))
+                            packed64 = Uint64(0)
+                            scale_byte = Uint8(0)
+                            if self.is_gated and self.fast_math:
+                                packed64, scale_byte = quantize_block_fp4_fast(
+                                    values, block_max, _qgs
+                                )
+                            else:
+                                packed64, scale_byte = quantize_block_fp4(
+                                    values, block_max, _qgs
+                                )
+                            packed_base = _sfb << Int32(3)
+                            dst_pcol = row & Int32(63)
+                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                            row_high = row >> Int32(6)
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                sA_u8[dst_flat] = Uint8(
+                                    (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                            outer_m_idx = row % Int32(32)
+                            inner_m_idx = row // Int32(32)
+                            inner_k_idx = _sfb % Int32(4)
+                            k_tile_idx = _sfb // Int32(4)
+                            sf_raw_idx = (
+                                k_tile_idx * Int32(32 * 4 * 4)
+                                + outer_m_idx * Int32(4 * 4)
+                                + inner_m_idx * Int32(4)
+                                + inner_k_idx
+                            )
+                            st_shared_u8(sfa_base_addr + sf_raw_idx, scale_byte)
+                            _qi += Int32(self.num_mma_warps * self.num_threads_per_warp)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                    if cutlass.const_expr(self.is_w4a8):
+                        # ===== w4a8 FC1: direct-global operands, raw FP8 MMA =====
+                        # Re-assert the MMA warps' register budget at the top of
+                        # the w4a8 hot region: without a dominating setmaxnreg,
+                        # ptxas register-targets for occupancy (observed: 40-reg
+                        # compile, accumulators spilled around every QMMA).
+                        cute.arch.setmaxregister_increase(self.mma_register_requirement)
+                        # Probe-pinned addressing (tests/test_w4a8_fragment_probe):
+                        # lane t (c=t%4, g=t/4) expands the packed-FP4 word for
+                        # orig k [K0+8c, +8) into the (b0,b1) regs of the k32
+                        # mxf8f6f4 atom; A regs are contiguous u32 loads; SFA row
+                        # r is read from lanes 4*(r%8)+(r//8) byte 0, SFB col n
+                        # from lane 4n byte 0.
+                        # Accumulate into a FLAT rmem tensor (simple strides,
+                        # constant indices): the nested partition_C layout of
+                        # gate_acc/up_acc defeats register promotion under
+                        # scalar element access (observed: 40-reg compile with
+                        # GBs of local spill traffic). Results copy into the
+                        # layout-native accumulators once per pass for the
+                        # shared epilogue.
+                        # Two passes (gate, then up) keep one 128-register
+                        # accumulator hot at a time -- interleaving both blows the
+                        # 232-register budget and thrashes spills. Per k32 block
+                        # the B words for all n-atoms are loaded and expanded
+                        # once into register arrays (the m-atom loop reuses
+                        # them), batching the global loads back-to-back for
+                        # memory-level parallelism.
+                        # fc1_k_tile_cnt counts 128-wide FP4-position tiles over
+                        # the byte-backed packed_a view (2K positions); the E4M3
+                        # contraction advances 128 BYTES per iteration, so halve.
+                        for _pass in cutlass.range_constexpr(
+                            self.w4a8_fc1_windows_per_slice
+                        ):
+                            # Flat rmem tensors keep compile-time fragment
+                            # indices explicit without rebuilding an SSA tuple
+                            # after every QMMA. The flat shape avoids the
+                            # promotion issue
+                            # of scalar indexing through partition_C's nested
+                            # layout.
+                            w4a8_facc = cute.make_rmem_tensor(
+                                (4 * fc1_m_tiles * fc1_n_tiles,),
+                                cutlass.Float32,
+                            )
+                            w4a8_facc.fill(0.0)
+                            if cutlass.const_expr(self.w4a8_fused):
+                                # Fused single sweep: the up accumulator rides
+                                # the same k loop (64 hot regs at tile_m<=32).
+                                w4a8_facc_u = cute.make_rmem_tensor(
+                                    (4 * fc1_m_tiles * fc1_n_tiles,),
+                                    cutlass.Float32,
+                                )
+                                w4a8_facc_u.fill(0.0)
+                            # ---- cp.async double-buffered operand staging ----
+                            # Per 128-deep k-tile: the B tile (8.5KB padded), the
+                            # SFB byte rows, the residual byte rows, and the
+                            # A-scale byte rows are staged by the MMA warps while
+                            # the previous tile computes. A payload stays as
+                            # direct global loads (16 words per k32 block,
+                            # covered by the MMA stream).
+                            KT_fc1 = fc1_k_tile_cnt // 2
+
+                            for _w4a8_kt in range(KT_fc1):
+                                fc1_epoch = (
+                                    slice_idx
+                                    * Int32(
+                                        self.w4a8_fc1_windows_per_slice * KT_fc1
+                                        + (
+                                            phase1_output_tile_cnt // 2
+                                            if self.w4a8_fc2_pair
+                                            else phase1_output_tile_cnt
+                                        )
+                                    )
+                                    + Int32(_pass * KT_fc1)
+                                    + _w4a8_kt
+                                    + Int32(1)
+                                )
+                                par = (fc1_epoch - Int32(1)) & Int32(
+                                    self.w4a8_depth - 1
+                                )
+                                if cutlass.const_expr(self.w4a8_named_pipeline):
+                                    self._sync_w4a8_stage_ready(par)
+                                else:
+                                    _spin_wait_shared_ge_i32(
+                                        w4a8_pipe_addr + (par << Int32(2)), fc1_epoch
+                                    )
+                                    cute.arch.fence_proxy("async.shared", space="cta")
+
+                                if cutlass.const_expr(self.w4a8_depth == 4):
+                                    b_buf = (
+                                        w4a8_sb0
+                                        + (w4a8_sb1 - w4a8_sb0) * (par >> Int32(1))
+                                        + (par & Int32(1)) * Int32(128 * 64)
+                                    )
+                                else:
+                                    b_buf = w4a8_sb0 + (w4a8_sb1 - w4a8_sb0) * par
+                                sa_buf = w4a8_sa0 + par * Int32(
+                                    self.tile_shape_mnk[0] * 128
+                                )
+                                if cutlass.const_expr(self.w4a8_fused):
+                                    sfb_buf = w4a8_sfbb + (par << Int32(10))
+                                    res_buf = w4a8_res0 + (par << Int32(11))
+                                else:
+                                    sfb_buf = w4a8_sfbb + (par << Int32(9))
+                                    res_buf = w4a8_res0 + (par << Int32(10))
+                                # A-scale staging bufs: the sSFA region is
+                                # tiny at small tiles (tile_m*8 per stage) and
+                                # its base bytes carry the FC2 intermediate
+                                # scales. At depth 4 the sSFB_up region is
+                                # entirely free (residual bufs moved to
+                                # sC/sA), so A-scale bufs live there.
+                                if cutlass.const_expr(
+                                    self.w4a8_repacked or self.w4a8_small
+                                ):
+                                    asc_buf = w4a8_resb + par * Int32(
+                                        self.tile_shape_mnk[0] * 4
+                                    )
+                                else:
+                                    asc_buf = sfa_base_addr + (par << Int32(9))
+
+                                n_in_arr = cute.make_rmem_tensor((fc1_n_tiles,), Int32)
+                                sfb_words = cute.make_rmem_tensor(
+                                    (fc1_n_tiles,), Uint32
+                                )
+                                res_w0 = cute.make_rmem_tensor((fc1_n_tiles,), Uint32)
+                                res_w1 = cute.make_rmem_tensor((fc1_n_tiles,), Uint32)
+                                if cutlass.const_expr(self.w4a8_fused):
+                                    sfb_words_u = cute.make_rmem_tensor(
+                                        (fc1_n_tiles,), Uint32
+                                    )
+                                    res_w0_u = cute.make_rmem_tensor(
+                                        (fc1_n_tiles,), Uint32
+                                    )
+                                    res_w1_u = cute.make_rmem_tensor(
+                                        (fc1_n_tiles,), Uint32
+                                    )
+                                for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                    if cutlass.const_expr(
+                                        not self.w4a8_small
+                                        and not self.w4a8_split_materialized
+                                    ):
+                                        # The two-N-warp V-map alternates N8
+                                        # fragments inside each N32 group.
+                                        n_in = w4a8_n8_thread_base + Int32(
+                                            (_nt >> 1) * 32 + (_nt & 1) * 8
+                                        )
+                                    else:
+                                        n_in = w4a8_n8_thread_base + Int32(_nt * 32)
+                                    n_in_arr[_nt] = n_in
+                                    sfb_words[_nt] = ld_shared_u32(
+                                        sfb_buf + (n_in << Int32(2))
+                                    )
+                                    if cutlass.const_expr(self.w4a8_fused):
+                                        sfb_words_u[_nt] = ld_shared_u32(
+                                            sfb_buf + Int32(512) + (n_in << Int32(2))
+                                        )
+                                    if cutlass.const_expr(self.w4a8_residual):
+                                        res_w0[_nt] = ld_shared_u32(
+                                            res_buf + (n_in << Int32(3))
+                                        )
+                                        res_w1[_nt] = ld_shared_u32(
+                                            res_buf + (n_in << Int32(3)) + Int32(4)
+                                        )
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            res_w0_u[_nt] = ld_shared_u32(
+                                                res_buf
+                                                + Int32(1024)
+                                                + (n_in << Int32(3))
+                                            )
+                                            res_w1_u[_nt] = ld_shared_u32(
+                                                res_buf
+                                                + Int32(1024)
+                                                + (n_in << Int32(3))
+                                                + Int32(4)
+                                            )
+                                asc_words = cute.make_rmem_tensor(
+                                    (fc1_m_tiles,), Uint32
+                                )
+                                row_lo_arr = cute.make_rmem_tensor(
+                                    (fc1_m_tiles,), Int32
+                                )
+                                for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                    row_lo = (
+                                        w4a8_m_warp_offset
+                                        + lane_g
+                                        + Int32(_mt) * w4a8_m_block_stride
+                                    )
+                                    row_lo_arr[_mt] = row_lo
+                                    sel = row_lo + ((lane_c & Int32(1)) << Int32(3))
+                                    asc_words[_mt] = ld_shared_u32(
+                                        asc_buf + (sel << Int32(2))
+                                    )
+
+                                for _kb in cutlass.range_constexpr(n_k32_per_tile):
+                                    b_lo = cute.make_rmem_tensor((fc1_n_tiles,), Uint32)
+                                    b_hi = cute.make_rmem_tensor((fc1_n_tiles,), Uint32)
+                                    if cutlass.const_expr(self.w4a8_fused):
+                                        b_lo_u = cute.make_rmem_tensor(
+                                            (fc1_n_tiles,), Uint32
+                                        )
+                                        b_hi_u = cute.make_rmem_tensor(
+                                            (fc1_n_tiles,), Uint32
+                                        )
+                                    if cutlass.const_expr(self.w4a8_repacked):
+                                        for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                            local_n8 = n_in_arr[_nt] >> Int32(3)
+                                            chunk = local_n8 >> Int32(2)
+                                            n8_in_chunk = local_n8 & Int32(3)
+                                            packed_word = ld_shared_u32(
+                                                b_buf
+                                                + (
+                                                    (
+                                                        (Int32(_kb * 4) + chunk)
+                                                        * Int32(32)
+                                                        + Int32(lane_id)
+                                                    )
+                                                    * Int32(4)
+                                                    + n8_in_chunk
+                                                )
+                                                * Int32(4)
+                                            )
+                                            blo, bhi = e2m1x8_to_qmma_e2m1x8(
+                                                packed_word
+                                            )
+                                            b_lo[_nt] = blo
+                                            b_hi[_nt] = bhi
+                                            if cutlass.const_expr(self.w4a8_fused):
+                                                packed_word_u = ld_shared_u32(
+                                                    b_buf
+                                                    + Int32(128 * 64)
+                                                    + (
+                                                        (
+                                                            (Int32(_kb * 4) + chunk)
+                                                            * Int32(32)
+                                                            + Int32(lane_id)
+                                                        )
+                                                        * Int32(4)
+                                                        + n8_in_chunk
+                                                    )
+                                                    * Int32(4)
+                                                )
+                                                blo_u, bhi_u = e2m1x8_to_qmma_e2m1x8(
+                                                    packed_word_u
+                                                )
+                                                b_lo_u[_nt] = blo_u
+                                                b_hi_u[_nt] = bhi_u
+                                    else:
+                                        for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                            if cutlass.const_expr(self.w4a8_b_tma):
+                                                # TMA layout (probe-pinned): chunk
+                                                # = kb ^ ((row>>1)&3) over 64B rows.
+                                                w4a8_bk = (
+                                                    Int32(_kb)
+                                                    ^ (
+                                                        (n_in_arr[_nt] >> Int32(1))
+                                                        & Int32(3)
+                                                    )
+                                                ) << Int32(4)
+                                            else:
+                                                w4a8_bk = Int32(_kb * 16)
+                                            w_pk = ld_shared_u32(
+                                                b_buf
+                                                + n_in_arr[_nt] * Int32(self.w4a8_b_pad)
+                                                + w4a8_bk
+                                                + (lane_c << Int32(2))
+                                            )
+                                            if cutlass.const_expr(self.w4a8_residual):
+                                                if cutlass.const_expr(_kb < 2):
+                                                    res_word = res_w0[_nt]
+                                                else:
+                                                    res_word = res_w1[_nt]
+                                                res_b = (
+                                                    res_word
+                                                    >> (
+                                                        Uint32((_kb * 2) % 4 * 8)
+                                                        + (Uint32(lane_c) >> Uint32(1))
+                                                        * Uint32(8)
+                                                    )
+                                                ) & Uint32(0xFF)
+                                                res_h2 = broadcast_f32_to_half2(
+                                                    fp8_e4m3_to_f32(res_b)
+                                                )
+                                                blo, bhi = (
+                                                    e2m1x8_mul_residual_to_e4m3x8(
+                                                        w_pk, res_h2
+                                                    )
+                                                )
+                                            else:
+                                                blo, bhi = e2m1x8_to_qmma_e2m1x8(w_pk)
+                                            b_lo[_nt] = blo
+                                            b_hi[_nt] = bhi
+                                            if cutlass.const_expr(self.w4a8_fused):
+                                                w_pk_u = ld_shared_u32(
+                                                    b_buf
+                                                    + Int32(128 * 64)
+                                                    + n_in_arr[_nt]
+                                                    * Int32(self.w4a8_b_pad)
+                                                    + w4a8_bk
+                                                    + (lane_c << Int32(2))
+                                                )
+                                                if cutlass.const_expr(
+                                                    self.w4a8_residual
+                                                ):
+                                                    if cutlass.const_expr(_kb < 2):
+                                                        res_word_u = res_w0_u[_nt]
+                                                    else:
+                                                        res_word_u = res_w1_u[_nt]
+                                                    res_b_u = (
+                                                        res_word_u
+                                                        >> (
+                                                            Uint32((_kb * 2) % 4 * 8)
+                                                            + (
+                                                                Uint32(lane_c)
+                                                                >> Uint32(1)
+                                                            )
+                                                            * Uint32(8)
+                                                        )
+                                                    ) & Uint32(0xFF)
+                                                    res_h2_u = broadcast_f32_to_half2(
+                                                        fp8_e4m3_to_f32(res_b_u)
+                                                    )
+                                                    blo_u, bhi_u = (
+                                                        e2m1x8_mul_residual_to_e4m3x8(
+                                                            w_pk_u, res_h2_u
+                                                        )
+                                                    )
+                                                else:
+                                                    blo_u, bhi_u = (
+                                                        e2m1x8_to_qmma_e2m1x8(w_pk_u)
+                                                    )
+                                                b_lo_u[_nt] = blo_u
+                                                b_hi_u[_nt] = bhi_u
+                                    for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                        row_lo = row_lo_arr[_mt]
+                                        row_hi = row_lo + Int32(8)
+                                        a_addr_lo = (
+                                            sa_buf
+                                            + (row_lo << Int32(7))
+                                            + Int32(_kb * 32)
+                                            + (lane_c << Int32(3))
+                                        )
+                                        a_addr_hi = (
+                                            sa_buf
+                                            + (row_hi << Int32(7))
+                                            + Int32(_kb * 32)
+                                            + (lane_c << Int32(3))
+                                        )
+                                        a0, a2 = ld_shared_v2_u32(a_addr_lo)
+                                        a1, a3 = ld_shared_v2_u32(a_addr_hi)
+                                        # Keep the four UE8M0 bytes packed.
+                                        # QMMA's compile-time byte-id operands
+                                        # select the K32 byte directly, avoiding
+                                        # two shift/mask sequences per MMA.
+                                        sfa_w = asc_words[_mt]
+                                        for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                            _fi = ((_mt * fc1_n_tiles) + _nt) * 4
+                                            if cutlass.const_expr(self.w4a8_residual):
+                                                d0, d1, d2, d3 = (
+                                                    mxfp8_mma_m16n8k32_f32_e4m3(
+                                                        w4a8_facc[_fi],
+                                                        w4a8_facc[_fi + 1],
+                                                        w4a8_facc[_fi + 2],
+                                                        w4a8_facc[_fi + 3],
+                                                        a0,
+                                                        a1,
+                                                        a2,
+                                                        a3,
+                                                        b_lo[_nt],
+                                                        b_hi[_nt],
+                                                        sfa_w,
+                                                        sfb_words[_nt],
+                                                        bid_a=_kb,
+                                                        bid_b=_kb,
+                                                    )
+                                                )
+                                            else:
+                                                d0, d1, d2, d3 = (
+                                                    mxfp8_mma_m16n8k32_f32_e2m1(
+                                                        w4a8_facc[_fi],
+                                                        w4a8_facc[_fi + 1],
+                                                        w4a8_facc[_fi + 2],
+                                                        w4a8_facc[_fi + 3],
+                                                        a0,
+                                                        a1,
+                                                        a2,
+                                                        a3,
+                                                        b_lo[_nt],
+                                                        b_hi[_nt],
+                                                        sfa_w,
+                                                        sfb_words[_nt],
+                                                        bid_a=_kb,
+                                                        bid_b=_kb,
+                                                    )
+                                                )
+                                            w4a8_facc[_fi] = d0
+                                            w4a8_facc[_fi + 1] = d1
+                                            w4a8_facc[_fi + 2] = d2
+                                            w4a8_facc[_fi + 3] = d3
+                                            if cutlass.const_expr(self.w4a8_fused):
+                                                if cutlass.const_expr(
+                                                    self.w4a8_residual
+                                                ):
+                                                    u0, u1, u2, u3 = (
+                                                        mxfp8_mma_m16n8k32_f32_e4m3(
+                                                            w4a8_facc_u[_fi],
+                                                            w4a8_facc_u[_fi + 1],
+                                                            w4a8_facc_u[_fi + 2],
+                                                            w4a8_facc_u[_fi + 3],
+                                                            a0,
+                                                            a1,
+                                                            a2,
+                                                            a3,
+                                                            b_lo_u[_nt],
+                                                            b_hi_u[_nt],
+                                                            sfa_w,
+                                                            sfb_words_u[_nt],
+                                                            bid_a=_kb,
+                                                            bid_b=_kb,
+                                                        )
+                                                    )
+                                                else:
+                                                    u0, u1, u2, u3 = (
+                                                        mxfp8_mma_m16n8k32_f32_e2m1(
+                                                            w4a8_facc_u[_fi],
+                                                            w4a8_facc_u[_fi + 1],
+                                                            w4a8_facc_u[_fi + 2],
+                                                            w4a8_facc_u[_fi + 3],
+                                                            a0,
+                                                            a1,
+                                                            a2,
+                                                            a3,
+                                                            b_lo_u[_nt],
+                                                            b_hi_u[_nt],
+                                                            sfa_w,
+                                                            sfb_words_u[_nt],
+                                                            bid_a=_kb,
+                                                            bid_b=_kb,
+                                                        )
+                                                    )
+                                                w4a8_facc_u[_fi] = u0
+                                                w4a8_facc_u[_fi + 1] = u1
+                                                w4a8_facc_u[_fi + 2] = u2
+                                                w4a8_facc_u[_fi + 3] = u3
+                                if cutlass.const_expr(self.w4a8_named_pipeline):
+                                    self._arrive_w4a8_stage_done(par)
+                                else:
+                                    cute.arch.sync_warp()
+                                    if lane_c == Int32(0) and lane_g == Int32(0):
+                                        atomic_add_shared_i32(
+                                            w4a8_pipe_addr
+                                            + Int32(16)
+                                            + (par << Int32(2)),
+                                            Int32(1),
+                                        )
+                            # Hand the pass result to the epilogue's
+                            # layout-native accumulator (cold copy).
+                            for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                    _fi = ((_mt * fc1_n_tiles) + _nt) * 4
+                                    if cutlass.const_expr(_pass == 0):
+                                        o_sl = gate_acc[(None, _mt, _nt)]
+                                    else:
+                                        o_sl = up_acc[(None, _mt, _nt)]
+                                    o_sl[0] = w4a8_facc[_fi]
+                                    o_sl[1] = w4a8_facc[_fi + 1]
+                                    o_sl[2] = w4a8_facc[_fi + 2]
+                                    o_sl[3] = w4a8_facc[_fi + 3]
+                                    if cutlass.const_expr(self.w4a8_fused):
+                                        u_sl = up_acc[(None, _mt, _nt)]
+                                        u_sl[0] = w4a8_facc_u[_fi]
+                                        u_sl[1] = w4a8_facc_u[_fi + 1]
+                                        u_sl[2] = w4a8_facc_u[_fi + 2]
+                                        u_sl[3] = w4a8_facc_u[_fi + 3]
+                        self.pass_gate_barrier.arrive_unaligned()
+
+                        # All MMA warps must be past their FC1 staging-buffer
+                        # reads before sC is rewritten below: without the old
+                        # per-k-tile CTA barriers, a fast warp's epilogue store
+                        # could clobber a lagging warp's staged A tile in sC.
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        # Activation into sC (same math as the nvfp4 path), then
+                        # w4a8 quantize: E4M3 payload + UE8M0 scales into the
+                        # repurposed sA/sSFA smem regions at plain layouts.
+                        for epi_m in cutlass.range_constexpr(epi_rest_m):
+                            epi_m_valid = valid_rows - Int32(epi_m) * Int32(
+                                self.epi_tile[0]
+                            )
+                            epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                            if epi_m_valid > Int32(0):
+                                for mma_n_in_epi in cutlass.range_constexpr(
+                                    MmaNPerEpiN
+                                ):
+                                    for mma_m_in_epi in cutlass.range_constexpr(
+                                        MmaMPerEpiM
+                                    ):
+                                        mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                        mma_n = mma_n_in_epi
+                                        tRS_rD_slice = tRS_rD[
+                                            (None, mma_m_in_epi, mma_n_in_epi)
+                                        ]
+                                        gate_slice = tRS_rGate[(None, mma_m, mma_n)]
+                                        if cutlass.const_expr(self.is_gated):
+                                            up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                            for elem_idx in cutlass.range_constexpr(
+                                                cute.size(tRS_rD_slice)
+                                            ):
+                                                g = alpha_value * gate_slice[elem_idx]
+                                                u = alpha_value * up_slice[elem_idx]
+                                                tRS_rD_slice[elem_idx] = (
+                                                    self._gated_activation_value(g, u)
+                                                )
+                                        else:
+                                            for elem_idx in cutlass.range_constexpr(
+                                                cute.size(tRS_rD_slice)
+                                            ):
+                                                g = alpha_value * gate_slice[elem_idx]
+                                                relu_g = fmax_f32(
+                                                    g, cutlass.Float32(0.0)
+                                                )
+                                                tRS_rD_slice[elem_idx] = relu_g * relu_g
+
+                                acc_vec = tRS_rD.load()
+                                acc_vec = acc_vec.to(cutlass.BFloat16)
+                                tRS_rD_out.store(acc_vec)
+                                cute.copy(
+                                    tiled_copy_r2s,
+                                    tRS_rD_out,
+                                    tRS_sD[(None, None, None, epi_buffer)],
+                                )
+                                cute.arch.fence_proxy("async.shared", space="cta")
+                            self.epilog_sync_barrier.arrive_and_wait()
+
+                            rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                            epi_rows = epi_m_valid
+                            if epi_rows > Int32(self.epi_tile[0]):
+                                epi_rows = Int32(self.epi_tile[0])
+                            if epi_rows < Int32(0):
+                                epi_rows = Int32(0)
+                            mx_blocks_tile = Int32(self.tile_shape_mnk[2] // 32)
+                            quant_idx = Int32(tidx)
+                            while quant_idx < epi_rows * mx_blocks_tile:
+                                local_row = quant_idx // mx_blocks_tile
+                                row = rows_offset + local_row
+                                mx_block = quant_idx - local_row * mx_blocks_tile
+                                block_start = mx_block * Int32(32)
+                                values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                                block_max = cutlass.Float32(0.0)
+                                for elem_idx in cutlass.range_constexpr(32):
+                                    value = cutlass.Float32(
+                                        sC[
+                                            local_row,
+                                            block_start + elem_idx,
+                                            epi_buffer,
+                                        ]
+                                    )
+                                    values[elem_idx] = value
+                                    block_max = fmax_f32(block_max, fabs_f32(value))
+                                payload, mx_scale_byte = quantize_block_fp8_mx(
+                                    values, block_max
+                                )
+                                pay_addr = (
+                                    sa_flat_addr
+                                    + row * Int32(self.tile_shape_mnk[2])
+                                    + block_start
+                                )
+                                for word_idx in cutlass.range_constexpr(8):
+                                    st_shared_u32(
+                                        pay_addr + Int32(word_idx * 4),
+                                        payload[word_idx],
+                                    )
+                                st_shared_u8(
+                                    sfa_base_addr + row * mx_blocks_tile + mx_block,
+                                    Uint8(mx_scale_byte & Uint32(0xFF)),
+                                )
+                                quant_idx += Int32(
+                                    self.num_mma_warps * self.num_threads_per_warp
+                                )
+
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        if cutlass.const_expr(self.materialize_intermediate):
+                            self._store_w4a8_materialized_intermediate(
+                                intermediate_u32,
+                                sa_flat_addr,
+                                sfa_base_addr,
+                                Int32(tidx),
+                                task_m_tile_idx,
+                                task_slice_begin_idx + slice_idx,
+                                valid_rows,
+                                rows_capacity,
+                                gate_tile_cnt,
+                            )
+
+                    if cutlass.const_expr((not self.swap_ab) and (not self.is_w4a8)):
+                        # Gate GEMM (inlined to avoid @cute.jit pass-by-value for acc)
+                        fz_crSFA = cute.filter_zeros(crSFA)
+                        fz_crSFB = cute.filter_zeros(crSFB)
+                        gate_acc.fill(0.0)
+                        cons_state.reset_count()
+                        peek = ml_pipeline.consumer_try_wait(cons_state)
+                        ml_pipeline.consumer_wait(cons_state, peek)
+                        csA_p = csA[None, None, None, cons_state.index]
+                        csB_p = csB[None, None, None, cons_state.index]
+                        csSFA_p = csSFA[None, None, None, cons_state.index]
+                        csSFB_p = csSFB[None, None, None, cons_state.index]
+                        cute.copy(smem_copy_A, csA_p[None, None, 0], crA[None, None, 0])
+                        cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                        fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                        fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                        cute.copy(
+                            smem_copy_SFA,
+                            fz_csSFA_p[None, None, 0],
+                            fz_crSFA[None, None, 0],
+                        )
+                        cute.copy(
+                            smem_copy_SFB,
+                            fz_csSFB_p[None, None, 0],
+                            fz_crSFB[None, None, 0],
+                        )
+                        for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):
+                            for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                                k_next = (
+                                    0
+                                    if k_block_idx + 1 == num_k_blocks
+                                    else k_block_idx + 1
+                                )
+                                if k_block_idx == num_k_blocks - 1:
+                                    ml_pipeline.consumer_release(cons_state)
+                                    cons_state.advance()
+                                    peek = ml_pipeline.consumer_try_wait(cons_state)
+                                    csA_p = csA[None, None, None, cons_state.index]
+                                    csB_p = csB[None, None, None, cons_state.index]
+                                    csSFA_p = csSFA[None, None, None, cons_state.index]
+                                    csSFB_p = csSFB[None, None, None, cons_state.index]
+                                    fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                                    fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                                    ml_pipeline.consumer_wait(cons_state, peek)
+                                for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                    for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                        mma_atom.set(
+                                            WarpField.SFA,
+                                            tCrSFA[None, _mt, k_block_idx].iterator,
+                                        )
+                                        mma_atom.set(
+                                            WarpField.SFB,
+                                            tCrSFB[None, _nt, k_block_idx].iterator,
+                                        )
+                                        cute.gemm(
+                                            mma_atom,
+                                            gate_acc[None, _mt, _nt],
+                                            tCrA[None, _mt, k_block_idx],
+                                            tCrB[None, _nt, k_block_idx],
+                                            gate_acc[None, _mt, _nt],
+                                        )
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_next],
+                                    crB[None, None, k_next],
+                                )
+                                fz_csSFA_cur = cute.filter_zeros(
+                                    csSFA[None, None, None, cons_state.index]
+                                )
+                                fz_csSFB_cur = cute.filter_zeros(
+                                    csSFB[None, None, None, cons_state.index]
+                                )
+                                cute.copy(
+                                    smem_copy_SFA,
+                                    fz_csSFA_cur[None, None, k_next],
+                                    fz_crSFA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_SFB,
+                                    fz_csSFB_cur[None, None, k_next],
+                                    fz_crSFB[None, None, k_next],
+                                )
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = (
+                                0
+                                if k_block_idx + 1 == num_k_blocks
+                                else k_block_idx + 1
+                            )
+                            if k_block_idx == num_k_blocks - 1:
+                                ml_pipeline.consumer_release(cons_state)
+                                cons_state.advance()
+                            if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_next],
+                                    crB[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_SFA,
+                                    fz_csSFA_p[None, None, k_next],
+                                    fz_crSFA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_SFB,
+                                    fz_csSFB_p[None, None, k_next],
+                                    fz_crSFB[None, None, k_next],
+                                )
+                            for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                    mma_atom.set(
+                                        WarpField.SFA,
+                                        tCrSFA[None, _mt, k_block_idx].iterator,
+                                    )
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB[None, _nt, k_block_idx].iterator,
+                                    )
+                                    cute.gemm(
+                                        mma_atom,
+                                        gate_acc[None, _mt, _nt],
+                                        tCrA[None, _mt, k_block_idx],
+                                        tCrB[None, _nt, k_block_idx],
+                                        gate_acc[None, _mt, _nt],
+                                    )
+                        # Signal FC1 gate/only completion before producer warps
+                        # reuse the shared A/gate buffers for the next pass.
+                        self.pass_gate_barrier.arrive_unaligned()
+
+                        if self.is_gated:
+                            # Up GEMM (inlined, same pattern)
+                            up_acc.fill(0.0)
+                            up_cons_state.reset_count()
+                            peek = up_pipeline.consumer_try_wait(up_cons_state)
+                            up_pipeline.consumer_wait(up_cons_state, peek)
+                            csA_p = csA[None, None, None, up_cons_state.index]
+                            csB_p = csB_up[None, None, None, up_cons_state.index]
+                            csSFA_p = csSFA[None, None, None, up_cons_state.index]
+                            csSFB_p = csSFB_up[None, None, None, up_cons_state.index]
+                            cute.copy(
+                                smem_copy_A, csA_p[None, None, 0], crA[None, None, 0]
+                            )
+                            cute.copy(
+                                smem_copy_B, csB_p[None, None, 0], crB[None, None, 0]
+                            )
+                            fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                            fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p[None, None, 0],
+                                fz_crSFA[None, None, 0],
+                            )
+                            cute.copy(
+                                smem_copy_SFB,
+                                fz_csSFB_p[None, None, 0],
+                                fz_crSFB[None, None, 0],
+                            )
+                            for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):
+                                for k_block_idx in cutlass.range_constexpr(
+                                    num_k_blocks
+                                ):
+                                    k_next = (
+                                        0
+                                        if k_block_idx + 1 == num_k_blocks
+                                        else k_block_idx + 1
+                                    )
+                                    if k_block_idx == num_k_blocks - 1:
+                                        up_pipeline.consumer_release(up_cons_state)
+                                        up_cons_state.advance()
+                                        peek = up_pipeline.consumer_try_wait(
+                                            up_cons_state
+                                        )
+                                        csA_p = csA[
+                                            None, None, None, up_cons_state.index
+                                        ]
+                                        csB_p = csB_up[
+                                            None, None, None, up_cons_state.index
+                                        ]
+                                        csSFA_p = csSFA[
+                                            None, None, None, up_cons_state.index
+                                        ]
+                                        csSFB_p = csSFB_up[
+                                            None, None, None, up_cons_state.index
+                                        ]
+                                        fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                                        fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                                        up_pipeline.consumer_wait(up_cons_state, peek)
+                                    for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                        for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                            mma_atom.set(
+                                                WarpField.SFA,
+                                                tCrSFA[None, _mt, k_block_idx].iterator,
+                                            )
+                                            mma_atom.set(
+                                                WarpField.SFB,
+                                                tCrSFB[None, _nt, k_block_idx].iterator,
+                                            )
+                                            cute.gemm(
+                                                mma_atom,
+                                                up_acc[None, _mt, _nt],
+                                                tCrA[None, _mt, k_block_idx],
+                                                tCrB[None, _nt, k_block_idx],
+                                                up_acc[None, _mt, _nt],
+                                            )
+                                    cute.copy(
+                                        smem_copy_A,
+                                        csA_p[None, None, k_next],
+                                        crA[None, None, k_next],
+                                    )
+                                    cute.copy(
+                                        smem_copy_B,
+                                        csB_p[None, None, k_next],
+                                        crB[None, None, k_next],
+                                    )
+                                    cute.copy(
+                                        smem_copy_SFA,
+                                        fz_csSFA_p[None, None, k_next],
+                                        fz_crSFA[None, None, k_next],
+                                    )
+                                    cute.copy(
+                                        smem_copy_SFB,
+                                        fz_csSFB_p[None, None, k_next],
+                                        fz_crSFB[None, None, k_next],
+                                    )
+                            for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                                k_next = (
+                                    0
+                                    if k_block_idx + 1 == num_k_blocks
+                                    else k_block_idx + 1
+                                )
+                                if k_block_idx == num_k_blocks - 1:
+                                    up_pipeline.consumer_release(up_cons_state)
+                                    up_cons_state.advance()
+                                if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                                    cute.copy(
+                                        smem_copy_A,
+                                        csA_p[None, None, k_next],
+                                        crA[None, None, k_next],
+                                    )
+                                    cute.copy(
+                                        smem_copy_B,
+                                        csB_p[None, None, k_next],
+                                        crB[None, None, k_next],
+                                    )
+                                    cute.copy(
+                                        smem_copy_SFA,
+                                        fz_csSFA_p[None, None, k_next],
+                                        fz_crSFA[None, None, k_next],
+                                    )
+                                    cute.copy(
+                                        smem_copy_SFB,
+                                        fz_csSFB_p[None, None, k_next],
+                                        fz_crSFB[None, None, k_next],
+                                    )
+                                for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                    for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                        mma_atom.set(
+                                            WarpField.SFA,
+                                            tCrSFA[None, _mt, k_block_idx].iterator,
+                                        )
+                                        mma_atom.set(
+                                            WarpField.SFB,
+                                            tCrSFB[None, _nt, k_block_idx].iterator,
+                                        )
+                                        cute.gemm(
+                                            mma_atom,
+                                            up_acc[None, _mt, _nt],
+                                            tCrA[None, _mt, k_block_idx],
+                                            tCrB[None, _nt, k_block_idx],
+                                            up_acc[None, _mt, _nt],
+                                        )
+                        # Activation + quant into sA
+                        sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
+                        packed_cols = Int32(self.tile_shape_mnk[2] // 2)
+                        sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
+                        gs_value = global_scale[task_expert_idx].to(cutlass.Float32)
+                        if cutlass.const_expr(self.dynamic_down_scale):
+                            fc2_down_alpha_value = down_alpha_value
+
+                        for epi_m in cutlass.range_constexpr(epi_rest_m):
+                            epi_m_valid = valid_rows - Int32(epi_m) * Int32(
+                                self.epi_tile[0]
+                            )
+                            epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                            if epi_m_valid > Int32(0):
+                                for mma_n_in_epi in cutlass.range_constexpr(
+                                    MmaNPerEpiN
+                                ):
+                                    for mma_m_in_epi in cutlass.range_constexpr(
+                                        MmaMPerEpiM
+                                    ):
+                                        mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                        mma_n = mma_n_in_epi
+                                        tRS_rD_slice = tRS_rD[
+                                            (None, mma_m_in_epi, mma_n_in_epi)
+                                        ]
+                                        gate_slice = tRS_rGate[(None, mma_m, mma_n)]
+                                        if self.is_gated:
+                                            up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                            for elem_idx in cutlass.range_constexpr(
+                                                cute.size(tRS_rD_slice)
+                                            ):
+                                                g = alpha_value * gate_slice[elem_idx]
+                                                u = alpha_value * up_slice[elem_idx]
+                                                tRS_rD_slice[elem_idx] = (
+                                                    self._gated_activation_value(g, u)
+                                                )
+                                        else:
+                                            for elem_idx in cutlass.range_constexpr(
+                                                cute.size(tRS_rD_slice)
+                                            ):
+                                                g = alpha_value * gate_slice[elem_idx]
+                                                relu_g = fmax_f32(
+                                                    g, cutlass.Float32(0.0)
+                                                )
+                                                tRS_rD_slice[elem_idx] = relu_g * relu_g
+
+                                acc_vec = tRS_rD.load()
+                                acc_vec = acc_vec.to(cutlass.BFloat16)
+                                tRS_rD_out.store(acc_vec)
+                                cute.copy(
+                                    tiled_copy_r2s,
+                                    tRS_rD_out,
+                                    tRS_sD[(None, None, None, epi_buffer)],
+                                )
+                                cute.arch.fence_proxy("async.shared", space="cta")
+                            self.epilog_sync_barrier.arrive_and_wait()
+
+                            rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                            epi_rows = epi_m_valid
+                            if epi_rows > Int32(self.epi_tile[0]):
+                                epi_rows = Int32(self.epi_tile[0])
+                            if epi_rows < Int32(0):
+                                epi_rows = Int32(0)
+                            quant_gs_value = gs_value
+                            if cutlass.const_expr(self.dynamic_down_scale):
+                                if epi_rows > Int32(0):
+                                    local_max = cutlass.Float32(0.0)
+                                    scan_idx = Int32(tidx)
+                                    scan_total = (
+                                        epi_rows * sf_blocks_per_row * Int32(16)
+                                    )
+                                    while scan_idx < scan_total:
+                                        sr = scan_idx // (sf_blocks_per_row * Int32(16))
+                                        sc = scan_idx % (sf_blocks_per_row * Int32(16))
+                                        local_max = fmax_f32(
+                                            local_max,
+                                            fabs_f32(
+                                                cutlass.Float32(sC[sr, sc, epi_buffer])
+                                            ),
+                                        )
+                                        scan_idx += Int32(
+                                            self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                        )
+                                    warp_amax = warp_reduce(local_max, fmax_f32)
+                                    lane_id = Int32(tidx) & Int32(31)
+                                    if lane_id == Int32(0):
+                                        st_shared_f32(
+                                            reduce_scratch_addr + warp_idx * Int32(4),
+                                            warp_amax,
+                                        )
+                                    self.epilog_sync_barrier.arrive_and_wait()
+                                    if warp_idx == 0:
+                                        tile_amax = cutlass.Float32(0.0)
+                                        if lane_id < Int32(self.num_mma_warps):
+                                            tile_amax = ld_shared_f32(
+                                                reduce_scratch_addr + lane_id * Int32(4)
+                                            )
+                                        tile_amax = warp_reduce(tile_amax, fmax_f32)
+                                        if lane_id == Int32(0):
+                                            st_shared_f32(
+                                                reduce_scratch_addr, tile_amax
+                                            )
+                                    self.epilog_sync_barrier.arrive_and_wait()
+                                    tile_amax = ld_shared_f32(reduce_scratch_addr)
+                                    tile_gs_value = cutlass.Float32(0.0)
+                                    if tile_amax > cutlass.Float32(0.0):
+                                        tile_gs_value = (
+                                            cutlass.Float32(_FC2_TILE_RECIP_GS_NUM)
+                                            / tile_amax
+                                        )
+                                    tile_gs_value = fmax_f32(
+                                        tile_gs_value, cutlass.Float32(1.0e-12)
+                                    )
+                                    if tile_gs_value != cutlass.Float32(0.0):
+                                        fc2_down_alpha_value = down_alpha_value * (
+                                            gs_value / tile_gs_value
+                                        )
+                                    quant_gs_value = tile_gs_value
+                                    self.epilog_sync_barrier.arrive_and_wait()
+                            quant_idx = Int32(tidx)
+                            while quant_idx < epi_rows * sf_blocks_per_row:
+                                local_row = quant_idx // sf_blocks_per_row
+                                row = rows_offset + local_row
+                                sf_block = quant_idx - local_row * sf_blocks_per_row
+                                block_start = sf_block * Int32(16)
+
+                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_max = cutlass.Float32(0.0)
+                                for elem_idx in cutlass.range_constexpr(16):
+                                    value = cutlass.Float32(
+                                        sC[
+                                            local_row,
+                                            block_start + elem_idx,
+                                            epi_buffer,
+                                        ]
+                                    )
+                                    values[elem_idx] = value
+                                    block_max = fmax_f32(block_max, fabs_f32(value))
+
+                                packed64 = Uint64(0)
+                                scale_byte = Uint8(0)
+                                if self.is_gated and self.fast_math:
+                                    packed64, scale_byte = quantize_block_fp4_fast(
+                                        values, block_max, quant_gs_value
+                                    )
+                                else:
+                                    packed64, scale_byte = quantize_block_fp4(
+                                        values, block_max, quant_gs_value
+                                    )
+                                packed_base = sf_block << Int32(3)
+                                dst_pcol = row & Int32(63)
+                                xor_bits = (
+                                    (dst_pcol >> Int32(1)) & Int32(0x3)
+                                ) << Int32(4)
+                                row_high = row >> Int32(6)
+                                for byte_idx in cutlass.range_constexpr(8):
+                                    src_pcol = packed_base + Int32(byte_idx)
+                                    dst_row = (
+                                        (src_pcol ^ xor_bits) << Int32(1)
+                                    ) + row_high
+                                    dst_flat = dst_row * packed_cols + dst_pcol
+                                    byte_val = Uint8(
+                                        (packed64 >> Uint64(byte_idx * 8))
+                                        & Uint64(0xFF)
+                                    )
+                                    sA_u8[dst_flat] = byte_val
+
+                                outer_m_idx = row % Int32(32)
+                                inner_m_idx = row // Int32(32)
+                                inner_k_idx = sf_block % Int32(4)
+                                k_tile_idx = sf_block // Int32(4)
+                                sf_raw_idx = (
+                                    k_tile_idx * Int32(32 * 4 * 4)
+                                    + outer_m_idx * Int32(4 * 4)
+                                    + inner_m_idx * Int32(4)
+                                    + inner_k_idx
+                                )
+                                st_shared_u8(sfa_base_addr + sf_raw_idx, scale_byte)
+                                quant_idx += Int32(
+                                    self.num_mma_warps * self.num_threads_per_warp
+                                )
+
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        # epilog_sync: MMA-only barrier. Producer warps do not
+                        # wait for quant; they load B_down into the separate sB
+                        # buffer and can therefore prefetch it earlier.
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                    # ============================================================
+                    # PHASE B: Sweep ALL FC2 output tiles using cached sA
+                    # No CTA-wide barrier needed here: gate is done with sB/sSFB
+                    # (barrier at line 925 ensured that), up uses sB_up/sSFB_up,
+                    # and DMA's B_down loads into sB/sSFB don't conflict with
+                    # MMA's activation+quant on sC/sA/sSFA. The phase2_pipeline
+                    # handles B_down availability for FC2 GEMM.
+                    # ============================================================
+                    scatter_N = Int32(scatter_output.shape[1])
+                    lane_id = Int32(tidx) & Int32(31)
+                    warp_in_tile = Int32(tidx) >> Int32(5)
+                    warp_m_base = (warp_in_tile >> Int32(1)) * Int32(64)
+                    warp_n_base = (warp_in_tile & Int32(1)) * Int32(64)
+
+                    # FC2's intermediate A/SF were quant-written to the first
+                    # half of the shared 128-row atom, so phase B reads offset 0
+                    # (vs FC1's per-task offset). Re-slice both. Identity at
+                    # tile_m==128.
+                    if cutlass.const_expr(
+                        (not self.is_w4a8) and self.sfa_tiles_per_block > 1
+                    ):
+                        _sA_p2 = cute.local_tile(
+                            sA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (Int32(0), 0, None),
+                        )
+                        tCrA = tiled_mma.make_fragment_A(
+                            thr_mma.partition_A(_sA_p2)[None, None, None, 0]
+                        )
+                        csA = thr_ld_A.partition_S(_sA_p2)
+                        crA = thr_ld_A.retile(tCrA)
+                        _sSFA_p2 = cute.local_tile(
+                            sSFA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (Int32(0), 0, None),
+                        )
+                        tCrSFA = self._dense_cls._partition_fragment_SFA(
+                            self,
+                            _sSFA_p2[None, None, 0],
+                            thr_mma,
+                            tidx,
+                        )
+                        csSFA = thr_ld_SFA.partition_S(_sSFA_p2)
+                        crSFA = thr_ld_SFA.retile(tCrSFA)
+
+                    expert_idx = task_expert_idx
+
+                    if cutlass.const_expr(not self.is_w4a8):
+                        csA_phase2 = csA[None, None, None, 0]
+                        csSFA_phase2 = csSFA[None, None, None, 0]
+
+                        # Consume all output tiles continuously from phase2_pipeline.
+
+                        # Hoist A-side register loads: sA is constant across all
+                        # FC2 output tiles (quantized intermediate). Load crA and
+                        # crSFA for all k-blocks once, reuse for all 32 tiles.
+                        fz_crSFA_p2 = cute.filter_zeros(crSFA)
+                        cute.copy(
+                            smem_copy_A, csA_phase2[None, None, 0], crA[None, None, 0]
+                        )
+                        fz_csSFA_p2 = cute.filter_zeros(csSFA_phase2)
+                        cute.copy(
+                            smem_copy_SFA,
+                            fz_csSFA_p2[None, None, 0],
+                            fz_crSFA_p2[None, None, 0],
+                        )
+                        for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
+                            k_pre = _kb_pre + 1
+                            cute.copy(
+                                smem_copy_A,
+                                csA_phase2[None, None, k_pre],
+                                crA[None, None, k_pre],
+                            )
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p2[None, None, k_pre],
+                                fz_crSFA_p2[None, None, k_pre],
+                            )
+
+                    # Seed FC1-epilogue scratch that the FC2 loop re-binds. With
+                    # the non-swap FC1 wrapped in `const_expr(not swap_ab)`, these
+                    # names don't reliably escape to here, so the dynamic FC2 loop
+                    # would otherwise see a None->typed flip on its first trace.
+                    # Values are overwritten inside FC2 (write-before-read).
+                    k_next = 0
+                    mma_m = 0
+                    mma_n = 0
+                    rows_offset = Int32(0)
+                    local_row = Int32(0)
+                    # Stable scalar loop state for the non-small FC2-A reload
+                    # path. These are overwritten before every K32 use.
+                    a0 = Uint32(0)
+                    a1 = Uint32(0)
+                    a2 = Uint32(0)
+                    a3 = Uint32(0)
+                    sfa_w = Uint32(0)
+                    row_lo = Int32(0)
+                    row_hi = Int32(0)
+                    if cutlass.const_expr(self.is_w4a8):
+                        # FC2 contracts the same quantized intermediate tile
+                        # against every output-N tile. Small M16/M32 kernels
+                        # hoist its A fragments once; larger kernels reload
+                        # from shared memory to cap register lifetime.
+                        mx_blocks_tile_p2 = Int32(self.tile_shape_mnk[2] // 32)
+                        if cutlass.const_expr(self.w4a8_fc2_hoist_a):
+                            w4a8_a2_regs = cute.make_rmem_tensor(
+                                (fc2_m_tiles, n_k32_per_tile, 4), cutlass.Uint32
+                            )
+                            w4a8_sfa2_regs = cute.make_rmem_tensor(
+                                (fc2_m_tiles,), cutlass.Uint32
+                            )
+                            for _mt in cutlass.range_constexpr(fc2_m_tiles):
+                                row_lo = lane_g + Int32(_mt * 16)
+                                row_hi = row_lo + Int32(8)
+                                for _kb in cutlass.range_constexpr(n_k32_per_tile):
+                                    a_addr_lo = (
+                                        sa_flat_addr
+                                        + row_lo * Int32(self.tile_shape_mnk[2])
+                                        + Int32(_kb * 32)
+                                        + Int32(8) * lane_c
+                                    )
+                                    a_addr_hi = (
+                                        sa_flat_addr
+                                        + row_hi * Int32(self.tile_shape_mnk[2])
+                                        + Int32(_kb * 32)
+                                        + Int32(8) * lane_c
+                                    )
+                                    a0, a2 = ld_shared_v2_u32(a_addr_lo)
+                                    a1, a3 = ld_shared_v2_u32(a_addr_hi)
+                                    w4a8_a2_regs[_mt, _kb, 0] = a0
+                                    w4a8_a2_regs[_mt, _kb, 1] = a1
+                                    w4a8_a2_regs[_mt, _kb, 2] = a2
+                                    w4a8_a2_regs[_mt, _kb, 3] = a3
+                                # One aligned word contains all four K32 scale
+                                # bytes for this row.  Cache it once; each QMMA
+                                # below selects its byte with the immediate bid_a.
+                                sfa_w = Uint32(0)
+                                if lane_c < Int32(2):
+                                    sf_row = row_lo
+                                    if lane_c == Int32(1):
+                                        sf_row = row_hi
+                                    sf_idx = sf_row * mx_blocks_tile_p2
+                                    sfa_w = ld_shared_u32(
+                                        sfa_base_addr + (sf_idx << Int32(0))
+                                    )
+                                w4a8_sfa2_regs[_mt] = sfa_w
+                    phase2_cons_state.reset_count()
+                    for output_tile_idx in range(
+                        0,
+                        phase1_output_tile_cnt,
+                        self.w4a8_fc2_compute_width,
+                        unroll=4,
+                    ):
+                        if cutlass.const_expr(not self.is_w4a8):
+                            phase2_peek = phase2_pipeline.consumer_try_wait(
+                                phase2_cons_state
+                            )
+                            phase2_pipeline.consumer_wait(
+                                phase2_cons_state, phase2_peek
+                            )
+                            csB_phase2 = csB[None, None, None, phase2_cons_state.index]
+                            csSFB_phase2 = csSFB[
+                                None, None, None, phase2_cons_state.index
+                            ]
+
+                            # Only load B-side (B_down changes per output tile; A is hoisted)
+                            cute.copy(
+                                smem_copy_B,
+                                csB_phase2[None, None, 0],
+                                crB[None, None, 0],
+                            )
+                            f2 = cute.filter_zeros(csSFB_phase2)
+                            f4 = cute.filter_zeros(crSFB)
+                            cute.copy(
+                                smem_copy_SFB, f2[None, None, 0], f4[None, None, 0]
+                            )
+
+                        if cutlass.const_expr(not self.is_w4a8):
+                            down_acc.fill(0.0)
+                        if cutlass.const_expr(self.is_w4a8):
+                            # w4a8 FC2: A from the epilogue's plain smem region,
+                            # B_down/scales/residuals cp.async double-buffered
+                            # across output tiles, raw FP8 MMA.
+                            w4a8_facc2 = cute.make_rmem_tensor(
+                                (
+                                    4
+                                    * self.w4a8_fc2_compute_width
+                                    * fc2_m_tiles
+                                    * fc2_n_tiles,
+                                ),
+                                cutlass.Float32,
+                            )
+                            w4a8_facc2.fill(0.0)
+                            w4a8_fc2_windows = (
+                                phase1_output_tile_cnt // 2
+                                if self.w4a8_fc2_pair
+                                else phase1_output_tile_cnt
+                            )
+                            fc2_epoch = (
+                                slice_idx
+                                * Int32(
+                                    self.w4a8_fc1_windows_per_slice
+                                    * (fc1_k_tile_cnt // 2)
+                                    + w4a8_fc2_windows
+                                )
+                                + Int32(
+                                    self.w4a8_fc1_windows_per_slice
+                                    * (fc1_k_tile_cnt // 2)
+                                )
+                                + (
+                                    (output_tile_idx >> Int32(1))
+                                    if cutlass.const_expr(self.w4a8_fc2_pair)
+                                    else output_tile_idx
+                                )
+                                + Int32(1)
+                            )
+                            par = (fc2_epoch - Int32(1)) & Int32(self.w4a8_depth - 1)
+                            if cutlass.const_expr(self.w4a8_named_pipeline):
+                                self._sync_w4a8_stage_ready(par)
+                            else:
+                                _spin_wait_shared_ge_i32(
+                                    w4a8_pipe_addr + (par << Int32(2)), fc2_epoch
+                                )
+                                cute.arch.fence_proxy("async.shared", space="cta")
+
+                            if cutlass.const_expr(self.w4a8_depth == 4):
+                                b_buf = (
+                                    w4a8_sb0
+                                    + (w4a8_sb1 - w4a8_sb0) * (par >> Int32(1))
+                                    + (par & Int32(1)) * Int32(128 * 64)
+                                )
+                            else:
+                                b_buf = w4a8_sb0 + (w4a8_sb1 - w4a8_sb0) * par
+                            if cutlass.const_expr(self.w4a8_fc2_pair):
+                                sfb_buf = w4a8_sfbb + (par << Int32(10))
+                                res_buf = w4a8_res2 + (par << Int32(11))
+                            else:
+                                sfb_buf = w4a8_sfbb + (par << Int32(9))
+                                res_buf = w4a8_res2 + (par << Int32(10))
+                            n_in_arr2 = cute.make_rmem_tensor((fc2_n_tiles,), Int32)
+                            sfb_words2 = cute.make_rmem_tensor(
+                                (self.w4a8_fc2_compute_width, fc2_n_tiles),
+                                Uint32,
+                            )
+                            res2_w0 = cute.make_rmem_tensor(
+                                (self.w4a8_fc2_compute_width, fc2_n_tiles),
+                                Uint32,
+                            )
+                            res2_w1 = cute.make_rmem_tensor(
+                                (self.w4a8_fc2_compute_width, fc2_n_tiles),
+                                Uint32,
+                            )
+                            for _nt in cutlass.range_constexpr(fc2_n_tiles):
+                                if cutlass.const_expr(
+                                    not self.w4a8_small
+                                    and not self.w4a8_split_materialized
+                                ):
+                                    n_in = w4a8_n8_thread_base + Int32(
+                                        (_nt >> 1) * 32 + (_nt & 1) * 8
+                                    )
+                                else:
+                                    n_in = w4a8_n8_thread_base + Int32(_nt * 32)
+                                n_in_arr2[_nt] = n_in
+                                for _ot in cutlass.range_constexpr(
+                                    self.w4a8_fc2_compute_width
+                                ):
+                                    sfb_words2[_ot, _nt] = ld_shared_u32(
+                                        sfb_buf + Int32(_ot * 512) + (n_in << Int32(2))
+                                    )
+                                    if cutlass.const_expr(self.w4a8_residual):
+                                        res2_w0[_ot, _nt] = ld_shared_u32(
+                                            res_buf
+                                            + Int32(_ot * 1024)
+                                            + (n_in << Int32(3))
+                                        )
+                                        res2_w1[_ot, _nt] = ld_shared_u32(
+                                            res_buf
+                                            + Int32(_ot * 1024)
+                                            + (n_in << Int32(3))
+                                            + Int32(4)
+                                        )
+                            for _kb in cutlass.range_constexpr(n_k32_per_tile):
+                                b_lo = cute.make_rmem_tensor(
+                                    (self.w4a8_fc2_compute_width, fc2_n_tiles),
+                                    Uint32,
+                                )
+                                b_hi = cute.make_rmem_tensor(
+                                    (self.w4a8_fc2_compute_width, fc2_n_tiles),
+                                    Uint32,
+                                )
+                                if cutlass.const_expr(self.w4a8_repacked):
+                                    for _ot in cutlass.range_constexpr(
+                                        self.w4a8_fc2_compute_width
+                                    ):
+                                        for _nt in cutlass.range_constexpr(fc2_n_tiles):
+                                            local_n8 = n_in_arr2[_nt] >> Int32(3)
+                                            chunk = Int32(_ot * 4) + (
+                                                local_n8 >> Int32(2)
+                                            )
+                                            n8_in_chunk = local_n8 & Int32(3)
+                                            packed_word2 = ld_shared_u32(
+                                                b_buf
+                                                + (
+                                                    (
+                                                        (Int32(_kb * 8) + chunk)
+                                                        * Int32(32)
+                                                        + Int32(lane_id)
+                                                    )
+                                                    * Int32(4)
+                                                    + n8_in_chunk
+                                                )
+                                                * Int32(4)
+                                            )
+                                            blo, bhi = e2m1x8_to_qmma_e2m1x8(
+                                                packed_word2
+                                            )
+                                            b_lo[_ot, _nt] = blo
+                                            b_hi[_ot, _nt] = bhi
+                                else:
+                                    for _ot in cutlass.range_constexpr(
+                                        self.w4a8_fc2_compute_width
+                                    ):
+                                        for _nt in cutlass.range_constexpr(fc2_n_tiles):
+                                            if cutlass.const_expr(self.w4a8_b_tma):
+                                                w4a8_bk2 = (
+                                                    Int32(_kb)
+                                                    ^ (
+                                                        (n_in_arr2[_nt] >> Int32(1))
+                                                        & Int32(3)
+                                                    )
+                                                ) << Int32(4)
+                                            else:
+                                                w4a8_bk2 = Int32(_kb * 16)
+                                            w_dn = ld_shared_u32(
+                                                b_buf
+                                                + Int32(_ot * 128 * 64)
+                                                + n_in_arr2[_nt]
+                                                * Int32(self.w4a8_b_pad)
+                                                + w4a8_bk2
+                                                + (lane_c << Int32(2))
+                                            )
+                                            if cutlass.const_expr(self.w4a8_residual):
+                                                if cutlass.const_expr(_kb < 2):
+                                                    res_word = res2_w0[_ot, _nt]
+                                                else:
+                                                    res_word = res2_w1[_ot, _nt]
+                                                res_b = (
+                                                    res_word
+                                                    >> (
+                                                        Uint32((_kb * 2) % 4 * 8)
+                                                        + (Uint32(lane_c) >> Uint32(1))
+                                                        * Uint32(8)
+                                                    )
+                                                ) & Uint32(0xFF)
+                                                res_h2 = broadcast_f32_to_half2(
+                                                    fp8_e4m3_to_f32(res_b)
+                                                )
+                                                blo, bhi = (
+                                                    e2m1x8_mul_residual_to_e4m3x8(
+                                                        w_dn, res_h2
+                                                    )
+                                                )
+                                            else:
+                                                blo, bhi = e2m1x8_to_qmma_e2m1x8(w_dn)
+                                            b_lo[_ot, _nt] = blo
+                                            b_hi[_ot, _nt] = bhi
+                                for _ot in cutlass.range_constexpr(
+                                    self.w4a8_fc2_compute_width
+                                ):
+                                    for _mt in cutlass.range_constexpr(fc2_m_tiles):
+                                        if cutlass.const_expr(self.w4a8_fc2_hoist_a):
+                                            a0 = w4a8_a2_regs[_mt, _kb, 0]
+                                            a1 = w4a8_a2_regs[_mt, _kb, 1]
+                                            a2 = w4a8_a2_regs[_mt, _kb, 2]
+                                            a3 = w4a8_a2_regs[_mt, _kb, 3]
+                                            sfa_w = w4a8_sfa2_regs[_mt]
+                                        else:
+                                            row_lo = (
+                                                w4a8_m_warp_offset
+                                                + lane_g
+                                                + Int32(_mt) * w4a8_m_block_stride
+                                            )
+                                            row_hi = row_lo + Int32(8)
+                                            a0, a2 = ld_shared_v2_u32(
+                                                sa_flat_addr
+                                                + row_lo * Int32(self.tile_shape_mnk[2])
+                                                + Int32(_kb * 32)
+                                                + Int32(8) * lane_c
+                                            )
+                                            a1, a3 = ld_shared_v2_u32(
+                                                sa_flat_addr
+                                                + row_hi * Int32(self.tile_shape_mnk[2])
+                                                + Int32(_kb * 32)
+                                                + Int32(8) * lane_c
+                                            )
+                                            sfa_w = Uint32(0)
+                                            if lane_c < Int32(2):
+                                                sfa_w = ld_shared_u32(
+                                                    sfa_base_addr
+                                                    + (row_lo + (lane_c << Int32(3)))
+                                                    * mx_blocks_tile_p2
+                                                )
+                                        for _nt in cutlass.range_constexpr(fc2_n_tiles):
+                                            _fi = (
+                                                (
+                                                    (_ot * fc2_m_tiles + _mt)
+                                                    * fc2_n_tiles
+                                                )
+                                                + _nt
+                                            ) * 4
+                                            if cutlass.const_expr(self.w4a8_residual):
+                                                d0, d1, d2, d3 = (
+                                                    mxfp8_mma_m16n8k32_f32_e4m3(
+                                                        w4a8_facc2[_fi],
+                                                        w4a8_facc2[_fi + 1],
+                                                        w4a8_facc2[_fi + 2],
+                                                        w4a8_facc2[_fi + 3],
+                                                        a0,
+                                                        a1,
+                                                        a2,
+                                                        a3,
+                                                        b_lo[_ot, _nt],
+                                                        b_hi[_ot, _nt],
+                                                        sfa_w,
+                                                        sfb_words2[_ot, _nt],
+                                                        bid_a=_kb,
+                                                        bid_b=_kb,
+                                                    )
+                                                )
+                                            else:
+                                                d0, d1, d2, d3 = (
+                                                    mxfp8_mma_m16n8k32_f32_e2m1(
+                                                        w4a8_facc2[_fi],
+                                                        w4a8_facc2[_fi + 1],
+                                                        w4a8_facc2[_fi + 2],
+                                                        w4a8_facc2[_fi + 3],
+                                                        a0,
+                                                        a1,
+                                                        a2,
+                                                        a3,
+                                                        b_lo[_ot, _nt],
+                                                        b_hi[_ot, _nt],
+                                                        sfa_w,
+                                                        sfb_words2[_ot, _nt],
+                                                        bid_a=_kb,
+                                                        bid_b=_kb,
+                                                    )
+                                                )
+                                            w4a8_facc2[_fi] = d0
+                                            w4a8_facc2[_fi + 1] = d1
+                                            w4a8_facc2[_fi + 2] = d2
+                                            w4a8_facc2[_fi + 3] = d3
+                        if cutlass.const_expr(not self.is_w4a8):
+                            for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                                k_next = (
+                                    0
+                                    if k_block_idx + 1 == num_k_blocks
+                                    else k_block_idx + 1
+                                )
+                                if k_block_idx == num_k_blocks - 1:
+                                    phase2_pipeline.consumer_release(phase2_cons_state)
+                                    phase2_cons_state.advance()
+                                if k_next > 0:
+                                    # Only B-side for next k-block (A already in registers)
+                                    cute.copy(
+                                        smem_copy_B,
+                                        csB_phase2[None, None, k_next],
+                                        crB[None, None, k_next],
+                                    )
+                                    f2 = cute.filter_zeros(csSFB_phase2)
+                                    f4 = cute.filter_zeros(crSFB)
+                                    cute.copy(
+                                        smem_copy_SFB,
+                                        f2[None, None, k_next],
+                                        f4[None, None, k_next],
+                                    )
+                                for _mt in cutlass.range_constexpr(fc2_m_tiles):
+                                    for _nt in cutlass.range_constexpr(fc2_n_tiles):
+                                        mma_atom.set(
+                                            WarpField.SFA,
+                                            tCrSFA[None, _mt, k_block_idx].iterator,
+                                        )
+                                        mma_atom.set(
+                                            WarpField.SFB,
+                                            tCrSFB[None, _nt, k_block_idx].iterator,
+                                        )
+                                        cute.gemm(
+                                            mma_atom,
+                                            down_acc[None, _mt, _nt],
+                                            tCrA[None, _mt, k_block_idx],
+                                            tCrB[None, _nt, k_block_idx],
+                                            down_acc[None, _mt, _nt],
+                                        )
+
+                        # Drain each compile-time FC2 output in the window.  In
+                        # the paired W4A8 specialization both N128 accumulator
+                        # sets remain live through the K loop above, then reuse
+                        # the existing epilogue/scatter body one at a time.
+                        for _fc2_out in cutlass.range_constexpr(
+                            self.w4a8_fc2_compute_width
+                        ):
+                            if cutlass.const_expr(self.is_w4a8):
+                                for _mt in cutlass.range_constexpr(fc2_m_tiles):
+                                    for _nt in cutlass.range_constexpr(fc2_n_tiles):
+                                        _fi = (
+                                            (
+                                                (_fc2_out * fc2_m_tiles + _mt)
+                                                * fc2_n_tiles
+                                            )
+                                            + _nt
+                                        ) * 4
+                                        dn_sl = down_acc[(None, _mt, _nt)]
+                                        dn_sl[0] = w4a8_facc2[_fi]
+                                        dn_sl[1] = w4a8_facc2[_fi + 1]
+                                        dn_sl[2] = w4a8_facc2[_fi + 2]
+                                        dn_sl[3] = w4a8_facc2[_fi + 3]
+
+                            # Scatter using precomputed metadata (no redundant
+                            # global metadata loads).
+                            output_tile_idx_cur = output_tile_idx + Int32(_fc2_out)
+                            tile_n_base_cur = output_tile_idx_cur * Int32(
+                                self.tile_shape_mnk[1]
+                            )
+                            for epi_m in cutlass.range_constexpr(epi_rest_m):
+                                for mma_n_in_epi in cutlass.range_constexpr(
+                                    MmaNPerEpiN
+                                ):
+                                    for mma_m_in_epi in cutlass.range_constexpr(
+                                        MmaMPerEpiM
+                                    ):
+                                        mma_n = mma_n_in_epi
+                                        mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                        tRS_rD_slice = tRS_rD[
+                                            (None, mma_m_in_epi, mma_n_in_epi)
+                                        ]
+                                        down_epi_acc_slice = down_acc[
+                                            (None, mma_m, mma_n)
+                                        ]
+                                        for elem_idx in cutlass.range_constexpr(
+                                            cute.size(tRS_rD_slice)
+                                        ):
+                                            if cutlass.const_expr(
+                                                self.dynamic_down_scale
+                                            ):
+                                                tRS_rD_slice[elem_idx] = (
+                                                    fc2_down_alpha_value
+                                                    * down_epi_acc_slice[elem_idx]
+                                                )
+                                            else:
+                                                tRS_rD_slice[elem_idx] = (
+                                                    down_alpha_value
+                                                    * down_epi_acc_slice[elem_idx]
+                                                )
+
+                                acc_vec = tRS_rD.load()
+                                acc_vec = acc_vec.to(cutlass.BFloat16)
+                                tRS_rD_out.store(acc_vec)
+                                epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                                cute.copy(
+                                    tiled_copy_r2s,
+                                    tRS_rD_out,
+                                    tRS_sD[(None, None, None, epi_buffer)],
+                                )
+                                cute.arch.fence_proxy("async.shared", space="cta")
+                                # Vector scatter reads wider spans from sC than
+                                # the scalar path, so wait for all MMA warps.
+                                self.epilog_sync_barrier.arrive_and_wait()
+                                rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+
+                                # Per-warp scatter: each warp scatters its own
+                                # quadrant of sC (64 M-rows × 64 N-cols).
+                                warp_epi_rows = valid_rows - rows_offset - warp_m_base
+                                if warp_epi_rows > Int32(64):
+                                    warp_epi_rows = Int32(64)
+                                if warp_epi_rows < Int32(0):
+                                    warp_epi_rows = Int32(0)
+                                tile_vec_cols = Int32(64) // Int32(8)
+                                vec_idx = lane_id
+                                while vec_idx < warp_epi_rows * tile_vec_cols:
+                                    local_row = vec_idx // tile_vec_cols
+                                    local_vec_col = vec_idx - local_row * tile_vec_cols
+                                    local_col = warp_n_base + local_vec_col * Int32(8)
+                                    global_col = tile_n_base_cur + local_col
+                                    cached_row = rows_offset + warp_m_base + local_row
+                                    tok = ld_shared_i32_relaxed(
+                                        scatter_tok_base_addr + cached_row * Int32(4)
+                                    )
+                                    wv = ld_shared_f32(
+                                        scatter_weight_base_addr + cached_row * Int32(4)
+                                    )
+                                    if cutlass.const_expr(self.w4a8_repacked):
+                                        sc_logical = Int32(
+                                            cute.crd2idx(
+                                                (
+                                                    warp_m_base + local_row,
+                                                    local_col,
+                                                    epi_buffer,
+                                                ),
+                                                epi_smem_staged.outer,
+                                            )
+                                        )
+                                        sc_yyy_mask = Int32(
+                                            ((1 << epi_smem_staged.inner.num_bits) - 1)
+                                            << (
+                                                epi_smem_staged.inner.num_base
+                                                + epi_smem_staged.inner.num_shift
+                                            )
+                                        )
+                                        sc_logical_bytes = sc_logical << Int32(1)
+                                        sc_physical_bytes = sc_logical_bytes ^ (
+                                            (sc_logical_bytes & sc_yyy_mask)
+                                            >> Int32(epi_smem_staged.inner.num_shift)
+                                        )
+                                        sc_addr = sC_base_addr + sc_physical_bytes
+                                    if cutlass.const_expr(self.w4a8_repacked):
+                                        _sc0, _sc1, _sc2, _sc3 = ld_shared_v4_u32(
+                                            sc_addr
+                                        )
+                                        sc_v0, sc_v1 = bfloat2_to_float2_scaled(
+                                            _sc0, wv
+                                        )
+                                        sc_v2, sc_v3 = bfloat2_to_float2_scaled(
+                                            _sc1, wv
+                                        )
+                                        sc_v4, sc_v5 = bfloat2_to_float2_scaled(
+                                            _sc2, wv
+                                        )
+                                        sc_v6, sc_v7 = bfloat2_to_float2_scaled(
+                                            _sc3, wv
+                                        )
+                                    else:
+                                        sc_v0 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col,
+                                                epi_buffer,
+                                            ]
+                                        )
+                                        sc_v1 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col + Int32(1),
+                                                epi_buffer,
+                                            ]
+                                        )
+                                        sc_v2 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col + Int32(2),
+                                                epi_buffer,
+                                            ]
+                                        )
+                                        sc_v3 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col + Int32(3),
+                                                epi_buffer,
+                                            ]
+                                        )
+                                        sc_v4 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col + Int32(4),
+                                                epi_buffer,
+                                            ]
+                                        )
+                                        sc_v5 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col + Int32(5),
+                                                epi_buffer,
+                                            ]
+                                        )
+                                        sc_v6 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col + Int32(6),
+                                                epi_buffer,
+                                            ]
+                                        )
+                                        sc_v7 = wv * cutlass.Float32(
+                                            sC[
+                                                warp_m_base + local_row,
+                                                local_col + Int32(7),
+                                                epi_buffer,
+                                            ]
+                                        )
+                                    if cutlass.const_expr(self.deterministic_output):
+                                        scatter_output[tok, global_col] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[tok, global_col]
+                                                )
+                                                + sc_v0
+                                            )
+                                        )
+                                        scatter_output[tok, global_col + Int32(1)] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[
+                                                        tok, global_col + Int32(1)
+                                                    ]
+                                                )
+                                                + sc_v1
+                                            )
+                                        )
+                                        scatter_output[tok, global_col + Int32(2)] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[
+                                                        tok, global_col + Int32(2)
+                                                    ]
+                                                )
+                                                + sc_v2
+                                            )
+                                        )
+                                        scatter_output[tok, global_col + Int32(3)] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[
+                                                        tok, global_col + Int32(3)
+                                                    ]
+                                                )
+                                                + sc_v3
+                                            )
+                                        )
+                                        scatter_output[tok, global_col + Int32(4)] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[
+                                                        tok, global_col + Int32(4)
+                                                    ]
+                                                )
+                                                + sc_v4
+                                            )
+                                        )
+                                        scatter_output[tok, global_col + Int32(5)] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[
+                                                        tok, global_col + Int32(5)
+                                                    ]
+                                                )
+                                                + sc_v5
+                                            )
+                                        )
+                                        scatter_output[tok, global_col + Int32(6)] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[
+                                                        tok, global_col + Int32(6)
+                                                    ]
+                                                )
+                                                + sc_v6
+                                            )
+                                        )
+                                        scatter_output[tok, global_col + Int32(7)] = (
+                                            cutlass.BFloat16(
+                                                cutlass.Float32(
+                                                    scatter_output[
+                                                        tok, global_col + Int32(7)
+                                                    ]
+                                                )
+                                                + sc_v7
+                                            )
+                                        )
+                                    else:
+                                        scatter_add_v4_bf16x2(
+                                            get_ptr_as_int64(
+                                                scatter_output,
+                                                tok * scatter_N + global_col,
+                                            ),
+                                            sc_v0,
+                                            sc_v1,
+                                            sc_v2,
+                                            sc_v3,
+                                            sc_v4,
+                                            sc_v5,
+                                            sc_v6,
+                                            sc_v7,
+                                        )
+                                    vec_idx += Int32(self.num_threads_per_warp)
+
+                                # All warps must finish the current scatter
+                                # before the next output reuses sC.
+                                self.epilog_sync_barrier.arrive_and_wait()
+
+                        if cutlass.const_expr(self.w4a8_named_pipeline):
+                            self._arrive_w4a8_stage_done(par)
+                        elif cutlass.const_expr(self.is_w4a8):
+                            # Both outputs in a paired window are now past
+                            # their B/sC reads, so release the producer buffer
+                            # exactly once.
+                            if Int32(tidx) == Int32(0):
+                                atomic_add_shared_i32(
+                                    w4a8_pipe_addr + Int32(16) + (par << Int32(2)),
+                                    Int32(self.num_mma_warps),
+                                )
+
+                    # Signal that FC2/scatter no longer needs sA, so the DMA
+                    # warp may start the next slice/task's FC1 loads.
+                    self.pass_final_barrier.arrive_unaligned()
+                    slice_idx += Int32(1)
+
+            elif warp_idx < self.num_mma_warps + self.num_dma_warps:
+                task_expert_idx = work_item[_WORK_EXPERT]
+                task_m_tile_idx = work_item[_WORK_M_TILE]
+                task_slice_begin_idx = work_item[_WORK_SLICE_BEGIN]
+                task_slice_count_val = work_item[_WORK_SLICE_COUNT]
+                task_valid_rows_val = work_item[_WORK_VALID_ROWS]
+
+                # gA and gSFA are tiled in 128-row atoms; a sub-128 MMA tile maps
+                # to block (task_m_tile_idx // tiles_per_block). The within-block
+                # half is selected in the fragment partition. Identity when
+                # tile_m>=128 (tiles_per_block==1).
+                sa_block_idx = task_m_tile_idx // Int32(self.sa_tiles_per_block)
+                tAgA_mk = tAgA[(None, sa_block_idx, None, Int32(0))]
+                sfa_block_idx = task_m_tile_idx // Int32(self.sfa_tiles_per_block)
+                tAgSFA_mk = tAgSFA[(None, sfa_block_idx, None, Int32(0))]
+                slice_idx = Int32(0)
+                while slice_idx < task_slice_count_val:
+                    intermediate_slice = task_slice_begin_idx + slice_idx
+
+                    # FC1 producer slice. Gated activation packs [up, gate]
+                    # across N; relu2 uses a single FC1 pass.
+                    tBgB_w13_up_nk = tBgB_w13[
+                        (None, intermediate_slice, None, task_expert_idx)
+                    ]
+                    tBgSFB_w13_up_nk = tBgSFB_w13[
+                        (None, intermediate_slice, None, task_expert_idx)
+                    ]
+                    gate_slice_idx = intermediate_slice
+                    if self.is_gated:
+                        gate_slice_idx = intermediate_slice + gate_tile_cnt
+                    if cutlass.const_expr(self.swap_ab):
+                        # swap: atom-lo is the 128-row atom holding gate row n
+                        # (n//128 + slice); the consumer reads the gate's 32-int
+                        # subs from it at within-atom offset gate_lo_sub.
+                        gate_slice_idx = intermediate_slice + Int32(gate_lo_off)
+                    tBgB_w13_gate_nk = tBgB_w13[
+                        (None, gate_slice_idx, None, task_expert_idx)
+                    ]
+                    tBgSFB_w13_gate_nk = tBgSFB_w13[
+                        (None, gate_slice_idx, None, task_expert_idx)
+                    ]
+                    if cutlass.const_expr(self.swap_ab and gate_lo_sub > 0):
+                        gate_hi_idx = intermediate_slice + Int32(gate_lo_off + 1)
+                        tBgB_w13_gate_hi_nk = tBgB_w13[
+                            (None, gate_hi_idx, None, task_expert_idx)
+                        ]
+                        tBgSFB_w13_gate_hi_nk = tBgSFB_w13[
+                            (None, gate_hi_idx, None, task_expert_idx)
+                        ]
+
+                    # ---- FC1 gate pass ----
+                    if cutlass.const_expr(self.is_w4a8):
+                        # w4a8 producer: DMA warp(s) stage each k-tile's
+                        # operands into the staging buffers and publishes them
+                        # via per-buffer ready epochs; the MMA warps consume by
+                        # spinning on the epoch (no CTA barriers in the k loop)
+                        # and acknowledge via per-buffer done counts. Epochs are
+                        # monotonic per task, so buffer reuse across passes,
+                        # FC2, and slices is ordered by the flags alone.
+                        w4a8_KT = fc1_k_tile_cnt // 2
+                        w4a8_passes = self.w4a8_fc1_windows_per_slice
+                        m_row_base_p = task_m_tile_idx * Int32(self.tile_shape_mnk[0])
+                        w4a8_pend_par = Int32(0)
+                        w4a8_pend_epoch = Int32(0)
+                        # With two producer warps, epochs split by parity:
+                        # warp 0 stages odd epochs (pars 0,2), warp 1 even
+                        # (pars 1,3) — disjoint buffers, independent FIFOs.
+                        w4a8_warp_off = warp_idx - Int32(self.tma_load_warp_id)
+                        asc_base_p = Int64(m_row_base_p) * Int64(a_mx_per_row)
+                        cur_slice_p = task_slice_begin_idx + slice_idx
+                        for _pp in cutlass.range_constexpr(w4a8_passes):
+                            if cutlass.const_expr(_pp == 0):
+                                p_n_tile = cur_slice_p
+                                if cutlass.const_expr(self.is_gated):
+                                    p_n_tile = cur_slice_p + gate_tile_cnt
+                            else:
+                                p_n_tile = cur_slice_p
+                            if cutlass.const_expr(self.w4a8_fused):
+                                # Fused: this window also stages the up half.
+                                pu_n_tile = cur_slice_p
+                                nu_base_p = pu_n_tile * Int32(self.tile_shape_mnk[1])
+                            n_base_p = p_n_tile * Int32(self.tile_shape_mnk[1])
+                            b_row_u32p = b_w13_u32.shape[1]
+                            b_base_p = Int64(task_expert_idx) * Int64(
+                                b_w13_u32.shape[0] * b_row_u32p
+                            ) + Int64(n_base_p) * Int64(b_row_u32p)
+                            sfb_row_p = sfb_w13_mx.shape[1]
+                            sfb_base_p = Int64(task_expert_idx) * Int64(
+                                sfb_w13_mx.shape[0] * sfb_row_p
+                            ) + Int64(n_base_p) * Int64(sfb_row_p)
+                            if cutlass.const_expr(self.w4a8_fused):
+                                b_base_pu = Int64(task_expert_idx) * Int64(
+                                    b_w13_u32.shape[0] * b_row_u32p
+                                ) + Int64(nu_base_p) * Int64(b_row_u32p)
+                                sfb_base_pu = Int64(task_expert_idx) * Int64(
+                                    sfb_w13_mx.shape[0] * sfb_row_p
+                                ) + Int64(nu_base_p) * Int64(sfb_row_p)
+                            if cutlass.const_expr(self.w4a8_residual):
+                                res_row_p = w13_residual.shape[1]
+                                res_base_p = Int64(task_expert_idx) * Int64(
+                                    w13_residual.shape[0] * res_row_p
+                                ) + Int64(n_base_p) * Int64(res_row_p)
+                                if cutlass.const_expr(self.w4a8_fused):
+                                    res_base_pu = Int64(task_expert_idx) * Int64(
+                                        w13_residual.shape[0] * res_row_p
+                                    ) + Int64(nu_base_p) * Int64(res_row_p)
+                            w4a8_uses = w4a8_passes * w4a8_KT + (
+                                phase1_output_tile_cnt // 2
+                                if self.w4a8_fc2_pair
+                                else phase1_output_tile_cnt
+                            )
+                            for _pkt in range(w4a8_KT):
+                                # Unified buffer-use epochs: gate tiles, up
+                                # tiles, then FC2 tiles share one sequence, so
+                                # every cross-phase buffer reuse is ordered by
+                                # the same ready/done flags.
+                                epoch = (
+                                    slice_idx * Int32(w4a8_uses)
+                                    + Int32(_pp * w4a8_KT)
+                                    + _pkt
+                                    + Int32(1)
+                                )
+                                par = (epoch - Int32(1)) & Int32(self.w4a8_depth - 1)
+                                w4a8_owned = Int32(1)
+                                if cutlass.const_expr(self.num_dma_warps > 1):
+                                    w4a8_owned = Int32(
+                                        ((epoch - Int32(1)) & Int32(1)) == w4a8_warp_off
+                                    )
+                                if w4a8_owned > Int32(0):
+                                    need = (
+                                        (epoch - Int32(1))
+                                        >> Int32(self.w4a8_depth_log2)
+                                    ) * Int32(self.num_mma_warps)
+                                    if cutlass.const_expr(not self.w4a8_named_pipeline):
+                                        _spin_wait_shared_ge_i32(
+                                            w4a8_pipe_addr
+                                            + Int32(16)
+                                            + (par << Int32(2)),
+                                            need,
+                                        )
+                                    if cutlass.const_expr(self.w4a8_repacked):
+                                        # Canonical compute format: select the
+                                        # N128 gate/up halves from their N256
+                                        # repack tiles and compact each into
+                                        # one 8KB shared half. The inner
+                                        # [chunk,lane,n8] order is preserved
+                                        # for vector fragment loads.
+                                        w4a8_b_dst = (
+                                            w4a8_sb0 + (w4a8_sb1 - w4a8_sb0) * par
+                                        )
+                                        rp_nt = p_n_tile >> Int32(1)
+                                        rp_half = p_n_tile & Int32(1)
+                                        rp_tile = (
+                                            task_expert_idx
+                                            * Int32(b_w13_u32.shape[0] // 256)
+                                            + rp_nt
+                                        ) * Int32(w4a8_KT) + Int32(_pkt)
+                                        _w4a8_stage_repacked_b_half(
+                                            w13_rp,
+                                            w4a8_b_dst,
+                                            Int64(rp_tile) * Int64(4096),
+                                            rp_half,
+                                            Int32(lane_id),
+                                            32,
+                                        )
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            rp_ntu = pu_n_tile >> Int32(1)
+                                            rp_halfu = pu_n_tile & Int32(1)
+                                            rp_tileu = (
+                                                task_expert_idx
+                                                * Int32(b_w13_u32.shape[0] // 256)
+                                                + rp_ntu
+                                            ) * Int32(w4a8_KT) + Int32(_pkt)
+                                            _w4a8_stage_repacked_b_half(
+                                                w13_rp,
+                                                w4a8_b_dst + Int32(128 * 64),
+                                                Int64(rp_tileu) * Int64(4096),
+                                                rp_halfu,
+                                                Int32(lane_id),
+                                                32,
+                                            )
+                                    elif cutlass.const_expr(self.w4a8_b_tma):
+                                        # B granule through TMA: one box per
+                                        # 8KB half; granule bytes complete on
+                                        # this par's mbarrier. Region/stage
+                                        # selection mirrors the consumers'
+                                        # b_buf math exactly.
+                                        if lane_id == Int32(0):
+                                            cute.arch.mbarrier_arrive_and_expect_tx(
+                                                w4a8_tma_mbar_ptr + par,
+                                                Int32(
+                                                    2 * _W4A8_TMA_TILE_BYTES
+                                                    if self.w4a8_fused
+                                                    else _W4A8_TMA_TILE_BYTES
+                                                ),
+                                            )
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            if par == Int32(0):
+                                                cute.copy(
+                                                    tma_b_w13,
+                                                    tBgB_w13_gate_nk[(None, _pkt)],
+                                                    tBsB_w13[(None, 0)],
+                                                    tma_bar_ptr=w4a8_tma_mbar_ptr + par,
+                                                )
+                                                cute.copy(
+                                                    tma_b_w13,
+                                                    tBgB_w13_up_nk[(None, _pkt)],
+                                                    tBsB_w13[(None, 1)],
+                                                    tma_bar_ptr=w4a8_tma_mbar_ptr + par,
+                                                )
+                                            else:
+                                                cute.copy(
+                                                    tma_b_w13,
+                                                    tBgB_w13_gate_nk[(None, _pkt)],
+                                                    tBsB_w13_up[(None, 0)],
+                                                    tma_bar_ptr=w4a8_tma_mbar_ptr + par,
+                                                )
+                                                cute.copy(
+                                                    tma_b_w13,
+                                                    tBgB_w13_up_nk[(None, _pkt)],
+                                                    tBsB_w13_up[(None, 1)],
+                                                    tma_bar_ptr=w4a8_tma_mbar_ptr + par,
+                                                )
+                                        else:
+                                            # Non-fused small (relu2): region
+                                            # par>>1, stage par&1, single box.
+                                            if (par >> Int32(1)) == Int32(0):
+                                                cute.copy(
+                                                    tma_b_w13,
+                                                    tBgB_w13_gate_nk[(None, _pkt)],
+                                                    tBsB_w13[(None, par & Int32(1))],
+                                                    tma_bar_ptr=w4a8_tma_mbar_ptr + par,
+                                                )
+                                            else:
+                                                cute.copy(
+                                                    tma_b_w13,
+                                                    tBgB_w13_gate_nk[(None, _pkt)],
+                                                    tBsB_w13_up[(None, par & Int32(1))],
+                                                    tma_bar_ptr=w4a8_tma_mbar_ptr + par,
+                                                )
+                                    else:
+                                        if cutlass.const_expr(self.w4a8_depth == 4):
+                                            w4a8_b_dst = (
+                                                w4a8_sb0
+                                                + (w4a8_sb1 - w4a8_sb0)
+                                                * (par >> Int32(1))
+                                                + (par & Int32(1)) * Int32(128 * 64)
+                                            )
+                                        else:
+                                            w4a8_b_dst = (
+                                                w4a8_sb0 + (w4a8_sb1 - w4a8_sb0) * par
+                                            )
+                                        _w4a8_stage_b_tile(
+                                            b_w13_u32,
+                                            w4a8_b_dst,
+                                            b_base_p + Int64(_pkt) * Int64(16),
+                                            Int32(b_row_u32p),
+                                            Int32(lane_id),
+                                            32,
+                                            self.w4a8_b_pad,
+                                        )
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            _w4a8_stage_b_tile(
+                                                b_w13_u32,
+                                                w4a8_b_dst + Int32(128 * 64),
+                                                b_base_pu + Int64(_pkt) * Int64(16),
+                                                Int32(b_row_u32p),
+                                                Int32(lane_id),
+                                                32,
+                                                self.w4a8_b_pad,
+                                            )
+                                    if cutlass.const_expr(
+                                        self.materialize_intermediate
+                                        and self.share_input_across_experts
+                                    ):
+                                        _w4a8_stage_a_tile_gather(
+                                            pa_u32,
+                                            token_map,
+                                            w4a8_sa0
+                                            + par * Int32(self.tile_shape_mnk[0] * 128),
+                                            m_row_base_p,
+                                            task_valid_rows_val,
+                                            Int32(_pkt) * Int32(32),
+                                            a_u32_per_row,
+                                            Int32(lane_id),
+                                            32,
+                                            self.tile_shape_mnk[0],
+                                        )
+                                    else:
+                                        _w4a8_stage_a_tile(
+                                            pa_u32,
+                                            w4a8_sa0
+                                            + par * Int32(self.tile_shape_mnk[0] * 128),
+                                            Int64(m_row_base_p) * Int64(a_u32_per_row)
+                                            + Int64(_pkt) * Int64(32),
+                                            a_u32_per_row,
+                                            Int32(lane_id),
+                                            32,
+                                            self.tile_shape_mnk[0],
+                                        )
+                                    if cutlass.const_expr(self.w4a8_fused):
+                                        w4a8_sfb_dst = w4a8_sfbb + (par << Int32(10))
+                                    else:
+                                        w4a8_sfb_dst = w4a8_sfbb + (par << Int32(9))
+                                    if cutlass.const_expr(self.w4a8_repacked):
+                                        _w4a8_stage_repacked_sfb_half(
+                                            w13_sfb_rp,
+                                            w4a8_sfb_dst,
+                                            Int64(rp_tile) * Int64(256),
+                                            rp_half,
+                                            Int32(lane_id),
+                                            32,
+                                        )
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            _w4a8_stage_repacked_sfb_half(
+                                                w13_sfb_rp,
+                                                w4a8_sfb_dst + Int32(512),
+                                                Int64(rp_tileu) * Int64(256),
+                                                rp_halfu,
+                                                Int32(lane_id),
+                                                32,
+                                            )
+                                    else:
+                                        _w4a8_stage_bytes4(
+                                            sfb_w13_mx,
+                                            w4a8_sfb_dst,
+                                            sfb_base_p + Int64(_pkt) * Int64(4),
+                                            Int32(sfb_row_p),
+                                            Int32(lane_id),
+                                            32,
+                                        )
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            _w4a8_stage_bytes4(
+                                                sfb_w13_mx,
+                                                w4a8_sfb_dst + Int32(512),
+                                                sfb_base_pu + Int64(_pkt) * Int64(4),
+                                                Int32(sfb_row_p),
+                                                Int32(lane_id),
+                                                32,
+                                            )
+                                    if cutlass.const_expr(self.w4a8_residual):
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            w4a8_res_dst = w4a8_res0 + (
+                                                par << Int32(11)
+                                            )
+                                        else:
+                                            w4a8_res_dst = w4a8_res0 + (
+                                                par << Int32(10)
+                                            )
+                                        _w4a8_stage_bytes8(
+                                            w13_residual,
+                                            w4a8_res_dst,
+                                            res_base_p + Int64(_pkt) * Int64(8),
+                                            Int32(res_row_p),
+                                            Int32(lane_id),
+                                            32,
+                                        )
+                                        if cutlass.const_expr(self.w4a8_fused):
+                                            _w4a8_stage_bytes8(
+                                                w13_residual,
+                                                w4a8_res_dst + Int32(1024),
+                                                res_base_pu + Int64(_pkt) * Int64(8),
+                                                Int32(res_row_p),
+                                                Int32(lane_id),
+                                                32,
+                                            )
+                                    w4a8_asc_dst = (
+                                        (
+                                            w4a8_resb
+                                            + par * Int32(self.tile_shape_mnk[0] * 4)
+                                        )
+                                        if cutlass.const_expr(
+                                            self.w4a8_repacked or self.w4a8_small
+                                        )
+                                        else (sfa_base_addr + (par << Int32(9)))
+                                    )
+                                    if cutlass.const_expr(
+                                        self.materialize_intermediate
+                                        and self.share_input_across_experts
+                                    ):
+                                        _w4a8_stage_scale_tile_gather(
+                                            scale_storage,
+                                            token_map,
+                                            w4a8_asc_dst,
+                                            m_row_base_p,
+                                            task_valid_rows_val,
+                                            Int32(_pkt) * Int32(4),
+                                            a_mx_per_row,
+                                            Int32(lane_id),
+                                            32,
+                                            self.tile_shape_mnk[0],
+                                        )
+                                    else:
+                                        _w4a8_stage_bytes4(
+                                            scale_storage,
+                                            w4a8_asc_dst,
+                                            asc_base_p + Int64(_pkt) * Int64(4),
+                                            a_mx_per_row,
+                                            Int32(lane_id),
+                                            32,
+                                            self.tile_shape_mnk[0],
+                                        )
+                                    cute.arch.cp_async_commit_group()
+                                    # A single producer owns multiple buffers,
+                                    # so it can defer publication of the current
+                                    # window until after staging the next one.
+                                    # With two producers at depth two, however,
+                                    # each warp owns only one buffer: deferring
+                                    # would make its next acquire wait on an
+                                    # epoch that it has not published.  Flush the
+                                    # current window immediately in that regime;
+                                    # the other producer supplies the overlap.
+                                    if cutlass.const_expr(
+                                        self.w4a8_depth <= self.num_dma_warps
+                                    ):
+                                        if cutlass.const_expr(self.w4a8_b_tma):
+                                            cute.arch.mbarrier_wait(
+                                                w4a8_tma_mbar_ptr + par,
+                                                phase=(w4a8_mbar_phase >> par)
+                                                & Int32(1),
+                                            )
+                                            w4a8_mbar_phase = w4a8_mbar_phase ^ (
+                                                Int32(1) << par
+                                            )
+                                        cute.arch.cp_async_wait_group(0)
+                                        cute.arch.fence_proxy(
+                                            "async.shared", space="cta"
+                                        )
+                                        if cutlass.const_expr(self.w4a8_named_pipeline):
+                                            self._arrive_w4a8_stage_ready(par)
+                                            self._sync_w4a8_stage_done(par)
+                                        else:
+                                            if lane_id == Int32(0):
+                                                _st_shared_release_i32(
+                                                    w4a8_pipe_addr + (par << Int32(2)),
+                                                    epoch,
+                                                )
+                                        w4a8_pend_epoch = Int32(0)
+                                    else:
+                                        if cutlass.const_expr(self.w4a8_b_tma):
+                                            if w4a8_pend_epoch > Int32(0):
+                                                cute.arch.mbarrier_wait(
+                                                    w4a8_tma_mbar_ptr + w4a8_pend_par,
+                                                    phase=(
+                                                        w4a8_mbar_phase >> w4a8_pend_par
+                                                    )
+                                                    & Int32(1),
+                                                )
+                                                w4a8_mbar_phase = w4a8_mbar_phase ^ (
+                                                    Int32(1) << w4a8_pend_par
+                                                )
+                                        cute.arch.cp_async_wait_group(1)
+                                        cute.arch.fence_proxy(
+                                            "async.shared", space="cta"
+                                        )
+                                        if lane_id == Int32(0):
+                                            if w4a8_pend_epoch > Int32(0):
+                                                _st_shared_release_i32(
+                                                    w4a8_pipe_addr
+                                                    + (w4a8_pend_par << Int32(2)),
+                                                    w4a8_pend_epoch,
+                                                )
+                                        w4a8_pend_par = par
+                                        w4a8_pend_epoch = epoch
+                        # The small NVFP4 path aliases FC2 residual staging
+                        # onto the FC1-A payload range.  Publish the final
+                        # deferred FC1 window before waiting for every MMA
+                        # warp to finish its FC1 reads; only then may FC2
+                        # enter the aliased range.  Per-parity done counts
+                        # cannot express this cross-parity lifetime edge.
+                        if cutlass.const_expr(self.w4a8_residual and self.w4a8_small):
+                            if cutlass.const_expr(self.w4a8_b_tma):
+                                if w4a8_pend_epoch > Int32(0):
+                                    cute.arch.mbarrier_wait(
+                                        w4a8_tma_mbar_ptr + w4a8_pend_par,
+                                        phase=(w4a8_mbar_phase >> w4a8_pend_par)
+                                        & Int32(1),
+                                    )
+                                    w4a8_mbar_phase = w4a8_mbar_phase ^ (
+                                        Int32(1) << w4a8_pend_par
+                                    )
+                            cute.arch.cp_async_wait_group(0)
+                            cute.arch.fence_proxy("async.shared", space="cta")
+                            if lane_id == Int32(0):
+                                if w4a8_pend_epoch > Int32(0):
+                                    _st_shared_release_i32(
+                                        w4a8_pipe_addr + (w4a8_pend_par << Int32(2)),
+                                        w4a8_pend_epoch,
+                                    )
+                            w4a8_pend_epoch = Int32(0)
+                            self.pass_gate_barrier.wait_unaligned()
+                        # ---- FC2 B_down staging (per output tile) ----
+                        dn_row_u32p = b_down_u32.shape[1]
+                        dn_base_p = Int64(task_expert_idx) * Int64(
+                            b_down_u32.shape[0] * dn_row_u32p
+                        ) + Int64(cur_slice_p) * Int64(16)
+                        dnsf_row_p = sfb_down_mx.shape[1]
+                        dnsf_base_p = Int64(task_expert_idx) * Int64(
+                            sfb_down_mx.shape[0] * dnsf_row_p
+                        ) + Int64(cur_slice_p) * Int64(4)
+                        if cutlass.const_expr(self.w4a8_residual):
+                            dnres_row_p = down_residual.shape[1]
+                            dnres_base_p = Int64(task_expert_idx) * Int64(
+                                down_residual.shape[0] * dnres_row_p
+                            ) + Int64(cur_slice_p) * Int64(8)
+                        w4a8_fc2_step = 2 if self.w4a8_fc2_pair else 1
+                        for _pt in range(0, phase1_output_tile_cnt, w4a8_fc2_step):
+                            epoch2 = (
+                                slice_idx * Int32(w4a8_uses)
+                                + Int32(w4a8_passes * w4a8_KT)
+                                + (
+                                    (_pt >> Int32(1))
+                                    if cutlass.const_expr(self.w4a8_fc2_pair)
+                                    else _pt
+                                )
+                                + Int32(1)
+                            )
+                            par2 = (epoch2 - Int32(1)) & Int32(self.w4a8_depth - 1)
+                            w4a8_owned2 = Int32(1)
+                            if cutlass.const_expr(self.num_dma_warps > 1):
+                                w4a8_owned2 = Int32(
+                                    ((epoch2 - Int32(1)) & Int32(1)) == w4a8_warp_off
+                                )
+                            if w4a8_owned2 > Int32(0):
+                                need2 = (
+                                    (epoch2 - Int32(1)) >> Int32(self.w4a8_depth_log2)
+                                ) * Int32(self.num_mma_warps)
+                                if cutlass.const_expr(not self.w4a8_named_pipeline):
+                                    _spin_wait_shared_ge_i32(
+                                        w4a8_pipe_addr + Int32(16) + (par2 << Int32(2)),
+                                        need2,
+                                    )
+                                row_off_p = Int64(_pt) * Int64(128)
+                                if cutlass.const_expr(self.w4a8_repacked):
+                                    w4a8_b2_dst = (
+                                        w4a8_sb0 + (w4a8_sb1 - w4a8_sb0) * par2
+                                    )
+                                    rp_tile2 = (
+                                        task_expert_idx
+                                        * Int32(b_down_u32.shape[0] // 256)
+                                        + (_pt >> Int32(1))
+                                    ) * gate_tile_cnt + cur_slice_p
+                                    _w4a8_stage_repacked_b_full(
+                                        down_rp,
+                                        w4a8_b2_dst,
+                                        Int64(rp_tile2) * Int64(4096),
+                                        Int32(lane_id),
+                                        32,
+                                    )
+                                elif cutlass.const_expr(self.w4a8_b_tma):
+                                    if lane_id == Int32(0):
+                                        cute.arch.mbarrier_arrive_and_expect_tx(
+                                            w4a8_tma_mbar_ptr + par2,
+                                            Int32(
+                                                2 * _W4A8_TMA_TILE_BYTES
+                                                if self.w4a8_fc2_pair
+                                                else _W4A8_TMA_TILE_BYTES
+                                            ),
+                                        )
+                                    if cutlass.const_expr(self.w4a8_fc2_pair):
+                                        if par2 == Int32(0):
+                                            cute.copy(
+                                                tma_b_down,
+                                                tBgB_down[
+                                                    (
+                                                        None,
+                                                        _pt,
+                                                        cur_slice_p,
+                                                        task_expert_idx,
+                                                    )
+                                                ],
+                                                tBsB_down[(None, 0)],
+                                                tma_bar_ptr=w4a8_tma_mbar_ptr + par2,
+                                            )
+                                            cute.copy(
+                                                tma_b_down,
+                                                tBgB_down[
+                                                    (
+                                                        None,
+                                                        _pt + Int32(1),
+                                                        cur_slice_p,
+                                                        task_expert_idx,
+                                                    )
+                                                ],
+                                                tBsB_down[(None, 1)],
+                                                tma_bar_ptr=w4a8_tma_mbar_ptr + par2,
+                                            )
+                                        else:
+                                            cute.copy(
+                                                tma_b_down,
+                                                tBgB_down[
+                                                    (
+                                                        None,
+                                                        _pt,
+                                                        cur_slice_p,
+                                                        task_expert_idx,
+                                                    )
+                                                ],
+                                                tBsB_down_up[(None, 0)],
+                                                tma_bar_ptr=w4a8_tma_mbar_ptr + par2,
+                                            )
+                                            cute.copy(
+                                                tma_b_down,
+                                                tBgB_down[
+                                                    (
+                                                        None,
+                                                        _pt + Int32(1),
+                                                        cur_slice_p,
+                                                        task_expert_idx,
+                                                    )
+                                                ],
+                                                tBsB_down_up[(None, 1)],
+                                                tma_bar_ptr=w4a8_tma_mbar_ptr + par2,
+                                            )
+                                    else:
+                                        if (par2 >> Int32(1)) == Int32(0):
+                                            cute.copy(
+                                                tma_b_down,
+                                                tBgB_down[
+                                                    (
+                                                        None,
+                                                        _pt,
+                                                        cur_slice_p,
+                                                        task_expert_idx,
+                                                    )
+                                                ],
+                                                tBsB_down[(None, par2 & Int32(1))],
+                                                tma_bar_ptr=w4a8_tma_mbar_ptr + par2,
+                                            )
+                                        else:
+                                            cute.copy(
+                                                tma_b_down,
+                                                tBgB_down[
+                                                    (
+                                                        None,
+                                                        _pt,
+                                                        cur_slice_p,
+                                                        task_expert_idx,
+                                                    )
+                                                ],
+                                                tBsB_down_up[(None, par2 & Int32(1))],
+                                                tma_bar_ptr=w4a8_tma_mbar_ptr + par2,
+                                            )
+                                else:
+                                    if cutlass.const_expr(self.w4a8_depth == 4):
+                                        w4a8_b2_dst = (
+                                            w4a8_sb0
+                                            + (w4a8_sb1 - w4a8_sb0) * (par2 >> Int32(1))
+                                            + (par2 & Int32(1)) * Int32(128 * 64)
+                                        )
+                                    else:
+                                        w4a8_b2_dst = (
+                                            w4a8_sb0 + (w4a8_sb1 - w4a8_sb0) * par2
+                                        )
+                                    _w4a8_stage_b_tile(
+                                        b_down_u32,
+                                        w4a8_b2_dst,
+                                        dn_base_p + row_off_p * Int64(dn_row_u32p),
+                                        Int32(dn_row_u32p),
+                                        Int32(lane_id),
+                                        32,
+                                        self.w4a8_b_pad,
+                                    )
+                                    if cutlass.const_expr(self.w4a8_fc2_pair):
+                                        row_off_p2 = row_off_p + Int64(128)
+                                        _w4a8_stage_b_tile(
+                                            b_down_u32,
+                                            w4a8_b2_dst + Int32(128 * 64),
+                                            dn_base_p + row_off_p2 * Int64(dn_row_u32p),
+                                            Int32(dn_row_u32p),
+                                            Int32(lane_id),
+                                            32,
+                                            self.w4a8_b_pad,
+                                        )
+                                if cutlass.const_expr(self.w4a8_fc2_pair):
+                                    w4a8_sfb2_dst = w4a8_sfbb + (par2 << Int32(10))
+                                else:
+                                    w4a8_sfb2_dst = w4a8_sfbb + (par2 << Int32(9))
+                                if cutlass.const_expr(self.w4a8_repacked):
+                                    _w4a8_stage_repacked_sfb_full(
+                                        down_sfb_rp,
+                                        w4a8_sfb2_dst,
+                                        Int64(rp_tile2) * Int64(256),
+                                        Int32(lane_id),
+                                        32,
+                                    )
+                                else:
+                                    _w4a8_stage_bytes4(
+                                        sfb_down_mx,
+                                        w4a8_sfb2_dst,
+                                        dnsf_base_p + row_off_p * Int64(dnsf_row_p),
+                                        Int32(dnsf_row_p),
+                                        Int32(lane_id),
+                                        32,
+                                    )
+                                    if cutlass.const_expr(self.w4a8_fc2_pair):
+                                        _w4a8_stage_bytes4(
+                                            sfb_down_mx,
+                                            w4a8_sfb2_dst + Int32(512),
+                                            dnsf_base_p
+                                            + (row_off_p + Int64(128))
+                                            * Int64(dnsf_row_p),
+                                            Int32(dnsf_row_p),
+                                            Int32(lane_id),
+                                            32,
+                                        )
+                                if cutlass.const_expr(self.w4a8_residual):
+                                    if cutlass.const_expr(self.w4a8_fc2_pair):
+                                        w4a8_res2_dst = w4a8_res2 + (par2 << Int32(11))
+                                    else:
+                                        w4a8_res2_dst = w4a8_res2 + (par2 << Int32(10))
+                                    _w4a8_stage_bytes8(
+                                        down_residual,
+                                        w4a8_res2_dst,
+                                        dnres_base_p + row_off_p * Int64(dnres_row_p),
+                                        Int32(dnres_row_p),
+                                        Int32(lane_id),
+                                        32,
+                                    )
+                                    if cutlass.const_expr(self.w4a8_fc2_pair):
+                                        _w4a8_stage_bytes8(
+                                            down_residual,
+                                            w4a8_res2_dst + Int32(1024),
+                                            dnres_base_p
+                                            + (row_off_p + Int64(128))
+                                            * Int64(dnres_row_p),
+                                            Int32(dnres_row_p),
+                                            Int32(lane_id),
+                                            32,
+                                        )
+                                cute.arch.cp_async_commit_group()
+                                if cutlass.const_expr(
+                                    self.w4a8_depth <= self.num_dma_warps
+                                ):
+                                    if cutlass.const_expr(self.w4a8_b_tma):
+                                        cute.arch.mbarrier_wait(
+                                            w4a8_tma_mbar_ptr + par2,
+                                            phase=(w4a8_mbar_phase >> par2) & Int32(1),
+                                        )
+                                        w4a8_mbar_phase = w4a8_mbar_phase ^ (
+                                            Int32(1) << par2
+                                        )
+                                    cute.arch.cp_async_wait_group(0)
+                                    cute.arch.fence_proxy("async.shared", space="cta")
+                                    if cutlass.const_expr(self.w4a8_named_pipeline):
+                                        self._arrive_w4a8_stage_ready(par2)
+                                        self._sync_w4a8_stage_done(par2)
+                                    else:
+                                        if lane_id == Int32(0):
+                                            _st_shared_release_i32(
+                                                w4a8_pipe_addr + (par2 << Int32(2)),
+                                                epoch2,
+                                            )
+                                    w4a8_pend_epoch = Int32(0)
+                                else:
+                                    if cutlass.const_expr(self.w4a8_b_tma):
+                                        if w4a8_pend_epoch > Int32(0):
+                                            cute.arch.mbarrier_wait(
+                                                w4a8_tma_mbar_ptr + w4a8_pend_par,
+                                                phase=(w4a8_mbar_phase >> w4a8_pend_par)
+                                                & Int32(1),
+                                            )
+                                            w4a8_mbar_phase = w4a8_mbar_phase ^ (
+                                                Int32(1) << w4a8_pend_par
+                                            )
+                                    cute.arch.cp_async_wait_group(1)
+                                    cute.arch.fence_proxy("async.shared", space="cta")
+                                    if lane_id == Int32(0):
+                                        if w4a8_pend_epoch > Int32(0):
+                                            _st_shared_release_i32(
+                                                w4a8_pipe_addr
+                                                + (w4a8_pend_par << Int32(2)),
+                                                w4a8_pend_epoch,
+                                            )
+                                    w4a8_pend_par = par2
+                                    w4a8_pend_epoch = epoch2
+                        if cutlass.const_expr(self.w4a8_b_tma):
+                            if w4a8_pend_epoch > Int32(0):
+                                cute.arch.mbarrier_wait(
+                                    w4a8_tma_mbar_ptr + w4a8_pend_par,
+                                    phase=(w4a8_mbar_phase >> w4a8_pend_par) & Int32(1),
+                                )
+                                w4a8_mbar_phase = w4a8_mbar_phase ^ (
+                                    Int32(1) << w4a8_pend_par
+                                )
+                        cute.arch.cp_async_wait_group(0)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        if lane_id == Int32(0):
+                            if w4a8_pend_epoch > Int32(0):
+                                _st_shared_release_i32(
+                                    w4a8_pipe_addr + (w4a8_pend_par << Int32(2)),
+                                    w4a8_pend_epoch,
+                                )
+                        w4a8_pend_epoch = Int32(0)
+                    prod_state.reset_count()
+                    for k_tile in range(
+                        0, fc1_k_tile_cnt if not self.is_w4a8 else 0, 1, unroll=4
+                    ):
+                        ml_pipeline.producer_acquire(prod_state)
+                        cute.copy(
+                            tma_a,
+                            tAgA_mk[(None, k_tile)],
+                            tAsA[(None, prod_state.index)],
+                            tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                        )
+                        cute.copy(
+                            tma_sfa,
+                            tAgSFA_mk[(None, k_tile)],
+                            tAsSFA[(None, prod_state.index)],
+                            tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                        )
+                        cute.copy(
+                            tma_b_w13,
+                            tBgB_w13_gate_nk[(None, k_tile)],
+                            tBsB_w13[(None, prod_state.index)],
+                            tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                        )
+                        cute.copy(
+                            tma_sfb_w13,
+                            tBgSFB_w13_gate_nk[(None, k_tile)],
+                            tBsSFB_w13[(None, prod_state.index)],
+                            tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                        )
+                        if cutlass.const_expr(self.swap_ab and gate_lo_sub > 0):
+                            # atom-hi (the next 128-row atom) staged in sB_up/
+                            # sSFB_up under ml_pipeline. Safe to share with the up
+                            # pass: within a slice pass_gate_barrier orders the
+                            # gate GEMM read before the up pass overwrite; across
+                            # slices the next gate pass also rewrites sA (read by
+                            # this slice's FC2), so the ml_pipeline sA dependency
+                            # serializes it -- no extra buffer needed (verified
+                            # bit-identical to a dedicated buffer). ml_tx_count
+                            # accounts for the extra bytes.
+                            cute.copy(
+                                tma_b_w13,
+                                tBgB_w13_gate_hi_nk[(None, k_tile)],
+                                tBsB_w13_up[(None, prod_state.index)],
+                                tma_bar_ptr=ml_pipeline.producer_get_barrier(
+                                    prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_sfb_w13,
+                                tBgSFB_w13_gate_hi_nk[(None, k_tile)],
+                                tBsSFB_w13_up[(None, prod_state.index)],
+                                tma_bar_ptr=ml_pipeline.producer_get_barrier(
+                                    prod_state
+                                ),
+                            )
+                        ml_pipeline.producer_commit(prod_state)
+                        prod_state.advance()
+
+                    # Pair with the MMA warps' FC1 completion arrival before
+                    # generic shared-buffer reuse.  Small NVFP4 completed this
+                    # handoff inside its specialized producer path, before its
+                    # first aliased FC2 residual write.
+                    if cutlass.const_expr(self.is_w4a8):
+                        if cutlass.const_expr(
+                            not (self.w4a8_residual and self.w4a8_small)
+                        ):
+                            self.pass_gate_barrier.arrive_unaligned()
+                    else:
+                        self.pass_gate_barrier.wait_unaligned()
+
+                    if self.is_gated:
+                        # ---- FC1 up pass ----
+                        up_prod_state.reset_count()
+                        for k_tile in range(
+                            0, fc1_k_tile_cnt if not self.is_w4a8 else 0, 1, unroll=4
+                        ):
+                            up_pipeline.producer_acquire(up_prod_state)
+                            cute.copy(
+                                tma_a,
+                                tAgA_mk[(None, k_tile)],
+                                tAsA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_b_w13,
+                                tBgB_w13_up_nk[(None, k_tile)],
+                                tBsB_w13_up[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_sfa,
+                                tAgSFA_mk[(None, k_tile)],
+                                tAsSFA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_sfb_w13,
+                                tBgSFB_w13_up_nk[(None, k_tile)],
+                                tBsSFB_w13_up[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            up_pipeline.producer_commit(up_prod_state)
+                            up_prod_state.advance()
+
+                    # ---- FC2 B_down loads: continuous pipeline ----
+                    # No barrier needed: sB/sSFB are free (gate done, up uses
+                    # sB_up/sSFB_up). phase2_pipeline handles data availability.
+                    # intermediate_slice selects the K-tile of GEMM2 (FC1 output N-tile
+                    # = GEMM2 K-tile since intermediate dim is the reduction dim).
+                    # Load ALL FC2 tiles continuously once stage1 no longer needs
+                    # the gate staging buffers.
+                    phase2_prod_state.reset_count()
+                    for output_tile_idx in range(
+                        0,
+                        phase1_output_tile_cnt if not self.is_w4a8 else 0,
+                        1,
+                        unroll=4,
+                    ):
+                        phase2_pipeline.producer_acquire(phase2_prod_state)
+                        cute.copy(
+                            tma_b_down,
+                            tBgB_down[
+                                (
+                                    None,
+                                    output_tile_idx,
+                                    intermediate_slice,
+                                    task_expert_idx,
+                                )
+                            ],
+                            tBsB_down[(None, phase2_prod_state.index)],
+                            tma_bar_ptr=phase2_pipeline.producer_get_barrier(
+                                phase2_prod_state
+                            ),
+                        )
+                        cute.copy(
+                            tma_sfb_down,
+                            tBgSFB_down[
+                                (
+                                    None,
+                                    output_tile_idx,
+                                    intermediate_slice,
+                                    task_expert_idx,
+                                )
+                            ],
+                            tBsSFB_down[(None, phase2_prod_state.index)],
+                            tma_bar_ptr=phase2_pipeline.producer_get_barrier(
+                                phase2_prod_state
+                            ),
+                        )
+                        phase2_pipeline.producer_commit(phase2_prod_state)
+                        phase2_prod_state.advance()
+
+                    # Ensure MMA warps finish FC2/scatter before DMA starts the
+                    # next slice/task's FC1 loads into shared A buffers.
+                    self.pass_final_barrier.wait_unaligned()
+                    slice_idx += Int32(1)
+
+        if cutlass.const_expr(not self.is_w4a8):
+            if warp_idx == self.tma_load_warp_id:
+                ml_pipeline.producer_tail(prod_state)
+                if self.is_gated:
+                    up_pipeline.producer_tail(up_prod_state)
+                phase2_pipeline.producer_tail(phase2_prod_state)
+
+        if cutlass.const_expr(
+            self.materialize_intermediate and not self.external_materialized_fc2
+        ):
+            # Every phase-A task has now published its MXFP8 activation tile.
+            # Phase B is a dense, uniform domain: one full-K task per physical
+            # M tile and N256 output tile.  A deterministic grid-stride walk
+            # gives each resident CTA balanced work without returning to the
+            # atomic queue used for irregular/streaming phase-A tasks.
+            self._resident_grid_barrier(
+                barrier_count,
+                barrier_epoch,
+                Int32(gdim_z),
+                is_cta_leader,
+            )
+            phase2_packed_output_tiles = output_tile_cnt // Int32(2)
+            phase2_task_output_tiles = phase2_packed_output_tiles
+            if cutlass.const_expr(self.w4a8_m128_materialized):
+                # M128 deliberately runs one N128 half per task.  The prepared
+                # weights remain N256-tile-major, so the helper receives both
+                # this task coordinate and the packed-tile count.
+                phase2_task_output_tiles = output_tile_cnt
+            if cutlass.const_expr(self.w4a8_m1_materialized):
+                phase2_tail = total_pairs * phase2_task_output_tiles
+                phase2_slot = Int32(bidz)
+                while phase2_slot < phase2_tail:
+                    phase2_m_tile = phase2_slot // phase2_task_output_tiles
+                    phase2_output_tile = (
+                        phase2_slot - phase2_m_tile * phase2_task_output_tiles
+                    )
+                    phase2_expert = topk_ids[phase2_m_tile].to(Int32)
+                    self._run_w4a8_materialized_fc2(
+                        intermediate_u32,
+                        down_rp,
+                        down_sfb_rp,
+                        scatter_output,
+                        token_map,
+                        token_weights,
+                        down_alpha,
+                        global_scale,
+                        sa_flat_addr,
+                        w4a8_sb0,
+                        w4a8_sb1,
+                        w4a8_sfbb,
+                        Int32(tidx),
+                        warp_idx,
+                        phase2_m_tile,
+                        phase2_expert,
+                        phase2_output_tile,
+                        Int32(1),
+                        rows_capacity,
+                        gate_tile_cnt,
+                        phase2_packed_output_tiles,
+                    )
+                    cute.arch.sync_threads()
+                    phase2_slot += Int32(gdim_z)
+            else:
+                phase2_m_tiles = expert_tile_base[num_experts]
+                phase2_tail = phase2_m_tiles * phase2_task_output_tiles
+                phase2_slot = Int32(bidz)
+                while phase2_slot < phase2_tail:
+                    phase2_m_tile = phase2_slot // phase2_task_output_tiles
+                    phase2_output_tile = (
+                        phase2_slot - phase2_m_tile * phase2_task_output_tiles
+                    )
+                    phase1_meta = phase2_m_tile * materialized_num_groups
+                    phase2_expert = task_expert[phase1_meta].to(Int32)
+                    phase2_valid_rows = task_valid_rows[phase1_meta].to(Int32)
+                    self._run_w4a8_materialized_fc2(
+                        intermediate_u32,
+                        down_rp,
+                        down_sfb_rp,
+                        scatter_output,
+                        token_map,
+                        token_weights,
+                        down_alpha,
+                        global_scale,
+                        sa_flat_addr,
+                        w4a8_sb0,
+                        w4a8_sb1,
+                        w4a8_sfbb,
+                        Int32(tidx),
+                        warp_idx,
+                        phase2_m_tile,
+                        phase2_expert,
+                        phase2_output_tile,
+                        phase2_valid_rows,
+                        rows_capacity,
+                        gate_tile_cnt,
+                        phase2_packed_output_tiles,
+                    )
+                    cute.arch.sync_threads()
+                    phase2_slot += Int32(gdim_z)
+        return
+
+
+__all__ = ["MoEDynamicKernelBackend"]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/micro.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/micro.py
@@ -1,0 +1,4975 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/micro.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""MoEMicroKernelBackend — compact routed NVFP4 MoE kernel for SM120."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import BFloat16, Float32, Uint32
+
+from cutlass.cutlass_dsl import Int32, Int64
+
+from flashinfer.experimental.sm12x._lib.utils import (
+    current_cuda_stream,
+    get_num_sm,
+    get_max_active_clusters,
+    make_ptr,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_add_global_i32,
+    cvt_e4m3_to_f32_via_f16,
+    cvt_e4m3x4_to_f32x4,
+    cvt_e8m0_to_f32,
+    cvt_e8m0x4_to_f32x4,
+    cvt_f32_to_e4m3,
+    cvt_w4a16_packed_e4m3_scale_to_f32,
+    fmax_f32,
+    fp4_dot4_sum_f32acc,
+    fp4_dot8_sum_f32acc,
+    get_ptr_as_int64,
+    ld_global_acquire_i32,
+    ld_global_nc_u32,
+    ld_global_nc_v4_u32,
+    mx_scale_from_amax32,
+    nvfp4_scale_from_amax,
+    quant_dequant_e4m3_2,
+    pack_f32x2_to_f16x2,
+    prefetch_global_l2,
+    quant_dequant_2,
+    spin_wait_global_eq_i32,
+    st_global_i32,
+    st_global_release_i32,
+    threadfence,
+    warp_reduce,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    SWIGLUOAI_UNINTERLEAVE,
+    is_gated_moe_activation,
+    normalize_moe_activation,
+    normalize_swiglu_alpha_for_activation,
+    normalize_swiglu_beta_for_activation,
+    normalize_swiglu_limit_for_activation,
+)
+
+
+_BLOCK_SIZE = 16
+_FP8_E4M3_MAX = 448.0
+_FC2_TILE_RECIP_GS_NUM = 6.0 * _FP8_E4M3_MAX
+_NUM_WARPS = 16
+_BLOCK_DIM = _NUM_WARPS * 32
+_K_PER_CTA = 16
+_MAX_DIRECT_K_SEGMENTS = 12
+_W4A16_PACKED_E4M3_SCALE_CACHE_VERSION = 1
+
+
+def _direct_k_segments_supported(k_segments: int) -> bool:
+    return 1 <= int(k_segments) <= _MAX_DIRECT_K_SEGMENTS
+
+
+def _align_up(value: int, align: int) -> int:
+    return ((int(value) + int(align) - 1) // int(align)) * int(align)
+
+
+def _direct_k_segments_for_k(k: int) -> int:
+    return _align_up(k, 32 * _BLOCK_SIZE) // (32 * _BLOCK_SIZE)
+
+
+def _fc1_chunks_for_m(m: int, n: int) -> int:
+    rows_per_warp = max(1, int(m))
+    rows_per_chunk = max(_BLOCK_SIZE, _NUM_WARPS * rows_per_warp)
+    chunks = max(1, int(n) // rows_per_chunk)
+    while chunks > 1:
+        i_chunk = int(n) // chunks
+        if int(n) % chunks == 0 and i_chunk % _BLOCK_SIZE == 0:
+            return chunks
+        chunks -= 1
+    return 1
+
+
+@dataclass(frozen=True)
+class _ShapeConfig:
+    """Compile-time shape constants."""
+
+    k_dim: int
+    n: int
+    two_n: int
+    weight_E: int
+    num_topk: int
+    k_half: int
+    n_half: int
+    w1_sf_rows: int
+    w1_sf_cols: int
+    w2_sf_rows: int
+    w2_sf_cols: int
+    k_blocks: int
+    k_segments: int
+    k_segments_aligned: bool
+    fc1_chunks: int
+    fc1_chunks_per_block: int
+    i_chunk: int
+    rows_per_warp_fc1: int
+    smem_xh_stride: int
+    smem_xh_size: int
+    inter_blocks: int
+    inter_u32: int
+    fc2_n_chunks: int
+
+
+def _make_shape_config(
+    *,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    weight_E: int,
+    is_gated: bool = True,
+) -> _ShapeConfig:
+    k_half = k // 2
+    n_half = n // 2
+    two_n = 2 * n if is_gated else n
+    w1_sf_rows = _align_up(two_n, 128)
+    w1_sf_cols = _align_up(k // _BLOCK_SIZE, 4)
+    w2_sf_rows = _align_up(k, 128)
+    w2_sf_cols = _align_up(n // _BLOCK_SIZE, 4)
+    k_blocks = k // _BLOCK_SIZE
+    k_segments = _direct_k_segments_for_k(k)
+    k_segments_aligned = k_blocks == k_segments * 32
+    fc1_chunks = _fc1_chunks_for_m(m, n)
+    fc1_chunks_per_block = 16  # chunks per 128-wide swizzle block
+    i_chunk = n // fc1_chunks
+    rows_per_warp_fc1 = i_chunk // _NUM_WARPS
+    smem_xh_stride = k_segments * (_BLOCK_SIZE // 2) + 1
+    smem_xh_size = k_half + (k // (_BLOCK_SIZE * 8))
+    inter_blocks = i_chunk // _BLOCK_SIZE
+    fc2_n_chunks = (n // 2 + 127) // 128
+    inter_u32 = fc2_n_chunks * 128 * num_topk
+    return _ShapeConfig(
+        k_dim=k,
+        n=n,
+        two_n=two_n,
+        weight_E=weight_E,
+        num_topk=num_topk,
+        k_half=k_half,
+        n_half=n_half,
+        w1_sf_rows=w1_sf_rows,
+        w1_sf_cols=w1_sf_cols,
+        w2_sf_rows=w2_sf_rows,
+        w2_sf_cols=w2_sf_cols,
+        k_blocks=k_blocks,
+        k_segments=k_segments,
+        k_segments_aligned=k_segments_aligned,
+        fc1_chunks=fc1_chunks,
+        fc1_chunks_per_block=fc1_chunks_per_block,
+        i_chunk=i_chunk,
+        rows_per_warp_fc1=rows_per_warp_fc1,
+        smem_xh_stride=smem_xh_stride,
+        smem_xh_size=smem_xh_size,
+        inter_blocks=inter_blocks,
+        inter_u32=inter_u32,
+        fc2_n_chunks=fc2_n_chunks,
+    )
+
+
+def _remake_shape_config_fc1(cfg: _ShapeConfig, fc1_chunks: int) -> _ShapeConfig:
+    i_chunk = cfg.n // fc1_chunks
+    rows_per_warp_fc1 = i_chunk // _NUM_WARPS
+    smem_xh_stride = cfg.k_segments * (_BLOCK_SIZE // 2) + 1
+    smem_xh_size = cfg.k_half + (cfg.k_dim // (_BLOCK_SIZE * 8))
+    inter_blocks = i_chunk // _BLOCK_SIZE
+    fc2_n_chunks = (cfg.n // 2 + 127) // 128
+    inter_u32 = fc2_n_chunks * 128 * cfg.num_topk
+    return _ShapeConfig(
+        k_dim=cfg.k_dim,
+        n=cfg.n,
+        two_n=cfg.two_n,
+        weight_E=cfg.weight_E,
+        num_topk=cfg.num_topk,
+        k_half=cfg.k_half,
+        n_half=cfg.n_half,
+        w1_sf_rows=cfg.w1_sf_rows,
+        w1_sf_cols=cfg.w1_sf_cols,
+        w2_sf_rows=cfg.w2_sf_rows,
+        w2_sf_cols=cfg.w2_sf_cols,
+        k_blocks=cfg.k_blocks,
+        k_segments=cfg.k_segments,
+        k_segments_aligned=cfg.k_segments_aligned,
+        fc1_chunks=fc1_chunks,
+        fc1_chunks_per_block=cfg.fc1_chunks_per_block,
+        i_chunk=i_chunk,
+        rows_per_warp_fc1=rows_per_warp_fc1,
+        smem_xh_stride=smem_xh_stride,
+        smem_xh_size=smem_xh_size,
+        inter_blocks=inter_blocks,
+        inter_u32=inter_u32,
+        fc2_n_chunks=fc2_n_chunks,
+    )
+
+
+@cute.jit
+def _block_dot_hfma2_f32acc(
+    u_a: Uint32,
+    u_b: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Float32:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    xh4 = Uint32(smem_xh[xh_base + Int32(4)])
+    xh5 = Uint32(smem_xh[xh_base + Int32(5)])
+    xh6 = Uint32(smem_xh[xh_base + Int32(6)])
+    xh7 = Uint32(smem_xh[xh_base + Int32(7)])
+    return fp4_dot8_sum_f32acc(u_a, u_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+
+
+@cute.jit
+def _block_dot_hfma2_pair_f32acc(
+    up_a: Uint32,
+    up_b: Uint32,
+    gate_a: Uint32,
+    gate_b: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Tuple[Float32, Float32]:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    xh4 = Uint32(smem_xh[xh_base + Int32(4)])
+    xh5 = Uint32(smem_xh[xh_base + Int32(5)])
+    xh6 = Uint32(smem_xh[xh_base + Int32(6)])
+    xh7 = Uint32(smem_xh[xh_base + Int32(7)])
+    up = fp4_dot8_sum_f32acc(up_a, up_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+    gate = fp4_dot8_sum_f32acc(gate_a, gate_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+    return up, gate
+
+
+@cute.jit
+def _block_dot4_f32acc(
+    u_val: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Float32:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    return fp4_dot4_sum_f32acc(u_val, xh0, xh1, xh2, xh3)
+
+
+@cute.jit
+def _block_dot4_pair_f32acc(
+    up_val: Uint32,
+    gate_val: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Tuple[Float32, Float32]:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    up = fp4_dot4_sum_f32acc(up_val, xh0, xh1, xh2, xh3)
+    gate = fp4_dot4_sum_f32acc(gate_val, xh0, xh1, xh2, xh3)
+    return up, gate
+
+
+@cute.jit
+def _token_publish_fc1_ready(
+    barrier_count: cute.Tensor,
+    barrier_epoch: cute.Tensor,
+    token_idx: Int32,
+    expected_epoch: Int32,
+    chunks_per_token: Int32,
+    is_cta_leader: Int32,
+):
+    if is_cta_leader > Int32(0):
+        count_addr = get_ptr_as_int64(barrier_count, token_idx)
+        epoch_addr = get_ptr_as_int64(barrier_epoch, token_idx)
+        arrived = atomic_add_global_i32(count_addr, Int32(1))
+        if arrived == chunks_per_token - Int32(1):
+            st_global_i32(count_addr, Int32(0))
+            st_global_release_i32(epoch_addr, expected_epoch + Int32(1))
+
+
+@cute.jit
+def _token_wait_fc1_ready(
+    barrier_epoch: cute.Tensor,
+    token_idx: Int32,
+    expected_epoch: Int32,
+    is_cta_leader: Int32,
+):
+    cute.arch.sync_threads()
+    if is_cta_leader > Int32(0):
+        epoch_addr = get_ptr_as_int64(barrier_epoch, token_idx)
+        spin_wait_global_eq_i32(epoch_addr, expected_epoch)
+    cute.arch.sync_threads()
+
+
+class MoEMicroKernelBackend:
+    """Decode-focused compact MoE kernel for SM120."""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        fast_math: bool = False,
+        activation: str = "silu",
+        share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        single_token: bool = False,
+        dynamic_down_scale: bool = False,
+        compile_time_phase: int = 0,
+        w4a16_mode: bool = False,
+        a8_mx_mode: bool = False,
+        scale_format: str = "e4m3_k16",
+        e8m0_scale_layout: str = "packed",
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+        w13_layout: str = "w13",
+    ):
+        activation = normalize_moe_activation(activation)
+        if int(compile_time_phase) not in {0, 1, 2}:
+            raise ValueError(f"unsupported direct micro phase {compile_time_phase!r}")
+        if scale_format not in {"e4m3_k16", "e8m0_k32"}:
+            raise ValueError(f"unsupported micro scale_format {scale_format!r}")
+        if w4a16_mode and a8_mx_mode:
+            raise ValueError("w4a16_mode and a8_mx_mode are mutually exclusive")
+        if scale_format == "e8m0_k32" and not (w4a16_mode or a8_mx_mode):
+            raise ValueError("e8m0_k32 scales require the W4A16 or a8_mx micro mode")
+        if e8m0_scale_layout not in {"packed", "logical"}:
+            raise ValueError(
+                f"unsupported micro e8m0_scale_layout {e8m0_scale_layout!r}"
+            )
+        swiglu_limit = normalize_swiglu_limit_for_activation(activation, swiglu_limit)
+        swiglu_alpha = normalize_swiglu_alpha_for_activation(activation, swiglu_alpha)
+        swiglu_beta = normalize_swiglu_beta_for_activation(activation, swiglu_beta)
+        if w13_layout not in {"w13", "w31"}:
+            raise ValueError(f"unsupported micro w13_layout {w13_layout!r}")
+        self.scale_format = scale_format
+        self.scale_format_e8m0_k32 = scale_format == "e8m0_k32"
+        self.e8m0_scale_layout = e8m0_scale_layout
+        self.e8m0_scale_layout_logical = e8m0_scale_layout == "logical"
+        self.w13_layout = w13_layout
+        # "w31" (gate_up) keeps the gate half first; "w13" (up_gate) keeps up first.
+        self.w13_gate_first = w13_layout == "w31"
+        self.has_swiglu_limit = swiglu_limit is not None
+        self.swiglu_limit = 0.0 if swiglu_limit is None else float(swiglu_limit)
+        self.swiglu_alpha = float(swiglu_alpha)
+        self.swiglu_beta = float(swiglu_beta)
+        self.sf_vec_size = sf_vec_size
+        del fast_math
+        self.activation = activation
+        self.is_gated = is_gated_moe_activation(activation)
+        self.is_swigluoai = activation == SWIGLUOAI_UNINTERLEAVE
+        self.share_input_across_experts = share_input_across_experts
+        self.share_expert_scales = share_expert_scales
+        self.single_token = single_token
+        self.dynamic_down_scale = dynamic_down_scale
+        self.compile_time_phase = int(compile_time_phase)
+        self.w4a16_mode = w4a16_mode
+        # a8_mx: quantize-dequantize activations through E4M3 with per-32
+        # UE8M0 block scales (no global scale) so decode numerics track the
+        # w4a8 prefill recipe. Same f16 dot-product math and weights.
+        self.a8_mx_mode = a8_mx_mode
+        self._cfg = None
+        self.m_const = 0
+        self.m1_fc2_onepass = False
+        self.m1_fc2_rows_per_cta = _K_PER_CTA * 2
+        self.launch_block_dim = _BLOCK_DIM
+        self.grid_x = 0
+
+    @property
+    def __cache_key__(self):
+        return (
+            self.sf_vec_size,
+            self.activation,
+            self.share_input_across_experts,
+            self.share_expert_scales,
+            self.single_token,
+            self.dynamic_down_scale,
+            self.compile_time_phase,
+            self.w4a16_mode,
+            self.a8_mx_mode,
+            self.scale_format,
+            self.e8m0_scale_layout,
+            self.w13_layout,
+            self.has_swiglu_limit,
+            self.swiglu_limit,
+            self.swiglu_alpha,
+            self.swiglu_beta,
+            _W4A16_PACKED_E4M3_SCALE_CACHE_VERSION,
+            self._cfg,
+            self.m_const,
+            self.m1_fc2_onepass,
+            self.m1_fc2_rows_per_cta,
+            self.launch_block_dim,
+        )
+
+    @cute.jit
+    def _fp4_dot4_for_math(
+        self,
+        u_packed: Uint32,
+        x0: Uint32,
+        x1: Uint32,
+        x2: Uint32,
+        x3: Uint32,
+    ) -> Float32:
+        return fp4_dot4_sum_f32acc(u_packed, x0, x1, x2, x3)
+
+    @cute.jit
+    def _scale_byte_to_f32(self, byte: Uint32) -> Float32:
+        """Decode one block-scale byte to f32 (E8M0 in MXFP4 mode, else E4M3)."""
+        if cutlass.const_expr(self.scale_format_e8m0_k32):
+            return cvt_e8m0_to_f32(byte)
+        if cutlass.const_expr(self.w4a16_mode):
+            return cvt_w4a16_packed_e4m3_scale_to_f32(byte)
+        return cvt_e4m3_to_f32_via_f16(byte)
+
+    @cute.jit
+    def _scale_word_to_f32x4(
+        self, word: Uint32
+    ) -> Tuple[Float32, Float32, Float32, Float32]:
+        """Decode 4 packed block-scale bytes to f32x4 (E8M0 in MXFP4 mode)."""
+        if cutlass.const_expr(self.scale_format_e8m0_k32):
+            return cvt_e8m0x4_to_f32x4(word)
+        return cvt_e4m3x4_to_f32x4(word)
+
+    @cute.jit
+    def _packed_scale_col(self, n: Int32) -> Int32:
+        """Column of size_n row n in the shared _pack_e8m0_k32_scales [K/32, N]
+        grid. For N a multiple of 64 the Marlin permute is a per-row column
+        permutation (verified): (n & ~63) | ((n&7)<<3) | swap_bits01((n>>3)&7)."""
+        hi = (n >> Int32(3)) & Int32(7)
+        hi_sw = (
+            (hi & Int32(4))
+            | ((hi & Int32(1)) << Int32(1))
+            | ((hi >> Int32(1)) & Int32(1))
+        )
+        return (n & ~Int32(63)) | ((n & Int32(7)) << Int32(3)) | hi_sw
+
+    @cute.jit
+    def _ld_e8m0_scale(
+        self,
+        base_addr: Int64,
+        ebase: Int64,
+        kb32: Int32,
+        out_row: Int32,
+        n_cols: Int32,
+        k32_cols: Int32,
+    ) -> Float32:
+        """E8M0 scale from either packed [K/32, N] or logical [N, K/32]."""
+        if cutlass.const_expr(self.e8m0_scale_layout_logical):
+            addr = base_addr + ebase + Int64(out_row) * Int64(k32_cols) + Int64(kb32)
+        else:
+            col = self._packed_scale_col(out_row)
+            addr = base_addr + ebase + Int64(kb32) * Int64(n_cols) + Int64(col)
+        word = ld_global_nc_u32(addr & ~Int64(3))
+        byte = (word >> Uint32((addr & Int64(3)) * Int64(8))) & Uint32(0xFF)
+        return cvt_e8m0_to_f32(byte)
+
+    @cute.jit
+    def _packed_e4m3_scale_col(self, n: Int32) -> Int32:
+        """Column of row n in _permute_nvfp4_scales' packed E4M3 grid."""
+        x = n & Int32(63)
+        perm_pos = ((x & Int32(7)) << Int32(3)) + (x >> Int32(3))
+        rem = perm_pos & Int32(3)
+        rem_swapped = rem
+        if rem == Int32(1):
+            rem_swapped = Int32(2)
+        elif rem == Int32(2):
+            rem_swapped = Int32(1)
+        return (n & ~Int32(63)) + (perm_pos & ~Int32(3)) + rem_swapped
+
+    @cute.jit
+    def _ld_e4m3_packed_scale(
+        self,
+        base_addr: Int64,
+        ebase: Int64,
+        kb16: Int32,
+        out_row: Int32,
+        n_cols: Int32,
+    ) -> Float32:
+        col = self._packed_e4m3_scale_col(out_row)
+        return self._ld_e4m3_packed_scale_col(base_addr, ebase, kb16, col, n_cols)
+
+    @cute.jit
+    def _ld_e4m3_packed_scale_col(
+        self,
+        base_addr: Int64,
+        ebase: Int64,
+        kb16: Int32,
+        col: Int32,
+        n_cols: Int32,
+    ) -> Float32:
+        addr = base_addr + ebase + Int64(kb16) * Int64(n_cols) + Int64(col)
+        word = ld_global_nc_u32(addr & ~Int64(3))
+        byte = (word >> Uint32((addr & Int64(3)) * Int64(8))) & Uint32(0xFF)
+        return cvt_w4a16_packed_e4m3_scale_to_f32(byte)
+
+    @cute.jit
+    def _block_dot_hfma2_for_math(
+        self,
+        u_a: Uint32,
+        u_b: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Float32:
+        return _block_dot_hfma2_f32acc(u_a, u_b, smem_xh, xh_base)
+
+    @cute.jit
+    def _block_dot_hfma2_pair_for_math(
+        self,
+        up_a: Uint32,
+        up_b: Uint32,
+        gate_a: Uint32,
+        gate_b: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Tuple[Float32, Float32]:
+        return _block_dot_hfma2_pair_f32acc(
+            up_a, up_b, gate_a, gate_b, smem_xh, xh_base
+        )
+
+    @cute.jit
+    def _block_dot_hfma2_pair_regs_for_math(
+        self,
+        up_a: Uint32,
+        up_b: Uint32,
+        gate_a: Uint32,
+        gate_b: Uint32,
+        xh0: Uint32,
+        xh1: Uint32,
+        xh2: Uint32,
+        xh3: Uint32,
+        xh4: Uint32,
+        xh5: Uint32,
+        xh6: Uint32,
+        xh7: Uint32,
+    ) -> Tuple[Float32, Float32]:
+        """Paired up/gate fp4_dot8 over pre-loaded activation registers."""
+        up = fp4_dot8_sum_f32acc(up_a, up_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+        gate = fp4_dot8_sum_f32acc(
+            gate_a, gate_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7
+        )
+        return up, gate
+
+    @cute.jit
+    def _block_dot4_for_math(
+        self,
+        u_val: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Float32:
+        return _block_dot4_f32acc(u_val, smem_xh, xh_base)
+
+    @cute.jit
+    def _block_dot4_pair_for_math(
+        self,
+        up_val: Uint32,
+        gate_val: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Tuple[Float32, Float32]:
+        return _block_dot4_pair_f32acc(up_val, gate_val, smem_xh, xh_base)
+
+    @classmethod
+    def is_supported(
+        cls,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+    ) -> bool:
+        # Micro keeps the m tokens' activations resident; 8 is the register
+        # budget ceiling. The FC1 task decode and FC2 are generic in m, so any
+        # 1<=m<=8 is correct (not just powers of two).
+        if not (1 <= m <= 8):
+            return False
+        if k <= 0 or k % _BLOCK_SIZE != 0 or k % 128 != 0:
+            return False
+        if _direct_k_segments_for_k(k) > _MAX_DIRECT_K_SEGMENTS:
+            return False
+        if n <= 0 or n % _BLOCK_SIZE != 0:
+            return False
+        fc1_chunks = _fc1_chunks_for_m(m, n)
+        if n % fc1_chunks != 0:
+            return False
+        i_chunk = n // fc1_chunks
+        if i_chunk % _BLOCK_SIZE != 0:
+            return False
+        k_segments = _direct_k_segments_for_k(k)
+        return (
+            _direct_k_segments_supported(k_segments)
+            and 0 < num_topk <= 32
+            and weight_E > 0
+        )
+
+    def configure(
+        self,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+        *,
+        max_active_ctas: int | None = None,
+        device: torch.device | None = None,
+    ):
+        cfg = _make_shape_config(
+            m=m, k=k, n=n, num_topk=num_topk, weight_E=weight_E, is_gated=self.is_gated
+        )
+        num_fc1_chunks = _fc1_chunks_for_m(m, n)
+        if self.w4a16_mode and m == 1 and n <= 2048:
+            # The 4-output-rows/warp retile only helps the k_segments==8 aligned
+            # gated path (its activation reg-hoist + dual-dot assume 4 rows).
+            # The packed-scale GLM k_segments==12 path is scale-load limited; one
+            # row/warp keeps those strided packed scale loads out of the inner
+            # row loop without retaining the old native scale grid.
+            rows_per_warp_div = 2
+            if cfg.k_segments_aligned and cfg.k_segments == 8 and self.is_gated:
+                rows_per_warp_div = 4
+            elif cfg.k_segments_aligned and cfg.k_segments == 12 and self.is_gated:
+                rows_per_warp_div = 1
+            num_fc1_chunks = min(num_fc1_chunks, n // (rows_per_warp_div * _BLOCK_SIZE))
+        if self.w4a16_mode and m > 1:
+            # Keep W4A16 multi-token FC1 chunks narrow enough to stay within
+            # the 512-thread launch register limit.
+            num_fc1_chunks = max(num_fc1_chunks, n // (_BLOCK_SIZE * 2))
+        if self.a8_mx_mode:
+            # Per-32 self-ranging blocks: chunks must hold whole 32-blocks
+            # (the default policy picks i_chunk=16 at m<=2).
+            # The standalone FC1 phase only writes the contiguous FP32
+            # intermediate; it never forms the FC2 per-32 activation scale.
+            # It can therefore use the native 16-row tile, which doubles the
+            # decode work grid without changing quantization semantics.
+            a8_chunk_rows = 16 if self.compile_time_phase == 1 else 32
+            a8_chunks = max(1, min(num_fc1_chunks, n // a8_chunk_rows))
+            while a8_chunks > 1 and (
+                n % a8_chunks != 0 or (n // a8_chunks) % a8_chunk_rows != 0
+            ):
+                a8_chunks -= 1
+            num_fc1_chunks = a8_chunks
+        cfg = _remake_shape_config_fc1(cfg, num_fc1_chunks)
+
+        fc1_tasks = m * cfg.num_topk * cfg.fc1_chunks
+        w4a16_rowpair_fc2 = bool(self.w4a16_mode and m > 1 and cfg.fc2_n_chunks == 1)
+        m1_half_cta_fc2 = bool(self.compile_time_phase == 2 and m == 1)
+        m1_fc2_rows = _K_PER_CTA if m1_half_cta_fc2 else _K_PER_CTA * 2
+        if m == 1:
+            fc2_tasks = cfg.k_dim // m1_fc2_rows
+        elif w4a16_rowpair_fc2:
+            fc2_tasks = (m * cfg.k_dim) // (_K_PER_CTA * 2)
+        else:
+            fc2_tasks = (m * cfg.k_dim) // (_K_PER_CTA * 4)
+        if max_active_ctas is None:
+            max_active_ctas = min(get_num_sm(device), get_max_active_clusters(1))
+        if self.compile_time_phase == 1:
+            # A standalone FC1 phase has no cooperative-grid requirement.
+            grid_x = max(1, fc1_tasks)
+        elif self.compile_time_phase == 2:
+            # Likewise FC2 can expose every output-row task directly once
+            # FC1 has completed in a prior launch.
+            grid_x = max(1, fc2_tasks)
+        elif m == 1:
+            grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
+        elif m == 2:
+            grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
+        elif num_fc1_chunks < 16:
+            grid_x = max(1, min(int(max_active_ctas), fc2_tasks))
+        else:
+            grid_x = max(1, min(int(max_active_ctas), fc1_tasks, fc2_tasks))
+        m1_fc2_onepass = bool(m == 1 and grid_x >= fc2_tasks)
+
+        if self.a8_mx_mode and self.compile_time_phase != 1 and cfg.i_chunk % 32 != 0:
+            # The per-32 block scale reads the partner 16-block; the FC2
+            # intermediate chunk must hold whole 32-blocks.
+            raise ValueError("a8_mx micro mode requires i_chunk % 32 == 0")
+        self._cfg = cfg
+        self.m_const = m if m in (1, 9) else 0
+        self.m1_fc2_onepass = m1_fc2_onepass
+        self.m1_fc2_rows_per_cta = m1_fc2_rows
+        self.launch_block_dim = _K_PER_CTA * 16 if m1_half_cta_fc2 else _BLOCK_DIM
+        self.grid_x = grid_x
+
+    @cute.jit
+    def _resident_grid_barrier(
+        self,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        grid_x: Int32,
+        is_cta_leader: Int32,
+    ):
+        cute.arch.sync_threads()
+        threadfence()
+        if is_cta_leader > Int32(0):
+            barrier_count_addr = get_ptr_as_int64(barrier_count, Int32(0))
+            barrier_epoch_addr = get_ptr_as_int64(barrier_epoch, Int32(0))
+            old_epoch = ld_global_acquire_i32(barrier_epoch_addr)
+            arrived = atomic_add_global_i32(barrier_count_addr, Int32(1))
+            if arrived == grid_x - Int32(1):
+                st_global_i32(barrier_count_addr, Int32(0))
+                st_global_release_i32(barrier_epoch_addr, old_epoch + Int32(1))
+            else:
+                spin_wait_global_eq_i32(barrier_epoch_addr, old_epoch)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _m1_fc2_rowpair_narrow(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        k_chunk_off = fc2_task * Int32(self.m1_fc2_rows_per_cta)
+        k_row0 = k_chunk_off + warp_id * Int32(2)
+        k_row1 = k_row0 + Int32(1)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        num_cb = sf_cols >> Int32(2)
+        lane_cb = lane >> Int32(3)
+        w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+        k_col0 = Int32(0)
+        k_col1 = Int32(0)
+        if cutlass.const_expr(self.w4a16_mode):
+            k_col0 = self._packed_e4m3_scale_col(k_row0)
+            k_col1 = self._packed_e4m3_scale_col(k_row1)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            if cutlass.const_expr(
+                self.w4a16_mode
+                and (not self.is_gated)
+                and cfg.k_dim == 2688
+                and cfg.n == 1856
+            ):
+                scale_lane = router_w
+            else:
+                alpha_fc2 = w2_alphas[eid]
+                scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
+
+            row_rb0 = k_row0 >> Int32(7)
+            row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+            row_mode_32_0 = k_row0 & Int32(31)
+            row_rb1 = k_row1 >> Int32(7)
+            row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+            row_mode_32_1 = k_row1 & Int32(31)
+
+            kk_off = Int32(kk) * Int32(128)
+            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+            u_packed0 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row0) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            if cutlass.const_expr(self.scale_format_e8m0_k32):
+                ebase_w2p = Int64(eid) * Int64((cfg.n // 32) * cfg.k_dim)
+                kb32_i = lane >> Int32(2)
+                bsf_f0 = (
+                    self._ld_e8m0_scale(
+                        w2s_base_addr,
+                        ebase_w2p,
+                        kb32_i,
+                        k_row0,
+                        Int32(cfg.k_dim),
+                        Int32(cfg.n // 32),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            elif cutlass.const_expr(self.w4a16_mode):
+                kb16_i = lane >> Int32(1)
+                bsf_f0 = (
+                    self._ld_e4m3_packed_scale_col(
+                        w2s_base_addr,
+                        ebase_sf_packed_e4m3,
+                        kb16_i,
+                        k_col0,
+                        Int32(cfg.k_dim),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            else:
+                bsf_off0 = (
+                    Int64(row_rb0) * Int64(sf_cols * 128)
+                    + Int64(lane_cb) * Int64(512)
+                    + Int64(row_mode_32_0) * Int64(16)
+                    + Int64(row_mode_a0) * Int64(4)
+                )
+                sf_word0 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f0 = (
+                    self._scale_byte_to_f32(bsf_byte0)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            out_acc0 = (
+                out_acc0
+                + bsf_f0
+                * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed1 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row1) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            if cutlass.const_expr(self.scale_format_e8m0_k32):
+                bsf_f1 = (
+                    self._ld_e8m0_scale(
+                        w2s_base_addr,
+                        ebase_w2p,
+                        kb32_i,
+                        k_row1,
+                        Int32(cfg.k_dim),
+                        Int32(cfg.n // 32),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            elif cutlass.const_expr(self.w4a16_mode):
+                kb16_i = lane >> Int32(1)
+                bsf_f1 = (
+                    self._ld_e4m3_packed_scale_col(
+                        w2s_base_addr,
+                        ebase_sf_packed_e4m3,
+                        kb16_i,
+                        k_col1,
+                        Int32(cfg.k_dim),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            else:
+                bsf_off1 = (
+                    Int64(row_rb1) * Int64(sf_cols * 128)
+                    + Int64(lane_cb) * Int64(512)
+                    + Int64(row_mode_32_1) * Int64(16)
+                    + Int64(row_mode_a1) * Int64(4)
+                )
+                sf_word1 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f1 = (
+                    self._scale_byte_to_f32(bsf_byte1)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            out_acc1 = (
+                out_acc1
+                + bsf_f1
+                * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        if lane == Int32(0):
+            scatter_output[k_row0] = BFloat16(sum_warp0)
+            scatter_output[k_row1] = BFloat16(sum_warp1)
+
+    @cute.jit
+    def _m1_fc2_rowpair_wide(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        k_chunk_off = fc2_task * Int32(self.m1_fc2_rows_per_cta)
+        k_row0 = k_chunk_off + warp_id * Int32(2)
+        k_row1 = k_row0 + Int32(1)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        num_cb = sf_cols >> Int32(2)
+        lane_cb = lane >> Int32(3)
+        w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+        k_col0 = Int32(0)
+        k_col1 = Int32(0)
+        if cutlass.const_expr(self.w4a16_mode):
+            k_col0 = self._packed_e4m3_scale_col(k_row0)
+            k_col1 = self._packed_e4m3_scale_col(k_row1)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            if cutlass.const_expr(
+                self.w4a16_mode
+                and (not self.is_gated)
+                and cfg.k_dim == 2688
+                and cfg.n == 1856
+            ):
+                scale_lane = router_w
+            else:
+                alpha_fc2 = w2_alphas[eid]
+                scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
+
+            row_rb0 = k_row0 >> Int32(7)
+            row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+            row_mode_32_0 = k_row0 & Int32(31)
+            row_rb1 = k_row1 >> Int32(7)
+            row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+            row_mode_32_1 = k_row1 & Int32(31)
+
+            for nc in cutlass.range_constexpr(cfg.fc2_n_chunks):
+                chunk_base = Int32(nc) * Int32(128)
+                kk_off = Int32(kk) * n_u32_per_expert + chunk_base
+                cb_idx = Int32(nc) * Int32(4) + lane_cb
+                w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                # If the last 256-wide chunk overhangs a non-256-aligned n
+                # (e.g. n=384), lanes past num_cb index the uninitialized
+                # intermediate tail. The weight there is already masked to 0,
+                # but 0 * NaN = NaN, so mask the activation read too. Gated by
+                # constexpr so 256-aligned shapes emit no extra runtime work.
+                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
+                    xh0 = (
+                        Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    xh1 = (
+                        Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    xh2 = (
+                        Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    xh3 = (
+                        Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                else:
+                    xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                    xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                    xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                    xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                u_packed0 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row0) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                    ebase_w2p = Int64(eid) * Int64((cfg.n // 32) * cfg.k_dim)
+                    kb32_i = (chunk_base + lane * Int32(4)) >> Int32(4)
+                    bsf_f0 = (
+                        self._ld_e8m0_scale(
+                            w2s_base_addr,
+                            ebase_w2p,
+                            kb32_i,
+                            k_row0,
+                            Int32(cfg.k_dim),
+                            Int32(cfg.n // 32),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                elif cutlass.const_expr(self.w4a16_mode):
+                    kb16_i = (chunk_base + lane * Int32(4)) >> Int32(3)
+                    bsf_f0 = (
+                        self._ld_e4m3_packed_scale_col(
+                            w2s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            kb16_i,
+                            k_col0,
+                            Int32(cfg.k_dim),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                else:
+                    bsf_off0 = (
+                        Int64(row_rb0) * Int64(sf_cols * 128)
+                        + Int64(cb_idx) * Int64(512)
+                        + Int64(row_mode_32_0) * Int64(16)
+                        + Int64(row_mode_a0) * Int64(4)
+                    )
+                    sf_word0 = (
+                        ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                    bsf_f0 = (
+                        self._scale_byte_to_f32(bsf_byte0)
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                out_acc0 = (
+                    out_acc0
+                    + bsf_f0
+                    * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed1 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row1) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                    bsf_f1 = (
+                        self._ld_e8m0_scale(
+                            w2s_base_addr,
+                            ebase_w2p,
+                            kb32_i,
+                            k_row1,
+                            Int32(cfg.k_dim),
+                            Int32(cfg.n // 32),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                elif cutlass.const_expr(self.w4a16_mode):
+                    kb16_i = (chunk_base + lane * Int32(4)) >> Int32(3)
+                    bsf_f1 = (
+                        self._ld_e4m3_packed_scale_col(
+                            w2s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            kb16_i,
+                            k_col1,
+                            Int32(cfg.k_dim),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                else:
+                    bsf_off1 = (
+                        Int64(row_rb1) * Int64(sf_cols * 128)
+                        + Int64(cb_idx) * Int64(512)
+                        + Int64(row_mode_32_1) * Int64(16)
+                        + Int64(row_mode_a1) * Int64(4)
+                    )
+                    sf_word1 = (
+                        ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                    bsf_f1 = (
+                        self._scale_byte_to_f32(bsf_byte1)
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                out_acc1 = (
+                    out_acc1
+                    + bsf_f1
+                    * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        if lane == Int32(0):
+            scatter_output[k_row0] = BFloat16(sum_warp0)
+            scatter_output[k_row1] = BFloat16(sum_warp1)
+
+    @cute.jit
+    def _m2_fc2_rowquad_narrow(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        rows_per_cta = Int32(_K_PER_CTA * 4)
+        linear_row_base = fc2_task * rows_per_cta
+        t = linear_row_base // Int32(cfg.k_dim)
+        k_chunk_off = linear_row_base - t * Int32(cfg.k_dim)
+        k_row0 = k_chunk_off + warp_id * Int32(4)
+        k_row1 = k_row0 + Int32(1)
+        k_row2 = k_row0 + Int32(2)
+        k_row3 = k_row0 + Int32(3)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+        token_inter_base = t * Int32(cfg.inter_u32)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        num_cb = sf_cols >> Int32(2)
+        lane_cb = lane >> Int32(3)
+        w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+        out_acc2 = Float32(0.0)
+        out_acc3 = Float32(0.0)
+
+        row_rb0 = k_row0 >> Int32(7)
+        row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+        row_mode_32_0 = k_row0 & Int32(31)
+        row_rb1 = k_row1 >> Int32(7)
+        row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+        row_mode_32_1 = k_row1 & Int32(31)
+        row_rb2 = k_row2 >> Int32(7)
+        row_mode_a2 = (k_row2 >> Int32(5)) & Int32(3)
+        row_mode_32_2 = k_row2 & Int32(31)
+        row_rb3 = k_row3 >> Int32(7)
+        row_mode_a3 = (k_row3 >> Int32(5)) & Int32(3)
+        row_mode_32_3 = k_row3 & Int32(31)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            if cutlass.const_expr(
+                self.w4a16_mode
+                and (not self.is_gated)
+                and cfg.k_dim == 2688
+                and cfg.n == 1856
+            ):
+                scale_lane = router_w
+            else:
+                alpha_fc2 = w2_alphas[eid]
+                scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+
+            kk_off = token_inter_base + Int32(kk) * Int32(128)
+            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+            u_packed0 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row0) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_off0 = (
+                Int64(row_rb0) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_0) * Int64(16)
+                + Int64(row_mode_a0) * Int64(4)
+            )
+            sf_word0 = (
+                ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f0 = (
+                self._scale_byte_to_f32(bsf_byte0)
+                if w_valid > Int32(0)
+                else Float32(0.0)
+            )
+            out_acc0 = (
+                out_acc0
+                + bsf_f0
+                * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed1 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row1) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_off1 = (
+                Int64(row_rb1) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_1) * Int64(16)
+                + Int64(row_mode_a1) * Int64(4)
+            )
+            sf_word1 = (
+                ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f1 = (
+                self._scale_byte_to_f32(bsf_byte1)
+                if w_valid > Int32(0)
+                else Float32(0.0)
+            )
+            out_acc1 = (
+                out_acc1
+                + bsf_f1
+                * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed2 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row2) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_off2 = (
+                Int64(row_rb2) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_2) * Int64(16)
+                + Int64(row_mode_a2) * Int64(4)
+            )
+            sf_word2 = (
+                ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off2)
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_byte2 = (sf_word2 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f2 = (
+                self._scale_byte_to_f32(bsf_byte2)
+                if w_valid > Int32(0)
+                else Float32(0.0)
+            )
+            out_acc2 = (
+                out_acc2
+                + bsf_f2
+                * self._fp4_dot4_for_math(u_packed2, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed3 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row3) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_off3 = (
+                Int64(row_rb3) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_3) * Int64(16)
+                + Int64(row_mode_a3) * Int64(4)
+            )
+            sf_word3 = (
+                ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off3)
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            bsf_byte3 = (sf_word3 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f3 = (
+                self._scale_byte_to_f32(bsf_byte3)
+                if w_valid > Int32(0)
+                else Float32(0.0)
+            )
+            out_acc3 = (
+                out_acc3
+                + bsf_f3
+                * self._fp4_dot4_for_math(u_packed3, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        sum_warp2 = cute.arch.warp_reduction_sum(out_acc2)
+        sum_warp3 = cute.arch.warp_reduction_sum(out_acc3)
+        if lane == Int32(0):
+            out_base = t * Int32(cfg.k_dim)
+            scatter_output[out_base + k_row0] = BFloat16(sum_warp0)
+            scatter_output[out_base + k_row1] = BFloat16(sum_warp1)
+            scatter_output[out_base + k_row2] = BFloat16(sum_warp2)
+            scatter_output[out_base + k_row3] = BFloat16(sum_warp3)
+
+    @cute.jit
+    def _m2_fc2_rowpair_narrow(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        rows_per_cta = Int32(_K_PER_CTA * 2)
+        linear_row_base = fc2_task * rows_per_cta
+        t = linear_row_base // Int32(cfg.k_dim)
+        k_chunk_off = linear_row_base - t * Int32(cfg.k_dim)
+        k_row0 = k_chunk_off + warp_id * Int32(2)
+        k_row1 = k_row0 + Int32(1)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        token_inter_base = t * Int32(cfg.inter_u32)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        num_cb = sf_cols >> Int32(2)
+        lane_cb = lane >> Int32(3)
+        w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+        k_col0 = Int32(0)
+        k_col1 = Int32(0)
+        if cutlass.const_expr(self.w4a16_mode):
+            k_col0 = self._packed_e4m3_scale_col(k_row0)
+            k_col1 = self._packed_e4m3_scale_col(k_row1)
+
+        row_rb0 = k_row0 >> Int32(7)
+        row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+        row_mode_32_0 = k_row0 & Int32(31)
+        row_rb1 = k_row1 >> Int32(7)
+        row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+        row_mode_32_1 = k_row1 & Int32(31)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            if cutlass.const_expr(
+                self.w4a16_mode
+                and (not self.is_gated)
+                and cfg.k_dim == 2688
+                and cfg.n == 1856
+            ):
+                scale_lane = router_w
+            else:
+                alpha_fc2 = w2_alphas[eid]
+                scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
+
+            kk_off = token_inter_base + Int32(kk) * Int32(128)
+            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+            u_packed0 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row0) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            if cutlass.const_expr(self.scale_format_e8m0_k32):
+                ebase_w2p = Int64(eid) * Int64((cfg.n // 32) * cfg.k_dim)
+                kb32_i = lane >> Int32(2)
+                bsf_f0 = (
+                    self._ld_e8m0_scale(
+                        w2s_base_addr,
+                        ebase_w2p,
+                        kb32_i,
+                        k_row0,
+                        Int32(cfg.k_dim),
+                        Int32(cfg.n // 32),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            elif cutlass.const_expr(self.w4a16_mode):
+                kb16_i = lane >> Int32(1)
+                bsf_f0 = (
+                    self._ld_e4m3_packed_scale_col(
+                        w2s_base_addr,
+                        ebase_sf_packed_e4m3,
+                        kb16_i,
+                        k_col0,
+                        Int32(cfg.k_dim),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            else:
+                bsf_off0 = (
+                    Int64(row_rb0) * Int64(sf_cols * 128)
+                    + Int64(lane_cb) * Int64(512)
+                    + Int64(row_mode_32_0) * Int64(16)
+                    + Int64(row_mode_a0) * Int64(4)
+                )
+                sf_word0 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f0 = (
+                    self._scale_byte_to_f32(bsf_byte0)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            out_acc0 = (
+                out_acc0
+                + bsf_f0
+                * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed1 = (
+                ld_global_nc_u32(
+                    w2_base_addr
+                    + ebase_w
+                    + Int64(k_row1) * Int64(cfg.n_half)
+                    + lane_byte_off
+                )
+                if w_valid > Int32(0)
+                else Uint32(0)
+            )
+            if cutlass.const_expr(self.scale_format_e8m0_k32):
+                bsf_f1 = (
+                    self._ld_e8m0_scale(
+                        w2s_base_addr,
+                        ebase_w2p,
+                        kb32_i,
+                        k_row1,
+                        Int32(cfg.k_dim),
+                        Int32(cfg.n // 32),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            elif cutlass.const_expr(self.w4a16_mode):
+                kb16_i = lane >> Int32(1)
+                bsf_f1 = (
+                    self._ld_e4m3_packed_scale_col(
+                        w2s_base_addr,
+                        ebase_sf_packed_e4m3,
+                        kb16_i,
+                        k_col1,
+                        Int32(cfg.k_dim),
+                    )
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            else:
+                bsf_off1 = (
+                    Int64(row_rb1) * Int64(sf_cols * 128)
+                    + Int64(lane_cb) * Int64(512)
+                    + Int64(row_mode_32_1) * Int64(16)
+                    + Int64(row_mode_a1) * Int64(4)
+                )
+                sf_word1 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f1 = (
+                    self._scale_byte_to_f32(bsf_byte1)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+            out_acc1 = (
+                out_acc1
+                + bsf_f1
+                * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        if lane == Int32(0):
+            out_base = t * Int32(cfg.k_dim)
+            scatter_output[out_base + k_row0] = BFloat16(sum_warp0)
+            scatter_output[out_base + k_row1] = BFloat16(sum_warp1)
+
+    @cute.jit
+    def _m2_fc2_rowquad_wide(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        rows_per_cta = Int32(_K_PER_CTA * 4)
+        linear_row_base = fc2_task * rows_per_cta
+        t = linear_row_base // Int32(cfg.k_dim)
+        k_chunk_off = linear_row_base - t * Int32(cfg.k_dim)
+        k_row0 = k_chunk_off + warp_id * Int32(4)
+        k_row1 = k_row0 + Int32(1)
+        k_row2 = k_row0 + Int32(2)
+        k_row3 = k_row0 + Int32(3)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+        token_inter_base = t * Int32(cfg.inter_u32)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        num_cb = sf_cols >> Int32(2)
+        lane_cb = lane >> Int32(3)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+        out_acc2 = Float32(0.0)
+        out_acc3 = Float32(0.0)
+        k_col0 = Int32(0)
+        k_col1 = Int32(0)
+        k_col2 = Int32(0)
+        k_col3 = Int32(0)
+        if cutlass.const_expr(self.w4a16_mode):
+            k_col0 = self._packed_e4m3_scale_col(k_row0)
+            k_col1 = self._packed_e4m3_scale_col(k_row1)
+            k_col2 = self._packed_e4m3_scale_col(k_row2)
+            k_col3 = self._packed_e4m3_scale_col(k_row3)
+
+        row_rb0 = k_row0 >> Int32(7)
+        row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+        row_mode_32_0 = k_row0 & Int32(31)
+        row_rb1 = k_row1 >> Int32(7)
+        row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+        row_mode_32_1 = k_row1 & Int32(31)
+        row_rb2 = k_row2 >> Int32(7)
+        row_mode_a2 = (k_row2 >> Int32(5)) & Int32(3)
+        row_mode_32_2 = k_row2 & Int32(31)
+        row_rb3 = k_row3 >> Int32(7)
+        row_mode_a3 = (k_row3 >> Int32(5)) & Int32(3)
+        row_mode_32_3 = k_row3 & Int32(31)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            if cutlass.const_expr(
+                self.w4a16_mode
+                and (not self.is_gated)
+                and cfg.k_dim == 2688
+                and cfg.n == 1856
+            ):
+                scale_lane = router_w
+            else:
+                alpha_fc2 = w2_alphas[eid]
+                scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
+
+            for nc in cutlass.range_constexpr(cfg.fc2_n_chunks):
+                chunk_base = Int32(nc) * Int32(128)
+                cb_idx = Int32(nc) * Int32(4) + lane_cb
+                w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                if cutlass.const_expr(nc + 1 < cfg.fc2_n_chunks):
+                    next_cb_idx = Int32(nc + 1) * Int32(4) + lane_cb
+                    if next_cb_idx < num_cb:
+                        next_chunk_base = Int32(nc + 1) * Int32(128)
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + ebase_w
+                            + Int64(k_row0) * Int64(cfg.n_half)
+                            + Int64(next_chunk_base)
+                            + lane_byte_off,
+                        )
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + ebase_w
+                            + Int64(k_row1) * Int64(cfg.n_half)
+                            + Int64(next_chunk_base)
+                            + lane_byte_off,
+                        )
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + ebase_w
+                            + Int64(k_row2) * Int64(cfg.n_half)
+                            + Int64(next_chunk_base)
+                            + lane_byte_off,
+                        )
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + ebase_w
+                            + Int64(k_row3) * Int64(cfg.n_half)
+                            + Int64(next_chunk_base)
+                            + lane_byte_off,
+                        )
+                elif cutlass.const_expr(kk + 1 < cfg.num_topk):
+                    next_eid_addr = t * Int32(cfg.num_topk) + Int32(kk + 1)
+                    next_eid = Int32(topk_ids[next_eid_addr])
+                    next_ebase_w = Int64(next_eid) * Int64(cfg.k_dim * cfg.n_half)
+                    next_ebase_sf = Int64(next_eid) * Int64(
+                        cfg.w2_sf_rows * cfg.w2_sf_cols
+                    )
+                    next_cb_idx = lane_cb
+                    if next_cb_idx < num_cb:
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + next_ebase_w
+                            + Int64(k_row0) * Int64(cfg.n_half)
+                            + lane_byte_off,
+                        )
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + next_ebase_w
+                            + Int64(k_row1) * Int64(cfg.n_half)
+                            + lane_byte_off,
+                        )
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + next_ebase_w
+                            + Int64(k_row2) * Int64(cfg.n_half)
+                            + lane_byte_off,
+                        )
+                        prefetch_global_l2(
+                            w2_base_addr
+                            + next_ebase_w
+                            + Int64(k_row3) * Int64(cfg.n_half)
+                            + lane_byte_off,
+                        )
+                        if cutlass.const_expr(
+                            (not self.w4a16_mode) and (not self.scale_format_e8m0_k32)
+                        ):
+                            next_bsf_off0 = (
+                                Int64(row_rb0) * Int64(sf_cols * 128)
+                                + Int64(next_cb_idx) * Int64(512)
+                                + Int64(row_mode_32_0) * Int64(16)
+                                + Int64(row_mode_a0) * Int64(4)
+                            )
+                            next_bsf_off1 = (
+                                Int64(row_rb1) * Int64(sf_cols * 128)
+                                + Int64(next_cb_idx) * Int64(512)
+                                + Int64(row_mode_32_1) * Int64(16)
+                                + Int64(row_mode_a1) * Int64(4)
+                            )
+                            next_bsf_off2 = (
+                                Int64(row_rb2) * Int64(sf_cols * 128)
+                                + Int64(next_cb_idx) * Int64(512)
+                                + Int64(row_mode_32_2) * Int64(16)
+                                + Int64(row_mode_a2) * Int64(4)
+                            )
+                            next_bsf_off3 = (
+                                Int64(row_rb3) * Int64(sf_cols * 128)
+                                + Int64(next_cb_idx) * Int64(512)
+                                + Int64(row_mode_32_3) * Int64(16)
+                                + Int64(row_mode_a3) * Int64(4)
+                            )
+                            prefetch_global_l2(
+                                w2s_base_addr + next_ebase_sf + next_bsf_off0
+                            )
+                            prefetch_global_l2(
+                                w2s_base_addr + next_ebase_sf + next_bsf_off1
+                            )
+                            prefetch_global_l2(
+                                w2s_base_addr + next_ebase_sf + next_bsf_off2
+                            )
+                            prefetch_global_l2(
+                                w2s_base_addr + next_ebase_sf + next_bsf_off3
+                            )
+                kk_off = token_inter_base + Int32(kk) * n_u32_per_expert + chunk_base
+                # See _m1_fc2_rowpair_wide: mask the intermediate tail read for
+                # non-256-aligned n (0 weight * NaN tail = NaN). constexpr-gated.
+                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
+                    xh0 = (
+                        Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    xh1 = (
+                        Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    xh2 = (
+                        Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    xh3 = (
+                        Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                else:
+                    xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                    xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                    xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                    xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                u_packed0 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row0) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                    ebase_w2p = Int64(eid) * Int64((cfg.n // 32) * cfg.k_dim)
+                    kb32_i = (chunk_base + lane * Int32(4)) >> Int32(4)
+                    bsf_f0 = (
+                        self._ld_e8m0_scale(
+                            w2s_base_addr,
+                            ebase_w2p,
+                            kb32_i,
+                            k_row0,
+                            Int32(cfg.k_dim),
+                            Int32(cfg.n // 32),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                elif cutlass.const_expr(self.w4a16_mode):
+                    kb16_i = (chunk_base + lane * Int32(4)) >> Int32(3)
+                    bsf_f0 = (
+                        self._ld_e4m3_packed_scale_col(
+                            w2s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            kb16_i,
+                            k_col0,
+                            Int32(cfg.k_dim),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                else:
+                    bsf_off0 = (
+                        Int64(row_rb0) * Int64(sf_cols * 128)
+                        + Int64(cb_idx) * Int64(512)
+                        + Int64(row_mode_32_0) * Int64(16)
+                        + Int64(row_mode_a0) * Int64(4)
+                    )
+                    sf_word0 = (
+                        ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                    bsf_f0 = (
+                        self._scale_byte_to_f32(bsf_byte0)
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                out_acc0 = (
+                    out_acc0
+                    + bsf_f0
+                    * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed1 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row1) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                    bsf_f1 = (
+                        self._ld_e8m0_scale(
+                            w2s_base_addr,
+                            ebase_w2p,
+                            kb32_i,
+                            k_row1,
+                            Int32(cfg.k_dim),
+                            Int32(cfg.n // 32),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                elif cutlass.const_expr(self.w4a16_mode):
+                    kb16_i = (chunk_base + lane * Int32(4)) >> Int32(3)
+                    bsf_f1 = (
+                        self._ld_e4m3_packed_scale_col(
+                            w2s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            kb16_i,
+                            k_col1,
+                            Int32(cfg.k_dim),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                else:
+                    bsf_off1 = (
+                        Int64(row_rb1) * Int64(sf_cols * 128)
+                        + Int64(cb_idx) * Int64(512)
+                        + Int64(row_mode_32_1) * Int64(16)
+                        + Int64(row_mode_a1) * Int64(4)
+                    )
+                    sf_word1 = (
+                        ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                    bsf_f1 = (
+                        self._scale_byte_to_f32(bsf_byte1)
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                out_acc1 = (
+                    out_acc1
+                    + bsf_f1
+                    * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed2 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row2) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                    bsf_f2 = (
+                        self._ld_e8m0_scale(
+                            w2s_base_addr,
+                            ebase_w2p,
+                            kb32_i,
+                            k_row2,
+                            Int32(cfg.k_dim),
+                            Int32(cfg.n // 32),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                elif cutlass.const_expr(self.w4a16_mode):
+                    kb16_i = (chunk_base + lane * Int32(4)) >> Int32(3)
+                    bsf_f2 = (
+                        self._ld_e4m3_packed_scale_col(
+                            w2s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            kb16_i,
+                            k_col2,
+                            Int32(cfg.k_dim),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                else:
+                    bsf_off2 = (
+                        Int64(row_rb2) * Int64(sf_cols * 128)
+                        + Int64(cb_idx) * Int64(512)
+                        + Int64(row_mode_32_2) * Int64(16)
+                        + Int64(row_mode_a2) * Int64(4)
+                    )
+                    sf_word2 = (
+                        ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off2)
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    bsf_byte2 = (sf_word2 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                    bsf_f2 = (
+                        self._scale_byte_to_f32(bsf_byte2)
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                out_acc2 = (
+                    out_acc2
+                    + bsf_f2
+                    * self._fp4_dot4_for_math(u_packed2, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed3 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row3) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                    bsf_f3 = (
+                        self._ld_e8m0_scale(
+                            w2s_base_addr,
+                            ebase_w2p,
+                            kb32_i,
+                            k_row3,
+                            Int32(cfg.k_dim),
+                            Int32(cfg.n // 32),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                elif cutlass.const_expr(self.w4a16_mode):
+                    kb16_i = (chunk_base + lane * Int32(4)) >> Int32(3)
+                    bsf_f3 = (
+                        self._ld_e4m3_packed_scale_col(
+                            w2s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            kb16_i,
+                            k_col3,
+                            Int32(cfg.k_dim),
+                        )
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                else:
+                    bsf_off3 = (
+                        Int64(row_rb3) * Int64(sf_cols * 128)
+                        + Int64(cb_idx) * Int64(512)
+                        + Int64(row_mode_32_3) * Int64(16)
+                        + Int64(row_mode_a3) * Int64(4)
+                    )
+                    sf_word3 = (
+                        ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off3)
+                        if w_valid > Int32(0)
+                        else Uint32(0)
+                    )
+                    bsf_byte3 = (sf_word3 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                    bsf_f3 = (
+                        self._scale_byte_to_f32(bsf_byte3)
+                        if w_valid > Int32(0)
+                        else Float32(0.0)
+                    )
+                out_acc3 = (
+                    out_acc3
+                    + bsf_f3
+                    * self._fp4_dot4_for_math(u_packed3, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        sum_warp2 = cute.arch.warp_reduction_sum(out_acc2)
+        sum_warp3 = cute.arch.warp_reduction_sum(out_acc3)
+        if lane == Int32(0):
+            out_base = t * Int32(cfg.k_dim)
+            scatter_output[out_base + k_row0] = BFloat16(sum_warp0)
+            scatter_output[out_base + k_row1] = BFloat16(sum_warp1)
+            scatter_output[out_base + k_row2] = BFloat16(sum_warp2)
+            scatter_output[out_base + k_row3] = BFloat16(sum_warp3)
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,
+        w1_weights: cute.Tensor,
+        w1_scales: cute.Tensor,
+        w1_alphas: cute.Tensor,
+        input_gs: cute.Tensor,
+        down_input_scale: cute.Tensor,
+        intermediate: cute.Tensor,
+        w2_weights: cute.Tensor,
+        w2_scales: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        m_val: Int32,
+    ):
+        cfg = self._cfg
+        bidx_x, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        gdim_x, _, _ = cute.arch.grid_dim()
+        if cutlass.const_expr(self.compile_time_phase == 2):
+            self._run_fc2(
+                Int32(bidx_x),
+                Int32(gdim_x),
+                tidx // Int32(32),
+                tidx % Int32(32),
+                m_val,
+                w2_weights,
+                w2_scales,
+                w2_alphas,
+                intermediate,
+                topk_ids,
+                topk_weights,
+                scatter_output,
+            )
+            return
+        is_cta_leader = Int32(1) if Int32(tidx) == Int32(0) else Int32(0)
+        m1_epoch0 = Int32(0)
+        if cutlass.const_expr(self.m_const == 1):
+            m1_epoch0 = ld_global_acquire_i32(get_ptr_as_int64(barrier_epoch, Int32(0)))
+
+        if cutlass.const_expr(cfg.k_segments == 2):
+            smem_xh_ptr = cute.arch.alloc_smem(Uint32, 2 * cfg.smem_xh_size)
+            smem_xh = cute.make_tensor(
+                smem_xh_ptr, cute.make_layout(2 * cfg.smem_xh_size)
+            )
+        else:
+            smem_xh_ptr = cute.arch.alloc_smem(Uint32, cfg.smem_xh_size)
+            smem_xh = cute.make_tensor(smem_xh_ptr, cute.make_layout(cfg.smem_xh_size))
+        smem_int_ptr = cute.arch.alloc_smem(Float32, cfg.i_chunk)
+        smem_int = cute.make_tensor(smem_int_ptr, cute.make_layout(cfg.i_chunk))
+        reduce_scratch_ptr = cute.arch.alloc_smem(Float32, _NUM_WARPS)
+        reduce_scratch = cute.make_tensor(
+            reduce_scratch_ptr, cute.make_layout(_NUM_WARPS)
+        )
+
+        warp_id = tidx // Int32(32)
+        lane = tidx % Int32(32)
+        w1_base_addr = w1_weights.iterator.toint()
+        w1s_base_addr = w1_scales.iterator.toint()
+
+        # ===================================================================
+        # PHASE 1: FC1 over route-order tasks
+        # ===================================================================
+        fc1_task_count = m_val * Int32(cfg.num_topk * cfg.fc1_chunks)
+        fc1_task = Int32(bidx_x)
+        if cutlass.const_expr(cfg.k_segments == 2):
+            buf_idx = Int32(0)
+            # Pre-loop: quantize first task into buf[0]
+            if fc1_task < fc1_task_count:
+                route_idx_0 = fc1_task // Int32(cfg.fc1_chunks)
+                t0 = route_idx_0 // Int32(cfg.num_topk)
+                eid_addr_0 = t0 * Int32(cfg.num_topk) + (
+                    route_idx_0 - t0 * Int32(cfg.num_topk)
+                )
+                gs_fc1_0 = input_gs[Int32(topk_ids[eid_addr_0])]
+                in_blk = tidx
+                while in_blk < Int32(cfg.k_dim // _BLOCK_SIZE):
+                    x_base = t0 * Int32(cfg.k_dim) + in_blk * Int32(_BLOCK_SIZE)
+                    pad_off = in_blk // Int32(8)
+                    phys_base = in_blk * Int32(_BLOCK_SIZE // 2) + pad_off
+                    if cutlass.const_expr(self.w4a16_mode):
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                            v0 = Float32(a_input[x_base + Int32(i * 2)])
+                            v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                            smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(v0, v1)
+                    if cutlass.const_expr(self.a8_mx_mode):
+                        # Per-32 UE8M0 + E4M3 quantize-dequant (w4a8 prefill numerics).
+                        blk_peak = Float32(0.0)
+                        pair_delta = (
+                            Int32(1) - Int32(2) * (in_blk & Int32(1))
+                        ) * Int32(_BLOCK_SIZE)
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                            v = Float32(a_input[x_base + Int32(i)])
+                            w = Float32(a_input[x_base + pair_delta + Int32(i)])
+                            blk_peak = fmax_f32(blk_peak, fmax_f32(v, -v))
+                            blk_peak = fmax_f32(blk_peak, fmax_f32(w, -w))
+                        scale32, inv32 = mx_scale_from_amax32(blk_peak)
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                            v0 = Float32(a_input[x_base + Int32(i * 2)])
+                            v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                            f0, f1 = quant_dequant_e4m3_2(v0, v1, inv32, scale32)
+                            smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(f0, f1)
+                    if cutlass.const_expr(
+                        (not self.w4a16_mode) and (not self.a8_mx_mode)
+                    ):
+                        blk_peak = Float32(0.0)
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                            v = Float32(a_input[x_base + Int32(i)])
+                            abs_v = v
+                            if v < Float32(0.0):
+                                abs_v = -v
+                            if abs_v > blk_peak:
+                                blk_peak = abs_v
+                        q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc1_0)
+                        if q_scale > Float32(_FP8_E4M3_MAX):
+                            q_scale = Float32(_FP8_E4M3_MAX)
+                        sf_val = self._scale_byte_to_f32(cvt_f32_to_e4m3(q_scale))
+                        eff_scale = Float32(0.0)
+                        if gs_fc1_0 != Float32(0.0):
+                            eff_scale = sf_val / gs_fc1_0
+                        if eff_scale < Float32(1e-30):
+                            eff_scale = Float32(1e-30)
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                            v0 = Float32(a_input[x_base + Int32(i * 2)])
+                            v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                            f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                            smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(f0, f1)
+                    in_blk += Int32(_BLOCK_DIM)
+                cute.arch.sync_threads()
+        else:
+            prev_t = Int32(-1)
+        while fc1_task < fc1_task_count:
+            if cutlass.const_expr(
+                self.w4a16_mode
+                and self.m_const == 9
+                and (not cfg.k_segments_aligned)
+                and cfg.k_segments == 6
+                and cfg.k_blocks == 168
+            ):
+                route_count = m_val * Int32(cfg.num_topk)
+                chunk_idx = fc1_task // route_count
+                route_idx = fc1_task - chunk_idx * route_count
+            else:
+                route_idx = fc1_task // Int32(cfg.fc1_chunks)
+                chunk_idx = fc1_task - route_idx * Int32(cfg.fc1_chunks)
+            t = route_idx // Int32(cfg.num_topk)
+            k_idx = route_idx - t * Int32(cfg.num_topk)
+            i_chunk_off = chunk_idx * Int32(cfg.i_chunk)
+
+            eid_addr = t * Int32(cfg.num_topk) + k_idx
+            eid = Int32(topk_ids[eid_addr])
+            if cutlass.const_expr(
+                self.w4a16_mode
+                and (not self.is_gated)
+                and cfg.k_dim == 2688
+                and cfg.n == 1856
+            ):
+                alpha_fc1 = Float32(1.0)
+                gs_fc1 = Float32(1.0)
+                gs_fc2 = Float32(1.0)
+            else:
+                alpha_fc1 = w1_alphas[eid]
+                gs_fc1 = input_gs[eid]
+                gs_fc2 = down_input_scale[eid]
+                if cutlass.const_expr(self.a8_mx_mode):
+                    # a8_mx activations are self-ranging: fold the calibrated
+                    # input global scale out of the combined nvfp4 alpha.
+                    alpha_fc1 = alpha_fc1 * gs_fc1
+
+            # ---- Input quantization ----
+            if cutlass.const_expr(cfg.k_segments != 2):
+                need_quant = Int32(1)
+                if cutlass.const_expr(self.share_input_across_experts):
+                    need_quant = Int32(1) if t != prev_t else Int32(0)
+                if need_quant > Int32(0):
+                    in_blk = tidx
+                    while in_blk < Int32(cfg.k_dim // _BLOCK_SIZE):
+                        x_base = t * Int32(cfg.k_dim) + in_blk * Int32(_BLOCK_SIZE)
+                        pad_off = in_blk // Int32(8)
+                        phys_base = in_blk * Int32(_BLOCK_SIZE // 2) + pad_off
+                        if cutlass.const_expr(self.w4a16_mode):
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(
+                                    v0, v1
+                                )
+                        if cutlass.const_expr(self.a8_mx_mode):
+                            # Per-32 UE8M0 + E4M3 quantize-dequant (w4a8 prefill numerics).
+                            blk_peak = Float32(0.0)
+                            pair_delta = (
+                                Int32(1) - Int32(2) * (in_blk & Int32(1))
+                            ) * Int32(_BLOCK_SIZE)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                                v = Float32(a_input[x_base + Int32(i)])
+                                w = Float32(a_input[x_base + pair_delta + Int32(i)])
+                                blk_peak = fmax_f32(blk_peak, fmax_f32(v, -v))
+                                blk_peak = fmax_f32(blk_peak, fmax_f32(w, -w))
+                            scale32, inv32 = mx_scale_from_amax32(blk_peak)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                f0, f1 = quant_dequant_e4m3_2(v0, v1, inv32, scale32)
+                                smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(
+                                    f0, f1
+                                )
+                        if cutlass.const_expr(
+                            (not self.w4a16_mode) and (not self.a8_mx_mode)
+                        ):
+                            blk_peak = Float32(0.0)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                                v = Float32(a_input[x_base + Int32(i)])
+                                abs_v = v
+                                if v < Float32(0.0):
+                                    abs_v = -v
+                                if abs_v > blk_peak:
+                                    blk_peak = abs_v
+                            q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc1)
+                            if q_scale > Float32(_FP8_E4M3_MAX):
+                                q_scale = Float32(_FP8_E4M3_MAX)
+                            sf_val = self._scale_byte_to_f32(cvt_f32_to_e4m3(q_scale))
+                            eff_scale = Float32(0.0)
+                            if gs_fc1 != Float32(0.0):
+                                eff_scale = sf_val / gs_fc1
+                            if eff_scale < Float32(1e-30):
+                                eff_scale = Float32(1e-30)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                                smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(
+                                    f0, f1
+                                )
+                        in_blk += Int32(_BLOCK_DIM)
+                    if cutlass.const_expr(self.share_input_across_experts):
+                        prev_t = t
+                cute.arch.sync_threads()
+
+            # ---- FC1 weight load + dot product ----
+            ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
+            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * cfg.two_n)
+            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.k_dim // 16) * cfg.two_n)
+            thread_byte_off = Int64(lane) * Int64(cfg.k_half // 32)
+            xh_buf_base = Int32(0)
+            if cutlass.const_expr(cfg.k_segments == 2):
+                xh_buf_base = buf_idx * Int32(cfg.smem_xh_size)
+            lane_seg_base = lane * Int32(cfg.k_segments)
+            lane_pad_base = lane_seg_base // Int32(8)
+            xh_base_t = (
+                xh_buf_base + lane_seg_base * Int32(_BLOCK_SIZE // 2) + lane_pad_base
+            )
+
+            # The FC1 activation lives in smem with a lane-segmented, padded
+            # layout that depends only on the lane (and input token), not on the
+            # FC1 output row. The k_segments==8 gated path computes
+            # rows_per_warp_fc1 (=4) output rows per warp, and each row's eight
+            # paired fp4_dot8 calls re-read the SAME 64 activation words from
+            # smem. Hoist those reads ONCE per warp-task into registers so the
+            # per-row dots consume them from register, removing 3x of the smem
+            # activation traffic on the issue-bound decode loop. Scoped to the
+            # k_segments==8 aligned gated path (the TP=2 DeepSeek-V4-Flash shape);
+            # every other FC1 variant keeps reading from smem unchanged.
+            hoist_xh = cutlass.const_expr(
+                cfg.k_segments_aligned and cfg.k_segments == 8 and self.is_gated
+            )
+            if cutlass.const_expr(hoist_xh):
+                xa0 = Uint32(smem_xh[xh_base_t + Int32(0)])
+                xa1 = Uint32(smem_xh[xh_base_t + Int32(1)])
+                xa2 = Uint32(smem_xh[xh_base_t + Int32(2)])
+                xa3 = Uint32(smem_xh[xh_base_t + Int32(3)])
+                xa4 = Uint32(smem_xh[xh_base_t + Int32(4)])
+                xa5 = Uint32(smem_xh[xh_base_t + Int32(5)])
+                xa6 = Uint32(smem_xh[xh_base_t + Int32(6)])
+                xa7 = Uint32(smem_xh[xh_base_t + Int32(7)])
+                xa8 = Uint32(smem_xh[xh_base_t + Int32(8)])
+                xa9 = Uint32(smem_xh[xh_base_t + Int32(9)])
+                xa10 = Uint32(smem_xh[xh_base_t + Int32(10)])
+                xa11 = Uint32(smem_xh[xh_base_t + Int32(11)])
+                xa12 = Uint32(smem_xh[xh_base_t + Int32(12)])
+                xa13 = Uint32(smem_xh[xh_base_t + Int32(13)])
+                xa14 = Uint32(smem_xh[xh_base_t + Int32(14)])
+                xa15 = Uint32(smem_xh[xh_base_t + Int32(15)])
+                xa16 = Uint32(smem_xh[xh_base_t + Int32(16)])
+                xa17 = Uint32(smem_xh[xh_base_t + Int32(17)])
+                xa18 = Uint32(smem_xh[xh_base_t + Int32(18)])
+                xa19 = Uint32(smem_xh[xh_base_t + Int32(19)])
+                xa20 = Uint32(smem_xh[xh_base_t + Int32(20)])
+                xa21 = Uint32(smem_xh[xh_base_t + Int32(21)])
+                xa22 = Uint32(smem_xh[xh_base_t + Int32(22)])
+                xa23 = Uint32(smem_xh[xh_base_t + Int32(23)])
+                xa24 = Uint32(smem_xh[xh_base_t + Int32(24)])
+                xa25 = Uint32(smem_xh[xh_base_t + Int32(25)])
+                xa26 = Uint32(smem_xh[xh_base_t + Int32(26)])
+                xa27 = Uint32(smem_xh[xh_base_t + Int32(27)])
+                xa28 = Uint32(smem_xh[xh_base_t + Int32(28)])
+                xa29 = Uint32(smem_xh[xh_base_t + Int32(29)])
+                xa30 = Uint32(smem_xh[xh_base_t + Int32(30)])
+                xa31 = Uint32(smem_xh[xh_base_t + Int32(31)])
+                xa32 = Uint32(smem_xh[xh_base_t + Int32(32)])
+                xa33 = Uint32(smem_xh[xh_base_t + Int32(33)])
+                xa34 = Uint32(smem_xh[xh_base_t + Int32(34)])
+                xa35 = Uint32(smem_xh[xh_base_t + Int32(35)])
+                xa36 = Uint32(smem_xh[xh_base_t + Int32(36)])
+                xa37 = Uint32(smem_xh[xh_base_t + Int32(37)])
+                xa38 = Uint32(smem_xh[xh_base_t + Int32(38)])
+                xa39 = Uint32(smem_xh[xh_base_t + Int32(39)])
+                xa40 = Uint32(smem_xh[xh_base_t + Int32(40)])
+                xa41 = Uint32(smem_xh[xh_base_t + Int32(41)])
+                xa42 = Uint32(smem_xh[xh_base_t + Int32(42)])
+                xa43 = Uint32(smem_xh[xh_base_t + Int32(43)])
+                xa44 = Uint32(smem_xh[xh_base_t + Int32(44)])
+                xa45 = Uint32(smem_xh[xh_base_t + Int32(45)])
+                xa46 = Uint32(smem_xh[xh_base_t + Int32(46)])
+                xa47 = Uint32(smem_xh[xh_base_t + Int32(47)])
+                xa48 = Uint32(smem_xh[xh_base_t + Int32(48)])
+                xa49 = Uint32(smem_xh[xh_base_t + Int32(49)])
+                xa50 = Uint32(smem_xh[xh_base_t + Int32(50)])
+                xa51 = Uint32(smem_xh[xh_base_t + Int32(51)])
+                xa52 = Uint32(smem_xh[xh_base_t + Int32(52)])
+                xa53 = Uint32(smem_xh[xh_base_t + Int32(53)])
+                xa54 = Uint32(smem_xh[xh_base_t + Int32(54)])
+                xa55 = Uint32(smem_xh[xh_base_t + Int32(55)])
+                xa56 = Uint32(smem_xh[xh_base_t + Int32(56)])
+                xa57 = Uint32(smem_xh[xh_base_t + Int32(57)])
+                xa58 = Uint32(smem_xh[xh_base_t + Int32(58)])
+                xa59 = Uint32(smem_xh[xh_base_t + Int32(59)])
+                xa60 = Uint32(smem_xh[xh_base_t + Int32(60)])
+                xa61 = Uint32(smem_xh[xh_base_t + Int32(61)])
+                xa62 = Uint32(smem_xh[xh_base_t + Int32(62)])
+                xa63 = Uint32(smem_xh[xh_base_t + Int32(63)])
+
+            for r_iter in cutlass.range_constexpr(cfg.rows_per_warp_fc1):
+                i_local = warp_id * Int32(cfg.rows_per_warp_fc1) + Int32(r_iter)
+                i = i_chunk_off + i_local
+
+                if cutlass.const_expr(self.is_gated):
+                    # Physical FC1-half rows for output channel i. "w13" (up_gate)
+                    # keeps up in the first half; "w31" (gate_up) swaps them.
+                    if cutlass.const_expr(self.w13_gate_first):
+                        row_u = Int32(cfg.n) + i
+                        row_g = i
+                    else:
+                        row_u = i
+                        row_g = Int32(cfg.n) + i
+                    up_byte_addr = (
+                        w1_base_addr
+                        + ebase_w
+                        + Int64(row_u) * Int64(cfg.k_half)
+                        + thread_byte_off
+                    )
+                    rb_u = row_u >> Int32(7)
+                    mode_a_u = (row_u >> Int32(5)) & Int32(3)
+                    mode_32_u = row_u & Int32(31)
+                    bsf_base_u = Int64(rb_u) * Int64(cfg.w1_sf_cols * 128) + Int64(
+                        mode_32_u * Int32(16) + mode_a_u * Int32(4)
+                    )
+                    rb_g = row_g >> Int32(7)
+                    mode_a_g = (row_g >> Int32(5)) & Int32(3)
+                    mode_32_g = row_g & Int32(31)
+                    bsf_base_g = Int64(rb_g) * Int64(cfg.w1_sf_cols * 128) + Int64(
+                        mode_32_g * Int32(16) + mode_a_g * Int32(4)
+                    )
+                    scale_row_u = row_u
+                    scale_row_g = row_g
+                    if cutlass.const_expr(
+                        self.w4a16_mode and (not self.w13_gate_first)
+                    ):
+                        # Main W4A16 scales are packed in kernel-native gate/up
+                        # order. ModelOpt "w13" weights remain up/gate, so only
+                        # the scale rows need the half swap in the micro path.
+                        scale_row_u = row_g
+                        scale_row_g = row_u
+                else:
+                    row_g = i
+                    rb_g = row_g >> Int32(7)
+                    mode_a_g = (row_g >> Int32(5)) & Int32(3)
+                    mode_32_g = row_g & Int32(31)
+                    bsf_base_g = Int64(rb_g) * Int64(cfg.w1_sf_cols * 128) + Int64(
+                        mode_32_g * Int32(16) + mode_a_g * Int32(4)
+                    )
+                    scale_row_g = row_g
+                scale_col_g = Int32(0)
+                if cutlass.const_expr(self.w4a16_mode):
+                    scale_col_g = self._packed_e4m3_scale_col(scale_row_g)
+                if cutlass.const_expr(self.is_gated):
+                    scale_col_u = Int32(0)
+                    if cutlass.const_expr(self.w4a16_mode):
+                        scale_col_u = self._packed_e4m3_scale_col(scale_row_u)
+                gate_byte_addr = (
+                    w1_base_addr
+                    + ebase_w
+                    + Int64(row_g) * Int64(cfg.k_half)
+                    + thread_byte_off
+                )
+                col_blk_off = Int64(lane) * Int64((cfg.k_segments // 4) * 512)
+
+                if cutlass.const_expr(cfg.k_segments_aligned and cfg.k_segments == 8):
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                        uw_b0, uw_b1, uw_b2, uw_b3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(16)
+                        )
+                        uw_c0, uw_c1, uw_c2, uw_c3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(32)
+                        )
+                        uw_d0, uw_d1, uw_d2, uw_d3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(48)
+                        )
+
+                        if cutlass.const_expr(self.scale_format_e8m0_k32):
+                            kbb = (lane * Int32(cfg.k_segments)) >> Int32(1)
+                            nc1 = Int32(cfg.two_n)
+                            u_k0 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb + Int32(0),
+                                row_u,
+                                nc1,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k1 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb + Int32(1),
+                                row_u,
+                                nc1,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k2 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb + Int32(2),
+                                row_u,
+                                nc1,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k3 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb + Int32(3),
+                                row_u,
+                                nc1,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            sf_u0 = u_k0
+                            sf_u1 = u_k0
+                            sf_u2 = u_k1
+                            sf_u3 = u_k1
+                            sf_u4 = u_k2
+                            sf_u5 = u_k2
+                            sf_u6 = u_k3
+                            sf_u7 = u_k3
+                        elif cutlass.const_expr(self.w4a16_mode):
+                            k16_u = lane * Int32(cfg.k_segments)
+                            sf_u0 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(0),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u1 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(1),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u2 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(2),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u3 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(3),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u4 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(4),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u5 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(5),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u6 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(6),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u7 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(7),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                        else:
+                            bsf_addr_u_a = (
+                                w1s_base_addr + ebase_sf + bsf_base_u + col_blk_off
+                            )
+                            bsf_addr_u_b = bsf_addr_u_a + Int64(512)
+                            sf_u0, sf_u1, sf_u2, sf_u3 = self._scale_word_to_f32x4(
+                                ld_global_nc_u32(bsf_addr_u_a)
+                            )
+                            sf_u4, sf_u5, sf_u6, sf_u7 = self._scale_word_to_f32x4(
+                                ld_global_nc_u32(bsf_addr_u_b)
+                            )
+
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+                    gw_b0, gw_b1, gw_b2, gw_b3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(16)
+                    )
+                    gw_c0, gw_c1, gw_c2, gw_c3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(32)
+                    )
+                    gw_d0, gw_d1, gw_d2, gw_d3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(48)
+                    )
+
+                    if cutlass.const_expr(self.scale_format_e8m0_k32):
+                        kbbg = (lane * Int32(cfg.k_segments)) >> Int32(1)
+                        nc1g = Int32(cfg.two_n)
+                        g_k0 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbbg + Int32(0),
+                            row_g,
+                            nc1g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k1 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbbg + Int32(1),
+                            row_g,
+                            nc1g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k2 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbbg + Int32(2),
+                            row_g,
+                            nc1g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k3 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbbg + Int32(3),
+                            row_g,
+                            nc1g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        sf_g0 = g_k0
+                        sf_g1 = g_k0
+                        sf_g2 = g_k1
+                        sf_g3 = g_k1
+                        sf_g4 = g_k2
+                        sf_g5 = g_k2
+                        sf_g6 = g_k3
+                        sf_g7 = g_k3
+                    elif cutlass.const_expr(self.w4a16_mode):
+                        k16_g = lane * Int32(cfg.k_segments)
+                        sf_g0 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(0),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g1 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(1),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g2 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(2),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g3 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(3),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g4 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(4),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g5 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(5),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g6 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(6),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g7 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(7),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                    else:
+                        bsf_addr_g_a = (
+                            w1s_base_addr + ebase_sf + bsf_base_g + col_blk_off
+                        )
+                        bsf_addr_g_b = bsf_addr_g_a + Int64(512)
+                        sf_g0, sf_g1, sf_g2, sf_g3 = self._scale_word_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_g_a)
+                        )
+                        sf_g4, sf_g5, sf_g6, sf_g7 = self._scale_word_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_g_b)
+                        )
+
+                    if cutlass.const_expr(not self.is_gated):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_t + Int32(0)
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_t + Int32(8)
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_t + Int32(16)
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_t + Int32(24)
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_t + Int32(32)
+                            )
+                            + sf_g5
+                            * self._block_dot_hfma2_for_math(
+                                gw_c2, gw_c3, smem_xh, xh_base_t + Int32(40)
+                            )
+                            + sf_g6
+                            * self._block_dot_hfma2_for_math(
+                                gw_d0, gw_d1, smem_xh, xh_base_t + Int32(48)
+                            )
+                            + sf_g7
+                            * self._block_dot_hfma2_for_math(
+                                gw_d2, gw_d3, smem_xh, xh_base_t + Int32(56)
+                            )
+                        )
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0, dot_g0 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_a0,
+                            uw_a1,
+                            gw_a0,
+                            gw_a1,
+                            xa0,
+                            xa1,
+                            xa2,
+                            xa3,
+                            xa4,
+                            xa5,
+                            xa6,
+                            xa7,
+                        )
+                        dot_u1, dot_g1 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_a2,
+                            uw_a3,
+                            gw_a2,
+                            gw_a3,
+                            xa8,
+                            xa9,
+                            xa10,
+                            xa11,
+                            xa12,
+                            xa13,
+                            xa14,
+                            xa15,
+                        )
+                        dot_u2, dot_g2 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_b0,
+                            uw_b1,
+                            gw_b0,
+                            gw_b1,
+                            xa16,
+                            xa17,
+                            xa18,
+                            xa19,
+                            xa20,
+                            xa21,
+                            xa22,
+                            xa23,
+                        )
+                        dot_u3, dot_g3 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_b2,
+                            uw_b3,
+                            gw_b2,
+                            gw_b3,
+                            xa24,
+                            xa25,
+                            xa26,
+                            xa27,
+                            xa28,
+                            xa29,
+                            xa30,
+                            xa31,
+                        )
+                        dot_u4, dot_g4 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_c0,
+                            uw_c1,
+                            gw_c0,
+                            gw_c1,
+                            xa32,
+                            xa33,
+                            xa34,
+                            xa35,
+                            xa36,
+                            xa37,
+                            xa38,
+                            xa39,
+                        )
+                        dot_u5, dot_g5 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_c2,
+                            uw_c3,
+                            gw_c2,
+                            gw_c3,
+                            xa40,
+                            xa41,
+                            xa42,
+                            xa43,
+                            xa44,
+                            xa45,
+                            xa46,
+                            xa47,
+                        )
+                        dot_u6, dot_g6 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_d0,
+                            uw_d1,
+                            gw_d0,
+                            gw_d1,
+                            xa48,
+                            xa49,
+                            xa50,
+                            xa51,
+                            xa52,
+                            xa53,
+                            xa54,
+                            xa55,
+                        )
+                        dot_u7, dot_g7 = self._block_dot_hfma2_pair_regs_for_math(
+                            uw_d2,
+                            uw_d3,
+                            gw_d2,
+                            gw_d3,
+                            xa56,
+                            xa57,
+                            xa58,
+                            xa59,
+                            xa60,
+                            xa61,
+                            xa62,
+                            xa63,
+                        )
+                        partial_up = (
+                            sf_u0 * dot_u0
+                            + sf_u1 * dot_u1
+                            + sf_u2 * dot_u2
+                            + sf_u3 * dot_u3
+                            + sf_u4 * dot_u4
+                            + sf_u5 * dot_u5
+                            + sf_u6 * dot_u6
+                            + sf_u7 * dot_u7
+                        )
+                        partial_gate = (
+                            sf_g0 * dot_g0
+                            + sf_g1 * dot_g1
+                            + sf_g2 * dot_g2
+                            + sf_g3 * dot_g3
+                            + sf_g4 * dot_g4
+                            + sf_g5 * dot_g5
+                            + sf_g6 * dot_g6
+                            + sf_g7 * dot_g7
+                        )
+                elif cutlass.const_expr(cfg.k_segments_aligned and cfg.k_segments == 6):
+                    xh_off0 = Int32(0)
+                    xh_off1 = Int32(8) + (
+                        (lane_seg_base + Int32(1)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off2 = Int32(16) + (
+                        (lane_seg_base + Int32(2)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off3 = Int32(24) + (
+                        (lane_seg_base + Int32(3)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off4 = Int32(32) + (
+                        (lane_seg_base + Int32(4)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off5 = Int32(40) + (
+                        (lane_seg_base + Int32(5)) // Int32(8) - lane_pad_base
+                    )
+
+                    scale_pair_off = Int64(lane_seg_base // Int32(4)) * Int64(512)
+                    scale_lane_mod = lane_seg_base % Int32(4)
+
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                        uw_b0, uw_b1, uw_b2, uw_b3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(16)
+                        )
+                        uw_c0, uw_c1, uw_c2, uw_c3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(32)
+                        )
+
+                        sf_u0 = Float32(0.0)
+                        sf_u1 = Float32(0.0)
+                        sf_u2 = Float32(0.0)
+                        sf_u3 = Float32(0.0)
+                        sf_u4 = Float32(0.0)
+                        sf_u5 = Float32(0.0)
+                        if cutlass.const_expr(self.scale_format_e8m0_k32):
+                            kbb_u = lane_seg_base >> Int32(1)
+                            nc_u = Int32(cfg.two_n)
+                            u_k0 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(0),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k1 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(1),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k2 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(2),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            sf_u0 = u_k0
+                            sf_u1 = u_k0
+                            sf_u2 = u_k1
+                            sf_u3 = u_k1
+                            sf_u4 = u_k2
+                            sf_u5 = u_k2
+                        elif cutlass.const_expr(self.w4a16_mode):
+                            sf_u0 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base + Int32(0),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u1 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base + Int32(1),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u2 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base + Int32(2),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u3 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base + Int32(3),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u4 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base + Int32(4),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u5 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base + Int32(5),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                        else:
+                            sf_word_u_a = ld_global_nc_u32(
+                                w1s_base_addr + ebase_sf + bsf_base_u + scale_pair_off
+                            )
+                            sf_word_u_b = ld_global_nc_u32(
+                                w1s_base_addr
+                                + ebase_sf
+                                + bsf_base_u
+                                + scale_pair_off
+                                + Int64(512)
+                            )
+                            if scale_lane_mod == Int32(0):
+                                sf_u0 = self._scale_byte_to_f32(
+                                    sf_word_u_a & Uint32(0xFF)
+                                )
+                                sf_u1 = self._scale_byte_to_f32(
+                                    (sf_word_u_a >> Uint32(8)) & Uint32(0xFF)
+                                )
+                                sf_u2 = self._scale_byte_to_f32(
+                                    (sf_word_u_a >> Uint32(16)) & Uint32(0xFF)
+                                )
+                                sf_u3 = self._scale_byte_to_f32(
+                                    (sf_word_u_a >> Uint32(24)) & Uint32(0xFF)
+                                )
+                                sf_u4 = self._scale_byte_to_f32(
+                                    sf_word_u_b & Uint32(0xFF)
+                                )
+                                sf_u5 = self._scale_byte_to_f32(
+                                    (sf_word_u_b >> Uint32(8)) & Uint32(0xFF)
+                                )
+                            else:
+                                sf_u0 = self._scale_byte_to_f32(
+                                    (sf_word_u_a >> Uint32(16)) & Uint32(0xFF)
+                                )
+                                sf_u1 = self._scale_byte_to_f32(
+                                    (sf_word_u_a >> Uint32(24)) & Uint32(0xFF)
+                                )
+                                sf_u2 = self._scale_byte_to_f32(
+                                    sf_word_u_b & Uint32(0xFF)
+                                )
+                                sf_u3 = self._scale_byte_to_f32(
+                                    (sf_word_u_b >> Uint32(8)) & Uint32(0xFF)
+                                )
+                                sf_u4 = self._scale_byte_to_f32(
+                                    (sf_word_u_b >> Uint32(16)) & Uint32(0xFF)
+                                )
+                                sf_u5 = self._scale_byte_to_f32(
+                                    (sf_word_u_b >> Uint32(24)) & Uint32(0xFF)
+                                )
+
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+                    gw_b0, gw_b1, gw_b2, gw_b3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(16)
+                    )
+                    gw_c0, gw_c1, gw_c2, gw_c3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(32)
+                    )
+
+                    sf_g0 = Float32(0.0)
+                    sf_g1 = Float32(0.0)
+                    sf_g2 = Float32(0.0)
+                    sf_g3 = Float32(0.0)
+                    sf_g4 = Float32(0.0)
+                    sf_g5 = Float32(0.0)
+                    if cutlass.const_expr(self.scale_format_e8m0_k32):
+                        kbb_g = lane_seg_base >> Int32(1)
+                        nc_g = Int32(cfg.two_n)
+                        g_k0 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(0),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k1 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(1),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k2 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(2),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        sf_g0 = g_k0
+                        sf_g1 = g_k0
+                        sf_g2 = g_k1
+                        sf_g3 = g_k1
+                        sf_g4 = g_k2
+                        sf_g5 = g_k2
+                    elif cutlass.const_expr(self.w4a16_mode):
+                        sf_g0 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            lane_seg_base + Int32(0),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g1 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            lane_seg_base + Int32(1),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g2 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            lane_seg_base + Int32(2),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g3 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            lane_seg_base + Int32(3),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g4 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            lane_seg_base + Int32(4),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g5 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            lane_seg_base + Int32(5),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                    else:
+                        sf_word_g_a = ld_global_nc_u32(
+                            w1s_base_addr + ebase_sf + bsf_base_g + scale_pair_off
+                        )
+                        sf_word_g_b = ld_global_nc_u32(
+                            w1s_base_addr
+                            + ebase_sf
+                            + bsf_base_g
+                            + scale_pair_off
+                            + Int64(512)
+                        )
+                        if scale_lane_mod == Int32(0):
+                            sf_g0 = self._scale_byte_to_f32(sf_word_g_a & Uint32(0xFF))
+                            sf_g1 = self._scale_byte_to_f32(
+                                (sf_word_g_a >> Uint32(8)) & Uint32(0xFF)
+                            )
+                            sf_g2 = self._scale_byte_to_f32(
+                                (sf_word_g_a >> Uint32(16)) & Uint32(0xFF)
+                            )
+                            sf_g3 = self._scale_byte_to_f32(
+                                (sf_word_g_a >> Uint32(24)) & Uint32(0xFF)
+                            )
+                            sf_g4 = self._scale_byte_to_f32(sf_word_g_b & Uint32(0xFF))
+                            sf_g5 = self._scale_byte_to_f32(
+                                (sf_word_g_b >> Uint32(8)) & Uint32(0xFF)
+                            )
+                        else:
+                            sf_g0 = self._scale_byte_to_f32(
+                                (sf_word_g_a >> Uint32(16)) & Uint32(0xFF)
+                            )
+                            sf_g1 = self._scale_byte_to_f32(
+                                (sf_word_g_a >> Uint32(24)) & Uint32(0xFF)
+                            )
+                            sf_g2 = self._scale_byte_to_f32(sf_word_g_b & Uint32(0xFF))
+                            sf_g3 = self._scale_byte_to_f32(
+                                (sf_word_g_b >> Uint32(8)) & Uint32(0xFF)
+                            )
+                            sf_g4 = self._scale_byte_to_f32(
+                                (sf_word_g_b >> Uint32(16)) & Uint32(0xFF)
+                            )
+                            sf_g5 = self._scale_byte_to_f32(
+                                (sf_word_g_b >> Uint32(24)) & Uint32(0xFF)
+                            )
+
+                    if cutlass.const_expr(not self.is_gated):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                            )
+                            + sf_g5
+                            * self._block_dot_hfma2_for_math(
+                                gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                            )
+                        )
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0, dot_g0 = self._block_dot_hfma2_pair_for_math(
+                            uw_a0, uw_a1, gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                        )
+                        dot_u1, dot_g1 = self._block_dot_hfma2_pair_for_math(
+                            uw_a2, uw_a3, gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                        )
+                        dot_u2, dot_g2 = self._block_dot_hfma2_pair_for_math(
+                            uw_b0, uw_b1, gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                        )
+                        dot_u3, dot_g3 = self._block_dot_hfma2_pair_for_math(
+                            uw_b2, uw_b3, gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                        )
+                        dot_u4, dot_g4 = self._block_dot_hfma2_pair_for_math(
+                            uw_c0, uw_c1, gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                        )
+                        dot_u5, dot_g5 = self._block_dot_hfma2_pair_for_math(
+                            uw_c2, uw_c3, gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                        )
+                        partial_up = (
+                            sf_u0 * dot_u0
+                            + sf_u1 * dot_u1
+                            + sf_u2 * dot_u2
+                            + sf_u3 * dot_u3
+                            + sf_u4 * dot_u4
+                            + sf_u5 * dot_u5
+                        )
+                        partial_gate = (
+                            sf_g0 * dot_g0
+                            + sf_g1 * dot_g1
+                            + sf_g2 * dot_g2
+                            + sf_g3 * dot_g3
+                            + sf_g4 * dot_g4
+                            + sf_g5 * dot_g5
+                        )
+                elif cutlass.const_expr(
+                    cfg.k_segments_aligned and cfg.k_segments == 12
+                ):
+                    xh_off0 = Int32(0)
+                    xh_off1 = Int32(8) + (
+                        (lane_seg_base + Int32(1)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off2 = Int32(16) + (
+                        (lane_seg_base + Int32(2)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off3 = Int32(24) + (
+                        (lane_seg_base + Int32(3)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off4 = Int32(32) + (
+                        (lane_seg_base + Int32(4)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off5 = Int32(40) + (
+                        (lane_seg_base + Int32(5)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off6 = Int32(48) + (
+                        (lane_seg_base + Int32(6)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off7 = Int32(56) + (
+                        (lane_seg_base + Int32(7)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off8 = Int32(64) + (
+                        (lane_seg_base + Int32(8)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off9 = Int32(72) + (
+                        (lane_seg_base + Int32(9)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off10 = Int32(80) + (
+                        (lane_seg_base + Int32(10)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off11 = Int32(88) + (
+                        (lane_seg_base + Int32(11)) // Int32(8) - lane_pad_base
+                    )
+
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                        uw_b0, uw_b1, uw_b2, uw_b3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(16)
+                        )
+                        uw_c0, uw_c1, uw_c2, uw_c3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(32)
+                        )
+                        uw_d0, uw_d1, uw_d2, uw_d3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(48)
+                        )
+                        uw_e0, uw_e1, uw_e2, uw_e3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(64)
+                        )
+                        uw_f0, uw_f1, uw_f2, uw_f3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(80)
+                        )
+
+                        if cutlass.const_expr(self.scale_format_e8m0_k32):
+                            kbb_u = (lane * Int32(cfg.k_segments)) >> Int32(1)
+                            nc_u = Int32(cfg.two_n)
+                            u_k0 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(0),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k1 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(1),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k2 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(2),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k3 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(3),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k4 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(4),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            u_k5 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                kbb_u + Int32(5),
+                                row_u,
+                                nc_u,
+                                Int32(cfg.k_dim // 32),
+                            )
+                            sf_u0 = u_k0
+                            sf_u1 = u_k0
+                            sf_u2 = u_k1
+                            sf_u3 = u_k1
+                            sf_u4 = u_k2
+                            sf_u5 = u_k2
+                            sf_u6 = u_k3
+                            sf_u7 = u_k3
+                            sf_u8 = u_k4
+                            sf_u9 = u_k4
+                            sf_u10 = u_k5
+                            sf_u11 = u_k5
+                        elif cutlass.const_expr(self.w4a16_mode):
+                            k16_u = lane * Int32(cfg.k_segments)
+                            sf_u0 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(0),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u1 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(1),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u2 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(2),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u3 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(3),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u4 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(4),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u5 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(5),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u6 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(6),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u7 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(7),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u8 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(8),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u9 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(9),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u10 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(10),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u11 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(11),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                        else:
+                            bsf_addr_u_a = (
+                                w1s_base_addr + ebase_sf + bsf_base_u + col_blk_off
+                            )
+                            bsf_addr_u_b = bsf_addr_u_a + Int64(512)
+                            bsf_addr_u_c = bsf_addr_u_a + Int64(1024)
+                            sf_u0, sf_u1, sf_u2, sf_u3 = self._scale_word_to_f32x4(
+                                ld_global_nc_u32(bsf_addr_u_a)
+                            )
+                            sf_u4, sf_u5, sf_u6, sf_u7 = self._scale_word_to_f32x4(
+                                ld_global_nc_u32(bsf_addr_u_b)
+                            )
+                            sf_u8, sf_u9, sf_u10, sf_u11 = self._scale_word_to_f32x4(
+                                ld_global_nc_u32(bsf_addr_u_c)
+                            )
+
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+                    gw_b0, gw_b1, gw_b2, gw_b3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(16)
+                    )
+                    gw_c0, gw_c1, gw_c2, gw_c3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(32)
+                    )
+                    gw_d0, gw_d1, gw_d2, gw_d3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(48)
+                    )
+                    gw_e0, gw_e1, gw_e2, gw_e3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(64)
+                    )
+                    gw_f0, gw_f1, gw_f2, gw_f3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(80)
+                    )
+
+                    if cutlass.const_expr(self.scale_format_e8m0_k32):
+                        kbb_g = (lane * Int32(cfg.k_segments)) >> Int32(1)
+                        nc_g = Int32(cfg.two_n)
+                        g_k0 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(0),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k1 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(1),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k2 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(2),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k3 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(3),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k4 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(4),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        g_k5 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            kbb_g + Int32(5),
+                            row_g,
+                            nc_g,
+                            Int32(cfg.k_dim // 32),
+                        )
+                        sf_g0 = g_k0
+                        sf_g1 = g_k0
+                        sf_g2 = g_k1
+                        sf_g3 = g_k1
+                        sf_g4 = g_k2
+                        sf_g5 = g_k2
+                        sf_g6 = g_k3
+                        sf_g7 = g_k3
+                        sf_g8 = g_k4
+                        sf_g9 = g_k4
+                        sf_g10 = g_k5
+                        sf_g11 = g_k5
+                    elif cutlass.const_expr(self.w4a16_mode):
+                        k16_g = lane * Int32(cfg.k_segments)
+                        sf_g0 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(0),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g1 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(1),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g2 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(2),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g3 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(3),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g4 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(4),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g5 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(5),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g6 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(6),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g7 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(7),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g8 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(8),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g9 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(9),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g10 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(10),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g11 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(11),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                    else:
+                        bsf_addr_g_a = (
+                            w1s_base_addr + ebase_sf + bsf_base_g + col_blk_off
+                        )
+                        bsf_addr_g_b = bsf_addr_g_a + Int64(512)
+                        bsf_addr_g_c = bsf_addr_g_a + Int64(1024)
+                        sf_g0, sf_g1, sf_g2, sf_g3 = self._scale_word_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_g_a)
+                        )
+                        sf_g4, sf_g5, sf_g6, sf_g7 = self._scale_word_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_g_b)
+                        )
+                        sf_g8, sf_g9, sf_g10, sf_g11 = self._scale_word_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_g_c)
+                        )
+
+                    if cutlass.const_expr(not self.is_gated):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                            )
+                            + sf_g5
+                            * self._block_dot_hfma2_for_math(
+                                gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                            )
+                            + sf_g6
+                            * self._block_dot_hfma2_for_math(
+                                gw_d0, gw_d1, smem_xh, xh_base_t + xh_off6
+                            )
+                            + sf_g7
+                            * self._block_dot_hfma2_for_math(
+                                gw_d2, gw_d3, smem_xh, xh_base_t + xh_off7
+                            )
+                            + sf_g8
+                            * self._block_dot_hfma2_for_math(
+                                gw_e0, gw_e1, smem_xh, xh_base_t + xh_off8
+                            )
+                            + sf_g9
+                            * self._block_dot_hfma2_for_math(
+                                gw_e2, gw_e3, smem_xh, xh_base_t + xh_off9
+                            )
+                            + sf_g10
+                            * self._block_dot_hfma2_for_math(
+                                gw_f0, gw_f1, smem_xh, xh_base_t + xh_off10
+                            )
+                            + sf_g11
+                            * self._block_dot_hfma2_for_math(
+                                gw_f2, gw_f3, smem_xh, xh_base_t + xh_off11
+                            )
+                        )
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0, dot_g0 = self._block_dot_hfma2_pair_for_math(
+                            uw_a0, uw_a1, gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                        )
+                        dot_u1, dot_g1 = self._block_dot_hfma2_pair_for_math(
+                            uw_a2, uw_a3, gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                        )
+                        dot_u2, dot_g2 = self._block_dot_hfma2_pair_for_math(
+                            uw_b0, uw_b1, gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                        )
+                        dot_u3, dot_g3 = self._block_dot_hfma2_pair_for_math(
+                            uw_b2, uw_b3, gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                        )
+                        dot_u4, dot_g4 = self._block_dot_hfma2_pair_for_math(
+                            uw_c0, uw_c1, gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                        )
+                        dot_u5, dot_g5 = self._block_dot_hfma2_pair_for_math(
+                            uw_c2, uw_c3, gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                        )
+                        dot_u6, dot_g6 = self._block_dot_hfma2_pair_for_math(
+                            uw_d0, uw_d1, gw_d0, gw_d1, smem_xh, xh_base_t + xh_off6
+                        )
+                        dot_u7, dot_g7 = self._block_dot_hfma2_pair_for_math(
+                            uw_d2, uw_d3, gw_d2, gw_d3, smem_xh, xh_base_t + xh_off7
+                        )
+                        dot_u8, dot_g8 = self._block_dot_hfma2_pair_for_math(
+                            uw_e0, uw_e1, gw_e0, gw_e1, smem_xh, xh_base_t + xh_off8
+                        )
+                        dot_u9, dot_g9 = self._block_dot_hfma2_pair_for_math(
+                            uw_e2, uw_e3, gw_e2, gw_e3, smem_xh, xh_base_t + xh_off9
+                        )
+                        dot_u10, dot_g10 = self._block_dot_hfma2_pair_for_math(
+                            uw_f0, uw_f1, gw_f0, gw_f1, smem_xh, xh_base_t + xh_off10
+                        )
+                        dot_u11, dot_g11 = self._block_dot_hfma2_pair_for_math(
+                            uw_f2, uw_f3, gw_f2, gw_f3, smem_xh, xh_base_t + xh_off11
+                        )
+                        partial_up = (
+                            sf_u0 * dot_u0
+                            + sf_u1 * dot_u1
+                            + sf_u2 * dot_u2
+                            + sf_u3 * dot_u3
+                            + sf_u4 * dot_u4
+                            + sf_u5 * dot_u5
+                            + sf_u6 * dot_u6
+                            + sf_u7 * dot_u7
+                            + sf_u8 * dot_u8
+                            + sf_u9 * dot_u9
+                            + sf_u10 * dot_u10
+                            + sf_u11 * dot_u11
+                        )
+                        partial_gate = (
+                            sf_g0 * dot_g0
+                            + sf_g1 * dot_g1
+                            + sf_g2 * dot_g2
+                            + sf_g3 * dot_g3
+                            + sf_g4 * dot_g4
+                            + sf_g5 * dot_g5
+                            + sf_g6 * dot_g6
+                            + sf_g7 * dot_g7
+                            + sf_g8 * dot_g8
+                            + sf_g9 * dot_g9
+                            + sf_g10 * dot_g10
+                            + sf_g11 * dot_g11
+                        )
+                elif cutlass.const_expr(cfg.k_segments_aligned and cfg.k_segments == 2):
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+
+                    col_blk_off_2 = Int64(lane // Int32(2)) * Int64(512)
+                    sf_shift0 = Uint32((lane % Int32(2)) * Int32(16))
+                    sf_shift1 = sf_shift0 + Uint32(8)
+
+                    if cutlass.const_expr(self.is_gated):
+                        if cutlass.const_expr(self.scale_format_e8m0_k32):
+                            sf_u0 = self._ld_e8m0_scale(
+                                w1s_base_addr,
+                                ebase_sf_packed,
+                                lane,
+                                row_u,
+                                Int32(cfg.two_n),
+                                Int32(cfg.k_dim // 32),
+                            )
+                            sf_u1 = sf_u0
+                        elif cutlass.const_expr(self.w4a16_mode):
+                            k16_u = lane * Int32(2)
+                            sf_u0 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(0),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                            sf_u1 = self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                k16_u + Int32(1),
+                                scale_col_u,
+                                Int32(cfg.two_n),
+                            )
+                        else:
+                            sf_word_u = ld_global_nc_u32(
+                                w1s_base_addr + ebase_sf + bsf_base_u + col_blk_off_2
+                            )
+                            sf_u0 = self._scale_byte_to_f32(
+                                (sf_word_u >> sf_shift0) & Uint32(0xFF)
+                            )
+                            sf_u1 = self._scale_byte_to_f32(
+                                (sf_word_u >> sf_shift1) & Uint32(0xFF)
+                            )
+                    if cutlass.const_expr(self.scale_format_e8m0_k32):
+                        sf_g0 = self._ld_e8m0_scale(
+                            w1s_base_addr,
+                            ebase_sf_packed,
+                            lane,
+                            row_g,
+                            Int32(cfg.two_n),
+                            Int32(cfg.k_dim // 32),
+                        )
+                        sf_g1 = sf_g0
+                    elif cutlass.const_expr(self.w4a16_mode):
+                        k16_g = lane * Int32(2)
+                        sf_g0 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(0),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                        sf_g1 = self._ld_e4m3_packed_scale_col(
+                            w1s_base_addr,
+                            ebase_sf_packed_e4m3,
+                            k16_g + Int32(1),
+                            scale_col_g,
+                            Int32(cfg.two_n),
+                        )
+                    else:
+                        sf_word_g = ld_global_nc_u32(
+                            w1s_base_addr + ebase_sf + bsf_base_g + col_blk_off_2
+                        )
+                        sf_g0 = self._scale_byte_to_f32(
+                            (sf_word_g >> sf_shift0) & Uint32(0xFF)
+                        )
+                        sf_g1 = self._scale_byte_to_f32(
+                            (sf_word_g >> sf_shift1) & Uint32(0xFF)
+                        )
+
+                    seg_blk0 = lane * Int32(2)
+                    seg_blk1 = seg_blk0 + Int32(1)
+                    xh_base0 = xh_buf_base + seg_blk0 * Int32(8) + seg_blk0 // Int32(8)
+                    xh_base1 = xh_buf_base + seg_blk1 * Int32(8) + seg_blk1 // Int32(8)
+
+                    if cutlass.const_expr(not self.is_gated):
+                        dot_g0 = self._block_dot_hfma2_for_math(
+                            gw_a0, gw_a1, smem_xh, xh_base0
+                        )
+                        dot_g1 = self._block_dot_hfma2_for_math(
+                            gw_a2, gw_a3, smem_xh, xh_base1
+                        )
+                        partial_gate = sf_g0 * dot_g0 + sf_g1 * dot_g1
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0a, dot_g0a = self._block_dot4_pair_for_math(
+                            uw_a0, gw_a0, smem_xh, xh_base0
+                        )
+                        dot_u0b, dot_g0b = self._block_dot4_pair_for_math(
+                            uw_a1, gw_a1, smem_xh, xh_base0 + Int32(4)
+                        )
+                        dot_u1a, dot_g1a = self._block_dot4_pair_for_math(
+                            uw_a2, gw_a2, smem_xh, xh_base1
+                        )
+                        dot_u1b, dot_g1b = self._block_dot4_pair_for_math(
+                            uw_a3, gw_a3, smem_xh, xh_base1 + Int32(4)
+                        )
+                        partial_up = sf_u0 * (dot_u0a + dot_u0b) + sf_u1 * (
+                            dot_u1a + dot_u1b
+                        )
+                        partial_gate = sf_g0 * (dot_g0a + dot_g0b) + sf_g1 * (
+                            dot_g1a + dot_g1b
+                        )
+                elif cutlass.const_expr(
+                    (not self.is_gated)
+                    and (not cfg.k_segments_aligned)
+                    and cfg.k_segments == 6
+                    and cfg.k_blocks == 168
+                ):
+                    tail_seg_count = Int32(6)
+                    lane_seg_base_tail = lane * Int32(6)
+                    if lane >= Int32(16):
+                        if lane < Int32(24):
+                            tail_seg_count = Int32(5)
+                            lane_seg_base_tail = Int32(96) + (lane - Int32(16)) * Int32(
+                                5
+                            )
+                        else:
+                            tail_seg_count = Int32(4)
+                            lane_seg_base_tail = Int32(136) + (
+                                lane - Int32(24)
+                            ) * Int32(4)
+                    lane_pad_base_tail = lane_seg_base_tail // Int32(8)
+                    xh_base_tail = (
+                        xh_buf_base
+                        + lane_seg_base_tail * Int32(_BLOCK_SIZE // 2)
+                        + lane_pad_base_tail
+                    )
+                    xh_off0 = Int32(0)
+                    xh_off1 = Int32(8) + (
+                        (lane_seg_base_tail + Int32(1)) // Int32(8) - lane_pad_base_tail
+                    )
+                    xh_off2 = Int32(16) + (
+                        (lane_seg_base_tail + Int32(2)) // Int32(8) - lane_pad_base_tail
+                    )
+                    xh_off3 = Int32(24) + (
+                        (lane_seg_base_tail + Int32(3)) // Int32(8) - lane_pad_base_tail
+                    )
+                    xh_off4 = Int32(32) + (
+                        (lane_seg_base_tail + Int32(4)) // Int32(8) - lane_pad_base_tail
+                    )
+                    xh_off5 = Int32(40) + (
+                        (lane_seg_base_tail + Int32(5)) // Int32(8) - lane_pad_base_tail
+                    )
+
+                    gate_row_addr_u6 = (
+                        w1_base_addr + ebase_w + Int64(row_g) * Int64(cfg.k_half)
+                    )
+                    lane_byte_base = Int64(lane_seg_base_tail) * Int64(_BLOCK_SIZE // 2)
+                    gw_a0 = Uint32(0)
+                    gw_a1 = Uint32(0)
+                    gw_a2 = Uint32(0)
+                    gw_a3 = Uint32(0)
+                    gw_b0 = Uint32(0)
+                    gw_b1 = Uint32(0)
+                    gw_b2 = Uint32(0)
+                    gw_b3 = Uint32(0)
+                    gw_c0 = Uint32(0)
+                    gw_c1 = Uint32(0)
+                    gw_c2 = Uint32(0)
+                    gw_c3 = Uint32(0)
+                    if tail_seg_count == Int32(5):
+                        gw_a0 = ld_global_nc_u32(gate_row_addr_u6 + lane_byte_base)
+                        gw_a1 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(4)
+                        )
+                        gw_a2 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(8)
+                        )
+                        gw_a3 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(12)
+                        )
+                        gw_b0 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(16)
+                        )
+                        gw_b1 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(20)
+                        )
+                        gw_b2 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(24)
+                        )
+                        gw_b3 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(28)
+                        )
+                        gw_c0 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(32)
+                        )
+                        gw_c1 = ld_global_nc_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(36)
+                        )
+                    else:
+                        gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(
+                            gate_row_addr_u6 + lane_byte_base
+                        )
+                        gw_b0, gw_b1, gw_b2, gw_b3 = ld_global_nc_v4_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(16)
+                        )
+                    if tail_seg_count == Int32(6):
+                        gw_c0, gw_c1, gw_c2, gw_c3 = ld_global_nc_v4_u32(
+                            gate_row_addr_u6 + lane_byte_base + Int64(32)
+                        )
+
+                    scale_pair_off = Int64(lane_seg_base_tail // Int32(4)) * Int64(512)
+                    scale_lane_mod = lane_seg_base_tail % Int32(4)
+                    sf_g0 = Float32(0.0)
+                    sf_g1 = Float32(0.0)
+                    sf_g2 = Float32(0.0)
+                    sf_g3 = Float32(0.0)
+                    sf_g4 = Float32(0.0)
+                    sf_g5 = Float32(0.0)
+                    if cutlass.const_expr(self.w4a16_mode):
+                        sf_g0 = (
+                            self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base_tail + Int32(0),
+                                scale_col_g,
+                                Int32(cfg.two_n),
+                            )
+                            if tail_seg_count > Int32(0)
+                            else Float32(0.0)
+                        )
+                        sf_g1 = (
+                            self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base_tail + Int32(1),
+                                scale_col_g,
+                                Int32(cfg.two_n),
+                            )
+                            if tail_seg_count > Int32(1)
+                            else Float32(0.0)
+                        )
+                        sf_g2 = (
+                            self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base_tail + Int32(2),
+                                scale_col_g,
+                                Int32(cfg.two_n),
+                            )
+                            if tail_seg_count > Int32(2)
+                            else Float32(0.0)
+                        )
+                        sf_g3 = (
+                            self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base_tail + Int32(3),
+                                scale_col_g,
+                                Int32(cfg.two_n),
+                            )
+                            if tail_seg_count > Int32(3)
+                            else Float32(0.0)
+                        )
+                        sf_g4 = (
+                            self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base_tail + Int32(4),
+                                scale_col_g,
+                                Int32(cfg.two_n),
+                            )
+                            if tail_seg_count > Int32(4)
+                            else Float32(0.0)
+                        )
+                        sf_g5 = (
+                            self._ld_e4m3_packed_scale_col(
+                                w1s_base_addr,
+                                ebase_sf_packed_e4m3,
+                                lane_seg_base_tail + Int32(5),
+                                scale_col_g,
+                                Int32(cfg.two_n),
+                            )
+                            if tail_seg_count > Int32(5)
+                            else Float32(0.0)
+                        )
+                    else:
+                        sf_word_g_a = ld_global_nc_u32(
+                            w1s_base_addr + ebase_sf + bsf_base_g + scale_pair_off
+                        )
+                        sf_word_g_b = (
+                            ld_global_nc_u32(
+                                w1s_base_addr
+                                + ebase_sf
+                                + bsf_base_g
+                                + scale_pair_off
+                                + Int64(512)
+                            )
+                            if tail_seg_count > Int32(4)
+                            else Uint32(0)
+                        )
+                        sf_a0, sf_a1, sf_a2, sf_a3 = self._scale_word_to_f32x4(
+                            sf_word_g_a
+                        )
+                        sf_b0, sf_b1, sf_b2, sf_b3 = self._scale_word_to_f32x4(
+                            sf_word_g_b
+                        )
+                        if tail_seg_count == Int32(6):
+                            if scale_lane_mod == Int32(0):
+                                sf_g0 = sf_a0
+                                sf_g1 = sf_a1
+                                sf_g2 = sf_a2
+                                sf_g3 = sf_a3
+                                sf_g4 = sf_b0
+                                sf_g5 = sf_b1
+                            else:
+                                sf_g0 = sf_a2
+                                sf_g1 = sf_a3
+                                sf_g2 = sf_b0
+                                sf_g3 = sf_b1
+                                sf_g4 = sf_b2
+                                sf_g5 = sf_b3
+                        elif tail_seg_count == Int32(5):
+                            if scale_lane_mod == Int32(0):
+                                sf_g0 = sf_a0
+                                sf_g1 = sf_a1
+                                sf_g2 = sf_a2
+                                sf_g3 = sf_a3
+                                sf_g4 = sf_b0
+                            elif scale_lane_mod == Int32(1):
+                                sf_g0 = sf_a1
+                                sf_g1 = sf_a2
+                                sf_g2 = sf_a3
+                                sf_g3 = sf_b0
+                                sf_g4 = sf_b1
+                            elif scale_lane_mod == Int32(2):
+                                sf_g0 = sf_a2
+                                sf_g1 = sf_a3
+                                sf_g2 = sf_b0
+                                sf_g3 = sf_b1
+                                sf_g4 = sf_b2
+                            else:
+                                sf_g0 = sf_a3
+                                sf_g1 = sf_b0
+                                sf_g2 = sf_b1
+                                sf_g3 = sf_b2
+                                sf_g4 = sf_b3
+                        else:
+                            sf_g0 = sf_a0
+                            sf_g1 = sf_a1
+                            sf_g2 = sf_a2
+                            sf_g3 = sf_a3
+
+                    partial_gate = Float32(0.0)
+                    if tail_seg_count == Int32(6):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_tail + xh_off0
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_tail + xh_off1
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_tail + xh_off2
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_tail + xh_off3
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_tail + xh_off4
+                            )
+                            + sf_g5
+                            * self._block_dot_hfma2_for_math(
+                                gw_c2, gw_c3, smem_xh, xh_base_tail + xh_off5
+                            )
+                        )
+                    elif tail_seg_count == Int32(5):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_tail + xh_off0
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_tail + xh_off1
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_tail + xh_off2
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_tail + xh_off3
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_tail + xh_off4
+                            )
+                        )
+                    else:
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_tail + xh_off0
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_tail + xh_off1
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_tail + xh_off2
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_tail + xh_off3
+                            )
+                        )
+                else:
+                    partial_up = Float32(0.0)
+                    partial_gate = Float32(0.0)
+                    if cutlass.const_expr(cfg.k_segments_aligned):
+                        for seg in cutlass.range_constexpr(cfg.k_segments):
+                            seg_byte_off = Int64(seg * (_BLOCK_SIZE // 2))
+                            scale_col = lane * Int32(cfg.k_segments) + Int32(seg)
+                            sf_group_off = Int64(scale_col // Int32(4)) * Int64(512)
+                            sf_shift = Uint32((scale_col % Int32(4)) * Int32(8))
+                            xh_base = (
+                                xh_buf_base
+                                + scale_col * Int32(_BLOCK_SIZE // 2)
+                                + scale_col // Int32(8)
+                            )
+
+                            gw0 = ld_global_nc_u32(gate_byte_addr + seg_byte_off)
+                            gw1 = ld_global_nc_u32(
+                                gate_byte_addr + seg_byte_off + Int64(4)
+                            )
+                            if cutlass.const_expr(self.w4a16_mode):
+                                sf_g = self._ld_e4m3_packed_scale_col(
+                                    w1s_base_addr,
+                                    ebase_sf_packed_e4m3,
+                                    scale_col,
+                                    scale_col_g,
+                                    Int32(cfg.two_n),
+                                )
+                            else:
+                                sf_word_g = ld_global_nc_u32(
+                                    w1s_base_addr + ebase_sf + bsf_base_g + sf_group_off
+                                )
+                                sf_g = self._scale_byte_to_f32(
+                                    (sf_word_g >> sf_shift) & Uint32(0xFF)
+                                )
+
+                            if cutlass.const_expr(self.is_gated):
+                                uw0 = ld_global_nc_u32(up_byte_addr + seg_byte_off)
+                                uw1 = ld_global_nc_u32(
+                                    up_byte_addr + seg_byte_off + Int64(4)
+                                )
+                                if cutlass.const_expr(self.w4a16_mode):
+                                    sf_u = self._ld_e4m3_packed_scale_col(
+                                        w1s_base_addr,
+                                        ebase_sf_packed_e4m3,
+                                        scale_col,
+                                        scale_col_u,
+                                        Int32(cfg.two_n),
+                                    )
+                                else:
+                                    sf_word_u = ld_global_nc_u32(
+                                        w1s_base_addr
+                                        + ebase_sf
+                                        + bsf_base_u
+                                        + sf_group_off
+                                    )
+                                    sf_u = self._scale_byte_to_f32(
+                                        (sf_word_u >> sf_shift) & Uint32(0xFF)
+                                    )
+                                dot_u, dot_g = self._block_dot_hfma2_pair_for_math(
+                                    uw0, uw1, gw0, gw1, smem_xh, xh_base
+                                )
+                                partial_up = partial_up + sf_u * dot_u
+                                partial_gate = partial_gate + sf_g * dot_g
+                            else:
+                                partial_gate = (
+                                    partial_gate
+                                    + sf_g
+                                    * self._block_dot_hfma2_for_math(
+                                        gw0,
+                                        gw1,
+                                        smem_xh,
+                                        xh_base,
+                                    )
+                                )
+                    else:
+                        gate_row_addr = (
+                            w1_base_addr + ebase_w + Int64(row_g) * Int64(cfg.k_half)
+                        )
+                        if cutlass.const_expr(self.is_gated):
+                            up_row_addr = (
+                                w1_base_addr
+                                + ebase_w
+                                + Int64(row_u) * Int64(cfg.k_half)
+                            )
+                        for seg in cutlass.range_constexpr(cfg.k_segments):
+                            scale_col = lane * Int32(cfg.k_segments) + Int32(seg)
+                            valid_seg = (
+                                Int32(1)
+                                if scale_col < Int32(cfg.k_blocks)
+                                else Int32(0)
+                            )
+                            seg_byte_off = Int64(scale_col) * Int64(_BLOCK_SIZE // 2)
+                            sf_group_off = Int64(scale_col // Int32(4)) * Int64(512)
+                            sf_shift = Uint32((scale_col % Int32(4)) * Int32(8))
+                            xh_base = (
+                                xh_buf_base
+                                + scale_col * Int32(_BLOCK_SIZE // 2)
+                                + scale_col // Int32(8)
+                            )
+                            xh_base = xh_base if valid_seg > Int32(0) else xh_buf_base
+
+                            gw0 = (
+                                ld_global_nc_u32(gate_row_addr + seg_byte_off)
+                                if valid_seg > Int32(0)
+                                else Uint32(0)
+                            )
+                            gw1 = (
+                                ld_global_nc_u32(
+                                    gate_row_addr + seg_byte_off + Int64(4)
+                                )
+                                if valid_seg > Int32(0)
+                                else Uint32(0)
+                            )
+                            if cutlass.const_expr(self.scale_format_e8m0_k32):
+                                sf_g = (
+                                    self._ld_e8m0_scale(
+                                        w1s_base_addr,
+                                        ebase_sf_packed,
+                                        scale_col >> Int32(1),
+                                        row_g,
+                                        Int32(cfg.two_n),
+                                        Int32(cfg.k_dim // 32),
+                                    )
+                                    if valid_seg > Int32(0)
+                                    else Float32(0.0)
+                                )
+                            elif cutlass.const_expr(self.w4a16_mode):
+                                sf_g = (
+                                    self._ld_e4m3_packed_scale_col(
+                                        w1s_base_addr,
+                                        ebase_sf_packed_e4m3,
+                                        scale_col,
+                                        scale_col_g,
+                                        Int32(cfg.two_n),
+                                    )
+                                    if valid_seg > Int32(0)
+                                    else Float32(0.0)
+                                )
+                            else:
+                                sf_word_g = (
+                                    ld_global_nc_u32(
+                                        w1s_base_addr
+                                        + ebase_sf
+                                        + bsf_base_g
+                                        + sf_group_off
+                                    )
+                                    if valid_seg > Int32(0)
+                                    else Uint32(0)
+                                )
+                                sf_g = (
+                                    self._scale_byte_to_f32(
+                                        (sf_word_g >> sf_shift) & Uint32(0xFF)
+                                    )
+                                    if valid_seg > Int32(0)
+                                    else Float32(0.0)
+                                )
+
+                            if cutlass.const_expr(self.is_gated):
+                                uw0 = (
+                                    ld_global_nc_u32(up_row_addr + seg_byte_off)
+                                    if valid_seg > Int32(0)
+                                    else Uint32(0)
+                                )
+                                uw1 = (
+                                    ld_global_nc_u32(
+                                        up_row_addr + seg_byte_off + Int64(4)
+                                    )
+                                    if valid_seg > Int32(0)
+                                    else Uint32(0)
+                                )
+                                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                                    sf_u = (
+                                        self._ld_e8m0_scale(
+                                            w1s_base_addr,
+                                            ebase_sf_packed,
+                                            scale_col >> Int32(1),
+                                            row_u,
+                                            Int32(cfg.two_n),
+                                            Int32(cfg.k_dim // 32),
+                                        )
+                                        if valid_seg > Int32(0)
+                                        else Float32(0.0)
+                                    )
+                                elif cutlass.const_expr(self.w4a16_mode):
+                                    sf_u = (
+                                        self._ld_e4m3_packed_scale_col(
+                                            w1s_base_addr,
+                                            ebase_sf_packed_e4m3,
+                                            scale_col,
+                                            scale_col_u,
+                                            Int32(cfg.two_n),
+                                        )
+                                        if valid_seg > Int32(0)
+                                        else Float32(0.0)
+                                    )
+                                else:
+                                    sf_word_u = (
+                                        ld_global_nc_u32(
+                                            w1s_base_addr
+                                            + ebase_sf
+                                            + bsf_base_u
+                                            + sf_group_off
+                                        )
+                                        if valid_seg > Int32(0)
+                                        else Uint32(0)
+                                    )
+                                    sf_u = (
+                                        self._scale_byte_to_f32(
+                                            (sf_word_u >> sf_shift) & Uint32(0xFF)
+                                        )
+                                        if valid_seg > Int32(0)
+                                        else Float32(0.0)
+                                    )
+                                dot_u, dot_g = self._block_dot_hfma2_pair_for_math(
+                                    uw0, uw1, gw0, gw1, smem_xh, xh_base
+                                )
+                                partial_up = partial_up + sf_u * dot_u
+                                partial_gate = partial_gate + sf_g * dot_g
+                            else:
+                                partial_gate = (
+                                    partial_gate
+                                    + sf_g
+                                    * self._block_dot_hfma2_for_math(
+                                        gw0,
+                                        gw1,
+                                        smem_xh,
+                                        xh_base,
+                                    )
+                                )
+                # ---- Activation + intermediate quant ----
+                gate_red = cute.arch.warp_reduction_sum(partial_gate) * alpha_fc1
+                if cutlass.const_expr(self.is_gated):
+                    up_red = cute.arch.warp_reduction_sum(partial_up) * alpha_fc1
+                if lane == Int32(0):
+                    if cutlass.const_expr(self.is_gated):
+                        if cutlass.const_expr(self.has_swiglu_limit):
+                            limit = Float32(self.swiglu_limit)
+                            neg_limit = Float32(-self.swiglu_limit)
+                            if gate_red > limit:
+                                gate_red = limit
+                            if up_red > limit:
+                                up_red = limit
+                            if up_red < neg_limit:
+                                up_red = neg_limit
+                        sigmoid_arg = gate_red
+                        up_term = up_red
+                        if cutlass.const_expr(self.is_swigluoai):
+                            sigmoid_arg = Float32(self.swiglu_alpha) * gate_red
+                            up_term = up_red + Float32(self.swiglu_beta)
+                        sigmoid = Float32(1.0) / (
+                            Float32(1.0) + cute.math.exp(-sigmoid_arg, fastmath=False)
+                        )
+                        activated = sigmoid * gate_red * up_term
+                    else:
+                        relu_val = fmax_f32(gate_red, Float32(0.0))
+                        activated = relu_val * relu_val
+                    smem_int[i_local] = Float32(BFloat16(activated))
+
+            # Look-ahead: quantize next task into other buffer (k_segments==2 only)
+            if cutlass.const_expr(cfg.k_segments == 2):
+                next_task = fc1_task + Int32(gdim_x)
+                need_quant_next = Int32(0)
+                t_next = t
+                next_route = route_idx
+                if next_task < fc1_task_count:
+                    next_route = next_task // Int32(cfg.fc1_chunks)
+                    t_next = next_route // Int32(cfg.num_topk)
+                    need_quant_next = Int32(1)
+                    if cutlass.const_expr(self.share_input_across_experts):
+                        need_quant_next = Int32(1) if t_next != t else Int32(0)
+                if need_quant_next > Int32(0):
+                    next_eid_addr = t_next * Int32(cfg.num_topk) + (
+                        next_route - t_next * Int32(cfg.num_topk)
+                    )
+                    gs_fc1_next = input_gs[Int32(topk_ids[next_eid_addr])]
+                    next_buf_base = (Int32(1) - buf_idx) * Int32(cfg.smem_xh_size)
+                    in_blk = tidx
+                    while in_blk < Int32(cfg.k_dim // _BLOCK_SIZE):
+                        x_base = t_next * Int32(cfg.k_dim) + in_blk * Int32(_BLOCK_SIZE)
+                        pad_off = in_blk // Int32(8)
+                        phys_base = in_blk * Int32(_BLOCK_SIZE // 2) + pad_off
+                        if cutlass.const_expr(self.w4a16_mode):
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                smem_xh[next_buf_base + phys_base + Int32(i)] = (
+                                    pack_f32x2_to_f16x2(v0, v1)
+                                )
+                        if cutlass.const_expr(self.a8_mx_mode):
+                            # Per-32 UE8M0 + E4M3 quantize-dequant (w4a8 prefill numerics).
+                            blk_peak = Float32(0.0)
+                            pair_delta = (
+                                Int32(1) - Int32(2) * (in_blk & Int32(1))
+                            ) * Int32(_BLOCK_SIZE)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                                v = Float32(a_input[x_base + Int32(i)])
+                                w = Float32(a_input[x_base + pair_delta + Int32(i)])
+                                blk_peak = fmax_f32(blk_peak, fmax_f32(v, -v))
+                                blk_peak = fmax_f32(blk_peak, fmax_f32(w, -w))
+                            scale32, inv32 = mx_scale_from_amax32(blk_peak)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                f0, f1 = quant_dequant_e4m3_2(v0, v1, inv32, scale32)
+                                smem_xh[next_buf_base + phys_base + Int32(i)] = (
+                                    pack_f32x2_to_f16x2(f0, f1)
+                                )
+                        if cutlass.const_expr(
+                            (not self.w4a16_mode) and (not self.a8_mx_mode)
+                        ):
+                            blk_peak = Float32(0.0)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                                v = Float32(a_input[x_base + Int32(i)])
+                                abs_v = v
+                                if v < Float32(0.0):
+                                    abs_v = -v
+                                if abs_v > blk_peak:
+                                    blk_peak = abs_v
+                            q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc1_next)
+                            if q_scale > Float32(_FP8_E4M3_MAX):
+                                q_scale = Float32(_FP8_E4M3_MAX)
+                            sf_val = self._scale_byte_to_f32(cvt_f32_to_e4m3(q_scale))
+                            eff_scale = Float32(0.0)
+                            if gs_fc1_next != Float32(0.0):
+                                eff_scale = sf_val / gs_fc1_next
+                            if eff_scale < Float32(1e-30):
+                                eff_scale = Float32(1e-30)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                                smem_xh[next_buf_base + phys_base + Int32(i)] = (
+                                    pack_f32x2_to_f16x2(f0, f1)
+                                )
+                        in_blk += Int32(_BLOCK_DIM)
+
+            cute.arch.sync_threads()
+
+            gs_fc2_eff = gs_fc2
+            if cutlass.const_expr(self.dynamic_down_scale):
+                local_max = Float32(0.0)
+                scan_idx = Int32(tidx)
+                while scan_idx < Int32(cfg.i_chunk):
+                    v = smem_int[scan_idx]
+                    abs_v = v
+                    if v < Float32(0.0):
+                        abs_v = -v
+                    local_max = fmax_f32(local_max, abs_v)
+                    scan_idx += Int32(_BLOCK_DIM)
+                warp_max = warp_reduce(local_max, fmax_f32)
+                if lane == Int32(0):
+                    reduce_scratch[warp_id] = warp_max
+                cute.arch.sync_threads()
+                tile_amax = Float32(0.0)
+                if warp_id == Int32(0):
+                    if lane < Int32(_NUM_WARPS):
+                        tile_amax = reduce_scratch[lane]
+                    tile_amax = warp_reduce(tile_amax, fmax_f32)
+                    if lane == Int32(0):
+                        reduce_scratch[Int32(0)] = tile_amax
+                cute.arch.sync_threads()
+                gs_fc2_eff = Float32(0.0)
+                if reduce_scratch[Int32(0)] > Float32(0.0):
+                    gs_fc2_eff = (
+                        Float32(_FC2_TILE_RECIP_GS_NUM) / reduce_scratch[Int32(0)]
+                    )
+                gs_fc2_eff = fmax_f32(gs_fc2_eff, Float32(1.0e-12))
+            fc2_rescale = Float32(1.0)
+            if cutlass.const_expr(self.dynamic_down_scale):
+                if gs_fc2_eff != Float32(0.0):
+                    fc2_rescale = gs_fc2 / gs_fc2_eff
+            if tidx < Int32(cfg.inter_blocks):
+                mid_blk = tidx
+                if cutlass.const_expr(self.a8_mx_mode):
+                    # Per-32 UE8M0 + E4M3 quantize-dequant of the FC2 input
+                    # (self-ranging: no global scale, no dynamic rescale).
+                    blk_peak = Float32(0.0)
+                    pair_delta = (Int32(1) - Int32(2) * (mid_blk & Int32(1))) * Int32(
+                        _BLOCK_SIZE
+                    )
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                        v = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i)]
+                        w = smem_int[
+                            mid_blk * Int32(_BLOCK_SIZE) + pair_delta + Int32(i)
+                        ]
+                        blk_peak = fmax_f32(blk_peak, fmax_f32(v, -v))
+                        blk_peak = fmax_f32(blk_peak, fmax_f32(w, -w))
+                    scale32, inv32 = mx_scale_from_amax32(blk_peak)
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                        v0 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2)]
+                        v1 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2 + 1)]
+                        f0, f1 = quant_dequant_e4m3_2(v0, v1, inv32, scale32)
+                        # The combined nvfp4 FC2 alpha is 1/(gs_fc2 * gs_w2);
+                        # a8_mx quantizes without the global scale, so fold it
+                        # into the dequantized values here (post-roundtrip:
+                        # exact alpha-equivalent, single site for all FC2
+                        # variants).
+                        f0 = f0 * gs_fc2
+                        f1 = f1 * gs_fc2
+                        half_base = chunk_idx * Int32(
+                            cfg.i_chunk // 2
+                        ) + mid_blk * Int32(_BLOCK_SIZE // 2)
+                        n_blk = half_base // Int32(128)
+                        h_local = half_base - n_blk * Int32(128)
+                        h_i = h_local + Int32(i)
+                        packed_idx = (
+                            t * Int32(cfg.inter_u32)
+                            + k_idx * Int32(cfg.fc2_n_chunks * 128)
+                            + n_blk * Int32(128)
+                            + (h_i % Int32(4)) * Int32(32)
+                            + (h_i // Int32(4))
+                        )
+                        intermediate[packed_idx] = pack_f32x2_to_f16x2(f0, f1)
+                if cutlass.const_expr(self.w4a16_mode):
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                        v0 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2)]
+                        v1 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2 + 1)]
+                        half_base = chunk_idx * Int32(
+                            cfg.i_chunk // 2
+                        ) + mid_blk * Int32(_BLOCK_SIZE // 2)
+                        n_blk = half_base // Int32(128)
+                        h_local = half_base - n_blk * Int32(128)
+                        h_i = h_local + Int32(i)
+                        packed_idx = (
+                            t * Int32(cfg.inter_u32)
+                            + k_idx * Int32(cfg.fc2_n_chunks * 128)
+                            + n_blk * Int32(128)
+                            + (h_i % Int32(4)) * Int32(32)
+                            + (h_i // Int32(4))
+                        )
+                        intermediate[packed_idx] = pack_f32x2_to_f16x2(v0, v1)
+                if cutlass.const_expr((not self.w4a16_mode) and (not self.a8_mx_mode)):
+                    blk_peak = Float32(0.0)
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                        v = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i)]
+                        abs_v = v
+                        if v < Float32(0.0):
+                            abs_v = -v
+                        if abs_v > blk_peak:
+                            blk_peak = abs_v
+                    q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc2_eff)
+                    if q_scale > Float32(_FP8_E4M3_MAX):
+                        q_scale = Float32(_FP8_E4M3_MAX)
+                    sf_val = self._scale_byte_to_f32(cvt_f32_to_e4m3(q_scale))
+                    eff_scale = Float32(0.0)
+                    if gs_fc2_eff != Float32(0.0):
+                        eff_scale = sf_val / gs_fc2_eff
+                    if eff_scale < Float32(1e-30):
+                        eff_scale = Float32(1e-30)
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                        v0 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2)]
+                        v1 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2 + 1)]
+                        f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                        f0 = f0 * fc2_rescale
+                        f1 = f1 * fc2_rescale
+                        half_base = chunk_idx * Int32(
+                            cfg.i_chunk // 2
+                        ) + mid_blk * Int32(_BLOCK_SIZE // 2)
+                        n_blk = half_base // Int32(128)
+                        h_local = half_base - n_blk * Int32(128)
+                        h_i = h_local + Int32(i)
+                        packed_idx = (
+                            t * Int32(cfg.inter_u32)
+                            + k_idx * Int32(cfg.fc2_n_chunks * 128)
+                            + n_blk * Int32(128)
+                            + (h_i % Int32(4)) * Int32(32)
+                            + (h_i // Int32(4))
+                        )
+                        intermediate[packed_idx] = pack_f32x2_to_f16x2(f0, f1)
+
+            cute.arch.sync_threads()
+            if cutlass.const_expr(cfg.k_segments == 2):
+                if need_quant_next > Int32(0):
+                    buf_idx = Int32(1) - buf_idx
+            fc1_task += Int32(gdim_x)
+
+        if cutlass.const_expr(self.compile_time_phase == 1):
+            return
+
+        if cutlass.const_expr(self.m_const == 1):
+            _token_publish_fc1_ready(
+                barrier_count,
+                barrier_epoch,
+                Int32(0),
+                m1_epoch0,
+                Int32(gdim_x),
+                is_cta_leader,
+            )
+            _token_wait_fc1_ready(barrier_epoch, Int32(0), m1_epoch0, is_cta_leader)
+        else:
+            self._resident_grid_barrier(
+                barrier_count, barrier_epoch, Int32(gdim_x), is_cta_leader
+            )
+
+        self._run_fc2(
+            bidx_x,
+            gdim_x,
+            warp_id,
+            lane,
+            m_val,
+            w2_weights,
+            w2_scales,
+            w2_alphas,
+            intermediate,
+            topk_ids,
+            topk_weights,
+            scatter_output,
+        )
+
+    @cute.jit
+    def _run_fc2(
+        self,
+        bidx_x: Int32,
+        gdim_x: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        m_val: Int32,
+        w2_weights: cute.Tensor,
+        w2_scales: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        intermediate: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        # FC2 is intentionally factored out so native NVFP4 decode can run it
+        # in a second, non-cooperative launch after FC1 has materialized the
+        # exact same intermediate representation.
+        cfg = self._cfg
+        w2_base_addr = w2_weights.iterator.toint()
+        w2s_base_addr = w2_scales.iterator.toint()
+        # ---- m==1 FC2 rowpair ----
+        if cutlass.const_expr(self.m_const == 1):
+            fc2_chunks_m1 = Int32(cfg.k_dim // self.m1_fc2_rows_per_cta)
+            if cutlass.const_expr(self.m1_fc2_onepass):
+                fc2_task = Int32(bidx_x)
+                if fc2_task < fc2_chunks_m1:
+                    if cutlass.const_expr(cfg.fc2_n_chunks > 1):
+                        self._m1_fc2_rowpair_wide(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+                    else:
+                        self._m1_fc2_rowpair_narrow(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+            else:
+                fc2_task = Int32(bidx_x)
+                while fc2_task < fc2_chunks_m1:
+                    if cutlass.const_expr(cfg.fc2_n_chunks > 1):
+                        self._m1_fc2_rowpair_wide(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+                    else:
+                        self._m1_fc2_rowpair_narrow(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+                    fc2_task += Int32(gdim_x)
+
+        # ---- m>=2 FC2 rowquad ----
+        else:
+            if cutlass.const_expr(self.w4a16_mode and cfg.fc2_n_chunks == 1):
+                fc2_task_count = (m_val * Int32(cfg.k_dim)) // Int32(_K_PER_CTA * 2)
+            else:
+                fc2_task_count = (m_val * Int32(cfg.k_dim)) // Int32(_K_PER_CTA * 4)
+            fc2_task = Int32(bidx_x)
+            while fc2_task < fc2_task_count:
+                if cutlass.const_expr(self.w4a16_mode and cfg.fc2_n_chunks == 1):
+                    self._m2_fc2_rowpair_narrow(
+                        fc2_task,
+                        warp_id,
+                        lane,
+                        w2_base_addr,
+                        w2s_base_addr,
+                        intermediate,
+                        w2_alphas,
+                        topk_ids,
+                        topk_weights,
+                        scatter_output,
+                    )
+                elif cutlass.const_expr(cfg.fc2_n_chunks > 1):
+                    self._m2_fc2_rowquad_wide(
+                        fc2_task,
+                        warp_id,
+                        lane,
+                        w2_base_addr,
+                        w2s_base_addr,
+                        intermediate,
+                        w2_alphas,
+                        topk_ids,
+                        topk_weights,
+                        scatter_output,
+                    )
+                else:
+                    self._m2_fc2_rowquad_narrow(
+                        fc2_task,
+                        warp_id,
+                        lane,
+                        w2_base_addr,
+                        w2s_base_addr,
+                        intermediate,
+                        w2_alphas,
+                        topk_ids,
+                        topk_weights,
+                        scatter_output,
+                    )
+                fc2_task += Int32(gdim_x)
+
+    @cute.jit
+    def __call__(
+        self,
+        x_ptr: cute.Pointer,
+        w1_ptr: cute.Pointer,
+        w1s_ptr: cute.Pointer,
+        w1a_ptr: cute.Pointer,
+        a1_ptr: cute.Pointer,
+        a2_ptr: cute.Pointer,
+        inter_ptr: cute.Pointer,
+        w2_ptr: cute.Pointer,
+        w2s_ptr: cute.Pointer,
+        w2a_ptr: cute.Pointer,
+        tid_ptr: cute.Pointer,
+        tw_ptr: cute.Pointer,
+        out_ptr: cute.Pointer,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        m_val: Int32,
+        grid_x: Int32,
+        stream,
+    ):
+        cfg = self._cfg
+        a_input = cute.make_tensor(x_ptr, cute.make_layout(Int32(m_val * cfg.k_dim)))
+        w1_weights = cute.make_tensor(
+            w1_ptr, cute.make_layout(Int64(cfg.weight_E * cfg.two_n * cfg.k_half))
+        )
+        if cutlass.const_expr(self.scale_format_e8m0_k32):
+            w1_scales = cute.make_tensor(
+                w1s_ptr,
+                cute.make_layout(Int64(cfg.weight_E * (cfg.k_dim // 32) * cfg.two_n)),
+            )
+        elif cutlass.const_expr(self.w4a16_mode):
+            w1_scales = cute.make_tensor(
+                w1s_ptr,
+                cute.make_layout(Int64(cfg.weight_E * (cfg.k_dim // 16) * cfg.two_n)),
+            )
+        else:
+            w1_scales = cute.make_tensor(
+                w1s_ptr,
+                cute.make_layout(Int64(cfg.weight_E * cfg.w1_sf_rows * cfg.w1_sf_cols)),
+            )
+        w1_alphas = cute.make_tensor(w1a_ptr, cute.make_layout(Int32(cfg.weight_E)))
+        input_gs = cute.make_tensor(a1_ptr, cute.make_layout(Int32(cfg.weight_E)))
+        down_input_scale = cute.make_tensor(
+            a2_ptr, cute.make_layout(Int32(cfg.weight_E))
+        )
+        intermediate = cute.make_tensor(
+            inter_ptr, cute.make_layout(Int32(m_val * cfg.inter_u32))
+        )
+        w2_weights = cute.make_tensor(
+            w2_ptr, cute.make_layout(Int64(cfg.weight_E * cfg.k_dim * cfg.n_half))
+        )
+        if cutlass.const_expr(self.scale_format_e8m0_k32):
+            w2_scales = cute.make_tensor(
+                w2s_ptr,
+                cute.make_layout(Int64(cfg.weight_E * (cfg.n // 32) * cfg.k_dim)),
+            )
+        elif cutlass.const_expr(self.w4a16_mode):
+            w2_scales = cute.make_tensor(
+                w2s_ptr,
+                cute.make_layout(Int64(cfg.weight_E * (cfg.n // 16) * cfg.k_dim)),
+            )
+        else:
+            w2_scales = cute.make_tensor(
+                w2s_ptr,
+                cute.make_layout(Int64(cfg.weight_E * cfg.w2_sf_rows * cfg.w2_sf_cols)),
+            )
+        w2_alphas = cute.make_tensor(w2a_ptr, cute.make_layout(Int32(cfg.weight_E)))
+        topk_ids_tensor = cute.make_tensor(
+            tid_ptr, cute.make_layout(Int32(m_val * cfg.num_topk))
+        )
+        topk_weights_tensor = cute.make_tensor(
+            tw_ptr, cute.make_layout(Int32(m_val * cfg.num_topk))
+        )
+        scatter_output_tensor = cute.make_tensor(
+            out_ptr, cute.make_layout(Int32(m_val * cfg.k_dim))
+        )
+
+        self.kernel(
+            a_input,
+            w1_weights,
+            w1_scales,
+            w1_alphas,
+            input_gs,
+            down_input_scale,
+            intermediate,
+            w2_weights,
+            w2_scales,
+            w2_alphas,
+            topk_ids_tensor,
+            topk_weights_tensor,
+            scatter_output_tensor,
+            barrier_count,
+            barrier_epoch,
+            m_val,
+        ).launch(
+            grid=(grid_x, Int32(1), Int32(1)),
+            block=(self.launch_block_dim, 1, 1),
+            # The fused and FC1-only bodies are 512-thread cooperative CTAs;
+            # the FC2-only m=1 specialization is a 256-thread independent CTA.
+            # One block per SM preserves each variant's register budget.
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @staticmethod
+    def launch(
+        compiled_fn,
+        *,
+        x: torch.Tensor,
+        w1_fp4: torch.Tensor,
+        w1_blockscale: torch.Tensor,
+        w1_alphas: torch.Tensor,
+        a1_gscale: torch.Tensor,
+        a2_gscale: torch.Tensor,
+        inter_fp32: torch.Tensor,
+        w2_fp4: torch.Tensor,
+        w2_blockscale: torch.Tensor,
+        w2_alphas: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        out: torch.Tensor,
+        barrier_count: torch.Tensor,
+        barrier_epoch: torch.Tensor,
+        m: int,
+        grid_x: int,
+    ):
+        def ptr(dt, t):
+            return make_ptr(dt, t.data_ptr(), cute.AddressSpace.gmem, assumed_align=16)
+
+        ids_dtype = cutlass.Int64 if topk_ids.dtype == torch.int64 else cutlass.Int32
+        stream = current_cuda_stream()
+
+        compiled_fn(
+            ptr(cutlass.BFloat16, x),
+            ptr(cutlass.Uint8, w1_fp4),
+            ptr(cutlass.Uint8, w1_blockscale.view(torch.uint8)),
+            ptr(cutlass.Float32, w1_alphas),
+            ptr(cutlass.Float32, a1_gscale),
+            ptr(cutlass.Float32, a2_gscale),
+            ptr(cutlass.Uint32, inter_fp32.view(torch.uint32)),
+            ptr(cutlass.Uint8, w2_fp4),
+            ptr(cutlass.Uint8, w2_blockscale.view(torch.uint8)),
+            ptr(cutlass.Float32, w2_alphas),
+            ptr(ids_dtype, topk_ids),
+            ptr(cutlass.Float32, topk_weights),
+            ptr(cutlass.BFloat16, out),
+            barrier_count,
+            barrier_epoch,
+            Int32(m),
+            Int32(grid_x),
+            stream,
+        )
+
+
+__all__ = ["MoEMicroKernelBackend"]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/reference.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/reference.py
@@ -1,0 +1,1368 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/reference.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+# NOTE(one-time port): the flashinfer-TRTLLM cross-oracle helpers
+# (prepare_flashinfer_trtllm_fp4_e8m0_k32_weights and friends) were removed
+# here -- experimental package code may not import flashinfer core (zero
+# outbound imports). They remain in the b12x repo for cross-kernel parity
+# studies.
+from flashinfer.experimental.sm12x._lib.intrinsics import fp4_quantize_values_torch
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    SWIGLUOAI_UNINTERLEAVE,
+    is_gated_moe_activation,
+    moe_activation_w1_rows,
+    normalize_moe_activation,
+    normalize_swiglu_alpha_for_activation,
+    normalize_swiglu_beta_for_activation,
+    normalize_swiglu_limit_for_activation,
+)
+
+
+@dataclass(frozen=True)
+class OracleMetrics:
+    max_abs: float
+    rmse: float
+    mean_abs: float
+    cos: float
+
+
+@dataclass(frozen=True)
+class MoERouteTrace:
+    token_idx: int
+    route_idx: int
+    expert_idx: int
+    activation: str
+    router_weight: float
+    alpha_fc1: float
+    alpha_fc2: float
+    gs_fc1: float
+    gs_fc2: float
+    x_dequant: torch.Tensor
+    fc1_out: torch.Tensor | None
+    gate_out: torch.Tensor | None
+    up_out: torch.Tensor | None
+    intermediate: torch.Tensor
+    int_dequant: torch.Tensor
+    down_out: torch.Tensor
+    routed_out: torch.Tensor
+    routed_out_accum: torch.Tensor
+
+
+_E8M0_K32_BF16_MAX_SCALE_BYTE = 247
+
+
+def compare_to_reference(
+    actual: torch.Tensor, reference: torch.Tensor
+) -> OracleMetrics:
+    actual_fp32 = actual.float()
+    reference_fp32 = reference.float()
+    diff = actual_fp32 - reference_fp32
+    actual_rows = actual_fp32.reshape(actual_fp32.shape[0], -1)
+    reference_rows = reference_fp32.reshape(reference_fp32.shape[0], -1)
+    dot = (actual_rows * reference_rows).sum(dim=1)
+    actual_norm = actual_rows.norm(dim=1)
+    reference_norm = reference_rows.norm(dim=1)
+    denom = actual_norm * reference_norm
+    both_zero = (actual_norm <= 1e-12) & (reference_norm <= 1e-12)
+    cos_rows = torch.where(
+        both_zero,
+        torch.ones_like(dot),
+        torch.where(denom > 1e-24, dot / denom, torch.zeros_like(dot)),
+    )
+    cos = cos_rows.mean().item()
+    return OracleMetrics(
+        max_abs=diff.abs().max().item(),
+        rmse=diff.square().mean().sqrt().item(),
+        mean_abs=diff.abs().mean().item(),
+        cos=cos,
+    )
+
+
+def unswizzle_block_scale(
+    swizzled_scale: torch.Tensor, rows: int, cols_blocks: int
+) -> torch.Tensor:
+    cols_padded = ((cols_blocks + 3) // 4) * 4
+    rows_padded = ((rows + 127) // 128) * 128
+    unswizzled = swizzled_scale.view(torch.float8_e4m3fn).reshape(
+        rows_padded // 128,
+        cols_padded // 4,
+        32,
+        4,
+        4,
+    )
+    unswizzled = unswizzled.permute(0, 3, 2, 1, 4).contiguous()
+    unswizzled = unswizzled.reshape(rows_padded, cols_padded)
+    return unswizzled[:rows, :cols_blocks].to(torch.float32)
+
+
+def _validate_reference_inputs(
+    w1_fp4: torch.Tensor,
+    I_tp: int,
+    activation: str,
+) -> None:
+    activation = normalize_moe_activation(activation)
+    expected_w1_rows = moe_activation_w1_rows(activation, I_tp)
+    if w1_fp4.shape[1] != expected_w1_rows:
+        raise ValueError(
+            f"expected w1_fp4.shape[1] == {expected_w1_rows} for activation "
+            f"{activation!r}, got {w1_fp4.shape[1]}"
+        )
+
+
+def _normalize_reference_swiglu_params(
+    activation: str,
+    swiglu_limit: float | None,
+    swiglu_alpha: float | None,
+    swiglu_beta: float | None,
+) -> tuple[str, float | None, float, float]:
+    activation = normalize_moe_activation(activation)
+    return (
+        activation,
+        normalize_swiglu_limit_for_activation(activation, swiglu_limit),
+        normalize_swiglu_alpha_for_activation(activation, swiglu_alpha),
+        normalize_swiglu_beta_for_activation(activation, swiglu_beta),
+    )
+
+
+def _gated_row_slices(
+    activation: str,
+    I_tp: int,
+    *,
+    w13_layout: str | None = None,
+) -> tuple[slice, slice]:
+    activation = normalize_moe_activation(activation)
+    if w13_layout is not None:
+        layout = _normalize_w13_layout(w13_layout)
+        if layout == "w31":
+            return slice(0, I_tp), slice(I_tp, 2 * I_tp)
+        return slice(I_tp, 2 * I_tp), slice(0, I_tp)
+    if activation == SWIGLUOAI_UNINTERLEAVE:
+        return slice(0, I_tp), slice(I_tp, 2 * I_tp)
+    return slice(I_tp, 2 * I_tp), slice(0, I_tp)
+
+
+def _apply_gated_activation(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    *,
+    activation: str,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+) -> torch.Tensor:
+    if swiglu_limit is not None:
+        gate = torch.clamp(gate, max=float(swiglu_limit))
+        up = torch.clamp(up, min=-float(swiglu_limit), max=float(swiglu_limit))
+    if activation == SWIGLUOAI_UNINTERLEAVE:
+        return (
+            gate * torch.sigmoid(float(swiglu_alpha) * gate) * (up + float(swiglu_beta))
+        )
+    return gate * torch.sigmoid(gate) * up
+
+
+def _make_fp4_lut(device: torch.device) -> torch.Tensor:
+    return torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+
+
+def _dequant_fp4(
+    packed_u8: torch.Tensor,
+    rows: int,
+    cols: int,
+    fp4_lut: torch.Tensor,
+) -> torch.Tensor:
+    if packed_u8.dtype == torch.int8:
+        packed_u8 = packed_u8.view(torch.uint8)
+    lo = (packed_u8 & 0x0F).to(torch.int64)
+    hi = ((packed_u8 >> 4) & 0x0F).to(torch.int64)
+    return torch.stack([fp4_lut[lo], fp4_lut[hi]], dim=-1).reshape(rows, cols)
+
+
+def _apply_block_scales(
+    raw: torch.Tensor,
+    sf_f32: torch.Tensor,
+    rows: int,
+    cols: int,
+    *,
+    block_size: int,
+) -> torch.Tensor:
+    n_blocks = (int(cols) + int(block_size) - 1) // int(block_size)
+    sf = sf_f32[:rows, :n_blocks]
+    padded_cols = n_blocks * int(block_size)
+    if padded_cols != int(cols):
+        padded = raw.new_zeros((int(rows), padded_cols))
+        padded[:, : int(cols)] = raw
+        raw = padded
+    scaled = raw * sf.unsqueeze(-1).expand(rows, n_blocks, block_size).reshape(
+        rows,
+        padded_cols,
+    )
+    return scaled[:, : int(cols)]
+
+
+def _e8m0_scales_to_float(scales: torch.Tensor) -> torch.Tensor:
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if scales.dtype == torch.uint8:
+        if e8m0_dtype is None:
+            raise TypeError("uint8 E8M0 scales require torch.float8_e8m0fnu")
+        scales = scales.view(e8m0_dtype)
+    return scales.to(torch.float32)
+
+
+def _e8m0_scale_bytes(
+    scales: torch.Tensor,
+    *,
+    scale_byte_clamp: int | None = None,
+) -> torch.Tensor:
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if scales.dtype == torch.uint8:
+        scale_bytes = scales
+    elif e8m0_dtype is not None and scales.dtype == e8m0_dtype:
+        scale_bytes = scales.view(torch.uint8)
+    else:
+        raise TypeError("E8M0 K/32 scales must be torch.uint8 or torch.float8_e8m0fnu")
+    if scale_byte_clamp is None:
+        return scale_bytes.contiguous()
+    return scale_bytes.clamp(max=int(scale_byte_clamp)).contiguous()
+
+
+def _normalize_w13_layout(w13_layout: str) -> str:
+    layout = str(w13_layout).lower()
+    if layout not in {"w13", "w31"}:
+        raise ValueError(f"unsupported W13 layout {w13_layout!r}")
+    return layout
+
+
+def _quantize_vec_to_fp4_dequant(
+    vals_f32: torch.Tensor,
+    global_scale: float,
+    *,
+    block_size: int,
+    fp8_e4m3_max: float,
+    scale_math: str = "direct_division",
+) -> torch.Tensor:
+    cols = vals_f32.shape[0]
+    n_blocks = cols // block_size
+    blocked = vals_f32.reshape(n_blocks, block_size)
+    block_max = blocked.abs().amax(dim=-1)
+
+    raw_scale = (block_max * global_scale / 6.0).clamp(max=fp8_e4m3_max)
+    sf_e4m3 = raw_scale.to(torch.float8_e4m3fn).to(torch.float32)
+
+    sf_times_gs = (
+        sf_e4m3.unsqueeze(-1).expand(n_blocks, block_size).reshape(cols) / global_scale
+    ).clamp(min=1e-30)
+    if scale_math == "direct_division":
+        scaled = vals_f32 / sf_times_gs
+    elif scale_math == "reciprocal_multiply":
+        # The micro kernel materializes ``1 / effective_scale`` once and then
+        # multiplies each value.  This is observably different from direct
+        # division at FP4 round-to-nearest-even ties, so its oracle must retain
+        # the same floating-point evaluation order.
+        scaled = vals_f32 * sf_times_gs.reciprocal()
+    else:
+        raise ValueError(f"unsupported NVFP4 scale math {scale_math!r}")
+    quant = fp4_quantize_values_torch(scaled)
+    sf_only = sf_e4m3.unsqueeze(-1).expand(n_blocks, block_size).reshape(cols)
+    return quant * sf_only
+
+
+def _trace_nvfp4_route(
+    *,
+    x_f32: torch.Tensor,
+    w1_fp4_eid: torch.Tensor,
+    w1_blockscale_eid: torch.Tensor,
+    alpha_fc1: float,
+    w2_fp4_eid: torch.Tensor,
+    w2_blockscale_eid: torch.Tensor,
+    alpha_fc2: float,
+    gs_fc1: float,
+    gs_fc2: float,
+    K: int,
+    I_tp: int,
+    token_idx: int,
+    route_idx: int,
+    expert_idx: int,
+    router_weight: float,
+    activation: str,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    quant_scale_math: str = "direct_division",
+) -> MoERouteTrace:
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    block_size = 16
+    fp8_e4m3_max = float(torch.finfo(torch.float8_e4m3fn).max)
+    fp4_lut = _make_fp4_lut(x_f32.device)
+    is_gated = is_gated_moe_activation(activation)
+
+    x_dequant = _quantize_vec_to_fp4_dequant(
+        x_f32,
+        gs_fc1,
+        block_size=block_size,
+        fp8_e4m3_max=fp8_e4m3_max,
+        scale_math=quant_scale_math,
+    )
+    w2_sf = unswizzle_block_scale(w2_blockscale_eid, K, I_tp // block_size)
+
+    fc1_out = None
+    gate_out = None
+    up_out = None
+    if is_gated:
+        w13_sf = unswizzle_block_scale(w1_blockscale_eid, 2 * I_tp, K // block_size)
+        gate_rows, up_rows = _gated_row_slices(activation, I_tp)
+        up_dequant = _apply_block_scales(
+            _dequant_fp4(w1_fp4_eid[up_rows], I_tp, K, fp4_lut),
+            w13_sf[up_rows],
+            I_tp,
+            K,
+            block_size=block_size,
+        )
+        gate_dequant = _apply_block_scales(
+            _dequant_fp4(w1_fp4_eid[gate_rows], I_tp, K, fp4_lut),
+            w13_sf[gate_rows],
+            I_tp,
+            K,
+            block_size=block_size,
+        )
+        gate_out = (gate_dequant @ x_dequant) * alpha_fc1
+        up_out = (up_dequant @ x_dequant) * alpha_fc1
+        intermediate = (
+            _apply_gated_activation(
+                gate_out,
+                up_out,
+                activation=activation,
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+            )
+            .to(torch.bfloat16)
+            .float()
+        )
+    else:
+        w1_sf = unswizzle_block_scale(w1_blockscale_eid, I_tp, K // block_size)
+        fc1_dequant = _apply_block_scales(
+            _dequant_fp4(w1_fp4_eid[:I_tp], I_tp, K, fp4_lut),
+            w1_sf[:I_tp],
+            I_tp,
+            K,
+            block_size=block_size,
+        )
+        fc1_out = (fc1_dequant @ x_dequant) * alpha_fc1
+        intermediate = torch.square(torch.relu(fc1_out)).to(torch.bfloat16).float()
+
+    int_dequant = _quantize_vec_to_fp4_dequant(
+        intermediate,
+        gs_fc2,
+        block_size=block_size,
+        fp8_e4m3_max=fp8_e4m3_max,
+        scale_math=quant_scale_math,
+    )
+    down_dequant = _apply_block_scales(
+        _dequant_fp4(w2_fp4_eid, K, I_tp, fp4_lut),
+        w2_sf,
+        K,
+        I_tp,
+        block_size=block_size,
+    )
+    down_out_f32 = (down_dequant @ int_dequant) * alpha_fc2
+    down_out = down_out_f32.to(torch.bfloat16)
+    routed_out = (router_weight * down_out.float()).to(torch.bfloat16)
+    routed_out_accum = down_out_f32 * router_weight
+    return MoERouteTrace(
+        token_idx=token_idx,
+        route_idx=route_idx,
+        expert_idx=expert_idx,
+        activation=activation,
+        router_weight=router_weight,
+        alpha_fc1=alpha_fc1,
+        alpha_fc2=alpha_fc2,
+        gs_fc1=gs_fc1,
+        gs_fc2=gs_fc2,
+        x_dequant=x_dequant,
+        fc1_out=fc1_out,
+        gate_out=gate_out,
+        up_out=up_out,
+        intermediate=intermediate,
+        int_dequant=int_dequant,
+        down_out=down_out,
+        routed_out=routed_out,
+        routed_out_accum=routed_out_accum,
+    )
+
+
+def trace_moe_reference_nvfp4_route(
+    x: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    E: int,
+    K: int,
+    I_tp: int,
+    *,
+    token_idx: int,
+    route_idx: int,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    quant_scale_math: str = "direct_division",
+) -> MoERouteTrace:
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    del E
+    _validate_reference_inputs(w1_fp4, I_tp, activation)
+    if token_idx < 0 or token_idx >= x.shape[0]:
+        raise IndexError(
+            f"token_idx {token_idx} is out of range for batch {x.shape[0]}"
+        )
+    if route_idx < 0 or route_idx >= topk_ids.shape[1]:
+        raise IndexError(
+            f"route_idx {route_idx} is out of range for top_k {topk_ids.shape[1]}"
+        )
+
+    x_f32 = x[token_idx].float()
+    expert_idx = int(topk_ids[token_idx, route_idx].item())
+    router_weight = float(topk_weights[token_idx, route_idx].item())
+    alpha_fc1 = float(w1_alphas[expert_idx].item())
+    alpha_fc2 = float(w2_alphas[expert_idx].item())
+    gs_fc1 = (
+        float(a1_gscale[expert_idx].item())
+        if a1_gscale.numel() > 1
+        else float(a1_gscale.item())
+    )
+    gs_fc2 = (
+        float(a2_gscale[expert_idx].item())
+        if a2_gscale.numel() > 1
+        else float(a2_gscale.item())
+    )
+    return _trace_nvfp4_route(
+        x_f32=x_f32,
+        w1_fp4_eid=w1_fp4[expert_idx],
+        w1_blockscale_eid=w1_blockscale[expert_idx],
+        alpha_fc1=alpha_fc1,
+        w2_fp4_eid=w2_fp4[expert_idx],
+        w2_blockscale_eid=w2_blockscale[expert_idx],
+        alpha_fc2=alpha_fc2,
+        gs_fc1=gs_fc1,
+        gs_fc2=gs_fc2,
+        K=K,
+        I_tp=I_tp,
+        token_idx=token_idx,
+        route_idx=route_idx,
+        expert_idx=expert_idx,
+        router_weight=router_weight,
+        activation=activation,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        quant_scale_math=quant_scale_math,
+    )
+
+
+def moe_reference_f32(
+    x: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    E: int,
+    K: int,
+    I_tp: int,
+    *,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+) -> torch.Tensor:
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    _validate_reference_inputs(w1_fp4, I_tp, activation)
+    del E
+    is_gated = is_gated_moe_activation(activation)
+    block_size = 16
+    fp8_e4m3_max = float(torch.finfo(torch.float8_e4m3fn).max)
+
+    fp4_lut = torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+        device=x.device,
+    )
+
+    def dequant_fp4(packed_u8: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+        lo = (packed_u8 & 0x0F).to(torch.int64)
+        hi = ((packed_u8 >> 4) & 0x0F).to(torch.int64)
+        return torch.stack([fp4_lut[lo], fp4_lut[hi]], dim=-1).reshape(rows, cols)
+
+    def apply_block_scales(
+        raw: torch.Tensor, sf_f32: torch.Tensor, rows: int, cols: int
+    ) -> torch.Tensor:
+        n_blocks = cols // block_size
+        sf = sf_f32[:rows, :n_blocks]
+        return raw * sf.unsqueeze(-1).expand(rows, n_blocks, block_size).reshape(
+            rows, cols
+        )
+
+    def quantize_vec_to_fp4_dequant(
+        vals_f32: torch.Tensor, global_scale: float
+    ) -> torch.Tensor:
+        cols = vals_f32.shape[0]
+        n_blocks = cols // block_size
+        blocked = vals_f32.reshape(n_blocks, block_size)
+        block_max = blocked.abs().amax(dim=-1)
+
+        raw_scale = (block_max * global_scale / 6.0).clamp(max=fp8_e4m3_max)
+        sf_e4m3 = raw_scale.to(torch.float8_e4m3fn).to(torch.float32)
+
+        sf_times_gs = (
+            sf_e4m3.unsqueeze(-1).expand(n_blocks, block_size).reshape(cols)
+            / global_scale
+        )
+        scaled = vals_f32 / sf_times_gs.clamp(min=1e-30)
+        quant = fp4_quantize_values_torch(scaled)
+        sf_only = sf_e4m3.unsqueeze(-1).expand(n_blocks, block_size).reshape(cols)
+        return quant * sf_only
+
+    device = x.device
+    m = x.shape[0]
+    top_k = topk_ids.shape[1]
+    output = torch.zeros(m, K, dtype=torch.float32, device=device)
+
+    for t in range(m):
+        x_f32 = x[t].float()
+        for k_idx in range(top_k):
+            eid = int(topk_ids[t, k_idx].item())
+            router_w = float(topk_weights[t, k_idx].item())
+            alpha_fc1 = float(w1_alphas[eid].item())
+            alpha_fc2 = float(w2_alphas[eid].item())
+
+            gs_fc1 = (
+                float(a1_gscale[eid].item())
+                if a1_gscale.numel() > 1
+                else float(a1_gscale.item())
+            )
+            gs_fc2 = (
+                float(a2_gscale[eid].item())
+                if a2_gscale.numel() > 1
+                else float(a2_gscale.item())
+            )
+
+            x_dequant = quantize_vec_to_fp4_dequant(x_f32, gs_fc1)
+
+            w2_sf = unswizzle_block_scale(w2_blockscale[eid], K, I_tp // block_size)
+
+            if is_gated:
+                w13_sf = unswizzle_block_scale(
+                    w1_blockscale[eid], 2 * I_tp, K // block_size
+                )
+                gate_rows, up_rows = _gated_row_slices(activation, I_tp)
+                up_dequant = apply_block_scales(
+                    dequant_fp4(w1_fp4[eid, up_rows], I_tp, K),
+                    w13_sf[up_rows],
+                    I_tp,
+                    K,
+                )
+                gate_dequant = apply_block_scales(
+                    dequant_fp4(w1_fp4[eid, gate_rows], I_tp, K),
+                    w13_sf[gate_rows],
+                    I_tp,
+                    K,
+                )
+                gate_out = (gate_dequant @ x_dequant) * alpha_fc1
+                up_out = (up_dequant @ x_dequant) * alpha_fc1
+                intermediate = _apply_gated_activation(
+                    gate_out,
+                    up_out,
+                    activation=activation,
+                    swiglu_limit=swiglu_limit,
+                    swiglu_alpha=swiglu_alpha,
+                    swiglu_beta=swiglu_beta,
+                )
+            else:
+                w1_sf = unswizzle_block_scale(w1_blockscale[eid], I_tp, K // block_size)
+                fc1_dequant = apply_block_scales(
+                    dequant_fp4(w1_fp4[eid, :I_tp], I_tp, K),
+                    w1_sf[:I_tp],
+                    I_tp,
+                    K,
+                )
+                fc1_out = (fc1_dequant @ x_dequant) * alpha_fc1
+                intermediate = torch.square(torch.relu(fc1_out))
+
+            int_dequant = quantize_vec_to_fp4_dequant(intermediate, gs_fc2)
+            down_dequant = apply_block_scales(
+                dequant_fp4(w2_fp4[eid], K, I_tp),
+                w2_sf,
+                K,
+                I_tp,
+            )
+            down_out = (down_dequant @ int_dequant) * alpha_fc2
+            output[t] += router_w * down_out
+
+    return output
+
+
+def moe_reference_w4a16_f32(
+    x: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    E: int,
+    K: int,
+    I_tp: int,
+    *,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+) -> torch.Tensor:
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    _validate_reference_inputs(w1_fp4, I_tp, activation)
+    del E
+    is_gated = is_gated_moe_activation(activation)
+
+    block_size = 16
+    fp4_lut = _make_fp4_lut(x.device)
+    device = x.device
+    m = x.shape[0]
+    top_k = topk_ids.shape[1]
+    output = torch.zeros(m, K, dtype=torch.float32, device=device)
+
+    for t in range(m):
+        x_f32 = x[t].float()
+        for k_idx in range(top_k):
+            eid = int(topk_ids[t, k_idx].item())
+            router_w = float(topk_weights[t, k_idx].item())
+            alpha_fc1 = float(w1_alphas[eid].item())
+            alpha_fc2 = float(w2_alphas[eid].item())
+
+            w2_sf = unswizzle_block_scale(w2_blockscale[eid], K, I_tp // block_size)
+
+            if is_gated:
+                w13_sf = unswizzle_block_scale(
+                    w1_blockscale[eid], 2 * I_tp, K // block_size
+                )
+                gate_rows, up_rows = _gated_row_slices(activation, I_tp)
+                up_dequant = _apply_block_scales(
+                    _dequant_fp4(w1_fp4[eid, up_rows], I_tp, K, fp4_lut),
+                    w13_sf[up_rows],
+                    I_tp,
+                    K,
+                    block_size=block_size,
+                )
+                gate_dequant = _apply_block_scales(
+                    _dequant_fp4(w1_fp4[eid, gate_rows], I_tp, K, fp4_lut),
+                    w13_sf[gate_rows],
+                    I_tp,
+                    K,
+                    block_size=block_size,
+                )
+                gate_out = (gate_dequant @ x_f32) * alpha_fc1
+                up_out = (up_dequant @ x_f32) * alpha_fc1
+                intermediate = _apply_gated_activation(
+                    gate_out,
+                    up_out,
+                    activation=activation,
+                    swiglu_limit=swiglu_limit,
+                    swiglu_alpha=swiglu_alpha,
+                    swiglu_beta=swiglu_beta,
+                )
+            else:
+                w1_sf = unswizzle_block_scale(w1_blockscale[eid], I_tp, K // block_size)
+                fc1_dequant = _apply_block_scales(
+                    _dequant_fp4(w1_fp4[eid, :I_tp], I_tp, K, fp4_lut),
+                    w1_sf[:I_tp],
+                    I_tp,
+                    K,
+                    block_size=block_size,
+                )
+                fc1_out = (fc1_dequant @ x_f32) * alpha_fc1
+                intermediate = torch.square(torch.relu(fc1_out))
+
+            down_dequant = _apply_block_scales(
+                _dequant_fp4(w2_fp4[eid], K, I_tp, fp4_lut),
+                w2_sf,
+                K,
+                I_tp,
+                block_size=block_size,
+            )
+            down_out = (down_dequant @ intermediate) * alpha_fc2
+            output[t] += router_w * down_out
+
+    return output
+
+
+def moe_reference_w4a16_fp4_e8m0_k32(
+    x: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_e8m0_scale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_e8m0_scale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    E: int,
+    K: int,
+    I_tp: int,
+    *,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    w13_layout: str = "w31",
+) -> torch.Tensor:
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    _validate_reference_inputs(w1_fp4, I_tp, activation)
+    if int(E) != int(w1_fp4.shape[0]) or int(E) != int(w2_fp4.shape[0]):
+        raise ValueError("E must match the expert dimension of w1_fp4 and w2_fp4")
+    is_gated = is_gated_moe_activation(activation)
+    w13_layout = _normalize_w13_layout(w13_layout)
+
+    block_size = 32
+    if int(K) % block_size != 0:
+        raise ValueError(f"E8M0 K/32 oracle requires K divisible by 32, got K={K}")
+    if int(I_tp) % 8 != 0:
+        raise ValueError(
+            f"E8M0 K/32 oracle requires compact I_tp divisible by 8, got I_tp={I_tp}"
+        )
+    w1_rows = moe_activation_w1_rows(activation, I_tp)
+    expected_w1_scale = (int(E), w1_rows, int(K) // block_size)
+    expected_w2_scale = (int(E), int(K), (int(I_tp) + block_size - 1) // block_size)
+    if tuple(w1_e8m0_scale.shape) != expected_w1_scale:
+        raise ValueError(
+            f"w1_e8m0_scale must have shape {expected_w1_scale}, got {tuple(w1_e8m0_scale.shape)}"
+        )
+    if tuple(w2_e8m0_scale.shape) != expected_w2_scale:
+        raise ValueError(
+            f"w2_e8m0_scale must have shape {expected_w2_scale}, got {tuple(w2_e8m0_scale.shape)}"
+        )
+
+    fp4_lut = _make_fp4_lut(x.device)
+    output = torch.zeros(x.shape[0], K, dtype=torch.float32, device=x.device)
+    top_k = topk_ids.shape[1]
+
+    for t in range(x.shape[0]):
+        x_f32 = x[t].float()
+        for k_idx in range(top_k):
+            eid = int(topk_ids[t, k_idx].item())
+            router_w = float(topk_weights[t, k_idx].item())
+            alpha_fc1 = (
+                float(w1_alphas[eid].item())
+                if w1_alphas.numel() > 1
+                else float(w1_alphas.item())
+            )
+            alpha_fc2 = (
+                float(w2_alphas[eid].item())
+                if w2_alphas.numel() > 1
+                else float(w2_alphas.item())
+            )
+
+            w2_sf = _e8m0_scales_to_float(w2_e8m0_scale[eid])
+            if is_gated:
+                w13_sf = _e8m0_scales_to_float(w1_e8m0_scale[eid])
+                gate_rows, up_rows = _gated_row_slices(
+                    activation,
+                    I_tp,
+                    w13_layout=w13_layout,
+                )
+                up_dequant = _apply_block_scales(
+                    _dequant_fp4(w1_fp4[eid, up_rows], I_tp, K, fp4_lut),
+                    w13_sf[up_rows],
+                    I_tp,
+                    K,
+                    block_size=block_size,
+                )
+                gate_dequant = _apply_block_scales(
+                    _dequant_fp4(w1_fp4[eid, gate_rows], I_tp, K, fp4_lut),
+                    w13_sf[gate_rows],
+                    I_tp,
+                    K,
+                    block_size=block_size,
+                )
+                gate_out = (gate_dequant @ x_f32) * alpha_fc1
+                up_out = (up_dequant @ x_f32) * alpha_fc1
+                intermediate = _apply_gated_activation(
+                    gate_out,
+                    up_out,
+                    activation=activation,
+                    swiglu_limit=swiglu_limit,
+                    swiglu_alpha=swiglu_alpha,
+                    swiglu_beta=swiglu_beta,
+                )
+            else:
+                w1_sf = _e8m0_scales_to_float(w1_e8m0_scale[eid])
+                fc1_dequant = _apply_block_scales(
+                    _dequant_fp4(w1_fp4[eid, :I_tp], I_tp, K, fp4_lut),
+                    w1_sf[:I_tp],
+                    I_tp,
+                    K,
+                    block_size=block_size,
+                )
+                fc1_out = (fc1_dequant @ x_f32) * alpha_fc1
+                intermediate = torch.square(torch.relu(fc1_out))
+
+            down_dequant = _apply_block_scales(
+                _dequant_fp4(w2_fp4[eid], K, I_tp, fp4_lut),
+                w2_sf,
+                K,
+                I_tp,
+                block_size=block_size,
+            )
+            down_out = (down_dequant @ intermediate) * alpha_fc2
+            output[t] += router_w * down_out
+
+    return output
+
+
+def moe_reference_nvfp4(
+    x: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    E: int,
+    K: int,
+    I_tp: int,
+    *,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    quant_scale_math: str = "direct_division",
+) -> torch.Tensor:
+    """Evaluate the routed NVFP4 reference on the GPU.
+
+    ``quant_scale_math`` selects the floating-point evaluation order used by
+    activation quantization.  The dynamic kernel uses direct division while
+    the micro kernel computes a reciprocal once and multiplies each value;
+    callers comparing against micro must request ``"reciprocal_multiply"``.
+    """
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    _validate_reference_inputs(w1_fp4, I_tp, activation)
+    m = x.shape[0]
+    top_k = topk_ids.shape[1]
+    output = torch.zeros(m, K, dtype=torch.float32, device=x.device)
+
+    for t in range(m):
+        for k_idx in range(top_k):
+            eid = int(topk_ids[t, k_idx].item())
+            trace = trace_moe_reference_nvfp4_route(
+                x,
+                w1_fp4,
+                w1_blockscale,
+                w1_alphas,
+                w2_fp4,
+                w2_blockscale,
+                w2_alphas,
+                a1_gscale,
+                a2_gscale,
+                topk_ids,
+                topk_weights,
+                E,
+                K,
+                I_tp,
+                token_idx=t,
+                route_idx=k_idx,
+                activation=activation,
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+                quant_scale_math=quant_scale_math,
+            )
+            assert trace.expert_idx == eid
+            output[t] += trace.routed_out_accum
+
+    return output.to(torch.bfloat16)
+
+
+# =============================================================================
+# W4A8 (MXFP8 activations x FP4 weights) reference oracle
+# =============================================================================
+
+
+def decompose_nvfp4_scales_to_mx_residual(
+    scales: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Decompose per-K/16 E4M3 scales for the w4a8 hardware block-scale MMA.
+
+    Each adjacent K/16 scale pair (s0, s1) becomes a shared per-K/32 UE8M0
+    hardware exponent ``E = max(floor(log2(s0)), floor(log2(s1)))`` plus
+    per-K/16 residual multipliers ``r_j = s_j / 2^E`` stored as E4M3 (applied
+    in-register during nibble expansion).  Residuals for the max-exponent
+    block lie in [1, 2); the partner residual can underflow E4M3 when the
+    pair's exponents differ by more than ~2^9 (quantified by
+    ``nvfp4_mx_residual_quality_report``).
+
+    `scales` is `[..., rows, K/16]` in float8_e4m3fn or any float dtype.
+    Returns ``(ue8m0_bytes [..., rows, K/32] uint8,
+    residual [..., rows, K/16] float8_e4m3fn)``.
+    """
+    s = scales.to(torch.float32)
+    if s.shape[-1] % 2 != 0:
+        raise ValueError(f"K/16 scale count must be even, got {s.shape[-1]}")
+    pairs = s.reshape(*s.shape[:-1], s.shape[-1] // 2, 2)
+    if bool((pairs < 0).any().item()):
+        raise ValueError("NVFP4 block scales must be non-negative")
+    _ZERO_SENTINEL = -(2**30)
+    mant, exp = torch.frexp(pairs)
+    del mant
+    floor_log2 = torch.where(pairs > 0, exp - 1, torch.full_like(exp, _ZERO_SENTINEL))
+    e_shared = floor_log2.amax(dim=-1)
+    both_zero = e_shared <= _ZERO_SENTINEL // 2
+    e_shared = torch.where(both_zero, torch.zeros_like(e_shared), e_shared)
+    ue8m0 = (e_shared + 127).clamp(0, 254).to(torch.uint8)
+    pow2 = torch.exp2(e_shared.to(torch.float32)).unsqueeze(-1)
+    residual = torch.where(pairs > 0, pairs / pow2, torch.zeros_like(pairs))
+    residual_e4m3 = residual.clamp(max=448.0).to(torch.float8_e4m3fn)
+    return ue8m0, residual_e4m3.reshape(s.shape)
+
+
+def nvfp4_mx_residual_quality_report(scales: torch.Tensor) -> dict[str, float]:
+    """Quantify the loss of the NVFP4 -> (UE8M0, E4M3 residual) decomposition.
+
+    Reports, over all nonzero per-K/16 scales: the fraction of residuals
+    flushed to zero by E4M3 (whole block silenced), the fraction rounded in
+    the subnormal range, the max/mean relative residual rounding error, and
+    the largest K/32-pair exponent delta.  Run on real checkpoints before
+    claiming full-fidelity NVFP4 serving.
+    """
+    s = scales.to(torch.float32)
+    ue8m0, residual_e4m3 = decompose_nvfp4_scales_to_mx_residual(s)
+    del ue8m0
+    pairs = s.reshape(-1, 2)
+    nonzero = pairs > 0
+    mant, exp = torch.frexp(pairs)
+    del mant
+    floor_log2 = torch.where(nonzero, exp - 1, torch.zeros_like(exp))
+    delta = torch.where(
+        nonzero.all(dim=-1),
+        (floor_log2[:, 0] - floor_log2[:, 1]).abs(),
+        torch.zeros(pairs.shape[0], dtype=exp.dtype, device=s.device),
+    )
+    e_shared = torch.where(nonzero, floor_log2, torch.full_like(exp, -(2**30))).amax(
+        dim=-1
+    )
+    residual_exact = torch.where(
+        nonzero,
+        pairs / torch.exp2(e_shared.to(torch.float32)).unsqueeze(-1),
+        torch.zeros_like(pairs),
+    )
+    residual_stored = residual_e4m3.to(torch.float32).reshape(-1, 2)
+
+    nz = nonzero.reshape(-1)
+    exact = residual_exact.reshape(-1)[nz]
+    stored = residual_stored.reshape(-1)[nz]
+    flushed = (stored == 0) & (exact > 0)
+    subnormal = (exact > 0) & (exact < 2.0**-6)
+    rel_err = torch.where(
+        exact > 0, (stored - exact).abs() / exact, torch.zeros_like(exact)
+    )
+    total = max(int(nz.sum().item()), 1)
+    return {
+        "nonzero_scales": float(total),
+        "flushed_fraction": float(flushed.sum().item()) / total,
+        "subnormal_fraction": float(subnormal.sum().item()) / total,
+        "max_rel_residual_error": float(rel_err.max().item()) if total else 0.0,
+        "mean_rel_residual_error": float(rel_err.mean().item()) if total else 0.0,
+        "max_pair_exponent_delta": float(delta.max().item()),
+    }
+
+
+def _quant_dequant_mxfp8_rows(x: torch.Tensor) -> torch.Tensor:
+    from flashinfer.experimental.sm12x._lib.intrinsics import quant_dequant_mxfp8_torch
+
+    return quant_dequant_mxfp8_torch(x)
+
+
+def _dequant_w4a8_weight_e8m0_k32(
+    w_packed: torch.Tensor,
+    scale_bytes: torch.Tensor,
+    rows: int,
+    cols: int,
+    fp4_lut: torch.Tensor,
+) -> torch.Tensor:
+    """Effective w4a8 weight values for an MXFP4 (e8m0/K32) source: exact."""
+    raw = _dequant_fp4(w_packed, rows, cols, fp4_lut)
+    scale = torch.exp2(scale_bytes.to(torch.float32) - 127.0)
+    n_blocks = cols // 32
+    return raw.view(rows, n_blocks, 32) * scale[:rows, :n_blocks].unsqueeze(-1)
+
+
+def _dequant_w4a8_weight_nvfp4_residual(
+    w_packed: torch.Tensor,
+    ue8m0_bytes: torch.Tensor,
+    residual_e4m3: torch.Tensor,
+    rows: int,
+    cols: int,
+    fp4_lut: torch.Tensor,
+) -> torch.Tensor:
+    """Effective w4a8 weight values for an NVFP4 source via the residual path.
+
+    Emulates the in-register expansion exactly: f16 nibble decode, f16
+    multiply by the stored E4M3 residual, RN round to the E4M3 payload, then
+    the shared per-K/32 hardware exponent.
+    """
+    raw = _dequant_fp4(w_packed, rows, cols, fp4_lut)
+    n16 = cols // 16
+    r = residual_e4m3.to(torch.float16)[:rows, :n16]
+    prod_f16 = raw.view(rows, n16, 16).to(torch.float16) * r.unsqueeze(-1)
+    payload = (
+        prod_f16.to(torch.float32)
+        .clamp(-448.0, 448.0)
+        .to(torch.float8_e4m3fn)
+        .to(torch.float32)
+    )
+    n32 = cols // 32
+    scale = torch.exp2(ue8m0_bytes.to(torch.float32)[:rows, :n32] - 127.0)
+    return payload.view(rows, n32, 32) * scale.unsqueeze(-1)
+
+
+def _w4a8_effective_weight(
+    w_packed: torch.Tensor,
+    mx_scale_bytes: torch.Tensor,
+    residual_e4m3: torch.Tensor | None,
+    rows: int,
+    cols: int,
+    fp4_lut: torch.Tensor,
+) -> torch.Tensor:
+    if residual_e4m3 is None:
+        return _dequant_w4a8_weight_e8m0_k32(
+            w_packed, mx_scale_bytes, rows, cols, fp4_lut
+        ).view(rows, cols)
+    return _dequant_w4a8_weight_nvfp4_residual(
+        w_packed, mx_scale_bytes, residual_e4m3, rows, cols, fp4_lut
+    ).view(rows, cols)
+
+
+def moe_reference_w4a8_mx(
+    x: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_mx_scales: torch.Tensor,
+    w1_residual: torch.Tensor | None,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_mx_scales: torch.Tensor,
+    w2_residual: torch.Tensor | None,
+    w2_alphas: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    E: int,
+    K: int,
+    I_tp: int,
+    *,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    w13_layout: str = "w13",
+) -> torch.Tensor:
+    """W4A8 MoE oracle: MXFP8 (UE8M0/K32 + E4M3) activations x FP4 weights.
+
+    Activations are dynamically quantized per 32-element block with no global
+    scale (identical for every route of a token).  Weight semantics depend on
+    the source: ``w*_residual is None`` means an MXFP4 (e8m0/K32) checkpoint
+    consumed exactly; otherwise the NVFP4 residual-decomposition path is
+    emulated (see ``decompose_nvfp4_scales_to_mx_residual``).  ``w*_mx_scales``
+    are unswizzled ``[E, rows, K/32]`` UE8M0 bytes; ``w*_alphas`` carry the
+    per-expert weight global dequant scale (ones for MXFP4 sources).
+    """
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    if activation == SWIGLUOAI_UNINTERLEAVE:
+        raise NotImplementedError(
+            "W4A8 MoE reference does not support swigluoai_uninterleave"
+        )
+    _validate_reference_inputs(w1_fp4, I_tp, activation)
+    if K % 32 != 0 or I_tp % 32 != 0:
+        raise ValueError("K and I_tp must be divisible by 32 for w4a8")
+    is_gated = is_gated_moe_activation(activation)
+    w13_layout = _normalize_w13_layout(w13_layout)
+    device = x.device
+    fp4_lut = _make_fp4_lut(device)
+    m = x.shape[0]
+
+    x_qd = _quant_dequant_mxfp8_rows(x.float())
+    output = torch.zeros(m, K, dtype=torch.float32, device=device)
+
+    for eid in range(E):
+        route_mask = topk_ids == eid
+        token_mask = route_mask.any(dim=1)
+        if not bool(token_mask.any().item()):
+            continue
+        alpha_fc1 = float(w1_alphas[eid].item())
+        alpha_fc2 = float(w2_alphas[eid].item())
+        fc1_rows = w1_fp4.shape[1]
+        w13_eff = _w4a8_effective_weight(
+            w1_fp4[eid],
+            w1_mx_scales[eid],
+            None if w1_residual is None else w1_residual[eid],
+            fc1_rows,
+            K,
+            fp4_lut,
+        )
+        w2_eff = _w4a8_effective_weight(
+            w2_fp4[eid],
+            w2_mx_scales[eid],
+            None if w2_residual is None else w2_residual[eid],
+            K,
+            I_tp,
+            fp4_lut,
+        )
+        xs = x_qd[token_mask]
+        if is_gated:
+            gate_rows, up_rows = _gated_row_slices(
+                activation,
+                I_tp,
+                w13_layout=w13_layout,
+            )
+            up_out = (xs @ w13_eff[up_rows].T) * alpha_fc1
+            gate_out = (xs @ w13_eff[gate_rows].T) * alpha_fc1
+            intermediate = _apply_gated_activation(
+                gate_out,
+                up_out,
+                activation=activation,
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+            )
+        else:
+            fc1_out = (xs @ w13_eff.T) * alpha_fc1
+            intermediate = torch.square(torch.relu(fc1_out))
+        int_qd = _quant_dequant_mxfp8_rows(intermediate)
+        down_out = (int_qd @ w2_eff.T) * alpha_fc2
+        route_weight = (topk_weights.float() * route_mask.float()).sum(dim=1)[
+            token_mask
+        ]
+        output[token_mask] += route_weight.unsqueeze(1) * down_out
+
+    return output
+
+
+def trace_moe_reference_w4a8_route(
+    x: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_mx_scales: torch.Tensor,
+    w1_residual: torch.Tensor | None,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_mx_scales: torch.Tensor,
+    w2_residual: torch.Tensor | None,
+    w2_alphas: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    E: int,
+    K: int,
+    I_tp: int,
+    *,
+    token_idx: int,
+    route_idx: int,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    w13_layout: str = "w13",
+) -> MoERouteTrace:
+    """Single-route stage trace for the w4a8 oracle (kernel debugging aid)."""
+    activation, swiglu_limit, swiglu_alpha, swiglu_beta = (
+        _normalize_reference_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+    )
+    if activation == SWIGLUOAI_UNINTERLEAVE:
+        raise NotImplementedError(
+            "W4A8 MoE reference does not support swigluoai_uninterleave"
+        )
+    del E
+    _validate_reference_inputs(w1_fp4, I_tp, activation)
+    is_gated = is_gated_moe_activation(activation)
+    w13_layout = _normalize_w13_layout(w13_layout)
+    device = x.device
+    fp4_lut = _make_fp4_lut(device)
+
+    expert_idx = int(topk_ids[token_idx, route_idx].item())
+    router_weight = float(topk_weights[token_idx, route_idx].item())
+    alpha_fc1 = float(w1_alphas[expert_idx].item())
+    alpha_fc2 = float(w2_alphas[expert_idx].item())
+
+    x_qd = _quant_dequant_mxfp8_rows(x[token_idx].float().unsqueeze(0))[0]
+    fc1_rows = w1_fp4.shape[1]
+    w13_eff = _w4a8_effective_weight(
+        w1_fp4[expert_idx],
+        w1_mx_scales[expert_idx],
+        None if w1_residual is None else w1_residual[expert_idx],
+        fc1_rows,
+        K,
+        fp4_lut,
+    )
+    w2_eff = _w4a8_effective_weight(
+        w2_fp4[expert_idx],
+        w2_mx_scales[expert_idx],
+        None if w2_residual is None else w2_residual[expert_idx],
+        K,
+        I_tp,
+        fp4_lut,
+    )
+    fc1_out = None
+    gate_out = None
+    up_out = None
+    if is_gated:
+        gate_rows, up_rows = _gated_row_slices(
+            activation,
+            I_tp,
+            w13_layout=w13_layout,
+        )
+        up_out = (w13_eff[up_rows] @ x_qd) * alpha_fc1
+        gate_out = (w13_eff[gate_rows] @ x_qd) * alpha_fc1
+        intermediate = _apply_gated_activation(
+            gate_out,
+            up_out,
+            activation=activation,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+        )
+    else:
+        fc1_out = (w13_eff @ x_qd) * alpha_fc1
+        intermediate = torch.square(torch.relu(fc1_out))
+    int_qd = _quant_dequant_mxfp8_rows(intermediate.unsqueeze(0))[0]
+    down_out = (w2_eff @ int_qd) * alpha_fc2
+    routed_out = router_weight * down_out
+
+    return MoERouteTrace(
+        token_idx=token_idx,
+        route_idx=route_idx,
+        expert_idx=expert_idx,
+        activation=activation,
+        router_weight=router_weight,
+        alpha_fc1=alpha_fc1,
+        alpha_fc2=alpha_fc2,
+        gs_fc1=1.0,
+        gs_fc2=1.0,
+        x_dequant=x_qd,
+        fc1_out=fc1_out,
+        gate_out=gate_out,
+        up_out=up_out,
+        intermediate=intermediate,
+        int_dequant=int_qd,
+        down_out=down_out,
+        routed_out=routed_out,
+        routed_out_accum=routed_out,
+    )

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/relu2.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/relu2.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/relu2.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""ReLU2 wrappers for the activation-specialized fused MoE backends."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from flashinfer.experimental.sm12x.moe._shared.kernels.dynamic import (
+    MoEDynamicKernelBackend,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.micro import (
+    MoEMicroKernelBackend,
+)
+
+
+class MoEMicroKernelRelu2(MoEMicroKernelBackend):
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        fast_math: bool = False,
+        share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        single_token: bool = False,
+        dynamic_down_scale: bool = False,
+        a8_mx_mode: bool = False,
+        scale_format: str = "e4m3_k16",
+        e8m0_scale_layout: str = "packed",
+    ):
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            output_tile_count_n,
+            fast_math=fast_math,
+            activation="relu2",
+            share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=single_token,
+            dynamic_down_scale=dynamic_down_scale,
+            a8_mx_mode=a8_mx_mode,
+            scale_format=scale_format,
+            e8m0_scale_layout=e8m0_scale_layout,
+        )
+
+    @classmethod
+    def is_supported(
+        cls,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+    ) -> bool:
+        return super().is_supported(m, k, n, num_topk, weight_E)
+
+
+class MoEDynamicKernelRelu2(MoEDynamicKernelBackend):
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        *,
+        fast_math: bool = False,
+        dynamic_down_scale: bool = False,
+        share_input_across_experts: bool = False,
+        deterministic_output: bool = False,
+        num_topk: int = 1,
+        swap_ab: bool = False,
+        quant_recipe: str = "nvfp4",
+        w4a8_repacked: bool = False,
+        direct_routing: bool = False,
+        work_source: str = "materialized_queue",
+        materialize_intermediate: bool = False,
+    ):
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            fast_math=fast_math,
+            activation="relu2",
+            dynamic_down_scale=dynamic_down_scale,
+            share_input_across_experts=share_input_across_experts,
+            deterministic_output=deterministic_output,
+            num_topk=num_topk,
+            swap_ab=swap_ab,
+            quant_recipe=quant_recipe,
+            w4a8_repacked=w4a8_repacked,
+            direct_routing=direct_routing,
+            work_source=work_source,
+            materialize_intermediate=materialize_intermediate,
+        )
+
+
+__all__ = [
+    "MoEDynamicKernelRelu2",
+    "MoEMicroKernelRelu2",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/silu.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/silu.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/silu.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""SwiGLU wrappers for the activation-specialized fused MoE backends."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from flashinfer.experimental.sm12x.moe._shared.kernels.dynamic import (
+    MoEDynamicKernelBackend,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.micro import (
+    MoEMicroKernelBackend,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    SWIGLUOAI_UNINTERLEAVE,
+    normalize_swiglu_alpha_for_activation,
+    normalize_swiglu_beta_for_activation,
+    normalize_swiglu_limit_for_activation,
+)
+
+
+class MoEMicroKernelSilu(MoEMicroKernelBackend):
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        fast_math: bool = False,
+        share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        single_token: bool = False,
+        dynamic_down_scale: bool = False,
+        compile_time_phase: int = 0,
+        a8_mx_mode: bool = False,
+        scale_format: str = "e4m3_k16",
+        e8m0_scale_layout: str = "packed",
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+    ):
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            output_tile_count_n,
+            fast_math=fast_math,
+            activation="silu",
+            share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=single_token,
+            dynamic_down_scale=dynamic_down_scale,
+            compile_time_phase=compile_time_phase,
+            a8_mx_mode=a8_mx_mode,
+            scale_format=scale_format,
+            e8m0_scale_layout=e8m0_scale_layout,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+        )
+
+    @classmethod
+    def is_supported(
+        cls,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+    ) -> bool:
+        return super().is_supported(m, k, n, num_topk, weight_E)
+
+
+class MoEDynamicKernelSilu(MoEDynamicKernelBackend):
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        *,
+        fast_math: bool = False,
+        dynamic_down_scale: bool = False,
+        share_input_across_experts: bool = False,
+        deterministic_output: bool = False,
+        num_topk: int = 1,
+        swap_ab: bool = False,
+        quant_recipe: str = "nvfp4",
+        w4a8_repacked: bool = False,
+        direct_routing: bool = False,
+        work_source: str = "materialized_queue",
+        materialize_intermediate: bool = False,
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+    ):
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            fast_math=fast_math,
+            activation="silu",
+            dynamic_down_scale=dynamic_down_scale,
+            share_input_across_experts=share_input_across_experts,
+            deterministic_output=deterministic_output,
+            num_topk=num_topk,
+            swap_ab=swap_ab,
+            quant_recipe=quant_recipe,
+            w4a8_repacked=w4a8_repacked,
+            direct_routing=direct_routing,
+            work_source=work_source,
+            materialize_intermediate=materialize_intermediate,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+        )
+
+
+class MoEMicroKernelSwiGLUOAI(MoEMicroKernelBackend):
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        fast_math: bool = False,
+        share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        single_token: bool = False,
+        dynamic_down_scale: bool = False,
+        a8_mx_mode: bool = False,
+        scale_format: str = "e4m3_k16",
+        e8m0_scale_layout: str = "packed",
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+    ):
+        activation = SWIGLUOAI_UNINTERLEAVE
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            output_tile_count_n,
+            fast_math=fast_math,
+            activation=activation,
+            share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=single_token,
+            dynamic_down_scale=dynamic_down_scale,
+            a8_mx_mode=a8_mx_mode,
+            scale_format=scale_format,
+            e8m0_scale_layout=e8m0_scale_layout,
+            swiglu_limit=normalize_swiglu_limit_for_activation(
+                activation, swiglu_limit
+            ),
+            swiglu_alpha=normalize_swiglu_alpha_for_activation(
+                activation, swiglu_alpha
+            ),
+            swiglu_beta=normalize_swiglu_beta_for_activation(activation, swiglu_beta),
+        )
+
+    @classmethod
+    def is_supported(
+        cls,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+    ) -> bool:
+        return super().is_supported(m, k, n, num_topk, weight_E)
+
+
+class MoEDynamicKernelSwiGLUOAI(MoEDynamicKernelBackend):
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        *,
+        fast_math: bool = False,
+        dynamic_down_scale: bool = False,
+        share_input_across_experts: bool = False,
+        deterministic_output: bool = False,
+        num_topk: int = 1,
+        swap_ab: bool = False,
+        quant_recipe: str = "nvfp4",
+        w4a8_repacked: bool = False,
+        direct_routing: bool = False,
+        work_source: str = "materialized_queue",
+        materialize_intermediate: bool = False,
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+    ):
+        activation = SWIGLUOAI_UNINTERLEAVE
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            fast_math=fast_math,
+            activation=activation,
+            dynamic_down_scale=dynamic_down_scale,
+            share_input_across_experts=share_input_across_experts,
+            deterministic_output=deterministic_output,
+            num_topk=num_topk,
+            swap_ab=swap_ab,
+            quant_recipe=quant_recipe,
+            w4a8_repacked=w4a8_repacked,
+            direct_routing=direct_routing,
+            work_source=work_source,
+            materialize_intermediate=materialize_intermediate,
+            swiglu_limit=normalize_swiglu_limit_for_activation(
+                activation, swiglu_limit
+            ),
+            swiglu_alpha=normalize_swiglu_alpha_for_activation(
+                activation, swiglu_alpha
+            ),
+            swiglu_beta=normalize_swiglu_beta_for_activation(activation, swiglu_beta),
+        )
+
+
+__all__ = [
+    "MoEDynamicKernelSilu",
+    "MoEDynamicKernelSwiGLUOAI",
+    "MoEMicroKernelSilu",
+    "MoEMicroKernelSwiGLUOAI",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/tiny_decode.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/tiny_decode.py
@@ -1,0 +1,560 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/tiny_decode.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""MoETinyDecodeKernelBackend — tiny-decode (M<=4) W4A8-MX MoE for SM120.
+
+Reads the N256/K128 in-place-REPACKED weight storage (the "rp" layout produced
+by _logical_weight_to_w4a8_rp_inplace) directly.
+
+Consumes the N256/K128 in-place-repacked FP4 weights and e8m0 sfb grids
+directly (inverse mappings verified in tests/test_w4a8_rp_inverse_mapping.py),
+with BF16 activations (no input quantization) and f32 accumulation. Two plain
+(non-cooperative) launches: FC1 dots gate+up rows into an fp32 intermediate,
+FC2 applies SiLU inline and folds router-weighted partials into the bf16
+output via scatter-add. The wrapper zeroes the intermediate and output first;
+there are no grid barriers and no CTA co-residency assumptions, so the
+kernels are safe on busy serving streams.
+
+Thread mapping (256 threads/CTA), the core of the rp coalescing story: one rp
+(nt, kt) tile is 4096 contiguous int32 words whose flat index decomposes as
+``k32<<10 | n8c<<7 | r8<<4 | cgrp<<2 | n8i``. Thread t = (n8c=t>>5, r8=(t>>2)&7,
+cgrp=t&3) issues one 16 B ``ld.global.nc.v4`` per k32 covering n8i=0..3 — four
+8-apart logical rows at one k window — so a warp (fixed n8c) covers a fully
+coalesced 512 B run per k32, and the 4-lane cgrp butterfly folds the k dim.
+
+The prep rotation normalizes both declared w13 layouts to the same rp tile
+order (tiles [0, N/256) hold the "up" rows, [N/256, 2N/256) the "gate" rows of
+the same channels), so FC1 stores inter rows through ``(p + n) % 2n`` and FC2
+reads gate at [0, n), up at [n, 2n) unconditionally.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Float32
+from cutlass.cutlass_dsl import Int32, Int64
+
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream, make_ptr
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    cvt_bf16x2_to_f16x2,
+    cvt_e8m0x4_to_f32x4,
+    fp4_dot4_sum_f32acc,
+    get_ptr_as_int64,
+    ld_global_nc_u32,
+    ld_global_nc_v4_u32,
+    pack_f32x2_to_f16x2,
+    red_add_global_f32,
+    scatter_add_bf16x2,
+    warp_reduce,
+)
+
+_BLOCK_THREADS = 256
+_FC1_KT_PER_TASK = 4
+_FC2_KT_PER_TASK = 2
+
+
+class MoETinyDecodeKernelBackend:
+    """Tiny-M (decode) W4A8-MX kernel reading the repacked weight layout."""
+
+    def __init__(
+        self,
+        *,
+        activation: str = "silu",
+        w13_layout: str = "w31",
+        compile_time_phase: int = 1,
+    ):
+        if activation != "silu":
+            raise ValueError(f"tiny_decode supports silu only, got {activation!r}")
+        if int(compile_time_phase) not in (1, 2):
+            raise ValueError(f"unsupported tiny_decode phase {compile_time_phase!r}")
+        self.compile_time_phase = int(compile_time_phase)
+        self.activation = activation
+        self.w13_layout = w13_layout
+        self._cfg_key = None
+        self._c = None
+        self.grid_x = 0
+
+    def configure(
+        self,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+        *,
+        device: torch.device | None = None,
+    ) -> None:
+        del device
+        # Weights arrive in the ceil-tiled rp layout: partial 256-row / 128-col
+        # tiles are stored zero-filled, so any n % 32 shard works. FC1's
+        # zero rows contribute exact +0.0 through the rotated scatter-add;
+        # FC2 bounds its intermediate loads by k2_tail_g32 (see the kernel).
+        if k % 256 != 0 or n % 32 != 0:
+            raise ValueError("tiny_decode requires k % 256 == 0 and n % 32 == 0")
+        if m < 1 or m > 4:
+            raise ValueError("tiny_decode supports 1 <= m <= 4")
+        rt = m * num_topk
+        kt13 = k // 128
+        kt2 = -(-n // 128)
+        nt13 = -(-(2 * n) // 256)
+        if kt13 % _FC1_KT_PER_TASK != 0:
+            raise ValueError("tiny_decode k-tile counts not divisible by task sizes")
+        # FC2 walks the intermediate dim in per-task groups of K tiles. Odd
+        # tile counts (e.g. n=384 -> 3 tiles from GLM 2048/TP6 padded shards)
+        # drop to one tile per task; partials are scatter-added, so the task
+        # split does not change results.
+        fc2_kt_per_task = _FC2_KT_PER_TASK if kt2 % _FC2_KT_PER_TASK == 0 else 1
+        cfg = dict(
+            m=m,
+            k=k,
+            n=n,
+            two_n=2 * n,
+            num_topk=num_topk,
+            weight_E=weight_E,
+            rt=rt,
+            nt13=nt13,
+            kt13=kt13,
+            fc1_ktg=kt13 // _FC1_KT_PER_TASK,
+            nt2=k // 256,
+            kt2=kt2,
+            # Index of the partial FC2 K tile (== kt2 when none) and how many
+            # 32-value groups of it are logically valid.
+            kt2_full=n // 128,
+            k2_tail_g32=(n % 128) // 32,
+            # Half-aligned rp storage: each gated half is zero-padded to a
+            # 128-row boundary (up at [0, n_pad128), gate at [n_pad128, ...)).
+            n_pad128=kt2 * 128,
+            fc2_kt_per_task=fc2_kt_per_task,
+            fc2_ktg=kt2 // fc2_kt_per_task,
+            w13_words=nt13 * kt13 * 4096,
+            w2_words=(k // 256) * kt2 * 4096,
+            sfb13_bytes=nt13 * kt13 * 1024,
+            sfb2_bytes=(k // 256) * kt2 * 1024,
+            fc1_tasks=rt * nt13 * (kt13 // _FC1_KT_PER_TASK),
+            fc2_tasks=rt * (k // 256) * (kt2 // fc2_kt_per_task),
+        )
+        self._c = cfg
+        self._cfg_key = tuple(sorted(cfg.items()))
+        self.grid_x = (
+            cfg["fc1_tasks"] if self.compile_time_phase == 1 else cfg["fc2_tasks"]
+        )
+
+    @property
+    def __cache_key__(self):
+        return (
+            self.activation,
+            self.w13_layout,
+            self.compile_time_phase,
+            self._cfg_key,
+            self.grid_x,
+        )
+
+    @cute.jit
+    def _row_block_dot(
+        self,
+        tile_word: Int64,
+        srow: Int64,
+        n8c: Int32,
+        r8: Int32,
+        cgrp: Int32,
+        x0_0: cutlass.Uint32,
+        x1_0: cutlass.Uint32,
+        x2_0: cutlass.Uint32,
+        x3_0: cutlass.Uint32,
+        x0_1: cutlass.Uint32,
+        x1_1: cutlass.Uint32,
+        x2_1: cutlass.Uint32,
+        x3_1: cutlass.Uint32,
+        x0_2: cutlass.Uint32,
+        x1_2: cutlass.Uint32,
+        x2_2: cutlass.Uint32,
+        x3_2: cutlass.Uint32,
+        x0_3: cutlass.Uint32,
+        x1_3: cutlass.Uint32,
+        x2_3: cutlass.Uint32,
+        x3_3: cutlass.Uint32,
+    ):
+        """Dot 4 n8i rows (v=0..3) x 128 k window against packed activations.
+
+        Activation f16x2 quads are per k32 (x*_<k32>). Returns 4 row partials.
+        """
+        word_off = Int64(n8c * Int32(128) + r8 * Int32(16) + cgrp * Int32(4)) * Int64(4)
+        acc = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+        xq = (
+            (x0_0, x1_0, x2_0, x3_0),
+            (x0_1, x1_1, x2_1, x3_1),
+            (x0_2, x1_2, x2_2, x3_2),
+            (x0_3, x1_3, x2_3, x3_3),
+        )
+        for v in cutlass.range_constexpr(4):
+            sv = ld_global_nc_u32(srow + Int64(v * 32))
+            sk = cvt_e8m0x4_to_f32x4(sv)
+            accv = Float32(0.0)
+            for k32 in cutlass.range_constexpr(4):
+                words = ld_global_nc_v4_u32(tile_word + Int64(k32 * 4096) + word_off)
+                x0, x1, x2, x3 = xq[k32]
+                accv += sk[k32] * fp4_dot4_sum_f32acc(words[v], x0, x1, x2, x3)
+            acc[v] += accv
+        return acc[0], acc[1], acc[2], acc[3]
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,  # bf16 [m*k]
+        w13: cute.Tensor,  # u8 rp bytes, expert-major
+        sfb13: cute.Tensor,  # u8 sfb bytes, expert-major
+        inter: cute.Tensor,  # f32 [rt * 2n] (pre-zeroed for phase 1)
+        w2: cute.Tensor,  # u8 rp bytes
+        sfb2: cute.Tensor,  # u8 sfb bytes
+        topk_ids: cute.Tensor,  # i32 [rt]
+        topk_weights: cute.Tensor,  # f32 [rt]
+        out: cute.Tensor,  # bf16 [m*k] (pre-zeroed for phase 2)
+    ):
+        c = self._c
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        n8c = tidx // Int32(32)
+        r8 = (tidx // Int32(4)) % Int32(8)
+        cgrp = tidx % Int32(4)
+
+        x_base = get_ptr_as_int64(a_input, Int32(0))
+        w13_base = get_ptr_as_int64(w13, Int32(0))
+        sfb13_base = get_ptr_as_int64(sfb13, Int32(0))
+        inter_base = get_ptr_as_int64(inter, Int32(0))
+        w2_base = get_ptr_as_int64(w2, Int32(0))
+        sfb2_base = get_ptr_as_int64(sfb2, Int32(0))
+        out_base = get_ptr_as_int64(out, Int32(0))
+
+        if cutlass.const_expr(self.compile_time_phase == 1):
+            # ---- FC1: block = (rt, nt13, ktg) ----
+            fc1_per_rt = Int32(c["nt13"] * c["fc1_ktg"])
+            rt_idx = bidx // fc1_per_rt
+            rem = bidx % fc1_per_rt
+            nt = rem // Int32(c["fc1_ktg"])
+            ktg = rem % Int32(c["fc1_ktg"])
+            eid = Int64(Int32(topk_ids[rt_idx]))
+            tok = rt_idx // Int32(c["num_topk"])
+            we_base = w13_base + eid * Int64(c["w13_words"] * 4)
+            se_base = sfb13_base + eid * Int64(c["sfb13_bytes"])
+            xt_base = x_base + Int64(tok) * Int64(c["k"] * 2)
+            srow_base = se_base + Int64(r8 * Int32(4) + n8c * Int32(128))
+
+            acc0 = Float32(0.0)
+            acc1 = Float32(0.0)
+            acc2 = Float32(0.0)
+            acc3 = Float32(0.0)
+            for kt_i in cutlass.range_constexpr(_FC1_KT_PER_TASK):
+                kt = ktg * Int32(_FC1_KT_PER_TASK) + Int32(kt_i)
+                col_tile = nt * Int32(c["kt13"]) + kt
+                tile_word = we_base + Int64(col_tile) * Int64(4096 * 4)
+                srow = srow_base + Int64(col_tile) * Int64(1024)
+                xs = []
+                for k32 in cutlass.range_constexpr(4):
+                    ax = xt_base + (
+                        Int64(kt * Int32(128) + cgrp * Int32(8)) + Int64(k32 * 32)
+                    ) * Int64(2)
+                    bq = ld_global_nc_v4_u32(ax)
+                    xs.append(
+                        (
+                            cvt_bf16x2_to_f16x2(bq[0]),
+                            cvt_bf16x2_to_f16x2(bq[1]),
+                            cvt_bf16x2_to_f16x2(bq[2]),
+                            cvt_bf16x2_to_f16x2(bq[3]),
+                        )
+                    )
+                d0, d1, d2, d3 = self._row_block_dot(
+                    tile_word,
+                    srow,
+                    n8c,
+                    r8,
+                    cgrp,
+                    xs[0][0],
+                    xs[0][1],
+                    xs[0][2],
+                    xs[0][3],
+                    xs[1][0],
+                    xs[1][1],
+                    xs[1][2],
+                    xs[1][3],
+                    xs[2][0],
+                    xs[2][1],
+                    xs[2][2],
+                    xs[2][3],
+                    xs[3][0],
+                    xs[3][1],
+                    xs[3][2],
+                    xs[3][3],
+                )
+                acc0 += d0
+                acc1 += d1
+                acc2 += d2
+                acc3 += d3
+            acc0 = warp_reduce(acc0, lambda a, b: a + b, width=4)
+            acc1 = warp_reduce(acc1, lambda a, b: a + b, width=4)
+            acc2 = warp_reduce(acc2, lambda a, b: a + b, width=4)
+            acc3 = warp_reduce(acc3, lambda a, b: a + b, width=4)
+            if cgrp == Int32(0):
+                ibase_rt = inter_base + Int64(rt_idx) * Int64(c["two_n"] * 4)
+                accs = (acc0, acc1, acc2, acc3)
+                for v in cutlass.range_constexpr(4):
+                    p = nt * Int32(256) + n8c * Int32(32) + Int32(v * 8) + r8
+                    if cutlass.const_expr(c["k2_tail_g32"] > 0):
+                        # Half-aligned tail storage: up rows at
+                        # [0, n_pad128), gate rows at [n_pad128, 2*n_pad128),
+                        # each half zero-padded past the logical n. Skip the
+                        # dead rows' stores (their accs are exact zeros, but
+                        # the mapped inter rows would go out of bounds).
+                        is_gate = p >= Int32(c["n_pad128"])
+                        half_dst = p
+                        r_log = p + Int32(c["n"])
+                        if is_gate:
+                            half_dst = p - Int32(c["n_pad128"])
+                            r_log = half_dst
+                        if half_dst < Int32(c["n"]):
+                            red_add_global_f32(
+                                ibase_rt + Int64(r_log) * Int64(4), accs[v]
+                            )
+                    else:
+                        r_log = p + Int32(c["n"])
+                        if r_log >= Int32(c["two_n"]):
+                            r_log -= Int32(c["two_n"])
+                        red_add_global_f32(ibase_rt + Int64(r_log) * Int64(4), accs[v])
+
+        if cutlass.const_expr(self.compile_time_phase == 2):
+            # ---- FC2: block = (rt, nt2, ktg2) ----
+            fc2_per_rt = Int32(c["nt2"] * c["fc2_ktg"])
+            rt_idx = bidx // fc2_per_rt
+            rem = bidx % fc2_per_rt
+            nt = rem // Int32(c["fc2_ktg"])
+            ktg = rem % Int32(c["fc2_ktg"])
+            eid = Int64(Int32(topk_ids[rt_idx]))
+            tok = rt_idx // Int32(c["num_topk"])
+            rw = Float32(topk_weights[rt_idx])
+            we_base = w2_base + eid * Int64(c["w2_words"] * 4)
+            se_base = sfb2_base + eid * Int64(c["sfb2_bytes"])
+            srow_base = se_base + Int64(r8 * Int32(4) + n8c * Int32(128))
+            ibase = rt_idx * Int32(c["two_n"])
+
+            acc0 = Float32(0.0)
+            acc1 = Float32(0.0)
+            acc2 = Float32(0.0)
+            acc3 = Float32(0.0)
+            for kt_i in cutlass.range_constexpr(c["fc2_kt_per_task"]):
+                kt = ktg * Int32(c["fc2_kt_per_task"]) + Int32(kt_i)
+                col_tile = nt * Int32(c["kt2"]) + kt
+                tile_word = we_base + Int64(col_tile) * Int64(4096 * 4)
+                srow = srow_base + Int64(col_tile) * Int64(1024)
+                xs = []
+                if cutlass.const_expr(c["k2_tail_g32"] > 0):
+                    # Ceil-tiled FC2 K tail: 32-groups past the logical n get
+                    # zero activations (their rp weights/scales are zero-filled
+                    # too), which also keeps the intermediate loads in bounds.
+                    kt_valid_g32 = Int32(4)
+                    if kt == Int32(c["kt2_full"]):
+                        kt_valid_g32 = Int32(c["k2_tail_g32"])
+                    for k32 in cutlass.range_constexpr(4):
+                        ich = (
+                            ibase + kt * Int32(128) + cgrp * Int32(8) + Int32(k32 * 32)
+                        )
+                        quads = []
+                        for jp in cutlass.range_constexpr(4):
+                            a0 = Float32(0.0)
+                            a1 = Float32(0.0)
+                            if Int32(k32) < kt_valid_g32:
+                                g0 = Float32(inter[ich + Int32(2 * jp)])
+                                g1 = Float32(inter[ich + Int32(2 * jp + 1)])
+                                u0 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp)])
+                                u1 = Float32(
+                                    inter[ich + Int32(c["n"]) + Int32(2 * jp + 1)]
+                                )
+                                s0 = Float32(1.0) / (
+                                    Float32(1.0) + cute.math.exp(-g0, fastmath=False)
+                                )
+                                s1 = Float32(1.0) / (
+                                    Float32(1.0) + cute.math.exp(-g1, fastmath=False)
+                                )
+                                a0 = s0 * g0 * u0 * rw
+                                a1 = s1 * g1 * u1 * rw
+                            quads.append(pack_f32x2_to_f16x2(a0, a1))
+                        xs.append((quads[0], quads[1], quads[2], quads[3]))
+                else:
+                    for k32 in cutlass.range_constexpr(4):
+                        ich = (
+                            ibase + kt * Int32(128) + cgrp * Int32(8) + Int32(k32 * 32)
+                        )
+                        quads = []
+                        for jp in cutlass.range_constexpr(4):
+                            g0 = Float32(inter[ich + Int32(2 * jp)])
+                            g1 = Float32(inter[ich + Int32(2 * jp + 1)])
+                            u0 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp)])
+                            u1 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp + 1)])
+                            s0 = Float32(1.0) / (
+                                Float32(1.0) + cute.math.exp(-g0, fastmath=False)
+                            )
+                            s1 = Float32(1.0) / (
+                                Float32(1.0) + cute.math.exp(-g1, fastmath=False)
+                            )
+                            a0 = s0 * g0 * u0 * rw
+                            a1 = s1 * g1 * u1 * rw
+                            quads.append(pack_f32x2_to_f16x2(a0, a1))
+                        xs.append((quads[0], quads[1], quads[2], quads[3]))
+                d0, d1, d2, d3 = self._row_block_dot(
+                    tile_word,
+                    srow,
+                    n8c,
+                    r8,
+                    cgrp,
+                    xs[0][0],
+                    xs[0][1],
+                    xs[0][2],
+                    xs[0][3],
+                    xs[1][0],
+                    xs[1][1],
+                    xs[1][2],
+                    xs[1][3],
+                    xs[2][0],
+                    xs[2][1],
+                    xs[2][2],
+                    xs[2][3],
+                    xs[3][0],
+                    xs[3][1],
+                    xs[3][2],
+                    xs[3][3],
+                )
+                acc0 += d0
+                acc1 += d1
+                acc2 += d2
+                acc3 += d3
+            acc0 = warp_reduce(acc0, lambda a, b: a + b, width=4)
+            acc1 = warp_reduce(acc1, lambda a, b: a + b, width=4)
+            acc2 = warp_reduce(acc2, lambda a, b: a + b, width=4)
+            acc3 = warp_reduce(acc3, lambda a, b: a + b, width=4)
+            # pair consecutive output rows: partner lane differs in r8 bit0 (lane^4)
+            o0 = cute.arch.shuffle_sync_bfly(acc0, offset=4)
+            o1 = cute.arch.shuffle_sync_bfly(acc1, offset=4)
+            o2 = cute.arch.shuffle_sync_bfly(acc2, offset=4)
+            o3 = cute.arch.shuffle_sync_bfly(acc3, offset=4)
+            if cgrp == Int32(0):
+                if (r8 % Int32(2)) == Int32(0):
+                    ob = out_base + Int64(tok) * Int64(c["k"] * 2)
+                    accs = (acc0, acc1, acc2, acc3)
+                    others = (o0, o1, o2, o3)
+                    for v in cutlass.range_constexpr(4):
+                        p2 = nt * Int32(256) + n8c * Int32(32) + Int32(v * 8) + r8
+                        scatter_add_bf16x2(
+                            ob + Int64(p2) * Int64(2), accs[v], others[v]
+                        )
+
+    @cute.jit
+    def __call__(
+        self,
+        x_ptr: cute.Pointer,
+        w13_ptr: cute.Pointer,
+        sfb13_ptr: cute.Pointer,
+        inter_ptr: cute.Pointer,
+        w2_ptr: cute.Pointer,
+        sfb2_ptr: cute.Pointer,
+        tid_ptr: cute.Pointer,
+        tw_ptr: cute.Pointer,
+        out_ptr: cute.Pointer,
+        stream,
+    ):
+        c = self._c
+        a_input = cute.make_tensor(x_ptr, cute.make_layout(Int32(c["m"] * c["k"])))
+        w13 = cute.make_tensor(
+            w13_ptr, cute.make_layout(Int64(c["weight_E"] * c["w13_words"] * 4))
+        )
+        sfb13 = cute.make_tensor(
+            sfb13_ptr, cute.make_layout(Int64(c["weight_E"] * c["sfb13_bytes"]))
+        )
+        inter = cute.make_tensor(
+            inter_ptr, cute.make_layout(Int32(c["rt"] * c["two_n"]))
+        )
+        w2 = cute.make_tensor(
+            w2_ptr, cute.make_layout(Int64(c["weight_E"] * c["w2_words"] * 4))
+        )
+        sfb2 = cute.make_tensor(
+            sfb2_ptr, cute.make_layout(Int64(c["weight_E"] * c["sfb2_bytes"]))
+        )
+        topk_ids = cute.make_tensor(tid_ptr, cute.make_layout(Int32(c["rt"])))
+        topk_weights = cute.make_tensor(tw_ptr, cute.make_layout(Int32(c["rt"])))
+        out = cute.make_tensor(out_ptr, cute.make_layout(Int32(c["m"] * c["k"])))
+
+        self.kernel(
+            a_input,
+            w13,
+            sfb13,
+            inter,
+            w2,
+            sfb2,
+            topk_ids,
+            topk_weights,
+            out,
+        ).launch(
+            grid=(Int32(self.grid_x), Int32(1), Int32(1)),
+            block=(_BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    @staticmethod
+    def launch(
+        compiled_fc1,
+        compiled_fc2,
+        *,
+        x: torch.Tensor,
+        w13_rp: torch.Tensor,
+        sfb13: torch.Tensor,
+        inter_fp32: torch.Tensor,
+        w2_rp: torch.Tensor,
+        sfb2: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        out: torch.Tensor,
+    ):
+        def ptr(dt, t, align=16):
+            return make_ptr(
+                dt, t.data_ptr(), cute.AddressSpace.gmem, assumed_align=align
+            )
+
+        inter_fp32.zero_()
+        out.zero_()
+        stream = current_cuda_stream()
+        args = (
+            ptr(cutlass.BFloat16, x),
+            ptr(cutlass.Uint8, w13_rp.view(torch.uint8)),
+            ptr(cutlass.Uint8, sfb13.view(torch.uint8)),
+            ptr(cutlass.Float32, inter_fp32),
+            ptr(cutlass.Uint8, w2_rp.view(torch.uint8)),
+            ptr(cutlass.Uint8, sfb2.view(torch.uint8)),
+            ptr(cutlass.Int32, topk_ids, 4),
+            ptr(cutlass.Float32, topk_weights, 4),
+            ptr(cutlass.BFloat16, out),
+            stream,
+        )
+        compiled_fc1(*args)
+        compiled_fc2(*args)
+
+
+class MoETinyDecodeKernelBackendPhase1(MoETinyDecodeKernelBackend):
+    """Phase-1 compile identity for exact launch/resource attribution."""
+
+    def __init__(self, *, activation: str = "silu", w13_layout: str = "w31"):
+        super().__init__(
+            activation=activation,
+            w13_layout=w13_layout,
+            compile_time_phase=1,
+        )
+
+
+class MoETinyDecodeKernelBackendPhase2(MoETinyDecodeKernelBackend):
+    """Phase-2 compile identity for exact launch/resource attribution."""
+
+    def __init__(self, *, activation: str = "silu", w13_layout: str = "w31"):
+        super().__init__(
+            activation=activation,
+            w13_layout=w13_layout,
+            compile_time_phase=2,
+        )

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a16/__init__.py @ 5aa74cb3 (2026-05-15) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Internal CuTeDSL W4A16 MoE implementation package."""
+
+__all__: list[str] = []

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/host.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/host.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a16/host.py @ 3663c726 (2026-07-03) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Host-side helpers for the CuTeDSL W4A16 MoE path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    SUPPORTED_MOE_ACTIVATIONS,
+    is_gated_moe_activation,
+    normalize_moe_activation,
+)
+
+
+_W4A16_ALLOWED_ROUTED_SIZES = (8, 16, 32, 48, 64)
+_ROUTED_SIZE_TARGET_FILL = 0.9
+_SUPPORTED_ACTIVATIONS = SUPPORTED_MOE_ACTIVATIONS
+
+
+@dataclass(frozen=True)
+class W4A16PackedShape:
+    num_experts: int
+    hidden_size: int
+    intermediate_size: int
+    w13_rows: int
+    is_gated: bool
+
+
+@dataclass(frozen=True)
+class W4A16PackedBuffers:
+    intermediate_cache13: torch.Tensor
+    intermediate_cache2: torch.Tensor
+    output: torch.Tensor
+    fc1_c_tmp: torch.Tensor | None = None
+    fc2_c_tmp: torch.Tensor | None = None
+    packed_route_indices: torch.Tensor | None = None
+    block_expert_ids: torch.Tensor | None = None
+    packed_route_count: torch.Tensor | None = None
+    expert_offsets: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class W4A16BufferPlan:
+    routed_rows: int
+    fc1_cols: int
+    route_slots: int
+    route_blocks: int
+    fc1_c_tmp_elements: int
+    fc2_c_tmp_elements: int
+    intermediate_cache13_elements: int
+    intermediate_cache2_elements: int
+
+
+def validate_activation(activation: str) -> bool:
+    activation = normalize_moe_activation(activation)
+    return is_gated_moe_activation(activation)
+
+
+def validate_w4a16_packed_inputs(
+    w13_fp4: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+) -> W4A16PackedShape:
+    is_gated = validate_activation(activation)
+    if w13_fp4.dtype != torch.uint8 or w2_fp4.dtype != torch.uint8:
+        raise TypeError("packed FP4 weights must be torch.uint8")
+    if (
+        w13_global_scale.dtype != torch.float32
+        or w2_global_scale.dtype != torch.float32
+    ):
+        raise TypeError("global scales must be torch.float32")
+
+    num_experts = int(w13_fp4.shape[0])
+    hidden_size = int(w2_fp4.shape[1])
+    intermediate_size = int(w2_fp4.shape[2] * 2)
+    w13_rows = intermediate_size * (2 if is_gated else 1)
+    if tuple(w13_fp4.shape) != (num_experts, w13_rows, hidden_size // 2):
+        raise ValueError(
+            f"expected w13_fp4 shape {(num_experts, w13_rows, hidden_size // 2)}, "
+            f"got {tuple(w13_fp4.shape)}"
+        )
+    if tuple(w2_fp4.shape) != (num_experts, hidden_size, intermediate_size // 2):
+        raise ValueError(
+            f"expected w2_fp4 shape {(num_experts, hidden_size, intermediate_size // 2)}, "
+            f"got {tuple(w2_fp4.shape)}"
+        )
+    return W4A16PackedShape(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        w13_rows=w13_rows,
+        is_gated=is_gated,
+    )
+
+
+def validate_nf3_moe_inputs(
+    w13_codes: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_codes: torch.Tensor,
+    w2_scale: torch.Tensor,
+    *,
+    activation: str,
+) -> W4A16PackedShape:
+    """Validate NF3 ("nf3_2p1") code/scale inputs to the packer.
+
+    Codes are integer tensors of values 0..7 in kernel-native output order:
+        w13_codes [E, 2*I, hidden]  w2_codes [E, hidden, I]
+    Scales are per-K/32-group ``t_s`` floats:
+        w13_scale [E, 2*I, hidden//32]  w2_scale [E, hidden, I//32]
+    The NF3 runtime contract requires K % 32 == 0 and N % 64 == 0 for both
+    GEMMs (the scale byte encoding and the 64-N tile packing).
+    """
+    is_gated = validate_activation(activation)
+    _int_dtypes = (torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64)
+    if w13_codes.dtype not in _int_dtypes or w2_codes.dtype not in _int_dtypes:
+        raise TypeError("NF3 codes must be integer tensors of values 0..7")
+
+    num_experts = int(w2_codes.shape[0])
+    hidden_size = int(w2_codes.shape[1])
+    intermediate_size = int(w2_codes.shape[2])
+    w13_rows = intermediate_size * (2 if is_gated else 1)
+    if tuple(w13_codes.shape) != (num_experts, w13_rows, hidden_size):
+        raise ValueError(
+            f"expected w13_codes shape {(num_experts, w13_rows, hidden_size)}, "
+            f"got {tuple(w13_codes.shape)}"
+        )
+    if tuple(w2_codes.shape) != (num_experts, hidden_size, intermediate_size):
+        raise ValueError(
+            f"expected w2_codes shape {(num_experts, hidden_size, intermediate_size)}, "
+            f"got {tuple(w2_codes.shape)}"
+        )
+    for name, size_k, size_n in (
+        ("w13", hidden_size, w13_rows),
+        ("w2", intermediate_size, hidden_size),
+    ):
+        if int(size_k) % 32 != 0:
+            raise ValueError(f"NF3 {name} requires K % 32 == 0, got {size_k}")
+        if int(size_n) % 64 != 0:
+            raise ValueError(f"NF3 {name} requires N % 64 == 0, got {size_n}")
+    if tuple(w13_scale.shape) != (num_experts, w13_rows, hidden_size // 32):
+        raise ValueError(
+            f"expected w13_scale shape {(num_experts, w13_rows, hidden_size // 32)}, "
+            f"got {tuple(w13_scale.shape)}"
+        )
+    if tuple(w2_scale.shape) != (num_experts, hidden_size, intermediate_size // 32):
+        raise ValueError(
+            "expected w2_scale shape "
+            f"{(num_experts, hidden_size, intermediate_size // 32)}, "
+            f"got {tuple(w2_scale.shape)}"
+        )
+    return W4A16PackedShape(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        w13_rows=w13_rows,
+        is_gated=is_gated,
+    )
+
+
+def unswizzle_block_scale(
+    swizzled_scale: torch.Tensor, rows: int, cols_blocks: int
+) -> torch.Tensor:
+    cols_padded = ((cols_blocks + 3) // 4) * 4
+    rows_padded = ((rows + 127) // 128) * 128
+    unswizzled = swizzled_scale.view(torch.float8_e4m3fn).reshape(
+        rows_padded // 128,
+        cols_padded // 4,
+        32,
+        4,
+        4,
+    )
+    unswizzled = unswizzled.permute(0, 3, 2, 1, 4).contiguous()
+    unswizzled = unswizzled.reshape(rows_padded, cols_padded)
+    return unswizzled[:rows, :cols_blocks].to(torch.float32)
+
+
+def unswizzle_expert_scales(
+    swizzled: torch.Tensor,
+    *,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    if swizzled.dtype != torch.float8_e4m3fn:
+        swizzled = swizzled.view(torch.float8_e4m3fn)
+    scales = [
+        unswizzle_block_scale(swizzled[e], rows, cols // 16).to(torch.float8_e4m3fn)
+        for e in range(swizzled.shape[0])
+    ]
+    return torch.stack(scales, dim=0).contiguous()
+
+
+def reorder_w13_to_gate_up(
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+    *,
+    intermediate_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    half = int(intermediate_size)
+    return (
+        torch.cat([w13[:, half:], w13[:, :half]], dim=1).contiguous(),
+        torch.cat([w13_scale[:, half:], w13_scale[:, :half]], dim=1).contiguous(),
+    )
+
+
+def select_route_block_size_m(m: int, topk: int, num_experts: int) -> int:
+    avg_routes_per_expert = (int(m) * int(topk)) / int(num_experts)
+    for routed_size in _W4A16_ALLOWED_ROUTED_SIZES:
+        if avg_routes_per_expert < _ROUTED_SIZE_TARGET_FILL * routed_size:
+            return routed_size
+    return _W4A16_ALLOWED_ROUTED_SIZES[-1]
+
+
+def max_packed_route_slots(numel: int, block_size: int, num_experts: int) -> int:
+    max_packed_routes = int(numel) + int(num_experts) * (int(block_size) - 1)
+    if int(numel) < int(num_experts):
+        max_packed_routes = min(
+            int(numel) * int(block_size),
+            max_packed_routes,
+        )
+    return max_packed_routes
+
+
+def route_pack_numel_capacity(numel: int, topk: int = 1) -> int:
+    topk = max(int(topk), 1)
+    tokens = (max(int(numel), 1) + topk - 1) // topk
+    return route_pack_token_capacity(tokens, topk) * topk
+
+
+def route_pack_token_capacity(tokens: int, topk: int) -> int:
+    del topk
+    return 1 << (max(int(tokens), 1) - 1).bit_length()
+
+
+def max_w4a16_route_capacity(routed_rows: int, num_experts: int) -> tuple[int, int]:
+    route_slots = 0
+    route_blocks = 0
+    for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
+        slots = max_packed_route_slots(
+            int(routed_rows), int(block_size), int(num_experts)
+        )
+        route_slots = max(route_slots, slots)
+        route_blocks = max(
+            route_blocks, (slots + int(block_size) - 1) // int(block_size)
+        )
+    return max(route_slots, 1), max(route_blocks, 1)
+
+
+def packed_gemm_scratch_elements(
+    *,
+    size_n: int,
+    route_slots: int,
+    moe_block_size: int,
+    sms: int,
+) -> int:
+    elements = min(
+        int(size_n) * int(route_slots),
+        int(sms) * 4 * int(moe_block_size) * 256,
+    )
+    if moe_block_size == 8:
+        elements *= 2
+    return max(elements, 1)
+
+
+def plan_w4a16_buffers(
+    prepared,
+    *,
+    m: int,
+    topk: int,
+    route_num_experts: int | None = None,
+    sms: int,
+) -> W4A16BufferPlan:
+    routed_rows = int(m) * int(topk)
+    route_num_experts = (
+        int(prepared.num_experts)
+        if route_num_experts is None
+        else int(route_num_experts)
+    )
+    intermediate_size = int(prepared.intermediate_size)
+    hidden_size = int(prepared.hidden_size)
+    fc1_cols = (2 if prepared.is_gated else 1) * intermediate_size
+    block_size_m = select_route_block_size_m(m, topk, route_num_experts)
+    route_slots = max_packed_route_slots(routed_rows, block_size_m, route_num_experts)
+    route_blocks = (route_slots + block_size_m - 1) // block_size_m
+    scratch_sms = int(sms)
+    return W4A16BufferPlan(
+        routed_rows=routed_rows,
+        fc1_cols=fc1_cols,
+        route_slots=route_slots,
+        route_blocks=route_blocks,
+        fc1_c_tmp_elements=packed_gemm_scratch_elements(
+            size_n=fc1_cols,
+            route_slots=route_slots,
+            moe_block_size=block_size_m,
+            sms=scratch_sms,
+        ),
+        fc2_c_tmp_elements=packed_gemm_scratch_elements(
+            size_n=hidden_size,
+            route_slots=route_slots,
+            moe_block_size=block_size_m,
+            sms=scratch_sms,
+        ),
+        intermediate_cache13_elements=routed_rows * max(fc1_cols, hidden_size),
+        intermediate_cache2_elements=routed_rows * intermediate_size,
+    )
+
+
+def make_w4a16_packed_buffers(
+    prepared,
+    *,
+    m: int,
+    topk: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    route_num_experts: int | None = None,
+) -> W4A16PackedBuffers:
+    route_num_experts = (
+        int(prepared.num_experts)
+        if route_num_experts is None
+        else int(route_num_experts)
+    )
+    sms = int(torch.cuda.get_device_properties(device).multi_processor_count)
+    plan = plan_w4a16_buffers(
+        prepared,
+        m=m,
+        topk=topk,
+        route_num_experts=route_num_experts,
+        sms=sms,
+    )
+    fc1_c_tmp = torch.empty(
+        (plan.fc1_c_tmp_elements,),
+        dtype=torch.float32,
+        device=device,
+    )
+    fc2_c_tmp = torch.empty(
+        (plan.fc2_c_tmp_elements,),
+        dtype=torch.float32,
+        device=device,
+    )
+    return W4A16PackedBuffers(
+        intermediate_cache13=torch.empty(
+            (plan.intermediate_cache13_elements,),
+            dtype=dtype,
+            device=device,
+        ),
+        intermediate_cache2=torch.empty(
+            (plan.routed_rows, int(prepared.intermediate_size)),
+            dtype=dtype,
+            device=device,
+        ),
+        output=torch.empty((m, prepared.hidden_size), dtype=dtype, device=device),
+        fc1_c_tmp=fc1_c_tmp,
+        fc2_c_tmp=fc2_c_tmp,
+        packed_route_indices=torch.empty(
+            (plan.route_slots,), dtype=torch.int32, device=device
+        ),
+        block_expert_ids=torch.empty(
+            (plan.route_blocks,), dtype=torch.int32, device=device
+        ),
+        packed_route_count=torch.empty((1,), dtype=torch.int32, device=device),
+        expert_offsets=torch.empty(
+            (route_num_experts + 1,), dtype=torch.int32, device=device
+        ),
+    )
+
+
+__all__ = [
+    "W4A16BufferPlan",
+    "W4A16PackedBuffers",
+    "W4A16PackedShape",
+    "make_w4a16_packed_buffers",
+    "max_w4a16_route_capacity",
+    "packed_gemm_scratch_elements",
+    "max_packed_route_slots",
+    "plan_w4a16_buffers",
+    "reorder_w13_to_gate_up",
+    "route_pack_numel_capacity",
+    "route_pack_token_capacity",
+    "select_route_block_size_m",
+    "unswizzle_block_scale",
+    "unswizzle_expert_scales",
+    "validate_activation",
+    "validate_nf3_moe_inputs",
+    "validate_w4a16_packed_inputs",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/kernel.py
@@ -1,0 +1,9294 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a16/kernel.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""CuTeDSL W4A16 NVFP4/BF16 W4A16 MoE kernels."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from functools import partial
+from typing import NamedTuple
+
+import cuda.bindings.driver as cuda
+import cuda.bindings.runtime as cuda_runtime
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.base_dsl.compiler import OptLevel
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, dsl_user_op
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    compile as sm12x_compile,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    atomic_add_global_i32,
+    bf16_mma_m16n8k16_f32,
+    bf16_mma_rhs_fragments_as_mma_a_m16n8k16_f32,
+    bfloat2_broadcast_lane,
+    bfloat2_mul,
+    bfloat2_to_float2_scaled,
+    broadcast_f32_to_half2,
+    broadcast_f32_to_bfloat2,
+    cp_async4_shared_global,
+    cp_async4_shared_global_pred,
+    fabs_f32,
+    fmax_f32,
+    f16_mma_m16n8k16_f32,
+    f16_mma_rhs_fragments_as_mma_a_m16n8k16_f32,
+    half2_to_float2_scaled,
+    get_ptr_as_int64,
+    half2_mul,
+    ld_global_acquire_i32,
+    ld_global_nc_u32,
+    ld_global_v4_f32,
+    ld_shared_f32,
+    ld_shared_i32_relaxed,
+    ld_shared_u32,
+    ld_shared_v2_u32,
+    ld_shared_v4_f32,
+    ld_shared_v4_u32,
+    ldmatrix_m8n8x4_b16,
+    ldmatrix_m8n8x2_b16,
+    packed_dequant_e2m1x4_to_bfloat2x2,
+    packed_dequant_e2m1x4_to_half2x2,
+    packed_dequant_e4m3x4_to_bfloat2x2,
+    packed_dequant_e4m3x4_to_half2x2,
+    packed_dequant_e8m0x4_to_bfloat2x2,
+    packed_dequant_e8m0x4_to_half2x2,
+    packed_dequant_nf3x8_to_bfloat2x4,
+    nf3_codebook_pools,
+    pack_f32x2_to_bfloat2,
+    pack_f32x2_to_f16x2,
+    red_add_global_bf16x2,
+    red_add_global_release_i32,
+    red_max_global_f32_nonnegative,
+    shared_ptr_to_u32,
+    st_global_v4_u32,
+    st_global_i32,
+    st_global_v4_f32,
+    st_shared_bf16_from_f32,
+    st_shared_f16_from_f32,
+    st_shared_f32,
+    st_shared_i32,
+    st_shared_u32,
+    st_shared_v4_f32,
+    st_shared_v4_u32,
+    threadfence,
+    warp_reduce,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream, make_ptr
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.route_pack import (
+    pack_topk_routes_by_expert as _pack_topk_routes_by_expert,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+    _W4A16_ALLOWED_ROUTED_SIZES,
+    max_packed_route_slots,
+    packed_gemm_scratch_elements,
+    plan_w4a16_buffers,
+    select_route_block_size_m,
+    validate_activation,
+)
+from flashinfer.experimental.sm12x._lib.runtime_control import (
+    raise_if_kernel_resolution_frozen,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    SWIGLUOAI_UNINTERLEAVE,
+    is_gated_moe_activation,
+    normalize_moe_activation,
+    normalize_swiglu_alpha_for_activation,
+    normalize_swiglu_beta_for_activation,
+    normalize_swiglu_limit_for_activation,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.micro import (
+    MoEMicroKernelBackend,
+)
+
+
+_ALLOWED_ROUTED_SIZES = _W4A16_ALLOWED_ROUTED_SIZES
+_PACK_FACTOR = 8
+_STAGES = 4
+_E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT = 64
+_DEVICE_MAX_REG_BYTES = 255 * 1024
+_DEFAULT_MAX_SHARED_MEM = 101_376
+_SCALAR_ACC_FRAGMENT_WIDTH = 1
+_WEIGHT_LAYOUTS = {"packed", "modelopt", "nf3_2p1"}
+_MODEL_OPT_W13_LAYOUTS = {"w13", "w31"}
+# NF3 codebook: 8 bf16 codepoints for the 3-bit ("nf3_2p1") weight layout. The
+# device dequant reads these as prmt pools (see nf3_codebook_pools); the host
+# injects the 4 pool words as compile-time constants into the GEMM.
+_NF3_CODEBOOK = (-1.0, -0.6047, -0.3563, -0.1275, 0.1275, 0.3563, 0.6047, 1.0)
+_SCALE_FORMATS = {
+    "e4m3_k16": "e4m3_k16",
+    "e8m0_k32": "e8m0_k32",
+    "e4m3_k32": "e4m3_k32",
+}
+_E8M0_K32_FP16_GLOBAL_COMPENSATION = float(2.0**7)
+_E8M0_K32_BF16_GLOBAL_COMPENSATION = float(2.0**119)
+_MAX_DIRECT_TOPK_ROUTE_M = 6
+_W4A16_SMALL_M_DIRECT_MAX_M = 8
+
+# TC-decode: a small-M decode specialization that runs on the PACKED W4A16
+# object (the same weights/scales the prefill GEMM uses). It reuses the packed
+# tensor-core MMA inner loop but folds the top-k sum into the FC2 store
+# epilogue (dropping the separate top-k-sum launch). It never regresses vs the
+# packed GEMM within its supported M range, so it is ALWAYS used for the small-M
+# direct-topk decode sizes — there is no opt-in/opt-out switch.
+# TC-decode is available for the whole small-M direct-topk range. Its only hard
+# ceiling is the direct-topk route cap (above it, expert route-packing wins).
+# _TC_DECODE_M is retained for callers/tests that enumerate the supported sizes.
+_TC_DECODE_MAX_M = _W4A16_SMALL_M_DIRECT_MAX_M
+_TC_DECODE_M = tuple(range(1, _TC_DECODE_MAX_M + 1))
+
+
+@dsl_user_op
+def _materialize_w4a16_topk_route_f32(value, *, loc=None, ip=None):
+    """Keep the BF16-to-F32 conversion outside the unrolled reduction add.
+
+    NVVM 23 otherwise folds the conversion into ``add.rn.f32.bf16``.  On
+    SM120, ptxas assigns the six live BF16 sources to a sparse register span
+    for that instruction sequence, increasing this kernel from 15 to 18 GPRs.
+    The identity ``mov.b32`` is an opaque precision/lifetime boundary in NVVM;
+    ptxas removes it and emits the spill-free 15-GPR CVT/FADD sequence.
+    """
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [cutlass.Float32(value).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _m_specialization_key(size_m: int) -> int:
+    """M bucket for branches that genuinely specialize on token count."""
+    return 1 if int(size_m) == 1 else 0
+
+
+def _fake_m_for_specialization(size_m: int) -> int:
+    return 1 if _m_specialization_key(size_m) == 1 else 2
+
+
+# The W4A16 launch model chooses blocks/SM from static resource usage
+# for each specialization.  These register counts were measured from the local
+# SM121 JIT output and keep launch occupancy stable across refactors.
+_W4A16_REGS_SM121 = {
+    (256, 1, 8, 8, True): 118,
+    (256, 1, 16, 4, True): 118,
+    (256, 1, 16, 8, True): 118,
+    (256, 1, 32, 2, True): 118,
+    (128, 1, 4, 8, True): 118,
+    (128, 1, 8, 4, True): 120,
+    (256, 1, 8, 8, False): 158,
+    (128, 1, 4, 8, False): 154,
+    (128, 1, 8, 4, False): 143,
+    (256, 2, 16, 4, False): 212,
+    (128, 2, 4, 8, False): 215,
+    (128, 2, 8, 4, False): 214,
+    (256, 3, 16, 4, False): 249,
+    (128, 3, 4, 8, False): 249,
+    (128, 3, 8, 4, False): 250,
+    (256, 4, 16, 4, False): 255,
+    (128, 4, 4, 8, False): 255,
+    (128, 4, 8, 4, False): 255,
+}
+# Layout overlay: the nf3_2p1 dequant inner loop (codebook prmt pools, 12B
+# staged triples) allocates fewer registers than the packed e2m1 loop.
+# Measured from ncu on SM120 JIT output at the production hybrid tile config;
+# unmeasured specializations fall back to the packed table (a conservative
+# upper bound).
+_W4A16_REGS_SM121_NF3 = {
+    (256, 4, 16, 4, False): 238,
+}
+_SMALL_BATCH_TILE_CONFIGS = (
+    (128, 128, 256),
+    (64, 128, 128),
+    (128, 64, 128),
+)
+_LARGE_BATCH_TILE_CONFIGS = (
+    (64, 256, 256),
+    (64, 128, 128),
+    (128, 64, 128),
+)
+
+
+def _covering_count(total: int, quantum: int) -> int:
+    return (total + quantum - 1) // quantum
+
+
+def _e8m0_logical_tail_scale_n(size_n: int) -> int:
+    return (
+        (int(size_n) + _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT - 1)
+        // _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT
+    ) * _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT
+
+
+def _normalize_swiglu_limit(swiglu_limit: float | None) -> float | None:
+    return normalize_swiglu_limit_for_activation("silu", swiglu_limit)
+
+
+def _normalize_activation_swiglu_params(
+    activation: str,
+    swiglu_limit: float | None,
+    swiglu_alpha: float | None,
+    swiglu_beta: float | None,
+) -> tuple[float | None, float, float]:
+    activation = normalize_moe_activation(activation)
+    return (
+        normalize_swiglu_limit_for_activation(activation, swiglu_limit),
+        normalize_swiglu_alpha_for_activation(activation, swiglu_alpha),
+        normalize_swiglu_beta_for_activation(activation, swiglu_beta),
+    )
+
+
+def _w4a16_num_regs(
+    *,
+    cta_threads: int,
+    cta_m_blocks: int,
+    cta_n_blocks: int,
+    cta_k_blocks: int,
+    uses_m_block_8: bool,
+    weight_layout: str = "packed",
+) -> int:
+    key = (
+        int(cta_threads),
+        int(cta_m_blocks),
+        int(cta_n_blocks),
+        int(cta_k_blocks),
+        bool(uses_m_block_8),
+    )
+    if weight_layout == "nf3_2p1":
+        hit = _W4A16_REGS_SM121_NF3.get(key)
+        if hit is not None:
+            return hit
+    try:
+        return _W4A16_REGS_SM121[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"missing W4A16 register count for NVFP4 BF16 specialization {key}"
+        ) from exc
+
+
+def _shared_memory_footprint(
+    *,
+    cta_m_blocks: int,
+    tile_n: int,
+    tile_k: int,
+    scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
+) -> int:
+    cta_m = int(cta_m_blocks) * 16
+    cta_n = int(tile_n)
+    cta_k = int(tile_k)
+    sh_block_meta_size = cta_m * 16
+    sh_a_size = _STAGES * (cta_m * cta_k) * 2
+    sh_b_size = _STAGES * (cta_k * cta_n // _PACK_FACTOR) * 4
+    if weight_layout == "nf3_2p1":
+        # NF3 stages 12-byte triples per 32-code unit instead of 16-byte int4
+        # units (see b_unit_bytes) -- 3/4 of the packed B stage footprint.
+        sh_b_size = sh_b_size * 3 // 4
+    sh_red_size = cta_m * (cta_n + 8) * 2
+    sh_bias_size = cta_n * 2
+    tmp_size = min(sh_b_size, sh_red_size) + sh_bias_size
+    tmp_size = max(max(sh_b_size, sh_red_size), tmp_size)
+    sh_s_size = (
+        _covering_count(cta_k, _scale_group_size(scale_format)) * cta_n * 2 * _STAGES
+    )
+    return tmp_size + sh_a_size + sh_s_size + sh_block_meta_size
+
+
+def _determine_blocks_per_sm(
+    *,
+    problem_m: int,
+    problem_n: int,
+    top_k: int,
+    cta_threads: int,
+    cta_m_blocks: int,
+    tile_n: int,
+    tile_k: int,
+    uses_m_block_8: bool,
+    sms: int,
+    max_shared_mem: int,
+    scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
+) -> int:
+    num_regs = _w4a16_num_regs(
+        cta_threads=cta_threads,
+        cta_m_blocks=cta_m_blocks,
+        cta_n_blocks=tile_n // 16,
+        cta_k_blocks=tile_k // 16,
+        uses_m_block_8=uses_m_block_8,
+        weight_layout=weight_layout,
+    )
+    register_bytes = max(num_regs, 1) * int(cta_threads) * 4
+    smem_bytes = _shared_memory_footprint(
+        cta_m_blocks=cta_m_blocks,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        scale_format=scale_format,
+        weight_layout=weight_layout,
+    )
+    blocks_per_sm_limit = min(
+        _DEVICE_MAX_REG_BYTES // register_bytes,
+        int(max_shared_mem) // (smem_bytes + 1536),
+    )
+    if uses_m_block_8:
+        # Small-M (moe_block_size==8) TC-decode is weight-bandwidth/overhead
+        # bound, not parallelism bound (only m*top_k route-blocks of GEMM work).
+        # The fused FC1->activation->FC2 path crosses several grid barriers whose
+        # tid==0 atomic-counter increment serializes across all grid_x CTAs, so an
+        # oversized grid pays barrier-atomic latency proportional to grid_x for no
+        # extra GEMM throughput. Pin one persistent CTA per SM to minimize the
+        # barrier participant count while still covering the machine for the
+        # I_tp=1024 GEMMs. The split-K persistent loop is grid_x-agnostic, so this
+        # is numerically identical.
+        blocks_per_sm_limit = 1
+    elif cta_m_blocks == 1:
+        blocks_per_sm_limit = max(min(blocks_per_sm_limit, 4), 1)
+    else:
+        blocks_per_sm_limit = max(min(blocks_per_sm_limit, 2), 1)
+
+    work_cta_count = (int(problem_n) // int(tile_n)) * int(problem_m) * int(top_k) * 4
+    if work_cta_count < int(sms) * blocks_per_sm_limit:
+        blocks_per_sm_limit = max(work_cta_count // int(sms), 1)
+    return int(blocks_per_sm_limit)
+
+
+def _candidate_tile_fits(
+    *,
+    problem_n: int,
+    problem_k: int,
+    cta_m_blocks: int,
+    tile_n: int,
+    tile_k: int,
+    cta_threads: int,
+    max_shared_mem: int,
+    scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
+    allow_logical_tail: bool = False,
+) -> bool:
+    if int(tile_k) == -1 or int(tile_n) == -1 or int(cta_threads) == -1:
+        return False
+    scale_group_size = _scale_group_size(scale_format)
+    exact_n = int(problem_n) % int(tile_n) == 0
+    exact_k = int(problem_k) % int(tile_k) == 0
+    exact_scale_k = int(problem_k) % scale_group_size == 0
+    if not allow_logical_tail:
+        if not exact_n or not exact_k:
+            return False
+        if not exact_scale_k or int(tile_k) % scale_group_size != 0:
+            return False
+    elif (
+        _normalize_scale_format(scale_format) != "e8m0_k32"
+        or int(problem_n) % 16 != 0
+        or int(problem_k) % 8 != 0
+        or int(tile_n) % 16 != 0
+        or int(tile_k) % scale_group_size != 0
+    ):
+        return False
+    if int(tile_n) < 64 or int(tile_k) < 64 or int(cta_threads) < 128:
+        return False
+    smem_bytes = _shared_memory_footprint(
+        cta_m_blocks=cta_m_blocks,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        scale_format=scale_format,
+        weight_layout=weight_layout,
+    )
+    return smem_bytes <= int(max_shared_mem)
+
+
+def _select_tile_config(
+    *,
+    problem_m: int,
+    problem_n: int,
+    problem_k: int,
+    top_k: int,
+    moe_block_size: int,
+    sms: int,
+    max_shared_mem: int,
+    required_cta_threads: int | None = None,
+    scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
+    allow_logical_tail: bool = False,
+) -> tuple[int, int, int, int]:
+    cta_m_blocks = _covering_count(moe_block_size, 16)
+    uses_m_block_8 = moe_block_size == 8
+    configs = (
+        _LARGE_BATCH_TILE_CONFIGS if cta_m_blocks > 1 else _SMALL_BATCH_TILE_CONFIGS
+    )
+    best_blocks_per_sm = 0
+    best_tile_config: tuple[int, int, int, int] | None = None
+    for tile_k, tile_n, cta_threads in configs:
+        if required_cta_threads is not None and int(cta_threads) != int(
+            required_cta_threads
+        ):
+            continue
+        if not _candidate_tile_fits(
+            problem_n=problem_n,
+            problem_k=problem_k,
+            cta_m_blocks=cta_m_blocks,
+            tile_n=tile_n,
+            tile_k=tile_k,
+            cta_threads=cta_threads,
+            max_shared_mem=int(max_shared_mem) - 512,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+            allow_logical_tail=allow_logical_tail,
+        ):
+            continue
+        occupancy_problem_n = (
+            _covering_count(int(problem_n), int(tile_n)) * int(tile_n)
+            if allow_logical_tail
+            else int(problem_n)
+        )
+        blocks_per_sm_limit = _determine_blocks_per_sm(
+            problem_m=problem_m,
+            problem_n=occupancy_problem_n,
+            top_k=top_k,
+            cta_threads=cta_threads,
+            cta_m_blocks=cta_m_blocks,
+            tile_n=tile_n,
+            tile_k=tile_k,
+            uses_m_block_8=uses_m_block_8,
+            sms=sms,
+            max_shared_mem=max_shared_mem,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+        )
+        if blocks_per_sm_limit > best_blocks_per_sm:
+            best_blocks_per_sm = blocks_per_sm_limit
+            best_tile_config = (tile_k, tile_n, cta_threads, blocks_per_sm_limit)
+    if best_tile_config is None:
+        cta_thread_msg = (
+            ""
+            if required_cta_threads is None
+            else f", required_cta_threads={required_cta_threads}"
+        )
+        raise ValueError(
+            "no valid W4A16 tile config for "
+            f"M/N/K={problem_m}/{problem_n}/{problem_k}, moe_block_size={moe_block_size}"
+            f"{cta_thread_msg}"
+        )
+    return best_tile_config
+
+
+@dataclass(frozen=True)
+class W4A16GemmCompileResult:
+    compiled: object
+    tile_n: int
+    tile_k: int
+    moe_block_size: int
+    max_m_blocks: int
+    blocks_per_sm: int
+    weight_layout: str = "packed"
+    scale_format: str = "e4m3_k16"
+    w13_layout: str = "w13"
+
+
+@dataclass(frozen=True)
+class W4A16ActivationCompileResult:
+    compiled: object
+    rows: int
+    intermediate_size: int
+    activation: str
+    swiglu_limit: float | None
+    swiglu_alpha: float
+    swiglu_beta: float
+
+
+@dataclass(frozen=True)
+class W4A16TopKSumCompileResult:
+    compiled: object
+    m: int
+    topk: int
+    hidden_size: int
+
+
+@dataclass(frozen=True)
+class W4A16FusedMoeCompileResult:
+    compiled: object
+    size_m: int
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    top_k: int
+    activation: str
+    apply_router_weight_on_input: bool
+    zero_fc2_output: bool
+    element_dtype: str
+    fast_math: bool
+    swiglu_limit: float | None
+    swiglu_alpha: float
+    swiglu_beta: float
+    fc1_tile_n: int
+    fc1_tile_k: int
+    fc2_tile_n: int
+    fc2_tile_k: int
+    moe_block_size: int
+    max_m_blocks: int
+    blocks_per_sm: int
+    weight_layout: str = "packed"
+    w13_layout: str = "w13"
+    direct_topk_routes: bool = False
+    scale_format: str = "e4m3_k16"
+    tc_decode_fused_sum: bool = False
+    collect_activation_amax: bool = False
+
+
+@dataclass(frozen=True)
+class _W4A16GemmLaunch:
+    kernel: W4A16GemmCompileResult
+    c_tmp: torch.Tensor
+
+
+class _W4A16SmallMDirectLaunch(NamedTuple):
+    compiled: object
+    grid_x: int
+    m: int
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    topk: int
+    activation: str
+    fast_math: bool
+    topk_ids_dtype: torch.dtype
+
+
+class MoEMicroKernelW4A16SmallMDirect(MoEMicroKernelBackend):
+    """Decode-sized W4A16 specialization using the native ModelOpt layout."""
+
+    _SUPPORTED_M = tuple(range(1, _W4A16_SMALL_M_DIRECT_MAX_M + 1))
+
+    @classmethod
+    def is_supported(
+        cls,
+        *,
+        m: int,
+        hidden_size: int,
+        intermediate_size: int,
+        topk: int,
+        num_experts: int,
+        scale_format: str = "e4m3_k16",
+    ) -> bool:
+        # E8M0 reads the shared packed scale grid. Both block axes must be /32.
+        # The FC2 chunking (256 intermediate values per chunk, fc2_n_chunks)
+        # masks a tail inside a single chunk correctly (I=128 oracle-covered),
+        # but multi-chunk shards with a partial last chunk (352, 384) index
+        # scale columns past the e8m0 grid and corrupt decode outputs — the
+        # e4m3_k16 path masks this fine; e8m0 must cover multi-chunk exactly.
+        if scale_format == "e8m0_k32":
+            fc2_n_chunks = ((int(intermediate_size) // 2) + 127) // 128
+            scale_block_ok = (
+                int(hidden_size) % 32 == 0
+                and int(intermediate_size) % 32 == 0
+                and (fc2_n_chunks == 1 or int(intermediate_size) % 256 == 0)
+            )
+        else:
+            scale_block_ok = True
+        return (
+            int(m) in cls._SUPPORTED_M
+            and int(m) <= _W4A16_SMALL_M_DIRECT_MAX_M
+            and int(hidden_size) > 0
+            and int(hidden_size) % 128 == 0
+            and int(intermediate_size) > 0
+            and int(intermediate_size) % 16 == 0
+            and scale_block_ok
+            and 0 < int(topk) <= 32
+            and int(num_experts) > 0
+            and MoEMicroKernelBackend.is_supported(
+                int(m),
+                int(hidden_size),
+                int(intermediate_size),
+                int(topk),
+                int(num_experts),
+            )
+        )
+
+    def __init__(
+        self,
+        *,
+        activation: str,
+        fast_math: bool,
+        share_input_across_experts: bool,
+        share_expert_scales: bool,
+        single_token: bool,
+        scale_format: str = "e4m3_k16",
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+        w13_layout: str = "w13",
+    ):
+        super().__init__(
+            sf_vec_size=16,
+            mma_tiler_mn=(64, 128),
+            output_tile_count_n=1,
+            fast_math=fast_math,
+            activation=activation,
+            share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=single_token,
+            dynamic_down_scale=False,
+            w4a16_mode=True,
+            scale_format=scale_format,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            w13_layout=w13_layout,
+        )
+
+
+class W4A16GemmKernel:
+    def __init__(
+        self,
+        *,
+        size_m: int,
+        size_n: int,
+        size_k: int,
+        num_experts: int,
+        top_k: int,
+        mul_topk_weights: bool,
+        tile_n: int,
+        tile_k: int,
+        moe_block_size: int,
+        max_m_blocks: int,
+        element_dtype: str = "bf16",
+        epilogue_activation: str | None = None,
+        weight_layout: str = "packed",
+        scale_format: str = "e4m3_k16",
+        w13_layout: str = "w13",
+        source_n_rotation: int = 0,
+        single_token_route_fast_path: bool = False,
+        direct_topk_routes: bool = False,
+        fused_topk_sum: bool = False,
+        fused_sum_topk: int = 1,
+        schedule_whole_tiles: bool = False,
+    ):
+        if element_dtype not in {"bf16", "fp16"}:
+            raise ValueError(f"unsupported element_dtype {element_dtype!r}")
+        if weight_layout not in _WEIGHT_LAYOUTS:
+            raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+        scale_format = _normalize_scale_format(scale_format)
+        if weight_layout == "modelopt":
+            if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+                raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+        else:
+            w13_layout = "packed"
+            source_n_rotation = 0
+        if weight_layout == "nf3_2p1":
+            if scale_format != "e4m3_k32":
+                raise ValueError(
+                    "nf3_2p1 W4A16 weights require scale_format='e4m3_k32'"
+                )
+            if element_dtype != "bf16":
+                raise ValueError("nf3_2p1 W4A16 weights are bf16-activation only (v1)")
+        if epilogue_activation not in (None, "relu2"):
+            raise ValueError(
+                "W4A16 GEMM epilogue activation currently supports only relu2"
+            )
+        if tile_n % 16 != 0 or tile_k % 16 != 0:
+            raise ValueError("tile_n/tile_k must be multiples of 16")
+        scale_group_size = _scale_group_size(scale_format)
+        has_n_tile_tail = int(size_n) % int(tile_n) != 0
+        has_k_tile_tail = int(size_k) % int(tile_k) != 0
+        has_scale_k_tail = int(size_k) % scale_group_size != 0
+        has_logical_tail = has_n_tile_tail or has_k_tile_tail or has_scale_k_tail
+        if has_logical_tail:
+            if weight_layout != "modelopt" or scale_format != "e8m0_k32":
+                raise ValueError(
+                    "W4A16 logical tail tiles are only supported for native "
+                    "E8M0 K/32 weights"
+                )
+            if int(size_n) % 16 != 0:
+                raise ValueError(
+                    "native E8M0 W4A16 tail tiles require size_n % 16 == 0"
+                )
+            if int(size_k) % 8 != 0:
+                raise ValueError("native E8M0 W4A16 tail tiles require size_k % 8 == 0")
+            if int(tile_k) % scale_group_size != 0:
+                raise ValueError(
+                    "native E8M0 W4A16 tail tiles require tile_k multiples of 32"
+                )
+        else:
+            if size_n % tile_n != 0:
+                raise ValueError("size_n must be divisible by tile_n")
+            if size_k % tile_k != 0:
+                raise ValueError("size_k must be divisible by tile_k")
+            if scale_format == "e8m0_k32" and (size_k % 32 != 0 or tile_k % 32 != 0):
+                raise ValueError(
+                    "E8M0 K/32 W4A16 scales require size_k/tile_k multiples of 32"
+                )
+            if scale_format == "e4m3_k32" and (size_k % 32 != 0 or tile_k % 32 != 0):
+                raise ValueError(
+                    "E4M3 K/32 W4A16 scales require size_k/tile_k multiples of 32"
+                )
+        if moe_block_size not in _ALLOWED_ROUTED_SIZES:
+            raise ValueError(f"unsupported moe_block_size {moe_block_size}")
+        if moe_block_size != 8 and moe_block_size % 16 != 0:
+            raise ValueError("moe_block_size must be 8 or a multiple of 16")
+        cta_threads = tile_n * tile_k // 64
+        if cta_threads not in (128, 256):
+            raise ValueError("W4A16 GEMM expects 128 or 256 CTA threads")
+        self.size_m = int(size_m)
+        self.size_n = int(size_n)
+        self.size_k = int(size_k)
+        self.num_experts = int(num_experts)
+        self.top_k = int(top_k)
+        self.mul_topk_weights = bool(mul_topk_weights)
+        self.tile_n = int(tile_n)
+        self.tile_k = int(tile_k)
+        self.cta_n_blocks = int(tile_n // 16)
+        self.cta_k_blocks = int(tile_k // 16)
+        self.cta_threads = int(cta_threads)
+        self.moe_block_size = int(moe_block_size)
+        self.element_dtype = element_dtype
+        self.is_fp16 = element_dtype == "fp16"
+        self.epilogue_relu2 = epilogue_activation == "relu2"
+        self.weight_layout = weight_layout
+        self.weight_layout_nf3 = weight_layout == "nf3_2p1"
+        self.scale_format = scale_format
+        self.scale_format_e8m0_k32 = scale_format == "e8m0_k32"
+        # k32 scale cadence (two K16 rows share one scale group). Shared by the
+        # native E8M0 K/32 path and the NF3 e4m3-style K/32 path; the scale
+        # DECODE stays keyed on scale_format_e8m0_k32 (e4m3_k32 uses the e4m3
+        # decode arm, its 2**116 compensation lives in the global_scale tensor).
+        self.scale_k32 = scale_format in ("e8m0_k32", "e4m3_k32")
+        # NF3 codebook prmt pools (host-computed compile-time constants injected
+        # into the device dequant). Only consumed by the nf3_2p1 path; cheap to
+        # compute unconditionally.
+        (
+            self._nf3_cb0,
+            self._nf3_cb1,
+            self._nf3_cb2,
+            self._nf3_cb3,
+        ) = nf3_codebook_pools(_NF3_CODEBOOK)
+        self.scale_group_size = int(scale_group_size)
+        self.scale_k_groups = _covering_count(self.size_k, self.scale_group_size)
+        self.n_tiles = _covering_count(self.size_n, self.tile_n)
+        self.k_tiles = _covering_count(self.size_k, self.tile_k)
+        self.covered_size_n = self.n_tiles * self.tile_n
+        self.covered_size_k = self.k_tiles * self.tile_k
+        self.has_n_tile_tail = bool(has_n_tile_tail)
+        self.has_k_tile_tail = bool(has_k_tile_tail)
+        self.has_scale_k_tail = bool(has_scale_k_tail)
+        self.has_logical_tail = bool(has_logical_tail)
+        self.scale_size_n = (
+            _e8m0_logical_tail_scale_n(self.size_n)
+            if self.scale_format_e8m0_k32 and self.has_n_tile_tail
+            else self.size_n
+        )
+        self.scale_n_groups = self.scale_size_n // 16
+        self.w13_layout = w13_layout
+        self.source_n_rotation = int(source_n_rotation)
+        self.single_token_route_fast_path = bool(single_token_route_fast_path)
+        self.direct_topk_routes = bool(direct_topk_routes)
+        self.fused_topk_sum = bool(fused_topk_sum)
+        self.fused_sum_topk = int(fused_sum_topk)
+        # Whole-tile persistent scheduling: every mn-tile is computed by one
+        # CTA over the full K (grid-strided waves, ragged last wave), skipping
+        # the split-K tail machinery entirely. Requires the host to bound the
+        # wave count; used by the exact-geometry hybrid decode schedule.
+        self.schedule_whole_tiles = bool(schedule_whole_tiles)
+        if self.schedule_whole_tiles and not self.direct_topk_routes:
+            raise ValueError("schedule_whole_tiles requires direct_topk_routes")
+        if self.fused_topk_sum and not self.direct_topk_routes:
+            raise ValueError("fused_topk_sum requires direct_topk_routes")
+        if self.fused_topk_sum and self.fused_sum_topk < 1:
+            raise ValueError("fused_sum_topk must be >= 1")
+        self.cta_m_blocks = int(_covering_count(moe_block_size, 16))
+        self.uses_m_block_8 = moe_block_size == 8
+        self.max_m_blocks = int(max_m_blocks)
+        if torch.cuda.is_available():
+            props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            self.sms = int(props.multi_processor_count)
+            max_shared_mem = int(
+                getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+            )
+        else:
+            self.sms = 120
+            max_shared_mem = _DEFAULT_MAX_SHARED_MEM
+        self.blocks_per_sm = _determine_blocks_per_sm(
+            problem_m=self.size_m,
+            problem_n=self.covered_size_n,
+            top_k=self.top_k,
+            cta_threads=self.cta_threads,
+            cta_m_blocks=self.cta_m_blocks,
+            tile_n=self.tile_n,
+            tile_k=self.tile_k,
+            uses_m_block_8=self.uses_m_block_8,
+            sms=self.sms,
+            max_shared_mem=max_shared_mem,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+        )
+
+        # W4A16 shared-memory geometry, in int4 units unless noted.
+        self.a_sh_stride = 16 * self.cta_k_blocks // 8
+        self.a_sh_stage = self.a_sh_stride * (16 * self.cta_m_blocks)
+        self.a_gl_rd_delta_o = 16 * self.cta_k_blocks // 8
+        self.a_sh_wr_delta = self.a_sh_stride * (
+            self.cta_threads // self.a_gl_rd_delta_o
+        )
+        self.a_sh_wr_iters = _covering_count(self.a_sh_stage, self.a_sh_wr_delta)
+        self.a_sh_rd_delta_i = self.a_sh_stride * 16
+
+        self.b_sh_stride = ((self.cta_n_blocks * 16) * 16 // _PACK_FACTOR) // 4
+        self.b_thread_vecs = 1
+        self.b_sh_stride_threads = self.b_sh_stride
+        self.b_sh_stage = self.b_sh_stride * self.cta_k_blocks
+        self.b_sh_wr_iters = self.b_sh_stage // self.cta_threads
+        # NF3 ("nf3_2p1") stages 12-byte triples per 32-code unit instead of the
+        # 16-byte int4 unit; the per-thread unit count is unchanged, only the
+        # bytes-per-unit and the 16-byte cp.async chunk count differ.
+        self.b_unit_bytes = 12 if self.weight_layout_nf3 else 16
+        self.b_sh_stage_bytes = self.b_sh_stage * self.b_unit_bytes
+        if self.weight_layout_nf3:
+            if self.b_sh_stage_bytes % 16 != 0:
+                raise ValueError(
+                    "nf3_2p1 B stage bytes must be a multiple of 16; "
+                    f"got {self.b_sh_stage_bytes}"
+                )
+            self.b_sh_chunks = self.b_sh_stage_bytes // 16
+            self.b_sh_wr_iters_nf3 = _covering_count(self.b_sh_chunks, self.cta_threads)
+        else:
+            self.b_sh_chunks = self.b_sh_stage
+            self.b_sh_wr_iters_nf3 = self.b_sh_wr_iters
+
+        self.s_sh_stride = 16 * self.cta_n_blocks // 16
+        self.s_tb_groups = (
+            self.cta_k_blocks // 2 if self.scale_k32 else self.cta_k_blocks
+        )
+        self.s_sh_stage = self.s_tb_groups * self.s_sh_stride
+        self.tb_n_warps = self.cta_n_blocks // 4
+
+        sh_block_route_indices = self.moe_block_size // 4
+        sh_rd_block_route_indices = self.moe_block_size // 4
+        sh_block_topk_weights = self.moe_block_size // 2
+        self.sh_valid_count_off = (
+            sh_block_route_indices + sh_rd_block_route_indices + sh_block_topk_weights
+        )
+        self.sh_route_off = 0
+        self.sh_rd_route_off = sh_block_route_indices
+        self.sh_topk_off = sh_block_route_indices + sh_rd_block_route_indices
+
+        sh_red_size = (2 * self.cta_n_blocks + 1) * 16 * self.cta_m_blocks
+        # B region size in int4 (16-byte) units. NF3 units are 12 bytes, so the
+        # region is 0.75x; round the total up to a 16-byte multiple so the
+        # following SMEM regions keep their 16-byte alignment (exact for all
+        # supported tiles since b_sh_stage is a multiple of 4).
+        sh_b_size = _covering_count(_STAGES * self.b_sh_stage_bytes, 16)
+        sh_size_min = min(sh_red_size, sh_b_size)
+        sh_size_max = max(sh_red_size, sh_b_size)
+        sh_bias_size = self.cta_n_blocks * 16 // 8
+        sh_b_red_bias_size = max(sh_size_max, sh_size_min + sh_bias_size)
+        self.sh_b_off = self.sh_valid_count_off
+        self.sh_red_off = self.sh_valid_count_off
+        self.sh_s_off = self.sh_valid_count_off + sh_b_red_bias_size
+        self.sh_a_off = self.sh_s_off + _STAGES * self.s_sh_stage
+        self.shared_int4 = self.sh_a_off + _STAGES * self.a_sh_stage
+        self.shared_words = self.shared_int4 * 4
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (
+            self.size_n,
+            self.size_k,
+            self.covered_size_n,
+            self.covered_size_k,
+            self.scale_k_groups,
+            self.has_logical_tail,
+            self.num_experts,
+            self.top_k,
+            self.mul_topk_weights,
+            self.tile_n,
+            self.tile_k,
+            self.cta_threads,
+            self.moe_block_size,
+            self.element_dtype,
+            self.epilogue_relu2,
+            self.weight_layout,
+            self.scale_format,
+            self.w13_layout,
+            self.source_n_rotation,
+            self.single_token_route_fast_path,
+            self.direct_topk_routes,
+            self.fused_topk_sum,
+            self.fused_sum_topk,
+            self.cta_m_blocks,
+            self.uses_m_block_8,
+            self.shared_words,
+            # Launch bounds are part of the compiled kernel.  Keep binaries
+            # planned for different residency targets out of the same cache
+            # entry even when their arithmetic geometry otherwise matches.
+            self.blocks_per_sm,
+            self.schedule_whole_tiles,
+        )
+
+    @cute.jit
+    def _activation_smem_permuted_offset(self, i: Int32) -> Int32:
+        row = i // Int32(self.a_gl_rd_delta_o)
+        return Int32(self.a_gl_rd_delta_o) * row + (
+            (i - row * Int32(self.a_gl_rd_delta_o)) ^ (row & Int32(7))
+        )
+
+    @cute.jit
+    def _int4_addr(self, smem_base: Int32, int4_off: Int32) -> Int32:
+        return smem_base + int4_off * Int32(16)
+
+    @cute.jit
+    def _dequant_e2m1x4_to_elem2x2(self, packed: Uint32):
+        if cutlass.const_expr(self.is_fp16):
+            return packed_dequant_e2m1x4_to_half2x2(packed)
+        return packed_dequant_e2m1x4_to_bfloat2x2(packed)
+
+    @cute.jit
+    def _dequant_e4m3x4_to_elem2x2(self, packed: Uint32):
+        if cutlass.const_expr(self.is_fp16):
+            return packed_dequant_e4m3x4_to_half2x2(packed)
+        return packed_dequant_e4m3x4_to_bfloat2x2(packed)
+
+    @cute.jit
+    def _dequant_scale_x4_to_elem2x2(self, packed: Uint32):
+        if cutlass.const_expr(self.scale_format_e8m0_k32):
+            if cutlass.const_expr(self.is_fp16):
+                return packed_dequant_e8m0x4_to_half2x2(packed)
+            return packed_dequant_e8m0x4_to_bfloat2x2(packed)
+        if cutlass.const_expr(self.is_fp16):
+            return packed_dequant_e4m3x4_to_half2x2(packed)
+        return packed_dequant_e4m3x4_to_bfloat2x2(packed)
+
+    @cute.jit
+    def _elem2_mul(self, a: Uint32, b: Uint32) -> Uint32:
+        if cutlass.const_expr(self.is_fp16):
+            return half2_mul(a, b)
+        return bfloat2_mul(a, b)
+
+    @cute.jit
+    def _broadcast_f32_to_elem2(self, x: cutlass.Float32) -> Uint32:
+        if cutlass.const_expr(self.is_fp16):
+            return broadcast_f32_to_half2(x)
+        return broadcast_f32_to_bfloat2(x)
+
+    @cute.jit
+    def _pack_f32x2_to_elem2(self, x0: cutlass.Float32, x1: cutlass.Float32) -> Uint32:
+        if cutlass.const_expr(self.is_fp16):
+            return pack_f32x2_to_f16x2(x0, x1)
+        return pack_f32x2_to_bfloat2(x0, x1)
+
+    @cute.jit
+    def _elem2_to_f32x2(self, packed: Uint32):
+        if cutlass.const_expr(self.is_fp16):
+            return half2_to_float2_scaled(packed, cutlass.Float32(1.0))
+        return bfloat2_to_float2_scaled(packed, cutlass.Float32(1.0))
+
+    @cute.jit
+    def _relu2_elem2(self, packed: Uint32) -> Uint32:
+        x0, x1 = self._elem2_to_f32x2(packed)
+        if x0 < cutlass.Float32(0.0):
+            x0 = cutlass.Float32(0.0)
+        if x1 < cutlass.Float32(0.0):
+            x1 = cutlass.Float32(0.0)
+        return self._pack_f32x2_to_elem2(x0 * x0, x1 * x1)
+
+    @cute.jit
+    def _st_shared_elem_from_f32(self, addr: Int32, val: cutlass.Float32):
+        if cutlass.const_expr(self.is_fp16):
+            st_shared_f16_from_f32(addr, val)
+        else:
+            st_shared_bf16_from_f32(addr, val)
+
+    @cute.jit
+    def _mma_m16n8k16_f32(
+        self,
+        d0: cutlass.Float32,
+        d1: cutlass.Float32,
+        d2: cutlass.Float32,
+        d3: cutlass.Float32,
+        a0: Uint32,
+        a1: Uint32,
+        a2: Uint32,
+        a3: Uint32,
+        b0: Uint32,
+        b1: Uint32,
+    ):
+        if cutlass.const_expr(self.is_fp16):
+            return f16_mma_m16n8k16_f32(d0, d1, d2, d3, a0, a1, a2, a3, b0, b1)
+        return bf16_mma_m16n8k16_f32(d0, d1, d2, d3, a0, a1, a2, a3, b0, b1)
+
+    @cute.jit
+    def _mma_rhs_fragments_as_mma_a_m16n8k16_f32(
+        self,
+        d0: cutlass.Float32,
+        d1: cutlass.Float32,
+        d2: cutlass.Float32,
+        d3: cutlass.Float32,
+        b0_0: Uint32,
+        b1_0: Uint32,
+        b0_1: Uint32,
+        b1_1: Uint32,
+        a0: Uint32,
+        a1: Uint32,
+    ):
+        if cutlass.const_expr(self.is_fp16):
+            return f16_mma_rhs_fragments_as_mma_a_m16n8k16_f32(
+                d0, d1, d2, d3, b0_0, b1_0, b0_1, b1_1, a0, a1
+            )
+        return bf16_mma_rhs_fragments_as_mma_a_m16n8k16_f32(
+            d0, d1, d2, d3, b0_0, b1_0, b0_1, b1_1, a0, a1
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+        grid_x: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        grid = (grid_x, 1, 1)
+        self.kernel(
+            a_bf16_flat,
+            b_i32_flat,
+            c_bf16_flat,
+            scales_i32_flat,
+            global_scale,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            topk_weights_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            active_m,
+        ).launch(
+            grid=grid,
+            block=[self.cta_threads, 1, 1],
+            min_blocks_per_mp=self.blocks_per_sm,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        tid = Int32(tidx)
+        cta = Int32(bidx)
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            words: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, self.shared_words],
+                1024,
+            ]
+
+        storage = smem.allocate(Storage)
+        smem_base = shared_ptr_to_u32(storage.words.data_ptr())
+
+        grid_x, _, _ = cute.arch.grid_dim()
+        self._run_persistent_gemm(
+            a_bf16_flat,
+            b_i32_flat,
+            c_bf16_flat,
+            scales_i32_flat,
+            global_scale,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            topk_weights_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            cta,
+            Int32(grid_x),
+            Int32(active_m),
+        )
+
+    @cute.jit
+    def _run_persistent_gemm(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        cta: Int32,
+        grid_x: Int32,
+        active_size_m: Int32,
+        emit_tile: cutlass.Constexpr = None,
+    ):
+        n_tiles = Int32(self.n_tiles)
+        route_blocks = active_size_m * Int32(self.top_k)
+        if cutlass.const_expr(not self.direct_topk_routes):
+            route_blocks = packed_route_count[Int32(0)].to(Int32) // Int32(
+                self.moe_block_size
+            )
+        k_tiles = Int32(self.k_tiles)
+        global_mn_tiles = route_blocks * n_tiles
+
+        tail_mn_tiles = global_mn_tiles
+        full_grid_mn_iters = Int32(0)
+        force_one_tile_per_cta = Int32(0)
+        if cutlass.const_expr(self.schedule_whole_tiles):
+            # Whole-tile waves: one CTA computes each mn-tile over the full K,
+            # task = cta + wave * grid_x, ragged last wave skipped through the
+            # route_block_idx bound below. No split-K tail, no lock traffic.
+            tail_mn_tiles = Int32(0)
+            full_grid_mn_iters = (global_mn_tiles + grid_x - Int32(1)) // grid_x
+        if cutlass.const_expr(not self.schedule_whole_tiles):
+            if cutlass.const_expr(self.uses_m_block_8):
+                # TC-decode small-M: when every mn-tile fits inside the launched grid
+                # (FC1 has only route_blocks*n_tiles tiles, far fewer than grid_x),
+                # the default tail path fans each mn-tile across multiple CTAs along
+                # K and pays a lock-serialized cross-CTA split-K finalize plus the
+                # reduction-turn handshake. Instead give the first global_mn_tiles
+                # CTAs exactly one full mn-tile (all k_tiles, reduce_slice_count==1,
+                # no finalize, no lock traffic) and idle the rest. grid_x and the
+                # grid-barrier participant count are unchanged (so FC2 coverage is
+                # untouched); only FC1's intra-GEMM work partition changes. Numerically
+                # identical: a single CTA computes the whole K-reduction per tile.
+                if global_mn_tiles <= grid_x:
+                    force_one_tile_per_cta = Int32(1)
+            if force_one_tile_per_cta != Int32(0):
+                tail_mn_tiles = Int32(0)
+                full_grid_mn_iters = Int32(1)
+            elif global_mn_tiles > grid_x:
+                tail_mn_tiles = global_mn_tiles - (global_mn_tiles // grid_x) * grid_x
+                if tail_mn_tiles * Int32(3) <= grid_x:
+                    tail_mn_tiles += grid_x
+                full_grid_mn_iters = (global_mn_tiles - tail_mn_tiles) // grid_x
+
+        iters = (k_tiles * tail_mn_tiles + grid_x - Int32(1)) // grid_x
+
+        lock_slot = Int32(0)
+        if tail_mn_tiles >= grid_x:
+            lock_slot = cta
+        else:
+            lock_slot = (iters * cta) // k_tiles - Int32(1)
+
+        in_tail_region = Int32(0)
+        has_work = Int32(1)
+        work_mn_tile = cta
+        reduce_k_tile = Int32(0)
+        route_block_idx = Int32(0)
+        output_n_tile = Int32(0)
+        if iters == Int32(0) and full_grid_mn_iters == Int32(0):
+            has_work = Int32(0)
+
+        while has_work != Int32(0):
+            reduce_tile_count = Int32(0)
+            reduce_slice_count = Int32(1)
+            reduce_slice_idx = Int32(0)
+
+            if in_tail_region == Int32(0) and full_grid_mn_iters > Int32(0):
+                route_block_idx = work_mn_tile // n_tiles
+                output_n_tile = work_mn_tile - route_block_idx * n_tiles
+                reduce_k_tile = Int32(0)
+                reduce_tile_count = k_tiles
+                full_grid_mn_iters -= Int32(1)
+            else:
+                if in_tail_region == Int32(0):
+                    in_tail_region = Int32(1)
+                    tail_mn_base = global_mn_tiles - tail_mn_tiles
+                    cta_iter_start = iters * cta
+                    work_mn_tile = cta_iter_start // k_tiles
+                    reduce_k_tile = cta_iter_start - work_mn_tile * k_tiles
+                    global_mn_tile = work_mn_tile + tail_mn_base
+                    route_block_idx = global_mn_tile // n_tiles
+                    output_n_tile = global_mn_tile - route_block_idx * n_tiles
+
+                if work_mn_tile < tail_mn_tiles and iters > Int32(0):
+                    reduce_tile_count = iters * (cta + Int32(1)) - (
+                        k_tiles * work_mn_tile + reduce_k_tile
+                    )
+                    if reduce_tile_count < Int32(0):
+                        reduce_tile_count = Int32(0)
+                    if reduce_k_tile + reduce_tile_count > k_tiles:
+                        reduce_tile_count = k_tiles - reduce_k_tile
+
+                    if reduce_tile_count > Int32(0):
+                        first_reduce_boundary = iters * (
+                            (k_tiles * work_mn_tile + iters - Int32(1)) // iters
+                        )
+                        if first_reduce_boundary <= k_tiles * (work_mn_tile + Int32(1)):
+                            reduce_boundary_offset = (
+                                first_reduce_boundary - k_tiles * work_mn_tile
+                            )
+                            reduce_slice_count = (
+                                k_tiles - reduce_boundary_offset + iters - Int32(1)
+                            ) // iters
+                            if reduce_boundary_offset > Int32(0):
+                                reduce_slice_count += Int32(1)
+                            reduce_boundary_delta = iters * cta - first_reduce_boundary
+                            if reduce_boundary_delta < Int32(0):
+                                reduce_slice_idx = reduce_slice_count - Int32(1)
+                            else:
+                                if reduce_boundary_offset == Int32(
+                                    0
+                                ) and reduce_boundary_delta == Int32(0):
+                                    reduce_slice_idx = reduce_slice_count - Int32(1)
+                                else:
+                                    reduce_slice_idx = (
+                                        reduce_slice_count
+                                        - Int32(1)
+                                        - reduce_boundary_delta // iters
+                                    )
+                                    if reduce_boundary_offset > Int32(0):
+                                        reduce_slice_idx -= Int32(1)
+
+                        if tail_mn_tiles >= grid_x:
+                            if reduce_slice_count > Int32(
+                                1
+                            ) and reduce_slice_idx == reduce_slice_count - Int32(1):
+                                lock_slot += Int32(1)
+                        else:
+                            lock_slot += Int32(1)
+                    else:
+                        has_work = Int32(0)
+                else:
+                    has_work = Int32(0)
+
+            if (
+                has_work != Int32(0)
+                and reduce_tile_count > Int32(0)
+                and route_block_idx < route_blocks
+            ):
+                if cutlass.const_expr(emit_tile is not None):
+                    # Trace-time tile emission hook: the caller owns expert
+                    # resolution and the _run_tile dispatch (e.g. the hybrid
+                    # multi-tier route map). The scheduling state machine above
+                    # is unchanged; only tile emission is delegated.
+                    emit_tile(
+                        route_block_idx,
+                        output_n_tile,
+                        reduce_k_tile,
+                        reduce_tile_count,
+                        reduce_slice_count,
+                        reduce_slice_idx,
+                        lock_slot,
+                    )
+                else:
+                    if cutlass.const_expr(self.direct_topk_routes):
+                        expert_idx = packed_route_indices[route_block_idx].to(Int32)
+                    else:
+                        expert_idx = block_expert_ids[route_block_idx].to(Int32)
+                    if expert_idx >= Int32(0):
+                        self._run_tile(
+                            a_bf16_flat,
+                            b_i32_flat,
+                            c_bf16_flat,
+                            scales_i32_flat,
+                            global_scale,
+                            packed_route_indices,
+                            topk_weights_flat,
+                            c_tmp_f32_flat,
+                            locks_i32_flat,
+                            smem_base,
+                            tid,
+                            route_block_idx,
+                            expert_idx,
+                            output_n_tile,
+                            reduce_k_tile,
+                            reduce_tile_count,
+                            reduce_slice_count,
+                            reduce_slice_idx,
+                            lock_slot,
+                            active_size_m,
+                        )
+
+            if has_work != Int32(0):
+                if in_tail_region == Int32(0):
+                    work_mn_tile += grid_x
+                else:
+                    reduce_k_tile = Int32(0)
+                    work_mn_tile += Int32(1)
+                    output_n_tile += Int32(1)
+                    if output_n_tile == n_tiles:
+                        output_n_tile = Int32(0)
+                        route_block_idx += Int32(1)
+
+    @cute.jit
+    def _read_moe_block_data(
+        self,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        global_scale_f32: cutlass.Float32,
+        active_size_m: Int32,
+    ) -> Int32:
+        if cutlass.const_expr(self.direct_topk_routes):
+            if tid == Int32(0):
+                idx = route_block_idx
+                st_shared_i32(smem_base + Int32(self.sh_route_off * 16), idx)
+                rd_row = idx // Int32(self.top_k)
+                st_shared_i32(smem_base + Int32(self.sh_rd_route_off * 16), rd_row)
+                if cutlass.const_expr(self.mul_topk_weights):
+                    topk = topk_weights_flat[idx].to(cutlass.Float32) * global_scale_f32
+                    st_shared_u32(
+                        smem_base + Int32(self.sh_topk_off * 16),
+                        self._broadcast_f32_to_elem2(topk),
+                    )
+            cute.arch.sync_threads()
+            return Int32(1)
+
+        if cutlass.const_expr(self.single_token_route_fast_path):
+            if tid == Int32(0):
+                idx = packed_route_indices[
+                    route_block_idx * Int32(self.moe_block_size)
+                ].to(Int32)
+                st_shared_i32(smem_base + Int32(self.sh_route_off * 16), idx)
+                rd_row = idx // Int32(self.top_k)
+                st_shared_i32(smem_base + Int32(self.sh_rd_route_off * 16), rd_row)
+                if cutlass.const_expr(self.mul_topk_weights):
+                    safe_idx = idx
+                    if idx >= active_size_m * Int32(self.top_k):
+                        safe_idx = Int32(0)
+                    topk = (
+                        topk_weights_flat[safe_idx].to(cutlass.Float32)
+                        * global_scale_f32
+                    )
+                    st_shared_u32(
+                        smem_base + Int32(self.sh_topk_off * 16),
+                        self._broadcast_f32_to_elem2(topk),
+                    )
+            cute.arch.sync_threads()
+            return Int32(1)
+
+        route_indices_int4_addr = self._int4_addr(
+            smem_base, Int32(self.sh_route_off) + tid
+        )
+        route_indices_gmem = get_ptr_as_int64(
+            packed_route_indices,
+            route_block_idx * Int32(self.moe_block_size) + tid * Int32(4),
+        )
+        cp_async4_shared_global_pred(
+            route_indices_int4_addr,
+            route_indices_gmem,
+            (tid < Int32(self.moe_block_size // 4)).to(Int32),
+        )
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        if tid >= Int32(self.cta_threads - 32):
+            size_per_thread = _covering_count(self.moe_block_size, 32)
+            lane = tid - Int32(self.cta_threads - 32)
+            local_count = Int32(0)
+            for i in cutlass.range_constexpr(size_per_thread):
+                j = lane * Int32(size_per_thread) + Int32(i)
+                if j < Int32(self.moe_block_size):
+                    idx = ld_shared_i32_relaxed(
+                        smem_base + Int32(self.sh_route_off * 16) + j * Int32(4)
+                    )
+                    if idx < active_size_m * Int32(self.top_k):
+                        local_count += Int32(1)
+            valid = cute.arch.warp_redux_sync(local_count, "add")
+            if lane == Int32(0):
+                st_shared_i32(smem_base + Int32(self.sh_valid_count_off * 16), valid)
+
+        if tid < Int32(self.moe_block_size):
+            idx = ld_shared_i32_relaxed(
+                smem_base + Int32(self.sh_route_off * 16) + tid * Int32(4)
+            )
+            rd_row = idx // Int32(self.top_k)
+            st_shared_i32(
+                smem_base + Int32(self.sh_rd_route_off * 16) + tid * Int32(4),
+                rd_row,
+            )
+            if cutlass.const_expr(self.mul_topk_weights):
+                safe_idx = idx
+                if idx >= active_size_m * Int32(self.top_k):
+                    safe_idx = Int32(0)
+                topk = (
+                    topk_weights_flat[safe_idx].to(cutlass.Float32) * global_scale_f32
+                )
+                packed_topk = self._broadcast_f32_to_elem2(topk)
+                # top-k weights are cached as packed element pairs.
+                topk_word_addr = (
+                    smem_base + Int32(self.sh_topk_off * 16) + tid * Int32(4)
+                )
+                st_shared_u32(topk_word_addr, packed_topk)
+
+        cute.arch.sync_threads()
+        valid_count = ld_shared_i32_relaxed(
+            smem_base + Int32(self.sh_valid_count_off * 16)
+        )
+        cute.arch.sync_threads()
+        return valid_count
+
+    @cute.jit
+    def _run_tile(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        active_size_m: Int32,
+    ):
+        if cutlass.const_expr(self.uses_m_block_8):
+            self._run_tile_m8(
+                a_bf16_flat,
+                b_i32_flat,
+                c_bf16_flat,
+                scales_i32_flat,
+                global_scale,
+                packed_route_indices,
+                topk_weights_flat,
+                c_tmp_f32_flat,
+                locks_i32_flat,
+                smem_base,
+                tid,
+                route_block_idx,
+                expert_idx,
+                output_n_tile,
+                reduce_k_tile,
+                reduce_tile_count,
+                reduce_slice_count,
+                reduce_slice_idx,
+                lock_slot,
+                active_size_m,
+            )
+        else:
+            self._run_tile_large_m(
+                a_bf16_flat,
+                b_i32_flat,
+                c_bf16_flat,
+                scales_i32_flat,
+                global_scale,
+                packed_route_indices,
+                topk_weights_flat,
+                c_tmp_f32_flat,
+                locks_i32_flat,
+                smem_base,
+                tid,
+                route_block_idx,
+                expert_idx,
+                output_n_tile,
+                reduce_k_tile,
+                reduce_tile_count,
+                reduce_slice_count,
+                reduce_slice_idx,
+                lock_slot,
+                active_size_m,
+            )
+
+    @cute.jit
+    def _tile_common_prologue(
+        self,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        active_size_m: Int32,
+    ):
+        global_scale_f32 = global_scale[expert_idx].to(cutlass.Float32)
+        if cutlass.const_expr(self.scale_format_e8m0_k32):
+            if cutlass.const_expr(self.is_fp16):
+                global_scale_f32 *= cutlass.Float32(_E8M0_K32_FP16_GLOBAL_COMPENSATION)
+            else:
+                global_scale_f32 *= cutlass.Float32(_E8M0_K32_BF16_GLOBAL_COMPENSATION)
+        block_valid_rows = self._read_moe_block_data(
+            packed_route_indices,
+            topk_weights_flat,
+            smem_base,
+            tid,
+            route_block_idx,
+            global_scale_f32,
+            active_size_m,
+        )
+        (
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            b_sh_rd,
+            s_sh_rd,
+        ) = self._tile_stream_offsets(tid, expert_idx, output_n_tile)
+        return (
+            global_scale_f32,
+            block_valid_rows,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            b_sh_rd,
+            s_sh_rd,
+        )
+
+    @cute.jit
+    def _tile_stream_offsets(self, tid: Int32, expert_idx: Int32, output_n_tile: Int32):
+        a_gl_stride = Int32(self.size_k // 8)
+        b_gl_stride = Int32(16 * self.size_n // (_PACK_FACTOR * 4))
+        s_gl_stride = Int32(self.scale_n_groups)
+        if cutlass.const_expr(self.scale_k32):
+            if cutlass.const_expr(self.scale_format_e8m0_k32 and self.has_logical_tail):
+                scales_expert_stride = Int32(self.scale_k_groups * self.scale_n_groups)
+            else:
+                scales_expert_stride = Int32((self.size_n * self.size_k) // (32 * 16))
+        else:
+            scales_expert_stride = Int32((self.size_n * self.size_k) // (16 * 16))
+        b_expert_off = (
+            Int32((self.size_n * self.size_k) // (_PACK_FACTOR * 4)) * expert_idx
+        )
+        scales_expert_off = scales_expert_stride * expert_idx
+
+        a_gl_rd_row = tid // Int32(self.a_gl_rd_delta_o)
+        a_gl_rd_col0 = tid - a_gl_rd_row * Int32(self.a_gl_rd_delta_o)
+        a_sh_wr = Int32(self.a_sh_stride) * (tid // Int32(self.a_gl_rd_delta_o)) + (
+            tid - (tid // Int32(self.a_gl_rd_delta_o)) * Int32(self.a_gl_rd_delta_o)
+        )
+        a_rows_per_iter = Int32(self.cta_threads // self.a_gl_rd_delta_o)
+
+        if cutlass.const_expr(self.cta_threads <= self.b_sh_stride):
+            b_gl_rd_base = tid
+        else:
+            b_gl_rd_base = b_gl_stride * (tid // Int32(self.b_sh_stride)) + (
+                tid % Int32(self.b_sh_stride)
+            )
+        b_gl_rd_base += b_expert_off + Int32(self.b_sh_stride) * output_n_tile
+        b_sh_rd = tid
+        b_sh_rd += (b_sh_rd // Int32(self.b_sh_stride)) * Int32(
+            self.b_sh_stride * (self.b_sh_wr_iters - 1)
+        )
+
+        s_sh_rd = Int32(8) * ((tid // Int32(32)) % Int32(self.tb_n_warps)) + (
+            tid & Int32(31)
+        ) // Int32(4)
+        return (
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            b_sh_rd,
+            s_sh_rd,
+        )
+
+    @cute.jit
+    def _a_shared_read_offset(self, tid: Int32, lanes_per_row: cutlass.Constexpr[int]):
+        a_sh_rd = Int32(self.a_sh_stride) * (
+            (tid & Int32(31)) % Int32(lanes_per_row)
+        ) + (tid & Int32(31)) // Int32(lanes_per_row)
+        a_sh_rd += (
+            Int32(2)
+            * ((tid // Int32(32)) // Int32(self.tb_n_warps))
+            * Int32(self.b_sh_wr_iters)
+        )
+        return a_sh_rd
+
+    @cute.jit
+    def _run_tile_m8(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        active_size_m: Int32,
+    ):
+        (
+            global_scale_f32,
+            block_valid_rows,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            b_sh_rd,
+            s_sh_rd,
+        ) = self._tile_common_prologue(
+            global_scale,
+            packed_route_indices,
+            topk_weights_flat,
+            smem_base,
+            tid,
+            route_block_idx,
+            expert_idx,
+            output_n_tile,
+            active_size_m,
+        )
+        a_sh_rd = self._a_shared_read_offset(tid, 8)
+
+        # LLVM 23 also promotes this 16-f32 accumulator across the pipelined
+        # control-flow joins, repeatedly packing adjacent values through i64
+        # temporaries.  Keep the values in independent scalar fragments, as in
+        # the large-M path below, so those PHIs remain scalar.
+        acc = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(16 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        for frag in cutlass.range_constexpr(16 // _SCALAR_ACC_FRAGMENT_WIDTH):
+            acc[frag].fill(0.0)
+
+        k_tiles = reduce_tile_count
+        self._prefetch_initial_tiles(
+            a_bf16_flat,
+            b_i32_flat,
+            scales_i32_flat,
+            smem_base,
+            tid,
+            k_tiles,
+            reduce_k_tile,
+            block_valid_rows,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            output_n_tile,
+            expert_idx,
+        )
+
+        b_scale_cur = cute.make_rmem_tensor((2, 4), Uint32)
+        b_scale_next = cute.make_rmem_tensor((2, 4), Uint32)
+        self._load_b_scale_register_bundle(
+            b_scale_cur,
+            smem_base,
+            tid,
+            b_sh_rd,
+            s_sh_rd,
+            Int32(0),
+            Int32(0),
+        )
+        a_regs_cur = cute.make_rmem_tensor((2,), Uint32)
+        a_regs_next = cute.make_rmem_tensor((2,), Uint32)
+        self._load_a_register_bundle(
+            a_regs_cur,
+            smem_base,
+            a_sh_rd,
+            Int32(0),
+            Int32(0),
+            True,
+        )
+        self._run_mma_pipeline(
+            a_bf16_flat,
+            b_i32_flat,
+            scales_i32_flat,
+            smem_base,
+            tid,
+            acc,
+            acc,
+            acc,
+            acc,
+            b_scale_cur,
+            b_scale_next,
+            a_regs_cur,
+            a_regs_next,
+            b_sh_rd,
+            s_sh_rd,
+            a_sh_rd,
+            k_tiles,
+            reduce_k_tile,
+            block_valid_rows,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            output_n_tile,
+            expert_idx,
+            True,
+        )
+
+        self._finish_tile(
+            acc,
+            acc,
+            acc,
+            acc,
+            c_bf16_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            output_n_tile,
+            block_valid_rows,
+            global_scale_f32,
+            reduce_slice_count,
+            reduce_slice_idx,
+            lock_slot,
+            True,
+        )
+
+    @cute.jit
+    def _run_tile_large_m(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        active_size_m: Int32,
+    ):
+        (
+            global_scale_f32,
+            block_valid_rows,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            b_sh_rd,
+            s_sh_rd,
+        ) = self._tile_common_prologue(
+            global_scale,
+            packed_route_indices,
+            topk_weights_flat,
+            smem_base,
+            tid,
+            route_block_idx,
+            expert_idx,
+            output_n_tile,
+            active_size_m,
+        )
+        a_sh_rd = self._a_shared_read_offset(tid, 16)
+
+        # Keep each accumulator element in its own scalar rmem tensor. LLVM 23
+        # otherwise promotes the 128-f32 accumulator to wide vector PHIs and
+        # repeatedly packs/unpacks adjacent f32 values through i64 temporaries.
+        acc0 = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        for frag in cutlass.range_constexpr(32 // _SCALAR_ACC_FRAGMENT_WIDTH):
+            acc0[frag].fill(0.0)
+        acc1 = acc0
+        acc2 = acc0
+        acc3 = acc0
+        if cutlass.const_expr(self.cta_m_blocks > 1):
+            acc1 = [
+                cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+                for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+            ]
+            for frag in cutlass.range_constexpr(32 // _SCALAR_ACC_FRAGMENT_WIDTH):
+                acc1[frag].fill(0.0)
+        if cutlass.const_expr(self.cta_m_blocks > 2):
+            acc2 = [
+                cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+                for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+            ]
+            for frag in cutlass.range_constexpr(32 // _SCALAR_ACC_FRAGMENT_WIDTH):
+                acc2[frag].fill(0.0)
+        if cutlass.const_expr(self.cta_m_blocks > 3):
+            acc3 = [
+                cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+                for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+            ]
+            for frag in cutlass.range_constexpr(32 // _SCALAR_ACC_FRAGMENT_WIDTH):
+                acc3[frag].fill(0.0)
+
+        k_tiles = reduce_tile_count
+        self._prefetch_initial_tiles(
+            a_bf16_flat,
+            b_i32_flat,
+            scales_i32_flat,
+            smem_base,
+            tid,
+            k_tiles,
+            reduce_k_tile,
+            block_valid_rows,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            output_n_tile,
+            expert_idx,
+        )
+
+        b_scale_cur = cute.make_rmem_tensor((2, 4), Uint32)
+        b_scale_next = cute.make_rmem_tensor((2, 4), Uint32)
+        self._load_b_scale_register_bundle(
+            b_scale_cur,
+            smem_base,
+            tid,
+            b_sh_rd,
+            s_sh_rd,
+            Int32(0),
+            Int32(0),
+        )
+        a_regs = cute.make_rmem_tensor((self.cta_m_blocks, 4), Uint32)
+        a_regs_next = cute.make_rmem_tensor((self.cta_m_blocks, 4), Uint32)
+        self._load_a_register_bundle(
+            a_regs,
+            smem_base,
+            a_sh_rd,
+            Int32(0),
+            Int32(0),
+            False,
+        )
+        self._run_mma_pipeline(
+            a_bf16_flat,
+            b_i32_flat,
+            scales_i32_flat,
+            smem_base,
+            tid,
+            acc0,
+            acc1,
+            acc2,
+            acc3,
+            b_scale_cur,
+            b_scale_next,
+            a_regs,
+            a_regs_next,
+            b_sh_rd,
+            s_sh_rd,
+            a_sh_rd,
+            k_tiles,
+            reduce_k_tile,
+            block_valid_rows,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            output_n_tile,
+            expert_idx,
+            False,
+        )
+
+        self._finish_tile(
+            acc0,
+            acc1,
+            acc2,
+            acc3,
+            c_bf16_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            output_n_tile,
+            block_valid_rows,
+            global_scale_f32,
+            reduce_slice_count,
+            reduce_slice_idx,
+            lock_slot,
+            False,
+        )
+
+    @cute.jit
+    def _run_mma_pipeline(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+        b_scale_cur: cute.Tensor,
+        b_scale_next: cute.Tensor,
+        a_regs_cur: cute.Tensor,
+        a_regs_next: cute.Tensor,
+        b_sh_rd: Int32,
+        s_sh_rd: Int32,
+        a_sh_rd: Int32,
+        k_tiles: Int32,
+        reduce_k_tile: Int32,
+        block_valid_rows: Int32,
+        a_gl_stride: Int32,
+        b_gl_stride: Int32,
+        s_gl_stride: Int32,
+        scales_expert_off: Int32,
+        b_gl_rd_base: Int32,
+        a_gl_rd_row: Int32,
+        a_gl_rd_col0: Int32,
+        a_sh_wr: Int32,
+        a_rows_per_iter: Int32,
+        output_n_tile: Int32,
+        expert_idx: Int32,
+        uses_m_block_8: cutlass.Constexpr[bool],
+    ):
+        b_frag = cute.make_rmem_tensor((2, 2), Uint32)
+        tile_idx = Int32(0)
+        while tile_idx < k_tiles:
+            for pipe in cutlass.range_constexpr(_STAGES):
+                if tile_idx < k_tiles:
+                    for kk in cutlass.range_constexpr(self.b_sh_wr_iters):
+                        self._load_next_fragment_bundle(
+                            b_scale_next,
+                            a_regs_next,
+                            smem_base,
+                            tid,
+                            b_sh_rd,
+                            s_sh_rd,
+                            a_sh_rd,
+                            pipe,
+                            kk,
+                            tile_idx,
+                            k_tiles,
+                            uses_m_block_8,
+                        )
+
+                        self._prefetch_pipeline_step(
+                            a_bf16_flat,
+                            b_i32_flat,
+                            scales_i32_flat,
+                            smem_base,
+                            tid,
+                            pipe,
+                            kk,
+                            tile_idx,
+                            k_tiles,
+                            reduce_k_tile,
+                            block_valid_rows,
+                            a_gl_stride,
+                            b_gl_stride,
+                            s_gl_stride,
+                            scales_expert_off,
+                            b_gl_rd_base,
+                            a_gl_rd_row,
+                            a_gl_rd_col0,
+                            a_sh_wr,
+                            a_rows_per_iter,
+                            output_n_tile,
+                            expert_idx,
+                        )
+
+                        for jj in cutlass.range_constexpr(4):
+                            if cutlass.const_expr(self.weight_layout_nf3):
+                                # NF3 triple: lo16 = half (jj % 2) of word
+                                # (jj // 2); hi8 = byte jj of the hi word; scale
+                                # register is the same per-jj lane as packed.
+                                lo_w = b_scale_cur[0, jj // 2]
+                                lo16 = (lo_w >> Uint32(16 * (jj % 2))) & Uint32(0xFFFF)
+                                hi8 = (b_scale_cur[0, 2] >> Uint32(8 * jj)) & Uint32(
+                                    0xFF
+                                )
+                                s = b_scale_cur[1, jj]
+                                self._scaled_dequant_b_fragment_nf3(
+                                    b_frag, lo16, hi8, s
+                                )
+                            else:
+                                q, s = self._select_b_scale_register(jj, b_scale_cur)
+                                self._scaled_dequant_b_fragment(b_frag, q, s)
+                            if cutlass.const_expr(uses_m_block_8):
+                                self._mma_accumulate_m8(
+                                    acc0,
+                                    jj,
+                                    a_regs_cur,
+                                    b_frag,
+                                )
+                            else:
+                                for mb in cutlass.range_constexpr(self.cta_m_blocks):
+                                    if cutlass.const_expr(mb == 0):
+                                        self._mma_accumulate_large_m(
+                                            acc0, a_regs_cur, mb, jj, b_frag
+                                        )
+                                    elif cutlass.const_expr(mb == 1):
+                                        self._mma_accumulate_large_m(
+                                            acc1, a_regs_cur, mb, jj, b_frag
+                                        )
+                                    elif cutlass.const_expr(mb == 2):
+                                        self._mma_accumulate_large_m(
+                                            acc2, a_regs_cur, mb, jj, b_frag
+                                        )
+                                    else:
+                                        self._mma_accumulate_large_m(
+                                            acc3, a_regs_cur, mb, jj, b_frag
+                                        )
+
+                        if cutlass.const_expr(uses_m_block_8):
+                            self._copy_a_register_bundle(
+                                a_regs_cur,
+                                a_regs_next,
+                                uses_m_block_8,
+                            )
+                            self._copy_b_scale_register_bundle(
+                                b_scale_cur, b_scale_next
+                            )
+                        else:
+                            self._copy_b_scale_register_bundle(
+                                b_scale_cur, b_scale_next
+                            )
+                            self._copy_a_register_bundle(
+                                a_regs_cur,
+                                a_regs_next,
+                                uses_m_block_8,
+                            )
+                    tile_idx += Int32(1)
+            cute.arch.sync_threads()
+            if tile_idx < k_tiles:
+                self._load_b_scale_register_bundle(
+                    b_scale_cur,
+                    smem_base,
+                    tid,
+                    b_sh_rd,
+                    s_sh_rd,
+                    Int32(0),
+                    Int32(0),
+                )
+                self._load_a_register_bundle(
+                    a_regs_cur,
+                    smem_base,
+                    a_sh_rd,
+                    Int32(0),
+                    Int32(0),
+                    uses_m_block_8,
+                )
+
+    @cute.jit
+    def _finish_tile(
+        self,
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+        c_bf16_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        output_n_tile: Int32,
+        block_valid_rows: Int32,
+        global_scale_f32: cutlass.Float32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        uses_m_block_8: cutlass.Constexpr[bool],
+    ):
+        if cutlass.const_expr(uses_m_block_8):
+            self._fold_cta_partials_m8(acc0, smem_base, tid)
+        else:
+            self._fold_cta_partials_large_m(acc0, acc1, acc2, acc3, smem_base, tid)
+
+        if reduce_slice_count > Int32(1):
+            self._wait_for_reduction_turn(
+                locks_i32_flat, lock_slot, reduce_slice_idx, tid
+            )
+            self._combine_splitk_accumulators(
+                acc0,
+                acc1,
+                acc2,
+                acc3,
+                c_tmp_f32_flat,
+                block_valid_rows,
+                lock_slot,
+                reduce_slice_idx,
+                reduce_slice_count,
+                tid,
+                uses_m_block_8,
+            )
+            self._publish_reduction_turn(
+                locks_i32_flat,
+                lock_slot,
+                reduce_slice_idx == reduce_slice_count - Int32(1),
+                tid,
+            )
+
+        if reduce_slice_idx == reduce_slice_count - Int32(1):
+            if cutlass.const_expr(uses_m_block_8):
+                self._store_tile_m8(
+                    acc0,
+                    c_bf16_flat,
+                    smem_base,
+                    tid,
+                    output_n_tile,
+                    block_valid_rows,
+                    global_scale_f32,
+                )
+            else:
+                self._store_tile_large_m(
+                    acc0,
+                    acc1,
+                    acc2,
+                    acc3,
+                    c_bf16_flat,
+                    smem_base,
+                    tid,
+                    output_n_tile,
+                    block_valid_rows,
+                    global_scale_f32,
+                )
+
+    @cute.jit
+    def _wait_for_reduction_turn(
+        self,
+        locks_i32_flat: cute.Tensor,
+        lock_slot: Int32,
+        count: Int32,
+        tid: Int32,
+    ):
+        lock_addr = get_ptr_as_int64(locks_i32_flat, lock_slot)
+        if tid == Int32(0):
+            state = Int32(-1)
+            while state != count:
+                state = ld_global_acquire_i32(lock_addr)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _publish_reduction_turn(
+        self,
+        locks_i32_flat: cute.Tensor,
+        lock_slot: Int32,
+        reset,
+        tid: Int32,
+    ):
+        lock_addr = get_ptr_as_int64(locks_i32_flat, lock_slot)
+        cute.arch.sync_threads()
+        if tid == Int32(0):
+            if reset:
+                st_global_i32(lock_addr, Int32(0))
+            else:
+                red_add_global_release_i32(lock_addr, Int32(1))
+
+    @cute.jit
+    def _merge_splitk_vec4(
+        self,
+        c_tmp_f32_flat: cute.Tensor,
+        f32_off: Int32,
+        reduce_slice_idx: Int32,
+        reduce_slice_count: Int32,
+        c0: cutlass.Float32,
+        c1: cutlass.Float32,
+        c2: cutlass.Float32,
+        c3: cutlass.Float32,
+    ):
+        if reduce_slice_idx != Int32(0):
+            r0, r1, r2, r3 = ld_global_v4_f32(get_ptr_as_int64(c_tmp_f32_flat, f32_off))
+            c0 = c0 + r0
+            c1 = c1 + r1
+            c2 = c2 + r2
+            c3 = c3 + r3
+        if reduce_slice_idx != reduce_slice_count - Int32(1):
+            st_global_v4_f32(
+                get_ptr_as_int64(c_tmp_f32_flat, f32_off),
+                c0,
+                c1,
+                c2,
+                c3,
+            )
+        return c0, c1, c2, c3
+
+    @cute.jit
+    def _combine_splitk_accumulators(
+        self,
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+        c_tmp_f32_flat: cute.Tensor,
+        block_valid_rows: Int32,
+        lock_slot: Int32,
+        reduce_slice_idx: Int32,
+        reduce_slice_count: Int32,
+        tid: Int32,
+        uses_m_block_8: cutlass.Constexpr[bool],
+    ):
+        active_threads = Int32(32 * self.tb_n_warps)
+        c_size_int4 = Int32((self.cta_m_blocks * 16 * self.cta_n_blocks * 16) // 4)
+        c_cur_offset = lock_slot * c_size_int4
+        if cutlass.const_expr(uses_m_block_8):
+            if tid < active_threads:
+                for jj in cutlass.range_constexpr(4):
+                    k = jj * 2
+                    (
+                        acc0[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc0[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc0[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc0[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                    ) = self._merge_splitk_slot(
+                        c_tmp_f32_flat,
+                        c_cur_offset,
+                        active_threads,
+                        Int32(k),
+                        tid,
+                        reduce_slice_idx,
+                        reduce_slice_count,
+                        acc0[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc0[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc0[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc0[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                    )
+        else:
+            lane_row = (tid & Int32(31)) // Int32(4)
+            if tid < active_threads:
+                for mb in cutlass.range_constexpr(self.cta_m_blocks):
+                    if cutlass.const_expr(mb == 0):
+                        self._combine_splitk_accumulator_block(
+                            acc0,
+                            mb,
+                            c_tmp_f32_flat,
+                            c_cur_offset,
+                            active_threads,
+                            block_valid_rows,
+                            lane_row,
+                            tid,
+                            reduce_slice_idx,
+                            reduce_slice_count,
+                        )
+                    elif cutlass.const_expr(mb == 1):
+                        self._combine_splitk_accumulator_block(
+                            acc1,
+                            mb,
+                            c_tmp_f32_flat,
+                            c_cur_offset,
+                            active_threads,
+                            block_valid_rows,
+                            lane_row,
+                            tid,
+                            reduce_slice_idx,
+                            reduce_slice_count,
+                        )
+                    elif cutlass.const_expr(mb == 2):
+                        self._combine_splitk_accumulator_block(
+                            acc2,
+                            mb,
+                            c_tmp_f32_flat,
+                            c_cur_offset,
+                            active_threads,
+                            block_valid_rows,
+                            lane_row,
+                            tid,
+                            reduce_slice_idx,
+                            reduce_slice_count,
+                        )
+                    else:
+                        self._combine_splitk_accumulator_block(
+                            acc3,
+                            mb,
+                            c_tmp_f32_flat,
+                            c_cur_offset,
+                            active_threads,
+                            block_valid_rows,
+                            lane_row,
+                            tid,
+                            reduce_slice_idx,
+                            reduce_slice_count,
+                        )
+
+    @cute.jit
+    def _combine_splitk_accumulator_block(
+        self,
+        acc,
+        mb: cutlass.Constexpr[int],
+        c_tmp_f32_flat: cute.Tensor,
+        c_cur_offset: Int32,
+        active_threads: Int32,
+        block_valid_rows: Int32,
+        lane_row: Int32,
+        tid: Int32,
+        reduce_slice_idx: Int32,
+        reduce_slice_count: Int32,
+    ):
+        for flat_j in cutlass.range_constexpr(8):
+            row_valid = Int32(mb * 16) + lane_row < block_valid_rows
+            if row_valid:
+                (
+                    acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                ) = self._merge_splitk_slot(
+                    c_tmp_f32_flat,
+                    c_cur_offset,
+                    active_threads,
+                    Int32(mb * 8 + flat_j),
+                    tid,
+                    reduce_slice_idx,
+                    reduce_slice_count,
+                    acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                )
+
+    @cute.jit
+    def _merge_splitk_slot(
+        self,
+        c_tmp_f32_flat: cute.Tensor,
+        c_cur_offset: Int32,
+        active_threads: Int32,
+        slot: Int32,
+        tid: Int32,
+        reduce_slice_idx: Int32,
+        reduce_slice_count: Int32,
+        c0: cutlass.Float32,
+        c1: cutlass.Float32,
+        c2: cutlass.Float32,
+        c3: cutlass.Float32,
+    ):
+        int4_off = c_cur_offset + active_threads * slot + tid
+        return self._merge_splitk_vec4(
+            c_tmp_f32_flat,
+            int4_off * Int32(4),
+            reduce_slice_idx,
+            reduce_slice_count,
+            c0,
+            c1,
+            c2,
+            c3,
+        )
+
+    @cute.jit
+    def _load_a_registers_large_m(
+        self,
+        smem_base: Int32,
+        a_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+        m_block: Int32,
+    ):
+        a_addr = self._int4_addr(
+            smem_base,
+            Int32(self.sh_a_off)
+            + pipe * Int32(self.a_sh_stage)
+            + self._activation_smem_permuted_offset(
+                Int32(2) * kk + m_block * Int32(self.a_sh_rd_delta_i) + a_sh_rd
+            ),
+        )
+        return ldmatrix_m8n8x4_b16(a_addr)
+
+    @cute.jit
+    def _load_a_registers_m8(
+        self,
+        smem_base: Int32,
+        a_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        a_addr = self._int4_addr(
+            smem_base,
+            Int32(self.sh_a_off)
+            + pipe * Int32(self.a_sh_stage)
+            + self._activation_smem_permuted_offset(Int32(2) * kk + a_sh_rd),
+        )
+        return ldmatrix_m8n8x2_b16(a_addr)
+
+    @cute.jit
+    def _load_a_registers_large_m_bundle(
+        self,
+        regs: cute.Tensor,
+        smem_base: Int32,
+        a_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        for mb in cutlass.range_constexpr(self.cta_m_blocks):
+            a0, a1, a2, a3 = self._load_a_registers_large_m(
+                smem_base,
+                a_sh_rd,
+                pipe,
+                kk,
+                Int32(mb),
+            )
+            regs[mb, 0] = a0
+            regs[mb, 1] = a1
+            regs[mb, 2] = a2
+            regs[mb, 3] = a3
+
+    @cute.jit
+    def _load_a_registers_m8_bundle(
+        self,
+        regs: cute.Tensor,
+        smem_base: Int32,
+        a_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        a0, a1 = self._load_a_registers_m8(smem_base, a_sh_rd, pipe, kk)
+        regs[0] = a0
+        regs[1] = a1
+
+    @cute.jit
+    def _clear_a_register_bundle_large_m(self, regs: cute.Tensor):
+        for mb in cutlass.range_constexpr(self.cta_m_blocks):
+            for reg in cutlass.range_constexpr(4):
+                regs[mb, reg] = Uint32(0)
+
+    @cute.jit
+    def _clear_a_register_bundle_m8(self, regs: cute.Tensor):
+        for reg in cutlass.range_constexpr(2):
+            regs[reg] = Uint32(0)
+
+    @cute.jit
+    def _copy_a_register_bundle_large_m(self, dst: cute.Tensor, src: cute.Tensor):
+        for mb in cutlass.range_constexpr(self.cta_m_blocks):
+            for reg in cutlass.range_constexpr(4):
+                dst[mb, reg] = src[mb, reg]
+
+    @cute.jit
+    def _copy_a_register_bundle_m8(self, dst: cute.Tensor, src: cute.Tensor):
+        for reg in cutlass.range_constexpr(2):
+            dst[reg] = src[reg]
+
+    @cute.jit
+    def _load_a_register_bundle(
+        self,
+        regs: cute.Tensor,
+        smem_base: Int32,
+        a_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+        uses_m_block_8: cutlass.Constexpr[bool],
+    ):
+        if cutlass.const_expr(uses_m_block_8):
+            self._load_a_registers_m8_bundle(regs, smem_base, a_sh_rd, pipe, kk)
+        else:
+            self._load_a_registers_large_m_bundle(regs, smem_base, a_sh_rd, pipe, kk)
+
+    @cute.jit
+    def _clear_a_register_bundle(
+        self,
+        regs: cute.Tensor,
+        uses_m_block_8: cutlass.Constexpr[bool],
+    ):
+        if cutlass.const_expr(uses_m_block_8):
+            self._clear_a_register_bundle_m8(regs)
+        else:
+            self._clear_a_register_bundle_large_m(regs)
+
+    @cute.jit
+    def _copy_a_register_bundle(
+        self,
+        dst: cute.Tensor,
+        src: cute.Tensor,
+        uses_m_block_8: cutlass.Constexpr[bool],
+    ):
+        if cutlass.const_expr(uses_m_block_8):
+            self._copy_a_register_bundle_m8(dst, src)
+        else:
+            self._copy_a_register_bundle_large_m(dst, src)
+
+    @cute.jit
+    def _load_b_scale_registers(
+        self,
+        smem_base: Int32,
+        tid: Int32,
+        b_sh_rd: Int32,
+        s_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        if cutlass.const_expr(self.weight_layout == "modelopt"):
+            q0, q1, q2, q3 = self._load_b_registers_modelopt_shared(
+                smem_base,
+                b_sh_rd,
+                pipe,
+                kk,
+            )
+        elif cutlass.const_expr(self.weight_layout_nf3):
+            # NF3-MAPPING-V1: the thread's 32-code unit index within the pipe's
+            # B region equals the stock staged-unit index (algebraically
+            # identical to b_sh_stride*kk + b_sh_rd): cur_group_id is the K16 row
+            # within the tile, (tid % b_sh_stride) is the N-pair. Each unit is a
+            # 12-byte (lo0, lo1, hi) triple; three scalar u32 loads over stride-3
+            # words are bank-conflict free (gcd(3, 32) == 1). q3 is unused.
+            nf3_warp_id = tid // Int32(32)
+            nf3_warp_row = nf3_warp_id // Int32(self.tb_n_warps)
+            nf3_group = Int32(self.b_sh_wr_iters) * nf3_warp_row + kk
+            nf3_unit = nf3_group * Int32(self.b_sh_stride) + (
+                tid % Int32(self.b_sh_stride)
+            )
+            b_addr = (
+                smem_base
+                + Int32(self.sh_b_off * 16)
+                + pipe * Int32(self.b_sh_stage_bytes)
+                + nf3_unit * Int32(12)
+            )
+            q0 = ld_shared_u32(b_addr)
+            q1 = ld_shared_u32(b_addr + Int32(4))
+            q2 = ld_shared_u32(b_addr + Int32(8))
+            q3 = Uint32(0)
+        else:
+            b_addr = self._int4_addr(
+                smem_base,
+                Int32(self.sh_b_off)
+                + pipe * Int32(self.b_sh_stage)
+                + Int32(self.b_sh_stride) * kk
+                + b_sh_rd,
+            )
+            q0, q1, q2, q3 = ld_shared_v4_u32(b_addr)
+
+        warp_id = tid // Int32(32)
+        warp_row = warp_id // Int32(self.tb_n_warps)
+        cur_group_id = Int32(self.b_sh_wr_iters) * warp_row + kk
+        if cutlass.const_expr(self.scale_k32):
+            scale_group_id = cur_group_id // Int32(2)
+        else:
+            scale_group_id = cur_group_id
+        s_addr = (
+            smem_base
+            + Int32(self.sh_s_off * 16)
+            + pipe * Int32(self.s_sh_stage * 16)
+            + (s_sh_rd + scale_group_id * Int32(2 * self.s_sh_stride)) * Int32(8)
+        )
+        s_pack0, s_pack1 = ld_shared_v2_u32(s_addr)
+        s0, s1 = self._dequant_scale_x4_to_elem2x2(s_pack0)
+        s2, s3 = self._dequant_scale_x4_to_elem2x2(s_pack1)
+        return q0, q1, q2, q3, s0, s1, s2, s3
+
+    @cute.jit
+    def _load_b_scale_register_bundle(
+        self,
+        regs: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        b_sh_rd: Int32,
+        s_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        q0, q1, q2, q3, s0, s1, s2, s3 = self._load_b_scale_registers(
+            smem_base,
+            tid,
+            b_sh_rd,
+            s_sh_rd,
+            pipe,
+            kk,
+        )
+        regs[0, 0] = q0
+        regs[0, 1] = q1
+        regs[0, 2] = q2
+        regs[0, 3] = q3
+        regs[1, 0] = s0
+        regs[1, 1] = s1
+        regs[1, 2] = s2
+        regs[1, 3] = s3
+
+    @cute.jit
+    def _clear_b_scale_register_bundle(self, regs: cute.Tensor):
+        for row in cutlass.range_constexpr(2):
+            for col in cutlass.range_constexpr(4):
+                regs[row, col] = Uint32(0)
+
+    @cute.jit
+    def _copy_b_scale_register_bundle(self, dst: cute.Tensor, src: cute.Tensor):
+        for row in cutlass.range_constexpr(2):
+            for col in cutlass.range_constexpr(4):
+                dst[row, col] = src[row, col]
+
+    @cute.jit
+    def _select_b_scale_register(self, jj: cutlass.Constexpr[int], regs: cute.Tensor):
+        return regs[0, jj], regs[1, jj]
+
+    @cute.jit
+    def _load_next_fragment_bundle(
+        self,
+        b_scale_next: cute.Tensor,
+        a_regs_next: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        b_sh_rd: Int32,
+        s_sh_rd: Int32,
+        a_sh_rd: Int32,
+        pipe: cutlass.Constexpr[int],
+        kk: cutlass.Constexpr[int],
+        tile_idx: Int32,
+        k_tiles: Int32,
+        uses_m_block_8: cutlass.Constexpr[bool],
+    ):
+        self._clear_b_scale_register_bundle(b_scale_next)
+        self._clear_a_register_bundle(a_regs_next, uses_m_block_8)
+
+        if cutlass.const_expr(kk + 1 < self.b_sh_wr_iters):
+            if tile_idx < k_tiles:
+                self._load_b_scale_register_bundle(
+                    b_scale_next,
+                    smem_base,
+                    tid,
+                    b_sh_rd,
+                    s_sh_rd,
+                    Int32(pipe),
+                    Int32(kk + 1),
+                )
+                self._load_a_register_bundle(
+                    a_regs_next,
+                    smem_base,
+                    a_sh_rd,
+                    Int32(pipe),
+                    Int32(kk + 1),
+                    uses_m_block_8,
+                )
+        else:
+            next_tile = tile_idx + Int32(1)
+            if next_tile < k_tiles:
+                self._load_b_scale_register_bundle(
+                    b_scale_next,
+                    smem_base,
+                    tid,
+                    b_sh_rd,
+                    s_sh_rd,
+                    Int32((pipe + 1) % _STAGES),
+                    Int32(0),
+                )
+                self._load_a_register_bundle(
+                    a_regs_next,
+                    smem_base,
+                    a_sh_rd,
+                    Int32((pipe + 1) % _STAGES),
+                    Int32(0),
+                    uses_m_block_8,
+                )
+
+    @cute.jit
+    def _scaled_dequant_b_fragment(self, frag: cute.Tensor, q: Uint32, s: Uint32):
+        bq1 = q
+        bq0 = bq1 << Uint32(8)
+        b0_0, b0_1 = self._dequant_e2m1x4_to_elem2x2(bq0)
+        b1_0, b1_1 = self._dequant_e2m1x4_to_elem2x2(bq1)
+        s_lane0 = bfloat2_broadcast_lane(s, Int32(0))
+        s_lane1 = bfloat2_broadcast_lane(s, Int32(1))
+        b0_0 = self._elem2_mul(b0_0, s_lane0)
+        b0_1 = self._elem2_mul(b0_1, s_lane0)
+        b1_0 = self._elem2_mul(b1_0, s_lane1)
+        b1_1 = self._elem2_mul(b1_1, s_lane1)
+        frag[0, 0] = b0_0
+        frag[0, 1] = b0_1
+        frag[1, 0] = b1_0
+        frag[1, 1] = b1_1
+
+    @cute.jit
+    def _scaled_dequant_b_fragment_nf3(
+        self, frag: cute.Tensor, lo16: Uint32, hi8: Uint32, s: Uint32
+    ):
+        # NF3: 8 3-bit codes (2 lo-bits in lo16, 1 hi-bit in hi8) -> 4 bf16x2
+        # codebook fragments, in the SAME element order the packed path uses:
+        # o0=(cb[c0],cb[c1]) -> frag[0,0], o1 -> frag[0,1], o2 -> frag[1,0],
+        # o3 -> frag[1,1]. frag[0,*] takes the N-col-0 scale lane, frag[1,*] the
+        # N-col-1 lane (identical broadcast to _scaled_dequant_b_fragment).
+        o0, o1, o2, o3 = packed_dequant_nf3x8_to_bfloat2x4(
+            lo16,
+            hi8,
+            Uint32(self._nf3_cb0),
+            Uint32(self._nf3_cb1),
+            Uint32(self._nf3_cb2),
+            Uint32(self._nf3_cb3),
+        )
+        s_lane0 = bfloat2_broadcast_lane(s, Int32(0))
+        s_lane1 = bfloat2_broadcast_lane(s, Int32(1))
+        frag[0, 0] = self._elem2_mul(o0, s_lane0)
+        frag[0, 1] = self._elem2_mul(o1, s_lane0)
+        frag[1, 0] = self._elem2_mul(o2, s_lane1)
+        frag[1, 1] = self._elem2_mul(o3, s_lane1)
+
+    @cute.jit
+    def _mma_accumulate_m8(
+        self,
+        acc,
+        jj: cutlass.Constexpr[int],
+        a_regs: cute.Tensor,
+        b_frag: cute.Tensor,
+    ):
+        d0, d1, d2, d3 = self._mma_rhs_fragments_as_mma_a_m16n8k16_f32(
+            acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            b_frag[0, 0],
+            b_frag[1, 0],
+            b_frag[0, 1],
+            b_frag[1, 1],
+            a_regs[0],
+            a_regs[1],
+        )
+        acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d0
+        acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d1
+        acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d2
+        acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d3
+
+    @cute.jit
+    def _mma_accumulate_large_m(
+        self,
+        acc,
+        a_regs: cute.Tensor,
+        mb: cutlass.Constexpr[int],
+        jj: cutlass.Constexpr[int],
+        b_frag: cute.Tensor,
+    ):
+        d0, d1, d2, d3 = self._mma_m16n8k16_f32(
+            acc[(jj * 8) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 8 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 8 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 8 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            a_regs[mb, 0],
+            a_regs[mb, 1],
+            a_regs[mb, 2],
+            a_regs[mb, 3],
+            b_frag[0, 0],
+            b_frag[0, 1],
+        )
+        acc[(jj * 8) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d0
+        acc[(jj * 8 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d1
+        acc[(jj * 8 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d2
+        acc[(jj * 8 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d3
+        d0, d1, d2, d3 = self._mma_m16n8k16_f32(
+            acc[(jj * 8 + 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8 + 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 8 + 5) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8 + 5) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 8 + 6) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8 + 6) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            acc[(jj * 8 + 7) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                (jj * 8 + 7) % _SCALAR_ACC_FRAGMENT_WIDTH
+            ],
+            a_regs[mb, 0],
+            a_regs[mb, 1],
+            a_regs[mb, 2],
+            a_regs[mb, 3],
+            b_frag[1, 0],
+            b_frag[1, 1],
+        )
+        acc[(jj * 8 + 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8 + 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d0
+        acc[(jj * 8 + 5) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8 + 5) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d1
+        acc[(jj * 8 + 6) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8 + 6) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d2
+        acc[(jj * 8 + 7) // _SCALAR_ACC_FRAGMENT_WIDTH][
+            (jj * 8 + 7) % _SCALAR_ACC_FRAGMENT_WIDTH
+        ] = d3
+
+    @cute.jit
+    def _source_n_from_logical(self, logical_n: Int32) -> Int32:
+        source_n = logical_n
+        if cutlass.const_expr(self.source_n_rotation != 0):
+            source_n += Int32(self.source_n_rotation)
+            if source_n >= Int32(self.size_n):
+                source_n -= Int32(self.size_n)
+        return source_n
+
+    @cute.jit
+    def _stage_b_tile_modelopt_native(
+        self,
+        b_u8_flat: cute.Tensor,
+        smem_addr: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        tile_idx: Int32,
+        local_int4: Int32,
+    ):
+        chunks_per_row = Int32(self.tile_k // 32)
+        local_n = local_int4 // chunks_per_row
+        local_k_vec = local_int4 - local_n * chunks_per_row
+        logical_n = output_n_tile * Int32(self.tile_n) + local_n
+        source_n = self._source_n_from_logical(logical_n)
+        packed_cols = Int32(self.size_k // 2)
+        tile_byte = tile_idx * Int32(self.tile_k // 2) + local_k_vec * Int32(16)
+        byte_offset = (
+            Int64(expert_idx) * Int64(self.size_n * (self.size_k // 2))
+            + Int64(source_n) * Int64(packed_cols)
+            + Int64(tile_byte)
+        )
+        if cutlass.const_expr(self.has_logical_tail):
+            valid_n = logical_n < Int32(self.size_n)
+            valid_bytes = packed_cols - tile_byte
+            if valid_bytes > Int32(16):
+                valid_bytes = Int32(16)
+            if (
+                valid_n
+                and valid_bytes >= Int32(16)
+                and cutlass.const_expr(not self.has_scale_k_tail)
+            ):
+                cp_async4_shared_global(
+                    smem_addr,
+                    get_ptr_as_int64(b_u8_flat, byte_offset),
+                )
+            else:
+                v0 = Uint32(0)
+                v1 = Uint32(0)
+                v2 = Uint32(0)
+                v3 = Uint32(0)
+                if valid_n and valid_bytes > Int32(0):
+                    src = get_ptr_as_int64(b_u8_flat, byte_offset)
+                    if valid_bytes >= Int32(4):
+                        v0 = ld_global_nc_u32(src)
+                    if valid_bytes >= Int32(8):
+                        v1 = ld_global_nc_u32(src + Int64(4))
+                    if valid_bytes >= Int32(12):
+                        v2 = ld_global_nc_u32(src + Int64(8))
+                    if valid_bytes >= Int32(16):
+                        v3 = ld_global_nc_u32(src + Int64(12))
+                st_shared_v4_u32(smem_addr, v0, v1, v2, v3)
+        else:
+            cp_async4_shared_global(
+                smem_addr,
+                get_ptr_as_int64(b_u8_flat, byte_offset),
+            )
+
+    @cute.jit
+    def _load_modelopt_shared_byte(
+        self,
+        smem_base: Int32,
+        pipe: Int32,
+        n_tile: Int32,
+        k_tile: Int32,
+        warp_id: Int32,
+        tc_col: Int32,
+        tc_row: Int32,
+        n_delta: cutlass.Constexpr[int],
+        k_delta: cutlass.Constexpr[int],
+    ) -> Uint32:
+        local_n = n_tile * Int32(64) + warp_id * Int32(16) + tc_col + Int32(n_delta)
+        local_k = k_tile * Int32(16) + tc_row + Int32(k_delta)
+        byte_offset = local_n * Int32(self.tile_k // 2) + local_k // Int32(2)
+        word_byte_offset = byte_offset - (byte_offset & Int32(3))
+        word = ld_shared_u32(
+            smem_base
+            + Int32(self.sh_b_off * 16)
+            + pipe * Int32(self.b_sh_stage * 16)
+            + word_byte_offset
+        )
+        shift = Uint32((byte_offset - word_byte_offset) * Int32(8))
+        return (word >> shift) & Uint32(0xFF)
+
+    @cute.jit
+    def _pack_modelopt_byte_pair(
+        self,
+        word: Uint32,
+        q: Uint32,
+        low_shift: cutlass.Constexpr[int],
+        high_shift: cutlass.Constexpr[int],
+    ) -> Uint32:
+        low = q & Uint32(0xF)
+        high = (q >> Uint32(4)) & Uint32(0xF)
+        return word | (low << Uint32(low_shift)) | (high << Uint32(high_shift))
+
+    @cute.jit
+    def _load_modelopt_shared_packed_word_for_lane(
+        self,
+        smem_base: Int32,
+        pipe: Int32,
+        n_tile: Int32,
+        k_tile: Int32,
+        warp_id: Int32,
+        tc_col: Int32,
+        tc_row: Int32,
+    ) -> Uint32:
+        q0 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 0, 0
+        )
+        q1 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 0, 8
+        )
+        q2 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 8, 0
+        )
+        q3 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 8, 8
+        )
+        word = Uint32(0)
+        word = self._pack_modelopt_byte_pair(word, q0, 0, 16)
+        word = self._pack_modelopt_byte_pair(word, q1, 4, 20)
+        word = self._pack_modelopt_byte_pair(word, q2, 8, 24)
+        word = self._pack_modelopt_byte_pair(word, q3, 12, 28)
+        return word
+
+    @cute.jit
+    def _load_b_registers_modelopt_shared(
+        self,
+        smem_base: Int32,
+        b_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        packed_word_index = (Int32(self.b_sh_stride) * kk + b_sh_rd) * Int32(4)
+        words_per_k_tile = Int32((self.tile_n // 64) * 128)
+        k_tile = packed_word_index // words_per_k_tile
+        pos_in_k_tile = packed_word_index - k_tile * words_per_k_tile
+        n_tile = pos_in_k_tile // Int32(128)
+        pos = pos_in_k_tile - n_tile * Int32(128)
+        th_id = pos // Int32(4)
+        tc_col = th_id // Int32(4)
+        tc_row = (th_id - tc_col * Int32(4)) * Int32(2)
+        q0 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(0), tc_col, tc_row
+        )
+        q1 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(1), tc_col, tc_row
+        )
+        q2 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(2), tc_col, tc_row
+        )
+        q3 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(3), tc_col, tc_row
+        )
+        return q0, q1, q2, q3
+
+    @cute.jit
+    def _stage_k_tile_async(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        pipe: Int32,
+        tile_idx: Int32,
+        block_valid_rows: Int32,
+        a_gl_stride: Int32,
+        b_gl_stride: Int32,
+        s_gl_stride: Int32,
+        scales_expert_off: Int32,
+        b_gl_rd_base: Int32,
+        a_gl_rd_row: Int32,
+        a_gl_rd_col0: Int32,
+        a_sh_wr: Int32,
+        a_rows_per_iter: Int32,
+        output_n_tile: Int32,
+        expert_idx: Int32,
+    ):
+        for i in cutlass.range_constexpr(self.a_sh_wr_iters):
+            row = a_rows_per_iter * Int32(i) + a_gl_rd_row
+            route_index = Int32(0)
+            if row < Int32(self.moe_block_size):
+                route_index = ld_shared_i32_relaxed(
+                    smem_base + Int32(self.sh_rd_route_off * 16) + row * Int32(4)
+                )
+            a_int4 = (
+                route_index * a_gl_stride
+                + tile_idx * Int32(self.a_gl_rd_delta_o)
+                + a_gl_rd_col0
+            )
+            a_dst = self._int4_addr(
+                smem_base,
+                Int32(self.sh_a_off)
+                + pipe * Int32(self.a_sh_stage)
+                + self._activation_smem_permuted_offset(
+                    Int32(i * self.a_sh_wr_delta) + a_sh_wr
+                ),
+            )
+            if cutlass.const_expr(self.has_k_tile_tail):
+                a_k_int4 = tile_idx * Int32(self.a_gl_rd_delta_o) + a_gl_rd_col0
+                if row < block_valid_rows and a_k_int4 < a_gl_stride:
+                    cp_async4_shared_global(
+                        a_dst,
+                        get_ptr_as_int64(a_bf16_flat, a_int4 * Int32(8)),
+                    )
+                else:
+                    st_shared_v4_u32(a_dst, Uint32(0), Uint32(0), Uint32(0), Uint32(0))
+            else:
+                cp_async4_shared_global_pred(
+                    a_dst,
+                    get_ptr_as_int64(a_bf16_flat, a_int4 * Int32(8)),
+                    (row < block_valid_rows).to(Int32),
+                )
+
+        if cutlass.const_expr(self.weight_layout_nf3):
+            # NF3 flat-span staging: the packer lays the per-(expert,
+            # output_n_tile, k-stage) B block out as ONE contiguous 12-byte-triple
+            # span (n_tile-major, then K16-row, then N-pair), so we copy it
+            # verbatim as 16-byte cp.async chunks. SMEM byte X of the pipe's B
+            # region == global byte X of the span, so the register read (unit*12)
+            # indexes it directly. b_gl_rd_base is unused on this path.
+            nf3_units_per_expert = (self.size_n * self.size_k) // 32
+            nf3_ntile_stride = (self.size_k // 16) * (self.tile_n // 2)
+            nf3_span_base_unit = (
+                Int32(nf3_units_per_expert) * expert_idx
+                + Int32(nf3_ntile_stride) * output_n_tile
+                + tile_idx * Int32(self.cta_k_blocks * self.b_sh_stride)
+            )
+            for i in cutlass.range_constexpr(self.b_sh_wr_iters_nf3):
+                nf3_chunk = Int32(i * self.cta_threads) + tid
+                b_dst = (
+                    smem_base
+                    + Int32(self.sh_b_off * 16)
+                    + pipe * Int32(self.b_sh_stage_bytes)
+                    + nf3_chunk * Int32(16)
+                )
+                # int32-element index of the chunk's first word:
+                # (span_base_unit*12 + chunk*16) / 4 = span_base_unit*3 + chunk*4.
+                b_src_i32 = nf3_span_base_unit * Int32(3) + nf3_chunk * Int32(4)
+                cp_async4_shared_global_pred(
+                    b_dst,
+                    get_ptr_as_int64(b_i32_flat, b_src_i32),
+                    (nf3_chunk < Int32(self.b_sh_chunks)).to(Int32),
+                )
+
+        for i in cutlass.range_constexpr(
+            0 if self.weight_layout_nf3 else self.b_sh_wr_iters
+        ):
+            b_src_int4 = (
+                b_gl_rd_base
+                + tile_idx * Int32(self.cta_k_blocks) * b_gl_stride
+                + Int32(i * (self.cta_threads // self.b_sh_stride)) * b_gl_stride
+            )
+            b_dst = self._int4_addr(
+                smem_base,
+                Int32(self.sh_b_off)
+                + pipe * Int32(self.b_sh_stage)
+                + Int32(i * self.cta_threads)
+                + tid,
+            )
+            if cutlass.const_expr(self.weight_layout == "packed"):
+                cp_async4_shared_global(
+                    b_dst,
+                    get_ptr_as_int64(b_i32_flat, b_src_int4 * Int32(4)),
+                )
+            else:
+                self._stage_b_tile_modelopt_native(
+                    b_i32_flat,
+                    b_dst,
+                    expert_idx,
+                    output_n_tile,
+                    tile_idx,
+                    Int32(i * self.cta_threads) + tid,
+                )
+
+        if tid < Int32(self.s_sh_stage):
+            s_k_group = tile_idx * Int32(self.s_tb_groups) + tid // Int32(
+                self.s_sh_stride
+            )
+            s_n_group = Int32(self.s_sh_stride) * output_n_tile + (
+                tid % Int32(self.s_sh_stride)
+            )
+            s_src_int4 = scales_expert_off + s_gl_stride * s_k_group + s_n_group
+            s_dst = self._int4_addr(
+                smem_base,
+                Int32(self.sh_s_off) + pipe * Int32(self.s_sh_stage) + tid,
+            )
+            if cutlass.const_expr(self.has_logical_tail):
+                if s_k_group < Int32(self.scale_k_groups) and s_n_group < Int32(
+                    self.scale_n_groups
+                ):
+                    cp_async4_shared_global(
+                        s_dst,
+                        get_ptr_as_int64(scales_i32_flat, s_src_int4 * Int32(4)),
+                    )
+                else:
+                    st_shared_v4_u32(s_dst, Uint32(0), Uint32(0), Uint32(0), Uint32(0))
+            else:
+                cp_async4_shared_global(
+                    s_dst,
+                    get_ptr_as_int64(scales_i32_flat, s_src_int4 * Int32(4)),
+                )
+
+        cute.arch.cp_async_commit_group()
+
+    @cute.jit
+    def _prefetch_pipeline_step(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        pipe: cutlass.Constexpr[int],
+        kk: cutlass.Constexpr[int],
+        tile_idx: Int32,
+        k_tiles: Int32,
+        reduce_k_tile: Int32,
+        block_valid_rows: Int32,
+        a_gl_stride: Int32,
+        b_gl_stride: Int32,
+        s_gl_stride: Int32,
+        scales_expert_off: Int32,
+        b_gl_rd_base: Int32,
+        a_gl_rd_row: Int32,
+        a_gl_rd_col0: Int32,
+        a_sh_wr: Int32,
+        a_rows_per_iter: Int32,
+        output_n_tile: Int32,
+        expert_idx: Int32,
+    ):
+        if cutlass.const_expr(kk == self.b_sh_wr_iters - 2):
+            self._prefetch_lookahead_tile(
+                a_bf16_flat,
+                b_i32_flat,
+                scales_i32_flat,
+                smem_base,
+                tid,
+                pipe,
+                tile_idx,
+                k_tiles,
+                reduce_k_tile,
+                block_valid_rows,
+                a_gl_stride,
+                b_gl_stride,
+                s_gl_stride,
+                scales_expert_off,
+                b_gl_rd_base,
+                a_gl_rd_row,
+                a_gl_rd_col0,
+                a_sh_wr,
+                a_rows_per_iter,
+                output_n_tile,
+                expert_idx,
+            )
+
+    @cute.jit
+    def _prefetch_initial_tiles(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        k_tiles: Int32,
+        reduce_k_tile: Int32,
+        block_valid_rows: Int32,
+        a_gl_stride: Int32,
+        b_gl_stride: Int32,
+        s_gl_stride: Int32,
+        scales_expert_off: Int32,
+        b_gl_rd_base: Int32,
+        a_gl_rd_row: Int32,
+        a_gl_rd_col0: Int32,
+        a_sh_wr: Int32,
+        a_rows_per_iter: Int32,
+        output_n_tile: Int32,
+        expert_idx: Int32,
+    ):
+        for pipe in cutlass.range_constexpr(_STAGES - 1):
+            if Int32(pipe) < k_tiles:
+                self._stage_k_tile_async(
+                    a_bf16_flat,
+                    b_i32_flat,
+                    scales_i32_flat,
+                    smem_base,
+                    tid,
+                    Int32(pipe),
+                    reduce_k_tile + Int32(pipe),
+                    block_valid_rows,
+                    a_gl_stride,
+                    b_gl_stride,
+                    s_gl_stride,
+                    scales_expert_off,
+                    b_gl_rd_base,
+                    a_gl_rd_row,
+                    a_gl_rd_col0,
+                    a_sh_wr,
+                    a_rows_per_iter,
+                    output_n_tile,
+                    expert_idx,
+                )
+            else:
+                cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(_STAGES - 2)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _prefetch_lookahead_tile(
+        self,
+        a_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        pipe: cutlass.Constexpr[int],
+        tile_idx: Int32,
+        k_tiles: Int32,
+        reduce_k_tile: Int32,
+        block_valid_rows: Int32,
+        a_gl_stride: Int32,
+        b_gl_stride: Int32,
+        s_gl_stride: Int32,
+        scales_expert_off: Int32,
+        b_gl_rd_base: Int32,
+        a_gl_rd_row: Int32,
+        a_gl_rd_col0: Int32,
+        a_sh_wr: Int32,
+        a_rows_per_iter: Int32,
+        output_n_tile: Int32,
+        expert_idx: Int32,
+    ):
+        fetch_tile = tile_idx + Int32(_STAGES - 1)
+        if fetch_tile < k_tiles:
+            self._stage_k_tile_async(
+                a_bf16_flat,
+                b_i32_flat,
+                scales_i32_flat,
+                smem_base,
+                tid,
+                Int32((pipe + _STAGES - 1) % _STAGES),
+                reduce_k_tile + fetch_tile,
+                block_valid_rows,
+                a_gl_stride,
+                b_gl_stride,
+                s_gl_stride,
+                scales_expert_off,
+                b_gl_rd_base,
+                a_gl_rd_row,
+                a_gl_rd_col0,
+                a_sh_wr,
+                a_rows_per_iter,
+                output_n_tile,
+                expert_idx,
+            )
+        else:
+            cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(_STAGES - 2)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _reduction_offsets(self, tid: Int32):
+        red_idx = tid // Int32(self.b_sh_stride_threads)
+        red_sh_stride = Int32(self.b_sh_stride_threads * 4 * 2)
+        red_sh_delta = Int32(self.b_sh_stride_threads)
+        red_sh_rd = red_sh_stride * (tid // Int32(self.b_sh_stride_threads)) + (
+            tid % Int32(self.b_sh_stride_threads)
+        )
+        return red_idx, red_sh_stride, red_sh_delta, red_sh_rd
+
+    @cute.jit
+    def _fold_cta_partials_m8(self, acc, smem_base: Int32, tid: Int32):
+        red_off = self.cta_threads // self.b_sh_stride_threads // 2
+        if cutlass.const_expr(red_off >= 1):
+            red_idx, red_sh_stride, red_sh_delta, red_sh_rd = self._reduction_offsets(
+                tid
+            )
+            if cutlass.const_expr(red_off == 2):
+                if Int32(2) <= red_idx and red_idx < Int32(4):
+                    for jj in cutlass.range_constexpr(4):
+                        red_sh_wr = red_sh_delta * Int32(jj * 2) + (
+                            red_sh_rd - red_sh_stride * Int32(2)
+                        )
+                        st_shared_v4_f32(
+                            self._int4_addr(
+                                smem_base, Int32(self.sh_red_off) + red_sh_wr
+                            ),
+                            acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ],
+                            acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ],
+                            acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ],
+                            acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ],
+                        )
+                cute.arch.sync_threads()
+
+            if Int32(1) <= red_idx and red_idx < Int32(2):
+                for jj in cutlass.range_constexpr(4):
+                    red_sh_wr = red_sh_delta * Int32(jj * 2) + (
+                        red_sh_rd - red_sh_stride
+                    )
+                    if cutlass.const_expr(red_off > 1):
+                        rd_addr = self._int4_addr(
+                            smem_base,
+                            Int32(self.sh_red_off)
+                            + red_sh_delta * Int32(jj * 2)
+                            + red_sh_rd,
+                        )
+                        wr_addr = self._int4_addr(
+                            smem_base, Int32(self.sh_red_off) + red_sh_wr
+                        )
+                        r0, r1, r2, r3 = ld_shared_v4_f32(rd_addr)
+                        w0, w1, w2, w3 = ld_shared_v4_f32(wr_addr)
+                        acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ] = (
+                            acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ]
+                            + r0
+                            + w0
+                        )
+                        acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ] = (
+                            acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ]
+                            + r1
+                            + w1
+                        )
+                        acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ] = (
+                            acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ]
+                            + r2
+                            + w2
+                        )
+                        acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ] = (
+                            acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                                (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                            ]
+                            + r3
+                            + w3
+                        )
+                    st_shared_v4_f32(
+                        self._int4_addr(smem_base, Int32(self.sh_red_off) + red_sh_wr),
+                        acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                    )
+            cute.arch.sync_threads()
+
+            if red_idx == Int32(0):
+                for jj in cutlass.range_constexpr(4):
+                    rd_addr = self._int4_addr(
+                        smem_base,
+                        Int32(self.sh_red_off)
+                        + red_sh_delta * Int32(jj * 2)
+                        + red_sh_rd,
+                    )
+                    r0, r1, r2, r3 = ld_shared_v4_f32(rd_addr)
+                    acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r0
+                    )
+                    acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r1
+                    )
+                    acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r2
+                    )
+                    acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r3
+                    )
+            cute.arch.sync_threads()
+
+    @cute.jit
+    def _output_store_cursor(self, tid: Int32, output_n_tile: Int32):
+        c_gl_stride = Int32(self.size_n // 8)
+        c_sh_stride = Int32(2 * self.cta_n_blocks + 1)
+        c_gl_wr_delta = c_gl_stride * Int32(self.cta_threads // (2 * self.cta_n_blocks))
+        c_sh_rd_delta = c_sh_stride * Int32(self.cta_threads // (2 * self.cta_n_blocks))
+        c_gl_wr = (
+            c_gl_stride * (tid // Int32(2 * self.cta_n_blocks))
+            + (tid % Int32(2 * self.cta_n_blocks))
+            + Int32(2 * self.cta_n_blocks) * output_n_tile
+        )
+        c_sh_rd = c_sh_stride * (tid // Int32(2 * self.cta_n_blocks)) + (
+            tid % Int32(2 * self.cta_n_blocks)
+        )
+        return c_gl_stride, c_sh_stride, c_gl_wr_delta, c_sh_rd_delta, c_gl_wr, c_sh_rd
+
+    @cute.jit
+    def _output_store_cursor_tail(self, tid: Int32, output_n_tile: Int32):
+        c_gl_stride = Int32(self.size_n // 8)
+        c_gl_stride_covered = Int32(self.covered_size_n // 8)
+        c_sh_stride = Int32(2 * self.cta_n_blocks + 1)
+        c_gl_wr_delta = c_gl_stride_covered * Int32(
+            self.cta_threads // (2 * self.cta_n_blocks)
+        )
+        c_sh_rd_delta = c_sh_stride * Int32(self.cta_threads // (2 * self.cta_n_blocks))
+        c_gl_wr = (
+            c_gl_stride_covered * (tid // Int32(2 * self.cta_n_blocks))
+            + (tid % Int32(2 * self.cta_n_blocks))
+            + Int32(2 * self.cta_n_blocks) * output_n_tile
+        )
+        c_sh_rd = c_sh_stride * (tid // Int32(2 * self.cta_n_blocks)) + (
+            tid % Int32(2 * self.cta_n_blocks)
+        )
+        return (
+            c_gl_stride,
+            c_gl_stride_covered,
+            c_sh_stride,
+            c_gl_wr_delta,
+            c_sh_rd_delta,
+            c_gl_wr,
+            c_sh_rd,
+        )
+
+    @cute.jit
+    def _drain_output_smem(
+        self,
+        c_bf16_flat: cute.Tensor,
+        smem_base: Int32,
+        c_gl_stride: Int32,
+        c_gl_wr: Int32,
+        c_gl_wr_delta: Int32,
+        c_sh_rd: Int32,
+        c_sh_rd_delta: Int32,
+        block_valid_rows: Int32,
+        store_iters: cutlass.Constexpr[int],
+    ):
+        for _ in cutlass.range_constexpr(store_iters):
+            row = c_gl_wr // c_gl_stride
+            if row < block_valid_rows:
+                route_index = ld_shared_i32_relaxed(
+                    smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
+                )
+                true_idx = route_index * c_gl_stride + (c_gl_wr % c_gl_stride)
+                q0, q1, q2, q3 = ld_shared_v4_u32(
+                    self._int4_addr(smem_base, Int32(self.sh_red_off) + c_sh_rd)
+                )
+                if cutlass.const_expr(self.mul_topk_weights):
+                    scale_bf2 = ld_shared_u32(
+                        smem_base + Int32(self.sh_topk_off * 16) + row * Int32(4)
+                    )
+                    q0 = self._elem2_mul(q0, scale_bf2)
+                    q1 = self._elem2_mul(q1, scale_bf2)
+                    q2 = self._elem2_mul(q2, scale_bf2)
+                    q3 = self._elem2_mul(q3, scale_bf2)
+                if cutlass.const_expr(self.epilogue_relu2):
+                    q0 = self._relu2_elem2(q0)
+                    q1 = self._relu2_elem2(q1)
+                    q2 = self._relu2_elem2(q2)
+                    q3 = self._relu2_elem2(q3)
+                if cutlass.const_expr(self.fused_topk_sum):
+                    # Fold the per-route partials into the per-token output in
+                    # the epilogue (drops the separate top-k-sum launch). The
+                    # output must be zeroed before launch; each route slot maps
+                    # to token = route_index // top_k.  bf16x2 add lands two
+                    # consecutive hidden lanes per word.
+                    token_idx = route_index // Int32(self.fused_sum_topk)
+                    out_idx = token_idx * c_gl_stride + (c_gl_wr % c_gl_stride)
+                    out_addr = get_ptr_as_int64(c_bf16_flat, out_idx * Int32(8))
+                    red_add_global_bf16x2(out_addr, q0)
+                    red_add_global_bf16x2(out_addr + Int64(4), q1)
+                    red_add_global_bf16x2(out_addr + Int64(8), q2)
+                    red_add_global_bf16x2(out_addr + Int64(12), q3)
+                else:
+                    st_global_v4_u32(
+                        get_ptr_as_int64(c_bf16_flat, true_idx * Int32(8)),
+                        q0,
+                        q1,
+                        q2,
+                        q3,
+                    )
+            c_gl_wr += c_gl_wr_delta
+            c_sh_rd += c_sh_rd_delta
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _drain_output_smem_tail(
+        self,
+        c_bf16_flat: cute.Tensor,
+        smem_base: Int32,
+        c_gl_stride: Int32,
+        c_gl_stride_covered: Int32,
+        c_gl_wr: Int32,
+        c_gl_wr_delta: Int32,
+        c_sh_rd: Int32,
+        c_sh_rd_delta: Int32,
+        block_valid_rows: Int32,
+        store_iters: cutlass.Constexpr[int],
+    ):
+        for _ in cutlass.range_constexpr(store_iters):
+            row = c_gl_wr // c_gl_stride_covered
+            col_word = c_gl_wr - row * c_gl_stride_covered
+            if row < block_valid_rows and col_word < c_gl_stride:
+                route_index = ld_shared_i32_relaxed(
+                    smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
+                )
+                true_idx = route_index * c_gl_stride + col_word
+                q0, q1, q2, q3 = ld_shared_v4_u32(
+                    self._int4_addr(smem_base, Int32(self.sh_red_off) + c_sh_rd)
+                )
+                if cutlass.const_expr(self.mul_topk_weights):
+                    scale_bf2 = ld_shared_u32(
+                        smem_base + Int32(self.sh_topk_off * 16) + row * Int32(4)
+                    )
+                    q0 = self._elem2_mul(q0, scale_bf2)
+                    q1 = self._elem2_mul(q1, scale_bf2)
+                    q2 = self._elem2_mul(q2, scale_bf2)
+                    q3 = self._elem2_mul(q3, scale_bf2)
+                if cutlass.const_expr(self.epilogue_relu2):
+                    q0 = self._relu2_elem2(q0)
+                    q1 = self._relu2_elem2(q1)
+                    q2 = self._relu2_elem2(q2)
+                    q3 = self._relu2_elem2(q3)
+                if cutlass.const_expr(self.fused_topk_sum):
+                    token_idx = route_index // Int32(self.fused_sum_topk)
+                    out_idx = token_idx * c_gl_stride + col_word
+                    out_addr = get_ptr_as_int64(c_bf16_flat, out_idx * Int32(8))
+                    red_add_global_bf16x2(out_addr, q0)
+                    red_add_global_bf16x2(out_addr + Int64(4), q1)
+                    red_add_global_bf16x2(out_addr + Int64(8), q2)
+                    red_add_global_bf16x2(out_addr + Int64(12), q3)
+                else:
+                    st_global_v4_u32(
+                        get_ptr_as_int64(c_bf16_flat, true_idx * Int32(8)),
+                        q0,
+                        q1,
+                        q2,
+                        q3,
+                    )
+            c_gl_wr += c_gl_wr_delta
+            c_sh_rd += c_sh_rd_delta
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _store_tile_m8(
+        self,
+        acc,
+        c_bf16_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        output_n_tile: Int32,
+        block_valid_rows: Int32,
+        global_scale_f32: cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.has_n_tile_tail):
+            (
+                c_gl_stride,
+                c_gl_stride_covered,
+                c_sh_stride,
+                c_gl_wr_delta,
+                c_sh_rd_delta,
+                c_gl_wr,
+                c_sh_rd,
+            ) = self._output_store_cursor_tail(tid, output_n_tile)
+        else:
+            (
+                c_gl_stride,
+                c_sh_stride,
+                c_gl_wr_delta,
+                c_sh_rd_delta,
+                c_gl_wr,
+                c_sh_rd,
+            ) = self._output_store_cursor(tid, output_n_tile)
+            c_gl_stride_covered = c_gl_stride
+        c_sh_wr = (
+            Int32(8) * c_sh_stride * (((tid & Int32(31)) % Int32(4)) * Int32(2))
+            + (tid & Int32(31)) // Int32(4)
+            + Int32(64) * (tid // Int32(32))
+        )
+
+        if tid // Int32(32) < Int32(self.tb_n_warps):
+            write_scale = cutlass.Float32(1.0)
+            if cutlass.const_expr(not self.mul_topk_weights):
+                write_scale = global_scale_f32
+            for jj in cutlass.range_constexpr(4):
+                wr = c_sh_wr + Int32(16 * jj)
+                self._st_shared_elem_from_f32(
+                    smem_base + Int32(self.sh_red_off * 16) + (wr * Int32(2)),
+                    acc[(jj * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    * write_scale,
+                )
+                self._st_shared_elem_from_f32(
+                    smem_base
+                    + Int32(self.sh_red_off * 16)
+                    + ((wr + Int32(8) * c_sh_stride) * Int32(2)),
+                    acc[(jj * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    * write_scale,
+                )
+                self._st_shared_elem_from_f32(
+                    smem_base
+                    + Int32(self.sh_red_off * 16)
+                    + ((wr + Int32(8)) * Int32(2)),
+                    acc[(jj * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    * write_scale,
+                )
+                self._st_shared_elem_from_f32(
+                    smem_base
+                    + Int32(self.sh_red_off * 16)
+                    + ((wr + Int32(8) + Int32(8) * c_sh_stride) * Int32(2)),
+                    acc[(jj * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (jj * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    * write_scale,
+                )
+        cute.arch.sync_threads()
+
+        store_iters = _covering_count(16, self.cta_threads // (2 * self.cta_n_blocks))
+        if cutlass.const_expr(self.has_n_tile_tail):
+            self._drain_output_smem_tail(
+                c_bf16_flat,
+                smem_base,
+                c_gl_stride,
+                c_gl_stride_covered,
+                c_gl_wr,
+                c_gl_wr_delta,
+                c_sh_rd,
+                c_sh_rd_delta,
+                block_valid_rows,
+                store_iters,
+            )
+        else:
+            self._drain_output_smem(
+                c_bf16_flat,
+                smem_base,
+                c_gl_stride,
+                c_gl_wr,
+                c_gl_wr_delta,
+                c_sh_rd,
+                c_sh_rd_delta,
+                block_valid_rows,
+                store_iters,
+            )
+
+    @cute.jit
+    def _fold_cta_partials_large_m(
+        self,
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+        smem_base: Int32,
+        tid: Int32,
+    ):
+        red_off = self.cta_threads // self.b_sh_stride_threads // 2
+        if cutlass.const_expr(red_off >= 1):
+            red_idx, red_sh_stride, red_sh_delta, red_sh_rd = self._reduction_offsets(
+                tid
+            )
+
+            for mb in cutlass.range_constexpr(self.cta_m_blocks):
+                if cutlass.const_expr(mb == 0):
+                    self._fold_cta_partials_large_m_block(
+                        acc0,
+                        smem_base,
+                        red_off,
+                        red_idx,
+                        red_sh_stride,
+                        red_sh_delta,
+                        red_sh_rd,
+                    )
+                elif cutlass.const_expr(mb == 1):
+                    self._fold_cta_partials_large_m_block(
+                        acc1,
+                        smem_base,
+                        red_off,
+                        red_idx,
+                        red_sh_stride,
+                        red_sh_delta,
+                        red_sh_rd,
+                    )
+                elif cutlass.const_expr(mb == 2):
+                    self._fold_cta_partials_large_m_block(
+                        acc2,
+                        smem_base,
+                        red_off,
+                        red_idx,
+                        red_sh_stride,
+                        red_sh_delta,
+                        red_sh_rd,
+                    )
+                else:
+                    self._fold_cta_partials_large_m_block(
+                        acc3,
+                        smem_base,
+                        red_off,
+                        red_idx,
+                        red_sh_stride,
+                        red_sh_delta,
+                        red_sh_rd,
+                    )
+
+    @cute.jit
+    def _fold_cta_partials_large_m_block(
+        self,
+        acc,
+        smem_base: Int32,
+        red_off: cutlass.Constexpr[int],
+        red_idx: Int32,
+        red_sh_stride: Int32,
+        red_sh_delta: Int32,
+        red_sh_rd: Int32,
+    ):
+        if cutlass.const_expr(red_off == 2):
+            if Int32(2) <= red_idx and red_idx < Int32(4):
+                for flat_j in cutlass.range_constexpr(8):
+                    red_sh_wr = red_sh_delta * Int32(flat_j) + (
+                        red_sh_rd - red_sh_stride * Int32(2)
+                    )
+                    st_shared_v4_f32(
+                        self._int4_addr(smem_base, Int32(self.sh_red_off) + red_sh_wr),
+                        acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                        acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ],
+                    )
+            cute.arch.sync_threads()
+
+        if Int32(1) <= red_idx and red_idx < Int32(2):
+            for flat_j in cutlass.range_constexpr(8):
+                red_sh_wr = red_sh_delta * Int32(flat_j) + (red_sh_rd - red_sh_stride)
+                if cutlass.const_expr(red_off > 1):
+                    rd_addr = self._int4_addr(
+                        smem_base,
+                        Int32(self.sh_red_off)
+                        + red_sh_delta * Int32(flat_j)
+                        + red_sh_rd,
+                    )
+                    wr_addr = self._int4_addr(
+                        smem_base,
+                        Int32(self.sh_red_off) + red_sh_wr,
+                    )
+                    r0, r1, r2, r3 = ld_shared_v4_f32(rd_addr)
+                    w0, w1, w2, w3 = ld_shared_v4_f32(wr_addr)
+                    acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r0
+                        + w0
+                    )
+                    acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r1
+                        + w1
+                    )
+                    acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r2
+                        + w2
+                    )
+                    acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ] = (
+                        acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                            (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                        ]
+                        + r3
+                        + w3
+                    )
+                st_shared_v4_f32(
+                    self._int4_addr(smem_base, Int32(self.sh_red_off) + red_sh_wr),
+                    acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                    acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ],
+                )
+        cute.arch.sync_threads()
+
+        if red_idx == Int32(0):
+            for flat_j in cutlass.range_constexpr(8):
+                rd_addr = self._int4_addr(
+                    smem_base,
+                    Int32(self.sh_red_off) + red_sh_delta * Int32(flat_j) + red_sh_rd,
+                )
+                r0, r1, r2, r3 = ld_shared_v4_f32(rd_addr)
+                acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ] = (
+                    acc[(flat_j * 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    + r0
+                )
+                acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ] = (
+                    acc[(flat_j * 4 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    + r1
+                )
+                acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ] = (
+                    acc[(flat_j * 4 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    + r2
+                )
+                acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ] = (
+                    acc[(flat_j * 4 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                        (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                    ]
+                    + r3
+                )
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _write_bf16x2_shared(
+        self,
+        smem_base: Int32,
+        half2_idx: Int32,
+        c0: cutlass.Float32,
+        c1: cutlass.Float32,
+        write_scale: cutlass.Float32,
+    ):
+        packed = self._pack_f32x2_to_elem2(c0 * write_scale, c1 * write_scale)
+        st_shared_u32(
+            smem_base + Int32(self.sh_red_off * 16) + half2_idx * Int32(4),
+            packed,
+        )
+
+    @cute.jit
+    def _store_tile_large_m(
+        self,
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+        c_bf16_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        output_n_tile: Int32,
+        block_valid_rows: Int32,
+        global_scale_f32: cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.has_n_tile_tail):
+            (
+                c_gl_stride,
+                c_gl_stride_covered,
+                c_sh_stride,
+                c_gl_wr_delta,
+                c_sh_rd_delta,
+                c_gl_wr,
+                c_sh_rd,
+            ) = self._output_store_cursor_tail(tid, output_n_tile)
+        else:
+            (
+                c_gl_stride,
+                c_sh_stride,
+                c_gl_wr_delta,
+                c_sh_rd_delta,
+                c_gl_wr,
+                c_sh_rd,
+            ) = self._output_store_cursor(tid, output_n_tile)
+            c_gl_stride_covered = c_gl_stride
+        c_sh_wr = (
+            Int32(4) * c_sh_stride * ((tid & Int32(31)) // Int32(4))
+            + (tid & Int32(31)) % Int32(4)
+            + Int32(32) * (tid // Int32(32))
+        )
+
+        if tid // Int32(32) < Int32(self.tb_n_warps):
+            write_scale = cutlass.Float32(1.0)
+            if cutlass.const_expr(not self.mul_topk_weights):
+                write_scale = global_scale_f32
+            for mb in cutlass.range_constexpr(self.cta_m_blocks):
+                if cutlass.const_expr(mb == 0):
+                    self._store_tile_large_m_block(
+                        acc0, smem_base, c_sh_wr, c_sh_stride, write_scale
+                    )
+                elif cutlass.const_expr(mb == 1):
+                    self._store_tile_large_m_block(
+                        acc1, smem_base, c_sh_wr, c_sh_stride, write_scale
+                    )
+                elif cutlass.const_expr(mb == 2):
+                    self._store_tile_large_m_block(
+                        acc2, smem_base, c_sh_wr, c_sh_stride, write_scale
+                    )
+                else:
+                    self._store_tile_large_m_block(
+                        acc3, smem_base, c_sh_wr, c_sh_stride, write_scale
+                    )
+                c_sh_wr += Int32(16 * (4 * (2 * self.cta_n_blocks + 1)))
+        cute.arch.sync_threads()
+
+        store_iters = _covering_count(
+            16 * self.cta_m_blocks,
+            self.cta_threads // (2 * self.cta_n_blocks),
+        )
+        if cutlass.const_expr(self.has_n_tile_tail):
+            self._drain_output_smem_tail(
+                c_bf16_flat,
+                smem_base,
+                c_gl_stride,
+                c_gl_stride_covered,
+                c_gl_wr,
+                c_gl_wr_delta,
+                c_sh_rd,
+                c_sh_rd_delta,
+                block_valid_rows,
+                store_iters,
+            )
+        else:
+            self._drain_output_smem(
+                c_bf16_flat,
+                smem_base,
+                c_gl_stride,
+                c_gl_wr,
+                c_gl_wr_delta,
+                c_sh_rd,
+                c_sh_rd_delta,
+                block_valid_rows,
+                store_iters,
+            )
+
+    @cute.jit
+    def _store_tile_large_m_block(
+        self,
+        acc,
+        smem_base: Int32,
+        c_sh_wr: Int32,
+        c_sh_stride: Int32,
+        write_scale: cutlass.Float32,
+    ):
+        for jj in cutlass.range_constexpr(4):
+            wr = c_sh_wr + Int32(8 * jj)
+            self._write_bf16x2_shared(
+                smem_base,
+                wr,
+                acc[(jj * 8) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                acc[(jj * 8 + 1) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8 + 1) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                write_scale,
+            )
+            self._write_bf16x2_shared(
+                smem_base,
+                wr + (Int32(4) * c_sh_stride) * Int32(8) + Int32(0),
+                acc[(jj * 8 + 2) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8 + 2) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                acc[(jj * 8 + 3) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                write_scale,
+            )
+            self._write_bf16x2_shared(
+                smem_base,
+                wr + Int32(4),
+                acc[(jj * 8 + 4) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8 + 4) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                acc[(jj * 8 + 5) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8 + 5) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                write_scale,
+            )
+            self._write_bf16x2_shared(
+                smem_base,
+                wr + (Int32(4) * c_sh_stride) * Int32(8) + Int32(4),
+                acc[(jj * 8 + 6) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8 + 6) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                acc[(jj * 8 + 7) // _SCALAR_ACC_FRAGMENT_WIDTH][
+                    (jj * 8 + 7) % _SCALAR_ACC_FRAGMENT_WIDTH
+                ],
+                write_scale,
+            )
+
+
+class W4A16FusedMoeKernel:
+    def __init__(
+        self,
+        *,
+        size_m: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+        top_k: int,
+        activation: str,
+        apply_router_weight_on_input: bool,
+        zero_fc2_output: bool,
+        fc1_tile_n: int,
+        fc1_tile_k: int,
+        fc2_tile_n: int,
+        fc2_tile_k: int,
+        moe_block_size: int,
+        max_m_blocks: int,
+        element_dtype: str = "bf16",
+        fast_math: bool = True,
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+        weight_layout: str = "packed",
+        scale_format: str = "e4m3_k16",
+        w13_layout: str = "w13",
+        direct_topk_routes: bool = False,
+        tc_decode_fused_sum: bool = False,
+        tc_zero_output: bool = True,
+        collect_activation_amax: bool = False,
+        schedule_whole_tiles: bool = False,
+    ):
+        activation = normalize_moe_activation(activation)
+        is_gated = validate_activation(activation)
+        swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_activation_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+        if weight_layout not in _WEIGHT_LAYOUTS:
+            raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+        scale_format = _normalize_scale_format(scale_format)
+        if weight_layout == "modelopt":
+            if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+                raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+        else:
+            w13_layout = "packed"
+        self.tc_decode_fused_sum = bool(tc_decode_fused_sum)
+        # When two TC-decode launches share one pre-zeroed output (the NF3 hybrid
+        # runs an NVFP4 launch then an NF3 launch into the same tensor), only the
+        # first must zero it. Default True preserves single-launch behavior.
+        self.tc_zero_output = bool(tc_zero_output)
+        self.collect_activation_amax = bool(collect_activation_amax)
+        if self.collect_activation_amax and bool(direct_topk_routes):
+            raise ValueError("activation amax collection requires route-packed W4A16")
+        if self.collect_activation_amax and self.tc_decode_fused_sum:
+            raise ValueError(
+                "activation amax collection is incompatible with TC-decode"
+            )
+        if self.tc_decode_fused_sum and not bool(direct_topk_routes):
+            raise ValueError("tc_decode_fused_sum requires direct_topk_routes")
+        if self.tc_decode_fused_sum and element_dtype != "bf16":
+            raise ValueError("tc_decode_fused_sum currently requires bf16 activations")
+        fc1_cols = int(intermediate_size) * (2 if is_gated else 1)
+        routed_rows = int(size_m) * int(top_k)
+        self.size_m = int(size_m)
+        self.hidden_size = int(hidden_size)
+        self.intermediate_size = int(intermediate_size)
+        self.fc1_cols = int(fc1_cols)
+        self.num_experts = int(num_experts)
+        self.top_k = int(top_k)
+        self.moe_block_size = int(moe_block_size)
+        self.activation = activation
+        self.activation_is_gated = is_gated
+        self.activation_is_swigluoai = activation == SWIGLUOAI_UNINTERLEAVE
+        self.has_swiglu_limit = swiglu_limit is not None
+        self.swiglu_limit = 0.0 if swiglu_limit is None else swiglu_limit
+        self.swiglu_alpha = float(swiglu_alpha)
+        self.swiglu_beta = float(swiglu_beta)
+        self.weight_layout = weight_layout
+        self.scale_format = scale_format
+        self.w13_layout = w13_layout
+        self.apply_router_weight_on_input = bool(apply_router_weight_on_input)
+        self.zero_fc2_output = bool(zero_fc2_output)
+        self.element_dtype = element_dtype
+        self.is_fp16 = element_dtype == "fp16"
+        self.fast_math = bool(fast_math)
+        self.direct_topk_routes = bool(direct_topk_routes)
+        self.schedule_whole_tiles = bool(schedule_whole_tiles)
+        fc1_source_n_rotation = (
+            int(intermediate_size)
+            if (weight_layout == "modelopt" and w13_layout == "w13" and is_gated)
+            else 0
+        )
+        self.fc1 = W4A16GemmKernel(
+            size_m=size_m,
+            size_n=fc1_cols,
+            size_k=hidden_size,
+            num_experts=num_experts,
+            top_k=top_k,
+            mul_topk_weights=bool(apply_router_weight_on_input),
+            tile_n=fc1_tile_n,
+            tile_k=fc1_tile_k,
+            moe_block_size=moe_block_size,
+            max_m_blocks=max_m_blocks,
+            element_dtype=element_dtype,
+            epilogue_activation=None if is_gated else "relu2",
+            weight_layout=weight_layout,
+            scale_format=scale_format,
+            w13_layout=w13_layout,
+            source_n_rotation=fc1_source_n_rotation,
+            single_token_route_fast_path=size_m == 1 and not self.direct_topk_routes,
+            direct_topk_routes=self.direct_topk_routes,
+            schedule_whole_tiles=self.schedule_whole_tiles,
+        )
+        self.fc2 = W4A16GemmKernel(
+            size_m=routed_rows,
+            size_n=hidden_size,
+            size_k=intermediate_size,
+            num_experts=num_experts,
+            top_k=1,
+            mul_topk_weights=not bool(apply_router_weight_on_input),
+            tile_n=fc2_tile_n,
+            tile_k=fc2_tile_k,
+            moe_block_size=moe_block_size,
+            max_m_blocks=max_m_blocks,
+            element_dtype=element_dtype,
+            weight_layout=weight_layout,
+            scale_format=scale_format,
+            w13_layout=w13_layout,
+            single_token_route_fast_path=size_m == 1 and not self.direct_topk_routes,
+            direct_topk_routes=self.direct_topk_routes,
+            fused_topk_sum=self.tc_decode_fused_sum,
+            fused_sum_topk=int(top_k),
+            schedule_whole_tiles=self.schedule_whole_tiles,
+        )
+        self.cta_threads = max(self.fc1.cta_threads, self.fc2.cta_threads)
+        if self.fc1.cta_threads != self.fc2.cta_threads:
+            raise ValueError(
+                "fused W4A16 kernel expects matching FC1/FC2 thread counts"
+            )
+        self.sms = self.fc1.sms
+        self.blocks_per_sm = min(self.fc1.blocks_per_sm, self.fc2.blocks_per_sm)
+        self.shared_words = max(self.fc1.shared_words, self.fc2.shared_words)
+        self.barrier_count_off = self.sms * 4
+        self.barrier_sense_off = self.sms * 4 + 1
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (
+            self.hidden_size,
+            self.intermediate_size,
+            self.fc1_cols,
+            self.num_experts,
+            self.top_k,
+            self.activation,
+            self.activation_is_gated,
+            self.activation_is_swigluoai,
+            self.has_swiglu_limit,
+            self.swiglu_limit,
+            self.swiglu_alpha,
+            self.swiglu_beta,
+            self.weight_layout,
+            self.scale_format,
+            self.apply_router_weight_on_input,
+            self.zero_fc2_output,
+            self.element_dtype,
+            self.fast_math,
+            self.direct_topk_routes,
+            self.tc_zero_output,
+            self.collect_activation_amax,
+            self.fc1.__cache_key__,
+            self.fc2.__cache_key__,
+            self.cta_threads,
+            self.sms,
+            self.shared_words,
+            self.blocks_per_sm,
+        )
+
+    @cute.jit
+    def _cast_elem(self, x: cutlass.Float32):
+        if cutlass.const_expr(self.is_fp16):
+            return cutlass.Float16(x)
+        return cutlass.BFloat16(x)
+
+    @cute.jit
+    def _clamp_swiglu_inputs(
+        self,
+        gate: cutlass.Float32,
+        up: cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.has_swiglu_limit):
+            limit = cutlass.Float32(self.swiglu_limit)
+            neg_limit = cutlass.Float32(-self.swiglu_limit)
+            if gate > limit:
+                gate = limit
+            if up > limit:
+                up = limit
+            if up < neg_limit:
+                up = neg_limit
+        return gate, up
+
+    @cute.jit
+    def __call__(
+        self,
+        a_bf16_ptr: cute.Pointer,
+        w13_i32_flat: cute.Tensor,
+        w2_i32_flat: cute.Tensor,
+        fc1_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        fc2_bf16_flat: cute.Tensor,
+        w13_scales_i32_flat: cute.Tensor,
+        w2_scales_i32_flat: cute.Tensor,
+        w13_global_scale: cute.Tensor,
+        w2_global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        activation_amax_flat: cute.Tensor,
+        layer_idx: cutlass.Int32,
+        topk_weights_ptr: cute.Pointer,
+        fc1_c_tmp_f32_flat: cute.Tensor,
+        fc2_c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+        grid_x: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        a_bf16_flat = cute.make_tensor(
+            a_bf16_ptr,
+            layout=cute.make_layout((active_m * Int32(self.hidden_size),), stride=(1,)),
+        )
+        topk_weights_flat = cute.make_tensor(
+            topk_weights_ptr,
+            layout=cute.make_layout((active_m * Int32(self.top_k),), stride=(1,)),
+        )
+        grid = (grid_x, 1, 1)
+        self.kernel(
+            a_bf16_flat,
+            w13_i32_flat,
+            w2_i32_flat,
+            fc1_bf16_flat,
+            activated_bf16_flat,
+            fc2_bf16_flat,
+            w13_scales_i32_flat,
+            w2_scales_i32_flat,
+            w13_global_scale,
+            w2_global_scale,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            activation_amax_flat,
+            layer_idx,
+            topk_weights_flat,
+            fc1_c_tmp_f32_flat,
+            fc2_c_tmp_f32_flat,
+            locks_i32_flat,
+            active_m,
+        ).launch(
+            grid=grid,
+            block=[self.cta_threads, 1, 1],
+            min_blocks_per_mp=self.blocks_per_sm,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_bf16_flat: cute.Tensor,
+        w13_i32_flat: cute.Tensor,
+        w2_i32_flat: cute.Tensor,
+        fc1_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        fc2_bf16_flat: cute.Tensor,
+        w13_scales_i32_flat: cute.Tensor,
+        w2_scales_i32_flat: cute.Tensor,
+        w13_global_scale: cute.Tensor,
+        w2_global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        activation_amax_flat: cute.Tensor,
+        layer_idx: cutlass.Int32,
+        topk_weights_flat: cute.Tensor,
+        fc1_c_tmp_f32_flat: cute.Tensor,
+        fc2_c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        grid_x_raw, _, _ = cute.arch.grid_dim()
+        tid = Int32(tidx)
+        cta = Int32(bidx)
+        grid_x = Int32(grid_x_raw)
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            words: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, self.shared_words],
+                1024,
+            ]
+
+        storage = smem.allocate(Storage)
+        smem_base = shared_ptr_to_u32(storage.words.data_ptr())
+
+        self._moe_body(
+            a_bf16_flat,
+            w13_i32_flat,
+            w2_i32_flat,
+            fc1_bf16_flat,
+            activated_bf16_flat,
+            fc2_bf16_flat,
+            w13_scales_i32_flat,
+            w2_scales_i32_flat,
+            w13_global_scale,
+            w2_global_scale,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            activation_amax_flat,
+            layer_idx,
+            topk_weights_flat,
+            fc1_c_tmp_f32_flat,
+            fc2_c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            cta,
+            grid_x,
+            active_m,
+        )
+
+    @cute.jit
+    def _moe_body(
+        self,
+        a_bf16_flat: cute.Tensor,
+        w13_i32_flat: cute.Tensor,
+        w2_i32_flat: cute.Tensor,
+        fc1_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        fc2_bf16_flat: cute.Tensor,
+        w13_scales_i32_flat: cute.Tensor,
+        w2_scales_i32_flat: cute.Tensor,
+        w13_global_scale: cute.Tensor,
+        w2_global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        activation_amax_flat: cute.Tensor,
+        layer_idx: cutlass.Int32,
+        topk_weights_flat: cute.Tensor,
+        fc1_c_tmp_f32_flat: cute.Tensor,
+        fc2_c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        cta: Int32,
+        grid_x: Int32,
+        active_m: cutlass.Int32,
+        fc1_emit_tile: cutlass.Constexpr = None,
+        fc2_emit_tile: cutlass.Constexpr = None,
+    ):
+        # Phase assembly shared by the single-tier fused kernel and the hybrid
+        # multi-tier entry: zero prologue, FC1, grid barrier, activation, grid
+        # barrier, FC2. The emit hooks delegate per-tile expert resolution and
+        # dispatch (used by the hybrid route map); None keeps the single-tier
+        # resolution inside _run_persistent_gemm.
+        if cutlass.const_expr(self.tc_decode_fused_sum):
+            # The TC-decode FC2 epilogue atomically accumulates per-route
+            # partials directly into the per-token output, so the output must be
+            # pre-zeroed. Previously this was a SEPARATE host-side output.zero_()
+            # kernel launch on the latency-bound decode critical path (an extra
+            # launch + its grid-fill memset before the fused kernel even starts).
+            # Fold it into the fused kernel prologue here: every CTA zeroes a
+            # grid-strided slice of the output BEFORE FC1, and the EXISTING
+            # post-FC1 grid barrier (already required to order FC1 writes before
+            # the activation/FC2 read) makes all zero stores globally visible
+            # before the first FC2 atomic -- so no extra barrier is added. The
+            # tiny m*hidden bf16 memset (decode: <=4*4096 elems) is dwarfed by
+            # FC1's whole-K FP4-weight stream, but we delete one whole kernel
+            # launch from the per-decode chain. The TC-decode output is per-token
+            # (top_k routes atomically summed into the SAME token row), so the
+            # zero span is active_m*hidden_size -- NOT the per-route
+            # active_m*top_k*hidden_size of _zero_fc2_output.
+            # tc_zero_output=False skips the zero (a paired earlier launch has
+            # already zeroed the shared output); the grid barrier below is
+            # unconditional so ordering is preserved either way.
+            if cutlass.const_expr(self.tc_zero_output):
+                zidx = cta * Int32(self.cta_threads) + tid
+                zstride = grid_x * Int32(self.cta_threads)
+                ztotal = active_m * Int32(self.hidden_size)
+                zzero = self._cast_elem(cutlass.Float32(0.0))
+                while zidx < ztotal:
+                    fc2_bf16_flat[zidx] = zzero
+                    zidx += zstride
+
+        if cutlass.const_expr(self.activation_is_gated):
+            self.fc1._run_persistent_gemm(
+                a_bf16_flat,
+                w13_i32_flat,
+                fc1_bf16_flat,
+                w13_scales_i32_flat,
+                w13_global_scale,
+                packed_route_indices,
+                block_expert_ids,
+                packed_route_count,
+                topk_weights_flat,
+                fc1_c_tmp_f32_flat,
+                locks_i32_flat,
+                smem_base,
+                tid,
+                cta,
+                grid_x,
+                active_m,
+                fc1_emit_tile,
+            )
+            self._grid_barrier(locks_i32_flat, tid, grid_x)
+            self._run_activation(
+                fc1_bf16_flat,
+                activated_bf16_flat,
+                tid,
+                cta,
+                grid_x,
+                active_m,
+            )
+        else:
+            self.fc1._run_persistent_gemm(
+                a_bf16_flat,
+                w13_i32_flat,
+                activated_bf16_flat,
+                w13_scales_i32_flat,
+                w13_global_scale,
+                packed_route_indices,
+                block_expert_ids,
+                packed_route_count,
+                topk_weights_flat,
+                fc1_c_tmp_f32_flat,
+                locks_i32_flat,
+                smem_base,
+                tid,
+                cta,
+                grid_x,
+                active_m,
+                fc1_emit_tile,
+            )
+        self._grid_barrier(locks_i32_flat, tid, grid_x)
+        if cutlass.const_expr(self.collect_activation_amax):
+            self._collect_activation_amax_epilogue(
+                a_bf16_flat,
+                activated_bf16_flat,
+                packed_route_indices,
+                block_expert_ids,
+                packed_route_count,
+                activation_amax_flat,
+                layer_idx,
+                smem_base,
+                tid,
+                cta,
+                grid_x,
+                active_m,
+            )
+        if cutlass.const_expr(self.zero_fc2_output):
+            self._zero_fc2_output(fc2_bf16_flat, tid, cta, grid_x, active_m)
+            self._grid_barrier(locks_i32_flat, tid, grid_x)
+        self.fc2._run_persistent_gemm(
+            activated_bf16_flat,
+            w2_i32_flat,
+            fc2_bf16_flat,
+            w2_scales_i32_flat,
+            w2_global_scale,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            topk_weights_flat,
+            fc2_c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            cta,
+            grid_x,
+            active_m * Int32(self.top_k),
+            fc2_emit_tile,
+        )
+
+    @cute.jit
+    def _grid_barrier(
+        self,
+        locks_i32_flat: cute.Tensor,
+        tid: Int32,
+        grid_x: Int32,
+    ):
+        cute.arch.sync_threads()
+        if tid == Int32(0):
+            count_addr = get_ptr_as_int64(locks_i32_flat, Int32(self.barrier_count_off))
+            sense_addr = get_ptr_as_int64(locks_i32_flat, Int32(self.barrier_sense_off))
+            old_sense = ld_global_acquire_i32(sense_addr)
+            old_count = atomic_add_global_i32(count_addr, Int32(1))
+            if old_count == grid_x - Int32(1):
+                st_global_i32(count_addr, Int32(0))
+                threadfence()
+                red_add_global_release_i32(sense_addr, Int32(1))
+            else:
+                sense = old_sense
+                while sense == old_sense:
+                    sense = ld_global_acquire_i32(sense_addr)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _zero_fc2_output(
+        self,
+        fc2_bf16_flat: cute.Tensor,
+        tid: Int32,
+        cta: Int32,
+        grid_x: Int32,
+        active_m: cutlass.Int32,
+    ):
+        idx = cta * Int32(self.cta_threads) + tid
+        stride = grid_x * Int32(self.cta_threads)
+        total = active_m * Int32(self.top_k * self.hidden_size)
+        zero = self._cast_elem(cutlass.Float32(0.0))
+        while idx < total:
+            fc2_bf16_flat[idx] = zero
+            idx += stride
+
+    @cute.jit
+    def _reduce_and_red_activation_amax(
+        self,
+        local_max: cutlass.Float32,
+        activation_amax_flat: cute.Tensor,
+        layer_idx: cutlass.Int32,
+        expert_idx: Int32,
+        slot: Int32,
+        smem_base: Int32,
+        tid: Int32,
+    ):
+        lane = tid & Int32(31)
+        warp_idx = tid // Int32(32)
+        warp_amax = warp_reduce(local_max, fmax_f32)
+        if lane == Int32(0):
+            st_shared_f32(smem_base + warp_idx * Int32(4), warp_amax)
+        cute.arch.sync_threads()
+
+        if warp_idx == Int32(0):
+            block_amax = cutlass.Float32(0.0)
+            if lane < Int32(self.cta_threads // 32):
+                block_amax = ld_shared_f32(smem_base + lane * Int32(4))
+            block_amax = warp_reduce(block_amax, fmax_f32)
+            if lane == Int32(0) and block_amax > cutlass.Float32(0.0):
+                out_idx = (layer_idx * Int32(self.num_experts) + expert_idx) * Int32(
+                    2
+                ) + slot
+                red_max_global_f32_nonnegative(
+                    get_ptr_as_int64(activation_amax_flat, out_idx),
+                    block_amax,
+                )
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _collect_activation_amax_epilogue(
+        self,
+        a_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        activation_amax_flat: cute.Tensor,
+        layer_idx: cutlass.Int32,
+        smem_base: Int32,
+        tid: Int32,
+        cta: Int32,
+        grid_x: Int32,
+        active_m: cutlass.Int32,
+    ):
+        live_routes = active_m * Int32(self.top_k)
+        route_count = packed_route_count[Int32(0)].to(Int32)
+        route_blocks = (route_count + Int32(self.moe_block_size) - Int32(1)) // Int32(
+            self.moe_block_size
+        )
+        expert_idx = cta
+        while expert_idx < Int32(self.num_experts):
+            local_fc1 = cutlass.Float32(0.0)
+            local_fc2 = cutlass.Float32(0.0)
+            has_route_block = Int32(0)
+            block_idx = Int32(0)
+            while block_idx < route_blocks:
+                block_expert = block_expert_ids[block_idx].to(Int32)
+                if block_expert == expert_idx:
+                    has_route_block = Int32(1)
+                    route_pos = block_idx * Int32(self.moe_block_size)
+                    route_stop = route_pos + Int32(self.moe_block_size)
+                    if route_stop > route_count:
+                        route_stop = route_count
+                    while route_pos < route_stop:
+                        route_idx = packed_route_indices[route_pos].to(Int32)
+                        if route_idx >= Int32(0) and route_idx < live_routes:
+                            token_idx = route_idx // Int32(self.top_k)
+                            fc1_col = tid
+                            while fc1_col < Int32(self.hidden_size):
+                                v1 = a_bf16_flat[
+                                    token_idx * Int32(self.hidden_size) + fc1_col
+                                ].to(cutlass.Float32)
+                                local_fc1 = fmax_f32(local_fc1, fabs_f32(v1))
+                                fc1_col += Int32(self.cta_threads)
+
+                            fc2_col = tid
+                            while fc2_col < Int32(self.intermediate_size):
+                                v2 = activated_bf16_flat[
+                                    route_idx * Int32(self.intermediate_size) + fc2_col
+                                ].to(cutlass.Float32)
+                                local_fc2 = fmax_f32(local_fc2, fabs_f32(v2))
+                                fc2_col += Int32(self.cta_threads)
+                        route_pos += Int32(1)
+                block_idx += Int32(1)
+
+            if has_route_block != Int32(0):
+                self._reduce_and_red_activation_amax(
+                    local_fc1,
+                    activation_amax_flat,
+                    layer_idx,
+                    expert_idx,
+                    Int32(0),
+                    smem_base,
+                    tid,
+                )
+                self._reduce_and_red_activation_amax(
+                    local_fc2,
+                    activation_amax_flat,
+                    layer_idx,
+                    expert_idx,
+                    Int32(1),
+                    smem_base,
+                    tid,
+                )
+            expert_idx += grid_x
+
+    @cute.jit
+    def _run_activation(
+        self,
+        fc1_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        tid: Int32,
+        cta: Int32,
+        grid_x: Int32,
+        active_m: cutlass.Int32,
+    ):
+        idx = cta * Int32(self.cta_threads) + tid
+        stride = grid_x * Int32(self.cta_threads)
+        total = active_m * Int32(self.top_k * self.intermediate_size)
+        while idx < total:
+            if cutlass.const_expr(self.activation_is_gated):
+                row = idx // Int32(self.intermediate_size)
+                col = idx - row * Int32(self.intermediate_size)
+                base = row * Int32(self.fc1_cols)
+                gate = fc1_bf16_flat[base + col].to(cutlass.Float32)
+                up = fc1_bf16_flat[base + Int32(self.intermediate_size) + col].to(
+                    cutlass.Float32
+                )
+                gate, up = self._clamp_swiglu_inputs(gate, up)
+                sigmoid_arg = gate
+                up_term = up
+                if cutlass.const_expr(self.activation_is_swigluoai):
+                    sigmoid_arg = cutlass.Float32(self.swiglu_alpha) * gate
+                    up_term = up + cutlass.Float32(self.swiglu_beta)
+                if cutlass.const_expr(self.fast_math):
+                    exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=True)
+                else:
+                    exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=False)
+                silu = gate / (cutlass.Float32(1.0) + exp_neg_gate)
+                if cutlass.const_expr(self.activation_is_swigluoai):
+                    activated_bf16_flat[idx] = self._cast_elem(silu * up_term)
+                else:
+                    activated_bf16_flat[idx] = self._cast_elem(
+                        self._cast_elem(silu) * self._cast_elem(up_term)
+                    )
+            else:
+                x = fc1_bf16_flat[idx].to(cutlass.Float32)
+                if x < cutlass.Float32(0.0):
+                    x = cutlass.Float32(0.0)
+                activated_bf16_flat[idx] = self._cast_elem(x * x)
+            idx += stride
+
+
+class W4A16FusedMoeHybridKernel:
+    """Two-tier heterogeneous-quantization fused MoE entry.
+
+    Composition over W4A16FusedMoeKernel: each tier's fused kernel supplies
+    its FC1/FC2 children and the shared phase machinery (_moe_body, grid
+    barrier, activation). This entry only widens the launch ABI to carry both
+    tiers' weights plus a global-expert descriptor map, and installs the
+    route-map emit hooks that resolve tier + local expert per mn-tile. Tier 0
+    drives scheduling; both tiers are validated to identical geometry, so the
+    schedule constants agree by construction.
+
+    Route contract: the routes tensor carries GLOBAL expert ids (one per
+    size_m*top_k slot, -1 for inactive). tier_local_map holds one int32
+    descriptor per global expert id: (tier << 8) | local_expert_id, negative
+    for unmapped. Unmapped or out-of-range ids skip the tile, matching the
+    -1-route behavior of the single-tier direct path.
+    """
+
+    ABI_VERSION = 1
+
+    def __init__(
+        self,
+        *,
+        tier0: W4A16FusedMoeKernel,
+        tier1: W4A16FusedMoeKernel,
+        map_slots: int,
+    ):
+        for name, moe in (("tier0", tier0), ("tier1", tier1)):
+            if not moe.direct_topk_routes:
+                raise ValueError(f"hybrid W4A16 {name} requires direct_topk_routes")
+            if not moe.tc_decode_fused_sum:
+                raise ValueError(f"hybrid W4A16 {name} requires tc_decode_fused_sum")
+            if not moe.activation_is_gated:
+                raise ValueError(f"hybrid W4A16 {name} requires a gated activation")
+            if moe.collect_activation_amax:
+                raise ValueError(
+                    f"hybrid W4A16 {name} is incompatible with activation amax"
+                )
+            if moe.zero_fc2_output:
+                raise ValueError(f"hybrid W4A16 {name} forbids zero_fc2_output")
+            if not moe.tc_zero_output:
+                raise ValueError(f"hybrid W4A16 {name} requires tc_zero_output")
+        for attr in (
+            "size_m",
+            "hidden_size",
+            "intermediate_size",
+            "fc1_cols",
+            "top_k",
+            "moe_block_size",
+            "activation",
+            "activation_is_swigluoai",
+            "has_swiglu_limit",
+            "swiglu_limit",
+            "swiglu_alpha",
+            "swiglu_beta",
+            "element_dtype",
+            "is_fp16",
+            "fast_math",
+            "apply_router_weight_on_input",
+            "cta_threads",
+            "sms",
+            "blocks_per_sm",
+            "barrier_count_off",
+            "barrier_sense_off",
+            "schedule_whole_tiles",
+        ):
+            if getattr(tier0, attr) != getattr(tier1, attr):
+                raise ValueError(
+                    f"hybrid W4A16 tiers disagree on {attr}: "
+                    f"{getattr(tier0, attr)!r} != {getattr(tier1, attr)!r}"
+                )
+        for phase in ("fc1", "fc2"):
+            gemm0 = getattr(tier0, phase)
+            gemm1 = getattr(tier1, phase)
+            if (gemm0.n_tiles, gemm0.k_tiles, gemm0.tile_n, gemm0.tile_k) != (
+                gemm1.n_tiles,
+                gemm1.k_tiles,
+                gemm1.tile_n,
+                gemm1.tile_k,
+            ):
+                raise ValueError(f"hybrid W4A16 tiers disagree on {phase} tiling")
+            if (
+                gemm0.top_k,
+                gemm0.mul_topk_weights,
+                gemm0.fused_topk_sum,
+                gemm0.fused_sum_topk,
+                gemm0.moe_block_size,
+                gemm0.cta_threads,
+                gemm0.schedule_whole_tiles,
+            ) != (
+                gemm1.top_k,
+                gemm1.mul_topk_weights,
+                gemm1.fused_topk_sum,
+                gemm1.fused_sum_topk,
+                gemm1.moe_block_size,
+                gemm1.cta_threads,
+                gemm1.schedule_whole_tiles,
+            ):
+                raise ValueError(f"hybrid W4A16 tiers disagree on {phase} semantics")
+        if int(map_slots) < tier0.num_experts + tier1.num_experts:
+            raise ValueError(
+                "hybrid W4A16 map_slots must cover both tiers' expert counts"
+            )
+        if tier0.num_experts > 256 or tier1.num_experts > 256:
+            raise ValueError(
+                "hybrid W4A16 local expert ids must fit the 8-bit descriptor field"
+            )
+        self.tier0 = tier0
+        self.tier1 = tier1
+        self.map_slots = int(map_slots)
+        self.size_m = tier0.size_m
+        self.hidden_size = tier0.hidden_size
+        self.intermediate_size = tier0.intermediate_size
+        self.top_k = tier0.top_k
+        self.element_dtype = tier0.element_dtype
+        self.cta_threads = tier0.cta_threads
+        self.sms = tier0.sms
+        self.blocks_per_sm = tier0.blocks_per_sm
+        self.shared_words = max(tier0.shared_words, tier1.shared_words)
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (
+            "w4a16_fused_moe_hybrid",
+            self.ABI_VERSION,
+            self.map_slots,
+            self.tier0.__cache_key__,
+            self.tier1.__cache_key__,
+            self.shared_words,
+        )
+
+    @cute.jit
+    def _emit_route_map_tile(
+        self,
+        is_fc1: cutlass.Constexpr,
+        a_bf16_flat: cute.Tensor,
+        t0_b_i32_flat: cute.Tensor,
+        t0_scales_i32_flat: cute.Tensor,
+        t0_global_scale: cute.Tensor,
+        t1_b_i32_flat: cute.Tensor,
+        t1_scales_i32_flat: cute.Tensor,
+        t1_global_scale: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        global_topk_ids_i32_flat: cute.Tensor,
+        tier_local_map_i32_flat: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        active_size_m: Int32,
+        route_block_idx: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+    ):
+        gid = global_topk_ids_i32_flat[route_block_idx].to(Int32)
+        if gid >= Int32(0) and gid < Int32(self.map_slots):
+            descriptor = tier_local_map_i32_flat[gid].to(Int32)
+            if descriptor >= Int32(0):
+                tier = descriptor >> Int32(8)
+                local_expert = descriptor & Int32(0xFF)
+                if tier == Int32(0):
+                    if local_expert < Int32(self.tier0.num_experts):
+                        if cutlass.const_expr(is_fc1):
+                            self.tier0.fc1._run_tile(
+                                a_bf16_flat,
+                                t0_b_i32_flat,
+                                c_bf16_flat,
+                                t0_scales_i32_flat,
+                                t0_global_scale,
+                                global_topk_ids_i32_flat,
+                                topk_weights_flat,
+                                c_tmp_f32_flat,
+                                locks_i32_flat,
+                                smem_base,
+                                tid,
+                                route_block_idx,
+                                local_expert,
+                                output_n_tile,
+                                reduce_k_tile,
+                                reduce_tile_count,
+                                reduce_slice_count,
+                                reduce_slice_idx,
+                                lock_slot,
+                                active_size_m,
+                            )
+                        else:
+                            self.tier0.fc2._run_tile(
+                                a_bf16_flat,
+                                t0_b_i32_flat,
+                                c_bf16_flat,
+                                t0_scales_i32_flat,
+                                t0_global_scale,
+                                global_topk_ids_i32_flat,
+                                topk_weights_flat,
+                                c_tmp_f32_flat,
+                                locks_i32_flat,
+                                smem_base,
+                                tid,
+                                route_block_idx,
+                                local_expert,
+                                output_n_tile,
+                                reduce_k_tile,
+                                reduce_tile_count,
+                                reduce_slice_count,
+                                reduce_slice_idx,
+                                lock_slot,
+                                active_size_m,
+                            )
+                else:
+                    if tier == Int32(1):
+                        if local_expert < Int32(self.tier1.num_experts):
+                            if cutlass.const_expr(is_fc1):
+                                self.tier1.fc1._run_tile(
+                                    a_bf16_flat,
+                                    t1_b_i32_flat,
+                                    c_bf16_flat,
+                                    t1_scales_i32_flat,
+                                    t1_global_scale,
+                                    global_topk_ids_i32_flat,
+                                    topk_weights_flat,
+                                    c_tmp_f32_flat,
+                                    locks_i32_flat,
+                                    smem_base,
+                                    tid,
+                                    route_block_idx,
+                                    local_expert,
+                                    output_n_tile,
+                                    reduce_k_tile,
+                                    reduce_tile_count,
+                                    reduce_slice_count,
+                                    reduce_slice_idx,
+                                    lock_slot,
+                                    active_size_m,
+                                )
+                            else:
+                                self.tier1.fc2._run_tile(
+                                    a_bf16_flat,
+                                    t1_b_i32_flat,
+                                    c_bf16_flat,
+                                    t1_scales_i32_flat,
+                                    t1_global_scale,
+                                    global_topk_ids_i32_flat,
+                                    topk_weights_flat,
+                                    c_tmp_f32_flat,
+                                    locks_i32_flat,
+                                    smem_base,
+                                    tid,
+                                    route_block_idx,
+                                    local_expert,
+                                    output_n_tile,
+                                    reduce_k_tile,
+                                    reduce_tile_count,
+                                    reduce_slice_count,
+                                    reduce_slice_idx,
+                                    lock_slot,
+                                    active_size_m,
+                                )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_bf16_ptr: cute.Pointer,
+        t0_w13_i32_flat: cute.Tensor,
+        t0_w2_i32_flat: cute.Tensor,
+        t0_w13_scales_i32_flat: cute.Tensor,
+        t0_w2_scales_i32_flat: cute.Tensor,
+        t0_w13_global_scale: cute.Tensor,
+        t0_w2_global_scale: cute.Tensor,
+        t1_w13_i32_flat: cute.Tensor,
+        t1_w2_i32_flat: cute.Tensor,
+        t1_w13_scales_i32_flat: cute.Tensor,
+        t1_w2_scales_i32_flat: cute.Tensor,
+        t1_w13_global_scale: cute.Tensor,
+        t1_w2_global_scale: cute.Tensor,
+        global_topk_ids_i32_flat: cute.Tensor,
+        tier_local_map_i32_flat: cute.Tensor,
+        fc1_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        output_bf16_flat: cute.Tensor,
+        topk_weights_ptr: cute.Pointer,
+        fc1_c_tmp_f32_flat: cute.Tensor,
+        fc2_c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+        grid_x: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        a_bf16_flat = cute.make_tensor(
+            a_bf16_ptr,
+            layout=cute.make_layout((active_m * Int32(self.hidden_size),), stride=(1,)),
+        )
+        topk_weights_flat = cute.make_tensor(
+            topk_weights_ptr,
+            layout=cute.make_layout((active_m * Int32(self.top_k),), stride=(1,)),
+        )
+        self.kernel(
+            a_bf16_flat,
+            t0_w13_i32_flat,
+            t0_w2_i32_flat,
+            t0_w13_scales_i32_flat,
+            t0_w2_scales_i32_flat,
+            t0_w13_global_scale,
+            t0_w2_global_scale,
+            t1_w13_i32_flat,
+            t1_w2_i32_flat,
+            t1_w13_scales_i32_flat,
+            t1_w2_scales_i32_flat,
+            t1_w13_global_scale,
+            t1_w2_global_scale,
+            global_topk_ids_i32_flat,
+            tier_local_map_i32_flat,
+            fc1_bf16_flat,
+            activated_bf16_flat,
+            output_bf16_flat,
+            topk_weights_flat,
+            fc1_c_tmp_f32_flat,
+            fc2_c_tmp_f32_flat,
+            locks_i32_flat,
+            active_m,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=[self.cta_threads, 1, 1],
+            min_blocks_per_mp=self.blocks_per_sm,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_bf16_flat: cute.Tensor,
+        t0_w13_i32_flat: cute.Tensor,
+        t0_w2_i32_flat: cute.Tensor,
+        t0_w13_scales_i32_flat: cute.Tensor,
+        t0_w2_scales_i32_flat: cute.Tensor,
+        t0_w13_global_scale: cute.Tensor,
+        t0_w2_global_scale: cute.Tensor,
+        t1_w13_i32_flat: cute.Tensor,
+        t1_w2_i32_flat: cute.Tensor,
+        t1_w13_scales_i32_flat: cute.Tensor,
+        t1_w2_scales_i32_flat: cute.Tensor,
+        t1_w13_global_scale: cute.Tensor,
+        t1_w2_global_scale: cute.Tensor,
+        global_topk_ids_i32_flat: cute.Tensor,
+        tier_local_map_i32_flat: cute.Tensor,
+        fc1_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        output_bf16_flat: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        fc1_c_tmp_f32_flat: cute.Tensor,
+        fc2_c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        grid_x_raw, _, _ = cute.arch.grid_dim()
+        tid = Int32(tidx)
+        cta = Int32(bidx)
+        grid_x = Int32(grid_x_raw)
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            words: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, self.shared_words],
+                1024,
+            ]
+
+        storage = smem.allocate(Storage)
+        smem_base = shared_ptr_to_u32(storage.words.data_ptr())
+
+        fc1_emit_tile = partial(
+            self._emit_route_map_tile,
+            True,
+            a_bf16_flat,
+            t0_w13_i32_flat,
+            t0_w13_scales_i32_flat,
+            t0_w13_global_scale,
+            t1_w13_i32_flat,
+            t1_w13_scales_i32_flat,
+            t1_w13_global_scale,
+            fc1_bf16_flat,
+            global_topk_ids_i32_flat,
+            tier_local_map_i32_flat,
+            topk_weights_flat,
+            fc1_c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            active_m,
+        )
+        fc2_emit_tile = partial(
+            self._emit_route_map_tile,
+            False,
+            activated_bf16_flat,
+            t0_w2_i32_flat,
+            t0_w2_scales_i32_flat,
+            t0_w2_global_scale,
+            t1_w2_i32_flat,
+            t1_w2_scales_i32_flat,
+            t1_w2_global_scale,
+            output_bf16_flat,
+            global_topk_ids_i32_flat,
+            tier_local_map_i32_flat,
+            topk_weights_flat,
+            fc2_c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            active_m * Int32(self.top_k),
+        )
+        # Tier 0 drives the shared phase assembly; the unused single-tier
+        # route/amax parameters receive placeholder tensors that the direct
+        # route + no-amax const_expr configuration never reads.
+        self.tier0._moe_body(
+            a_bf16_flat,
+            t0_w13_i32_flat,
+            t0_w2_i32_flat,
+            fc1_bf16_flat,
+            activated_bf16_flat,
+            output_bf16_flat,
+            t0_w13_scales_i32_flat,
+            t0_w2_scales_i32_flat,
+            t0_w13_global_scale,
+            t0_w2_global_scale,
+            global_topk_ids_i32_flat,
+            global_topk_ids_i32_flat,
+            global_topk_ids_i32_flat,
+            global_topk_ids_i32_flat,
+            Int32(0),
+            topk_weights_flat,
+            fc1_c_tmp_f32_flat,
+            fc2_c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            cta,
+            grid_x,
+            active_m,
+            fc1_emit_tile,
+            fc2_emit_tile,
+        )
+
+
+class W4A16ActivationKernel:
+    def __init__(
+        self,
+        *,
+        rows: int,
+        intermediate_size: int,
+        activation: str,
+        element_dtype: str = "bf16",
+        fast_math: bool = True,
+        swiglu_limit: float | None = None,
+        swiglu_alpha: float | None = None,
+        swiglu_beta: float | None = None,
+    ):
+        activation = normalize_moe_activation(activation)
+        is_gated = validate_activation(activation)
+        swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_activation_swiglu_params(
+            activation,
+            swiglu_limit,
+            swiglu_alpha,
+            swiglu_beta,
+        )
+        if element_dtype not in {"bf16", "fp16"}:
+            raise ValueError(f"unsupported element_dtype {element_dtype!r}")
+        if rows <= 0 or intermediate_size <= 0:
+            raise ValueError("rows and intermediate_size must be positive")
+        self.rows = int(rows)
+        self.intermediate_size = int(intermediate_size)
+        self.activation = activation
+        self.is_gated = is_gated
+        self.is_swigluoai = activation == SWIGLUOAI_UNINTERLEAVE
+        self.has_swiglu_limit = swiglu_limit is not None
+        self.swiglu_limit = 0.0 if swiglu_limit is None else swiglu_limit
+        self.swiglu_alpha = float(swiglu_alpha)
+        self.swiglu_beta = float(swiglu_beta)
+        self.element_dtype = element_dtype
+        self.is_fp16 = element_dtype == "fp16"
+        self.fast_math = bool(fast_math)
+        self.cta_threads = 256
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (
+            self.intermediate_size,
+            self.activation,
+            self.is_gated,
+            self.is_swigluoai,
+            self.has_swiglu_limit,
+            self.swiglu_limit,
+            self.swiglu_alpha,
+            self.swiglu_beta,
+            self.element_dtype,
+            self.fast_math,
+            self.cta_threads,
+        )
+
+    @cute.jit
+    def _cast_elem(self, x: cutlass.Float32):
+        if cutlass.const_expr(self.is_fp16):
+            return cutlass.Float16(x)
+        return cutlass.BFloat16(x)
+
+    @cute.jit
+    def _clamp_swiglu_inputs(
+        self,
+        gate: cutlass.Float32,
+        up: cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.has_swiglu_limit):
+            limit = cutlass.Float32(self.swiglu_limit)
+            neg_limit = cutlass.Float32(-self.swiglu_limit)
+            if gate > limit:
+                gate = limit
+            if up > limit:
+                up = limit
+            if up < neg_limit:
+                up = neg_limit
+        return gate, up
+
+    @cute.jit
+    def __call__(
+        self,
+        fc1_flat: cute.Tensor,
+        activated_flat: cute.Tensor,
+        active_rows: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        total = active_rows * Int32(self.intermediate_size)
+        grid = (_covering_count(total, self.cta_threads), 1, 1)
+        self.kernel(fc1_flat, activated_flat, active_rows).launch(
+            grid=grid,
+            block=[self.cta_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        fc1_flat: cute.Tensor,
+        activated_flat: cute.Tensor,
+        active_rows: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        idx = Int32(bidx) * Int32(self.cta_threads) + Int32(tidx)
+        total = Int32(active_rows) * Int32(self.intermediate_size)
+        if idx < total:
+            if cutlass.const_expr(self.is_gated):
+                row = idx // Int32(self.intermediate_size)
+                col = idx - row * Int32(self.intermediate_size)
+                base = row * Int32(2 * self.intermediate_size)
+                gate = fc1_flat[base + col].to(cutlass.Float32)
+                up = fc1_flat[base + Int32(self.intermediate_size) + col].to(
+                    cutlass.Float32
+                )
+                gate, up = self._clamp_swiglu_inputs(gate, up)
+                sigmoid_arg = gate
+                up_term = up
+                if cutlass.const_expr(self.is_swigluoai):
+                    sigmoid_arg = cutlass.Float32(self.swiglu_alpha) * gate
+                    up_term = up + cutlass.Float32(self.swiglu_beta)
+                if cutlass.const_expr(self.fast_math):
+                    exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=True)
+                else:
+                    exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=False)
+                silu = gate / (cutlass.Float32(1.0) + exp_neg_gate)
+                if cutlass.const_expr(self.is_swigluoai):
+                    activated_flat[idx] = self._cast_elem(silu * up_term)
+                else:
+                    activated_flat[idx] = self._cast_elem(
+                        self._cast_elem(silu) * self._cast_elem(up_term)
+                    )
+            else:
+                x = fc1_flat[idx].to(cutlass.Float32)
+                if x < cutlass.Float32(0.0):
+                    x = cutlass.Float32(0.0)
+                activated_flat[idx] = self._cast_elem(x * x)
+
+
+class W4A16TopKSumKernel:
+    def __init__(self, *, topk: int, hidden_size: int, element_dtype: str = "bf16"):
+        if element_dtype not in {"bf16", "fp16"}:
+            raise ValueError(f"unsupported element_dtype {element_dtype!r}")
+        if topk <= 0 or hidden_size <= 0:
+            raise ValueError("topk and hidden_size must be positive")
+        self.topk = int(topk)
+        self.hidden_size = int(hidden_size)
+        self.element_dtype = element_dtype
+        self.is_fp16 = element_dtype == "fp16"
+        self.cta_threads = 256
+
+    @cute.jit
+    def _cast_elem(self, x: cutlass.Float32):
+        if cutlass.const_expr(self.is_fp16):
+            return cutlass.Float16(x)
+        return cutlass.BFloat16(x)
+
+    @cute.jit
+    def __call__(
+        self,
+        fc2_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        active_m: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        fc2_flat = cute.make_tensor(
+            fc2_ptr,
+            layout=cute.make_layout(
+                (active_m * Int32(self.topk * self.hidden_size),), stride=(1,)
+            ),
+        )
+        output_flat = cute.make_tensor(
+            output_ptr,
+            layout=cute.make_layout((active_m * Int32(self.hidden_size),), stride=(1,)),
+        )
+        total = active_m * Int32(self.hidden_size)
+        grid = (_covering_count(total, self.cta_threads), 1, 1)
+        self.kernel(fc2_flat, output_flat, active_m).launch(
+            grid=grid,
+            block=[self.cta_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        fc2_flat: cute.Tensor,
+        output_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        idx = Int32(bidx) * Int32(self.cta_threads) + Int32(tidx)
+        total = active_m * Int32(self.hidden_size)
+        if idx < total:
+            token = idx // Int32(self.hidden_size)
+            col = idx - token * Int32(self.hidden_size)
+            acc = cutlass.Float32(0.0)
+            for route in cutlass.range_constexpr(self.topk):
+                row = token * Int32(self.topk) + Int32(route)
+                route_value = fc2_flat[row * Int32(self.hidden_size) + col].to(
+                    cutlass.Float32
+                )
+                acc += _materialize_w4a16_topk_route_f32(route_value)
+            output_flat[idx] = self._cast_elem(acc)
+
+
+_CACHE: dict[tuple, W4A16GemmCompileResult] = {}
+_FUSED_CACHE: dict[tuple, W4A16FusedMoeCompileResult] = {}
+_ACTIVATION_CACHE: dict[tuple, W4A16ActivationCompileResult] = {}
+_SUM_CACHE: dict[tuple, W4A16TopKSumCompileResult] = {}
+_SMALL_M_DIRECT_CACHE: dict[tuple, _W4A16SmallMDirectLaunch] = {}
+
+
+def _normalize_element_dtype(dtype: torch.dtype) -> str:
+    if dtype == torch.bfloat16:
+        return "bf16"
+    if dtype == torch.float16:
+        return "fp16"
+    raise TypeError(f"unsupported W4A16 activation dtype {dtype}")
+
+
+def _normalize_scale_format(scale_format: str) -> str:
+    try:
+        return _SCALE_FORMATS[scale_format.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "scale_format must be one of 'e4m3_k16', 'e8m0_k32', or 'e4m3_k32', "
+            f"got {scale_format!r}"
+        ) from exc
+
+
+def _scale_group_size(scale_format: str) -> int:
+    return (
+        32 if _normalize_scale_format(scale_format) in ("e8m0_k32", "e4m3_k32") else 16
+    )
+
+
+def _scale_fake_int32_elements(
+    *,
+    num_experts: int,
+    size_k: int,
+    size_n: int,
+    scale_format: str,
+    allow_k_tail: bool = False,
+    allow_n_tail: bool = False,
+) -> int:
+    group_size = _scale_group_size(scale_format)
+    if int(size_n) % 16 != 0:
+        raise ValueError(f"W4A16 {scale_format} scales require size_n divisible by 16")
+    if int(size_k) % group_size != 0 and not allow_k_tail:
+        raise ValueError(
+            f"W4A16 {scale_format} scales require size_k divisible by {group_size}, "
+            f"got {size_k}"
+        )
+    groups_k = (
+        _covering_count(int(size_k), group_size)
+        if allow_k_tail
+        else int(size_k) // group_size
+    )
+    scale_size_n = (
+        _e8m0_logical_tail_scale_n(int(size_n)) if allow_n_tail else int(size_n)
+    )
+    return int(num_experts) * groups_k * (scale_size_n // 4)
+
+
+def _cutlass_element_dtype(element_dtype: str):
+    if element_dtype == "bf16":
+        return cutlass.BFloat16
+    if element_dtype == "fp16":
+        return cutlass.Float16
+    raise ValueError(f"unsupported element_dtype {element_dtype!r}")
+
+
+def _small_m_direct_supported(
+    *,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    element_dtype: str,
+    weight_layout: str,
+    w13_layout: str,
+    scale_format: str = "e4m3_k16",
+    expert_map: torch.Tensor | None = None,
+) -> bool:
+    if os.environ.get("FLASHINFER_EXP_SM12X_W4A16_SMALL_M_DIRECT", "1") == "0":
+        return False
+    activation = normalize_moe_activation(activation)
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_activation_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    if activation == SWIGLUOAI_UNINTERLEAVE and swiglu_limit is None:
+        return False
+    return (
+        element_dtype == "bf16"
+        # Packed serving weights use the W4A16 TC-decode path for small M.
+        # The direct micro kernel is kept limited to native ModelOpt weights.
+        and weight_layout == "modelopt"
+        and w13_layout in ("w13", "w31")
+        and not bool(apply_router_weight_on_input)
+        and (swiglu_limit is None or activation in ("silu", SWIGLUOAI_UNINTERLEAVE))
+        and expert_map is None
+        and MoEMicroKernelW4A16SmallMDirect.is_supported(
+            m=m,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            topk=topk,
+            num_experts=num_experts,
+            scale_format=scale_format,
+        )
+    )
+
+
+def _compile_w4a16_small_m_direct(
+    *,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    fast_math: bool,
+    topk_ids_dtype: torch.dtype,
+    device: torch.device | None,
+    scale_format: str = "e4m3_k16",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    w13_layout: str = "w13",
+) -> _W4A16SmallMDirectLaunch:
+    if topk_ids_dtype not in (torch.int32, torch.int64):
+        raise TypeError("small-M W4A16 direct path requires int32/int64 topk_ids")
+    activation = normalize_moe_activation(activation)
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_activation_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    cache_key = (
+        "w4a16_small_m_direct",
+        None if device is None else int(device.index or 0),
+        int(m),
+        int(hidden_size),
+        int(intermediate_size),
+        int(num_experts),
+        int(topk),
+        activation,
+        bool(fast_math),
+        topk_ids_dtype,
+        scale_format,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+        w13_layout,
+    )
+    cached = _SMALL_M_DIRECT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    kernel = MoEMicroKernelW4A16SmallMDirect(
+        activation=activation,
+        fast_math=bool(fast_math),
+        share_input_across_experts=(int(m) == 1),
+        share_expert_scales=True,
+        single_token=(int(m) == 1),
+        scale_format=scale_format,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        w13_layout=w13_layout,
+    )
+    kernel.configure(
+        int(m),
+        int(hidden_size),
+        int(intermediate_size),
+        int(topk),
+        int(num_experts),
+        device=device,
+    )
+
+    def dummy(dt):
+        return make_ptr(dt, 16, cute.AddressSpace.gmem, assumed_align=16)
+
+    ids_dtype = cutlass.Int32 if topk_ids_dtype == torch.int32 else cutlass.Int64
+    barrier_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = sm12x_compile(
+        kernel,
+        dummy(cutlass.BFloat16),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Float32),
+        dummy(cutlass.Float32),
+        dummy(cutlass.Float32),
+        dummy(cutlass.Uint32),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Float32),
+        dummy(ids_dtype),
+        dummy(cutlass.Float32),
+        dummy(cutlass.BFloat16),
+        barrier_fake,
+        barrier_fake,
+        Int32(m),
+        Int32(kernel.grid_x),
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_facts(
+            "moe.w4a16.small_m_direct",
+            1,
+            ("device_index", None if device is None else int(device.index or 0)),
+            ("m", int(m)),
+            ("hidden_size", int(hidden_size)),
+            ("intermediate_size", int(intermediate_size)),
+            ("num_experts", int(num_experts)),
+            ("topk", int(topk)),
+            ("activation", activation),
+            ("fast_math", bool(fast_math)),
+            ("topk_ids_dtype", str(topk_ids_dtype)),
+            ("scale_format", scale_format),
+            ("swiglu_limit", swiglu_limit),
+            ("swiglu_alpha", swiglu_alpha),
+            ("swiglu_beta", swiglu_beta),
+            ("w13_layout", w13_layout),
+            ("grid_x", int(kernel.grid_x)),
+        ),
+    )
+    launch = _W4A16SmallMDirectLaunch(
+        compiled=compiled,
+        grid_x=int(kernel.grid_x),
+        m=int(m),
+        hidden_size=int(hidden_size),
+        intermediate_size=int(intermediate_size),
+        num_experts=int(num_experts),
+        topk=int(topk),
+        activation=activation,
+        fast_math=bool(fast_math),
+        topk_ids_dtype=topk_ids_dtype,
+    )
+    _SMALL_M_DIRECT_CACHE[cache_key] = launch
+    return launch
+
+
+def compile_w4a16_gemm(
+    *,
+    size_m: int,
+    size_n: int,
+    size_k: int,
+    num_experts: int,
+    top_k: int,
+    mul_topk_weights: bool,
+    tile_n: int,
+    tile_k: int,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str = "bf16",
+    scale_format: str = "e4m3_k16",
+) -> W4A16GemmCompileResult:
+    scale_format = _normalize_scale_format(scale_format)
+    cutlass_dtype = _cutlass_element_dtype(element_dtype)
+    if torch.cuda.is_available():
+        device = int(torch.cuda.current_device())
+    else:
+        device = None
+    kernel = W4A16GemmKernel(
+        size_m=size_m,
+        size_n=size_n,
+        size_k=size_k,
+        num_experts=num_experts,
+        top_k=top_k,
+        mul_topk_weights=mul_topk_weights,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        element_dtype=element_dtype,
+        scale_format=scale_format,
+    )
+    cache_key = (
+        "w4a16_gemm",
+        device,
+        kernel.__cache_key__,
+    )
+    cached = _CACHE.get(cache_key)
+    if cached is not None:
+        return replace(
+            cached,
+            max_m_blocks=max_m_blocks,
+            blocks_per_sm=kernel.blocks_per_sm,
+        )
+
+    compile_size_m = _fake_m_for_specialization(size_m)
+    compile_route_blocks = 1
+    compile_route_slots = compile_route_blocks * int(moe_block_size)
+    a_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype,
+        (compile_size_m * size_k,),
+        assumed_align=16,
+    )
+    b_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (num_experts * (size_k // 16) * (size_n // 16 * 32),),
+        assumed_align=16,
+    )
+    c_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype,
+        (compile_size_m * top_k * size_n,),
+        assumed_align=16,
+    )
+    scales_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (
+            _scale_fake_int32_elements(
+                num_experts=num_experts,
+                size_k=size_k,
+                size_n=size_n,
+                scale_format=scale_format,
+            ),
+        ),
+        assumed_align=16,
+    )
+    global_scale_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (num_experts,),
+        assumed_align=16,
+    )
+    packed_routes_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (compile_route_slots,),
+        assumed_align=16,
+    )
+    block_experts_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (compile_route_blocks,),
+        assumed_align=16,
+    )
+    route_count_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    topk_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (compile_size_m * top_k,),
+        assumed_align=4,
+    )
+    c_tmp_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (
+            max(
+                size_n * compile_route_slots,
+                4 * 256 * moe_block_size * 256,
+            ),
+        ),
+        assumed_align=16,
+    )
+    locks_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (4 * 256,),
+        assumed_align=16,
+    )
+
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = sm12x_compile(
+        kernel,
+        a_fake,
+        b_fake,
+        c_fake,
+        scales_fake,
+        global_scale_fake,
+        packed_routes_fake,
+        block_experts_fake,
+        route_count_fake,
+        topk_fake,
+        c_tmp_fake,
+        locks_fake,
+        Int32(compile_size_m),
+        Int32(1),
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "moe.w4a16.gemm",
+            1,
+            cache_key,
+        ),
+    )
+    result = W4A16GemmCompileResult(
+        compiled=compiled,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        blocks_per_sm=kernel.blocks_per_sm,
+        scale_format=scale_format,
+    )
+    _CACHE[cache_key] = result
+    return result
+
+
+def compile_w4a16_fused_moe(
+    *,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    top_k: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    zero_fc2_output: bool,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str = "bf16",
+    fast_math: bool = True,
+    sms: int,
+    max_shared_mem: int,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    weight_layout: str = "packed",
+    scale_format: str = "e4m3_k16",
+    w13_layout: str = "w13",
+    direct_topk_routes: bool = False,
+    tc_decode_fused_sum: bool = False,
+    collect_activation_amax: bool = False,
+    force_tile_config: tuple[int, int, int, int] | None = None,
+) -> W4A16FusedMoeCompileResult:
+    scale_format = _normalize_scale_format(scale_format)
+    cutlass_dtype = _cutlass_element_dtype(element_dtype)
+    device = int(torch.cuda.current_device()) if torch.cuda.is_available() else None
+    activation = normalize_moe_activation(activation)
+    is_gated = validate_activation(activation)
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_activation_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    if weight_layout not in _WEIGHT_LAYOUTS:
+        raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+    if weight_layout == "modelopt":
+        if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+            raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+    else:
+        w13_layout = "packed"
+    direct_topk_routes = bool(direct_topk_routes)
+    tc_decode_fused_sum = bool(tc_decode_fused_sum)
+    collect_activation_amax = bool(collect_activation_amax)
+    if collect_activation_amax and (direct_topk_routes or tc_decode_fused_sum):
+        raise ValueError(
+            "W4A16 activation amax collection requires the route-packed fused path"
+        )
+    # The TC-decode path validates M in {1,2,4,8} itself and uses direct-topk
+    # routing for the whole {1,2,4,8} range, so it lifts the default decode cap.
+    direct_topk_m_cap = (
+        _W4A16_SMALL_M_DIRECT_MAX_M if tc_decode_fused_sum else _MAX_DIRECT_TOPK_ROUTE_M
+    )
+    if direct_topk_routes and (
+        int(size_m) > direct_topk_m_cap
+        or weight_layout not in ("packed", "nf3_2p1")
+        or bool(zero_fc2_output)
+    ):
+        raise ValueError(
+            "direct_topk_routes is only valid for small-M packed W4A16 without expert_map"
+        )
+    fc1_cols = int(intermediate_size) * (2 if is_gated else 1)
+    routed_rows = int(size_m) * int(top_k)
+    # Logical K/N tails are needed for every shard the tile table can't
+    # divide, not just sub-32 ones: 2048/TP6 = 352 and 3072/TP16 = 192 are
+    # 32-aligned yet have no dividing tile_k/tile_n. %32 shards are the
+    # ceil-scale-grid subset of the same machinery (%32 != 0 implies
+    # %128 != 0).
+    allow_native_logical_tail = (
+        weight_layout == "modelopt"
+        and scale_format == "e8m0_k32"
+        and int(intermediate_size) % 128 != 0
+    )
+    fc1_tile_k, fc1_tile_n, fc1_cta_threads, _ = _select_tile_config(
+        problem_m=size_m,
+        problem_n=fc1_cols,
+        problem_k=hidden_size,
+        top_k=top_k,
+        moe_block_size=moe_block_size,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        scale_format=scale_format,
+        weight_layout=weight_layout,
+        allow_logical_tail=allow_native_logical_tail,
+    )
+    fc2_tile_k, fc2_tile_n, fc2_cta_threads, _ = _select_tile_config(
+        problem_m=routed_rows,
+        problem_n=hidden_size,
+        problem_k=intermediate_size,
+        top_k=1,
+        moe_block_size=moe_block_size,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        scale_format=scale_format,
+        weight_layout=weight_layout,
+        allow_logical_tail=allow_native_logical_tail,
+    )
+    if fc1_cta_threads != fc2_cta_threads:
+        common_cta_threads = min(fc1_cta_threads, fc2_cta_threads)
+        fc1_tile_k, fc1_tile_n, fc1_cta_threads, _ = _select_tile_config(
+            problem_m=size_m,
+            problem_n=fc1_cols,
+            problem_k=hidden_size,
+            top_k=top_k,
+            moe_block_size=moe_block_size,
+            sms=sms,
+            max_shared_mem=max_shared_mem,
+            required_cta_threads=common_cta_threads,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+            allow_logical_tail=allow_native_logical_tail,
+        )
+        fc2_tile_k, fc2_tile_n, fc2_cta_threads, _ = _select_tile_config(
+            problem_m=routed_rows,
+            problem_n=hidden_size,
+            problem_k=intermediate_size,
+            top_k=1,
+            moe_block_size=moe_block_size,
+            sms=sms,
+            max_shared_mem=max_shared_mem,
+            required_cta_threads=common_cta_threads,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+            allow_logical_tail=allow_native_logical_tail,
+        )
+        if fc1_cta_threads != fc2_cta_threads:
+            raise ValueError(
+                "fused W4A16 FC1/FC2 selected different thread counts: "
+                f"{fc1_cta_threads} vs {fc2_cta_threads}"
+            )
+    # TC-decode FC1 wide-N override (single-wave-collapse sizes only): in the m8
+    # fused path the host right-sizes grid_x to the FC1 mn-tile count and forces
+    # one whole mn-tile per CTA over the full K. With the default fc1_tile_n=128,
+    # FC1 (N=fc1_cols=2*intermediate_size) produces size_m*top_k*(fc1_cols/128)
+    # mn-tiles. For TP=2 I_tp=1024 (fc1_cols=2048 => 16 n-tiles/route) bs=1 is
+    # 96 tiles (<= 188 SMs, one wave); bs=2 is 192 -- JUST over the single-wave
+    # SM cap -- forcing a 2-wave launch of grid_x=96 (half the machine idle per
+    # wave, a serialized second FC1 wave of pure tail latency on the bandwidth-
+    # bound decode). Widening FC1 to tile_n=256 (256-wide N slab per CTA over
+    # full K; tile_k=64 keeps cta_threads=256) HALVES FC1's mn-tile count, so
+    # bs=2 collapses to 96 tiles = exactly ONE wave, removing that whole second
+    # FC1 wave. The narrower tile_k=64 is slower per-tile, so we apply this ONLY
+    # where it turns a 2-wave launch into a 1-wave launch: the default 128-wide
+    # FC1 spans 2 waves (sms < default_mn_tiles <= 2*sms) AND the wide tile fits
+    # in one (default/2 <= sms). bs=1 (one wave already) and bs>=4 (still multi-
+    # wave after halving) keep the faster default 128x128 tile.
+    # Guarded by fc1_cols%256==0, smem-fit, and 256-thread geometry so the fused
+    # FC1/FC2 single-thread-geometry contract is preserved.
+    default_fc1_mn_tiles = (
+        int(size_m) * int(top_k) * (int(fc1_cols) // int(fc1_tile_n))
+        if fc1_tile_n > 0
+        else 0
+    )
+    if (
+        bool(tc_decode_fused_sum)
+        and int(fc1_cols) % 256 == 0
+        and fc1_tile_n == 128
+        and (fc1_tile_n * fc1_tile_k) // 64 == 256
+        and int(sms) < default_fc1_mn_tiles <= 2 * int(sms)
+        and (default_fc1_mn_tiles // 2) <= int(sms)
+    ):
+        wide_fc1_tile_k = 64
+        if _candidate_tile_fits(
+            problem_n=fc1_cols,
+            problem_k=hidden_size,
+            cta_m_blocks=_covering_count(moe_block_size, 16),
+            tile_n=256,
+            tile_k=wide_fc1_tile_k,
+            cta_threads=256,
+            max_shared_mem=int(max_shared_mem) - 512,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+        ):
+            fc1_tile_n = 256
+            fc1_tile_k = wide_fc1_tile_k
+            fc1_cta_threads = 256
+    # TC-decode FC2 wide-N override: in the m8 fused path the host right-sizes
+    # grid_x to the FC1 mn-tile count (one persistent wave, no split-K). FC2
+    # (N=hidden_size, K=intermediate_size) with the default tile_n=128 produces
+    # route_blocks*(hidden_size/128) mn-tiles -- roughly double FC1's count --
+    # so FC2 would need ~2 persistent waves while FC1 fits in 1; that second
+    # FC2 wave is pure serialized tail latency on the bandwidth-bound decode.
+    # Selecting tile_n=256 for FC2 (a 256-wide N slab per CTA over full K)
+    # halves FC2's mn-tile count so it also fits one wave. Guarded by smem-fit,
+    # hidden_size%256==0, and matching cta_threads so the fused single
+    # thread-geometry contract is preserved.
+    if (
+        bool(tc_decode_fused_sum)
+        and int(hidden_size) % 256 == 0
+        and fc2_tile_n == 128
+        and fc1_cta_threads == 256
+    ):
+        wide_fc2_tile_k = 64
+        if _candidate_tile_fits(
+            problem_n=hidden_size,
+            problem_k=intermediate_size,
+            cta_m_blocks=_covering_count(moe_block_size, 16),
+            tile_n=256,
+            tile_k=wide_fc2_tile_k,
+            cta_threads=256,
+            max_shared_mem=int(max_shared_mem) - 512,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+        ):
+            fc2_tile_n = 256
+            fc2_tile_k = wide_fc2_tile_k
+            fc2_cta_threads = 256
+    # TC-decode FC2 ultra-wide override (perfect wave-balance with FC1): the
+    # persistent grid_x is right-sized to FC1's mn-tile count. After the FC1/FC2
+    # wide-N (tile_n=256) overrides, bs=2 still has FC1=route_blocks*8 tiles vs
+    # FC2=route_blocks*16 tiles -- FC2 is DOUBLE FC1 and thus needs a second
+    # persistent wave at grid_x sized to FC1. That FC2 second wave is pure
+    # serialized tail latency on the bandwidth-bound decode. Widening FC2 to
+    # tile_n=512 (a 512-wide N slab per CTA over full K) halves FC2's mn-tile
+    # count again so FC2 == FC1's tile count and fits the SAME single wave. A
+    # 512-wide N tile needs tile_k=32 to keep cta_threads=256 (512*32/64); that
+    # is below the generic tile_k>=64 fits-floor, so we validate the footprint
+    # directly here. tile_k=32 == the e8m0_k32 scale group, so cta_k_blocks=2
+    # with one e8m0 scale group per k-tile -- the existing scale layout is a
+    # clean covering. Fire ONLY when it drops FC2 from >1 wave to FC1's wave
+    # count (bs=2). Numerically identical: only the FC2 output-tile width changes.
+    fc1_mn_after = (
+        int(size_m) * int(top_k) * (int(fc1_cols) // int(fc1_tile_n))
+        if fc1_tile_n > 0
+        else 0
+    )
+    fc2_mn_after = (
+        int(size_m) * int(top_k) * (int(hidden_size) // int(fc2_tile_n))
+        if fc2_tile_n > 0
+        else 0
+    )
+    if (
+        bool(tc_decode_fused_sum)
+        and int(hidden_size) % 512 == 0
+        and fc2_tile_n == 256
+        and fc1_cta_threads == 256
+        and fc1_mn_after > 0
+        and fc2_mn_after > fc1_mn_after
+        and (fc2_mn_after // 2) <= fc1_mn_after
+        and fc1_mn_after <= int(sms)
+    ):
+        ultra_fc2_tile_k = 32
+        ultra_smem = _shared_memory_footprint(
+            cta_m_blocks=_covering_count(moe_block_size, 16),
+            tile_n=512,
+            tile_k=ultra_fc2_tile_k,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+        )
+        if (
+            int(intermediate_size) % ultra_fc2_tile_k == 0
+            and ultra_smem <= int(max_shared_mem) - 512
+        ):
+            fc2_tile_n = 512
+            fc2_tile_k = ultra_fc2_tile_k
+            fc2_cta_threads = 256
+    if force_tile_config is not None:
+        # Explicit (fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n) pin. The
+        # NF3 ("nf3_2p1") flat-span weight layout is packed for a specific CTA
+        # N-tile, so hybrid deployments pin ONE tile config across every m
+        # regime instead of the m-dependent auto selection (and TC-decode
+        # wide-N overrides) above. Overrides whatever was selected; the tiles
+        # land in the GEMM cache keys, so no cache collision is possible.
+        fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n = (
+            int(v) for v in force_tile_config
+        )
+        fc1_cta_threads = (fc1_tile_n * fc1_tile_k) // 64
+        fc2_cta_threads = (fc2_tile_n * fc2_tile_k) // 64
+        if fc1_cta_threads != fc2_cta_threads:
+            raise ValueError(
+                "force_tile_config FC1/FC2 thread counts must match, got "
+                f"{fc1_cta_threads} vs {fc2_cta_threads}"
+            )
+        for name, forced_pn, forced_pk, forced_tn, forced_tk in (
+            ("fc1", fc1_cols, hidden_size, fc1_tile_n, fc1_tile_k),
+            ("fc2", hidden_size, intermediate_size, fc2_tile_n, fc2_tile_k),
+        ):
+            if not _candidate_tile_fits(
+                problem_n=forced_pn,
+                problem_k=forced_pk,
+                cta_m_blocks=_covering_count(moe_block_size, 16),
+                tile_n=forced_tn,
+                tile_k=forced_tk,
+                cta_threads=fc1_cta_threads,
+                max_shared_mem=int(max_shared_mem) - 512,
+                scale_format=scale_format,
+                weight_layout=weight_layout,
+                allow_logical_tail=allow_native_logical_tail,
+            ):
+                raise ValueError(
+                    f"force_tile_config {name} tile "
+                    f"(tile_k={forced_tk}, tile_n={forced_tn}) does not fit "
+                    f"problem N/K={forced_pn}/{forced_pk} at "
+                    f"moe_block_size={moe_block_size}"
+                )
+    kernel = W4A16FusedMoeKernel(
+        size_m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=top_k,
+        activation=activation,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        zero_fc2_output=zero_fc2_output,
+        fc1_tile_n=fc1_tile_n,
+        fc1_tile_k=fc1_tile_k,
+        fc2_tile_n=fc2_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        element_dtype=element_dtype,
+        fast_math=fast_math,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        weight_layout=weight_layout,
+        scale_format=scale_format,
+        w13_layout=w13_layout,
+        direct_topk_routes=direct_topk_routes,
+        tc_decode_fused_sum=tc_decode_fused_sum,
+        collect_activation_amax=collect_activation_amax,
+    )
+    cache_key = (
+        "w4a16_fused_moe",
+        device,
+        kernel.__cache_key__,
+    )
+    cached = _FUSED_CACHE.get(cache_key)
+    if cached is not None:
+        return replace(
+            cached,
+            size_m=size_m,
+            max_m_blocks=max_m_blocks,
+            blocks_per_sm=kernel.blocks_per_sm,
+        )
+
+    if (not collect_activation_amax) and _small_m_direct_supported(
+        m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        topk=top_k,
+        activation=activation,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        element_dtype=element_dtype,
+        weight_layout=weight_layout,
+        w13_layout=w13_layout,
+        scale_format=scale_format,
+    ):
+        for ids_dtype in (torch.int32, torch.int64):
+            _compile_w4a16_small_m_direct(
+                m=size_m,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                topk=top_k,
+                activation=activation,
+                fast_math=fast_math,
+                topk_ids_dtype=ids_dtype,
+                scale_format=scale_format,
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+                w13_layout=w13_layout,
+                device=torch.device("cuda", device) if device is not None else None,
+            )
+
+    compile_size_m = _fake_m_for_specialization(size_m)
+    compile_routed_rows = int(compile_size_m) * int(top_k)
+    compile_route_blocks = compile_routed_rows if direct_topk_routes else 1
+    compile_route_slots = compile_route_blocks * int(moe_block_size)
+    packed_route_fake_elements = (
+        compile_routed_rows if direct_topk_routes else compile_route_slots
+    )
+    a_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    if weight_layout == "modelopt":
+        w13_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Uint8,
+            (num_experts * fc1_cols * (hidden_size // 2),),
+            assumed_align=16,
+        )
+        w2_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Uint8,
+            (num_experts * hidden_size * (intermediate_size // 2),),
+            assumed_align=16,
+        )
+    elif weight_layout == "nf3_2p1":
+        # NF3: int32, 3 words per 32-code unit; (size_n // 2) units per K16 row.
+        w13_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (hidden_size // 16) * (fc1_cols // 2) * 3,),
+            assumed_align=16,
+        )
+        w2_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (intermediate_size // 16) * (hidden_size // 2) * 3,),
+            assumed_align=16,
+        )
+    else:
+        w13_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (hidden_size // 16) * (fc1_cols // 16 * 32),),
+            assumed_align=16,
+        )
+        w2_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (intermediate_size // 16) * (hidden_size // 16 * 32),),
+            assumed_align=16,
+        )
+    fc1_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype,
+        (compile_routed_rows * fc1_cols,),
+        assumed_align=16,
+    )
+    activated_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype,
+        (compile_routed_rows * intermediate_size,),
+        assumed_align=16,
+    )
+    fc2_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype,
+        (compile_routed_rows * hidden_size,),
+        assumed_align=16,
+    )
+    w13_scales_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (
+            _scale_fake_int32_elements(
+                num_experts=num_experts,
+                size_k=hidden_size,
+                size_n=fc1_cols,
+                scale_format=scale_format,
+                allow_n_tail=allow_native_logical_tail,
+            ),
+        ),
+        assumed_align=16,
+    )
+    w2_scales_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (
+            _scale_fake_int32_elements(
+                num_experts=num_experts,
+                size_k=intermediate_size,
+                size_n=hidden_size,
+                scale_format=scale_format,
+                allow_k_tail=allow_native_logical_tail,
+            ),
+        ),
+        assumed_align=16,
+    )
+    w13_global_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (num_experts,),
+        assumed_align=16,
+    )
+    w2_global_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (num_experts,),
+        assumed_align=16,
+    )
+    packed_routes_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (packed_route_fake_elements,),
+        assumed_align=16,
+    )
+    block_experts_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (compile_route_blocks,),
+        assumed_align=16,
+    )
+    route_count_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    activation_amax_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (num_experts * 2,),
+        assumed_align=4,
+    )
+    topk_fake = make_ptr(cutlass.Float32, 4, cute.AddressSpace.gmem, assumed_align=4)
+    fc1_c_tmp_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (
+            max(
+                fc1_cols * compile_route_slots,
+                4 * 256 * moe_block_size * 256,
+            ),
+        ),
+        assumed_align=16,
+    )
+    fc2_c_tmp_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (
+            max(
+                hidden_size * compile_route_slots,
+                4 * 256 * moe_block_size * 256,
+            ),
+        ),
+        assumed_align=16,
+    )
+    locks_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (4 * 256 + 2,),
+        assumed_align=16,
+    )
+
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = sm12x_compile(
+        kernel,
+        a_fake,
+        w13_fake,
+        w2_fake,
+        fc1_fake,
+        activated_fake,
+        fc2_fake,
+        w13_scales_fake,
+        w2_scales_fake,
+        w13_global_fake,
+        w2_global_fake,
+        packed_routes_fake,
+        block_experts_fake,
+        route_count_fake,
+        activation_amax_fake,
+        0,
+        topk_fake,
+        fc1_c_tmp_fake,
+        fc2_c_tmp_fake,
+        locks_fake,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "moe.w4a16.fused_moe",
+            1,
+            cache_key,
+        ),
+        dsl_compile_options=OptLevel(2),
+    )
+    result = W4A16FusedMoeCompileResult(
+        compiled=compiled,
+        size_m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=top_k,
+        activation=activation,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        zero_fc2_output=bool(zero_fc2_output),
+        element_dtype=element_dtype,
+        fast_math=bool(fast_math),
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        fc1_tile_n=fc1_tile_n,
+        fc1_tile_k=fc1_tile_k,
+        fc2_tile_n=fc2_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        blocks_per_sm=kernel.blocks_per_sm,
+        weight_layout=weight_layout,
+        w13_layout=w13_layout,
+        direct_topk_routes=kernel.direct_topk_routes,
+        scale_format=scale_format,
+        tc_decode_fused_sum=bool(tc_decode_fused_sum),
+        collect_activation_amax=collect_activation_amax,
+    )
+    _FUSED_CACHE[cache_key] = result
+    return result
+
+
+@dataclass(frozen=True)
+class W4A16FusedMoeHybridCompileResult:
+    compiled: object
+    size_m: int
+    hidden_size: int
+    intermediate_size: int
+    top_k: int
+    activation: str
+    element_dtype: str
+    fast_math: bool
+    map_slots: int
+    tier0_num_experts: int
+    tier0_weight_layout: str
+    tier0_scale_format: str
+    tier0_w13_layout: str
+    tier1_num_experts: int
+    tier1_weight_layout: str
+    tier1_scale_format: str
+    tier1_w13_layout: str
+    fc1_tile_n: int
+    fc1_tile_k: int
+    fc2_tile_n: int
+    fc2_tile_k: int
+    moe_block_size: int
+    max_m_blocks: int
+    cta_threads: int
+    blocks_per_sm: int
+    shared_memory_bytes: int
+    schedule_whole_tiles: bool
+    direct_topk_routes: bool
+    tc_decode_fused_sum: bool
+    # -1 when the compiled object came from the on-disk object cache, whose
+    # loader does not expose CUDA-dialect introspection; a fresh compile of the
+    # identical source/toolchain state ran the spill admission below at least
+    # once before the entry could exist.
+    registers_per_thread: int
+    local_memory_bytes: int
+
+
+def _query_w4a16_kernel_resources(compiled: object) -> tuple[str, int, int] | None:
+    """Return (symbol, registers/thread, local bytes/thread) for a one-kernel
+    CUDA-dialect compile result, or None when the object does not expose the
+    introspection surface (e.g. an on-disk object-cache reload)."""
+
+    kernel_info = getattr(compiled, "kernel_info", None)
+    to_executor = getattr(compiled, "to", None)
+    if not isinstance(kernel_info, dict) or not callable(to_executor):
+        return None
+    symbols = tuple(kernel_info)
+    if len(symbols) != 1 or not isinstance(symbols[0], str) or not symbols[0]:
+        return None
+    executor = to_executor(int(torch.cuda.current_device()))
+    libraries = tuple(
+        getattr(getattr(executor, "jit_module", None), "cuda_library", None) or ()
+    )
+    if len(libraries) != 1:
+        return None
+    success = cuda_runtime.cudaError_t(0)
+    kernel_status, kernel_handle = cuda_runtime.cudaLibraryGetKernel(
+        libraries[0], symbols[0].encode("utf-8")
+    )
+    if kernel_status != success:
+        raise RuntimeError(
+            f"cudaLibraryGetKernel failed for {symbols[0]}: {kernel_status}"
+        )
+    attributes_status, attributes = cuda_runtime.cudaFuncGetAttributes(kernel_handle)
+    if attributes_status != success:
+        raise RuntimeError(
+            f"cudaFuncGetAttributes failed for {symbols[0]}: {attributes_status}"
+        )
+    registers_per_thread = int(getattr(attributes, "numRegs", -1))
+    local_memory_bytes = int(getattr(attributes, "localSizeBytes", -1))
+    if registers_per_thread < 0 or local_memory_bytes < 0:
+        raise RuntimeError(f"incomplete CUDA function attributes for {symbols[0]}")
+    return symbols[0], registers_per_thread, local_memory_bytes
+
+
+def _w4a16_weight_flat_elements(
+    *,
+    num_experts: int,
+    size_n: int,
+    size_k: int,
+    weight_layout: str,
+) -> int:
+    """Flat element count of a packed W4A16 weight tensor (uint8 for modelopt,
+    int32 otherwise), matching the compile-time fake construction."""
+
+    if weight_layout == "modelopt":
+        return int(num_experts) * int(size_n) * (int(size_k) // 2)
+    if weight_layout == "nf3_2p1":
+        return int(num_experts) * (int(size_k) // 16) * (int(size_n) // 2) * 3
+    return int(num_experts) * (int(size_k) // 16) * (int(size_n) // 16 * 32)
+
+
+def compile_w4a16_fused_moe_hybrid(
+    *,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    tier0_num_experts: int,
+    tier1_num_experts: int,
+    top_k: int,
+    activation: str,
+    map_slots: int,
+    moe_block_size: int = 8,
+    element_dtype: str = "bf16",
+    fast_math: bool = True,
+    sms: int,
+    max_shared_mem: int,
+    tier0_weight_layout: str = "packed",
+    tier0_scale_format: str = "e4m3_k16",
+    tier0_w13_layout: str = "packed",
+    tier1_weight_layout: str = "nf3_2p1",
+    tier1_scale_format: str = "e4m3_k32",
+    tier1_w13_layout: str = "w13",
+    force_tile_config: tuple[int, int, int, int],
+    schedule_whole_tiles: bool = True,
+) -> W4A16FusedMoeHybridCompileResult:
+    """Compile the two-tier heterogeneous-quantization fused MoE kernel.
+
+    v1 contract: TC-decode direct-topk geometry (gated activation, fused FC2
+    top-k sum) with an explicitly pinned tile config shared by both tiers.
+    Spill admission is fail-closed on every fresh compile: nonzero local
+    memory raises before the result can be cached or launched.
+    """
+
+    activation = normalize_moe_activation(activation)
+    if not validate_activation(activation):
+        raise ValueError("hybrid W4A16 requires a gated activation")
+    cutlass_dtype = _cutlass_element_dtype(element_dtype)
+    device = int(torch.cuda.current_device()) if torch.cuda.is_available() else None
+    fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n = (int(v) for v in force_tile_config)
+    max_m_blocks = int(size_m) * int(top_k)
+
+    def _tier_kernel(
+        num_experts: int, weight_layout: str, scale_format: str, w13_layout: str
+    ) -> W4A16FusedMoeKernel:
+        return W4A16FusedMoeKernel(
+            size_m=size_m,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            top_k=top_k,
+            activation=activation,
+            apply_router_weight_on_input=False,
+            zero_fc2_output=False,
+            fc1_tile_n=fc1_tile_n,
+            fc1_tile_k=fc1_tile_k,
+            fc2_tile_n=fc2_tile_n,
+            fc2_tile_k=fc2_tile_k,
+            moe_block_size=moe_block_size,
+            max_m_blocks=max_m_blocks,
+            element_dtype=element_dtype,
+            fast_math=fast_math,
+            weight_layout=weight_layout,
+            scale_format=scale_format,
+            w13_layout=w13_layout,
+            direct_topk_routes=True,
+            tc_decode_fused_sum=True,
+            schedule_whole_tiles=bool(schedule_whole_tiles),
+        )
+
+    kernel = W4A16FusedMoeHybridKernel(
+        tier0=_tier_kernel(
+            int(tier0_num_experts),
+            tier0_weight_layout,
+            _normalize_scale_format(tier0_scale_format),
+            tier0_w13_layout,
+        ),
+        tier1=_tier_kernel(
+            int(tier1_num_experts),
+            tier1_weight_layout,
+            _normalize_scale_format(tier1_scale_format),
+            tier1_w13_layout,
+        ),
+        map_slots=int(map_slots),
+    )
+    if kernel.shared_words * 4 > int(max_shared_mem) - 512:
+        raise ValueError(
+            "hybrid W4A16 shared memory exceeds the device limit: "
+            f"{kernel.shared_words * 4} > {int(max_shared_mem) - 512}"
+        )
+
+    cache_key = (
+        "w4a16_fused_moe_hybrid",
+        device,
+        kernel.__cache_key__,
+    )
+    cached = _FUSED_CACHE.get(cache_key)
+    if cached is not None:
+        return replace(cached, size_m=size_m, max_m_blocks=max_m_blocks)
+
+    fc1_cols = kernel.tier0.fc1_cols
+    compile_size_m = _fake_m_for_specialization(size_m)
+    compile_routed_rows = int(compile_size_m) * int(top_k)
+
+    def _weight_fake(num_experts: int, size_n: int, size_k: int, weight_layout: str):
+        elements = _w4a16_weight_flat_elements(
+            num_experts=num_experts,
+            size_n=size_n,
+            size_k=size_k,
+            weight_layout=weight_layout,
+        )
+        fake_dtype = cutlass.Uint8 if weight_layout == "modelopt" else cutlass.Int32
+        return cute.runtime.make_fake_compact_tensor(
+            fake_dtype, (elements,), assumed_align=16
+        )
+
+    def _scales_fake(num_experts: int, size_n: int, size_k: int, scale_format: str):
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (
+                _scale_fake_int32_elements(
+                    num_experts=num_experts,
+                    size_k=size_k,
+                    size_n=size_n,
+                    scale_format=scale_format,
+                ),
+            ),
+            assumed_align=16,
+        )
+
+    def _global_fake(num_experts: int):
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32, (num_experts,), assumed_align=16
+        )
+
+    a_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    topk_fake = make_ptr(cutlass.Float32, 4, cute.AddressSpace.gmem, assumed_align=4)
+    tier0 = kernel.tier0
+    tier1 = kernel.tier1
+    scratch_elements = max(
+        fc1_cols * compile_routed_rows,
+        hidden_size * compile_routed_rows,
+        4 * 256 * moe_block_size * 256,
+    )
+    compile_args = (
+        a_fake,
+        _weight_fake(tier0.num_experts, fc1_cols, hidden_size, tier0.weight_layout),
+        _weight_fake(
+            tier0.num_experts, hidden_size, intermediate_size, tier0.weight_layout
+        ),
+        _scales_fake(tier0.num_experts, fc1_cols, hidden_size, tier0.scale_format),
+        _scales_fake(
+            tier0.num_experts, hidden_size, intermediate_size, tier0.scale_format
+        ),
+        _global_fake(tier0.num_experts),
+        _global_fake(tier0.num_experts),
+        _weight_fake(tier1.num_experts, fc1_cols, hidden_size, tier1.weight_layout),
+        _weight_fake(
+            tier1.num_experts, hidden_size, intermediate_size, tier1.weight_layout
+        ),
+        _scales_fake(tier1.num_experts, fc1_cols, hidden_size, tier1.scale_format),
+        _scales_fake(
+            tier1.num_experts, hidden_size, intermediate_size, tier1.scale_format
+        ),
+        _global_fake(tier1.num_experts),
+        _global_fake(tier1.num_experts),
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32, (compile_routed_rows,), assumed_align=16
+        ),
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32, (int(map_slots),), assumed_align=16
+        ),
+        cute.runtime.make_fake_compact_tensor(
+            cutlass_dtype, (compile_routed_rows * fc1_cols,), assumed_align=16
+        ),
+        cute.runtime.make_fake_compact_tensor(
+            cutlass_dtype,
+            (compile_routed_rows * intermediate_size,),
+            assumed_align=16,
+        ),
+        cute.runtime.make_fake_compact_tensor(
+            cutlass_dtype, (compile_size_m * hidden_size,), assumed_align=16
+        ),
+        topk_fake,
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32, (scratch_elements,), assumed_align=16
+        ),
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32, (scratch_elements,), assumed_align=16
+        ),
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32, (4 * 256 + 2,), assumed_align=16
+        ),
+        1,
+        1,
+        current_cuda_stream(),
+    )
+
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = sm12x_compile(
+        kernel,
+        *compile_args,
+        compile_spec=KernelCompileSpec.from_key(
+            "moe.w4a16.fused_moe_hybrid",
+            W4A16FusedMoeHybridKernel.ABI_VERSION,
+            cache_key,
+        ),
+    )
+    registers_per_thread = -1
+    local_memory_bytes = -1
+    resources = _query_w4a16_kernel_resources(compiled)
+    if resources is not None:
+        _, registers_per_thread, local_memory_bytes = resources
+        if local_memory_bytes != 0:
+            raise RuntimeError(
+                "hybrid W4A16 codegen spills to local memory "
+                f"({local_memory_bytes} bytes/thread); refusing to admit the "
+                "kernel for the latency-critical decode path"
+            )
+
+    result = W4A16FusedMoeHybridCompileResult(
+        compiled=compiled,
+        size_m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        activation=activation,
+        element_dtype=element_dtype,
+        fast_math=bool(fast_math),
+        map_slots=int(map_slots),
+        tier0_num_experts=tier0.num_experts,
+        tier0_weight_layout=tier0.weight_layout,
+        tier0_scale_format=tier0.scale_format,
+        tier0_w13_layout=tier0.w13_layout,
+        tier1_num_experts=tier1.num_experts,
+        tier1_weight_layout=tier1.weight_layout,
+        tier1_scale_format=tier1.scale_format,
+        tier1_w13_layout=tier1.w13_layout,
+        fc1_tile_n=fc1_tile_n,
+        fc1_tile_k=fc1_tile_k,
+        fc2_tile_n=fc2_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        cta_threads=kernel.cta_threads,
+        blocks_per_sm=kernel.blocks_per_sm,
+        shared_memory_bytes=kernel.shared_words * 4,
+        schedule_whole_tiles=bool(schedule_whole_tiles),
+        direct_topk_routes=True,
+        tc_decode_fused_sum=True,
+        registers_per_thread=registers_per_thread,
+        local_memory_bytes=local_memory_bytes,
+    )
+    _FUSED_CACHE[cache_key] = result
+    return result
+
+
+def clear_w4a16_kernel_cache() -> None:
+    _CACHE.clear()
+    _FUSED_CACHE.clear()
+    _ACTIVATION_CACHE.clear()
+    _SUM_CACHE.clear()
+    _SMALL_M_DIRECT_CACHE.clear()
+
+
+def compile_w4a16_activation(
+    *,
+    rows: int,
+    intermediate_size: int,
+    activation: str,
+    element_dtype: str = "bf16",
+    fast_math: bool = True,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+) -> W4A16ActivationCompileResult:
+    cutlass_dtype = _cutlass_element_dtype(element_dtype)
+    activation = normalize_moe_activation(activation)
+    is_gated = validate_activation(activation)
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_activation_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    kernel = W4A16ActivationKernel(
+        rows=rows,
+        intermediate_size=intermediate_size,
+        activation=activation,
+        element_dtype=element_dtype,
+        fast_math=fast_math,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+    )
+    cache_key = (
+        "w4a16_activation",
+        kernel.__cache_key__,
+    )
+    cached = _ACTIVATION_CACHE.get(cache_key)
+    if cached is not None:
+        return replace(cached, rows=rows)
+
+    w13_shards = 2 if is_gated else 1
+    compile_rows = _fake_m_for_specialization(rows)
+    fc1_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype,
+        (compile_rows * w13_shards * intermediate_size,),
+        assumed_align=16,
+    )
+    activated_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype,
+        (compile_rows * intermediate_size,),
+        assumed_align=16,
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = sm12x_compile(
+        kernel,
+        fc1_fake,
+        activated_fake,
+        Int32(compile_rows),
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "moe.w4a16.activation",
+            1,
+            cache_key,
+        ),
+    )
+    result = W4A16ActivationCompileResult(
+        compiled=compiled,
+        rows=rows,
+        intermediate_size=intermediate_size,
+        activation=activation,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+    )
+    _ACTIVATION_CACHE[cache_key] = result
+    return result
+
+
+def compile_w4a16_topk_sum(
+    *,
+    m: int,
+    topk: int,
+    hidden_size: int,
+    element_dtype: str = "bf16",
+) -> W4A16TopKSumCompileResult:
+    cutlass_dtype = _cutlass_element_dtype(element_dtype)
+    cache_key = ("w4a16_topk_sum", element_dtype, topk, hidden_size)
+    cached = _SUM_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    fc2_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    output_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    kernel = W4A16TopKSumKernel(
+        topk=topk,
+        hidden_size=hidden_size,
+        element_dtype=element_dtype,
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = sm12x_compile(
+        kernel,
+        fc2_fake,
+        output_fake,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "moe.w4a16.topk_sum",
+            1,
+            cache_key,
+        ),
+    )
+    result = W4A16TopKSumCompileResult(
+        compiled=compiled,
+        m=0,
+        topk=topk,
+        hidden_size=hidden_size,
+    )
+    _SUM_CACHE[cache_key] = result
+    return result
+
+
+def _w4a16_small_m_direct_launch_flat(
+    a_input: torch.Tensor,
+    w13_u8: torch.Tensor,
+    w13_scale_u8: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    inter_u32: torch.Tensor,
+    w2_u8: torch.Tensor,
+    w2_scale_u8: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    output: torch.Tensor,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    fast_math: bool,
+    scale_format: str,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    w13_layout: str,
+    stream_int: int,
+) -> None:
+    swiglu_limit = float(swiglu_limit_value) if has_swiglu_limit else None
+    direct_launch = _compile_w4a16_small_m_direct(
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        topk=topk,
+        activation=activation,
+        fast_math=bool(fast_math),
+        topk_ids_dtype=topk_ids.dtype,
+        scale_format=scale_format,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        w13_layout=w13_layout,
+        device=a_input.device,
+    )
+
+    def ptr(dt, tensor: torch.Tensor):
+        return make_ptr(dt, tensor.data_ptr(), cute.AddressSpace.gmem, assumed_align=16)
+
+    ids_dtype = cutlass.Int64 if topk_ids.dtype == torch.int64 else cutlass.Int32
+    direct_launch.compiled(
+        ptr(cutlass.BFloat16, a_input),
+        ptr(cutlass.Uint8, w13_u8),
+        ptr(cutlass.Uint8, w13_scale_u8.view(torch.uint8)),
+        ptr(cutlass.Float32, w13_global_scale),
+        ptr(cutlass.Float32, w13_global_scale),
+        ptr(cutlass.Float32, w2_global_scale),
+        ptr(cutlass.Uint32, inter_u32.view(torch.uint32)),
+        ptr(cutlass.Uint8, w2_u8),
+        ptr(cutlass.Uint8, w2_scale_u8.view(torch.uint8)),
+        ptr(cutlass.Float32, w2_global_scale),
+        ptr(ids_dtype, topk_ids),
+        ptr(cutlass.Float32, topk_weights),
+        ptr(cutlass.BFloat16, output),
+        barrier_count,
+        barrier_epoch,
+        Int32(m),
+        Int32(direct_launch.grid_x),
+        cuda.CUstream(stream_int),
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::w4a16_small_m_direct_launch",
+    mutates_args="unknown",
+)
+def _w4a16_small_m_direct_launch_op(
+    a_input: torch.Tensor,
+    w13_u8: torch.Tensor,
+    w13_scale_u8: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    inter_u32: torch.Tensor,
+    w2_u8: torch.Tensor,
+    w2_scale_u8: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    output: torch.Tensor,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    fast_math: bool,
+    scale_format: str,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    w13_layout: str,
+    stream_int: int,
+) -> None:
+    _w4a16_small_m_direct_launch_flat(
+        a_input=a_input,
+        w13_u8=w13_u8,
+        w13_scale_u8=w13_scale_u8,
+        w13_global_scale=w13_global_scale,
+        w2_global_scale=w2_global_scale,
+        inter_u32=inter_u32,
+        w2_u8=w2_u8,
+        w2_scale_u8=w2_scale_u8,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        output=output,
+        barrier_count=barrier_count,
+        barrier_epoch=barrier_epoch,
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        topk=topk,
+        activation=activation,
+        fast_math=fast_math,
+        scale_format=scale_format,
+        has_swiglu_limit=has_swiglu_limit,
+        swiglu_limit_value=swiglu_limit_value,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        w13_layout=w13_layout,
+        stream_int=stream_int,
+    )
+
+
+@_w4a16_small_m_direct_launch_op.register_fake
+def _w4a16_small_m_direct_launch_fake(
+    a_input: torch.Tensor,
+    w13_u8: torch.Tensor,
+    w13_scale_u8: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    inter_u32: torch.Tensor,
+    w2_u8: torch.Tensor,
+    w2_scale_u8: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    output: torch.Tensor,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    fast_math: bool,
+    scale_format: str,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    w13_layout: str,
+    stream_int: int,
+) -> None:
+    return None
+
+
+def _w4a16_fused_moe_launch_flat(
+    a_input: torch.Tensor,
+    w13_arg: torch.Tensor,
+    w2_arg: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    fc2_out: torch.Tensor,
+    w13_scale_i32: torch.Tensor,
+    w2_scale_i32: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    packed_route_indices: torch.Tensor,
+    block_expert_ids: torch.Tensor,
+    packed_route_count: torch.Tensor,
+    activation_amax: torch.Tensor | None,
+    layer_idx: int,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    zero_fc2_output: bool,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    weight_layout: str,
+    scale_format: str,
+    w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    direct_topk_routes: bool,
+    tc_decode_fused_sum: bool,
+    collect_activation_amax: bool,
+    stream_int: int,
+) -> None:
+    swiglu_limit = float(swiglu_limit_value) if has_swiglu_limit else None
+    collect_activation_amax = bool(collect_activation_amax)
+    if collect_activation_amax and activation_amax is None:
+        raise ValueError("activation_amax is required for calibrated W4A16 launch")
+    activation_amax_arg = (
+        activation_amax.view(-1) if activation_amax is not None else w13_global_scale
+    )
+    fused = compile_w4a16_fused_moe(
+        size_m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=topk,
+        activation=activation,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        zero_fc2_output=bool(zero_fc2_output),
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        element_dtype=element_dtype,
+        fast_math=bool(fast_math),
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        weight_layout=weight_layout,
+        scale_format=scale_format,
+        w13_layout=w13_layout,
+        direct_topk_routes=bool(direct_topk_routes),
+        tc_decode_fused_sum=bool(tc_decode_fused_sum),
+        collect_activation_amax=collect_activation_amax,
+        # The custom-op boundary cannot carry the compiled launch object. Re-pin
+        # its selected geometry so tile-specific packs (notably NF3) resolve the
+        # identical cache entry instead of silently recompiling with auto tiles.
+        force_tile_config=(fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n),
+    )
+    fused.compiled(
+        make_ptr(
+            _cutlass_element_dtype(element_dtype),
+            a_input.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        w13_arg,
+        w2_arg,
+        fc1_out,
+        activated,
+        fc2_out,
+        w13_scale_i32,
+        w2_scale_i32,
+        w13_global_scale,
+        w2_global_scale,
+        packed_route_indices,
+        block_expert_ids,
+        packed_route_count,
+        activation_amax_arg,
+        int(layer_idx),
+        make_ptr(
+            cutlass.Float32,
+            topk_weights.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        fc1_scratch,
+        fc2_scratch,
+        workspace,
+        m,
+        _w4a16_fused_persistent_grid_x(
+            fused=fused,
+            m=m,
+            topk=topk,
+            intermediate_size=intermediate_size,
+            activation=activation,
+            direct_topk_routes=bool(direct_topk_routes),
+            sms=sms,
+        ),
+        cuda.CUstream(stream_int),
+    )
+
+
+def _w4a16_fused_persistent_grid_x(
+    *,
+    fused: W4A16FusedMoeCompileResult,
+    m: int,
+    topk: int,
+    intermediate_size: int,
+    activation: str,
+    direct_topk_routes: bool,
+    sms: int,
+) -> int:
+    """Right-size the persistent grid for the fused FC1+FC2 launch.
+
+    The default over-subscribes the cooperative grid (sms*blocks_per_sm CTAs)
+    and forces the larger GEMM into the cross-CTA split-K tail (lock-serialized
+    finalize + c_tmp gmem round-trip) whenever its mn-tile count exceeds the
+    grid. For the small-M direct-topk decode the host knows the exact FC1
+    mn-tile count, so pick the fewest full persistent waves that fit the
+    co-residency cap and set grid_x to that wave's tile count. Then every CTA
+    owns whole FC1 (and FC2, whose tile count is an integer multiple) mn-tiles
+    over the full K -- no split-K reduction, no lock traffic -- with fewer
+    grid-barrier participants, while staying <= the cap so the cooperative
+    barrier never deadlocks. Falls back to the default for the route-pack path
+    where the host cannot know route_blocks ahead of the launch.
+    """
+    cap = int(sms) * int(fused.blocks_per_sm)
+    if not direct_topk_routes or m <= 0:
+        return max(cap, 1)
+    is_gated = is_gated_moe_activation(activation)
+    fc1_cols = int(intermediate_size) * (2 if is_gated else 1)
+    fc1_tile_n = int(getattr(fused, "fc1_tile_n", 0))
+    if fc1_tile_n <= 0 or fc1_cols % fc1_tile_n != 0:
+        return max(cap, 1)
+    n_tiles = fc1_cols // fc1_tile_n
+    route_blocks = int(m) * int(topk)
+    fc1_mn_tiles = route_blocks * n_tiles
+    if fc1_mn_tiles <= 0 or cap <= 0:
+        return max(cap, 1)
+    if bool(getattr(fused, "schedule_whole_tiles", False)):
+        # Whole-tile scheduling tolerates ragged waves, so the whole-cover
+        # constraint below does not apply. Minimize the FC1+FC2 critical path
+        # in whole-tile waves per CTA; ties go to the smaller grid (fewer
+        # grid-barrier participants). Measured on the GLM-5.2 TP4 hybrid
+        # shard (m=4: FC2 768 tiles), cap=188 CTAs runs FC2 in 5-deep waves
+        # vs 6-deep at the FC1-right-sized 128 CTAs: 95.9us vs 107.1us.
+        fc2_tile_n = int(getattr(fused, "fc2_tile_n", 0))
+        hidden = int(getattr(fused, "hidden_size", 0))
+        if fc2_tile_n <= 0 or hidden <= 0 or hidden % fc2_tile_n != 0:
+            return max(cap, 1)
+        fc2_mn_tiles = route_blocks * (hidden // fc2_tile_n)
+
+        def whole_tile_critical_path(grid: int) -> int:
+            return -(-fc1_mn_tiles // grid) + -(-fc2_mn_tiles // grid)
+
+        candidates = sorted({int(cap), min(fc1_mn_tiles, int(cap))})
+        return min(candidates, key=lambda g: (whole_tile_critical_path(g), g))
+    waves = (fc1_mn_tiles + cap - 1) // cap
+    if waves <= 0:
+        return max(cap, 1)
+    # Only commit to the right-sized grid when every wave is a whole tile cover
+    # (no remainder => no split-K tail); otherwise keep the safe default.
+    if fc1_mn_tiles % waves != 0:
+        return max(cap, 1)
+    grid_x = fc1_mn_tiles // waves
+    if grid_x < 1 or grid_x > cap:
+        return max(cap, 1)
+    return grid_x
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::w4a16_fused_moe_launch",
+    mutates_args="unknown",
+)
+def _w4a16_fused_moe_launch_op(
+    a_input: torch.Tensor,
+    w13_arg: torch.Tensor,
+    w2_arg: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    fc2_out: torch.Tensor,
+    w13_scale_i32: torch.Tensor,
+    w2_scale_i32: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    packed_route_indices: torch.Tensor,
+    block_expert_ids: torch.Tensor,
+    packed_route_count: torch.Tensor,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    zero_fc2_output: bool,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    weight_layout: str,
+    scale_format: str,
+    w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    direct_topk_routes: bool,
+    tc_decode_fused_sum: bool,
+    stream_int: int,
+) -> None:
+    _w4a16_fused_moe_launch_flat(
+        a_input=a_input,
+        w13_arg=w13_arg,
+        w2_arg=w2_arg,
+        fc1_out=fc1_out,
+        activated=activated,
+        fc2_out=fc2_out,
+        w13_scale_i32=w13_scale_i32,
+        w2_scale_i32=w2_scale_i32,
+        w13_global_scale=w13_global_scale,
+        w2_global_scale=w2_global_scale,
+        packed_route_indices=packed_route_indices,
+        block_expert_ids=block_expert_ids,
+        packed_route_count=packed_route_count,
+        activation_amax=None,
+        layer_idx=0,
+        topk_weights=topk_weights,
+        fc1_scratch=fc1_scratch,
+        fc2_scratch=fc2_scratch,
+        workspace=workspace,
+        m=m,
+        size_m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        zero_fc2_output=zero_fc2_output,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        element_dtype=element_dtype,
+        fast_math=fast_math,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        has_swiglu_limit=has_swiglu_limit,
+        swiglu_limit_value=swiglu_limit_value,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        weight_layout=weight_layout,
+        scale_format=scale_format,
+        w13_layout=w13_layout,
+        fc1_tile_k=fc1_tile_k,
+        fc1_tile_n=fc1_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        fc2_tile_n=fc2_tile_n,
+        direct_topk_routes=direct_topk_routes,
+        tc_decode_fused_sum=tc_decode_fused_sum,
+        collect_activation_amax=False,
+        stream_int=stream_int,
+    )
+
+
+@_w4a16_fused_moe_launch_op.register_fake
+def _w4a16_fused_moe_launch_fake(
+    a_input: torch.Tensor,
+    w13_arg: torch.Tensor,
+    w2_arg: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    fc2_out: torch.Tensor,
+    w13_scale_i32: torch.Tensor,
+    w2_scale_i32: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    packed_route_indices: torch.Tensor,
+    block_expert_ids: torch.Tensor,
+    packed_route_count: torch.Tensor,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    zero_fc2_output: bool,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    weight_layout: str,
+    scale_format: str,
+    w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    direct_topk_routes: bool,
+    tc_decode_fused_sum: bool,
+    stream_int: int,
+) -> None:
+    return None
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::w4a16_fused_moe_calibrated_launch",
+    mutates_args="unknown",
+)
+def _w4a16_fused_moe_calibrated_launch_op(
+    a_input: torch.Tensor,
+    w13_arg: torch.Tensor,
+    w2_arg: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    fc2_out: torch.Tensor,
+    w13_scale_i32: torch.Tensor,
+    w2_scale_i32: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    packed_route_indices: torch.Tensor,
+    block_expert_ids: torch.Tensor,
+    packed_route_count: torch.Tensor,
+    activation_amax: torch.Tensor,
+    layer_idx: int,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    zero_fc2_output: bool,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    weight_layout: str,
+    scale_format: str,
+    w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    stream_int: int,
+) -> None:
+    _w4a16_fused_moe_launch_flat(
+        a_input=a_input,
+        w13_arg=w13_arg,
+        w2_arg=w2_arg,
+        fc1_out=fc1_out,
+        activated=activated,
+        fc2_out=fc2_out,
+        w13_scale_i32=w13_scale_i32,
+        w2_scale_i32=w2_scale_i32,
+        w13_global_scale=w13_global_scale,
+        w2_global_scale=w2_global_scale,
+        packed_route_indices=packed_route_indices,
+        block_expert_ids=block_expert_ids,
+        packed_route_count=packed_route_count,
+        activation_amax=activation_amax,
+        layer_idx=layer_idx,
+        topk_weights=topk_weights,
+        fc1_scratch=fc1_scratch,
+        fc2_scratch=fc2_scratch,
+        workspace=workspace,
+        m=m,
+        size_m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        zero_fc2_output=zero_fc2_output,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        element_dtype=element_dtype,
+        fast_math=fast_math,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        has_swiglu_limit=has_swiglu_limit,
+        swiglu_limit_value=swiglu_limit_value,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        weight_layout=weight_layout,
+        scale_format=scale_format,
+        w13_layout=w13_layout,
+        fc1_tile_k=fc1_tile_k,
+        fc1_tile_n=fc1_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        fc2_tile_n=fc2_tile_n,
+        direct_topk_routes=False,
+        tc_decode_fused_sum=False,
+        collect_activation_amax=True,
+        stream_int=stream_int,
+    )
+
+
+@_w4a16_fused_moe_calibrated_launch_op.register_fake
+def _w4a16_fused_moe_calibrated_launch_fake(
+    a_input: torch.Tensor,
+    w13_arg: torch.Tensor,
+    w2_arg: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    fc2_out: torch.Tensor,
+    w13_scale_i32: torch.Tensor,
+    w2_scale_i32: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    packed_route_indices: torch.Tensor,
+    block_expert_ids: torch.Tensor,
+    packed_route_count: torch.Tensor,
+    activation_amax: torch.Tensor,
+    layer_idx: int,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    zero_fc2_output: bool,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    has_swiglu_limit: bool,
+    swiglu_limit_value: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    weight_layout: str,
+    scale_format: str,
+    w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    stream_int: int,
+) -> None:
+    return None
+
+
+def _w4a16_topk_sum_launch_flat(
+    fc2_out: torch.Tensor,
+    output: torch.Tensor,
+    m: int,
+    topk: int,
+    hidden_size: int,
+    element_dtype: str,
+    stream_int: int,
+) -> None:
+    sum_kernel = compile_w4a16_topk_sum(
+        m=m,
+        topk=topk,
+        hidden_size=hidden_size,
+        element_dtype=element_dtype,
+    )
+    sum_kernel.compiled(
+        make_ptr(
+            _cutlass_element_dtype(element_dtype),
+            fc2_out.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            _cutlass_element_dtype(element_dtype),
+            output.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        m,
+        cuda.CUstream(stream_int),
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::w4a16_topk_sum_launch",
+    mutates_args=("output",),
+)
+def _w4a16_topk_sum_launch_op(
+    fc2_out: torch.Tensor,
+    output: torch.Tensor,
+    m: int,
+    topk: int,
+    hidden_size: int,
+    element_dtype: str,
+    stream_int: int,
+) -> None:
+    _w4a16_topk_sum_launch_flat(
+        fc2_out=fc2_out,
+        output=output,
+        m=m,
+        topk=topk,
+        hidden_size=hidden_size,
+        element_dtype=element_dtype,
+        stream_int=stream_int,
+    )
+
+
+@_w4a16_topk_sum_launch_op.register_fake
+def _w4a16_topk_sum_launch_fake(
+    fc2_out: torch.Tensor,
+    output: torch.Tensor,
+    m: int,
+    topk: int,
+    hidden_size: int,
+    element_dtype: str,
+    stream_int: int,
+) -> None:
+    return None
+
+
+def _get_c_tmp(
+    elements: int,
+    *,
+    device: torch.device,
+    scratch: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if scratch is not None:
+        if scratch.dtype != torch.float32:
+            raise TypeError("W4A16 c_tmp scratch buffers must be torch.float32")
+        if scratch.device != device:
+            raise ValueError(f"W4A16 c_tmp scratch buffers must be on {device}")
+        if not scratch.is_contiguous():
+            raise ValueError("W4A16 c_tmp scratch buffers must be contiguous")
+        if int(scratch.numel()) >= int(elements):
+            return scratch[: int(elements)]
+    if torch.cuda.is_current_stream_capturing():
+        raise RuntimeError(
+            "W4A16 GEMM scratch is not initialized for CUDA graph capture; "
+            "provide a preallocated fc*_c_tmp workspace with sufficient capacity"
+        )
+    return torch.empty((elements,), dtype=torch.float32, device=device)
+
+
+def _validate_topk_ids(
+    topk_ids: torch.Tensor,
+    *,
+    require_cuda: bool,
+    require_contiguous: bool = True,
+) -> None:
+    if topk_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("topk_ids must be torch.int32 or torch.int64")
+    if require_cuda and not topk_ids.is_cuda:
+        raise ValueError("topk_ids must be a CUDA tensor")
+    if require_contiguous and not topk_ids.is_contiguous():
+        raise ValueError("topk_ids must be contiguous")
+
+
+def _validate_expert_map(
+    expert_map: torch.Tensor | None,
+    *,
+    device: torch.device | None = None,
+    exact_num_experts: int | None = None,
+) -> None:
+    if expert_map is None:
+        return
+    if expert_map.dtype != torch.int32:
+        raise TypeError("expert_map must be torch.int32")
+    if device is None:
+        if not expert_map.is_cuda:
+            raise ValueError("expert_map must be a CUDA tensor")
+    elif expert_map.device != device:
+        raise ValueError("expert_map must be on the same device as a_input")
+    if exact_num_experts is None:
+        if expert_map.ndim != 1 or not expert_map.is_contiguous():
+            raise ValueError("expert_map must be a contiguous rank-1 tensor")
+        return
+    if not expert_map.is_contiguous():
+        raise ValueError("expert_map must be contiguous")
+    if expert_map.ndim != 1 or int(expert_map.numel()) != int(exact_num_experts):
+        raise ValueError(
+            f"expert_map must have shape {(int(exact_num_experts),)}, got {tuple(expert_map.shape)}"
+        )
+
+
+def _validate_activation_amax(
+    activation_amax: torch.Tensor | None,
+    *,
+    layer_idx: int | None,
+    num_experts: int,
+    device: torch.device,
+) -> int | None:
+    if activation_amax is None:
+        if layer_idx is not None:
+            raise ValueError("layer_idx requires activation_amax")
+        return None
+    if layer_idx is None:
+        raise ValueError("layer_idx is required when activation_amax is provided")
+    if activation_amax.dtype != torch.float32:
+        raise TypeError("activation_amax must be torch.float32")
+    if activation_amax.device != device:
+        raise ValueError("activation_amax must be on the same device as a_input")
+    if not activation_amax.is_cuda:
+        raise ValueError("activation_amax must be a CUDA tensor")
+    if not activation_amax.is_contiguous():
+        raise ValueError("activation_amax must be contiguous")
+    if activation_amax.ndim != 3 or int(activation_amax.shape[2]) != 2:
+        raise ValueError("activation_amax must have shape [num_layers, num_experts, 2]")
+    if int(activation_amax.shape[1]) < int(num_experts):
+        raise ValueError(
+            "activation_amax expert dimension is smaller than the local expert count"
+        )
+    layer = int(layer_idx)
+    if layer < 0 or layer >= int(activation_amax.shape[0]):
+        raise ValueError(
+            f"layer_idx {layer} is out of bounds for activation_amax with "
+            f"{int(activation_amax.shape[0])} layers"
+        )
+    return layer
+
+
+def _compile_w4a16_gemm_launch(
+    *,
+    size_m: int,
+    size_n: int,
+    size_k: int,
+    num_experts: int,
+    top_k: int,
+    mul_topk_weights: bool,
+    moe_block_size: int,
+    max_m_blocks: int,
+    element_dtype: str,
+    packed_route_indices: torch.Tensor,
+    sms: int,
+    max_shared_mem: int,
+    device: torch.device,
+    c_tmp: torch.Tensor | None = None,
+    scale_format: str = "e4m3_k16",
+) -> _W4A16GemmLaunch:
+    tile_k, tile_n, _, _ = _select_tile_config(
+        problem_m=size_m,
+        problem_n=size_n,
+        problem_k=size_k,
+        top_k=top_k,
+        moe_block_size=moe_block_size,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        scale_format=scale_format,
+    )
+    kernel = compile_w4a16_gemm(
+        size_m=size_m,
+        size_n=size_n,
+        size_k=size_k,
+        num_experts=num_experts,
+        top_k=top_k,
+        mul_topk_weights=mul_topk_weights,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        moe_block_size=moe_block_size,
+        max_m_blocks=max_m_blocks,
+        element_dtype=element_dtype,
+        scale_format=scale_format,
+    )
+    c_tmp = _get_c_tmp(
+        packed_gemm_scratch_elements(
+            size_n=size_n,
+            route_slots=int(packed_route_indices.numel()),
+            moe_block_size=moe_block_size,
+            sms=sms,
+        ),
+        device=device,
+        scratch=c_tmp,
+    )
+    return _W4A16GemmLaunch(kernel=kernel, c_tmp=c_tmp)
+
+
+def pack_topk_routes_by_expert(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    *,
+    expert_map: torch.Tensor | None = None,
+    packed_route_indices: torch.Tensor | None = None,
+    block_expert_ids: torch.Tensor | None = None,
+    packed_route_count: torch.Tensor | None = None,
+    expert_offsets: torch.Tensor | None = None,
+    stream: cuda.CUstream | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Group top-k routes by expert and pad each group to the GEMM M-block size."""
+    _validate_topk_ids(topk_ids, require_cuda=True)
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+    if num_experts <= 0:
+        raise ValueError(f"num_experts must be positive, got {num_experts}")
+    _validate_expert_map(expert_map, exact_num_experts=int(num_experts))
+    del stream
+    return _pack_topk_routes_by_expert(
+        topk_ids,
+        int(block_size),
+        int(num_experts),
+        expert_map=expert_map,
+        packed_route_indices=packed_route_indices,
+        block_expert_ids=block_expert_ids,
+        packed_route_count=packed_route_count,
+        expert_offsets=expert_offsets,
+    )
+
+
+def run_w4a16_moe(
+    a_input: torch.Tensor,
+    prepared,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    activation: str,
+    intermediate_cache13: torch.Tensor,
+    intermediate_cache2: torch.Tensor,
+    output: torch.Tensor,
+    fc1_c_tmp: torch.Tensor | None = None,
+    fc2_c_tmp: torch.Tensor | None = None,
+    packed_route_indices: torch.Tensor | None = None,
+    block_expert_ids: torch.Tensor | None = None,
+    packed_route_count: torch.Tensor | None = None,
+    expert_offsets: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+    activation_amax: torch.Tensor | None = None,
+    layer_idx: int | None = None,
+    apply_router_weight_on_input: bool = False,
+    fast_math: bool = True,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    fused_launch: W4A16FusedMoeCompileResult | None = None,
+    topk_sum_launch: W4A16TopKSumCompileResult | None = None,
+    stream: cuda.CUstream | None = None,
+) -> torch.Tensor:
+    activation = normalize_moe_activation(activation)
+    is_gated = validate_activation(activation)
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_activation_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    element_dtype = _normalize_element_dtype(a_input.dtype)
+    if output.dtype != a_input.dtype:
+        raise TypeError(f"output must have dtype {a_input.dtype}, got {output.dtype}")
+    prepared_dtype = getattr(prepared, "params_dtype", a_input.dtype)
+    if prepared_dtype != a_input.dtype:
+        raise TypeError(
+            f"prepared weights were built for {prepared_dtype}, but a_input has dtype {a_input.dtype}"
+        )
+    weight_layout = getattr(prepared, "weight_layout", "packed")
+    if weight_layout not in _WEIGHT_LAYOUTS:
+        raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+    scale_format = _normalize_scale_format(
+        getattr(prepared, "scale_format", None)
+        or (
+            "e8m0_k32"
+            if getattr(prepared, "source_format", "") == "fp4_e8m0_k32"
+            else "e4m3_k16"
+        )
+    )
+    w13_layout = getattr(
+        prepared,
+        "w13_layout",
+        "w13" if weight_layout == "modelopt" else "packed",
+    )
+    if weight_layout == "modelopt":
+        if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+            raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+    else:
+        w13_layout = "packed"
+    if topk_weights.dtype != torch.float32:
+        raise TypeError("topk_weights must be torch.float32")
+    _validate_topk_ids(topk_ids, require_cuda=False, require_contiguous=False)
+    if (
+        not a_input.is_contiguous()
+        or not topk_weights.is_contiguous()
+        or not topk_ids.is_contiguous()
+    ):
+        raise ValueError("a_input, topk_weights, and topk_ids must be contiguous")
+    _validate_expert_map(expert_map, device=a_input.device)
+
+    m, hidden_size = a_input.shape
+    topk = int(topk_ids.shape[1])
+    if tuple(topk_weights.shape) != (m, topk):
+        raise ValueError(f"topk_weights must have shape {(m, topk)}")
+    if int(prepared.hidden_size) != hidden_size:
+        raise ValueError("prepared hidden_size does not match a_input")
+    if bool(prepared.is_gated) != is_gated:
+        raise ValueError("prepared weights do not match activation")
+    if tuple(output.shape) != (m, hidden_size):
+        raise ValueError(f"output must have shape {(m, hidden_size)}")
+    if expert_map is not None and int(expert_map.numel()) < int(prepared.num_experts):
+        raise ValueError("expert_map cannot be shorter than the local expert count")
+    layer_idx_int = _validate_activation_amax(
+        activation_amax,
+        layer_idx=layer_idx,
+        num_experts=int(prepared.num_experts),
+        device=a_input.device,
+    )
+    collect_activation_amax = activation_amax is not None
+
+    route_num_experts = (
+        int(expert_map.numel()) if expert_map is not None else int(prepared.num_experts)
+    )
+    if fused_launch is None:
+        block_size_m = select_route_block_size_m(m, topk, route_num_experts)
+    else:
+        block_size_m = int(fused_launch.moe_block_size)
+    if block_size_m not in _ALLOWED_ROUTED_SIZES:
+        raise ValueError(f"unsupported W4A16 moe_block_size={block_size_m}")
+
+    stream = current_cuda_stream() if stream is None else stream
+    if (not collect_activation_amax) and _small_m_direct_supported(
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=int(prepared.intermediate_size),
+        num_experts=int(prepared.num_experts),
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        element_dtype=element_dtype,
+        weight_layout=weight_layout,
+        w13_layout=w13_layout,
+        scale_format=scale_format,
+        expert_map=expert_map,
+    ):
+        if topk_ids.dtype not in (torch.int32, torch.int64):
+            raise TypeError("W4A16 small-M direct path requires int32/int64 topk_ids")
+        if not topk_ids.is_cuda:
+            raise ValueError("W4A16 small-M direct path requires CUDA topk_ids")
+        if not intermediate_cache2.is_contiguous() or not output.is_contiguous():
+            raise ValueError(
+                "W4A16 small-M direct path requires contiguous intermediate_cache2 and output"
+            )
+        if intermediate_cache2.dtype != a_input.dtype:
+            raise TypeError(f"intermediate_cache2 must be {a_input.dtype}")
+        if int(prepared.workspace.numel()) < 2:
+            raise ValueError("prepared W4A16 workspace is too small for small-M direct")
+        intermediate_size = int(prepared.intermediate_size)
+        fc2_n_chunks = ((intermediate_size // 2) + 127) // 128
+        inter_u32_per_m = fc2_n_chunks * 128 * topk
+        inter_u32 = intermediate_cache2.view(-1).view(torch.uint32)
+        if int(inter_u32.numel()) < m * inter_u32_per_m:
+            raise ValueError(
+                "intermediate_cache2 is smaller than the W4A16 small-M direct scratch "
+                f"requirement: have_u32={int(inter_u32.numel())}, "
+                f"need_u32={m * inter_u32_per_m}"
+            )
+        micro_w13_scale = getattr(prepared, "micro_w13_scale", None)
+        micro_w2_scale = getattr(prepared, "micro_w2_scale", None)
+        micro_w13_global = getattr(prepared, "micro_w13_global_scale", None)
+        micro_w2_global = getattr(prepared, "micro_w2_global_scale", None)
+        if (
+            micro_w13_scale is None
+            or micro_w2_scale is None
+            or micro_w13_global is None
+            or micro_w2_global is None
+        ):
+            raise RuntimeError(
+                "W4A16 small-M direct path requires prepared micro scale metadata"
+            )
+        barrier_count = prepared.workspace[-2:-1]
+        barrier_epoch = prepared.workspace[-1:]
+        barrier_count.zero_()
+        barrier_epoch.zero_()
+        torch.ops.flashinfer_sm12x.w4a16_small_m_direct_launch(
+            a_input,
+            prepared.w13.view(torch.uint8),
+            micro_w13_scale,
+            micro_w13_global,
+            micro_w2_global,
+            inter_u32[: m * inter_u32_per_m],
+            prepared.w2.view(torch.uint8),
+            micro_w2_scale,
+            topk_ids,
+            topk_weights,
+            output,
+            barrier_count,
+            barrier_epoch,
+            m,
+            hidden_size,
+            intermediate_size,
+            int(prepared.num_experts),
+            topk,
+            activation,
+            bool(fast_math),
+            scale_format,
+            swiglu_limit is not None,
+            float(swiglu_limit or 0.0),
+            float(swiglu_alpha),
+            float(swiglu_beta),
+            w13_layout,
+            int(stream),
+        )
+        return output
+
+    # TC-decode: small-M packed decode that folds the top-k sum into the FC2
+    # store epilogue. Reuses the packed tensor-core MMA path; only the launch
+    # scheduling/epilogue changes. Requires the packed object, bf16 gated
+    # activation, int32 routes, no expert_map, and a runtime-compiled launch.
+    # A preplanned launch built with the TC-decode fused-sum epilogue carries
+    # ``tc_decode_fused_sum``; accept it through the binding path. A runtime
+    # ``fused_launch is None`` (e.g. the standalone benchmark) compiles its own.
+    preplanned_tc_decode = bool(getattr(fused_launch, "tc_decode_fused_sum", False))
+    use_tc_decode = bool(
+        (not collect_activation_amax)
+        and (fused_launch is None or preplanned_tc_decode)
+        and weight_layout in ("packed", "nf3_2p1")
+        and expert_map is None
+        and is_gated
+        and element_dtype == "bf16"
+        and topk_ids.dtype in (torch.int32, torch.int64)
+        and topk_ids.is_cuda
+        and int(m) <= _TC_DECODE_MAX_M
+    )
+    if use_tc_decode and topk_ids.dtype != torch.int32:
+        # The inline direct-topk route path needs int32 route indices.
+        topk_ids = topk_ids.to(torch.int32)
+
+    direct_topk_eligible = (
+        (not collect_activation_amax)
+        and (m <= _MAX_DIRECT_TOPK_ROUTE_M or use_tc_decode)
+        and weight_layout in ("packed", "nf3_2p1")
+        and expert_map is None
+    )
+    use_direct_topk_routes = bool(
+        direct_topk_eligible
+        and topk_ids.dtype == torch.int32
+        and (
+            fused_launch is None
+            or bool(getattr(fused_launch, "direct_topk_routes", False))
+        )
+    )
+    if (
+        bool(getattr(fused_launch, "direct_topk_routes", False))
+        and not use_direct_topk_routes
+    ):
+        raise RuntimeError(
+            "preplanned W4A16 direct top-k routing requires small-M packed "
+            "int32 topk_ids without expert_map"
+        )
+
+    # TC-decode requires the inline direct-topk route path (no route-pack).
+    use_tc_decode = bool(use_tc_decode and use_direct_topk_routes)
+
+    # A preplanned TC-decode launch atomically accumulates FC2 partials into the
+    # (pre-zeroed) output and emits no separate top-k sum. If it was selected but
+    # the decode preconditions don't hold, running it would corrupt the output,
+    # so fail loudly instead.
+    if preplanned_tc_decode and not use_tc_decode:
+        raise RuntimeError(
+            "preplanned TC-decode W4A16 launch requires small-M packed bf16 "
+            f"decode (m <= {_TC_DECODE_MAX_M}, cuda int32/int64 topk_ids, "
+            "no expert_map)"
+        )
+
+    route_slots_for_scratch = int(m) * int(topk) * int(block_size_m)
+    required_m_blocks = int(m) * int(topk) if use_direct_topk_routes else 0
+    if fused_launch is not None and not use_direct_topk_routes:
+        route_slots_capacity = max_packed_route_slots(
+            int(fused_launch.size_m) * int(topk),
+            int(block_size_m),
+            route_num_experts,
+        )
+        route_blocks_capacity = (route_slots_capacity + int(block_size_m) - 1) // int(
+            block_size_m
+        )
+        if packed_route_indices is not None:
+            if int(packed_route_indices.numel()) < route_slots_capacity:
+                raise ValueError(
+                    "packed_route_indices is smaller than the selected W4A16 launch capacity"
+                )
+            packed_route_indices = packed_route_indices[:route_slots_capacity]
+        if block_expert_ids is not None:
+            if int(block_expert_ids.numel()) < route_blocks_capacity:
+                raise ValueError(
+                    "block_expert_ids is smaller than the selected W4A16 launch capacity"
+                )
+            block_expert_ids = block_expert_ids[:route_blocks_capacity]
+    if use_direct_topk_routes:
+        packed_route_indices = topk_ids.view(-1)
+        if block_expert_ids is None:
+            block_expert_ids = packed_route_indices
+        if packed_route_count is None:
+            packed_route_count = packed_route_indices
+    else:
+        packed_route_indices, block_expert_ids, packed_route_count = (
+            pack_topk_routes_by_expert(
+                topk_ids,
+                block_size_m,
+                route_num_experts,
+                expert_map=expert_map,
+                packed_route_indices=packed_route_indices,
+                block_expert_ids=block_expert_ids,
+                packed_route_count=packed_route_count,
+                expert_offsets=expert_offsets,
+                stream=stream,
+            )
+        )
+        route_slots_for_scratch = int(packed_route_indices.numel())
+        required_m_blocks = int(block_expert_ids.numel())
+
+    props = torch.cuda.get_device_properties(a_input.device)
+    sms = int(props.multi_processor_count)
+    max_shared_mem = int(
+        getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+    )
+    buffer_plan = plan_w4a16_buffers(
+        prepared,
+        m=m,
+        topk=topk,
+        route_num_experts=route_num_experts,
+        sms=sms,
+    )
+    intermediate_size = int(prepared.intermediate_size)
+    fc1_cols = buffer_plan.fc1_cols
+
+    if intermediate_cache13.numel() < buffer_plan.intermediate_cache13_elements:
+        raise ValueError(
+            f"intermediate_cache13 has {intermediate_cache13.numel()} elements; "
+            f"need at least {buffer_plan.intermediate_cache13_elements}"
+        )
+    if intermediate_cache2.numel() < buffer_plan.intermediate_cache2_elements:
+        raise ValueError(
+            f"intermediate_cache2 has {intermediate_cache2.numel()} elements; "
+            f"need at least {buffer_plan.intermediate_cache2_elements}"
+        )
+    if (
+        intermediate_cache13.dtype != a_input.dtype
+        or intermediate_cache2.dtype != a_input.dtype
+    ):
+        raise TypeError(f"intermediate caches must be {a_input.dtype}")
+    if (
+        not intermediate_cache13.is_contiguous()
+        or not intermediate_cache2.is_contiguous()
+        or not output.is_contiguous()
+    ):
+        raise ValueError("intermediate caches and output must be contiguous")
+
+    intermediate_cache13_flat = intermediate_cache13.view(-1)
+    intermediate_cache2_flat = intermediate_cache2.view(-1)
+
+    if int(prepared.workspace.numel()) < sms * 4 + 2:
+        raise ValueError("prepared W4A16 workspace is too small for fused FC1+FC2")
+    if fused_launch is None:
+        fused = compile_w4a16_fused_moe(
+            size_m=m,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=int(prepared.num_experts),
+            top_k=topk,
+            activation=activation,
+            apply_router_weight_on_input=bool(apply_router_weight_on_input),
+            zero_fc2_output=expert_map is not None,
+            moe_block_size=block_size_m,
+            max_m_blocks=int(required_m_blocks),
+            element_dtype=element_dtype,
+            fast_math=bool(fast_math),
+            sms=sms,
+            max_shared_mem=max_shared_mem,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            weight_layout=weight_layout,
+            scale_format=scale_format,
+            w13_layout=w13_layout,
+            direct_topk_routes=use_direct_topk_routes,
+            tc_decode_fused_sum=use_tc_decode,
+            collect_activation_amax=collect_activation_amax,
+        )
+    else:
+        if int(fused_launch.size_m) < m:
+            raise RuntimeError(
+                "preplanned W4A16 fused MoE launch capacity is smaller than requested rows: "
+                f"requested={m}, planned={int(fused_launch.size_m)}"
+            )
+        expected_fused = (
+            hidden_size,
+            intermediate_size,
+            int(prepared.num_experts),
+            topk,
+            activation,
+            bool(apply_router_weight_on_input),
+            expert_map is not None,
+            element_dtype,
+            bool(fast_math),
+            swiglu_limit,
+            float(swiglu_alpha),
+            float(swiglu_beta),
+            weight_layout,
+            scale_format,
+            w13_layout,
+            bool(use_direct_topk_routes),
+            bool(collect_activation_amax),
+            block_size_m,
+        )
+        actual_fused = (
+            int(fused_launch.hidden_size),
+            int(fused_launch.intermediate_size),
+            int(fused_launch.num_experts),
+            int(fused_launch.top_k),
+            fused_launch.activation,
+            bool(fused_launch.apply_router_weight_on_input),
+            bool(fused_launch.zero_fc2_output),
+            fused_launch.element_dtype,
+            bool(fused_launch.fast_math),
+            fused_launch.swiglu_limit,
+            float(fused_launch.swiglu_alpha),
+            float(fused_launch.swiglu_beta),
+            getattr(fused_launch, "weight_layout", "packed"),
+            getattr(fused_launch, "scale_format", "e4m3_k16"),
+            getattr(
+                fused_launch,
+                "w13_layout",
+                "w13"
+                if getattr(fused_launch, "weight_layout", "packed") == "modelopt"
+                else "packed",
+            ),
+            bool(getattr(fused_launch, "direct_topk_routes", False)),
+            bool(getattr(fused_launch, "collect_activation_amax", False)),
+            int(fused_launch.moe_block_size),
+        )
+        if actual_fused != expected_fused or int(fused_launch.max_m_blocks) < int(
+            required_m_blocks
+        ):
+            raise RuntimeError(
+                "preplanned W4A16 fused MoE launch does not match requested contract: "
+                f"requested={expected_fused + (int(required_m_blocks),)}, "
+                f"planned={actual_fused + (int(fused_launch.max_m_blocks),)}"
+            )
+        fused = fused_launch
+    if weight_layout == "nf3_2p1":
+        prepared_tiles = (
+            int(getattr(prepared, "fc1_tile_n", 0)),
+            int(getattr(prepared, "fc2_tile_n", 0)),
+        )
+        compiled_tiles = (int(fused.fc1_tile_n), int(fused.fc2_tile_n))
+        if prepared_tiles != compiled_tiles:
+            raise RuntimeError(
+                "prepared NF3 packing geometry does not match the compiled "
+                "W4A16 launch: "
+                f"prepared_fc1_fc2_tile_n={prepared_tiles}, "
+                f"compiled_fc1_fc2_tile_n={compiled_tiles}"
+            )
+    capacity_m = int(fused.size_m)
+    capacity_routed_rows = capacity_m * topk
+    if intermediate_cache13_flat.numel() < capacity_routed_rows * max(
+        fc1_cols, hidden_size
+    ):
+        raise ValueError(
+            "intermediate_cache13 is smaller than the selected W4A16 launch capacity: "
+            f"capacity_rows={capacity_m}, topk={topk}"
+        )
+    if intermediate_cache2_flat.numel() < capacity_routed_rows * intermediate_size:
+        raise ValueError(
+            "intermediate_cache2 is smaller than the selected W4A16 launch capacity: "
+            f"capacity_rows={capacity_m}, topk={topk}"
+        )
+    fc1_out = intermediate_cache13_flat[: capacity_routed_rows * fc1_cols]
+    activated = intermediate_cache2_flat[: capacity_routed_rows * intermediate_size]
+    if use_tc_decode:
+        # FC2 atomically accumulates per-route partials directly into the
+        # per-token output, so the output is the FC2 store target and must be
+        # pre-zeroed. The fused tc_decode kernel now zeroes the output in its
+        # own prologue (before FC1, made visible by the existing post-FC1 grid
+        # barrier), so the separate host-side output.zero_() launch is removed
+        # from the decode critical path here. This drops the separate top-k-sum
+        # launch as well.
+        fc2_out = output.view(-1)
+    else:
+        fc2_out = intermediate_cache13_flat[: capacity_routed_rows * hidden_size]
+    fc1_scratch = _get_c_tmp(
+        packed_gemm_scratch_elements(
+            size_n=fc1_cols,
+            route_slots=int(route_slots_for_scratch),
+            moe_block_size=block_size_m,
+            sms=sms,
+        ),
+        device=a_input.device,
+        scratch=fc1_c_tmp,
+    )
+    fc2_scratch = _get_c_tmp(
+        packed_gemm_scratch_elements(
+            size_n=hidden_size,
+            route_slots=int(route_slots_for_scratch),
+            moe_block_size=block_size_m,
+            sms=sms,
+        ),
+        device=a_input.device,
+        scratch=fc2_c_tmp,
+    )
+    if weight_layout == "modelopt":
+        w13_arg = prepared.w13.view(torch.uint8).view(-1)
+        w2_arg = prepared.w2.view(torch.uint8).view(-1)
+    else:
+        w13_arg = prepared.w13.view(torch.int32).view(-1)
+        w2_arg = prepared.w2.view(torch.int32).view(-1)
+    launch_common = (
+        a_input,
+        w13_arg,
+        w2_arg,
+        fc1_out,
+        activated,
+        fc2_out,
+        prepared.w13_scale.view(torch.uint8).view(torch.int32).view(-1),
+        prepared.w2_scale.view(torch.uint8).view(torch.int32).view(-1),
+        prepared.w13_global_scale,
+        prepared.w2_global_scale,
+        packed_route_indices,
+        block_expert_ids,
+        packed_route_count,
+    )
+    launch_tail = (
+        topk_weights,
+        fc1_scratch,
+        fc2_scratch,
+        prepared.workspace,
+        m,
+        capacity_m,
+        hidden_size,
+        intermediate_size,
+        int(prepared.num_experts),
+        topk,
+        activation,
+        bool(apply_router_weight_on_input),
+        expert_map is not None,
+        block_size_m,
+        int(fused.max_m_blocks),
+        element_dtype,
+        bool(fast_math),
+        sms,
+        max_shared_mem,
+        swiglu_limit is not None,
+        float(swiglu_limit or 0.0),
+        float(swiglu_alpha),
+        float(swiglu_beta),
+        weight_layout,
+        scale_format,
+        w13_layout,
+        int(fused.fc1_tile_k),
+        int(fused.fc1_tile_n),
+        int(fused.fc2_tile_k),
+        int(fused.fc2_tile_n),
+    )
+    if collect_activation_amax:
+        assert activation_amax is not None
+        assert layer_idx_int is not None
+        torch.ops.flashinfer_sm12x.w4a16_fused_moe_calibrated_launch(
+            *launch_common,
+            activation_amax,
+            int(layer_idx_int),
+            *launch_tail,
+            int(stream),
+        )
+    else:
+        torch.ops.flashinfer_sm12x.w4a16_fused_moe_launch(
+            *launch_common,
+            *launch_tail,
+            bool(use_direct_topk_routes),
+            bool(use_tc_decode),
+            int(stream),
+        )
+
+    if use_tc_decode:
+        # FC2 already wrote the top-k-summed result into `output`.
+        return output
+
+    if topk_sum_launch is not None:
+        expected_sum = (topk, hidden_size)
+        actual_sum = (
+            int(topk_sum_launch.topk),
+            int(topk_sum_launch.hidden_size),
+        )
+        if actual_sum != expected_sum:
+            raise RuntimeError(
+                "preplanned W4A16 top-k sum launch does not match requested contract: "
+                f"requested={expected_sum}, planned={actual_sum}"
+            )
+    torch.ops.flashinfer_sm12x.w4a16_topk_sum_launch(
+        fc2_out,
+        output,
+        m,
+        topk,
+        hidden_size,
+        element_dtype,
+        int(stream),
+    )
+    return output
+
+
+def build_w4a16_tier_local_map(
+    tier0_global_ids,
+    tier1_global_ids,
+    *,
+    map_slots: int,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """Build the int32 [map_slots] global-expert descriptor table.
+
+    Entry g = (tier << 8) | local_expert_id for a mapped global expert id g,
+    -1 for unmapped. tierN_global_ids[i] is the global id of that tier's local
+    expert i, i.e. the order the tier's weights were packed in.
+    """
+
+    map_slots = int(map_slots)
+    table = torch.full((map_slots,), -1, dtype=torch.int32)
+    seen: set[int] = set()
+    for tier, ids in ((0, tier0_global_ids), (1, tier1_global_ids)):
+        ids_list = [int(v) for v in ids]
+        if len(ids_list) > 256:
+            raise ValueError(
+                f"tier {tier} has {len(ids_list)} experts; the descriptor "
+                "local-id field is 8 bits"
+            )
+        for local, gid in enumerate(ids_list):
+            if gid < 0 or gid >= map_slots:
+                raise ValueError(
+                    f"tier {tier} local expert {local} has global id {gid} "
+                    f"outside [0, {map_slots})"
+                )
+            if gid in seen:
+                raise ValueError(f"global expert id {gid} is mapped twice")
+            seen.add(gid)
+            table[gid] = (tier << 8) | local
+    if device is not None:
+        table = table.to(device)
+    return table.contiguous()
+
+
+def _w4a16_hybrid_validate_tensor(
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+    elements: int,
+    assumed_align: int,
+    exact: bool,
+) -> None:
+    if tensor.dtype != dtype:
+        raise TypeError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    actual = int(tensor.numel())
+    if (exact and actual != int(elements)) or (not exact and actual < int(elements)):
+        relation = "exactly" if exact else "at least"
+        raise ValueError(
+            f"{name} must contain {relation} {int(elements)} elements, got {actual}"
+        )
+    address = int(tensor.data_ptr())
+    if address == 0 or address % int(assumed_align) != 0:
+        raise ValueError(
+            f"{name} address {address:#x} violates assumed_align={int(assumed_align)}"
+        )
+
+
+def _w4a16_hybrid_validate_aliases(
+    tensors: tuple[tuple[str, torch.Tensor, bool], ...],
+) -> None:
+    """Reject byte overlaps involving a mutable tensor or a route-map input."""
+
+    protected = {"global_topk_ids", "tier_local_map"}
+    ranges = tuple(
+        (
+            name,
+            int(tensor.data_ptr()),
+            int(tensor.data_ptr()) + int(tensor.numel()) * int(tensor.element_size()),
+            bool(mutable),
+        )
+        for name, tensor, mutable in tensors
+    )
+    for left_idx in range(len(ranges)):
+        left_name, left_start, left_stop, left_mutable = ranges[left_idx]
+        for right_idx in range(left_idx + 1, len(ranges)):
+            right_name, right_start, right_stop, right_mutable = ranges[right_idx]
+            overlap_matters = (
+                left_mutable
+                or right_mutable
+                or left_name in protected
+                or right_name in protected
+            )
+            if not overlap_matters:
+                continue
+            if left_start < right_stop and right_start < left_stop:
+                raise ValueError(
+                    "hybrid W4A16 unsafe storage alias: "
+                    f"{left_name} overlaps {right_name}"
+                )
+
+
+def _w4a16_fused_moe_hybrid_launch_flat(
+    a_input: torch.Tensor,
+    t0_w13: torch.Tensor,
+    t0_w2: torch.Tensor,
+    t0_w13_scale_i32: torch.Tensor,
+    t0_w2_scale_i32: torch.Tensor,
+    t0_w13_global: torch.Tensor,
+    t0_w2_global: torch.Tensor,
+    t1_w13: torch.Tensor,
+    t1_w2: torch.Tensor,
+    t1_w13_scale_i32: torch.Tensor,
+    t1_w2_scale_i32: torch.Tensor,
+    t1_w13_global: torch.Tensor,
+    t1_w2_global: torch.Tensor,
+    global_topk_ids: torch.Tensor,
+    tier_local_map: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    output_out: torch.Tensor,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    t0_num_experts: int,
+    t1_num_experts: int,
+    topk: int,
+    activation: str,
+    map_slots: int,
+    moe_block_size: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    t0_weight_layout: str,
+    t0_scale_format: str,
+    t0_w13_layout: str,
+    t1_weight_layout: str,
+    t1_scale_format: str,
+    t1_w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    schedule_whole_tiles: bool,
+    stream_int: int,
+) -> None:
+    if not a_input.is_cuda:
+        raise ValueError("hybrid W4A16 input must be a CUDA tensor")
+    device_index = a_input.device.index
+    current_device = int(torch.cuda.current_device())
+    if device_index is None or int(device_index) != current_device:
+        raise ValueError(
+            "hybrid W4A16 input must be on the current CUDA device: "
+            f"cuda:{device_index} != cuda:{current_device}"
+        )
+    current_stream_int = int(torch.cuda.current_stream(a_input.device).cuda_stream)
+    if int(stream_int) != current_stream_int:
+        raise ValueError(
+            "hybrid W4A16 stream must be the current input-device stream: "
+            f"{int(stream_int)} != {current_stream_int}"
+        )
+    if int(m) < 1 or int(m) > int(size_m):
+        raise ValueError(f"hybrid W4A16 requires 1 <= m <= size_m, got m={m}")
+
+    hybrid = compile_w4a16_fused_moe_hybrid(
+        size_m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        tier0_num_experts=t0_num_experts,
+        tier1_num_experts=t1_num_experts,
+        top_k=topk,
+        activation=activation,
+        map_slots=map_slots,
+        moe_block_size=moe_block_size,
+        element_dtype=element_dtype,
+        fast_math=bool(fast_math),
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        tier0_weight_layout=t0_weight_layout,
+        tier0_scale_format=t0_scale_format,
+        tier0_w13_layout=t0_w13_layout,
+        tier1_weight_layout=t1_weight_layout,
+        tier1_scale_format=t1_scale_format,
+        tier1_w13_layout=t1_w13_layout,
+        force_tile_config=(fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n),
+        schedule_whole_tiles=bool(schedule_whole_tiles),
+    )
+
+    element_torch_dtype = torch.float16 if element_dtype == "fp16" else torch.bfloat16
+    fc1_cols = int(intermediate_size) * 2
+    routed_rows = int(m) * int(topk)
+    weight_dtypes = {
+        "modelopt": torch.uint8,
+    }
+    tensor_contracts = (
+        ("a_input", a_input, element_torch_dtype, m * hidden_size, 16, False, False),
+        (
+            "t0_w13",
+            t0_w13,
+            weight_dtypes.get(t0_weight_layout, torch.int32),
+            _w4a16_weight_flat_elements(
+                num_experts=t0_num_experts,
+                size_n=fc1_cols,
+                size_k=hidden_size,
+                weight_layout=t0_weight_layout,
+            ),
+            16,
+            True,
+            False,
+        ),
+        (
+            "t0_w2",
+            t0_w2,
+            weight_dtypes.get(t0_weight_layout, torch.int32),
+            _w4a16_weight_flat_elements(
+                num_experts=t0_num_experts,
+                size_n=hidden_size,
+                size_k=intermediate_size,
+                weight_layout=t0_weight_layout,
+            ),
+            16,
+            True,
+            False,
+        ),
+        (
+            "t1_w13",
+            t1_w13,
+            weight_dtypes.get(t1_weight_layout, torch.int32),
+            _w4a16_weight_flat_elements(
+                num_experts=t1_num_experts,
+                size_n=fc1_cols,
+                size_k=hidden_size,
+                weight_layout=t1_weight_layout,
+            ),
+            16,
+            True,
+            False,
+        ),
+        (
+            "t1_w2",
+            t1_w2,
+            weight_dtypes.get(t1_weight_layout, torch.int32),
+            _w4a16_weight_flat_elements(
+                num_experts=t1_num_experts,
+                size_n=hidden_size,
+                size_k=intermediate_size,
+                weight_layout=t1_weight_layout,
+            ),
+            16,
+            True,
+            False,
+        ),
+        ("t0_w13_scale_i32", t0_w13_scale_i32, torch.int32, 1, 16, False, False),
+        ("t0_w2_scale_i32", t0_w2_scale_i32, torch.int32, 1, 16, False, False),
+        ("t1_w13_scale_i32", t1_w13_scale_i32, torch.int32, 1, 16, False, False),
+        ("t1_w2_scale_i32", t1_w2_scale_i32, torch.int32, 1, 16, False, False),
+        (
+            "t0_w13_global",
+            t0_w13_global,
+            torch.float32,
+            t0_num_experts,
+            16,
+            True,
+            False,
+        ),
+        ("t0_w2_global", t0_w2_global, torch.float32, t0_num_experts, 16, True, False),
+        (
+            "t1_w13_global",
+            t1_w13_global,
+            torch.float32,
+            t1_num_experts,
+            16,
+            True,
+            False,
+        ),
+        ("t1_w2_global", t1_w2_global, torch.float32, t1_num_experts, 16, True, False),
+        (
+            "global_topk_ids",
+            global_topk_ids,
+            torch.int32,
+            routed_rows,
+            16,
+            False,
+            False,
+        ),
+        ("tier_local_map", tier_local_map, torch.int32, map_slots, 16, True, False),
+        (
+            "fc1_out",
+            fc1_out,
+            element_torch_dtype,
+            routed_rows * fc1_cols,
+            16,
+            False,
+            True,
+        ),
+        (
+            "activated",
+            activated,
+            element_torch_dtype,
+            routed_rows * intermediate_size,
+            16,
+            False,
+            True,
+        ),
+        (
+            "output_out",
+            output_out,
+            element_torch_dtype,
+            m * hidden_size,
+            16,
+            False,
+            True,
+        ),
+        ("topk_weights", topk_weights, torch.float32, routed_rows, 4, False, False),
+        ("fc1_scratch", fc1_scratch, torch.float32, 1, 16, False, True),
+        ("fc2_scratch", fc2_scratch, torch.float32, 1, 16, False, True),
+        (
+            "workspace",
+            workspace,
+            torch.int32,
+            int(sms) * 4 + 2,
+            16,
+            False,
+            True,
+        ),
+    )
+    for name, tensor, dtype, elements, align, exact, _ in tensor_contracts:
+        _w4a16_hybrid_validate_tensor(
+            name,
+            tensor,
+            dtype=dtype,
+            elements=elements,
+            assumed_align=align,
+            exact=exact,
+        )
+        if tensor.device != a_input.device:
+            raise ValueError(
+                f"{name} device {tensor.device} does not match input "
+                f"device {a_input.device}"
+            )
+    _w4a16_hybrid_validate_aliases(
+        tuple(
+            (name, tensor, mutable)
+            for name, tensor, _, _, _, _, mutable in tensor_contracts
+        )
+    )
+
+    grid_x = _w4a16_fused_persistent_grid_x(
+        fused=hybrid,
+        m=m,
+        topk=topk,
+        intermediate_size=intermediate_size,
+        activation=activation,
+        direct_topk_routes=True,
+        sms=sms,
+    )
+    hybrid.compiled(
+        make_ptr(
+            _cutlass_element_dtype(element_dtype),
+            a_input.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        t0_w13,
+        t0_w2,
+        t0_w13_scale_i32,
+        t0_w2_scale_i32,
+        t0_w13_global,
+        t0_w2_global,
+        t1_w13,
+        t1_w2,
+        t1_w13_scale_i32,
+        t1_w2_scale_i32,
+        t1_w13_global,
+        t1_w2_global,
+        global_topk_ids,
+        tier_local_map,
+        fc1_out,
+        activated,
+        output_out,
+        make_ptr(
+            cutlass.Float32,
+            topk_weights.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        fc1_scratch,
+        fc2_scratch,
+        workspace,
+        m,
+        grid_x,
+        cuda.CUstream(stream_int),
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::w4a16_fused_moe_hybrid_launch",
+    mutates_args="unknown",
+    device_types="cuda",
+)
+def _w4a16_fused_moe_hybrid_launch_op(
+    a_input: torch.Tensor,
+    t0_w13: torch.Tensor,
+    t0_w2: torch.Tensor,
+    t0_w13_scale_i32: torch.Tensor,
+    t0_w2_scale_i32: torch.Tensor,
+    t0_w13_global: torch.Tensor,
+    t0_w2_global: torch.Tensor,
+    t1_w13: torch.Tensor,
+    t1_w2: torch.Tensor,
+    t1_w13_scale_i32: torch.Tensor,
+    t1_w2_scale_i32: torch.Tensor,
+    t1_w13_global: torch.Tensor,
+    t1_w2_global: torch.Tensor,
+    global_topk_ids: torch.Tensor,
+    tier_local_map: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    output_out: torch.Tensor,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    t0_num_experts: int,
+    t1_num_experts: int,
+    topk: int,
+    activation: str,
+    map_slots: int,
+    moe_block_size: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    t0_weight_layout: str,
+    t0_scale_format: str,
+    t0_w13_layout: str,
+    t1_weight_layout: str,
+    t1_scale_format: str,
+    t1_w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    schedule_whole_tiles: bool,
+    stream_int: int,
+) -> None:
+    _w4a16_fused_moe_hybrid_launch_flat(
+        a_input,
+        t0_w13,
+        t0_w2,
+        t0_w13_scale_i32,
+        t0_w2_scale_i32,
+        t0_w13_global,
+        t0_w2_global,
+        t1_w13,
+        t1_w2,
+        t1_w13_scale_i32,
+        t1_w2_scale_i32,
+        t1_w13_global,
+        t1_w2_global,
+        global_topk_ids,
+        tier_local_map,
+        fc1_out,
+        activated,
+        output_out,
+        topk_weights,
+        fc1_scratch,
+        fc2_scratch,
+        workspace,
+        m,
+        size_m,
+        hidden_size,
+        intermediate_size,
+        t0_num_experts,
+        t1_num_experts,
+        topk,
+        activation,
+        map_slots,
+        moe_block_size,
+        element_dtype,
+        fast_math,
+        sms,
+        max_shared_mem,
+        t0_weight_layout,
+        t0_scale_format,
+        t0_w13_layout,
+        t1_weight_layout,
+        t1_scale_format,
+        t1_w13_layout,
+        fc1_tile_k,
+        fc1_tile_n,
+        fc2_tile_k,
+        fc2_tile_n,
+        schedule_whole_tiles,
+        stream_int,
+    )
+
+
+@_w4a16_fused_moe_hybrid_launch_op.register_fake
+def _w4a16_fused_moe_hybrid_launch_fake(
+    a_input: torch.Tensor,
+    t0_w13: torch.Tensor,
+    t0_w2: torch.Tensor,
+    t0_w13_scale_i32: torch.Tensor,
+    t0_w2_scale_i32: torch.Tensor,
+    t0_w13_global: torch.Tensor,
+    t0_w2_global: torch.Tensor,
+    t1_w13: torch.Tensor,
+    t1_w2: torch.Tensor,
+    t1_w13_scale_i32: torch.Tensor,
+    t1_w2_scale_i32: torch.Tensor,
+    t1_w13_global: torch.Tensor,
+    t1_w2_global: torch.Tensor,
+    global_topk_ids: torch.Tensor,
+    tier_local_map: torch.Tensor,
+    fc1_out: torch.Tensor,
+    activated: torch.Tensor,
+    output_out: torch.Tensor,
+    topk_weights: torch.Tensor,
+    fc1_scratch: torch.Tensor,
+    fc2_scratch: torch.Tensor,
+    workspace: torch.Tensor,
+    m: int,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    t0_num_experts: int,
+    t1_num_experts: int,
+    topk: int,
+    activation: str,
+    map_slots: int,
+    moe_block_size: int,
+    element_dtype: str,
+    fast_math: bool,
+    sms: int,
+    max_shared_mem: int,
+    t0_weight_layout: str,
+    t0_scale_format: str,
+    t0_w13_layout: str,
+    t1_weight_layout: str,
+    t1_scale_format: str,
+    t1_w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
+    schedule_whole_tiles: bool,
+    stream_int: int,
+) -> None:
+    return None
+
+
+def run_w4a16_moe_hybrid(
+    a_input: torch.Tensor,
+    prepared_tier0,
+    prepared_tier1,
+    topk_weights: torch.Tensor,
+    global_topk_ids: torch.Tensor,
+    tier_local_map: torch.Tensor,
+    *,
+    activation: str,
+    intermediate_cache13: torch.Tensor,
+    intermediate_cache2: torch.Tensor,
+    output: torch.Tensor,
+    force_tile_config: tuple[int, int, int, int],
+    size_m: int | None = None,
+    fc1_c_tmp: torch.Tensor | None = None,
+    fc2_c_tmp: torch.Tensor | None = None,
+    fast_math: bool = True,
+    schedule_whole_tiles: bool = True,
+    stream: cuda.CUstream | None = None,
+) -> torch.Tensor:
+    """Run one hybrid two-tier W4A16 fused MoE layer.
+
+    global_topk_ids carries GLOBAL expert ids ([m, topk] int32, -1 inactive);
+    tier_local_map is the descriptor table from build_w4a16_tier_local_map.
+    prepared_tier0/prepared_tier1 are per-tier prepared weight bundles whose
+    packing tile config must match force_tile_config.
+    """
+
+    activation = normalize_moe_activation(activation)
+    if not validate_activation(activation):
+        raise ValueError("hybrid W4A16 requires a gated activation")
+    element_dtype = _normalize_element_dtype(a_input.dtype)
+    m, hidden_size = a_input.shape
+    capacity_m = int(size_m) if size_m is not None else int(m)
+    topk = int(topk_weights.shape[-1])
+    if topk_weights.dtype != torch.float32:
+        raise TypeError("topk_weights must be torch.float32")
+    if global_topk_ids.dtype != torch.int32:
+        raise TypeError("global_topk_ids must be torch.int32")
+    if global_topk_ids.shape != (m, topk) and global_topk_ids.numel() != m * topk:
+        raise ValueError(
+            f"global_topk_ids must have m*topk={m * topk} elements, got "
+            f"{tuple(global_topk_ids.shape)}"
+        )
+
+    for name, prepared in (("tier0", prepared_tier0), ("tier1", prepared_tier1)):
+        prepared_dtype = getattr(prepared, "params_dtype", a_input.dtype)
+        if prepared_dtype != a_input.dtype:
+            raise TypeError(
+                f"{name} prepared weights were built for {prepared_dtype}, "
+                f"but a_input has dtype {a_input.dtype}"
+            )
+        if int(prepared.hidden_size) != int(hidden_size):
+            raise ValueError(f"{name} hidden_size mismatch")
+    intermediate_size = int(prepared_tier0.intermediate_size)
+    if int(prepared_tier1.intermediate_size) != intermediate_size:
+        raise ValueError("hybrid tiers disagree on intermediate_size")
+    fc1_cols = intermediate_size * 2
+
+    def _tier_layouts(prepared) -> tuple[str, str, str]:
+        weight_layout = getattr(prepared, "weight_layout", "packed")
+        scale_format = _normalize_scale_format(
+            getattr(prepared, "scale_format", None) or "e4m3_k16"
+        )
+        if weight_layout == "modelopt":
+            w13_layout = getattr(prepared, "w13_layout", "w13")
+        else:
+            w13_layout = "packed"
+        return weight_layout, scale_format, w13_layout
+
+    t0_layouts = _tier_layouts(prepared_tier0)
+    t1_layouts = _tier_layouts(prepared_tier1)
+
+    def _weight_args(prepared) -> tuple[torch.Tensor, torch.Tensor]:
+        if getattr(prepared, "weight_layout", "packed") == "modelopt":
+            return (
+                prepared.w13.view(torch.uint8).view(-1),
+                prepared.w2.view(torch.uint8).view(-1),
+            )
+        return (
+            prepared.w13.view(torch.int32).view(-1),
+            prepared.w2.view(torch.int32).view(-1),
+        )
+
+    t0_w13, t0_w2 = _weight_args(prepared_tier0)
+    t1_w13, t1_w2 = _weight_args(prepared_tier1)
+
+    props = torch.cuda.get_device_properties(a_input.device)
+    sms = int(props.multi_processor_count)
+    max_shared_mem = int(
+        getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+    )
+
+    capacity_routed_rows = capacity_m * topk
+    intermediate_cache13_flat = intermediate_cache13.view(-1)
+    intermediate_cache2_flat = intermediate_cache2.view(-1)
+    if intermediate_cache13_flat.numel() < capacity_routed_rows * fc1_cols:
+        raise ValueError("intermediate_cache13 is smaller than launch capacity")
+    if intermediate_cache2_flat.numel() < capacity_routed_rows * intermediate_size:
+        raise ValueError("intermediate_cache2 is smaller than launch capacity")
+    fc1_out = intermediate_cache13_flat[: capacity_routed_rows * fc1_cols]
+    activated = intermediate_cache2_flat[: capacity_routed_rows * intermediate_size]
+
+    scratch_elements = packed_gemm_scratch_elements(
+        size_n=max(fc1_cols, hidden_size),
+        route_slots=capacity_routed_rows,
+        moe_block_size=8,
+        sms=sms,
+    )
+    fc1_scratch = _get_c_tmp(scratch_elements, device=a_input.device, scratch=fc1_c_tmp)
+    fc2_scratch = _get_c_tmp(scratch_elements, device=a_input.device, scratch=fc2_c_tmp)
+    workspace = prepared_tier0.workspace
+    stream = current_cuda_stream() if stream is None else stream
+
+    fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n = (int(v) for v in force_tile_config)
+    torch.ops.flashinfer_sm12x.w4a16_fused_moe_hybrid_launch(
+        a_input,
+        t0_w13,
+        t0_w2,
+        prepared_tier0.w13_scale.view(torch.uint8).view(torch.int32).view(-1),
+        prepared_tier0.w2_scale.view(torch.uint8).view(torch.int32).view(-1),
+        prepared_tier0.w13_global_scale,
+        prepared_tier0.w2_global_scale,
+        t1_w13,
+        t1_w2,
+        prepared_tier1.w13_scale.view(torch.uint8).view(torch.int32).view(-1),
+        prepared_tier1.w2_scale.view(torch.uint8).view(torch.int32).view(-1),
+        prepared_tier1.w13_global_scale,
+        prepared_tier1.w2_global_scale,
+        global_topk_ids.view(-1),
+        tier_local_map,
+        fc1_out,
+        activated,
+        output.view(-1),
+        topk_weights,
+        fc1_scratch,
+        fc2_scratch,
+        workspace,
+        int(m),
+        capacity_m,
+        int(hidden_size),
+        intermediate_size,
+        int(prepared_tier0.num_experts),
+        int(prepared_tier1.num_experts),
+        topk,
+        activation,
+        int(tier_local_map.numel()),
+        8,
+        element_dtype,
+        bool(fast_math),
+        sms,
+        max_shared_mem,
+        t0_layouts[0],
+        t0_layouts[1],
+        t0_layouts[2],
+        t1_layouts[0],
+        t1_layouts[1],
+        t1_layouts[2],
+        fc1_tile_k,
+        fc1_tile_n,
+        fc2_tile_k,
+        fc2_tile_n,
+        bool(schedule_whole_tiles),
+        int(stream),
+    )
+    return output
+
+
+__all__ = [
+    "W4A16ActivationCompileResult",
+    "W4A16FusedMoeCompileResult",
+    "W4A16FusedMoeHybridCompileResult",
+    "W4A16GemmCompileResult",
+    "W4A16TopKSumCompileResult",
+    "W4A16FusedMoeKernel",
+    "W4A16FusedMoeHybridKernel",
+    "W4A16ActivationKernel",
+    "W4A16GemmKernel",
+    "W4A16TopKSumKernel",
+    "build_w4a16_tier_local_map",
+    "clear_w4a16_kernel_cache",
+    "compile_w4a16_activation",
+    "compile_w4a16_fused_moe",
+    "compile_w4a16_fused_moe_hybrid",
+    "compile_w4a16_gemm",
+    "compile_w4a16_topk_sum",
+    "pack_topk_routes_by_expert",
+    "run_w4a16_moe",
+    "run_w4a16_moe_hybrid",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/prepare.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/prepare.py
@@ -1,0 +1,1562 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a16/prepare.py @ 3663c726 (2026-07-03) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Local NVFP4/BF16 weight preparation for the CuTeDSL W4A16 path."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+    W4A16PackedBuffers,
+    make_w4a16_packed_buffers as _make_w4a16_packed_buffers,
+    unswizzle_expert_scales,
+    validate_nf3_moe_inputs,
+    validate_w4a16_packed_inputs,
+)
+
+
+_PACKED_TILE_SIZE = 16
+_PACKED_TILE_N_SIZE = 64
+_PACK_FACTOR_4BIT = 8
+_MODEL_OPT_W13_LAYOUTS = {"w13", "w31"}
+_SOURCE_FORMATS = {
+    "modelopt_nvfp4": "modelopt_nvfp4",
+    "fp4_e8m0_k32": "fp4_e8m0_k32",
+    "compressed_tensors": "compressed_tensors",
+}
+_E8M0_K32_BF16_MAX_SCALE_BYTE = 247
+_E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT = 64
+# Canonical W13 layout names are "w13"/"w31"; accept the physical FC1-half
+# spellings as aliases. Logical checkpoint order "w13" arrives up/gate and
+# needs a swap before the kernel's SwiGLU; "w31" is already kernel-native
+# gate/up order.
+_W13_LAYOUTS = {
+    "w13": "w13",
+    "w31": "w31",
+    "up_gate": "w13",
+    "gate_up": "w31",
+}
+_MODEL_OPT_NVFP4_FORMATS = {"modelopt_nvfp4"}
+# NF3 ("nf3_2p1") 3-bit codebook. Must match kernel._NF3_CODEBOOK. The scale
+# convention (see NF3_KERNEL_MODSPEC.md): weights decode to the FULL-precision
+# bf16 codebook value, the K/32 scale byte encodes t_s * 2**-4 (e4m3-style,
+# E4=0 arm), and the per-tensor global_scale carries the matching 2**116.
+_NF3_CODEBOOK = (-1.0, -0.6047, -0.3563, -0.1275, 0.1275, 0.3563, 0.6047, 1.0)
+_NF3_SCALE_GLOBAL = 2.0**116
+_NF3_SCALE_FLOOR = (
+    2.0**-10
+)  # f16(t_s*2^-4) must stay f16-NORMAL (>=2^-14) -> t_s >= 2^-10; real early-layer scales dip below the old 2^-7
+
+
+@dataclass(frozen=True)
+class W4A16PackedWeights:
+    w13: torch.Tensor
+    w13_scale: torch.Tensor
+    w13_global_scale: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+    w2_global_scale: torch.Tensor
+    workspace: torch.Tensor
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    is_gated: bool
+    params_dtype: torch.dtype
+    source_format: str = "modelopt_nvfp4"
+    w13_layout: str = "w13"
+    weight_layout: str = "packed"
+    scale_format: str = "e4m3_k16"
+
+
+@dataclass(frozen=True)
+class W4A16ModelOptWeights:
+    w13: torch.Tensor
+    w13_scale: torch.Tensor
+    w13_global_scale: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+    w2_global_scale: torch.Tensor
+    workspace: torch.Tensor
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    is_gated: bool
+    params_dtype: torch.dtype
+    source_format: str = "modelopt_nvfp4"
+    weight_layout: str = "modelopt"
+    scale_format: str = "e4m3_k16"
+    micro_w13_scale: torch.Tensor | None = None
+    micro_w13_global_scale: torch.Tensor | None = None
+    micro_w2_scale: torch.Tensor | None = None
+    micro_w2_global_scale: torch.Tensor | None = None
+    # Physical order of the two fused FC1 halves in source W13. "w13" (logical,
+    # == "up_gate" physical) needs a row rotation before W4A16 SwiGLU; "w31"
+    # (== "gate_up") is already in the kernel-native order.
+    w13_layout: str = "w13"
+
+
+@dataclass(frozen=True)
+class PreparedNF3MoeWeights:
+    """Runtime NF3 ("nf3_2p1") hybrid-expert W4A16 weights.
+
+    Mirrors W4A16PackedWeights so run_w4a16_moe consumes it identically. The
+    packed planes are int32 (3 words per 32-code unit); the K/32 scales are
+    e4m3-style bytes viewed uint8; the global scales carry the 2**116 the NF3
+    scale convention defers out of the codebook. fc1_tile_n / fc2_tile_n record
+    the CTA N-tile the flat-span packing was built for -- the kernel MUST be
+    compiled/launched with the SAME tile_n (read them back from the compiled
+    W4A16FusedMoeCompileResult).
+    """
+
+    w13: torch.Tensor
+    w13_scale: torch.Tensor
+    w13_global_scale: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+    w2_global_scale: torch.Tensor
+    workspace: torch.Tensor
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    is_gated: bool
+    params_dtype: torch.dtype
+    fc1_tile_n: int
+    fc2_tile_n: int
+    source_format: str = "nf3_2p1"
+    w13_layout: str = "packed"
+    weight_layout: str = "nf3_2p1"
+    scale_format: str = "e4m3_k32"
+
+
+def _make_workspace(
+    device: torch.device, *, max_blocks_per_sm: int = 4
+) -> torch.Tensor:
+    props = torch.cuda.get_device_properties(device)
+    sms = int(props.multi_processor_count)
+    return torch.zeros(
+        (sms * int(max_blocks_per_sm) + 2,),
+        dtype=torch.int32,
+        device=device,
+    )
+
+
+def _scale_perms() -> tuple[list[int], list[int]]:
+    scale_perm: list[int] = []
+    for i in range(8):
+        scale_perm.extend([i + 8 * j for j in range(8)])
+    scale_perm_single: list[int] = []
+    for i in range(4):
+        scale_perm_single.extend([2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
+    return scale_perm, scale_perm_single
+
+
+def _e8m0_logical_tail_scale_n(size_n: int) -> int:
+    return (
+        (int(size_n) + _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT - 1)
+        // _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT
+    ) * _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT
+
+
+def _permute_packed_scales(
+    scales: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    group_size: int,
+    output_size_n: int | None = None,
+) -> torch.Tensor:
+    scale_perm, scale_perm_single = _scale_perms()
+    if group_size < size_k and group_size != -1:
+        block = len(scale_perm)
+        if output_size_n is not None or int(size_n) % block != 0:
+            padded_n = (
+                ((int(size_n) + block - 1) // block) * block
+                if output_size_n is None
+                else int(output_size_n)
+            )
+            if padded_n < int(size_n) or padded_n % block != 0:
+                raise ValueError(
+                    f"output_size_n must be a multiple of {block} and >= size_n"
+                )
+            padded = scales.new_zeros((int(scales.shape[0]), padded_n))
+            padded[:, : int(size_n)] = scales
+            scales = padded.reshape((int(scales.shape[0]), -1, block))
+            scales = scales[:, :, scale_perm].reshape((int(scales.shape[0]), padded_n))
+            if output_size_n is None:
+                scales = scales[:, : int(size_n)]
+            return scales.contiguous()
+        scales = scales.reshape((-1, block))[:, scale_perm]
+    else:
+        block = len(scale_perm_single)
+        if output_size_n is not None or int(size_n) % block != 0:
+            padded_n = (
+                ((int(size_n) + block - 1) // block) * block
+                if output_size_n is None
+                else int(output_size_n)
+            )
+            if padded_n < int(size_n) or padded_n % block != 0:
+                raise ValueError(
+                    f"output_size_n must be a multiple of {block} and >= size_n"
+                )
+            padded = scales.new_zeros((int(scales.shape[0]), padded_n))
+            padded[:, : int(size_n)] = scales
+            scales = padded.reshape((int(scales.shape[0]), -1, block))
+            scales = scales[:, :, scale_perm_single].reshape(
+                (int(scales.shape[0]), padded_n)
+            )
+            if output_size_n is None:
+                scales = scales[:, : int(size_n)]
+            return scales.contiguous()
+        scales = scales.reshape((-1, block))[:, scale_perm_single]
+    return scales.reshape((-1, size_n)).contiguous()
+
+
+def _nvfp4_compute_scale_factor(
+    packed_scales: torch.Tensor,
+    a_dtype: torch.dtype,
+) -> float:
+    if a_dtype == torch.float16:
+        return 1.0
+    max_scalar = 0.0
+    for expert in range(int(packed_scales.shape[0])):
+        ws_float = packed_scales[expert].float() * (2**7)
+        nonzero_mask = ws_float > 0
+        if bool(nonzero_mask.any().item()):
+            max_scalar = max(max_scalar, float(ws_float[nonzero_mask].max().item()))
+    if max_scalar > 0.0 and max_scalar < 448 * (2**7):
+        return float(2 ** math.floor(math.log2((448 * (2**7)) / max_scalar)))
+    return 1.0
+
+
+def _process_nvfp4_packed_scales(
+    packed_scales: torch.Tensor,
+    *,
+    scale_factor: float,
+) -> torch.Tensor:
+    packed_scales = packed_scales.to(torch.float16)
+    packed_scales = packed_scales.view(-1, 4)[:, [0, 2, 1, 3]].view(
+        packed_scales.size(0),
+        -1,
+    )
+    if scale_factor > 1.0:
+        packed_scales = (packed_scales.float() * scale_factor).to(torch.float16)
+    packed_scales = packed_scales * (2**7)
+    packed_scales[packed_scales < 2] = 0
+    packed_scales = packed_scales.view(torch.int16) << 1
+    packed_scales = packed_scales.view(torch.float8_e4m3fn)
+    return packed_scales[:, 1::2].contiguous()
+
+
+def _process_nvfp4_packed_global_scale(
+    global_scale: torch.Tensor,
+    *,
+    a_dtype: torch.dtype,
+) -> torch.Tensor:
+    if a_dtype == torch.float16:
+        target_exponent = 5
+    elif a_dtype == torch.bfloat16:
+        target_exponent = 8
+    else:
+        raise TypeError(f"unsupported W4A16 activation dtype {a_dtype}")
+    fp4_exponent = 2
+    exponent_bias = 2 ** (target_exponent - 1) - 2 ** (fp4_exponent - 1)
+    return global_scale * (2.0 ** (exponent_bias - 7))
+
+
+def _process_nvfp4_micro_global_scale_from_packed(
+    packed_global_scale: torch.Tensor,
+    *,
+    a_dtype: torch.dtype,
+) -> torch.Tensor:
+    if a_dtype == torch.float16:
+        target_exponent = 5
+    elif a_dtype == torch.bfloat16:
+        target_exponent = 8
+    else:
+        raise TypeError(f"unsupported W4A16 activation dtype {a_dtype}")
+    fp4_exponent = 2
+    exponent_bias = 2 ** (target_exponent - 1) - 2 ** (fp4_exponent - 1)
+    return (
+        (packed_global_scale * (2.0 ** (-exponent_bias))).to(torch.float32).contiguous()
+    )
+
+
+def _normalize_source_format(source_format: str) -> str:
+    if source_format.lower() == "mxfp4_native":
+        raise ValueError(
+            "source_format='mxfp4_native' has been removed; use "
+            "source_format='fp4_e8m0_k32' for E8M0 K/32 scales, or add "
+            "a real MXFP4 source contract"
+        )
+    try:
+        return _SOURCE_FORMATS[source_format.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "source_format must be one of 'modelopt_nvfp4', "
+            "'fp4_e8m0_k32', or 'compressed_tensors', "
+            f"got {source_format!r}"
+        ) from exc
+
+
+def _normalize_w13_layout(w13_layout: str) -> str:
+    try:
+        return _W13_LAYOUTS[w13_layout.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "w13_layout must be one of 'w13'/'w31' (or the 'up_gate'/'gate_up' "
+            f"aliases), got {w13_layout!r}"
+        ) from exc
+
+
+def _source_global_scale(
+    global_scale: torch.Tensor, *, source_format: str
+) -> torch.Tensor:
+    if source_format == "compressed_tensors":
+        return (1.0 / global_scale).to(torch.float32).contiguous()
+    return global_scale.contiguous()
+
+
+def _validate_e8m0_k32_scales(
+    scales: torch.Tensor,
+    *,
+    rows: int,
+    cols: int,
+    name: str,
+    allow_k_tail: bool = False,
+) -> torch.Tensor:
+    """Validate source E8M0 K/32 scale tensor shape and dtype."""
+    if scales.ndim != 3:
+        raise ValueError(
+            f"{name} must be [E, N, ceil(K/32)], got {tuple(scales.shape)}"
+        )
+    if allow_k_tail:
+        if int(cols) % 8 != 0:
+            raise ValueError(
+                f"{name} compact E8M0 K-tail requires K divisible by 8, got {int(cols)}"
+            )
+        expected_cols = (int(cols) + 31) // 32
+    elif int(cols) % 32 != 0:
+        raise ValueError(f"{name} requires K divisible by 32, got {int(cols)}")
+    else:
+        expected_cols = int(cols) // 32
+    if tuple(scales.shape[1:]) != (int(rows), expected_cols):
+        raise ValueError(
+            f"{name} must have shape [E, {int(rows)}, {expected_cols}] for "
+            f"E8M0 K/32 scales, got {tuple(scales.shape)}"
+        )
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if scales.dtype == torch.uint8:
+        return scales.view(e8m0_dtype) if e8m0_dtype is not None else scales
+    if e8m0_dtype is not None and scales.dtype == e8m0_dtype:
+        return scales
+    raise TypeError(f"{name} must be torch.uint8 or torch.float8_e8m0fnu")
+
+
+def _pack_e8m0_k32_scales(
+    scales: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    row_rotation: int | None = None,
+    reuse_input_storage: bool = False,
+    allow_k_tail: bool = False,
+    padded_size_n: int | None = None,
+) -> torch.Tensor:
+    if allow_k_tail:
+        if int(size_k) % 8 != 0:
+            raise ValueError(
+                f"compact E8M0 K-tail requires K divisible by 8, got {size_k}"
+            )
+        scale_cols = (int(size_k) + 31) // 32
+    elif int(size_k) % 32 != 0:
+        raise ValueError(f"E8M0 K/32 scales require K divisible by 32, got {size_k}")
+    else:
+        scale_cols = int(size_k) // 32
+    if tuple(scales.shape[1:]) != (int(size_n), scale_cols):
+        raise ValueError(
+            f"expected E8M0 scale shape [E, {int(size_n)}, {scale_cols}], "
+            f"got {tuple(scales.shape)}"
+        )
+    output_size_n = int(size_n) if padded_size_n is None else int(padded_size_n)
+    if output_size_n < int(size_n):
+        raise ValueError(
+            f"padded_size_n must be >= size_n, got {output_size_n} < {int(size_n)}"
+        )
+    source = scales.view(torch.uint8)
+    if reuse_input_storage:
+        if output_size_n != int(size_n):
+            raise ValueError("reuse_input_storage requires unpadded E8M0 scales")
+        if allow_k_tail:
+            raise ValueError(
+                "reuse_input_storage is not supported for compact E8M0 K-tail scales"
+            )
+        if not source.is_contiguous():
+            raise ValueError("reuse_input_storage requires contiguous E8M0 scales")
+        source.clamp_(max=_E8M0_K32_BF16_MAX_SCALE_BYTE)
+        packed = source.reshape(
+            int(source.shape[0]),
+            scale_cols,
+            output_size_n,
+        )
+    else:
+        source = source.clamp(max=_E8M0_K32_BF16_MAX_SCALE_BYTE)
+        packed = torch.empty(
+            (int(source.shape[0]), scale_cols, output_size_n),
+            dtype=torch.uint8,
+            device=scales.device,
+        )
+    for expert in range(int(source.shape[0])):
+        expert_source = source[expert]
+        if row_rotation is not None:
+            expert_source = torch.cat(
+                [expert_source[row_rotation:], expert_source[:row_rotation]],
+                dim=0,
+            )
+        expert_packed = _permute_packed_scales(
+            expert_source.T.contiguous(),
+            size_k=size_k,
+            size_n=size_n,
+            group_size=32,
+            output_size_n=output_size_n,
+        )
+        expert_packed = (
+            expert_packed.view(-1, 4)[:, [0, 2, 1, 3]]
+            .reshape_as(expert_packed)
+            .contiguous()
+        )
+        packed[expert].copy_(expert_packed)
+    return packed.view(scales.dtype) if scales.dtype != torch.uint8 else packed
+
+
+def _repack_4bit_no_perm(
+    qweight_i32: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    out: torch.Tensor | None = None,
+    flat_scratch: torch.Tensor | None = None,
+    gather_scratch: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Pack 4-bit weights into the W4A16 A16 kernel layout."""
+    if qweight_i32.dtype != torch.int32:
+        raise TypeError("qweight_i32 must be torch.int32")
+    if tuple(qweight_i32.shape) != (size_k // _PACK_FACTOR_4BIT, size_n):
+        raise ValueError(
+            f"expected qweight shape {(size_k // _PACK_FACTOR_4BIT, size_n)}, "
+            f"got {tuple(qweight_i32.shape)}"
+        )
+    if size_k % _PACKED_TILE_SIZE != 0 or size_n % _PACKED_TILE_N_SIZE != 0:
+        raise ValueError(
+            f"W4A16 repack requires K,N multiples of 16,64; got {size_k},{size_n}"
+        )
+
+    k_tiles = size_k // _PACKED_TILE_SIZE
+    n_tiles = size_n // _PACKED_TILE_N_SIZE
+    packed_shape = (k_tiles, n_tiles, 128)
+    if out is not None and (
+        out.dtype != torch.int32 or tuple(out.shape) != packed_shape
+    ):
+        raise ValueError(
+            f"out must be int32 with shape {packed_shape}, got "
+            f"{out.dtype} {tuple(out.shape)}"
+        )
+    if flat_scratch is not None and (
+        flat_scratch.dtype != torch.int32 or tuple(flat_scratch.shape) != packed_shape
+    ):
+        raise ValueError(
+            f"flat_scratch must be int32 with shape {packed_shape}, got "
+            f"{flat_scratch.dtype} {tuple(flat_scratch.shape)}"
+        )
+    if gather_scratch is not None and (
+        gather_scratch.dtype != torch.int32
+        or tuple(gather_scratch.shape) != packed_shape
+    ):
+        raise ValueError(
+            f"gather_scratch must be int32 with shape {packed_shape}, got "
+            f"{gather_scratch.dtype} {tuple(gather_scratch.shape)}"
+        )
+
+    tiles = qweight_i32.view(
+        k_tiles,
+        2,
+        n_tiles,
+        _PACKED_TILE_N_SIZE,
+    )
+    if flat_scratch is None:
+        flat = tiles.permute(0, 2, 1, 3).reshape(
+            k_tiles,
+            n_tiles,
+            2 * _PACKED_TILE_N_SIZE,
+        )
+    else:
+        flat_scratch.view(k_tiles, n_tiles, 2, _PACKED_TILE_N_SIZE).copy_(
+            tiles.permute(0, 2, 1, 3)
+        )
+        flat = flat_scratch
+
+    device = qweight_i32.device
+    out_pos = torch.arange(128, device=device, dtype=torch.long)
+    th_id = out_pos // 4
+    warp_id = out_pos % 4
+    tc_col = th_id // 4
+    tc_row = (th_id % 4) * 2
+    offsets = torch.tensor([0, 1, 8, 9], device=device, dtype=torch.long)
+    pack_idx = torch.tensor([0, 2, 4, 6, 1, 3, 5, 7], device=device, dtype=torch.long)
+
+    elem = tc_row[:, None] + offsets[None, :]
+    row = elem // _PACK_FACTOR_4BIT
+    pos = elem % _PACK_FACTOR_4BIT
+    col1 = (warp_id * 16 + tc_col)[:, None].expand(-1, 4)
+    col2 = col1 + 8
+    source_index = torch.cat(
+        [row * _PACKED_TILE_N_SIZE + col1, row * _PACKED_TILE_N_SIZE + col2],
+        dim=1,
+    )[:, pack_idx]
+    source_shift = torch.cat([pos, pos], dim=1)[:, pack_idx] * 4
+
+    result = (
+        torch.empty(packed_shape, device=device, dtype=torch.int32)
+        if out is None
+        else out
+    )
+    result.zero_()
+    for slot in range(8):
+        gather_index = (
+            source_index[:, slot]
+            .view(1, 1, 128)
+            .expand(
+                k_tiles,
+                n_tiles,
+                128,
+            )
+        )
+        shift = source_shift[:, slot].view(1, 1, 128)
+        if gather_scratch is None:
+            gathered = flat.gather(2, gather_index)
+            nibble = (gathered >> shift) & 0xF
+            result |= nibble << (slot * 4)
+        else:
+            torch.gather(flat, 2, gather_index, out=gather_scratch)
+            torch.bitwise_right_shift(gather_scratch, shift, out=gather_scratch)
+            torch.bitwise_and(gather_scratch, 0xF, out=gather_scratch)
+            if slot:
+                torch.bitwise_left_shift(
+                    gather_scratch,
+                    slot * 4,
+                    out=gather_scratch,
+                )
+            torch.bitwise_or(result, gather_scratch, out=result)
+
+    return result.reshape(k_tiles, n_tiles * 128).contiguous()
+
+
+def _repack_weight(
+    weight: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    row_rotation: int | None = None,
+    reuse_input_storage: bool = False,
+) -> torch.Tensor:
+    num_experts = int(weight.shape[0])
+    if tuple(weight.shape[1:]) != (size_n, size_k // 2):
+        raise ValueError(
+            f"expected packed weight shape {(num_experts, size_n, size_k // 2)}, "
+            f"got {tuple(weight.shape)}"
+        )
+    if size_k % _PACKED_TILE_SIZE != 0 or size_n % _PACKED_TILE_N_SIZE != 0:
+        raise ValueError(
+            f"W4A16 repack requires K,N multiples of 16,64; got {size_k},{size_n}"
+        )
+
+    packed_shape = (
+        num_experts,
+        size_k // _PACKED_TILE_SIZE,
+        (size_n // _PACKED_TILE_N_SIZE) * 128,
+    )
+    if reuse_input_storage:
+        if not weight.is_contiguous():
+            raise ValueError("reuse_input_storage requires contiguous packed weights")
+        packed = weight.view(torch.int32).reshape(packed_shape)
+    else:
+        packed = torch.empty(packed_shape, device=weight.device, dtype=torch.int32)
+
+    k_tiles = size_k // _PACKED_TILE_SIZE
+    n_tiles = size_n // _PACKED_TILE_N_SIZE
+    qweight_scratch = torch.empty(
+        (size_k // _PACK_FACTOR_4BIT, size_n),
+        device=weight.device,
+        dtype=torch.int32,
+    )
+    flat_scratch = torch.empty(
+        (k_tiles, n_tiles, 128),
+        device=weight.device,
+        dtype=torch.int32,
+    )
+    gather_scratch = torch.empty_like(flat_scratch)
+
+    for expert in range(num_experts):
+        expert_weight = weight[expert].view(torch.int32)
+        if row_rotation is not None:
+            rotated_rows = int(size_n) - int(row_rotation)
+            qweight_scratch[:, :rotated_rows].copy_(expert_weight[row_rotation:].T)
+            qweight_scratch[:, rotated_rows:].copy_(expert_weight[:row_rotation].T)
+        else:
+            qweight_scratch.copy_(expert_weight.T)
+        _repack_4bit_no_perm(
+            qweight_scratch,
+            size_k=size_k,
+            size_n=size_n,
+            out=packed[expert].view(k_tiles, n_tiles, 128),
+            flat_scratch=flat_scratch,
+            gather_scratch=gather_scratch,
+        )
+    return packed
+
+
+def _permute_nvfp4_scales(
+    scales: torch.Tensor,
+    global_scales: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    a_dtype: torch.dtype,
+    row_rotation: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    combined_scale_factor = _nvfp4_compute_scale_factor(scales, a_dtype)
+    packed_scales: torch.Tensor | None = None
+    for expert in range(scales.shape[0]):
+        expert_source = scales[expert].to(a_dtype)
+        if row_rotation is not None:
+            expert_source = torch.cat(
+                [expert_source[row_rotation:], expert_source[:row_rotation]],
+                dim=0,
+            )
+        expert_scales = _permute_packed_scales(
+            expert_source.T,
+            size_k=size_k,
+            size_n=size_n,
+            group_size=16,
+        )
+        expert_packed = _process_nvfp4_packed_scales(
+            expert_scales,
+            scale_factor=combined_scale_factor,
+        )
+        if packed_scales is None:
+            packed_scales = torch.empty(
+                (int(scales.shape[0]), *expert_packed.shape),
+                dtype=expert_packed.dtype,
+                device=expert_packed.device,
+            )
+        packed_scales[expert].copy_(expert_packed)
+    if packed_scales is None:
+        packed_scales = torch.empty(
+            (0, size_k // _PACKED_TILE_SIZE, size_n // 2),
+            dtype=torch.float8_e4m3fn,
+            device=scales.device,
+        )
+    packed_global = _process_nvfp4_packed_global_scale(
+        global_scales,
+        a_dtype=a_dtype,
+    ).to(torch.float32)
+    packed_global = packed_global / combined_scale_factor
+    return packed_scales, packed_global.contiguous()
+
+
+# ---------------------------------------------------------------------------
+# NF3 ("nf3_2p1") packing.
+#
+# The kernel's B operand is a stream of 32-code "units" (2 N-columns x 16 K),
+# each a 12-byte (lo0, lo1, hi) triple. The GEMM reads unit index
+#   unit = cur_group_id * (tile_n // 2) + (tid % (tile_n // 2))
+# from the pipe's B SMEM region (see kernel._load_b_scale_registers,
+# NF3-MAPPING-V1) which -- verified algebraically -- equals the stock staged
+# unit index; cur_group_id is the K16 row within the CTA-K tile, (tid %
+# (tile_n // 2)) is the N-pair. The flat-span staging copies the packer's
+# global bytes verbatim, so the packer must place, at global unit
+#   I = nt*(K/16)*(tile_n/2) + R*(tile_n/2) + p          (n_tile-major)
+# the codes for CTA N-tile nt, K16-row-global R, N-pair p. The 4 jj words in
+# the triple correspond to the stock 4-u32 group; per jj the 8 codes decode
+# (packed_dequant_nf3x8_to_bfloat2x4) to fragments
+#   frag[0,0]=(cb[c0],cb[c1]) frag[0,1]=(cb[c2],cb[c3])
+#   frag[1,0]=(cb[c4],cb[c5]) frag[1,1]=(cb[c6],cb[c7])
+# which must equal the stock fragment identity for this thread/jj:
+#   frag[0,0]=(C1@K0,   C1@K0+1)  frag[0,1]=(C1@K0+8, C1@K0+9)
+#   frag[1,0]=(C2@K0,   C2@K0+1)  frag[1,1]=(C2@K0+8, C2@K0+9)
+# where, from _repack_4bit_no_perm composed with the read mapping,
+#   wru = p + (tile_n/2)*nt ; n_tile_64 = wru // 32 ; th_id = wru % 32
+#   tc_col = th_id // 4 ; tc_row = (th_id % 4) * 2
+#   C1 = n_tile_64*64 + jj*16 + tc_col ; C2 = C1 + 8 ; K0 = R*16 + tc_row
+# => code order [c0..c7] =
+#   [ (C1,K0),(C1,K0+1),(C1,K0+8),(C1,K0+9),
+#     (C2,K0),(C2,K0+1),(C2,K0+8),(C2,K0+9) ].
+# This whole chain is asserted by _nf3_pack_selftest against an independent
+# torch simulation of the kernel read+dequant.
+# ---------------------------------------------------------------------------
+
+
+def _nf3_check_shapes(size_k: int, size_n: int, tile_n: int) -> None:
+    if int(size_k) % 32 != 0:
+        raise ValueError(f"NF3 requires K % 32 == 0, got {size_k}")
+    if int(size_n) % 64 != 0:
+        raise ValueError(f"NF3 requires N % 64 == 0, got {size_n}")
+    if int(tile_n) % 16 != 0 or int(tile_n) < 64:
+        raise ValueError(f"NF3 tile_n must be a multiple of 16 and >= 64, got {tile_n}")
+    if int(size_n) % int(tile_n) != 0:
+        raise ValueError(f"NF3 requires N ({size_n}) divisible by tile_n ({tile_n})")
+
+
+def _nf3_code_gather_index(
+    size_k: int, size_n: int, tile_n: int, device: torch.device
+) -> torch.Tensor:
+    """[units, 4, 8] flat indices into a contiguous [N, K] code tensor.
+
+    Entry [I, jj, v] is the (C * size_k + K) index of the v-th code (NF3 order)
+    of triple word jj at global unit I. Built from the exact _repack /
+    read-mapping math documented above so the packer and the kernel agree.
+    """
+    _nf3_check_shapes(size_k, size_n, tile_n)
+    npairs = int(tile_n) // 2
+    k16 = int(size_k) // 16
+    units = k16 * (int(size_n) // 2)
+    ntile_units = k16 * npairs
+    idx_i = torch.arange(units, device=device, dtype=torch.long)
+    nt = idx_i // ntile_units
+    within = idx_i % ntile_units
+    R = within // npairs
+    p = within % npairs
+    wru = p + npairs * nt
+    n_tile_64 = wru // 32
+    th_id = wru % 32
+    tc_col = th_id // 4
+    tc_row = (th_id % 4) * 2
+    jj = torch.arange(4, device=device, dtype=torch.long)
+    col1 = jj[None, :] * 16 + tc_col[:, None]  # [units, 4]
+    col2 = col1 + 8
+    C1 = n_tile_64[:, None] * 64 + col1  # [units, 4]
+    C2 = n_tile_64[:, None] * 64 + col2
+    K0 = (R * 16 + tc_row)[:, None]  # [units, 1]
+    k_off = torch.tensor([0, 1, 8, 9], device=device, dtype=torch.long)
+    idx = torch.empty((units, 4, 8), device=device, dtype=torch.long)
+    for t in range(4):
+        idx[:, :, t] = C1 * int(size_k) + (K0 + k_off[t])
+        idx[:, :, 4 + t] = C2 * int(size_k) + (K0 + k_off[t])
+    return idx
+
+
+def _nf3_pack_codes(
+    codes_nk: torch.Tensor, *, size_k: int, size_n: int, tile_n: int
+) -> torch.Tensor:
+    """Pack one expert's [N, K] codes (0..7) into int32 [units*3] NF3 planes."""
+    if tuple(codes_nk.shape) != (int(size_n), int(size_k)):
+        raise ValueError(
+            f"expected codes shape {(int(size_n), int(size_k))}, "
+            f"got {tuple(codes_nk.shape)}"
+        )
+    device = codes_nk.device
+    flat = codes_nk.reshape(-1).to(torch.int64)
+    if bool((flat < 0).any()) or bool((flat > 7).any()):
+        raise ValueError("NF3 codes must be integers in [0, 7]")
+    idx = _nf3_code_gather_index(size_k, size_n, tile_n, device)  # [units,4,8]
+    g = flat[idx.reshape(-1)].reshape(idx.shape)  # [units,4,8]
+    sh_lo = (torch.arange(4, device=device, dtype=torch.int64) * 2).view(1, 1, 4)
+    sh_hi = torch.arange(4, device=device, dtype=torch.int64).view(1, 1, 4)
+    la = ((g[:, :, 0:4] & 3) << sh_lo).sum(-1)  # [units,4]
+    lb = ((g[:, :, 4:8] & 3) << sh_lo).sum(-1)
+    lo16 = la | (lb << 8)
+    ha = (((g[:, :, 0:4] >> 2) & 1) << sh_hi).sum(-1)
+    hb = (((g[:, :, 4:8] >> 2) & 1) << sh_hi).sum(-1)
+    hi8 = ha | (hb << 4)
+    lo0 = lo16[:, 0] | (lo16[:, 1] << 16)
+    lo1 = lo16[:, 2] | (lo16[:, 3] << 16)
+    hi = hi8[:, 0] | (hi8[:, 1] << 8) | (hi8[:, 2] << 16) | (hi8[:, 3] << 24)
+    words = torch.stack([lo0, lo1, hi], dim=1).reshape(-1)  # int64 in [0, 2**32)
+    words = torch.where(words >= 2**31, words - 2**32, words)
+    return words.to(torch.int32).contiguous()
+
+
+def _process_nf3_packed_scales(packed_scales: torch.Tensor) -> torch.Tensor:
+    """[rows, N] float t_s -> [rows, N] uint8 e4m3-style byte = highbyte(f16(t_s*2**-4)<<1)."""
+    packed_scales = packed_scales.to(torch.float16)
+    packed_scales = packed_scales.view(-1, 4)[:, [0, 2, 1, 3]].view(
+        packed_scales.size(0),
+        -1,
+    )
+    packed_scales = (packed_scales.float() * (2.0**-4)).to(torch.float16)
+    packed_scales = packed_scales.view(torch.int16) << 1
+    packed_scales = packed_scales.view(torch.uint8)
+    return packed_scales[:, 1::2].contiguous()
+
+
+def _nf3_pack_scales(t_s: torch.Tensor, *, size_k: int, size_n: int) -> torch.Tensor:
+    """Pack one expert's [N, K//32] scales into uint8 [K//32, N] (permuted)."""
+    if tuple(t_s.shape) != (int(size_n), int(size_k) // 32):
+        raise ValueError(
+            f"expected scale shape {(int(size_n), int(size_k) // 32)}, "
+            f"got {tuple(t_s.shape)}"
+        )
+    t_s = t_s.to(torch.float32)
+    # zero scales (whole group exactly zero in the checkpoint) MUST stay zero:
+    # stored byte 0 decodes to exact +0.0. Flooring them to _NF3_SCALE_FLOOR
+    # injects noise into all-zero groups (real early-layer experts have many)
+    # -> compounding early-layer error -> prompt-dependent degeneration.
+    zero_mask = t_s == 0
+    t_s = t_s.clamp(min=_NF3_SCALE_FLOOR)
+    t_s[zero_mask] = 0.0
+    if bool((t_s >= 32.0).any()):
+        raise ValueError("NF3 scales must be < 32 for the e4m3 K/32 encoding")
+    permuted = _permute_packed_scales(
+        t_s.T.contiguous(),
+        size_k=size_k,
+        size_n=size_n,
+        group_size=32,
+    )  # [K//32, N] float
+    return _process_nf3_packed_scales(permuted)
+
+
+def _nf3_pack_code_experts(
+    codes: torch.Tensor, *, size_k: int, size_n: int, tile_n: int
+) -> torch.Tensor:
+    packed = [
+        _nf3_pack_codes(codes[e], size_k=size_k, size_n=size_n, tile_n=tile_n)
+        for e in range(int(codes.shape[0]))
+    ]
+    return torch.stack(packed, dim=0).contiguous()
+
+
+def _nf3_pack_scale_experts(
+    t_s: torch.Tensor, *, size_k: int, size_n: int
+) -> torch.Tensor:
+    packed = [
+        _nf3_pack_scales(t_s[e], size_k=size_k, size_n=size_n)
+        for e in range(int(t_s.shape[0]))
+    ]
+    return torch.stack(packed, dim=0).contiguous()
+
+
+def _prepare_w4a16_packed_weights(
+    w13_fp4: torch.Tensor,
+    w13_blockscale: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype = torch.bfloat16,
+    source_format: str,
+    w13_layout: str = "w13",
+    reuse_input_storage: bool = False,
+) -> W4A16PackedWeights:
+    source_format = _normalize_source_format(source_format)
+    w13_layout = _normalize_w13_layout(w13_layout)
+    shape = validate_w4a16_packed_inputs(
+        w13_fp4,
+        w13_global_scale,
+        w2_fp4,
+        w2_global_scale,
+        activation=activation,
+    )
+    num_experts = shape.num_experts
+    hidden_size = shape.hidden_size
+    intermediate_size = shape.intermediate_size
+    w13_rows = shape.w13_rows
+    is_gated = shape.is_gated
+
+    w13 = w13_fp4
+    w13_scale = unswizzle_expert_scales(
+        w13_blockscale,
+        rows=w13_rows,
+        cols=hidden_size,
+    )
+    w13_row_rotation = None
+    if is_gated and w13_layout == "w13":
+        # In-place: the half-swap is folded into the repack via row_rotation;
+        # never materialize a second copy of the weights/scales.
+        w13_row_rotation = intermediate_size
+
+    w2_scale = unswizzle_expert_scales(
+        w2_blockscale,
+        rows=hidden_size,
+        cols=intermediate_size,
+    )
+
+    packed_w13 = _repack_weight(
+        w13 if reuse_input_storage else w13.contiguous(),
+        size_k=hidden_size,
+        size_n=w13_rows,
+        row_rotation=w13_row_rotation,
+        reuse_input_storage=reuse_input_storage,
+    )
+    packed_w2 = _repack_weight(
+        w2_fp4 if reuse_input_storage else w2_fp4.contiguous(),
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        reuse_input_storage=reuse_input_storage,
+    )
+    native_w13_global_scale = _source_global_scale(
+        w13_global_scale,
+        source_format=source_format,
+    )
+    native_w2_global_scale = _source_global_scale(
+        w2_global_scale,
+        source_format=source_format,
+    )
+    packed_w13_scale, packed_w13_global_scale = _permute_nvfp4_scales(
+        w13_scale,
+        native_w13_global_scale,
+        size_k=hidden_size,
+        size_n=w13_rows,
+        a_dtype=params_dtype,
+        row_rotation=w13_row_rotation,
+    )
+    packed_w2_scale, packed_w2_global_scale = _permute_nvfp4_scales(
+        w2_scale,
+        native_w2_global_scale,
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        a_dtype=params_dtype,
+    )
+
+    return W4A16PackedWeights(
+        w13=packed_w13,
+        w13_scale=packed_w13_scale,
+        w13_global_scale=packed_w13_global_scale,
+        w2=packed_w2,
+        w2_scale=packed_w2_scale,
+        w2_global_scale=packed_w2_global_scale,
+        workspace=_make_workspace(w13_fp4.device, max_blocks_per_sm=4),
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        is_gated=is_gated,
+        params_dtype=params_dtype,
+        source_format=source_format,
+        w13_layout=w13_layout,
+        scale_format="e4m3_k16",
+    )
+
+
+def prepare_w4a16_modelopt_nvfp4_weights(
+    w13_fp4: torch.Tensor,
+    w13_blockscale: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype = torch.bfloat16,
+    w13_layout: str = "w13",
+    reuse_input_storage: bool = False,
+) -> W4A16PackedWeights:
+    """Prepare ModelOpt NVFP4 tensors into the W4A16 packed runtime layout.
+
+    The per-block scales are the normal NVFP4 K/16 scale grid in sm12x swizzled
+    storage. The global scales are raw ModelOpt weight global scales; activation
+    input scales are not folded into W4A16 weight preparation. For gated
+    activations, ``w13_layout`` describes whether fused W13 rows arrive in
+    checkpoint/logical W13 order or already swapped W31 order.
+    """
+    return _prepare_w4a16_packed_weights(
+        w13_fp4,
+        w13_blockscale,
+        w13_global_scale,
+        w2_fp4,
+        w2_blockscale,
+        w2_global_scale,
+        activation=activation,
+        params_dtype=params_dtype,
+        source_format="modelopt_nvfp4",
+        w13_layout=w13_layout,
+        reuse_input_storage=reuse_input_storage,
+    )
+
+
+def prepare_w4a16_modelopt_native_weights(
+    w13_fp4: torch.Tensor,
+    w13_blockscale: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype = torch.bfloat16,
+    source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "w13",
+) -> W4A16ModelOptWeights:
+    """Prepare W4A16 metadata while keeping ModelOpt FP4 weights native.
+
+    This is the memory-safe path for GLM serving that needs A4 prefill and A16
+    decode in the same process. It keeps the checkpoint FP4 tensors resident
+    instead of materializing a second full W4A16 packed copy.
+    """
+    source_format = _normalize_source_format(source_format)
+    if source_format not in _MODEL_OPT_NVFP4_FORMATS:
+        raise ValueError(
+            "native W4A16 ModelOpt weights require source_format 'modelopt_nvfp4'"
+        )
+    w13_layout = _normalize_w13_layout(w13_layout)
+
+    shape = validate_w4a16_packed_inputs(
+        w13_fp4,
+        w13_global_scale,
+        w2_fp4,
+        w2_global_scale,
+        activation=activation,
+    )
+    num_experts = shape.num_experts
+    hidden_size = shape.hidden_size
+    intermediate_size = shape.intermediate_size
+    w13_rows = shape.w13_rows
+    is_gated = shape.is_gated
+
+    w13_scale = unswizzle_expert_scales(
+        w13_blockscale,
+        rows=w13_rows,
+        cols=hidden_size,
+    )
+    w2_scale = unswizzle_expert_scales(
+        w2_blockscale,
+        rows=hidden_size,
+        cols=intermediate_size,
+    )
+    native_w13_global_scale = _source_global_scale(
+        w13_global_scale,
+        source_format=source_format,
+    )
+    native_w2_global_scale = _source_global_scale(
+        w2_global_scale,
+        source_format=source_format,
+    )
+
+    # The W4A16 activation consumes FC1 output in gate/up logical order.
+    # Checkpoint-native ModelOpt GLM tensors are up/gate, while vLLM/FI can
+    # hand over gate/up tensors after its own W13 reorder. Keep that physical
+    # order explicit so source_format never implies a layout transformation.
+    w13_row_rotation = intermediate_size if is_gated and w13_layout == "w13" else None
+    packed_w13_scale, packed_w13_global_scale = _permute_nvfp4_scales(
+        w13_scale,
+        native_w13_global_scale,
+        size_k=hidden_size,
+        size_n=w13_rows,
+        a_dtype=params_dtype,
+        row_rotation=w13_row_rotation,
+    )
+    packed_w2_scale, packed_w2_global_scale = _permute_nvfp4_scales(
+        w2_scale,
+        native_w2_global_scale,
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        a_dtype=params_dtype,
+    )
+
+    return W4A16ModelOptWeights(
+        w13=w13_fp4,
+        w13_scale=packed_w13_scale,
+        w13_global_scale=packed_w13_global_scale,
+        w2=w2_fp4,
+        w2_scale=packed_w2_scale,
+        w2_global_scale=packed_w2_global_scale,
+        workspace=_make_workspace(w13_fp4.device, max_blocks_per_sm=4),
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        is_gated=is_gated,
+        params_dtype=params_dtype,
+        source_format=source_format,
+        micro_w13_scale=packed_w13_scale,
+        micro_w13_global_scale=_process_nvfp4_micro_global_scale_from_packed(
+            packed_w13_global_scale,
+            a_dtype=params_dtype,
+        ),
+        micro_w2_scale=packed_w2_scale,
+        micro_w2_global_scale=_process_nvfp4_micro_global_scale_from_packed(
+            packed_w2_global_scale,
+            a_dtype=params_dtype,
+        ),
+        w13_layout=w13_layout,
+    )
+
+
+def prepare_w4a16_e8m0_native_weights(
+    w13_fp4: torch.Tensor,
+    w13_e8m0_scale: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_e8m0_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype = torch.bfloat16,
+    w13_layout: str = "w13",
+) -> W4A16ModelOptWeights:
+    """Prepare native MXFP4 (E8M0 K/32) weights for the W4A16 path.
+
+    Keeps the FP4 weights resident as a single copy (``weight_layout="modelopt"``)
+    and carries two small scale forms so one object serves both kernels:
+    ``w13_scale``/``w2_scale`` are the packed E8M0 grid the main W4A16 GEMM reads
+    at med/large M, and ``micro_*`` are packed E8M0 grids in the native row order
+    that the small-M micro decode kernel reads. ``run_w4a16_moe`` routes small M
+    to micro and the rest to the main W4A16 kernel automatically.
+    """
+    w13_layout = _normalize_w13_layout(w13_layout)
+    shape = validate_w4a16_packed_inputs(
+        w13_fp4,
+        w13_global_scale,
+        w2_fp4,
+        w2_global_scale,
+        activation=activation,
+    )
+    num_experts = shape.num_experts
+    hidden_size = shape.hidden_size
+    intermediate_size = shape.intermediate_size
+    w13_rows = shape.w13_rows
+    is_gated = shape.is_gated
+    allow_w2_k_tail = intermediate_size % 32 != 0
+    padded_w13_scale_n = (
+        _e8m0_logical_tail_scale_n(w13_rows) if allow_w2_k_tail else w13_rows
+    )
+
+    w13_scale = _validate_e8m0_k32_scales(
+        w13_e8m0_scale,
+        rows=w13_rows,
+        cols=hidden_size,
+        name="w13_e8m0_scale",
+    )
+    w2_scale = _validate_e8m0_k32_scales(
+        w2_e8m0_scale,
+        rows=hidden_size,
+        cols=intermediate_size,
+        name="w2_e8m0_scale",
+        allow_k_tail=allow_w2_k_tail,
+    )
+    # Main-GEMM (med/large M) packed E8M0 scales. The "w13" (up_gate) layout
+    # needs the FC1 half-swap folded into the scale grid; the kernel applies the
+    # matching source_n_rotation to the native weights. micro reads the un-rotated
+    # grid and handles the layout itself (w13_gate_first).
+    w13_row_rotation = intermediate_size if (is_gated and w13_layout == "w13") else None
+    packed_w13_scale = _pack_e8m0_k32_scales(
+        w13_scale,
+        size_k=hidden_size,
+        size_n=w13_rows,
+        row_rotation=w13_row_rotation,
+        padded_size_n=padded_w13_scale_n,
+    )
+    micro_w13_scale = (
+        packed_w13_scale
+        if w13_row_rotation is None
+        else _pack_e8m0_k32_scales(
+            w13_scale,
+            size_k=hidden_size,
+            size_n=w13_rows,
+            padded_size_n=padded_w13_scale_n,
+        )
+    )
+    packed_w2_scale = _pack_e8m0_k32_scales(
+        w2_scale,
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        allow_k_tail=allow_w2_k_tail,
+    )
+    # Storage-compatible single grid: micro reads the SAME packed _pack_e8m0_k32
+    # scales the main GEMM reads (no separate K/16 micro grid).
+    w13_global = w13_global_scale.contiguous()
+    w2_global = w2_global_scale.contiguous()
+    return W4A16ModelOptWeights(
+        w13=w13_fp4,
+        w13_scale=packed_w13_scale,
+        w13_global_scale=w13_global,
+        w2=w2_fp4,
+        w2_scale=packed_w2_scale,
+        w2_global_scale=w2_global,
+        workspace=_make_workspace(w13_fp4.device, max_blocks_per_sm=4),
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        is_gated=is_gated,
+        params_dtype=params_dtype,
+        source_format="fp4_e8m0_k32",
+        scale_format="e8m0_k32",
+        micro_w13_scale=micro_w13_scale,
+        micro_w13_global_scale=w13_global,
+        micro_w2_scale=packed_w2_scale,
+        micro_w2_global_scale=w2_global,
+        w13_layout=w13_layout,
+    )
+
+
+def prepare_w4a16_compressed_tensors_weights(
+    w13_fp4: torch.Tensor,
+    w13_blockscale: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype = torch.bfloat16,
+    w13_layout: str = "w13",
+    reuse_input_storage: bool = False,
+) -> W4A16PackedWeights:
+    """Prepare CompressedTensors NVFP4 tensors into the W4A16 packed runtime layout.
+
+    The per-block scales are the normal NVFP4 K/16 scale grid in sm12x swizzled
+    storage. The CT global scales are stored inverted relative to the ModelOpt
+    weight global scale convention, so they are inverted before packing.
+    """
+    return _prepare_w4a16_packed_weights(
+        w13_fp4,
+        w13_blockscale,
+        w13_global_scale,
+        w2_fp4,
+        w2_blockscale,
+        w2_global_scale,
+        activation=activation,
+        params_dtype=params_dtype,
+        source_format="compressed_tensors",
+        w13_layout=w13_layout,
+        reuse_input_storage=reuse_input_storage,
+    )
+
+
+def prepare_w4a16_fp4_e8m0_k32_weights(
+    w13_fp4: torch.Tensor,
+    w13_e8m0_scale: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_e8m0_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype = torch.bfloat16,
+    w13_layout: str = "w13",
+    reuse_input_storage: bool = False,
+) -> W4A16PackedWeights:
+    """Prepare FP4 weights with E8M0 K/32 scales for W4A16.
+
+    The per-block source scales are [E, N, K/32] E8M0 bytes. They are only
+    saturated to the BF16 kernel's supported byte range and rearranged for
+    kernel access; they are not expanded to K/16 or folded into global scales.
+    """
+    w13_layout = _normalize_w13_layout(w13_layout)
+    shape = validate_w4a16_packed_inputs(
+        w13_fp4,
+        w13_global_scale,
+        w2_fp4,
+        w2_global_scale,
+        activation=activation,
+    )
+    num_experts = shape.num_experts
+    hidden_size = shape.hidden_size
+    intermediate_size = shape.intermediate_size
+    w13_rows = shape.w13_rows
+    is_gated = shape.is_gated
+
+    w13 = w13_fp4
+    w13_scale = _validate_e8m0_k32_scales(
+        w13_e8m0_scale,
+        rows=w13_rows,
+        cols=hidden_size,
+        name="w13_e8m0_scale",
+    )
+    w13_row_rotation = None
+    if is_gated and w13_layout != "w31":
+        w13_row_rotation = intermediate_size
+
+    w2_scale = _validate_e8m0_k32_scales(
+        w2_e8m0_scale,
+        rows=hidden_size,
+        cols=intermediate_size,
+        name="w2_e8m0_scale",
+    )
+
+    packed_w13 = _repack_weight(
+        w13 if reuse_input_storage else w13.contiguous(),
+        size_k=hidden_size,
+        size_n=w13_rows,
+        row_rotation=w13_row_rotation,
+        reuse_input_storage=reuse_input_storage,
+    )
+    packed_w2 = _repack_weight(
+        w2_fp4 if reuse_input_storage else w2_fp4.contiguous(),
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        reuse_input_storage=reuse_input_storage,
+    )
+    packed_w13_scale = _pack_e8m0_k32_scales(
+        w13_scale,
+        size_k=hidden_size,
+        size_n=w13_rows,
+        row_rotation=w13_row_rotation,
+        reuse_input_storage=reuse_input_storage,
+    )
+    packed_w2_scale = _pack_e8m0_k32_scales(
+        w2_scale,
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        reuse_input_storage=reuse_input_storage,
+    )
+
+    return W4A16PackedWeights(
+        w13=packed_w13,
+        w13_scale=packed_w13_scale,
+        w13_global_scale=w13_global_scale.contiguous(),
+        w2=packed_w2,
+        w2_scale=packed_w2_scale,
+        w2_global_scale=w2_global_scale.contiguous(),
+        workspace=_make_workspace(w13_fp4.device, max_blocks_per_sm=4),
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        is_gated=is_gated,
+        params_dtype=params_dtype,
+        source_format="fp4_e8m0_k32",
+        w13_layout=w13_layout,
+        scale_format="e8m0_k32",
+    )
+
+
+def prepare_w4a16_packed_weights(
+    *args,
+    source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "w13",
+    **kwargs,
+) -> W4A16PackedWeights:
+    source_format = _normalize_source_format(source_format)
+    w13_layout = _normalize_w13_layout(w13_layout)
+    if source_format == "modelopt_nvfp4":
+        return prepare_w4a16_modelopt_nvfp4_weights(
+            *args, w13_layout=w13_layout, **kwargs
+        )
+    if source_format == "compressed_tensors":
+        return prepare_w4a16_compressed_tensors_weights(
+            *args, w13_layout=w13_layout, **kwargs
+        )
+    if source_format == "fp4_e8m0_k32":
+        return prepare_w4a16_fp4_e8m0_k32_weights(
+            *args, w13_layout=w13_layout, **kwargs
+        )
+    raise AssertionError(f"unhandled W4A16 source_format {source_format!r}")
+
+
+def make_w4a16_packed_buffers(
+    prepared: W4A16PackedWeights | W4A16ModelOptWeights,
+    *,
+    m: int,
+    topk: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    route_num_experts: int | None = None,
+) -> W4A16PackedBuffers:
+    return _make_w4a16_packed_buffers(
+        prepared,
+        m=m,
+        topk=topk,
+        dtype=dtype,
+        device=device,
+        route_num_experts=route_num_experts,
+    )
+
+
+def prepare_nf3_moe_weights(
+    w13_codes: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_codes: torch.Tensor,
+    w2_scale: torch.Tensor,
+    *,
+    activation: str,
+    fc1_tile_n: int,
+    fc2_tile_n: int,
+    params_dtype: torch.dtype = torch.bfloat16,
+) -> PreparedNF3MoeWeights:
+    """Pack NF3 codes/scales into the runtime "nf3_2p1" W4A16 layout.
+
+    Inputs are per-expert integer codes (0..7) in kernel-native output order
+    (gate/up already resolved for FC1) and per-group float scales ``t_s``:
+        w13_codes [E, 2*I, hidden]   w13_scale [E, 2*I, hidden//32]
+        w2_codes  [E, hidden, I]     w2_scale  [E, hidden, I//32]
+    ``fc1_tile_n`` / ``fc2_tile_n`` MUST equal the CTA N-tiles the kernel will
+    use (read them from the compiled W4A16FusedMoeCompileResult) -- the
+    flat-span layout is tile_n specific.
+    """
+    if params_dtype != torch.bfloat16:
+        raise ValueError("nf3_2p1 W4A16 weights are bf16-only for v1")
+    shape = validate_nf3_moe_inputs(
+        w13_codes,
+        w13_scale,
+        w2_codes,
+        w2_scale,
+        activation=activation,
+    )
+    device = w13_codes.device
+    packed_w13 = _nf3_pack_code_experts(
+        w13_codes, size_k=shape.hidden_size, size_n=shape.w13_rows, tile_n=fc1_tile_n
+    )
+    packed_w2 = _nf3_pack_code_experts(
+        w2_codes,
+        size_k=shape.intermediate_size,
+        size_n=shape.hidden_size,
+        tile_n=fc2_tile_n,
+    )
+    packed_w13_scale = _nf3_pack_scale_experts(
+        w13_scale, size_k=shape.hidden_size, size_n=shape.w13_rows
+    )
+    packed_w2_scale = _nf3_pack_scale_experts(
+        w2_scale, size_k=shape.intermediate_size, size_n=shape.hidden_size
+    )
+    global_scale = torch.full(
+        (shape.num_experts,), _NF3_SCALE_GLOBAL, dtype=torch.float32, device=device
+    )
+    return PreparedNF3MoeWeights(
+        w13=packed_w13,
+        w13_scale=packed_w13_scale,
+        w13_global_scale=global_scale,
+        w2=packed_w2,
+        w2_scale=packed_w2_scale,
+        w2_global_scale=global_scale.clone(),
+        workspace=_make_workspace(device, max_blocks_per_sm=4),
+        hidden_size=shape.hidden_size,
+        intermediate_size=shape.intermediate_size,
+        num_experts=shape.num_experts,
+        is_gated=shape.is_gated,
+        params_dtype=params_dtype,
+        fc1_tile_n=int(fc1_tile_n),
+        fc2_tile_n=int(fc2_tile_n),
+    )
+
+
+def _nf3_pack_selftest() -> None:
+    """Prove the packer matches the kernel's read+dequant chain (torch/CPU).
+
+    Packs random codes, then INDEPENDENTLY simulates the kernel's flat-span
+    staging + register read (unit = cur_group_id*(tile_n//2) + tid%(tile_n//2))
+    + packed_dequant_nf3x8 fragment placement in pure torch, and asserts the
+    reconstructed dequantized matrix equals codebook[codes] at every (N, K).
+    """
+    codebook = _NF3_CODEBOOK
+
+    def simulate(packed, size_k, size_n, tile_n, tile_k):
+        cta_threads = tile_n * tile_k // 64
+        b_sh_stride = tile_n // 2
+        cta_k_blocks = tile_k // 16
+        b_sh_stage = b_sh_stride * cta_k_blocks
+        b_sh_wr_iters = b_sh_stage // cta_threads
+        tb_n_warps = tile_n // 64
+        b_chunks = b_sh_stage * 12 // 16
+        wr_iters_nf3 = (b_chunks + cta_threads - 1) // cta_threads
+        ntile_stride = (size_k // 16) * (tile_n // 2)
+        n_tiles = size_n // tile_n
+        k_tiles = size_k // tile_k
+        packed = packed.tolist()
+        w = [[None] * size_n for _ in range(size_k)]
+
+        def u32(x):
+            return x & 0xFFFFFFFF
+
+        for nt in range(n_tiles):
+            for tile_idx in range(k_tiles):
+                span_base_unit = (
+                    nt * ntile_stride + tile_idx * cta_k_blocks * b_sh_stride
+                )
+                smem = {}
+                for i in range(wr_iters_nf3):
+                    for tid in range(cta_threads):
+                        c = i * cta_threads + tid
+                        if c >= b_chunks:
+                            continue
+                        for word in range(4):
+                            smem[c * 4 + word] = u32(
+                                packed[span_base_unit * 3 + c * 4 + word]
+                            )
+                for tid in range(cta_threads):
+                    warp_row = (tid // 32) // tb_n_warps
+                    for kk in range(b_sh_wr_iters):
+                        cur = b_sh_wr_iters * warp_row + kk
+                        unit = cur * b_sh_stride + (tid % b_sh_stride)
+                        lo0 = smem[unit * 3 + 0]
+                        lo1 = smem[unit * 3 + 1]
+                        hi = smem[unit * 3 + 2]
+                        R = tile_idx * cta_k_blocks + cur
+                        p = tid % b_sh_stride
+                        for jj in range(4):
+                            lo_w = lo0 if (jj // 2) == 0 else lo1
+                            lo16 = (lo_w >> (16 * (jj % 2))) & 0xFFFF
+                            hi8 = (hi >> (8 * jj)) & 0xFF
+                            la = lo16 & 0xFF
+                            lb = (lo16 >> 8) & 0xFF
+                            ha = hi8 & 0xF
+                            hb = (hi8 >> 4) & 0xF
+
+                            def code(byte2, nib1, j):
+                                return ((byte2 >> (2 * j)) & 3) | (
+                                    ((nib1 >> j) & 1) << 2
+                                )
+
+                            cds = [code(la, ha, j) for j in range(4)] + [
+                                code(lb, hb, j) for j in range(4)
+                            ]
+                            wru = p + (tile_n // 2) * nt
+                            n64 = wru // 32
+                            th = wru % 32
+                            tc_col = th // 4
+                            tc_row = (th % 4) * 2
+                            col1 = jj * 16 + tc_col
+                            c1 = n64 * 64 + col1
+                            c2 = c1 + 8
+                            k0 = R * 16 + tc_row
+                            w[k0 + 0][c1] = codebook[cds[0]]
+                            w[k0 + 1][c1] = codebook[cds[1]]
+                            w[k0 + 8][c1] = codebook[cds[2]]
+                            w[k0 + 9][c1] = codebook[cds[3]]
+                            w[k0 + 0][c2] = codebook[cds[4]]
+                            w[k0 + 1][c2] = codebook[cds[5]]
+                            w[k0 + 8][c2] = codebook[cds[6]]
+                            w[k0 + 9][c2] = codebook[cds[7]]
+        return w
+
+    torch.manual_seed(0)
+    cases = [
+        (256, 128, 128, 128),
+        (256, 128, 128, 64),
+        (64, 256, 256, 64),
+        (512, 256, 256, 64),
+    ]
+    for size_k, size_n, tile_n, tile_k in cases:
+        codes = torch.randint(0, 8, (size_n, size_k), dtype=torch.int64)
+        packed = _nf3_pack_codes(codes, size_k=size_k, size_n=size_n, tile_n=tile_n)
+        w = simulate(packed, size_k, size_n, tile_n, tile_k)
+        for k in range(size_k):
+            for n in range(size_n):
+                expect = _NF3_CODEBOOK[int(codes[n, k])]
+                got = w[k][n]
+                assert got is not None, (
+                    f"unfilled ({k},{n}) for {(size_k, size_n, tile_n, tile_k)}"
+                )
+                assert abs(got - expect) < 1e-9, (
+                    f"mismatch at ({k},{n}) for {(size_k, size_n, tile_n, tile_k)}: "
+                    f"{got} != {expect}"
+                )
+    print("nf3 pack self-test PASSED")
+
+
+__all__ = [
+    "PreparedNF3MoeWeights",
+    "W4A16PackedBuffers",
+    "W4A16ModelOptWeights",
+    "W4A16PackedWeights",
+    "make_w4a16_packed_buffers",
+    "prepare_nf3_moe_weights",
+    "prepare_w4a16_compressed_tensors_weights",
+    "prepare_w4a16_e8m0_native_weights",
+    "prepare_w4a16_fp4_e8m0_k32_weights",
+    "prepare_w4a16_modelopt_native_weights",
+    "prepare_w4a16_modelopt_nvfp4_weights",
+    "prepare_w4a16_packed_weights",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/route_pack.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a16/route_pack.py
@@ -1,0 +1,484 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a16/route_pack.py @ ff1c8c8e (2026-06-23) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Triton route-packing kernels for W4A16 MoE."""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+import torch
+
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+    max_packed_route_slots,
+    route_pack_numel_capacity,
+)
+
+
+_COUNT_BLOCK_T = 256
+_SORT_BLOCK_T = 256
+_POST_PREFIX_BLOCK_T = 256
+_SMALL_PREFIX_MAX_PACKED_ROUTES = 4096
+_SMALL_PREFIX_MAX_ROUTE_BLOCKS = 128
+_SMALL_PREFIX_MAX_EXPERT_BLOCK_PRODUCT = 65536
+
+
+_FAST_COUNT_BLOCK_T = 1024
+
+
+@triton.jit
+def _w4a16_route_count_kernel(
+    topk_ids,
+    expert_map,
+    counts,
+    live_numel,
+    NUM_EXPERTS: tl.constexpr,
+    HAS_EXPERT_MAP: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    """Parallel atomic histogram of routes per (mapped) expert.
+
+    Multi-program replacement for the single-CTA count loop in
+    ``_pack_topk_routes_prefix_kernel`` -- same expert-id resolution as the
+    sort kernel (expert_map aware). Writes ``counts[NUM_EXPERTS]``."""
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_T + tl.arange(0, BLOCK_T)
+    raw_ids = tl.load(topk_ids + offsets, mask=offsets < live_numel, other=-1).to(
+        tl.int32
+    )
+    valid = (offsets < live_numel) & (raw_ids >= 0) & (raw_ids < NUM_EXPERTS)
+    ids = raw_ids
+    if HAS_EXPERT_MAP:
+        safe_ids = tl.minimum(tl.maximum(raw_ids, 0), NUM_EXPERTS - 1)
+        ids = tl.load(expert_map + safe_ids, mask=valid, other=-1).to(tl.int32)
+        valid = valid & (ids >= 0) & (ids < NUM_EXPERTS)
+    tl.atomic_add(counts + ids, 1, sem="relaxed", mask=valid)
+
+
+@triton.jit
+def _w4a16_route_prefix_from_counts_kernel(
+    counts,
+    packed_route_count,
+    expert_offsets,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    """Tiny over-experts block-padded prefix from precomputed counts.
+
+    Emits exactly the ``expert_offsets`` / ``packed_route_count`` contract of
+    ``_pack_topk_routes_prefix_kernel`` (clean block-padded prefix; the sort
+    kernel later advances expert_offsets in place)."""
+    experts = tl.arange(0, BLOCK_E)
+    mask = experts < NUM_EXPERTS
+    counts_v = tl.load(counts + experts, mask=mask, other=0)
+    padded = ((counts_v + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+    padded = tl.where(mask, padded, 0)
+    inclusive = tl.cumsum(padded, axis=0)
+    prefix = inclusive - padded
+    total = tl.sum(padded, axis=0)
+    tl.store(expert_offsets + experts, prefix, mask=mask)
+    tl.store(expert_offsets + NUM_EXPERTS, total)
+    tl.store(packed_route_count, total)
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 << (int(x) - 1).bit_length()
+
+
+def _workspace_slice(
+    tensor: torch.Tensor | None,
+    *,
+    name: str,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    elements = int(elements)
+    if tensor is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"{name} is not initialized for CUDA graph capture; "
+                "provide a preallocated W4A16 route-packing workspace"
+            )
+        return torch.empty((elements,), dtype=dtype, device=device)
+    if tensor.dtype != dtype:
+        raise TypeError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+    if tensor.device != device:
+        raise ValueError(f"{name} must be on device {device}, got {tensor.device}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    if int(tensor.numel()) < elements:
+        raise ValueError(
+            f"{name} has {tensor.numel()} elements; need at least {elements}"
+        )
+    return tensor[:elements]
+
+
+@triton.jit
+def _pack_topk_routes_post_prefix_kernel(
+    packed_route_indices,
+    block_expert_ids,
+    expert_offsets,
+    live_numel,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    MAX_PACKED_ROUTES: tl.constexpr,
+    MAX_ROUTE_BLOCKS: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_T + tl.arange(0, BLOCK_T)
+    tl.store(
+        packed_route_indices + offsets,
+        live_numel,
+        mask=offsets < MAX_PACKED_ROUTES,
+    )
+
+    block_rows = offsets * BLOCK_SIZE
+    block_experts = tl.full((BLOCK_T,), -1, dtype=tl.int32)
+    valid_blocks = offsets < MAX_ROUTE_BLOCKS
+    for expert in tl.range(0, NUM_EXPERTS):
+        start = tl.load(expert_offsets + expert)
+        end = tl.load(expert_offsets + expert + 1)
+        active = valid_blocks & (block_rows >= start) & (block_rows < end)
+        block_experts = tl.where(active, expert, block_experts)
+    tl.store(block_expert_ids + offsets, block_experts, mask=valid_blocks)
+
+
+@triton.jit
+def _pack_topk_routes_small_prefix_kernel(
+    topk_ids,
+    expert_map,
+    packed_route_indices,
+    block_expert_ids,
+    packed_route_count,
+    expert_offsets,
+    live_numel,
+    NUMEL_CAPACITY: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    MAX_PACKED_ROUTES: tl.constexpr,
+    MAX_ROUTE_BLOCKS: tl.constexpr,
+    HAS_EXPERT_MAP: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_ROUTE_INIT: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    experts = tl.arange(0, BLOCK_E)
+    expert_mask = experts < NUM_EXPERTS
+    counts = tl.zeros((BLOCK_E,), dtype=tl.int32)
+
+    route_offsets = tl.arange(0, BLOCK_T)
+    for start in tl.range(0, NUMEL_CAPACITY, BLOCK_T):
+        offsets = start + route_offsets
+        raw_ids = tl.load(topk_ids + offsets, mask=offsets < live_numel, other=-1).to(
+            tl.int32
+        )
+        valid = (offsets < live_numel) & (raw_ids >= 0) & (raw_ids < NUM_EXPERTS)
+        ids = raw_ids
+        if HAS_EXPERT_MAP:
+            safe_ids = tl.minimum(tl.maximum(raw_ids, 0), NUM_EXPERTS - 1)
+            ids = tl.load(expert_map + safe_ids, mask=valid, other=-1).to(tl.int32)
+            valid = valid & (ids >= 0) & (ids < NUM_EXPERTS)
+
+        matches = (
+            (experts[:, None] == ids[None, :]) & expert_mask[:, None] & valid[None, :]
+        )
+        counts += tl.sum(matches.to(tl.int32), axis=1)
+
+    padded = ((counts + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+    padded = tl.where(expert_mask, padded, 0)
+    inclusive = tl.cumsum(padded, axis=0)
+    prefix = inclusive - padded
+    total = tl.sum(padded, axis=0)
+
+    tl.store(expert_offsets + experts, prefix, mask=expert_mask)
+    tl.store(expert_offsets + NUM_EXPERTS, total)
+    tl.store(packed_route_count, total)
+
+    route_init_offsets = tl.arange(0, BLOCK_ROUTE_INIT)
+    tl.store(
+        packed_route_indices + route_init_offsets,
+        live_numel,
+        mask=route_init_offsets < MAX_PACKED_ROUTES,
+    )
+
+    block_offsets = tl.arange(0, BLOCK_M)
+    block_rows = block_offsets * BLOCK_SIZE
+    active = (
+        (block_offsets[None, :] < MAX_ROUTE_BLOCKS)
+        & expert_mask[:, None]
+        & (block_rows[None, :] >= prefix[:, None])
+        & (block_rows[None, :] < inclusive[:, None])
+    )
+    block_experts = tl.max(tl.where(active, experts[:, None], -1), axis=0)
+    tl.store(
+        block_expert_ids + block_offsets,
+        block_experts,
+        mask=block_offsets < MAX_ROUTE_BLOCKS,
+    )
+
+
+@triton.jit
+def _pack_topk_routes_prefix_kernel(
+    topk_ids,
+    expert_map,
+    packed_route_count,
+    expert_offsets,
+    live_numel,
+    NUMEL_CAPACITY: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    HAS_EXPERT_MAP: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    experts = tl.arange(0, BLOCK_E)
+    expert_mask = experts < NUM_EXPERTS
+    counts = tl.zeros((BLOCK_E,), dtype=tl.int32)
+
+    route_offsets = tl.arange(0, BLOCK_T)
+    for start in tl.range(0, NUMEL_CAPACITY, BLOCK_T):
+        offsets = start + route_offsets
+        raw_ids = tl.load(topk_ids + offsets, mask=offsets < live_numel, other=-1).to(
+            tl.int32
+        )
+        valid = (offsets < live_numel) & (raw_ids >= 0) & (raw_ids < NUM_EXPERTS)
+        ids = raw_ids
+        if HAS_EXPERT_MAP:
+            safe_ids = tl.minimum(tl.maximum(raw_ids, 0), NUM_EXPERTS - 1)
+            ids = tl.load(expert_map + safe_ids, mask=valid, other=-1).to(tl.int32)
+            valid = valid & (ids >= 0) & (ids < NUM_EXPERTS)
+
+        matches = (
+            (experts[:, None] == ids[None, :]) & expert_mask[:, None] & valid[None, :]
+        )
+        counts += tl.sum(matches.to(tl.int32), axis=1)
+
+    padded = ((counts + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+    padded = tl.where(expert_mask, padded, 0)
+    inclusive = tl.cumsum(padded, axis=0)
+    prefix = inclusive - padded
+    total = tl.sum(padded, axis=0)
+
+    tl.store(expert_offsets + experts, prefix, mask=expert_mask)
+    tl.store(expert_offsets + NUM_EXPERTS, total)
+    tl.store(packed_route_count, total)
+
+
+@triton.jit
+def _pack_topk_routes_sort_kernel(
+    topk_ids,
+    expert_map,
+    packed_route_indices,
+    expert_offsets,
+    live_numel,
+    NUM_EXPERTS: tl.constexpr,
+    HAS_EXPERT_MAP: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_T + tl.arange(0, BLOCK_T)
+    raw_ids = tl.load(topk_ids + offsets, mask=offsets < live_numel, other=-1).to(
+        tl.int32
+    )
+    valid = (offsets < live_numel) & (raw_ids >= 0) & (raw_ids < NUM_EXPERTS)
+    ids = raw_ids
+    if HAS_EXPERT_MAP:
+        safe_ids = tl.minimum(tl.maximum(raw_ids, 0), NUM_EXPERTS - 1)
+        ids = tl.load(expert_map + safe_ids, mask=valid, other=-1).to(tl.int32)
+        valid = valid & (ids >= 0) & (ids < NUM_EXPERTS)
+
+    ranks = tl.atomic_add(expert_offsets + ids, 1, sem="relaxed", mask=valid)
+    tl.store(packed_route_indices + ranks, offsets, mask=valid)
+
+
+def pack_topk_routes_by_expert(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    *,
+    expert_map: torch.Tensor | None = None,
+    packed_route_indices: torch.Tensor | None = None,
+    block_expert_ids: torch.Tensor | None = None,
+    packed_route_count: torch.Tensor | None = None,
+    expert_offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    numel = int(topk_ids.numel())
+    topk = int(topk_ids.shape[-1]) if topk_ids.ndim >= 2 else 1
+    numel_capacity = route_pack_numel_capacity(numel, topk=topk)
+    capacity_packed_routes = max_packed_route_slots(
+        numel_capacity, int(block_size), int(num_experts)
+    )
+    capacity_route_blocks = (capacity_packed_routes + int(block_size) - 1) // int(
+        block_size
+    )
+    if packed_route_indices is not None and block_expert_ids is not None:
+        if (
+            int(packed_route_indices.numel()) < capacity_packed_routes
+            or int(block_expert_ids.numel()) < capacity_route_blocks
+        ):
+            numel_capacity = numel
+            capacity_packed_routes = max_packed_route_slots(
+                numel, int(block_size), int(num_experts)
+            )
+            capacity_route_blocks = (
+                capacity_packed_routes + int(block_size) - 1
+            ) // int(block_size)
+    max_packed_routes = capacity_packed_routes
+    max_route_blocks = capacity_route_blocks
+    max_packed_routes = max(max_packed_routes, 1)
+    max_route_blocks = max(max_route_blocks, 1)
+
+    packed_route_indices = _workspace_slice(
+        packed_route_indices,
+        name="packed_route_indices",
+        elements=max_packed_routes,
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    block_expert_ids = _workspace_slice(
+        block_expert_ids,
+        name="block_expert_ids",
+        elements=max_route_blocks,
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    packed_route_count = _workspace_slice(
+        packed_route_count,
+        name="packed_route_count",
+        elements=1,
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    expert_offsets = _workspace_slice(
+        expert_offsets,
+        name="expert_offsets",
+        elements=int(num_experts) + 1,
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+
+    if numel == 0:
+        packed_route_indices.fill_(0)
+        block_expert_ids.fill_(-1)
+        packed_route_count.zero_()
+        return packed_route_indices, block_expert_ids, packed_route_count
+
+    block_e = _next_power_of_2(num_experts)
+    sort_grid = (triton.cdiv(numel, _SORT_BLOCK_T),)
+    expert_map_tensor = expert_map if expert_map is not None else topk_ids
+
+    block_route_init = _next_power_of_2(max(max_packed_routes, 1))
+    block_m = _next_power_of_2(max(max_route_blocks, 1))
+    use_small_prefix = (
+        block_route_init <= _SMALL_PREFIX_MAX_PACKED_ROUTES
+        and block_m <= _SMALL_PREFIX_MAX_ROUTE_BLOCKS
+        and block_e * block_m <= _SMALL_PREFIX_MAX_EXPERT_BLOCK_PRODUCT
+    )
+    if use_small_prefix:
+        # Decode-sized W4A16 MoE calls are launch-overhead sensitive. Keep the
+        # large-shape split kernel below, but fold prefix/post-prefix work into
+        # one launch when the vector sizes are safely bounded.
+        _pack_topk_routes_small_prefix_kernel[(1,)](
+            topk_ids,
+            expert_map_tensor,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            expert_offsets,
+            numel,
+            NUMEL_CAPACITY=numel_capacity,
+            BLOCK_SIZE=int(block_size),
+            NUM_EXPERTS=int(num_experts),
+            MAX_PACKED_ROUTES=max_packed_routes,
+            MAX_ROUTE_BLOCKS=max_route_blocks,
+            HAS_EXPERT_MAP=expert_map is not None,
+            BLOCK_E=block_e,
+            BLOCK_T=_COUNT_BLOCK_T,
+            BLOCK_ROUTE_INIT=block_route_init,
+            BLOCK_M=block_m,
+            num_warps=8,
+        )
+    else:
+        post_prefix_grid = (
+            max(
+                triton.cdiv(max_packed_routes, _POST_PREFIX_BLOCK_T),
+                triton.cdiv(max_route_blocks, _POST_PREFIX_BLOCK_T),
+            ),
+        )
+        if not torch.cuda.is_current_stream_capturing():
+            # FAST (eager prefill): parallel atomic count + tiny over-experts
+            # block-padded prefix, replacing the single-CTA count+prefix
+            # (~7-31x measured at prefill). Only the large path (routes > 4096,
+            # i.e. > 512 tokens) reaches here, and cudagraph capture is bounded
+            # to <=128 tokens (the small-prefix path), so this scratch alloc is
+            # never captured. The slow single-CTA kernel stays as the defensive
+            # captured-path fallback below.
+            expert_counts = torch.zeros(
+                int(num_experts), dtype=torch.int32, device=topk_ids.device
+            )
+            _w4a16_route_count_kernel[(triton.cdiv(numel, _FAST_COUNT_BLOCK_T),)](
+                topk_ids,
+                expert_map_tensor,
+                expert_counts,
+                numel,
+                NUM_EXPERTS=int(num_experts),
+                HAS_EXPERT_MAP=expert_map is not None,
+                BLOCK_T=_FAST_COUNT_BLOCK_T,
+                num_warps=4,
+            )
+            _w4a16_route_prefix_from_counts_kernel[(1,)](
+                expert_counts,
+                packed_route_count,
+                expert_offsets,
+                BLOCK_SIZE=int(block_size),
+                NUM_EXPERTS=int(num_experts),
+                BLOCK_E=block_e,
+                num_warps=4,
+            )
+        else:
+            _pack_topk_routes_prefix_kernel[(1,)](
+                topk_ids,
+                expert_map_tensor,
+                packed_route_count,
+                expert_offsets,
+                numel,
+                NUMEL_CAPACITY=numel_capacity,
+                BLOCK_SIZE=int(block_size),
+                NUM_EXPERTS=int(num_experts),
+                HAS_EXPERT_MAP=expert_map is not None,
+                BLOCK_E=block_e,
+                BLOCK_T=_COUNT_BLOCK_T,
+                num_warps=8,
+            )
+        _pack_topk_routes_post_prefix_kernel[post_prefix_grid](
+            packed_route_indices,
+            block_expert_ids,
+            expert_offsets,
+            numel,
+            BLOCK_SIZE=int(block_size),
+            NUM_EXPERTS=int(num_experts),
+            MAX_PACKED_ROUTES=max_packed_routes,
+            MAX_ROUTE_BLOCKS=max_route_blocks,
+            BLOCK_T=_POST_PREFIX_BLOCK_T,
+            num_warps=4,
+        )
+    _pack_topk_routes_sort_kernel[sort_grid](
+        topk_ids,
+        expert_map_tensor,
+        packed_route_indices,
+        expert_offsets,
+        numel,
+        NUM_EXPERTS=int(num_experts),
+        HAS_EXPERT_MAP=expert_map is not None,
+        BLOCK_T=_SORT_BLOCK_T,
+        num_warps=4,
+    )
+    return packed_route_indices, block_expert_ids, packed_route_count
+
+
+__all__ = ["pack_topk_routes_by_expert"]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a8/__init__.py @ 731ba9da (2026-06-30) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""W4A8-specific prepared-weight utilities for the unified MoE kernel."""
+
+from .weights import repack_w4a8_weights
+
+__all__ = ["repack_w4a8_weights"]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8/weights.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8/weights.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a8/weights.py @ 731ba9da (2026-06-30) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Prepared weight layout shared by the unified W4A8 MoE kernel."""
+
+from __future__ import annotations
+
+import torch
+
+
+_TILE_N = 256
+_TILE_K = 128
+
+
+def repack_w4a8_weights(
+    w_fp4: torch.Tensor,
+    w_sf: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Repack logical MXFP4 weights for the dynamic W4A8 mainloop.
+
+    ``w_fp4`` is ``[E, N, K/2]`` packed FP4 and ``w_sf`` is the matching
+    ``[E, N, K/32]`` E8M0 grid.  The returned tensors use the N256/K128
+    lane-major layouts consumed by :class:`MoEDynamicKernelBackend`.
+
+    This is a representation transform, not a standalone GEMM contract.  The
+    CUDA preparation path in :mod:`flashinfer.experimental.sm12x.moe.fused_moe._impl` performs the same
+    permutation in-place so serving can reuse checkpoint storage.
+    """
+
+    if w_fp4.dim() != 3 or w_sf.dim() != 3:
+        raise ValueError("w_fp4 must be [E, N, K/2] and w_sf [E, N, K/32]")
+    e, n, k_half = w_fp4.shape
+    k = k_half * 2
+    if w_sf.shape != (e, n, k // 32):
+        raise ValueError(f"w_sf shape {tuple(w_sf.shape)} != {(e, n, k // 32)}")
+    if n % _TILE_N != 0:
+        raise ValueError(f"N must be divisible by {_TILE_N}, got {n}")
+    if k % _TILE_K != 0:
+        raise ValueError(f"K must be divisible by {_TILE_K}, got {k}")
+    n_tiles = n // _TILE_N
+    k_tiles = k // _TILE_K
+
+    b_u32 = w_fp4.contiguous().view(torch.int32).reshape(e, n, k // 8)
+    b = b_u32.reshape(e, n_tiles, 8, 4, 8, k_tiles, 4, 4)
+    b_rp = (
+        b.permute(0, 1, 5, 6, 2, 4, 7, 3)
+        .reshape(e, n_tiles, k_tiles, 4, 8, 32, 4)
+        .contiguous()
+    )
+
+    sf = w_sf.contiguous().reshape(e, n_tiles, 32, 8, k_tiles, 4)
+    sfb = (
+        sf.permute(0, 1, 4, 2, 3, 5)
+        .contiguous()
+        .view(torch.int32)
+        .reshape(e, n_tiles, k_tiles, 32, 8)
+    )
+    return b_rp, sfb
+
+
+__all__ = ["repack_w4a8_weights"]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8_phase1.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8_phase1.py
@@ -1,0 +1,700 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a8_phase1.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Standalone materialized-W4A8 FC1 kernel for dense prefill regimes.
+
+The dynamic front-end still owns routing, input quantization, and publication
+of a compact expert-major M64 or M128 source domain.  This kernel consumes that
+domain as M64xN128 tasks, computes gate and up together in one K sweep, applies
+SiLU, and writes the existing caller-owned MXFP8 intermediate workspace.
+
+Keeping the compute body separate from routing and FC2 removes the monolithic
+kernel's register/shared-memory union.  The launch has a fixed two-CTA-per-SM
+capacity and uses only caller-owned storage, so it is safe to capture and
+replay without host reads or allocations.
+"""
+
+from __future__ import annotations
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+
+from cutlass.cutlass_dsl import Int32, Int64, Uint32
+
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    cp_async4_shared_global,
+    cp_async_u32_shared_global,
+    e2m1x8_to_qmma_e2m1x8,
+    fabs_f32,
+    get_ptr_as_int64,
+    ld_shared_bf16_to_f32,
+    ld_shared_u32,
+    ld_shared_v2_u32,
+    ld_shared_v4_u32,
+    mxfp8_mma_m16n8k32_f32_e2m1,
+    pack_f32x2_to_bfloat2,
+    quantize_block_fp8_mx,
+    shared_ptr_to_u32,
+    st_shared_u32,
+)
+
+
+class W4A8MaterializedPhase1Kernel:
+    """Compute one M64 chunk of each published FC1 source tile per task."""
+
+    tile_m = 64
+    source_tile_m = 128
+    tile_n = 128
+    tile_k = 64
+    num_warps = 4
+    threads_per_cta = num_warps * 32
+    stages = 2
+
+    # A retains a 128-byte row stride even though each stage advances K64.
+    # The XOR vector mapping used by QMMA can address all eight 16-byte slots
+    # for any row; the unused half is merely padding.  Each B half is a compact
+    # N128xK64 FP4 tile.  Gate and up are staged side by side.
+    a_payload_bytes = tile_m * 128
+    a_scale_bytes = tile_m * 4
+    b_payload_bytes = tile_n * tile_k // 2
+    sfb_bytes = (tile_n // 8) * 8 * 4
+
+    a_offset = 0
+    sfa_offset = a_offset + a_payload_bytes
+    gate_b_offset = sfa_offset + a_scale_bytes
+    up_b_offset = gate_b_offset + b_payload_bytes
+    gate_sfb_offset = up_b_offset + b_payload_bytes
+    up_sfb_offset = gate_sfb_offset + sfb_bytes
+    stage_bytes = up_sfb_offset + sfb_bytes
+    pipeline_bytes = stages * stage_bytes
+
+    # The post-MMA activation tile is smaller than the pipeline union and
+    # reuses it after all asynchronous copies have drained.
+    epilogue_bytes = tile_m * tile_n * 2
+    shared_bytes = max(pipeline_bytes, epilogue_bytes)
+    shared_words = (shared_bytes + 3) // 4
+
+    def __init__(
+        self,
+        *,
+        fast_math: bool = False,
+        source_tile_m: int = 128,
+        deterministic_output: bool = False,
+        num_topk: int = 1,
+    ):
+        if source_tile_m not in (64, 128):
+            raise ValueError(
+                f"materialized phase 1 source_tile_m must be 64 or 128, got {source_tile_m}"
+            )
+        self.fast_math = bool(fast_math)
+        self.source_tile_m = int(source_tile_m)
+        self.source_halves = self.source_tile_m // self.tile_m
+        self.deterministic_output = bool(deterministic_output)
+        if int(num_topk) <= 0:
+            raise ValueError(f"num_topk must be positive, got {num_topk}")
+        self.num_topk = int(num_topk)
+
+    @cute.jit
+    def __call__(
+        self,
+        packed_a_storage: cute.Tensor,
+        scale_storage: cute.Tensor,
+        w13_rp: cute.Tensor,
+        w13_sfb_rp: cute.Tensor,
+        intermediate_u32: cute.Tensor,
+        token_map: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        alpha: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        input_k128_tiles: cutlass.Int32,
+        intermediate_tiles: cutlass.Int32,
+        packed_w13_tiles: cutlass.Int32,
+        max_active_clusters: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            cute.recast_tensor(packed_a_storage, cutlass.Uint32),
+            scale_storage,
+            w13_rp,
+            w13_sfb_rp,
+            intermediate_u32,
+            token_map,
+            task_expert,
+            task_valid_rows,
+            expert_tile_base,
+            alpha,
+            input_global_scale,
+            input_k128_tiles,
+            intermediate_tiles,
+            packed_w13_tiles,
+        ).launch(
+            grid=(1, 1, max_active_clusters * Int32(2)),
+            block=[self.threads_per_cta, 1, 1],
+            min_blocks_per_mp=2,
+            stream=stream,
+        )
+
+    @cute.jit
+    def _stage_b_half_k64(
+        self,
+        weights: cute.Tensor,
+        dst_base: Int32,
+        tile_word_base: Int64,
+        packed_half: Int32,
+        k_half: Int32,
+        tid: Int32,
+    ):
+        # Prepared weights are [K32, N32-chunk, lane, n8-in-chunk].  Select
+        # two K32 blocks and one N128 half from the enclosing N256xK128 tile.
+        for i in cutlass.range_constexpr(
+            (2 * 4 * 32 + self.threads_per_cta - 1) // self.threads_per_cta
+        ):
+            idx = tid + Int32(i * self.threads_per_cta)
+            if idx < Int32(2 * 4 * 32):
+                lane = idx & Int32(31)
+                kc = idx >> Int32(5)
+                chunk = kc & Int32(3)
+                kb = (kc >> Int32(2)) + k_half * Int32(2)
+                src_word = (
+                    tile_word_base
+                    + Int64(kb * Int32(8 * 32 * 4))
+                    + Int64((packed_half * Int32(4) + chunk) * Int32(32 * 4))
+                    + Int64(lane * Int32(4))
+                )
+                cp_async4_shared_global(
+                    dst_base + (idx << Int32(4)),
+                    get_ptr_as_int64(weights, src_word),
+                )
+
+    @cute.jit
+    def _stage_sfb_half(
+        self,
+        scales: cute.Tensor,
+        dst_base: Int32,
+        tile_word_base: Int64,
+        packed_half: Int32,
+        tid: Int32,
+    ):
+        # Retain the complete packed K128 scale word.  The two K64 epochs use
+        # different compile-time QMMA byte ids from this same representation.
+        for i in cutlass.range_constexpr(
+            ((16 * 8) // 4 + self.threads_per_cta - 1) // self.threads_per_cta
+        ):
+            idx = tid + Int32(i * self.threads_per_cta)
+            if idx < Int32((16 * 8) // 4):
+                src_word = tile_word_base + Int64(packed_half * Int32(16 * 8) + idx * 4)
+                cp_async4_shared_global(
+                    dst_base + (idx << Int32(4)),
+                    get_ptr_as_int64(scales, src_word),
+                )
+
+    @cute.jit
+    def _stage_slice(
+        self,
+        packed_a_u32: cute.Tensor,
+        scale_storage: cute.Tensor,
+        w13_rp: cute.Tensor,
+        w13_sfb_rp: cute.Tensor,
+        token_map: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        source_m_tile: Int32,
+        m_half: Int32,
+        expert_idx: Int32,
+        output_tile: Int32,
+        valid_rows: Int32,
+        k64_slice: Int32,
+        input_k128_tiles: Int32,
+        intermediate_tiles: Int32,
+        packed_w13_tiles: Int32,
+    ):
+        stage = k64_slice & Int32(1)
+        stage_base = smem_base + stage * Int32(self.stage_bytes)
+        a_base = stage_base + Int32(self.a_offset)
+        sfa_base = stage_base + Int32(self.sfa_offset)
+        gate_b_base = stage_base + Int32(self.gate_b_offset)
+        up_b_base = stage_base + Int32(self.up_b_offset)
+        gate_sfb_base = stage_base + Int32(self.gate_sfb_offset)
+        up_sfb_base = stage_base + Int32(self.up_sfb_offset)
+
+        physical_row_base = source_m_tile * Int32(self.source_tile_m) + m_half * Int32(
+            self.tile_m
+        )
+        words_per_token = input_k128_tiles * Int32(32)
+
+        # Gather the shared input representation through the published route
+        # map.  Invalid tail rows may read token zero safely; no output is
+        # published for them.
+        for i in cutlass.range_constexpr(
+            (self.tile_m * 4 + self.threads_per_cta - 1) // self.threads_per_cta
+        ):
+            idx = tid + Int32(i * self.threads_per_cta)
+            if idx < Int32(self.tile_m * 4):
+                row = idx >> Int32(2)
+                vec = idx & Int32(3)
+                tok = Int32(0)
+                if row < valid_rows:
+                    tok = token_map[physical_row_base + row].to(Int32)
+                    if cutlass.const_expr(self.deterministic_output):
+                        tok = tok // Int32(self.num_topk)
+                physical_vec = vec ^ (row & Int32(7))
+                src_word = (
+                    tok * words_per_token + k64_slice * Int32(16) + (vec << Int32(2))
+                )
+                cp_async4_shared_global(
+                    a_base + row * Int32(128) + (physical_vec << Int32(4)),
+                    get_ptr_as_int64(packed_a_u32, src_word),
+                )
+
+        if tid < Int32(self.tile_m):
+            tok = Int32(0)
+            if tid < valid_rows:
+                tok = token_map[physical_row_base + tid].to(Int32)
+                if cutlass.const_expr(self.deterministic_output):
+                    tok = tok // Int32(self.num_topk)
+            sf_src = tok * input_k128_tiles * Int32(4) + (
+                k64_slice >> Int32(1)
+            ) * Int32(4)
+            cp_async_u32_shared_global(
+                sfa_base + (tid << Int32(2)),
+                get_ptr_as_int64(scale_storage, sf_src),
+            )
+
+        k128_slice = k64_slice >> Int32(1)
+        k_half = k64_slice & Int32(1)
+        input_k128_count = input_k128_tiles
+
+        up_packed_tile = output_tile >> Int32(1)
+        up_packed_half = output_tile & Int32(1)
+        gate_tile = output_tile + intermediate_tiles
+        gate_packed_tile = gate_tile >> Int32(1)
+        gate_packed_half = gate_tile & Int32(1)
+
+        up_tile = (
+            expert_idx * packed_w13_tiles + up_packed_tile
+        ) * input_k128_count + k128_slice
+        gate_tile_idx = (
+            expert_idx * packed_w13_tiles + gate_packed_tile
+        ) * input_k128_count + k128_slice
+
+        self._stage_b_half_k64(
+            w13_rp,
+            gate_b_base,
+            Int64(gate_tile_idx) * Int64(4096),
+            gate_packed_half,
+            k_half,
+            tid,
+        )
+        self._stage_b_half_k64(
+            w13_rp,
+            up_b_base,
+            Int64(up_tile) * Int64(4096),
+            up_packed_half,
+            k_half,
+            tid,
+        )
+        self._stage_sfb_half(
+            w13_sfb_rp,
+            gate_sfb_base,
+            Int64(gate_tile_idx) * Int64(256),
+            gate_packed_half,
+            tid,
+        )
+        self._stage_sfb_half(
+            w13_sfb_rp,
+            up_sfb_base,
+            Int64(up_tile) * Int64(256),
+            up_packed_half,
+            tid,
+        )
+
+    @cute.jit
+    def _activated_value(
+        self,
+        gate: cutlass.Float32,
+        up: cutlass.Float32,
+        alpha_value: cutlass.Float32,
+    ) -> cutlass.Float32:
+        gate = alpha_value * gate
+        up = alpha_value * up
+        sigmoid = cute.arch.rcp_approx(
+            cutlass.Float32(1.0) + cute.math.exp(-gate, fastmath=self.fast_math)
+        )
+        return gate * sigmoid * up
+
+    @cute.jit
+    def _run_task(
+        self,
+        packed_a_u32: cute.Tensor,
+        scale_storage: cute.Tensor,
+        w13_rp: cute.Tensor,
+        w13_sfb_rp: cute.Tensor,
+        intermediate_u32: cute.Tensor,
+        token_map: cute.Tensor,
+        alpha: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        warp_idx: Int32,
+        source_m_tile: Int32,
+        m_half: Int32,
+        expert_idx: Int32,
+        output_tile: Int32,
+        valid_rows: Int32,
+        rows_capacity: Int32,
+        input_k128_tiles: Int32,
+        intermediate_tiles: Int32,
+        packed_w13_tiles: Int32,
+    ):
+        lane = tid & Int32(31)
+        q = lane >> Int32(2)
+        c = lane & Int32(3)
+
+        self._stage_slice(
+            packed_a_u32,
+            scale_storage,
+            w13_rp,
+            w13_sfb_rp,
+            token_map,
+            smem_base,
+            tid,
+            source_m_tile,
+            m_half,
+            expert_idx,
+            output_tile,
+            valid_rows,
+            Int32(0),
+            input_k128_tiles,
+            intermediate_tiles,
+            packed_w13_tiles,
+        )
+        cute.arch.cp_async_commit_group()
+
+        # Keep each MMA's four accumulator registers as an independent
+        # fragment.  A single 4x4x4 mutable tensor makes the 4.6 lowering pack
+        # and unpack the complete live accumulator set around loop-carried
+        # values even though every MMA consumes exactly four adjacent values.
+        gate_acc = tuple(
+            tuple(cute.make_rmem_tensor((4,), cutlass.Float32) for _nt in range(4))
+            for _blk in range(4)
+        )
+        up_acc = tuple(
+            tuple(cute.make_rmem_tensor((4,), cutlass.Float32) for _nt in range(4))
+            for _blk in range(4)
+        )
+        for blk in cutlass.range_constexpr(4):
+            for nt in cutlass.range_constexpr(4):
+                gate_acc[blk][nt].fill(0.0)
+                up_acc[blk][nt].fill(0.0)
+
+        input_k64_tiles = input_k128_tiles * Int32(2)
+        k64_slice = Int32(0)
+        while k64_slice < input_k64_tiles:
+            stage = k64_slice & Int32(1)
+            stage_base = smem_base + stage * Int32(self.stage_bytes)
+            a_base = stage_base + Int32(self.a_offset)
+            sfa_base = stage_base + Int32(self.sfa_offset)
+            gate_b_base = stage_base + Int32(self.gate_b_offset)
+            up_b_base = stage_base + Int32(self.up_b_offset)
+            gate_sfb_base = stage_base + Int32(self.gate_sfb_offset)
+            up_sfb_base = stage_base + Int32(self.up_sfb_offset)
+
+            next_slice = k64_slice + Int32(1)
+            if next_slice < input_k64_tiles:
+                self._stage_slice(
+                    packed_a_u32,
+                    scale_storage,
+                    w13_rp,
+                    w13_sfb_rp,
+                    token_map,
+                    smem_base,
+                    tid,
+                    source_m_tile,
+                    m_half,
+                    expert_idx,
+                    output_tile,
+                    valid_rows,
+                    next_slice,
+                    input_k128_tiles,
+                    intermediate_tiles,
+                    packed_w13_tiles,
+                )
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(1)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            cute.arch.sync_threads()
+
+            scale_shift = Uint32(k64_slice & Int32(1)) * Uint32(16)
+            asc = cute.make_rmem_tensor((4,), Uint32)
+            for blk in cutlass.range_constexpr(4):
+                sf_row = Int32(blk * 16) + q + ((lane & Int32(1)) << Int32(3))
+                asc[blk] = ld_shared_u32(sfa_base + (sf_row << Int32(2))) >> scale_shift
+
+            for kb in cutlass.range_constexpr(2):
+                u_phys = (Int32(kb * 2) + (c >> Int32(1))) ^ q
+                a_frag = cute.make_rmem_tensor((4, 4), Uint32)
+                for blk in cutlass.range_constexpr(4):
+                    a_lo = (
+                        a_base
+                        + Int32(blk * 16 * 128)
+                        + (q << Int32(7))
+                        + (u_phys << Int32(4))
+                        + ((c & Int32(1)) << Int32(3))
+                    )
+                    a0, a2 = ld_shared_v2_u32(a_lo)
+                    a1, a3 = ld_shared_v2_u32(a_lo + Int32(8 * 128))
+                    a_frag[blk, 0] = a0
+                    a_frag[blk, 1] = a1
+                    a_frag[blk, 2] = a2
+                    a_frag[blk, 3] = a3
+
+                gw0, gw1, gw2, gw3 = ld_shared_v4_u32(
+                    gate_b_base
+                    + (((Int32(kb * 4) + warp_idx) * Int32(32) + lane) << Int32(4))
+                )
+                uw0, uw1, uw2, uw3 = ld_shared_v4_u32(
+                    up_b_base
+                    + (((Int32(kb * 4) + warp_idx) * Int32(32) + lane) << Int32(4))
+                )
+                gate_words = cute.make_rmem_tensor((4,), Uint32)
+                up_words = cute.make_rmem_tensor((4,), Uint32)
+                gate_words[0] = gw0
+                gate_words[1] = gw1
+                gate_words[2] = gw2
+                gate_words[3] = gw3
+                up_words[0] = uw0
+                up_words[1] = uw1
+                up_words[2] = uw2
+                up_words[3] = uw3
+
+                for nt in cutlass.range_constexpr(4):
+                    n8 = warp_idx * Int32(4) + Int32(nt)
+                    gb0, gb1 = e2m1x8_to_qmma_e2m1x8(gate_words[nt])
+                    ub0, ub1 = e2m1x8_to_qmma_e2m1x8(up_words[nt])
+                    gate_sfb = (
+                        ld_shared_u32(gate_sfb_base + ((n8 * Int32(8) + q) << Int32(2)))
+                        >> scale_shift
+                    )
+                    up_sfb = (
+                        ld_shared_u32(up_sfb_base + ((n8 * Int32(8) + q) << Int32(2)))
+                        >> scale_shift
+                    )
+                    for blk in cutlass.range_constexpr(4):
+                        gate_fragment = gate_acc[blk][nt]
+                        g0, g1, g2, g3 = mxfp8_mma_m16n8k32_f32_e2m1(
+                            gate_fragment[0],
+                            gate_fragment[1],
+                            gate_fragment[2],
+                            gate_fragment[3],
+                            a_frag[blk, 0],
+                            a_frag[blk, 1],
+                            a_frag[blk, 2],
+                            a_frag[blk, 3],
+                            gb0,
+                            gb1,
+                            asc[blk],
+                            gate_sfb,
+                            bid_a=kb,
+                            bid_b=kb,
+                        )
+                        gate_fragment[0] = g0
+                        gate_fragment[1] = g1
+                        gate_fragment[2] = g2
+                        gate_fragment[3] = g3
+                        up_fragment = up_acc[blk][nt]
+                        u0, u1, u2, u3 = mxfp8_mma_m16n8k32_f32_e2m1(
+                            up_fragment[0],
+                            up_fragment[1],
+                            up_fragment[2],
+                            up_fragment[3],
+                            a_frag[blk, 0],
+                            a_frag[blk, 1],
+                            a_frag[blk, 2],
+                            a_frag[blk, 3],
+                            ub0,
+                            ub1,
+                            asc[blk],
+                            up_sfb,
+                            bid_a=kb,
+                            bid_b=kb,
+                        )
+                        up_fragment[0] = u0
+                        up_fragment[1] = u1
+                        up_fragment[2] = u2
+                        up_fragment[3] = u3
+
+            cute.arch.sync_threads()
+            k64_slice += Int32(1)
+
+        # The pipeline region aliases the activation staging tile below.  A
+        # wait-group(1) is sufficient while consuming alternating stages, but
+        # the final (possibly empty) committed group must be fully retired
+        # before those shared addresses are repurposed by ordinary stores.
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.fence_proxy("async.shared", space="cta")
+        cute.arch.sync_threads()
+
+        alpha_value = alpha[expert_idx].to(cutlass.Float32) * input_global_scale[
+            expert_idx
+        ].to(cutlass.Float32)
+        epilogue_base = smem_base
+        col_base = warp_idx * Int32(32) + (c << Int32(1))
+        for nt in cutlass.range_constexpr(4):
+            col = col_base + Int32(nt * 8)
+            for blk in cutlass.range_constexpr(4):
+                gate_fragment = gate_acc[blk][nt]
+                up_fragment = up_acc[blk][nt]
+                row_lo = Int32(blk * 16) + q
+                row_hi = row_lo + Int32(8)
+                act0 = self._activated_value(
+                    gate_fragment[0], up_fragment[0], alpha_value
+                )
+                act1 = self._activated_value(
+                    gate_fragment[1], up_fragment[1], alpha_value
+                )
+                act2 = self._activated_value(
+                    gate_fragment[2], up_fragment[2], alpha_value
+                )
+                act3 = self._activated_value(
+                    gate_fragment[3], up_fragment[3], alpha_value
+                )
+                st_shared_u32(
+                    epilogue_base + (row_lo * Int32(self.tile_n) + col) * Int32(2),
+                    pack_f32x2_to_bfloat2(act0, act1),
+                )
+                st_shared_u32(
+                    epilogue_base + (row_hi * Int32(self.tile_n) + col) * Int32(2),
+                    pack_f32x2_to_bfloat2(act2, act3),
+                )
+
+        cute.arch.sync_threads()
+
+        physical_row_base = source_m_tile * Int32(self.source_tile_m) + m_half * Int32(
+            self.tile_m
+        )
+        words_per_row = intermediate_tiles * Int32(32)
+        if tid < valid_rows:
+            scale_word = Uint32(0)
+            for block in cutlass.range_constexpr(4):
+                values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                block_max = cutlass.Float32(0.0)
+                for elem in cutlass.range_constexpr(32):
+                    value = ld_shared_bf16_to_f32(
+                        epilogue_base
+                        + (tid * Int32(self.tile_n) + Int32(block * 32 + elem))
+                        * Int32(2)
+                    )
+                    values[elem] = value
+                    abs_value = fabs_f32(value)
+                    if abs_value > block_max:
+                        block_max = abs_value
+                payload, scale_byte = quantize_block_fp8_mx(values, block_max)
+                dst_word = (
+                    (physical_row_base + tid) * words_per_row
+                    + output_tile * Int32(32)
+                    + Int32(block * 8)
+                )
+                for word in cutlass.range_constexpr(8):
+                    intermediate_u32[dst_word + Int32(word)] = payload[word]
+                scale_word = scale_word | (
+                    (scale_byte & Uint32(0xFF)) << Uint32(block * 8)
+                )
+
+            sf_base = rows_capacity * words_per_row
+            intermediate_u32[
+                sf_base + output_tile * rows_capacity + physical_row_base + tid
+            ] = scale_word
+
+        # Only the first 64 threads perform the row-wise quantize/store.  The
+        # other warps must not advance the persistent task loop and overwrite
+        # the aliased shared activation tile while those threads still read it.
+        cute.arch.sync_threads()
+
+    @cute.kernel
+    def kernel(
+        self,
+        packed_a_u32: cute.Tensor,
+        scale_storage: cute.Tensor,
+        w13_rp: cute.Tensor,
+        w13_sfb_rp: cute.Tensor,
+        intermediate_u32: cute.Tensor,
+        token_map: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        alpha: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        input_k128_tiles: cutlass.Int32,
+        intermediate_tiles: cutlass.Int32,
+        packed_w13_tiles: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        _, _, bidz = cute.arch.block_idx()
+        _, _, gdimz = cute.arch.grid_dim()
+        tid = Int32(tidx)
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            words: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, self.shared_words],
+                1024,
+            ]
+
+        storage = smem.allocate(Storage)
+        smem_base = shared_ptr_to_u32(storage.words.data_ptr())
+
+        rows_capacity = Int32(token_map.shape[0])
+        num_experts = Int32(expert_tile_base.shape[0] - 1)
+        source_m_tiles = expert_tile_base[num_experts].to(Int32)
+        task_tail = source_m_tiles * Int32(self.source_halves) * intermediate_tiles
+        task_slot = Int32(bidz)
+        while task_slot < task_tail:
+            output_tile = task_slot % intermediate_tiles
+            source_half = task_slot // intermediate_tiles
+            if cutlass.const_expr(self.source_halves == 2):
+                m_half = source_half & Int32(1)
+                source_m_tile = source_half >> Int32(1)
+            else:
+                m_half = Int32(0)
+                source_m_tile = source_half
+            phase1_meta = source_m_tile * intermediate_tiles
+            expert_idx = task_expert[phase1_meta].to(Int32)
+            valid_rows = task_valid_rows[phase1_meta].to(Int32) - m_half * Int32(
+                self.tile_m
+            )
+            if valid_rows > Int32(self.tile_m):
+                valid_rows = Int32(self.tile_m)
+            if valid_rows > Int32(0):
+                self._run_task(
+                    packed_a_u32,
+                    scale_storage,
+                    w13_rp,
+                    w13_sfb_rp,
+                    intermediate_u32,
+                    token_map,
+                    alpha,
+                    input_global_scale,
+                    smem_base,
+                    tid,
+                    warp_idx,
+                    source_m_tile,
+                    m_half,
+                    expert_idx,
+                    output_tile,
+                    valid_rows,
+                    rows_capacity,
+                    input_k128_tiles,
+                    intermediate_tiles,
+                    packed_w13_tiles,
+                )
+            task_slot += Int32(gdimz)
+
+
+__all__ = ["W4A8MaterializedPhase1Kernel"]

--- a/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8_phase2.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/kernels/w4a8_phase2.py
@@ -1,0 +1,525 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/fused/w4a8_phase2.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Standalone materialized-W4A8 FC2 kernel for dense prefill regimes.
+
+The dynamic front-end and phase 1 publish an expert-major M64 or M128 source
+domain in MXFP8 form.  Keeping FC2 in the routing kernel would union phase-A
+and phase-B shared-memory/register requirements.  This kernel instead consumes
+the caller-owned materialization workspace as M64xN128 tasks.  The launch is
+fixed-capacity and stream ordered, so it remains safe for CUDA graph capture
+and replay without host reads or allocations.
+"""
+
+from __future__ import annotations
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+
+from cutlass.cutlass_dsl import Int32, Int64, Uint32
+
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    cp_async4_shared_global,
+    cp_async_u32_shared_global,
+    e2m1x8_to_qmma_e2m1x8,
+    get_ptr_as_int64,
+    ld_shared_u32,
+    ld_shared_v2_u32,
+    ld_shared_v4_u32,
+    mxfp8_mma_m16n8k32_f32_e2m1,
+    pack_f32x2_to_bfloat2,
+    scatter_add_bf16x2,
+    shared_ptr_to_u32,
+    st_global_u32,
+)
+
+
+class W4A8MaterializedPhase2Kernel:
+    """Consume materialization through compact M64xN128 FC2 CTAs."""
+
+    tile_m = 64
+    source_tile_m = 128
+    tile_n = 128
+    tile_k = 128
+    num_warps = 4
+    threads_per_cta = num_warps * 32
+    stages = 2
+
+    # Per stage: 64x128 E4M3 A, 64 packed A-scale words, N128xK128 FP4 B,
+    # and 16x8 packed B-scale words.  Keep the large regions 1 KiB aligned.
+    a_payload_bytes = tile_m * tile_k
+    a_scale_bytes = tile_m * 4
+    a_stage_bytes = a_payload_bytes + a_scale_bytes
+    a_storage_bytes = stages * a_stage_bytes
+    b_storage_offset = ((a_storage_bytes + 1023) // 1024) * 1024
+    b_stage_bytes = tile_n * tile_k // 2
+    b_storage_bytes = stages * b_stage_bytes
+    sfb_storage_offset = b_storage_offset + b_storage_bytes
+    sfb_stage_bytes = (tile_n // 8) * 8 * 4
+    shared_bytes = sfb_storage_offset + stages * sfb_stage_bytes
+    shared_words = (shared_bytes + 3) // 4
+
+    def __init__(
+        self,
+        *,
+        source_tile_m: int = 128,
+        deterministic_output: bool = False,
+    ):
+        if source_tile_m not in (64, 128):
+            raise ValueError(
+                f"materialized phase 2 source_tile_m must be 64 or 128, got {source_tile_m}"
+            )
+        self.source_tile_m = int(source_tile_m)
+        self.source_halves = self.source_tile_m // self.tile_m
+        self.deterministic_output = bool(deterministic_output)
+
+    @cute.jit
+    def __call__(
+        self,
+        intermediate_u32: cute.Tensor,
+        down_rp: cute.Tensor,
+        down_sfb_rp: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        intermediate_tiles: cutlass.Int32,
+        packed_output_tiles: cutlass.Int32,
+        max_active_clusters: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        # Two compact phase-B CTAs can reside per SM.  The grid is a fixed
+        # multiple of the preplanned resident-grid capacity; the device-side
+        # tail controls useful work and never changes the captured launch.
+        self.kernel(
+            intermediate_u32,
+            down_rp,
+            down_sfb_rp,
+            scatter_output,
+            token_map,
+            token_weights,
+            task_expert,
+            task_valid_rows,
+            expert_tile_base,
+            down_alpha,
+            global_scale,
+            intermediate_tiles,
+            packed_output_tiles,
+        ).launch(
+            grid=(1, 1, max_active_clusters * Int32(2)),
+            block=[self.threads_per_cta, 1, 1],
+            min_blocks_per_mp=2,
+            stream=stream,
+        )
+
+    @cute.jit
+    def _stage_slice(
+        self,
+        intermediate_u32: cute.Tensor,
+        down_rp: cute.Tensor,
+        down_sfb_rp: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        source_m_tile: Int32,
+        m_half: Int32,
+        expert_idx: Int32,
+        output_tile: Int32,
+        intermediate_slice: Int32,
+        rows_capacity: Int32,
+        intermediate_tiles: Int32,
+        packed_output_tiles: Int32,
+    ):
+        stage = intermediate_slice & Int32(1)
+        a_base = smem_base + stage * Int32(self.a_stage_bytes)
+        sfa_base = a_base + Int32(self.a_payload_bytes)
+        b_base = (
+            smem_base + Int32(self.b_storage_offset) + stage * Int32(self.b_stage_bytes)
+        )
+        sfb_base = (
+            smem_base
+            + Int32(self.sfb_storage_offset)
+            + stage * Int32(self.sfb_stage_bytes)
+        )
+
+        words_per_row = intermediate_tiles * Int32(32)
+        physical_row_base = source_m_tile * Int32(self.source_tile_m) + m_half * Int32(
+            self.tile_m
+        )
+
+        # A payload: 64 rows x eight 16-byte vectors.  Materialization is
+        # row-major; shared memory XORs vectors by row to match QMMA loads.
+        for i in cutlass.range_constexpr(
+            (self.tile_m * 8 + self.threads_per_cta - 1) // self.threads_per_cta
+        ):
+            idx = tid + Int32(i * self.threads_per_cta)
+            if idx < Int32(self.tile_m * 8):
+                row = idx >> Int32(3)
+                vec = idx & Int32(7)
+                physical_vec = vec ^ (row & Int32(7))
+                src_word = (
+                    (physical_row_base + row) * words_per_row
+                    + intermediate_slice * Int32(32)
+                    + (vec << Int32(2))
+                )
+                cp_async4_shared_global(
+                    a_base + row * Int32(self.tile_k) + (physical_vec << Int32(4)),
+                    get_ptr_as_int64(intermediate_u32, src_word),
+                )
+
+        # One packed K128 scale word per activation row.
+        if tid < Int32(self.tile_m):
+            sf_src = (
+                rows_capacity * words_per_row
+                + intermediate_slice * rows_capacity
+                + physical_row_base
+                + tid
+            )
+            cp_async_u32_shared_global(
+                sfa_base + (tid << Int32(2)),
+                get_ptr_as_int64(intermediate_u32, sf_src),
+            )
+
+        # Prepared weights are N256 tile-major.  Select the N128 half and
+        # compact its four K32 chunks into the phase-B shared tile.
+        packed_tile = output_tile >> Int32(1)
+        packed_half = output_tile & Int32(1)
+        b_tile = (
+            expert_idx * packed_output_tiles + packed_tile
+        ) * intermediate_tiles + intermediate_slice
+        b_word_base = Int64(b_tile) * Int64(4096)
+        for i in cutlass.range_constexpr(
+            (4 * 4 * 32 + self.threads_per_cta - 1) // self.threads_per_cta
+        ):
+            idx = tid + Int32(i * self.threads_per_cta)
+            if idx < Int32(4 * 4 * 32):
+                lane = idx & Int32(31)
+                kc = idx >> Int32(5)
+                chunk = kc & Int32(3)
+                kb = kc >> Int32(2)
+                src_word = (
+                    b_word_base
+                    + Int64(kb * 8 * 32 * 4)
+                    + Int64((packed_half * Int32(4) + chunk) * Int32(32 * 4))
+                    + Int64(lane * Int32(4))
+                )
+                cp_async4_shared_global(
+                    b_base + (idx << Int32(4)),
+                    get_ptr_as_int64(down_rp, src_word),
+                )
+
+        # The N128 half contains 16 n8 scale rows, eight u32 words each.
+        sfb_word_base = Int64(b_tile) * Int64(256)
+        for i in cutlass.range_constexpr(
+            ((16 * 8) // 4 + self.threads_per_cta - 1) // self.threads_per_cta
+        ):
+            idx = tid + Int32(i * self.threads_per_cta)
+            if idx < Int32((16 * 8) // 4):
+                src_word = sfb_word_base + Int64(packed_half * Int32(16 * 8) + idx * 4)
+                cp_async4_shared_global(
+                    sfb_base + (idx << Int32(4)),
+                    get_ptr_as_int64(down_sfb_rp, src_word),
+                )
+
+    @cute.jit
+    def _run_task(
+        self,
+        intermediate_u32: cute.Tensor,
+        down_rp: cute.Tensor,
+        down_sfb_rp: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        warp_idx: Int32,
+        source_m_tile: Int32,
+        m_half: Int32,
+        expert_idx: Int32,
+        output_tile: Int32,
+        valid_rows: Int32,
+        rows_capacity: Int32,
+        intermediate_tiles: Int32,
+        packed_output_tiles: Int32,
+    ):
+        lane = tid & Int32(31)
+        q = lane >> Int32(2)
+        c = lane & Int32(3)
+
+        self._stage_slice(
+            intermediate_u32,
+            down_rp,
+            down_sfb_rp,
+            smem_base,
+            tid,
+            source_m_tile,
+            m_half,
+            expert_idx,
+            output_tile,
+            Int32(0),
+            rows_capacity,
+            intermediate_tiles,
+            packed_output_tiles,
+        )
+        cute.arch.cp_async_commit_group()
+
+        # Each of four warps owns M64xN32: four M16 blocks by four N8
+        # fragments.  This is 64 FP32 accumulator registers per thread.
+        facc = tuple(
+            tuple(cute.make_rmem_tensor((4,), cutlass.Float32) for _nt in range(4))
+            for _blk in range(4)
+        )
+        for blk in cutlass.range_constexpr(4):
+            for nt in cutlass.range_constexpr(4):
+                facc[blk][nt].fill(0.0)
+
+        intermediate_slice = Int32(0)
+        while intermediate_slice < intermediate_tiles:
+            stage = intermediate_slice & Int32(1)
+            a_base = smem_base + stage * Int32(self.a_stage_bytes)
+            sfa_base = a_base + Int32(self.a_payload_bytes)
+            b_base = (
+                smem_base
+                + Int32(self.b_storage_offset)
+                + stage * Int32(self.b_stage_bytes)
+            )
+            sfb_base = (
+                smem_base
+                + Int32(self.sfb_storage_offset)
+                + stage * Int32(self.sfb_stage_bytes)
+            )
+
+            next_slice = intermediate_slice + Int32(1)
+            if next_slice < intermediate_tiles:
+                self._stage_slice(
+                    intermediate_u32,
+                    down_rp,
+                    down_sfb_rp,
+                    smem_base,
+                    tid,
+                    source_m_tile,
+                    m_half,
+                    expert_idx,
+                    output_tile,
+                    next_slice,
+                    rows_capacity,
+                    intermediate_tiles,
+                    packed_output_tiles,
+                )
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(1)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            cute.arch.sync_threads()
+
+            asc = cute.make_rmem_tensor((4,), Uint32)
+            for blk in cutlass.range_constexpr(4):
+                sf_row = Int32(blk * 16) + q + ((lane & Int32(1)) << Int32(3))
+                asc[blk] = ld_shared_u32(sfa_base + (sf_row << Int32(2)))
+
+            for kb in cutlass.range_constexpr(4):
+                u_phys = (Int32(kb * 2) + (c >> Int32(1))) ^ q
+                a_frag = cute.make_rmem_tensor((4, 4), Uint32)
+                for blk in cutlass.range_constexpr(4):
+                    a_lo = (
+                        a_base
+                        + Int32(blk * 16 * self.tile_k)
+                        + (q << Int32(7))
+                        + (u_phys << Int32(4))
+                        + ((c & Int32(1)) << Int32(3))
+                    )
+                    a0, a2 = ld_shared_v2_u32(a_lo)
+                    a1, a3 = ld_shared_v2_u32(a_lo + Int32(8 * self.tile_k))
+                    a_frag[blk, 0] = a0
+                    a_frag[blk, 1] = a1
+                    a_frag[blk, 2] = a2
+                    a_frag[blk, 3] = a3
+
+                w0, w1, w2, w3 = ld_shared_v4_u32(
+                    b_base
+                    + (((Int32(kb * 4) + warp_idx) * Int32(32) + lane) << Int32(4))
+                )
+                words = cute.make_rmem_tensor((4,), Uint32)
+                words[0] = w0
+                words[1] = w1
+                words[2] = w2
+                words[3] = w3
+                for nt in cutlass.range_constexpr(4):
+                    n8 = warp_idx * Int32(4) + Int32(nt)
+                    b0, b1 = e2m1x8_to_qmma_e2m1x8(words[nt])
+                    sfb_word = ld_shared_u32(
+                        sfb_base + ((n8 * Int32(8) + q) << Int32(2))
+                    )
+                    for blk in cutlass.range_constexpr(4):
+                        fragment = facc[blk][nt]
+                        d0, d1, d2, d3 = mxfp8_mma_m16n8k32_f32_e2m1(
+                            fragment[0],
+                            fragment[1],
+                            fragment[2],
+                            fragment[3],
+                            a_frag[blk, 0],
+                            a_frag[blk, 1],
+                            a_frag[blk, 2],
+                            a_frag[blk, 3],
+                            b0,
+                            b1,
+                            asc[blk],
+                            sfb_word,
+                            bid_a=kb,
+                            bid_b=kb,
+                        )
+                        fragment[0] = d0
+                        fragment[1] = d1
+                        fragment[2] = d2
+                        fragment[3] = d3
+
+            # No thread can recycle this parity until all four compute warps
+            # have consumed it.
+            cute.arch.sync_threads()
+            intermediate_slice += Int32(1)
+
+        scatter_n = Int32(scatter_output.shape[1])
+        physical_row_base = source_m_tile * Int32(self.source_tile_m) + m_half * Int32(
+            self.tile_m
+        )
+        down_scale = down_alpha[expert_idx].to(cutlass.Float32) * global_scale[
+            expert_idx
+        ].to(cutlass.Float32)
+        col_base = (
+            output_tile * Int32(self.tile_n) + warp_idx * Int32(32) + (c << Int32(1))
+        )
+        for nt in cutlass.range_constexpr(4):
+            col = col_base + Int32(nt * 8)
+            for blk in cutlass.range_constexpr(4):
+                fragment = facc[blk][nt]
+                row_lo = Int32(blk * 16) + q
+                row_hi = row_lo + Int32(8)
+                if row_lo < valid_rows:
+                    physical_row = physical_row_base + row_lo
+                    tok = token_map[physical_row].to(Int32)
+                    scale = down_scale * token_weights[physical_row].to(cutlass.Float32)
+                    if cutlass.const_expr(self.deterministic_output):
+                        # The routing front-end stores the token-major pair
+                        # index in token_map for deterministic specializations.
+                        # Each pair/output-column location has one producer, so
+                        # phase 2 can write it exactly once; the caller then
+                        # reduces routes in fixed top-k order.
+                        st_global_u32(
+                            get_ptr_as_int64(scatter_output, tok * scatter_n + col),
+                            pack_f32x2_to_bfloat2(
+                                scale * fragment[0], scale * fragment[1]
+                            ),
+                        )
+                    else:
+                        scatter_add_bf16x2(
+                            get_ptr_as_int64(scatter_output, tok * scatter_n + col),
+                            scale * fragment[0],
+                            scale * fragment[1],
+                        )
+                if row_hi < valid_rows:
+                    physical_row = physical_row_base + row_hi
+                    tok = token_map[physical_row].to(Int32)
+                    scale = down_scale * token_weights[physical_row].to(cutlass.Float32)
+                    if cutlass.const_expr(self.deterministic_output):
+                        st_global_u32(
+                            get_ptr_as_int64(scatter_output, tok * scatter_n + col),
+                            pack_f32x2_to_bfloat2(
+                                scale * fragment[2], scale * fragment[3]
+                            ),
+                        )
+                    else:
+                        scatter_add_bf16x2(
+                            get_ptr_as_int64(scatter_output, tok * scatter_n + col),
+                            scale * fragment[2],
+                            scale * fragment[3],
+                        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        intermediate_u32: cute.Tensor,
+        down_rp: cute.Tensor,
+        down_sfb_rp: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        intermediate_tiles: cutlass.Int32,
+        packed_output_tiles: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        _, _, bidz = cute.arch.block_idx()
+        _, _, gdimz = cute.arch.grid_dim()
+        tid = Int32(tidx)
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            words: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, self.shared_words],
+                1024,
+            ]
+
+        storage = smem.allocate(Storage)
+        smem_base = shared_ptr_to_u32(storage.words.data_ptr())
+
+        rows_capacity = Int32(token_map.shape[0])
+        num_experts = Int32(expert_tile_base.shape[0] - 1)
+        output_tiles = packed_output_tiles * Int32(2)
+        source_m_tiles = expert_tile_base[num_experts].to(Int32)
+        task_tail = source_m_tiles * Int32(self.source_halves) * output_tiles
+        task_slot = Int32(bidz)
+        while task_slot < task_tail:
+            output_tile = task_slot % output_tiles
+            source_half = task_slot // output_tiles
+            if cutlass.const_expr(self.source_halves == 2):
+                m_half = source_half & Int32(1)
+                source_m_tile = source_half >> Int32(1)
+            else:
+                m_half = Int32(0)
+                source_m_tile = source_half
+            phase1_meta = source_m_tile * intermediate_tiles
+            expert_idx = task_expert[phase1_meta].to(Int32)
+            valid_rows = task_valid_rows[phase1_meta].to(Int32) - m_half * Int32(
+                self.tile_m
+            )
+            valid_rows = cutlass.min(valid_rows, Int32(self.tile_m))
+            valid_rows = cutlass.max(valid_rows, Int32(0))
+            if valid_rows > Int32(0):
+                self._run_task(
+                    intermediate_u32,
+                    down_rp,
+                    down_sfb_rp,
+                    scatter_output,
+                    token_map,
+                    token_weights,
+                    down_alpha,
+                    global_scale,
+                    smem_base,
+                    tid,
+                    warp_idx,
+                    source_m_tile,
+                    m_half,
+                    expert_idx,
+                    output_tile,
+                    valid_rows,
+                    rows_capacity,
+                    intermediate_tiles,
+                    packed_output_tiles,
+                )
+            task_slot += Int32(gdimz)
+
+
+__all__ = ["W4A8MaterializedPhase2Kernel"]

--- a/flashinfer/experimental/sm12x/moe/_shared/routing.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/routing.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/triton_route.py @ a1e5af4e (2026-03-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.jit
+def _route_topk_kernel(
+    logits_ptr,
+    topk_logits_ptr,
+    topk_ids_ptr,
+    topk_weights_ptr,
+    logits_row_stride,
+    topk_row_stride,
+    num_experts,
+    BLOCK_E: tl.constexpr,
+    TOP_K: tl.constexpr,
+    TOPK_BLOCK: tl.constexpr,
+    RENORMALIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    expert_offsets = tl.arange(0, BLOCK_E)
+    expert_offsets_i32 = expert_offsets.to(tl.int32)
+    topk_offsets = tl.arange(0, TOPK_BLOCK)
+    topk_mask = topk_offsets < TOP_K
+    neg_inf = float("-inf")
+
+    row_ptr = logits_ptr + pid * logits_row_stride
+    logits = tl.load(
+        row_ptr + expert_offsets, mask=expert_offsets < num_experts, other=neg_inf
+    )
+    remaining = logits.to(tl.float32)
+
+    topk_logits = tl.full((TOPK_BLOCK,), neg_inf, tl.float32)
+    topk_ids = tl.zeros((TOPK_BLOCK,), dtype=tl.int32)
+
+    for slot in range(TOP_K):
+        best_logits = tl.max(remaining, axis=0)
+        best_ids = tl.max(
+            tl.where(remaining == best_logits, expert_offsets_i32, -1),
+            axis=0,
+        )
+        topk_logits = tl.where(topk_offsets == slot, best_logits, topk_logits)
+        topk_ids = tl.where(topk_offsets == slot, best_ids, topk_ids)
+        remaining = tl.where(expert_offsets == best_ids, neg_inf, remaining)
+
+    if RENORMALIZE:
+        masked_logits = tl.where(topk_mask, topk_logits, neg_inf)
+        shifted = masked_logits - tl.max(masked_logits, axis=0)
+        exp_logits = tl.where(topk_mask, tl.exp(shifted), 0.0)
+        topk_weights = exp_logits / tl.sum(exp_logits, axis=0)
+    else:
+        topk_weights = topk_logits
+
+    out_base = pid * topk_row_stride + topk_offsets
+    tl.store(topk_logits_ptr + out_base, topk_logits, mask=topk_mask)
+    tl.store(topk_ids_ptr + out_base, topk_ids, mask=topk_mask)
+    tl.store(topk_weights_ptr + out_base, topk_weights, mask=topk_mask)
+
+
+def route_topk(
+    router_logits: torch.Tensor,
+    topk_logits: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    renormalize: bool,
+) -> None:
+    if router_logits.ndim != 2:
+        raise ValueError(
+            "expected router_logits with rank 2, got shape "
+            f"{tuple(router_logits.shape)}"
+        )
+    if topk_logits.ndim != 2 or topk_ids.ndim != 2 or topk_weights.ndim != 2:
+        raise ValueError("top-k outputs must all have rank 2")
+    if topk_logits.shape != topk_ids.shape or topk_logits.shape != topk_weights.shape:
+        raise ValueError(
+            "top-k outputs must share a shape, got "
+            f"{tuple(topk_logits.shape)}, {tuple(topk_ids.shape)}, {tuple(topk_weights.shape)}"
+        )
+    if router_logits.shape[0] != topk_logits.shape[0]:
+        raise ValueError(
+            "router_logits batch mismatch: expected "
+            f"{router_logits.shape[0]}, got {topk_logits.shape[0]}"
+        )
+    if topk_ids.dtype != torch.int32:
+        raise ValueError(f"expected topk_ids dtype int32, got {topk_ids.dtype}")
+    if topk_logits.dtype != torch.float32:
+        raise ValueError(f"expected topk_logits dtype float32, got {topk_logits.dtype}")
+    if topk_weights.dtype != torch.float32:
+        raise ValueError(
+            f"expected topk_weights dtype float32, got {topk_weights.dtype}"
+        )
+    if not router_logits.is_cuda:
+        raise ValueError("route_topk requires CUDA tensors")
+    if router_logits.shape[1] > 1024:
+        raise ValueError(
+            f"route_topk currently supports up to 1024 experts, got {router_logits.shape[1]}"
+        )
+    if router_logits.stride(-1) != 1:
+        raise ValueError("router_logits must be contiguous in the expert dimension")
+    if (
+        topk_logits.stride(-1) != 1
+        or topk_ids.stride(-1) != 1
+        or topk_weights.stride(-1) != 1
+    ):
+        raise ValueError("top-k outputs must be contiguous in the top-k dimension")
+
+    num_tokens, num_experts = router_logits.shape
+    top_k = topk_logits.shape[1]
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    if top_k > num_experts:
+        raise ValueError(f"top_k={top_k} exceeds num_experts={num_experts}")
+
+    block_e = triton.next_power_of_2(num_experts)
+    topk_block = triton.next_power_of_2(top_k)
+    num_warps = 4 if block_e <= 256 else 8
+
+    _route_topk_kernel[(num_tokens,)](
+        router_logits,
+        topk_logits,
+        topk_ids,
+        topk_weights,
+        router_logits.stride(0),
+        topk_logits.stride(0),
+        num_experts,
+        BLOCK_E=block_e,
+        TOP_K=top_k,
+        TOPK_BLOCK=topk_block,
+        RENORMALIZE=renormalize,
+        num_warps=num_warps,
+    )

--- a/flashinfer/experimental/sm12x/moe/_shared/tuning/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/tuning/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/tuning/__init__.py @ b49787f5 (2026-07-08) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+from .registry import (
+    MAX_ACTIVE_CLUSTERS_POLICY,
+    Ladder,
+    MaxActiveClustersPolicy,
+    get_max_active_clusters_policy,
+    lookup_max_active_clusters,
+    register_max_active_clusters_policy,
+)
+
+
+_PACKAGE_DIR = pathlib.Path(__file__).resolve().parent
+for _policy_path in sorted(_PACKAGE_DIR.glob("*.py")):
+    if _policy_path.name in {"__init__.py", "registry.py"}:
+        continue
+    _module_name = f"{__name__}._generated_{_policy_path.stem.replace('.', '_')}"
+    if _module_name in sys.modules:
+        continue
+    _spec = importlib.util.spec_from_file_location(_module_name, _policy_path)
+    if _spec is None or _spec.loader is None:
+        continue
+    _module = importlib.util.module_from_spec(_spec)
+    sys.modules[_module_name] = _module
+    _spec.loader.exec_module(_module)
+
+__all__ = [
+    "MAX_ACTIVE_CLUSTERS_POLICY",
+    "Ladder",
+    "MaxActiveClustersPolicy",
+    "get_max_active_clusters_policy",
+    "lookup_max_active_clusters",
+    "register_max_active_clusters_policy",
+]

--- a/flashinfer/experimental/sm12x/moe/_shared/tuning/decode_max_active_clusters.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/tuning/decode_max_active_clusters.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/tuning/decode.max_active_clusters.py @ 3f7ff225 (2026-06-30) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Generated MoE decode MAX_ACTIVE_CLUSTERS tuning data."""
+
+from .registry import register_max_active_clusters_policy
+
+# micro:   routed_rows < 64 (direct-micro selection cutover)
+# dynamic: otherwise
+
+register_max_active_clusters_policy(
+    regime="decode",
+    backend="micro",
+    ladder=(
+        (2, 84),
+        (4, 127),
+        (8, 107),
+        (10, 84),
+        (16, 63),
+        (20, 84),
+    ),
+)
+
+register_max_active_clusters_policy(
+    regime="decode",
+    backend="dynamic",
+    ladder=(
+        (640, 188),
+        (1024, 147),
+    ),
+)
+
+# Prepared MXFP4 decode has two resident CTAs per SM.  A logical cap of 64 is
+# doubled by the launcher to a 128-CTA worker grid.  M=1 sizes that grid for the
+# wider of its fixed FC1 and FC2 domains; M=2 exactly fills it, and M=4/8 use a
+# short grid-stride tail without making every barrier span the full machine.
+register_max_active_clusters_policy(
+    regime="decode",
+    backend="dynamic_w4a8_decode",
+    ladder=((64, 64),),
+)

--- a/flashinfer/experimental/sm12x/moe/_shared/tuning/registry.py
+++ b/flashinfer/experimental/sm12x/moe/_shared/tuning/registry.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/moe/tuning/registry.py @ 3f7ff225 (2026-06-30) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+Ladder = tuple[tuple[int, int], ...]
+
+MAX_ACTIVE_CLUSTERS_POLICY: Dict[tuple[str, str], "MaxActiveClustersPolicy"] = {}
+
+
+@dataclass(frozen=True)
+class MaxActiveClustersPolicy:
+    ladder: Ladder
+
+
+def _validate_ladder(*, ladder: Ladder) -> None:
+    if not ladder:
+        raise ValueError("ladder must be non-empty")
+    previous_end = 0
+    for end_routed_rows, max_active_clusters in ladder:
+        if end_routed_rows <= previous_end:
+            raise ValueError(
+                "ladder end_routed_rows values must be strictly increasing"
+            )
+        if max_active_clusters <= 0:
+            raise ValueError("ladder max_active_clusters values must be positive")
+        previous_end = end_routed_rows
+
+
+def register_max_active_clusters_policy(
+    *,
+    regime: str,
+    backend: str,
+    ladder: Ladder,
+) -> None:
+    if not regime:
+        raise ValueError("regime must be non-empty")
+    if backend not in {"micro", "dynamic", "dynamic_w4a8_decode"}:
+        raise ValueError(f"unsupported backend {backend!r}")
+    _validate_ladder(ladder=ladder)
+    MAX_ACTIVE_CLUSTERS_POLICY[(str(regime), str(backend))] = MaxActiveClustersPolicy(
+        ladder=tuple(
+            (int(end_routed_rows), int(max_active_clusters))
+            for end_routed_rows, max_active_clusters in ladder
+        )
+    )
+
+
+def get_max_active_clusters_policy(
+    *,
+    regime: str,
+    backend: str,
+) -> MaxActiveClustersPolicy:
+    return MAX_ACTIVE_CLUSTERS_POLICY[(str(regime), str(backend))]
+
+
+def lookup_max_active_clusters(
+    *,
+    regime: str,
+    backend: str,
+    routed_rows: int,
+) -> int | None:
+    if routed_rows <= 0:
+        raise ValueError("routed_rows must be positive")
+    policy = MAX_ACTIVE_CLUSTERS_POLICY.get((str(regime), str(backend)))
+    if policy is None:
+        return None
+    for end_routed_rows, max_active_clusters in policy.ladder:
+        if routed_rows <= end_routed_rows:
+            return int(max_active_clusters)
+    return None

--- a/flashinfer/experimental/sm12x/moe/ep_moe/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/ep_moe/__init__.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Expert-parallel MoE for SM12x (W4A16 experts).
+
+Each rank sees the replicated input and computes partial outputs for its
+local experts; cross-rank reduction is the caller's job (typically
+``comm.pcie.OneshotAllReduce``) — composed in user code, never imported here.
+
+Lifecycle: ``prepare_expert_map`` (host-side, one-time) -> ``plan(Caps)`` ->
+``bind`` (views only) -> ``run`` (capture safe).
+
+Example:
+    from flashinfer.experimental.sm12x.moe import ep_moe
+
+    emap    = ep_moe.prepare_expert_map(expert_map,        # int32 [global_E]
+                                        local_num_experts=local_E)
+    plan    = ep_moe.plan(ep_moe.Caps(...))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = ep_moe.bind(plan, scratch=scratch, ...)
+    partial = ep_moe.run(binding=binding)   # then all-reduce across ranks
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="ep_moe",
+    group="moe",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "Binding",
+        "ExpertMap",
+        "plan",
+        "bind",
+        "run",
+        "prepare_expert_map",
+        "is_supported",
+    ),
+    dtypes=("bf16",),
+    recipes=("w4a16",),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/integration/ep_moe.py",),
+    ),
+    test_path="tests/experimental/moe/test_ep_moe.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Binding,
+        Caps,
+        ExpertMap,
+        Plan,
+        bind,
+        is_supported,
+        plan,
+        prepare_expert_map,
+        run,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/moe/ep_moe/_impl.py
+++ b/flashinfer/experimental/sm12x/moe/ep_moe/_impl.py
@@ -1,0 +1,533 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/ep_moe.py @ 042b6aae (2026-06-30) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Conservative expert-parallel MoE entrypoints for replicated inputs.
+
+This module deliberately owns a contract separate from :mod:`tp_moe`:
+
+* every EP rank receives the same BF16 activations and global top-k routes;
+* ``expert_map`` maps global expert ids to this rank's local weight ids and
+  uses ``-1`` for non-local experts;
+* the W4A16 route-pack kernel filters non-local routes and produces a
+  zero-filled rank-local output partial; and
+* the caller is responsible for summing those partials across the EP group.
+
+There are no collectives here.  In particular, this is not the all-to-all or
+batched-expert activation contract used by DeepEP-style integrations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+
+from flashinfer.experimental.sm12x._lib.intrinsics import align_up
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+from flashinfer.experimental.sm12x._lib.utils import get_num_sm
+from flashinfer.experimental.sm12x.moe._shared.execution import MoEWeightPreparationPlan
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    moe_activation_w1_rows,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+    _W4A16_ALLOWED_ROUTED_SIZES,
+    max_packed_route_slots,
+    packed_gemm_scratch_elements,
+    route_pack_token_capacity,
+)
+
+# NOTE(one-time port): upstream, ep_moe and tp_moe were siblings in
+# b12x/integration/. The prepared-weights payload plumbing they share should
+# eventually hoist into moe/_shared/weights.py; until then this is the one
+# sanctioned intra-group op->op reach-through.
+from ..fused_moe._impl import (
+    SM12XFP4ExpertWeights,
+    _normalize_swiglu_params,
+    _prepared_payload_for_runtime,
+)
+
+
+def _tensor_version(tensor: torch.Tensor) -> int | None:
+    try:
+        return int(tensor._version)
+    except RuntimeError:
+        # Tensors created inside inference mode do not expose a version
+        # counter. They still retain the fixed-storage contract below.
+        return None
+
+
+@dataclass(frozen=True, kw_only=True)
+class EPExpertMap:
+    """A validated, static global-to-local expert map.
+
+    Preparing the map may synchronize with the device to validate its values.
+    Binding and execution only perform allocation-free metadata/version checks.
+    """
+
+    tensor: torch.Tensor
+    global_num_experts: int
+    local_num_experts: int
+    device: torch.device
+    _data_ptr: int
+    _version: int | None
+
+    def validate_static(self) -> None:
+        if self.tensor.data_ptr() != self._data_ptr:
+            raise RuntimeError("EP expert_map storage changed after preparation")
+        version = _tensor_version(self.tensor)
+        if self._version is not None and version != self._version:
+            raise RuntimeError("EP expert_map was mutated after preparation")
+        if self.tensor.device != self.device:
+            raise RuntimeError("EP expert_map device changed after preparation")
+
+
+def prepare_ep_expert_map(
+    expert_map: torch.Tensor,
+    *,
+    local_num_experts: int,
+    global_num_experts: int | None = None,
+    device: torch.device | str | None = None,
+) -> EPExpertMap:
+    """Validate and freeze one EP rank's global-to-local expert map.
+
+    Every local id must occur exactly once.  This matches vLLM's linear and
+    round-robin expert placement maps and prevents a malformed map from
+    indexing outside the rank-local weight allocation.
+    """
+
+    if not isinstance(expert_map, torch.Tensor):
+        raise TypeError("expert_map must be a torch.Tensor")
+    if expert_map.dtype != torch.int32:
+        raise TypeError("expert_map must have dtype torch.int32")
+    if expert_map.ndim != 1 or not expert_map.is_contiguous():
+        raise ValueError("expert_map must be a contiguous rank-1 tensor")
+    if expert_map.device.type == "cuda" and torch.cuda.is_current_stream_capturing():
+        raise RuntimeError("EP expert_map must be prepared before CUDA graph capture")
+
+    expected_device = expert_map.device if device is None else torch.device(device)
+    if expert_map.device != expected_device:
+        raise ValueError(
+            f"expert_map must be on {expected_device}, got {expert_map.device}"
+        )
+
+    global_e = int(expert_map.numel())
+    if global_num_experts is not None and global_e != int(global_num_experts):
+        raise ValueError(
+            "expert_map global expert count mismatch: "
+            f"expected {int(global_num_experts)}, got {global_e}"
+        )
+    local_e = int(local_num_experts)
+    if global_e <= 0:
+        raise ValueError("global_num_experts must be positive")
+    if local_e <= 0:
+        raise ValueError("local_num_experts must be positive")
+    if local_e > global_e:
+        raise ValueError(
+            f"local_num_experts={local_e} exceeds global_num_experts={global_e}"
+        )
+
+    values = expert_map.detach().cpu().tolist()
+    invalid = [value for value in values if value < -1 or value >= local_e]
+    if invalid:
+        raise ValueError(
+            "expert_map values must be -1 or valid local expert ids; "
+            f"found {invalid[0]} for local_num_experts={local_e}"
+        )
+    mapped = sorted(value for value in values if value >= 0)
+    expected = list(range(local_e))
+    if mapped != expected:
+        raise ValueError(
+            "expert_map must map every local expert id exactly once: "
+            f"expected {expected}, got {mapped}"
+        )
+
+    return EPExpertMap(
+        tensor=expert_map,
+        global_num_experts=global_e,
+        local_num_experts=local_e,
+        device=expected_device,
+        _data_ptr=expert_map.data_ptr(),
+        _version=_tensor_version(expert_map),
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class EPMoEScratchCaps:
+    """Capacity and weight metadata for replicated-input W4A16 EP."""
+
+    max_tokens: int
+    num_topk: int
+    global_num_experts: int
+    device: torch.device | str
+    weight_plan: MoEWeightPreparationPlan
+    apply_router_weight_on_input: bool = False
+    swiglu_limit: float | None = None
+    swiglu_alpha: float | None = None
+    swiglu_beta: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "max_tokens", max(int(self.max_tokens), 1))
+        object.__setattr__(self, "num_topk", max(int(self.num_topk), 1))
+        object.__setattr__(self, "global_num_experts", int(self.global_num_experts))
+        object.__setattr__(self, "device", torch.device(self.device))
+        object.__setattr__(
+            self,
+            "apply_router_weight_on_input",
+            bool(self.apply_router_weight_on_input),
+        )
+        if not isinstance(self.weight_plan, MoEWeightPreparationPlan):
+            raise TypeError("weight_plan must be a MoEWeightPreparationPlan")
+        if self.global_num_experts <= 0:
+            raise ValueError("global_num_experts must be positive")
+        if self.weight_plan.num_experts <= 0:
+            raise ValueError("the local weight plan must contain at least one expert")
+        if self.weight_plan.num_experts > self.global_num_experts:
+            raise ValueError(
+                "local expert count cannot exceed global expert count: "
+                f"local={self.weight_plan.num_experts}, "
+                f"global={self.global_num_experts}"
+            )
+        if "w4a16" not in self.weight_plan.quant_modes:
+            raise ValueError("replicated-input EP requires a W4A16 weight plan")
+        if self.weight_plan.io_dtype != "bfloat16":
+            raise TypeError(
+                "replicated-input W4A16 EP requires BF16 activations, got "
+                f"{self.weight_plan.io_dtype!r}"
+            )
+        limit, alpha, beta = _normalize_swiglu_params(
+            self.weight_plan.activation,
+            self.swiglu_limit,
+            self.swiglu_alpha,
+            self.swiglu_beta,
+        )
+        object.__setattr__(self, "swiglu_limit", limit)
+        object.__setattr__(self, "swiglu_alpha", alpha)
+        object.__setattr__(self, "swiglu_beta", beta)
+
+    @property
+    def local_num_experts(self) -> int:
+        return self.weight_plan.num_experts
+
+
+@dataclass(frozen=True)
+class _EPBufferSpec:
+    name: str
+    elements: int
+    dtype: torch.dtype
+    offset_bytes: int
+
+    @property
+    def nbytes(self) -> int:
+        return int(self.elements) * int(self.dtype.itemsize)
+
+
+def _make_buffer_layout(
+    specs: tuple[tuple[str, int, torch.dtype], ...],
+) -> tuple[tuple[_EPBufferSpec, ...], int]:
+    offset = 0
+    layout = []
+    for name, elements, dtype in specs:
+        offset = align_up(offset, 16)
+        spec = _EPBufferSpec(
+            name=name,
+            elements=max(int(elements), 1),
+            dtype=dtype,
+            offset_bytes=offset,
+        )
+        layout.append(spec)
+        offset += spec.nbytes
+    return tuple(layout), max(align_up(offset, 16), 1)
+
+
+def _map_scratch_views(
+    scratch: torch.Tensor,
+    layout: tuple[_EPBufferSpec, ...],
+) -> dict[str, torch.Tensor]:
+    views: dict[str, torch.Tensor] = {}
+    for spec in layout:
+        byte_view = scratch.narrow(0, spec.offset_bytes, spec.nbytes)
+        views[spec.name] = byte_view.view(spec.dtype)[: spec.elements]
+    return views
+
+
+@dataclass(frozen=True)
+class EPMoEScratchPlan:
+    caps: EPMoEScratchCaps
+    _layout: tuple[_EPBufferSpec, ...]
+    _nbytes: int
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        a: torch.Tensor,
+        experts: SM12XFP4ExpertWeights,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_map: EPExpertMap,
+        output: torch.Tensor,
+        fast_math: bool = True,
+    ) -> "EPMoEFP4Binding":
+        if not isinstance(experts, SM12XFP4ExpertWeights):
+            raise TypeError("experts must come from prepare_sm12x_fp4_moe_weights")
+        if experts.plan != self.caps.weight_plan:
+            raise ValueError("experts do not match the EP scratch weight plan")
+        if not isinstance(expert_map, EPExpertMap):
+            raise TypeError("expert_map must come from prepare_ep_expert_map")
+        expert_map.validate_static()
+        if expert_map.global_num_experts != self.caps.global_num_experts:
+            raise ValueError("expert_map global expert count does not match EP plan")
+        if expert_map.local_num_experts != self.caps.local_num_experts:
+            raise ValueError("expert_map local expert count does not match EP weights")
+        if expert_map.device != self.caps.device:
+            raise ValueError("expert_map device does not match EP plan")
+
+        if a.ndim != 2:
+            raise ValueError(f"a must be rank 2, got shape {tuple(a.shape)}")
+        m, k = map(int, a.shape)
+        if m > self.caps.max_tokens:
+            raise ValueError(
+                f"input tokens {m} exceed EP scratch capacity {self.caps.max_tokens}"
+            )
+        if k != self.caps.weight_plan.hidden_size:
+            raise ValueError(
+                f"input hidden size {k} does not match {self.caps.weight_plan.hidden_size}"
+            )
+        if a.dtype != torch.bfloat16:
+            raise TypeError(f"EP activations must be torch.bfloat16, got {a.dtype}")
+        if a.device != self.caps.device or not a.is_contiguous():
+            raise ValueError("a must be contiguous on the EP plan device")
+        expected_routes = (m, self.caps.num_topk)
+        if tuple(topk_ids.shape) != expected_routes:
+            raise ValueError(
+                f"topk_ids must have shape {expected_routes}, got {tuple(topk_ids.shape)}"
+            )
+        if tuple(topk_weights.shape) != expected_routes:
+            raise ValueError(
+                "topk_weights must have shape "
+                f"{expected_routes}, got {tuple(topk_weights.shape)}"
+            )
+        if topk_ids.dtype not in (torch.int32, torch.int64):
+            raise TypeError("topk_ids must have dtype torch.int32 or torch.int64")
+        if topk_weights.dtype != torch.float32:
+            raise TypeError("topk_weights must have dtype torch.float32")
+        for name, tensor in (("topk_ids", topk_ids), ("topk_weights", topk_weights)):
+            if tensor.device != self.caps.device or not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous on the EP plan device")
+        if output.shape != a.shape or output.dtype != a.dtype:
+            raise ValueError("output must have the same shape and dtype as a")
+        if output.device != a.device or not output.is_contiguous():
+            raise ValueError("output must be contiguous on the EP plan device")
+
+        storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="replicated-input EP MoE",
+        )
+        views = _map_scratch_views(storage, self._layout)
+        return EPMoEFP4Binding(
+            a=a,
+            experts=experts,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            expert_map=expert_map,
+            output=output,
+            max_tokens=self.caps.max_tokens,
+            num_topk=self.caps.num_topk,
+            apply_router_weight_on_input=self.caps.apply_router_weight_on_input,
+            fast_math=bool(fast_math),
+            swiglu_limit=self.caps.swiglu_limit,
+            swiglu_alpha=float(self.caps.swiglu_alpha),
+            swiglu_beta=float(self.caps.swiglu_beta),
+            intermediate_cache13=views["intermediate_cache13"],
+            intermediate_cache2=views["intermediate_cache2"],
+            fc1_c_tmp=views["fc1_c_tmp"],
+            fc2_c_tmp=views["fc2_c_tmp"],
+            packed_route_indices=views["packed_route_indices"],
+            block_expert_ids=views["block_expert_ids"],
+            packed_route_count=views["packed_route_count"],
+            expert_offsets=views["expert_offsets"],
+        )
+
+
+def plan_ep_moe_scratch(caps: EPMoEScratchCaps) -> EPMoEScratchPlan:
+    """Plan fixed-capacity scratch for replicated-input W4A16 EP."""
+
+    if not isinstance(caps, EPMoEScratchCaps):
+        raise TypeError("caps must be an EPMoEScratchCaps")
+    routed_rows = int(caps.max_tokens) * int(caps.num_topk)
+    route_capacity_rows = (
+        route_pack_token_capacity(caps.max_tokens, caps.num_topk) * caps.num_topk
+    )
+    hidden_size = int(caps.weight_plan.hidden_size)
+    intermediate_size = int(caps.weight_plan.intermediate_size)
+    fc1_cols = moe_activation_w1_rows(
+        caps.weight_plan.activation,
+        intermediate_size,
+    )
+    sms = max(int(get_num_sm(caps.device)), 1)
+    route_slots = 1
+    route_blocks = 1
+    fc1_tmp = 1
+    fc2_tmp = 1
+    for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
+        slots = max_packed_route_slots(
+            route_capacity_rows,
+            int(block_size),
+            caps.global_num_experts,
+        )
+        blocks = (slots + int(block_size) - 1) // int(block_size)
+        route_slots = max(route_slots, slots)
+        route_blocks = max(route_blocks, blocks)
+        fc1_tmp = max(
+            fc1_tmp,
+            packed_gemm_scratch_elements(
+                size_n=fc1_cols,
+                route_slots=slots,
+                moe_block_size=int(block_size),
+                sms=sms,
+            ),
+        )
+        fc2_tmp = max(
+            fc2_tmp,
+            packed_gemm_scratch_elements(
+                size_n=hidden_size,
+                route_slots=slots,
+                moe_block_size=int(block_size),
+                sms=sms,
+            ),
+        )
+
+    layout, nbytes = _make_buffer_layout(
+        (
+            (
+                "intermediate_cache13",
+                routed_rows * max(fc1_cols, hidden_size),
+                torch.bfloat16,
+            ),
+            (
+                "intermediate_cache2",
+                routed_rows * intermediate_size,
+                torch.bfloat16,
+            ),
+            ("fc1_c_tmp", fc1_tmp, torch.float32),
+            ("fc2_c_tmp", fc2_tmp, torch.float32),
+            ("packed_route_indices", route_slots, torch.int32),
+            ("block_expert_ids", route_blocks, torch.int32),
+            ("packed_route_count", 1, torch.int32),
+            ("expert_offsets", caps.global_num_experts + 1, torch.int32),
+        )
+    )
+    scratch_specs = (
+        scratch_buffer_spec(
+            "ep_moe.scratch",
+            nbytes=nbytes,
+            device=caps.device,
+        ),
+    )
+    return EPMoEScratchPlan(
+        caps=caps,
+        _layout=layout,
+        _nbytes=nbytes,
+        _scratch_specs=scratch_specs,
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class EPMoEFP4Binding:
+    """One allocation-free replicated-input EP launch binding."""
+
+    a: torch.Tensor
+    experts: SM12XFP4ExpertWeights
+    topk_weights: torch.Tensor
+    topk_ids: torch.Tensor
+    expert_map: EPExpertMap
+    output: torch.Tensor
+    max_tokens: int
+    num_topk: int
+    apply_router_weight_on_input: bool
+    fast_math: bool
+    swiglu_limit: float | None
+    swiglu_alpha: float
+    swiglu_beta: float
+    intermediate_cache13: torch.Tensor
+    intermediate_cache2: torch.Tensor
+    fc1_c_tmp: torch.Tensor
+    fc2_c_tmp: torch.Tensor
+    packed_route_indices: torch.Tensor
+    block_expert_ids: torch.Tensor
+    packed_route_count: torch.Tensor
+    expert_offsets: torch.Tensor
+
+    def run(self) -> torch.Tensor:
+        return sm12x_ep_moe_fp4(binding=self)
+
+
+def sm12x_ep_moe_fp4(*, binding: EPMoEFP4Binding) -> torch.Tensor:
+    """Execute one replicated-input EP rank and return its local partial."""
+
+    if not isinstance(binding, EPMoEFP4Binding):
+        raise TypeError("binding must be an EPMoEFP4Binding")
+    binding.expert_map.validate_static()
+    prepared = _prepared_payload_for_runtime(
+        binding.experts,
+        quant_mode="w4a16",
+        source_format=binding.experts.source_format,
+        activation=binding.experts.activation,
+        w13_layout=binding.experts.w13_layout,
+        dtype=binding.a.dtype,
+        hidden_size=int(binding.a.shape[1]),
+    )
+    if prepared is None:
+        raise RuntimeError("the EP W4A16 weight representation was not materialized")
+
+    from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+        run_w4a16_moe,
+    )
+
+    return run_w4a16_moe(
+        binding.a,
+        prepared,
+        binding.topk_weights,
+        binding.topk_ids,
+        activation=binding.experts.activation,
+        intermediate_cache13=binding.intermediate_cache13,
+        intermediate_cache2=binding.intermediate_cache2,
+        output=binding.output,
+        fc1_c_tmp=binding.fc1_c_tmp,
+        fc2_c_tmp=binding.fc2_c_tmp,
+        packed_route_indices=binding.packed_route_indices,
+        block_expert_ids=binding.block_expert_ids,
+        packed_route_count=binding.packed_route_count,
+        expert_offsets=binding.expert_offsets,
+        expert_map=binding.expert_map.tensor,
+        apply_router_weight_on_input=binding.apply_router_weight_on_input,
+        fast_math=binding.fast_math,
+        swiglu_limit=binding.swiglu_limit,
+        swiglu_alpha=binding.swiglu_alpha,
+        swiglu_beta=binding.swiglu_beta,
+    )
+
+
+__all__ = [
+    "EPExpertMap",
+    "EPMoEFP4Binding",
+    "EPMoEScratchCaps",
+    "EPMoEScratchPlan",
+    "sm12x_ep_moe_fp4",
+    "plan_ep_moe_scratch",
+    "prepare_ep_expert_map",
+]

--- a/flashinfer/experimental/sm12x/moe/ep_moe/api.py
+++ b/flashinfer/experimental/sm12x/moe/ep_moe/api.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for moe.ep_moe (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from ._impl import (
+    EPExpertMap as ExpertMap,
+)
+from ._impl import (
+    EPMoEFP4Binding as Binding,
+)
+from ._impl import (
+    EPMoEScratchCaps as Caps,
+)
+from ._impl import (
+    EPMoEScratchPlan as Plan,
+)
+from ._impl import (
+    plan_ep_moe_scratch as plan,
+)
+from ._impl import (
+    prepare_ep_expert_map as prepare_expert_map,
+)
+from ._impl import (
+    sm12x_ep_moe_fp4 as run,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "Binding",
+    "ExpertMap",
+    "plan",
+    "bind",
+    "run",
+    "prepare_expert_map",
+    "is_supported",
+]

--- a/flashinfer/experimental/sm12x/moe/fused_moe/__init__.py
+++ b/flashinfer/experimental/sm12x/moe/fused_moe/__init__.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Fused tensor-parallel MoE for SM12x: route -> FC1 -> activation -> FC2 ->
+scatter, in one launch family.
+
+Recipes (``META.recipes``) are arguments, not separate ops: nvfp4, mxfp4,
+w4a8_mx, w4a8_nvfp4, w4a16 (weight layouts packed/modelopt/nf3_2p1).  Activations:
+silu, relu2, swigluoai_uninterleave.  Kernel
+regimes (micro / dynamic / tiny-decode / w4a16) are selected declaratively by
+``plan_execution``.
+
+Weight lifecycle (host-side, one-time):
+    ``plan_weights`` -> ``prepare_weights`` -> ``ExpertWeights``
+Runtime lifecycle:
+    ``plan(Caps)`` -> ``bind`` / ``bind_sparse`` / ``bind_route``
+    (allocation-free views) -> ``run`` / ``run_sparse`` / ``route``
+    (CUDA-graph capture safe)
+``route_topk`` is a standalone one-shot top-k router; ``run_sparse`` fuses
+gate -> top-k -> experts from router logits.
+
+Example:
+    from flashinfer.experimental.sm12x.moe import fused_moe
+
+    wplan   = fused_moe.plan_weights(quant_modes="nvfp4",
+                                     source_format="modelopt_nvfp4", ...)
+    experts = fused_moe.prepare_weights(plan=wplan, ...)
+    plan    = fused_moe.plan(fused_moe.Caps(...))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = fused_moe.bind(plan, scratch=scratch, a=x, experts=experts,
+                             topk_weights=tw, topk_ids=ti)
+    out     = fused_moe.run(binding=binding)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="fused_moe",
+    group="moe",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "ExecutionPlan",
+        "Binding",
+        "SparseBinding",
+        "RouteBinding",
+        "ExpertWeights",
+        "Routing",
+        "WeightsPlan",
+        "plan",
+        "plan_execution",
+        "plan_weights",
+        "prepare_weights",
+        "bind",
+        "bind_sparse",
+        "bind_route",
+        "run",
+        "run_sparse",
+        "route",
+        "route_topk",
+        "is_supported",
+        "clear_caches",
+    ),
+    dtypes=("bf16",),
+    recipes=("nvfp4", "mxfp4", "w4a8_mx", "w4a8_nvfp4", "w4a16"),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/integration/tp_moe.py", "b12x/moe/"),
+    ),
+    test_path="tests/experimental/moe/test_fused_moe.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Binding,
+        Caps,
+        ExecutionPlan,
+        ExpertWeights,
+        Plan,
+        RouteBinding,
+        Routing,
+        SparseBinding,
+        WeightsPlan,
+        bind,
+        bind_route,
+        bind_sparse,
+        clear_caches,
+        is_supported,
+        plan,
+        plan_execution,
+        plan_weights,
+        prepare_weights,
+        route,
+        route_topk,
+        run,
+        run_sparse,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/moe/fused_moe/_impl.py
+++ b/flashinfer/experimental/sm12x/moe/fused_moe/_impl.py
@@ -1,0 +1,9810 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/tp_moe.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Tensor-parallel MoE entrypoints backed by fused CuTe DSL kernels."""
+
+from __future__ import annotations
+
+import os
+import logging
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import triton
+import triton.language as tl
+import torch
+import torch.nn.functional as F
+from torch.profiler import record_function
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    compile as sm12x_compile,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    align_up,
+    as_grouped_scale_view,
+)
+from flashinfer.experimental.sm12x._lib.utils import (
+    current_cuda_stream,
+    get_max_active_clusters,
+    get_num_sm,
+    make_ptr,
+)
+from cutlass.cutlass_dsl import Int32
+from flashinfer.experimental.sm12x.moe._shared.routing import (
+    route_topk as triton_route_topk,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.relu2 import (
+    MoEDynamicKernelRelu2,
+    MoEMicroKernelRelu2,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.silu import (
+    MoEDynamicKernelSilu,
+    MoEDynamicKernelSwiGLUOAI,
+    MoEMicroKernelSilu,
+    MoEMicroKernelSwiGLUOAI,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.activations import (
+    SWIGLUOAI_UNINTERLEAVE,
+    is_gated_moe_activation,
+    moe_activation_w1_rows,
+    normalize_moe_activation,
+    normalize_swiglu_alpha_for_activation,
+    normalize_swiglu_beta_for_activation,
+    normalize_swiglu_limit_for_activation,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.micro import (
+    _BLOCK_DIM as _DIRECT_MICRO_BLOCK_DIM,
+    _direct_k_segments_for_k,
+    _direct_k_segments_supported,
+)
+from flashinfer.experimental.sm12x.moe._shared.execution import (
+    MoEExecutionPlan,
+    MoERegime,
+    MoESpec,
+    MoEWeightPreparationPlan,
+    OutputReduction,
+    PreparedWeightLayout,
+    WeightPreparationTransform,
+    WorkScheduler,
+    lower_moe_execution,
+    make_moe_spec,
+    plan_moe_weight_preparation,
+)
+from flashinfer.experimental.sm12x.moe._shared.tuning import lookup_max_active_clusters
+from flashinfer.experimental.sm12x._lib.runtime_control import (
+    raise_if_kernel_resolution_frozen,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+logger = logging.getLogger(__name__)
+_FLASHINFER_EXP_SM12X_TIMING = (
+    os.getenv("FLASHINFER_EXP_SM12X_TIMING", "0") == "1"
+    or os.getenv("VLLM_FLASHINFER_EXP_SM12X_TIMING", "0") == "1"
+)
+_FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS = float(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS",
+        os.getenv("VLLM_FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS", "0"),
+    )
+)
+
+_NVFP4_BLOCK_SIZE = 16
+_RUNTIME_MEMREF_LIMIT = (1 << 31) - 1
+_LEVEL_TILE_M = 128
+_LEVEL_TILE_N = 128
+_DYNAMIC_SLICE_CHUNK = 1
+_DYNAMIC_WORK_SOURCE_ENV = "FLASHINFER_EXP_SM12X_DYNAMIC_WORK_SOURCE"
+_DYNAMIC_WORK_SOURCE_DEFAULT = "materialized_queue"
+_DYNAMIC_WORK_SOURCES = {
+    "persistent_grid",
+    "materialized_queue",
+    "ready_queue",
+}
+_W4A16_ROUTE_PACK_PREWARMED: set[tuple[object, ...]] = set()
+# W4A8's unified dynamic specialization consumes an N256/K128 lane-major
+# weight representation.  Preparation is independent from scheduling: the
+# same representation serves both materialized queue and persistent-grid work.
+_DYNAMIC_W4A8_REPACKED_ENV = "FLASHINFER_EXP_SM12X_DYNAMIC_W4A8_REPACKED"
+_DYNAMIC_W4A8_SHARE_INPUT_ENV = "FLASHINFER_EXP_SM12X_DYNAMIC_W4A8_SHARE_INPUT"
+_DYNAMIC_W4A8_MATERIALIZED_ENV = "FLASHINFER_EXP_SM12X_DYNAMIC_W4A8_MATERIALIZED"
+_W4A8_CONVERT_SCRATCH_MB_ENV = "FLASHINFER_EXP_SM12X_W4A8_CONVERT_SCRATCH_MB"
+_W4A8_CONVERT_SCRATCH_MB_DEFAULT = 64
+_FP4_SOURCE_FORMATS = {
+    "modelopt_nvfp4": "modelopt_nvfp4",
+    "fp4_e8m0_k32": "fp4_e8m0_k32",
+    "compressed_tensors": "compressed_tensors",
+}
+_W4A16_SCALE_FORMATS = {
+    "e4m3_k16": "e4m3_k16",
+    "e8m0_k32": "e8m0_k32",
+}
+_W13_LAYOUTS = {
+    "w13": "w13",
+    "w31": "w31",
+    # Accept the physical FC1-half spellings as aliases; "up_gate" needs the
+    # in-place W13 row rotation ("w13"), "gate_up" is already kernel-native.
+    "up_gate": "w13",
+    "gate_up": "w31",
+}
+
+_DEVICE_CAPABILITY_CACHE: dict[int, tuple[int, int]] = {}
+
+
+def _current_compute_capability() -> tuple[int, int] | None:
+    """Return the active CUDA device capability without repeated driver queries."""
+
+    if not torch.cuda.is_available():
+        return None
+    device_index = torch.cuda.current_device()
+    capability = _DEVICE_CAPABILITY_CACHE.get(device_index)
+    if capability is None:
+        capability = tuple(torch.cuda.get_device_capability(device_index))
+        _DEVICE_CAPABILITY_CACHE[device_index] = capability
+    return capability
+
+
+@dataclass(kw_only=True)
+class TPMoEWorkspace:
+    """Reusable scratch buffers for one `sm12x_moe_fp4` shape family."""
+
+    implementation: str
+    quant_mode: str
+    state_E: int
+    weight_E: int
+    max_rows: int
+    k: int
+    n: int
+    num_topk: int
+    device: torch.device
+    dtype: torch.dtype
+    row_counts: torch.Tensor
+    token_map: torch.Tensor
+    token_weights: torch.Tensor
+    packed_input: torch.Tensor
+    packed_input_scale: torch.Tensor
+    barrier_count: torch.Tensor
+    barrier_epoch: torch.Tensor
+    packed_a_view: object = None
+    sfa_ptr: object = None
+    packed_a_flat: torch.Tensor | None = None
+    scale_flat: torch.Tensor | None = None
+    packed_a_storage_ptr: object = None
+    route_workspace: "_TPRouteWorkspace | None" = None
+    volatile_launch_state: bool = False
+
+    def bind_fp4(self, **kwargs) -> "TPMoEFP4Binding":
+        return build_tp_moe_fp4_binding(scratch=self, **kwargs)
+
+    def bind_route(self, **kwargs) -> "TPMoERouteBinding":
+        return build_tp_moe_route_binding(scratch=self, **kwargs)
+
+    def bind_sparse_fp4(self, **kwargs) -> "TPMoESparseFP4Binding":
+        return build_tp_moe_sparse_fp4_binding(scratch=self, **kwargs)
+
+
+@dataclass(kw_only=True)
+class TPMicroWorkspace(TPMoEWorkspace):
+    routed_rows_capacity: int
+    active_expert_count: torch.Tensor
+    weight_expert_ids: torch.Tensor
+    global_to_local_expert: torch.Tensor
+    compact_topk_ids: torch.Tensor
+    micro_intermediate: torch.Tensor
+
+
+@dataclass(kw_only=True)
+class TPDynamicWorkspace(TPMoEWorkspace):
+    routed_rows_capacity: int
+    physical_tiles_capacity: int
+    task_capacity: int
+    route_output: torch.Tensor
+    materialized_intermediate: torch.Tensor
+    expert_write_rows: torch.Tensor
+    expert_tile_base: torch.Tensor
+    input_gs: torch.Tensor
+    down_input_scale: torch.Tensor
+    pair_head: torch.Tensor
+    producers_done_count: torch.Tensor
+    all_work_published: torch.Tensor
+    task_head: torch.Tensor
+    task_tail: torch.Tensor
+    task_ready: torch.Tensor
+    task_expert: torch.Tensor
+    task_m_tile: torch.Tensor
+    task_slice_begin: torch.Tensor
+    task_slice_count: torch.Tensor
+    task_valid_rows: torch.Tensor
+    tile_write_count: torch.Tensor
+    input_gs_src_ptr: int = 0
+    down_input_scale_src_ptr: int = 0
+
+
+@dataclass(kw_only=True)
+class TPW4A16Workspace:
+    implementation: str
+    quant_mode: str
+    activation: str
+    state_E: int
+    weight_E: int
+    max_rows: int
+    k: int
+    n: int
+    num_topk: int
+    device: torch.device
+    dtype: torch.dtype
+    routed_rows_capacity: int
+    intermediate_cache13: torch.Tensor
+    intermediate_cache2: torch.Tensor
+    fc1_c_tmp: torch.Tensor
+    fc2_c_tmp: torch.Tensor
+    packed_route_indices: torch.Tensor
+    block_expert_ids: torch.Tensor
+    packed_route_count: torch.Tensor
+    expert_offsets: torch.Tensor
+    planned_token_counts: frozenset[int] = field(default_factory=frozenset)
+    planned_apply_router_weight_on_input: bool = False
+    planned_swiglu_limit: float | None = None
+    planned_swiglu_alpha: float = 1.0
+    planned_swiglu_beta: float = 0.0
+    planned_scale_format: str = "e4m3_k16"
+    planned_collect_activation_amax: bool = False
+    planned_fused_moe_launches: dict[object, object] = field(default_factory=dict)
+    planned_topk_sum_launches: dict[int, object] = field(default_factory=dict)
+    # TC-decode fused-sum launches, keyed by exact token count (only the small-M
+    # decode sizes in TC-decode's supported set, packed layout only).
+    planned_tc_decode_launches: dict[int, object] = field(default_factory=dict)
+    route_workspace: "_TPRouteWorkspace | None" = None
+    volatile_launch_state: bool = False
+
+    def bind_fp4(self, **kwargs) -> "TPMoEFP4Binding":
+        return build_tp_moe_fp4_binding(scratch=self, **kwargs)
+
+    def bind_route(self, **kwargs) -> "TPMoERouteBinding":
+        return build_tp_moe_route_binding(scratch=self, **kwargs)
+
+    def bind_sparse_fp4(self, **kwargs) -> "TPMoESparseFP4Binding":
+        return build_tp_moe_sparse_fp4_binding(scratch=self, **kwargs)
+
+
+@dataclass
+class TPMoEWorkspacePool:
+    """Caller-owned capacity-based workspace cache for one execution lane.
+
+    A single explicit pool may be shared across layers in a lane. Independent
+    overlapping lanes must use distinct pools; internal fork/join streams share
+    the lane pool and therefore the same scratch arena.
+    """
+
+    workspaces: Dict[Tuple, object] = field(default_factory=dict)
+    route_workspaces: Dict[Tuple, "_TPRouteWorkspace"] = field(default_factory=dict)
+    core_arenas: Dict[Tuple, "_TPCoreArena"] = field(default_factory=dict)
+    shared_arena: torch.Tensor | None = None
+    shared_arena_nbytes: int = 0
+    route_workspace_nbytes: int = 0
+    core_arena_offset_bytes: int = 0
+    core_arena_nbytes: int = 0
+    frozen: bool = False
+
+    def clear(self) -> None:
+        self.workspaces.clear()
+        self.route_workspaces.clear()
+        self.core_arenas.clear()
+
+    def bind_shared_arena(
+        self,
+        shared_arena: torch.Tensor,
+        *,
+        route_workspace_nbytes: int,
+        core_workspace_nbytes: int,
+        frozen: bool = True,
+    ) -> None:
+        if shared_arena.dtype != torch.uint8:
+            raise TypeError(
+                f"shared_arena must have dtype torch.uint8, got {shared_arena.dtype}"
+            )
+        route_workspace_nbytes = align_up(max(int(route_workspace_nbytes), 0), 16)
+        core_workspace_nbytes = max(int(core_workspace_nbytes), 0)
+        required = route_workspace_nbytes + core_workspace_nbytes
+        if shared_arena.numel() < max(required, 1):
+            raise ValueError(
+                f"shared_arena has {shared_arena.numel()} bytes, but MoE workspace requires {required}"
+            )
+        self.clear()
+        self.shared_arena = shared_arena
+        self.shared_arena_nbytes = int(shared_arena.numel())
+        self.route_workspace_nbytes = route_workspace_nbytes
+        self.core_arena_offset_bytes = route_workspace_nbytes
+        self.core_arena_nbytes = core_workspace_nbytes
+        self.frozen = bool(frozen)
+
+    def bind_fp4(self, **kwargs) -> "TPMoEFP4Binding":
+        return build_tp_moe_fp4_binding(scratch=self, **kwargs)
+
+    def bind_route(self, **kwargs) -> "TPMoERouteBinding":
+        return build_tp_moe_route_binding(scratch=self, **kwargs)
+
+    def bind_sparse_fp4(self, **kwargs) -> "TPMoESparseFP4Binding":
+        return build_tp_moe_sparse_fp4_binding(scratch=self, **kwargs)
+
+
+@dataclass(frozen=True, kw_only=True)
+class _PreparedW4A8Weights:
+    """N256/K128 W4A8 weights prepared for the unified dynamic kernel."""
+
+    w13_rp: torch.Tensor
+    w13_sfb: torch.Tensor
+    w2_rp: torch.Tensor
+    w2_sfb: torch.Tensor
+    num_experts: int
+    hidden_size: int
+    intermediate_size: int
+    params_dtype: torch.dtype
+    source_format: str = "fp4_e8m0_k32"
+    w13_layout: str = "w13"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "source_format",
+            _normalize_fp4_source_format(self.source_format),
+        )
+        object.__setattr__(self, "w13_layout", _normalize_w13_layout(self.w13_layout))
+        object.__setattr__(self, "num_experts", int(self.num_experts))
+        object.__setattr__(self, "hidden_size", int(self.hidden_size))
+        object.__setattr__(self, "intermediate_size", int(self.intermediate_size))
+
+
+@dataclass(frozen=True, kw_only=True)
+class _PreparedWeightRepresentation:
+    """One materialized representation selected by the weight planner."""
+
+    quant_mode: str
+    layout: PreparedWeightLayout
+    value: Any
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "quant_mode", str(self.quant_mode).lower())
+        object.__setattr__(self, "layout", PreparedWeightLayout(self.layout))
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XFP4ExpertWeights:
+    """The sole owner and complete runtime contract for FP4 MoE experts.
+
+    The weight and scale fields are canonical storage handles.  A planner may
+    reinterpret or repack those allocations in place, but a representation is
+    invalid if its FC1/FC2 weights live in different storage.  Execution takes
+    this object directly; there is no raw-weights-plus-prepared dual API.
+    """
+
+    plan: MoEWeightPreparationPlan
+    a1_gscale: torch.Tensor  # reciprocal activation global scale for FC1 input
+    w1_fp4: torch.Tensor
+    w1_blockscale: torch.Tensor
+    w1_alphas: torch.Tensor
+    a2_gscale: torch.Tensor  # reciprocal activation global scale for FC2 input
+    w2_fp4: torch.Tensor
+    w2_blockscale: torch.Tensor
+    w2_alphas: torch.Tensor
+    representation: _PreparedWeightRepresentation | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.plan, MoEWeightPreparationPlan):
+            raise TypeError("plan must be a MoEWeightPreparationPlan")
+        for name, tensor in (
+            ("a1_gscale", self.a1_gscale),
+            ("w1_fp4", self.w1_fp4),
+            ("w1_blockscale", self.w1_blockscale),
+            ("w1_alphas", self.w1_alphas),
+            ("a2_gscale", self.a2_gscale),
+            ("w2_fp4", self.w2_fp4),
+            ("w2_blockscale", self.w2_blockscale),
+            ("w2_alphas", self.w2_alphas),
+        ):
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(f"{name} must be a torch.Tensor")
+        representation = self.representation
+        if representation is not None:
+            if not isinstance(representation, _PreparedWeightRepresentation):
+                raise TypeError(
+                    "representation must be a planner-created prepared weight "
+                    "representation"
+                )
+            key = (representation.quant_mode, representation.layout)
+            if representation.quant_mode not in self.plan.quant_modes:
+                raise ValueError(
+                    f"prepared quant_mode={representation.quant_mode!r} is absent "
+                    "from the weight-preparation plan"
+                )
+            required = self.plan.required_weight_layout(representation.quant_mode)
+            if required is not representation.layout:
+                raise ValueError(
+                    f"prepared layout={representation.layout.value!r} does not "
+                    "match planned layout="
+                    f"{required.value if required is not None else None!r}"
+                )
+            value = representation.value
+            prepared_w1 = getattr(value, "w13_rp", getattr(value, "w13", None))
+            prepared_w2 = getattr(value, "w2_rp", getattr(value, "w2", None))
+            prepared_s1 = getattr(value, "w13_sfb", getattr(value, "w13_scale", None))
+            prepared_s2 = getattr(value, "w2_sfb", getattr(value, "w2_scale", None))
+            if not isinstance(prepared_w1, torch.Tensor) or not isinstance(
+                prepared_w2, torch.Tensor
+            ):
+                raise TypeError("prepared representation is missing FC1/FC2 tensors")
+            if (
+                prepared_w1.untyped_storage().data_ptr()
+                != self.w1_fp4.untyped_storage().data_ptr()
+                or prepared_w2.untyped_storage().data_ptr()
+                != self.w2_fp4.untyped_storage().data_ptr()
+            ):
+                raise ValueError(
+                    "prepared FC1/FC2 tensors must reuse the expert package's "
+                    "canonical allocations; retaining source plus repack is invalid"
+                )
+            if self.plan.discards_source_parameters:
+                if not isinstance(prepared_s1, torch.Tensor) or not isinstance(
+                    prepared_s2, torch.Tensor
+                ):
+                    raise TypeError("prepared representation is missing FC1/FC2 scales")
+                if (
+                    prepared_s1.untyped_storage().data_ptr()
+                    != self.w1_blockscale.untyped_storage().data_ptr()
+                    or prepared_s2.untyped_storage().data_ptr()
+                    != self.w2_blockscale.untyped_storage().data_ptr()
+                ):
+                    raise ValueError(
+                        "a transferred representation must be the package's "
+                        "canonical scale storage"
+                    )
+            for name, expected_value in (
+                ("num_experts", self.num_experts),
+                ("hidden_size", self.hidden_size),
+                ("intermediate_size", self.intermediate_size),
+            ):
+                actual_value = getattr(value, name, None)
+                if actual_value is not None and int(actual_value) != expected_value:
+                    raise ValueError(
+                        f"prepared {name}={int(actual_value)} does not match "
+                        f"plan {name}={expected_value}"
+                    )
+            actual = {key}
+        else:
+            actual = set()
+        expected = {
+            (mode, required)
+            for mode in self.plan.quant_modes
+            if (required := self.plan.required_weight_layout(mode)) is not None
+        }
+        if actual != expected:
+            raise ValueError(
+                "materialized weight representation does not match the plan: "
+                f"expected={sorted((m, l.value) for m, l in expected)}, "
+                f"actual={sorted((m, l.value) for m, l in actual)}"
+            )
+        source_mode_selected = bool({"nvfp4", "w4a8_nvfp4"} & self.plan.quant_modes)
+        if source_mode_selected or representation is None:
+            if self.w1_fp4.ndim != 3 or self.w2_fp4.ndim != 3:
+                raise ValueError("source-native FP4 expert weights must be rank-3")
+            actual_w2 = (
+                int(self.w2_fp4.shape[0]),
+                int(self.w2_fp4.shape[1]),
+                int(self.w2_fp4.shape[2]) * 2,
+            )
+            expected_w2 = (
+                self.num_experts,
+                self.hidden_size,
+                self.intermediate_size,
+            )
+            if actual_w2 != expected_w2:
+                raise ValueError(
+                    "FC2 shape does not match the prepared plan: "
+                    f"actual={actual_w2}, expected={expected_w2}"
+                )
+
+    @property
+    def source_format(self) -> str:
+        return self.plan.source_format
+
+    @property
+    def w13_layout(self) -> str:
+        return self.plan.w13_layout
+
+    @property
+    def activation(self) -> str:
+        return self.plan.activation
+
+    @property
+    def num_experts(self) -> int:
+        return self.plan.num_experts
+
+    @property
+    def hidden_size(self) -> int:
+        return self.plan.hidden_size
+
+    @property
+    def intermediate_size(self) -> int:
+        return self.plan.intermediate_size
+
+    def representation_for(self, quant_mode: str) -> Any | None:
+        quant_mode = str(quant_mode).lower()
+        required = self.plan.required_weight_layout(quant_mode)
+        if required is None:
+            return None
+        representation = self.representation
+        if (
+            representation is not None
+            and representation.quant_mode == quant_mode
+            and representation.layout is required
+        ):
+            return representation.value
+        raise RuntimeError(
+            f"planned {quant_mode!r} representation {required.value!r} was not "
+            "materialized"
+        )
+
+
+def _prepared_payload_for_runtime(
+    experts: SM12XFP4ExpertWeights,
+    *,
+    quant_mode: str,
+    source_format: str,
+    activation: str,
+    w13_layout: str,
+    dtype: torch.dtype,
+    hidden_size: int,
+) -> Any | None:
+    if not isinstance(experts, SM12XFP4ExpertWeights):
+        raise TypeError(
+            "runtime MoE launches require SM12XFP4ExpertWeights from "
+            "prepare_sm12x_fp4_moe_weights"
+        )
+    expected = (
+        str(quant_mode).lower(),
+        _normalize_fp4_source_format(source_format),
+        normalize_moe_activation(activation),
+        _normalize_w13_layout_for_activation(activation, w13_layout),
+        str(dtype).removeprefix("torch."),
+        int(hidden_size),
+    )
+    actual = (
+        str(quant_mode).lower(),
+        experts.source_format,
+        experts.plan.activation,
+        experts.w13_layout,
+        experts.plan.io_dtype,
+        experts.hidden_size,
+    )
+    if expected != actual:
+        raise ValueError(
+            "prepared-weight contract does not match runtime: "
+            f"runtime={expected}, experts={actual}"
+        )
+    return experts.representation_for(quant_mode)
+
+
+def _select_prepared_quant_mode(
+    experts: SM12XFP4ExpertWeights,
+    requested: str | None,
+) -> str:
+    modes = experts.plan.quant_modes
+    if requested is None:
+        if len(modes) != 1:
+            raise ValueError(
+                "quant_mode is required when a prepared-weight plan contains "
+                f"multiple recipes: {sorted(modes)}"
+            )
+        return next(iter(modes))
+    quant_mode = _normalize_quant_mode_requested(requested)
+    if quant_mode not in modes:
+        raise ValueError(
+            f"quant_mode={quant_mode!r} is absent from the prepared-weight "
+            f"plan {sorted(modes)}"
+        )
+    return quant_mode
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XTopKRouting:
+    """Top-k routing selection for sparse-block MoE wrappers."""
+
+    topk_weights: torch.Tensor
+    topk_ids: torch.Tensor
+    router_logits: torch.Tensor | None = None
+    flat_ids: torch.Tensor | None = None
+    flat_weights: torch.Tensor | None = None
+
+
+@dataclass(kw_only=True)
+class _TPRouteWorkspace:
+    router_logits: torch.Tensor
+    topk_logits: torch.Tensor
+    topk_ids: torch.Tensor
+    topk_weights: torch.Tensor
+
+
+@dataclass(frozen=True)
+class _TensorAllocSpec:
+    name: str
+    shape: Tuple[int, ...]
+    dtype: torch.dtype
+    init: str = "empty"
+
+
+@dataclass(frozen=True, kw_only=True)
+class _TPCoreWorkspacePlan:
+    implementation: str
+    quant_mode: str
+    activation: str
+    swiglu_limit: float | None = None
+    swiglu_alpha: float = 1.0
+    swiglu_beta: float = 0.0
+    state_E: int
+    weight_E: int
+    routed_rows: int
+    max_rows: int
+    k: int
+    n: int
+    num_topk: int
+    device: torch.device
+    dtype: torch.dtype
+    deterministic_output: bool = False
+    dynamic_physical_tiles: int | None = None
+    dynamic_task_capacity: int | None = None
+    tensor_specs: Tuple[_TensorAllocSpec, ...] = ()
+
+
+@dataclass
+class _TPCoreArena:
+    plan: _TPCoreWorkspacePlan
+    shared_arena: torch.Tensor
+    tensors: Dict[str, torch.Tensor]
+
+
+@dataclass(frozen=True, kw_only=True)
+class TPMoEArenaLayout:
+    route_workspace_nbytes: int
+    core_workspace_nbytes: int
+    total_nbytes: int
+    core_token_counts: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True, kw_only=True)
+class TPMoEPlan:
+    """Logical launch plan plus precision-neutral MoE execution descriptors."""
+
+    spec: MoESpec
+    execution: MoEExecutionPlan
+    implementation: str
+    quant_mode: str
+    activation: str
+    swiglu_limit: float | None = None
+    swiglu_alpha: float = 1.0
+    swiglu_beta: float = 0.0
+    state_E: int
+    weight_E: int
+    routed_rows: int
+    max_rows: int
+    k: int
+    n: int
+    num_topk: int
+    device: torch.device
+    dtype: torch.dtype
+    max_tokens_per_launch: int
+    dynamic_physical_tiles: int | None = None
+    dynamic_task_capacity: int | None = None
+
+    @property
+    def deterministic_output(self) -> bool:
+        return self.execution.reduction is OutputReduction.ROUTE_BUFFER_TOPK_SUM
+
+
+@dataclass(frozen=True, kw_only=True)
+class TPMoEScratchCaps:
+    max_tokens: int
+    num_topk: int
+    device: torch.device | str
+    weight_plan: MoEWeightPreparationPlan
+    quant_mode: str
+    core_token_counts: tuple[int, ...] | None = None
+    route_num_experts: int | None = None
+    route_logits_dtype: torch.dtype | None = None
+    apply_router_weight_on_input: bool = False
+    swiglu_limit: float | None = None
+    swiglu_alpha: float | None = None
+    swiglu_beta: float | None = None
+    collect_activation_amax: bool = False
+    deterministic_output: bool | None = None
+    frozen: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "max_tokens", max(int(self.max_tokens), 1))
+        object.__setattr__(self, "num_topk", max(int(self.num_topk), 1))
+        object.__setattr__(self, "device", torch.device(self.device))
+        if not isinstance(self.weight_plan, MoEWeightPreparationPlan):
+            raise TypeError("weight_plan must be a MoEWeightPreparationPlan")
+        quant_mode = _normalize_quant_mode_for_source(
+            self.quant_mode,
+            self.weight_plan.source_format,
+        )
+        if quant_mode not in self.weight_plan.quant_modes:
+            raise ValueError(
+                f"quant_mode={quant_mode!r} is absent from the weight plan"
+            )
+        object.__setattr__(self, "quant_mode", quant_mode)
+        if self.core_token_counts is not None:
+            object.__setattr__(
+                self,
+                "core_token_counts",
+                tuple(max(int(count), 1) for count in self.core_token_counts),
+            )
+        if self.route_num_experts is not None:
+            object.__setattr__(
+                self,
+                "route_num_experts",
+                max(int(self.route_num_experts), 0),
+            )
+        limit, alpha, beta = _normalize_swiglu_params(
+            self.activation,
+            self.swiglu_limit,
+            self.swiglu_alpha,
+            self.swiglu_beta,
+        )
+        object.__setattr__(self, "swiglu_limit", limit)
+        object.__setattr__(self, "swiglu_alpha", alpha)
+        object.__setattr__(self, "swiglu_beta", beta)
+        object.__setattr__(
+            self, "collect_activation_amax", bool(self.collect_activation_amax)
+        )
+        if self.deterministic_output is not None:
+            object.__setattr__(
+                self, "deterministic_output", bool(self.deterministic_output)
+            )
+        object.__setattr__(self, "frozen", bool(self.frozen))
+
+    @property
+    def weight_E(self) -> int:
+        return self.weight_plan.num_experts
+
+    @property
+    def k(self) -> int:
+        return self.weight_plan.hidden_size
+
+    @property
+    def n(self) -> int:
+        return self.weight_plan.intermediate_size
+
+    @property
+    def dtype(self) -> torch.dtype:
+        try:
+            return {
+                "bfloat16": torch.bfloat16,
+                "float16": torch.float16,
+            }[self.weight_plan.io_dtype]
+        except KeyError as exc:
+            raise TypeError(
+                f"unsupported MoE plan dtype {self.weight_plan.io_dtype!r}"
+            ) from exc
+
+    @property
+    def activation(self) -> str:
+        return self.weight_plan.activation
+
+    @property
+    def source_format(self) -> str:
+        return self.weight_plan.source_format
+
+    @property
+    def w13_layout(self) -> str:
+        return self.weight_plan.w13_layout
+
+    @property
+    def w4a16_weight_layout(self) -> str | None:
+        return self.weight_plan.w4a16_weight_layout
+
+    @property
+    def w4a16_scale_format(self) -> str | None:
+        return self.weight_plan.w4a16_scale_format
+
+
+@dataclass(frozen=True)
+class TPMoEScratchPlan:
+    caps: TPMoEScratchCaps
+    layout: TPMoEArenaLayout
+    launch_plan: TPMoEPlan
+    _core_workspace_plan: _TPCoreWorkspacePlan
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        a: torch.Tensor,
+        experts: SM12XFP4ExpertWeights,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        output: torch.Tensor | None = None,
+        input_scales_static: bool = False,
+        fast_math: bool | None = None,
+        unit_scale_contract: bool = False,
+        activation_amax: torch.Tensor | None = None,
+        layer_idx: int | None = None,
+    ) -> "TPMoEFP4Binding":
+        if not isinstance(experts, SM12XFP4ExpertWeights):
+            raise TypeError("experts must come from prepare_sm12x_fp4_moe_weights")
+        if experts.plan != self.caps.weight_plan:
+            raise ValueError(
+                "experts do not match the plan used to size TP MoE scratch"
+            )
+        if int(a.shape[0]) > int(self.caps.max_tokens):
+            raise ValueError(
+                f"input tokens {int(a.shape[0])} exceed TP MoE scratch capacity "
+                f"{int(self.caps.max_tokens)}"
+            )
+        if int(a.shape[1]) != int(self.caps.k):
+            raise ValueError(
+                f"input hidden size {int(a.shape[1])} does not match TP MoE "
+                f"scratch K={int(self.caps.k)}"
+            )
+        if int(topk_ids.shape[1]) != int(self.caps.num_topk):
+            raise ValueError(
+                f"top-k {int(topk_ids.shape[1])} does not match TP MoE scratch "
+                f"top-k={int(self.caps.num_topk)}"
+            )
+        scratch_storage = scratch_tensor(scratch, self._scratch_specs, owner="TP MoE")
+        # Eager vLLM bind: MAP caller-owned scratch into per-spec kernel-arg views
+        # and build the binding directly. NEVER construct a workspace/arena object
+        # (no _materialize_core_arena / _TPCoreArena) and never init/allocate -- the
+        # kernel prologue zeros counters/queues, weight_expert_ids is write-first,
+        # and the launch wrapper re-zeros the barrier scalars in-place
+        # (volatile_launch_state=True on the reconstructed workspaces below). This
+        # keeps bind allocation-free / CUDA-graph-capturable, matching the
+        # compressed-MLA views-container discipline.
+        tensors = _map_core_workspace_views(
+            self._core_workspace_plan,
+            scratch_storage,
+            offset_bytes=self.layout.route_workspace_nbytes,
+            capacity_nbytes=self.layout.core_workspace_nbytes,
+            do_init=False,
+        )
+        return _build_tp_moe_fp4_binding_from_views(
+            plan=self._core_workspace_plan,
+            tensors=tensors,
+            a=a,
+            experts=experts,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            apply_router_weight_on_input=self.caps.apply_router_weight_on_input,
+            output=output,
+            input_scales_static=input_scales_static,
+            fast_math=fast_math,
+            quant_mode=self.caps.quant_mode,
+            unit_scale_contract=unit_scale_contract,
+            swiglu_limit=self.caps.swiglu_limit,
+            swiglu_alpha=self.caps.swiglu_alpha,
+            swiglu_beta=self.caps.swiglu_beta,
+            activation_amax=activation_amax,
+            layer_idx=layer_idx,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class TPMoEFP4Binding:
+    a: torch.Tensor
+    experts: SM12XFP4ExpertWeights
+    topk_weights: torch.Tensor
+    topk_ids: torch.Tensor
+    implementation: str
+    state_E: int
+    weight_E: int
+    max_rows: int
+    k: int
+    n: int
+    num_topk: int
+    device: torch.device
+    dtype: torch.dtype
+    apply_router_weight_on_input: bool = False
+    output: torch.Tensor | None = None
+    input_scales_static: bool = False
+    fast_math: bool | None = None
+    quant_mode: str | None = None
+    deterministic_output: bool = False
+    unit_scale_contract: bool = False
+    swiglu_limit: float | None = None
+    swiglu_alpha: float | None = None
+    swiglu_beta: float | None = None
+    activation_amax: torch.Tensor | None = None
+    layer_idx: int | None = None
+    row_counts: torch.Tensor | None = None
+    token_map: torch.Tensor | None = None
+    token_weights: torch.Tensor | None = None
+    packed_input: torch.Tensor | None = None
+    packed_input_scale: torch.Tensor | None = None
+    barrier_count: torch.Tensor | None = None
+    barrier_epoch: torch.Tensor | None = None
+    packed_a_view: object = None
+    sfa_ptr: object = None
+    packed_a_flat: torch.Tensor | None = None
+    scale_flat: torch.Tensor | None = None
+    packed_a_storage_ptr: object = None
+    routed_rows_capacity: int | None = None
+    active_expert_count: torch.Tensor | None = None
+    weight_expert_ids: torch.Tensor | None = None
+    global_to_local_expert: torch.Tensor | None = None
+    compact_topk_ids: torch.Tensor | None = None
+    micro_intermediate: torch.Tensor | None = None
+    physical_tiles_capacity: int | None = None
+    task_capacity: int | None = None
+    expert_write_rows: torch.Tensor | None = None
+    expert_tile_base: torch.Tensor | None = None
+    input_gs: torch.Tensor | None = None
+    down_input_scale: torch.Tensor | None = None
+    pair_head: torch.Tensor | None = None
+    producers_done_count: torch.Tensor | None = None
+    all_work_published: torch.Tensor | None = None
+    task_head: torch.Tensor | None = None
+    task_tail: torch.Tensor | None = None
+    task_ready: torch.Tensor | None = None
+    task_expert: torch.Tensor | None = None
+    task_m_tile: torch.Tensor | None = None
+    task_slice_begin: torch.Tensor | None = None
+    task_slice_count: torch.Tensor | None = None
+    task_valid_rows: torch.Tensor | None = None
+    tile_write_count: torch.Tensor | None = None
+    route_output: torch.Tensor | None = None
+    materialized_intermediate: torch.Tensor | None = None
+    intermediate_cache13: torch.Tensor | None = None
+    intermediate_cache2: torch.Tensor | None = None
+    fc1_c_tmp: torch.Tensor | None = None
+    fc2_c_tmp: torch.Tensor | None = None
+    packed_route_indices: torch.Tensor | None = None
+    block_expert_ids: torch.Tensor | None = None
+    packed_route_count: torch.Tensor | None = None
+    expert_offsets: torch.Tensor | None = None
+    fused_launch: object | None = None
+    topk_sum_launch: object | None = None
+
+    def run(self) -> torch.Tensor:
+        return sm12x_moe_fp4(binding=self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class TPMoERouteBinding:
+    hidden_states: torch.Tensor
+    top_k: int
+    scratch: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool | None = None
+    gate_weight: torch.Tensor | None = None
+    gate_bias: torch.Tensor | None = None
+    router_logits: torch.Tensor | None = None
+    renormalize: bool = True
+
+    def run(self) -> SM12XTopKRouting:
+        return sm12x_route_experts_fast(binding=self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class TPMoESparseFP4Binding:
+    hidden_states: torch.Tensor
+    experts: SM12XFP4ExpertWeights
+    scratch: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool
+    routing: SM12XTopKRouting | None = None
+    top_k: int | None = None
+    gate_weight: torch.Tensor | None = None
+    gate_bias: torch.Tensor | None = None
+    router_logits: torch.Tensor | None = None
+    renormalize_topk: bool = True
+    routed_scaling_factor: float = 1.0
+    output: torch.Tensor | None = None
+    return_routing: bool = False
+    input_scales_static: bool = False
+    fast_math: bool | None = None
+    quant_mode: str | None = None
+    swiglu_limit: float | None = None
+    swiglu_alpha: float | None = None
+    swiglu_beta: float | None = None
+    activation_amax: torch.Tensor | None = None
+    layer_idx: int | None = None
+
+    def run(self) -> torch.Tensor | tuple[torch.Tensor, SM12XTopKRouting]:
+        return sm12x_sparse_moe_fp4(binding=self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class _TPMoEWorkspacePolicy:
+    can_chunk: bool
+
+
+@dataclass
+class _WeightViews:
+    """Cached weight views for the concatenated expert-weight layout."""
+
+    w13: torch.Tensor  # [2*n, k//2, E] uint8 (permuted view, no copy)
+    down: torch.Tensor  # [k, n//2, E] uint8 (permuted view, no copy)
+    w13_sf: torch.Tensor  # 6D MMA view for concatenated w13 scale factors
+    down_sf: torch.Tensor  # [E, down_sf_rows, sf_cols] uint8 (view)
+    w1_alpha: torch.Tensor  # [E] float32 contiguous tensor
+    w2_alpha: torch.Tensor  # [E] float32 contiguous tensor
+    w1_storage: torch.Tensor  # original [E, w1_n, k//2] tensor for direct micro
+    w1_scale_storage: torch.Tensor
+    w2_storage: torch.Tensor  # original [E, k, n//2] tensor for direct micro
+    w2_scale_storage: torch.Tensor
+    # Pre-computed fp4 views and CuTe pointers
+    w13_fp4: object = None
+    down_fp4: object = None
+    sfb_w13_ptr: object = None
+    sfb_down_ptr: object = None
+    # w4a8 recipe operands (None unless prepared): plain UE8M0 K/32 grids and
+    # E4M3 per-K/16 residuals from the NVFP4 scale decomposition.
+    sfb_w13_mx: torch.Tensor | None = None
+    sfb_down_mx: torch.Tensor | None = None
+    w13_residual: torch.Tensor | None = None
+    down_residual: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class _PackedInputBindingViews:
+    packed_a_view: object
+    sfa_ptr: object
+    packed_a_flat: torch.Tensor
+    scale_flat: torch.Tensor
+    packed_a_storage_ptr: object
+
+
+@dataclass(frozen=True)
+class _ActivationKernelSpec:
+    activation: str
+    is_gated: bool
+    micro_kernel_cls: type
+    dynamic_kernel_cls: type
+    default_w13_layout: str = "w13"
+
+    def w1_rows(self, n: int) -> int:
+        return (2 if self.is_gated else 1) * n
+
+    def make_micro_kernel(
+        self,
+        *,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        **kernel_kwargs,
+    ):
+        if self.is_gated:
+            kernel_kwargs.update(
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+            )
+        return self.micro_kernel_cls(**kernel_kwargs)
+
+    def make_dynamic_kernel(
+        self,
+        *,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        **kernel_kwargs,
+    ):
+        if self.is_gated:
+            kernel_kwargs.update(
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+            )
+        return self.dynamic_kernel_cls(**kernel_kwargs)
+
+
+_ACTIVATION_KERNEL_SPECS = {
+    "silu": _ActivationKernelSpec(
+        activation="silu",
+        is_gated=True,
+        micro_kernel_cls=MoEMicroKernelSilu,
+        dynamic_kernel_cls=MoEDynamicKernelSilu,
+    ),
+    SWIGLUOAI_UNINTERLEAVE: _ActivationKernelSpec(
+        activation=SWIGLUOAI_UNINTERLEAVE,
+        is_gated=True,
+        micro_kernel_cls=MoEMicroKernelSwiGLUOAI,
+        dynamic_kernel_cls=MoEDynamicKernelSwiGLUOAI,
+        default_w13_layout="w31",
+    ),
+    "relu2": _ActivationKernelSpec(
+        activation="relu2",
+        is_gated=False,
+        micro_kernel_cls=MoEMicroKernelRelu2,
+        dynamic_kernel_cls=MoEDynamicKernelRelu2,
+    ),
+}
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value not in ("", "0", "false", "False")
+
+
+def _dynamic_deterministic_output_enabled(
+    *, quant_mode: str, device: torch.device
+) -> bool:
+    if torch.device(device).type != "cuda":
+        return False
+    if _normalize_quant_mode(quant_mode) == "w4a16":
+        return False
+    return _env_flag("FLASHINFER_EXP_SM12X_DYNAMIC_DETERMINISTIC_OUTPUT", default=False)
+
+
+def _dynamic_work_source() -> str:
+    """Select the compile-time dynamic-kernel work source.
+
+    ``materialized_queue`` load-balances the fully published work domain and is
+    the production default. ``persistent_grid`` provides arithmetic striding
+    for controlled A/B measurements. ``ready_queue`` enables the experimental
+    overlapped publisher.
+    """
+
+    source = (
+        os.environ.get(_DYNAMIC_WORK_SOURCE_ENV, _DYNAMIC_WORK_SOURCE_DEFAULT)
+        .strip()
+        .lower()
+    )
+    aliases = {
+        "grid": "persistent_grid",
+        "queue": "materialized_queue",
+        "streaming": "ready_queue",
+    }
+    source = aliases.get(source, source)
+    if source not in _DYNAMIC_WORK_SOURCES:
+        raise ValueError(
+            f"unsupported {_DYNAMIC_WORK_SOURCE_ENV}={source!r}; "
+            f"expected one of {sorted(_DYNAMIC_WORK_SOURCES)}"
+        )
+    return source
+
+
+def default_moe_quant_mode() -> str:
+    return "nvfp4"
+
+
+_W4A8_QUANT_MODES = {"w4a8_mx", "w4a8_nvfp4"}
+
+
+def _is_w4a8_quant_mode(quant_mode: str) -> bool:
+    return quant_mode in _W4A8_QUANT_MODES
+
+
+def _micro_scale_format_for_quant_mode(quant_mode: str) -> str:
+    quant_mode = _normalize_quant_mode(quant_mode)
+    return "e8m0_k32" if quant_mode == "w4a8_mx" else "e4m3_k16"
+
+
+def _micro_e8m0_scale_layout_for_quant_mode(quant_mode: str) -> str:
+    quant_mode = _normalize_quant_mode(quant_mode)
+    return "logical" if quant_mode == "w4a8_mx" else "packed"
+
+
+def _normalize_quant_mode_requested(quant_mode: str | None) -> str:
+    if quant_mode is None:
+        return "nvfp4"
+    normalized = str(quant_mode).lower()
+    if normalized not in {"nvfp4", "w4a16"} | _W4A8_QUANT_MODES:
+        raise ValueError(f"unsupported quant_mode {quant_mode!r}")
+    return normalized
+
+
+def _normalize_quant_mode(quant_mode: str | None) -> str:
+    return _normalize_quant_mode_requested(quant_mode)
+
+
+def _normalize_fp4_source_format(source_format: str) -> str:
+    if source_format.lower() == "mxfp4_native":
+        raise ValueError(
+            "source_format='mxfp4_native' has been removed; use "
+            "source_format='fp4_e8m0_k32' for byte-preserved E8M0 K/32 "
+            "scales, or add a real MXFP4 source contract"
+        )
+    try:
+        return _FP4_SOURCE_FORMATS[source_format.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "source_format must be one of 'modelopt_nvfp4', "
+            "'fp4_e8m0_k32', or 'compressed_tensors', "
+            f"got {source_format!r}"
+        ) from exc
+
+
+def _normalize_quant_mode_for_source(
+    quant_mode: str | None,
+    source_format: str,
+) -> str:
+    source_format = _normalize_fp4_source_format(source_format)
+    normalized = _normalize_quant_mode_requested(quant_mode)
+    _validate_fp4_source_format_for_quant_mode(
+        source_format=source_format,
+        quant_mode=normalized,
+    )
+    return normalized
+
+
+def _normalize_w4a16_scale_format(scale_format: str) -> str:
+    try:
+        return _W4A16_SCALE_FORMATS[scale_format.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "scale_format must be one of 'e4m3_k16' or 'e8m0_k32', "
+            f"got {scale_format!r}"
+        ) from exc
+
+
+def _w4a16_scale_format_for_source(source_format: str) -> str:
+    source_format = _normalize_fp4_source_format(source_format)
+    return "e8m0_k32" if source_format == "fp4_e8m0_k32" else "e4m3_k16"
+
+
+def _w4a16_weight_layout_for_source(source_format: str) -> str:
+    """W4A16 weight layout implied by the FP4 source format.
+
+    All serving W4A16 sources (E8M0 K/32 and NVFP4) are repacked to ``packed``;
+    small-M decode is served by the TC-decode path on that same packed object,
+    so no native ``modelopt`` copy is needed.
+    Must mirror ``_get_w4a16_packed_weights`` so the plan-time launch and the
+    runtime ``prepared.weight_layout`` agree. (The ``modelopt`` layout + micro
+    decode kernel remain reachable for offline/benchmark use via the prepare API,
+    just not auto-routed here.)
+    """
+    _normalize_fp4_source_format(source_format)
+    return "packed"
+
+
+_W4A16_WEIGHT_LAYOUTS = {"packed", "modelopt"}
+
+
+def _normalize_w4a16_weight_layout(weight_layout: str) -> str:
+    layout = str(weight_layout).lower()
+    if layout not in _W4A16_WEIGHT_LAYOUTS:
+        raise ValueError(
+            "weight_layout must be one of "
+            f"{sorted(_W4A16_WEIGHT_LAYOUTS)}, got {weight_layout!r}"
+        )
+    return layout
+
+
+def _normalize_w13_layout(w13_layout: str) -> str:
+    try:
+        return _W13_LAYOUTS[w13_layout.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "w13_layout must be one of 'w13'/'w31' (or the 'up_gate'/'gate_up' "
+            f"aliases), got {w13_layout!r}"
+        ) from exc
+
+
+def _normalize_w13_layout_for_activation(activation: str, w13_layout: str) -> str:
+    activation = normalize_moe_activation(activation)
+    layout = _normalize_w13_layout(w13_layout)
+    if activation == SWIGLUOAI_UNINTERLEAVE:
+        return "w31"
+    return layout
+
+
+def _normalize_swiglu_params(
+    activation: str,
+    swiglu_limit: float | None,
+    swiglu_alpha: float | None,
+    swiglu_beta: float | None,
+) -> tuple[float | None, float, float]:
+    activation = normalize_moe_activation(activation)
+    return (
+        normalize_swiglu_limit_for_activation(activation, swiglu_limit),
+        normalize_swiglu_alpha_for_activation(activation, swiglu_alpha),
+        normalize_swiglu_beta_for_activation(activation, swiglu_beta),
+    )
+
+
+def _validate_fp4_source_format_for_quant_mode(
+    *, source_format: str, quant_mode: str
+) -> None:
+    """Validate a canonical checkpoint-format/numeric-recipe pair."""
+
+    source_format = _normalize_fp4_source_format(source_format)
+    quant_mode = _normalize_quant_mode_requested(quant_mode)
+    if quant_mode == "w4a16":
+        return
+    if source_format == "modelopt_nvfp4":
+        return
+    if source_format == "fp4_e8m0_k32" and quant_mode == "w4a8_mx":
+        return
+    raise ValueError(
+        f"source_format={source_format!r} with quant_mode={quant_mode!r} is "
+        "unsupported; use quant_mode='w4a16' for non-NVFP4 sources, "
+        "quant_mode='w4a8_mx' for source_format='fp4_e8m0_k32', or "
+        "source_format='modelopt_nvfp4' for NVFP4/W4A8-NVFP4 kernels"
+    )
+
+
+def _get_activation_kernel_spec(
+    activation: str,
+    *,
+    quant_mode: str = "nvfp4",
+) -> _ActivationKernelSpec:
+    if _normalize_quant_mode(quant_mode) == "w4a16":
+        raise ValueError(
+            "W4A16 dispatch uses flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel directly"
+        )
+    if (
+        _is_w4a8_quant_mode(_normalize_quant_mode(quant_mode))
+        and activation == SWIGLUOAI_UNINTERLEAVE
+    ):
+        raise NotImplementedError(
+            "activation='swigluoai_uninterleave' is not supported for W4A8 MoE"
+        )
+    try:
+        return _ACTIVATION_KERNEL_SPECS[normalize_moe_activation(activation)]
+    except KeyError as exc:
+        raise ValueError(f"unsupported activation {activation!r}") from exc
+
+
+def _activation_w1_rows(activation: str, n: int) -> int:
+    return moe_activation_w1_rows(activation, n)
+
+
+# Override for the dynamic-kernel MMA tile (tile_m, tile_n). Set via the env
+# FLASHINFER_EXP_SM12X_DYNAMIC_TILE_MN="64x128" or programmatically (tp_moe._DYNAMIC_TILE_MN_OVERRIDE).
+# Used to specialize/benchmark dynamic across the tile set it should cover.
+_DYNAMIC_TILE_MN_OVERRIDE: Tuple[int, int] | None = None
+
+
+def _dynamic_tile_mn_override() -> Tuple[int, int] | None:
+    env = os.environ.get("FLASHINFER_EXP_SM12X_DYNAMIC_TILE_MN")
+    if env:
+        m, n = (int(x) for x in env.split("x"))
+        return (m, n)
+    return _DYNAMIC_TILE_MN_OVERRIDE
+
+
+def _dynamic_tile_n(quant_mode: str = "nvfp4") -> int:
+    _normalize_quant_mode(quant_mode)
+    ovr = _dynamic_tile_mn_override()
+    return ovr[1] if ovr is not None else _LEVEL_TILE_N
+
+
+def _dynamic_tile_m(quant_mode: str = "nvfp4") -> int:
+    _normalize_quant_mode(quant_mode)
+    ovr = _dynamic_tile_mn_override()
+    return ovr[0] if ovr is not None else _LEVEL_TILE_M
+
+
+def _select_dynamic_tile_mn(
+    routed_rows: int,
+    n: int,
+    quant_mode: str = "nvfp4",
+    *,
+    num_experts: int,
+    activation: str = "silu",
+    compute_capability: tuple[int, int] | None = None,
+) -> Tuple[int, int]:
+    """Tile planner for the dynamic kernel.
+
+    Generally keyed on average routed rows per expert, with narrowly measured
+    static-shape tactic entries for serving workloads whose route distribution
+    is known.  The scratch plan and kernel build both call this with the same
+    inputs, so they select the SAME tile -- a mismatch mis-sizes grouped
+    task/scale scratch.
+
+    tile_n is fixed at 128 (the verified column). A small tile_m cuts per-expert
+    M-tile padding and dead rows in the grouped GEMM for small decode-band
+    workloads; 128 amortizes best for large prefill. An explicit
+    FLASHINFER_EXP_SM12X_DYNAMIC_TILE_MN / programmatic override wins (for benchmarking).
+    """
+    quant_mode = _normalize_quant_mode(quant_mode)
+    ovr = _dynamic_tile_mn_override()
+    if ovr is not None:
+        return ovr
+    routed_rows = max(1, int(routed_rows))
+    num_experts = max(1, int(num_experts))
+    if _is_w4a8_quant_mode(quant_mode):
+        if compute_capability is None:
+            compute_capability = _current_compute_capability()
+        # DSV4-Flash TP2 speculative-verify band.  Like the CUTLASS tactic
+        # selector, this is keyed only by the static workload shape and routed
+        # row count; live expert counts still come from the device histogram.
+        # M32 reduces repeated expert-weight streaming for the measured
+        # 64--384-token band without adding a second routing/scheduling path.
+        if (
+            quant_mode == "w4a8_mx"
+            and activation == "silu"
+            and num_experts == 256
+            and int(n) == 1024
+            and 384 <= routed_rows <= 2304
+        ):
+            return (32, _LEVEL_TILE_N)
+        # GB10 has only 48 SMs and substantially less memory bandwidth than
+        # desktop SM120 parts.  Its fused M32 specialization keeps FC1/FC2 in
+        # one persistent kernel and wins through the measured DSV4 TP2 prefill
+        # band; the M64/M128 tactics split routing, FC1, and FC2 into three
+        # launches and lose 16--36% here.  Keep the SM120 crossover unchanged.
+        if (
+            compute_capability == (12, 1)
+            and quant_mode == "w4a8_mx"
+            and activation == "silu"
+            and num_experts == 256
+            and int(n) == 1024
+            and 2304 < routed_rows <= 384 * num_experts
+        ):
+            return (32, _LEVEL_TILE_N)
+        # W4A8 uses M16/M32 for sparse decode and the split M64 compute path
+        # for dense prefill.  DSV4 TP2 graph-replay probes place M32->M64
+        # between 34.5 and 36 routed rows/expert (M32 wins at 34.5; M64 wins
+        # at 36).  Keep the conservative integer boundary at 36.  M128 remains
+        # an explicit research override: its external compute tasks are also
+        # M64, while its coarser routing domain adds expert-tail waste.
+        if routed_rows >= 36 * num_experts:
+            return (64, _LEVEL_TILE_N)
+        if routed_rows > 16 * num_experts:
+            return (32, _LEVEL_TILE_N)
+        return (16, _LEVEL_TILE_N)
+    activation = _get_activation_kernel_spec(
+        activation, quant_mode=quant_mode
+    ).activation
+    if activation == "relu2":
+        return (_LEVEL_TILE_M, _LEVEL_TILE_N)
+    # Gated NVFP4 supports the full M16/M32/M64/M128 ladder.  DSV4 TP2/TP4
+    # boundary probes put M16->M32 between 14 and 15 routed rows/expert
+    # (M16 wins at 14; M32 wins by 2.7-3.0% at 15), with later crossovers near
+    # 48 and 96.  Integer products keep this deterministic at boundaries.
+    if routed_rows < 15 * num_experts:
+        tile_m = 16
+    elif routed_rows < 48 * num_experts:
+        tile_m = 32
+    elif routed_rows < 96 * num_experts:
+        tile_m = 64
+    else:
+        tile_m = _LEVEL_TILE_M
+    return (tile_m, _LEVEL_TILE_N)
+
+
+def _w4a8_dynamic_dense_candidate(
+    *,
+    quant_mode: str,
+    activation: str,
+    routed_rows: int,
+    num_experts: int,
+    k: int,
+    n: int,
+    deterministic_output: bool,
+) -> bool:
+    """Whether the proven token-major materialized W4A8 regime can run.
+
+    This is intentionally a structural predicate, separate from the feature
+    env flags.  All dispatch, preparation, scratch validation, and kernel
+    specialization sites use the same predicate so they cannot disagree about
+    which representation the launch consumes.
+    """
+
+    return bool(
+        _normalize_quant_mode(quant_mode) == "w4a8_mx"
+        and activation == "silu"
+        and k % 256 == 0
+        # Half-aligned ceil-tiled rp storage keeps the up/gate halves on
+        # 128-row tile boundaries, so the per-tile pairing works for any
+        # 32-aligned shard (352 = 2048/TP6, 192 = 3072/TP16).
+        and n % 32 == 0
+        and _select_dynamic_tile_mn(
+            routed_rows,
+            n,
+            quant_mode,
+            num_experts=num_experts,
+            activation=activation,
+        )
+        in {(32, 128), (64, 128), (128, 128)}
+        and _dynamic_work_source() != "ready_queue"
+    )
+
+
+def _w4a8_dynamic_decode_candidate(
+    *,
+    quant_mode: str,
+    activation: str,
+    routed_rows: int,
+    num_experts: int,
+    n: int,
+    deterministic_output: bool,
+) -> bool:
+    """Whether prepared W4A8 should use its shared-input decode regime."""
+
+    return bool(
+        _normalize_quant_mode(quant_mode) == "w4a8_mx"
+        and activation == "silu"
+        and 0 < routed_rows <= _W4A8_DECODE_MAX_ROUTED_ROWS
+        and _select_dynamic_tile_mn(
+            routed_rows,
+            n,
+            quant_mode,
+            num_experts=num_experts,
+            activation=activation,
+        )
+        == (16, 128)
+        and _dynamic_work_source() != "ready_queue"
+        and not deterministic_output
+    )
+
+
+def _w4a8_dynamic_direct_candidate(
+    *,
+    quant_mode: str,
+    activation: str,
+    routed_rows: int,
+    num_experts: int,
+    n: int,
+    deterministic_output: bool,
+) -> bool:
+    """Whether tiny prepared W4A8 can bypass grouped route compaction."""
+
+    direct_limit = _DIRECT_ROUTING_MAX_ROUTED_ROWS
+    if _current_compute_capability() == (12, 1) and num_experts == 256 and n == 1024:
+        # DSV4F TP2 is bandwidth-bound in this band; grouping routes avoids
+        # re-streaming weights when speculative tokens share experts.
+        direct_limit = 0
+    return bool(
+        routed_rows <= direct_limit
+        and _w4a8_dynamic_decode_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=num_experts,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+    )
+
+
+def _nvfp4_dynamic_direct_candidate(
+    *,
+    quant_mode: str,
+    activation: str,
+    routed_rows: int,
+    num_experts: int,
+    n: int,
+    deterministic_output: bool,
+) -> bool:
+    """Whether tiny A4 execution can bypass grouped route compaction."""
+
+    return bool(
+        _normalize_quant_mode(quant_mode) == "nvfp4"
+        and activation == "silu"
+        and 0 < routed_rows <= _DIRECT_ROUTING_MAX_ROUTED_ROWS
+        and _select_dynamic_tile_mn(
+            routed_rows,
+            n,
+            quant_mode,
+            num_experts=num_experts,
+            activation=activation,
+        )
+        == (16, 128)
+        and _dynamic_work_source() != "ready_queue"
+        and not deterministic_output
+    )
+
+
+def _dynamic_direct_routing_candidate(
+    *,
+    quant_mode: str,
+    activation: str,
+    routed_rows: int,
+    num_experts: int,
+    n: int,
+    deterministic_output: bool,
+) -> bool:
+    return bool(
+        _w4a8_dynamic_direct_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=num_experts,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+        or _nvfp4_dynamic_direct_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=num_experts,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+    )
+
+
+def _w4a8_dynamic_materialized_enabled(
+    *,
+    quant_mode: str,
+    activation: str,
+    num_tokens: int,
+    routed_rows: int,
+    num_experts: int,
+    k: int,
+    n: int,
+    w4a8_repacked: bool,
+    share_input_across_experts: bool,
+    deterministic_output: bool,
+) -> bool:
+    """Resolve the complete unified-W4A8 specialization as one decision."""
+
+    dense_candidate = _w4a8_dynamic_dense_candidate(
+        quant_mode=quant_mode,
+        activation=activation,
+        routed_rows=routed_rows,
+        num_experts=num_experts,
+        k=k,
+        n=n,
+        deterministic_output=deterministic_output,
+    )
+    m1_candidate = bool(
+        int(num_tokens) == 1
+        and k % 256 == 0
+        # Half-aligned ceil-tiled rp storage keeps the up/gate halves on
+        # 128-row tile boundaries, so the per-tile pairing works for any
+        # 32-aligned shard (352 = 2048/TP6, 192 = 3072/TP16).
+        and n % 32 == 0
+        and _w4a8_dynamic_direct_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=num_experts,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+    )
+    candidate = dense_candidate or m1_candidate
+    return bool(
+        candidate
+        and w4a8_repacked
+        and share_input_across_experts
+        and _env_flag(_DYNAMIC_W4A8_MATERIALIZED_ENV, default=candidate)
+    )
+
+
+_WEIGHT_CACHE: Dict[Tuple[int, int, int], _WeightViews] = {}
+_MICRO_KERNEL_CACHE: Dict[Tuple, object] = {}
+_DYNAMIC_KERNEL_CACHE: Dict[Tuple, object] = {}
+_MAC_CACHE: Dict[Tuple[int, str], int] = {}  # (device_idx, impl) → max_active_clusters
+# Micro owns the tiny tail below this routed-row cutover; dynamic owns the rest.
+# The measured GLM crossover under CUDA graph replay is 64 routed rows.
+_MICRO_DYNAMIC_CUTOVER_PAIRS_DEFAULT = 64
+# Micro keeps the m tokens' activations resident in registers; 8 is the budget
+# ceiling. Micro is correct for any 1<=m<=8 (not just powers of two).
+_MICRO_MAX_TOKENS = 8
+# Prepared MXFP4 decode keeps the shared-input producer through M=8, while
+# pair-direct routing wins through M=4 for the common top-k=8 regime.
+_W4A8_DECODE_MAX_ROUTED_ROWS = 64
+_DIRECT_ROUTING_MAX_ROUTED_ROWS = 32
+_MICRO_DYNAMIC_CUTOVER_PAIRS_CACHE: Dict[str, int] = {}
+_DYNAMIC_MULTICTA_CACHE: bool | None = None
+_DYNAMIC_DOWN_SCALE_CACHE: bool | None = None
+_LAST_WEIGHTS: Tuple = (None, None)  # (cache_key, views)
+_LAST_KERNEL: Tuple = (None, None)  # (cache_key, (compiled, mac))
+_MICRO_DIRECT_LAUNCH_CAP_CACHE: Dict[Tuple[int, int], bool] = {}
+_CURRENT_DISPATCH_STAGE: str | None = None
+_DIRECT_MICRO_SHAPE_ATTR = "_sm12x_direct_micro_shape"
+
+
+def _tensor_version(t: torch.Tensor) -> int:
+    try:
+        return int(t._version)
+    except RuntimeError:
+        # Inference tensors intentionally do not track a version counter.
+        # Model weights/scales are expected to be immutable during serving.
+        return 0
+
+
+@contextmanager
+def sm12x_moe_dispatch_context(stage: str | None):
+    global _CURRENT_DISPATCH_STAGE
+    previous_stage = _CURRENT_DISPATCH_STAGE
+    _CURRENT_DISPATCH_STAGE = stage
+    try:
+        yield
+    finally:
+        _CURRENT_DISPATCH_STAGE = previous_stage
+
+
+def clear_tp_moe_caches() -> None:
+    """Clear runtime caches owned by `tp_moe`.
+
+    Explicit workspaces and workspace pools are caller-owned and intentionally
+    unaffected by this helper.
+    """
+    from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+        clear_w4a16_kernel_cache,
+    )
+
+    global _LAST_WEIGHTS
+    global _LAST_KERNEL
+    global _MICRO_DYNAMIC_CUTOVER_PAIRS_CACHE
+    global _DYNAMIC_MULTICTA_CACHE
+    global _DYNAMIC_DOWN_SCALE_CACHE
+    _WEIGHT_CACHE.clear()
+    clear_w4a16_kernel_cache()
+    _MICRO_KERNEL_CACHE.clear()
+    _DYNAMIC_KERNEL_CACHE.clear()
+    _MAC_CACHE.clear()
+    _MICRO_DIRECT_LAUNCH_CAP_CACHE.clear()
+    _MICRO_DYNAMIC_CUTOVER_PAIRS_CACHE.clear()
+    _DYNAMIC_MULTICTA_CACHE = None
+    _DYNAMIC_DOWN_SCALE_CACHE = None
+    _LAST_WEIGHTS = (None, None)
+    _LAST_KERNEL = (None, None)
+
+
+_FAST_MATH_DEFAULT = _env_flag("FLASHINFER_EXP_SM12X_FAST_MATH", default=True)
+
+
+def _first_env(*names: str) -> str | None:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None:
+            return value
+    return None
+
+
+def _get_micro_dynamic_cutover_pairs(quant_mode: str = "nvfp4") -> int:
+    quant_mode = _normalize_quant_mode(quant_mode)
+    cached = _MICRO_DYNAMIC_CUTOVER_PAIRS_CACHE.get(quant_mode)
+    if cached is None:
+        cutover = os.environ.get("FLASHINFER_EXP_SM12X_MICRO_DYNAMIC_CUTOVER_PAIRS")
+        if cutover is None:
+            cached = _MICRO_DYNAMIC_CUTOVER_PAIRS_DEFAULT
+        else:
+            cached = max(0, int(cutover))
+        _MICRO_DYNAMIC_CUTOVER_PAIRS_CACHE[quant_mode] = cached
+    return cached
+
+
+def _arena_core_token_counts(
+    *,
+    max_tokens: int,
+    num_topk: int,
+    core_token_counts: tuple[int, ...] | None,
+    quant_mode: str,
+) -> tuple[int, ...]:
+    max_tokens = max(int(max_tokens), 1)
+    num_topk = max(int(num_topk), 1)
+    quant_mode = _normalize_quant_mode(quant_mode)
+    if quant_mode == "w4a16":
+        from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+            route_pack_token_capacity,
+        )
+
+        max_tokens = route_pack_token_capacity(max_tokens, num_topk)
+    if core_token_counts is None:
+        normalized = (max_tokens,)
+    else:
+        normalized = tuple(
+            max(int(token_count), 1) for token_count in core_token_counts
+        )
+        if quant_mode == "w4a16":
+            normalized = tuple(
+                route_pack_token_capacity(token_count, num_topk)
+                for token_count in normalized
+            )
+        if max_tokens not in normalized:
+            normalized = (max_tokens, *normalized)
+    normalized = tuple(dict.fromkeys(normalized))
+    micro_cutover_pairs = _get_micro_dynamic_cutover_pairs(quant_mode)
+    max_micro_tokens = micro_cutover_pairs // num_topk
+    if max_micro_tokens >= 1:
+        micro_boundary_tokens = min(max_tokens, max_micro_tokens)
+        if quant_mode == "w4a16":
+            micro_boundary_tokens = route_pack_token_capacity(
+                micro_boundary_tokens,
+                num_topk,
+            )
+        if micro_boundary_tokens not in normalized:
+            normalized = (*normalized, micro_boundary_tokens)
+    return normalized
+
+
+def _dynamic_multicta_enabled() -> bool:
+    global _DYNAMIC_MULTICTA_CACHE
+    if _DYNAMIC_MULTICTA_CACHE is None:
+        multicta_env = _first_env(
+            "FLASHINFER_EXP_SM12X_DYNAMIC_ENABLE_MULTICTA",
+            "FLASHINFER_EXP_SM12X_LEVEL10_ENABLE_MULTICTA",
+        )
+        if multicta_env is None:
+            multicta_env = "1"
+        _DYNAMIC_MULTICTA_CACHE = multicta_env == "1"
+    return _DYNAMIC_MULTICTA_CACHE
+
+
+def _dynamic_down_scale_enabled() -> bool:
+    global _DYNAMIC_DOWN_SCALE_CACHE
+    if _DYNAMIC_DOWN_SCALE_CACHE is None:
+        _DYNAMIC_DOWN_SCALE_CACHE = _env_flag(
+            "FLASHINFER_EXP_SM12X_ENABLE_DYNAMIC_DOWN_SCALE", default=False
+        )
+    return _DYNAMIC_DOWN_SCALE_CACHE
+
+
+def _flatten_routing_ids(topk_ids: torch.Tensor) -> torch.Tensor:
+    with record_function("tp_moe.flatten_routing_ids"):
+        flat_ids = topk_ids.view(-1)
+        if flat_ids.dtype not in (torch.int32, torch.int64):
+            with record_function("tp_moe.flatten_routing_ids.cast_int32"):
+                return flat_ids.to(torch.int32)
+        if not flat_ids.is_contiguous():
+            with record_function("tp_moe.flatten_routing_ids.contiguous"):
+                return flat_ids.contiguous()
+        return flat_ids
+
+
+def _flatten_routing_weights(topk_weights: torch.Tensor) -> torch.Tensor:
+    with record_function("tp_moe.flatten_routing_weights"):
+        flat_weights = topk_weights.view(-1)
+        if flat_weights.dtype != torch.float32:
+            with record_function("tp_moe.flatten_routing_weights.cast_fp32"):
+                return flat_weights.to(torch.float32)
+        if not flat_weights.is_contiguous():
+            with record_function("tp_moe.flatten_routing_weights.contiguous"):
+                return flat_weights.contiguous()
+        return flat_weights
+
+
+def _prepare_expert_scale(scale: torch.Tensor, weight_E: int) -> torch.Tensor:
+    with record_function("tp_moe.prepare_expert_scale"):
+        if scale.numel() == 1:
+            with record_function("tp_moe.prepare_expert_scale.expand_scalar"):
+                return scale.reshape(()).expand(weight_E).to(torch.float32).contiguous()
+        if scale.numel() != weight_E:
+            raise ValueError(
+                f"expected expert scale with {weight_E} elements, got {scale.numel()}"
+            )
+        # A contiguous [E] scale stays contiguous through reshape + to(float32),
+        # so the trailing .contiguous() was redundant here (kept in the scalar
+        # .expand() branch above, where expand yields a non-contiguous view).
+        return scale.reshape(weight_E).to(torch.float32)
+
+
+def _prepare_expert_scale_vector(
+    scale: torch.Tensor,
+    weight_E: int,
+    *,
+    name: str,
+) -> torch.Tensor:
+    with record_function("tp_moe.prepare_expert_scale_vector"):
+        if scale.numel() == 1:
+            with record_function("tp_moe.prepare_expert_scale_vector.expand_scalar"):
+                return scale.reshape(()).expand(weight_E).to(torch.float32).contiguous()
+        if scale.numel() != weight_E:
+            raise ValueError(
+                f"expected {name} with {weight_E} elements, got {scale.numel()}"
+            )
+        return scale.reshape(weight_E).to(torch.float32).contiguous()
+
+
+def _safe_dynamic_max_rows_per_launch(
+    E: int,
+    k: int,
+    _n: int,
+    quant_mode: str = "nvfp4",
+) -> int:
+    """Largest graph-safe routed-row budget for the compact dynamic workspace.
+
+    Dynamic now stores routed activations in a compact physical-tile pool, so
+    the dominant CuTe memref extents scale with `rows_padded` rather than
+    `E * max_rows`. Graph-safe chunking still has to budget for the worst-case
+    active-expert envelope, so it reserves `E - 1` extra 128-row tiles in that
+    large-row regime.
+    """
+    tile_m = _dynamic_tile_m(quant_mode)
+    rows_padded_limit = _dynamic_rows_padded_limit(k, quant_mode=quant_mode)
+    extra_rows = max(0, E - 1) * tile_m
+    safe_rows = rows_padded_limit - extra_rows
+    if safe_rows <= 0:
+        return tile_m
+    return max(tile_m, safe_rows - (safe_rows % tile_m))
+
+
+def _dynamic_rows_padded_limit(k: int, *, quant_mode: str = "nvfp4") -> int:
+    tile_m = _dynamic_tile_m(quant_mode)
+    cols_pad_k = align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    _qm = _normalize_quant_mode(quant_mode)
+    input_cols = k if (_qm == "w4a16" or _is_w4a8_quant_mode(_qm)) else k // 2
+    rows_padded_limit = min(
+        _RUNTIME_MEMREF_LIMIT // max(1, input_cols),
+        _RUNTIME_MEMREF_LIMIT // max(1, cols_pad_k),
+    )
+    return rows_padded_limit - (rows_padded_limit % tile_m)
+
+
+def _safe_dynamic_token_chunk(
+    E: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    quant_mode: str = "nvfp4",
+) -> int:
+    """Largest token chunk that fits the compact dynamic launch ABI."""
+    tile_m = _dynamic_tile_m(quant_mode)
+    safe_rows = _safe_dynamic_max_rows_per_launch(E, k, n, quant_mode)
+    max_tokens = max(1, safe_rows // max(1, num_topk))
+    while max_tokens > 1 and align_up(max_tokens * num_topk, tile_m) > safe_rows:
+        max_tokens -= 1
+    return max_tokens
+
+
+def _dynamic_token_chunk_limit(
+    E: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    quant_mode: str = "nvfp4",
+) -> int:
+    """Largest token chunk supported by the compact dynamic launch ABI."""
+    return _safe_dynamic_token_chunk(E, k, n, num_topk, quant_mode)
+
+
+def _workspace_policy(
+    workspace: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool,
+) -> _TPMoEWorkspacePolicy:
+    is_pool = isinstance(workspace, TPMoEWorkspacePool)
+    return _TPMoEWorkspacePolicy(
+        can_chunk=is_pool,
+    )
+
+
+def select_tp_moe_backend(
+    *,
+    num_tokens: int,
+    num_topk: int,
+    quant_mode: str = "nvfp4",
+) -> str:
+    """Pick the fused MoE backend from the intrinsic routed workload shape.
+
+    Direct-micro owns the tiny-decode tail where it wins on GPU time; dynamic
+    owns all larger routed workloads.
+    """
+    routed_rows = num_tokens * num_topk
+    cutover = _get_micro_dynamic_cutover_pairs(quant_mode)
+    if num_tokens <= _MICRO_MAX_TOKENS and routed_rows < cutover:
+        return "micro"
+    return "dynamic"
+
+
+def _dynamic_task_geometry(
+    E: int,
+    n: int,
+    routed_rows: int,
+    tile_m: int = _LEVEL_TILE_M,
+    tile_n: int = _LEVEL_TILE_N,
+) -> tuple[int, int, int]:
+    routed_rows = max(1, routed_rows)
+    base_m_tiles = align_up(routed_rows, tile_m) // tile_m
+    # At most one new physical tile is introduced per active expert beyond the
+    # first, and the routed workload cannot touch more experts than routed rows.
+    active_expert_upper_bound = min(E, routed_rows)
+    max_m_tiles = max(1, base_m_tiles + active_expert_upper_bound - 1)
+    gate_tile_cnt = max(1, (n + tile_n - 1) // tile_n)
+    slice_groups = max(
+        1, (gate_tile_cnt + _DYNAMIC_SLICE_CHUNK - 1) // _DYNAMIC_SLICE_CHUNK
+    )
+    max_tasks = max_m_tiles * slice_groups
+    return max_m_tiles, gate_tile_cnt, max_tasks
+
+
+def _refresh_dynamic_workspace_scales(
+    workspace: TPDynamicWorkspace,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    *,
+    input_scales_static: bool,
+    force: bool = False,
+) -> None:
+    a1_src_ptr = a1_gscale.data_ptr()
+    a2_src_ptr = a2_gscale.data_ptr()
+    if (
+        force
+        or not input_scales_static
+        or workspace.input_gs_src_ptr != a1_src_ptr
+        or workspace.down_input_scale_src_ptr != a2_src_ptr
+    ):
+        workspace.input_gs.copy_(a1_gscale.expand(workspace.weight_E))
+        workspace.down_input_scale.copy_(a2_gscale.expand(workspace.weight_E))
+        workspace.input_gs_src_ptr = a1_src_ptr if input_scales_static else 0
+        workspace.down_input_scale_src_ptr = a2_src_ptr if input_scales_static else 0
+
+
+def _packed_input_binding_views(
+    *,
+    packed_input: torch.Tensor,
+    packed_input_scale: torch.Tensor,
+) -> _PackedInputBindingViews:
+    sf_dtype = cutlass.Float8E4M3FN
+    # Keep as uint8 — the float4 element type is conveyed to CUTLASS via
+    # _gptr / compile-time dtype, and dlpack does not support float4.
+    return _PackedInputBindingViews(
+        packed_a_view=packed_input.permute(1, 2, 0),
+        packed_a_flat=packed_input.view(-1),
+        scale_flat=packed_input_scale.view(-1),
+        sfa_ptr=make_ptr(
+            sf_dtype,
+            packed_input_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        packed_a_storage_ptr=make_ptr(
+            cutlass.Uint8,
+            packed_input.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+    )
+
+
+def _finalize_workspace_views(workspace: TPMoEWorkspace) -> None:
+    views = _packed_input_binding_views(
+        packed_input=workspace.packed_input,
+        packed_input_scale=workspace.packed_input_scale,
+    )
+    workspace.packed_a_view = views.packed_a_view
+    workspace.packed_a_flat = views.packed_a_flat
+    workspace.scale_flat = views.scale_flat
+    workspace.sfa_ptr = views.sfa_ptr
+    workspace.packed_a_storage_ptr = views.packed_a_storage_ptr
+
+
+def _build_tp_moe_fp4_binding_from_views(
+    *,
+    plan: _TPCoreWorkspacePlan,
+    tensors: Dict[str, torch.Tensor],
+    a: torch.Tensor,
+    experts: SM12XFP4ExpertWeights,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    apply_router_weight_on_input: bool = False,
+    output: torch.Tensor | None = None,
+    input_scales_static: bool = False,
+    fast_math: bool | None = None,
+    quant_mode: str | None = None,
+    unit_scale_contract: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    activation_amax: torch.Tensor | None = None,
+    layer_idx: int | None = None,
+) -> TPMoEFP4Binding:
+    if not isinstance(experts, SM12XFP4ExpertWeights):
+        raise TypeError("experts must come from prepare_sm12x_fp4_moe_weights")
+    if a.ndim != 2:
+        raise ValueError(
+            f"expected input activations with rank 2, got {tuple(a.shape)}"
+        )
+    if topk_weights.ndim != 2 or topk_ids.ndim != 2:
+        raise ValueError("topk_weights and topk_ids must be rank-2 tensors")
+    if topk_weights.shape != topk_ids.shape:
+        raise ValueError(
+            "topk_weights and topk_ids shape mismatch: "
+            f"{tuple(topk_weights.shape)} vs {tuple(topk_ids.shape)}"
+        )
+    if topk_ids.shape[0] != a.shape[0]:
+        raise ValueError(
+            f"routing batch mismatch: expected {a.shape[0]}, got {topk_ids.shape[0]}"
+        )
+
+    source_format = experts.source_format
+    quant_mode = _normalize_quant_mode_for_source(
+        quant_mode if quant_mode is not None else plan.quant_mode,
+        source_format,
+    )
+    unit_scale_contract = bool(unit_scale_contract and quant_mode == "w4a16")
+    activation = experts.activation
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    w13_layout = experts.w13_layout
+    _validate_fp4_source_format_for_quant_mode(
+        source_format=source_format,
+        quant_mode=quant_mode,
+    )
+    if quant_mode != plan.quant_mode:
+        raise ValueError(
+            f"scratch plan quant_mode={plan.quant_mode!r} cannot bind "
+            f"quant_mode={quant_mode!r}"
+        )
+    plan_activation = activation
+    if quant_mode != "w4a16":
+        plan_activation = _get_activation_kernel_spec(
+            activation,
+            quant_mode=quant_mode,
+        ).activation
+    if plan_activation != plan.activation:
+        raise ValueError(
+            f"scratch plan activation={plan.activation!r} cannot bind "
+            f"activation={activation!r}"
+        )
+    if (
+        swiglu_limit != plan.swiglu_limit
+        or swiglu_alpha != plan.swiglu_alpha
+        or swiglu_beta != plan.swiglu_beta
+    ):
+        raise ValueError(
+            "scratch plan activation params do not match binding params: "
+            f"planned=(limit={plan.swiglu_limit}, alpha={plan.swiglu_alpha}, beta={plan.swiglu_beta}), "
+            f"binding=(limit={swiglu_limit}, alpha={swiglu_alpha}, beta={swiglu_beta})"
+        )
+
+    m, k = map(int, a.shape)
+    _prepared_payload_for_runtime(
+        experts,
+        quant_mode=quant_mode,
+        source_format=source_format,
+        activation=activation,
+        w13_layout=w13_layout,
+        dtype=a.dtype,
+        hidden_size=k,
+    )
+    num_topk = int(topk_ids.shape[1])
+    weight_E = experts.num_experts
+    n = experts.intermediate_size
+    if k != plan.k:
+        raise ValueError(f"scratch plan K={plan.k} cannot bind input K={k}")
+    if num_topk != plan.num_topk:
+        raise ValueError(
+            f"scratch plan top-k={plan.num_topk} cannot bind top-k={num_topk}"
+        )
+    if weight_E != plan.weight_E:
+        raise ValueError(
+            f"scratch plan weight_E={plan.weight_E} cannot bind weight_E={weight_E}"
+        )
+    if n != plan.n:
+        raise ValueError(f"scratch plan N={plan.n} cannot bind N={n}")
+    if m * num_topk > plan.routed_rows:
+        raise ValueError(
+            f"scratch plan routed-row capacity {plan.routed_rows} cannot bind "
+            f"{m * num_topk} routed rows"
+        )
+
+    common_kwargs = dict(
+        a=a,
+        experts=experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        implementation=plan.implementation,
+        state_E=plan.state_E,
+        weight_E=plan.weight_E,
+        max_rows=plan.max_rows,
+        k=plan.k,
+        n=plan.n,
+        num_topk=plan.num_topk,
+        device=plan.device,
+        dtype=plan.dtype,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        output=output,
+        input_scales_static=bool(input_scales_static),
+        fast_math=fast_math,
+        quant_mode=quant_mode,
+        deterministic_output=plan.deterministic_output,
+        unit_scale_contract=unit_scale_contract,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        activation_amax=activation_amax,
+        layer_idx=layer_idx,
+    )
+    if plan.implementation == "w4a16":
+        return TPMoEFP4Binding(
+            **common_kwargs,
+            routed_rows_capacity=plan.routed_rows,
+            intermediate_cache13=tensors["intermediate_cache13"],
+            intermediate_cache2=tensors["intermediate_cache2"],
+            fc1_c_tmp=tensors["fc1_c_tmp"],
+            fc2_c_tmp=tensors["fc2_c_tmp"],
+            packed_route_indices=tensors["packed_route_indices"],
+            block_expert_ids=tensors["block_expert_ids"],
+            packed_route_count=tensors["packed_route_count"],
+            expert_offsets=tensors["expert_offsets"],
+        )
+
+    if plan.implementation == "micro":
+        view_kwargs = _packed_input_binding_views(
+            packed_input=tensors["packed_input"],
+            packed_input_scale=tensors["packed_input_scale"],
+        )
+        return TPMoEFP4Binding(
+            **common_kwargs,
+            row_counts=tensors["row_counts"],
+            token_map=tensors["token_map"],
+            token_weights=tensors["token_weights"],
+            packed_input=tensors["packed_input"],
+            packed_input_scale=tensors["packed_input_scale"],
+            barrier_count=tensors["barrier_count"],
+            barrier_epoch=tensors["barrier_epoch"],
+            routed_rows_capacity=plan.routed_rows,
+            packed_a_view=view_kwargs.packed_a_view,
+            sfa_ptr=view_kwargs.sfa_ptr,
+            packed_a_flat=view_kwargs.packed_a_flat,
+            scale_flat=view_kwargs.scale_flat,
+            packed_a_storage_ptr=view_kwargs.packed_a_storage_ptr,
+            active_expert_count=tensors["active_expert_count"],
+            weight_expert_ids=tensors["weight_expert_ids"],
+            global_to_local_expert=tensors["global_to_local_expert"],
+            compact_topk_ids=tensors["compact_topk_ids"],
+            micro_intermediate=tensors["micro_intermediate"],
+        )
+
+    if plan.implementation == "dynamic":
+        if plan.dynamic_physical_tiles is None or plan.dynamic_task_capacity is None:
+            raise RuntimeError("dynamic TP MoE binding plan is missing capacities")
+        tensors["input_gs"].copy_(experts.a1_gscale.expand(plan.weight_E))
+        tensors["down_input_scale"].copy_(experts.a2_gscale.expand(plan.weight_E))
+        view_kwargs = _packed_input_binding_views(
+            packed_input=tensors["packed_input"],
+            packed_input_scale=tensors["packed_input_scale"],
+        )
+        return TPMoEFP4Binding(
+            **common_kwargs,
+            row_counts=tensors["row_counts"],
+            token_map=tensors["token_map"],
+            token_weights=tensors["token_weights"],
+            packed_input=tensors["packed_input"],
+            packed_input_scale=tensors["packed_input_scale"],
+            barrier_count=tensors["barrier_count"],
+            barrier_epoch=tensors["barrier_epoch"],
+            routed_rows_capacity=plan.routed_rows,
+            packed_a_view=view_kwargs.packed_a_view,
+            sfa_ptr=view_kwargs.sfa_ptr,
+            packed_a_flat=view_kwargs.packed_a_flat,
+            scale_flat=view_kwargs.scale_flat,
+            packed_a_storage_ptr=view_kwargs.packed_a_storage_ptr,
+            physical_tiles_capacity=plan.dynamic_physical_tiles,
+            task_capacity=plan.dynamic_task_capacity,
+            route_output=tensors["route_output"],
+            materialized_intermediate=tensors["materialized_intermediate"],
+            expert_write_rows=tensors["expert_write_rows"],
+            expert_tile_base=tensors["expert_tile_base"],
+            input_gs=tensors["input_gs"],
+            down_input_scale=tensors["down_input_scale"],
+            pair_head=tensors["pair_head"],
+            producers_done_count=tensors["producers_done_count"],
+            all_work_published=tensors["all_work_published"],
+            task_head=tensors["task_head"],
+            task_tail=tensors["task_tail"],
+            task_ready=tensors["task_ready"],
+            task_expert=tensors["task_expert"],
+            task_m_tile=tensors["task_m_tile"],
+            task_slice_begin=tensors["task_slice_begin"],
+            task_slice_count=tensors["task_slice_count"],
+            task_valid_rows=tensors["task_valid_rows"],
+            tile_write_count=tensors["tile_write_count"],
+        )
+
+    raise ValueError(
+        f"unsupported TP MoE binding implementation {plan.implementation!r}"
+    )
+
+
+def _dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _tensor_numel(shape: Tuple[int, ...]) -> int:
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    return numel
+
+
+def _plan_core_workspace(
+    implementation: str,
+    quant_mode: str,
+    state_E: int,
+    weight_E: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    *,
+    routed_rows: int,
+    max_rows: int,
+    activation: str = "silu",
+    dynamic_physical_tiles: int | None = None,
+    dynamic_task_capacity: int | None = None,
+    source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "w13",
+    w4a16_weight_layout: str | None = None,
+    w4a16_scale_format: str | None = None,
+    apply_router_weight_on_input: bool = False,
+    deterministic_output: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+) -> _TPCoreWorkspacePlan:
+    source_format = _normalize_fp4_source_format(source_format)
+    quant_mode = _normalize_quant_mode_for_source(quant_mode, source_format)
+    activation = normalize_moe_activation(activation)
+    deterministic_output = bool(deterministic_output and implementation == "dynamic")
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    if implementation == "w4a16":
+        from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+            _W4A16_ALLOWED_ROUTED_SIZES,
+            max_packed_route_slots,
+            packed_gemm_scratch_elements,
+        )
+        from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+            _small_m_direct_supported,
+        )
+
+        w13_layout = _normalize_w13_layout(w13_layout)
+        scale_format = (
+            _normalize_w4a16_scale_format(w4a16_scale_format)
+            if w4a16_scale_format is not None
+            else _w4a16_scale_format_for_source(source_format)
+        )
+        weight_layout = (
+            _normalize_w4a16_weight_layout(w4a16_weight_layout)
+            if w4a16_weight_layout is not None
+            else _w4a16_weight_layout_for_source(source_format)
+        )
+        routed_capacity = max(int(routed_rows), 1)
+        fc1_cols = _activation_w1_rows(activation, int(n))
+        route_slots_capacity = 1
+        route_blocks_capacity = 1
+        fc1_c_tmp_elements = 1
+        fc2_c_tmp_elements = 1
+        sms = max(1, int(get_num_sm(device)))
+        for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
+            route_slots = max_packed_route_slots(
+                routed_capacity,
+                int(block_size),
+                int(weight_E),
+            )
+            route_blocks = (route_slots + int(block_size) - 1) // int(block_size)
+            route_slots_capacity = max(route_slots_capacity, route_slots)
+            route_blocks_capacity = max(route_blocks_capacity, route_blocks)
+            fc1_c_tmp_elements = max(
+                fc1_c_tmp_elements,
+                packed_gemm_scratch_elements(
+                    size_n=fc1_cols,
+                    route_slots=route_slots,
+                    moe_block_size=int(block_size),
+                    sms=sms,
+                ),
+            )
+            fc2_c_tmp_elements = max(
+                fc2_c_tmp_elements,
+                packed_gemm_scratch_elements(
+                    size_n=int(k),
+                    route_slots=route_slots,
+                    moe_block_size=int(block_size),
+                    sms=sms,
+                ),
+            )
+        intermediate_cache2_elements = routed_capacity * int(n)
+        direct_m = routed_capacity // max(int(num_topk), 1)
+        if routed_capacity == direct_m * int(num_topk) and _small_m_direct_supported(
+            m=direct_m,
+            hidden_size=int(k),
+            intermediate_size=int(n),
+            num_experts=int(weight_E),
+            topk=int(num_topk),
+            activation=activation,
+            apply_router_weight_on_input=bool(apply_router_weight_on_input),
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            element_dtype=_w4a16_element_dtype(dtype),
+            weight_layout=weight_layout,
+            w13_layout=w13_layout,
+            scale_format=scale_format,
+            expert_map=None,
+        ):
+            fc2_n_chunks = ((int(n) // 2) + 127) // 128
+            direct_cache2_u32 = direct_m * fc2_n_chunks * 128 * int(num_topk)
+            direct_cache2_nbytes = direct_cache2_u32 * _dtype_nbytes(torch.uint32)
+            intermediate_cache2_elements = max(
+                intermediate_cache2_elements,
+                align_up(direct_cache2_nbytes, _dtype_nbytes(dtype))
+                // _dtype_nbytes(dtype),
+            )
+        return _TPCoreWorkspacePlan(
+            implementation=implementation,
+            quant_mode=quant_mode,
+            activation=activation,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            state_E=state_E,
+            weight_E=weight_E,
+            routed_rows=routed_capacity,
+            max_rows=max(max_rows, routed_capacity),
+            k=k,
+            n=n,
+            num_topk=num_topk,
+            device=device,
+            dtype=dtype,
+            deterministic_output=False,
+            tensor_specs=(
+                _TensorAllocSpec(
+                    "intermediate_cache13",
+                    (routed_capacity * max(fc1_cols, int(k)),),
+                    dtype,
+                ),
+                _TensorAllocSpec(
+                    "intermediate_cache2",
+                    (intermediate_cache2_elements,),
+                    dtype,
+                ),
+                _TensorAllocSpec("fc1_c_tmp", (fc1_c_tmp_elements,), torch.float32),
+                _TensorAllocSpec("fc2_c_tmp", (fc2_c_tmp_elements,), torch.float32),
+                _TensorAllocSpec(
+                    "packed_route_indices", (route_slots_capacity,), torch.int32
+                ),
+                _TensorAllocSpec(
+                    "block_expert_ids", (route_blocks_capacity,), torch.int32
+                ),
+                _TensorAllocSpec("packed_route_count", (1,), torch.int32),
+                _TensorAllocSpec("expert_offsets", (int(weight_E) + 1,), torch.int32),
+            ),
+        )
+
+    activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
+
+    cols_pad_k = align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    direct_micro_tokens = max(1, routed_rows // max(1, num_topk))
+    direct_micro_k_supported = (
+        k > 0
+        and k % _NVFP4_BLOCK_SIZE == 0
+        and k % 128 == 0
+        and _direct_k_segments_supported(_direct_k_segments_for_k(k))
+    )
+    direct_micro_token_supported = 1 <= direct_micro_tokens <= _MICRO_MAX_TOKENS
+    direct_micro_candidate = (
+        implementation == "micro"
+        and n % _NVFP4_BLOCK_SIZE == 0
+        and direct_micro_k_supported
+        and 0 < num_topk <= 32
+        and weight_E > 0
+        and routed_rows == direct_micro_tokens * num_topk
+        and direct_micro_token_supported
+    )
+    barrier_slots = max(1, routed_rows)
+    if direct_micro_candidate:
+        barrier_slots = max(barrier_slots, routed_rows + direct_micro_tokens * 16)
+    common_specs = (
+        _TensorAllocSpec("row_counts", (state_E,), torch.int32, init="zeros"),
+        _TensorAllocSpec("barrier_count", (barrier_slots,), torch.int32, init="zeros"),
+        _TensorAllocSpec("barrier_epoch", (barrier_slots,), torch.int32, init="zeros"),
+    )
+    if implementation == "micro":
+        micro_rows_pad_k = align_up(max_rows, 128)
+        packed_input_shape = (state_E, max_rows, k // 2)
+        packed_input_dtype = torch.uint8
+        micro_intermediate_elements = state_E * n
+        if quant_mode == "w4a8_mx":
+            # tiny_decode stages fp32 [routed_rows, 2n] gate/up sums here.
+            micro_intermediate_elements = max(
+                micro_intermediate_elements, max_rows * 2 * n
+            )
+        if direct_micro_candidate:
+            fc2_n_chunks = (n // 2 + 127) // 128
+            micro_intermediate_elements = max(
+                micro_intermediate_elements,
+                direct_micro_tokens * num_topk * k
+                + direct_micro_tokens * num_topk * fc2_n_chunks * 128,
+            )
+        return _TPCoreWorkspacePlan(
+            implementation=implementation,
+            quant_mode=quant_mode,
+            activation=activation_spec.activation,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            state_E=state_E,
+            weight_E=weight_E,
+            routed_rows=routed_rows,
+            max_rows=max_rows,
+            k=k,
+            n=n,
+            num_topk=num_topk,
+            device=device,
+            dtype=dtype,
+            deterministic_output=False,
+            tensor_specs=common_specs
+            + (
+                _TensorAllocSpec(
+                    "token_map", (state_E, max_rows), torch.int32, init="zeros"
+                ),
+                _TensorAllocSpec(
+                    "token_weights", (state_E, max_rows), torch.float32, init="zeros"
+                ),
+                _TensorAllocSpec(
+                    "packed_input", packed_input_shape, packed_input_dtype
+                ),
+                _TensorAllocSpec(
+                    "packed_input_scale",
+                    (state_E, micro_rows_pad_k, cols_pad_k),
+                    torch.uint8,
+                ),
+                _TensorAllocSpec(
+                    "active_expert_count", (1,), torch.int32, init="zeros"
+                ),
+                _TensorAllocSpec(
+                    "weight_expert_ids", (state_E,), torch.int32, init="arange"
+                ),
+                _TensorAllocSpec("global_to_local_expert", (weight_E,), torch.int32),
+                _TensorAllocSpec("compact_topk_ids", (routed_rows,), torch.int32),
+                _TensorAllocSpec(
+                    "micro_intermediate",
+                    (micro_intermediate_elements,),
+                    torch.float32,
+                    init="zeros",
+                ),
+            ),
+        )
+
+    # Tile planner: must match the kernel's choice (keyed identically on the
+    # workspace capacity) so the grouped task/scale scratch is sized correctly.
+    dynamic_tile_m, dynamic_tile_n = _select_dynamic_tile_mn(
+        routed_rows,
+        n,
+        quant_mode,
+        num_experts=state_E,
+        activation=activation_spec.activation,
+    )
+    if dynamic_physical_tiles is None or dynamic_task_capacity is None:
+        dynamic_tiles, _, dynamic_max_tasks = _dynamic_task_geometry(
+            state_E,
+            n,
+            routed_rows,
+            tile_m=dynamic_tile_m,
+            tile_n=dynamic_tile_n,
+        )
+        if _dynamic_direct_routing_candidate(
+            quant_mode=quant_mode,
+            activation=activation_spec.activation,
+            routed_rows=routed_rows,
+            num_experts=state_E,
+            n=n,
+            deterministic_output=False,
+        ):
+            direct_groups = max(
+                1,
+                ((n + dynamic_tile_n - 1) // dynamic_tile_n + _DYNAMIC_SLICE_CHUNK - 1)
+                // _DYNAMIC_SLICE_CHUNK,
+            )
+            dynamic_tiles = max(dynamic_tiles, routed_rows)
+            dynamic_max_tasks = max(dynamic_max_tasks, routed_rows * direct_groups)
+    else:
+        dynamic_tiles = dynamic_physical_tiles
+        dynamic_max_tasks = dynamic_task_capacity
+    dynamic_rows_padded = dynamic_tiles * dynamic_tile_m
+    # NVFP4 scale addressing uses 128-row hardware SF atoms even when the
+    # compute tile is M16/M32/M64.  The final partial atom therefore needs
+    # physical storage through its full 128-row extent.  W4A8 uses a plain
+    # row-major scale plane, for which the extra tail is harmless.
+    dynamic_scale_rows = align_up(dynamic_rows_padded, 128)
+    packed_input_cols = k if _is_w4a8_quant_mode(quant_mode) else k // 2
+    packed_input_shape = (1, dynamic_rows_padded, packed_input_cols)
+    packed_input_dtype = torch.uint8
+    # Atomic scatter writes directly into the caller-owned [M, K] output and
+    # never addresses route_output.  Reserve only one ABI-compatible row for
+    # that production-default policy; the opt-in deterministic reduction owns
+    # a distinct fixed-capacity plan with one row per routed pair.
+    route_output_rows = max(int(routed_rows), 1) if deterministic_output else 1
+    # Materialized W4A8 phase 1 writes one E4M3 byte per activation plus one
+    # UE8M0 byte per K32 block.  This storage must not alias route_output:
+    # deterministic phase 2 writes one BF16 row per token-major route there
+    # before the fixed-order top-k reduction.  Keep a small aligned sentinel
+    # for non-W4A8 dynamic plans so every binding has an invariant ABI.
+    materialized_intermediate_bytes = 16
+    if _is_w4a8_quant_mode(quant_mode):
+        materialized_intermediate_bytes = max(
+            16,
+            dynamic_rows_padded * (n + n // 32),
+        )
+    materialized_intermediate_rows = max(
+        1,
+        (materialized_intermediate_bytes + int(k) * int(dtype.itemsize) - 1)
+        // (int(k) * int(dtype.itemsize)),
+    )
+    return _TPCoreWorkspacePlan(
+        implementation=implementation,
+        quant_mode=quant_mode,
+        activation=activation_spec.activation,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        state_E=state_E,
+        weight_E=weight_E,
+        routed_rows=routed_rows,
+        max_rows=max_rows,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+        device=device,
+        dtype=dtype,
+        deterministic_output=deterministic_output,
+        dynamic_physical_tiles=dynamic_tiles,
+        dynamic_task_capacity=dynamic_max_tasks,
+        tensor_specs=common_specs
+        + (
+            _TensorAllocSpec(
+                "token_map", (dynamic_rows_padded,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "token_weights", (dynamic_rows_padded,), torch.float32, init="zeros"
+            ),
+            _TensorAllocSpec("route_output", (route_output_rows, int(k)), dtype),
+            _TensorAllocSpec(
+                "materialized_intermediate",
+                (materialized_intermediate_rows, int(k)),
+                dtype,
+            ),
+            _TensorAllocSpec("packed_input", packed_input_shape, packed_input_dtype),
+            _TensorAllocSpec(
+                "packed_input_scale", (dynamic_scale_rows, cols_pad_k), torch.uint8
+            ),
+            _TensorAllocSpec(
+                "expert_write_rows", (state_E,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "expert_tile_base", (state_E + 1,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec("input_gs", (weight_E,), torch.float32),
+            _TensorAllocSpec("down_input_scale", (weight_E,), torch.float32),
+            _TensorAllocSpec("pair_head", (1,), torch.int32, init="zeros"),
+            _TensorAllocSpec("producers_done_count", (1,), torch.int32, init="zeros"),
+            _TensorAllocSpec("all_work_published", (1,), torch.int32, init="zeros"),
+            _TensorAllocSpec("task_head", (1,), torch.int32, init="zeros"),
+            _TensorAllocSpec("task_tail", (1,), torch.int32, init="zeros"),
+            _TensorAllocSpec(
+                "task_ready", (dynamic_max_tasks,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "task_expert", (dynamic_max_tasks,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "task_m_tile", (dynamic_max_tasks,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "task_slice_begin", (dynamic_max_tasks,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "task_slice_count", (dynamic_max_tasks,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "task_valid_rows", (dynamic_max_tasks,), torch.int32, init="zeros"
+            ),
+            _TensorAllocSpec(
+                "tile_write_count", (dynamic_tiles,), torch.int32, init="zeros"
+            ),
+        ),
+    )
+
+
+def _allocate_arena_tensor(
+    shared_arena: torch.Tensor,
+    offset: int,
+    spec: _TensorAllocSpec,
+    *,
+    do_init: bool = True,
+) -> tuple[torch.Tensor, int]:
+    alignment = max(16, _dtype_nbytes(spec.dtype))
+    offset = align_up(offset, alignment)
+    nbytes = _tensor_numel(spec.shape) * _dtype_nbytes(spec.dtype)
+    storage = shared_arena.narrow(0, offset, nbytes)
+    if spec.dtype == torch.uint8:
+        tensor = storage.view(spec.shape)
+    else:
+        tensor = storage.view(spec.dtype).view(spec.shape)
+    # The vLLM eager-bind path passes do_init=False: a binding must only MAP
+    # caller-owned scratch into views and must never write/allocate (any
+    # allocation -- e.g. the init="arange" temp -- is illegal under CUDA graph
+    # capture). Per-call state is instead owned by the kernel: the persistent MoE
+    # kernel zeros its counters/queues in its Phase-0 prologue and writes
+    # weight_expert_ids/token_map write-first, and the launch wrapper re-zeros the
+    # read-before-write barrier scalars in-place (gated on volatile_launch_state).
+    # The sglang workspace/pool path keeps do_init=True (one-time, pre-capture).
+    if do_init:
+        if spec.init == "zeros":
+            tensor.zero_()
+        elif spec.init == "arange":
+            tensor.copy_(
+                torch.arange(
+                    tensor.numel(), dtype=tensor.dtype, device=tensor.device
+                ).view(spec.shape)
+            )
+        elif spec.init != "empty":
+            raise ValueError(f"unsupported tensor init mode {spec.init!r}")
+    return tensor, offset + nbytes
+
+
+def _core_workspace_nbytes(plan: _TPCoreWorkspacePlan) -> int:
+    arena_nbytes = 0
+    for spec in plan.tensor_specs:
+        arena_nbytes = align_up(arena_nbytes, max(16, _dtype_nbytes(spec.dtype)))
+        arena_nbytes += _tensor_numel(spec.shape) * _dtype_nbytes(spec.dtype)
+    return int(arena_nbytes)
+
+
+def _emit_core_workspace_stats(
+    plan: _TPCoreWorkspacePlan,
+    *,
+    storage: str,
+    required_nbytes: int,
+    capacity_nbytes: int | None = None,
+) -> None:
+    return
+
+
+def _map_core_workspace_views(
+    plan: _TPCoreWorkspacePlan,
+    shared_arena: torch.Tensor,
+    *,
+    offset_bytes: int = 0,
+    capacity_nbytes: int | None = None,
+    do_init: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Map caller-owned scratch into the per-spec kernel-arg views (no arena/workspace
+    object). With do_init=False this is the vLLM eager-bind primitive: pure
+    narrow()+view() at computed offsets, zero allocation, zero init writes."""
+    arena_nbytes = _core_workspace_nbytes(plan)
+    offset_bytes = int(offset_bytes)
+    if capacity_nbytes is None:
+        capacity_nbytes = shared_arena.numel() - offset_bytes
+    if capacity_nbytes < arena_nbytes:
+        raise ValueError(
+            f"MoE core arena requires {arena_nbytes} bytes, but only {capacity_nbytes} are available"
+        )
+    relative_offset = 0
+    tensors: Dict[str, torch.Tensor] = {}
+    for spec in plan.tensor_specs:
+        tensor, absolute_next = _allocate_arena_tensor(
+            shared_arena,
+            offset_bytes + relative_offset,
+            spec,
+            do_init=do_init,
+        )
+        tensors[spec.name] = tensor
+        relative_offset = absolute_next - offset_bytes
+    return tensors
+
+
+def _materialize_core_arena(
+    plan: _TPCoreWorkspacePlan,
+    shared_arena: torch.Tensor,
+    *,
+    offset_bytes: int = 0,
+    capacity_nbytes: int | None = None,
+) -> _TPCoreArena:
+    # SGLANG workspace/arena materialization (one-time, pre-capture; init writes
+    # allowed). The vLLM eager bind path must NEVER call this -- it maps views via
+    # _map_core_workspace_views and builds the binding directly, never owning or
+    # constructing a workspace/arena object.
+    tensors = _map_core_workspace_views(
+        plan,
+        shared_arena,
+        offset_bytes=offset_bytes,
+        capacity_nbytes=capacity_nbytes,
+        do_init=True,
+    )
+    return _TPCoreArena(plan=plan, shared_arena=shared_arena, tensors=tensors)
+
+
+def _allocate_core_arena(plan: _TPCoreWorkspacePlan) -> _TPCoreArena:
+    arena_nbytes = _core_workspace_nbytes(plan)
+    shared_arena = torch.empty(
+        arena_nbytes,
+        dtype=torch.uint8,
+        device=plan.device,
+    )
+    arena = _materialize_core_arena(plan, shared_arena)
+    _emit_core_workspace_stats(
+        plan,
+        storage="standalone",
+        required_nbytes=arena_nbytes,
+    )
+    return arena
+
+
+def _materialize_workspace_from_core_arena(
+    plan: _TPCoreWorkspacePlan,
+    arena: _TPCoreArena,
+    *,
+    a1_gscale: torch.Tensor | None,
+    a2_gscale: torch.Tensor | None,
+    input_scales_static: bool,
+    volatile_launch_state: bool = False,
+) -> TPMoEWorkspace | TPW4A16Workspace:
+    tensors = arena.tensors
+    if plan.implementation == "w4a16":
+        return TPW4A16Workspace(
+            implementation=plan.implementation,
+            quant_mode=plan.quant_mode,
+            activation=plan.activation,
+            planned_swiglu_limit=plan.swiglu_limit,
+            planned_swiglu_alpha=plan.swiglu_alpha,
+            planned_swiglu_beta=plan.swiglu_beta,
+            state_E=plan.state_E,
+            weight_E=plan.weight_E,
+            max_rows=plan.max_rows,
+            k=plan.k,
+            n=plan.n,
+            num_topk=plan.num_topk,
+            device=plan.device,
+            dtype=plan.dtype,
+            routed_rows_capacity=plan.routed_rows,
+            intermediate_cache13=tensors["intermediate_cache13"],
+            intermediate_cache2=tensors["intermediate_cache2"],
+            fc1_c_tmp=tensors["fc1_c_tmp"],
+            fc2_c_tmp=tensors["fc2_c_tmp"],
+            packed_route_indices=tensors["packed_route_indices"],
+            block_expert_ids=tensors["block_expert_ids"],
+            packed_route_count=tensors["packed_route_count"],
+            expert_offsets=tensors["expert_offsets"],
+            volatile_launch_state=bool(volatile_launch_state),
+        )
+    if a1_gscale is None or a2_gscale is None:
+        raise ValueError("NVFP4 workspace materialization requires input scale tensors")
+
+    common_kwargs = dict(
+        implementation=plan.implementation,
+        quant_mode=plan.quant_mode,
+        state_E=plan.state_E,
+        weight_E=plan.weight_E,
+        max_rows=plan.max_rows,
+        k=plan.k,
+        n=plan.n,
+        num_topk=plan.num_topk,
+        device=plan.device,
+        dtype=plan.dtype,
+        row_counts=tensors["row_counts"],
+        barrier_count=tensors["barrier_count"],
+        barrier_epoch=tensors["barrier_epoch"],
+        volatile_launch_state=bool(volatile_launch_state),
+    )
+    if plan.implementation == "micro":
+        workspace = TPMicroWorkspace(
+            **common_kwargs,
+            routed_rows_capacity=plan.routed_rows,
+            token_map=tensors["token_map"],
+            token_weights=tensors["token_weights"],
+            packed_input=tensors["packed_input"],
+            packed_input_scale=tensors["packed_input_scale"],
+            active_expert_count=tensors["active_expert_count"],
+            weight_expert_ids=tensors["weight_expert_ids"],
+            global_to_local_expert=tensors["global_to_local_expert"],
+            compact_topk_ids=tensors["compact_topk_ids"],
+            micro_intermediate=tensors["micro_intermediate"],
+        )
+        _finalize_workspace_views(workspace)
+        return workspace
+
+    assert plan.dynamic_physical_tiles is not None
+    assert plan.dynamic_task_capacity is not None
+    workspace = TPDynamicWorkspace(
+        **common_kwargs,
+        routed_rows_capacity=plan.routed_rows,
+        physical_tiles_capacity=plan.dynamic_physical_tiles,
+        task_capacity=plan.dynamic_task_capacity,
+        route_output=tensors["route_output"],
+        materialized_intermediate=tensors["materialized_intermediate"],
+        token_map=tensors["token_map"],
+        token_weights=tensors["token_weights"],
+        packed_input=tensors["packed_input"],
+        packed_input_scale=tensors["packed_input_scale"],
+        expert_write_rows=tensors["expert_write_rows"],
+        expert_tile_base=tensors["expert_tile_base"],
+        input_gs=tensors["input_gs"],
+        down_input_scale=tensors["down_input_scale"],
+        pair_head=tensors["pair_head"],
+        producers_done_count=tensors["producers_done_count"],
+        all_work_published=tensors["all_work_published"],
+        task_head=tensors["task_head"],
+        task_tail=tensors["task_tail"],
+        task_ready=tensors["task_ready"],
+        task_expert=tensors["task_expert"],
+        task_m_tile=tensors["task_m_tile"],
+        task_slice_begin=tensors["task_slice_begin"],
+        task_slice_count=tensors["task_slice_count"],
+        task_valid_rows=tensors["task_valid_rows"],
+        tile_write_count=tensors["tile_write_count"],
+    )
+    _refresh_dynamic_workspace_scales(
+        workspace,
+        a1_gscale,
+        a2_gscale,
+        input_scales_static=input_scales_static,
+        force=volatile_launch_state,
+    )
+    _finalize_workspace_views(workspace)
+    return workspace
+
+
+def _alloc_workspace(
+    implementation: str,
+    quant_mode: str,
+    state_E: int,
+    weight_E: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    *,
+    routed_rows: int,
+    max_rows: int,
+    input_scales_static: bool,
+    deterministic_output: bool = False,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    dynamic_physical_tiles: int | None = None,
+    dynamic_task_capacity: int | None = None,
+    pool: TPMoEWorkspacePool | None = None,
+    storage_key: tuple | None = None,
+) -> TPMoEWorkspace | TPW4A16Workspace:
+    plan = _plan_core_workspace(
+        implementation,
+        quant_mode,
+        state_E,
+        weight_E,
+        k,
+        n,
+        num_topk,
+        device,
+        dtype,
+        routed_rows=routed_rows,
+        max_rows=max_rows,
+        deterministic_output=deterministic_output,
+        activation=activation,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        dynamic_physical_tiles=dynamic_physical_tiles,
+        dynamic_task_capacity=dynamic_task_capacity,
+    )
+    if pool is not None:
+        if storage_key is None:
+            raise ValueError(
+                "storage_key is required when allocating from a workspace pool"
+            )
+        arena = pool.core_arenas.get(storage_key)
+        if arena is None or arena.plan != plan:
+            if pool.shared_arena is None:
+                arena = _allocate_core_arena(plan)
+            else:
+                if pool.shared_arena.device != plan.device:
+                    raise ValueError(
+                        f"MoE pool arena device {pool.shared_arena.device} does not match plan device {plan.device}"
+                    )
+                arena = _materialize_core_arena(
+                    plan,
+                    pool.shared_arena,
+                    offset_bytes=pool.core_arena_offset_bytes,
+                    capacity_nbytes=pool.core_arena_nbytes,
+                )
+                _emit_core_workspace_stats(
+                    plan,
+                    storage="shared",
+                    required_nbytes=_core_workspace_nbytes(plan),
+                    capacity_nbytes=pool.core_arena_nbytes,
+                )
+            pool.core_arenas[storage_key] = arena
+    else:
+        arena = _allocate_core_arena(plan)
+    return _materialize_workspace_from_core_arena(
+        plan,
+        arena,
+        a1_gscale=a1_gscale,
+        a2_gscale=a2_gscale,
+        input_scales_static=input_scales_static,
+        volatile_launch_state=bool(pool is not None and pool.shared_arena is not None),
+    )
+
+
+def _unswizzle_block_scales_batched(
+    swizzled_u8: torch.Tensor, rows: int, cols_blocks: int
+) -> torch.Tensor:
+    """Invert the FlashInfer vec16 scale swizzle for a stack of experts.
+
+    Batched equivalent of ``reference.unswizzle_block_scale``; returns f32
+    ``[E, rows, cols_blocks]``.
+    """
+    E = swizzled_u8.shape[0]
+    rows_pad = align_up(rows, 128)
+    cols_pad = align_up(cols_blocks, 4)
+    s = swizzled_u8.reshape(E, rows_pad // 128, cols_pad // 4, 32, 4, 4)
+    s = s.permute(0, 1, 4, 3, 2, 5).reshape(E, rows_pad, cols_pad)
+    return s[:, :rows, :cols_blocks].view(torch.float8_e4m3fn).to(torch.float32)
+
+
+def _derive_w4a8_weight_grids(
+    blockscale_u8: torch.Tensor, rows: int, k_dim: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """NVFP4 checkpoint scales -> (UE8M0 K/32 grid, E4M3 residual grid)."""
+    from flashinfer.experimental.sm12x.moe._shared.kernels.reference import (
+        decompose_nvfp4_scales_to_mx_residual,
+    )
+
+    scales = _unswizzle_block_scales_batched(blockscale_u8, rows, k_dim // 16)
+    ue8m0, residual = decompose_nvfp4_scales_to_mx_residual(scales)
+    return ue8m0.contiguous(), residual.view(torch.uint8).contiguous()
+
+
+def _as_e8m0_k32_grid(
+    scales: torch.Tensor, rows: int, k_dim: int, *, name: str
+) -> torch.Tensor:
+    """Validate a checkpoint-native per-K/32 E8M0 grid for w4a8_mx."""
+    if scales.dtype not in (torch.uint8, torch.float8_e8m0fnu):
+        raise ValueError(
+            f"{name} must be E8M0 bytes (uint8/float8_e8m0fnu) for w4a8_mx, "
+            f"got {scales.dtype}"
+        )
+    grid = scales.view(torch.uint8)
+    # Already-prepared ceil-tiled sfb views arrive with padded extents
+    # (rows to 256-tiles, K to 128-tiles); logical grids arrive unpadded.
+    rows_pad = -(-rows // 256) * 256
+    cols = k_dim // 32
+    cols_pad = (-(-k_dim // 128) * 128) // 32
+    expected = (int(grid.shape[0]), rows, cols)
+    expected_pad = (int(grid.shape[0]), rows_pad, cols_pad)
+    if grid.dim() != 3 or tuple(grid.shape) not in (expected, expected_pad):
+        raise ValueError(
+            f"{name} must be [E, rows, K//32] = {expected} (or the ceil-tiled "
+            f"{expected_pad}) for w4a8_mx, got {tuple(grid.shape)}"
+        )
+    return grid.contiguous()
+
+
+def _w4a8_rp_shape(size_n: int, size_k: int) -> tuple[int, int, int, int, int, int]:
+    size_n = int(size_n)
+    size_k = int(size_k)
+    if size_n % 8 != 0 or size_k % 32 != 0:
+        raise ValueError(
+            "W4A8 weight repack requires N multiple of 8 and K "
+            f"multiple of 32; got N={size_n}, K={size_k}"
+        )
+    # Ceil-tiled: shards that 256/128 tiles don't divide (e.g. 2048/TP6 = 352)
+    # store zero-filled tail tiles so the fixed 4096-word tile addressing
+    # stays uniform; kernels bound their reads by the logical sizes.
+    return (-(-size_n // 256), -(-size_k // 128), 4, 8, 32, 4)
+
+
+def _w4a8_sfb_shape(size_n: int, size_k: int) -> tuple[int, int, int, int]:
+    size_n = int(size_n)
+    size_k = int(size_k)
+    if size_n % 8 != 0 or size_k % 32 != 0:
+        raise ValueError(
+            "W4A8 scale repack requires N multiple of 8 and K "
+            f"multiple of 32; got N={size_n}, K={size_k}"
+        )
+    return (-(-size_n // 256), -(-size_k // 128), 32, 8)
+
+
+def _w4a16_packed_weight_shape(size_k: int, size_n: int) -> tuple[int, int]:
+    size_k = int(size_k)
+    size_n = int(size_n)
+    if size_k % 16 != 0 or size_n % 64 != 0:
+        raise ValueError(
+            f"W4A16 packed weights require K,N multiples of 16,64; got "
+            f"K={size_k}, N={size_n}"
+        )
+    return (size_k // 16, (size_n // 64) * 128)
+
+
+@triton.jit
+def _w4a16_packed_to_qweight_kernel(
+    src,
+    q,
+    total_programs: tl.constexpr,
+    k_tiles: tl.constexpr,
+    n_tiles: tl.constexpr,
+    q_cols: tl.constexpr,
+    src_expert_stride: tl.constexpr,
+    q_expert_stride: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if pid >= total_programs:
+        return
+    tile = pid
+    expert = tile // (k_tiles * n_tiles)
+    rem = tile - expert * (k_tiles * n_tiles)
+    kt = rem // n_tiles
+    nt = rem - kt * n_tiles
+    offs = tl.arange(0, 128)
+    source_half = offs // 64
+    source_row = offs - source_half * 64
+    warp_id = source_row // 16
+    col_in_warp = source_row - warp_id * 16
+    col_group = col_in_warp // 8
+    tc_col = col_in_warp - col_group * 8
+    slot_base = col_group * 2 + source_half
+
+    values = tl.zeros((128,), tl.int32)
+    for row_pair in range(4):
+        th_id = tc_col * 4 + row_pair
+        source_lane = th_id * 4 + warp_id
+        word = tl.load(
+            src
+            + expert * src_expert_stride
+            + kt * (n_tiles * 128)
+            + nt * 128
+            + source_lane
+        )
+        low = (word >> (slot_base * 4)) & 0xF
+        high = (word >> ((slot_base + 4) * 4)) & 0xF
+        values |= low << (row_pair * 8)
+        values |= high << (row_pair * 8 + 4)
+
+    q_base = expert * q_expert_stride + (nt * 64 + source_row) * q_cols
+    tl.store(q + q_base + kt * 2 + source_half, values)
+
+
+@triton.jit
+def _qweight_to_w4a8_rp_kernel(
+    q,
+    dst,
+    total_programs: tl.constexpr,
+    n_tiles_256: tl.constexpr,
+    k_tiles_128: tl.constexpr,
+    q_cols: tl.constexpr,
+    rows: tl.constexpr,
+    q_expert_stride: tl.constexpr,
+    dst_expert_stride: tl.constexpr,
+    row_rotation: tl.constexpr,
+    half_rows: tl.constexpr,
+    half_rows_pad: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if pid >= total_programs:
+        return
+    block_in_tile = pid % tl.cdiv(4096, BLOCK)
+    tile = pid // tl.cdiv(4096, BLOCK)
+    expert = tile // (n_tiles_256 * k_tiles_128)
+    rem = tile - expert * (n_tiles_256 * k_tiles_128)
+    nt = rem // k_tiles_128
+    kt = rem - nt * k_tiles_128
+    idx = block_in_tile * BLOCK + tl.arange(0, BLOCK)
+    mask = idx < 4096
+
+    n8i = idx & 3
+    tmp = idx >> 2
+    combined = tmp & 31
+    cgrp = combined & 3
+    r8 = combined >> 2
+    tmp = tmp >> 5
+    n8c = tmp & 7
+    k32 = tmp >> 3
+
+    row = n8c * 32 + n8i * 8 + r8
+    dst_row = nt * 256 + row
+    src_col = kt * 16 + k32 * 4 + cgrp
+    if half_rows_pad > 0:
+        # Gated W13 with a ceil-tiled half: dst rows [0, half_pad) hold the
+        # up half, [half_pad, 2*half_pad) the gate half, each zero-padded to
+        # a 128-row boundary so the dynamic kernel's per-128-tile up/gate
+        # pairing stays aligned. `row_rotation` here is the SOURCE row of the
+        # up half (n for w31 sources, 0 for w13); the other half starts at
+        # (rotation + half) % (2*half).
+        is_gate = dst_row >= half_rows_pad
+        half_dst = dst_row - tl.where(is_gate, half_rows_pad, 0)
+        half_src_base = row_rotation + tl.where(is_gate, half_rows, 0)
+        half_src_base = tl.where(
+            half_src_base >= 2 * half_rows,
+            half_src_base - 2 * half_rows,
+            half_src_base,
+        )
+        src_row = half_src_base + half_dst
+        in_bounds = (
+            (dst_row < 2 * half_rows_pad) & (half_dst < half_rows) & (src_col < q_cols)
+        )
+    else:
+        src_row = dst_row + row_rotation
+        src_row = tl.where(src_row >= rows, src_row - rows, src_row)
+        # Tail tiles: positions past the logical N/K read as zero (FP4 zero
+        # rows and columns), keeping the fixed tile addressing uniform.
+        in_bounds = (dst_row < rows) & (src_col < q_cols)
+    src_row = tl.where(in_bounds, src_row, 0)
+    src_col = tl.where(in_bounds, src_col, 0)
+    values = tl.load(
+        q + expert * q_expert_stride + src_row * q_cols + src_col,
+        mask=mask & in_bounds,
+        other=0,
+    )
+    values = tl.where(in_bounds, values, 0)
+    dst_base = expert * dst_expert_stride + (nt * k_tiles_128 + kt) * 4096
+    tl.store(dst + dst_base + idx, values, mask=mask)
+
+
+@triton.jit
+def _e8m0_scale_to_grid_kernel(
+    scale,
+    grid,
+    total_elements: tl.constexpr,
+    rows: tl.constexpr,
+    scale_cols: tl.constexpr,
+    rows_pad: tl.constexpr,
+    scale_expert_stride: tl.constexpr,
+    grid_expert_stride: tl.constexpr,
+    source_is_logical: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    idx = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = idx < total_elements
+    expert = idx // (rows * scale_cols)
+    rem = idx - expert * (rows * scale_cols)
+    row = rem // scale_cols
+    col = rem - row * scale_cols
+
+    if source_is_logical:
+        src_off = expert * scale_expert_stride + row * scale_cols + col
+    else:
+        perm = (row % 8) * 8 + (row // 8) % 8
+        pre_row = (row // 64) * 64 + perm
+        flat = col * rows_pad + pre_row
+        group4 = flat // 4
+        byte = flat - group4 * 4
+        src_byte = tl.where(byte == 1, 2, tl.where(byte == 2, 1, byte))
+        src_off = expert * scale_expert_stride + group4 * 4 + src_byte
+    values = tl.load(scale + src_off, mask=mask, other=0)
+    values = tl.minimum(values, 247)
+    tl.store(
+        grid + expert * grid_expert_stride + row * scale_cols + col,
+        values,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _grid_to_w4a8_sfb_kernel(
+    grid,
+    dst,
+    total_elements: tl.constexpr,
+    rows: tl.constexpr,
+    scale_cols: tl.constexpr,
+    n_tiles_256: tl.constexpr,
+    k_tiles_128: tl.constexpr,
+    grid_expert_stride: tl.constexpr,
+    dst_expert_stride: tl.constexpr,
+    row_rotation: tl.constexpr,
+    half_rows: tl.constexpr,
+    half_rows_pad: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    idx = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = idx < total_elements
+    expert = idx // dst_expert_stride
+    local = idx - expert * dst_expert_stride
+
+    kb = local & 3
+    tmp = local >> 2
+    row8 = tmp & 7
+    tmp = tmp >> 3
+    n32 = tmp & 31
+    tmp = tmp >> 5
+    kt = tmp % k_tiles_128
+    nt = tmp // k_tiles_128
+
+    dst_row = nt * 256 + n32 * 8 + row8
+    col = kt * 4 + kb
+    if half_rows_pad > 0:
+        # Same half-aligned mapping as the weight repack (see
+        # _qweight_to_w4a8_rp_kernel).
+        is_gate = dst_row >= half_rows_pad
+        half_dst = dst_row - tl.where(is_gate, half_rows_pad, 0)
+        half_src_base = row_rotation + tl.where(is_gate, half_rows, 0)
+        half_src_base = tl.where(
+            half_src_base >= 2 * half_rows,
+            half_src_base - 2 * half_rows,
+            half_src_base,
+        )
+        row = half_src_base + half_dst
+        in_bounds = (
+            (dst_row < 2 * half_rows_pad) & (half_dst < half_rows) & (col < scale_cols)
+        )
+    else:
+        row = dst_row + row_rotation
+        row = tl.where(row >= rows, row - rows, row)
+        # Tail tiles: scale bytes past the logical grid are zero (2^-127
+        # scale on already-zero FP4 weights).
+        in_bounds = (dst_row < rows) & (col < scale_cols)
+    row = tl.where(in_bounds, row, 0)
+    col = tl.where(in_bounds, col, 0)
+    values = tl.load(
+        grid + expert * grid_expert_stride + row * scale_cols + col,
+        mask=mask & in_bounds,
+        other=0,
+    )
+    values = tl.where(in_bounds, values, 0)
+    tl.store(dst + expert * dst_expert_stride + local, values, mask=mask)
+
+
+def _w4a8_convert_scratch_nbytes() -> int:
+    raw = os.environ.get(_W4A8_CONVERT_SCRATCH_MB_ENV)
+    mb = _W4A8_CONVERT_SCRATCH_MB_DEFAULT
+    if raw is not None and raw.strip():
+        mb = max(1, int(raw))
+    return int(mb) << 20
+
+
+def _w4a8_convert_chunk_experts(
+    *,
+    weight_E: int,
+    scratch_elements_per_expert: int,
+    dtype: torch.dtype,
+) -> int:
+    per_expert = max(1, int(scratch_elements_per_expert)) * _dtype_nbytes(dtype)
+    chunk = _w4a8_convert_scratch_nbytes() // per_expert
+    return max(1, min(int(weight_E), int(chunk)))
+
+
+def _decode_w4a16_packed_expert_to_qweight(
+    packed_expert: torch.Tensor,
+    q_scratch: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+) -> None:
+    """Decode one W4A16-packed expert into a caller-owned qweight scratch."""
+    packed = packed_expert.view(torch.int32)
+    size_k = int(size_k)
+    size_n = int(size_n)
+    k_tiles = size_k // 16
+    n_tiles = size_n // 64
+    if tuple(packed.shape) != (k_tiles, n_tiles * 128):
+        raise ValueError(
+            f"packed expert must be {(k_tiles, n_tiles * 128)}, "
+            f"got {tuple(packed.shape)}"
+        )
+    if q_scratch.dtype != torch.int32 or tuple(q_scratch.shape) != (
+        size_n,
+        size_k // 8,
+    ):
+        raise ValueError(
+            f"q_scratch must be int32 {(size_n, size_k // 8)}, "
+            f"got {q_scratch.dtype} {tuple(q_scratch.shape)}"
+        )
+
+    src = packed.reshape(k_tiles, n_tiles, 128)
+    out_pos = torch.arange(128, device=packed.device, dtype=torch.long)
+    th_id = out_pos // 4
+    warp_id = out_pos % 4
+    tc_col = th_id // 4
+    tc_row = (th_id % 4) * 2
+    offsets = torch.tensor([0, 1, 8, 9], device=packed.device, dtype=torch.long)
+    pack_idx = torch.tensor(
+        [0, 2, 4, 6, 1, 3, 5, 7],
+        device=packed.device,
+        dtype=torch.long,
+    )
+    elem = tc_row[:, None] + offsets[None, :]
+    row = elem // 8
+    pos = elem % 8
+    col1 = (warp_id * 16 + tc_col)[:, None].expand(-1, 4)
+    col2 = col1 + 8
+    source_index = torch.cat(
+        [row * 64 + col1, row * 64 + col2],
+        dim=1,
+    )[:, pack_idx]
+    source_shift = (torch.cat([pos, pos], dim=1)[:, pack_idx] * 4).to(torch.int32)
+    source_half = source_index // 64
+    source_col = source_index % 64
+
+    for kt in range(k_tiles):
+        cols = q_scratch[:, kt * 2 : (kt + 1) * 2]
+        cols.zero_()
+        cols_view = cols.view(n_tiles, 64, 2)
+        src_tile = src[kt]
+        for slot in range(8):
+            values = ((src_tile >> (slot * 4)) & 0xF) << source_shift[:, slot].view(
+                1, 128
+            )
+            values = values.to(torch.int32)
+            for half in (0, 1):
+                mask = source_half[:, slot] == half
+                idx = (
+                    source_col[:, slot][mask]
+                    .view(1, -1)
+                    .expand(
+                        n_tiles,
+                        -1,
+                    )
+                )
+                cols_view[:, :, half].scatter_add_(1, idx, values[:, mask])
+
+
+def _copy_qweight_to_w4a8_rp_inplace(
+    dst: torch.Tensor,
+    qweight: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    row_rotation: int | None = None,
+) -> None:
+    size_k = int(size_k)
+    size_n = int(size_n)
+    nt = size_n // 256
+    kt = size_k // 128
+    if dst.dtype != torch.int32 or tuple(dst.shape) != _w4a8_rp_shape(size_n, size_k):
+        raise ValueError(
+            f"dst must be W4A8 rp int32 {_w4a8_rp_shape(size_n, size_k)}, "
+            f"got {dst.dtype} {tuple(dst.shape)}"
+        )
+    if qweight.dtype != torch.int32 or tuple(qweight.shape) != (size_n, size_k // 8):
+        raise ValueError(
+            f"qweight must be int32 {(size_n, size_k // 8)}, "
+            f"got {qweight.dtype} {tuple(qweight.shape)}"
+        )
+    rotation = 0 if row_rotation is None else int(row_rotation)
+    if rotation < 0 or rotation >= size_n:
+        raise ValueError(f"row_rotation={rotation} is invalid for N={size_n}")
+
+    dst_view = dst.view(nt, kt, 4, 8, 8, 4, 4)
+    wrap_tmp: torch.Tensor | None = None
+    for n_tile in range(nt):
+        src_start = (n_tile * 256 + rotation) % size_n
+        if src_start + 256 <= size_n:
+            block = qweight[src_start : src_start + 256]
+        else:
+            if wrap_tmp is None:
+                wrap_tmp = torch.empty(
+                    (256, size_k // 8),
+                    dtype=qweight.dtype,
+                    device=qweight.device,
+                )
+            first = size_n - src_start
+            wrap_tmp[:first].copy_(qweight[src_start:])
+            wrap_tmp[first:].copy_(qweight[: 256 - first])
+            block = wrap_tmp
+        src = block.reshape(8, 4, 8, kt, 4, 4).permute(3, 4, 0, 2, 5, 1)
+        dst_view[n_tile].copy_(src)
+
+
+def _logical_weight_to_w4a8_rp_inplace(
+    weight: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    row_rotation: int | None = None,
+    gated_half_rows: int | None = None,
+) -> torch.Tensor:
+    size_k = int(size_k)
+    size_n = int(size_n)
+    if weight.dtype != torch.uint8 or tuple(weight.shape[1:]) != (
+        size_n,
+        size_k // 2,
+    ):
+        raise ValueError(
+            f"logical FP4 weight must be uint8 [E, {size_n}, {size_k // 2}], "
+            f"got {weight.dtype} {tuple(weight.shape)}"
+        )
+    rp_shape = _w4a8_rp_shape(size_n, size_k)
+    n_tiles = -(-size_n // 256)
+    k_tiles = -(-size_k // 128)
+    rp_words = _tensor_numel(rp_shape)
+    has_tail = rp_words != size_n * (size_k // 8)
+    # Gated W13 tails place each half's zero rows at a 128-row boundary so
+    # the dynamic kernel's per-tile up/gate pairing stays aligned. The
+    # interpretation of row_rotation shifts to "source row of the up half"
+    # (numerically identical for the aligned case).
+    half_rows = 0
+    half_rows_pad = 0
+    if has_tail and gated_half_rows is not None:
+        half_rows = int(gated_half_rows)
+        half_rows_pad = -(-half_rows // 128) * 128
+        assert 2 * half_rows == size_n, (half_rows, size_n)
+        assert 2 * half_rows_pad == n_tiles * 256, (half_rows_pad, n_tiles)
+    if weight.is_cuda:
+        weight_E = int(weight.shape[0])
+        q_cols = size_k // 8
+        chunk = _w4a8_convert_chunk_experts(
+            weight_E=weight_E,
+            scratch_elements_per_expert=size_n * q_cols,
+            dtype=torch.int32,
+        )
+        block = 1024
+        row_rot = 0 if row_rotation is None else int(row_rotation)
+        weight_i32 = weight.view(torch.int32)
+        # Ceil-tiled tails don't fit the source storage; write a fresh
+        # destination and read the (never-aliased) source directly.
+        out_i32 = (
+            torch.empty((weight_E, rp_words), dtype=torch.int32, device=weight.device)
+            if has_tail
+            else None
+        )
+        dst_expert_stride = rp_words
+        blocks_per_tile = triton.cdiv(4096, block)
+        for e0 in range(0, weight_E, chunk):
+            e1 = min(weight_E, e0 + chunk)
+            if has_tail:
+                q_chunk = weight_i32[e0:e1].reshape(e1 - e0, size_n, q_cols)
+                dst_chunk = out_i32[e0:e1]
+            else:
+                q_chunk = torch.empty(
+                    (e1 - e0, size_n, q_cols),
+                    dtype=torch.int32,
+                    device=weight.device,
+                )
+                q_chunk.copy_(weight_i32[e0:e1].reshape(e1 - e0, size_n, q_cols))
+                dst_chunk = weight_i32[e0:e1]
+            total_programs = (e1 - e0) * n_tiles * k_tiles
+            total_programs *= blocks_per_tile
+            _qweight_to_w4a8_rp_kernel[(total_programs,)](
+                q_chunk,
+                dst_chunk,
+                total_programs,
+                n_tiles,
+                k_tiles,
+                q_cols,
+                size_n,
+                size_n * q_cols,
+                dst_expert_stride,
+                row_rot,
+                half_rows,
+                half_rows_pad,
+                BLOCK=block,
+                num_warps=4,
+            )
+        base = out_i32 if has_tail else weight_i32
+        return base.view(weight_E, *rp_shape)
+
+    if has_tail:
+        raise NotImplementedError(
+            "ceil-tiled W4A8 repack tails are CUDA-only; move the weights to "
+            f"a CUDA device (N={size_n}, K={size_k})"
+        )
+    q_scratch = torch.empty(
+        (size_n, size_k // 8),
+        dtype=torch.int32,
+        device=weight.device,
+    )
+    weight_i32 = weight.view(torch.int32)
+    for expert in range(int(weight.shape[0])):
+        q_scratch.copy_(weight_i32[expert].reshape(size_n, size_k // 8))
+        dst = weight_i32[expert].view(rp_shape)
+        _copy_qweight_to_w4a8_rp_inplace(
+            dst,
+            q_scratch,
+            size_k=size_k,
+            size_n=size_n,
+            row_rotation=row_rotation,
+        )
+    return weight_i32.view(int(weight.shape[0]), *rp_shape)
+
+
+def _packed_w4a16_weight_to_w4a8_rp_inplace(
+    packed_weight: torch.Tensor,
+    *,
+    size_k: int,
+    size_n: int,
+    row_rotation: int | None = None,
+) -> torch.Tensor:
+    size_k = int(size_k)
+    size_n = int(size_n)
+    packed = packed_weight.view(torch.int32)
+    packed_shape = _w4a16_packed_weight_shape(size_k, size_n)
+    if packed.dim() != 3 or tuple(packed.shape[1:]) != packed_shape:
+        raise ValueError(
+            f"W4A16 packed weight must be [E, {packed_shape[0]}, "
+            f"{packed_shape[1]}], got {tuple(packed.shape)}"
+        )
+    rp_shape = _w4a8_rp_shape(size_n, size_k)
+    if packed.is_cuda:
+        weight_E = int(packed.shape[0])
+        q_cols = size_k // 8
+        chunk = _w4a8_convert_chunk_experts(
+            weight_E=weight_E,
+            scratch_elements_per_expert=size_n * q_cols,
+            dtype=torch.int32,
+        )
+        block = 1024
+        row_rot = 0 if row_rotation is None else int(row_rotation)
+        src_expert_stride = _tensor_numel(packed_shape)
+        dst_expert_stride = _tensor_numel(rp_shape)
+        blocks_per_tile = triton.cdiv(4096, block)
+        for e0 in range(0, weight_E, chunk):
+            e1 = min(weight_E, e0 + chunk)
+            q_scratch = torch.empty(
+                (e1 - e0, size_n, q_cols),
+                dtype=torch.int32,
+                device=packed.device,
+            )
+            total_decode = (e1 - e0) * (size_k // 16) * (size_n // 64)
+            _w4a16_packed_to_qweight_kernel[(total_decode,)](
+                packed[e0:e1],
+                q_scratch,
+                total_decode,
+                size_k // 16,
+                size_n // 64,
+                q_cols,
+                src_expert_stride,
+                size_n * q_cols,
+                num_warps=4,
+            )
+            total_pack = (e1 - e0) * (size_n // 256) * (size_k // 128)
+            total_pack *= blocks_per_tile
+            _qweight_to_w4a8_rp_kernel[(total_pack,)](
+                q_scratch,
+                packed[e0:e1],
+                total_pack,
+                size_n // 256,
+                size_k // 128,
+                q_cols,
+                size_n,
+                size_n * q_cols,
+                dst_expert_stride,
+                row_rot,
+                BLOCK=block,
+                num_warps=4,
+            )
+        return packed.view(weight_E, *rp_shape)
+
+    q_scratch = torch.empty(
+        (size_n, size_k // 8),
+        dtype=torch.int32,
+        device=packed.device,
+    )
+    for expert in range(int(packed.shape[0])):
+        _decode_w4a16_packed_expert_to_qweight(
+            packed[expert],
+            q_scratch,
+            size_k=size_k,
+            size_n=size_n,
+        )
+        dst = packed[expert].view(rp_shape)
+        _copy_qweight_to_w4a8_rp_inplace(
+            dst,
+            q_scratch,
+            size_k=size_k,
+            size_n=size_n,
+            row_rotation=row_rotation,
+        )
+    return packed.view(int(packed.shape[0]), *rp_shape)
+
+
+def _recover_w4a16_e8m0_scale_expert(
+    scale: torch.Tensor,
+    grid_scratch: torch.Tensor,
+    *,
+    rows: int,
+    k_dim: int,
+) -> None:
+    rows = int(rows)
+    k_dim = int(k_dim)
+    scale_cols = k_dim // 32
+    packed = scale.view(torch.uint8)
+    if packed.dim() != 2 or int(packed.shape[0]) != scale_cols:
+        raise ValueError(
+            f"packed E8M0 scale expert must be [{scale_cols}, >= {rows}], "
+            f"got {tuple(packed.shape)}"
+        )
+    if int(packed.shape[1]) < rows or int(packed.shape[1]) % 64 != 0:
+        raise ValueError(
+            f"packed E8M0 scale expert second dim must be a multiple of 64 "
+            f"and >= {rows}, got {int(packed.shape[1])}"
+        )
+    if grid_scratch.dtype != torch.uint8 or tuple(grid_scratch.shape) != (
+        rows,
+        scale_cols,
+    ):
+        raise ValueError(
+            f"grid_scratch must be uint8 {(rows, scale_cols)}, "
+            f"got {grid_scratch.dtype} {tuple(grid_scratch.shape)}"
+        )
+
+    perm = torch.tensor(
+        [i + 8 * j for i in range(8) for j in range(8)],
+        dtype=torch.long,
+        device=packed.device,
+    )
+    inv_perm = torch.empty_like(perm)
+    inv_perm[perm] = torch.arange(64, dtype=torch.long, device=packed.device)
+
+    stage = torch.empty_like(packed)
+    stage.view(-1, 4).copy_(packed.view(-1, 4)[:, [0, 2, 1, 3]])
+    stage.copy_(stage.reshape(-1, 64)[:, inv_perm].reshape_as(stage))
+    grid_scratch.copy_(stage.transpose(0, 1)[:rows])
+
+
+def _copy_scale_grid_to_w4a8_sfb_inplace(
+    dst: torch.Tensor,
+    grid: torch.Tensor,
+    *,
+    rows: int,
+    k_dim: int,
+    row_rotation: int | None = None,
+) -> None:
+    rows = int(rows)
+    k_dim = int(k_dim)
+    nt = rows // 256
+    kt = k_dim // 128
+    if grid.dtype != torch.uint8 or tuple(grid.shape) != (rows, k_dim // 32):
+        raise ValueError(
+            f"scale grid must be uint8 {(rows, k_dim // 32)}, "
+            f"got {grid.dtype} {tuple(grid.shape)}"
+        )
+    dst_u8 = dst.view(torch.uint8).view(nt, kt, 32, 8, 4)
+    rotation = 0 if row_rotation is None else int(row_rotation)
+    if rotation < 0 or rotation >= rows:
+        raise ValueError(f"row_rotation={rotation} is invalid for rows={rows}")
+
+    wrap_tmp: torch.Tensor | None = None
+    for n_tile in range(nt):
+        src_start = (n_tile * 256 + rotation) % rows
+        if src_start + 256 <= rows:
+            block = grid[src_start : src_start + 256]
+        else:
+            if wrap_tmp is None:
+                wrap_tmp = torch.empty(
+                    (256, k_dim // 32),
+                    dtype=grid.dtype,
+                    device=grid.device,
+                )
+            first = rows - src_start
+            wrap_tmp[:first].copy_(grid[src_start:])
+            wrap_tmp[first:].copy_(grid[: 256 - first])
+            block = wrap_tmp
+        src = block.reshape(32, 8, kt, 4).permute(2, 0, 1, 3)
+        dst_u8[n_tile].copy_(src)
+
+
+def _e8m0_scale_to_w4a8_sfb_inplace(
+    scale: torch.Tensor,
+    *,
+    weight_E: int,
+    rows: int,
+    k_dim: int,
+    row_rotation: int | None = None,
+    gated_half_rows: int | None = None,
+) -> torch.Tensor:
+    weight_E = int(weight_E)
+    rows = int(rows)
+    k_dim = int(k_dim)
+    scale_cols = k_dim // 32
+    scale_u8 = scale.view(torch.uint8)
+    is_logical, is_packed = _validate_e8m0_scale_w4a8_convertible(
+        scale_u8,
+        weight_E=weight_E,
+        rows=rows,
+        k_dim=k_dim,
+    )
+    sfb_shape = _w4a8_sfb_shape(rows, k_dim)
+    n_tiles = -(-rows // 256)
+    k_tiles = -(-k_dim // 128)
+    sfb_bytes = _tensor_numel(sfb_shape) * 4
+    has_tail = sfb_bytes != rows * (k_dim // 32)
+    half_rows = 0
+    half_rows_pad = 0
+    if has_tail and gated_half_rows is not None:
+        half_rows = int(gated_half_rows)
+        half_rows_pad = -(-half_rows // 128) * 128
+        assert 2 * half_rows == rows, (half_rows, rows)
+    if scale.is_cuda:
+        scale_cols = k_dim // 32
+        rows_pad = rows if is_logical else int(scale_u8.shape[2])
+        if rows_pad != rows:
+            raise ValueError(
+                "W4A8 in-place scale conversion requires unpadded E8M0 "
+                f"scale storage; got rows={rows}, rows_pad={rows_pad}"
+            )
+        chunk = _w4a8_convert_chunk_experts(
+            weight_E=weight_E,
+            scratch_elements_per_expert=rows * scale_cols,
+            dtype=torch.uint8,
+        )
+        block = 256
+        row_rot = 0 if row_rotation is None else int(row_rotation)
+        total_per_expert = rows * scale_cols
+        source_stride = rows * scale_cols if is_logical else scale_cols * rows_pad
+        # Ceil-tiled tails don't fit the source storage in place.
+        out_u8 = (
+            torch.empty((weight_E, sfb_bytes), dtype=torch.uint8, device=scale.device)
+            if has_tail
+            else None
+        )
+        for e0 in range(0, weight_E, chunk):
+            e1 = min(weight_E, e0 + chunk)
+            chunk_experts = e1 - e0
+            grid_scratch = torch.empty(
+                (chunk_experts, rows, scale_cols),
+                dtype=torch.uint8,
+                device=scale.device,
+            )
+            total = chunk_experts * total_per_expert
+            _e8m0_scale_to_grid_kernel[(triton.cdiv(total, block),)](
+                scale_u8[e0:e1],
+                grid_scratch,
+                total,
+                rows,
+                scale_cols,
+                rows_pad,
+                source_stride,
+                total_per_expert,
+                is_logical,
+                BLOCK=block,
+                num_warps=4,
+            )
+            dst_chunk = out_u8[e0:e1] if has_tail else scale_u8[e0:e1]
+            total_sfb = chunk_experts * sfb_bytes
+            _grid_to_w4a8_sfb_kernel[(triton.cdiv(total_sfb, block),)](
+                grid_scratch,
+                dst_chunk,
+                total_sfb,
+                rows,
+                scale_cols,
+                n_tiles,
+                k_tiles,
+                total_per_expert,
+                sfb_bytes,
+                row_rot,
+                half_rows,
+                half_rows_pad,
+                BLOCK=block,
+                num_warps=4,
+            )
+        base = out_u8 if has_tail else scale_u8
+        return base.view(torch.int32).view(weight_E, *sfb_shape)
+
+    if has_tail:
+        raise NotImplementedError(
+            "ceil-tiled W4A8 scale tails are CUDA-only; move the scales to "
+            f"a CUDA device (rows={rows}, K={k_dim})"
+        )
+    grid_scratch = torch.empty(
+        (rows, scale_cols),
+        dtype=torch.uint8,
+        device=scale.device,
+    )
+    for expert in range(weight_E):
+        if is_logical:
+            grid_scratch.copy_(scale_u8[expert])
+            grid_scratch.clamp_(max=247)
+        else:
+            _recover_w4a16_e8m0_scale_expert(
+                scale_u8[expert],
+                grid_scratch,
+                rows=rows,
+                k_dim=k_dim,
+            )
+        dst = scale_u8[expert].view(torch.int32).view(sfb_shape)
+        _copy_scale_grid_to_w4a8_sfb_inplace(
+            dst,
+            grid_scratch,
+            rows=rows,
+            k_dim=k_dim,
+            row_rotation=row_rotation,
+        )
+    return scale_u8.view(torch.int32).view(weight_E, *sfb_shape)
+
+
+def _validate_e8m0_scale_w4a8_convertible(
+    scale_u8: torch.Tensor,
+    *,
+    weight_E: int,
+    rows: int,
+    k_dim: int,
+) -> tuple[bool, bool]:
+    weight_E = int(weight_E)
+    rows = int(rows)
+    k_dim = int(k_dim)
+    scale_cols = k_dim // 32
+    logical_shape = (weight_E, rows, scale_cols)
+    packed_shape = (weight_E, scale_cols)
+    is_logical = scale_u8.dim() == 3 and tuple(scale_u8.shape) == logical_shape
+    is_packed = (
+        scale_u8.dim() == 3
+        and tuple(scale_u8.shape[:2]) == packed_shape
+        and int(scale_u8.shape[2]) >= rows
+        and int(scale_u8.shape[2]) % 64 == 0
+    )
+    if not is_logical and not is_packed:
+        raise ValueError(
+            "E8M0 scale must be logical [E, rows, K//32] or W4A16 packed "
+            f"[E, K//32, rows_pad]; got {tuple(scale_u8.shape)}"
+        )
+    _w4a8_sfb_shape(rows, k_dim)
+    return is_logical, is_packed
+
+
+def _swap_w13_scale_halves_inplace(
+    blockscale: torch.Tensor, *, rows: int, cols_blocks: int
+) -> None:
+    """Swap the FC1 half blocks of a FlashInfer vec16-swizzled scale stack."""
+    u8 = blockscale.view(torch.uint8)
+    E = u8.shape[0]
+    rows_pad = align_up(rows, 128)
+    cols_pad = align_up(cols_blocks, 4)
+    grid = (
+        u8.reshape(E, rows_pad // 128, cols_pad // 4, 32, 4, 4)
+        .permute(0, 1, 4, 3, 2, 5)
+        .reshape(E, rows_pad, cols_pad)
+    )
+    half = rows // 2
+    swapped = torch.cat([grid[:, half:rows], grid[:, :half], grid[:, rows:]], dim=1)
+    back = (
+        swapped.reshape(E, rows_pad // 128, 4, 32, cols_pad // 4, 4)
+        .permute(0, 1, 4, 3, 2, 5)
+        .reshape(E, -1)
+    )
+    u8.reshape(E, -1).copy_(back)
+
+
+# Storages already flipped to the kernel-native [up; gate] order, keyed by
+# data_ptr. Values hold the tensors so the allocator cannot recycle a
+# registered address (a recycled data_ptr would skip the flip for new weights);
+# deliberately NOT cleared with the view caches — the storage stays normalized.
+_W13_NORMALIZED_STORAGES: Dict[Tuple[int, int], Tuple[torch.Tensor, torch.Tensor]] = {}
+
+
+def _ensure_w13_kernel_order_inplace(
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    *,
+    n: int,
+    k: int,
+    quant_mode: str = "nvfp4",
+) -> None:
+    """One-time in-place flip of gate-first ("w31") FC1 storage to kernel order.
+
+    The gated micro/dynamic kernels consume fused FC1 weights as [up; gate]
+    ("w13"). vLLM fuses [gate; up], so flip the caller's weight and block-scale
+    storage once at first use — the load-time mirror of the W4A16 prepare-path
+    row rotation. Mutates caller storage in place.
+    """
+    reg_key = (w1_fp4.data_ptr(), w1_blockscale.data_ptr())
+    if reg_key in _W13_NORMALIZED_STORAGES:
+        return
+    if not w1_fp4.is_contiguous() or not w1_blockscale.is_contiguous():
+        raise ValueError("w31 FC1 normalization requires contiguous w1 storage")
+    w1_u8 = w1_fp4.view(torch.uint8)
+    if w1_u8.dim() != 3 or int(w1_u8.shape[1]) != 2 * n:
+        raise ValueError(
+            f"w31 FC1 weights must be [E, 2n, k//2]; got {tuple(w1_u8.shape)} for n={n}"
+        )
+    E = int(w1_u8.shape[0])
+    # Swap halves a few experts at a time to bound the temporary.
+    per_expert = int(w1_u8.shape[1]) * int(w1_u8.shape[2])
+    chunk = max(1, min(E, (32 << 20) // max(1, per_expert)))
+    for e0 in range(0, E, chunk):
+        sl = w1_u8[e0 : e0 + chunk]
+        tmp = sl[:, :n].clone()
+        sl[:, :n] = sl[:, n:]
+        sl[:, n:] = tmp
+    if quant_mode == "w4a8_mx":
+        # MXFP4 sources carry plain [E, 2n, K//32] grids — swap rows directly.
+        grid = _as_e8m0_k32_grid(w1_blockscale, 2 * n, k, name="w1_blockscale")
+        tmp = grid[:, :n].clone()
+        grid[:, :n] = grid[:, n:]
+        grid[:, n:] = tmp
+    else:
+        _swap_w13_scale_halves_inplace(w1_blockscale, rows=2 * n, cols_blocks=k // 16)
+    _W13_NORMALIZED_STORAGES[reg_key] = (w1_fp4, w1_blockscale)
+
+
+def _get_weight_views(
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    n: int,
+    k: int,
+    *,
+    activation_spec: _ActivationKernelSpec,
+    quant_mode: str = "nvfp4",
+    w13_layout: str = "w13",
+) -> _WeightViews:
+    """Create weight views from the expert-weight layout.
+
+    For gated SwiGLU kernels, ``w1_fp4`` is `[E, 2*n, k//2]`; ``w13_layout``
+    names the source half order ("w31"/gate-first sources are flipped to the
+    kernel-native [up; gate] order in place, once per storage).
+    For relu2 kernels, ``w1_fp4`` is `[E, n, k//2]`.
+    """
+    global _LAST_WEIGHTS
+    quant_mode = _normalize_quant_mode(quant_mode)
+    if quant_mode == "w4a8_mx" and w1_fp4.dim() != 3:
+        # In-place N256/K128-repacked storage (tiny_decode band): view flat as the
+        # source-native 3-D shape for pointer plumbing. The prep rotation
+        # already normalized the half order -- never flip rp storage in place.
+        e_dim = w1_fp4.shape[0]
+        # Ceil-tiled storage views back as ceil-row/col 3-D shapes (equal to
+        # the logical shapes when the tiles divide exactly); consumers use rp
+        # tile addressing from the base pointer, never these extents.
+        w1_rows_pad = -(-activation_spec.w1_rows(n) // 256) * 256
+        n_pad = -(-n // 128) * 128
+        w1_fp4 = w1_fp4.view(torch.uint8).reshape(e_dim, w1_rows_pad, k // 2)
+        w2_fp4 = w2_fp4.view(torch.uint8).reshape(e_dim, k, n_pad // 2)
+        w1_blockscale = w1_blockscale.view(torch.uint8).reshape(
+            e_dim, w1_rows_pad, k // 32
+        )
+        w2_blockscale = w2_blockscale.view(torch.uint8).reshape(e_dim, k, n_pad // 32)
+        w13_layout = "w13"
+    w13_layout = _normalize_w13_layout_for_activation(
+        activation_spec.activation,
+        w13_layout,
+    )
+    if w13_layout == "w31" and activation_spec.is_gated:
+        _ensure_w13_kernel_order_inplace(
+            w1_fp4, w1_blockscale, n=n, k=k, quant_mode=quant_mode
+        )
+    key = (
+        w1_fp4.data_ptr(),
+        w1_blockscale.data_ptr(),
+        w2_fp4.data_ptr(),
+        w2_blockscale.data_ptr(),
+        w1_alphas.data_ptr(),
+        w2_alphas.data_ptr(),
+        activation_spec.activation,
+        quant_mode if _is_w4a8_quant_mode(quant_mode) else "nvfp4",
+    )
+    last_wkey, last_wval = _LAST_WEIGHTS
+    if last_wkey == key:
+        return last_wval
+    cached = _WEIGHT_CACHE.get(key)
+    if cached is not None:
+        _LAST_WEIGHTS = (key, cached)
+        return cached
+
+    # Permute [E, w1_n, k//2] → [w1_n, k//2, E] (view, no copy!)
+    w13 = w1_fp4.permute(1, 2, 0)  # [w1_n, k//2, E]
+    down = w2_fp4.permute(1, 2, 0)  # [k, n//2, E]
+
+    # Compact contiguous scale storage for the FC1 weights.
+    w1_n = activation_spec.w1_rows(n)
+    bs_u8 = w1_blockscale.view(torch.uint8)
+    w1_scale_storage = w1_blockscale
+    w2_scale_storage = w2_blockscale
+    if quant_mode == "w4a8_mx":
+        # MXFP4 sources carry checkpoint-native per-K/32 E8M0 grids
+        # ([E, rows, K//32] bytes); there is no vec16 scale stack to view.
+        # The w4a8 kernels never read the vec16 SF descriptors, so the
+        # vec16 view slots are pointed at the grid bytes below purely to
+        # plumb valid addresses through the launch.
+        w13_sf = _as_e8m0_k32_grid(w1_blockscale, w1_n, k, name="w1_blockscale")
+        down_sf = _as_e8m0_k32_grid(w2_blockscale, k, n, name="w2_blockscale")
+        w1_scale_storage = w13_sf
+        w2_scale_storage = down_sf
+    else:
+        w13_sf = as_grouped_scale_view(bs_u8, w1_n, k)
+        down_sf = as_grouped_scale_view(w2_blockscale.view(torch.uint8), k, n)
+    if not w1_alphas.is_contiguous() or not w2_alphas.is_contiguous():
+        raise ValueError("w1_alphas and w2_alphas must be contiguous")
+
+    sf_dtype = cutlass.Float8E4M3FN
+    views = _WeightViews(
+        w13=w13,
+        down=down,
+        w13_sf=w13_sf,
+        down_sf=down_sf,
+        w1_alpha=w1_alphas,
+        w2_alpha=w2_alphas,
+        w1_storage=w1_fp4,
+        w1_scale_storage=w1_scale_storage,
+        w2_storage=w2_fp4,
+        w2_scale_storage=w2_scale_storage,
+    )
+    # Keep as uint8 for dlpack compatibility — torch float4 types are not
+    # supported by dlpack, and sglang may load weights as native float4.
+    # The CUTLASS kernel receives the element type via _gptr / compile-time
+    # dtype, not from the torch tensor dtype.
+    views.w13_fp4 = w13.view(torch.uint8)
+    views.down_fp4 = down.view(torch.uint8)
+    views.sfb_w13_ptr = make_ptr(
+        sf_dtype, w13_sf.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
+    )
+    views.sfb_down_ptr = make_ptr(
+        sf_dtype, down_sf.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
+    )
+    if _is_w4a8_quant_mode(quant_mode):
+        if quant_mode == "w4a8_nvfp4":
+            views.sfb_w13_mx, views.w13_residual = _derive_w4a8_weight_grids(
+                bs_u8, w1_n, k
+            )
+            views.sfb_down_mx, views.down_residual = _derive_w4a8_weight_grids(
+                w2_blockscale.view(torch.uint8), k, n
+            )
+        else:
+            # w4a8_mx: the checkpoint E8M0 K/32 grids feed the kernel
+            # directly. Residuals stay None — the w4a8_mx kernel neither
+            # stages nor reads them (const_expr-gated) and the launch
+            # substitutes dummy pointers.
+            views.sfb_w13_mx = w13_sf
+            views.sfb_down_mx = down_sf
+    _WEIGHT_CACHE[key] = views
+    _LAST_WEIGHTS = (key, views)
+    return views
+
+
+# --------------------------------------------------------------------------
+# Prepared W4A8 weight representation
+# --------------------------------------------------------------------------
+
+
+def _w4a8_prepared_dict(prepared: object) -> dict[str, torch.Tensor]:
+    """Normalize public prepared metadata to the dynamic launch ABI."""
+
+    if isinstance(prepared, dict):
+        values = prepared
+    else:
+        values = {
+            name: getattr(prepared, name)
+            for name in ("w13_rp", "w13_sfb", "w2_rp", "w2_sfb")
+        }
+    for name, value in values.items():
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"prepared W4A8 {name} must be a tensor")
+    return values
+
+
+def _w4a8_prepared_weight_views(
+    prepared: object,
+    w1_alphas: torch.Tensor,
+    w2_alphas: torch.Tensor,
+) -> _WeightViews:
+    """Build pointer carriers when source-native storage was compacted.
+
+    Every source-layout operand is compile-time dead in the repacked W4A8
+    specialization.  Reuse the prepared tensors as valid pointer carriers so
+    serving does not need to retain a second copy of the logical weights.
+    """
+
+    if not w1_alphas.is_contiguous() or not w2_alphas.is_contiguous():
+        raise ValueError("w1_alphas and w2_alphas must be contiguous")
+    views = _w4a8_prepared_dict(prepared)
+    w13_rp = views["w13_rp"]
+    w13_sfb = views["w13_sfb"]
+    w2_rp = views["w2_rp"]
+    w2_sfb = views["w2_sfb"]
+    return _WeightViews(
+        w13=w13_rp,
+        down=w2_rp,
+        w13_sf=w13_sfb,
+        down_sf=w2_sfb,
+        w1_alpha=w1_alphas,
+        w2_alpha=w2_alphas,
+        w1_storage=w13_rp,
+        w1_scale_storage=w13_sfb,
+        w2_storage=w2_rp,
+        w2_scale_storage=w2_sfb,
+        w13_fp4=w13_rp,
+        down_fp4=w2_rp,
+        sfb_w13_mx=w13_sfb,
+        sfb_down_mx=w2_sfb,
+    )
+
+
+def _require_unit_weight_alphas(
+    w1_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    context: str,
+) -> None:
+    unit_alphas = bool(
+        torch.all(w1_global_scale == 1.0).item()
+        and torch.all(w2_global_scale == 1.0).item()
+    )
+    if not unit_alphas:
+        raise RuntimeError(f"{context} requires unit w1/w2 global scales")
+
+
+def _prepare_w4a8_from_e8m0_source(
+    *,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    activation: str,
+    params_dtype: torch.dtype,
+    source_format: str,
+    w13_layout: str,
+) -> _PreparedW4A8Weights:
+    source_format = _normalize_fp4_source_format(source_format)
+    if source_format != "fp4_e8m0_k32":
+        raise ValueError(
+            "W4A8 preparation requires source_format='fp4_e8m0_k32', "
+            f"got {source_format!r}"
+        )
+    activation = normalize_moe_activation(activation)
+    w13_layout = _normalize_w13_layout_for_activation(activation, w13_layout)
+    _require_unit_weight_alphas(
+        w1_global_scale,
+        w2_global_scale,
+        context="W4A8 preparation",
+    )
+
+    if w1_fp4.dtype != torch.uint8 or w2_fp4.dtype != torch.uint8:
+        raise TypeError(
+            "W4A8 preparation requires logical uint8 FP4 weights; "
+            f"got w1={w1_fp4.dtype}, w2={w2_fp4.dtype}"
+        )
+    if w1_fp4.dim() != 3 or w2_fp4.dim() != 3:
+        raise ValueError(
+            "W4A8 preparation requires logical rank-3 FP4 weights; "
+            f"got w1={tuple(w1_fp4.shape)}, w2={tuple(w2_fp4.shape)}"
+        )
+    weight_E = int(w1_fp4.shape[0])
+    if int(w2_fp4.shape[0]) != weight_E:
+        raise ValueError(
+            "W4A8 preparation expert count mismatch: "
+            f"w1={int(w1_fp4.shape[0])}, w2={int(w2_fp4.shape[0])}"
+        )
+    k = int(w2_fp4.shape[1])
+    n = int(w2_fp4.shape[2]) * 2
+    if int(w1_fp4.shape[2]) * 2 != k:
+        raise ValueError(
+            "W4A8 preparation hidden size mismatch: "
+            f"w1 K={int(w1_fp4.shape[2]) * 2}, w2 K={k}"
+        )
+    w1_rows = _activation_w1_rows(activation, n)
+    expected_w1_shape = (weight_E, w1_rows, k // 2)
+    expected_w2_shape = (weight_E, k, n // 2)
+    if tuple(w1_fp4.shape) != expected_w1_shape:
+        raise ValueError(
+            "W4A8 preparation requires w1 logical shape "
+            f"{expected_w1_shape}; got {tuple(w1_fp4.shape)}"
+        )
+    if tuple(w2_fp4.shape) != expected_w2_shape:
+        raise ValueError(
+            "W4A8 preparation requires w2 logical shape "
+            f"{expected_w2_shape}; got {tuple(w2_fp4.shape)}"
+        )
+    _as_e8m0_k32_grid(w1_blockscale, w1_rows, k, name="w1_blockscale")
+    _as_e8m0_k32_grid(w2_blockscale, k, n, name="w2_blockscale")
+
+    is_gated = is_gated_moe_activation(activation)
+    row_rotation = n if w13_layout == "w31" and is_gated else None
+    w13_rp = _logical_weight_to_w4a8_rp_inplace(
+        w1_fp4,
+        size_k=k,
+        size_n=w1_rows,
+        row_rotation=row_rotation,
+        gated_half_rows=n if is_gated else None,
+    )
+    w2_rp = _logical_weight_to_w4a8_rp_inplace(
+        w2_fp4,
+        size_k=n,
+        size_n=k,
+    )
+    w13_sfb = _e8m0_scale_to_w4a8_sfb_inplace(
+        w1_blockscale,
+        weight_E=weight_E,
+        rows=w1_rows,
+        k_dim=k,
+        row_rotation=row_rotation,
+        gated_half_rows=n if is_gated else None,
+    )
+    w2_sfb = _e8m0_scale_to_w4a8_sfb_inplace(
+        w2_blockscale,
+        weight_E=weight_E,
+        rows=k,
+        k_dim=n,
+    )
+    return _PreparedW4A8Weights(
+        w13_rp=w13_rp,
+        w13_sfb=w13_sfb,
+        w2_rp=w2_rp,
+        w2_sfb=w2_sfb,
+        num_experts=weight_E,
+        hidden_size=k,
+        intermediate_size=n,
+        params_dtype=params_dtype,
+        source_format=source_format,
+        w13_layout=w13_layout,
+    )
+
+
+def _prepare_modelopt_nvfp4_runtime_alphas(
+    w1_global_scale: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    *,
+    weight_E: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Prepare W4A4 runtime alphas from raw ModelOpt NVFP4 scales.
+
+    ModelOpt stores per-expert weight global scales separately from activation
+    input scales. The existing NVFP4 W4A4 kernels consume
+    ``weight_global_scale * input_scale`` while vLLM exposes reciprocal input
+    scales in ``a*_gscale``. Keep that conversion in SM12X preparation so
+    integrations do not mutate checkpoint-owned scale tensors in-place.
+    """
+    if weight_E is None:
+        weight_E = int(w1_global_scale.numel())
+    w1_scale = _prepare_expert_scale_vector(
+        w1_global_scale,
+        weight_E,
+        name="w1_global_scale",
+    )
+    w2_scale = _prepare_expert_scale_vector(
+        w2_global_scale,
+        weight_E,
+        name="w2_global_scale",
+    )
+    a1_recip = _prepare_expert_scale_vector(a1_gscale, weight_E, name="a1_gscale")
+    a2_recip = _prepare_expert_scale_vector(a2_gscale, weight_E, name="a2_gscale")
+    w1_runtime = torch.empty_like(w1_scale)
+    w2_runtime = torch.empty_like(w2_scale)
+    torch.div(w1_scale, a1_recip, out=w1_runtime)
+    torch.div(w2_scale, a2_recip, out=w2_runtime)
+    return w1_runtime.contiguous(), w2_runtime.contiguous()
+
+
+def plan_sm12x_fp4_moe_weights(
+    *,
+    quant_modes: str | Sequence[str],
+    source_format: str,
+    activation: str,
+    params_dtype: torch.dtype,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    w13_layout: str = "w13",
+    w4a16_layout: PreparedWeightLayout | str | None = None,
+) -> MoEWeightPreparationPlan:
+    """Plan the one canonical weight allocation used by selected recipes."""
+
+    source_format = _normalize_fp4_source_format(source_format)
+    activation = normalize_moe_activation(activation)
+    w13_layout = _normalize_w13_layout_for_activation(activation, w13_layout)
+    modes = (quant_modes,) if isinstance(quant_modes, str) else tuple(quant_modes)
+    if not modes:
+        raise ValueError("quant_modes must contain at least one recipe")
+    specs = tuple(
+        make_moe_spec(
+            quant_mode=_normalize_quant_mode_for_source(mode, source_format),
+            source_format=source_format,
+            activation=activation,
+            io_dtype=str(params_dtype).removeprefix("torch."),
+            w13_layout=w13_layout,
+        )
+        for mode in modes
+    )
+    return plan_moe_weight_preparation(
+        specs,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        w4a16_layout=w4a16_layout,
+    )
+
+
+def prepare_sm12x_fp4_moe_weights(
+    *,
+    plan: MoEWeightPreparationPlan,
+    w1_global_scale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    params_dtype: torch.dtype,
+) -> SM12XFP4ExpertWeights:
+    """Transfer source tensors into the planner-selected runtime owner."""
+
+    if not isinstance(plan, MoEWeightPreparationPlan):
+        raise TypeError("plan must be a MoEWeightPreparationPlan")
+    actual_dtype = str(params_dtype).removeprefix("torch.")
+    if actual_dtype != plan.io_dtype:
+        raise ValueError(
+            f"params_dtype={actual_dtype!r} does not match plan dtype={plan.io_dtype!r}"
+        )
+    if int(w1_fp4.shape[0]) != plan.num_experts:
+        raise ValueError(
+            f"w1 expert count {int(w1_fp4.shape[0])} does not match "
+            f"plan expert count {plan.num_experts}"
+        )
+
+    w1_runtime_alphas = _prepare_expert_scale_vector(
+        w1_global_scale,
+        plan.num_experts,
+        name="w1_global_scale",
+    )
+    w2_runtime_alphas = _prepare_expert_scale_vector(
+        w2_global_scale,
+        plan.num_experts,
+        name="w2_global_scale",
+    )
+    if plan.prepares_runtime_alphas:
+        w1_runtime_alphas, w2_runtime_alphas = _prepare_modelopt_nvfp4_runtime_alphas(
+            w1_global_scale,
+            a1_gscale,
+            w2_global_scale,
+            a2_gscale,
+            weight_E=plan.num_experts,
+        )
+
+    representation: _PreparedWeightRepresentation | None = None
+    if WeightPreparationTransform.W4A16_NATIVE in plan.transforms:
+        if representation is not None:
+            raise AssertionError("weight plan selected multiple prepared layouts")
+        from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.prepare import (
+            prepare_w4a16_e8m0_native_weights,
+            prepare_w4a16_modelopt_native_weights,
+        )
+
+        if plan.source_format == "modelopt_nvfp4":
+            value = prepare_w4a16_modelopt_native_weights(
+                w1_fp4,
+                w1_blockscale,
+                w1_global_scale,
+                w2_fp4,
+                w2_blockscale,
+                w2_global_scale,
+                activation=plan.activation,
+                params_dtype=params_dtype,
+                source_format=plan.source_format,
+                w13_layout=plan.w13_layout,
+            )
+        elif plan.source_format == "fp4_e8m0_k32":
+            value = prepare_w4a16_e8m0_native_weights(
+                w1_fp4,
+                w1_blockscale,
+                w1_global_scale,
+                w2_fp4,
+                w2_blockscale,
+                w2_global_scale,
+                activation=plan.activation,
+                params_dtype=params_dtype,
+                w13_layout=plan.w13_layout,
+            )
+        else:
+            raise AssertionError(
+                f"planner selected native W4A16 for {plan.source_format!r}"
+            )
+        representation = _PreparedWeightRepresentation(
+            quant_mode="w4a16",
+            layout=PreparedWeightLayout.SOURCE_NATIVE,
+            value=value,
+        )
+
+    if WeightPreparationTransform.W4A16_PACKED in plan.transforms:
+        if representation is not None:
+            raise AssertionError("weight plan selected multiple prepared layouts")
+        from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.prepare import (
+            prepare_w4a16_packed_weights,
+        )
+
+        value = prepare_w4a16_packed_weights(
+            w1_fp4,
+            w1_blockscale,
+            w1_global_scale,
+            w2_fp4,
+            w2_blockscale,
+            w2_global_scale,
+            activation=plan.activation,
+            params_dtype=params_dtype,
+            source_format=plan.source_format,
+            w13_layout=plan.w13_layout,
+            reuse_input_storage=True,
+        )
+        representation = _PreparedWeightRepresentation(
+            quant_mode="w4a16",
+            layout=PreparedWeightLayout.MMA_PACKED,
+            value=value,
+        )
+
+    if WeightPreparationTransform.W4A8_QMMA in plan.transforms:
+        if representation is not None:
+            raise AssertionError("weight plan selected multiple prepared layouts")
+        value = _prepare_w4a8_from_e8m0_source(
+            w1_fp4=w1_fp4,
+            w1_blockscale=w1_blockscale,
+            w1_global_scale=w1_global_scale,
+            w2_fp4=w2_fp4,
+            w2_blockscale=w2_blockscale,
+            w2_global_scale=w2_global_scale,
+            activation=plan.activation,
+            params_dtype=params_dtype,
+            source_format=plan.source_format,
+            w13_layout=plan.w13_layout,
+        )
+        representation = _PreparedWeightRepresentation(
+            quant_mode="w4a8_mx",
+            layout=PreparedWeightLayout.QMMA_REPACKED,
+            value=value,
+        )
+
+    canonical_w1 = w1_fp4
+    canonical_s1 = w1_blockscale
+    canonical_a1 = w1_runtime_alphas
+    canonical_w2 = w2_fp4
+    canonical_s2 = w2_blockscale
+    canonical_a2 = w2_runtime_alphas
+    source_mode_selected = bool({"nvfp4", "w4a8_nvfp4"} & plan.quant_modes)
+    if representation is not None and not source_mode_selected:
+        value = representation.value
+        canonical_w1 = getattr(value, "w13_rp", getattr(value, "w13", None))
+        canonical_s1 = getattr(value, "w13_sfb", getattr(value, "w13_scale", None))
+        canonical_w2 = getattr(value, "w2_rp", getattr(value, "w2", None))
+        canonical_s2 = getattr(value, "w2_sfb", getattr(value, "w2_scale", None))
+        canonical_a1 = getattr(value, "w13_global_scale", canonical_a1)
+        canonical_a2 = getattr(value, "w2_global_scale", canonical_a2)
+        if not all(
+            isinstance(tensor, torch.Tensor)
+            for tensor in (canonical_w1, canonical_s1, canonical_w2, canonical_s2)
+        ):
+            raise RuntimeError(
+                "prepared representation is missing canonical runtime tensors"
+            )
+
+    return SM12XFP4ExpertWeights(
+        plan=plan,
+        a1_gscale=a1_gscale,
+        w1_fp4=canonical_w1,
+        w1_blockscale=canonical_s1,
+        w1_alphas=canonical_a1,
+        a2_gscale=a2_gscale,
+        w2_fp4=canonical_w2,
+        w2_blockscale=canonical_s2,
+        w2_alphas=canonical_a2,
+        representation=representation,
+    )
+
+
+def _band_runs_direct_micro(
+    *,
+    num_tokens: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    weight_E: int,
+    activation: str,
+    quant_mode: str,
+) -> bool:
+    """Whether direct-micro can run this (tiny-decode band) shape.
+
+    Direct-micro owns the tiny-decode band when it supports the shape. Shapes it
+    rejects (for example, more than 12 direct K segments, ``k % 128 != 0``, or
+    ``n % 16 != 0``) route to the dynamic grouped GEMM.
+    """
+    _qm = _normalize_quant_mode(quant_mode)
+    if _qm != "nvfp4" and not _is_w4a8_quant_mode(_qm):
+        return False
+    micro_cls = _get_activation_kernel_spec(
+        activation, quant_mode=quant_mode
+    ).micro_kernel_cls
+    return micro_cls.is_supported(
+        m=num_tokens, k=k, n=n, num_topk=num_topk, weight_E=weight_E
+    )
+
+
+def _resolve_workspace_layout(
+    *,
+    num_tokens: int,
+    weight_E: int,
+    num_topk: int,
+    k: int,
+    n: int,
+    activation: str,
+    quant_mode: str = "nvfp4",
+) -> tuple[str, int, int]:
+    routed_rows = num_tokens * num_topk
+    if _normalize_quant_mode(quant_mode) == "w4a16":
+        return "w4a16", weight_E, max(1, routed_rows)
+    normalized_quant_mode = _normalize_quant_mode(quant_mode)
+    if _is_w4a8_quant_mode(normalized_quant_mode):
+        # Native W4A8 serving prepares its weights in-place into the dynamic
+        # kernel's N256/K128 representation.  Use one workspace family for all
+        # W4A8-MX sizes so compacted checkpoints never require a second
+        # source-native copy merely to enter the tiny-decode band.
+        if normalized_quant_mode == "w4a8_mx":
+            if _tiny_decode_enabled() and _tiny_decode_supports(
+                num_tokens=num_tokens, k=k, n=n, activation=activation
+            ):
+                return "micro", max(1, routed_rows), max(1, routed_rows)
+            tile_m, _ = _select_dynamic_tile_mn(
+                routed_rows,
+                n,
+                quant_mode,
+                num_experts=weight_E,
+                activation=activation,
+            )
+            return "dynamic", weight_E, align_up(routed_rows, tile_m)
+
+        # W4A8-on-NVFP4 retains source-native weights, so tiny decode can still
+        # use the direct micro specialization.
+        band = select_tp_moe_backend(
+            num_tokens=num_tokens, num_topk=num_topk, quant_mode="nvfp4"
+        )
+        # Micro keeps m<=8 tokens register-resident and measured 2.2x faster
+        # than the w4a8 dynamic kernel at m=8/topk=10 (0.076 vs 0.169 ms), so
+        # the w4a8 micro band covers all micro-capable m, not just the
+        # routed-pairs cutover tuned for nvfp4.
+        if (
+            band == "micro" or num_tokens <= _MICRO_MAX_TOKENS
+        ) and _band_runs_direct_micro(
+            num_tokens=num_tokens,
+            k=k,
+            n=n,
+            num_topk=num_topk,
+            weight_E=weight_E,
+            activation=activation,
+            quant_mode=quant_mode,
+        ):
+            return "micro", max(1, routed_rows), max(1, routed_rows)
+        tile_m, _ = _select_dynamic_tile_mn(
+            routed_rows,
+            n,
+            quant_mode,
+            num_experts=weight_E,
+            activation=activation,
+        )
+        return "dynamic", weight_E, align_up(routed_rows, tile_m)
+    implementation = select_tp_moe_backend(
+        num_tokens=num_tokens,
+        num_topk=num_topk,
+        quant_mode=quant_mode,
+    )
+    if implementation == "micro" and not _band_runs_direct_micro(
+        num_tokens=num_tokens,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+        weight_E=weight_E,
+        activation=activation,
+        quant_mode=quant_mode,
+    ):
+        # Tiny-decode band, but micro cannot run this shape; dynamic is the
+        # general fallback.
+        implementation = "dynamic"
+    if implementation == "micro":
+        return implementation, max(1, routed_rows), max(1, routed_rows)
+    tile_m, _ = _select_dynamic_tile_mn(
+        routed_rows,
+        n,
+        quant_mode,
+        num_experts=weight_E,
+        activation=activation,
+    )
+    return implementation, weight_E, align_up(routed_rows, tile_m)
+
+
+def plan_tp_moe_execution(
+    *,
+    num_tokens: int,
+    num_topk: int,
+    device: torch.device | str,
+    weight_plan: MoEWeightPreparationPlan,
+    quant_mode: str,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    apply_router_weight_on_input: bool = False,
+    deterministic_output: bool | None = None,
+) -> TPMoEPlan:
+    """Lower one recipe from an authoritative weight-preparation plan.
+
+    ``implementation`` names the concrete kernel family. ``spec`` and
+    ``execution`` carry the independent numeric and scheduling decisions.
+    """
+    if not isinstance(weight_plan, MoEWeightPreparationPlan):
+        raise TypeError("weight_plan must be a MoEWeightPreparationPlan")
+    quant_mode = _normalize_quant_mode_for_source(
+        quant_mode,
+        weight_plan.source_format,
+    )
+    if quant_mode not in weight_plan.quant_modes:
+        raise ValueError(f"quant_mode={quant_mode!r} is absent from the weight plan")
+    try:
+        dtype = {
+            "bfloat16": torch.bfloat16,
+            "float16": torch.float16,
+        }[weight_plan.io_dtype]
+    except KeyError as exc:
+        raise TypeError(f"unsupported MoE plan dtype {weight_plan.io_dtype!r}") from exc
+    device = torch.device(device)
+    weight_E = weight_plan.num_experts
+    k = weight_plan.hidden_size
+    n = weight_plan.intermediate_size
+    source_format = weight_plan.source_format
+    activation = weight_plan.activation
+    w13_layout = weight_plan.w13_layout
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    if quant_mode == "w4a16":
+        _activation_w1_rows(activation, 1)
+    else:
+        activation = _get_activation_kernel_spec(
+            activation, quant_mode=quant_mode
+        ).activation
+    w13_layout = _normalize_w13_layout_for_activation(activation, w13_layout)
+    routed_rows = num_tokens * num_topk
+    implementation, state_E, max_rows = _resolve_workspace_layout(
+        num_tokens=num_tokens,
+        weight_E=weight_E,
+        num_topk=num_topk,
+        k=k,
+        n=n,
+        activation=activation,
+        quant_mode=quant_mode,
+    )
+    dynamic_physical_tiles = None
+    dynamic_task_capacity = None
+    dynamic_tile_m = None
+    dynamic_tile_n = None
+    max_tokens_per_launch = num_tokens
+    if implementation == "dynamic":
+        # Tile planner (same routed_rows/n as _plan_core_workspace and the kernel
+        # build) -> the task/row geometry sized here matches what the kernel
+        # indexes. Must NOT use the bare _dynamic_tile_m (would size for 128 while
+        # the kernel runs the planner's tile -> scratch under-size).
+        dynamic_tile_m, dynamic_tile_n = _select_dynamic_tile_mn(
+            routed_rows,
+            n,
+            quant_mode,
+            num_experts=state_E,
+            activation=activation,
+        )
+        dynamic_physical_tiles, gate_tile_cnt, dynamic_task_capacity = (
+            _dynamic_task_geometry(
+                state_E,
+                n,
+                routed_rows,
+                tile_m=dynamic_tile_m,
+                tile_n=dynamic_tile_n,
+            )
+        )
+        if _dynamic_direct_routing_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=state_E,
+            n=n,
+            deterministic_output=False,
+        ):
+            direct_groups = max(
+                1,
+                (gate_tile_cnt + _DYNAMIC_SLICE_CHUNK - 1) // _DYNAMIC_SLICE_CHUNK,
+            )
+            dynamic_physical_tiles = max(dynamic_physical_tiles, routed_rows)
+            dynamic_task_capacity = max(
+                dynamic_task_capacity, routed_rows * direct_groups
+            )
+        max_tokens_per_launch = _dynamic_token_chunk_limit(
+            weight_E,
+            k,
+            n,
+            num_topk,
+            quant_mode,
+        )
+    spec = make_moe_spec(
+        quant_mode=quant_mode,
+        source_format=source_format,
+        activation=activation,
+        io_dtype=str(dtype).removeprefix("torch."),
+        w13_layout=w13_layout,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    execution_scheduler = None
+    if implementation == "micro":
+        regime = MoERegime.DIRECT
+    elif implementation == "dynamic":
+        dynamic_work_source = _dynamic_work_source()
+        if dynamic_work_source == "ready_queue":
+            regime = MoERegime.STREAMING_FUSED
+        else:
+            regime = MoERegime.MATERIALIZED_FUSED
+            execution_scheduler = (
+                WorkScheduler.ATOMIC_QUEUE
+                if dynamic_work_source == "materialized_queue"
+                else WorkScheduler.PERSISTENT_GRID
+            )
+    else:
+        regime = MoERegime.MATERIALIZED_PERSISTENT
+    if deterministic_output is None:
+        deterministic_output = _dynamic_deterministic_output_enabled(
+            quant_mode=quant_mode,
+            device=device,
+        )
+    route_block_rows = None
+    if implementation == "w4a16":
+        from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+            select_route_block_size_m,
+        )
+
+        route_block_rows = select_route_block_size_m(
+            num_tokens,
+            num_topk,
+            weight_E,
+        )
+    execution = lower_moe_execution(
+        spec,
+        regime=regime,
+        tile_m=dynamic_tile_m,
+        tile_n=dynamic_tile_n,
+        route_block_rows=route_block_rows,
+        deterministic_output=bool(deterministic_output),
+        scheduler=execution_scheduler,
+        required_weight_layout=weight_plan.required_weight_layout(quant_mode),
+    )
+    if not weight_plan.supports(
+        quant_mode=quant_mode,
+        execution=execution,
+    ):
+        raise RuntimeError(
+            f"weight plan does not support execution layout "
+            f"{execution.weight_layout.value!r}"
+        )
+    return TPMoEPlan(
+        spec=spec,
+        execution=execution,
+        implementation=implementation,
+        quant_mode=quant_mode,
+        activation=activation,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        state_E=state_E,
+        weight_E=weight_E,
+        routed_rows=routed_rows,
+        max_rows=max_rows,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+        device=device,
+        dtype=dtype,
+        max_tokens_per_launch=max_tokens_per_launch,
+        dynamic_physical_tiles=dynamic_physical_tiles,
+        dynamic_task_capacity=dynamic_task_capacity,
+    )
+
+
+def _validate_workspace(
+    workspace: object,
+    *,
+    plan: TPMoEPlan,
+) -> None:
+    def _canonical_device(device: torch.device) -> torch.device:
+        device = torch.device(device)
+        if device.type == "cuda" and device.index is None:
+            return torch.device("cuda", torch.cuda.current_device())
+        return device
+
+    expected = (
+        plan.implementation,
+        plan.quant_mode,
+        plan.weight_E,
+        plan.k,
+        plan.n,
+        plan.num_topk,
+        _canonical_device(plan.device),
+        plan.dtype,
+    )
+    actual = (
+        workspace.implementation,
+        workspace.quant_mode,
+        workspace.weight_E,
+        workspace.k,
+        workspace.n,
+        workspace.num_topk,
+        _canonical_device(workspace.device),
+        workspace.dtype,
+    )
+    if actual != expected:
+        raise ValueError(
+            "workspace metadata mismatch: "
+            f"expected {(plan.implementation, plan.quant_mode, plan.weight_E, plan.k, plan.n, plan.num_topk, plan.device, plan.dtype)}, "
+            f"got {actual}"
+        )
+    if plan.implementation == "w4a16":
+        if not isinstance(workspace, TPW4A16Workspace):
+            raise TypeError("expected a TPW4A16Workspace for the W4A16 backend")
+        if workspace.activation != plan.activation:
+            raise ValueError("workspace activation mismatch")
+        if workspace.state_E < plan.state_E:
+            raise ValueError(
+                "workspace expert capacity mismatch: "
+                f"expected at least {plan.state_E}, got {workspace.state_E}"
+            )
+        if workspace.max_rows < plan.max_rows:
+            raise ValueError(
+                "workspace row capacity mismatch: "
+                f"expected at least {plan.max_rows}, got {workspace.max_rows}"
+            )
+        if workspace.routed_rows_capacity < plan.routed_rows:
+            raise ValueError(
+                "workspace routed-row capacity mismatch: "
+                f"expected at least {plan.routed_rows}, got {workspace.routed_rows_capacity}"
+            )
+        return
+    if workspace.state_E < plan.state_E:
+        raise ValueError(
+            "workspace expert capacity mismatch: "
+            f"expected at least {plan.state_E}, got {workspace.state_E}"
+        )
+    if workspace.max_rows < plan.max_rows:
+        raise ValueError(
+            "workspace row capacity mismatch: "
+            f"expected at least {plan.max_rows}, got {workspace.max_rows}"
+        )
+    if plan.implementation == "micro" and not isinstance(workspace, TPMicroWorkspace):
+        raise TypeError("expected a TPMicroWorkspace for the direct-micro backend")
+    if plan.implementation == "dynamic" and not isinstance(
+        workspace, TPDynamicWorkspace
+    ):
+        raise TypeError("expected a TPDynamicWorkspace for the dynamic backend")
+    if (
+        isinstance(workspace, TPMicroWorkspace)
+        and workspace.routed_rows_capacity < plan.routed_rows
+    ):
+        raise ValueError(
+            "workspace routed-row capacity mismatch: "
+            f"expected at least {plan.routed_rows}, got {workspace.routed_rows_capacity}"
+        )
+    if (
+        isinstance(workspace, TPDynamicWorkspace)
+        and workspace.routed_rows_capacity < plan.routed_rows
+    ):
+        raise ValueError(
+            "workspace routed-row capacity mismatch: "
+            f"expected at least {plan.routed_rows}, got {workspace.routed_rows_capacity}"
+        )
+    if (
+        isinstance(workspace, TPDynamicWorkspace)
+        and plan.dynamic_physical_tiles is not None
+        and workspace.physical_tiles_capacity < plan.dynamic_physical_tiles
+    ):
+        raise ValueError(
+            "workspace physical-tile capacity mismatch: "
+            f"expected at least {plan.dynamic_physical_tiles}, got {workspace.physical_tiles_capacity}"
+        )
+    if (
+        isinstance(workspace, TPDynamicWorkspace)
+        and plan.dynamic_task_capacity is not None
+        and workspace.task_capacity < plan.dynamic_task_capacity
+    ):
+        raise ValueError(
+            "workspace task capacity mismatch: "
+            f"expected at least {plan.dynamic_task_capacity}, got {workspace.task_capacity}"
+        )
+    if (
+        isinstance(workspace, TPDynamicWorkspace)
+        and plan.deterministic_output
+        and workspace.route_output.numel() < plan.routed_rows * plan.k
+    ):
+        raise ValueError(
+            "workspace deterministic route-output capacity mismatch: "
+            f"expected at least {plan.routed_rows * plan.k} elements, got "
+            f"{workspace.route_output.numel()}"
+        )
+
+
+def _workspace_pool_key(
+    implementation: str,
+    *,
+    quant_mode: str,
+    activation: str,
+    state_E: int,
+    weight_E: int,
+    max_rows: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple:
+    # Pool-backed workspaces are capacity-based. Avoid
+    # exact-shape keys here or long-tail prompt lengths will accumulate one
+    # retained workspace per distinct routed-row count.
+    if implementation in ("micro", "dynamic", "w4a16"):
+        state_E = -1
+        max_rows = -1
+    return (
+        implementation,
+        quant_mode,
+        activation if implementation == "w4a16" else "",
+        state_E,
+        weight_E,
+        max_rows,
+        k,
+        n,
+        num_topk,
+        device.index or 0,
+        dtype,
+    )
+
+
+def _lookup_capture_micro_workspace(
+    workspace: TPMoEWorkspacePool,
+    *,
+    plan: TPMoEPlan,
+) -> TPMicroWorkspace | None:
+    if plan.implementation != "micro":
+        return None
+    for candidate in workspace.workspaces.values():
+        if not isinstance(candidate, TPMicroWorkspace):
+            continue
+        if (
+            candidate.implementation != plan.implementation
+            or candidate.quant_mode != plan.quant_mode
+            or candidate.weight_E != plan.weight_E
+            or candidate.k != plan.k
+            or candidate.n != plan.n
+            or candidate.num_topk != plan.num_topk
+            or candidate.device != plan.device
+            or candidate.dtype != plan.dtype
+        ):
+            continue
+        if candidate.state_E < plan.state_E:
+            continue
+        if candidate.max_rows < plan.max_rows:
+            continue
+        if candidate.routed_rows_capacity < plan.routed_rows:
+            continue
+        return candidate
+    return None
+
+
+def _normalize_w4a16_swiglu_limit(value: float | None) -> float | None:
+    return None if value is None else float(value)
+
+
+def _validate_frozen_w4a16_launch(
+    workspace: TPW4A16Workspace,
+    *,
+    plan: TPMoEPlan,
+    apply_router_weight_on_input: bool,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    weight_layout: str,
+    scale_format: str,
+    collect_activation_amax: bool = False,
+) -> None:
+    scale_format = _normalize_w4a16_scale_format(scale_format)
+    token_count = int(plan.max_tokens_per_launch)
+    planned_capacity = min(
+        (
+            planned
+            for planned in workspace.planned_token_counts
+            if planned >= token_count
+        ),
+        default=None,
+    )
+    if planned_capacity is None:
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace was asked to launch an unplanned token "
+            f"count: tokens={token_count}, planned={sorted(workspace.planned_token_counts)}"
+        )
+    if bool(apply_router_weight_on_input) != bool(
+        workspace.planned_apply_router_weight_on_input
+    ):
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace apply_router_weight_on_input mismatch: "
+            f"requested={bool(apply_router_weight_on_input)}, "
+            f"planned={workspace.planned_apply_router_weight_on_input}"
+        )
+    requested_limit = _normalize_w4a16_swiglu_limit(swiglu_limit)
+    if requested_limit != workspace.planned_swiglu_limit:
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace swiglu_limit mismatch: "
+            f"requested={requested_limit}, planned={workspace.planned_swiglu_limit}"
+        )
+    if float(swiglu_alpha) != float(workspace.planned_swiglu_alpha):
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace swiglu_alpha mismatch: "
+            f"requested={float(swiglu_alpha)}, planned={workspace.planned_swiglu_alpha}"
+        )
+    if float(swiglu_beta) != float(workspace.planned_swiglu_beta):
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace swiglu_beta mismatch: "
+            f"requested={float(swiglu_beta)}, planned={workspace.planned_swiglu_beta}"
+        )
+    planned_scale_format = _normalize_w4a16_scale_format(
+        getattr(workspace, "planned_scale_format", "e4m3_k16")
+    )
+    if scale_format != planned_scale_format:
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace scale_format mismatch: "
+            f"requested={scale_format!r}, planned={planned_scale_format!r}"
+        )
+    fused = workspace.planned_fused_moe_launches.get(
+        (weight_layout, scale_format, planned_capacity, bool(collect_activation_amax))
+    )
+    if fused is None:
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace is missing its preplanned fused launch "
+            f"for capacity={planned_capacity}, weight_layout={weight_layout!r}, "
+            f"scale_format={scale_format!r}, "
+            f"collect_activation_amax={bool(collect_activation_amax)}"
+        )
+    if planned_capacity not in workspace.planned_topk_sum_launches:
+        raise RuntimeError(
+            "frozen W4A16 MoE workspace is missing its preplanned top-k sum launch "
+            f"for capacity={planned_capacity}"
+        )
+
+
+def _w4a16_preplanned_launches(
+    workspace: TPW4A16Workspace,
+    *,
+    token_count: int,
+    weight_layout: str,
+    scale_format: str = "e4m3_k16",
+    collect_activation_amax: bool = False,
+) -> tuple[object | None, object | None]:
+    token_count = int(token_count)
+    scale_format = _normalize_w4a16_scale_format(scale_format)
+    collect_activation_amax = bool(collect_activation_amax)
+    if not workspace.planned_token_counts:
+        return None, None
+    # Prefer a preplanned TC-decode launch for an exact small-M decode size. It
+    # was compiled at this exact token count (its FC2 atomically sums per-route
+    # partials into the output), so it only applies when m matches exactly.
+    from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+        _TC_DECODE_MAX_M,
+    )
+
+    if (
+        not collect_activation_amax
+        and weight_layout == "packed"
+        and token_count <= _TC_DECODE_MAX_M
+    ):
+        tc_decode = workspace.planned_tc_decode_launches.get(token_count)
+        if tc_decode is not None:
+            return tc_decode, workspace.planned_topk_sum_launches.get(token_count)
+    planned_capacity = min(
+        (
+            planned
+            for planned in workspace.planned_token_counts
+            if planned >= token_count
+        ),
+        default=None,
+    )
+    if planned_capacity is None:
+        raise RuntimeError(
+            "W4A16 MoE workspace was asked to launch an unplanned token count: "
+            f"tokens={token_count}, planned={sorted(workspace.planned_token_counts)}"
+        )
+    fused = workspace.planned_fused_moe_launches.get(
+        (weight_layout, scale_format, planned_capacity, collect_activation_amax)
+    )
+    topk_sum = workspace.planned_topk_sum_launches.get(planned_capacity)
+    if fused is None or topk_sum is None:
+        raise RuntimeError(
+            "W4A16 MoE workspace is missing preplanned launches for "
+            f"capacity={planned_capacity}, weight_layout={weight_layout!r}, "
+            f"scale_format={scale_format!r}, "
+            f"collect_activation_amax={collect_activation_amax}"
+        )
+    return fused, topk_sum
+
+
+def _resolve_workspace(
+    workspace: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool,
+    *,
+    plan: TPMoEPlan,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    input_scales_static: bool,
+    apply_router_weight_on_input: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float = 1.0,
+    swiglu_beta: float = 0.0,
+    weight_layout: str = "packed",
+    scale_format: str = "e4m3_k16",
+    collect_activation_amax: bool = False,
+) -> object:
+    scale_format = _normalize_w4a16_scale_format(scale_format)
+    if isinstance(workspace, (TPMoEWorkspace, TPW4A16Workspace)):
+        _validate_workspace(workspace, plan=plan)
+        if isinstance(workspace, TPDynamicWorkspace):
+            _refresh_dynamic_workspace_scales(
+                workspace,
+                a1_gscale,
+                a2_gscale,
+                input_scales_static=input_scales_static,
+            )
+        return workspace
+
+    if not isinstance(workspace, TPMoEWorkspacePool):
+        raise TypeError(
+            "workspace must be a TPMoEWorkspace, TPW4A16Workspace, or TPMoEWorkspacePool"
+        )
+
+    key = _workspace_pool_key(
+        plan.implementation,
+        state_E=plan.state_E,
+        weight_E=plan.weight_E,
+        max_rows=plan.max_rows,
+        k=plan.k,
+        n=plan.n,
+        num_topk=plan.num_topk,
+        device=plan.device,
+        dtype=plan.dtype,
+        quant_mode=plan.quant_mode,
+        activation=plan.activation,
+    )
+    resolved = workspace.workspaces.get(key)
+    if resolved is None and torch.cuda.is_current_stream_capturing():
+        capture_micro = _lookup_capture_micro_workspace(workspace, plan=plan)
+        if capture_micro is not None:
+            # Capture may switch to a dedicated stream, but the micro
+            # workspace is stream-agnostic scratch. Reuse the warmed eager
+            # workspace instead of allocating a fresh one inside capture.
+            workspace.workspaces[key] = capture_micro
+            resolved = capture_micro
+    if resolved is None:
+        if workspace.frozen:
+            raise RuntimeError(
+                "frozen MoE workspace pool does not contain a preplanned workspace "
+                f"for implementation={plan.implementation!r}, quant_mode={plan.quant_mode!r}, "
+                f"tokens={plan.max_tokens_per_launch}, routed_rows={plan.routed_rows}"
+            )
+        if plan.implementation == "w4a16" and torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "W4A16 workspace is not initialized for CUDA graph capture; "
+                "run a warmup with the workspace pool or allocate a sufficient workspace before capture"
+            )
+        resolved = _alloc_workspace(
+            plan.implementation,
+            plan.quant_mode,
+            plan.state_E,
+            plan.weight_E,
+            plan.k,
+            plan.n,
+            plan.num_topk,
+            plan.device,
+            plan.dtype,
+            a1_gscale,
+            a2_gscale,
+            routed_rows=plan.routed_rows,
+            max_rows=plan.max_rows,
+            input_scales_static=input_scales_static,
+            deterministic_output=plan.deterministic_output,
+            activation=plan.activation,
+            dynamic_physical_tiles=plan.dynamic_physical_tiles,
+            dynamic_task_capacity=plan.dynamic_task_capacity,
+            pool=workspace,
+            storage_key=key,
+        )
+        workspace.workspaces[key] = resolved
+        return resolved
+
+    needs_growth = (
+        resolved.state_E < plan.state_E
+        or resolved.max_rows < plan.max_rows
+        or (
+            isinstance(resolved, (TPDynamicWorkspace, TPMicroWorkspace))
+            and resolved.routed_rows_capacity < plan.routed_rows
+        )
+        or (
+            isinstance(resolved, TPW4A16Workspace)
+            and resolved.routed_rows_capacity < plan.routed_rows
+        )
+        or (
+            isinstance(resolved, TPDynamicWorkspace)
+            and plan.dynamic_physical_tiles is not None
+            and resolved.physical_tiles_capacity < plan.dynamic_physical_tiles
+        )
+        or (
+            isinstance(resolved, TPDynamicWorkspace)
+            and plan.dynamic_task_capacity is not None
+            and resolved.task_capacity < plan.dynamic_task_capacity
+        )
+        or (
+            isinstance(resolved, TPDynamicWorkspace)
+            and plan.deterministic_output
+            and resolved.route_output.numel() < plan.routed_rows * plan.k
+        )
+    )
+    if needs_growth:
+        if workspace.frozen:
+            raise RuntimeError(
+                "frozen MoE workspace pool capacity is too small for a requested "
+                f"launch: implementation={plan.implementation!r}, quant_mode={plan.quant_mode!r}, "
+                f"tokens={plan.max_tokens_per_launch}, routed_rows={plan.routed_rows}"
+            )
+        if plan.implementation == "w4a16" and torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "W4A16 workspace capacity is too small for CUDA graph capture; "
+                "run an eager warmup with a larger routed-row budget before capture"
+            )
+        dynamic_tiles = plan.dynamic_physical_tiles
+        dynamic_tasks = plan.dynamic_task_capacity
+        if isinstance(resolved, TPDynamicWorkspace):
+            dynamic_tiles = max(dynamic_tiles or 0, resolved.physical_tiles_capacity)
+            dynamic_tasks = max(dynamic_tasks or 0, resolved.task_capacity)
+        resolved = _alloc_workspace(
+            plan.implementation,
+            plan.quant_mode,
+            max(plan.state_E, resolved.state_E),
+            plan.weight_E,
+            plan.k,
+            plan.n,
+            plan.num_topk,
+            plan.device,
+            plan.dtype,
+            a1_gscale,
+            a2_gscale,
+            routed_rows=max(
+                plan.routed_rows, getattr(resolved, "routed_rows_capacity", 0)
+            ),
+            max_rows=max(plan.max_rows, resolved.max_rows),
+            input_scales_static=input_scales_static,
+            deterministic_output=plan.deterministic_output,
+            activation=plan.activation,
+            dynamic_physical_tiles=dynamic_tiles,
+            dynamic_task_capacity=dynamic_tasks,
+            pool=workspace,
+            storage_key=key,
+        )
+        workspace.workspaces[key] = resolved
+        return resolved
+
+    if workspace.frozen and isinstance(resolved, TPW4A16Workspace):
+        _validate_frozen_w4a16_launch(
+            resolved,
+            plan=plan,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            weight_layout=weight_layout,
+            scale_format=scale_format,
+            collect_activation_amax=collect_activation_amax,
+        )
+
+    if isinstance(resolved, TPDynamicWorkspace):
+        _refresh_dynamic_workspace_scales(
+            resolved,
+            a1_gscale,
+            a2_gscale,
+            input_scales_static=input_scales_static,
+            force=resolved.volatile_launch_state,
+        )
+    return resolved
+
+
+def plan_tp_moe_arena_layout(
+    *,
+    max_tokens: int,
+    num_topk: int,
+    device: torch.device | str,
+    weight_plan: MoEWeightPreparationPlan,
+    quant_mode: str,
+    core_token_counts: tuple[int, ...] | None = None,
+    route_num_experts: int | None = None,
+    route_logits_dtype: torch.dtype | None = None,
+    apply_router_weight_on_input: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    collect_activation_amax: bool = False,
+    deterministic_output: bool | None = None,
+) -> TPMoEArenaLayout:
+    """Compute the byte layout needed by one lane-owned MoE pool."""
+    if not isinstance(weight_plan, MoEWeightPreparationPlan):
+        raise TypeError("weight_plan must be a MoEWeightPreparationPlan")
+    source_format = weight_plan.source_format
+    quant_mode = _normalize_quant_mode_for_source(quant_mode, source_format)
+    if quant_mode not in weight_plan.quant_modes:
+        raise ValueError(f"quant_mode={quant_mode!r} is absent from the weight plan")
+    activation = weight_plan.activation
+    w13_layout = weight_plan.w13_layout
+    w4a16_weight_layout = weight_plan.w4a16_weight_layout
+    w4a16_scale_format = weight_plan.w4a16_scale_format
+    weight_E = weight_plan.num_experts
+    k = weight_plan.hidden_size
+    n = weight_plan.intermediate_size
+    try:
+        dtype = {
+            "bfloat16": torch.bfloat16,
+            "float16": torch.float16,
+        }[weight_plan.io_dtype]
+    except KeyError as exc:
+        raise TypeError(f"unsupported MoE plan dtype {weight_plan.io_dtype!r}") from exc
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    device = torch.device(device)
+    if deterministic_output is None:
+        deterministic_output = _dynamic_deterministic_output_enabled(
+            quant_mode=quant_mode,
+            device=device,
+        )
+    else:
+        deterministic_output = bool(deterministic_output)
+    max_tokens = max(int(max_tokens), 1)
+    weight_E = max(int(weight_E), 1)
+    k = max(int(k), 1)
+    n = max(int(n), 1)
+    num_topk = max(int(num_topk), 1)
+    core_token_counts = _arena_core_token_counts(
+        max_tokens=max_tokens,
+        num_topk=num_topk,
+        core_token_counts=core_token_counts,
+        quant_mode=quant_mode,
+    )
+    route_num_experts = int(
+        route_num_experts if route_num_experts is not None else weight_E
+    )
+    route_logits_dtype = route_logits_dtype or dtype
+    core_nbytes = 0
+    for token_count in core_token_counts:
+        plan = plan_tp_moe_execution(
+            num_tokens=token_count,
+            num_topk=num_topk,
+            device=device,
+            weight_plan=weight_plan,
+            quant_mode=quant_mode,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            deterministic_output=deterministic_output,
+        )
+        core_plan = _plan_core_workspace(
+            plan.implementation,
+            plan.quant_mode,
+            plan.state_E,
+            plan.weight_E,
+            plan.k,
+            plan.n,
+            plan.num_topk,
+            plan.device,
+            plan.dtype,
+            routed_rows=plan.routed_rows,
+            max_rows=plan.max_rows,
+            activation=plan.activation,
+            dynamic_physical_tiles=plan.dynamic_physical_tiles,
+            dynamic_task_capacity=plan.dynamic_task_capacity,
+            source_format=source_format,
+            w13_layout=w13_layout,
+            w4a16_weight_layout=w4a16_weight_layout,
+            w4a16_scale_format=w4a16_scale_format,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            deterministic_output=plan.deterministic_output,
+            swiglu_limit=plan.swiglu_limit,
+            swiglu_alpha=plan.swiglu_alpha,
+            swiglu_beta=plan.swiglu_beta,
+        )
+        core_nbytes = max(core_nbytes, _core_workspace_nbytes(core_plan))
+    if route_num_experts > 0:
+        route_nbytes = _route_workspace_nbytes(
+            num_tokens=max_tokens,
+            num_experts=route_num_experts,
+            top_k=num_topk,
+            logits_dtype=route_logits_dtype,
+        )
+    else:
+        route_nbytes = 0
+    route_nbytes = align_up(route_nbytes, 16)
+    return TPMoEArenaLayout(
+        route_workspace_nbytes=route_nbytes,
+        core_workspace_nbytes=core_nbytes,
+        total_nbytes=max(route_nbytes + core_nbytes, 1),
+        core_token_counts=core_token_counts,
+    )
+
+
+def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+    deterministic_output = caps.deterministic_output
+    if deterministic_output is None:
+        deterministic_output = _dynamic_deterministic_output_enabled(
+            quant_mode=caps.quant_mode,
+            device=torch.device(caps.device),
+        )
+    layout = plan_tp_moe_arena_layout(
+        max_tokens=caps.max_tokens,
+        num_topk=caps.num_topk,
+        device=caps.device,
+        weight_plan=caps.weight_plan,
+        core_token_counts=caps.core_token_counts,
+        route_num_experts=caps.route_num_experts,
+        route_logits_dtype=caps.route_logits_dtype,
+        quant_mode=caps.quant_mode,
+        apply_router_weight_on_input=caps.apply_router_weight_on_input,
+        swiglu_limit=caps.swiglu_limit,
+        swiglu_alpha=caps.swiglu_alpha,
+        swiglu_beta=caps.swiglu_beta,
+        collect_activation_amax=caps.collect_activation_amax,
+        deterministic_output=deterministic_output,
+    )
+    capacity_tokens = max(layout.core_token_counts or (int(caps.max_tokens),))
+    launch_plan = plan_tp_moe_execution(
+        num_tokens=capacity_tokens,
+        num_topk=caps.num_topk,
+        device=caps.device,
+        weight_plan=caps.weight_plan,
+        quant_mode=caps.quant_mode,
+        swiglu_limit=caps.swiglu_limit,
+        swiglu_alpha=caps.swiglu_alpha,
+        swiglu_beta=caps.swiglu_beta,
+        apply_router_weight_on_input=caps.apply_router_weight_on_input,
+        deterministic_output=deterministic_output,
+    )
+    core_workspace_plan = _plan_core_workspace(
+        launch_plan.implementation,
+        launch_plan.quant_mode,
+        launch_plan.state_E,
+        launch_plan.weight_E,
+        launch_plan.k,
+        launch_plan.n,
+        launch_plan.num_topk,
+        launch_plan.device,
+        launch_plan.dtype,
+        routed_rows=launch_plan.routed_rows,
+        max_rows=launch_plan.max_rows,
+        activation=launch_plan.activation,
+        dynamic_physical_tiles=launch_plan.dynamic_physical_tiles,
+        dynamic_task_capacity=launch_plan.dynamic_task_capacity,
+        source_format=caps.source_format,
+        w13_layout=caps.w13_layout,
+        w4a16_weight_layout=caps.w4a16_weight_layout,
+        w4a16_scale_format=caps.w4a16_scale_format,
+        apply_router_weight_on_input=caps.apply_router_weight_on_input,
+        deterministic_output=launch_plan.deterministic_output,
+        swiglu_limit=launch_plan.swiglu_limit,
+        swiglu_alpha=launch_plan.swiglu_alpha,
+        swiglu_beta=launch_plan.swiglu_beta,
+    )
+    return TPMoEScratchPlan(
+        caps=caps,
+        layout=layout,
+        launch_plan=launch_plan,
+        _core_workspace_plan=core_workspace_plan,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "tp_moe.scratch",
+                nbytes=layout.total_nbytes,
+                device=torch.device(caps.device),
+            ),
+        ),
+    )
+
+
+def _w4a16_element_dtype(dtype: torch.dtype) -> str:
+    if dtype == torch.bfloat16:
+        return "bf16"
+    if dtype == torch.float16:
+        return "fp16"
+    raise TypeError(f"unsupported W4A16 activation dtype {dtype}")
+
+
+def _prewarm_w4a16_planned_launches(
+    workspace: TPW4A16Workspace,
+    *,
+    token_counts: tuple[int, ...],
+    apply_router_weight_on_input: bool,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
+    w13_layout: str = "w13",
+    collect_activation_amax: bool = False,
+) -> None:
+    """Resolve every W4A16 kernel shape owned by a frozen arena.
+
+    ``weight_layout`` and ``w13_layout`` must match the prepared weights the
+    binding will run with: E8M0 sources keep native ``modelopt`` weights (so the
+    FC1 ``source_n_rotation`` depends on ``w13_layout``), while NVFP4 sources are
+    ``packed`` (rotation already folded in, ``w13_layout`` irrelevant).
+    """
+    if workspace.device.type != "cuda":
+        raise RuntimeError("W4A16 MoE launch planning requires a CUDA device")
+    scale_format = _normalize_w4a16_scale_format(scale_format)
+    weight_layout = _normalize_w4a16_weight_layout(weight_layout)
+    w13_layout = _normalize_w13_layout(w13_layout)
+    collect_activation_amax = bool(collect_activation_amax)
+
+    from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+        max_packed_route_slots,
+        select_route_block_size_m,
+    )
+    from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+        _DEFAULT_MAX_SHARED_MEM,
+        _TC_DECODE_MAX_M,
+        compile_w4a16_fused_moe,
+        compile_w4a16_topk_sum,
+        pack_topk_routes_by_expert,
+    )
+
+    token_counts = tuple(
+        sorted({max(int(token_count), 1) for token_count in token_counts})
+    )
+    if not token_counts:
+        raise ValueError("W4A16 launch planning requires at least one token count")
+
+    t0 = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    with torch.cuda.device(workspace.device):
+        is_capturing = torch.cuda.is_current_stream_capturing()
+        props = torch.cuda.get_device_properties(workspace.device)
+        sms = int(props.multi_processor_count)
+        max_shared_mem = int(
+            getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+        )
+        element_dtype = _w4a16_element_dtype(workspace.dtype)
+        fused_launches: dict[object, object] = {}
+        topk_sum_launches: dict[int, object] = {}
+        tc_decode_launches: dict[int, object] = {}
+        # TC-decode is a packed-layout small-M decode path; always build its
+        # fused-sum launch variant for the supported decode sizes so the binding
+        # can dispatch to it instead of the general fused launch.
+        build_tc_decode = bool(
+            not collect_activation_amax
+            and weight_layout == "packed"
+            and element_dtype == "bf16"
+        )
+        for token_count in token_counts:
+            t_token = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+            block_size_m = select_route_block_size_m(
+                token_count,
+                workspace.num_topk,
+                workspace.weight_E,
+            )
+            routed_rows = int(token_count) * int(workspace.num_topk)
+            route_slots = max_packed_route_slots(
+                routed_rows,
+                block_size_m,
+                workspace.weight_E,
+            )
+            max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
+            t_shape = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+            fused_launches[
+                (weight_layout, scale_format, token_count, collect_activation_amax)
+            ] = compile_w4a16_fused_moe(
+                size_m=token_count,
+                hidden_size=workspace.k,
+                intermediate_size=workspace.n,
+                num_experts=workspace.weight_E,
+                top_k=workspace.num_topk,
+                activation=workspace.activation,
+                apply_router_weight_on_input=bool(apply_router_weight_on_input),
+                zero_fc2_output=False,
+                moe_block_size=block_size_m,
+                max_m_blocks=max_m_blocks,
+                element_dtype=element_dtype,
+                sms=sms,
+                max_shared_mem=max_shared_mem,
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+                weight_layout=weight_layout,
+                scale_format=scale_format,
+                w13_layout=w13_layout,
+                collect_activation_amax=collect_activation_amax,
+            )
+            t_fused = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+            topk_sum_launches[token_count] = compile_w4a16_topk_sum(
+                m=token_count,
+                topk=workspace.num_topk,
+                hidden_size=workspace.k,
+                element_dtype=element_dtype,
+            )
+            t_sum = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+
+            # The real route-pack launch happens in run_w4a16_moe. During CUDA
+            # graph capture this prewarm-only launch would be recorded as
+            # useless work in every captured MoE graph.
+            if is_capturing:
+                if _FLASHINFER_EXP_SM12X_TIMING:
+                    total_ms = (t_sum - t_token) * 1000.0
+                    if total_ms >= _FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS:
+                        logger.warning(
+                            "sm12x_w4a16_prewarm timing tokens=%d capturing=%s "
+                            "shape=%.3fms compile_fused=%.3fms "
+                            "compile_sum=%.3fms route_pack=skipped total=%.3fms",
+                            int(token_count),
+                            is_capturing,
+                            (t_shape - t_token) * 1000.0,
+                            (t_fused - t_shape) * 1000.0,
+                            (t_sum - t_fused) * 1000.0,
+                            total_ms,
+                        )
+                continue
+
+            route_pack_key = (
+                workspace.device.type,
+                int(torch.cuda.current_device()),
+                int(token_count) * int(workspace.num_topk),
+                int(block_size_m),
+                int(workspace.weight_E),
+                bool(False),
+            )
+            if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
+                if _FLASHINFER_EXP_SM12X_TIMING:
+                    total_ms = (t_sum - t_token) * 1000.0
+                    if total_ms >= _FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS:
+                        logger.warning(
+                            "sm12x_w4a16_prewarm timing tokens=%d capturing=%s "
+                            "shape=%.3fms compile_fused=%.3fms "
+                            "compile_sum=%.3fms route_pack=cached total=%.3fms",
+                            int(token_count),
+                            is_capturing,
+                            (t_shape - t_token) * 1000.0,
+                            (t_fused - t_shape) * 1000.0,
+                            (t_sum - t_fused) * 1000.0,
+                            total_ms,
+                        )
+                continue
+
+            dummy_topk_ids = torch.empty(
+                token_count,
+                workspace.num_topk,
+                dtype=torch.int32,
+                device=workspace.device,
+            )
+            dummy_topk_ids.zero_()
+            pack_topk_routes_by_expert(
+                dummy_topk_ids,
+                block_size_m,
+                workspace.weight_E,
+                packed_route_indices=workspace.packed_route_indices,
+                block_expert_ids=workspace.block_expert_ids,
+                packed_route_count=workspace.packed_route_count,
+                expert_offsets=workspace.expert_offsets,
+            )
+            _W4A16_ROUTE_PACK_PREWARMED.add(route_pack_key)
+            if _FLASHINFER_EXP_SM12X_TIMING:
+                t_route = time.perf_counter()
+                total_ms = (t_route - t_token) * 1000.0
+                if total_ms >= _FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS:
+                    logger.warning(
+                        "sm12x_w4a16_prewarm timing tokens=%d capturing=%s "
+                        "shape=%.3fms compile_fused=%.3fms compile_sum=%.3fms "
+                        "route_pack=%.3fms total=%.3fms",
+                        int(token_count),
+                        is_capturing,
+                        (t_shape - t_token) * 1000.0,
+                        (t_fused - t_shape) * 1000.0,
+                        (t_sum - t_fused) * 1000.0,
+                        (t_route - t_sum) * 1000.0,
+                        total_ms,
+                    )
+        if build_tc_decode:
+            # The capture/route-pack token counts above are powers of two, but the
+            # real decode shapes are seqs*(1+num_spec) (e.g. 3, 6 under MTP). The
+            # binding looks up TC-decode launches by the *exact* runtime m, so build
+            # one for every small-M size in the supported range, independent of the
+            # capture buckets.
+            for tc_m in range(1, _TC_DECODE_MAX_M + 1):
+                tc_block_size_m = select_route_block_size_m(
+                    tc_m, workspace.num_topk, workspace.weight_E
+                )
+                tc_decode_launches[tc_m] = compile_w4a16_fused_moe(
+                    size_m=tc_m,
+                    hidden_size=workspace.k,
+                    intermediate_size=workspace.n,
+                    num_experts=workspace.weight_E,
+                    top_k=workspace.num_topk,
+                    activation=workspace.activation,
+                    apply_router_weight_on_input=bool(apply_router_weight_on_input),
+                    zero_fc2_output=False,
+                    moe_block_size=tc_block_size_m,
+                    # Direct-topk routing uses one block per routed row.
+                    max_m_blocks=tc_m * int(workspace.num_topk),
+                    element_dtype=element_dtype,
+                    sms=sms,
+                    max_shared_mem=max_shared_mem,
+                    swiglu_limit=swiglu_limit,
+                    swiglu_alpha=swiglu_alpha,
+                    swiglu_beta=swiglu_beta,
+                    weight_layout=weight_layout,
+                    scale_format=scale_format,
+                    w13_layout=w13_layout,
+                    direct_topk_routes=True,
+                    tc_decode_fused_sum=True,
+                )
+
+        workspace.planned_fused_moe_launches = fused_launches
+        workspace.planned_topk_sum_launches = topk_sum_launches
+        workspace.planned_tc_decode_launches = tc_decode_launches
+        workspace.planned_scale_format = scale_format
+        workspace.planned_collect_activation_amax = collect_activation_amax
+    if _FLASHINFER_EXP_SM12X_TIMING:
+        t_done = time.perf_counter()
+        total_ms = (t_done - t0) * 1000.0
+        if total_ms >= _FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS:
+            logger.warning(
+                "sm12x_w4a16_prewarm_total timing counts=%s capturing=%s total=%.3fms",
+                token_counts,
+                is_capturing,
+                total_ms,
+            )
+
+
+def materialize_tp_moe_arena_workspaces(
+    pool: TPMoEWorkspacePool,
+    *,
+    caps: TPMoEScratchCaps,
+) -> None:
+    """Materialize graph-sensitive pool state from one authoritative plan."""
+    if not isinstance(caps, TPMoEScratchCaps):
+        raise TypeError("caps must be a TPMoEScratchCaps")
+    t0 = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    weight_plan = caps.weight_plan
+    max_tokens = caps.max_tokens
+    num_topk = caps.num_topk
+    device = caps.device
+    quant_mode = caps.quant_mode
+    source_format = caps.source_format
+    w13_layout = caps.w13_layout
+    apply_router_weight_on_input = caps.apply_router_weight_on_input
+    swiglu_limit = caps.swiglu_limit
+    swiglu_alpha = caps.swiglu_alpha
+    swiglu_beta = caps.swiglu_beta
+    collect_activation_amax = caps.collect_activation_amax
+    deterministic_output = caps.deterministic_output
+    if deterministic_output is None:
+        deterministic_output = _dynamic_deterministic_output_enabled(
+            quant_mode=quant_mode,
+            device=torch.device(device),
+        )
+    w4a16_scale_format = caps.w4a16_scale_format or _w4a16_scale_format_for_source(
+        source_format
+    )
+    w4a16_weight_layout = caps.w4a16_weight_layout or _w4a16_weight_layout_for_source(
+        source_format
+    )
+    core_token_counts = _arena_core_token_counts(
+        max_tokens=max_tokens,
+        num_topk=num_topk,
+        core_token_counts=caps.core_token_counts,
+        quant_mode=quant_mode,
+    )
+    t_counts = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    selected: dict[tuple, tuple[TPMoEPlan, _TPCoreWorkspacePlan, int]] = {}
+    for token_count in core_token_counts:
+        plan = plan_tp_moe_execution(
+            num_tokens=token_count,
+            num_topk=num_topk,
+            device=device,
+            weight_plan=weight_plan,
+            quant_mode=quant_mode,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            deterministic_output=deterministic_output,
+        )
+        core_plan = _plan_core_workspace(
+            plan.implementation,
+            plan.quant_mode,
+            plan.state_E,
+            plan.weight_E,
+            plan.k,
+            plan.n,
+            plan.num_topk,
+            plan.device,
+            plan.dtype,
+            routed_rows=plan.routed_rows,
+            max_rows=plan.max_rows,
+            activation=plan.activation,
+            dynamic_physical_tiles=plan.dynamic_physical_tiles,
+            dynamic_task_capacity=plan.dynamic_task_capacity,
+            source_format=source_format,
+            w13_layout=w13_layout,
+            w4a16_weight_layout=w4a16_weight_layout,
+            w4a16_scale_format=w4a16_scale_format,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            deterministic_output=plan.deterministic_output,
+            swiglu_limit=plan.swiglu_limit,
+            swiglu_alpha=plan.swiglu_alpha,
+            swiglu_beta=plan.swiglu_beta,
+        )
+        required_nbytes = _core_workspace_nbytes(core_plan)
+        key = _workspace_pool_key(
+            plan.implementation,
+            quant_mode=plan.quant_mode,
+            activation=plan.activation,
+            state_E=plan.state_E,
+            weight_E=plan.weight_E,
+            max_rows=plan.max_rows,
+            k=plan.k,
+            n=plan.n,
+            num_topk=plan.num_topk,
+            device=plan.device,
+            dtype=plan.dtype,
+        )
+        existing_selection = selected.get(key)
+        if existing_selection is None or required_nbytes > existing_selection[2]:
+            selected[key] = (plan, core_plan, required_nbytes)
+
+    t_selected = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+    materialize_ms = 0.0
+    prewarm_ms = 0.0
+    for key, (plan, core_plan, required_nbytes) in selected.items():
+        existing = pool.workspaces.get(key)
+        if existing is not None:
+            with suppress(TypeError, ValueError):
+                _validate_workspace(existing, plan=plan)
+                if isinstance(existing, TPW4A16Workspace) and (
+                    not set(core_token_counts).issubset(existing.planned_token_counts)
+                    or existing.planned_apply_router_weight_on_input
+                    != bool(apply_router_weight_on_input)
+                    or existing.planned_swiglu_limit != plan.swiglu_limit
+                    or existing.planned_swiglu_alpha != plan.swiglu_alpha
+                    or existing.planned_swiglu_beta != plan.swiglu_beta
+                    or _normalize_w4a16_scale_format(
+                        getattr(existing, "planned_scale_format", "e4m3_k16")
+                    )
+                    != w4a16_scale_format
+                    or bool(getattr(existing, "planned_collect_activation_amax", False))
+                    != collect_activation_amax
+                ):
+                    pass
+                else:
+                    continue
+
+        if pool.shared_arena is None:
+            arena = _allocate_core_arena(core_plan)
+        else:
+            if pool.shared_arena.device != plan.device:
+                raise ValueError(
+                    f"MoE pool arena device {pool.shared_arena.device} does not match plan device {plan.device}"
+                )
+            arena = _materialize_core_arena(
+                core_plan,
+                pool.shared_arena,
+                offset_bytes=pool.core_arena_offset_bytes,
+                capacity_nbytes=pool.core_arena_nbytes,
+            )
+            _emit_core_workspace_stats(
+                core_plan,
+                storage="shared",
+                required_nbytes=required_nbytes,
+                capacity_nbytes=pool.core_arena_nbytes,
+            )
+        pool.core_arenas[key] = arena
+
+        if quant_mode == "w4a16":
+            a1_init = None
+            a2_init = None
+        else:
+            a1_init = torch.ones((), dtype=torch.float32, device=plan.device)
+            a2_init = torch.ones((), dtype=torch.float32, device=plan.device)
+        t_materialize0 = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+        materialized = _materialize_workspace_from_core_arena(
+            core_plan,
+            arena,
+            a1_gscale=a1_init,
+            a2_gscale=a2_init,
+            input_scales_static=True,
+            volatile_launch_state=bool(pool.shared_arena is not None),
+        )
+        if _FLASHINFER_EXP_SM12X_TIMING:
+            materialize_ms += (time.perf_counter() - t_materialize0) * 1000.0
+        if quant_mode == "w4a16":
+            if not isinstance(materialized, TPW4A16Workspace):
+                raise TypeError(
+                    "expected W4A16 arena materialization to create TPW4A16Workspace"
+                )
+            materialized.planned_token_counts = frozenset(core_token_counts)
+            materialized.planned_apply_router_weight_on_input = bool(
+                apply_router_weight_on_input
+            )
+            materialized.planned_swiglu_limit = plan.swiglu_limit
+            materialized.planned_swiglu_alpha = plan.swiglu_alpha
+            materialized.planned_swiglu_beta = plan.swiglu_beta
+            materialized.planned_collect_activation_amax = collect_activation_amax
+            t_prewarm0 = time.perf_counter() if _FLASHINFER_EXP_SM12X_TIMING else 0.0
+            _prewarm_w4a16_planned_launches(
+                materialized,
+                token_counts=core_token_counts,
+                apply_router_weight_on_input=bool(apply_router_weight_on_input),
+                swiglu_limit=materialized.planned_swiglu_limit,
+                swiglu_alpha=materialized.planned_swiglu_alpha,
+                swiglu_beta=materialized.planned_swiglu_beta,
+                scale_format=w4a16_scale_format,
+                weight_layout=w4a16_weight_layout,
+                w13_layout=w13_layout,
+                collect_activation_amax=collect_activation_amax,
+            )
+            if _FLASHINFER_EXP_SM12X_TIMING:
+                prewarm_ms += (time.perf_counter() - t_prewarm0) * 1000.0
+        pool.workspaces[key] = materialized
+    if _FLASHINFER_EXP_SM12X_TIMING:
+        t_done = time.perf_counter()
+        total_ms = (t_done - t0) * 1000.0
+        if total_ms >= _FLASHINFER_EXP_SM12X_TIMING_THRESHOLD_MS:
+            logger.warning(
+                "sm12x_tp_moe_materialize timing max_tokens=%d counts=%s "
+                "selected=%d quant=%s counts=%.3fms select=%.3fms "
+                "materialize=%.3fms prewarm=%.3fms total=%.3fms",
+                max_tokens,
+                core_token_counts,
+                len(selected),
+                quant_mode,
+                (t_counts - t0) * 1000.0,
+                (t_selected - t_counts) * 1000.0,
+                materialize_ms,
+                prewarm_ms,
+                total_ms,
+            )
+
+
+def allocate_tp_moe_workspace_pool(
+    *,
+    shared_arena: torch.Tensor | None = None,
+    route_workspace_nbytes: int = 0,
+    core_workspace_nbytes: int = 0,
+    frozen: bool = False,
+) -> TPMoEWorkspacePool:
+    """Allocate an explicit caller-owned workspace pool for one execution lane."""
+    pool = TPMoEWorkspacePool()
+    if shared_arena is not None:
+        pool.bind_shared_arena(
+            shared_arena,
+            route_workspace_nbytes=route_workspace_nbytes,
+            core_workspace_nbytes=core_workspace_nbytes,
+            frozen=frozen,
+        )
+    return pool
+
+
+def build_tp_moe_fp4_binding(
+    *,
+    scratch: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool,
+    a: torch.Tensor,
+    experts: SM12XFP4ExpertWeights,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    apply_router_weight_on_input: bool = False,
+    output: torch.Tensor | None = None,
+    input_scales_static: bool = False,
+    fast_math: bool | None = None,
+    quant_mode: str | None = None,
+    unit_scale_contract: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    activation_amax: torch.Tensor | None = None,
+    layer_idx: int | None = None,
+) -> TPMoEFP4Binding:
+    workspace = scratch
+    if not isinstance(experts, SM12XFP4ExpertWeights):
+        raise TypeError("experts must come from prepare_sm12x_fp4_moe_weights")
+    if not isinstance(
+        workspace, (TPMoEWorkspace, TPW4A16Workspace, TPMoEWorkspacePool)
+    ):
+        raise TypeError("scratch must be a TP MoE scratch object")
+    if a.ndim != 2:
+        raise ValueError(
+            f"expected input activations with rank 2, got {tuple(a.shape)}"
+        )
+    if topk_weights.ndim != 2 or topk_ids.ndim != 2:
+        raise ValueError("topk_weights and topk_ids must be rank-2 tensors")
+    if topk_weights.shape != topk_ids.shape:
+        raise ValueError(
+            "topk_weights and topk_ids shape mismatch: "
+            f"{tuple(topk_weights.shape)} vs {tuple(topk_ids.shape)}"
+        )
+    if topk_ids.shape[0] != a.shape[0]:
+        raise ValueError(
+            f"routing batch mismatch: expected {a.shape[0]}, got {topk_ids.shape[0]}"
+        )
+    source_format = experts.source_format
+    workspace_quant_mode = getattr(workspace, "quant_mode", None)
+    quant_mode = _select_prepared_quant_mode(
+        experts,
+        quant_mode if quant_mode is not None else workspace_quant_mode,
+    )
+    _validate_fp4_source_format_for_quant_mode(
+        source_format=source_format,
+        quant_mode=quant_mode,
+    )
+    collect_activation_amax = activation_amax is not None
+    unit_scale_contract = bool(unit_scale_contract and quant_mode == "w4a16")
+    activation = experts.activation
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    w13_layout = experts.w13_layout
+    m, k = map(int, a.shape)
+    prepared_payload = _prepared_payload_for_runtime(
+        experts,
+        quant_mode=quant_mode,
+        source_format=source_format,
+        activation=activation,
+        w13_layout=w13_layout,
+        dtype=a.dtype,
+        hidden_size=k,
+    )
+    num_topk = int(topk_ids.shape[1])
+    requested_deterministic_output = _dynamic_deterministic_output_enabled(
+        quant_mode=quant_mode,
+        device=a.device,
+    )
+    deterministic_output = False
+    if isinstance(workspace, TPMoEWorkspacePool):
+        weight_layout = "packed"
+        scale_format = "e4m3_k16"
+        if quant_mode == "w4a16":
+            if prepared_payload is not None:
+                weight_layout = getattr(prepared_payload, "weight_layout", "packed")
+                scale_format = _normalize_w4a16_scale_format(
+                    getattr(
+                        prepared_payload,
+                        "scale_format",
+                        _w4a16_scale_format_for_source(source_format),
+                    )
+                )
+            else:
+                weight_layout = _w4a16_weight_layout_for_source(source_format)
+                scale_format = _w4a16_scale_format_for_source(source_format)
+        plan = plan_tp_moe_execution(
+            num_tokens=m,
+            num_topk=num_topk,
+            device=a.device,
+            weight_plan=experts.plan,
+            quant_mode=quant_mode,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            deterministic_output=requested_deterministic_output,
+        )
+        deterministic_output = plan.deterministic_output
+        workspace = _resolve_workspace(
+            workspace,
+            plan=plan,
+            a1_gscale=experts.a1_gscale,
+            a2_gscale=experts.a2_gscale,
+            input_scales_static=input_scales_static,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            weight_layout=weight_layout,
+            scale_format=scale_format,
+            collect_activation_amax=collect_activation_amax,
+        )
+    elif isinstance(workspace, TPDynamicWorkspace):
+        deterministic_output = requested_deterministic_output
+        if deterministic_output and workspace.route_output.numel() < m * num_topk * k:
+            raise ValueError(
+                "dynamic workspace was planned without enough deterministic "
+                "route-output capacity: "
+                f"expected at least {m * num_topk * k} elements, got "
+                f"{workspace.route_output.numel()}"
+            )
+    common_kwargs = dict(
+        a=a,
+        experts=experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        output=output,
+        input_scales_static=bool(input_scales_static),
+        fast_math=fast_math,
+        quant_mode=quant_mode,
+        deterministic_output=deterministic_output,
+        unit_scale_contract=unit_scale_contract,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        activation_amax=activation_amax,
+        layer_idx=layer_idx,
+    )
+    if isinstance(workspace, TPW4A16Workspace):
+        if quant_mode != "w4a16":
+            raise ValueError(
+                f"TPW4A16Workspace cannot bind non-W4A16 quant_mode {quant_mode!r}"
+            )
+        weight_layout = "packed"
+        scale_format = "e4m3_k16"
+        if prepared_payload is not None:
+            weight_layout = getattr(
+                prepared_payload,
+                "weight_layout",
+                "packed",
+            )
+            scale_format = _normalize_w4a16_scale_format(
+                getattr(
+                    prepared_payload,
+                    "scale_format",
+                    _w4a16_scale_format_for_source(source_format),
+                )
+            )
+        elif quant_mode == "w4a16":
+            weight_layout = _w4a16_weight_layout_for_source(source_format)
+            scale_format = _w4a16_scale_format_for_source(source_format)
+        fused_launch, topk_sum_launch = _w4a16_preplanned_launches(
+            workspace,
+            token_count=m,
+            weight_layout=weight_layout,
+            scale_format=scale_format,
+            collect_activation_amax=collect_activation_amax,
+        )
+        return TPMoEFP4Binding(
+            **common_kwargs,
+            implementation=workspace.implementation,
+            state_E=workspace.state_E,
+            weight_E=workspace.weight_E,
+            max_rows=workspace.max_rows,
+            k=workspace.k,
+            n=workspace.n,
+            num_topk=workspace.num_topk,
+            device=workspace.device,
+            dtype=workspace.dtype,
+            routed_rows_capacity=workspace.routed_rows_capacity,
+            intermediate_cache13=workspace.intermediate_cache13,
+            intermediate_cache2=workspace.intermediate_cache2,
+            fc1_c_tmp=workspace.fc1_c_tmp,
+            fc2_c_tmp=workspace.fc2_c_tmp,
+            packed_route_indices=workspace.packed_route_indices,
+            block_expert_ids=workspace.block_expert_ids,
+            packed_route_count=workspace.packed_route_count,
+            expert_offsets=workspace.expert_offsets,
+            fused_launch=fused_launch,
+            topk_sum_launch=topk_sum_launch,
+        )
+    if isinstance(workspace, TPMicroWorkspace):
+        return TPMoEFP4Binding(
+            **common_kwargs,
+            implementation=workspace.implementation,
+            state_E=workspace.state_E,
+            weight_E=workspace.weight_E,
+            max_rows=workspace.max_rows,
+            k=workspace.k,
+            n=workspace.n,
+            num_topk=workspace.num_topk,
+            device=workspace.device,
+            dtype=workspace.dtype,
+            row_counts=workspace.row_counts,
+            token_map=workspace.token_map,
+            token_weights=workspace.token_weights,
+            packed_input=workspace.packed_input,
+            packed_input_scale=workspace.packed_input_scale,
+            barrier_count=workspace.barrier_count,
+            barrier_epoch=workspace.barrier_epoch,
+            packed_a_view=workspace.packed_a_view,
+            sfa_ptr=workspace.sfa_ptr,
+            packed_a_flat=workspace.packed_a_flat,
+            scale_flat=workspace.scale_flat,
+            packed_a_storage_ptr=workspace.packed_a_storage_ptr,
+            routed_rows_capacity=workspace.routed_rows_capacity,
+            active_expert_count=workspace.active_expert_count,
+            weight_expert_ids=workspace.weight_expert_ids,
+            global_to_local_expert=workspace.global_to_local_expert,
+            compact_topk_ids=workspace.compact_topk_ids,
+            micro_intermediate=workspace.micro_intermediate,
+        )
+    if isinstance(workspace, TPDynamicWorkspace):
+        return TPMoEFP4Binding(
+            **common_kwargs,
+            implementation=workspace.implementation,
+            state_E=workspace.state_E,
+            weight_E=workspace.weight_E,
+            max_rows=workspace.max_rows,
+            k=workspace.k,
+            n=workspace.n,
+            num_topk=workspace.num_topk,
+            device=workspace.device,
+            dtype=workspace.dtype,
+            row_counts=workspace.row_counts,
+            token_map=workspace.token_map,
+            token_weights=workspace.token_weights,
+            packed_input=workspace.packed_input,
+            packed_input_scale=workspace.packed_input_scale,
+            barrier_count=workspace.barrier_count,
+            barrier_epoch=workspace.barrier_epoch,
+            packed_a_view=workspace.packed_a_view,
+            sfa_ptr=workspace.sfa_ptr,
+            packed_a_flat=workspace.packed_a_flat,
+            scale_flat=workspace.scale_flat,
+            packed_a_storage_ptr=workspace.packed_a_storage_ptr,
+            routed_rows_capacity=workspace.routed_rows_capacity,
+            physical_tiles_capacity=workspace.physical_tiles_capacity,
+            task_capacity=workspace.task_capacity,
+            route_output=workspace.route_output,
+            materialized_intermediate=workspace.materialized_intermediate,
+            expert_write_rows=workspace.expert_write_rows,
+            expert_tile_base=workspace.expert_tile_base,
+            input_gs=workspace.input_gs,
+            down_input_scale=workspace.down_input_scale,
+            pair_head=workspace.pair_head,
+            producers_done_count=workspace.producers_done_count,
+            all_work_published=workspace.all_work_published,
+            task_head=workspace.task_head,
+            task_tail=workspace.task_tail,
+            task_ready=workspace.task_ready,
+            task_expert=workspace.task_expert,
+            task_m_tile=workspace.task_m_tile,
+            task_slice_begin=workspace.task_slice_begin,
+            task_slice_count=workspace.task_slice_count,
+            task_valid_rows=workspace.task_valid_rows,
+            tile_write_count=workspace.tile_write_count,
+        )
+    if not isinstance(workspace, TPMoEWorkspace):
+        raise TypeError("expected a materialized TP MoE workspace")
+    return TPMoEFP4Binding(
+        **common_kwargs,
+        implementation=workspace.implementation,
+        state_E=workspace.state_E,
+        weight_E=workspace.weight_E,
+        max_rows=workspace.max_rows,
+        k=workspace.k,
+        n=workspace.n,
+        num_topk=workspace.num_topk,
+        device=workspace.device,
+        dtype=workspace.dtype,
+        row_counts=workspace.row_counts,
+        token_map=workspace.token_map,
+        token_weights=workspace.token_weights,
+        packed_input=workspace.packed_input,
+        packed_input_scale=workspace.packed_input_scale,
+        barrier_count=workspace.barrier_count,
+        barrier_epoch=workspace.barrier_epoch,
+        packed_a_view=workspace.packed_a_view,
+        sfa_ptr=workspace.sfa_ptr,
+        packed_a_flat=workspace.packed_a_flat,
+        scale_flat=workspace.scale_flat,
+        packed_a_storage_ptr=workspace.packed_a_storage_ptr,
+    )
+
+
+def build_tp_moe_route_binding(
+    *,
+    scratch: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool | None = None,
+    hidden_states: torch.Tensor,
+    top_k: int,
+    gate_weight: torch.Tensor | None = None,
+    gate_bias: torch.Tensor | None = None,
+    router_logits: torch.Tensor | None = None,
+    renormalize: bool = True,
+) -> TPMoERouteBinding:
+    if scratch is not None and not isinstance(
+        scratch,
+        (TPMoEWorkspace, TPW4A16Workspace, TPMoEWorkspacePool),
+    ):
+        raise TypeError("scratch must be a TP MoE scratch object or None")
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            "expected hidden_states with rank 2, got shape "
+            f"{tuple(hidden_states.shape)}"
+        )
+    if int(top_k) <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+    if router_logits is not None and gate_weight is not None:
+        raise ValueError("pass either router_logits or gate_weight, not both")
+    if router_logits is None and gate_weight is None:
+        raise ValueError("expected router_logits or gate_weight")
+    return TPMoERouteBinding(
+        hidden_states=hidden_states,
+        top_k=int(top_k),
+        scratch=scratch,
+        gate_weight=gate_weight,
+        gate_bias=gate_bias,
+        router_logits=router_logits,
+        renormalize=bool(renormalize),
+    )
+
+
+def build_tp_moe_sparse_fp4_binding(
+    *,
+    scratch: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool,
+    hidden_states: torch.Tensor,
+    experts: SM12XFP4ExpertWeights,
+    routing: SM12XTopKRouting | None = None,
+    top_k: int | None = None,
+    gate_weight: torch.Tensor | None = None,
+    gate_bias: torch.Tensor | None = None,
+    router_logits: torch.Tensor | None = None,
+    renormalize_topk: bool = True,
+    routed_scaling_factor: float = 1.0,
+    output: torch.Tensor | None = None,
+    return_routing: bool = False,
+    input_scales_static: bool = False,
+    fast_math: bool | None = None,
+    quant_mode: str | None = None,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    activation_amax: torch.Tensor | None = None,
+    layer_idx: int | None = None,
+) -> TPMoESparseFP4Binding:
+    if not isinstance(scratch, (TPMoEWorkspace, TPW4A16Workspace, TPMoEWorkspacePool)):
+        raise TypeError("scratch must be a TP MoE scratch object")
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            "expected hidden_states with rank 2, got shape "
+            f"{tuple(hidden_states.shape)}"
+        )
+    if not isinstance(experts, SM12XFP4ExpertWeights):
+        raise TypeError("experts must be a SM12XFP4ExpertWeights")
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        experts.activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    _select_prepared_quant_mode(experts, quant_mode)
+    if routing is not None:
+        if (
+            top_k is not None
+            or gate_weight is not None
+            or gate_bias is not None
+            or router_logits is not None
+        ):
+            raise ValueError(
+                "routing is mutually exclusive with top_k/gate_weight/gate_bias/router_logits"
+            )
+    elif top_k is None:
+        raise ValueError("top_k is required when routing is not provided")
+    return TPMoESparseFP4Binding(
+        hidden_states=hidden_states,
+        experts=experts,
+        scratch=scratch,
+        routing=routing,
+        top_k=None if top_k is None else int(top_k),
+        gate_weight=gate_weight,
+        gate_bias=gate_bias,
+        router_logits=router_logits,
+        renormalize_topk=bool(renormalize_topk),
+        routed_scaling_factor=float(routed_scaling_factor),
+        output=output,
+        return_routing=bool(return_routing),
+        input_scales_static=bool(input_scales_static),
+        fast_math=fast_math,
+        quant_mode=quant_mode,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        activation_amax=activation_amax,
+        layer_idx=layer_idx,
+    )
+
+
+def _get_kernel_cache(impl: str) -> Dict[Tuple, Tuple]:
+    if impl == "micro":
+        return _MICRO_KERNEL_CACHE
+    if impl == "dynamic":
+        return _DYNAMIC_KERNEL_CACHE
+    raise ValueError(f"unsupported implementation {impl!r}")
+
+
+def _get_impl_mac(impl: str, *, routed_rows: int | None = None) -> int:
+    dev_idx = torch.cuda.current_device()
+    key = (dev_idx, impl)
+    mac = _MAC_CACHE.get(key)
+    sm_count = get_num_sm(torch.device("cuda"))
+    mac_limit = min(get_max_active_clusters(1), sm_count)
+    override_name = f"FLASHINFER_EXP_SM12X_{impl.upper()}_MAX_ACTIVE_CLUSTERS"
+    if impl.startswith("dynamic"):
+        mac_override = _first_env(
+            override_name,
+            "FLASHINFER_EXP_SM12X_DYNAMIC_MAX_ACTIVE_CLUSTERS",
+            "FLASHINFER_EXP_SM12X_LEVEL10_MAX_ACTIVE_CLUSTERS",
+        )
+    else:
+        mac_override = _first_env(override_name)
+    if mac is None:
+        if mac_override is not None:
+            mac = max(1, min(int(mac_override), mac_limit))
+        else:
+            mac = mac_limit
+        _MAC_CACHE[key] = mac
+    if mac_override is not None:
+        return mac
+    if routed_rows is not None:
+        tuned_mac = lookup_max_active_clusters(
+            regime="decode",
+            backend=impl,
+            routed_rows=int(routed_rows),
+        )
+        if tuned_mac is not None:
+            return max(1, min(int(tuned_mac), mac_limit))
+    return mac
+
+
+def _select_micro_mma_tiler_mn(
+    max_rows: int,
+    n: int,
+    *,
+    resident_clusters: int | None = None,
+) -> tuple[int, int]:
+    if os.environ.get("FLASHINFER_EXP_SM12X_MOE_TILE_MN"):
+        return tuple(
+            int(x) for x in os.environ["FLASHINFER_EXP_SM12X_MOE_TILE_MN"].split("x")
+        )
+    sm_count = get_num_sm(torch.device("cuda"))
+    coarse_tile = (128, 128)
+    if max_rows <= 32 and n <= 256:
+        return (64, 128)
+    if resident_clusters is not None and resident_clusters < sm_count:
+        return coarse_tile
+    coarse_tiles = ((max_rows + coarse_tile[0] - 1) // coarse_tile[0]) * (
+        (n + coarse_tile[1] - 1) // coarse_tile[1]
+    )
+    # Single-token decode often lands exactly on the "half the machine" boundary.
+    # Keeping the coarse 128x128 tile there leaves the M dimension badly underfilled.
+    if max_rows <= 64 or (max_rows <= 128 and coarse_tiles <= max(1, sm_count // 2)):
+        return (64, 128)
+    return (128, 128)
+
+
+def _get_micro_kernel(
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    *,
+    topk_ids_dtype: torch.dtype,
+    fast_math: bool,
+    share_input_across_experts: bool = False,
+    share_expert_scales: bool = False,
+    single_token: bool = False,
+    mac_override: int | None = None,
+    activation: str = "silu",
+    device: torch.device | None = None,
+    quant_mode: str = "nvfp4",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    compile_time_phase: int = 0,
+):
+    quant_mode = _normalize_quant_mode(quant_mode)
+    activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
+    mac = mac_override if mac_override is not None else _get_impl_mac("micro")
+    is_w4a8 = _is_w4a8_quant_mode(quant_mode)
+    scale_format = _micro_scale_format_for_quant_mode(quant_mode)
+    e8m0_scale_layout = _micro_e8m0_scale_layout_for_quant_mode(quant_mode)
+    dynamic_down_scale = _dynamic_down_scale_enabled() and not is_w4a8
+
+    micro_kwargs = dict(
+        sf_vec_size=16,
+        mma_tiler_mn=(64, 128),
+        output_tile_count_n=1,
+        fast_math=fast_math,
+        share_input_across_experts=share_input_across_experts and not is_w4a8,
+        share_expert_scales=share_expert_scales,
+        single_token=single_token,
+        dynamic_down_scale=dynamic_down_scale,
+        a8_mx_mode=is_w4a8,
+        scale_format=scale_format,
+        e8m0_scale_layout=e8m0_scale_layout,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+    )
+    # The native NVFP4 split is currently a GLM SiLU decode specialization.
+    # Keep existing activation wrappers untouched for the normal fused phase.
+    if compile_time_phase:
+        micro_kwargs["compile_time_phase"] = int(compile_time_phase)
+    kernel = activation_spec.make_micro_kernel(**micro_kwargs)
+    kernel.configure(m, k, n, num_topk, weight_E, max_active_ctas=mac, device=device)
+    kernel_key = kernel.__cache_key__
+
+    global _LAST_KERNEL
+    cache_key = (
+        quant_mode,
+        "micro_direct",
+        kernel_key,
+        topk_ids_dtype,
+    )
+    last_kkey, last_kval = _LAST_KERNEL
+    if last_kkey == cache_key:
+        return last_kval, kernel.grid_x
+    reuse_compiled = (
+        os.environ.get("FLASHINFER_EXP_SM12X_MICRO_REUSE_COMPILED", "1") != "0"
+    )
+    if reuse_compiled:
+        cached = _MICRO_KERNEL_CACHE.get(cache_key)
+        if cached is not None:
+            _LAST_KERNEL = (cache_key, cached)
+            return cached, kernel.grid_x
+
+    def dummy(dt):
+        return make_ptr(dt, 16, cute.AddressSpace.gmem, assumed_align=16)
+
+    ids_dtype = cutlass.Int32 if topk_ids_dtype == torch.int32 else cutlass.Int64
+    barrier_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compile_kwargs = {}
+    compile_options = os.environ.get("FLASHINFER_EXP_SM12X_DIRECT_CUTE_OPTIONS", "")
+    if compile_options:
+        compile_kwargs["options"] = compile_options
+    compile_m = int(kernel.m_const) if int(kernel.m_const) != 0 else 8
+    compiled = sm12x_compile(
+        kernel,
+        dummy(cutlass.BFloat16),  # x_ptr
+        dummy(cutlass.Uint8),  # w1_ptr
+        dummy(cutlass.Uint8),  # w1s_ptr
+        dummy(cutlass.Float32),  # w1a_ptr
+        dummy(cutlass.Float32),  # a1_ptr
+        dummy(cutlass.Float32),  # a2_ptr
+        dummy(cutlass.Uint32),  # inter_ptr
+        dummy(cutlass.Uint8),  # w2_ptr
+        dummy(cutlass.Uint8),  # w2s_ptr
+        dummy(cutlass.Float32),  # w2a_ptr
+        dummy(ids_dtype),  # tid_ptr
+        dummy(cutlass.Float32),  # tw_ptr
+        dummy(cutlass.BFloat16),  # out_ptr
+        barrier_fake,  # barrier_count
+        barrier_fake,  # barrier_epoch
+        Int32(compile_m),  # m_val
+        Int32(1),  # grid_x
+        current_cuda_stream(),  # stream
+        compile_spec=KernelCompileSpec.from_key(
+            "integration.tp_moe.micro_direct",
+            1,
+            cache_key,
+        ),
+        **compile_kwargs,
+    )
+    with suppress(Exception):
+        setattr(
+            compiled,
+            _DIRECT_MICRO_SHAPE_ATTR,
+            cache_key,
+        )
+
+    if reuse_compiled:
+        _MICRO_KERNEL_CACHE[cache_key] = compiled
+    _LAST_KERNEL = (cache_key, compiled)
+    return compiled, kernel.grid_x
+
+
+def _direct_micro_shape_accepts_block_dim(compiled, block_dim: int) -> bool:
+    return True
+
+
+def _compiled_direct_micro_accepts_block_dim(compiled, block_dim: int) -> bool:
+    """Return whether the compiled direct micro kernel can launch `block_dim` threads."""
+    cache_key = (
+        id(compiled),
+        int(block_dim),
+        getattr(compiled, _DIRECT_MICRO_SHAPE_ATTR, None),
+    )
+    cached = _MICRO_DIRECT_LAUNCH_CAP_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    if not _direct_micro_shape_accepts_block_dim(compiled, block_dim):
+        _MICRO_DIRECT_LAUNCH_CAP_CACHE[cache_key] = False
+        return False
+
+    accepted = False
+    try:
+        from cuda.bindings import driver, runtime
+
+        executor = compiled.to(None)
+        kernel_info = getattr(compiled, "kernel_info", None) or {}
+        kernel_name = next(iter(kernel_info.keys()), None)
+        if kernel_name is None and hasattr(compiled, "_get_name"):
+            kernel_name = compiled._get_name()
+        if isinstance(kernel_name, str):
+            kernel_name = kernel_name.encode()
+        if kernel_name is None:
+            raise RuntimeError("compiled micro kernel did not expose a kernel name")
+
+        jit_module = getattr(executor, "jit_module", None)
+        cuda_library = getattr(jit_module, "cuda_library", None)
+        if isinstance(cuda_library, (list, tuple)):
+            cuda_library = cuda_library[0] if cuda_library else None
+        if cuda_library is None:
+            cuda_library = getattr(executor, "kernel", None)
+        if cuda_library is None:
+            raise RuntimeError("compiled micro kernel did not expose a CUDA library")
+
+        err, kernel = runtime.cudaLibraryGetKernel(cuda_library, kernel_name)
+        if err != runtime.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaLibraryGetKernel failed with {err}")
+        cu_kernel = driver.CUkernel(int(kernel))
+        err, max_threads = driver.cuKernelGetAttribute(
+            driver.CUfunction_attribute.CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+            cu_kernel,
+            0,
+        )
+        if err != driver.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"cuKernelGetAttribute failed with {err}")
+        accepted = int(max_threads) >= int(block_dim)
+    except Exception:
+        accepted = False
+
+    _MICRO_DIRECT_LAUNCH_CAP_CACHE[cache_key] = accepted
+    return accepted
+
+
+class _DynamicMoELaunch:
+    """Thin wrapper that makes num_tokens and max_rows runtime Int32."""
+
+    def __init__(self, kernel, k, num_topk):
+        self._kernel = kernel
+        self._k = k
+        self._half_k = k // 2
+        self._num_topk = num_topk
+        self._cols_pad_k = align_up(k // _NVFP4_BLOCK_SIZE, 4)
+
+    @cute.jit
+    def __call__(
+        self,
+        a_ptr: cute.Pointer,
+        topk_ids_ptr: cute.Pointer,
+        topk_weights_ptr: cute.Pointer,
+        packed_a_ptr: cute.Pointer,
+        sfa_ptr: cute.Pointer,
+        packed_a_storage_ptr: cute.Pointer,
+        scale_storage_ptr: cute.Pointer,
+        intermediate_ptr: cute.Pointer,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        pair_head: cute.Tensor,
+        producers_done_count: cute.Tensor,
+        all_work_published: cute.Tensor,
+        task_head: cute.Tensor,
+        task_tail: cute.Tensor,
+        task_ready_ptr: cute.Pointer,
+        task_expert_ptr: cute.Pointer,
+        task_m_tile_ptr: cute.Pointer,
+        task_slice_begin_ptr: cute.Pointer,
+        task_slice_count_ptr: cute.Pointer,
+        task_valid_rows_ptr: cute.Pointer,
+        tile_write_count_ptr: cute.Pointer,
+        b_w13: cute.Tensor,
+        sfb_w13_ptr: cute.Pointer,
+        b_down: cute.Tensor,
+        sfb_down_ptr: cute.Pointer,
+        row_counts: cute.Tensor,
+        expert_write_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_ptr: cute.Pointer,
+        token_map_ptr: cute.Pointer,
+        token_weights_ptr: cute.Pointer,
+        num_tokens: cutlass.Int32,
+        max_rows: cutlass.Int32,
+        scatter_rows: cutlass.Int32,
+        rows_padded: cutlass.Int32,
+        max_tasks: cutlass.Int32,
+        max_phys_tiles: cutlass.Int32,
+        max_active_clusters: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        a_input = cute.make_tensor(
+            a_ptr, layout=cute.make_layout((num_tokens, self._k), stride=(self._k, 1))
+        )
+        topk_ids = cute.make_tensor(
+            topk_ids_ptr,
+            layout=cute.make_layout((num_tokens * self._num_topk,), stride=(1,)),
+        )
+        topk_weights_t = cute.make_tensor(
+            topk_weights_ptr,
+            layout=cute.make_layout((num_tokens * self._num_topk,), stride=(1,)),
+        )
+        scatter_output = cute.make_tensor(
+            scatter_ptr,
+            layout=cute.make_layout((scatter_rows, self._k), stride=(self._k, 1)),
+        )
+        packed_a = cute.make_tensor(
+            packed_a_ptr,
+            layout=cute.make_layout(
+                (rows_padded, self._k, 1), stride=(self._k, 1, rows_padded * self._k)
+            ),
+        )
+        packed_a_storage = cute.make_tensor(
+            packed_a_storage_ptr,
+            layout=cute.make_layout((rows_padded * self._half_k,), stride=(1,)),
+        )
+        scale_storage = cute.make_tensor(
+            scale_storage_ptr,
+            layout=cute.make_layout((rows_padded * self._cols_pad_k,), stride=(1,)),
+        )
+        intermediate_u32 = cute.make_tensor(
+            intermediate_ptr, layout=cute.make_layout((1,), stride=(1,))
+        )
+        token_map = cute.make_tensor(
+            token_map_ptr, layout=cute.make_layout((rows_padded,), stride=(1,))
+        )
+        token_weights_t = cute.make_tensor(
+            token_weights_ptr, layout=cute.make_layout((rows_padded,), stride=(1,))
+        )
+        task_ready = cute.make_tensor(
+            task_ready_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_expert = cute.make_tensor(
+            task_expert_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_m_tile = cute.make_tensor(
+            task_m_tile_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_slice_begin = cute.make_tensor(
+            task_slice_begin_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_slice_count = cute.make_tensor(
+            task_slice_count_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_valid_rows = cute.make_tensor(
+            task_valid_rows_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        tile_write_count = cute.make_tensor(
+            tile_write_count_ptr,
+            layout=cute.make_layout((max_phys_tiles,), stride=(1,)),
+        )
+        self._kernel(
+            a_input,
+            topk_ids,
+            topk_weights_t,
+            packed_a,
+            sfa_ptr,
+            packed_a_storage,
+            scale_storage,
+            intermediate_u32,
+            barrier_count,
+            barrier_epoch,
+            pair_head,
+            producers_done_count,
+            all_work_published,
+            task_head,
+            task_tail,
+            task_ready,
+            task_expert,
+            task_m_tile,
+            task_slice_begin,
+            task_slice_count,
+            task_valid_rows,
+            tile_write_count,
+            b_w13,
+            sfb_w13_ptr,
+            b_down,
+            sfb_down_ptr,
+            row_counts,
+            expert_write_rows,
+            expert_tile_base,
+            input_global_scale,
+            alpha,
+            down_alpha,
+            global_scale,
+            scatter_output,
+            token_map,
+            token_weights_t,
+            max_active_clusters=max_active_clusters,
+            stream=stream,
+        )
+
+
+class _DynamicMoEW4A8Launch:
+    """w4a8 variant of _DynamicMoELaunch: adds the plain UE8M0 weight-scale
+    grids (and, for the NVFP4-source recipe, the E4M3 residual grids), and
+    sizes the packed-A scratch for one E4M3 byte per element with plain
+    per-32 activation scales."""
+
+    def __init__(self, kernel, k, n, w1_n, num_topk):
+        self._kernel = kernel
+        self._k = k
+        self._n = n
+        self._w1_n = w1_n
+        self._num_topk = num_topk
+
+    @cute.jit
+    def __call__(
+        self,
+        a_ptr: cute.Pointer,
+        topk_ids_ptr: cute.Pointer,
+        topk_weights_ptr: cute.Pointer,
+        packed_a_ptr: cute.Pointer,
+        sfa_ptr: cute.Pointer,
+        packed_a_storage_ptr: cute.Pointer,
+        scale_storage_ptr: cute.Pointer,
+        intermediate_ptr: cute.Pointer,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        pair_head: cute.Tensor,
+        producers_done_count: cute.Tensor,
+        all_work_published: cute.Tensor,
+        task_head: cute.Tensor,
+        task_tail: cute.Tensor,
+        task_ready_ptr: cute.Pointer,
+        task_expert_ptr: cute.Pointer,
+        task_m_tile_ptr: cute.Pointer,
+        task_slice_begin_ptr: cute.Pointer,
+        task_slice_count_ptr: cute.Pointer,
+        task_valid_rows_ptr: cute.Pointer,
+        tile_write_count_ptr: cute.Pointer,
+        b_w13: cute.Tensor,
+        sfb_w13_ptr: cute.Pointer,
+        b_down: cute.Tensor,
+        sfb_down_ptr: cute.Pointer,
+        sfb_w13_mx_ptr: cute.Pointer,
+        sfb_down_mx_ptr: cute.Pointer,
+        w13_residual_ptr: cute.Pointer,
+        down_residual_ptr: cute.Pointer,
+        w13_rp_ptr: cute.Pointer,
+        w13_sfb_rp_ptr: cute.Pointer,
+        down_rp_ptr: cute.Pointer,
+        down_sfb_rp_ptr: cute.Pointer,
+        row_counts: cute.Tensor,
+        expert_write_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_ptr: cute.Pointer,
+        token_map_ptr: cute.Pointer,
+        token_weights_ptr: cute.Pointer,
+        num_tokens: cutlass.Int32,
+        max_rows: cutlass.Int32,
+        scatter_rows: cutlass.Int32,
+        rows_padded: cutlass.Int32,
+        max_tasks: cutlass.Int32,
+        max_phys_tiles: cutlass.Int32,
+        max_active_clusters: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        a_input = cute.make_tensor(
+            a_ptr, layout=cute.make_layout((num_tokens, self._k), stride=(self._k, 1))
+        )
+        topk_ids = cute.make_tensor(
+            topk_ids_ptr,
+            layout=cute.make_layout((num_tokens * self._num_topk,), stride=(1,)),
+        )
+        topk_weights_t = cute.make_tensor(
+            topk_weights_ptr,
+            layout=cute.make_layout((num_tokens * self._num_topk,), stride=(1,)),
+        )
+        scatter_output = cute.make_tensor(
+            scatter_ptr,
+            layout=cute.make_layout((scatter_rows, self._k), stride=(self._k, 1)),
+        )
+        # E4M3 storage is one byte per element; the fp4-typed view spans 2k
+        # nibble positions so the byte footprint is k per row.
+        packed_a = cute.make_tensor(
+            packed_a_ptr,
+            layout=cute.make_layout(
+                (rows_padded, 2 * self._k, 1),
+                stride=(2 * self._k, 1, rows_padded * 2 * self._k),
+            ),
+        )
+        packed_a_storage = cute.make_tensor(
+            packed_a_storage_ptr,
+            layout=cute.make_layout((rows_padded * self._k,), stride=(1,)),
+        )
+        scale_storage = cute.make_tensor(
+            scale_storage_ptr,
+            layout=cute.make_layout((rows_padded * (self._k // 32),), stride=(1,)),
+        )
+        intermediate_u32 = cute.make_tensor(
+            intermediate_ptr,
+            layout=cute.make_layout(
+                (rows_padded * (self._n + self._n // 32) // 4,), stride=(1,)
+            ),
+        )
+        sfb_w13_mx = cute.make_tensor(
+            sfb_w13_mx_ptr,
+            layout=cute.make_layout(
+                (self._w1_n, self._k // 32, row_counts.shape[0]),
+                stride=(self._k // 32, 1, self._w1_n * (self._k // 32)),
+            ),
+        )
+        sfb_down_mx = cute.make_tensor(
+            sfb_down_mx_ptr,
+            layout=cute.make_layout(
+                (self._k, self._n // 32, row_counts.shape[0]),
+                stride=(self._n // 32, 1, self._k * (self._n // 32)),
+            ),
+        )
+        w13_residual = cute.make_tensor(
+            w13_residual_ptr,
+            layout=cute.make_layout(
+                (self._w1_n, self._k // 16, row_counts.shape[0]),
+                stride=(self._k // 16, 1, self._w1_n * (self._k // 16)),
+            ),
+        )
+        down_residual = cute.make_tensor(
+            down_residual_ptr,
+            layout=cute.make_layout(
+                (self._k, self._n // 16, row_counts.shape[0]),
+                stride=(self._n // 16, 1, self._k * (self._n // 16)),
+            ),
+        )
+        num_experts = row_counts.shape[0]
+        if cutlass.const_expr(self._kernel.w4a8_repacked):
+            w13_rp = cute.make_tensor(
+                w13_rp_ptr,
+                layout=cute.make_layout(
+                    (num_experts * (self._w1_n // 256) * (self._k // 128) * 4096,),
+                    stride=(1,),
+                ),
+            )
+            w13_sfb_rp = cute.make_tensor(
+                w13_sfb_rp_ptr,
+                layout=cute.make_layout(
+                    (num_experts * (self._w1_n // 256) * (self._k // 128) * 256,),
+                    stride=(1,),
+                ),
+            )
+            down_rp = cute.make_tensor(
+                down_rp_ptr,
+                layout=cute.make_layout(
+                    (num_experts * (self._k // 256) * (self._n // 128) * 4096,),
+                    stride=(1,),
+                ),
+            )
+            down_sfb_rp = cute.make_tensor(
+                down_sfb_rp_ptr,
+                layout=cute.make_layout(
+                    (num_experts * (self._k // 256) * (self._n // 128) * 256,),
+                    stride=(1,),
+                ),
+            )
+        else:
+            # CUTLASS DSL 4.6 rejects zero-sized layouts.  Repacked tensors are
+            # compile-time dead in this specialization, so retain ABI-stable
+            # sentinel views instead of constructing e.g. w1_n // 256 == 0.
+            sentinel_layout = cute.make_layout((1,), stride=(1,))
+            w13_rp = cute.make_tensor(w13_rp_ptr, layout=sentinel_layout)
+            w13_sfb_rp = cute.make_tensor(w13_sfb_rp_ptr, layout=sentinel_layout)
+            down_rp = cute.make_tensor(down_rp_ptr, layout=sentinel_layout)
+            down_sfb_rp = cute.make_tensor(down_sfb_rp_ptr, layout=sentinel_layout)
+        token_map = cute.make_tensor(
+            token_map_ptr, layout=cute.make_layout((rows_padded,), stride=(1,))
+        )
+        token_weights_t = cute.make_tensor(
+            token_weights_ptr, layout=cute.make_layout((rows_padded,), stride=(1,))
+        )
+        task_ready = cute.make_tensor(
+            task_ready_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_expert = cute.make_tensor(
+            task_expert_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_m_tile = cute.make_tensor(
+            task_m_tile_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_slice_begin = cute.make_tensor(
+            task_slice_begin_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_slice_count = cute.make_tensor(
+            task_slice_count_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        task_valid_rows = cute.make_tensor(
+            task_valid_rows_ptr, layout=cute.make_layout((max_tasks,), stride=(1,))
+        )
+        tile_write_count = cute.make_tensor(
+            tile_write_count_ptr,
+            layout=cute.make_layout((max_phys_tiles,), stride=(1,)),
+        )
+        self._kernel(
+            a_input,
+            topk_ids,
+            topk_weights_t,
+            packed_a,
+            sfa_ptr,
+            packed_a_storage,
+            scale_storage,
+            intermediate_u32,
+            barrier_count,
+            barrier_epoch,
+            pair_head,
+            producers_done_count,
+            all_work_published,
+            task_head,
+            task_tail,
+            task_ready,
+            task_expert,
+            task_m_tile,
+            task_slice_begin,
+            task_slice_count,
+            task_valid_rows,
+            tile_write_count,
+            b_w13,
+            sfb_w13_ptr,
+            b_down,
+            sfb_down_ptr,
+            row_counts,
+            expert_write_rows,
+            expert_tile_base,
+            input_global_scale,
+            alpha,
+            down_alpha,
+            global_scale,
+            scatter_output,
+            token_map,
+            token_weights_t,
+            max_active_clusters=max_active_clusters,
+            stream=stream,
+            sfb_w13_mx=sfb_w13_mx,
+            sfb_down_mx=sfb_down_mx,
+            w13_residual=w13_residual,
+            down_residual=down_residual,
+            w13_rp=w13_rp,
+            w13_sfb_rp=w13_sfb_rp,
+            down_rp=down_rp,
+            down_sfb_rp=down_sfb_rp,
+        )
+
+
+def _get_dynamic_kernel(
+    E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    max_rows: int,
+    *,
+    topk_ids_dtype: torch.dtype,
+    fast_math: bool,
+    mac_override: int | None = None,
+    activation: str = "silu",
+    quant_mode: str = "nvfp4",
+    w4a8_repacked: bool = False,
+    direct_routing: bool = False,
+    share_input_across_experts: bool = False,
+    deterministic_output: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+):
+    quant_mode = _normalize_quant_mode(quant_mode)
+    share_input_across_experts = bool(
+        share_input_across_experts
+        and (quant_mode == "nvfp4" or (quant_mode == "w4a8_mx" and w4a8_repacked))
+    )
+    activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        activation_spec.activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    sf_vec_size = 16
+    mac = mac_override if mac_override is not None else _get_impl_mac("dynamic")
+    is_w4a8 = _is_w4a8_quant_mode(quant_mode)
+    # w4a8 is self-ranging; the dynamic per-tile FC2 scale does not apply.
+    dynamic_down_scale = _dynamic_down_scale_enabled() and not is_w4a8
+    work_source = _dynamic_work_source()
+    # Tile planner (same routed_rows as the scratch plan -> consistent choice).
+    mma_tiler_mn = _select_dynamic_tile_mn(
+        m * num_topk,
+        n,
+        quant_mode,
+        num_experts=E,
+        activation=activation_spec.activation,
+    )
+    materialize_intermediate = _w4a8_dynamic_materialized_enabled(
+        quant_mode=quant_mode,
+        activation=activation_spec.activation,
+        num_tokens=m,
+        routed_rows=m * num_topk,
+        num_experts=E,
+        k=k,
+        n=n,
+        w4a8_repacked=w4a8_repacked,
+        share_input_across_experts=share_input_across_experts,
+        deterministic_output=deterministic_output,
+    )
+    # Gated FC1 swap_ab: a non-128 (but 32-aligned) per-shard intermediate needs
+    # the 32-col-tile/swapped FC1 so the gate-half base lands on a tile boundary
+    # inside one SF atom (env override for dev: FLASHINFER_EXP_SM12X_DYNAMIC_SWAP_AB=0/1).
+    swap_ab = bool(
+        quant_mode == "nvfp4"
+        and activation_spec.is_gated
+        and int(n) % 128 != 0
+        and int(n) % 32 == 0
+    )
+    _swap_env = os.environ.get("FLASHINFER_EXP_SM12X_DYNAMIC_SWAP_AB")
+    if _swap_env is not None:
+        swap_ab = _swap_env != "0"
+    if is_w4a8:
+        swap_ab = False
+
+    global _LAST_KERNEL
+    cache_key = (
+        quant_mode,
+        "dynamic",
+        E,
+        k,
+        n,
+        num_topk,
+        mma_tiler_mn,
+        topk_ids_dtype,
+        fast_math,
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+        dynamic_down_scale,
+        share_input_across_experts,
+        swap_ab,
+        bool(deterministic_output),
+        work_source,
+        bool(w4a8_repacked),
+        bool(direct_routing),
+        materialize_intermediate,
+    )
+    last_kkey, last_kval = _LAST_KERNEL
+    if last_kkey == cache_key:
+        return last_kval, mac
+    reuse_compiled = _first_env(
+        "FLASHINFER_EXP_SM12X_DYNAMIC_REUSE_COMPILED",
+        "FLASHINFER_EXP_SM12X_LEVEL10_REUSE_COMPILED",
+    )
+    if reuse_compiled is None:
+        reuse_compiled = "1"
+    reuse_compiled = reuse_compiled != "0"
+    if reuse_compiled:
+        cached = _DYNAMIC_KERNEL_CACHE.get(cache_key)
+        if cached is not None:
+            _LAST_KERNEL = (cache_key, cached)
+            return cached, mac
+
+    weight_dtype = cutlass.Float4E2M1FN
+    a_scratch_dtype = weight_dtype
+    sf_dtype = cutlass.Float8E4M3FN
+    a_dtype = cutlass.BFloat16
+    alpha_dtype = cutlass.Float32
+
+    kernel_kwargs = dict(
+        sf_vec_size=sf_vec_size,
+        mma_tiler_mn=mma_tiler_mn,
+        fast_math=fast_math,
+        dynamic_down_scale=dynamic_down_scale,
+    )
+    kernel_kwargs["share_input_across_experts"] = share_input_across_experts
+    kernel_kwargs["deterministic_output"] = bool(deterministic_output)
+    kernel_kwargs["num_topk"] = int(num_topk)
+    kernel_kwargs["swap_ab"] = swap_ab
+    kernel_kwargs["work_source"] = work_source
+    kernel_kwargs["materialize_intermediate"] = materialize_intermediate
+    kernel_kwargs["swiglu_limit"] = swiglu_limit
+    kernel_kwargs["swiglu_alpha"] = swiglu_alpha
+    kernel_kwargs["swiglu_beta"] = swiglu_beta
+    kernel_kwargs["direct_routing"] = bool(direct_routing)
+    if is_w4a8:
+        kernel_kwargs["quant_recipe"] = quant_mode
+        kernel_kwargs["w4a8_repacked"] = bool(w4a8_repacked)
+    kernel = activation_spec.make_dynamic_kernel(**kernel_kwargs)
+    if is_w4a8:
+        launch = _DynamicMoEW4A8Launch(
+            kernel,
+            k=k,
+            n=n,
+            w1_n=activation_spec.w1_rows(n),
+            num_topk=num_topk,
+        )
+    else:
+        launch = _DynamicMoELaunch(kernel, k=k, num_topk=num_topk)
+
+    topk_ids_cutlass_dtype = (
+        cutlass.Int32 if topk_ids_dtype == torch.int32 else cutlass.Int64
+    )
+    topk_ids_align = 4 if topk_ids_dtype == torch.int32 else 8
+
+    # a_input, topk_ids, topk_weights, scatter_output are pointers — shapes
+    # are constructed at runtime from num_tokens Int32.
+    a_input_fake = make_ptr(a_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    topk_ids_fake = make_ptr(
+        topk_ids_cutlass_dtype,
+        topk_ids_align,
+        cute.AddressSpace.gmem,
+        assumed_align=topk_ids_align,
+    )
+    topk_weights_fake = make_ptr(
+        cutlass.Float32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+
+    packed_a_fake = make_ptr(
+        a_scratch_dtype, 16, cute.AddressSpace.gmem, assumed_align=16
+    )
+    sfa_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    packed_a_storage_fake = make_ptr(
+        cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16
+    )
+    scale_storage_fake = make_ptr(
+        cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16
+    )
+    intermediate_fake = make_ptr(
+        cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16
+    )
+    barrier_count_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    barrier_epoch_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    pair_head_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    producers_done_count_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    all_work_published_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    task_head_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    task_tail_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    task_ready_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    task_expert_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    task_m_tile_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    task_slice_begin_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    task_slice_count_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    task_valid_rows_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    tile_write_count_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    w1_n = activation_spec.w1_rows(n)
+    b_w13_fake = cute.runtime.make_fake_compact_tensor(
+        weight_dtype,
+        (w1_n, k, E),
+        stride_order=(1, 0, 2),
+        assumed_align=16,
+    )
+    sfb_w13_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    b_down_fake = cute.runtime.make_fake_compact_tensor(
+        weight_dtype,
+        (k, n, E),
+        stride_order=(1, 0, 2),
+        assumed_align=16,
+    )
+    sfb_down_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    row_counts_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (E,),
+        assumed_align=4,
+    )
+    expert_write_rows_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (E,),
+        assumed_align=4,
+    )
+    expert_tile_base_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (E + 1,),
+        assumed_align=4,
+    )
+    input_gs_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (E,),
+        assumed_align=16,
+    )
+    alpha_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (E,),
+        assumed_align=16,
+    )
+    down_alpha_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (E,),
+        assumed_align=16,
+    )
+    global_scale_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (E,),
+        assumed_align=16,
+    )
+    scatter_fake = make_ptr(a_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    token_map_fake = make_ptr(cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4)
+    token_weights_fake = make_ptr(
+        alpha_dtype, 16, cute.AddressSpace.gmem, assumed_align=16
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=launch, cache_key=cache_key
+    )
+    dsl_compile_options = None
+    if is_w4a8:
+        # ptxas -O3's scheduler register-starves the scalar-heavy w4a8
+        # mainloop (40-reg compile, accumulators spilled around every MMA);
+        # -O2 allocates honestly (observed 255 regs, 320B stack).
+        from cutlass.base_dsl.compiler import OptLevel
+
+        dsl_compile_options = OptLevel(2)
+    compiled = sm12x_compile(
+        launch,
+        a_input_fake,
+        topk_ids_fake,
+        topk_weights_fake,
+        packed_a_fake,
+        sfa_fake,
+        packed_a_storage_fake,
+        scale_storage_fake,
+        intermediate_fake,
+        barrier_count_fake,
+        barrier_epoch_fake,
+        pair_head_fake,
+        producers_done_count_fake,
+        all_work_published_fake,
+        task_head_fake,
+        task_tail_fake,
+        task_ready_fake,
+        task_expert_fake,
+        task_m_tile_fake,
+        task_slice_begin_fake,
+        task_slice_count_fake,
+        task_valid_rows_fake,
+        tile_write_count_fake,
+        b_w13_fake,
+        sfb_w13_fake,
+        b_down_fake,
+        sfb_down_fake,
+        *(
+            (
+                make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            )
+            if is_w4a8
+            else ()
+        ),
+        row_counts_fake,
+        expert_write_rows_fake,
+        expert_tile_base_fake,
+        input_gs_fake,
+        alpha_fake,
+        down_alpha_fake,
+        global_scale_fake,
+        scatter_fake,
+        token_map_fake,
+        token_weights_fake,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "integration.tp_moe.dynamic",
+            1,
+            cache_key,
+        ),
+        dsl_compile_options=dsl_compile_options,
+    )
+
+    if reuse_compiled:
+        _DYNAMIC_KERNEL_CACHE[cache_key] = compiled
+    _LAST_KERNEL = (cache_key, compiled)
+    return compiled, mac
+
+
+def _launch_dynamic_flat(
+    *,
+    packed_a_view: torch.Tensor,
+    packed_a_flat: torch.Tensor,
+    scale_flat: torch.Tensor,
+    materialized_intermediate: torch.Tensor,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    pair_head: torch.Tensor,
+    producers_done_count: torch.Tensor,
+    all_work_published: torch.Tensor,
+    task_head: torch.Tensor,
+    task_tail: torch.Tensor,
+    task_ready: torch.Tensor,
+    task_expert: torch.Tensor,
+    task_m_tile: torch.Tensor,
+    task_slice_begin: torch.Tensor,
+    task_slice_count: torch.Tensor,
+    task_valid_rows: torch.Tensor,
+    tile_write_count: torch.Tensor,
+    row_counts: torch.Tensor,
+    expert_write_rows: torch.Tensor,
+    expert_tile_base: torch.Tensor,
+    input_gs: torch.Tensor,
+    down_input_scale: torch.Tensor,
+    token_map: torch.Tensor,
+    token_weights: torch.Tensor,
+    w13_fp4: torch.Tensor,
+    w13_sf: torch.Tensor,
+    down_fp4: torch.Tensor,
+    down_sf: torch.Tensor,
+    sfb_w13_mx: torch.Tensor,
+    sfb_down_mx: torch.Tensor,
+    w13_residual: torch.Tensor,
+    down_residual: torch.Tensor,
+    w13_rp: torch.Tensor,
+    w13_sfb_rp: torch.Tensor,
+    down_rp: torch.Tensor,
+    down_sfb_rp: torch.Tensor,
+    w1_alpha: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    a: torch.Tensor,
+    flat_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    routed_rows: int,
+    max_rows: int,
+    scatter_rows: int,
+    physical_tiles_capacity: int,
+    task_capacity: int,
+    topk_ids_are_i32: bool,
+    fast_math: bool,
+    activation: str,
+    quant_mode: str,
+    w4a8_repacked: bool,
+    share_input_across_experts: bool,
+    deterministic_output: bool,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    volatile_launch_state: bool,
+) -> None:
+    quant_mode = _normalize_quant_mode(quant_mode)
+    if w4a8_repacked and int(n) % 128 != 0:
+        # Half-aligned ceil-tiled rp/sfb storage is byte-identical to the
+        # storage of zero-padded n_pad weights, and the dynamic kernel has no
+        # external tensor with an n extent (output is [m, k]); launching at
+        # n_pad therefore computes the exact result — the padded FC1 columns
+        # are silu(0)*0 = 0 and w2's padded K rows are zero. tiny_decode
+        # keeps the logical-n bounds for the decode band.
+        n = -(-int(n) // 128) * 128
+    decode_regime = bool(
+        w4a8_repacked
+        and _w4a8_dynamic_decode_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=E,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+    )
+    direct_routing = bool(
+        (quant_mode != "w4a8_mx" or w4a8_repacked)
+        and _dynamic_direct_routing_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=E,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+    )
+    mac_backend = "dynamic_w4a8_decode" if decode_regime else "dynamic"
+    effective_mac = _get_impl_mac(mac_backend, routed_rows=routed_rows)
+    multicta_enabled = _dynamic_multicta_enabled()
+    selected_tile_m = _select_dynamic_tile_mn(
+        m * num_topk,
+        n,
+        quant_mode,
+        num_experts=E,
+        activation=activation,
+    )[0]
+    materialize_intermediate = _w4a8_dynamic_materialized_enabled(
+        quant_mode=quant_mode,
+        activation=activation,
+        num_tokens=m,
+        routed_rows=routed_rows,
+        num_experts=E,
+        k=k,
+        n=n,
+        w4a8_repacked=w4a8_repacked,
+        share_input_across_experts=share_input_across_experts,
+        deterministic_output=deterministic_output,
+    )
+    if materialize_intermediate:
+        required_intermediate_bytes = (
+            physical_tiles_capacity * selected_tile_m * (n + n // 32)
+        )
+        available_intermediate_bytes = (
+            materialized_intermediate.numel() * materialized_intermediate.element_size()
+        )
+        if available_intermediate_bytes < required_intermediate_bytes:
+            raise ValueError(
+                "dynamic W4A8 materialized scratch exceeds preplanned capacity: "
+                f"need {required_intermediate_bytes} bytes, have "
+                f"{available_intermediate_bytes}"
+            )
+    if not multicta_enabled:
+        effective_mac = 1
+    elif w4a8_repacked and selected_tile_m <= 32:
+        # The compact repacked-W4A8 storage specialization is deliberately
+        # sized for two resident CTAs/SM (49.15 KiB and a two-block register
+        # limit).  The generic resident-grid cap is one CTA/SM because its
+        # barrier must never over-launch.  This specialization has a proven-
+        # resident second wave, so expose it to the same materialized work
+        # queue.  Preserve routed-row MAC tuning proportionally and cap at the
+        # physical two-wave grid.
+        effective_mac = min(
+            effective_mac * 2,
+            get_num_sm(torch.device("cuda")) * 2,
+        )
+        if (
+            _current_compute_capability() == (12, 1)
+            and E == 256
+            and k == 6144
+            and n == 1024
+            and 24 <= routed_rows <= 48
+        ):
+            # DSV4F TP2 decode saturates Spark's memory controllers with 24
+            # resident CTAs; a larger grid only adds barrier participants.
+            effective_mac = min(effective_mac, 24)
+    if direct_routing:
+        # One physical M tile per routed pair and one task per N128 slice.
+        # Materialized M=1 has a second, wider route x N256 phase; size the
+        # resident grid for whichever fixed phase exposes more parallel work.
+        direct_task_count = routed_rows * max(1, (n + 127) // 128)
+        if materialize_intermediate and m == 1:
+            direct_task_count = max(
+                direct_task_count,
+                routed_rows * max(1, (k + 255) // 256),
+            )
+        effective_mac = min(effective_mac, direct_task_count)
+    # Do not enlarge this grid beyond the measured resident count: the fused
+    # kernel has a resident-grid barrier, so over-launching would deadlock.
+    compiled, mac = _get_dynamic_kernel(
+        E,
+        m,
+        k,
+        n,
+        num_topk,
+        max_rows,
+        topk_ids_dtype=torch.int32 if topk_ids_are_i32 else torch.int64,
+        fast_math=fast_math,
+        mac_override=effective_mac,
+        activation=activation,
+        quant_mode=quant_mode,
+        w4a8_repacked=w4a8_repacked,
+        direct_routing=direct_routing,
+        share_input_across_experts=share_input_across_experts,
+        deterministic_output=deterministic_output,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+    )
+    if volatile_launch_state:
+        barrier_count.zero_()
+        barrier_epoch.zero_()
+
+    def _gptr(dtype, t, align=16):
+        return make_ptr(
+            dtype, t.data_ptr(), cute.AddressSpace.gmem, assumed_align=align
+        )
+
+    ids_cutlass_dtype = cutlass.Int32 if topk_ids_are_i32 else cutlass.Int64
+    ids_align = 4 if topk_ids_are_i32 else 8
+    compiled(
+        _gptr(cutlass.BFloat16, a),
+        _gptr(ids_cutlass_dtype, flat_ids, ids_align),
+        _gptr(cutlass.Float32, flat_weights, 4),
+        _gptr(cutlass.Float4E2M1FN, packed_a_view),
+        _gptr(cutlass.Float8E4M3FN, scale_flat),
+        _gptr(cutlass.Uint8, packed_a_flat),
+        _gptr(cutlass.Uint8, scale_flat),
+        _gptr(cutlass.Uint32, materialized_intermediate),
+        barrier_count,
+        barrier_epoch,
+        pair_head,
+        producers_done_count,
+        all_work_published,
+        task_head,
+        task_tail,
+        _gptr(cutlass.Int32, task_ready, 4),
+        _gptr(cutlass.Int32, task_expert, 4),
+        _gptr(cutlass.Int32, task_m_tile, 4),
+        _gptr(cutlass.Int32, task_slice_begin, 4),
+        _gptr(cutlass.Int32, task_slice_count, 4),
+        _gptr(cutlass.Int32, task_valid_rows, 4),
+        _gptr(cutlass.Int32, tile_write_count, 4),
+        w13_fp4,
+        _gptr(cutlass.Float8E4M3FN, w13_sf),
+        down_fp4,
+        _gptr(cutlass.Float8E4M3FN, down_sf),
+        *(
+            (
+                _gptr(cutlass.Uint8, sfb_w13_mx),
+                _gptr(cutlass.Uint8, sfb_down_mx),
+                _gptr(cutlass.Uint8, w13_residual),
+                _gptr(cutlass.Uint8, down_residual),
+                _gptr(cutlass.Uint32, w13_rp),
+                _gptr(cutlass.Uint32, w13_sfb_rp),
+                _gptr(cutlass.Uint32, down_rp),
+                _gptr(cutlass.Uint32, down_sfb_rp),
+            )
+            if _is_w4a8_quant_mode(quant_mode)
+            else ()
+        ),
+        row_counts,
+        expert_write_rows,
+        expert_tile_base,
+        input_gs,
+        w1_alpha,
+        w2_alpha,
+        down_input_scale,
+        _gptr(cutlass.BFloat16, scatter_output),
+        _gptr(cutlass.Int32, token_map, 4),
+        _gptr(cutlass.Float32, token_weights, 4),
+        m,
+        max_rows,
+        scatter_rows,
+        physical_tiles_capacity
+        * _select_dynamic_tile_mn(
+            m * num_topk,
+            n,
+            quant_mode,
+            num_experts=E,
+            activation=activation,
+        )[0],
+        task_capacity,
+        physical_tiles_capacity,
+        mac,
+        current_cuda_stream(),
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::tp_moe_dynamic_launch",
+    mutates_args="unknown",
+)
+def _tp_moe_dynamic_launch_op(
+    packed_a_view: torch.Tensor,
+    packed_a_flat: torch.Tensor,
+    scale_flat: torch.Tensor,
+    materialized_intermediate: torch.Tensor,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    pair_head: torch.Tensor,
+    producers_done_count: torch.Tensor,
+    all_work_published: torch.Tensor,
+    task_head: torch.Tensor,
+    task_tail: torch.Tensor,
+    task_ready: torch.Tensor,
+    task_expert: torch.Tensor,
+    task_m_tile: torch.Tensor,
+    task_slice_begin: torch.Tensor,
+    task_slice_count: torch.Tensor,
+    task_valid_rows: torch.Tensor,
+    tile_write_count: torch.Tensor,
+    row_counts: torch.Tensor,
+    expert_write_rows: torch.Tensor,
+    expert_tile_base: torch.Tensor,
+    input_gs: torch.Tensor,
+    down_input_scale: torch.Tensor,
+    token_map: torch.Tensor,
+    token_weights: torch.Tensor,
+    w13_fp4: torch.Tensor,
+    w13_sf: torch.Tensor,
+    down_fp4: torch.Tensor,
+    down_sf: torch.Tensor,
+    sfb_w13_mx: torch.Tensor,
+    sfb_down_mx: torch.Tensor,
+    w13_residual: torch.Tensor,
+    down_residual: torch.Tensor,
+    w13_rp: torch.Tensor,
+    w13_sfb_rp: torch.Tensor,
+    down_rp: torch.Tensor,
+    down_sfb_rp: torch.Tensor,
+    w1_alpha: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    a: torch.Tensor,
+    flat_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    routed_rows: int,
+    max_rows: int,
+    scatter_rows: int,
+    physical_tiles_capacity: int,
+    task_capacity: int,
+    topk_ids_are_i32: bool,
+    fast_math: bool,
+    activation: str,
+    quant_mode: str,
+    w4a8_repacked: bool,
+    share_input_across_experts: bool,
+    deterministic_output: bool,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    volatile_launch_state: bool,
+) -> None:
+    _launch_dynamic_flat(
+        packed_a_view=packed_a_view,
+        packed_a_flat=packed_a_flat,
+        scale_flat=scale_flat,
+        materialized_intermediate=materialized_intermediate,
+        sfb_w13_mx=sfb_w13_mx,
+        sfb_down_mx=sfb_down_mx,
+        w13_residual=w13_residual,
+        down_residual=down_residual,
+        w13_rp=w13_rp,
+        w13_sfb_rp=w13_sfb_rp,
+        down_rp=down_rp,
+        down_sfb_rp=down_sfb_rp,
+        barrier_count=barrier_count,
+        barrier_epoch=barrier_epoch,
+        pair_head=pair_head,
+        producers_done_count=producers_done_count,
+        all_work_published=all_work_published,
+        task_head=task_head,
+        task_tail=task_tail,
+        task_ready=task_ready,
+        task_expert=task_expert,
+        task_m_tile=task_m_tile,
+        task_slice_begin=task_slice_begin,
+        task_slice_count=task_slice_count,
+        task_valid_rows=task_valid_rows,
+        tile_write_count=tile_write_count,
+        row_counts=row_counts,
+        expert_write_rows=expert_write_rows,
+        expert_tile_base=expert_tile_base,
+        input_gs=input_gs,
+        down_input_scale=down_input_scale,
+        token_map=token_map,
+        token_weights=token_weights,
+        w13_fp4=w13_fp4,
+        w13_sf=w13_sf,
+        down_fp4=down_fp4,
+        down_sf=down_sf,
+        w1_alpha=w1_alpha,
+        w2_alpha=w2_alpha,
+        a=a,
+        flat_ids=flat_ids,
+        flat_weights=flat_weights,
+        scatter_output=scatter_output,
+        E=E,
+        m=m,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+        routed_rows=routed_rows,
+        max_rows=max_rows,
+        scatter_rows=scatter_rows,
+        physical_tiles_capacity=physical_tiles_capacity,
+        task_capacity=task_capacity,
+        topk_ids_are_i32=topk_ids_are_i32,
+        fast_math=fast_math,
+        activation=activation,
+        quant_mode=quant_mode,
+        w4a8_repacked=w4a8_repacked,
+        share_input_across_experts=share_input_across_experts,
+        deterministic_output=deterministic_output,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        volatile_launch_state=volatile_launch_state,
+    )
+
+
+@_tp_moe_dynamic_launch_op.register_fake
+def _tp_moe_dynamic_launch_fake(
+    packed_a_view: torch.Tensor,
+    packed_a_flat: torch.Tensor,
+    scale_flat: torch.Tensor,
+    materialized_intermediate: torch.Tensor,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    pair_head: torch.Tensor,
+    producers_done_count: torch.Tensor,
+    all_work_published: torch.Tensor,
+    task_head: torch.Tensor,
+    task_tail: torch.Tensor,
+    task_ready: torch.Tensor,
+    task_expert: torch.Tensor,
+    task_m_tile: torch.Tensor,
+    task_slice_begin: torch.Tensor,
+    task_slice_count: torch.Tensor,
+    task_valid_rows: torch.Tensor,
+    tile_write_count: torch.Tensor,
+    row_counts: torch.Tensor,
+    expert_write_rows: torch.Tensor,
+    expert_tile_base: torch.Tensor,
+    input_gs: torch.Tensor,
+    down_input_scale: torch.Tensor,
+    token_map: torch.Tensor,
+    token_weights: torch.Tensor,
+    w13_fp4: torch.Tensor,
+    w13_sf: torch.Tensor,
+    down_fp4: torch.Tensor,
+    down_sf: torch.Tensor,
+    sfb_w13_mx: torch.Tensor,
+    sfb_down_mx: torch.Tensor,
+    w13_residual: torch.Tensor,
+    down_residual: torch.Tensor,
+    w13_rp: torch.Tensor,
+    w13_sfb_rp: torch.Tensor,
+    down_rp: torch.Tensor,
+    down_sfb_rp: torch.Tensor,
+    w1_alpha: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    a: torch.Tensor,
+    flat_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    routed_rows: int,
+    max_rows: int,
+    scatter_rows: int,
+    physical_tiles_capacity: int,
+    task_capacity: int,
+    topk_ids_are_i32: bool,
+    fast_math: bool,
+    activation: str,
+    quant_mode: str,
+    w4a8_repacked: bool,
+    share_input_across_experts: bool,
+    deterministic_output: bool,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    volatile_launch_state: bool,
+) -> None:
+    return None
+
+
+def _launch_dynamic(
+    *,
+    workspace: TPDynamicWorkspace,
+    weights: _WeightViews,
+    a: torch.Tensor,
+    flat_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    routed_rows: int,
+    max_rows: int,
+    topk_ids_dtype: torch.dtype,
+    fast_math: bool,
+    stream,
+    activation: str = "silu",
+    quant_mode: str = "nvfp4",
+    w4a8_prepared: dict | None = None,
+    share_input_across_experts: bool = False,
+    deterministic_output: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float = 1.0,
+    swiglu_beta: float = 0.0,
+) -> None:
+    del stream
+    if deterministic_output and workspace.route_output.numel() < routed_rows * k:
+        raise RuntimeError(
+            "deterministic dynamic launch exceeds the planned route-output "
+            f"capacity: need {routed_rows * k} elements, got "
+            f"{workspace.route_output.numel()}"
+        )
+    kernel_output = workspace.route_output if deterministic_output else scatter_output
+    scatter_rows = routed_rows if deterministic_output else m
+    w4a8_repacked = w4a8_prepared is not None
+    w13_rp = w4a8_prepared["w13_rp"] if w4a8_repacked else workspace.row_counts
+    w13_sfb_rp = w4a8_prepared["w13_sfb"] if w4a8_repacked else workspace.row_counts
+    down_rp = w4a8_prepared["w2_rp"] if w4a8_repacked else workspace.row_counts
+    down_sfb_rp = w4a8_prepared["w2_sfb"] if w4a8_repacked else workspace.row_counts
+    torch.ops.flashinfer_sm12x.tp_moe_dynamic_launch(
+        workspace.packed_a_view,
+        workspace.packed_a_flat,
+        workspace.scale_flat,
+        workspace.materialized_intermediate,
+        workspace.barrier_count,
+        workspace.barrier_epoch,
+        workspace.pair_head,
+        workspace.producers_done_count,
+        workspace.all_work_published,
+        workspace.task_head,
+        workspace.task_tail,
+        workspace.task_ready,
+        workspace.task_expert,
+        workspace.task_m_tile,
+        workspace.task_slice_begin,
+        workspace.task_slice_count,
+        workspace.task_valid_rows,
+        workspace.tile_write_count,
+        workspace.row_counts,
+        workspace.expert_write_rows,
+        workspace.expert_tile_base,
+        workspace.input_gs,
+        workspace.down_input_scale,
+        workspace.token_map,
+        workspace.token_weights,
+        weights.w13_fp4,
+        weights.w13_sf,
+        weights.down_fp4,
+        weights.down_sf,
+        weights.sfb_w13_mx if weights.sfb_w13_mx is not None else workspace.row_counts,
+        weights.sfb_down_mx
+        if weights.sfb_down_mx is not None
+        else workspace.row_counts,
+        weights.w13_residual
+        if weights.w13_residual is not None
+        else workspace.row_counts,
+        weights.down_residual
+        if weights.down_residual is not None
+        else workspace.row_counts,
+        w13_rp,
+        w13_sfb_rp,
+        down_rp,
+        down_sfb_rp,
+        weights.w1_alpha,
+        weights.w2_alpha,
+        a,
+        flat_ids,
+        flat_weights,
+        kernel_output,
+        E,
+        m,
+        k,
+        n,
+        num_topk,
+        routed_rows,
+        max_rows,
+        scatter_rows,
+        workspace.physical_tiles_capacity,
+        workspace.task_capacity,
+        topk_ids_dtype == torch.int32,
+        bool(fast_math),
+        activation,
+        quant_mode,
+        w4a8_repacked,
+        bool(share_input_across_experts),
+        bool(deterministic_output),
+        swiglu_limit,
+        float(swiglu_alpha),
+        float(swiglu_beta),
+        workspace.volatile_launch_state,
+    )
+
+
+def _launch_dynamic_topk_sum(
+    *,
+    route_output: torch.Tensor,
+    output: torch.Tensor,
+    m: int,
+    num_topk: int,
+    k: int,
+    stream,
+) -> None:
+    if route_output.numel() < m * num_topk * k:
+        raise RuntimeError(
+            "top-k reduction exceeds the planned route-output capacity: "
+            f"need {m * num_topk * k} elements, got {route_output.numel()}"
+        )
+    from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+        compile_w4a16_topk_sum,
+    )
+
+    element_dtype = _w4a16_element_dtype(output.dtype)
+    compile_w4a16_topk_sum(
+        m=m,
+        topk=num_topk,
+        hidden_size=k,
+        element_dtype=element_dtype,
+    )
+    torch.ops.flashinfer_sm12x.w4a16_topk_sum_launch(
+        route_output,
+        output,
+        m,
+        num_topk,
+        k,
+        element_dtype,
+        int(stream),
+    )
+
+
+def _launch_compact_micro_flat(
+    *,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    w1_alpha: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    input_gs: torch.Tensor,
+    down_input_scale: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    fast_math: bool,
+    share_input_across_experts: bool,
+    share_expert_scales: bool,
+    activation: str,
+    quant_mode: str,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    volatile_launch_state: bool,
+) -> None:
+    quant_mode = _normalize_quant_mode(quant_mode)
+    activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
+    micro_cls = activation_spec.micro_kernel_cls
+    use_native_nvfp4_split = (
+        quant_mode == "w4a8_nvfp4"
+        and 1 <= m <= 8
+        and activation == "silu"
+        and os.environ.get("FLASHINFER_EXP_SM12X_NVFP4_SPLIT_DECODE", "1") != "0"
+    )
+    if use_native_nvfp4_split:
+        # Preserve the ModelOpt NVFP4 representation and scalar math exactly.
+        # Stream order supplies the FC1->FC2 dependency, so the 188-CTA
+        # resident-grid barrier in the fused decode body is unnecessary.
+        for phase in (1, 2):
+            compiled, grid_x = _get_micro_kernel(
+                weight_E,
+                m,
+                k,
+                n,
+                num_topk,
+                topk_ids_dtype=launch_ids.dtype,
+                fast_math=fast_math,
+                share_input_across_experts=share_input_across_experts,
+                share_expert_scales=share_expert_scales,
+                single_token=True,
+                activation=activation,
+                device=a.device,
+                quant_mode=quant_mode,
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+                compile_time_phase=phase,
+            )
+            split_block_dim = (
+                _DIRECT_MICRO_BLOCK_DIM // 2
+                if phase == 2 and m == 1
+                else _DIRECT_MICRO_BLOCK_DIM
+            )
+            if not _compiled_direct_micro_accepts_block_dim(compiled, split_block_dim):
+                raise RuntimeError(
+                    "compiled split NVFP4 micro MoE kernel cannot launch"
+                )
+            micro_cls.launch(
+                compiled,
+                x=a,
+                w1_fp4=w1_storage,
+                w1_blockscale=w1_scale_storage,
+                w1_alphas=w1_alpha,
+                a1_gscale=input_gs,
+                a2_gscale=down_input_scale,
+                inter_fp32=micro_intermediate,
+                w2_fp4=w2_storage,
+                w2_blockscale=w2_scale_storage,
+                w2_alphas=w2_alpha,
+                topk_ids=launch_ids.view(m, num_topk),
+                topk_weights=flat_weights.view(m, num_topk),
+                out=scatter_output,
+                barrier_count=barrier_count,
+                barrier_epoch=barrier_epoch,
+                m=m,
+                grid_x=grid_x,
+            )
+        return
+    compiled, grid_x = _get_micro_kernel(
+        weight_E,
+        m,
+        k,
+        n,
+        num_topk,
+        topk_ids_dtype=launch_ids.dtype,
+        fast_math=fast_math,
+        share_input_across_experts=share_input_across_experts,
+        share_expert_scales=share_expert_scales,
+        single_token=(m == 1),
+        activation=activation,
+        device=a.device,
+        quant_mode=quant_mode,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+    )
+    if not _compiled_direct_micro_accepts_block_dim(
+        compiled,
+        _DIRECT_MICRO_BLOCK_DIM,
+    ):
+        raise RuntimeError("compiled direct micro MoE kernel cannot launch")
+    if volatile_launch_state:
+        barrier_count.zero_()
+        barrier_epoch.zero_()
+    micro_cls.launch(
+        compiled,
+        x=a,
+        w1_fp4=w1_storage,
+        w1_blockscale=w1_scale_storage,
+        w1_alphas=w1_alpha,
+        a1_gscale=input_gs,
+        a2_gscale=down_input_scale,
+        inter_fp32=micro_intermediate,
+        w2_fp4=w2_storage,
+        w2_blockscale=w2_scale_storage,
+        w2_alphas=w2_alpha,
+        topk_ids=launch_ids.view(m, num_topk),
+        topk_weights=flat_weights.view(m, num_topk),
+        out=scatter_output,
+        barrier_count=barrier_count,
+        barrier_epoch=barrier_epoch,
+        m=m,
+        grid_x=grid_x,
+    )
+
+
+def _tiny_decode_enabled() -> bool:
+    # Default on; FLASHINFER_EXP_SM12X_W4A8_TINY_DECODE=0 is the kill switch.
+    return os.environ.get("FLASHINFER_EXP_SM12X_W4A8_TINY_DECODE", "1") != "0"
+
+
+def _tiny_decode_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bool:
+    # The rp storage is ceil-tiled with zero-filled tails, and the tiny FC2
+    # bounds its intermediate loads by the logical n, so any 32-aligned shard
+    # works (e.g. 352 from GLM 2048/TP6, 192 from DS4-Pro 3072/TP16).
+    return (
+        1 <= num_tokens <= 4
+        # On the DSV4F TP2 shard, dynamic's tensor-core path overtakes the
+        # scalar tiny kernel once three tokens provide 24 routed rows.
+        and not (
+            _current_compute_capability() == (12, 1)
+            and num_tokens >= 3
+            and k == 6144
+            and n == 1024
+        )
+        and activation == "silu"
+        and k % 256 == 0
+        and n % 32 == 0
+        and (k // 128) % 4 == 0
+    )
+
+
+_TINY_DECODE_KERNEL_CACHE: dict = {}
+
+
+def _get_tiny_decode_kernel(
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    *,
+    device: torch.device | None = None,
+):
+    from flashinfer.experimental.sm12x.moe._shared.kernels.tiny_decode import (
+        MoETinyDecodeKernelBackendPhase1,
+        MoETinyDecodeKernelBackendPhase2,
+    )
+
+    compiled_phases = []
+    for kernel_cls in (
+        MoETinyDecodeKernelBackendPhase1,
+        MoETinyDecodeKernelBackendPhase2,
+    ):
+        kernel = kernel_cls()
+        kernel.configure(m, k, n, num_topk, weight_E, device=device)
+        cache_key = ("tiny_decode",) + kernel.__cache_key__
+        cached = _TINY_DECODE_KERNEL_CACHE.get(cache_key)
+        if cached is not None:
+            compiled_phases.append(cached)
+            continue
+
+        def dummy(dt):
+            return make_ptr(dt, 16, cute.AddressSpace.gmem, assumed_align=16)
+
+        raise_if_kernel_resolution_frozen(
+            "cute.compile", target=kernel, cache_key=cache_key
+        )
+        compiled = sm12x_compile(
+            kernel,
+            dummy(cutlass.BFloat16),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Float32),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Int32),
+            dummy(cutlass.Float32),
+            dummy(cutlass.BFloat16),
+            current_cuda_stream(),
+            compile_spec=KernelCompileSpec.from_key(
+                "integration.tp_moe.tiny_decode",
+                1,
+                cache_key,
+            ),
+        )
+        _TINY_DECODE_KERNEL_CACHE[cache_key] = compiled
+        compiled_phases.append(compiled)
+    return compiled_phases[0], compiled_phases[1]
+
+
+def _launch_tiny_decode_flat(
+    *,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+) -> None:
+    from flashinfer.experimental.sm12x.moe._shared.kernels.tiny_decode import (
+        MoETinyDecodeKernelBackend,
+    )
+
+    del barrier_count, barrier_epoch
+    compiled_fc1, compiled_fc2 = _get_tiny_decode_kernel(
+        weight_E, m, k, n, num_topk, device=a.device
+    )
+    rt = m * num_topk
+    inter = micro_intermediate.view(torch.float32).reshape(-1)[: rt * 2 * n]
+    MoETinyDecodeKernelBackend.launch(
+        compiled_fc1,
+        compiled_fc2,
+        x=a.reshape(-1),
+        w13_rp=w1_storage,
+        sfb13=w1_scale_storage,
+        inter_fp32=inter,
+        w2_rp=w2_storage,
+        sfb2=w2_scale_storage,
+        topk_ids=launch_ids,
+        topk_weights=flat_weights,
+        out=scatter_output.reshape(-1),
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::tp_moe_tiny_decode_launch",
+    mutates_args="unknown",
+)
+def _tp_moe_tiny_decode_launch_op(
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    volatile_launch_state: bool,
+) -> None:
+    del volatile_launch_state
+    _launch_tiny_decode_flat(
+        barrier_count=barrier_count,
+        barrier_epoch=barrier_epoch,
+        micro_intermediate=micro_intermediate,
+        w1_storage=w1_storage,
+        w1_scale_storage=w1_scale_storage,
+        w2_storage=w2_storage,
+        w2_scale_storage=w2_scale_storage,
+        a=a,
+        launch_ids=launch_ids,
+        flat_weights=flat_weights,
+        scatter_output=scatter_output,
+        weight_E=weight_E,
+        m=m,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+    )
+
+
+@_tp_moe_tiny_decode_launch_op.register_fake
+def _tp_moe_tiny_decode_launch_fake(
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    volatile_launch_state: bool,
+) -> None:
+    return None
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::tp_moe_compact_micro_launch",
+    mutates_args="unknown",
+)
+def _tp_moe_compact_micro_launch_op(
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    w1_alpha: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    input_gs: torch.Tensor,
+    down_input_scale: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    fast_math: bool,
+    share_input_across_experts: bool,
+    share_expert_scales: bool,
+    activation: str,
+    quant_mode: str,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    volatile_launch_state: bool,
+) -> None:
+    _launch_compact_micro_flat(
+        barrier_count=barrier_count,
+        barrier_epoch=barrier_epoch,
+        micro_intermediate=micro_intermediate,
+        w1_storage=w1_storage,
+        w1_scale_storage=w1_scale_storage,
+        w2_storage=w2_storage,
+        w2_scale_storage=w2_scale_storage,
+        w1_alpha=w1_alpha,
+        w2_alpha=w2_alpha,
+        a=a,
+        launch_ids=launch_ids,
+        flat_weights=flat_weights,
+        input_gs=input_gs,
+        down_input_scale=down_input_scale,
+        scatter_output=scatter_output,
+        weight_E=weight_E,
+        m=m,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+        fast_math=fast_math,
+        share_input_across_experts=share_input_across_experts,
+        share_expert_scales=share_expert_scales,
+        activation=activation,
+        quant_mode=quant_mode,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        volatile_launch_state=volatile_launch_state,
+    )
+
+
+@_tp_moe_compact_micro_launch_op.register_fake
+def _tp_moe_compact_micro_launch_fake(
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    w1_alpha: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    input_gs: torch.Tensor,
+    down_input_scale: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    fast_math: bool,
+    share_input_across_experts: bool,
+    share_expert_scales: bool,
+    activation: str,
+    quant_mode: str,
+    swiglu_limit: float | None,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    volatile_launch_state: bool,
+) -> None:
+    return None
+
+
+def _launch_micro(
+    *,
+    workspace: TPMicroWorkspace,
+    weights: _WeightViews,
+    a: torch.Tensor,
+    flat_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    input_gs: torch.Tensor,
+    down_input_scale: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    routed_rows: int,
+    topk_ids_dtype: torch.dtype,
+    fast_math: bool,
+    stream,
+    share_input_across_experts: bool = False,
+    share_expert_scales: bool = False,
+    activation: str = "silu",
+    quant_mode: str = "nvfp4",
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float = 1.0,
+    swiglu_beta: float = 0.0,
+    unit_scale_contract: bool = False,
+) -> None:
+    del stream, unit_scale_contract
+    quant_mode = _normalize_quant_mode(quant_mode)
+    if quant_mode == "w4a8_mx":
+        # The w4a8_mx tiny band reaches the compact family only via the
+        # tiny_decode resolve gate; its weights are N256/K128-repacked,
+        # which direct-micro cannot read.
+        if flat_ids.dtype == torch.int32 and flat_ids.is_contiguous():
+            launch_ids = flat_ids
+        else:
+            launch_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+            launch_ids.copy_(flat_ids.to(torch.int32))
+        torch.ops.flashinfer_sm12x.tp_moe_tiny_decode_launch(
+            workspace.barrier_count,
+            workspace.barrier_epoch,
+            workspace.micro_intermediate,
+            weights.w1_storage,
+            weights.w1_scale_storage,
+            weights.w2_storage,
+            weights.w2_scale_storage,
+            a,
+            launch_ids,
+            flat_weights,
+            scatter_output,
+            weight_E,
+            m,
+            k,
+            n,
+            num_topk,
+            workspace.volatile_launch_state,
+        )
+        return
+    activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
+    micro_cls = activation_spec.micro_kernel_cls
+    del routed_rows, topk_ids_dtype
+    use_micro_direct = (
+        quant_mode == "nvfp4" or _is_w4a8_quant_mode(quant_mode)
+    ) and micro_cls.is_supported(
+        m=m,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+        weight_E=weight_E,
+    )
+    # _resolve_workspace_layout routes unsupported shapes to dynamic, so a
+    # micro workspace must always be able to run its bound shape.
+    if not use_micro_direct:
+        raise RuntimeError(
+            "compact MoE workspace reached with a shape direct-micro cannot run "
+            f"(m={m}, k={k}, n={n}, num_topk={num_topk}); such shapes must route "
+            "to the dynamic backend (see _resolve_workspace_layout)."
+        )
+    if flat_ids.dtype == torch.int32 and flat_ids.is_contiguous():
+        launch_ids = flat_ids
+    else:
+        launch_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+        launch_ids.copy_(flat_ids.to(torch.int32))
+    torch.ops.flashinfer_sm12x.tp_moe_compact_micro_launch(
+        workspace.barrier_count,
+        workspace.barrier_epoch,
+        workspace.micro_intermediate,
+        weights.w1_storage,
+        weights.w1_scale_storage,
+        weights.w2_storage,
+        weights.w2_scale_storage,
+        weights.w1_alpha,
+        weights.w2_alpha,
+        a,
+        launch_ids,
+        flat_weights,
+        input_gs,
+        down_input_scale,
+        scatter_output,
+        weight_E,
+        m,
+        k,
+        n,
+        num_topk,
+        bool(fast_math),
+        bool(share_input_across_experts),
+        bool(share_expert_scales),
+        activation,
+        quant_mode,
+        swiglu_limit,
+        float(swiglu_alpha),
+        float(swiglu_beta),
+        workspace.volatile_launch_state,
+    )
+
+
+def _require_binding_field(binding: TPMoEFP4Binding, field_name: str):
+    value = getattr(binding, field_name)
+    if value is None:
+        raise RuntimeError(f"TP MoE FP4 binding is missing {field_name}")
+    return value
+
+
+def sm12x_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
+    """Execute one fully planned, prepared, and scratch-bound FP4 MoE launch."""
+    if not isinstance(binding, TPMoEFP4Binding):
+        raise TypeError("binding must be a TPMoEFP4Binding")
+
+    a = binding.a
+    experts = binding.experts
+    if not isinstance(experts, SM12XFP4ExpertWeights):
+        raise TypeError("binding.experts must be a SM12XFP4ExpertWeights")
+    a1_gscale = experts.a1_gscale
+    w1_fp4 = experts.w1_fp4
+    w1_blockscale = experts.w1_blockscale
+    w1_alphas = experts.w1_alphas
+    a2_gscale = experts.a2_gscale
+    w2_fp4 = experts.w2_fp4
+    w2_blockscale = experts.w2_blockscale
+    w2_alphas = experts.w2_alphas
+    topk_weights = binding.topk_weights
+    topk_ids = binding.topk_ids
+    workspace = None
+    apply_router_weight_on_input = binding.apply_router_weight_on_input
+    output = binding.output
+    input_scales_static = binding.input_scales_static
+    fast_math = binding.fast_math
+    activation = experts.activation
+    quant_mode = binding.quant_mode
+    swiglu_limit = binding.swiglu_limit
+    swiglu_alpha = binding.swiglu_alpha
+    swiglu_beta = binding.swiglu_beta
+    activation_amax = binding.activation_amax
+    layer_idx = binding.layer_idx
+    unit_scale_contract = binding.unit_scale_contract
+    source_format = experts.source_format
+    w13_layout = experts.w13_layout
+    quant_mode = _normalize_quant_mode_for_source(quant_mode, source_format)
+    unit_scale_contract = bool(unit_scale_contract and quant_mode == "w4a16")
+
+    if binding.implementation == "micro":
+        workspace = TPMicroWorkspace(
+            implementation=binding.implementation,
+            # Eager-bind maps views only and no longer zeros the read-before-write
+            # barrier scalars; the launch wrapper must re-zero them in-place each
+            # call (gated on volatile_launch_state), like the W4A16 path.
+            volatile_launch_state=True,
+            quant_mode=quant_mode,
+            state_E=binding.state_E,
+            weight_E=binding.weight_E,
+            max_rows=binding.max_rows,
+            k=binding.k,
+            n=binding.n,
+            num_topk=binding.num_topk,
+            device=binding.device,
+            dtype=binding.dtype,
+            row_counts=_require_binding_field(binding, "row_counts"),
+            token_map=_require_binding_field(binding, "token_map"),
+            token_weights=_require_binding_field(binding, "token_weights"),
+            packed_input=_require_binding_field(binding, "packed_input"),
+            packed_input_scale=_require_binding_field(binding, "packed_input_scale"),
+            barrier_count=_require_binding_field(binding, "barrier_count"),
+            barrier_epoch=_require_binding_field(binding, "barrier_epoch"),
+            packed_a_view=binding.packed_a_view,
+            sfa_ptr=binding.sfa_ptr,
+            packed_a_flat=binding.packed_a_flat,
+            scale_flat=binding.scale_flat,
+            packed_a_storage_ptr=binding.packed_a_storage_ptr,
+            routed_rows_capacity=_require_binding_field(
+                binding, "routed_rows_capacity"
+            ),
+            active_expert_count=_require_binding_field(binding, "active_expert_count"),
+            weight_expert_ids=_require_binding_field(binding, "weight_expert_ids"),
+            global_to_local_expert=_require_binding_field(
+                binding, "global_to_local_expert"
+            ),
+            compact_topk_ids=_require_binding_field(binding, "compact_topk_ids"),
+            micro_intermediate=_require_binding_field(binding, "micro_intermediate"),
+        )
+    elif binding.implementation == "dynamic":
+        workspace = TPDynamicWorkspace(
+            implementation=binding.implementation,
+            # Eager-bind maps views only and no longer zeros the read-before-write
+            # barrier scalars; the launch wrapper must re-zero them in-place each
+            # call (gated on volatile_launch_state), like the W4A16 path.
+            volatile_launch_state=True,
+            quant_mode=quant_mode,
+            state_E=binding.state_E,
+            weight_E=binding.weight_E,
+            max_rows=binding.max_rows,
+            k=binding.k,
+            n=binding.n,
+            num_topk=binding.num_topk,
+            device=binding.device,
+            dtype=binding.dtype,
+            row_counts=_require_binding_field(binding, "row_counts"),
+            token_map=_require_binding_field(binding, "token_map"),
+            token_weights=_require_binding_field(binding, "token_weights"),
+            packed_input=_require_binding_field(binding, "packed_input"),
+            packed_input_scale=_require_binding_field(binding, "packed_input_scale"),
+            barrier_count=_require_binding_field(binding, "barrier_count"),
+            barrier_epoch=_require_binding_field(binding, "barrier_epoch"),
+            packed_a_view=binding.packed_a_view,
+            sfa_ptr=binding.sfa_ptr,
+            packed_a_flat=binding.packed_a_flat,
+            scale_flat=binding.scale_flat,
+            packed_a_storage_ptr=binding.packed_a_storage_ptr,
+            routed_rows_capacity=_require_binding_field(
+                binding, "routed_rows_capacity"
+            ),
+            physical_tiles_capacity=_require_binding_field(
+                binding, "physical_tiles_capacity"
+            ),
+            task_capacity=_require_binding_field(binding, "task_capacity"),
+            route_output=_require_binding_field(binding, "route_output"),
+            materialized_intermediate=_require_binding_field(
+                binding, "materialized_intermediate"
+            ),
+            expert_write_rows=_require_binding_field(binding, "expert_write_rows"),
+            expert_tile_base=_require_binding_field(binding, "expert_tile_base"),
+            input_gs=_require_binding_field(binding, "input_gs"),
+            down_input_scale=_require_binding_field(binding, "down_input_scale"),
+            pair_head=_require_binding_field(binding, "pair_head"),
+            producers_done_count=_require_binding_field(
+                binding, "producers_done_count"
+            ),
+            all_work_published=_require_binding_field(binding, "all_work_published"),
+            task_head=_require_binding_field(binding, "task_head"),
+            task_tail=_require_binding_field(binding, "task_tail"),
+            task_ready=_require_binding_field(binding, "task_ready"),
+            task_expert=_require_binding_field(binding, "task_expert"),
+            task_m_tile=_require_binding_field(binding, "task_m_tile"),
+            task_slice_begin=_require_binding_field(binding, "task_slice_begin"),
+            task_slice_count=_require_binding_field(binding, "task_slice_count"),
+            task_valid_rows=_require_binding_field(binding, "task_valid_rows"),
+            tile_write_count=_require_binding_field(binding, "tile_write_count"),
+        )
+    elif binding.implementation != "w4a16":
+        raise TypeError(
+            f"unsupported TP MoE FP4 binding implementation {binding.implementation!r}"
+        )
+
+    quant_mode_arg = quant_mode
+    source_format = _normalize_fp4_source_format(source_format)
+    quant_mode = _normalize_quant_mode_for_source(quant_mode_arg, source_format)
+    unit_scale_contract = bool(unit_scale_contract and quant_mode == "w4a16")
+    activation = normalize_moe_activation(activation)
+    swiglu_limit, swiglu_alpha, swiglu_beta = _normalize_swiglu_params(
+        activation,
+        swiglu_limit,
+        swiglu_alpha,
+        swiglu_beta,
+    )
+    w13_layout = _normalize_w13_layout_for_activation(activation, w13_layout)
+    _validate_fp4_source_format_for_quant_mode(
+        source_format=source_format,
+        quant_mode=quant_mode,
+    )
+    if activation_amax is not None and quant_mode != "w4a16":
+        raise NotImplementedError(
+            "activation_amax calibration is only supported for W4A16"
+        )
+    num_topk = topk_ids.shape[1]
+    m, k = a.shape
+    prepared_payload = _prepared_payload_for_runtime(
+        experts,
+        quant_mode=quant_mode,
+        source_format=source_format,
+        activation=activation,
+        w13_layout=w13_layout,
+        dtype=a.dtype,
+        hidden_size=k,
+    )
+    device = a.device
+    prepared_hidden = experts.hidden_size
+    if prepared_hidden != k:
+        raise ValueError(
+            f"prepared hidden_size mismatch: expected {k}, got {prepared_hidden}"
+        )
+    prepared_dtype = experts.plan.io_dtype
+    if prepared_dtype != str(a.dtype).removeprefix("torch."):
+        raise TypeError(
+            f"prepared weights were built for {prepared_dtype}, but a has "
+            f"dtype {a.dtype}"
+        )
+    weight_E = experts.num_experts
+    n = experts.intermediate_size
+    routed_rows = m * num_topk
+    if apply_router_weight_on_input and quant_mode != "w4a16":
+        raise NotImplementedError(
+            "apply_router_weight_on_input is not implemented in sm12x_moe_fp4"
+        )
+    if activation == SWIGLUOAI_UNINTERLEAVE and _is_w4a8_quant_mode(quant_mode):
+        raise NotImplementedError(
+            "activation='swigluoai_uninterleave' is not supported for W4A8 MoE"
+        )
+    if fast_math is None:
+        fast_math = _FAST_MATH_DEFAULT
+    # Shared scalar input scales are weight-side constants in the benchmarked
+    # path, so treat them as static and avoid re-expanding them every launch.
+    effective_input_scales_static = input_scales_static or (
+        a1_gscale.numel() == 1 and a2_gscale.numel() == 1
+    )
+    if quant_mode == "w4a16":
+        from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+            run_w4a16_moe,
+        )
+
+        if output is None:
+            if torch.cuda.is_current_stream_capturing():
+                raise ValueError(
+                    "CUDA graph capture requires a caller-owned output buffer"
+                )
+            scatter_output = torch.empty(m, k, dtype=a.dtype, device=device)
+        else:
+            scatter_output = output
+        if scatter_output.shape != (m, k):
+            raise ValueError(
+                f"output must have shape {(m, k)}, got {tuple(scatter_output.shape)}"
+            )
+        if scatter_output.dtype != a.dtype:
+            raise ValueError(
+                f"output must have dtype {a.dtype}, got {scatter_output.dtype}"
+            )
+        if scatter_output.device != device:
+            raise ValueError(
+                f"output must be on device {device}, got {scatter_output.device}"
+            )
+        if not scatter_output.is_contiguous():
+            raise ValueError("output must be contiguous")
+
+        prepared = prepared_payload
+        if prepared is None:
+            raise RuntimeError(
+                "the W4A16 weight plan did not materialize its required representation"
+            )
+        if binding.implementation != "w4a16":
+            raise TypeError("expected a W4A16 TP MoE binding")
+        if (binding.routed_rows_capacity or 0) < routed_rows:
+            raise RuntimeError(
+                "W4A16 TP MoE binding capacity is too small: "
+                f"capacity={binding.routed_rows_capacity}, requested={routed_rows}"
+            )
+        intermediate_cache13 = _require_binding_field(binding, "intermediate_cache13")
+        intermediate_cache2 = _require_binding_field(binding, "intermediate_cache2")
+        fc1_c_tmp = _require_binding_field(binding, "fc1_c_tmp")
+        fc2_c_tmp = _require_binding_field(binding, "fc2_c_tmp")
+        packed_route_indices = _require_binding_field(binding, "packed_route_indices")
+        block_expert_ids = _require_binding_field(binding, "block_expert_ids")
+        packed_route_count = _require_binding_field(binding, "packed_route_count")
+        expert_offsets = _require_binding_field(binding, "expert_offsets")
+        fused_launch = binding.fused_launch
+        topk_sum_launch = binding.topk_sum_launch
+        if not topk_weights.is_contiguous():
+            if torch.cuda.is_current_stream_capturing():
+                raise ValueError(
+                    "CUDA graph capture requires contiguous W4A16 topk_weights"
+                )
+            topk_weights = topk_weights.contiguous()
+        if not topk_ids.is_contiguous():
+            if torch.cuda.is_current_stream_capturing():
+                raise ValueError(
+                    "CUDA graph capture requires contiguous W4A16 topk_ids"
+                )
+            topk_ids = topk_ids.contiguous()
+        return run_w4a16_moe(
+            a,
+            prepared,
+            topk_weights,
+            topk_ids,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            fast_math=fast_math,
+            intermediate_cache13=intermediate_cache13,
+            intermediate_cache2=intermediate_cache2,
+            output=scatter_output,
+            fc1_c_tmp=fc1_c_tmp,
+            fc2_c_tmp=fc2_c_tmp,
+            packed_route_indices=packed_route_indices,
+            block_expert_ids=block_expert_ids,
+            packed_route_count=packed_route_count,
+            expert_offsets=expert_offsets,
+            activation_amax=activation_amax,
+            layer_idx=layer_idx,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            fused_launch=fused_launch,
+            topk_sum_launch=topk_sum_launch,
+        )
+    activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
+    plan = plan_tp_moe_execution(
+        num_tokens=m,
+        num_topk=num_topk,
+        device=device,
+        weight_plan=experts.plan,
+        quant_mode=quant_mode,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        deterministic_output=bool(binding.deterministic_output),
+    )
+
+    impl = plan.implementation
+    max_rows = plan.max_rows
+    if impl == "dynamic" and m > plan.max_tokens_per_launch:
+        raise ValueError(
+            "the bound MoE launch exceeds the dynamic kernel's per-launch "
+            f"token limit ({m} > {plan.max_tokens_per_launch}); split the "
+            "request while constructing bindings"
+        )
+
+    s = _resolve_workspace(
+        workspace,
+        plan=plan,
+        a1_gscale=a1_gscale,
+        a2_gscale=a2_gscale,
+        input_scales_static=effective_input_scales_static,
+    )
+
+    # CUDA graph capture may run on a non-default stream, so the launch stream
+    # must be fetched per-call rather than cached per-device.
+    stream = current_cuda_stream()
+
+    if impl == "micro":
+        assert isinstance(s, TPMicroWorkspace)
+        flat_ids = _flatten_routing_ids(topk_ids)
+        flat_weights = _flatten_routing_weights(topk_weights)
+
+        wv = _get_weight_views(
+            w1_fp4,
+            w1_blockscale,
+            w2_fp4,
+            w2_blockscale,
+            w1_alphas,
+            w2_alphas,
+            n,
+            k,
+            activation_spec=activation_spec,
+            quant_mode=quant_mode,
+            w13_layout=w13_layout,
+        )
+        input_gs = _prepare_expert_scale(a1_gscale, weight_E)
+        down_input_scale = _prepare_expert_scale(a2_gscale, weight_E)
+    else:
+        assert isinstance(s, TPDynamicWorkspace)
+        if prepared_payload is not None and quant_mode == "w4a8_mx":
+            wv = _w4a8_prepared_weight_views(
+                prepared_payload,
+                w1_alphas,
+                w2_alphas,
+            )
+        else:
+            wv = _get_weight_views(
+                w1_fp4,
+                w1_blockscale,
+                w2_fp4,
+                w2_blockscale,
+                w1_alphas,
+                w2_alphas,
+                n,
+                k,
+                activation_spec=activation_spec,
+                quant_mode=quant_mode,
+                w13_layout=w13_layout,
+            )
+        input_gs = s.input_gs
+        down_input_scale = s.down_input_scale
+        flat_ids = _flatten_routing_ids(topk_ids)
+        flat_weights = _flatten_routing_weights(topk_weights)
+
+    if output is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise ValueError("CUDA graph capture requires a caller-owned output buffer")
+        scatter_output = torch.zeros(m, k, dtype=a.dtype, device=device)
+    else:
+        scatter_output = output
+    if scatter_output.shape != (m, k):
+        raise ValueError(
+            f"output must have shape {(m, k)}, got {tuple(scatter_output.shape)}"
+        )
+    if scatter_output.dtype != a.dtype:
+        raise ValueError(
+            f"output must have dtype {a.dtype}, got {scatter_output.dtype}"
+        )
+    if scatter_output.device != device:
+        raise ValueError(
+            f"output must be on device {device}, got {scatter_output.device}"
+        )
+    if not scatter_output.is_contiguous():
+        raise ValueError("output must be contiguous")
+
+    if impl == "dynamic":
+        deterministic_output = plan.deterministic_output
+        dense_w4a8_candidate = _w4a8_dynamic_dense_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=weight_E,
+            k=k,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+        decode_w4a8_candidate = _w4a8_dynamic_decode_candidate(
+            quant_mode=quant_mode,
+            activation=activation,
+            routed_rows=routed_rows,
+            num_experts=weight_E,
+            n=n,
+            deterministic_output=deterministic_output,
+        )
+        dynamic_w4a8_prepared = (
+            _w4a8_prepared_dict(prepared_payload)
+            if prepared_payload is not None and quant_mode == "w4a8_mx"
+            else None
+        )
+        if quant_mode == "w4a8_mx" and dynamic_w4a8_prepared is None:
+            raise RuntimeError(
+                "the W4A8-MX weight plan did not materialize its required "
+                "QMMA representation"
+            )
+        _launch_dynamic(
+            workspace=s,
+            weights=wv,
+            a=a,
+            flat_ids=flat_ids,
+            flat_weights=flat_weights,
+            scatter_output=scatter_output,
+            E=weight_E,
+            m=m,
+            k=k,
+            n=n,
+            num_topk=num_topk,
+            routed_rows=routed_rows,
+            max_rows=max_rows,
+            topk_ids_dtype=flat_ids.dtype,
+            fast_math=fast_math,
+            stream=stream,
+            activation=activation,
+            quant_mode=quant_mode,
+            w4a8_prepared=dynamic_w4a8_prepared,
+            deterministic_output=deterministic_output,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            share_input_across_experts=(
+                (quant_mode == "nvfp4" and a1_gscale.numel() == 1)
+                or (
+                    dynamic_w4a8_prepared is not None
+                    and _env_flag(
+                        _DYNAMIC_W4A8_SHARE_INPUT_ENV,
+                        default=(dense_w4a8_candidate or decode_w4a8_candidate),
+                    )
+                )
+            ),
+        )
+        if deterministic_output:
+            _launch_dynamic_topk_sum(
+                route_output=s.route_output,
+                output=scatter_output,
+                m=m,
+                num_topk=num_topk,
+                k=k,
+                stream=stream,
+            )
+    else:
+        _launch_micro(
+            workspace=s,
+            weights=wv,
+            a=a,
+            flat_ids=flat_ids,
+            flat_weights=flat_weights,
+            input_gs=input_gs,
+            down_input_scale=down_input_scale,
+            scatter_output=scatter_output,
+            weight_E=weight_E,
+            m=m,
+            k=k,
+            n=n,
+            num_topk=num_topk,
+            routed_rows=routed_rows,
+            topk_ids_dtype=flat_ids.dtype,
+            fast_math=fast_math,
+            stream=stream,
+            share_input_across_experts=(
+                activation in ("relu2", "silu")
+                and m == 1
+                and a1_gscale.numel() == 1
+                and os.environ.get(
+                    "FLASHINFER_EXP_SM12X_MICRO_SHARE_INPUT_ACROSS_EXPERTS", "1"
+                )
+                != "0"
+            ),
+            share_expert_scales=(
+                activation in ("relu2", "silu")
+                and a1_gscale.numel() == 1
+                and a2_gscale.numel() == 1
+            ),
+            activation=activation,
+            quant_mode=quant_mode,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            unit_scale_contract=unit_scale_contract,
+        )
+    return scatter_output
+
+
+def _validate_sparse_routing(
+    hidden_states: torch.Tensor, routing: SM12XTopKRouting
+) -> None:
+    if routing.topk_ids.ndim != 2:
+        raise ValueError(
+            f"expected topk_ids with rank 2, got shape {tuple(routing.topk_ids.shape)}"
+        )
+    if routing.topk_weights.ndim != 2:
+        raise ValueError(
+            "expected topk_weights with rank 2, got shape "
+            f"{tuple(routing.topk_weights.shape)}"
+        )
+    if routing.topk_ids.shape != routing.topk_weights.shape:
+        raise ValueError(
+            "topk_ids and topk_weights must have the same shape, got "
+            f"{tuple(routing.topk_ids.shape)} and {tuple(routing.topk_weights.shape)}"
+        )
+    if routing.topk_ids.shape[0] != hidden_states.shape[0]:
+        raise ValueError(
+            "routing batch mismatch: expected "
+            f"{hidden_states.shape[0]}, got {routing.topk_ids.shape[0]}"
+        )
+    if (
+        routing.router_logits is not None
+        and routing.router_logits.shape[0] != hidden_states.shape[0]
+    ):
+        raise ValueError(
+            "router_logits batch mismatch: expected "
+            f"{hidden_states.shape[0]}, got {routing.router_logits.shape[0]}"
+        )
+    if (
+        routing.flat_ids is not None
+        and routing.flat_ids.numel() != routing.topk_ids.numel()
+    ):
+        raise ValueError(
+            "flat_ids size mismatch: expected "
+            f"{routing.topk_ids.numel()}, got {routing.flat_ids.numel()}"
+        )
+    if (
+        routing.flat_weights is not None
+        and routing.flat_weights.numel() != routing.topk_weights.numel()
+    ):
+        raise ValueError(
+            "flat_weights size mismatch: expected "
+            f"{routing.topk_weights.numel()}, got {routing.flat_weights.numel()}"
+        )
+
+
+def _alloc_route_workspace(
+    *,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    device: torch.device,
+    logits_dtype: torch.dtype,
+) -> _TPRouteWorkspace:
+    required = _route_workspace_nbytes(
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        logits_dtype=logits_dtype,
+    )
+    _emit_route_workspace_stats(
+        storage="standalone",
+        required_nbytes=required,
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        device=device,
+        logits_dtype=logits_dtype,
+    )
+    return _TPRouteWorkspace(
+        router_logits=torch.empty(
+            num_tokens, num_experts, device=device, dtype=logits_dtype
+        ),
+        topk_logits=torch.empty(num_tokens, top_k, device=device, dtype=torch.float32),
+        topk_ids=torch.empty(num_tokens, top_k, device=device, dtype=torch.int32),
+        topk_weights=torch.empty(num_tokens, top_k, device=device, dtype=torch.float32),
+    )
+
+
+def _route_workspace_specs(
+    *,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    logits_dtype: torch.dtype,
+) -> tuple[_TensorAllocSpec, ...]:
+    return (
+        _TensorAllocSpec("router_logits", (num_tokens, num_experts), logits_dtype),
+        _TensorAllocSpec("topk_logits", (num_tokens, top_k), torch.float32),
+        _TensorAllocSpec("topk_ids", (num_tokens, top_k), torch.int32),
+        _TensorAllocSpec("topk_weights", (num_tokens, top_k), torch.float32),
+    )
+
+
+def _route_workspace_nbytes(
+    *,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    logits_dtype: torch.dtype,
+) -> int:
+    offset = 0
+    for spec in _route_workspace_specs(
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        logits_dtype=logits_dtype,
+    ):
+        offset = align_up(offset, max(16, _dtype_nbytes(spec.dtype)))
+        offset += _tensor_numel(spec.shape) * _dtype_nbytes(spec.dtype)
+    return int(offset)
+
+
+def _emit_route_workspace_stats(
+    *,
+    storage: str,
+    required_nbytes: int,
+    capacity_nbytes: int | None = None,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    device: torch.device,
+    logits_dtype: torch.dtype,
+) -> None:
+    return
+
+
+def _materialize_route_workspace(
+    shared_arena: torch.Tensor,
+    *,
+    offset_bytes: int,
+    capacity_nbytes: int,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    logits_dtype: torch.dtype,
+) -> _TPRouteWorkspace:
+    required = _route_workspace_nbytes(
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        logits_dtype=logits_dtype,
+    )
+    if capacity_nbytes < required:
+        raise ValueError(
+            f"MoE route workspace requires {required} bytes, but only {capacity_nbytes} are available"
+        )
+    _emit_route_workspace_stats(
+        storage="shared",
+        required_nbytes=required,
+        capacity_nbytes=capacity_nbytes,
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        device=shared_arena.device,
+        logits_dtype=logits_dtype,
+    )
+    offset = int(offset_bytes)
+    tensors: Dict[str, torch.Tensor] = {}
+    for spec in _route_workspace_specs(
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        logits_dtype=logits_dtype,
+    ):
+        tensors[spec.name], offset = _allocate_arena_tensor(shared_arena, offset, spec)
+    return _TPRouteWorkspace(
+        router_logits=tensors["router_logits"],
+        topk_logits=tensors["topk_logits"],
+        topk_ids=tensors["topk_ids"],
+        topk_weights=tensors["topk_weights"],
+    )
+
+
+def _slice_route_workspace(
+    route_workspace: _TPRouteWorkspace, num_tokens: int
+) -> _TPRouteWorkspace:
+    if route_workspace.router_logits.shape[0] == num_tokens:
+        return route_workspace
+    return _TPRouteWorkspace(
+        router_logits=route_workspace.router_logits[:num_tokens],
+        topk_logits=route_workspace.topk_logits[:num_tokens],
+        topk_ids=route_workspace.topk_ids[:num_tokens],
+        topk_weights=route_workspace.topk_weights[:num_tokens],
+    )
+
+
+def _get_route_workspace(
+    hidden_states: torch.Tensor,
+    *,
+    num_experts: int,
+    top_k: int,
+    logits_dtype: torch.dtype,
+    workspace: TPMoEWorkspace | TPW4A16Workspace | TPMoEWorkspacePool | None,
+) -> _TPRouteWorkspace | None:
+    if workspace is None:
+        return None
+
+    m = hidden_states.shape[0]
+    device = hidden_states.device
+
+    if isinstance(workspace, TPMoEWorkspacePool):
+        key = (
+            device.index,
+            num_experts,
+            top_k,
+            logits_dtype,
+        )
+        route_workspace = workspace.route_workspaces.get(key)
+        needs_growth = (
+            route_workspace is None
+            or route_workspace.router_logits.shape[0] < m
+            or route_workspace.router_logits.shape[1] != num_experts
+            or route_workspace.topk_ids.shape[1] != top_k
+            or route_workspace.router_logits.dtype != logits_dtype
+            or route_workspace.router_logits.device != device
+        )
+        if needs_growth:
+            if workspace.shared_arena is None:
+                route_workspace = _alloc_route_workspace(
+                    num_tokens=m,
+                    num_experts=num_experts,
+                    top_k=top_k,
+                    device=device,
+                    logits_dtype=logits_dtype,
+                )
+            else:
+                if workspace.shared_arena.device != device:
+                    raise ValueError(
+                        f"MoE pool arena device {workspace.shared_arena.device} does not match hidden_states device {device}"
+                    )
+                route_workspace = _materialize_route_workspace(
+                    workspace.shared_arena,
+                    offset_bytes=0,
+                    capacity_nbytes=workspace.route_workspace_nbytes,
+                    num_tokens=m,
+                    num_experts=num_experts,
+                    top_k=top_k,
+                    logits_dtype=logits_dtype,
+                )
+            workspace.route_workspaces[key] = route_workspace
+        return _slice_route_workspace(route_workspace, m)
+
+    route_workspace = workspace.route_workspace
+    if (
+        route_workspace is None
+        or route_workspace.router_logits.shape != (m, num_experts)
+        or route_workspace.topk_logits.shape != (m, top_k)
+        or route_workspace.router_logits.dtype != logits_dtype
+        or route_workspace.router_logits.device != device
+    ):
+        route_workspace = _alloc_route_workspace(
+            num_tokens=m,
+            num_experts=num_experts,
+            top_k=top_k,
+            device=device,
+            logits_dtype=logits_dtype,
+        )
+        workspace.route_workspace = route_workspace
+    return route_workspace
+
+
+def _select_experts_reference(
+    hidden_states: torch.Tensor,
+    *,
+    top_k: int,
+    gate_weight: torch.Tensor | None = None,
+    gate_bias: torch.Tensor | None = None,
+    router_logits: torch.Tensor | None = None,
+    renormalize: bool = True,
+) -> SM12XTopKRouting:
+    """Reference routing selection for sparse-block MoE wrappers.
+
+    Keep this path simple and obviously correct. Optimized routing should live
+    in a separate public fast path rather than accreting special cases here.
+    """
+
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            "expected hidden_states with rank 2, got shape "
+            f"{tuple(hidden_states.shape)}"
+        )
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+    if router_logits is not None and gate_weight is not None:
+        raise ValueError("pass either router_logits or gate_weight, not both")
+    if router_logits is None and gate_weight is None:
+        raise ValueError("expected router_logits or gate_weight")
+
+    if router_logits is None:
+        assert gate_weight is not None
+        if gate_weight.ndim != 2:
+            raise ValueError(
+                f"expected gate_weight with rank 2, got shape {tuple(gate_weight.shape)}"
+            )
+        if gate_weight.shape[1] != hidden_states.shape[1]:
+            raise ValueError(
+                "gate_weight hidden-size mismatch: expected "
+                f"{hidden_states.shape[1]}, got {gate_weight.shape[1]}"
+            )
+        if gate_bias is not None:
+            if gate_bias.ndim != 1:
+                raise ValueError(
+                    f"expected gate_bias with rank 1, got shape {tuple(gate_bias.shape)}"
+                )
+            if gate_bias.shape[0] != gate_weight.shape[0]:
+                raise ValueError(
+                    "gate_bias expert mismatch: expected "
+                    f"{gate_weight.shape[0]}, got {gate_bias.shape[0]}"
+                )
+        router_logits = F.linear(hidden_states, gate_weight, gate_bias)
+    else:
+        if router_logits.ndim != 2:
+            raise ValueError(
+                "expected router_logits with rank 2, got shape "
+                f"{tuple(router_logits.shape)}"
+            )
+        if router_logits.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                "router_logits batch mismatch: expected "
+                f"{hidden_states.shape[0]}, got {router_logits.shape[0]}"
+            )
+
+    num_experts = router_logits.shape[1]
+    if top_k > num_experts:
+        raise ValueError(f"top_k={top_k} exceeds num_experts={num_experts}")
+
+    topk_logits, topk_ids = torch.topk(router_logits, k=top_k, dim=-1)
+    if renormalize:
+        topk_weights = torch.softmax(topk_logits.to(torch.float32), dim=-1)
+    else:
+        topk_weights = topk_logits.to(torch.float32)
+    return SM12XTopKRouting(
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        router_logits=router_logits,
+    )
+
+
+def sm12x_route_experts_fast(*, binding: TPMoERouteBinding) -> SM12XTopKRouting:
+    """Public sparse-routing entrypoint for higher-level integrations.
+
+    This is the optimization seam for future fast routing work. The current
+    implementation preserves the simple reference math, but when caller-owned
+    scratch is available through the binding it reuses route buffers for the gate
+    logits and top-k outputs.
+    """
+    if not isinstance(binding, TPMoERouteBinding):
+        raise TypeError("binding must be a TPMoERouteBinding")
+    hidden_states = binding.hidden_states
+    top_k = binding.top_k
+    gate_weight = binding.gate_weight
+    gate_bias = binding.gate_bias
+    router_logits = binding.router_logits
+    renormalize = binding.renormalize
+    scratch = binding.scratch
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            "expected hidden_states with rank 2, got shape "
+            f"{tuple(hidden_states.shape)}"
+        )
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+    if router_logits is not None and gate_weight is not None:
+        raise ValueError("pass either router_logits or gate_weight, not both")
+    if router_logits is None and gate_weight is None:
+        raise ValueError("expected router_logits or gate_weight")
+
+    if router_logits is None:
+        assert gate_weight is not None
+        if gate_weight.ndim != 2:
+            raise ValueError(
+                f"expected gate_weight with rank 2, got shape {tuple(gate_weight.shape)}"
+            )
+        if gate_weight.shape[1] != hidden_states.shape[1]:
+            raise ValueError(
+                "gate_weight hidden-size mismatch: expected "
+                f"{hidden_states.shape[1]}, got {gate_weight.shape[1]}"
+            )
+        if gate_bias is not None:
+            if gate_bias.ndim != 1:
+                raise ValueError(
+                    f"expected gate_bias with rank 1, got shape {tuple(gate_bias.shape)}"
+                )
+            if gate_bias.shape[0] != gate_weight.shape[0]:
+                raise ValueError(
+                    "gate_bias expert mismatch: expected "
+                    f"{gate_weight.shape[0]}, got {gate_bias.shape[0]}"
+                )
+        num_experts = gate_weight.shape[0]
+        logits_dtype = torch.result_type(hidden_states, gate_weight)
+    else:
+        if router_logits.ndim != 2:
+            raise ValueError(
+                "expected router_logits with rank 2, got shape "
+                f"{tuple(router_logits.shape)}"
+            )
+        if router_logits.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                "router_logits batch mismatch: expected "
+                f"{hidden_states.shape[0]}, got {router_logits.shape[0]}"
+            )
+        num_experts = router_logits.shape[1]
+        logits_dtype = router_logits.dtype
+
+    if top_k > num_experts:
+        raise ValueError(f"top_k={top_k} exceeds num_experts={num_experts}")
+
+    if not hidden_states.is_cuda or num_experts > 1024:
+        selected = _select_experts_reference(
+            hidden_states,
+            top_k=top_k,
+            gate_weight=gate_weight,
+            gate_bias=gate_bias,
+            router_logits=router_logits,
+            renormalize=renormalize,
+        )
+        topk_ids_i32 = selected.topk_ids.to(torch.int32)
+        return SM12XTopKRouting(
+            topk_weights=selected.topk_weights,
+            topk_ids=topk_ids_i32,
+            router_logits=selected.router_logits,
+            flat_ids=topk_ids_i32.view(-1),
+            flat_weights=selected.topk_weights.reshape(-1),
+        )
+
+    route_workspace = _get_route_workspace(
+        hidden_states,
+        num_experts=num_experts,
+        top_k=top_k,
+        logits_dtype=logits_dtype,
+        workspace=scratch,
+    )
+    if route_workspace is None:
+        route_workspace = _alloc_route_workspace(
+            num_tokens=hidden_states.shape[0],
+            num_experts=num_experts,
+            top_k=top_k,
+            device=hidden_states.device,
+            logits_dtype=logits_dtype,
+        )
+
+    if router_logits is None:
+        assert gate_weight is not None
+        torch.mm(hidden_states, gate_weight.t(), out=route_workspace.router_logits)
+        if gate_bias is not None:
+            route_workspace.router_logits.add_(
+                gate_bias.to(route_workspace.router_logits.dtype)
+            )
+        router_logits = route_workspace.router_logits
+    else:
+        if not router_logits.is_contiguous():
+            route_workspace.router_logits.copy_(router_logits)
+            router_logits = route_workspace.router_logits
+
+    triton_route_topk(
+        router_logits,
+        route_workspace.topk_logits,
+        route_workspace.topk_ids,
+        route_workspace.topk_weights,
+        renormalize=renormalize,
+    )
+    topk_ids = route_workspace.topk_ids
+    topk_weights = route_workspace.topk_weights
+
+    return SM12XTopKRouting(
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        router_logits=router_logits,
+        flat_ids=topk_ids.view(-1),
+        flat_weights=topk_weights.view(-1),
+    )
+
+
+def sm12x_sparse_moe_fp4(
+    *, binding: TPMoESparseFP4Binding
+) -> torch.Tensor | tuple[torch.Tensor, SM12XTopKRouting]:
+    """Execute a fully bound ``gate -> top-k -> routed experts`` block."""
+    if not isinstance(binding, TPMoESparseFP4Binding):
+        raise TypeError("binding must be a TPMoESparseFP4Binding")
+    hidden_states = binding.hidden_states
+    experts = binding.experts
+    workspace = binding.scratch
+    routing = binding.routing
+    top_k = binding.top_k
+    gate_weight = binding.gate_weight
+    gate_bias = binding.gate_bias
+    router_logits = binding.router_logits
+    renormalize_topk = binding.renormalize_topk
+    routed_scaling_factor = binding.routed_scaling_factor
+    output = binding.output
+    return_routing = binding.return_routing
+    input_scales_static = binding.input_scales_static
+    fast_math = binding.fast_math
+    quant_mode = binding.quant_mode
+    swiglu_limit = binding.swiglu_limit
+    swiglu_alpha = binding.swiglu_alpha
+    swiglu_beta = binding.swiglu_beta
+    activation_amax = binding.activation_amax
+    layer_idx = binding.layer_idx
+
+    quant_mode_normalized = _select_prepared_quant_mode(
+        experts,
+        quant_mode,
+    )
+
+    if routing is not None:
+        if (
+            top_k is not None
+            or gate_weight is not None
+            or gate_bias is not None
+            or router_logits is not None
+        ):
+            raise ValueError(
+                "routing is mutually exclusive with top_k/gate_weight/gate_bias/router_logits"
+            )
+        selected = routing
+    else:
+        if top_k is None:
+            raise ValueError("top_k is required when routing is not provided")
+        route_binding = build_tp_moe_route_binding(
+            scratch=workspace,
+            hidden_states=hidden_states,
+            top_k=top_k,
+            gate_weight=gate_weight,
+            gate_bias=gate_bias,
+            router_logits=router_logits,
+            renormalize=renormalize_topk,
+        )
+        selected = sm12x_route_experts_fast(
+            binding=route_binding,
+        )
+
+    _validate_sparse_routing(hidden_states, selected)
+
+    moe_binding = build_tp_moe_fp4_binding(
+        scratch=workspace,
+        a=hidden_states,
+        experts=experts,
+        topk_weights=selected.topk_weights,
+        topk_ids=selected.topk_ids,
+        output=output,
+        input_scales_static=input_scales_static,
+        fast_math=fast_math,
+        quant_mode=quant_mode_normalized,
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+        activation_amax=activation_amax,
+        layer_idx=layer_idx,
+    )
+    routed_output = sm12x_moe_fp4(binding=moe_binding)
+    if routed_scaling_factor != 1.0:
+        routed_output.mul_(routed_scaling_factor)
+    if return_routing:
+        return routed_output, selected
+    return routed_output

--- a/flashinfer/experimental/sm12x/moe/fused_moe/api.py
+++ b/flashinfer/experimental/sm12x/moe/fused_moe/api.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for moe.fused_moe (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from .._shared.execution import (
+    MoEWeightPreparationPlan as WeightsPlan,
+)
+from .._shared.routing import (
+    route_topk,
+)
+from ._impl import (
+    SM12XFP4ExpertWeights as ExpertWeights,
+)
+from ._impl import (
+    SM12XTopKRouting as Routing,
+)
+from ._impl import (
+    TPMoEFP4Binding as Binding,
+)
+from ._impl import (
+    TPMoEPlan as ExecutionPlan,
+)
+from ._impl import (
+    TPMoERouteBinding as RouteBinding,
+)
+from ._impl import (
+    TPMoEScratchCaps as Caps,
+)
+from ._impl import (
+    TPMoEScratchPlan as Plan,
+)
+from ._impl import (
+    TPMoESparseFP4Binding as SparseBinding,
+)
+from ._impl import (
+    build_tp_moe_route_binding as bind_route,
+)
+from ._impl import (
+    build_tp_moe_sparse_fp4_binding as bind_sparse,
+)
+from ._impl import (
+    clear_tp_moe_caches as clear_caches,
+)
+from ._impl import (
+    plan_sm12x_fp4_moe_weights as plan_weights,
+)
+from ._impl import (
+    plan_tp_moe_execution as plan_execution,
+)
+from ._impl import (
+    plan_tp_moe_scratch as plan,
+)
+from ._impl import (
+    prepare_sm12x_fp4_moe_weights as prepare_weights,
+)
+from ._impl import (
+    sm12x_moe_fp4 as run,
+)
+from ._impl import (
+    sm12x_route_experts_fast as route,
+)
+from ._impl import (
+    sm12x_sparse_moe_fp4 as run_sparse,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0 and triton."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "ExecutionPlan",
+    "Binding",
+    "SparseBinding",
+    "RouteBinding",
+    "ExpertWeights",
+    "Routing",
+    "WeightsPlan",
+    "plan",
+    "plan_execution",
+    "plan_weights",
+    "prepare_weights",
+    "bind",
+    "bind_sparse",
+    "bind_route",
+    "run",
+    "run_sparse",
+    "route",
+    "route_topk",
+    "is_supported",
+    "clear_caches",
+]

--- a/flashinfer/experimental/sm12x/norm/__init__.py
+++ b/flashinfer/experimental/sm12x/norm/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Norm/residual ops for flashinfer.experimental.sm12x.
+
+- ``mhc``: fused RMSNorm + hyper-connection residual mixing + projection
+  (DeepSeek-style mHC), pre/post/post-pre phases.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_OP_MODULES = ("mhc",)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _OP_MODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(_OP_MODULES)
+
+
+__all__ = list(_OP_MODULES)

--- a/flashinfer/experimental/sm12x/norm/mhc/__init__.py
+++ b/flashinfer/experimental/sm12x/norm/mhc/__init__.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""mHC residual for SM12x: fused RMSNorm + hyper-connection mixing +
+projection (DeepSeek-style), BF16 with TF32 projection paths.
+
+Three phases share one plan/binding; the phase is the verb because the
+signatures differ: ``run_pre`` (residual -> mixed input + carry),
+``run_post`` (output mix-back), ``run_post_pre`` (fused post+pre between
+layers). Sinkhorn-normalized mix matrices; hidden sizes 4096/7168; mix
+constants exposed as ``MIXES`` / ``MULT`` / ``PARTIALS``.
+
+Planned lifecycle: ``plan(Caps(...))`` -> ``bind`` (views only) ->
+``run_*`` (capture safe; torch.compile-safe via opaque custom ops).
+
+Example:
+    from flashinfer.experimental.sm12x.norm import mhc
+
+    plan    = mhc.plan(mhc.Caps(...))
+    spec    = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = mhc.bind(plan, scratch=scratch, ...)
+    residual, post, comb, y = mhc.run_post_pre(..., binding=binding)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="mhc",
+    group="norm",
+    api_style="planned",
+    entry_points=(
+        "Caps",
+        "Plan",
+        "Binding",
+        "plan",
+        "bind",
+        "run_pre",
+        "run_post",
+        "run_post_pre",
+        "MIXES",
+        "MULT",
+        "PARTIALS",
+        "DEFAULT_SPLIT_K",
+        "DEFAULT_BLOCK_K",
+        "DEFAULT_BLOCK_H",
+        "is_supported",
+    ),
+    dtypes=("bf16",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=(
+            "b12x/integration/residual.py",
+            "b12x/integration/residual_kernels.py",
+        ),
+    ),
+    test_path="tests/experimental/norm/test_mhc.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        DEFAULT_BLOCK_H,
+        DEFAULT_BLOCK_K,
+        DEFAULT_SPLIT_K,
+        MIXES,
+        MULT,
+        PARTIALS,
+        Binding,
+        Caps,
+        Plan,
+        bind,
+        is_supported,
+        plan,
+        run_post,
+        run_post_pre,
+        run_pre,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/norm/mhc/_impl.py
+++ b/flashinfer/experimental/sm12x/norm/mhc/_impl.py
@@ -1,0 +1,1801 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/residual.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""CuTeDSL mHC residual helpers for DeepSeek-style residual mixing."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+
+from flashinfer.experimental.sm12x._lib.scratch_layout import (
+    SCRATCH_ALIGN_BYTES,
+    align_up,
+    dtype_nbytes,
+    materialize_scratch_view,
+)
+from flashinfer.experimental.sm12x._lib.scratch import (
+    ScratchBufferSpec,
+    scratch_buffer_spec,
+    scratch_tensor,
+)
+
+
+MHC_MULT = 4
+MHC_MIXES = (2 + MHC_MULT) * MHC_MULT
+MHC_PARTIALS = 1 + MHC_MIXES
+MHC_DEFAULT_SPLIT_K = 64
+MHC_DEFAULT_BLOCK_K = 256
+MHC_DEFAULT_BLOCK_H = 512
+MHC_SOURCE_TILE_H = 128
+MHC_GRAM_BLOCK_H = 1024
+MHC_SUPPORTED_HIDDEN_SIZES = (4096, 7168)
+
+
+def _required_mhc_split_k(hidden_size: int, block_k: int) -> int:
+    total_k = MHC_MULT * int(hidden_size)
+    block_k = int(block_k)
+    if block_k <= 0 or total_k % block_k != 0:
+        return -1
+    return total_k // block_k
+
+
+def _supports_fused_mhc_gram(
+    *,
+    hidden_size: int,
+    split_k: int,
+    block_k: int,
+    block_h: int,
+) -> bool:
+    hidden_size = int(hidden_size)
+    split_k = int(split_k)
+    block_k = int(block_k)
+    block_h = int(block_h)
+    required_split_k = _required_mhc_split_k(hidden_size, block_k)
+    return (
+        hidden_size in MHC_SUPPORTED_HIDDEN_SIZES
+        and block_k == MHC_DEFAULT_BLOCK_K
+        and block_h == MHC_DEFAULT_BLOCK_H
+        and hidden_size % MHC_SOURCE_TILE_H == 0
+        and hidden_size % MHC_GRAM_BLOCK_H == 0
+        and required_split_k > 0
+        and split_k == required_split_k
+    )
+
+
+def _supports_mhc_post_hidden(hidden_size: int) -> bool:
+    return int(hidden_size) in MHC_SUPPORTED_HIDDEN_SIZES
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XMHCBinding:
+    partials: torch.Tensor | None = None
+    y: torch.Tensor | None = None
+    post_buffer: torch.Tensor | None = None
+    comb_buffer: torch.Tensor | None = None
+    out: torch.Tensor | None = None
+    split_k: int = MHC_DEFAULT_SPLIT_K
+    expected_m: int | None = None
+
+    def pre(
+        self,
+        residual: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        *,
+        rms_eps: float,
+        hc_eps: float,
+        sinkhorn_iters: int,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float = 0.0,
+        block_k: int = MHC_DEFAULT_BLOCK_K,
+        block_h: int = MHC_DEFAULT_BLOCK_H,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return sm12x_mhc_pre(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps=rms_eps,
+            hc_eps=hc_eps,
+            sinkhorn_iters=sinkhorn_iters,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+            binding=self,
+            block_k=block_k,
+            block_h=block_h,
+        )
+
+    def post_pre(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        prev_post: torch.Tensor,
+        prev_comb: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        *,
+        rms_eps: float,
+        hc_eps: float,
+        sinkhorn_iters: int,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float = 0.0,
+        fn_bf16: torch.Tensor | None = None,
+        expected_m: int | None = None,
+        block_k: int = MHC_DEFAULT_BLOCK_K,
+        block_h: int = MHC_DEFAULT_BLOCK_H,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return sm12x_mhc_post_pre(
+            x,
+            residual,
+            prev_post,
+            prev_comb,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps=rms_eps,
+            hc_eps=hc_eps,
+            sinkhorn_iters=sinkhorn_iters,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+            fn_bf16=fn_bf16,
+            expected_m=expected_m,
+            binding=self,
+            block_k=block_k,
+            block_h=block_h,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SM12XMHCScratchCaps:
+    device: torch.device | str
+    max_tokens: int
+    hidden_size: int
+    dtype: torch.dtype = torch.bfloat16
+    split_k: int = MHC_DEFAULT_SPLIT_K
+
+    def __post_init__(self) -> None:
+        device = torch.device(self.device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        object.__setattr__(self, "device", device)
+        object.__setattr__(self, "max_tokens", max(int(self.max_tokens), 1))
+        object.__setattr__(self, "hidden_size", max(int(self.hidden_size), 1))
+        object.__setattr__(self, "split_k", max(int(self.split_k), 1))
+        if self.dtype != torch.bfloat16:
+            raise ValueError(
+                f"mHC scratch currently supports torch.bfloat16 outputs, got {self.dtype}"
+            )
+
+
+@dataclass(frozen=True)
+class _MHCScratchLayout:
+    nbytes: int
+    partials_offset_bytes: int
+
+
+@dataclass(frozen=True)
+class SM12XMHCScratchPlan:
+    caps: SM12XMHCScratchCaps
+    layout: _MHCScratchLayout
+    _scratch_specs: tuple[ScratchBufferSpec, ...]
+
+    def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        return self._scratch_specs
+
+    def shapes_and_dtypes(self) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
+        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+
+    def _partials_from_scratch(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+    ) -> torch.Tensor:
+        scratch_storage = scratch_tensor(
+            scratch,
+            self._scratch_specs,
+            owner="mHC",
+        )
+        max_tokens = int(self.caps.max_tokens)
+        split_k = int(self.caps.split_k)
+        partials, _ = materialize_scratch_view(
+            scratch_storage,
+            offset_bytes=self.layout.partials_offset_bytes,
+            shape=(max_tokens, split_k, MHC_PARTIALS),
+            dtype=torch.float32,
+        )
+        return partials
+
+    def bind(
+        self,
+        *,
+        scratch: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+        tokens: int | None = None,
+        expected_m: int | None = None,
+        y: torch.Tensor | None = None,
+        post: torch.Tensor | None = None,
+        comb: torch.Tensor | None = None,
+        out: torch.Tensor | None = None,
+    ) -> SM12XMHCBinding:
+        live_tokens = int(self.caps.max_tokens) if tokens is None else int(tokens)
+        if live_tokens < 0 or live_tokens > int(self.caps.max_tokens):
+            raise ValueError(
+                f"tokens={live_tokens} exceeds MHC scratch capacity {self.caps.max_tokens}"
+            )
+        expected_m = _canonicalize_mhc_expected_m(
+            expected_m,
+            min_tokens=live_tokens,
+            max_tokens=int(self.caps.max_tokens),
+        )
+        partials = self._partials_from_scratch(scratch=scratch)[:live_tokens]
+        _validate_mhc_binding_views(
+            partials=partials,
+            y=y,
+            post=post,
+            comb=comb,
+            out=out,
+            tokens=live_tokens,
+            hidden_size=int(self.caps.hidden_size),
+            split_k=int(self.caps.split_k),
+            dtype=self.caps.dtype,
+            device=self.caps.device,
+        )
+        return SM12XMHCBinding(
+            partials=partials,
+            y=y,
+            post_buffer=post,
+            comb_buffer=comb,
+            out=out,
+            split_k=int(self.caps.split_k),
+            expected_m=expected_m,
+        )
+
+
+def _validate_optional_view(
+    tensor: torch.Tensor | None,
+    *,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+    name: str,
+) -> None:
+    if tensor is None:
+        return
+    if tuple(tensor.shape) != shape or tensor.dtype != dtype or tensor.device != device:
+        raise ValueError(
+            f"{name} must have shape {shape}, dtype {dtype}, and device {device}; "
+            f"got shape={tuple(tensor.shape)}, dtype={tensor.dtype}, device={tensor.device}"
+        )
+    _require_contiguous(tensor, name=name)
+
+
+def _canonicalize_mhc_expected_m(
+    expected_m: int | None,
+    *,
+    min_tokens: int = 0,
+    max_tokens: int | None = None,
+) -> int | None:
+    if expected_m is None:
+        return None
+    expected = int(expected_m)
+    if expected <= 0:
+        raise ValueError(f"expected_m must be positive when provided, got {expected}")
+    if expected < int(min_tokens):
+        raise ValueError(
+            f"expected_m={expected} is smaller than live tokens={int(min_tokens)}"
+        )
+    if max_tokens is not None and expected > int(max_tokens):
+        raise ValueError(
+            f"expected_m={expected} exceeds MHC scratch capacity {int(max_tokens)}"
+        )
+    return expected
+
+
+def _use_mhc_prefill_bf16_project(
+    *,
+    norm_weight: torch.Tensor | None,
+    policy_m: int,
+    fn_bf16: torch.Tensor | None,
+) -> bool:
+    prefill_bf16_min_tokens = int(
+        os.environ.get("FLASHINFER_EXP_SM12X_MHC_PREFILL_BF16_MIN_TOKENS", "384")
+    )
+    return (
+        norm_weight is not None
+        and int(policy_m) >= prefill_bf16_min_tokens
+        and fn_bf16 is not None
+        and os.environ.get("FLASHINFER_EXP_SM12X_MHC_PREFILL_BF16_MMA", "1") != "0"
+    )
+
+
+def _use_mhc_prefill_tf32_project(
+    *,
+    norm_weight: torch.Tensor | None,
+    policy_m: int,
+) -> bool:
+    prefill_bf16_min_tokens = os.environ.get(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_BF16_MIN_TOKENS", "384"
+    )
+    prefill_tf32_min_tokens = int(
+        os.environ.get(
+            "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_MIN_TOKENS", prefill_bf16_min_tokens
+        )
+    )
+    prefill_tf32_enabled = os.environ.get(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_MMA",
+        os.environ.get("FLASHINFER_EXP_SM12X_MHC_PREFILL_BF16_MMA", "1"),
+    )
+    return (
+        norm_weight is not None
+        and int(policy_m) >= prefill_tf32_min_tokens
+        and prefill_tf32_enabled != "0"
+    )
+
+
+def _validate_mhc_binding_views(
+    *,
+    partials: torch.Tensor | None,
+    y: torch.Tensor | None,
+    post: torch.Tensor | None,
+    comb: torch.Tensor | None,
+    out: torch.Tensor | None,
+    tokens: int,
+    hidden_size: int,
+    split_k: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    if partials is not None:
+        _validate_optional_view(
+            partials,
+            shape=(tokens, split_k, MHC_PARTIALS),
+            dtype=torch.float32,
+            device=device,
+            name="mHC partials",
+        )
+    _validate_optional_view(
+        y,
+        shape=(tokens, hidden_size),
+        dtype=dtype,
+        device=device,
+        name="mHC y",
+    )
+    _validate_optional_view(
+        post,
+        shape=(tokens, MHC_MULT),
+        dtype=torch.float32,
+        device=device,
+        name="mHC post",
+    )
+    _validate_optional_view(
+        comb,
+        shape=(tokens, MHC_MULT, MHC_MULT),
+        dtype=torch.float32,
+        device=device,
+        name="mHC comb",
+    )
+    _validate_optional_view(
+        out,
+        shape=(tokens, MHC_MULT, hidden_size),
+        dtype=dtype,
+        device=device,
+        name="mHC out",
+    )
+
+
+def _shape_numel(shape: tuple[int, ...]) -> int:
+    numel = 1
+    for dim in shape:
+        numel *= int(dim)
+    return numel
+
+
+def _slice_capacity_view(
+    tensor: torch.Tensor | None,
+    *,
+    tokens: int,
+    tail_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+    name: str,
+) -> torch.Tensor | None:
+    if tensor is None:
+        return None
+    expected = (tokens, *tail_shape)
+    if tuple(tensor.shape) == expected:
+        return tensor
+    if (
+        tensor.ndim == len(expected)
+        and int(tensor.shape[0]) >= tokens
+        and tuple(tensor.shape[1:]) == tail_shape
+        and tensor.dtype == dtype
+        and tensor.device == device
+    ):
+        return tensor[:tokens]
+    raise ValueError(
+        f"{name} must have shape {expected} or capacity >= {tokens} with tail "
+        f"{tail_shape}, dtype {dtype}, and device {device}; got "
+        f"shape={tuple(tensor.shape)}, dtype={tensor.dtype}, device={tensor.device}"
+    )
+
+
+def _layout_mhc_scratch(caps: SM12XMHCScratchCaps) -> _MHCScratchLayout:
+    cursor = 0
+
+    def reserve(shape: tuple[int, ...], dtype: torch.dtype) -> tuple[int, int]:
+        nonlocal cursor
+        offset = align_up(cursor, max(SCRATCH_ALIGN_BYTES, dtype_nbytes(dtype)))
+        cursor = offset + _shape_numel(shape) * dtype_nbytes(dtype)
+        return offset, cursor
+
+    partials_offset_bytes, _ = reserve(
+        (int(caps.max_tokens), int(caps.split_k), MHC_PARTIALS),
+        torch.float32,
+    )
+    return _MHCScratchLayout(
+        nbytes=cursor,
+        partials_offset_bytes=partials_offset_bytes,
+    )
+
+
+def plan_mhc_scratch(caps: SM12XMHCScratchCaps) -> SM12XMHCScratchPlan:
+    layout = _layout_mhc_scratch(caps)
+    return SM12XMHCScratchPlan(
+        caps=caps,
+        layout=layout,
+        _scratch_specs=(
+            scratch_buffer_spec(
+                "mhc.scratch",
+                nbytes=layout.nbytes,
+                device=caps.device,
+            ),
+        ),
+    )
+
+
+def _require_contiguous(tensor: torch.Tensor, *, name: str) -> None:
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_pre_inputs(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+) -> tuple[int, int, int]:
+    if residual.device.type != "cuda":
+        raise ValueError("residual must be a CUDA tensor")
+    if residual.dtype != torch.bfloat16:
+        raise ValueError(f"residual must be torch.bfloat16, got {residual.dtype}")
+    if residual.ndim != 2:
+        raise ValueError(
+            f"residual must be rank-2 [tokens, hidden], got {tuple(residual.shape)}"
+        )
+    tokens, hidden_size = map(int, residual.shape)
+    if hidden_size <= 0:
+        raise ValueError("hidden_size must be positive")
+    if fn.dtype != torch.float32:
+        raise ValueError(f"fn must be torch.float32, got {fn.dtype}")
+    if fn.shape != (MHC_MIXES, hidden_size):
+        raise ValueError(
+            f"fn must have shape {(MHC_MIXES, hidden_size)}, got {tuple(fn.shape)}"
+        )
+    if hc_scale.dtype != torch.float32 or tuple(hc_scale.shape) != (3,):
+        raise ValueError(
+            f"hc_scale must be float32 shape [3], got {hc_scale.dtype} {tuple(hc_scale.shape)}"
+        )
+    if hc_base.dtype != torch.float32 or tuple(hc_base.shape) != (MHC_MIXES,):
+        raise ValueError(
+            f"hc_base must be float32 shape [{MHC_MIXES}], got {hc_base.dtype} {tuple(hc_base.shape)}"
+        )
+    if (
+        fn.device != residual.device
+        or hc_scale.device != residual.device
+        or hc_base.device != residual.device
+    ):
+        raise ValueError("fn, hc_scale, and hc_base must be on the residual device")
+    _require_contiguous(residual, name="residual")
+    _require_contiguous(fn, name="fn")
+    _require_contiguous(hc_scale, name="hc_scale")
+    _require_contiguous(hc_base, name="hc_base")
+    return tokens, hidden_size, MHC_MULT * hidden_size
+
+
+def _validate_post_pre_inputs(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+) -> tuple[int, int, int]:
+    if residual.device.type != "cuda":
+        raise ValueError("residual must be a CUDA tensor")
+    if residual.dtype != torch.bfloat16:
+        raise ValueError(f"residual must be torch.bfloat16, got {residual.dtype}")
+    if residual.ndim != 3:
+        raise ValueError(
+            f"residual must be rank-3 [tokens, 4, hidden], got {tuple(residual.shape)}"
+        )
+    tokens, hc_mult, hidden_size = map(int, residual.shape)
+    if hc_mult != MHC_MULT:
+        raise ValueError(f"residual hc dimension must be {MHC_MULT}, got {hc_mult}")
+    if hidden_size <= 0:
+        raise ValueError("hidden_size must be positive")
+    if fn.dtype != torch.float32:
+        raise ValueError(f"fn must be torch.float32, got {fn.dtype}")
+    if fn.shape != (MHC_MIXES, MHC_MULT * hidden_size):
+        raise ValueError(
+            "fn must have shape "
+            f"{(MHC_MIXES, MHC_MULT * hidden_size)}, got {tuple(fn.shape)}"
+        )
+    if hc_scale.dtype != torch.float32 or tuple(hc_scale.shape) != (3,):
+        raise ValueError(
+            "hc_scale must be float32 shape [3], got "
+            f"{hc_scale.dtype} {tuple(hc_scale.shape)}"
+        )
+    if hc_base.dtype != torch.float32 or tuple(hc_base.shape) != (MHC_MIXES,):
+        raise ValueError(
+            f"hc_base must be float32 shape [{MHC_MIXES}], got "
+            f"{hc_base.dtype} {tuple(hc_base.shape)}"
+        )
+    if (
+        fn.device != residual.device
+        or hc_scale.device != residual.device
+        or hc_base.device != residual.device
+    ):
+        raise ValueError("fn, hc_scale, and hc_base must be on the residual device")
+    _require_contiguous(residual, name="residual")
+    _require_contiguous(fn, name="fn")
+    _require_contiguous(hc_scale, name="hc_scale")
+    _require_contiguous(hc_base, name="hc_base")
+    return tokens, hidden_size, MHC_MULT * hidden_size
+
+
+def _validate_norm_weight(
+    norm_weight: torch.Tensor | None,
+    *,
+    hidden_size: int,
+    device: torch.device,
+) -> None:
+    if norm_weight is None:
+        return
+    if norm_weight.dtype not in (torch.bfloat16, torch.float32):
+        raise ValueError(f"norm_weight must be bf16 or fp32, got {norm_weight.dtype}")
+    if norm_weight.device != device:
+        raise ValueError("norm_weight must be on the residual device")
+    if tuple(norm_weight.shape) != (hidden_size,):
+        raise ValueError(
+            f"norm_weight must have shape {(hidden_size,)}, got {tuple(norm_weight.shape)}"
+        )
+    _require_contiguous(norm_weight, name="norm_weight")
+
+
+def _canonicalize_post_mix_input(
+    post: torch.Tensor,
+    *,
+    tokens: int,
+    device: torch.device,
+    name: str,
+) -> torch.Tensor:
+    if post.dtype != torch.float32 or post.device != device:
+        raise ValueError(
+            f"{name} must be float32 on device {device}, got {post.dtype} on {post.device}"
+        )
+    if tuple(post.shape) == (tokens, MHC_MULT, 1):
+        post = post.squeeze(-1)
+    elif tuple(post.shape) != (tokens, MHC_MULT):
+        raise ValueError(
+            f"{name} must have shape {(tokens, MHC_MULT)} or {(tokens, MHC_MULT, 1)}, "
+            f"got {tuple(post.shape)}"
+        )
+    _require_contiguous(post, name=name)
+    return post
+
+
+def _sm12x_mhc_pre_impl(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    *,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    residual_out: torch.Tensor | None = None,
+    y_out: torch.Tensor | None = None,
+    post_out: torch.Tensor | None = None,
+    comb_out: torch.Tensor | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+    binding: SM12XMHCBinding | None = None,
+    split_k: int = MHC_DEFAULT_SPLIT_K,
+    block_k: int = MHC_DEFAULT_BLOCK_K,
+    block_h: int = MHC_DEFAULT_BLOCK_H,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    # See sm12x_mhc_post_pre: caller-owned buffers -> mutating ops; no buffers
+    # (e.g. torch.compile) -> a single functional op (allocate + return) so the
+    # compile graph has zero auto_functionalized mHC nodes. No is_compiling.
+    _caller_owned_buffers = (
+        binding is not None
+        or residual_out is not None
+        or y_out is not None
+        or post_out is not None
+        or comb_out is not None
+    )
+    partials = None
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("residual_out", residual_out),
+                ("y_out", y_out),
+                ("post_out", post_out),
+                ("comb_out", comb_out),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "mHC binding owns scratch and output buffers; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        partials = binding.partials
+        residual_out = binding.out
+        y_out = binding.y
+        post_out = binding.post_buffer
+        comb_out = binding.comb_buffer
+        split_k = int(binding.split_k)
+
+    tokens, hidden_size, _ = _validate_pre_inputs(residual, fn, hc_scale, hc_base)
+    _validate_norm_weight(norm_weight, hidden_size=hidden_size, device=residual.device)
+
+    split_k = int(split_k)
+    block_k = int(block_k)
+    block_h = int(block_h)
+    sinkhorn_iters = int(sinkhorn_iters)
+    if sinkhorn_iters <= 0:
+        raise ValueError(f"sinkhorn_iters must be positive, got {sinkhorn_iters}")
+    if split_k <= 0:
+        raise ValueError(f"split_k must be positive, got {split_k}")
+    if block_k <= 0:
+        raise ValueError(f"block_k must be positive, got {block_k}")
+    if block_h <= 0:
+        raise ValueError(f"block_h must be positive, got {block_h}")
+
+    if partials is None:
+        partials = torch.empty(
+            (tokens, split_k, MHC_PARTIALS),
+            dtype=torch.float32,
+            device=residual.device,
+        )
+
+    if partials is not None:
+        partials = _slice_capacity_view(
+            partials,
+            tokens=tokens,
+            tail_shape=(split_k, MHC_PARTIALS),
+            dtype=torch.float32,
+            device=residual.device,
+            name="mHC partials",
+        )
+        if partials.dtype != torch.float32 or partials.device != residual.device:
+            raise ValueError("mHC partials must be float32 on the residual device")
+        _require_contiguous(partials, name="mHC partials")
+
+    if residual_out is None:
+        residual_out = torch.empty(
+            (tokens, MHC_MULT, hidden_size),
+            dtype=residual.dtype,
+            device=residual.device,
+        )
+    else:
+        residual_out = _slice_capacity_view(
+            residual_out,
+            tokens=tokens,
+            tail_shape=(MHC_MULT, hidden_size),
+            dtype=residual.dtype,
+            device=residual.device,
+            name="residual_out",
+        )
+
+    if y_out is None:
+        y_out = torch.empty(
+            (tokens, hidden_size), dtype=residual.dtype, device=residual.device
+        )
+    else:
+        y_out = _slice_capacity_view(
+            y_out,
+            tokens=tokens,
+            tail_shape=(hidden_size,),
+            dtype=residual.dtype,
+            device=residual.device,
+            name="y_out",
+        )
+    if post_out is None:
+        post_out = torch.empty(
+            (tokens, MHC_MULT), dtype=torch.float32, device=residual.device
+        )
+    else:
+        post_out = _slice_capacity_view(
+            post_out,
+            tokens=tokens,
+            tail_shape=(MHC_MULT,),
+            dtype=torch.float32,
+            device=residual.device,
+            name="post_out",
+        )
+    if comb_out is None:
+        comb_out = torch.empty(
+            (tokens, MHC_MULT, MHC_MULT), dtype=torch.float32, device=residual.device
+        )
+    else:
+        comb_out = _slice_capacity_view(
+            comb_out,
+            tokens=tokens,
+            tail_shape=(MHC_MULT, MHC_MULT),
+            dtype=torch.float32,
+            device=residual.device,
+            name="comb_out",
+        )
+
+    if residual_out.shape != (tokens, MHC_MULT, hidden_size):
+        raise ValueError("residual_out must have shape [tokens, 4, hidden_size]")
+    if residual_out.dtype != residual.dtype or residual_out.device != residual.device:
+        raise ValueError("residual_out must match the residual dtype and device")
+    if (
+        y_out.shape != (tokens, hidden_size)
+        or y_out.dtype != residual.dtype
+        or y_out.device != residual.device
+    ):
+        raise ValueError(
+            "y_out must match shape [tokens, hidden_size], residual dtype, and residual device"
+        )
+    if (
+        post_out.shape != (tokens, MHC_MULT)
+        or post_out.dtype != torch.float32
+        or post_out.device != residual.device
+    ):
+        raise ValueError(
+            "post_out must match shape [tokens, 4], dtype float32, and residual device"
+        )
+    if (
+        comb_out.shape != (tokens, MHC_MULT, MHC_MULT)
+        or comb_out.dtype != torch.float32
+        or comb_out.device != residual.device
+    ):
+        raise ValueError(
+            "comb_out must match shape [tokens, 4, 4], dtype float32, and residual device"
+        )
+    _require_contiguous(residual_out, name="residual_out")
+    _require_contiguous(y_out, name="y_out")
+    _require_contiguous(post_out, name="post_out")
+    _require_contiguous(comb_out, name="comb_out")
+
+    if tokens == 0:
+        return residual_out, post_out, comb_out, y_out
+
+    if (
+        partials is not None
+        and _supports_fused_mhc_gram(
+            hidden_size=hidden_size,
+            split_k=split_k,
+            block_k=block_k,
+            block_h=block_h,
+        )
+        and float(rms_eps) == 1.0e-6
+        and float(hc_eps) == 1.0e-6
+        and sinkhorn_iters == 20
+    ):
+        from flashinfer.experimental.sm12x.norm.mhc._kernels import (
+            run_mhc_finalize_gram,
+            run_mhc_pre_functional,
+            run_mhc_pre_partial,
+        )
+
+        if not _caller_owned_buffers:
+            # No caller buffers (e.g. torch.compile): one functional op runs the
+            # whole pre (partial + finalize) and returns fresh tensors, so the
+            # compile graph carries ZERO auto_functionalized mHC nodes.
+            return run_mhc_pre_functional(
+                residual=residual,
+                fn=fn,
+                scale=hc_scale,
+                bias=hc_base,
+                rms_eps=float(rms_eps),
+                hc_eps=float(hc_eps),
+                sinkhorn_iters=sinkhorn_iters,
+                norm_weight=norm_weight,
+                norm_eps=float(norm_eps),
+            )
+
+        run_mhc_pre_partial(
+            residual=residual,
+            fn=fn,
+            partials=partials,
+            out=residual_out,
+            compute_gram=norm_weight is not None,
+        )
+        run_mhc_finalize_gram(
+            residual=residual_out,
+            partials=partials,
+            scale=hc_scale,
+            bias=hc_base,
+            y=y_out,
+            post=post_out,
+            comb=comb_out,
+            rms_eps=float(rms_eps),
+            hc_eps=float(hc_eps),
+            sinkhorn_iters=sinkhorn_iters,
+            norm_weight=norm_weight,
+            norm_eps=float(norm_eps),
+        )
+        return residual_out, post_out, comb_out, y_out
+
+    raise ValueError(
+        "sm12x_mhc_pre is served only by the fused Gram kernel, which "
+        "supports the decode config "
+        f"(hidden_size divisible by {MHC_GRAM_BLOCK_H}, "
+        f"split_k=hc_mult*hidden_size/{MHC_DEFAULT_BLOCK_K}, "
+        f"block_k={MHC_DEFAULT_BLOCK_K}, block_h={MHC_DEFAULT_BLOCK_H}, "
+        "sinkhorn_iters=20); got "
+        f"hidden_size={hidden_size}, split_k={split_k}, block_k={block_k}, "
+        f"block_h={block_h}, sinkhorn_iters={sinkhorn_iters}"
+    )
+
+
+def _sm12x_mhc_post_pre_impl(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    *,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    residual_out: torch.Tensor | None = None,
+    y_out: torch.Tensor | None = None,
+    post_out: torch.Tensor | None = None,
+    comb_out: torch.Tensor | None = None,
+    fn_bf16: torch.Tensor | None = None,
+    expected_m: int | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+    binding: SM12XMHCBinding | None = None,
+    split_k: int = MHC_DEFAULT_SPLIT_K,
+    block_k: int = MHC_DEFAULT_BLOCK_K,
+    block_h: int = MHC_DEFAULT_BLOCK_H,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Whether the caller owns the output/scratch buffers (binding or
+    # explicit out tensors). When it does, the post-pre partial writes them in
+    # place (mutating op). When it does not and no expected_m policy is supplied
+    # (e.g. the torch.compile path passes nothing), we use the functional alloc
+    # op: it returns partials+residual_out with ZERO mutated args, avoiding the
+    # auto_functionalized 2-mutated-arg decomposition assertion.
+    _caller_owned_buffers = (
+        binding is not None
+        or residual_out is not None
+        or y_out is not None
+        or post_out is not None
+        or comb_out is not None
+    )
+    partials = None
+    if binding is not None:
+        extras = [
+            name
+            for name, value in (
+                ("residual_out", residual_out),
+                ("y_out", y_out),
+                ("post_out", post_out),
+                ("comb_out", comb_out),
+            )
+            if value is not None
+        ]
+        if extras:
+            raise ValueError(
+                "mHC binding owns scratch and output buffers; "
+                f"do not also pass {', '.join(extras)}"
+            )
+        partials = binding.partials
+        residual_out = binding.out
+        y_out = binding.y
+        post_out = binding.post_buffer
+        comb_out = binding.comb_buffer
+        split_k = int(binding.split_k)
+        if (
+            expected_m is not None
+            and binding.expected_m is not None
+            and int(expected_m) != int(binding.expected_m)
+        ):
+            raise ValueError(
+                "expected_m does not match the mHC binding's expected_m: "
+                f"{expected_m} vs {binding.expected_m}"
+            )
+        if expected_m is None:
+            expected_m = binding.expected_m
+
+    tokens, hidden_size, _ = _validate_post_pre_inputs(residual, fn, hc_scale, hc_base)
+    expected_m = _canonicalize_mhc_expected_m(expected_m, min_tokens=tokens)
+    policy_m = tokens if expected_m is None else expected_m
+    _validate_norm_weight(norm_weight, hidden_size=hidden_size, device=residual.device)
+    if x.dtype != residual.dtype or x.dtype != torch.bfloat16:
+        raise ValueError(
+            f"x and residual must both be torch.bfloat16, got {x.dtype} and {residual.dtype}"
+        )
+    if x.ndim != 2 or tuple(x.shape) != (tokens, hidden_size):
+        raise ValueError(
+            f"x must have shape {(tokens, hidden_size)}, got {tuple(x.shape)}"
+        )
+    if x.device != residual.device:
+        raise ValueError(
+            "x, residual, fn, hc_scale, and hc_base must be on the same device"
+        )
+    prev_post = _canonicalize_post_mix_input(
+        prev_post,
+        tokens=tokens,
+        device=residual.device,
+        name="prev_post",
+    )
+    if prev_comb.dtype != torch.float32 or tuple(prev_comb.shape) != (
+        tokens,
+        MHC_MULT,
+        MHC_MULT,
+    ):
+        raise ValueError(
+            f"prev_comb must be float32 shape {(tokens, MHC_MULT, MHC_MULT)}, "
+            f"got {prev_comb.dtype} {tuple(prev_comb.shape)}"
+        )
+    if prev_comb.device != residual.device:
+        raise ValueError("prev_comb must be on the residual device")
+    _require_contiguous(x, name="x")
+    _require_contiguous(prev_comb, name="prev_comb")
+
+    split_k = int(split_k)
+    block_k = int(block_k)
+    block_h = int(block_h)
+    sinkhorn_iters = int(sinkhorn_iters)
+    if sinkhorn_iters <= 0:
+        raise ValueError(f"sinkhorn_iters must be positive, got {sinkhorn_iters}")
+    if split_k <= 0:
+        raise ValueError(f"split_k must be positive, got {split_k}")
+    if block_k <= 0:
+        raise ValueError(f"block_k must be positive, got {block_k}")
+    if block_h <= 0:
+        raise ValueError(f"block_h must be positive, got {block_h}")
+
+    if partials is None:
+        # The Gram post_pre needs a partials scratch buffer (the launch boundary
+        # between the partial pass and the multi-CTA finalize).
+        partials = torch.empty(
+            (tokens, split_k, MHC_PARTIALS), dtype=torch.float32, device=residual.device
+        )
+    # The source-tile CuTe post_pre path uses the shared scratch partials as
+    # the launch boundary between post+partial reduction and y/post/comb finalize.
+    if partials is not None:
+        partials = _slice_capacity_view(
+            partials,
+            tokens=tokens,
+            tail_shape=(split_k, MHC_PARTIALS),
+            dtype=torch.float32,
+            device=residual.device,
+            name="mHC partials",
+        )
+        if partials.dtype != torch.float32 or partials.device != residual.device:
+            raise ValueError("mHC partials must be float32 on the residual device")
+        _require_contiguous(partials, name="mHC partials")
+
+    if residual_out is None:
+        residual_out = torch.empty_like(residual)
+    else:
+        residual_out = _slice_capacity_view(
+            residual_out,
+            tokens=tokens,
+            tail_shape=(MHC_MULT, hidden_size),
+            dtype=residual.dtype,
+            device=residual.device,
+            name="residual_out",
+        )
+    if y_out is None:
+        y_out = torch.empty(
+            (tokens, hidden_size), dtype=residual.dtype, device=residual.device
+        )
+    else:
+        y_out = _slice_capacity_view(
+            y_out,
+            tokens=tokens,
+            tail_shape=(hidden_size,),
+            dtype=residual.dtype,
+            device=residual.device,
+            name="y_out",
+        )
+    if post_out is None:
+        post_out = torch.empty(
+            (tokens, MHC_MULT), dtype=torch.float32, device=residual.device
+        )
+    else:
+        post_out = _slice_capacity_view(
+            post_out,
+            tokens=tokens,
+            tail_shape=(MHC_MULT,),
+            dtype=torch.float32,
+            device=residual.device,
+            name="post_out",
+        )
+    if comb_out is None:
+        comb_out = torch.empty(
+            (tokens, MHC_MULT, MHC_MULT), dtype=torch.float32, device=residual.device
+        )
+    else:
+        comb_out = _slice_capacity_view(
+            comb_out,
+            tokens=tokens,
+            tail_shape=(MHC_MULT, MHC_MULT),
+            dtype=torch.float32,
+            device=residual.device,
+            name="comb_out",
+        )
+
+    if (
+        residual_out.shape != residual.shape
+        or residual_out.dtype != residual.dtype
+        or residual_out.device != residual.device
+    ):
+        raise ValueError("residual_out must match residual shape, dtype, and device")
+    if (
+        y_out.shape != (tokens, hidden_size)
+        or y_out.dtype != residual.dtype
+        or y_out.device != residual.device
+    ):
+        raise ValueError(
+            "y_out must match shape [tokens, hidden_size], residual dtype, and residual device"
+        )
+    if (
+        post_out.shape != (tokens, MHC_MULT)
+        or post_out.dtype != torch.float32
+        or post_out.device != residual.device
+    ):
+        raise ValueError(
+            "post_out must match shape [tokens, 4], dtype float32, and residual device"
+        )
+    if (
+        comb_out.shape != (tokens, MHC_MULT, MHC_MULT)
+        or comb_out.dtype != torch.float32
+        or comb_out.device != residual.device
+    ):
+        raise ValueError(
+            "comb_out must match shape [tokens, 4, 4], dtype float32, and residual device"
+        )
+    _require_contiguous(residual_out, name="residual_out")
+    _require_contiguous(y_out, name="y_out")
+    _require_contiguous(post_out, name="post_out")
+    _require_contiguous(comb_out, name="comb_out")
+
+    if tokens == 0:
+        return residual_out, post_out, comb_out, y_out
+
+    if (
+        partials is not None
+        and _supports_fused_mhc_gram(
+            hidden_size=hidden_size,
+            split_k=split_k,
+            block_k=block_k,
+            block_h=block_h,
+        )
+        and float(rms_eps) == 1.0e-6
+        and float(hc_eps) == 1.0e-6
+        and sinkhorn_iters == 20
+    ):
+        # The Gram-trick fused post_pre is THE mHC decode post_pre kernel: one
+        # partial pass (POST + the fn@flat reduction + residual_out's 4x4 Gram)
+        # feeds a multi-CTA finalize whose RMSNorm uses sum_h y^2 = pre^T G pre
+        # (no per-hidden reduction, so no single-CTA bottleneck). Sinkhorn runs
+        # the caller's iteration count (the full 20, matching vLLM and the
+        # reference; Sinkhorn is ~0.015us/iter so the cost is negligible). The
+        # Gram + RMSNorm are skipped when there is no fused norm_weight.
+        from flashinfer.experimental.sm12x.norm.mhc._kernels import (
+            run_mhc_finalize_gram,
+            _selected_post_pre_decode_split_n,
+            run_mhc_post_pre_functional,
+            run_mhc_post_pre_partial,
+            run_mhc_post_pre_prefill_block_m_partial,
+            run_mhc_post_pre_prefill_gram,
+            run_mhc_post_pre_prefill_partial,
+            mhc_prefill_tf32_project_splits,
+            run_mhc_prefill_bf16_project,
+            run_mhc_prefill_tf32_project,
+        )
+
+        if not _caller_owned_buffers and expected_m is None:
+            # No caller buffers (e.g. torch.compile): one functional op runs the
+            # whole post_pre (partial + finalize) and returns fresh tensors, so
+            # the compile graph carries ZERO auto_functionalized mHC nodes.
+            return run_mhc_post_pre_functional(
+                x=x,
+                residual=residual,
+                prev_post=prev_post,
+                prev_comb=prev_comb,
+                fn=fn,
+                scale=hc_scale,
+                bias=hc_base,
+                rms_eps=float(rms_eps),
+                hc_eps=float(hc_eps),
+                sinkhorn_iters=sinkhorn_iters,
+                norm_weight=norm_weight,
+                norm_eps=float(norm_eps),
+            )
+
+        prefill_min_tokens = int(
+            os.environ.get("FLASHINFER_EXP_SM12X_MHC_PREFILL_MIN_TOKENS", "96")
+        )
+        use_prefill_tf32_mma = _use_mhc_prefill_tf32_project(
+            norm_weight=norm_weight,
+            policy_m=policy_m,
+        )
+        use_prefill_bf16_mma = (
+            _use_mhc_prefill_bf16_project(
+                norm_weight=norm_weight,
+                policy_m=policy_m,
+                fn_bf16=fn_bf16,
+            )
+            and not use_prefill_tf32_mma
+        )
+        use_prefill_block_m = (
+            not use_prefill_tf32_mma
+            and not use_prefill_bf16_mma
+            and norm_weight is not None
+            and policy_m >= prefill_min_tokens
+            and os.environ.get("FLASHINFER_EXP_SM12X_MHC_PREFILL_BLOCK_M", "1") != "0"
+        )
+        prefill_block_m_size = int(
+            os.environ.get("FLASHINFER_EXP_SM12X_MHC_PREFILL_BLOCK_M_SIZE", "2")
+        )
+        prefill_tile_n_default = 12 if hidden_size == 7168 else 24
+        prefill_tile_n = int(
+            os.environ.get(
+                "FLASHINFER_EXP_SM12X_MHC_PREFILL_TILE_N", str(prefill_tile_n_default)
+            )
+        )
+        use_prefill_compact = (
+            not use_prefill_tf32_mma
+            and not use_prefill_bf16_mma
+            and not use_prefill_block_m
+            and norm_weight is not None
+            and policy_m >= prefill_min_tokens
+            and os.environ.get("FLASHINFER_EXP_SM12X_MHC_PREFILL_COMPACT", "1") != "0"
+        )
+        decode_source_splits = 0
+        if not (
+            use_prefill_tf32_mma
+            or use_prefill_bf16_mma
+            or use_prefill_block_m
+            or use_prefill_compact
+        ):
+            decode_source_splits, _ = _selected_post_pre_decode_split_n(
+                num_tokens=tokens,
+                hidden_size=hidden_size,
+            )
+        if use_prefill_tf32_mma:
+            run_mhc_post_pre_prefill_gram(
+                x=x,
+                residual=residual,
+                prev_post=prev_post,
+                prev_comb=prev_comb,
+                partials=partials,
+                out=residual_out,
+            )
+            run_mhc_prefill_tf32_project(
+                out=residual_out,
+                fn=fn,
+                partials=partials,
+            )
+        elif use_prefill_bf16_mma:
+            run_mhc_post_pre_prefill_gram(
+                x=x,
+                residual=residual,
+                prev_post=prev_post,
+                prev_comb=prev_comb,
+                partials=partials,
+                out=residual_out,
+            )
+            run_mhc_prefill_bf16_project(
+                out=residual_out,
+                fn_bf16=fn_bf16,
+                partials=partials,
+            )
+        elif use_prefill_block_m:
+            run_mhc_post_pre_prefill_block_m_partial(
+                x=x,
+                residual=residual,
+                prev_post=prev_post,
+                prev_comb=prev_comb,
+                fn=fn,
+                partials=partials,
+                out=residual_out,
+                compute_gram=True,
+                block_m=prefill_block_m_size,
+                tile_n=prefill_tile_n,
+            )
+        elif use_prefill_compact:
+            run_mhc_post_pre_prefill_partial(
+                x=x,
+                residual=residual,
+                prev_post=prev_post,
+                prev_comb=prev_comb,
+                fn=fn,
+                partials=partials,
+                out=residual_out,
+                compute_gram=True,
+            )
+        else:
+            run_mhc_post_pre_partial(
+                x=x,
+                residual=residual,
+                prev_post=prev_post,
+                prev_comb=prev_comb,
+                fn=fn,
+                partials=partials,
+                out=residual_out,
+                compute_gram=norm_weight is not None,
+            )
+        run_mhc_finalize_gram(
+            residual=residual_out,
+            partials=partials,
+            scale=hc_scale,
+            bias=hc_base,
+            y=y_out,
+            post=post_out,
+            comb=comb_out,
+            rms_eps=float(rms_eps),
+            hc_eps=float(hc_eps),
+            sinkhorn_iters=sinkhorn_iters,
+            norm_weight=norm_weight,
+            norm_eps=float(norm_eps),
+            compact_partials=(
+                use_prefill_tf32_mma
+                or use_prefill_bf16_mma
+                or use_prefill_block_m
+                or use_prefill_compact
+            ),
+            compact_projection_splits=(
+                mhc_prefill_tf32_project_splits(
+                    tokens=tokens,
+                    hidden_size=hidden_size,
+                )
+                if use_prefill_tf32_mma
+                else 1
+            ),
+            active_source_splits=decode_source_splits,
+        )
+        return residual_out, post_out, comb_out, y_out
+
+    raise ValueError(
+        "sm12x_mhc_post_pre is served only by the fused Gram kernel, which "
+        "supports the decode config "
+        f"(hidden_size divisible by {MHC_GRAM_BLOCK_H}, "
+        f"split_k=hc_mult*hidden_size/{MHC_DEFAULT_BLOCK_K}, "
+        f"block_k={MHC_DEFAULT_BLOCK_K}, block_h={MHC_DEFAULT_BLOCK_H}, "
+        "sinkhorn_iters=20); got "
+        f"hidden_size={hidden_size}, split_k={split_k}, block_k={block_k}, "
+        f"block_h={block_h}, sinkhorn_iters={sinkhorn_iters}"
+    )
+
+
+def _sm12x_mhc_post_impl(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    tokens, hc_mult, hidden_size = residual.shape
+    if hc_mult != MHC_MULT:
+        raise ValueError(f"residual hc dimension must be {MHC_MULT}, got {hc_mult}")
+    if x.dtype != residual.dtype or x.dtype != torch.bfloat16:
+        raise ValueError(
+            f"x and residual must both be torch.bfloat16, got {x.dtype} and "
+            f"{residual.dtype}"
+        )
+    if x.ndim != 2 or tuple(x.shape) != (tokens, hidden_size):
+        raise ValueError(
+            f"x must have shape {(tokens, hidden_size)}, got {tuple(x.shape)}"
+        )
+    if x.device != residual.device:
+        raise ValueError("x and residual must be on the same device")
+    prev_post = _canonicalize_post_mix_input(
+        prev_post,
+        tokens=tokens,
+        device=residual.device,
+        name="prev_post",
+    )
+    if prev_comb.dtype != torch.float32 or tuple(prev_comb.shape) != (
+        tokens,
+        MHC_MULT,
+        MHC_MULT,
+    ):
+        raise ValueError(
+            f"prev_comb must be float32 shape {(tokens, MHC_MULT, MHC_MULT)}, "
+            f"got {prev_comb.dtype} {tuple(prev_comb.shape)}"
+        )
+    if prev_comb.device != residual.device:
+        raise ValueError("prev_comb must be on the residual device")
+    _require_contiguous(x, name="x")
+    _require_contiguous(residual, name="residual")
+    _require_contiguous(prev_comb, name="prev_comb")
+
+    if out is None:
+        # No caller buffer (e.g. torch.compile): the functional op allocates and
+        # returns, so the compile graph carries zero auto_functionalized mHC
+        # nodes. No is_compiling -- purely caller-intent.
+        if not _supports_mhc_post_hidden(hidden_size):
+            raise ValueError(
+                "sm12x_mhc_post is served only by the post-only mHC kernel, which "
+                f"supports hidden_size in {MHC_SUPPORTED_HIDDEN_SIZES}; "
+                f"got hidden_size={hidden_size}"
+            )
+        from flashinfer.experimental.sm12x.norm.mhc._kernels import (
+            run_mhc_post_functional,
+        )
+
+        return run_mhc_post_functional(
+            x=x,
+            residual=residual,
+            prev_post=prev_post,
+            prev_comb=prev_comb,
+        )
+
+    out = _slice_capacity_view(
+        out,
+        tokens=tokens,
+        tail_shape=(MHC_MULT, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+        name="out",
+    )
+    if (
+        out.shape != residual.shape
+        or out.dtype != residual.dtype
+        or out.device != residual.device
+    ):
+        raise ValueError("out must match residual shape, dtype, and device")
+    _require_contiguous(out, name="out")
+
+    if tokens == 0:
+        return out
+    if _supports_mhc_post_hidden(hidden_size):
+        from flashinfer.experimental.sm12x.norm.mhc._kernels import run_mhc_post
+
+        run_mhc_post(
+            x=x,
+            residual=residual,
+            prev_post=prev_post,
+            prev_comb=prev_comb,
+            out=out,
+        )
+        return out
+
+    raise ValueError(
+        "sm12x_mhc_post is served only by the post-only mHC kernel, which "
+        f"supports hidden_size in {MHC_SUPPORTED_HIDDEN_SIZES}; "
+        f"got hidden_size={hidden_size}"
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_pre_planned_functional",
+    mutates_args=(),
+)
+def _mhc_pre_planned_functional_op(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+    split_k: int,
+    block_k: int,
+    block_h: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _sm12x_mhc_pre_impl(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps=float(rms_eps),
+        hc_eps=float(hc_eps),
+        sinkhorn_iters=int(sinkhorn_iters),
+        norm_weight=norm_weight if fuse_norm else None,
+        norm_eps=float(norm_eps),
+        split_k=int(split_k),
+        block_k=int(block_k),
+        block_h=int(block_h),
+    )
+
+
+@_mhc_pre_planned_functional_op.register_fake
+def _mhc_pre_planned_functional_fake(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+    split_k: int,
+    block_k: int,
+    block_h: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    del fn, hc_scale, hc_base, norm_weight
+    del rms_eps, hc_eps, sinkhorn_iters, norm_eps, fuse_norm
+    del split_k, block_k, block_h
+    tokens = residual.shape[0]
+    hidden_size = residual.shape[1]
+    y = torch.empty(
+        (tokens, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    post = torch.empty(
+        (tokens, MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb = torch.empty(
+        (tokens, MHC_MULT, MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    residual_out = torch.empty(
+        (tokens, MHC_MULT, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    return residual_out, post, comb, y
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_pre_planned_functional",
+    mutates_args=(),
+)
+def _mhc_post_pre_planned_functional_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    fn_bf16: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    has_fn_bf16: bool,
+    expected_m: int,
+    has_expected_m: bool,
+    fuse_norm: bool,
+    split_k: int,
+    block_k: int,
+    block_h: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _sm12x_mhc_post_pre_impl(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps=float(rms_eps),
+        hc_eps=float(hc_eps),
+        sinkhorn_iters=int(sinkhorn_iters),
+        fn_bf16=fn_bf16 if has_fn_bf16 else None,
+        expected_m=int(expected_m) if has_expected_m else None,
+        norm_weight=norm_weight if fuse_norm else None,
+        norm_eps=float(norm_eps),
+        split_k=int(split_k),
+        block_k=int(block_k),
+        block_h=int(block_h),
+    )
+
+
+@_mhc_post_pre_planned_functional_op.register_fake
+def _mhc_post_pre_planned_functional_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    fn_bf16: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    has_fn_bf16: bool,
+    expected_m: int,
+    has_expected_m: bool,
+    fuse_norm: bool,
+    split_k: int,
+    block_k: int,
+    block_h: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    del x, prev_post, prev_comb, fn, hc_scale, hc_base, fn_bf16, norm_weight
+    del rms_eps, hc_eps, sinkhorn_iters, norm_eps, has_fn_bf16
+    del expected_m, has_expected_m, fuse_norm, split_k, block_k, block_h
+    tokens = residual.shape[0]
+    hidden_size = residual.shape[2]
+    residual_out = torch.empty_like(residual)
+    y = torch.empty(
+        (tokens, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    post = torch.empty(
+        (tokens, MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb = torch.empty(
+        (tokens, MHC_MULT, MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    return residual_out, post, comb, y
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_planned_functional",
+    mutates_args=(),
+)
+def _mhc_post_planned_functional_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+) -> torch.Tensor:
+    return _sm12x_mhc_post_impl(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+    )
+
+
+@_mhc_post_planned_functional_op.register_fake
+def _mhc_post_planned_functional_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+) -> torch.Tensor:
+    del x, prev_post, prev_comb
+    return torch.empty_like(residual)
+
+
+def sm12x_mhc_pre(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    *,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    residual_out: torch.Tensor | None = None,
+    y_out: torch.Tensor | None = None,
+    post_out: torch.Tensor | None = None,
+    comb_out: torch.Tensor | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+    binding: SM12XMHCBinding | None = None,
+    split_k: int = MHC_DEFAULT_SPLIT_K,
+    block_k: int = MHC_DEFAULT_BLOCK_K,
+    block_h: int = MHC_DEFAULT_BLOCK_H,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    compiling = torch.compiler.is_compiling()
+    no_caller_owned_buffers = (
+        binding is None
+        and residual_out is None
+        and y_out is None
+        and post_out is None
+        and comb_out is None
+    )
+    if compiling and no_caller_owned_buffers:
+        norm_weight_for_kernel = norm_weight if norm_weight is not None else residual
+        return torch.ops.flashinfer_sm12x.mhc_pre_planned_functional(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            norm_weight_for_kernel,
+            float(rms_eps),
+            float(hc_eps),
+            int(sinkhorn_iters),
+            float(norm_eps),
+            norm_weight is not None,
+            int(split_k),
+            int(block_k),
+            int(block_h),
+        )
+    if compiling:
+        raise RuntimeError(
+            "sm12x_mhc_pre must be opaque to torch.compile; caller-owned mHC "
+            "buffers are not supported inside Dynamo."
+        )
+    return _sm12x_mhc_pre_impl(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps=rms_eps,
+        hc_eps=hc_eps,
+        sinkhorn_iters=sinkhorn_iters,
+        residual_out=residual_out,
+        y_out=y_out,
+        post_out=post_out,
+        comb_out=comb_out,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
+        binding=binding,
+        split_k=split_k,
+        block_k=block_k,
+        block_h=block_h,
+    )
+
+
+def sm12x_mhc_post_pre(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    *,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    residual_out: torch.Tensor | None = None,
+    y_out: torch.Tensor | None = None,
+    post_out: torch.Tensor | None = None,
+    comb_out: torch.Tensor | None = None,
+    fn_bf16: torch.Tensor | None = None,
+    expected_m: int | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+    binding: SM12XMHCBinding | None = None,
+    split_k: int = MHC_DEFAULT_SPLIT_K,
+    block_k: int = MHC_DEFAULT_BLOCK_K,
+    block_h: int = MHC_DEFAULT_BLOCK_H,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    compiling = torch.compiler.is_compiling()
+    no_caller_owned_buffers = (
+        binding is None
+        and residual_out is None
+        and y_out is None
+        and post_out is None
+        and comb_out is None
+    )
+    if compiling and no_caller_owned_buffers:
+        fn_bf16_for_kernel = fn_bf16 if fn_bf16 is not None else fn
+        norm_weight_for_kernel = norm_weight if norm_weight is not None else residual
+        return torch.ops.flashinfer_sm12x.mhc_post_pre_planned_functional(
+            x,
+            residual,
+            prev_post,
+            prev_comb,
+            fn,
+            hc_scale,
+            hc_base,
+            fn_bf16_for_kernel,
+            norm_weight_for_kernel,
+            float(rms_eps),
+            float(hc_eps),
+            int(sinkhorn_iters),
+            float(norm_eps),
+            fn_bf16 is not None,
+            0 if expected_m is None else int(expected_m),
+            expected_m is not None,
+            norm_weight is not None,
+            int(split_k),
+            int(block_k),
+            int(block_h),
+        )
+    if compiling:
+        raise RuntimeError(
+            "sm12x_mhc_post_pre must be opaque to torch.compile; caller-owned "
+            "mHC buffers are not supported inside Dynamo."
+        )
+    return _sm12x_mhc_post_pre_impl(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps=rms_eps,
+        hc_eps=hc_eps,
+        sinkhorn_iters=sinkhorn_iters,
+        residual_out=residual_out,
+        y_out=y_out,
+        post_out=post_out,
+        comb_out=comb_out,
+        fn_bf16=fn_bf16,
+        expected_m=expected_m,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
+        binding=binding,
+        split_k=split_k,
+        block_k=block_k,
+        block_h=block_h,
+    )
+
+
+def sm12x_mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    compiling = torch.compiler.is_compiling()
+    if compiling and out is None:
+        return torch.ops.flashinfer_sm12x.mhc_post_planned_functional(
+            x,
+            residual,
+            prev_post,
+            prev_comb,
+        )
+    if compiling:
+        raise RuntimeError(
+            "sm12x_mhc_post must be opaque to torch.compile; caller-owned mHC "
+            "outputs are not supported inside Dynamo."
+        )
+    return _sm12x_mhc_post_impl(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        out=out,
+    )
+
+
+__all__ = [
+    "SM12XMHCBinding",
+    "SM12XMHCScratchCaps",
+    "SM12XMHCScratchPlan",
+    "MHC_DEFAULT_BLOCK_H",
+    "MHC_DEFAULT_BLOCK_K",
+    "MHC_DEFAULT_SPLIT_K",
+    "MHC_GRAM_BLOCK_H",
+    "MHC_MULT",
+    "MHC_MIXES",
+    "MHC_PARTIALS",
+    "MHC_SOURCE_TILE_H",
+    "MHC_SUPPORTED_HIDDEN_SIZES",
+    "sm12x_mhc_post",
+    "sm12x_mhc_pre",
+    "sm12x_mhc_post_pre",
+    "plan_mhc_scratch",
+]

--- a/flashinfer/experimental/sm12x/norm/mhc/_kernels.py
+++ b/flashinfer/experimental/sm12x/norm/mhc/_kernels.py
@@ -1,0 +1,6228 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/integration/residual_kernels.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""CuTeDSL kernels for the mHC residual path."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import os
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as cutlass_utils
+import cutlass.utils.hopper_helpers as sm90_utils_basic
+import torch
+from cutlass import Float32, Int32, Uint32, const_expr
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync, warp, warpgroup
+from cutlass.cute.runtime import from_dlpack
+from cutlass.utils import LayoutEnum
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    DimKey,
+    KernelCompileSpec,
+    tensor_key,
+)
+from flashinfer.experimental.sm12x._lib.compiler import (
+    launch as sm12x_launch,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import (
+    bf16_mma_m16n8k16_f32,
+    bfloat2_to_float2_scaled,
+    f32_to_raw_bits,
+    get_ptr_as_int64,
+    ld_global_nc_u32,
+    ldmatrix_m8n8x4_b16,
+    pack_f32x2_to_bfloat2,
+    shared_ptr_to_u32,
+    st_shared_u32,
+    tf32_mma_m16n8k8_f32,
+)
+from flashinfer.experimental.sm12x._lib.utils import current_cuda_stream
+
+_MHC_MULT = 4
+_TOKENS = 1
+_HIDDEN = 4096
+_TOTAL_K = _MHC_MULT * _HIDDEN
+_SPLIT_K = 64
+_SOURCE_TILE_H = 128
+_SOURCE_TILES = _HIDDEN // _SOURCE_TILE_H
+_SUPPORTED_HIDDEN_SIZES = (_HIDDEN, 7168)
+_MIXES = 24
+_PARTIALS = 1 + _MIXES
+_PARTIALS_PER_CTA = 2
+_MHC_PDL = os.getenv("FLASHINFER_EXP_SM12X_MHC_PDL", "0") != "0"
+# Partials handled per post_pre-partial CTA. mix_groups = ceil(25/this), so the
+# partial-kernel grid is (32 source tiles x mix_groups). 4 (-> 7 groups, 224
+# CTAs) maximizes fn-read parallelism without excess grid-scheduling overhead.
+_POST_PRE_PARTIALS_PER_CTA = 4
+_THREADS = 128
+_PREFILL_THREADS = int(os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_THREADS", "512"))
+_PREFILL_GRAM_THREADS = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_GRAM_THREADS",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_THREADS", "1024"),
+    )
+)
+_PREFILL_BLOCK_M = 2
+_PREFILL_BLOCK_TILE_N = 24
+_PREFILL_MMA_THREADS = 32
+_PREFILL_MMA_TILE_M = 16
+_PREFILL_MMA_TILE_N = 8
+_PREFILL_MMA_TILE_K = 16
+_PREFILL_TMA_COMPUTE_WARPS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_WARPS", "8")
+)
+_PREFILL_TMA_THREADS = (_PREFILL_TMA_COMPUTE_WARPS + 1) * 32
+_PREFILL_TMA_TILE_M = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_TILE_M", "128")
+)
+_PREFILL_TMA_TILE_N = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_TILE_N", "16")
+)
+_PREFILL_TMA_TILE_K = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_TILE_K", "64")
+)
+_PREFILL_TMA_STAGES = int(os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_STAGES", "3"))
+_PREFILL_TF32_TMA_M_WARPS = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_M_WARPS",
+        os.getenv(
+            "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_WARPS",
+            os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_WARPS", "1"),
+        ),
+    )
+)
+_PREFILL_TF32_TMA_N_WARPS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1")
+)
+_PREFILL_TF32_TMA_COMPUTE_WARPS = _PREFILL_TF32_TMA_M_WARPS * _PREFILL_TF32_TMA_N_WARPS
+_PREFILL_TF32_TMA_THREADS = (_PREFILL_TF32_TMA_COMPUTE_WARPS + 1) * 32
+_PREFILL_TF32_TMA_TILE_M = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_TILE_M",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_TILE_M", "16"),
+    )
+)
+_PREFILL_TF32_TMA_TILE_N = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_TILE_N", "8")
+)
+_PREFILL_TF32_TMA_TILE_K = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_TILE_K",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_TILE_K", "256"),
+    )
+)
+_PREFILL_TF32_TMA_STAGES = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_STAGES",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TMA_STAGES", "1"),
+    )
+)
+_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS", "4096")
+)
+_PREFILL_TF32_TMA_LONG_MIN_TOKENS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_MIN_TOKENS", "8192")
+)
+# At hidden=4096, one CTA owns all 24 mix columns so A is loaded once instead
+# of once per 8-column N tile. M192/K64 gives the best 4096-token balance of B
+# reuse and SM coverage; K splitting supplies enough CTAs for all SMs.
+# Keep the previous geometry for hidden=7168, where wide-N regresses.
+_PREFILL_TF32_TMA_CHUNK_4096_M_WARPS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_M_WARPS", "12")
+)
+_PREFILL_TF32_TMA_CHUNK_OTHER_M_WARPS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_M_WARPS", "2")
+)
+_PREFILL_TF32_TMA_CHUNK_4096_N_WARPS = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_N_WARPS",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1"),
+    )
+)
+_PREFILL_TF32_TMA_CHUNK_OTHER_N_WARPS = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_N_WARPS",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1"),
+    )
+)
+_PREFILL_TF32_TMA_CHUNK_4096_TILE_M = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_M", "192")
+)
+_PREFILL_TF32_TMA_CHUNK_OTHER_TILE_M = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_M", "32")
+)
+_PREFILL_TF32_TMA_CHUNK_4096_TILE_N = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_N",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_TILE_N", "24"),
+    )
+)
+_PREFILL_TF32_TMA_CHUNK_OTHER_TILE_N = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_N",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_TILE_N", "8"),
+    )
+)
+_PREFILL_TF32_TMA_CHUNK_4096_TILE_K = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_K",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_TILE_K", "64"),
+    )
+)
+_PREFILL_TF32_TMA_CHUNK_4096_STAGES = int(
+    os.getenv(
+        "FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_STAGES",
+        os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_STAGES", "2"),
+    )
+)
+_PREFILL_TF32_TMA_CHUNK_4096_K_SPLITS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_CHUNK_K_SPLITS", "8")
+)
+# At 8192+ tokens, four K splits give the same 256-CTA launch while doubling
+# useful work per CTA relative to the 4096-token specialization.
+_PREFILL_TF32_TMA_LONG_4096_M_WARPS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_M_WARPS", "8")
+)
+_PREFILL_TF32_TMA_LONG_4096_N_WARPS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_N_WARPS", "1")
+)
+_PREFILL_TF32_TMA_LONG_4096_TILE_M = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_TILE_M", "128")
+)
+_PREFILL_TF32_TMA_LONG_4096_TILE_N = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_TILE_N", "24")
+)
+_PREFILL_TF32_TMA_LONG_4096_TILE_K = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_TILE_K", "64")
+)
+_PREFILL_TF32_TMA_LONG_4096_STAGES = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_STAGES", "2")
+)
+_PREFILL_TF32_TMA_LONG_4096_K_SPLITS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_TF32_TMA_LONG_K_SPLITS", "4")
+)
+_PREFILL_FINALIZE_THREADS = int(
+    os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_FINALIZE_THREADS", "256")
+)
+_POST_PRE_CHUNK = 12
+
+# --- Gram-trick split finalize (multi-CTA fuse_norm, no per-h norm reduction) -
+# The post_pre-partial kernel additionally reduces the 4x4 Gram of residual_out
+# G[m,m'] = sum_h ro[m,h] ro[m',h] (10 unique entries) into free partials rows
+# [32, 64) (one row per source tile). The finalize then gets sum_h y^2 =
+# pre^T G pre as a scalar, so it no longer reduces over hidden and can run
+# multi-CTA (one block per hidden tile) like the no-norm path. 10 packed pairs:
+#   0:(0,0) 1:(1,1) 2:(2,2) 3:(3,3) 4:(0,1) 5:(0,2) 6:(0,3) 7:(1,2) 8:(1,3) 9:(2,3)
+_GRAM_PAIRS = 10
+_GRAM_ROW0 = 32  # gram[tile] stored at partials[token, 32 + tile, 0:10]
+# 1024 threads cover one hidden tile per loop iteration.
+_GRAM_BLOCK_H = 1024
+
+
+@dsl_user_op
+def _materialize_residual_gram_f32(value, *, loc=None, ip=None):
+    """Keep rounded BF16 residual values in the F32 arithmetic domain."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(value).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _source_tiles_for_hidden(hidden_size: int) -> int:
+    hidden_size = int(hidden_size)
+    if hidden_size <= 0:
+        raise ValueError(f"hidden_size must be positive, got {hidden_size}")
+    if hidden_size not in _SUPPORTED_HIDDEN_SIZES:
+        raise ValueError(
+            f"hidden_size={hidden_size} is not supported by the mHC kernels; "
+            f"supported hidden sizes are {_SUPPORTED_HIDDEN_SIZES}"
+        )
+    if hidden_size % _SOURCE_TILE_H != 0:
+        raise ValueError(
+            f"hidden_size={hidden_size} must be divisible by source tile "
+            f"{_SOURCE_TILE_H}"
+        )
+    return hidden_size // _SOURCE_TILE_H
+
+
+def _split_k_for_hidden(hidden_size: int) -> int:
+    return 2 * _source_tiles_for_hidden(hidden_size)
+
+
+def _validate_split_k(hidden_size: int, split_k: int) -> None:
+    required = _split_k_for_hidden(hidden_size)
+    if int(split_k) != required:
+        raise ValueError(
+            f"split_k={split_k} does not match hidden_size={hidden_size}; "
+            f"expected {required}"
+        )
+
+
+def _hidden_specialization_name(hidden_size: int) -> str:
+    hidden_size = int(hidden_size)
+    if hidden_size not in _SUPPORTED_HIDDEN_SIZES:
+        raise ValueError(
+            f"hidden_size={hidden_size} is not supported by the mHC kernels; "
+            f"supported hidden sizes are {_SUPPORTED_HIDDEN_SIZES}"
+        )
+    return f"hidden{hidden_size}"
+
+
+def _convert_layout_acc_mn(
+    acc_layout: cute.Layout,
+    transpose: bool = False,
+) -> cute.Layout:
+    acc_layout_col_major = cute.make_layout(acc_layout.shape)
+    shape = (
+        (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+        (
+            acc_layout_col_major.shape[0][0],
+            *acc_layout_col_major.shape[0][2:],
+            acc_layout_col_major.shape[2],
+        ),
+        *acc_layout_col_major.shape[3:],
+    )
+    stride = (
+        (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+        (
+            acc_layout_col_major.stride[0][0],
+            *acc_layout_col_major.stride[0][2:],
+            acc_layout_col_major.stride[2],
+        ),
+        *acc_layout_col_major.stride[3:],
+    )
+    if const_expr(transpose):
+        shape = (shape[1], shape[0], *shape[2:])
+        stride = (stride[1], stride[0], *stride[2:])
+    return cute.composition(acc_layout, cute.make_layout(shape, stride=stride))
+
+
+def _reshape_acc_to_mn(
+    acc: cute.Tensor,
+    transpose: bool = False,
+) -> cute.Tensor:
+    return cute.make_tensor(
+        acc.iterator,
+        _convert_layout_acc_mn(acc.layout, transpose=transpose),
+    )
+
+
+def _to_kernel_tensor(
+    tensor: torch.Tensor,
+    dtype: type[cutlass.Numeric],
+    *,
+    assumed_align: int = 16,
+    dynamic_layout: bool = False,
+) -> cutlass.cute.Tensor:
+    tensor = tensor.detach()
+    cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
+    cute_tensor.element_type = dtype
+    if dynamic_layout and tensor.ndim >= 1:
+        leading_dim = next(
+            (idx for idx, stride in enumerate(tensor.stride()) if stride == 1),
+            None,
+        )
+        if leading_dim is not None:
+            cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+            cute_tensor.element_type = dtype
+    return cute_tensor
+
+
+def _assume_tma_source_aligned(tensor: cute.Tensor) -> cute.Tensor:
+    divby = 128 // tensor.element_type.width
+    strides = []
+    for dim, stride in enumerate(tensor.stride):
+        if dim == 1 or isinstance(stride, int):
+            strides.append(stride)
+        else:
+            strides.append(cute.assume(stride, divby=divby))
+    return cute.make_tensor(
+        tensor.iterator,
+        cute.make_layout(tensor.shape, stride=tuple(strides)),
+    )
+
+
+def _tensor_meta_key(
+    tensor: torch.Tensor,
+) -> tuple[tuple[int, ...], tuple[int, ...], str, tuple[str, int | None]]:
+    return (
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        str(tensor.dtype),
+        (tensor.device.type, tensor.device.index),
+    )
+
+
+def _validate_tensor_shape(
+    name: str,
+    tensor: torch.Tensor,
+    expected: tuple[int, ...],
+) -> None:
+    actual = tuple(int(dim) for dim in tensor.shape)
+    if actual != expected:
+        raise ValueError(f"{name} must have shape {expected}, got {actual}")
+
+
+def _norm_weight_kernel_tensor(
+    norm_weight: torch.Tensor | None,
+    fallback: torch.Tensor,
+) -> cutlass.cute.Tensor:
+    if norm_weight is None:
+        return _to_kernel_tensor(fallback, cutlass.BFloat16)
+    if norm_weight.dtype == torch.bfloat16:
+        return _to_kernel_tensor(norm_weight, cutlass.BFloat16)
+    if norm_weight.dtype == torch.float32:
+        return _to_kernel_tensor(norm_weight, cutlass.Float32)
+    raise ValueError(f"norm_weight must be bf16 or fp32, got {norm_weight.dtype}")
+
+
+@lru_cache(maxsize=8)
+def _finalize_storage_cls(num_threads: int, include_y: bool):
+    class FinalizeStorage:
+        pass
+
+    annotations = {
+        "partials": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, num_threads],
+            16,
+        ],
+        "pre": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _MHC_MULT],
+            16,
+        ],
+        "post": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _MHC_MULT],
+            16,
+        ],
+        "comb": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _MHC_MULT * _MHC_MULT],
+            16,
+        ],
+    }
+    if include_y:
+        annotations["y"] = cute.struct.Align[
+            cute.struct.MemRange[cutlass.BFloat16, _HIDDEN],
+            16,
+        ]
+    FinalizeStorage.__annotations__ = annotations
+    return cute.struct(FinalizeStorage)
+
+
+def _validate_post_pre_partials_per_cta(partials_per_cta: int) -> int:
+    partials_per_cta = int(partials_per_cta)
+    if partials_per_cta <= 0 or partials_per_cta > _PARTIALS:
+        raise ValueError(
+            "FLASHINFER_EXP_SM12X_MHC_PARTIALS_PER_CTA must be in "
+            f"[1, {_PARTIALS}], got {partials_per_cta}"
+        )
+    return partials_per_cta
+
+
+def _selected_post_pre_decode_split_n(
+    *,
+    num_tokens: int,
+    hidden_size: int,
+    compute_capability: tuple[int, int] | None = None,
+) -> tuple[int, int]:
+    raw_splits = os.environ.get("FLASHINFER_EXP_SM12X_MHC_DECODE_SPLITS")
+    if raw_splits is not None and raw_splits != "":
+        try:
+            splits = int(raw_splits)
+            tile_n = int(os.environ.get("FLASHINFER_EXP_SM12X_MHC_DECODE_TILE_N", "3"))
+        except ValueError as exc:
+            raise ValueError(
+                "FLASHINFER_EXP_SM12X_MHC_DECODE_SPLITS and FLASHINFER_EXP_SM12X_MHC_DECODE_TILE_N must be integers"
+            ) from exc
+        if splits == 0:
+            return 0, 0
+    else:
+        if compute_capability is None and torch.cuda.is_available():
+            compute_capability = tuple(torch.cuda.get_device_capability())
+        if compute_capability != (12, 1) or int(hidden_size) != _HIDDEN:
+            return 0, 0
+        if int(num_tokens) >= 10:
+            splits, tile_n = 8, 6
+        elif int(num_tokens) >= 8:
+            splits, tile_n = 4, 6
+        else:
+            return 0, 0
+    if splits <= 0 or splits > _SOURCE_TILES or int(hidden_size) % splits != 0:
+        raise ValueError(
+            "FLASHINFER_EXP_SM12X_MHC_DECODE_SPLITS must be a positive divisor of hidden_size "
+            f"no larger than {_SOURCE_TILES}, got {splits}"
+        )
+    if tile_n <= 0 or _MIXES % tile_n != 0:
+        raise ValueError(
+            f"FLASHINFER_EXP_SM12X_MHC_DECODE_TILE_N must divide {_MIXES}, got {tile_n}"
+        )
+    return splits, tile_n
+
+
+def _selected_mhc_decode_finalize_threads(
+    *,
+    num_tokens: int,
+    hidden_size: int,
+    compute_capability: tuple[int, int] | None = None,
+) -> int:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_MHC_DECODE_FINALIZE_THREADS")
+    if raw is not None and raw != "":
+        try:
+            threads = int(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid FLASHINFER_EXP_SM12X_MHC_DECODE_FINALIZE_THREADS={raw!r}"
+            ) from exc
+    else:
+        if compute_capability is None and torch.cuda.is_available():
+            compute_capability = tuple(torch.cuda.get_device_capability())
+        if compute_capability != (12, 1) or int(hidden_size) != _HIDDEN:
+            return 0
+        if int(num_tokens) >= 16:
+            threads = 128
+        elif int(num_tokens) >= 13:
+            threads = 512
+        elif int(num_tokens) >= 10:
+            threads = 128
+        elif int(num_tokens) >= 8:
+            threads = 512
+        else:
+            return 0
+    if threads == 0:
+        return 0
+    if (
+        threads <= 0
+        or threads > 1024
+        or threads % 32 != 0
+        or int(hidden_size) % (2 * threads) != 0
+    ):
+        raise ValueError(
+            "FLASHINFER_EXP_SM12X_MHC_DECODE_FINALIZE_THREADS must be a positive multiple of "
+            "32 that evenly vectorizes hidden_size, got "
+            f"threads={threads}, hidden_size={hidden_size}"
+        )
+    return threads
+
+
+def _selected_post_pre_partials_per_cta(
+    *,
+    num_tokens: int,
+    hidden_size: int,
+    compute_capability: tuple[int, int] | None = None,
+) -> int:
+    raw = os.environ.get("FLASHINFER_EXP_SM12X_MHC_PARTIALS_PER_CTA")
+    if raw is not None and raw != "":
+        try:
+            return _validate_post_pre_partials_per_cta(int(raw))
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid FLASHINFER_EXP_SM12X_MHC_PARTIALS_PER_CTA={raw!r}"
+            ) from exc
+
+    if compute_capability is None and torch.cuda.is_available():
+        compute_capability = tuple(torch.cuda.get_device_capability())
+    if compute_capability == (12, 1) and int(hidden_size) == _HIDDEN:
+        if int(num_tokens) >= 8:
+            return 25
+        if int(num_tokens) >= 4:
+            return 9
+    return _POST_PRE_PARTIALS_PER_CTA
+
+
+@lru_cache(maxsize=16)
+def _post_pre_partial_group_storage_cls(
+    partials_per_cta: int,
+    compute_gram: bool = False,
+):
+    partials_per_cta = _validate_post_pre_partials_per_cta(partials_per_cta)
+
+    class PostPrePartialGroupStorage:
+        pass
+
+    annotations = {
+        "warp_sums": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, partials_per_cta * (_THREADS // 32)],
+            16,
+        ],
+    }
+    if compute_gram:
+        annotations["gram_sums"] = cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _GRAM_PAIRS * (_THREADS // 32)],
+            16,
+        ]
+    PostPrePartialGroupStorage.__annotations__ = annotations
+    return cute.struct(PostPrePartialGroupStorage)
+
+
+@lru_cache(maxsize=16)
+def _post_pre_decode_split_n_storage_cls(
+    tile_n: int,
+    compute_gram: bool = False,
+):
+    nwarps = 256 // 32
+
+    class PostPreDecodeSplitNStorage:
+        pass
+
+    annotations = {
+        "warp_sums": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, (tile_n + 1) * nwarps],
+            16,
+        ],
+        "post": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _MHC_MULT],
+            16,
+        ],
+        "comb": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _MHC_MULT * _MHC_MULT],
+            16,
+        ],
+    }
+    if compute_gram:
+        annotations["gram_sums"] = cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _GRAM_PAIRS * nwarps],
+            16,
+        ]
+    PostPreDecodeSplitNStorage.__annotations__ = annotations
+    return cute.struct(PostPreDecodeSplitNStorage)
+
+
+@lru_cache(maxsize=4)
+def _post_pre_prefill_storage_cls(compute_gram: bool = False):
+    class PostPrePrefillStorage:
+        pass
+
+    nwarps = _PREFILL_THREADS // 32
+    annotations = {
+        "warp_sums": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _PARTIALS * nwarps],
+            16,
+        ],
+    }
+    if compute_gram:
+        annotations["gram_sums"] = cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _GRAM_PAIRS * nwarps],
+            16,
+        ]
+    PostPrePrefillStorage.__annotations__ = annotations
+    return cute.struct(PostPrePrefillStorage)
+
+
+@lru_cache(maxsize=1)
+def _post_pre_prefill_gram_storage_cls():
+    class PostPrePrefillGramStorage:
+        pass
+
+    nwarps = _PREFILL_GRAM_THREADS // 32
+    PostPrePrefillGramStorage.__annotations__ = {
+        "gram_sums": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _GRAM_PAIRS * nwarps],
+            16,
+        ],
+        "post_coeff": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _MHC_MULT],
+            16,
+        ],
+        "comb_coeff": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, _MHC_MULT * _MHC_MULT],
+            16,
+        ],
+    }
+    return cute.struct(PostPrePrefillGramStorage)
+
+
+@lru_cache(maxsize=1)
+def _prefill_bf16_mma_storage_cls():
+    class PrefillBf16MmaStorage:
+        pass
+
+    PrefillBf16MmaStorage.__annotations__ = {
+        "a_tile": cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.BFloat16,
+                _PREFILL_MMA_TILE_M * _PREFILL_MMA_TILE_K,
+            ],
+            128,
+        ],
+    }
+    return cute.struct(PrefillBf16MmaStorage)
+
+
+@lru_cache(maxsize=8)
+def _post_pre_prefill_block_m_storage_cls(
+    block_m: int,
+    compute_gram: bool = False,
+):
+    block_m = int(block_m)
+    if block_m <= 0:
+        raise ValueError(f"prefill block_m must be positive, got {block_m}")
+
+    class PostPrePrefillBlockMStorage:
+        pass
+
+    nwarps = _PREFILL_THREADS // 32
+    annotations = {
+        "warp_sums": cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, block_m * _PARTIALS * nwarps],
+            16,
+        ],
+    }
+    if compute_gram:
+        annotations["gram_sums"] = cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, block_m * _GRAM_PAIRS * nwarps],
+            16,
+        ]
+    PostPrePrefillBlockMStorage.__annotations__ = annotations
+    return cute.struct(PostPrePrefillBlockMStorage)
+
+
+@cute.jit
+def _warp_allreduce_sum(value: Float32) -> Float32:
+    for shift in cutlass.range_constexpr(5):
+        value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=1 << shift))
+    return value
+
+
+@cute.jit
+def _warp_quad_allreduce_sum(value: Float32) -> Float32:
+    value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=1))
+    value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=2))
+    return value
+
+
+@cute.jit
+def _warp_quad_allreduce_max(value: Float32) -> Float32:
+    peer = Float32(cute.arch.shuffle_sync_bfly(value, offset=1))
+    if peer > value:
+        value = peer
+    peer = Float32(cute.arch.shuffle_sync_bfly(value, offset=2))
+    if peer > value:
+        value = peer
+    return value
+
+
+@cute.jit
+def _warp_column4_allreduce_sum(value: Float32) -> Float32:
+    value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=4))
+    value = Float32(value + cute.arch.shuffle_sync_bfly(value, offset=8))
+    return value
+
+
+class MHCPostPrePartialKernel:
+    num_threads = _THREADS
+    hidden_size = _HIDDEN
+    total_k = _TOTAL_K
+    split_k = _SPLIT_K
+    source_tile_h = _SOURCE_TILE_H
+    source_tiles = _SOURCE_TILES
+    source_warps = (_SOURCE_TILES + 31) // 32
+    gram_row0 = _GRAM_ROW0
+    partials = _PARTIALS
+    partials_per_cta = _POST_PRE_PARTIALS_PER_CTA
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+        compute_gram: bool = False,
+        pre_only: bool = False,
+        post_only: bool = False,
+        partials_per_cta: int = _POST_PRE_PARTIALS_PER_CTA,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.total_k = _MHC_MULT * self.hidden_size
+        self.source_tiles = _source_tiles_for_hidden(self.hidden_size)
+        self.source_warps = (self.source_tiles + 31) // 32
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        self.gram_row0 = self.source_tiles
+        self.partials_per_cta = _validate_post_pre_partials_per_cta(partials_per_cta)
+        # When True, the partial_group==0 CTAs also reduce the 4x4 Gram of
+        # residual_out into partials rows [32, 64) for the Gram-trick finalize.
+        self.compute_gram = bool(compute_gram)
+        # When True, this is the standalone pre path: compute fn/residual
+        # partials directly from residual and do not materialize post_pre's
+        # residual_out side.
+        self.pre_only = bool(pre_only)
+        # When True, this is the standalone post path: materialize residual_out
+        # and skip the fn/residual partial reductions.
+        self.post_only = bool(post_only)
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr((not self.pre_only) and x.element_type != cutlass.BFloat16):
+            raise TypeError("x must be BFloat16")
+        if const_expr(residual.element_type != cutlass.BFloat16):
+            raise TypeError("residual must be BFloat16")
+        if const_expr(
+            (not self.pre_only) and prev_post.element_type != cutlass.Float32
+        ):
+            raise TypeError("prev_post must be Float32")
+        if const_expr(
+            (not self.pre_only) and prev_comb.element_type != cutlass.Float32
+        ):
+            raise TypeError("prev_comb must be Float32")
+        if const_expr((not self.post_only) and fn.element_type != cutlass.Float32):
+            raise TypeError("fn must be Float32")
+        if const_expr(
+            (not self.post_only) and partials.element_type != cutlass.Float32
+        ):
+            raise TypeError("partials must be Float32")
+        if const_expr(out.element_type != cutlass.BFloat16):
+            raise TypeError("out must be BFloat16")
+        partial_groups = (
+            1
+            if self.post_only
+            else (self.partials + self.partials_per_cta - 1) // self.partials_per_cta
+        )
+        self.kernel(x, residual, prev_post, prev_comb, fn, partials, out).launch(
+            grid=(
+                self.source_tiles,
+                partial_groups,
+                num_tokens,
+            ),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+    ):
+        hidden_tile, partial_group, token = cute.arch.block_idx()
+        tidx = cute.arch.thread_idx()[0]
+        lane = tidx % Int32(32)
+        warp = tidx // Int32(32)
+        nwarps = self.num_threads // 32
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(
+            _post_pre_partial_group_storage_cls(
+                self.partials_per_cta,
+                self.compute_gram,
+            )
+        )
+        warp_sums = storage.warp_sums.get_tensor(
+            cute.make_layout(
+                (self.partials_per_cta, self.num_threads // 32),
+                stride=(self.num_threads // 32, 1),
+            )
+        )
+        if const_expr(self.compute_gram):
+            gram_sums = storage.gram_sums.get_tensor(
+                cute.make_layout((_GRAM_PAIRS, nwarps), stride=(nwarps, 1))
+            )
+
+        partial0 = partial_group * Int32(self.partials_per_cta)
+        h = hidden_tile * Int32(self.source_tile_h) + tidx
+        if const_expr(self.pre_only):
+            r0 = Float32(residual[token, h])
+            r1 = r0
+            r2 = r0
+            r3 = r0
+            if partial_group == Int32(0):
+                out[token, Int32(0), h] = r0.to(cutlass.BFloat16)
+                out[token, Int32(1), h] = r0.to(cutlass.BFloat16)
+                out[token, Int32(2), h] = r0.to(cutlass.BFloat16)
+                out[token, Int32(3), h] = r0.to(cutlass.BFloat16)
+        else:
+            r0 = Float32(residual[token, Int32(0), h])
+            r1 = Float32(residual[token, Int32(1), h])
+            r2 = Float32(residual[token, Int32(2), h])
+            r3 = Float32(residual[token, Int32(3), h])
+
+        if const_expr(not self.pre_only):
+            xh = Float32(x[token, h])
+            o0 = (
+                Float32(prev_post[token, Int32(0)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(0)]) * r0
+                + Float32(prev_comb[token, Int32(1), Int32(0)]) * r1
+                + Float32(prev_comb[token, Int32(2), Int32(0)]) * r2
+                + Float32(prev_comb[token, Int32(3), Int32(0)]) * r3
+            ).to(cutlass.BFloat16)
+            o1 = (
+                Float32(prev_post[token, Int32(1)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(1)]) * r0
+                + Float32(prev_comb[token, Int32(1), Int32(1)]) * r1
+                + Float32(prev_comb[token, Int32(2), Int32(1)]) * r2
+                + Float32(prev_comb[token, Int32(3), Int32(1)]) * r3
+            ).to(cutlass.BFloat16)
+            o2 = (
+                Float32(prev_post[token, Int32(2)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(2)]) * r0
+                + Float32(prev_comb[token, Int32(1), Int32(2)]) * r1
+                + Float32(prev_comb[token, Int32(2), Int32(2)]) * r2
+                + Float32(prev_comb[token, Int32(3), Int32(2)]) * r3
+            ).to(cutlass.BFloat16)
+            o3 = (
+                Float32(prev_post[token, Int32(3)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(3)]) * r0
+                + Float32(prev_comb[token, Int32(1), Int32(3)]) * r1
+                + Float32(prev_comb[token, Int32(2), Int32(3)]) * r2
+                + Float32(prev_comb[token, Int32(3), Int32(3)]) * r3
+            ).to(cutlass.BFloat16)
+
+            if partial_group == Int32(0):
+                out[token, Int32(0), h] = o0
+                out[token, Int32(1), h] = o1
+                out[token, Int32(2), h] = o2
+                out[token, Int32(3), h] = o3
+
+            r0 = Float32(o0)
+            r1 = Float32(o1)
+            r2 = Float32(o2)
+            r3 = Float32(o3)
+
+        if const_expr(not self.post_only):
+            # Optional 4x4 Gram of residual_out (only the residual_out-owning group).
+            if const_expr(self.compute_gram):
+                if partial_group == Int32(0):
+                    gvals = cute.make_rmem_tensor(
+                        cute.make_layout((_GRAM_PAIRS,), stride=(1,)),
+                        Float32,
+                    )
+                    gvals[0] = r0 * r0
+                    gvals[1] = r1 * r1
+                    gvals[2] = r2 * r2
+                    gvals[3] = r3 * r3
+                    gvals[4] = r0 * r1
+                    gvals[5] = r0 * r2
+                    gvals[6] = r0 * r3
+                    gvals[7] = r1 * r2
+                    gvals[8] = r1 * r3
+                    gvals[9] = r2 * r3
+                    for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                        gvals[gp] = _warp_allreduce_sum(gvals[gp])
+                    if lane == Int32(0):
+                        for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                            gram_sums[gp, warp] = gvals[gp]
+
+            values = cute.make_rmem_tensor(
+                cute.make_layout((self.partials_per_cta,), stride=(1,)),
+                Float32,
+            )
+            for slot in cutlass.range_constexpr(self.partials_per_cta):
+                partial = partial0 + Int32(slot)
+                value = Float32(0.0)
+                if partial == Int32(0):
+                    value = r0 * r0 + r1 * r1 + r2 * r2 + r3 * r3
+                elif const_expr(self.pre_only):
+                    if partial < Int32(self.partials):
+                        mix = partial - Int32(1)
+                        value = Float32(fn[mix, h]) * r0
+                elif partial < Int32(self.partials):
+                    mix = partial - Int32(1)
+                    value = (
+                        Float32(fn[mix, h]) * r0
+                        + Float32(fn[mix, Int32(self.hidden_size) + h]) * r1
+                        + Float32(fn[mix, Int32(2 * self.hidden_size) + h]) * r2
+                        + Float32(fn[mix, Int32(3 * self.hidden_size) + h]) * r3
+                    )
+                values[slot] = _warp_allreduce_sum(value)
+            if lane == Int32(0):
+                for slot in cutlass.range_constexpr(self.partials_per_cta):
+                    warp_sums[slot, warp] = values[slot]
+            cute.arch.sync_threads()
+
+            if tidx == Int32(0):
+                for slot in cutlass.range_constexpr(self.partials_per_cta):
+                    total = Float32(0.0)
+                    src_warp = Int32(0)
+                    while src_warp < Int32(self.num_threads // 32):
+                        total += Float32(warp_sums[slot, src_warp])
+                        src_warp += Int32(1)
+                    partial = partial0 + Int32(slot)
+                    if partial < Int32(self.partials):
+                        partials[token, hidden_tile, partial] = total
+
+            if const_expr(self.compute_gram):
+                if partial_group == Int32(0):
+                    if tidx == Int32(0):
+                        for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                            gtotal = Float32(0.0)
+                            src_warp = Int32(0)
+                            while src_warp < Int32(nwarps):
+                                gtotal += Float32(gram_sums[gp, src_warp])
+                                src_warp += Int32(1)
+                            partials[token, Int32(self.gram_row0) + hidden_tile, gp] = (
+                                gtotal
+                            )
+
+        if const_expr(_MHC_PDL):
+            cute.arch.sync_threads()
+            cute.arch.griddepcontrol_launch_dependents()
+
+
+class MHCPostPreDecodeSplitNPartialKernel:
+    """Fused decode partial using split hidden slices and narrow output tiles."""
+
+    num_threads = 256
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+        source_splits: int = 4,
+        tile_n: int = 3,
+        bf16x2: bool = False,
+        compute_gram: bool = False,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.source_tiles = _source_tiles_for_hidden(self.hidden_size)
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        self.source_splits = int(source_splits)
+        if (
+            self.source_splits <= 0
+            or self.source_splits > self.source_tiles
+            or self.hidden_size % self.source_splits != 0
+        ):
+            raise ValueError(f"invalid decode source_splits={self.source_splits}")
+        self.hidden_per_split = self.hidden_size // self.source_splits
+        if self.hidden_per_split % self.num_threads != 0:
+            raise ValueError(
+                f"hidden_size/source_splits={self.hidden_per_split} must be "
+                f"divisible by {self.num_threads} threads"
+            )
+        self.hidden_iters = self.hidden_per_split // self.num_threads
+        self.tile_n = int(tile_n)
+        if self.tile_n <= 0 or _MIXES % self.tile_n != 0:
+            raise ValueError(f"decode tile_n must divide {_MIXES}, got {self.tile_n}")
+        self.n_tiles = _MIXES // self.tile_n
+        self.bf16x2 = bool(bf16x2)
+        if self.bf16x2 and self.hidden_per_split % (2 * self.num_threads) != 0:
+            raise ValueError(
+                f"hidden_size/source_splits={self.hidden_per_split} must be "
+                f"divisible by {2 * self.num_threads} for bf16x2"
+            )
+        self.hidden_pair_iters = self.hidden_per_split // (2 * self.num_threads)
+        self.compute_gram = bool(compute_gram)
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(x.element_type != cutlass.BFloat16):
+            raise TypeError("x must be BFloat16")
+        if const_expr(residual.element_type != cutlass.BFloat16):
+            raise TypeError("residual must be BFloat16")
+        if const_expr(prev_post.element_type != cutlass.Float32):
+            raise TypeError("prev_post must be Float32")
+        if const_expr(prev_comb.element_type != cutlass.Float32):
+            raise TypeError("prev_comb must be Float32")
+        if const_expr(fn.element_type != cutlass.Float32):
+            raise TypeError("fn must be Float32")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+        if const_expr(out.element_type != cutlass.BFloat16):
+            raise TypeError("out must be BFloat16")
+        self.kernel(x, residual, prev_post, prev_comb, fn, partials, out).launch(
+            grid=(num_tokens, self.n_tiles, self.source_splits),
+            block=[self.num_threads, 1, 1],
+            min_blocks_per_mp=3,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+    ):
+        token, n_tile, source_split = cute.arch.block_idx()
+        tidx = Int32(cute.arch.thread_idx()[0])
+        lane = tidx % Int32(32)
+        warp_idx = tidx // Int32(32)
+        nwarps = self.num_threads // 32
+        mix0 = n_tile * Int32(self.tile_n)
+
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(
+            _post_pre_decode_split_n_storage_cls(
+                self.tile_n,
+                self.compute_gram,
+            )
+        )
+        warp_sums = storage.warp_sums.get_tensor(
+            cute.make_layout((self.tile_n + 1, nwarps), stride=(nwarps, 1))
+        )
+        s_post = storage.post.get_tensor(cute.make_layout((_MHC_MULT,), stride=(1,)))
+        s_comb = storage.comb.get_tensor(
+            cute.make_layout((_MHC_MULT, _MHC_MULT), stride=(_MHC_MULT, 1))
+        )
+        if const_expr(self.compute_gram):
+            gram_sums = storage.gram_sums.get_tensor(
+                cute.make_layout((_GRAM_PAIRS, nwarps), stride=(nwarps, 1))
+            )
+
+        if tidx < Int32(_MHC_MULT):
+            s_post[tidx] = Float32(prev_post[token, tidx])
+        if tidx < Int32(_MHC_MULT * _MHC_MULT):
+            row = tidx // Int32(_MHC_MULT)
+            col = tidx - row * Int32(_MHC_MULT)
+            s_comb[row, col] = Float32(prev_comb[token, row, col])
+
+        cute.arch.sync_threads()
+
+        pm = cute.make_rmem_tensor(cute.make_layout((_MHC_MULT,), stride=(1,)), Float32)
+        cm = cute.make_rmem_tensor(
+            cute.make_layout((_MHC_MULT, _MHC_MULT), stride=(_MHC_MULT, 1)),
+            Float32,
+        )
+        for j in cutlass.range_constexpr(_MHC_MULT):
+            pm[j] = Float32(s_post[j])
+            for k in cutlass.range_constexpr(_MHC_MULT):
+                cm[k, j] = Float32(s_comb[k, j])
+
+        acc = cute.make_rmem_tensor(
+            cute.make_layout((self.tile_n,), stride=(1,)), Float32
+        )
+        for ni in cutlass.range_constexpr(self.tile_n):
+            acc[ni] = Float32(0.0)
+        sqr = Float32(0.0)
+        if const_expr(self.compute_gram):
+            gvals = cute.make_rmem_tensor(
+                cute.make_layout((_GRAM_PAIRS,), stride=(1,)), Float32
+            )
+            for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                gvals[gp] = Float32(0.0)
+
+        h_split0 = source_split * Int32(self.hidden_per_split)
+        if const_expr(self.bf16x2):
+            out_u32 = cute.recast_tensor(out, Uint32)
+            for hidden_pair_iter in cutlass.range_constexpr(self.hidden_pair_iters):
+                h = (
+                    h_split0
+                    + Int32(2 * hidden_pair_iter * self.num_threads)
+                    + tidx * Int32(2)
+                )
+                x_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        x,
+                        token * Int32(self.hidden_size) + h,
+                    )
+                )
+                rin0_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size) + h,
+                    )
+                )
+                rin1_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size)
+                        + Int32(self.hidden_size)
+                        + h,
+                    )
+                )
+                rin2_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size)
+                        + Int32(2 * self.hidden_size)
+                        + h,
+                    )
+                )
+                rin3_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size)
+                        + Int32(3 * self.hidden_size)
+                        + h,
+                    )
+                )
+                x0, x1 = bfloat2_to_float2_scaled(x_pair, Float32(1.0))
+                rin00, rin01 = bfloat2_to_float2_scaled(rin0_pair, Float32(1.0))
+                rin10, rin11 = bfloat2_to_float2_scaled(rin1_pair, Float32(1.0))
+                rin20, rin21 = bfloat2_to_float2_scaled(rin2_pair, Float32(1.0))
+                rin30, rin31 = bfloat2_to_float2_scaled(rin3_pair, Float32(1.0))
+
+                o_values = cute.make_rmem_tensor(
+                    cute.make_layout((_MHC_MULT, 2), stride=(2, 1)),
+                    Float32,
+                )
+                for pair_lane in cutlass.range_constexpr(2):
+                    xh = x0
+                    rin0 = rin00
+                    rin1 = rin10
+                    rin2 = rin20
+                    rin3 = rin30
+                    if const_expr(pair_lane == 1):
+                        xh = x1
+                        rin0 = rin01
+                        rin1 = rin11
+                        rin2 = rin21
+                        rin3 = rin31
+                    o_values[0, pair_lane] = (
+                        pm[0] * xh
+                        + cm[0, 0] * rin0
+                        + cm[1, 0] * rin1
+                        + cm[2, 0] * rin2
+                        + cm[3, 0] * rin3
+                    )
+                    o_values[1, pair_lane] = (
+                        pm[1] * xh
+                        + cm[0, 1] * rin0
+                        + cm[1, 1] * rin1
+                        + cm[2, 1] * rin2
+                        + cm[3, 1] * rin3
+                    )
+                    o_values[2, pair_lane] = (
+                        pm[2] * xh
+                        + cm[0, 2] * rin0
+                        + cm[1, 2] * rin1
+                        + cm[2, 2] * rin2
+                        + cm[3, 2] * rin3
+                    )
+                    o_values[3, pair_lane] = (
+                        pm[3] * xh
+                        + cm[0, 3] * rin0
+                        + cm[1, 3] * rin1
+                        + cm[2, 3] * rin2
+                        + cm[3, 3] * rin3
+                    )
+
+                o0_pair = pack_f32x2_to_bfloat2(o_values[0, 0], o_values[0, 1])
+                o1_pair = pack_f32x2_to_bfloat2(o_values[1, 0], o_values[1, 1])
+                o2_pair = pack_f32x2_to_bfloat2(o_values[2, 0], o_values[2, 1])
+                o3_pair = pack_f32x2_to_bfloat2(o_values[3, 0], o_values[3, 1])
+                r00, r01 = bfloat2_to_float2_scaled(o0_pair, Float32(1.0))
+                r10, r11 = bfloat2_to_float2_scaled(o1_pair, Float32(1.0))
+                r20, r21 = bfloat2_to_float2_scaled(o2_pair, Float32(1.0))
+                r30, r31 = bfloat2_to_float2_scaled(o3_pair, Float32(1.0))
+
+                if n_tile == Int32(0):
+                    out_h = h // Int32(2)
+                    out_u32[token, Int32(0), out_h] = o0_pair
+                    out_u32[token, Int32(1), out_h] = o1_pair
+                    out_u32[token, Int32(2), out_h] = o2_pair
+                    out_u32[token, Int32(3), out_h] = o3_pair
+                    sqr += r00 * r00 + r10 * r10 + r20 * r20 + r30 * r30
+                    sqr += r01 * r01 + r11 * r11 + r21 * r21 + r31 * r31
+                    if const_expr(self.compute_gram):
+                        gvals[0] += r00 * r00 + r01 * r01
+                        gvals[1] += r10 * r10 + r11 * r11
+                        gvals[2] += r20 * r20 + r21 * r21
+                        gvals[3] += r30 * r30 + r31 * r31
+                        gvals[4] += r00 * r10 + r01 * r11
+                        gvals[5] += r00 * r20 + r01 * r21
+                        gvals[6] += r00 * r30 + r01 * r31
+                        gvals[7] += r10 * r20 + r11 * r21
+                        gvals[8] += r10 * r30 + r11 * r31
+                        gvals[9] += r20 * r30 + r21 * r31
+
+                for pair_lane in cutlass.range_constexpr(2):
+                    hp = h + Int32(pair_lane)
+                    r0 = r00
+                    r1 = r10
+                    r2 = r20
+                    r3 = r30
+                    if const_expr(pair_lane == 1):
+                        r0 = r01
+                        r1 = r11
+                        r2 = r21
+                        r3 = r31
+                    for ni in cutlass.range_constexpr(self.tile_n):
+                        mix = mix0 + Int32(ni)
+                        acc[ni] += (
+                            Float32(fn[mix, hp]) * r0
+                            + Float32(fn[mix, Int32(self.hidden_size) + hp]) * r1
+                            + Float32(fn[mix, Int32(2 * self.hidden_size) + hp]) * r2
+                            + Float32(fn[mix, Int32(3 * self.hidden_size) + hp]) * r3
+                        )
+        else:
+            for hidden_iter in cutlass.range_constexpr(self.hidden_iters):
+                h = h_split0 + Int32(hidden_iter * self.num_threads) + tidx
+                xh = Float32(x[token, h])
+                rin0 = Float32(residual[token, Int32(0), h])
+                rin1 = Float32(residual[token, Int32(1), h])
+                rin2 = Float32(residual[token, Int32(2), h])
+                rin3 = Float32(residual[token, Int32(3), h])
+                o0 = (
+                    pm[0] * xh
+                    + cm[0, 0] * rin0
+                    + cm[1, 0] * rin1
+                    + cm[2, 0] * rin2
+                    + cm[3, 0] * rin3
+                ).to(cutlass.BFloat16)
+                o1 = (
+                    pm[1] * xh
+                    + cm[0, 1] * rin0
+                    + cm[1, 1] * rin1
+                    + cm[2, 1] * rin2
+                    + cm[3, 1] * rin3
+                ).to(cutlass.BFloat16)
+                o2 = (
+                    pm[2] * xh
+                    + cm[0, 2] * rin0
+                    + cm[1, 2] * rin1
+                    + cm[2, 2] * rin2
+                    + cm[3, 2] * rin3
+                ).to(cutlass.BFloat16)
+                o3 = (
+                    pm[3] * xh
+                    + cm[0, 3] * rin0
+                    + cm[1, 3] * rin1
+                    + cm[2, 3] * rin2
+                    + cm[3, 3] * rin3
+                ).to(cutlass.BFloat16)
+                r0 = Float32(o0)
+                r1 = Float32(o1)
+                r2 = Float32(o2)
+                r3 = Float32(o3)
+
+                if n_tile == Int32(0):
+                    out[token, Int32(0), h] = o0
+                    out[token, Int32(1), h] = o1
+                    out[token, Int32(2), h] = o2
+                    out[token, Int32(3), h] = o3
+                    sqr += r0 * r0 + r1 * r1 + r2 * r2 + r3 * r3
+                    if const_expr(self.compute_gram):
+                        gvals[0] += r0 * r0
+                        gvals[1] += r1 * r1
+                        gvals[2] += r2 * r2
+                        gvals[3] += r3 * r3
+                        gvals[4] += r0 * r1
+                        gvals[5] += r0 * r2
+                        gvals[6] += r0 * r3
+                        gvals[7] += r1 * r2
+                        gvals[8] += r1 * r3
+                        gvals[9] += r2 * r3
+
+                for ni in cutlass.range_constexpr(self.tile_n):
+                    mix = mix0 + Int32(ni)
+                    acc[ni] += (
+                        Float32(fn[mix, h]) * r0
+                        + Float32(fn[mix, Int32(self.hidden_size) + h]) * r1
+                        + Float32(fn[mix, Int32(2 * self.hidden_size) + h]) * r2
+                        + Float32(fn[mix, Int32(3 * self.hidden_size) + h]) * r3
+                    )
+
+        for ni in cutlass.range_constexpr(self.tile_n):
+            acc[ni] = _warp_allreduce_sum(acc[ni])
+        if n_tile == Int32(0):
+            sqr = _warp_allreduce_sum(sqr)
+            if const_expr(self.compute_gram):
+                for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                    gvals[gp] = _warp_allreduce_sum(gvals[gp])
+
+        if lane == Int32(0):
+            for ni in cutlass.range_constexpr(self.tile_n):
+                warp_sums[ni, warp_idx] = acc[ni]
+            if n_tile == Int32(0):
+                warp_sums[self.tile_n, warp_idx] = sqr
+                if const_expr(self.compute_gram):
+                    for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                        gram_sums[gp, warp_idx] = gvals[gp]
+        cute.arch.sync_threads()
+
+        if warp_idx == Int32(0):
+            if lane < Int32(self.tile_n):
+                total = Float32(0.0)
+                src_warp = Int32(0)
+                while src_warp < Int32(nwarps):
+                    total += Float32(warp_sums[lane, src_warp])
+                    src_warp += Int32(1)
+                partials[token, source_split, mix0 + lane + Int32(1)] = total
+            if n_tile == Int32(0):
+                if lane == Int32(0):
+                    total = Float32(0.0)
+                    src_warp = Int32(0)
+                    while src_warp < Int32(nwarps):
+                        total += Float32(warp_sums[self.tile_n, src_warp])
+                        src_warp += Int32(1)
+                    partials[token, source_split, Int32(0)] = total
+                if const_expr(self.compute_gram):
+                    if lane < Int32(_GRAM_PAIRS):
+                        total = Float32(0.0)
+                        src_warp = Int32(0)
+                        while src_warp < Int32(nwarps):
+                            total += Float32(gram_sums[lane, src_warp])
+                            src_warp += Int32(1)
+                        partials[
+                            token,
+                            Int32(self.source_tiles) + source_split,
+                            lane,
+                        ] = total
+
+        if const_expr(_MHC_PDL):
+            cute.arch.sync_threads()
+            cute.arch.griddepcontrol_launch_dependents()
+
+
+class MHCPostPrePrefillPartialKernel:
+    """Full-hidden post_pre partial kernel for large prefill shapes.
+
+    One CTA owns one token, loops over the full hidden dimension, and writes a
+    compact partial layout:
+      partials[token, 0, 0:25] = scalar partials
+      partials[token, 1, 0:10] = residual_out Gram entries
+    """
+
+    num_threads = _PREFILL_THREADS
+    partials = _PARTIALS
+    mixes = _MIXES
+    gram_pairs = _GRAM_PAIRS
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+        compute_gram: bool = True,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.total_k = _MHC_MULT * self.hidden_size
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        if self.hidden_size % self.num_threads != 0:
+            raise ValueError(
+                f"hidden_size={self.hidden_size} must be divisible by "
+                f"prefill threads={self.num_threads}"
+            )
+        self.hidden_iters = self.hidden_size // self.num_threads
+        self.compute_gram = bool(compute_gram)
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(x.element_type != cutlass.BFloat16):
+            raise TypeError("x must be BFloat16")
+        if const_expr(residual.element_type != cutlass.BFloat16):
+            raise TypeError("residual must be BFloat16")
+        if const_expr(prev_post.element_type != cutlass.Float32):
+            raise TypeError("prev_post must be Float32")
+        if const_expr(prev_comb.element_type != cutlass.Float32):
+            raise TypeError("prev_comb must be Float32")
+        if const_expr(fn.element_type != cutlass.Float32):
+            raise TypeError("fn must be Float32")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+        if const_expr(out.element_type != cutlass.BFloat16):
+            raise TypeError("out must be BFloat16")
+        self.kernel(x, residual, prev_post, prev_comb, fn, partials, out).launch(
+            grid=(num_tokens, 1, 1),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+    ):
+        token, _, _ = cute.arch.block_idx()
+        tidx = Int32(cute.arch.thread_idx()[0])
+        lane = tidx % Int32(32)
+        warp = tidx // Int32(32)
+        nwarps = self.num_threads // 32
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(_post_pre_prefill_storage_cls(self.compute_gram))
+        warp_sums = storage.warp_sums.get_tensor(
+            cute.make_layout((_PARTIALS, nwarps), stride=(nwarps, 1))
+        )
+        if const_expr(self.compute_gram):
+            gram_sums = storage.gram_sums.get_tensor(
+                cute.make_layout((_GRAM_PAIRS, nwarps), stride=(nwarps, 1))
+            )
+
+        values = cute.make_rmem_tensor(
+            cute.make_layout((_PARTIALS,), stride=(1,)),
+            Float32,
+        )
+        for slot in cutlass.range_constexpr(_PARTIALS):
+            values[slot] = Float32(0.0)
+
+        if const_expr(self.compute_gram):
+            gvals = cute.make_rmem_tensor(
+                cute.make_layout((_GRAM_PAIRS,), stride=(1,)),
+                Float32,
+            )
+            for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                gvals[gp] = Float32(0.0)
+
+        for hidden_iter in cutlass.range_constexpr(self.hidden_iters):
+            h = Int32(hidden_iter * self.num_threads) + tidx
+            xh = Float32(x[token, h])
+            rin0 = Float32(residual[token, Int32(0), h])
+            rin1 = Float32(residual[token, Int32(1), h])
+            rin2 = Float32(residual[token, Int32(2), h])
+            rin3 = Float32(residual[token, Int32(3), h])
+            o0 = (
+                Float32(prev_post[token, Int32(0)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(0)]) * rin0
+                + Float32(prev_comb[token, Int32(1), Int32(0)]) * rin1
+                + Float32(prev_comb[token, Int32(2), Int32(0)]) * rin2
+                + Float32(prev_comb[token, Int32(3), Int32(0)]) * rin3
+            ).to(cutlass.BFloat16)
+            o1 = (
+                Float32(prev_post[token, Int32(1)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(1)]) * rin0
+                + Float32(prev_comb[token, Int32(1), Int32(1)]) * rin1
+                + Float32(prev_comb[token, Int32(2), Int32(1)]) * rin2
+                + Float32(prev_comb[token, Int32(3), Int32(1)]) * rin3
+            ).to(cutlass.BFloat16)
+            o2 = (
+                Float32(prev_post[token, Int32(2)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(2)]) * rin0
+                + Float32(prev_comb[token, Int32(1), Int32(2)]) * rin1
+                + Float32(prev_comb[token, Int32(2), Int32(2)]) * rin2
+                + Float32(prev_comb[token, Int32(3), Int32(2)]) * rin3
+            ).to(cutlass.BFloat16)
+            o3 = (
+                Float32(prev_post[token, Int32(3)]) * xh
+                + Float32(prev_comb[token, Int32(0), Int32(3)]) * rin0
+                + Float32(prev_comb[token, Int32(1), Int32(3)]) * rin1
+                + Float32(prev_comb[token, Int32(2), Int32(3)]) * rin2
+                + Float32(prev_comb[token, Int32(3), Int32(3)]) * rin3
+            ).to(cutlass.BFloat16)
+            out[token, Int32(0), h] = o0
+            out[token, Int32(1), h] = o1
+            out[token, Int32(2), h] = o2
+            out[token, Int32(3), h] = o3
+
+            r0 = Float32(o0)
+            r1 = Float32(o1)
+            r2 = Float32(o2)
+            r3 = Float32(o3)
+            values[0] += r0 * r0 + r1 * r1 + r2 * r2 + r3 * r3
+            for mix in cutlass.range_constexpr(_MIXES):
+                values[mix + 1] += (
+                    Float32(fn[mix, h]) * r0
+                    + Float32(fn[mix, Int32(self.hidden_size) + h]) * r1
+                    + Float32(fn[mix, Int32(2 * self.hidden_size) + h]) * r2
+                    + Float32(fn[mix, Int32(3 * self.hidden_size) + h]) * r3
+                )
+
+            if const_expr(self.compute_gram):
+                gvals[0] += r0 * r0
+                gvals[1] += r1 * r1
+                gvals[2] += r2 * r2
+                gvals[3] += r3 * r3
+                gvals[4] += r0 * r1
+                gvals[5] += r0 * r2
+                gvals[6] += r0 * r3
+                gvals[7] += r1 * r2
+                gvals[8] += r1 * r3
+                gvals[9] += r2 * r3
+
+        for slot in cutlass.range_constexpr(_PARTIALS):
+            values[slot] = _warp_allreduce_sum(values[slot])
+        if const_expr(self.compute_gram):
+            for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                gvals[gp] = _warp_allreduce_sum(gvals[gp])
+
+        if lane == Int32(0):
+            for slot in cutlass.range_constexpr(_PARTIALS):
+                warp_sums[slot, warp] = values[slot]
+            if const_expr(self.compute_gram):
+                for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                    gram_sums[gp, warp] = gvals[gp]
+        cute.arch.sync_threads()
+
+        if tidx == Int32(0):
+            for slot in cutlass.range_constexpr(_PARTIALS):
+                total = Float32(0.0)
+                src_warp = Int32(0)
+                while src_warp < Int32(nwarps):
+                    total += Float32(warp_sums[slot, src_warp])
+                    src_warp += Int32(1)
+                partials[token, Int32(0), slot] = total
+
+            if const_expr(self.compute_gram):
+                for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                    gtotal = Float32(0.0)
+                    src_warp = Int32(0)
+                    while src_warp < Int32(nwarps):
+                        gtotal += Float32(gram_sums[gp, src_warp])
+                        src_warp += Int32(1)
+                    partials[token, Int32(1), gp] = gtotal
+
+
+class MHCPostPrePrefillBlockMPartialKernel:
+    """Block-M scalar prefill kernel for large post_pre shapes.
+
+    One CTA owns two tokens and twelve projection rows. Compared with the
+    compact one-token CTA, this shares fn loads across two tokens while still
+    emitting compact partials for the existing Gram/RMSNorm finalize.
+    """
+
+    num_threads = _PREFILL_THREADS
+    block_m = _PREFILL_BLOCK_M
+    tile_n = _PREFILL_BLOCK_TILE_N
+    partials = _PARTIALS
+    mixes = _MIXES
+    gram_pairs = _GRAM_PAIRS
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+        block_m: int = _PREFILL_BLOCK_M,
+        tile_n: int = _PREFILL_BLOCK_TILE_N,
+        compute_gram: bool = True,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.total_k = _MHC_MULT * self.hidden_size
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        if self.hidden_size % self.num_threads != 0:
+            raise ValueError(
+                f"hidden_size={self.hidden_size} must be divisible by "
+                f"prefill threads={self.num_threads}"
+            )
+        self.hidden_iters = self.hidden_size // self.num_threads
+        self.block_m = int(block_m)
+        if self.block_m <= 0:
+            raise ValueError(f"block_m must be positive, got {self.block_m}")
+        self.tile_n = int(tile_n)
+        if self.tile_n <= 0:
+            raise ValueError(f"tile_n must be positive, got {self.tile_n}")
+        self.n_tiles = (self.mixes + self.tile_n - 1) // self.tile_n
+        self.compute_gram = bool(compute_gram)
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(x.element_type != cutlass.BFloat16):
+            raise TypeError("x must be BFloat16")
+        if const_expr(residual.element_type != cutlass.BFloat16):
+            raise TypeError("residual must be BFloat16")
+        if const_expr(prev_post.element_type != cutlass.Float32):
+            raise TypeError("prev_post must be Float32")
+        if const_expr(prev_comb.element_type != cutlass.Float32):
+            raise TypeError("prev_comb must be Float32")
+        if const_expr(fn.element_type != cutlass.Float32):
+            raise TypeError("fn must be Float32")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+        if const_expr(out.element_type != cutlass.BFloat16):
+            raise TypeError("out must be BFloat16")
+        m_tiles = (num_tokens + Int32(self.block_m - 1)) // Int32(self.block_m)
+        self.kernel(
+            x, residual, prev_post, prev_comb, fn, partials, out, num_tokens
+        ).launch(
+            grid=(m_tiles, self.n_tiles, 1),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+        num_tokens: Int32,
+    ):
+        m_tile, n_tile, _ = cute.arch.block_idx()
+        tidx = Int32(cute.arch.thread_idx()[0])
+        lane = tidx % Int32(32)
+        warp = tidx // Int32(32)
+        nwarps = self.num_threads // 32
+        mix0 = Int32(n_tile * self.tile_n)
+
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(
+            _post_pre_prefill_block_m_storage_cls(self.block_m, self.compute_gram)
+        )
+        warp_sums = storage.warp_sums.get_tensor(
+            cute.make_layout(
+                (self.block_m, _PARTIALS, nwarps),
+                stride=(_PARTIALS * nwarps, nwarps, 1),
+            )
+        )
+        if const_expr(self.compute_gram):
+            gram_sums = storage.gram_sums.get_tensor(
+                cute.make_layout(
+                    (self.block_m, _GRAM_PAIRS, nwarps),
+                    stride=(_GRAM_PAIRS * nwarps, nwarps, 1),
+                )
+            )
+
+        acc = cute.make_rmem_tensor(
+            cute.make_layout((self.block_m, self.tile_n), stride=(self.tile_n, 1)),
+            Float32,
+        )
+        sqr = cute.make_rmem_tensor(
+            cute.make_layout((self.block_m,), stride=(1,)),
+            Float32,
+        )
+        oval = cute.make_rmem_tensor(
+            cute.make_layout((self.block_m, _MHC_MULT), stride=(_MHC_MULT, 1)),
+            Float32,
+        )
+        for mi in cutlass.range_constexpr(self.block_m):
+            sqr[mi] = Float32(0.0)
+            for c in cutlass.range_constexpr(_MHC_MULT):
+                oval[mi, c] = Float32(0.0)
+            for ni in cutlass.range_constexpr(self.tile_n):
+                acc[mi, ni] = Float32(0.0)
+
+        if const_expr(self.compute_gram):
+            gvals = cute.make_rmem_tensor(
+                cute.make_layout((self.block_m, _GRAM_PAIRS), stride=(_GRAM_PAIRS, 1)),
+                Float32,
+            )
+            for mi in cutlass.range_constexpr(self.block_m):
+                for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                    gvals[mi, gp] = Float32(0.0)
+
+        for hidden_iter in cutlass.range_constexpr(self.hidden_iters):
+            h = Int32(hidden_iter * self.num_threads) + tidx
+
+            for mi in cutlass.range_constexpr(self.block_m):
+                token = Int32(m_tile * self.block_m + mi)
+                oval[mi, 0] = Float32(0.0)
+                oval[mi, 1] = Float32(0.0)
+                oval[mi, 2] = Float32(0.0)
+                oval[mi, 3] = Float32(0.0)
+                if token < num_tokens:
+                    xh = Float32(x[token, h])
+                    rin0 = Float32(residual[token, Int32(0), h])
+                    rin1 = Float32(residual[token, Int32(1), h])
+                    rin2 = Float32(residual[token, Int32(2), h])
+                    rin3 = Float32(residual[token, Int32(3), h])
+                    o0 = (
+                        Float32(prev_post[token, Int32(0)]) * xh
+                        + Float32(prev_comb[token, Int32(0), Int32(0)]) * rin0
+                        + Float32(prev_comb[token, Int32(1), Int32(0)]) * rin1
+                        + Float32(prev_comb[token, Int32(2), Int32(0)]) * rin2
+                        + Float32(prev_comb[token, Int32(3), Int32(0)]) * rin3
+                    ).to(cutlass.BFloat16)
+                    o1 = (
+                        Float32(prev_post[token, Int32(1)]) * xh
+                        + Float32(prev_comb[token, Int32(0), Int32(1)]) * rin0
+                        + Float32(prev_comb[token, Int32(1), Int32(1)]) * rin1
+                        + Float32(prev_comb[token, Int32(2), Int32(1)]) * rin2
+                        + Float32(prev_comb[token, Int32(3), Int32(1)]) * rin3
+                    ).to(cutlass.BFloat16)
+                    o2 = (
+                        Float32(prev_post[token, Int32(2)]) * xh
+                        + Float32(prev_comb[token, Int32(0), Int32(2)]) * rin0
+                        + Float32(prev_comb[token, Int32(1), Int32(2)]) * rin1
+                        + Float32(prev_comb[token, Int32(2), Int32(2)]) * rin2
+                        + Float32(prev_comb[token, Int32(3), Int32(2)]) * rin3
+                    ).to(cutlass.BFloat16)
+                    o3 = (
+                        Float32(prev_post[token, Int32(3)]) * xh
+                        + Float32(prev_comb[token, Int32(0), Int32(3)]) * rin0
+                        + Float32(prev_comb[token, Int32(1), Int32(3)]) * rin1
+                        + Float32(prev_comb[token, Int32(2), Int32(3)]) * rin2
+                        + Float32(prev_comb[token, Int32(3), Int32(3)]) * rin3
+                    ).to(cutlass.BFloat16)
+
+                    r0 = Float32(o0)
+                    r1 = Float32(o1)
+                    r2 = Float32(o2)
+                    r3 = Float32(o3)
+                    oval[mi, 0] = r0
+                    oval[mi, 1] = r1
+                    oval[mi, 2] = r2
+                    oval[mi, 3] = r3
+
+                    if n_tile == Int32(0):
+                        out[token, Int32(0), h] = o0
+                        out[token, Int32(1), h] = o1
+                        out[token, Int32(2), h] = o2
+                        out[token, Int32(3), h] = o3
+                        g0 = _materialize_residual_gram_f32(r0)
+                        g1 = _materialize_residual_gram_f32(r1)
+                        g2 = _materialize_residual_gram_f32(r2)
+                        g3 = _materialize_residual_gram_f32(r3)
+                        if const_expr(self.compute_gram):
+                            gvals[mi, 0] += g0 * g0
+                            gvals[mi, 1] += g1 * g1
+                            gvals[mi, 2] += g2 * g2
+                            gvals[mi, 3] += g3 * g3
+                            gvals[mi, 4] += g0 * g1
+                            gvals[mi, 5] += g0 * g2
+                            gvals[mi, 6] += g0 * g3
+                            gvals[mi, 7] += g1 * g2
+                            gvals[mi, 8] += g1 * g3
+                            gvals[mi, 9] += g2 * g3
+                        else:
+                            sqr[mi] += g0 * g0 + g1 * g1 + g2 * g2 + g3 * g3
+
+            for ni in cutlass.range_constexpr(self.tile_n):
+                mix = mix0 + Int32(ni)
+                f0 = Float32(0.0)
+                f1 = Float32(0.0)
+                f2 = Float32(0.0)
+                f3 = Float32(0.0)
+                if mix < Int32(_MIXES):
+                    f0 = Float32(fn[mix, h])
+                    f1 = Float32(fn[mix, Int32(self.hidden_size) + h])
+                    f2 = Float32(fn[mix, Int32(2 * self.hidden_size) + h])
+                    f3 = Float32(fn[mix, Int32(3 * self.hidden_size) + h])
+                for mi in cutlass.range_constexpr(self.block_m):
+                    token = Int32(m_tile * self.block_m + mi)
+                    if token < num_tokens:
+                        acc[mi, ni] += (
+                            f0 * oval[mi, 0]
+                            + f1 * oval[mi, 1]
+                            + f2 * oval[mi, 2]
+                            + f3 * oval[mi, 3]
+                        )
+
+        if const_expr(self.compute_gram):
+            for mi in cutlass.range_constexpr(self.block_m):
+                sqr[mi] = gvals[mi, 0] + gvals[mi, 1] + gvals[mi, 2] + gvals[mi, 3]
+
+        for mi in cutlass.range_constexpr(self.block_m):
+            for ni in cutlass.range_constexpr(self.tile_n):
+                acc[mi, ni] = _warp_allreduce_sum(acc[mi, ni])
+            if n_tile == Int32(0):
+                sqr[mi] = _warp_allreduce_sum(sqr[mi])
+                if const_expr(self.compute_gram):
+                    for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                        gvals[mi, gp] = _warp_allreduce_sum(gvals[mi, gp])
+
+        if lane == Int32(0):
+            for mi in cutlass.range_constexpr(self.block_m):
+                for ni in cutlass.range_constexpr(self.tile_n):
+                    mix = mix0 + Int32(ni)
+                    if mix < Int32(_MIXES):
+                        warp_sums[mi, mix + Int32(1), warp] = acc[mi, ni]
+                if n_tile == Int32(0):
+                    warp_sums[mi, Int32(0), warp] = sqr[mi]
+                    if const_expr(self.compute_gram):
+                        for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                            gram_sums[mi, gp, warp] = gvals[mi, gp]
+        cute.arch.sync_threads()
+
+        if warp == Int32(0):
+            for mi in cutlass.range_constexpr(self.block_m):
+                token = Int32(m_tile * self.block_m + mi)
+                if token < num_tokens:
+                    mix = mix0 + lane
+                    if lane < Int32(self.tile_n) and mix < Int32(_MIXES):
+                        total = Float32(0.0)
+                        src_warp = Int32(0)
+                        while src_warp < Int32(nwarps):
+                            total += Float32(warp_sums[mi, mix + Int32(1), src_warp])
+                            src_warp += Int32(1)
+                        partials[token, Int32(0), mix + Int32(1)] = total
+                    if n_tile == Int32(0):
+                        if lane == Int32(0):
+                            total_sqr = Float32(0.0)
+                            src = Int32(0)
+                            while src < Int32(nwarps):
+                                total_sqr += Float32(warp_sums[mi, Int32(0), src])
+                                src += Int32(1)
+                            partials[token, Int32(0), Int32(0)] = total_sqr
+                        if const_expr(self.compute_gram):
+                            if lane < Int32(_GRAM_PAIRS):
+                                gtotal = Float32(0.0)
+                                src = Int32(0)
+                                while src < Int32(nwarps):
+                                    gtotal += Float32(gram_sums[mi, lane, src])
+                                    src += Int32(1)
+                                partials[token, Int32(1), lane] = gtotal
+
+
+class MHCPostPrePrefillGramKernel:
+    """Full-hidden post + compact Gram kernel for tensor-core prefill paths."""
+
+    num_threads = _PREFILL_GRAM_THREADS
+    gram_pairs = _GRAM_PAIRS
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        if self.hidden_size % self.num_threads != 0:
+            raise ValueError(
+                f"hidden_size={self.hidden_size} must be divisible by "
+                f"prefill threads={self.num_threads}"
+            )
+        self.hidden_pair_iters = (
+            self.hidden_size // 2 + self.num_threads - 1
+        ) // self.num_threads
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(x.element_type != cutlass.BFloat16):
+            raise TypeError("x must be BFloat16")
+        if const_expr(residual.element_type != cutlass.BFloat16):
+            raise TypeError("residual must be BFloat16")
+        if const_expr(prev_post.element_type != cutlass.Float32):
+            raise TypeError("prev_post must be Float32")
+        if const_expr(prev_comb.element_type != cutlass.Float32):
+            raise TypeError("prev_comb must be Float32")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+        if const_expr(out.element_type != cutlass.BFloat16):
+            raise TypeError("out must be BFloat16")
+        self.kernel(x, residual, prev_post, prev_comb, partials, out).launch(
+            grid=(num_tokens, 1, 1),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        residual: cute.Tensor,
+        prev_post: cute.Tensor,
+        prev_comb: cute.Tensor,
+        partials: cute.Tensor,
+        out: cute.Tensor,
+    ):
+        token, _, _ = cute.arch.block_idx()
+        tidx = Int32(cute.arch.thread_idx()[0])
+        lane = tidx % Int32(32)
+        warp = tidx // Int32(32)
+        nwarps = self.num_threads // 32
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(_post_pre_prefill_gram_storage_cls())
+        gram_sums = storage.gram_sums.get_tensor(
+            cute.make_layout((_GRAM_PAIRS, nwarps), stride=(nwarps, 1))
+        )
+        post_coeff = storage.post_coeff.get_tensor(
+            cute.make_layout((_MHC_MULT,), stride=(1,))
+        )
+        comb_coeff = storage.comb_coeff.get_tensor(
+            cute.make_layout((_MHC_MULT, _MHC_MULT), stride=(_MHC_MULT, 1))
+        )
+        if tidx < Int32(_MHC_MULT):
+            post_coeff[tidx] = prev_post[token, tidx]
+        if tidx < Int32(_MHC_MULT * _MHC_MULT):
+            source = tidx // Int32(_MHC_MULT)
+            target = tidx - source * Int32(_MHC_MULT)
+            comb_coeff[source, target] = prev_comb[token, source, target]
+        cute.arch.sync_threads()
+
+        gvals = cute.make_rmem_tensor(
+            cute.make_layout((_GRAM_PAIRS,), stride=(1,)),
+            Float32,
+        )
+        for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+            gvals[gp] = Float32(0.0)
+
+        token = Int32(token)
+        out_u32 = cute.recast_tensor(out, Uint32)
+        for hidden_pair_iter in cutlass.range_constexpr(self.hidden_pair_iters):
+            h = Int32(2 * hidden_pair_iter * self.num_threads) + tidx * Int32(2)
+            if h < Int32(self.hidden_size):
+                x_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        x,
+                        token * Int32(self.hidden_size) + h,
+                    )
+                )
+                rin0_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size) + h,
+                    )
+                )
+                rin1_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size)
+                        + Int32(self.hidden_size)
+                        + h,
+                    )
+                )
+                rin2_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size)
+                        + Int32(2 * self.hidden_size)
+                        + h,
+                    )
+                )
+                rin3_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        token * Int32(_MHC_MULT * self.hidden_size)
+                        + Int32(3 * self.hidden_size)
+                        + h,
+                    )
+                )
+                x0, x1 = bfloat2_to_float2_scaled(x_pair, Float32(1.0))
+                rin00, rin01 = bfloat2_to_float2_scaled(rin0_pair, Float32(1.0))
+                rin10, rin11 = bfloat2_to_float2_scaled(rin1_pair, Float32(1.0))
+                rin20, rin21 = bfloat2_to_float2_scaled(rin2_pair, Float32(1.0))
+                rin30, rin31 = bfloat2_to_float2_scaled(rin3_pair, Float32(1.0))
+
+                o_values = cute.make_rmem_tensor(
+                    cute.make_layout((_MHC_MULT, 2), stride=(2, 1)),
+                    Float32,
+                )
+                for pair_lane in cutlass.range_constexpr(2):
+                    xh = x0
+                    rin0 = rin00
+                    rin1 = rin10
+                    rin2 = rin20
+                    rin3 = rin30
+                    if const_expr(pair_lane == 1):
+                        xh = x1
+                        rin0 = rin01
+                        rin1 = rin11
+                        rin2 = rin21
+                        rin3 = rin31
+                    o_values[0, pair_lane] = (
+                        Float32(post_coeff[0]) * xh
+                        + Float32(comb_coeff[0, 0]) * rin0
+                        + Float32(comb_coeff[1, 0]) * rin1
+                        + Float32(comb_coeff[2, 0]) * rin2
+                        + Float32(comb_coeff[3, 0]) * rin3
+                    )
+                    o_values[1, pair_lane] = (
+                        Float32(post_coeff[1]) * xh
+                        + Float32(comb_coeff[0, 1]) * rin0
+                        + Float32(comb_coeff[1, 1]) * rin1
+                        + Float32(comb_coeff[2, 1]) * rin2
+                        + Float32(comb_coeff[3, 1]) * rin3
+                    )
+                    o_values[2, pair_lane] = (
+                        Float32(post_coeff[2]) * xh
+                        + Float32(comb_coeff[0, 2]) * rin0
+                        + Float32(comb_coeff[1, 2]) * rin1
+                        + Float32(comb_coeff[2, 2]) * rin2
+                        + Float32(comb_coeff[3, 2]) * rin3
+                    )
+                    o_values[3, pair_lane] = (
+                        Float32(post_coeff[3]) * xh
+                        + Float32(comb_coeff[0, 3]) * rin0
+                        + Float32(comb_coeff[1, 3]) * rin1
+                        + Float32(comb_coeff[2, 3]) * rin2
+                        + Float32(comb_coeff[3, 3]) * rin3
+                    )
+
+                o0_pair = pack_f32x2_to_bfloat2(o_values[0, 0], o_values[0, 1])
+                o1_pair = pack_f32x2_to_bfloat2(o_values[1, 0], o_values[1, 1])
+                o2_pair = pack_f32x2_to_bfloat2(o_values[2, 0], o_values[2, 1])
+                o3_pair = pack_f32x2_to_bfloat2(o_values[3, 0], o_values[3, 1])
+                out_h = h // Int32(2)
+                out_u32[token, Int32(0), out_h] = o0_pair
+                out_u32[token, Int32(1), out_h] = o1_pair
+                out_u32[token, Int32(2), out_h] = o2_pair
+                out_u32[token, Int32(3), out_h] = o3_pair
+
+                r00, r01 = bfloat2_to_float2_scaled(o0_pair, Float32(1.0))
+                r10, r11 = bfloat2_to_float2_scaled(o1_pair, Float32(1.0))
+                r20, r21 = bfloat2_to_float2_scaled(o2_pair, Float32(1.0))
+                r30, r31 = bfloat2_to_float2_scaled(o3_pair, Float32(1.0))
+                gvals[0] += r00 * r00
+                gvals[1] += r10 * r10
+                gvals[2] += r20 * r20
+                gvals[3] += r30 * r30
+                gvals[4] += r00 * r10
+                gvals[5] += r00 * r20
+                gvals[6] += r00 * r30
+                gvals[7] += r10 * r20
+                gvals[8] += r10 * r30
+                gvals[9] += r20 * r30
+                gvals[0] += r01 * r01
+                gvals[1] += r11 * r11
+                gvals[2] += r21 * r21
+                gvals[3] += r31 * r31
+                gvals[4] += r01 * r11
+                gvals[5] += r01 * r21
+                gvals[6] += r01 * r31
+                gvals[7] += r11 * r21
+                gvals[8] += r11 * r31
+                gvals[9] += r21 * r31
+
+        for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+            gvals[gp] = _warp_allreduce_sum(gvals[gp])
+
+        if lane == Int32(0):
+            for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                gram_sums[gp, warp] = gvals[gp]
+        cute.arch.sync_threads()
+
+        if tidx == Int32(0):
+            total_sq = Float32(0.0)
+            for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                gtotal = Float32(0.0)
+                src = Int32(0)
+                while src < Int32(nwarps):
+                    gtotal += Float32(gram_sums[gp, src])
+                    src += Int32(1)
+                partials[token, Int32(1), gp] = gtotal
+                if gp < 4:
+                    total_sq += gtotal
+            partials[token, Int32(0), Int32(0)] = total_sq
+
+        if const_expr(_MHC_PDL):
+            cute.arch.sync_threads()
+            cute.arch.griddepcontrol_launch_dependents()
+
+
+@cute.jit
+def _mhc_warp_mma_gemm(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsA: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_A: cute.TiledCopy,
+    smem_thr_copy_B: cute.TiledCopy,
+):
+    tCrA_copy_view = smem_thr_copy_A.retile(tCrA)
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    cute.copy(smem_thr_copy_A, tCsA[None, None, 0], tCrA_copy_view[None, None, 0])
+    cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCsA.shape[2])):
+        if k < cute.size(tCsA.shape[2]) - 1:
+            cute.copy(
+                smem_thr_copy_A,
+                tCsA[None, None, k + 1],
+                tCrA_copy_view[None, None, k + 1],
+            )
+            cute.copy(
+                smem_thr_copy_B,
+                tCsB[None, None, k + 1],
+                tCrB_copy_view[None, None, k + 1],
+            )
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+class MHCPrefillBf16ProjectTmaKernel:
+    """TMA-fed BF16 tensor-core projection for compact mHC prefill partials."""
+
+    num_threads = _PREFILL_TMA_THREADS
+    num_compute_warps = _PREFILL_TMA_COMPUTE_WARPS
+    producer_warp = _PREFILL_TMA_COMPUTE_WARPS
+    tile_m = _PREFILL_TMA_TILE_M
+    tile_n = _PREFILL_TMA_TILE_N
+    tile_k = _PREFILL_TMA_TILE_K
+    num_stages = _PREFILL_TMA_STAGES
+    buffer_align_bytes = 1024
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.total_k = _MHC_MULT * self.hidden_size
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        if self.total_k % self.tile_k != 0:
+            raise ValueError(
+                f"total_k={self.total_k} must be divisible by TMA tile_k={self.tile_k}"
+            )
+        m_per_mma_group = self.num_compute_warps * 16
+        if self.tile_m % m_per_mma_group != 0:
+            raise ValueError(
+                f"tile_m={self.tile_m} must be divisible by "
+                f"num_compute_warps*16={m_per_mma_group}"
+            )
+        self.k_tiles = self.total_k // self.tile_k
+        self.n_tiles = (_MIXES + self.tile_n - 1) // self.tile_n
+
+    def _get_tiled_mma(self) -> cute.TiledMma:
+        return cute.make_tiled_mma(
+            warp.MmaF16BF16Op(cutlass.BFloat16, Float32, (16, 8, 16)),
+            (self.num_compute_warps, 1, 1),
+            permutation_mnk=(self.num_compute_warps * 16, self.tile_n, 16),
+        )
+
+    def _get_smem_layouts(self) -> tuple[cute.ComposedLayout, cute.ComposedLayout]:
+        a_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(
+                LayoutEnum.ROW_MAJOR,
+                cutlass.BFloat16,
+                self.tile_k,
+            ),
+            cutlass.BFloat16,
+        )
+        b_layout_atom = a_layout_atom
+        sA_layout = cute.tile_to_shape(
+            a_layout_atom,
+            (self.tile_m, self.tile_k, self.num_stages),
+            order=(0, 1, 2),
+        )
+        sB_layout = cute.tile_to_shape(
+            b_layout_atom,
+            (self.tile_n, self.tile_k, self.num_stages),
+            order=(0, 1, 2),
+        )
+        return sA_layout, sB_layout
+
+    def _get_shared_storage_cls(
+        self,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+    ):
+        class SharedStorage:
+            pass
+
+        SharedStorage.__annotations__ = {
+            "mbar_ptr": cute.struct.MemRange[
+                cutlass.Int64,
+                self.num_stages * 2,
+            ],
+            "sA": cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(sA_layout)],
+                self.buffer_align_bytes,
+            ],
+            "sB": cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(sB_layout)],
+                self.buffer_align_bytes,
+            ],
+        }
+        return cute.struct(SharedStorage)
+
+    @cute.jit
+    def __call__(
+        self,
+        out_flat: cute.Tensor,
+        fn_bf16: cute.Tensor,
+        partials: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(out_flat.element_type != cutlass.BFloat16):
+            raise TypeError("out_flat must be BFloat16")
+        if const_expr(fn_bf16.element_type != cutlass.BFloat16):
+            raise TypeError("fn_bf16 must be BFloat16")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+
+        sA_layout, sB_layout = self._get_smem_layouts()
+        tiled_mma = self._get_tiled_mma()
+        SharedStorage = self._get_shared_storage_cls(sA_layout, sB_layout)
+        sA_tma_layout = cute.slice_(sA_layout, (None, None, 0))
+        sB_tma_layout = cute.slice_(sB_layout, (None, None, 0))
+        out_tma = _assume_tma_source_aligned(out_flat)
+        fn_tma = _assume_tma_source_aligned(fn_bf16)
+        tma_atom_A, tma_tensor_A = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            out_tma,
+            sA_tma_layout,
+            (self.tile_m, self.tile_k),
+            num_multicast=1,
+        )
+        tma_atom_B, tma_tensor_B = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            fn_tma,
+            sB_tma_layout,
+            (self.tile_n, self.tile_k),
+            num_multicast=1,
+        )
+        grid_m = (num_tokens + Int32(self.tile_m - 1)) // Int32(self.tile_m)
+        self.kernel(
+            tma_tensor_A,
+            tma_tensor_B,
+            partials,
+            tma_atom_A,
+            tma_atom_B,
+            sA_layout,
+            sB_layout,
+            tiled_mma,
+            SharedStorage,
+            num_tokens,
+        ).launch(
+            grid=(grid_m, self.n_tiles, 1),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        out_flat: cute.Tensor,
+        fn_bf16: cute.Tensor,
+        partials: cute.Tensor,
+        tma_atom_A: cute.CopyAtom,
+        tma_atom_B: cute.CopyAtom,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+        tiled_mma: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        num_tokens: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        m_tile, n_tile, _ = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_A)
+            cpasync.prefetch_descriptor(tma_atom_B)
+
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sA = storage.sA.get_tensor(sA_layout.outer, swizzle=sA_layout.inner)
+        sB = storage.sB.get_tensor(sB_layout.outer, swizzle=sB_layout.inner)
+
+        tma_copy_bytes = (
+            (self.tile_m + self.tile_n) * self.tile_k * cutlass.BFloat16.width // 8
+        )
+        load_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.num_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_compute_warps,
+            ),
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        cute.arch.sync_threads()
+
+        gA = cute.local_tile(
+            out_flat,
+            (self.tile_m, self.tile_k),
+            (None, None),
+        )
+        gB = cute.local_tile(
+            fn_bf16,
+            (self.tile_n, self.tile_k),
+            (None, None),
+        )
+        cta_layout = cute.make_layout(1)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_A,
+            0,
+            cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_B,
+            0,
+            cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB, 0, 2),
+        )
+
+        if warp_idx < Int32(self.num_compute_warps):
+            consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_stages,
+            )
+            thr_mma = tiled_mma.get_slice(tidx)
+            tCsA = thr_mma.partition_A(sA)
+            tCsB = thr_mma.partition_B(sB)
+            tCrA = thr_mma.make_fragment_A(tCsA[None, None, None, 0])
+            tCrB = thr_mma.make_fragment_B(tCsB[None, None, None, 0])
+            acc_shape = thr_mma.partition_shape_C((self.tile_m, self.tile_n))
+            acc = cute.make_rmem_tensor(acc_shape, Float32)
+            acc.fill(0.0)
+            smem_copy_atom_A = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                cutlass.BFloat16,
+            )
+            smem_copy_atom_B = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                cutlass.BFloat16,
+            )
+            smem_thr_copy_A = cute.make_tiled_copy_A(
+                smem_copy_atom_A,
+                tiled_mma,
+            ).get_slice(tidx)
+            smem_thr_copy_B = cute.make_tiled_copy_B(
+                smem_copy_atom_B,
+                tiled_mma,
+            ).get_slice(tidx)
+            tSsA = smem_thr_copy_A.partition_S(sA)
+            tSsB = smem_thr_copy_B.partition_S(sB)
+
+            for _k_tile in cutlass.range_constexpr(self.k_tiles):
+                load_pipeline.consumer_wait(consumer_state)
+                _mhc_warp_mma_gemm(
+                    thr_mma,
+                    acc,
+                    tCrA,
+                    tCrB,
+                    tSsA[None, None, None, consumer_state.index],
+                    tSsB[None, None, None, consumer_state.index],
+                    smem_thr_copy_A,
+                    smem_thr_copy_B,
+                )
+                load_pipeline.consumer_release(consumer_state)
+                consumer_state.advance()
+
+            acc_mn = _reshape_acc_to_mn(acc)
+            coord_mn = _reshape_acc_to_mn(
+                thr_mma.partition_C(
+                    cute.make_identity_tensor((self.tile_m, self.tile_n))
+                )
+            )
+            for acc_m in cutlass.range_constexpr(cute.size(acc_mn.shape[0])):
+                for acc_n in cutlass.range_constexpr(cute.size(acc_mn.shape[1])):
+                    coord = coord_mn[acc_m, acc_n]
+                    token = m_tile * Int32(self.tile_m) + coord[0]
+                    mix = n_tile * Int32(self.tile_n) + coord[1]
+                    if token < num_tokens and mix < Int32(_MIXES):
+                        partials[token, Int32(0), mix + Int32(1)] = acc_mn[
+                            acc_m,
+                            acc_n,
+                        ]
+
+        elif warp_idx == Int32(self.producer_warp):
+            producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer,
+                self.num_stages,
+            )
+            for k_tile in cutlass.range_constexpr(self.k_tiles):
+                load_pipeline.producer_acquire(producer_state)
+                cute.copy(
+                    tma_atom_A,
+                    tAgA[(None, m_tile, k_tile)],
+                    tAsA[(None, producer_state.index)],
+                    tma_bar_ptr=load_pipeline.producer_get_barrier(producer_state),
+                )
+                cute.copy(
+                    tma_atom_B,
+                    tBgB[(None, n_tile, k_tile)],
+                    tBsB[(None, producer_state.index)],
+                    tma_bar_ptr=load_pipeline.producer_get_barrier(producer_state),
+                )
+                load_pipeline.producer_commit(producer_state)
+                producer_state.advance()
+            load_pipeline.producer_tail(producer_state)
+
+
+class MHCPrefillTf32ProjectTmaKernel:
+    """TMA-fed TF32 tensor-core projection for compact mHC prefill partials."""
+
+    num_threads = _PREFILL_TF32_TMA_THREADS
+    num_m_warps = _PREFILL_TF32_TMA_M_WARPS
+    num_n_warps = _PREFILL_TF32_TMA_N_WARPS
+    num_compute_warps = _PREFILL_TF32_TMA_COMPUTE_WARPS
+    producer_warp = _PREFILL_TF32_TMA_COMPUTE_WARPS
+    tile_m = _PREFILL_TF32_TMA_TILE_M
+    tile_n = _PREFILL_TF32_TMA_TILE_N
+    tile_k = _PREFILL_TF32_TMA_TILE_K
+    num_stages = _PREFILL_TF32_TMA_STAGES
+    buffer_align_bytes = 1024
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+        chunk_geometry: bool = False,
+        long_geometry: bool = False,
+    ):
+        self.hidden_size = int(hidden_size)
+        use_4096_chunk_geometry = chunk_geometry and self.hidden_size == _HIDDEN
+        use_4096_long_geometry = long_geometry and self.hidden_size == _HIDDEN
+        if use_4096_long_geometry:
+            self.num_m_warps = _PREFILL_TF32_TMA_LONG_4096_M_WARPS
+            self.num_n_warps = _PREFILL_TF32_TMA_LONG_4096_N_WARPS
+            self.tile_m = _PREFILL_TF32_TMA_LONG_4096_TILE_M
+            self.tile_n = _PREFILL_TF32_TMA_LONG_4096_TILE_N
+            self.tile_k = _PREFILL_TF32_TMA_LONG_4096_TILE_K
+            self.num_stages = _PREFILL_TF32_TMA_LONG_4096_STAGES
+            self.k_splits = _PREFILL_TF32_TMA_LONG_4096_K_SPLITS
+        elif use_4096_chunk_geometry:
+            self.num_m_warps = _PREFILL_TF32_TMA_CHUNK_4096_M_WARPS
+            self.num_n_warps = _PREFILL_TF32_TMA_CHUNK_4096_N_WARPS
+            self.tile_m = _PREFILL_TF32_TMA_CHUNK_4096_TILE_M
+            self.tile_n = _PREFILL_TF32_TMA_CHUNK_4096_TILE_N
+            self.tile_k = _PREFILL_TF32_TMA_CHUNK_4096_TILE_K
+            self.num_stages = _PREFILL_TF32_TMA_CHUNK_4096_STAGES
+            self.k_splits = _PREFILL_TF32_TMA_CHUNK_4096_K_SPLITS
+        elif chunk_geometry:
+            self.num_m_warps = _PREFILL_TF32_TMA_CHUNK_OTHER_M_WARPS
+            self.num_n_warps = _PREFILL_TF32_TMA_CHUNK_OTHER_N_WARPS
+            self.tile_m = _PREFILL_TF32_TMA_CHUNK_OTHER_TILE_M
+            self.tile_n = _PREFILL_TF32_TMA_CHUNK_OTHER_TILE_N
+            self.tile_k = _PREFILL_TF32_TMA_TILE_K
+            self.num_stages = _PREFILL_TF32_TMA_STAGES
+            self.k_splits = 1
+        else:
+            self.num_m_warps = _PREFILL_TF32_TMA_M_WARPS
+            self.num_n_warps = _PREFILL_TF32_TMA_N_WARPS
+            self.tile_m = _PREFILL_TF32_TMA_TILE_M
+            self.tile_n = _PREFILL_TF32_TMA_TILE_N
+            self.tile_k = _PREFILL_TF32_TMA_TILE_K
+            self.num_stages = _PREFILL_TF32_TMA_STAGES
+            self.k_splits = 1
+        self.num_compute_warps = self.num_m_warps * self.num_n_warps
+        self.producer_warp = self.num_compute_warps
+        self.num_threads = (self.num_compute_warps + 1) * 32
+        self.total_k = _MHC_MULT * self.hidden_size
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        if self.total_k % self.tile_k != 0:
+            raise ValueError(
+                f"total_k={self.total_k} must be divisible by TF32 TMA tile_k={self.tile_k}"
+            )
+        if self.tile_k % 8 != 0:
+            raise ValueError(f"TF32 TMA tile_k={self.tile_k} must be divisible by 8")
+        if self.tile_n <= 0 or self.tile_n % 8 != 0:
+            raise ValueError(
+                f"TF32 TMA tile_n={self.tile_n} must be a positive multiple of 8 "
+                "for m16n8k8 warp MMA"
+            )
+        if self.num_n_warps <= 0 or (self.tile_n // 8) % self.num_n_warps != 0:
+            raise ValueError(
+                f"TF32 TMA N warps={self.num_n_warps} must divide "
+                f"tile_n/8={self.tile_n // 8}"
+            )
+        m_per_mma_group = self.num_m_warps * 16
+        if self.tile_m != m_per_mma_group:
+            raise ValueError(
+                f"TF32 TMA tile_m={self.tile_m} must equal "
+                f"num_compute_warps*16={m_per_mma_group}"
+            )
+        self.k_tiles = self.total_k // self.tile_k
+        if self.k_splits <= 0 or self.k_tiles % self.k_splits != 0:
+            raise ValueError(
+                f"TF32 TMA k_splits={self.k_splits} must be positive and divide "
+                f"k_tiles={self.k_tiles}"
+            )
+        if self.k_splits >= self.split_k:
+            raise ValueError(
+                f"TF32 TMA k_splits={self.k_splits} must be less than "
+                f"partials split_k={self.split_k}"
+            )
+        self.k_tiles_per_split = self.k_tiles // self.k_splits
+        self.n_tiles = (_MIXES + self.tile_n - 1) // self.tile_n
+        self.n_mma_tiles = self.tile_n // 8
+        self.n_mma_tiles_per_warp = self.n_mma_tiles // self.num_n_warps
+
+    def _get_smem_layouts(
+        self,
+    ) -> tuple[cute.ComposedLayout, cute.ComposedLayout]:
+        a_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(
+                LayoutEnum.ROW_MAJOR,
+                cutlass.BFloat16,
+                self.tile_k,
+            ),
+            cutlass.BFloat16,
+        )
+        b_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(
+                LayoutEnum.ROW_MAJOR,
+                cutlass.Float32,
+                self.tile_k,
+            ),
+            cutlass.Float32,
+        )
+        sA_layout = cute.tile_to_shape(
+            a_layout_atom,
+            (self.tile_m, self.tile_k, self.num_stages),
+            order=(0, 1, 2),
+        )
+        sB_layout = cute.tile_to_shape(
+            b_layout_atom,
+            (self.tile_n, self.tile_k, self.num_stages),
+            order=(0, 1, 2),
+        )
+        return sA_layout, sB_layout
+
+    def _get_shared_storage_cls(
+        self,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+    ):
+        class SharedStorage:
+            pass
+
+        SharedStorage.__annotations__ = {
+            "mbar_ptr": cute.struct.MemRange[
+                cutlass.Int64,
+                self.num_stages * 2,
+            ],
+            "sA": cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(sA_layout)],
+                self.buffer_align_bytes,
+            ],
+            "sB": cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(sB_layout)],
+                self.buffer_align_bytes,
+            ],
+        }
+        return cute.struct(SharedStorage)
+
+    @cute.jit
+    def __call__(
+        self,
+        out_flat: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(out_flat.element_type != cutlass.BFloat16):
+            raise TypeError("out_flat must be BFloat16")
+        if const_expr(fn.element_type != cutlass.Float32):
+            raise TypeError("fn must be Float32")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+
+        sA_layout, sB_layout = self._get_smem_layouts()
+        SharedStorage = self._get_shared_storage_cls(sA_layout, sB_layout)
+        sA_tma_layout = cute.slice_(sA_layout, (None, None, 0))
+        sB_tma_layout = cute.slice_(sB_layout, (None, None, 0))
+        out_tma = _assume_tma_source_aligned(out_flat)
+        fn_tma = _assume_tma_source_aligned(fn)
+        tma_atom_A, tma_tensor_A = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            out_tma,
+            sA_tma_layout,
+            (self.tile_m, self.tile_k),
+            num_multicast=1,
+        )
+        tma_atom_B, tma_tensor_B = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            fn_tma,
+            sB_tma_layout,
+            (self.tile_n, self.tile_k),
+            num_multicast=1,
+        )
+        grid_m = (num_tokens + Int32(self.tile_m - 1)) // Int32(self.tile_m)
+        self.kernel(
+            tma_tensor_A,
+            tma_tensor_B,
+            partials,
+            tma_atom_A,
+            tma_atom_B,
+            sA_layout,
+            sB_layout,
+            SharedStorage,
+            num_tokens,
+        ).launch(
+            grid=(grid_m, self.n_tiles, self.k_splits),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+            use_pdl=_MHC_PDL,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        out_flat: cute.Tensor,
+        fn: cute.Tensor,
+        partials: cute.Tensor,
+        tma_atom_A: cute.CopyAtom,
+        tma_atom_B: cute.CopyAtom,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+        SharedStorage: cutlass.Constexpr,
+        num_tokens: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        m_tile, n_tile, k_split = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if const_expr(_MHC_PDL):
+            cute.arch.griddepcontrol_wait()
+
+        partial_row = k_split + Int32(1)
+        if k_split == Int32(0):
+            partial_row = Int32(0)
+
+        if tidx == 0:
+            cpasync.prefetch_descriptor(tma_atom_A)
+            cpasync.prefetch_descriptor(tma_atom_B)
+
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sA = storage.sA.get_tensor(sA_layout.outer, swizzle=sA_layout.inner)
+        sB = storage.sB.get_tensor(sB_layout.outer, swizzle=sB_layout.inner)
+
+        tma_copy_bytes = (
+            self.tile_m * self.tile_k * cutlass.BFloat16.width // 8
+            + self.tile_n * self.tile_k * cutlass.Float32.width // 8
+        )
+        load_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.num_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_compute_warps,
+            ),
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+
+        gA = cute.local_tile(
+            out_flat,
+            (self.tile_m, self.tile_k),
+            (None, None),
+        )
+        gB = cute.local_tile(
+            fn,
+            (self.tile_n, self.tile_k),
+            (None, None),
+        )
+        cta_layout = cute.make_layout(1)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_A,
+            0,
+            cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_B,
+            0,
+            cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB, 0, 2),
+        )
+
+        if warp_idx < Int32(self.num_compute_warps):
+            warp_m = warp_idx // Int32(self.num_n_warps)
+            warp_n = warp_idx % Int32(self.num_n_warps)
+            lane = tidx & Int32(31)
+            lane_group = lane >> Int32(2)
+            lane_in_group = lane & Int32(3)
+            lane_pair_base = lane_in_group * Int32(2)
+            warp_m_base = warp_m * Int32(16)
+            row0 = warp_m_base + lane_group
+            row1 = row0 + Int32(8)
+            token0 = m_tile * Int32(self.tile_m) + row0
+            token1 = token0 + Int32(8)
+            acc = cute.make_rmem_tensor(
+                cute.make_layout((self.n_mma_tiles_per_warp, 4), stride=(4, 1)),
+                Float32,
+            )
+            acc.fill(0.0)
+            consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_stages,
+            )
+            for _k_tile in range(0, self.k_tiles_per_split, 1, unroll=1):
+                load_pipeline.consumer_wait(consumer_state)
+                for kk in cutlass.range_constexpr(self.tile_k // 8):
+                    k0 = Int32(kk * 8)
+                    a_k0 = k0 + lane_in_group
+                    a_k1 = a_k0 + Int32(4)
+
+                    # TMA zero-fills out-of-bounds rows, so all compute lanes
+                    # can load shared memory without a per-MMA token branch.
+                    a0_f = Float32(sA[row0, a_k0, consumer_state.index])
+                    a1_f = Float32(sA[row1, a_k0, consumer_state.index])
+                    a2_f = Float32(sA[row0, a_k1, consumer_state.index])
+                    a3_f = Float32(sA[row1, a_k1, consumer_state.index])
+
+                    # These values originate from BF16, so their promoted FP32
+                    # representation is already exact in TF32.  A raw bitcast
+                    # avoids four redundant cvt.rna.tf32.f32 instructions per
+                    # MMA step without changing the operand value.
+                    a0_tf32 = f32_to_raw_bits(a0_f)
+                    a1_tf32 = f32_to_raw_bits(a1_f)
+                    a2_tf32 = f32_to_raw_bits(a2_f)
+                    a3_tf32 = f32_to_raw_bits(a3_f)
+                    for warp_mma_n in cutlass.range_constexpr(
+                        self.n_mma_tiles_per_warp
+                    ):
+                        mma_n = Int32(warp_mma_n * self.num_n_warps) + warp_n
+                        b_mix_local = Int32(mma_n * 8) + lane_group
+                        # TMA likewise zero-fills a partial final N tile.
+                        b0_f = Float32(sB[b_mix_local, a_k0, consumer_state.index])
+                        b1_f = Float32(sB[b_mix_local, a_k1, consumer_state.index])
+
+                        d0, d1, d2, d3 = tf32_mma_m16n8k8_f32(
+                            acc[warp_mma_n, 0],
+                            acc[warp_mma_n, 1],
+                            acc[warp_mma_n, 2],
+                            acc[warp_mma_n, 3],
+                            a0_tf32,
+                            a1_tf32,
+                            a2_tf32,
+                            a3_tf32,
+                            f32_to_raw_bits(b0_f),
+                            f32_to_raw_bits(b1_f),
+                        )
+                        acc[warp_mma_n, 0] = d0
+                        acc[warp_mma_n, 1] = d1
+                        acc[warp_mma_n, 2] = d2
+                        acc[warp_mma_n, 3] = d3
+                load_pipeline.consumer_release(consumer_state)
+                consumer_state.advance()
+
+            for warp_mma_n in cutlass.range_constexpr(self.n_mma_tiles_per_warp):
+                mma_n = Int32(warp_mma_n * self.num_n_warps) + warp_n
+                mix0 = n_tile * Int32(self.tile_n) + Int32(mma_n * 8) + lane_pair_base
+                mix1 = mix0 + Int32(1)
+                if token0 < num_tokens:
+                    if mix0 < Int32(_MIXES):
+                        partials[token0, partial_row, mix0 + Int32(1)] = acc[
+                            warp_mma_n, 0
+                        ]
+                    if mix1 < Int32(_MIXES):
+                        partials[token0, partial_row, mix1 + Int32(1)] = acc[
+                            warp_mma_n, 1
+                        ]
+                if token1 < num_tokens:
+                    if mix0 < Int32(_MIXES):
+                        partials[token1, partial_row, mix0 + Int32(1)] = acc[
+                            warp_mma_n, 2
+                        ]
+                    if mix1 < Int32(_MIXES):
+                        partials[token1, partial_row, mix1 + Int32(1)] = acc[
+                            warp_mma_n, 3
+                        ]
+
+        elif warp_idx == Int32(self.producer_warp):
+            producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer,
+                self.num_stages,
+            )
+            for _k_tile in range(0, self.k_tiles_per_split, 1, unroll=1):
+                load_pipeline.producer_acquire(producer_state)
+                k_tile = k_split * Int32(self.k_tiles_per_split) + producer_state.count
+                cute.copy(
+                    tma_atom_A,
+                    tAgA[(None, m_tile, k_tile)],
+                    tAsA[(None, producer_state.index)],
+                    tma_bar_ptr=load_pipeline.producer_get_barrier(producer_state),
+                )
+                cute.copy(
+                    tma_atom_B,
+                    tBgB[(None, n_tile, k_tile)],
+                    tBsB[(None, producer_state.index)],
+                    tma_bar_ptr=load_pipeline.producer_get_barrier(producer_state),
+                )
+                load_pipeline.producer_commit(producer_state)
+                producer_state.advance()
+            load_pipeline.producer_tail(producer_state)
+
+        if const_expr(_MHC_PDL):
+            cute.arch.sync_threads()
+            cute.arch.griddepcontrol_launch_dependents()
+
+
+class MHCPrefillBf16ProjectKernel:
+    """BF16 tensor-core projection for compact mHC prefill partials."""
+
+    num_threads = _PREFILL_MMA_THREADS
+    tile_m = _PREFILL_MMA_TILE_M
+    tile_n = _PREFILL_MMA_TILE_N
+    tile_k = _PREFILL_MMA_TILE_K
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.total_k = _MHC_MULT * self.hidden_size
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        if self.total_k % self.tile_k != 0:
+            raise ValueError(
+                f"total_k={self.total_k} must be divisible by MMA tile_k={self.tile_k}"
+            )
+        self.k_iters = self.total_k // self.tile_k
+        self.n_tiles = (_MIXES + self.tile_n - 1) // self.tile_n
+
+    @cute.jit
+    def __call__(
+        self,
+        out: cute.Tensor,
+        fn_bf16: cute.Tensor,
+        partials: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(out.element_type != cutlass.BFloat16):
+            raise TypeError("out must be BFloat16")
+        if const_expr(fn_bf16.element_type != cutlass.BFloat16):
+            raise TypeError("fn_bf16 must be BFloat16")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+        grid_m = (num_tokens + Int32(self.tile_m - 1)) // Int32(self.tile_m)
+        self.kernel(out, fn_bf16, partials, num_tokens).launch(
+            grid=(grid_m, self.n_tiles, 1),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        out: cute.Tensor,
+        fn_bf16: cute.Tensor,
+        partials: cute.Tensor,
+        num_tokens: Int32,
+    ):
+        m_tile, n_tile, _ = cute.arch.block_idx()
+        lane = Int32(cute.arch.thread_idx()[0])
+        lane_group = lane >> Int32(2)
+        lane_pair_base = (lane & Int32(3)) * Int32(2)
+        b_mix = n_tile * Int32(self.tile_n) + lane_group
+        b_tid = lane & Int32(3)
+        a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+        a_col = (lane >> Int32(4)) * Int32(8)
+
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(_prefill_bf16_mma_storage_cls())
+        a_base_addr = shared_ptr_to_u32(storage.a_tile.data_ptr())
+
+        d0 = Float32(0.0)
+        d1 = Float32(0.0)
+        d2 = Float32(0.0)
+        d3 = Float32(0.0)
+
+        for k_iter in cutlass.range_constexpr(self.k_iters):
+            k0 = Int32(k_iter * self.tile_k)
+            linear = lane
+            while linear < Int32((self.tile_m * self.tile_k) // 2):
+                row = linear // Int32(self.tile_k // 2)
+                pair = linear - row * Int32(self.tile_k // 2)
+                token = m_tile * Int32(self.tile_m) + row
+                kval = k0 + pair * Int32(2)
+                value = Uint32(0)
+                if token < num_tokens:
+                    value = ld_global_nc_u32(
+                        get_ptr_as_int64(
+                            out,
+                            token * Int32(self.total_k) + kval,
+                        )
+                    )
+                st_shared_u32(
+                    a_base_addr
+                    + (row * Int32(self.tile_k) + pair * Int32(2)) * Int32(2),
+                    value,
+                )
+                linear += Int32(self.num_threads)
+            cute.arch.sync_warp()
+
+            a_byte = (a_row * Int32(self.tile_k) + a_col) * Int32(2)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(a_base_addr + a_byte)
+            b0 = ld_global_nc_u32(
+                get_ptr_as_int64(
+                    fn_bf16,
+                    b_mix * Int32(self.total_k) + k0 + b_tid * Int32(2),
+                )
+            )
+            b1 = ld_global_nc_u32(
+                get_ptr_as_int64(
+                    fn_bf16,
+                    b_mix * Int32(self.total_k) + k0 + Int32(8) + b_tid * Int32(2),
+                )
+            )
+            d0, d1, d2, d3 = bf16_mma_m16n8k16_f32(
+                d0, d1, d2, d3, a0, a1, a2, a3, b0, b1
+            )
+            cute.arch.sync_warp()
+
+        for reg_id in cutlass.range_constexpr(4):
+            row_slot = Int32(reg_id // 2)
+            token = m_tile * Int32(self.tile_m) + lane_group + row_slot * Int32(8)
+            mix = n_tile * Int32(self.tile_n) + lane_pair_base + Int32(reg_id % 2)
+            value = d0
+            if const_expr(reg_id == 1):
+                value = d1
+            elif const_expr(reg_id == 2):
+                value = d2
+            elif const_expr(reg_id == 3):
+                value = d3
+            if token < num_tokens and mix < Int32(_MIXES):
+                partials[token, Int32(0), mix + Int32(1)] = value
+
+
+class MHCFinalizeGramKernel:
+    """Multi-CTA fuse_norm finalize using the residual_out Gram matrix.
+
+    The partial kernel (compute_gram=True) provides G[m,m'] in partials rows
+    [32, 64), so sum_h y^2 = pre^T G pre is a scalar -- no per-h norm reduction.
+    Each CTA owns one or more hidden tiles, redundantly reduces partials+Gram and
+    runs the Sinkhorn (cheap), then writes its y tiles without cross-CTA sync.
+    Compact prefill partials use one CTA per token because prefill has enough
+    token parallelism and this avoids repeating the scalar finalize per tile.
+    """
+
+    num_threads = _GRAM_BLOCK_H
+    block_h = _GRAM_BLOCK_H
+    hidden_size = _HIDDEN
+    source_tiles = _SOURCE_TILES
+    source_warps = (_SOURCE_TILES + 31) // 32
+    total_k = _TOTAL_K
+    split_k = _SPLIT_K
+    mixes = _MIXES
+    partials = _PARTIALS
+    gram_row0 = _GRAM_ROW0
+    gram_pairs = _GRAM_PAIRS
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = _HIDDEN,
+        split_k: int | None = None,
+        rms_eps: float,
+        hc_eps: float,
+        sinkhorn_iters: int,
+        norm_eps: float,
+        fuse_norm: bool = True,
+        compact_partials: bool = False,
+        compact_projection_splits: int = 1,
+        single_cta: bool = False,
+        single_cta_threads: int = _PREFILL_FINALIZE_THREADS,
+        single_cta_groups: int = 1,
+        active_source_splits: int = 0,
+    ):
+        self.hidden_size = int(hidden_size)
+        self.single_cta = bool(single_cta)
+        self.single_cta_threads = int(single_cta_threads)
+        self.single_cta_groups = int(single_cta_groups)
+        if self.single_cta_groups <= 0:
+            raise ValueError("single_cta_groups must be positive")
+        if not self.single_cta and self.single_cta_groups != 1:
+            raise ValueError("single_cta_groups requires single_cta=True")
+        self.num_threads = (
+            self.single_cta_threads
+            if self.single_cta
+            else (_PREFILL_FINALIZE_THREADS if compact_partials else _GRAM_BLOCK_H)
+        )
+        self.block_h = self.num_threads
+        if self.hidden_size % self.block_h != 0:
+            raise ValueError(
+                f"hidden_size={self.hidden_size} must be divisible by "
+                f"finalize block_h={self.block_h}"
+            )
+        if self.single_cta and (
+            self.hidden_size % (2 * self.num_threads * self.single_cta_groups) != 0
+        ):
+            raise ValueError(
+                f"hidden_size={self.hidden_size} must be divisible by "
+                "2 * single-CTA threads * groups="
+                f"{2 * self.num_threads * self.single_cta_groups}"
+            )
+        self.source_tiles = _source_tiles_for_hidden(self.hidden_size)
+        self.hidden_tiles = self.hidden_size // self.block_h
+        if self.hidden_tiles % self.single_cta_groups != 0:
+            raise ValueError(
+                f"hidden tiles={self.hidden_tiles} must be divisible by "
+                f"single_cta_groups={self.single_cta_groups}"
+            )
+        self.active_source_splits = int(active_source_splits)
+        if self.active_source_splits == 0:
+            self.active_source_splits = self.source_tiles
+        if (
+            self.active_source_splits <= 0
+            or self.active_source_splits > self.source_tiles
+        ):
+            raise ValueError(
+                f"active_source_splits must be in [1, {self.source_tiles}], "
+                f"got {self.active_source_splits}"
+            )
+        self.source_warps = (self.active_source_splits + 31) // 32
+        self.total_k = _MHC_MULT * self.hidden_size
+        self.split_k = (
+            _split_k_for_hidden(self.hidden_size) if split_k is None else int(split_k)
+        )
+        _validate_split_k(self.hidden_size, self.split_k)
+        self.gram_row0 = self.source_tiles
+        self.rms_eps = float(rms_eps)
+        self.hc_eps = float(hc_eps)
+        self.sinkhorn_iters = int(sinkhorn_iters)
+        self.norm_eps = float(norm_eps)
+        # When False, norm_weight is ignored: y is the raw collapsed activation
+        # (no Gram reduction, no RMSNorm). The partial then skips the Gram.
+        self.fuse_norm = bool(fuse_norm)
+        self.compact_partials = bool(compact_partials)
+        self.compact_projection_splits = int(compact_projection_splits)
+        if self.compact_projection_splits <= 0:
+            raise ValueError("compact_projection_splits must be positive")
+        if not self.compact_partials and self.compact_projection_splits != 1:
+            raise ValueError("compact_projection_splits requires compact_partials=True")
+        if self.compact_partials and self.active_source_splits != self.source_tiles:
+            raise ValueError(
+                "active_source_splits is only valid for standard partial layouts"
+            )
+        if self.compact_projection_splits >= self.split_k:
+            raise ValueError(
+                "compact_projection_splits must be less than partials split_k"
+            )
+        self.tiles_per_cta = (
+            self.hidden_tiles // self.single_cta_groups
+            if self.single_cta
+            else self.hidden_tiles
+            if self.compact_partials
+            else 1
+        )
+        if (self.compact_partials or self.single_cta) and self.hidden_size % (
+            2 * self.num_threads
+        ) != 0:
+            raise ValueError(
+                f"hidden_size={self.hidden_size} must be divisible by "
+                f"2 * vectorized finalize threads={2 * self.num_threads}"
+            )
+
+    @cute.jit
+    def __call__(
+        self,
+        residual: cute.Tensor,
+        partials: cute.Tensor,
+        scale: cute.Tensor,
+        bias: cute.Tensor,
+        y: cute.Tensor,
+        post: cute.Tensor,
+        comb: cute.Tensor,
+        norm_weight: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(residual.element_type != cutlass.BFloat16):
+            raise TypeError("residual must be BFloat16")
+        if const_expr(partials.element_type != cutlass.Float32):
+            raise TypeError("partials must be Float32")
+        if const_expr(y.element_type != cutlass.BFloat16):
+            raise TypeError("y must be BFloat16")
+        if const_expr(
+            self.fuse_norm
+            and norm_weight.element_type != cutlass.BFloat16
+            and norm_weight.element_type != cutlass.Float32
+        ):
+            raise TypeError("norm_weight must be BFloat16 or Float32")
+        self.kernel(residual, partials, scale, bias, y, post, comb, norm_weight).launch(
+            grid=(self.hidden_tiles // self.tiles_per_cta, num_tokens, 1),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+            use_pdl=_MHC_PDL,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        residual: cute.Tensor,
+        partials: cute.Tensor,
+        scale: cute.Tensor,
+        bias: cute.Tensor,
+        y: cute.Tensor,
+        post: cute.Tensor,
+        comb: cute.Tensor,
+        norm_weight: cute.Tensor,
+    ):
+        tile_group, token, _ = cute.arch.block_idx()
+        tile_group = Int32(tile_group)
+        tidx = Int32(cute.arch.thread_idx()[0])
+
+        if const_expr(_MHC_PDL):
+            cute.arch.griddepcontrol_wait()
+
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(_finalize_storage_cls(self.num_threads, False))
+        s_pre = storage.pre.get_tensor(cute.make_layout((_MHC_MULT,), stride=(1,)))
+        s_post = storage.post.get_tensor(cute.make_layout((_MHC_MULT,), stride=(1,)))
+        s_comb = storage.comb.get_tensor(
+            cute.make_layout((_MHC_MULT, _MHC_MULT), stride=(_MHC_MULT, 1))
+        )
+
+        sums = cute.make_rmem_tensor(
+            cute.make_layout((self.partials,), stride=(1,)), Float32
+        )
+        gram = cute.make_rmem_tensor(
+            cute.make_layout((self.gram_pairs,), stride=(1,)), Float32
+        )
+        if const_expr(self.single_cta):
+            source_values = storage.partials.get_tensor(
+                cute.make_layout((self.num_threads,), stride=(1,))
+            )
+            if tidx < Int32(_PARTIALS):
+                total = Float32(0.0)
+                for source_split in cutlass.range_constexpr(self.active_source_splits):
+                    total += Float32(partials[token, source_split, tidx])
+                source_values[tidx] = total
+            if const_expr(self.fuse_norm):
+                if tidx < Int32(_GRAM_PAIRS):
+                    total = Float32(0.0)
+                    for source_split in cutlass.range_constexpr(
+                        self.active_source_splits
+                    ):
+                        total += Float32(
+                            partials[
+                                token,
+                                Int32(self.gram_row0 + source_split),
+                                tidx,
+                            ]
+                        )
+                    source_values[Int32(32) + tidx] = total
+            cute.arch.sync_threads()
+        elif const_expr(self.compact_partials):
+            if tidx == Int32(0):
+                for column in cutlass.range_constexpr(_PARTIALS):
+                    sums[column] = Float32(partials[token, Int32(0), column])
+                    if column > 0:
+                        for projection_split in cutlass.range_constexpr(
+                            1, self.compact_projection_splits
+                        ):
+                            sums[column] += Float32(
+                                partials[
+                                    token,
+                                    Int32(projection_split + 1),
+                                    column,
+                                ]
+                            )
+                if const_expr(self.fuse_norm):
+                    for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                        gram[gp] = Float32(partials[token, Int32(1), gp])
+        elif const_expr(self.source_warps == 1):
+            if tidx < Int32(32):
+                for column in cutlass.range_constexpr(_PARTIALS):
+                    value = Float32(0.0)
+                    if tidx < Int32(self.active_source_splits):
+                        value = Float32(partials[token, tidx, column])
+                    sums[column] = _warp_allreduce_sum(value)
+                if const_expr(self.fuse_norm):
+                    for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                        gvalue = Float32(0.0)
+                        if tidx < Int32(self.active_source_splits):
+                            gvalue = Float32(
+                                partials[token, Int32(self.gram_row0) + tidx, gp]
+                            )
+                        gram[gp] = _warp_allreduce_sum(gvalue)
+        elif const_expr(self.source_warps == 2):
+            lane = tidx % Int32(32)
+            warp = tidx // Int32(32)
+            source_tile = warp * Int32(32) + lane
+            source_sums = storage.partials.get_tensor(
+                cute.make_layout((self.num_threads,), stride=(1,))
+            )
+            if tidx < Int32(64):
+                for column in cutlass.range_constexpr(_PARTIALS):
+                    value = Float32(0.0)
+                    if source_tile < Int32(self.active_source_splits):
+                        value = Float32(partials[token, source_tile, column])
+                    value = _warp_allreduce_sum(value)
+                    if lane == Int32(0):
+                        source_sums[Int32(column * 2) + warp] = value
+                if const_expr(self.fuse_norm):
+                    for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                        gvalue = Float32(0.0)
+                        if source_tile < Int32(self.active_source_splits):
+                            gvalue = Float32(
+                                partials[token, Int32(self.gram_row0) + source_tile, gp]
+                            )
+                        gvalue = _warp_allreduce_sum(gvalue)
+                        if lane == Int32(0):
+                            source_sums[Int32((_PARTIALS + gp) * 2) + warp] = gvalue
+            cute.arch.sync_threads()
+            if tidx == Int32(0):
+                for column in cutlass.range_constexpr(_PARTIALS):
+                    sums[column] = Float32(source_sums[Int32(column * 2)]) + Float32(
+                        source_sums[Int32(column * 2 + 1)]
+                    )
+                if const_expr(self.fuse_norm):
+                    for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                        gram[gp] = Float32(
+                            source_sums[Int32((_PARTIALS + gp) * 2)]
+                        ) + Float32(source_sums[Int32((_PARTIALS + gp) * 2 + 1)])
+        else:
+            lane = tidx % Int32(32)
+            warp = tidx // Int32(32)
+            source_sums = storage.partials.get_tensor(
+                cute.make_layout((self.num_threads,), stride=(1,))
+            )
+            source_warp_threads = Int32(self.source_warps * 32)
+            for column in cutlass.range_constexpr(_PARTIALS):
+                value = Float32(0.0)
+                if tidx < source_warp_threads:
+                    if tidx < Int32(self.active_source_splits):
+                        value = Float32(partials[token, tidx, column])
+                    value = _warp_allreduce_sum(value)
+                    if lane == Int32(0):
+                        source_sums[warp] = value
+                cute.arch.sync_threads()
+                if tidx == Int32(0):
+                    total = Float32(0.0)
+                    src_warp = Int32(0)
+                    while src_warp < Int32(self.source_warps):
+                        total += Float32(source_sums[src_warp])
+                        src_warp += Int32(1)
+                    sums[column] = total
+                cute.arch.sync_threads()
+            if const_expr(self.fuse_norm):
+                for gp in cutlass.range_constexpr(_GRAM_PAIRS):
+                    gvalue = Float32(0.0)
+                    if tidx < source_warp_threads:
+                        if tidx < Int32(self.active_source_splits):
+                            gvalue = Float32(
+                                partials[token, Int32(self.gram_row0) + tidx, gp]
+                            )
+                        gvalue = _warp_allreduce_sum(gvalue)
+                        if lane == Int32(0):
+                            source_sums[warp] = gvalue
+                    cute.arch.sync_threads()
+                    if tidx == Int32(0):
+                        gtotal = Float32(0.0)
+                        src_warp = Int32(0)
+                        while src_warp < Int32(self.source_warps):
+                            gtotal += Float32(source_sums[src_warp])
+                            src_warp += Int32(1)
+                        gram[gp] = gtotal
+                    cute.arch.sync_threads()
+
+        if const_expr(self.single_cta):
+            lane = tidx % Int32(32)
+            if tidx == Int32(0):
+                s_post[0] = cute.math.rsqrt(
+                    Float32(source_values[0]) / Float32(self.total_k)
+                    + Float32(self.rms_eps),
+                    fastmath=True,
+                )
+            cute.arch.sync_threads()
+
+            mix_value = Float32(0.0)
+            one_value = Float32(1.0)
+            value = Float32(0.0)
+            if tidx < Int32(_MIXES):
+                mix_value = Float32(source_values[tidx + Int32(1)]) * Float32(s_post[0])
+                if tidx < Int32(4):
+                    value = one_value / (
+                        one_value
+                        + cute.math.exp(
+                            -(mix_value * Float32(scale[0]) + Float32(bias[tidx])),
+                            fastmath=True,
+                        )
+                    ) + Float32(self.hc_eps)
+                    s_pre[tidx] = value
+                elif tidx < Int32(8):
+                    value = Float32(2.0) / (
+                        one_value
+                        + cute.math.exp(
+                            -(mix_value * Float32(scale[1]) + Float32(bias[tidx])),
+                            fastmath=True,
+                        )
+                    )
+                    if tile_group == Int32(0):
+                        post[token, tidx - Int32(4)] = value
+                else:
+                    cidx = tidx - Int32(8)
+                    row = cidx // Int32(4)
+                    col = cidx - row * Int32(4)
+                    s_comb[row, col] = mix_value * Float32(scale[2]) + Float32(
+                        bias[tidx]
+                    )
+            cute.arch.sync_threads()
+
+            if tidx < Int32(32):
+                cvalue = Float32(0.0)
+                if lane < Int32(16):
+                    row = lane // Int32(4)
+                    col = lane - row * Int32(4)
+                    cvalue = Float32(s_comb[row, col])
+                row_max = _warp_quad_allreduce_max(cvalue)
+                cvalue = cute.math.exp(cvalue - row_max, fastmath=True)
+                row_sum = _warp_quad_allreduce_sum(cvalue)
+                cvalue = cvalue * cute.arch.rcp_approx(row_sum) + Float32(self.hc_eps)
+                col_sum = _warp_column4_allreduce_sum(cvalue) + Float32(self.hc_eps)
+                cvalue = cvalue * cute.arch.rcp_approx(col_sum)
+                for _ in cutlass.range_constexpr(self.sinkhorn_iters - 1):
+                    row_sum = _warp_quad_allreduce_sum(cvalue) + Float32(self.hc_eps)
+                    cvalue = cvalue * cute.arch.rcp_approx(row_sum)
+                    col_sum = _warp_column4_allreduce_sum(cvalue) + Float32(self.hc_eps)
+                    cvalue = cvalue * cute.arch.rcp_approx(col_sum)
+
+                if lane < Int32(16):
+                    row = lane // Int32(4)
+                    col = lane - row * Int32(4)
+                    s_comb[row, col] = cvalue
+                    if tile_group == Int32(0):
+                        comb[token, row, col] = cvalue
+
+                if const_expr(self.fuse_norm):
+                    p0 = Float32(s_pre[0])
+                    p1 = Float32(s_pre[1])
+                    p2 = Float32(s_pre[2])
+                    p3 = Float32(s_pre[3])
+                    term = Float32(0.0)
+                    if lane == Int32(0):
+                        term = p0 * p0 * Float32(source_values[Int32(32)])
+                    elif lane == Int32(1):
+                        term = p1 * p1 * Float32(source_values[Int32(33)])
+                    elif lane == Int32(2):
+                        term = p2 * p2 * Float32(source_values[Int32(34)])
+                    elif lane == Int32(3):
+                        term = p3 * p3 * Float32(source_values[Int32(35)])
+                    elif lane == Int32(4):
+                        term = (
+                            Float32(2.0) * p0 * p1 * Float32(source_values[Int32(36)])
+                        )
+                    elif lane == Int32(5):
+                        term = (
+                            Float32(2.0) * p0 * p2 * Float32(source_values[Int32(37)])
+                        )
+                    elif lane == Int32(6):
+                        term = (
+                            Float32(2.0) * p0 * p3 * Float32(source_values[Int32(38)])
+                        )
+                    elif lane == Int32(7):
+                        term = (
+                            Float32(2.0) * p1 * p2 * Float32(source_values[Int32(39)])
+                        )
+                    elif lane == Int32(8):
+                        term = (
+                            Float32(2.0) * p1 * p3 * Float32(source_values[Int32(40)])
+                        )
+                    elif lane == Int32(9):
+                        term = (
+                            Float32(2.0) * p2 * p3 * Float32(source_values[Int32(41)])
+                        )
+                    sy2 = _warp_allreduce_sum(term)
+                    if lane == Int32(0):
+                        s_post[0] = cute.math.rsqrt(
+                            sy2 / Float32(self.hidden_size) + Float32(self.norm_eps),
+                            fastmath=True,
+                        )
+
+        if tidx == Int32(0) and const_expr(not self.single_cta):
+            total_sqsum = Float32(sums[0])
+            mixes = cute.make_rmem_tensor(
+                cute.make_layout((self.mixes,), stride=(1,)), Float32
+            )
+            for mix in cutlass.range_constexpr(_MIXES):
+                mixes[mix] = Float32(sums[mix + 1])
+            inv_rms = cute.math.rsqrt(
+                total_sqsum / Float32(self.total_k) + Float32(self.rms_eps),
+                fastmath=True,
+            )
+            for mix in cutlass.range_constexpr(_MIXES):
+                mixes[mix] = mixes[mix] * inv_rms
+
+            s0 = Float32(scale[0])
+            s1 = Float32(scale[1])
+            s2 = Float32(scale[2])
+            one = Float32(1.0)
+            two = Float32(2.0)
+            eps = Float32(self.hc_eps)
+
+            pre0 = (
+                one
+                / (
+                    one
+                    + cute.math.exp(-(mixes[0] * s0 + Float32(bias[0])), fastmath=True)
+                )
+                + eps
+            )
+            pre1 = (
+                one
+                / (
+                    one
+                    + cute.math.exp(-(mixes[1] * s0 + Float32(bias[1])), fastmath=True)
+                )
+                + eps
+            )
+            pre2 = (
+                one
+                / (
+                    one
+                    + cute.math.exp(-(mixes[2] * s0 + Float32(bias[2])), fastmath=True)
+                )
+                + eps
+            )
+            pre3 = (
+                one
+                / (
+                    one
+                    + cute.math.exp(-(mixes[3] * s0 + Float32(bias[3])), fastmath=True)
+                )
+                + eps
+            )
+            s_pre[0] = pre0
+            s_pre[1] = pre1
+            s_pre[2] = pre2
+            s_pre[3] = pre3
+
+            post0 = two / (
+                one + cute.math.exp(-(mixes[4] * s1 + Float32(bias[4])), fastmath=True)
+            )
+            post1 = two / (
+                one + cute.math.exp(-(mixes[5] * s1 + Float32(bias[5])), fastmath=True)
+            )
+            post2 = two / (
+                one + cute.math.exp(-(mixes[6] * s1 + Float32(bias[6])), fastmath=True)
+            )
+            post3 = two / (
+                one + cute.math.exp(-(mixes[7] * s1 + Float32(bias[7])), fastmath=True)
+            )
+            if tile_group == Int32(0):
+                post[token, 0] = post0
+                post[token, 1] = post1
+                post[token, 2] = post2
+                post[token, 3] = post3
+
+            c00 = mixes[8] * s2 + Float32(bias[8])
+            c01 = mixes[9] * s2 + Float32(bias[9])
+            c02 = mixes[10] * s2 + Float32(bias[10])
+            c03 = mixes[11] * s2 + Float32(bias[11])
+            c10 = mixes[12] * s2 + Float32(bias[12])
+            c11 = mixes[13] * s2 + Float32(bias[13])
+            c12 = mixes[14] * s2 + Float32(bias[14])
+            c13 = mixes[15] * s2 + Float32(bias[15])
+            c20 = mixes[16] * s2 + Float32(bias[16])
+            c21 = mixes[17] * s2 + Float32(bias[17])
+            c22 = mixes[18] * s2 + Float32(bias[18])
+            c23 = mixes[19] * s2 + Float32(bias[19])
+            c30 = mixes[20] * s2 + Float32(bias[20])
+            c31 = mixes[21] * s2 + Float32(bias[21])
+            c32 = mixes[22] * s2 + Float32(bias[22])
+            c33 = mixes[23] * s2 + Float32(bias[23])
+
+            m0 = c00
+            if c01 > m0:
+                m0 = c01
+            if c02 > m0:
+                m0 = c02
+            if c03 > m0:
+                m0 = c03
+            m1 = c10
+            if c11 > m1:
+                m1 = c11
+            if c12 > m1:
+                m1 = c12
+            if c13 > m1:
+                m1 = c13
+            m2 = c20
+            if c21 > m2:
+                m2 = c21
+            if c22 > m2:
+                m2 = c22
+            if c23 > m2:
+                m2 = c23
+            m3 = c30
+            if c31 > m3:
+                m3 = c31
+            if c32 > m3:
+                m3 = c32
+            if c33 > m3:
+                m3 = c33
+
+            c00 = cute.math.exp(c00 - m0, fastmath=True)
+            c01 = cute.math.exp(c01 - m0, fastmath=True)
+            c02 = cute.math.exp(c02 - m0, fastmath=True)
+            c03 = cute.math.exp(c03 - m0, fastmath=True)
+            c10 = cute.math.exp(c10 - m1, fastmath=True)
+            c11 = cute.math.exp(c11 - m1, fastmath=True)
+            c12 = cute.math.exp(c12 - m1, fastmath=True)
+            c13 = cute.math.exp(c13 - m1, fastmath=True)
+            c20 = cute.math.exp(c20 - m2, fastmath=True)
+            c21 = cute.math.exp(c21 - m2, fastmath=True)
+            c22 = cute.math.exp(c22 - m2, fastmath=True)
+            c23 = cute.math.exp(c23 - m2, fastmath=True)
+            c30 = cute.math.exp(c30 - m3, fastmath=True)
+            c31 = cute.math.exp(c31 - m3, fastmath=True)
+            c32 = cute.math.exp(c32 - m3, fastmath=True)
+            c33 = cute.math.exp(c33 - m3, fastmath=True)
+
+            r0s = c00 + c01 + c02 + c03
+            r1s = c10 + c11 + c12 + c13
+            r2s = c20 + c21 + c22 + c23
+            r3s = c30 + c31 + c32 + c33
+            inv_r0 = cute.arch.rcp_approx(r0s)
+            inv_r1 = cute.arch.rcp_approx(r1s)
+            inv_r2 = cute.arch.rcp_approx(r2s)
+            inv_r3 = cute.arch.rcp_approx(r3s)
+            c00 = c00 * inv_r0 + eps
+            c01 = c01 * inv_r0 + eps
+            c02 = c02 * inv_r0 + eps
+            c03 = c03 * inv_r0 + eps
+            c10 = c10 * inv_r1 + eps
+            c11 = c11 * inv_r1 + eps
+            c12 = c12 * inv_r1 + eps
+            c13 = c13 * inv_r1 + eps
+            c20 = c20 * inv_r2 + eps
+            c21 = c21 * inv_r2 + eps
+            c22 = c22 * inv_r2 + eps
+            c23 = c23 * inv_r2 + eps
+            c30 = c30 * inv_r3 + eps
+            c31 = c31 * inv_r3 + eps
+            c32 = c32 * inv_r3 + eps
+            c33 = c33 * inv_r3 + eps
+
+            col0 = c00 + c10 + c20 + c30 + eps
+            col1 = c01 + c11 + c21 + c31 + eps
+            col2 = c02 + c12 + c22 + c32 + eps
+            col3 = c03 + c13 + c23 + c33 + eps
+            inv_col0 = cute.arch.rcp_approx(col0)
+            inv_col1 = cute.arch.rcp_approx(col1)
+            inv_col2 = cute.arch.rcp_approx(col2)
+            inv_col3 = cute.arch.rcp_approx(col3)
+            c00 = c00 * inv_col0
+            c10 = c10 * inv_col0
+            c20 = c20 * inv_col0
+            c30 = c30 * inv_col0
+            c01 = c01 * inv_col1
+            c11 = c11 * inv_col1
+            c21 = c21 * inv_col1
+            c31 = c31 * inv_col1
+            c02 = c02 * inv_col2
+            c12 = c12 * inv_col2
+            c22 = c22 * inv_col2
+            c32 = c32 * inv_col2
+            c03 = c03 * inv_col3
+            c13 = c13 * inv_col3
+            c23 = c23 * inv_col3
+            c33 = c33 * inv_col3
+
+            for _ in cutlass.range_constexpr(self.sinkhorn_iters - 1):
+                r0s = c00 + c01 + c02 + c03 + eps
+                r1s = c10 + c11 + c12 + c13 + eps
+                r2s = c20 + c21 + c22 + c23 + eps
+                r3s = c30 + c31 + c32 + c33 + eps
+                inv_r0 = cute.arch.rcp_approx(r0s)
+                inv_r1 = cute.arch.rcp_approx(r1s)
+                inv_r2 = cute.arch.rcp_approx(r2s)
+                inv_r3 = cute.arch.rcp_approx(r3s)
+                c00 = c00 * inv_r0
+                c01 = c01 * inv_r0
+                c02 = c02 * inv_r0
+                c03 = c03 * inv_r0
+                c10 = c10 * inv_r1
+                c11 = c11 * inv_r1
+                c12 = c12 * inv_r1
+                c13 = c13 * inv_r1
+                c20 = c20 * inv_r2
+                c21 = c21 * inv_r2
+                c22 = c22 * inv_r2
+                c23 = c23 * inv_r2
+                c30 = c30 * inv_r3
+                c31 = c31 * inv_r3
+                c32 = c32 * inv_r3
+                c33 = c33 * inv_r3
+
+                col0 = c00 + c10 + c20 + c30 + eps
+                col1 = c01 + c11 + c21 + c31 + eps
+                col2 = c02 + c12 + c22 + c32 + eps
+                col3 = c03 + c13 + c23 + c33 + eps
+                inv_col0 = cute.arch.rcp_approx(col0)
+                inv_col1 = cute.arch.rcp_approx(col1)
+                inv_col2 = cute.arch.rcp_approx(col2)
+                inv_col3 = cute.arch.rcp_approx(col3)
+                c00 = c00 * inv_col0
+                c10 = c10 * inv_col0
+                c20 = c20 * inv_col0
+                c30 = c30 * inv_col0
+                c01 = c01 * inv_col1
+                c11 = c11 * inv_col1
+                c21 = c21 * inv_col1
+                c31 = c31 * inv_col1
+                c02 = c02 * inv_col2
+                c12 = c12 * inv_col2
+                c22 = c22 * inv_col2
+                c32 = c32 * inv_col2
+                c03 = c03 * inv_col3
+                c13 = c13 * inv_col3
+                c23 = c23 * inv_col3
+                c33 = c33 * inv_col3
+
+            if tile_group == Int32(0):
+                comb[token, 0, 0] = c00
+                comb[token, 0, 1] = c01
+                comb[token, 0, 2] = c02
+                comb[token, 0, 3] = c03
+                comb[token, 1, 0] = c10
+                comb[token, 1, 1] = c11
+                comb[token, 1, 2] = c12
+                comb[token, 1, 3] = c13
+                comb[token, 2, 0] = c20
+                comb[token, 2, 1] = c21
+                comb[token, 2, 2] = c22
+                comb[token, 2, 3] = c23
+                comb[token, 3, 0] = c30
+                comb[token, 3, 1] = c31
+                comb[token, 3, 2] = c32
+                comb[token, 3, 3] = c33
+
+            if const_expr(self.fuse_norm):
+                # sum_h y^2 = pre^T G pre  (G symmetric, 10 packed entries)
+                sy2 = (
+                    pre0 * pre0 * Float32(gram[0])
+                    + pre1 * pre1 * Float32(gram[1])
+                    + pre2 * pre2 * Float32(gram[2])
+                    + pre3 * pre3 * Float32(gram[3])
+                    + two
+                    * (
+                        pre0 * pre1 * Float32(gram[4])
+                        + pre0 * pre2 * Float32(gram[5])
+                        + pre0 * pre3 * Float32(gram[6])
+                        + pre1 * pre2 * Float32(gram[7])
+                        + pre1 * pre3 * Float32(gram[8])
+                        + pre2 * pre3 * Float32(gram[9])
+                    )
+                )
+                s_post[0] = cute.math.rsqrt(
+                    sy2 / Float32(self.hidden_size) + Float32(self.norm_eps),
+                    fastmath=True,
+                )
+
+        cute.arch.sync_threads()
+
+        p0 = Float32(s_pre[0])
+        p1 = Float32(s_pre[1])
+        p2 = Float32(s_pre[2])
+        p3 = Float32(s_pre[3])
+        if const_expr(self.compact_partials or self.single_cta):
+            y_u32 = cute.recast_tensor(y, Uint32)
+            first_pair = Int32(0)
+            if const_expr(self.single_cta and self.single_cta_groups > 1):
+                first_pair = tile_group * Int32(
+                    self.hidden_size // (2 * self.single_cta_groups)
+                )
+            for pair_iter in cutlass.range_constexpr(
+                self.hidden_size // (2 * self.num_threads * self.single_cta_groups)
+            ):
+                h = (first_pair + Int32(pair_iter * self.num_threads) + tidx) * Int32(2)
+                residual_base = token * Int32(_MHC_MULT * self.hidden_size) + h
+                ro0_pair = ld_global_nc_u32(get_ptr_as_int64(residual, residual_base))
+                ro1_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        residual_base + Int32(self.hidden_size),
+                    )
+                )
+                ro2_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        residual_base + Int32(2 * self.hidden_size),
+                    )
+                )
+                ro3_pair = ld_global_nc_u32(
+                    get_ptr_as_int64(
+                        residual,
+                        residual_base + Int32(3 * self.hidden_size),
+                    )
+                )
+                ro00, ro01 = bfloat2_to_float2_scaled(ro0_pair, Float32(1.0))
+                ro10, ro11 = bfloat2_to_float2_scaled(ro1_pair, Float32(1.0))
+                ro20, ro21 = bfloat2_to_float2_scaled(ro2_pair, Float32(1.0))
+                ro30, ro31 = bfloat2_to_float2_scaled(ro3_pair, Float32(1.0))
+                norm0 = Float32(1.0)
+                norm1 = Float32(1.0)
+                if const_expr(self.fuse_norm):
+                    if const_expr(norm_weight.element_type == cutlass.BFloat16):
+                        norm_pair = ld_global_nc_u32(get_ptr_as_int64(norm_weight, h))
+                        norm0, norm1 = bfloat2_to_float2_scaled(
+                            norm_pair,
+                            Float32(1.0),
+                        )
+                    else:
+                        norm0 = Float32(norm_weight[h])
+                        norm1 = Float32(norm_weight[h + Int32(1)])
+                y_pre0 = (p0 * ro00 + p1 * ro10 + p2 * ro20 + p3 * ro30).to(
+                    cutlass.BFloat16
+                )
+                y_pre1 = (p0 * ro01 + p1 * ro11 + p2 * ro21 + p3 * ro31).to(
+                    cutlass.BFloat16
+                )
+                y0 = Float32(y_pre0)
+                y1 = Float32(y_pre1)
+                if const_expr(self.fuse_norm):
+                    rms = Float32(s_post[0])
+                    y0 = y0 * rms * norm0
+                    y1 = y1 * rms * norm1
+                y_u32[token, h // Int32(2)] = pack_f32x2_to_bfloat2(y0, y1)
+        else:
+            first_tile_h = tile_group * Int32(self.tiles_per_cta)
+            for tile_iter in cutlass.range_constexpr(self.tiles_per_cta):
+                h = (first_tile_h + Int32(tile_iter)) * Int32(self.block_h) + tidx
+                ro0 = Float32(residual[token, 0, h])
+                ro1 = Float32(residual[token, 1, h])
+                ro2 = Float32(residual[token, 2, h])
+                ro3 = Float32(residual[token, 3, h])
+                # Round y_prenorm to bf16 before applying the norm, matching the
+                # reference (and vLLM), so the only difference is the (negligible)
+                # fp32-vs-bf16 sum-of-squares used for rms.
+                y_pre = (p0 * ro0 + p1 * ro1 + p2 * ro2 + p3 * ro3).to(cutlass.BFloat16)
+                if const_expr(self.fuse_norm):
+                    rms = Float32(s_post[0])
+                    y[token, h] = (Float32(y_pre) * rms * Float32(norm_weight[h])).to(
+                        cutlass.BFloat16
+                    )
+                else:
+                    y[token, h] = y_pre
+
+
+@lru_cache(maxsize=64)
+def _post_pre_partial_kernel(
+    hidden_size: int,
+    split_k: int,
+    compute_gram: bool = False,
+    pre_only: bool = False,
+    post_only: bool = False,
+    partials_per_cta: int = _POST_PRE_PARTIALS_PER_CTA,
+) -> MHCPostPrePartialKernel:
+    return MHCPostPrePartialKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+        compute_gram=compute_gram,
+        pre_only=pre_only,
+        post_only=post_only,
+        partials_per_cta=partials_per_cta,
+    )
+
+
+@lru_cache(maxsize=32)
+def _post_pre_decode_split_n_partial_kernel(
+    hidden_size: int,
+    split_k: int,
+    source_splits: int,
+    tile_n: int,
+    bf16x2: bool = False,
+    compute_gram: bool = False,
+) -> MHCPostPreDecodeSplitNPartialKernel:
+    return MHCPostPreDecodeSplitNPartialKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+        source_splits=source_splits,
+        tile_n=tile_n,
+        bf16x2=bf16x2,
+        compute_gram=compute_gram,
+    )
+
+
+@lru_cache(maxsize=16)
+def _post_pre_prefill_partial_kernel(
+    hidden_size: int,
+    split_k: int,
+    compute_gram: bool = True,
+) -> MHCPostPrePrefillPartialKernel:
+    return MHCPostPrePrefillPartialKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+        compute_gram=compute_gram,
+    )
+
+
+@lru_cache(maxsize=16)
+def _post_pre_prefill_block_m_partial_kernel(
+    hidden_size: int,
+    split_k: int,
+    block_m: int = _PREFILL_BLOCK_M,
+    tile_n: int = _PREFILL_BLOCK_TILE_N,
+    compute_gram: bool = True,
+) -> MHCPostPrePrefillBlockMPartialKernel:
+    return MHCPostPrePrefillBlockMPartialKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+        block_m=block_m,
+        tile_n=tile_n,
+        compute_gram=compute_gram,
+    )
+
+
+@lru_cache(maxsize=16)
+def _post_pre_prefill_gram_kernel(
+    hidden_size: int,
+    split_k: int,
+) -> MHCPostPrePrefillGramKernel:
+    return MHCPostPrePrefillGramKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+    )
+
+
+@lru_cache(maxsize=16)
+def _prefill_bf16_project_kernel(
+    hidden_size: int,
+    split_k: int,
+) -> MHCPrefillBf16ProjectKernel:
+    return MHCPrefillBf16ProjectKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+    )
+
+
+@lru_cache(maxsize=16)
+def _prefill_bf16_project_tma_kernel(
+    hidden_size: int,
+    split_k: int,
+) -> MHCPrefillBf16ProjectTmaKernel:
+    return MHCPrefillBf16ProjectTmaKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+    )
+
+
+@lru_cache(maxsize=16)
+def _prefill_tf32_project_kernel(
+    hidden_size: int,
+    split_k: int,
+    chunk_geometry: bool = False,
+    long_geometry: bool = False,
+) -> MHCPrefillTf32ProjectTmaKernel:
+    return MHCPrefillTf32ProjectTmaKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+        chunk_geometry=chunk_geometry,
+        long_geometry=long_geometry,
+    )
+
+
+@lru_cache(maxsize=64)
+def _finalize_gram_kernel(
+    hidden_size: int,
+    split_k: int,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+    compact_partials: bool = False,
+    compact_projection_splits: int = 1,
+    single_cta: bool = False,
+    single_cta_threads: int = _PREFILL_FINALIZE_THREADS,
+    single_cta_groups: int = 1,
+    active_source_splits: int = 0,
+) -> MHCFinalizeGramKernel:
+    return MHCFinalizeGramKernel(
+        hidden_size=hidden_size,
+        split_k=split_k,
+        rms_eps=rms_eps,
+        hc_eps=hc_eps,
+        sinkhorn_iters=sinkhorn_iters,
+        norm_eps=norm_eps,
+        fuse_norm=fuse_norm,
+        compact_partials=compact_partials,
+        compact_projection_splits=compact_projection_splits,
+        single_cta=single_cta,
+        single_cta_threads=single_cta_threads,
+        single_cta_groups=single_cta_groups,
+        active_source_splits=active_source_splits,
+    )
+
+
+def _run_mhc_post_pre_partial_launch(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = False,
+) -> None:
+    tokens = int(x.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = int(partials.shape[1])
+    _validate_split_k(hidden_size, split_k)
+    decode_source_splits, decode_tile_n = _selected_post_pre_decode_split_n(
+        num_tokens=tokens,
+        hidden_size=hidden_size,
+    )
+    raw_bf16x2 = os.environ.get("FLASHINFER_EXP_SM12X_MHC_DECODE_BF16X2")
+    decode_bf16x2 = (
+        raw_bf16x2 != "0"
+        if raw_bf16x2 is not None
+        else tokens == 16 and hidden_size == _HIDDEN and decode_source_splits > 0
+    )
+    partials_per_cta = _selected_post_pre_partials_per_cta(
+        num_tokens=tokens,
+        hidden_size=hidden_size,
+    )
+    _validate_tensor_shape("x", x, (tokens, hidden_size))
+    _validate_tensor_shape("residual", residual, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("prev_post", prev_post, (tokens, _MHC_MULT))
+    _validate_tensor_shape("prev_comb", prev_comb, (tokens, _MHC_MULT, _MHC_MULT))
+    _validate_tensor_shape("fn", fn, (_MIXES, _MHC_MULT * hidden_size))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    decode_bf16x2 = decode_bf16x2 and all(
+        tensor.is_contiguous() and tensor.data_ptr() % 4 == 0
+        for tensor in (x, residual, out)
+    )
+    compute_gram = bool(compute_gram)
+    args = (
+        _to_kernel_tensor(x, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            prev_post,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            prev_comb,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(fn, cutlass.Float32),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(out, cutlass.BFloat16, dynamic_layout=True),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "x",
+            x,
+            dims=(DimKey.dynamic(), DimKey.exact(hidden_size)),
+        ),
+        tensor_key(
+            "residual",
+            residual,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "prev_post",
+            prev_post,
+            dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT)),
+        ),
+        tensor_key(
+            "prev_comb",
+            prev_comb,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(_MHC_MULT),
+            ),
+        ),
+        tensor_key(
+            "fn",
+            fn,
+            dims=(DimKey.exact(_MIXES), DimKey.exact(_MHC_MULT * hidden_size)),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+        tensor_key(
+            "out",
+            out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    if decode_source_splits > 0:
+        compile_name = (
+            "integration.residual.mhc_post_pre_decode_split_n_"
+            f"{hidden_specialization}_s{decode_source_splits}n{decode_tile_n}"
+            f"x{2 if decode_bf16x2 else 1}"
+        )
+        compile_key = (
+            ("hidden_size", hidden_size),
+            ("split_k", split_k),
+            ("source_splits", decode_source_splits),
+            ("tile_n", decode_tile_n),
+            ("bf16x2", decode_bf16x2),
+            ("compute_gram", compute_gram),
+            ("pdl", _MHC_PDL),
+            cache_key,
+        )
+        kernel = _post_pre_decode_split_n_partial_kernel(
+            hidden_size,
+            split_k,
+            decode_source_splits,
+            decode_tile_n,
+            decode_bf16x2,
+            compute_gram,
+        )
+    elif hidden_size == _HIDDEN and split_k == _SPLIT_K:
+        compile_name = (
+            "integration.residual.mhc_post_pre_partial_hidden4096_hctile128"
+            f"_all{partials_per_cta}"
+        )
+        compile_key = (
+            ("partials_per_cta", partials_per_cta),
+            ("compute_gram", compute_gram),
+            ("pdl", _MHC_PDL),
+            cache_key,
+        )
+        kernel = _post_pre_partial_kernel(
+            hidden_size,
+            split_k,
+            compute_gram,
+            False,
+            False,
+            partials_per_cta,
+        )
+    else:
+        compile_name = (
+            "integration.residual.mhc_post_pre_partial_"
+            f"{hidden_specialization}_hctile128_all{partials_per_cta}"
+        )
+        compile_key = (
+            ("hidden_size", hidden_size),
+            ("split_k", split_k),
+            ("source_tiles", hidden_size // _SOURCE_TILE_H),
+            ("partials_per_cta", partials_per_cta),
+            ("compute_gram", compute_gram),
+            ("pdl", _MHC_PDL),
+            cache_key,
+        )
+        kernel = _post_pre_partial_kernel(
+            hidden_size,
+            split_k,
+            compute_gram,
+            False,
+            False,
+            partials_per_cta,
+        )
+    sm12x_launch(
+        kernel,
+        compile_spec=KernelCompileSpec.from_key(compile_name, 4, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_pre_partial_launch",
+    mutates_args=("partials", "out"),
+)
+def _mhc_post_pre_partial_launch_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+) -> None:
+    _run_mhc_post_pre_partial_launch(
+        x=x,
+        residual=residual,
+        prev_post=prev_post,
+        prev_comb=prev_comb,
+        fn=fn,
+        partials=partials,
+        out=out,
+        compute_gram=compute_gram,
+    )
+
+
+@_mhc_post_pre_partial_launch_op.register_fake
+def _mhc_post_pre_partial_launch_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+) -> None:
+    return None
+
+
+def run_mhc_post_pre_partial(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = False,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_post_pre_partial_launch(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        fn,
+        partials,
+        out,
+        bool(compute_gram),
+    )
+
+
+def _run_mhc_post_pre_prefill_partial_launch(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = True,
+) -> None:
+    tokens = int(x.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = int(partials.shape[1])
+    _validate_split_k(hidden_size, split_k)
+    _validate_tensor_shape("x", x, (tokens, hidden_size))
+    _validate_tensor_shape("residual", residual, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("prev_post", prev_post, (tokens, _MHC_MULT))
+    _validate_tensor_shape("prev_comb", prev_comb, (tokens, _MHC_MULT, _MHC_MULT))
+    _validate_tensor_shape("fn", fn, (_MIXES, _MHC_MULT * hidden_size))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    compute_gram = bool(compute_gram)
+    args = (
+        _to_kernel_tensor(x, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            prev_post,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            prev_comb,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(fn, cutlass.Float32),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(out, cutlass.BFloat16, dynamic_layout=True),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "x",
+            x,
+            dims=(DimKey.dynamic(), DimKey.exact(hidden_size)),
+        ),
+        tensor_key(
+            "residual",
+            residual,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "prev_post",
+            prev_post,
+            dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT)),
+        ),
+        tensor_key(
+            "prev_comb",
+            prev_comb,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(_MHC_MULT),
+            ),
+        ),
+        tensor_key(
+            "fn",
+            fn,
+            dims=(DimKey.exact(_MIXES), DimKey.exact(_MHC_MULT * hidden_size)),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+        tensor_key(
+            "out",
+            out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    compile_name = (
+        "integration.residual.mhc_post_pre_prefill_partial_"
+        f"{hidden_specialization}_threads{_PREFILL_THREADS}"
+    )
+    compile_key = (
+        ("hidden_size", hidden_size),
+        ("split_k", split_k),
+        ("threads", _PREFILL_THREADS),
+        ("compute_gram", compute_gram),
+        cache_key,
+    )
+    sm12x_launch(
+        _post_pre_prefill_partial_kernel(
+            hidden_size,
+            split_k,
+            compute_gram,
+        ),
+        compile_spec=KernelCompileSpec.from_key(compile_name, 3, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_pre_prefill_partial_launch",
+    mutates_args=("partials", "out"),
+)
+def _mhc_post_pre_prefill_partial_launch_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+) -> None:
+    _run_mhc_post_pre_prefill_partial_launch(
+        x=x,
+        residual=residual,
+        prev_post=prev_post,
+        prev_comb=prev_comb,
+        fn=fn,
+        partials=partials,
+        out=out,
+        compute_gram=compute_gram,
+    )
+
+
+@_mhc_post_pre_prefill_partial_launch_op.register_fake
+def _mhc_post_pre_prefill_partial_launch_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+) -> None:
+    return None
+
+
+def run_mhc_post_pre_prefill_partial(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = True,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_post_pre_prefill_partial_launch(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        fn,
+        partials,
+        out,
+        bool(compute_gram),
+    )
+
+
+def _run_mhc_post_pre_prefill_block_m_partial_launch(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = True,
+    block_m: int = _PREFILL_BLOCK_M,
+    tile_n: int = _PREFILL_BLOCK_TILE_N,
+) -> None:
+    tokens = int(x.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = int(partials.shape[1])
+    block_m = int(block_m)
+    tile_n = int(tile_n)
+    _validate_split_k(hidden_size, split_k)
+    if block_m <= 0:
+        raise ValueError(f"block_m must be positive, got {block_m}")
+    if tile_n <= 0:
+        raise ValueError(f"tile_n must be positive, got {tile_n}")
+    _validate_tensor_shape("x", x, (tokens, hidden_size))
+    _validate_tensor_shape("residual", residual, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("prev_post", prev_post, (tokens, _MHC_MULT))
+    _validate_tensor_shape("prev_comb", prev_comb, (tokens, _MHC_MULT, _MHC_MULT))
+    _validate_tensor_shape("fn", fn, (_MIXES, _MHC_MULT * hidden_size))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    compute_gram = bool(compute_gram)
+    args = (
+        _to_kernel_tensor(x, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            prev_post,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            prev_comb,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(fn, cutlass.Float32),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(out, cutlass.BFloat16, dynamic_layout=True),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "x",
+            x,
+            dims=(DimKey.dynamic(), DimKey.exact(hidden_size)),
+        ),
+        tensor_key(
+            "residual",
+            residual,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "prev_post",
+            prev_post,
+            dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT)),
+        ),
+        tensor_key(
+            "prev_comb",
+            prev_comb,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(_MHC_MULT),
+            ),
+        ),
+        tensor_key(
+            "fn",
+            fn,
+            dims=(DimKey.exact(_MIXES), DimKey.exact(_MHC_MULT * hidden_size)),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+        tensor_key(
+            "out",
+            out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    compile_name = (
+        "integration.residual.mhc_post_pre_prefill_block_m_partial_"
+        f"{hidden_specialization}_threads{_PREFILL_THREADS}_m{block_m}_n{tile_n}"
+    )
+    compile_key = (
+        ("hidden_size", hidden_size),
+        ("split_k", split_k),
+        ("threads", _PREFILL_THREADS),
+        ("block_m", block_m),
+        ("tile_n", tile_n),
+        ("compute_gram", compute_gram),
+        cache_key,
+    )
+    sm12x_launch(
+        _post_pre_prefill_block_m_partial_kernel(
+            hidden_size,
+            split_k,
+            block_m,
+            tile_n,
+            compute_gram,
+        ),
+        compile_spec=KernelCompileSpec.from_key(compile_name, 3, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_pre_prefill_block_m_partial_launch",
+    mutates_args=("partials", "out"),
+)
+def _mhc_post_pre_prefill_block_m_partial_launch_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+    block_m: int,
+    tile_n: int,
+) -> None:
+    _run_mhc_post_pre_prefill_block_m_partial_launch(
+        x=x,
+        residual=residual,
+        prev_post=prev_post,
+        prev_comb=prev_comb,
+        fn=fn,
+        partials=partials,
+        out=out,
+        compute_gram=compute_gram,
+        block_m=block_m,
+        tile_n=tile_n,
+    )
+
+
+@_mhc_post_pre_prefill_block_m_partial_launch_op.register_fake
+def _mhc_post_pre_prefill_block_m_partial_launch_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+    block_m: int,
+    tile_n: int,
+) -> None:
+    return None
+
+
+def run_mhc_post_pre_prefill_block_m_partial(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = True,
+    block_m: int = _PREFILL_BLOCK_M,
+    tile_n: int = _PREFILL_BLOCK_TILE_N,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_post_pre_prefill_block_m_partial_launch(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        fn,
+        partials,
+        out,
+        bool(compute_gram),
+        int(block_m),
+        int(tile_n),
+    )
+
+
+def _run_mhc_post_pre_prefill_gram_launch(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    tokens = int(x.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = int(partials.shape[1])
+    _validate_split_k(hidden_size, split_k)
+    _validate_tensor_shape("x", x, (tokens, hidden_size))
+    _validate_tensor_shape("residual", residual, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("prev_post", prev_post, (tokens, _MHC_MULT))
+    _validate_tensor_shape("prev_comb", prev_comb, (tokens, _MHC_MULT, _MHC_MULT))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    args = (
+        _to_kernel_tensor(x, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            prev_post,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            prev_comb,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(out, cutlass.BFloat16, dynamic_layout=True),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "x",
+            x,
+            dims=(DimKey.dynamic(), DimKey.exact(hidden_size)),
+        ),
+        tensor_key(
+            "residual",
+            residual,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "prev_post",
+            prev_post,
+            dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT)),
+        ),
+        tensor_key(
+            "prev_comb",
+            prev_comb,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(_MHC_MULT),
+            ),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+        tensor_key(
+            "out",
+            out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    compile_name = (
+        "integration.residual.mhc_post_pre_prefill_gram_"
+        f"{hidden_specialization}_threads{_PREFILL_GRAM_THREADS}"
+    )
+    compile_key = (
+        ("impl", "bf16x2_io_coeff_smem_v2"),
+        ("hidden_size", hidden_size),
+        ("split_k", split_k),
+        ("threads", _PREFILL_GRAM_THREADS),
+        ("pdl", _MHC_PDL),
+        cache_key,
+    )
+    sm12x_launch(
+        _post_pre_prefill_gram_kernel(hidden_size, split_k),
+        compile_spec=KernelCompileSpec.from_key(compile_name, 2, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_pre_prefill_gram_launch",
+    mutates_args=("partials", "out"),
+)
+def _mhc_post_pre_prefill_gram_launch_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    _run_mhc_post_pre_prefill_gram_launch(
+        x=x,
+        residual=residual,
+        prev_post=prev_post,
+        prev_comb=prev_comb,
+        partials=partials,
+        out=out,
+    )
+
+
+@_mhc_post_pre_prefill_gram_launch_op.register_fake
+def _mhc_post_pre_prefill_gram_launch_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    return None
+
+
+def run_mhc_post_pre_prefill_gram(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_post_pre_prefill_gram_launch(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        partials,
+        out,
+    )
+
+
+def _run_mhc_prefill_bf16_project_launch(
+    *,
+    out: torch.Tensor,
+    fn_bf16: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    tokens = int(out.shape[0])
+    hidden_size = int(out.shape[2])
+    split_k = int(partials.shape[1])
+    _validate_split_k(hidden_size, split_k)
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("fn_bf16", fn_bf16, (_MIXES, _MHC_MULT * hidden_size))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    if fn_bf16.dtype != torch.bfloat16:
+        raise ValueError(f"fn_bf16 must be torch.bfloat16, got {fn_bf16.dtype}")
+    if fn_bf16.device != out.device or partials.device != out.device:
+        raise ValueError("fn_bf16, partials, and out must be on the same device")
+    if not fn_bf16.is_cuda:
+        raise ValueError("fn_bf16 must be CUDA")
+    if not fn_bf16.is_contiguous():
+        raise ValueError("fn_bf16 must be contiguous")
+    if os.getenv("FLASHINFER_EXP_SM12X_MHC_PREFILL_BF16_TMA", "1") != "0":
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous for TMA BF16 prefill projection")
+        out_flat = out.view(tokens, _MHC_MULT * hidden_size)
+        args = (
+            _to_kernel_tensor(out_flat, cutlass.BFloat16, dynamic_layout=True),
+            _to_kernel_tensor(fn_bf16, cutlass.BFloat16),
+            _to_kernel_tensor(
+                partials,
+                cutlass.Float32,
+                assumed_align=4,
+                dynamic_layout=True,
+            ),
+            Int32(tokens),
+            current_cuda_stream(),
+        )
+        cache_key = (
+            tensor_key(
+                "out_flat",
+                out_flat,
+                dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT * hidden_size)),
+            ),
+            tensor_key(
+                "fn_bf16",
+                fn_bf16,
+                dims=(DimKey.exact(_MIXES), DimKey.exact(_MHC_MULT * hidden_size)),
+            ),
+            tensor_key(
+                "partials",
+                partials,
+                dims=(
+                    DimKey.dynamic(),
+                    DimKey.exact(split_k),
+                    DimKey.exact(_PARTIALS),
+                ),
+            ),
+        )
+        hidden_specialization = _hidden_specialization_name(hidden_size)
+        compile_name = (
+            "integration.residual.mhc_prefill_bf16_project_tma_"
+            f"{hidden_specialization}_m{_PREFILL_TMA_TILE_M}_n{_PREFILL_TMA_TILE_N}"
+        )
+        compile_key = (
+            ("hidden_size", hidden_size),
+            ("split_k", split_k),
+            ("tile_m", _PREFILL_TMA_TILE_M),
+            ("tile_n", _PREFILL_TMA_TILE_N),
+            ("tile_k", _PREFILL_TMA_TILE_K),
+            ("stages", _PREFILL_TMA_STAGES),
+            ("compute_warps", _PREFILL_TMA_COMPUTE_WARPS),
+            ("threads", _PREFILL_TMA_THREADS),
+            cache_key,
+        )
+        sm12x_launch(
+            _prefill_bf16_project_tma_kernel(hidden_size, split_k),
+            compile_spec=KernelCompileSpec.from_key(compile_name, 1, compile_key),
+            compile_args=args,
+            runtime_args=args,
+        )
+        return
+    args = (
+        _to_kernel_tensor(out, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(fn_bf16, cutlass.BFloat16),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "out",
+            out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "fn_bf16",
+            fn_bf16,
+            dims=(DimKey.exact(_MIXES), DimKey.exact(_MHC_MULT * hidden_size)),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    compile_name = (
+        "integration.residual.mhc_prefill_bf16_project_"
+        f"{hidden_specialization}_m{_PREFILL_MMA_TILE_M}_n{_PREFILL_MMA_TILE_N}"
+    )
+    compile_key = (
+        ("hidden_size", hidden_size),
+        ("split_k", split_k),
+        ("tile_m", _PREFILL_MMA_TILE_M),
+        ("tile_n", _PREFILL_MMA_TILE_N),
+        ("tile_k", _PREFILL_MMA_TILE_K),
+        ("sync", "warp_v2"),
+        cache_key,
+    )
+    sm12x_launch(
+        _prefill_bf16_project_kernel(hidden_size, split_k),
+        compile_spec=KernelCompileSpec.from_key(compile_name, 1, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_prefill_bf16_project_launch",
+    mutates_args=("partials",),
+)
+def _mhc_prefill_bf16_project_launch_op(
+    out: torch.Tensor,
+    fn_bf16: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    _run_mhc_prefill_bf16_project_launch(
+        out=out,
+        fn_bf16=fn_bf16,
+        partials=partials,
+    )
+
+
+@_mhc_prefill_bf16_project_launch_op.register_fake
+def _mhc_prefill_bf16_project_launch_fake(
+    out: torch.Tensor,
+    fn_bf16: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    return None
+
+
+def run_mhc_prefill_bf16_project(
+    *,
+    out: torch.Tensor,
+    fn_bf16: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_prefill_bf16_project_launch(
+        out,
+        fn_bf16,
+        partials,
+    )
+
+
+def _run_mhc_prefill_tf32_project_launch(
+    *,
+    out: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    tokens = int(out.shape[0])
+    hidden_size = int(out.shape[2])
+    split_k = int(partials.shape[1])
+    _validate_split_k(hidden_size, split_k)
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("fn", fn, (_MIXES, _MHC_MULT * hidden_size))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    if fn.dtype != torch.float32:
+        raise ValueError(f"fn must be torch.float32, got {fn.dtype}")
+    if fn.device != out.device or partials.device != out.device:
+        raise ValueError("fn, partials, and out must be on the same device")
+    if not fn.is_cuda:
+        raise ValueError("fn must be CUDA")
+    if not out.is_contiguous():
+        raise ValueError("out must be contiguous for TF32 prefill projection")
+    if not fn.is_contiguous():
+        raise ValueError("fn must be contiguous")
+    out_flat = out.view(tokens, _MHC_MULT * hidden_size)
+    chunk_geometry = tokens >= _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
+    long_geometry = (
+        hidden_size == _HIDDEN and tokens >= _PREFILL_TF32_TMA_LONG_MIN_TOKENS
+    )
+    kernel = _prefill_tf32_project_kernel(
+        hidden_size,
+        split_k,
+        chunk_geometry,
+        long_geometry,
+    )
+    args = (
+        _to_kernel_tensor(out_flat, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(fn, cutlass.Float32),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "out_flat",
+            out_flat,
+            dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT * hidden_size)),
+        ),
+        tensor_key(
+            "fn",
+            fn,
+            dims=(DimKey.exact(_MIXES), DimKey.exact(_MHC_MULT * hidden_size)),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    compile_name = (
+        "integration.residual.mhc_prefill_tf32_project_tma_"
+        f"{hidden_specialization}_m{kernel.tile_m}_n{kernel.tile_n}"
+    )
+    compile_key = (
+        ("hidden_size", hidden_size),
+        ("split_k", split_k),
+        ("chunk_geometry", chunk_geometry),
+        ("chunk_min_tokens", _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS),
+        ("long_geometry", long_geometry),
+        ("long_min_tokens", _PREFILL_TF32_TMA_LONG_MIN_TOKENS),
+        ("tile_m", kernel.tile_m),
+        ("tile_n", kernel.tile_n),
+        ("tile_k", kernel.tile_k),
+        ("num_stages", kernel.num_stages),
+        ("num_m_warps", kernel.num_m_warps),
+        ("num_n_warps", kernel.num_n_warps),
+        ("num_compute_warps", kernel.num_compute_warps),
+        ("threads", kernel.num_threads),
+        ("k_splits", kernel.k_splits),
+        ("pdl", _MHC_PDL),
+        (
+            "operand_layout",
+            "tma_swizzled_branchless_a_bf16_b_f32_rawtf32_m16n8k8_v7",
+        ),
+        cache_key,
+    )
+    sm12x_launch(
+        kernel,
+        compile_spec=KernelCompileSpec.from_key(compile_name, 6, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+def mhc_prefill_tf32_project_splits(*, tokens: int, hidden_size: int) -> int:
+    """Return the projection split count selected by the TF32 prefill kernel."""
+    chunk_geometry = int(tokens) >= _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
+    long_geometry = (
+        int(hidden_size) == _HIDDEN and int(tokens) >= _PREFILL_TF32_TMA_LONG_MIN_TOKENS
+    )
+    return _prefill_tf32_project_kernel(
+        int(hidden_size),
+        _split_k_for_hidden(int(hidden_size)),
+        chunk_geometry,
+        long_geometry,
+    ).k_splits
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_prefill_tf32_project_launch",
+    mutates_args=("partials",),
+)
+def _mhc_prefill_tf32_project_launch_op(
+    out: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    _run_mhc_prefill_tf32_project_launch(
+        out=out,
+        fn=fn,
+        partials=partials,
+    )
+
+
+@_mhc_prefill_tf32_project_launch_op.register_fake
+def _mhc_prefill_tf32_project_launch_fake(
+    out: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    return None
+
+
+def run_mhc_prefill_tf32_project(
+    *,
+    out: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_prefill_tf32_project_launch(
+        out,
+        fn,
+        partials,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_pre_partial_alloc",
+    mutates_args=(),
+)
+def _mhc_post_pre_partial_alloc_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    compute_gram: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # Functional (allocate + return) post-pre partial. Allocating BOTH partials
+    # and residual_out internally and returning them gives this op ZERO mutated
+    # args, so it is never auto_functionalized. That avoids the
+    # decompose_auto_functionalized node-count assertion that fires for an
+    # auto_functionalized op carrying TWO mutated args sharing a symbolic dim
+    # (the second clone's as_strided sym_size gets CSE-collapsed on re-trace).
+    # residual_out is allocated contiguous.
+    tokens = int(residual.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = _split_k_for_hidden(hidden_size)
+    partials = torch.empty(
+        (tokens, split_k, _PARTIALS), dtype=torch.float32, device=residual.device
+    )
+    out = torch.empty(residual.shape, dtype=residual.dtype, device=residual.device)
+    _run_mhc_post_pre_partial_launch(
+        x=x,
+        residual=residual,
+        prev_post=prev_post,
+        prev_comb=prev_comb,
+        fn=fn,
+        partials=partials,
+        out=out,
+        compute_gram=compute_gram,
+    )
+    return partials, out
+
+
+@_mhc_post_pre_partial_alloc_op.register_fake
+def _mhc_post_pre_partial_alloc_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    compute_gram: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    tokens = residual.shape[0]
+    split_k = residual.shape[2] // (_SOURCE_TILE_H // 2)
+    partials = torch.empty(
+        (tokens, split_k, _PARTIALS), dtype=torch.float32, device=residual.device
+    )
+    out = torch.empty(residual.shape, dtype=residual.dtype, device=residual.device)
+    return partials, out
+
+
+def run_mhc_post_pre_partial_alloc(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    compute_gram: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.flashinfer_sm12x.mhc_post_pre_partial_alloc(
+        x, residual, prev_post, prev_comb, fn, bool(compute_gram)
+    )
+
+
+def _run_mhc_post_launch(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    tokens = int(x.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = _split_k_for_hidden(hidden_size)
+    _validate_tensor_shape("x", x, (tokens, hidden_size))
+    _validate_tensor_shape("residual", residual, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("prev_post", prev_post, (tokens, _MHC_MULT))
+    _validate_tensor_shape("prev_comb", prev_comb, (tokens, _MHC_MULT, _MHC_MULT))
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    args = (
+        _to_kernel_tensor(x, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            prev_post,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            prev_comb,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            prev_comb,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            prev_post,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(out, cutlass.BFloat16, dynamic_layout=True),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "x",
+            x,
+            dims=(DimKey.dynamic(), DimKey.exact(hidden_size)),
+        ),
+        tensor_key(
+            "residual",
+            residual,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "prev_post",
+            prev_post,
+            dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT)),
+        ),
+        tensor_key(
+            "prev_comb",
+            prev_comb,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(_MHC_MULT),
+            ),
+        ),
+        tensor_key(
+            "out",
+            out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    if hidden_size == _HIDDEN:
+        compile_name = "integration.residual.mhc_post_hidden4096_hctile128_all4"
+        compile_key = (
+            ("post_only", True),
+            cache_key,
+        )
+    else:
+        compile_name = (
+            f"integration.residual.mhc_post_{hidden_specialization}_hctile128_all4"
+        )
+        compile_key = (
+            ("hidden_size", hidden_size),
+            ("post_only", True),
+            cache_key,
+        )
+    sm12x_launch(
+        _post_pre_partial_kernel(hidden_size, split_k, False, False, True),
+        compile_spec=KernelCompileSpec.from_key(compile_name, 2, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_launch",
+    mutates_args=("out",),
+)
+def _mhc_post_launch_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    _run_mhc_post_launch(
+        x=x,
+        residual=residual,
+        prev_post=prev_post,
+        prev_comb=prev_comb,
+        out=out,
+    )
+
+
+@_mhc_post_launch_op.register_fake
+def _mhc_post_launch_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    return None
+
+
+def run_mhc_post(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_post_launch(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        out,
+    )
+
+
+def _run_mhc_pre_partial_launch(
+    *,
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = False,
+) -> None:
+    tokens = int(residual.shape[0])
+    hidden_size = int(residual.shape[1])
+    split_k = int(partials.shape[1])
+    _validate_split_k(hidden_size, split_k)
+    partials_per_cta = _selected_post_pre_partials_per_cta(
+        num_tokens=tokens,
+        hidden_size=hidden_size,
+    )
+    _validate_tensor_shape("residual", residual, (tokens, hidden_size))
+    _validate_tensor_shape("fn", fn, (_MIXES, hidden_size))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    _validate_tensor_shape("out", out, (tokens, _MHC_MULT, hidden_size))
+    compute_gram = bool(compute_gram)
+    args = (
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(fn, cutlass.Float32),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(out, cutlass.BFloat16, dynamic_layout=True),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    cache_key = (
+        tensor_key(
+            "residual",
+            residual,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "fn",
+            fn,
+            dims=(DimKey.exact(_MIXES), DimKey.exact(hidden_size)),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+        tensor_key(
+            "out",
+            out,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    if hidden_size == _HIDDEN and split_k == _SPLIT_K:
+        compile_name = (
+            "integration.residual.mhc_pre_partial_hidden4096_hctile128"
+            f"_all{partials_per_cta}"
+        )
+        compile_key = (
+            ("partials_per_cta", partials_per_cta),
+            ("compute_gram", compute_gram),
+            ("pre_only", True),
+            cache_key,
+        )
+    else:
+        compile_name = (
+            "integration.residual.mhc_pre_partial_"
+            f"{hidden_specialization}_hctile128_all{partials_per_cta}"
+        )
+        compile_key = (
+            ("hidden_size", hidden_size),
+            ("split_k", split_k),
+            ("source_tiles", hidden_size // _SOURCE_TILE_H),
+            ("partials_per_cta", partials_per_cta),
+            ("compute_gram", compute_gram),
+            ("pre_only", True),
+            cache_key,
+        )
+    sm12x_launch(
+        _post_pre_partial_kernel(
+            hidden_size,
+            split_k,
+            compute_gram,
+            True,
+            False,
+            partials_per_cta,
+        ),
+        compile_spec=KernelCompileSpec.from_key(compile_name, 2, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_pre_partial_launch",
+    mutates_args=("partials", "out"),
+)
+def _mhc_pre_partial_launch_op(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+) -> None:
+    _run_mhc_pre_partial_launch(
+        residual=residual,
+        fn=fn,
+        partials=partials,
+        out=out,
+        compute_gram=compute_gram,
+    )
+
+
+@_mhc_pre_partial_launch_op.register_fake
+def _mhc_pre_partial_launch_fake(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool,
+) -> None:
+    return None
+
+
+def run_mhc_pre_partial(
+    *,
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    partials: torch.Tensor,
+    out: torch.Tensor,
+    compute_gram: bool = False,
+) -> None:
+    torch.ops.flashinfer_sm12x.mhc_pre_partial_launch(
+        residual,
+        fn,
+        partials,
+        out,
+        bool(compute_gram),
+    )
+
+
+def _run_mhc_finalize_gram_launch(
+    *,
+    residual: torch.Tensor,
+    partials: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    y: torch.Tensor,
+    post: torch.Tensor,
+    comb: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    fuse_norm: bool,
+    compact_partials: bool = False,
+    compact_projection_splits: int = 1,
+    active_source_splits: int = 0,
+) -> None:
+    rms_eps = float(rms_eps)
+    hc_eps = float(hc_eps)
+    sinkhorn_iters = int(sinkhorn_iters)
+    norm_eps = float(norm_eps)
+    fuse_norm = bool(fuse_norm)
+    compact_partials = bool(compact_partials)
+    compact_projection_splits = int(compact_projection_splits)
+    active_source_splits = int(active_source_splits)
+    norm_weight_tensor = _norm_weight_kernel_tensor(
+        norm_weight if fuse_norm else None,
+        y,
+    )
+    tokens = int(residual.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = int(partials.shape[1])
+    _validate_split_k(hidden_size, split_k)
+    single_cta_threads = (
+        0
+        if compact_partials
+        else _selected_mhc_decode_finalize_threads(
+            num_tokens=tokens,
+            hidden_size=hidden_size,
+        )
+    )
+    single_cta = single_cta_threads > 0
+    raw_single_cta_groups = os.environ.get(
+        "FLASHINFER_EXP_SM12X_MHC_DECODE_FINALIZE_CTAS"
+    )
+    single_cta_groups = 1
+    if single_cta:
+        single_cta_groups = (
+            int(raw_single_cta_groups)
+            if raw_single_cta_groups is not None
+            else 8
+            if single_cta_threads == 128 and tokens >= 10
+            else 1
+        )
+    _validate_tensor_shape("residual", residual, (tokens, _MHC_MULT, hidden_size))
+    _validate_tensor_shape("partials", partials, (tokens, split_k, _PARTIALS))
+    _validate_tensor_shape("scale", scale, (3,))
+    _validate_tensor_shape("bias", bias, (_MIXES,))
+    _validate_tensor_shape("y", y, (tokens, hidden_size))
+    _validate_tensor_shape("post", post, (tokens, _MHC_MULT))
+    _validate_tensor_shape("comb", comb, (tokens, _MHC_MULT, _MHC_MULT))
+    if fuse_norm:
+        _validate_tensor_shape("norm_weight", norm_weight, (hidden_size,))
+    args = (
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            partials,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(scale, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(bias, cutlass.Float32, assumed_align=4),
+        _to_kernel_tensor(y, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(
+            post,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        _to_kernel_tensor(
+            comb,
+            cutlass.Float32,
+            assumed_align=4,
+            dynamic_layout=True,
+        ),
+        norm_weight_tensor,
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    norm_weight_key = (
+        tensor_key(
+            "norm_weight",
+            norm_weight,
+            dims=(DimKey.exact(hidden_size),),
+        )
+        if fuse_norm
+        else ("norm_weight", None)
+    )
+    common_key_tail = (
+        (
+            "impl",
+            "prefill_finalize_gram_bf16x2_io_v3"
+            if compact_partials
+            else (
+                "finalize_gram_single_cta_bf16x2_io_v2"
+                if single_cta
+                else "finalize_gram_multicta_v2"
+            ),
+        ),
+        ("math", "fast_exp_exact_sigmoid_rcp_approx_sinkhorn"),
+        ("fuse_norm", fuse_norm),
+        ("compact_partials", compact_partials),
+        ("compact_projection_splits", compact_projection_splits),
+        ("single_cta", single_cta),
+        ("single_cta_threads", single_cta_threads),
+        ("single_cta_groups", single_cta_groups),
+        ("active_source_splits", active_source_splits),
+        ("pdl", _MHC_PDL),
+        ("norm_eps", norm_eps if fuse_norm else 0.0),
+        rms_eps,
+        hc_eps,
+        sinkhorn_iters,
+        tensor_key(
+            "residual",
+            residual,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(hidden_size),
+            ),
+        ),
+        tensor_key(
+            "partials",
+            partials,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(split_k),
+                DimKey.exact(_PARTIALS),
+            ),
+        ),
+        tensor_key("scale", scale, dims=(DimKey.exact(3),)),
+        tensor_key("bias", bias, dims=(DimKey.exact(_MIXES),)),
+        tensor_key(
+            "y",
+            y,
+            dims=(DimKey.dynamic(), DimKey.exact(hidden_size)),
+        ),
+        tensor_key(
+            "post",
+            post,
+            dims=(DimKey.dynamic(), DimKey.exact(_MHC_MULT)),
+        ),
+        tensor_key(
+            "comb",
+            comb,
+            dims=(
+                DimKey.dynamic(),
+                DimKey.exact(_MHC_MULT),
+                DimKey.exact(_MHC_MULT),
+            ),
+        ),
+        norm_weight_key,
+    )
+    hidden_specialization = _hidden_specialization_name(hidden_size)
+    if hidden_size == _HIDDEN and split_k == _SPLIT_K:
+        suffix = "_compact" if compact_partials else ""
+        if single_cta:
+            suffix = f"_single_cta_t{single_cta_threads}g{single_cta_groups}"
+        compile_name = f"integration.residual.mhc_finalize_gram_hidden4096{suffix}"
+        compile_key = (
+            (
+                "block_h",
+                single_cta_threads
+                if single_cta
+                else (_PREFILL_FINALIZE_THREADS if compact_partials else _GRAM_BLOCK_H),
+            ),
+            ("source_tiles", _SOURCE_TILES),
+            ("gram_row0", _GRAM_ROW0),
+            *common_key_tail,
+        )
+    else:
+        suffix = "_compact" if compact_partials else ""
+        if single_cta:
+            suffix = f"_single_cta_t{single_cta_threads}g{single_cta_groups}"
+        compile_name = (
+            f"integration.residual.mhc_finalize_gram_{hidden_specialization}{suffix}"
+        )
+        compile_key = (
+            ("hidden_size", hidden_size),
+            ("split_k", split_k),
+            (
+                "block_h",
+                single_cta_threads
+                if single_cta
+                else (_PREFILL_FINALIZE_THREADS if compact_partials else _GRAM_BLOCK_H),
+            ),
+            ("source_tiles", hidden_size // _SOURCE_TILE_H),
+            ("gram_row0", hidden_size // _SOURCE_TILE_H),
+            *common_key_tail,
+        )
+    sm12x_launch(
+        _finalize_gram_kernel(
+            hidden_size,
+            split_k,
+            rms_eps,
+            hc_eps,
+            sinkhorn_iters,
+            norm_eps,
+            fuse_norm,
+            compact_partials,
+            compact_projection_splits,
+            single_cta,
+            single_cta_threads if single_cta else _PREFILL_FINALIZE_THREADS,
+            single_cta_groups,
+            active_source_splits,
+        ),
+        compile_spec=KernelCompileSpec.from_key(compile_name, 3, compile_key),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_finalize_gram_launch",
+    mutates_args=("y", "post", "comb"),
+)
+def _mhc_finalize_gram_launch_op(
+    residual: torch.Tensor,
+    partials: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    y: torch.Tensor,
+    post: torch.Tensor,
+    comb: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+    compact_partials: bool,
+    compact_projection_splits: int,
+    active_source_splits: int,
+) -> None:
+    _run_mhc_finalize_gram_launch(
+        residual=residual,
+        partials=partials,
+        scale=scale,
+        bias=bias,
+        y=y,
+        post=post,
+        comb=comb,
+        rms_eps=rms_eps,
+        hc_eps=hc_eps,
+        sinkhorn_iters=sinkhorn_iters,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
+        fuse_norm=fuse_norm,
+        compact_partials=compact_partials,
+        compact_projection_splits=compact_projection_splits,
+        active_source_splits=active_source_splits,
+    )
+
+
+@_mhc_finalize_gram_launch_op.register_fake
+def _mhc_finalize_gram_launch_fake(
+    residual: torch.Tensor,
+    partials: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    y: torch.Tensor,
+    post: torch.Tensor,
+    comb: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+    compact_partials: bool,
+    compact_projection_splits: int,
+    active_source_splits: int,
+) -> None:
+    return None
+
+
+def run_mhc_finalize_gram(
+    *,
+    residual: torch.Tensor,
+    partials: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    y: torch.Tensor,
+    post: torch.Tensor,
+    comb: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None,
+    norm_eps: float,
+    compact_partials: bool = False,
+    compact_projection_splits: int = 1,
+    active_source_splits: int = 0,
+) -> None:
+    # When norm_weight is None the kernel ignores it (fuse_norm=False), but it
+    # still needs a valid tensor arg. Do NOT alias `y` here: `y` is a mutated arg
+    # of this op, and passing a mutated arg a second time as a read-only arg makes
+    # auto_functionalized's decomposition fail under torch.compile (the
+    # replace_by_example node-count assertion). Use a fresh, non-mutated
+    # placeholder with y's (kernel-proven) shape/dtype instead.
+    norm_weight_for_kernel = (
+        norm_weight if norm_weight is not None else torch.empty_like(y)
+    )
+    torch.ops.flashinfer_sm12x.mhc_finalize_gram_launch(
+        residual,
+        partials,
+        scale,
+        bias,
+        y,
+        post,
+        comb,
+        norm_weight_for_kernel,
+        float(rms_eps),
+        float(hc_eps),
+        int(sinkhorn_iters),
+        float(norm_eps),
+        norm_weight is not None,
+        bool(compact_partials),
+        int(compact_projection_splits),
+        int(active_source_splits),
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_launch_functional",
+    mutates_args=(),
+)
+def _mhc_post_launch_functional_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+) -> torch.Tensor:
+    out = torch.empty_like(residual)
+    if int(x.shape[0]) != 0:
+        _run_mhc_post_launch(
+            x=x,
+            residual=residual,
+            prev_post=prev_post,
+            prev_comb=prev_comb,
+            out=out,
+        )
+    return out
+
+
+@_mhc_post_launch_functional_op.register_fake
+def _mhc_post_launch_functional_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(residual)
+
+
+def run_mhc_post_functional(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+) -> torch.Tensor:
+    return torch.ops.flashinfer_sm12x.mhc_post_launch_functional(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_pre_launch_functional",
+    mutates_args=(),
+)
+def _mhc_pre_launch_functional_op(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    tokens = int(residual.shape[0])
+    hidden_size = int(residual.shape[1])
+    split_k = _split_k_for_hidden(hidden_size)
+    partials = torch.empty(
+        (tokens, split_k, _PARTIALS),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    y = torch.empty(
+        (tokens, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    post = torch.empty(
+        (tokens, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb = torch.empty(
+        (tokens, _MHC_MULT, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    out = torch.empty(
+        (tokens, _MHC_MULT, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    if tokens != 0:
+        _run_mhc_pre_partial_launch(
+            residual=residual,
+            fn=fn,
+            partials=partials,
+            out=out,
+            compute_gram=fuse_norm,
+        )
+        _run_mhc_finalize_gram_launch(
+            residual=out,
+            partials=partials,
+            scale=scale,
+            bias=bias,
+            y=y,
+            post=post,
+            comb=comb,
+            rms_eps=rms_eps,
+            hc_eps=hc_eps,
+            sinkhorn_iters=sinkhorn_iters,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+            fuse_norm=fuse_norm,
+        )
+    return out, post, comb, y
+
+
+@_mhc_pre_launch_functional_op.register_fake
+def _mhc_pre_launch_functional_fake(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    tokens = residual.shape[0]
+    hidden_size = residual.shape[1]
+    y = torch.empty(
+        (tokens, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    post = torch.empty(
+        (tokens, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb = torch.empty(
+        (tokens, _MHC_MULT, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    out = torch.empty(
+        (tokens, _MHC_MULT, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    return out, post, comb, y
+
+
+def run_mhc_pre_functional(
+    *,
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None,
+    norm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    norm_weight_for_kernel = norm_weight if norm_weight is not None else residual
+    return torch.ops.flashinfer_sm12x.mhc_pre_launch_functional(
+        residual,
+        fn,
+        scale,
+        bias,
+        norm_weight_for_kernel,
+        float(rms_eps),
+        float(hc_eps),
+        int(sinkhorn_iters),
+        float(norm_eps),
+        norm_weight is not None,
+    )
+
+
+@torch.library.custom_op(
+    "flashinfer_sm12x::mhc_post_pre_launch_functional",
+    mutates_args=(),
+)
+def _mhc_post_pre_launch_functional_op(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    tokens = int(residual.shape[0])
+    hidden_size = int(residual.shape[2])
+    split_k = _split_k_for_hidden(hidden_size)
+    partials = torch.empty(
+        (tokens, split_k, _PARTIALS),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    residual_out = torch.empty_like(residual)
+    y = torch.empty(
+        (tokens, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    post = torch.empty(
+        (tokens, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb = torch.empty(
+        (tokens, _MHC_MULT, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    if tokens != 0:
+        _run_mhc_post_pre_partial_launch(
+            x=x,
+            residual=residual,
+            prev_post=prev_post,
+            prev_comb=prev_comb,
+            fn=fn,
+            partials=partials,
+            out=residual_out,
+            compute_gram=fuse_norm,
+        )
+        decode_source_splits, _ = _selected_post_pre_decode_split_n(
+            num_tokens=tokens,
+            hidden_size=hidden_size,
+        )
+        _run_mhc_finalize_gram_launch(
+            residual=residual_out,
+            partials=partials,
+            scale=scale,
+            bias=bias,
+            y=y,
+            post=post,
+            comb=comb,
+            rms_eps=rms_eps,
+            hc_eps=hc_eps,
+            sinkhorn_iters=sinkhorn_iters,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+            fuse_norm=fuse_norm,
+            active_source_splits=decode_source_splits,
+        )
+    return residual_out, post, comb, y
+
+
+@_mhc_post_pre_launch_functional_op.register_fake
+def _mhc_post_pre_launch_functional_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    fuse_norm: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    tokens = residual.shape[0]
+    hidden_size = residual.shape[2]
+    residual_out = torch.empty_like(residual)
+    y = torch.empty(
+        (tokens, hidden_size),
+        dtype=residual.dtype,
+        device=residual.device,
+    )
+    post = torch.empty(
+        (tokens, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb = torch.empty(
+        (tokens, _MHC_MULT, _MHC_MULT),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    return residual_out, post, comb, y
+
+
+def run_mhc_post_pre_functional(
+    *,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    prev_post: torch.Tensor,
+    prev_comb: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None,
+    norm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    norm_weight_for_kernel = norm_weight if norm_weight is not None else residual
+    return torch.ops.flashinfer_sm12x.mhc_post_pre_launch_functional(
+        x,
+        residual,
+        prev_post,
+        prev_comb,
+        fn,
+        scale,
+        bias,
+        norm_weight_for_kernel,
+        float(rms_eps),
+        float(hc_eps),
+        int(sinkhorn_iters),
+        float(norm_eps),
+        norm_weight is not None,
+    )
+
+
+__all__ = [
+    "run_mhc_finalize_gram",
+    "run_mhc_post",
+    "run_mhc_post_functional",
+    "run_mhc_pre_functional",
+    "run_mhc_post_pre_functional",
+    "run_mhc_pre_partial",
+    "run_mhc_post_pre_partial",
+    "run_mhc_post_pre_partial_alloc",
+]

--- a/flashinfer/experimental/sm12x/norm/mhc/api.py
+++ b/flashinfer/experimental/sm12x/norm/mhc/api.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for norm.mhc (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from ._impl import (
+    MHC_DEFAULT_BLOCK_H as DEFAULT_BLOCK_H,
+)
+from ._impl import (
+    MHC_DEFAULT_BLOCK_K as DEFAULT_BLOCK_K,
+)
+from ._impl import (
+    MHC_DEFAULT_SPLIT_K as DEFAULT_SPLIT_K,
+)
+from ._impl import (
+    MHC_MIXES as MIXES,
+)
+from ._impl import (
+    MHC_MULT as MULT,
+)
+from ._impl import (
+    MHC_PARTIALS as PARTIALS,
+)
+from ._impl import (
+    SM12XMHCBinding as Binding,
+)
+from ._impl import (
+    SM12XMHCScratchCaps as Caps,
+)
+from ._impl import (
+    SM12XMHCScratchPlan as Plan,
+)
+from ._impl import (
+    plan_mhc_scratch as plan,
+)
+from ._impl import (
+    sm12x_mhc_post as run_post,
+)
+from ._impl import (
+    sm12x_mhc_post_pre as run_post_pre,
+)
+from ._impl import (
+    sm12x_mhc_pre as run_pre,
+)
+from . import META
+
+
+def bind(plan: Plan, **kwargs) -> Binding:
+    """Bind runtime tensors and caller-owned scratch to a plan.
+
+    Views only — never allocates — so it is CUDA-graph-capture safe.
+    Delegates to ``plan.bind(**kwargs)``.
+    """
+    return plan.bind(**kwargs)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = [
+    "Caps",
+    "Plan",
+    "Binding",
+    "plan",
+    "bind",
+    "run_pre",
+    "run_post",
+    "run_post_pre",
+    "MIXES",
+    "MULT",
+    "PARTIALS",
+    "DEFAULT_SPLIT_K",
+    "DEFAULT_BLOCK_K",
+    "DEFAULT_BLOCK_H",
+    "is_supported",
+]

--- a/flashinfer/experimental/sm12x/quantization/__init__.py
+++ b/flashinfer/experimental/sm12x/quantization/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Quantization ops for flashinfer.experimental.sm12x.
+
+- ``mxfp8``: BF16/FP16 rows -> dense-GEMM MXFP8 layout (one-shot CuTe kernel).
+- ``nvfp4``: BF16 -> packed NVFP4 + e4m3 MMA-layout scales (TMA tile kernel;
+  revived by the CUTLASS DSL 4.6 migration).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_OP_MODULES = ("mxfp8", "nvfp4")
+
+
+def __getattr__(name: str) -> Any:
+    if name in _OP_MODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(_OP_MODULES)
+
+
+__all__ = list(_OP_MODULES)

--- a/flashinfer/experimental/sm12x/quantization/mxfp8/__init__.py
+++ b/flashinfer/experimental/sm12x/quantization/mxfp8/__init__.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""BF16/FP16 row quantization into the dense-GEMM MXFP8 layout (one-shot).
+
+Writes packed e4m3 values plus both scale layouts (row-major e8m0 and the
+MMA-swizzled physical layout) into caller-provided output tensors — no
+allocation, CUDA-graph safe.
+
+Example:
+    from flashinfer.experimental.sm12x.quantization import mxfp8
+
+    mxfp8.quantize_rows(x, values, scale_rows, scale_mma)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="mxfp8",
+    group="quantization",
+    api_style="oneshot",
+    entry_points=("quantize_rows", "is_supported"),
+    dtypes=("bf16", "fp16"),
+    recipes=("mxfp8",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/gemm/mxfp8_quant_cute.py",),
+    ),
+    test_path="tests/experimental/quantization/test_mxfp8.py",
+    since="0.7.0",
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import is_supported, quantize_rows  # noqa: F401
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/quantization/mxfp8/api.py
+++ b/flashinfer/experimental/sm12x/quantization/mxfp8/api.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for quantization.mxfp8 (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from ..._lib.gating import default_is_supported
+from ..._lib.quant.mxfp8_rows import (
+    quantize_mxfp8_rows_cute as quantize_rows,
+)
+from . import META
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = ["quantize_rows", "is_supported"]

--- a/flashinfer/experimental/sm12x/quantization/nvfp4/__init__.py
+++ b/flashinfer/experimental/sm12x/quantization/nvfp4/__init__.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""BF16 -> NVFP4 TMA tile quantizer for SM12x.
+
+Quantizes a [M, K] BF16 tensor (M, K multiples of 128) into packed FP4
+values plus e4m3 scales in the dense-GEMM MMA layout (sf vec 16), using a
+128x128 TMA tile kernel. ``plan(m, k)`` compiles the shape (host-side,
+cached); ``allocate_outputs`` sizes the output pair; ``run`` launches into
+the caller's outputs (allocation-free, capture safe). There is no bind step:
+the outputs container is the binding.
+
+Example:
+    from flashinfer.experimental.sm12x.quantization import nvfp4
+
+    plan = nvfp4.plan(m=256, k=512)
+    outs = nvfp4.allocate_outputs(plan)
+    nvfp4.run(plan=plan, x=x_bf16, global_scale=gs, outputs=outs)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="nvfp4",
+    group="quantization",
+    api_style="planned",
+    entry_points=(
+        "Outputs",
+        "Plan",
+        "plan",
+        "allocate_outputs",
+        "run",
+        "is_supported",
+    ),
+    dtypes=("bf16",),
+    recipes=("nvfp4",),
+    provenance=Provenance(
+        repo="https://github.com/lukealonso/b12x",
+        commit="6627d342",
+        paths=("b12x/quantization/",),
+    ),
+    test_path="tests/experimental/quantization/test_nvfp4.py",
+    since="0.7.0",
+    notes=(
+        "No bind step: outputs are caller-allocated via allocate_outputs. "
+        "Dead at the original port baseline; revived by the CUTLASS DSL 4.6 "
+        "migration."
+    ),
+)
+
+if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+    from .api import (  # noqa: F401
+        Outputs,
+        Plan,
+        allocate_outputs,
+        is_supported,
+        plan,
+        run,
+    )
+
+install_lazy_api(globals(), META)

--- a/flashinfer/experimental/sm12x/quantization/nvfp4/_impl.py
+++ b/flashinfer/experimental/sm12x/quantization/nvfp4/_impl.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/quantization/__init__.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""BF16 → NVFP4 TMA quantization kernel API."""
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from flashinfer.experimental.sm12x._lib.compiler import (
+    KernelCompileSpec,
+    compile as sm12x_compile,
+)
+from flashinfer.experimental.sm12x._lib.intrinsics import align_up
+from flashinfer.experimental.sm12x._lib.utils import (
+    current_cuda_stream,
+    get_max_active_clusters,
+    get_num_sm,
+    make_ptr,
+)
+from flashinfer.experimental.sm12x.quantization.nvfp4._kernel import TestKernel
+from flashinfer.experimental.sm12x._lib.runtime_control import (
+    raise_if_kernel_resolution_frozen,
+)
+
+_TILE_M = 128
+_TILE_K = 128
+_SF_VEC_SIZE = 16
+_KERNEL_CACHE: Dict[Tuple, object] = {}
+
+
+def _validate_tiled_shape(M: int, K: int) -> None:
+    if M <= 0 or K <= 0:
+        raise ValueError(f"M and K must be positive, got M={M}, K={K}")
+    if M % _TILE_M != 0 or K % _TILE_K != 0:
+        raise ValueError(
+            f"M and K must be multiples of ({_TILE_M}, {_TILE_K}), got M={M}, K={K}"
+        )
+
+
+def _validate_launch_tensor(
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    device: torch.device,
+) -> None:
+    if tensor.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+    if tuple(tensor.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {tuple(tensor.shape)}")
+    if tensor.device != device or tensor.device.type != "cuda":
+        raise ValueError(f"{name} must be on {device}, got {tensor.device}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _contiguous_byte_interval(tensor: torch.Tensor) -> tuple[int, int]:
+    begin = (
+        tensor.untyped_storage().data_ptr()
+        + tensor.storage_offset() * tensor.element_size()
+    )
+    return begin, begin + tensor.numel() * tensor.element_size()
+
+
+def _overlaps(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    lhs_begin, lhs_end = _contiguous_byte_interval(lhs)
+    rhs_begin, rhs_end = _contiguous_byte_interval(rhs)
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+
+@dataclass
+class BF16ToFP4TMAOutputs:
+    packed_a_storage: torch.Tensor
+    scale_storage: torch.Tensor
+    packed_a_view: object
+    sfa_ptr: object
+
+    @property
+    def packed_a_flat(self) -> torch.Tensor:
+        return self.packed_a_storage.view(-1)
+
+    @property
+    def scale_flat(self) -> torch.Tensor:
+        return self.scale_storage.view(-1)
+
+
+def allocate_bf16_to_fp4_tma_outputs(
+    M: int,
+    K: int,
+    *,
+    device: torch.device = torch.device("cuda"),
+) -> BF16ToFP4TMAOutputs:
+    _validate_tiled_shape(M, K)
+    rows_pad = align_up(M, _TILE_M)
+    cols_pad_sf = align_up(K // _SF_VEC_SIZE, 4)
+    packed_a_storage = torch.zeros(1, M, K // 2, dtype=torch.uint8, device=device)
+    scale_storage = torch.zeros(
+        rows_pad * cols_pad_sf, dtype=torch.uint8, device=device
+    )
+    packed_a_view = packed_a_storage.permute(1, 2, 0).view(torch.float4_e2m1fn_x2)
+    sfa_ptr = make_ptr(
+        cutlass.Float8E4M3FN,
+        scale_storage.data_ptr(),
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    return BF16ToFP4TMAOutputs(
+        packed_a_storage=packed_a_storage,
+        scale_storage=scale_storage,
+        packed_a_view=packed_a_view,
+        sfa_ptr=sfa_ptr,
+    )
+
+
+def compile_bf16_to_fp4_tma(M: int, K: int):
+    """Compile the BF16→FP4 TMA kernel for (M, K). Returns a launch callable.
+
+    The callable signature is: ``launch(bf16_input, global_scale, packed_a_flat, scale_flat)``
+    where packed_a_flat and scale_flat come from ``BF16ToFP4TMAOutputs``.
+    """
+    _validate_tiled_shape(M, K)
+    ab = cutlass.Float4E2M1FN
+    bf = cutlass.BFloat16
+    bf16_fake = cute.runtime.make_fake_compact_tensor(
+        bf, (M, K), stride_order=(1, 0), assumed_align=16
+    )
+    gs_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32, (1,), assumed_align=4
+    )
+    pa_fake = cute.runtime.make_fake_compact_tensor(
+        ab, (M, K, 1), stride_order=(1, 0, 2), assumed_align=16
+    )
+    scale_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Uint8,
+        (M * K // _SF_VEC_SIZE,),
+        assumed_align=16,
+    )
+    mac = min(get_max_active_clusters(1), get_num_sm(torch.device("cuda")))
+    if M == _TILE_M:
+        # CUTLASS DSL 4.6 already lowers the register count for these shapes;
+        # retain their original instruction schedule.
+        liveness_strategy = "retain"
+    else:
+        # CUTLASS DSL 4.6 otherwise keeps two BF16-derived FP32 values live
+        # across exact scale division.  Preserve the pair losslessly in one
+        # raw register to shorten that live range without adding memory work.
+        liveness_strategy = "packed"
+    cache_key = (M, K, liveness_strategy, mac)
+    cached = _KERNEL_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    kernel = TestKernel(liveness_strategy)
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    from cutlass.base_dsl.compiler import OptLevel
+
+    raw = sm12x_compile(
+        kernel,
+        bf16_fake,
+        gs_fake,
+        pa_fake,
+        scale_fake,
+        mac,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "quantization.bf16_to_fp4_tma",
+            2,
+            cache_key,
+            labels=("M", "K", "liveness_strategy", "mac"),
+        ),
+        dsl_compile_options=OptLevel(1),
+    )
+
+    def launch(bf16_input, global_scale, packed_a_flat, scale_flat):
+        device = bf16_input.device
+        _validate_launch_tensor(
+            bf16_input,
+            name="bf16_input",
+            dtype=torch.bfloat16,
+            shape=(M, K),
+            device=device,
+        )
+        _validate_launch_tensor(
+            global_scale,
+            name="global_scale",
+            dtype=torch.float32,
+            shape=(1,),
+            device=device,
+        )
+        _validate_launch_tensor(
+            packed_a_flat,
+            name="packed_a_flat",
+            dtype=torch.uint8,
+            shape=(M * K // 2,),
+            device=device,
+        )
+        _validate_launch_tensor(
+            scale_flat,
+            name="scale_flat",
+            dtype=torch.uint8,
+            shape=(M * K // _SF_VEC_SIZE,),
+            device=device,
+        )
+        if _overlaps(packed_a_flat, scale_flat):
+            raise ValueError("packed_a_flat and scale_flat must not overlap")
+        if _overlaps(bf16_input, packed_a_flat) or _overlaps(bf16_input, scale_flat):
+            raise ValueError("bf16_input must not overlap either output")
+        if _overlaps(global_scale, packed_a_flat) or _overlaps(
+            global_scale, scale_flat
+        ):
+            raise ValueError("global_scale must not overlap either output")
+        pa_view = (
+            packed_a_flat.view(1, M, K // 2)
+            .permute(1, 2, 0)
+            .view(torch.float4_e2m1fn_x2)
+        )
+        raw(bf16_input, global_scale, pa_view, scale_flat, current_cuda_stream())
+
+    _KERNEL_CACHE[cache_key] = launch
+    return launch

--- a/flashinfer/experimental/sm12x/quantization/nvfp4/_kernel.py
+++ b/flashinfer/experimental/sm12x/quantization/nvfp4/_kernel.py
@@ -1,0 +1,522 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+# Ported from b12x b12x/quantization/bf16_to_fp4_tma.py @ 6627d342 (2026-07-19) -- one-time curated port.
+# Upstream b12x is a research sandbox; this tree is the canonical home.
+"""Standalone BF16→FP4 quantization with a TMA packed-output store."""
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+import cuda.bindings.driver as cuda
+from cutlass.cutlass_dsl import Int32, Uint8, Uint32, Uint64, Float32, T, dsl_user_op
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync
+
+
+@dsl_user_op
+def fabs_f32(a, *, loc=None, ip=None):
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "abs.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fmax_f32(a, b, *, loc=None, ip=None):
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            "max.f32 $0, $1, $2;",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fmin_f32(a, b, *, loc=None, ip=None):
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            "min.f32 $0, $1, $2;",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def rcp_approx_ftz(a, *, loc=None, ip=None):
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "rcp.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def rcp_rn_f32(a, *, loc=None, ip=None):
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "{\n.reg .f32 one;\nmov.f32 one, 0f3F800000;\ndiv.rn.f32 $0, one, $1;\n}",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def ld_global_bf16x2(tensor, coord, *, loc=None, ip=None):
+    """Load two adjacent BF16 values as one raw 32-bit register."""
+    elem_ptr = tensor.iterator + cute.crd2idx(coord, tensor.layout, loc=loc, ip=ip)
+    address = llvm.ptrtoint(T.i64(), elem_ptr.llvm_ptr, loc=loc, ip=ip)
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [address],
+            "ld.global.b32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_bf16x2_to_f32x2(packed, *, loc=None, ip=None):
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(packed).ir_value(loc=loc, ip=ip)],
+        "{ .reg .b16 lo, hi; mov.b32 {lo, hi}, $2; "
+        "cvt.f32.bf16 $0, lo; cvt.f32.bf16 $1, hi; }",
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def cvt_bf16x2_to_f32x2_scaled(packed, scale, *, loc=None, ip=None):
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [
+            Uint32(packed).ir_value(loc=loc, ip=ip),
+            Float32(scale).ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b16 lo, hi; .reg .f32 flo, fhi; "
+        "mov.b32 {lo, hi}, $2; cvt.f32.bf16 flo, lo; "
+        "cvt.f32.bf16 fhi, hi; mul.rn.f32 $0, flo, $3; "
+        "mul.rn.f32 $1, fhi, $3; }",
+        "=f,=f,r,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def cvt_f32_to_e4m3(a, *, loc=None, ip=None):
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "{\n.reg .b16 fp8_pair;\n.reg .f32 zero;\nmov.f32 zero, 0f00000000;\ncvt.rn.satfinite.e4m3x2.f32 fp8_pair, zero, $1;\ncvt.u32.u16 $0, fp8_pair;\n}",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fp8_e4m3_to_f32_and_effective_rcp(
+    fp8_val, global_scale_recip, *, loc=None, ip=None
+):
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Uint32(fp8_val).ir_value(loc=loc, ip=ip),
+                Float32(global_scale_recip).ir_value(loc=loc, ip=ip),
+            ],
+            "{\n.reg .pred p_zero, p_subnormal;\n.reg .u32 exp_u, mant_u;\n.reg .s32 exp_s;\n.reg .f32 exp_f, mant_f, fp8_float, one, denom, result;\n"
+            "setp.eq.u32 p_zero, $1, 0;\nand.b32 mant_u, $1, 7;\nshr.b32 exp_u, $1, 3;\nand.b32 exp_u, exp_u, 15;\n"
+            "setp.eq.u32 p_subnormal, exp_u, 0;\nsub.s32 exp_s, exp_u, 7;\nselp.s32 exp_s, -6, exp_s, p_subnormal;\n"
+            "cvt.rn.f32.s32 exp_f, exp_s;\nex2.approx.f32 exp_f, exp_f;\n"
+            "cvt.rn.f32.u32 mant_f, mant_u;\nselp.f32 fp8_float, 0f00000000, 0f3F800000, p_subnormal;\n"
+            "fma.rn.f32 mant_f, mant_f, 0f3E000000, fp8_float;\n"
+            "mul.f32 fp8_float, exp_f, mant_f;\nmov.f32 one, 0f3F800000;\n"
+            "mul.rn.f32 denom, fp8_float, $2;\ndiv.rn.f32 result, one, denom;\n"
+            "selp.f32 $0, 0f00000000, result, p_zero;\n}",
+            "=f,r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_e2m1x8_f32(v0, v1, v2, v3, v4, v5, v6, v7, *, loc=None, ip=None):
+    args = [
+        Float32(v).ir_value(loc=loc, ip=ip) for v in [v0, v1, v2, v3, v4, v5, v6, v7]
+    ]
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            args,
+            "{\n.reg .b8 byte0, byte1, byte2, byte3;\n"
+            "cvt.rn.satfinite.e2m1x2.f32 byte0, $2, $1;\ncvt.rn.satfinite.e2m1x2.f32 byte1, $4, $3;\n"
+            "cvt.rn.satfinite.e2m1x2.f32 byte2, $6, $5;\ncvt.rn.satfinite.e2m1x2.f32 byte3, $8, $7;\n"
+            "mov.b32 $0, {byte0, byte1, byte2, byte3};\n}",
+            "=r,f,f,f,f,f,f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def canonicalize_fp4_zero_signs(packed: Uint32) -> Uint32:
+    """Clear the sign bit on FP4 values whose magnitude rounded to zero."""
+    magnitude = packed & Uint32(0x77777777)
+    nonzero = magnitude | (magnitude >> Uint32(1)) | (magnitude >> Uint32(2))
+    nonzero = nonzero & Uint32(0x11111111)
+    return packed & (Uint32(0x77777777) | (nonzero << Uint32(3)))
+
+
+@cute.jit
+def quantize_scale_fp4_fast(max_abs, global_scale_val, global_scale_recip):
+    scale_u32 = Uint32(0)
+    scale_byte = Uint8(0)
+    effective_recip = Float32(0.0)
+    if global_scale_val != Float32(0.0):
+        fp4_max_rcp = rcp_approx_ftz(Float32(6.0))
+        scale_float = global_scale_val * (max_abs * fp4_max_rcp)
+        scale_float = fmin_f32(scale_float, Float32(448.0))
+        scale_u32 = cvt_f32_to_e4m3(scale_float)
+        scale_byte = Uint8(scale_u32 & Uint32(0xFF))
+        effective_recip = fp8_e4m3_to_f32_and_effective_rcp(
+            scale_u32,
+            global_scale_recip,
+        )
+    return effective_recip, scale_byte
+
+
+class TestKernel:
+    def __init__(self, liveness_strategy: str):
+        if liveness_strategy not in {"retain", "packed"}:
+            raise ValueError(
+                f"unsupported BF16->FP4 liveness strategy: {liveness_strategy}"
+            )
+        self.liveness_strategy = liveness_strategy
+        self.tile_shape_mnk = (128, 128, 128)
+        self.threads_per_cta = 128
+        self.num_mma_warps = 4
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * 32,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        bf16_input: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_a: cute.Tensor,
+        scale_storage: cute.Tensor,
+        mac: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        ab = cutlass.Float4E2M1FN
+        fp4_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(utils.LayoutEnum.ROW_MAJOR, ab, 128), ab
+        )
+        fp4_staged = cute.tile_to_shape(fp4_atom, (128, 128, 1), order=(0, 1, 2))
+        fp4_smem1 = cute.slice_(fp4_staged, (None, None, 0))
+        tile_mk = cute.slice_(self.tile_shape_mnk, (None, 0, None))
+        tma_store_a, gOA = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(), packed_a, fp4_smem1, tile_mk
+        )
+        self.kernel(
+            bf16_input,
+            tma_store_a,
+            gOA,
+            global_scale,
+            scale_storage,
+            fp4_staged,
+            cute.cosize(fp4_staged),
+        ).launch(
+            grid=(mac, 1, 1),
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mInput: cute.Tensor,
+        tma_store_a: cute.CopyAtom,
+        mOA: cute.Tensor,
+        global_scale: cute.Tensor,
+        scale_storage: cute.Tensor,
+        fp4_smem: cute.ComposedLayout,
+        fp4_cs: cutlass.Constexpr,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        warp_idx = tidx // Int32(32)
+
+        M = Int32(mInput.shape[0])
+        K = Int32(mInput.shape[1])
+        k_tiles = K // Int32(128)
+        total_tiles = (M // Int32(128)) * k_tiles
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class S:
+            sFP4: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float4E2M1FN, fp4_cs], 1024
+            ]
+            # Four scale bytes are written directly to global memory so this
+            # rounded reciprocal slot stays inside the existing 9 KiB bucket.
+            sScale: cute.struct.Align[cute.struct.MemRange[cutlass.Uint8, 1020], 1024]
+            sGlobalScaleRecip: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, 1], 4
+            ]
+
+        st = smem.allocate(S)
+        sFP4 = st.sFP4.get_tensor(fp4_smem.outer, swizzle=fp4_smem.inner)
+        sScale = st.sScale.get_tensor(cute.make_layout(1020))
+        sGlobalScaleRecip = st.sGlobalScaleRecip.get_tensor(cute.make_layout(1))
+        sA_u8 = cute.recast_tensor(sFP4[None, None, 0], cutlass.Uint8)
+
+        cta_layout = cute.make_layout(1)
+        tile_mk = cute.slice_(self.tile_shape_mnk, (None, 0, None))
+        gOA = cute.local_tile(mOA, tile_mk, (None, None, None))
+        bSsA, bSgA = cpasync.tma_partition(
+            tma_store_a,
+            0,
+            cta_layout,
+            cute.group_modes(sFP4, 0, 2),
+            cute.group_modes(gOA, 0, 2),
+        )
+
+        store_pipeline = pipeline.PipelineTmaStore.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.num_mma_warps * 32
+            ),
+        )
+
+        if tidx == Int32(0):
+            cta_global_scale = global_scale[Int32(0)].to(cutlass.Float32)
+            global_scale_recip = cutlass.Float32(0.0)
+            if cta_global_scale != cutlass.Float32(0.0):
+                global_scale_recip = rcp_rn_f32(cta_global_scale)
+            sGlobalScaleRecip[Int32(0)] = global_scale_recip
+            cpasync.prefetch_descriptor(tma_store_a)
+        cute.arch.sync_threads()
+
+        tile_idx = Int32(bidx)
+
+        while tile_idx < total_tiles:
+            mt = tile_idx // k_tiles
+            kt = tile_idx % k_tiles
+            scale_tile_base = mt * (K * Int32(8)) + kt * Int32(1024)
+
+            blk = Int32(tidx)
+            while blk < Int32(128 * 8):
+                row = blk // Int32(8)
+                sf_col = blk % Int32(8)
+                col0 = sf_col * Int32(16)
+                bmax = cutlass.Float32(0.0)
+                packed_bf16x2 = Uint32(0)
+                if cutlass.const_expr(self.liveness_strategy == "packed"):
+                    # Keep the final adjacent pair in its lossless packed
+                    # representation across the exact scale division.  This
+                    # shortens two FP32 live ranges without adding loads.
+                    for e in cutlass.range_constexpr(14):
+                        coord = (
+                            mt * Int32(128) + row,
+                            kt * Int32(128) + col0 + Int32(e),
+                        )
+                        v = cutlass.Float32(mInput[coord])
+                        bmax = fmax_f32(bmax, fabs_f32(v))
+                    packed_bf16x2 = ld_global_bf16x2(
+                        mInput,
+                        (
+                            mt * Int32(128) + row,
+                            kt * Int32(128) + col0 + Int32(14),
+                        ),
+                    )
+                    pair0, pair1 = cvt_bf16x2_to_f32x2(packed_bf16x2)
+                    bmax = fmax_f32(bmax, fabs_f32(pair0))
+                    bmax = fmax_f32(bmax, fabs_f32(pair1))
+                else:
+                    # The 4.6 compiler already improves M == 128 codegen, so
+                    # retain its original instruction schedule unchanged.
+                    for e in cutlass.range_constexpr(16):
+                        coord = (
+                            mt * Int32(128) + row,
+                            kt * Int32(128) + col0 + Int32(e),
+                        )
+                        v = cutlass.Float32(mInput[coord])
+                        bmax = fmax_f32(bmax, fabs_f32(v))
+                block_global_scale = global_scale[Int32(0)].to(cutlass.Float32)
+                global_scale_recip = sGlobalScaleRecip[Int32(0)]
+                effective_recip, sbyte = quantize_scale_fp4_fast(
+                    bmax,
+                    block_global_scale,
+                    global_scale_recip,
+                )
+                p64 = Uint64(0)
+                if effective_recip != Float32(0.0):
+                    q = cute.make_rmem_tensor((8,), Float32)
+                    for e in cutlass.range_constexpr(8):
+                        q[e] = (
+                            cutlass.Float32(
+                                mInput[
+                                    mt * Int32(128) + row,
+                                    kt * Int32(128) + col0 + Int32(e),
+                                ]
+                            )
+                            * effective_recip
+                        )
+                    packed_lo = canonicalize_fp4_zero_signs(
+                        cvt_e2m1x8_f32(
+                            q[0],
+                            q[1],
+                            q[2],
+                            q[3],
+                            q[4],
+                            q[5],
+                            q[6],
+                            q[7],
+                        )
+                    )
+                    if cutlass.const_expr(self.liveness_strategy == "packed"):
+                        for e in cutlass.range_constexpr(6):
+                            q[e] = (
+                                cutlass.Float32(
+                                    mInput[
+                                        mt * Int32(128) + row,
+                                        kt * Int32(128) + col0 + Int32(8 + e),
+                                    ]
+                                )
+                                * effective_recip
+                            )
+                        q[6], q[7] = cvt_bf16x2_to_f32x2_scaled(
+                            packed_bf16x2,
+                            effective_recip,
+                        )
+                    else:
+                        for e in cutlass.range_constexpr(8):
+                            q[e] = (
+                                cutlass.Float32(
+                                    mInput[
+                                        mt * Int32(128) + row,
+                                        kt * Int32(128) + col0 + Int32(8 + e),
+                                    ]
+                                )
+                                * effective_recip
+                            )
+                    packed_hi = canonicalize_fp4_zero_signs(
+                        cvt_e2m1x8_f32(
+                            q[0],
+                            q[1],
+                            q[2],
+                            q[3],
+                            q[4],
+                            q[5],
+                            q[6],
+                            q[7],
+                        )
+                    )
+                    p64 = (Uint64(packed_hi) << Uint64(32)) | Uint64(packed_lo)
+                om = row % Int32(32)
+                im = row // Int32(32)
+                ik = sf_col % Int32(4)
+                ktile = sf_col // Int32(4)
+                sf_off = ktile * Int32(512) + om * Int32(16) + im * Int32(4) + ik
+                if sf_off < Int32(1020):
+                    sScale[sf_off] = sbyte
+                else:
+                    scale_storage[scale_tile_base + sf_off] = sbyte
+                pb = sf_col << Int32(3)
+                dpc = row & Int32(63)
+                xor = ((dpc >> Int32(1)) & Int32(0x3)) << Int32(4)
+                rhi = row >> Int32(6)
+                for bi in cutlass.range_constexpr(8):
+                    spc = pb + Int32(bi)
+                    dr = ((spc ^ xor) << Int32(1)) + rhi
+                    flat = dr * Int32(64) + dpc
+                    sA_u8[flat] = Uint8((p64 >> Uint64(bi * 8)) & Uint64(0xFF))
+                blk += Int32(self.num_mma_warps * 32)
+
+            cute.arch.fence_proxy("async.shared", space="cta")
+            self.epilog_sync_barrier.arrive_and_wait()
+            if warp_idx == Int32(0):
+                cute.copy(
+                    tma_store_a, bSsA[(None, Int32(0))], bSgA[(None, mt, kt, Int32(0))]
+                )
+                store_pipeline.producer_commit()
+                store_pipeline.producer_acquire()
+            scale_copy = Int32(tidx)
+            while scale_copy < Int32(1020):
+                scale_storage[scale_tile_base + scale_copy] = sScale[scale_copy]
+                scale_copy += Int32(self.num_mma_warps * 32)
+            self.epilog_sync_barrier.arrive_and_wait()
+
+            tile_idx += Int32(gdim)

--- a/flashinfer/experimental/sm12x/quantization/nvfp4/api.py
+++ b/flashinfer/experimental/sm12x/quantization/nvfp4/api.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Public surface for quantization.nvfp4 (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import torch
+
+from ..._lib.gating import default_is_supported
+from ._impl import (
+    BF16ToFP4TMAOutputs as Outputs,
+)
+from ._impl import (
+    allocate_bf16_to_fp4_tma_outputs as _allocate,
+)
+from ._impl import (
+    compile_bf16_to_fp4_tma as _compile,
+)
+from . import META
+
+
+@dataclass(frozen=True)
+class Plan:
+    """A compiled (m, k) shape; produced by :func:`plan`."""
+
+    m: int
+    k: int
+    launch: Callable[..., None]
+
+
+def plan(m: int, k: int) -> Plan:
+    """Compile the quantizer for (m, k); host-side, cached per shape."""
+    return Plan(m=int(m), k=int(k), launch=_compile(int(m), int(k)))
+
+
+def allocate_outputs(plan: Plan, *, device: torch.device | str = "cuda") -> Outputs:
+    """Allocate the packed-FP4 + MMA-layout-scale output pair for a plan."""
+    return _allocate(plan.m, plan.k, device=torch.device(device))
+
+
+def run(
+    *,
+    plan: Plan,
+    x: torch.Tensor,
+    global_scale: torch.Tensor,
+    outputs: Outputs,
+) -> None:
+    """Quantize ``x`` into ``outputs`` (allocation-free, capture safe)."""
+    plan.launch(x, global_scale, outputs.packed_a_flat, outputs.scale_flat)
+
+
+def is_supported(device=None) -> bool:
+    """True on SM120/SM121 with nvidia-cutlass-dsl >= 4.6.0."""
+    return default_is_supported(device, requires=META.requires)
+
+
+__all__ = ["Outputs", "Plan", "plan", "allocate_outputs", "run", "is_supported"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
-cu12 = ["nvidia-cutlass-dsl>=4.5.0"]
-cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.0"]
+cu12 = ["nvidia-cutlass-dsl>=4.5.2"]
+cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.2"]
 # DEPRECATED alias, kept so existing `pip install ".[nvep]"` commands keep
 # working. The moe_ep runtime deps (cuda-python, nccl4py) are now part of the
 # BASE dependencies (requirements.txt) and the NIXL-EP submodule build runs by
@@ -69,6 +69,9 @@ exclude = ["flashinfer-jit-cache*", "flashinfer-cubin*"]
 
 [tool.setuptools.package-data]
 "flashinfer" = ["_build_meta.py"]
+# JIT sources for the experimental PCIe collectives (compiled on-demand via
+# torch.utils.cpp_extension.load in flashinfer/experimental/sm12x/comm/pcie/).
+"flashinfer.experimental.sm12x.comm.pcie" = ["*.cu"]
 # JIT sources for the blk64 BSA kernel extension (compiled on-demand via
 # torch.utils.cpp_extension.load in flashinfer/cute_dsl/sparse/blk64/loader.py).
 # These live inside the package tree rather than csrc/, so they must be
@@ -104,6 +107,7 @@ exclude = [
   "flashinfer-jit-cache/",
   "3rdparty/",
   "flashinfer/data/cutlass/",
+  "flashinfer/experimental/",
   "flashinfer/cute_dsl/attention/fmha/fmha.py",
   "flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py",
   "flashinfer/cute_dsl/attention/fmha/helpers/",
@@ -167,3 +171,7 @@ ignore = [
 ]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+# Mechanically ported b12x kernels (one-time port): bugbear/simplify style
+# families off to keep the port diffable against upstream; correctness rules
+# (E/F) stay on. See flashinfer/experimental/README.md.
+"flashinfer/experimental/sm12x/**" = ["B", "SIM", "F401", "F841"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ nccl4py>=0.3.1
 ninja
 numpy
 nvidia-cudnn-frontend>=1.13.0
-nvidia-cutlass-dsl>=4.5.0
+nvidia-cutlass-dsl>=4.5.2
 nvidia-ml-py
 packaging>=24.2
 requests

--- a/tests/experimental/_lib/test_compile_cache.py
+++ b/tests/experimental/_lib/test_compile_cache.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Compile-cache re-rooting: the highest-risk mechanical edit of the port.
+
+Wrong fingerprint root ⇒ silent stale disk-cache hits (running old kernels),
+so these assertions are load-bearing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+compiler = importlib.import_module("flashinfer.experimental.sm12x._lib.compiler")
+env = importlib.import_module("flashinfer.experimental.sm12x._lib.env")
+
+
+def test_package_root_is_the_sm12x_subtree():
+    root = compiler._PACKAGE_ROOT
+    assert root.parts[-3:] == ("flashinfer", "experimental", "sm12x"), root
+    assert (root / "_lib" / "compiler.py").is_file()
+
+
+def test_fingerprint_tracks_source_edits(tmp_path, monkeypatch):
+    (tmp_path / "kernel.py").write_text("x = 1\n")
+    pycache = tmp_path / "__pycache__"
+    pycache.mkdir()
+    monkeypatch.setattr(compiler, "_PACKAGE_ROOT", tmp_path)
+
+    before = compiler._compute_sm12x_package_fingerprint()
+
+    (pycache / "kernel.cpython-312.pyc").write_bytes(b"ignored")
+    assert compiler._compute_sm12x_package_fingerprint() == before, (
+        "__pycache__ must not affect the fingerprint"
+    )
+
+    (tmp_path / "kernel.py").write_text("x = 2\n")
+    after = compiler._compute_sm12x_package_fingerprint()
+    assert after != before, "editing any source must change the fingerprint"
+
+
+def test_cache_dir_resolution_order(monkeypatch):
+    for name in (
+        "FLASHINFER_EXP_SM12X_COMPILE_CACHE_DIR",
+        "FLASHINFER_CACHE_DIR",
+        "XDG_CACHE_HOME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    assert compiler._cute_compile_cache_dir() == (
+        Path.home() / ".cache" / "flashinfer" / "experimental" / "sm12x" / "compile"
+    )
+
+    monkeypatch.setenv("XDG_CACHE_HOME", "/xdg")
+    assert compiler._cute_compile_cache_dir() == Path(
+        "/xdg/flashinfer/experimental/sm12x/compile"
+    )
+
+    monkeypatch.setenv("FLASHINFER_CACHE_DIR", "/fi-cache")
+    assert compiler._cute_compile_cache_dir() == Path(
+        "/fi-cache/experimental/sm12x/compile"
+    )
+
+    monkeypatch.setenv("FLASHINFER_EXP_SM12X_COMPILE_CACHE_DIR", "/explicit")
+    assert compiler._cute_compile_cache_dir() == Path("/explicit")
+
+
+def test_legacy_env_read_through(monkeypatch):
+    monkeypatch.setattr(env, "_synced", False)
+    created = []
+    try:
+        monkeypatch.setenv("B12X_MLA_FORCE_SPLIT", "3")
+        monkeypatch.setenv("B12X_CUTE_COMPILE_DISK_CACHE", "0")
+        monkeypatch.setenv("B12X_VLLM_ENGINE_STARTED", "1")
+        monkeypatch.setenv("B12X_DENSE_ATOM_24", "legacy")
+        monkeypatch.setenv("FLASHINFER_EXP_SM12X_DENSE_ATOM_24", "explicit")
+        for name in (
+            "FLASHINFER_EXP_SM12X_MLA_FORCE_SPLIT",
+            "FLASHINFER_EXP_SM12X_COMPILE_DISK_CACHE",
+            "FLASHINFER_EXP_SM12X_ENGINE_STARTED",
+        ):
+            monkeypatch.delenv(name, raising=False)
+            created.append(name)
+
+        import pytest
+
+        with pytest.warns(DeprecationWarning, match="legacy b12x environment"):
+            env.sync_legacy_env()
+
+        assert os.environ["FLASHINFER_EXP_SM12X_MLA_FORCE_SPLIT"] == "3"
+        assert os.environ["FLASHINFER_EXP_SM12X_COMPILE_DISK_CACHE"] == "0"
+        assert os.environ["FLASHINFER_EXP_SM12X_ENGINE_STARTED"] == "1"
+        # explicitly-set new-style names always win over legacy values
+        assert os.environ["FLASHINFER_EXP_SM12X_DENSE_ATOM_24"] == "explicit"
+
+        assert env.env_raw("MLA_FORCE_SPLIT") == "3"
+        assert env.env_flag("COMPILE_DISK_CACHE", default=True) is False
+    finally:
+        for name in created:
+            os.environ.pop(name, None)
+        monkeypatch.setattr(env, "_synced", False)

--- a/tests/experimental/_lib/test_cutlass_runtime_patches.py
+++ b/tests/experimental/_lib/test_cutlass_runtime_patches.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""CUTLASS DSL runtime patches: applied by default, disabled by kill switch.
+
+Runs in subprocesses because the patches mutate the process-global cutlass
+runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+PROBE = """
+import json, os
+{env_setup}
+from flashinfer.experimental.sm12x._lib import runtime_patches as rp
+rp.apply_cutlass_runtime_patches()
+rp.apply_cutlass_runtime_patches()  # second call must be a guarded no-op
+print(json.dumps({{
+    "warning_patched": rp._WARNING_PATCHED,
+    "frameinfo_patched": rp._DIRECT_FRAMEINFO_PATCHED,
+}}))
+"""
+
+
+def _run(env_setup: str) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "-c", PROBE.format(env_setup=env_setup)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert proc.returncode == 0, (
+        f"subprocess failed\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_patches_apply_by_default():
+    data = _run(
+        'os.environ.pop("FLASHINFER_EXP_SM12X_DISABLE_CUTLASS_RUNTIME_PATCHES", None)'
+    )
+    assert data["warning_patched"] is True
+    assert data["frameinfo_patched"] is True
+
+
+def test_kill_switch_disables_all_patches():
+    data = _run(
+        'os.environ["FLASHINFER_EXP_SM12X_DISABLE_CUTLASS_RUNTIME_PATCHES"] = "1"'
+    )
+    assert data["warning_patched"] is False
+    assert data["frameinfo_patched"] is False

--- a/tests/experimental/_lib/test_runtime_control.py
+++ b/tests/experimental/_lib/test_runtime_control.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Serving freeze guards (ported semantics from b12x runtime_control)."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+rc = importlib.import_module("flashinfer.experimental.sm12x._lib.runtime_control")
+
+
+def test_freeze_blocks_kernel_resolution_with_context():
+    assert not rc.kernel_resolution_frozen()
+    rc.freeze_kernel_resolution("unit-test")
+    try:
+        assert rc.kernel_resolution_frozen()
+        with pytest.raises(rc.KernelResolutionFrozenError) as excinfo:
+            rc.raise_if_kernel_resolution_frozen(
+                "compile",
+                target=test_freeze_blocks_kernel_resolution_with_context,
+                cache_key=("shape", 128),
+            )
+        message = str(excinfo.value)
+        assert "unit-test" in message
+        assert "compile" in message
+        assert "freeze_kernel_resolution" in message
+    finally:
+        rc.unfreeze_kernel_resolution()
+    assert not rc.kernel_resolution_frozen()
+    rc.raise_if_kernel_resolution_frozen("compile")  # no-op when unfrozen
+
+
+def test_compilation_aliases_are_the_same_functions():
+    assert rc.freeze_compilation is rc.freeze_kernel_resolution
+    assert rc.unfreeze_compilation is rc.unfreeze_kernel_resolution
+    assert rc.compilation_frozen is rc.kernel_resolution_frozen
+
+
+def test_namespace_root_reexports():
+    sm12x = importlib.import_module("flashinfer.experimental.sm12x")
+    assert sm12x.freeze_kernel_resolution is rc.freeze_kernel_resolution
+    assert sm12x.KernelResolutionFrozenError is rc.KernelResolutionFrozenError

--- a/tests/experimental/_reference/helpers.py
+++ b/tests/experimental/_reference/helpers.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+FLOAT4_E2M1_MAX = 6.0
+FLOAT8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+NVFP4_BLOCK_SIZE = 16
+
+E2M1_TO_FLOAT32 = [
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+]
+
+
+def prepare_tp_moe_fp4_experts(
+    *,
+    a: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    activation: str = "silu",
+    quant_mode: str = "nvfp4",
+    source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "w13",
+):
+    """Prepare one explicit expert owner from source tensors for a test."""
+    from flashinfer.experimental.sm12x.moe import fused_moe
+
+    normalized_mode = quant_mode.lower()
+    weight_E = int(w1_fp4.shape[0])
+    n = int(w2_fp4.shape[2]) * 2
+    weight_plan = fused_moe.plan_weights(
+        quant_modes=normalized_mode,
+        source_format=source_format,
+        activation=activation,
+        params_dtype=a.dtype,
+        num_experts=weight_E,
+        hidden_size=int(a.shape[1]),
+        intermediate_size=n,
+        w13_layout=w13_layout,
+    )
+    w1_global_scale = w1_alphas
+    w2_global_scale = w2_alphas
+    if normalized_mode in {"nvfp4", "w4a8_nvfp4"}:
+        w1_global_scale = (w1_alphas.float() * a1_gscale.float()).contiguous()
+        w2_global_scale = (w2_alphas.float() * a2_gscale.float()).contiguous()
+    return fused_moe.prepare_weights(
+        plan=weight_plan,
+        w1_fp4=w1_fp4,
+        w1_blockscale=w1_blockscale,
+        w1_global_scale=w1_global_scale,
+        a1_gscale=a1_gscale,
+        w2_fp4=w2_fp4,
+        w2_blockscale=w2_blockscale,
+        w2_global_scale=w2_global_scale,
+        a2_gscale=a2_gscale,
+        params_dtype=a.dtype,
+    )
+
+
+def make_tp_moe_fp4_binding(
+    *,
+    a: torch.Tensor,
+    experts: object,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    apply_router_weight_on_input: bool = False,
+    output: torch.Tensor | None = None,
+    input_scales_static: bool = False,
+    fast_math: bool | None = None,
+    quant_mode: str | None = None,
+    unit_scale_contract: bool = False,
+    swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+):
+    from flashinfer.experimental.sm12x.moe import fused_moe
+
+    modes = experts.plan.quant_modes
+    if quant_mode is None:
+        if len(modes) != 1:
+            raise ValueError("quant_mode is required for a multi-recipe expert plan")
+        normalized_mode = next(iter(modes))
+    else:
+        normalized_mode = quant_mode.lower()
+    plan = fused_moe.plan(
+        fused_moe.Caps(
+            max_tokens=int(a.shape[0]),
+            num_topk=int(topk_ids.shape[1]),
+            device=a.device,
+            weight_plan=experts.plan,
+            core_token_counts=(int(a.shape[0]),),
+            route_num_experts=0,
+            quant_mode=normalized_mode,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=plan.scratch_specs()[idx].device)
+        for idx, (shape, dtype) in enumerate(plan.shapes_and_dtypes())
+    )
+    return fused_moe.bind(
+        plan,
+        scratch=scratch,
+        a=a,
+        experts=experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        output=output,
+        input_scales_static=input_scales_static,
+        fast_math=fast_math,
+        unit_scale_contract=unit_scale_contract,
+    )
+
+
+def run_tp_moe_fp4(**kwargs) -> torch.Tensor:
+    from flashinfer.experimental.sm12x.moe import fused_moe
+
+    return fused_moe.run(binding=make_tp_moe_fp4_binding(**kwargs))
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def cast_from_fp4(x: torch.Tensor) -> torch.Tensor:
+    v_lo = x.to(torch.uint8) & 0xF
+    v_hi = (x.to(torch.uint8) >> 4) & 0xF
+    combined = torch.stack((v_lo, v_hi), dim=-1)
+    new_shape = combined.shape[:-2] + (combined.shape[-2] * combined.shape[-1],)
+    lookup = torch.tensor(E2M1_TO_FLOAT32, dtype=torch.float32, device=x.device)
+    return lookup[combined.to(torch.long)].reshape(new_shape)
+
+
+def cast_to_fp4(x: torch.Tensor) -> torch.Tensor:
+    sign = torch.sign(x)
+    x = torch.abs(x.clone())
+    x[(x >= 0.0) & (x <= 0.25)] = 0.0
+    x[(x > 0.25) & (x < 0.75)] = 0.5
+    x[(x >= 0.75) & (x <= 1.25)] = 1.0
+    x[(x > 1.25) & (x < 1.75)] = 1.5
+    x[(x >= 1.75) & (x <= 2.5)] = 2.0
+    x[(x > 2.5) & (x < 3.5)] = 3.0
+    x[(x >= 3.5) & (x <= 5.0)] = 4.0
+    x[x > 5.0] = 6.0
+    return x * sign
+
+
+def _reciprocal(x: torch.Tensor | float) -> torch.Tensor | float:
+    if isinstance(x, torch.Tensor):
+        return torch.where(x == 0, torch.zeros_like(x), 1.0 / x)
+    if x == 0:
+        return 0.0
+    return 1.0 / x
+
+
+def ref_fp4_quant(
+    x: torch.Tensor,
+    global_scale: torch.Tensor | float,
+    block_size: int = NVFP4_BLOCK_SIZE,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    sliced_shape = x.shape[:-1] + (x.shape[-1] // block_size, block_size)
+    sliced_x = x.reshape(sliced_shape)
+    vec_max = torch.max(torch.abs(sliced_x), dim=-1, keepdim=True)[0].to(torch.float32)
+    scale = global_scale * (vec_max * _reciprocal(FLOAT4_E2M1_MAX))
+    scale = scale.to(torch.float8_e4m3fn).to(torch.float32)
+    output_scale = _reciprocal(scale * _reciprocal(global_scale))
+    scaled_x = sliced_x.to(torch.float32) * output_scale
+    clipped_x = torch.clamp(scaled_x, -FLOAT4_E2M1_MAX, FLOAT4_E2M1_MAX).reshape(
+        x.shape
+    )
+    return cast_to_fp4(clipped_x), scale.squeeze(-1)
+
+
+def ref_grouped_fp4_quantize(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+    global_scale: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    num_groups, rows, cols = input_tensor.shape
+    quantized = torch.zeros(
+        (num_groups, rows, cols), dtype=torch.float32, device=input_tensor.device
+    )
+    scales = torch.zeros(
+        (num_groups, rows, cols // NVFP4_BLOCK_SIZE),
+        dtype=torch.float32,
+        device=input_tensor.device,
+    )
+    for group_idx in range(num_groups):
+        valid_rows = int(row_counts[group_idx].item())
+        if valid_rows == 0:
+            continue
+        quantized[group_idx, :valid_rows], scales[group_idx, :valid_rows] = (
+            ref_fp4_quant(
+                input_tensor[group_idx, :valid_rows].float(),
+                global_scale[group_idx],
+                NVFP4_BLOCK_SIZE,
+            )
+        )
+    return quantized, scales
+
+
+def ref_grouped_silu_mul_quantize(
+    input_tensor: torch.Tensor,
+    row_counts: torch.Tensor,
+    global_scale: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    cols = input_tensor.shape[-1] // 2
+    left = input_tensor[..., :cols].float()
+    right = input_tensor[..., cols:].float()
+    activated = (F.silu(left) * right).to(input_tensor.dtype).to(torch.float32)
+    return ref_grouped_fp4_quantize(activated, row_counts, global_scale)
+
+
+def swizzle_block_scale_reference(scale: torch.Tensor) -> torch.Tensor:
+    if scale.ndim == 2:
+        scale = scale.unsqueeze(0)
+        squeeze_batch = True
+    else:
+        squeeze_batch = False
+    batch, rows, cols = scale.shape
+    rows_padded = _align_up(rows, 128)
+    cols_padded = _align_up(cols, 4)
+    padded = torch.zeros(
+        (batch, rows_padded, cols_padded), dtype=scale.dtype, device=scale.device
+    )
+    padded[:, :rows, :cols] = scale
+    swizzled = padded.reshape(batch, rows_padded // 128, 4, 32, cols_padded // 4, 4)
+    swizzled = swizzled.permute(0, 1, 4, 3, 2, 5).contiguous()
+    swizzled = swizzled.reshape(batch, rows_padded, cols_padded)
+    return swizzled[0] if squeeze_batch else swizzled
+
+
+def recover_grouped_e4m3_scales(
+    scale_view: torch.Tensor,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    num_groups = scale_view.shape[-1]
+    rows_padded = _align_up(rows, 128)
+    cols_padded = _align_up(cols // NVFP4_BLOCK_SIZE, 4)
+    swizzled = scale_view.permute(5, 2, 4, 0, 1, 3).contiguous()
+    swizzled = swizzled.reshape(num_groups, rows_padded, cols_padded)
+    unswizzled = swizzled.view(
+        num_groups,
+        rows_padded // 128,
+        cols_padded // 4,
+        32,
+        4,
+        4,
+    )
+    unswizzled = unswizzled.permute(0, 1, 4, 3, 2, 5).contiguous()
+    unswizzled = unswizzled.reshape(num_groups, rows_padded, cols_padded)
+    return unswizzled[:, :rows, : cols // NVFP4_BLOCK_SIZE].to(torch.float32)
+
+
+def dequantize_grouped_nvfp4(
+    packed: torch.Tensor,
+    scale_view: torch.Tensor,
+    cols: int,
+    global_scale: torch.Tensor,
+) -> torch.Tensor:
+    if global_scale.numel() == 1:
+        global_scale = global_scale.expand(packed.shape[0]).contiguous()
+    packed_fp32 = cast_from_fp4(packed.view(torch.uint8)).view(
+        packed.shape[0], packed.shape[1], cols
+    )
+    scales = recover_grouped_e4m3_scales(scale_view, packed.shape[1], cols)
+    values = packed_fp32.view(
+        packed.shape[0], packed.shape[1], cols // NVFP4_BLOCK_SIZE, NVFP4_BLOCK_SIZE
+    )
+    return (values * scales.unsqueeze(-1) / global_scale.view(-1, 1, 1, 1)).reshape(
+        packed.shape[0], packed.shape[1], cols
+    )
+
+
+def dequantize_token_major_nvfp4(
+    x_fp4: torch.Tensor,
+    x_sf: torch.Tensor,
+    *,
+    hidden_size: int,
+    global_scale: torch.Tensor,
+) -> torch.Tensor:
+    x_fp4_float = cast_from_fp4(x_fp4.view(torch.uint8))
+    num_tokens = x_fp4_float.shape[0]
+    x_fp4_float = x_fp4_float.view(
+        num_tokens, hidden_size // NVFP4_BLOCK_SIZE, NVFP4_BLOCK_SIZE
+    )
+    scales = x_sf.float().view(num_tokens, hidden_size // NVFP4_BLOCK_SIZE, 1)
+    return (x_fp4_float * scales).view(num_tokens, hidden_size) / global_scale.item()
+
+
+def compute_global_scale(x: torch.Tensor) -> torch.Tensor:
+    amax = x.abs().max().to(torch.float32)
+    value = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / amax
+    return torch.tensor([value], dtype=torch.float32, device=x.device)
+
+
+def compute_per_group_global_scale(x: torch.Tensor) -> torch.Tensor:
+    amax = x.abs().amax(dim=(1, 2)).to(torch.float32)
+    numerator = torch.full_like(amax, FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX)
+    return torch.where(amax > 0, numerator / amax, torch.ones_like(amax))
+
+
+def llama_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    x_fp32 = x.float()
+    variance = x_fp32.pow(2).mean(dim=-1, keepdim=True)
+    return (x_fp32 * torch.rsqrt(variance + eps) * weight.float()).to(x.dtype)

--- a/tests/experimental/_reference/paged_attention_helpers.py
+++ b/tests/experimental/_reference/paged_attention_helpers.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import torch
+
+
+def make_paged_inputs(
+    *,
+    q_seqlens: list[int],
+    cache_seqlens: list[int],
+    page_size: int,
+    q_heads: int = 8,
+    kv_heads: int = 1,
+    head_dim: int = 256,
+    head_dim_qk: int | None = None,
+    head_dim_vo: int | None = None,
+    dtype: torch.dtype = torch.bfloat16,
+    seed: int = 0,
+    page_table_width: int | None = None,
+    num_pages: int | None = None,
+    vllm_combined_kv: bool = False,
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
+    if len(q_seqlens) != len(cache_seqlens):
+        raise ValueError("q_seqlens and cache_seqlens must have the same length")
+    torch.manual_seed(seed)
+    device = "cuda"
+    batch = len(q_seqlens)
+    total_q = sum(q_seqlens)
+    head_dim_qk = head_dim if head_dim_qk is None else head_dim_qk
+    head_dim_vo = head_dim if head_dim_vo is None else head_dim_vo
+    q = torch.randn(total_q, q_heads, head_dim_qk, device=device, dtype=dtype) / 4
+
+    pages_per_request = [
+        (cache_len + page_size - 1) // page_size for cache_len in cache_seqlens
+    ]
+    max_pages = max(pages_per_request, default=0)
+    if page_table_width is not None:
+        if page_table_width < max_pages:
+            raise ValueError(
+                f"page_table_width={page_table_width} is smaller than max_pages={max_pages}"
+            )
+        max_pages = page_table_width
+    total_pages_needed = sum(pages_per_request)
+    if num_pages is None:
+        num_pages = max(1, total_pages_needed * 2)
+    if num_pages < total_pages_needed:
+        raise ValueError(
+            f"num_pages={num_pages} is smaller than required total {total_pages_needed}"
+        )
+
+    if vllm_combined_kv:
+        # vLLM MiniMax-M3 layout: one combined cache [num_blocks, 2, page, H, D]
+        # with K = cache[:, 0] and V = cache[:, 1] as STRIDED slices.
+        if head_dim_qk != head_dim_vo:
+            raise ValueError("vllm_combined_kv requires head_dim_qk == head_dim_vo")
+        combined_kv_cache = (
+            torch.randn(
+                num_pages,
+                2,
+                page_size,
+                kv_heads,
+                head_dim_qk,
+                device=device,
+                dtype=dtype,
+            )
+            / 4
+        )
+        k_cache = combined_kv_cache[:, 0]
+        v_cache = combined_kv_cache[:, 1]
+    else:
+        k_cache = (
+            torch.randn(
+                num_pages,
+                page_size,
+                kv_heads,
+                head_dim_qk,
+                device=device,
+                dtype=dtype,
+            )
+            / 4
+        )
+        v_cache = (
+            torch.randn(
+                num_pages,
+                page_size,
+                kv_heads,
+                head_dim_vo,
+                device=device,
+                dtype=dtype,
+            )
+            / 4
+        )
+    page_table = torch.zeros(batch, max_pages, dtype=torch.int32, device=device)
+    page_order = torch.randperm(num_pages, device=device)
+    cursor = 0
+    for request_idx, num_req_pages in enumerate(pages_per_request):
+        if num_req_pages == 0:
+            continue
+        page_ids = page_order[cursor : cursor + num_req_pages].to(torch.int32)
+        cursor += num_req_pages
+        page_table[request_idx, :num_req_pages] = page_ids
+        page_table[request_idx, num_req_pages:] = page_ids[-1]
+
+    cache_seqlens_t = torch.tensor(cache_seqlens, dtype=torch.int32, device=device)
+    q_offsets = [0]
+    for q_len in q_seqlens:
+        q_offsets.append(q_offsets[-1] + q_len)
+    cu_seqlens_q = torch.tensor(q_offsets, dtype=torch.int32, device=device)
+    return q, k_cache, v_cache, page_table, cache_seqlens_t, cu_seqlens_q
+
+
+def quantize_paged_kv_cache_e4m3(
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    batch, _max_pages = page_table.shape
+    _, page_size, kv_heads, _head_dim = k_cache.shape
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    k_quant = torch.empty_like(k_cache, dtype=torch.float8_e4m3fn)
+    v_quant = torch.empty_like(v_cache, dtype=torch.float8_e4m3fn)
+    k_descale = torch.ones(
+        (batch, kv_heads), dtype=torch.float32, device=k_cache.device
+    )
+    v_descale = torch.ones(
+        (batch, kv_heads), dtype=torch.float32, device=v_cache.device
+    )
+    for request_idx in range(batch):
+        cache_len = int(cache_seqlens[request_idx].item())
+        num_pages = (cache_len + page_size - 1) // page_size
+        if num_pages == 0:
+            continue
+        page_ids = page_table[request_idx, :num_pages].to(torch.long)
+        k_pages = k_cache.index_select(0, page_ids).to(torch.float32)
+        v_pages = v_cache.index_select(0, page_ids).to(torch.float32)
+        k_scale = k_pages.abs().amax(dim=(0, 1, 3)) / finfo.max
+        v_scale = v_pages.abs().amax(dim=(0, 1, 3)) / finfo.max
+        k_scale = torch.where(k_scale > 0, k_scale, torch.ones_like(k_scale))
+        v_scale = torch.where(v_scale > 0, v_scale, torch.ones_like(v_scale))
+        k_descale[request_idx] = k_scale
+        v_descale[request_idx] = v_scale
+        k_quant[page_ids] = (
+            (k_pages / k_scale.view(1, 1, kv_heads, 1))
+            .clamp(
+                min=finfo.min,
+                max=finfo.max,
+            )
+            .to(torch.float8_e4m3fn)
+        )
+        v_quant[page_ids] = (
+            (v_pages / v_scale.view(1, 1, kv_heads, 1))
+            .clamp(
+                min=finfo.min,
+                max=finfo.max,
+            )
+            .to(torch.float8_e4m3fn)
+        )
+    return (
+        k_quant.contiguous(),
+        v_quant.contiguous(),
+        k_descale.contiguous(),
+        v_descale.contiguous(),
+    )
+
+
+def make_msa_q2k_indices(
+    *,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    num_kv_heads: int,
+    total_q_capacity: int | None = None,
+    topk: int = 16,
+    block_tokens: int = 128,
+    seed: int = 0,
+    force_block0: bool = False,
+    poison_padding: bool = False,
+) -> torch.Tensor:
+    """Build sorted MiniMax-MSA q2k block lists for tests.
+
+    The returned tensor has shape `[num_kv_heads, total_q_capacity, topk]`.
+    Lists are batch-local block ids, sorted ascending, with the local block
+    forced present and tail entries padded with -1 by default.
+    """
+    if cache_seqlens.ndim != 1 or cu_seqlens_q.ndim != 1:
+        raise ValueError("cache_seqlens and cu_seqlens_q must be rank-1 tensors")
+    if int(block_tokens) <= 0 or int(topk) <= 0:
+        raise ValueError("block_tokens and topk must be positive")
+    if int(num_kv_heads) <= 0:
+        raise ValueError("num_kv_heads must be positive")
+    device = cache_seqlens.device
+    q_offsets = [int(v) for v in cu_seqlens_q.detach().cpu().tolist()]
+    cache_lengths = [int(v) for v in cache_seqlens.detach().cpu().tolist()]
+    total_q = q_offsets[-1] if q_offsets else 0
+    if total_q_capacity is None:
+        total_q_capacity = total_q
+    total_q_capacity = int(total_q_capacity)
+    if total_q_capacity < total_q:
+        raise ValueError("total_q_capacity must cover cu_seqlens_q[-1]")
+
+    q2k = torch.full(
+        (int(num_kv_heads), total_q_capacity, int(topk)),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(int(seed))
+
+    poison_base = 1_000_000
+    for request_idx, (q_start, q_end) in enumerate(
+        zip(q_offsets[:-1], q_offsets[1:], strict=False)
+    ):
+        qo_len = q_end - q_start
+        cache_len = cache_lengths[request_idx]
+        for q_row in range(q_start, q_end):
+            token_local = q_row - q_start
+            visible = max(token_local + cache_len - qo_len + 1, 1)
+            num_visible_blocks = (visible + int(block_tokens) - 1) // int(block_tokens)
+            count = min(int(topk), num_visible_blocks)
+            local_block = max((visible - 1) // int(block_tokens), 0)
+            candidates = [
+                block for block in range(num_visible_blocks) if block != local_block
+            ]
+            for kv_head in range(int(num_kv_heads)):
+                selected = {local_block}
+                if force_block0 and local_block != 0 and len(selected) < count:
+                    selected.add(0)
+                remaining = count - len(selected)
+                if remaining > 0 and candidates:
+                    perm = torch.randperm(len(candidates), generator=gen).tolist()
+                    for idx in perm:
+                        block = candidates[idx]
+                        if block in selected:
+                            continue
+                        selected.add(block)
+                        if len(selected) == count:
+                            break
+                values = sorted(selected)
+                q2k[kv_head, q_row, : len(values)] = torch.tensor(
+                    values, dtype=torch.int32, device=device
+                )
+                if poison_padding and len(values) < int(topk):
+                    pad_count = int(topk) - len(values)
+                    poison = torch.arange(
+                        poison_base,
+                        poison_base + pad_count,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                    q2k[kv_head, q_row, len(values) :] = poison
+                    poison_base += pad_count
+    return q2k.contiguous()
+
+
+# Harvested from b12x tests/test_attention_paged_planner.py
+def _make_inputs(
+    *,
+    q_seqlens: list[int],
+    cache_seqlens: list[int],
+    page_size: int = 64,
+    q_heads: int = 8,
+    kv_heads: int = 1,
+    head_dim_qk: int = 256,
+    head_dim_vo: int = 256,
+    dtype: torch.dtype = torch.bfloat16,
+    kv_dtype: torch.dtype = torch.float8_e4m3fn,
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
+    device = "cuda"
+    batch = len(q_seqlens)
+    total_q = sum(q_seqlens)
+    q = torch.randn(total_q, q_heads, head_dim_qk, dtype=dtype, device=device)
+    max_pages = max(
+        (cache_len + page_size - 1) // page_size for cache_len in cache_seqlens
+    )
+    num_pages = (
+        sum((cache_len + page_size - 1) // page_size for cache_len in cache_seqlens) + 8
+    )
+    k_cache = torch.randn(
+        num_pages, page_size, kv_heads, head_dim_qk, dtype=torch.float32, device=device
+    ).to(kv_dtype)
+    v_cache = torch.randn(
+        num_pages, page_size, kv_heads, head_dim_vo, dtype=torch.float32, device=device
+    ).to(kv_dtype)
+    page_table = torch.zeros(batch, max_pages, dtype=torch.int32, device=device)
+    cursor = 0
+    for request_idx, cache_len in enumerate(cache_seqlens):
+        req_pages = (cache_len + page_size - 1) // page_size
+        page_ids = torch.arange(
+            cursor, cursor + req_pages, dtype=torch.int32, device=device
+        )
+        cursor += req_pages
+        page_table[request_idx, :req_pages] = page_ids
+        page_table[request_idx, req_pages:] = page_ids[-1]
+    cache_seqlens_t = torch.tensor(cache_seqlens, dtype=torch.int32, device=device)
+    offsets = [0]
+    for q_len in q_seqlens:
+        offsets.append(offsets[-1] + q_len)
+    cu_seqlens_q = torch.tensor(offsets, dtype=torch.int32, device=device)
+    return q, k_cache, v_cache, page_table, cache_seqlens_t, cu_seqlens_q

--- a/tests/experimental/attention/test_compressed_mla.py
+++ b/tests/experimental/attention/test_compressed_mla.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x.attention._shared.mla.compressed_reference import (
+    COMPRESSED_MLA_C128_PAGE_SIZE,
+    COMPRESSED_MLA_DSV4_PAGE_SIZE,
+    compressed_sparse_mla_reference,
+    pack_compressed_mla_kv_cache_reference,
+)
+from flashinfer.experimental.sm12x.attention import compressed_mla
+
+SM12XCompressedMLAScratchCaps = compressed_mla.Caps
+clear_mla_caches = compressed_mla.clear_caches
+compressed_mla_decode_forward = compressed_mla.run
+plan_compressed_mla_scratch = compressed_mla.plan
+
+from ..conftest import require_sm12x as require_sm120
+
+
+_COMPRESSED_HEAD_DIM = 512
+_SHARED_CORE_HEAD_DIM = 576
+_SHARED_CORE_V_HEAD_DIM = 512
+_LOCAL_Q_HEADS = 32
+_SM_SCALE = 1.0 / math.sqrt(_COMPRESSED_HEAD_DIM)
+
+
+def _make_split_merge_tensors(
+    *,
+    rows: int,
+    heads: int,
+    chunks: int,
+    device: torch.device,
+    seed: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    tmp_storage = torch.randn(
+        rows * heads * chunks * _COMPRESSED_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=gen,
+    )
+    tmp_output = tmp_storage.as_strided(
+        (rows, heads, chunks, _COMPRESSED_HEAD_DIM),
+        (
+            heads * _COMPRESSED_HEAD_DIM,
+            _COMPRESSED_HEAD_DIM,
+            rows * heads * _COMPRESSED_HEAD_DIM,
+            1,
+        ),
+    )
+    tmp_lse = torch.randn(
+        (rows, heads, chunks),
+        dtype=torch.float32,
+        device=device,
+        generator=gen,
+    )
+    output = torch.empty(
+        (rows, heads, _COMPRESSED_HEAD_DIM), dtype=torch.bfloat16, device=device
+    )
+    num_chunks_ptr = torch.tensor([chunks], dtype=torch.int32, device=device)
+    attn_sink = torch.zeros((heads,), dtype=torch.float32, device=device)
+    return tmp_output, tmp_lse, num_chunks_ptr, attn_sink, output
+
+
+def _make_compressed_binding(
+    *,
+    device: torch.device | str,
+    rows: int,
+    topk: int,
+    max_kv_rows: int,
+    q: torch.Tensor,
+    swa_indices: torch.Tensor,
+    swa_lengths: torch.Tensor,
+    indexed_indices: torch.Tensor | None = None,
+    indexed_lengths: torch.Tensor | None = None,
+    indexed_page_table: torch.Tensor | None = None,
+    use_cuda_graph: bool = False,
+    head_dim: int = _COMPRESSED_HEAD_DIM,
+    v_head_dim: int = _COMPRESSED_HEAD_DIM,
+    max_chunks_per_row: int = 64,
+    max_page_table_width: int | None = None,
+):
+    plan = plan_compressed_mla_scratch(
+        SM12XCompressedMLAScratchCaps(
+            device=device,
+            dtype=torch.bfloat16,
+            kv_dtype=torch.uint8,
+            num_q_heads=_LOCAL_Q_HEADS,
+            head_dim=head_dim,
+            v_head_dim=v_head_dim,
+            max_width=topk,
+            max_page_table_width=max_page_table_width,
+            max_q_rows=rows,
+            max_batch=rows,
+            max_kv_rows=max_kv_rows,
+            max_chunks_per_row=max_chunks_per_row,
+        )
+    )
+    (spec,) = plan.scratch_specs()
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = plan.bind(
+        scratch=scratch,
+        q=q,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+        indexed_indices=indexed_indices,
+        indexed_lengths=indexed_lengths,
+        indexed_page_table=indexed_page_table,
+    )
+    binding.scratch.use_cuda_graph = bool(use_cuda_graph)
+    return binding
+
+
+def _make_cache(
+    *,
+    tokens: int,
+    page_size: int,
+    seed: int,
+    device: torch.device | str,
+) -> torch.Tensor:
+    device = torch.device(device)
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    k_nope = (
+        torch.randn((tokens, 448), generator=gen, dtype=torch.float32, device=device)
+        * 0.05
+    )
+    k_rope = (
+        torch.randn((tokens, 64), generator=gen, dtype=torch.float32, device=device)
+        * 0.05
+    )
+    return pack_compressed_mla_kv_cache_reference(
+        k_nope,
+        k_rope.to(dtype=torch.bfloat16),
+        page_size=page_size,
+    )
+
+
+def _make_q(*, rows: int, seed: int, device: torch.device | str) -> torch.Tensor:
+    device = torch.device(device)
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    q = (
+        torch.randn(
+            (rows, _LOCAL_Q_HEADS, _COMPRESSED_HEAD_DIM),
+            generator=gen,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.04
+    )
+    return q.to(dtype=torch.bfloat16)
+
+
+@torch.inference_mode()
+def test_compressed_mla_shared_core_replays_under_cuda_graph() -> None:
+    device = require_sm120()
+    clear_mla_caches()
+
+    q = _make_q(rows=1, seed=21, device=device)
+    swa_cache_bytes = _make_cache(
+        tokens=32, page_size=COMPRESSED_MLA_DSV4_PAGE_SIZE, seed=22, device=device
+    )
+    indexed_cache_bytes = _make_cache(
+        tokens=32, page_size=COMPRESSED_MLA_C128_PAGE_SIZE, seed=23, device=device
+    )
+    swa_cache = swa_cache_bytes.view(torch.float8_e4m3fn)
+    indexed_cache = indexed_cache_bytes.view(torch.float8_e4m3fn)
+    swa_indices = torch.arange(16, dtype=torch.int32, device=device).unsqueeze(0)
+    indexed_indices = torch.arange(16, dtype=torch.int32, device=device).unsqueeze(0)
+    swa_lengths = torch.tensor([11], dtype=torch.int32, device=device)
+    indexed_lengths = torch.tensor([7], dtype=torch.int32, device=device)
+    attn_sink = torch.nn.Parameter(
+        torch.linspace(-0.1, 0.1, _LOCAL_Q_HEADS, dtype=torch.float32, device=device)
+    )
+    binding = _make_compressed_binding(
+        device=device,
+        rows=8,
+        topk=swa_indices.shape[1] + indexed_indices.shape[1],
+        max_kv_rows=8 * (swa_indices.shape[1] + indexed_indices.shape[1]),
+        q=q,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+        indexed_indices=indexed_indices,
+        indexed_lengths=indexed_lengths,
+        use_cuda_graph=True,
+    )
+
+    captured_out: torch.Tensor | None = None
+
+    def run() -> torch.Tensor:
+        nonlocal captured_out
+        captured_out = compressed_mla_decode_forward(
+            swa_k_cache=swa_cache,
+            binding=binding,
+            indexed_k_cache=indexed_cache,
+            indexed_page_size=COMPRESSED_MLA_C128_PAGE_SIZE,
+            attn_sink=attn_sink,
+            sm_scale=_SM_SCALE,
+        )
+        return captured_out
+
+    run()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert captured_out is not None
+
+    expected = compressed_sparse_mla_reference(
+        q,
+        swa_cache_bytes,
+        swa_indices,
+        swa_lengths,
+        extra_k_cache=indexed_cache_bytes,
+        extra_indices=indexed_indices,
+        extra_topk_lengths=indexed_lengths,
+        extra_page_size=COMPRESSED_MLA_C128_PAGE_SIZE,
+        attn_sink=attn_sink,
+        sm_scale=_SM_SCALE,
+    )
+    max_abs = (captured_out.float() - expected.float()).abs().max().item()
+    cos = torch.nn.functional.cosine_similarity(
+        captured_out.float().reshape(-1), expected.float().reshape(-1), dim=0
+    )
+    assert max_abs <= 0.10
+    assert cos.item() >= 0.9995
+
+    # Replay the same captured graph with shorter live sections. The launch grid,
+    # workspace, and tensor addresses stay fixed; one of the two capacity-planned
+    # chunks is now wholly empty and must contribute a neutral LSE without running
+    # its gather/MMA pipeline.
+    swa_lengths.fill_(1)
+    indexed_lengths.zero_()
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    expected_short = compressed_sparse_mla_reference(
+        q,
+        swa_cache_bytes,
+        swa_indices,
+        swa_lengths,
+        extra_k_cache=indexed_cache_bytes,
+        extra_indices=indexed_indices,
+        extra_topk_lengths=indexed_lengths,
+        extra_page_size=COMPRESSED_MLA_C128_PAGE_SIZE,
+        attn_sink=attn_sink,
+        sm_scale=_SM_SCALE,
+    )
+    max_abs_short = (captured_out.float() - expected_short.float()).abs().max().item()
+    cos_short = torch.nn.functional.cosine_similarity(
+        captured_out.float().reshape(-1), expected_short.float().reshape(-1), dim=0
+    )
+    assert max_abs_short <= 0.10
+    assert cos_short.item() >= 0.9995
+
+
+@torch.inference_mode()
+def test_compressed_mla_out_param_writes_directly_and_matches() -> None:
+    device = require_sm120()
+    clear_mla_caches()
+
+    rows = 8
+    q = _make_q(rows=rows, seed=311, device=device)
+    swa_cache = _make_cache(
+        tokens=32, page_size=COMPRESSED_MLA_DSV4_PAGE_SIZE, seed=312, device=device
+    )
+    attn_sink = torch.linspace(
+        -0.2, 0.15, _LOCAL_Q_HEADS, dtype=torch.float32, device=device
+    )
+
+    def _make_swa(width: int) -> tuple[torch.Tensor, torch.Tensor]:
+        indices = torch.full((rows, width), -1, dtype=torch.int32, device=device)
+        lengths = torch.empty((rows,), dtype=torch.int32, device=device)
+        for row in range(rows):
+            length = min(width, row + 1)
+            indices[row, :length] = torch.arange(
+                row, row - length, -1, dtype=torch.int32, device=device
+            )
+            lengths[row] = length
+        return indices, lengths
+
+    # The MG prefill kernel requires the FP8 topk widths (512/1024/2048);
+    # decode has no such floor.
+    for mode, width in (("decode", 8), ("extend", 512)):
+        swa_indices, swa_lengths = _make_swa(width)
+        binding = _make_compressed_binding(
+            device=device,
+            rows=rows,
+            topk=width,
+            max_kv_rows=rows * width,
+            q=q,
+            swa_indices=swa_indices,
+            swa_lengths=swa_lengths,
+        )
+        binding.scratch.mode = mode
+        baseline = compressed_mla_decode_forward(
+            swa_k_cache=swa_cache,
+            binding=binding,
+            attn_sink=attn_sink,
+            sm_scale=_SM_SCALE,
+        ).clone()
+
+        # NaN canary: every output position must be written by the kernel.
+        out = torch.full(
+            (rows, _LOCAL_Q_HEADS, _COMPRESSED_HEAD_DIM),
+            float("nan"),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        returned = compressed_mla_decode_forward(
+            swa_k_cache=swa_cache,
+            binding=binding,
+            attn_sink=attn_sink,
+            sm_scale=_SM_SCALE,
+            out=out,
+        )
+        assert returned.data_ptr() == out.data_ptr(), mode
+        assert not torch.isnan(out.float()).any(), mode
+        assert torch.equal(out, baseline), mode
+
+    swa_indices, swa_lengths = _make_swa(512)
+    binding = _make_compressed_binding(
+        device=device,
+        rows=rows,
+        topk=512,
+        max_kv_rows=rows * 512,
+        q=q,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+    )
+    binding.scratch.mode = "extend"
+    bad_shape = torch.empty(
+        (rows + 1, _LOCAL_Q_HEADS, _COMPRESSED_HEAD_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    with pytest.raises(ValueError, match="out must have shape"):
+        compressed_mla_decode_forward(
+            swa_k_cache=swa_cache,
+            binding=binding,
+            attn_sink=attn_sink,
+            sm_scale=_SM_SCALE,
+            out=bad_shape,
+        )
+    bad_dtype = torch.empty(
+        (rows, _LOCAL_Q_HEADS, _COMPRESSED_HEAD_DIM),
+        dtype=torch.float16,
+        device=device,
+    )
+    with pytest.raises(TypeError, match="out must be bfloat16"):
+        compressed_mla_decode_forward(
+            swa_k_cache=swa_cache,
+            binding=binding,
+            attn_sink=attn_sink,
+            sm_scale=_SM_SCALE,
+            out=bad_dtype,
+        )
+    non_contiguous = torch.empty(
+        (rows, _LOCAL_Q_HEADS, _COMPRESSED_HEAD_DIM * 2),
+        dtype=torch.bfloat16,
+        device=device,
+    )[..., ::2]
+    with pytest.raises(ValueError, match="out must be contiguous"):
+        compressed_mla_decode_forward(
+            swa_k_cache=swa_cache,
+            binding=binding,
+            attn_sink=attn_sink,
+            sm_scale=_SM_SCALE,
+            out=non_contiguous,
+        )

--- a/tests/experimental/attention/test_mla_kv_cache.py
+++ b/tests/experimental/attention/test_mla_kv_cache.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x.attention._shared.mla.kernel import (
+    run_unified_decode,
+)
+from flashinfer.experimental.sm12x.attention._shared.mla.kv_cache import (
+    clear_nvfp4_mla_fp8_rope_kv_cache_kernel_cache,
+    concat_and_cache_nvfp4_mla_fp8_rope,
+)
+from flashinfer.experimental.sm12x.attention._shared.mla.prefill_mg import (
+    run_unified_prefill_mg,
+)
+from flashinfer.experimental.sm12x.attention._shared.mla.traits import (
+    ComputeMode,
+    ModelType,
+    ScaleFormat,
+)
+from flashinfer.experimental.sm12x.attention.sparse_mla._scratch import (
+    SM12XSparseMLAScratchCaps,
+    plan_sparse_mla_scratch,
+)
+
+from .._reference.helpers import E2M1_TO_FLOAT32
+from ..conftest import require_sm12x as require_sm120
+
+
+_RECORD_BYTES = 368
+_NOPE_BYTES = 256
+_GROUP_SCALES_OFFSET = 256
+_ROPE_SCALE_OFFSET = 288
+_PAD_OFFSET = 292
+_ROPE_OFFSET = 304
+_PAGE_SIZE = 64
+_HEADS = 64
+_HEAD_DIM = 576
+_V_HEAD_DIM = 512
+_SENTINEL = 0xA5
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _isolate_writer_kernel_cache():
+    clear_nvfp4_mla_fp8_rope_kv_cache_kernel_cache()
+    yield
+    clear_nvfp4_mla_fp8_rope_kv_cache_kernel_cache()
+
+
+def _valid_cpu_writer_args() -> list[torch.Tensor]:
+    return [
+        torch.empty((2, _V_HEAD_DIM), dtype=torch.bfloat16),
+        torch.empty((2, _HEAD_DIM - _V_HEAD_DIM), dtype=torch.bfloat16),
+        torch.empty((2, _PAGE_SIZE, _RECORD_BYTES), dtype=torch.uint8),
+        torch.arange(2, dtype=torch.int64),
+    ]
+
+
+def _invalid_writer_args(case: str) -> tuple[torch.Tensor, ...]:
+    args = _valid_cpu_writer_args()
+    if case == "kv_c_shape":
+        args[0] = torch.empty((2, _V_HEAD_DIM - 1), dtype=torch.bfloat16)
+    elif case == "k_pe_shape":
+        args[1] = torch.empty((2, _HEAD_DIM - _V_HEAD_DIM - 1), dtype=torch.bfloat16)
+    elif case == "kv_c_dtype":
+        args[0] = torch.empty((2, _V_HEAD_DIM), dtype=torch.float32)
+    elif case == "k_pe_dtype":
+        args[1] = torch.empty((2, _HEAD_DIM - _V_HEAD_DIM), dtype=torch.float16)
+    elif case == "cache_shape":
+        args[2] = torch.empty((2, _PAGE_SIZE, _RECORD_BYTES - 1), dtype=torch.uint8)
+    elif case == "cache_dtype":
+        args[2] = torch.empty((2, _PAGE_SIZE, _RECORD_BYTES), dtype=torch.bfloat16)
+    elif case == "zero_num_blocks":
+        args[2] = torch.empty((0, _PAGE_SIZE, _RECORD_BYTES), dtype=torch.uint8)
+    elif case == "zero_block_size":
+        args[2] = torch.empty((2, 0, _RECORD_BYTES), dtype=torch.uint8)
+    elif case == "slot_dtype":
+        args[3] = torch.arange(2, dtype=torch.int32)
+    elif case == "slot_layout":
+        args[3] = torch.arange(4, dtype=torch.int64)[::2]
+    elif case == "short_source":
+        args[0] = args[0][:1]
+    elif case == "kv_c_inner_layout":
+        args[0] = torch.empty((2, 2 * _V_HEAD_DIM), dtype=torch.bfloat16)[:, ::2]
+    elif case == "cache_inner_layout":
+        args[2] = torch.empty((2, _PAGE_SIZE, 2 * _RECORD_BYTES), dtype=torch.uint8)[
+            ..., ::2
+        ]
+    elif case == "kv_c_row_alignment":
+        args[0] = torch.empty((2, _V_HEAD_DIM + 1), dtype=torch.bfloat16)[
+            :, :_V_HEAD_DIM
+        ]
+    elif case == "k_pe_row_alignment":
+        args[1] = torch.empty((2, _HEAD_DIM - _V_HEAD_DIM + 1), dtype=torch.bfloat16)[
+            :, : _HEAD_DIM - _V_HEAD_DIM
+        ]
+    elif case == "cache_record_alignment":
+        args[2] = torch.empty((2, _PAGE_SIZE, _RECORD_BYTES + 1), dtype=torch.uint8)[
+            ..., :_RECORD_BYTES
+        ]
+    elif case == "cache_base_alignment":
+        numel = 2 * _PAGE_SIZE * _RECORD_BYTES
+        args[2] = torch.empty(numel + 8, dtype=torch.uint8)[8:].view(
+            2, _PAGE_SIZE, _RECORD_BYTES
+        )
+    elif case != "cpu_device":
+        raise AssertionError(f"unknown invalid writer case {case}")
+    return tuple(args)
+
+
+@pytest.mark.parametrize(
+    ("case", "error", "match"),
+    [
+        ("kv_c_shape", ValueError, r"kv_c must be \(num_tokens, 512\)"),
+        ("k_pe_shape", ValueError, r"k_pe must be \(num_tokens, 64\)"),
+        ("kv_c_dtype", TypeError, "kv_c must be bf16/f16"),
+        ("k_pe_dtype", TypeError, "must match kv_c dtype"),
+        ("cache_shape", ValueError, "kv_cache must be"),
+        ("cache_dtype", TypeError, "kv_cache must be uint8"),
+        ("zero_num_blocks", ValueError, "num_blocks.*positive"),
+        ("zero_block_size", ValueError, "block_size.*positive"),
+        ("slot_dtype", TypeError, "slot_mapping must be a 1-D int64 tensor"),
+        ("slot_layout", ValueError, "slot_mapping must be contiguous"),
+        ("short_source", ValueError, "must cover slot_mapping"),
+        ("kv_c_inner_layout", ValueError, "must be innermost-contiguous"),
+        ("cache_inner_layout", ValueError, "must be innermost-contiguous"),
+        ("kv_c_row_alignment", ValueError, "must be 4-byte aligned"),
+        ("k_pe_row_alignment", ValueError, "k_pe.*4-byte aligned"),
+        ("cache_record_alignment", ValueError, "must be 16-byte aligned"),
+        ("cache_base_alignment", ValueError, "must be 16-byte aligned"),
+        ("cpu_device", ValueError, "all tensors must be on CUDA"),
+    ],
+)
+def test_writer_rejects_invalid_dtype_shape_device_and_layout(
+    case: str,
+    error: type[Exception],
+    match: str,
+) -> None:
+    with pytest.raises(error, match=match):
+        concat_and_cache_nvfp4_mla_fp8_rope(*_invalid_writer_args(case))
+
+
+def _make_exactly_quantizable_inputs(
+    *,
+    num_tokens: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    e2m1_values = torch.tensor(
+        [
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+            2.0,
+            -2.0,
+        ],
+        dtype=torch.float32,
+    )
+    e2m1_codes = torch.tensor(
+        [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 4, 12],
+        dtype=torch.uint8,
+    )
+    group_scales = torch.empty((num_tokens, 32), dtype=torch.float32)
+    nope = torch.empty((num_tokens, 32, 16), dtype=torch.float32)
+    codes = torch.empty((num_tokens, 32, 16), dtype=torch.uint8)
+    for token in range(num_tokens):
+        for group in range(32):
+            scale = 2.0 ** ((token + group) % 4 - 2)
+            shift = (5 * token + 3 * group) % 16
+            group_scales[token, group] = scale
+            nope[token, group] = torch.roll(e2m1_values, shifts=shift) * scale
+            codes[token, group] = torch.roll(e2m1_codes, shifts=shift)
+
+    packed_nope = (codes[..., 0::2] | (codes[..., 1::2] << 4)).reshape(
+        num_tokens, _NOPE_BYTES
+    )
+
+    e4m3_values = torch.tensor(
+        [
+            448.0,
+            -448.0,
+            416.0,
+            -416.0,
+            240.0,
+            -240.0,
+            120.0,
+            -120.0,
+            6.0,
+            -6.0,
+            1.5,
+            -1.5,
+            0.5,
+            -0.5,
+            0.0,
+            2.0,
+        ],
+        dtype=torch.float32,
+    ).repeat(4)
+    rope_scales = torch.tensor(
+        [2.0 ** (token - 4) for token in range(num_tokens)],
+        dtype=torch.float32,
+    )
+    rope = torch.stack(
+        [
+            torch.roll(e4m3_values, shifts=7 * token) * rope_scales[token]
+            for token in range(num_tokens)
+        ]
+    )
+    return (
+        nope.reshape(num_tokens, _V_HEAD_DIM).to(device=device, dtype=dtype),
+        rope.to(device=device, dtype=dtype),
+        packed_nope.to(device=device),
+        group_scales.to(device=device),
+        rope_scales.to(device=device),
+    )
+
+
+def _dequantize_records(
+    records: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    packed = records[:, :_NOPE_BYTES]
+    codes = torch.stack((packed & 0xF, (packed >> 4) & 0xF), dim=-1).reshape(
+        records.shape[0], _V_HEAD_DIM
+    )
+    e2m1 = torch.tensor(E2M1_TO_FLOAT32, dtype=torch.float32, device=records.device)
+    group_scales = (
+        records[:, _GROUP_SCALES_OFFSET:_ROPE_SCALE_OFFSET]
+        .contiguous()
+        .view(torch.float8_e4m3fn)
+        .float()
+    )
+    nope = (
+        e2m1[codes.long()].reshape(records.shape[0], 32, 16)
+        * group_scales.unsqueeze(-1)
+    ).reshape(records.shape[0], _V_HEAD_DIM)
+
+    rope_scales = (
+        records[:, _ROPE_SCALE_OFFSET:_PAD_OFFSET]
+        .contiguous()
+        .view(torch.float32)
+        .reshape(-1)
+    )
+    rope_q = (
+        records[:, _ROPE_OFFSET:_RECORD_BYTES]
+        .contiguous()
+        .view(torch.float8_e4m3fn)
+        .float()
+    )
+    rope = rope_q * rope_scales.unsqueeze(-1)
+    return nope, group_scales, rope, rope_scales
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+@torch.inference_mode()
+def test_writer_preserves_skipped_slots_and_writes_the_record_abi(
+    dtype: torch.dtype,
+) -> None:
+    device = require_sm120()
+    num_tokens = 6
+    kv_c, k_pe, expected_packed, expected_group_scales, expected_rope_scales = (
+        _make_exactly_quantizable_inputs(
+            num_tokens=num_tokens,
+            dtype=dtype,
+            device=device,
+        )
+    )
+
+    # The cache view has a full guard page on each side. The capacity slot
+    # targets the first trailing guard record without an upper-bound check. The
+    # huge slot's low 32 bits name an otherwise untouched in-cache record, so a
+    # check performed only after Int32 narrowing is also observable.
+    backing = torch.full(
+        (5, _PAGE_SIZE, _RECORD_BYTES),
+        _SENTINEL,
+        dtype=torch.uint8,
+        device=device,
+    )
+    cache = backing[1:4]
+    capacity = cache.shape[0] * cache.shape[1]
+    slot_mapping = torch.tensor(
+        [0, -1, capacity, 65, 2**40 + 17, 130],
+        dtype=torch.int64,
+        device=device,
+    )
+    if dtype == torch.float16:
+        concat_and_cache_nvfp4_mla_fp8_rope(
+            kv_c,
+            k_pe,
+            cache,
+            slot_mapping,
+            scale=torch.tensor([37.0], dtype=torch.float32, device=device),
+        )
+    else:
+        concat_and_cache_nvfp4_mla_fp8_rope(kv_c, k_pe, cache, slot_mapping)
+    torch.cuda.synchronize(device)
+
+    changed_records = (
+        (backing != _SENTINEL)
+        .any(dim=-1)
+        .reshape(-1)
+        .nonzero(as_tuple=False)
+        .reshape(-1)
+    )
+    expected_changed = torch.tensor(
+        [_PAGE_SIZE, 2 * _PAGE_SIZE + 1, 3 * _PAGE_SIZE + 2],
+        dtype=torch.int64,
+        device=device,
+    )
+    assert torch.equal(changed_records, expected_changed)
+
+    live_slots = torch.tensor([0, 65, 130], dtype=torch.int64, device=device)
+    live_tokens = torch.tensor([0, 3, 5], dtype=torch.int64, device=device)
+    records = cache.reshape(-1, _RECORD_BYTES).index_select(0, live_slots)
+
+    # These byte ranges are the public record ABI consumed by the real readers.
+    assert torch.equal(
+        records[:, :_NOPE_BYTES], expected_packed.index_select(0, live_tokens)
+    )
+    assert torch.count_nonzero(records[:, _PAD_OFFSET:_ROPE_OFFSET]).item() == 0
+
+    nope, group_scales, rope, rope_scales = _dequantize_records(records)
+    torch.testing.assert_close(
+        group_scales,
+        expected_group_scales.index_select(0, live_tokens),
+        rtol=0.0,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        rope_scales,
+        expected_rope_scales.index_select(0, live_tokens),
+        rtol=0.0,
+        atol=1e-7,
+    )
+    torch.testing.assert_close(
+        nope,
+        kv_c.index_select(0, live_tokens).float(),
+        rtol=0.0,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        rope,
+        k_pe.index_select(0, live_tokens).float(),
+        rtol=0.0,
+        atol=1e-5,
+    )
+
+
+def _make_written_reader_case(
+    *,
+    rows: int,
+    topk: int,
+    seed: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    kv_c = torch.randn(
+        (topk, _V_HEAD_DIM), generator=generator, dtype=torch.float32
+    ).to(device=device, dtype=torch.bfloat16)
+    k_pe = torch.randn(
+        (topk, _HEAD_DIM - _V_HEAD_DIM),
+        generator=generator,
+        dtype=torch.float32,
+    ).to(device=device, dtype=torch.bfloat16)
+    q = torch.randn(
+        (rows, _HEADS, _HEAD_DIM), generator=generator, dtype=torch.float32
+    ).to(device=device, dtype=torch.bfloat16)
+    indices = torch.stack(
+        [torch.randperm(topk, generator=generator) for _ in range(rows)]
+    ).to(device=device, dtype=torch.int32)
+
+    num_blocks = (topk + _PAGE_SIZE - 1) // _PAGE_SIZE
+    cache = torch.full(
+        (num_blocks, _PAGE_SIZE, _RECORD_BYTES),
+        _SENTINEL,
+        dtype=torch.uint8,
+        device=device,
+    )
+    slots = torch.arange(topk, dtype=torch.int64, device=device)
+    concat_and_cache_nvfp4_mla_fp8_rope(kv_c, k_pe, cache, slots)
+    return q, cache, indices
+
+
+def _reference_attention_from_records(
+    *,
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    nope, _, rope, _ = _dequantize_records(cache.reshape(-1, _RECORD_BYTES))
+    keys = torch.cat((nope, rope), dim=-1)
+    rows = []
+    for row, length in enumerate(lengths.cpu().tolist()):
+        selected = indices[row, :length].long()
+        selected_keys = keys.index_select(0, selected)
+        selected_values = nope.index_select(0, selected)
+        scores = q[row].float() @ selected_keys.T
+        probabilities = torch.softmax(scores * sm_scale, dim=-1)
+        rows.append(probabilities @ selected_values)
+    return torch.stack(rows)
+
+
+def _assert_reader_matches_dequantized_records(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+) -> None:
+    actual_f = actual.float()
+    max_abs = (actual_f - expected).abs().max().item()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_f.reshape(-1), expected.reshape(-1), dim=0
+    ).item()
+    assert max_abs < 0.03, f"max absolute error {max_abs:.8f} exceeded 0.03"
+    assert cosine > 0.999, f"cosine similarity {cosine:.8f} did not exceed 0.999"
+
+
+@torch.inference_mode()
+def test_writer_records_feed_production_head_multisplit_decode() -> None:
+    device = require_sm120()
+    topk = 129
+    q, cache, indices = _make_written_reader_case(
+        rows=1,
+        topk=topk,
+        seed=1301,
+        device=device,
+    )
+    lengths = torch.full((1,), topk, dtype=torch.int32, device=device)
+    sm_scale = _HEAD_DIM**-0.5
+
+    caps = SM12XSparseMLAScratchCaps(
+        device=device,
+        dtype=torch.bfloat16,
+        kv_dtype=torch.uint8,
+        num_q_heads=_HEADS,
+        max_q_rows=1,
+        max_batch=1,
+        max_width=topk,
+        max_kv_rows=topk,
+        head_dim=_HEAD_DIM,
+        v_head_dim=_V_HEAD_DIM,
+        max_chunks_per_row=8,
+        page_size=_PAGE_SIZE,
+    )
+    plan = plan_sparse_mla_scratch(caps)
+    (scratch_spec,) = plan.scratch_specs()
+    scratch_storage = torch.zeros(
+        scratch_spec.shape,
+        dtype=scratch_spec.dtype,
+        device=scratch_spec.device,
+    )
+    binding = plan.bind(
+        scratch=scratch_storage,
+        q=q,
+        selected_indices=indices,
+        cache_seqlens_int32=lengths,
+        nsa_cache_seqlens_int32=lengths,
+    )
+
+    actual = run_unified_decode(
+        q_all=q,
+        swa_k_cache=cache,
+        swa_indices=indices,
+        swa_topk_lengths=lengths,
+        workspace=binding.scratch,
+        sm_scale=sm_scale,
+        swa_page_size=_PAGE_SIZE,
+        forced_num_splits=2,
+        scale_format_override=ScaleFormat.NVFP4_E4M3,
+        fp8_rope_override=None,
+    )
+    expected = _reference_attention_from_records(
+        q=q,
+        cache=cache,
+        indices=indices,
+        lengths=lengths,
+        sm_scale=sm_scale,
+    )
+    torch.cuda.synchronize(device)
+    _assert_reader_matches_dequantized_records(actual, expected)
+
+
+@torch.inference_mode()
+def test_writer_records_feed_production_head_multitile_prefill_mg() -> None:
+    device = require_sm120()
+    topk = 129
+    q, cache, indices = _make_written_reader_case(
+        rows=2,
+        topk=topk,
+        seed=2302,
+        device=device,
+    )
+    lengths = torch.tensor([topk, 65], dtype=torch.int32, device=device)
+    sm_scale = _HEAD_DIM**-0.5
+
+    actual, _ = run_unified_prefill_mg(
+        q=q,
+        kv_cache=cache,
+        topk_indices=indices,
+        topk_length=lengths,
+        sm_scale=sm_scale,
+        page_block_size=_PAGE_SIZE,
+        compute_mode=ComputeMode.BF16,
+        mg_n_hg=2,
+        model_type=ModelType.GLM_NSA,
+        scale_format=ScaleFormat.NVFP4_E4M3,
+        fp8_rope=True,
+    )
+    expected = _reference_attention_from_records(
+        q=q,
+        cache=cache,
+        indices=indices,
+        lengths=lengths,
+        sm_scale=sm_scale,
+    )
+    torch.cuda.synchronize(device)
+    _assert_reader_matches_dequantized_records(actual, expected)

--- a/tests/experimental/attention/test_mla_nvfp4.py
+++ b/tests/experimental/attention/test_mla_nvfp4.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x.attention._shared.mla import api, traits
+from flashinfer.experimental.sm12x.attention._shared.mla.kernel import (
+    run_unified_decode,
+)
+from flashinfer.experimental.sm12x.attention._shared.mla.prefill_mg import (
+    run_unified_prefill_mg,
+)
+from flashinfer.experimental.sm12x.attention._shared.mla.smem import make_smem_layout
+from flashinfer.experimental.sm12x.attention._shared.mla.traits import (
+    ComputeMode,
+    ModelType,
+    ScaleFormat,
+)
+
+
+def test_nvfp4_decode_allocates_bf16_q_staging() -> None:
+    nvfp4_traits = traits.make_unified_traits(
+        ModelType.GLM_NSA,
+        ComputeMode.BF16,
+        ScaleFormat.NVFP4_E4M3,
+        fp8_rope=False,
+    )
+    layout = make_smem_layout(nvfp4_traits)
+
+    expected_bytes = nvfp4_traits.hpb * nvfp4_traits.q_nope_stride * 2
+    assert layout.q_fp8_bytes == expected_bytes
+    assert layout.q_sc_off >= layout.q_fp8_off + expected_bytes
+
+
+def test_nvfp4_decode_rejects_unknown_record_width() -> None:
+    with pytest.raises(ValueError, match="must be 368 or 432 bytes"):
+        _run_invalid_nvfp4_decode(record_bytes=400, fp8_rope=None)
+
+
+def test_nvfp4_decode_rejects_fp8_rope_layout_mismatch() -> None:
+    with pytest.raises(ValueError, match="disagrees with fp8_rope_override"):
+        _run_invalid_nvfp4_decode(record_bytes=368, fp8_rope=False)
+
+
+def test_nvfp4_mg_prefill_rejects_unknown_record_width() -> None:
+    with pytest.raises(ValueError, match="must be 368 or 432 bytes"):
+        _run_invalid_nvfp4_mg_prefill(record_bytes=400, fp8_rope=None)
+
+
+def test_nvfp4_mg_prefill_rejects_explicit_layout_mismatch() -> None:
+    with pytest.raises(ValueError, match="disagrees with fp8_rope"):
+        _run_invalid_nvfp4_mg_prefill(record_bytes=368, fp8_rope=False)
+
+
+def test_api_uses_traits_fp8_rope_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(traits, "KV_FP8_ROPE_ENABLED", True)
+    assert api._resolve_kv_fp8_rope(None) is True
+
+    monkeypatch.setattr(traits, "KV_FP8_ROPE_ENABLED", False)
+    assert api._resolve_kv_fp8_rope(None) is False
+
+
+def _run_invalid_nvfp4_decode(*, record_bytes: int, fp8_rope: bool | None) -> None:
+    rows = 1
+    topk = 4
+    run_unified_decode(
+        q_all=torch.empty((rows, 8, 576), dtype=torch.bfloat16),
+        swa_k_cache=torch.empty((1, 1, record_bytes), dtype=torch.uint8),
+        swa_indices=torch.zeros((rows, topk), dtype=torch.int32),
+        swa_topk_lengths=torch.full((rows,), topk, dtype=torch.int32),
+        workspace=object(),
+        sm_scale=0.1,
+        swa_page_size=64,
+        scale_format_override=ScaleFormat.NVFP4_E4M3,
+        fp8_rope_override=fp8_rope,
+    )
+
+
+def _run_invalid_nvfp4_mg_prefill(*, record_bytes: int, fp8_rope: bool | None) -> None:
+    rows = 1
+    topk = 4
+    run_unified_prefill_mg(
+        q=torch.empty((rows, 16, 576), dtype=torch.bfloat16),
+        kv_cache=torch.empty((1, 1, record_bytes), dtype=torch.uint8),
+        topk_indices=torch.zeros((rows, topk), dtype=torch.int32),
+        sm_scale=0.1,
+        page_block_size=1,
+        model_type=ModelType.GLM_NSA,
+        scale_format=ScaleFormat.NVFP4_E4M3,
+        fp8_rope=fp8_rope,
+    )

--- a/tests/experimental/attention/test_nsa_indexer.py
+++ b/tests/experimental/attention/test_nsa_indexer.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.attention.nsa_indexer.reference import (
+    pack_index_k_cache_reference,
+    contiguous_logits_reference,
+    paged_decode_logits_reference,
+    unpack_index_k_cache_reference,
+)
+
+
+_FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+
+
+def _make_real_page_table(
+    *,
+    page_starts: list[int],
+    seqlens: list[int],
+    width_blocks: int,
+    device: torch.device,
+) -> torch.Tensor:
+    real_page_table = torch.full(
+        (len(seqlens), width_blocks),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    for row_idx, (page_start, seq_len) in enumerate(
+        zip(page_starts, seqlens, strict=True)
+    ):
+        block_count = (int(seq_len) + 63) // 64
+        if block_count:
+            real_page_table[row_idx, :block_count] = torch.arange(
+                page_start,
+                page_start + block_count,
+                dtype=torch.int32,
+                device=device,
+            )
+    return real_page_table
+
+
+def _manual_paged_logits(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    k_matrix: torch.Tensor,
+    real_page_table: torch.Tensor,
+    query_row_to_batch: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+) -> torch.Tensor:
+    num_queries = q_fp8.shape[0]
+    width_tokens = real_page_table.shape[1] * 64
+    out = torch.full(
+        (num_queries, width_tokens),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    q_fp32 = q_fp8.to(torch.float32)
+    weights_f = weights.to(torch.float32)
+    for query_row in range(int(query_row_to_batch.numel())):
+        batch_row = int(query_row_to_batch[query_row].item())
+        seq_len = min(int(seqlens_per_query[query_row].item()), width_tokens)
+        for token_pos in range(seq_len):
+            page_col = token_pos // 64
+            page_id = int(real_page_table[batch_row, page_col].item())
+            if page_id < 0:
+                continue
+            token_idx = page_id * 64 + (token_pos % 64)
+            score = torch.matmul(q_fp32[query_row], k_matrix[token_idx]).relu_()
+            out[query_row, token_pos] = (score * weights_f[query_row]).sum()
+    return out
+
+
+def _quantize_rows_to_kv_fp8(k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    scale = k.abs().amax(dim=1) / _FP8_E4M3_MAX
+    scale = torch.where(scale > 0, scale, torch.ones_like(scale))
+    quant = (
+        (k / scale.unsqueeze(1))
+        .clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX)
+        .to(torch.float8_e4m3fn)
+    )
+    return quant, scale.to(torch.float32)
+
+
+def _manual_contiguous_logits(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    k_matrix: torch.Tensor,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+) -> torch.Tensor:
+    num_queries = q_fp8.shape[0]
+    out = torch.full(
+        (num_queries, k_matrix.shape[0]),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    q_fp32 = q_fp8.to(torch.float32)
+    weights_f = weights.to(torch.float32)
+    for query_row in range(int(k_start.numel())):
+        ks = max(0, int(k_start[query_row].item()))
+        ke = min(int(k_end[query_row].item()), k_matrix.shape[0])
+        if ke <= ks:
+            continue
+        score = torch.matmul(q_fp32[query_row], k_matrix[ks:ke].transpose(0, 1)).relu_()
+        out[query_row, ks:ke] = (score * weights_f[query_row].unsqueeze(1)).sum(dim=0)
+    return out
+
+
+def _scalar_paged_logits_oracle(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    k_dequant: torch.Tensor,
+    real_page_table: torch.Tensor,
+    query_row_to_batch: torch.Tensor,
+    seqlens_per_query: torch.Tensor,
+) -> torch.Tensor:
+    num_queries = q_fp8.shape[0]
+    width_tokens = real_page_table.shape[1] * 64
+    out = torch.full(
+        (num_queries, width_tokens),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    for query_row in range(int(query_row_to_batch.numel())):
+        batch_row = int(query_row_to_batch[query_row].item())
+        seq_len = min(max(0, int(seqlens_per_query[query_row].item())), width_tokens)
+        for logical_pos in range(seq_len):
+            page_id = int(real_page_table[batch_row, logical_pos // 64].item())
+            if page_id < 0:
+                continue
+            physical = page_id * 64 + (logical_pos % 64)
+            if physical < 0 or physical >= k_dequant.shape[0]:
+                continue
+            acc = torch.tensor(0.0, dtype=torch.float32, device=q_fp8.device)
+            for head in range(q_fp8.shape[1]):
+                score = torch.dot(
+                    q_fp8[query_row, head].to(torch.float32),
+                    k_dequant[physical].to(torch.float32),
+                )
+                acc = acc + torch.relu(score) * weights[query_row, head].to(
+                    torch.float32
+                )
+            out[query_row, logical_pos] = acc
+    return out
+
+
+def _scalar_contiguous_logits_oracle(
+    *,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    k_dequant: torch.Tensor,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+) -> torch.Tensor:
+    out = torch.full(
+        (q_fp8.shape[0], k_dequant.shape[0]),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    for query_row in range(int(k_start.numel())):
+        ks = max(0, int(k_start[query_row].item()))
+        ke = min(int(k_end[query_row].item()), k_dequant.shape[0])
+        for key_row in range(ks, ke):
+            acc = torch.tensor(0.0, dtype=torch.float32, device=q_fp8.device)
+            for head in range(q_fp8.shape[1]):
+                score = torch.dot(
+                    q_fp8[query_row, head].to(torch.float32),
+                    k_dequant[key_row].to(torch.float32),
+                )
+                acc = acc + torch.relu(score) * weights[query_row, head].to(
+                    torch.float32
+                )
+            out[query_row, key_row] = acc
+    return out
+
+
+@torch.inference_mode()
+def test_pack_nsa_index_k_cache_roundtrip_matches_input_for_odd_lengths() -> None:
+    device = torch.device("cpu")
+    for num_tokens in (63, 64, 65, 127, 128, 129):
+        gen = torch.Generator(device="cpu")
+        gen.manual_seed(70_000 + num_tokens)
+        k = (
+            torch.randn(
+                (num_tokens, 128), generator=gen, dtype=torch.float32, device=device
+            )
+            / 4
+        )
+        packed = pack_index_k_cache_reference(k)
+        unpacked = unpack_index_k_cache_reference(packed, num_tokens=num_tokens)
+        max_abs = (unpacked - k).abs().max().item()
+        rmse = torch.sqrt(((unpacked - k) ** 2).mean()).item()
+        assert packed.shape == (((num_tokens + 63) // 64), 64 * (128 + 4))
+        assert max_abs <= 0.08, f"num_tokens={num_tokens}: max_abs={max_abs:.6f}"
+        assert rmse <= 0.008, f"num_tokens={num_tokens}: rmse={rmse:.6f}"
+
+
+def test_paged_decode_logits_reference_matches_manual() -> None:
+    device = torch.device("cpu")
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(71_001)
+
+    page_starts = [2, 6, 10]
+    width_blocks = 3
+    num_tokens = (max(page_starts) + width_blocks) * 64
+    q_rows = 3
+    num_heads = 4
+    seqlens = torch.tensor([65, 96, 130], dtype=torch.int32, device=device)
+    real_page_table = _make_real_page_table(
+        page_starts=page_starts,
+        seqlens=seqlens.tolist(),
+        width_blocks=width_blocks,
+        device=device,
+    )
+    k = (
+        torch.randn(
+            (num_tokens, 128), generator=gen, dtype=torch.float32, device=device
+        )
+        / 3
+    )
+    index_k_cache = pack_index_k_cache_reference(k)
+    unpacked = unpack_index_k_cache_reference(index_k_cache, num_tokens=num_tokens)
+    q_fp8 = (
+        torch.randn(
+            (q_rows, num_heads, 128), generator=gen, dtype=torch.float32, device=device
+        )
+        / 2
+    ).to(torch.float8_e4m3fn)
+    weights = torch.randn(
+        (q_rows, num_heads), generator=gen, dtype=torch.float32, device=device
+    )
+
+    actual = paged_decode_logits_reference(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        query_row_to_batch=torch.arange(q_rows, dtype=torch.int32, device=device),
+        seqlens_per_query=seqlens,
+    )
+    expected = _manual_paged_logits(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_matrix=unpacked,
+        real_page_table=real_page_table,
+        query_row_to_batch=torch.arange(q_rows, dtype=torch.int32, device=device),
+        seqlens_per_query=seqlens,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+
+def test_contiguous_logits_reference_matches_manual() -> None:
+    device = torch.device("cpu")
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(71_002)
+
+    q_rows = 5
+    num_heads = 3
+    k_rows = 80
+    q_fp8 = (
+        torch.randn(
+            (q_rows, num_heads, 128), generator=gen, dtype=torch.float32, device=device
+        )
+        / 2
+    ).to(torch.float8_e4m3fn)
+    weights = torch.randn(
+        (q_rows, num_heads), generator=gen, dtype=torch.float32, device=device
+    )
+    k = (
+        torch.randn((k_rows, 128), generator=gen, dtype=torch.float32, device=device)
+        / 3
+    )
+    kv_fp8 = _quantize_rows_to_kv_fp8(k)
+    k_start = torch.tensor([0, 4, 12, 40, 40], dtype=torch.int32, device=device)
+    k_end = torch.tensor([8, 20, 20, 56, 40], dtype=torch.int32, device=device)
+
+    actual = contiguous_logits_reference(
+        q_fp8=q_fp8,
+        weights=weights,
+        kv_fp8=kv_fp8,
+        k_start=k_start,
+        k_end=k_end,
+    )
+    expected = _manual_contiguous_logits(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_matrix=kv_fp8[0].to(torch.float32) * kv_fp8[1].unsqueeze(1),
+        k_start=k_start,
+        k_end=k_end,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+
+def test_paged_decode_logits_reference_matches_scalar_oracle_for_expanded_queries() -> (
+    None
+):
+    device = torch.device("cpu")
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(71_003)
+
+    real_page_table = torch.tensor(
+        [
+            [4, -1, 1],
+            [7, 2, -1],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    q_rows = 4
+    num_heads = 5
+    num_tokens = 8 * 64
+    k = (
+        torch.randn(
+            (num_tokens, 128), generator=gen, dtype=torch.float32, device=device
+        )
+        / 5
+    )
+    index_k_cache = pack_index_k_cache_reference(k)
+    k_dequant = unpack_index_k_cache_reference(index_k_cache, num_tokens=num_tokens)
+    q_fp8 = (
+        torch.randn(
+            (q_rows, num_heads, 128), generator=gen, dtype=torch.float32, device=device
+        )
+        / 3
+    ).to(torch.float8_e4m3fn)
+    weights = torch.randn(
+        (q_rows, num_heads), generator=gen, dtype=torch.float32, device=device
+    )
+    query_row_to_batch = torch.tensor([1, 0, 1, 0], dtype=torch.int32, device=device)
+    seqlens_per_query = torch.tensor([65, 9, 130, 0], dtype=torch.int32, device=device)
+
+    actual = paged_decode_logits_reference(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        query_row_to_batch=query_row_to_batch,
+        seqlens_per_query=seqlens_per_query,
+    )
+    expected = _scalar_paged_logits_oracle(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_dequant=k_dequant,
+        real_page_table=real_page_table,
+        query_row_to_batch=query_row_to_batch,
+        seqlens_per_query=seqlens_per_query,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+
+def test_contiguous_logits_reference_matches_scalar_oracle_for_clamped_ranges() -> None:
+    device = torch.device("cpu")
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(71_004)
+
+    q_rows = 4
+    num_heads = 4
+    k_rows = 19
+    q_fp8 = (
+        torch.randn(
+            (q_rows, num_heads, 128), generator=gen, dtype=torch.float32, device=device
+        )
+        / 4
+    ).to(torch.float8_e4m3fn)
+    weights = torch.randn(
+        (q_rows, num_heads), generator=gen, dtype=torch.float32, device=device
+    )
+    k = (
+        torch.randn((k_rows, 128), generator=gen, dtype=torch.float32, device=device)
+        / 4
+    )
+    kv_fp8 = _quantize_rows_to_kv_fp8(k)
+    k_dequant = kv_fp8[0].to(torch.float32) * kv_fp8[1].unsqueeze(1)
+    k_start = torch.tensor([-3, 0, 7, 18], dtype=torch.int32, device=device)
+    k_end = torch.tensor([2, 0, 99, 18], dtype=torch.int32, device=device)
+
+    actual = contiguous_logits_reference(
+        q_fp8=q_fp8,
+        weights=weights,
+        kv_fp8=kv_fp8,
+        k_start=k_start,
+        k_end=k_end,
+    )
+    expected = _scalar_contiguous_logits_oracle(
+        q_fp8=q_fp8,
+        weights=weights,
+        k_dequant=k_dequant,
+        k_start=k_start,
+        k_end=k_end,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)

--- a/tests/experimental/attention/test_paged.py
+++ b/tests/experimental/attention/test_paged.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""attention.paged: decode and extend parity vs the in-tree reference through
+the eager public lifecycle (plan -> bind -> run), BF16 and FP8 KV — the same
+call sequence vLLM's integration uses.
+
+Note: b12x's paged CUDA-graph replay tests are stale against the current
+decode-graph planner heuristics (they fail upstream too), so they were not
+ported; graph coverage for the attention family comes from
+test_compressed_mla.py until they are refreshed.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.attention import paged
+from flashinfer.experimental.sm12x.attention.paged.reference import (
+    paged_attention_reference,
+)
+
+from .._reference.paged_attention_helpers import (
+    make_paged_inputs,
+    quantize_paged_kv_cache_e4m3,
+)
+from ..conftest import require_sm12x
+
+
+def _run_eager(
+    q,
+    k_cache,
+    v_cache,
+    page_table,
+    cache_seqlens,
+    cu_seqlens_q,
+    *,
+    mode: str,
+    k_descale=None,
+    v_descale=None,
+):
+    plan = paged.plan(
+        paged.Caps(
+            device=q.device,
+            mode=mode,
+            dtype=q.dtype,
+            kv_dtype=k_cache.dtype,
+            num_q_heads=q.shape[1],
+            num_kv_heads=k_cache.shape[2],
+            head_dim_qk=q.shape[2],
+            head_dim_vo=v_cache.shape[3],
+            page_size=k_cache.shape[1],
+            max_total_q=q.shape[0],
+            max_batch=page_table.shape[0],
+            max_page_table_width=page_table.shape[1],
+            max_work_items=1024,
+            max_partial_rows=16384,
+            num_cache_pages=k_cache.shape[0],
+            use_cuda_graph=False,
+        )
+    )
+    spec = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=q.device)
+    output = torch.empty(
+        (q.shape[0], q.shape[1], v_cache.shape[3]), dtype=q.dtype, device=q.device
+    )
+    binding = paged.bind(
+        plan,
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        active_total_q=int(q.shape[0]),
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    out, lse = paged.run(binding=binding)
+    return out, lse
+
+
+def _cosine(a: torch.Tensor, b: torch.Tensor) -> float:
+    return torch.nn.functional.cosine_similarity(
+        a.float().reshape(-1), b.float().reshape(-1), dim=0
+    ).item()
+
+
+def test_run_decode_matches_reference() -> None:
+    require_sm12x()
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1, 1, 1, 1],
+        cache_seqlens=[64, 128, 192, 256],
+        page_size=64,
+        seed=73,
+    )
+    out, _ = _run_eager(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, mode="decode"
+    )
+    ref_out, _ = paged_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, causal=True
+    )
+    torch.cuda.synchronize()
+    assert (out - ref_out).abs().max().item() <= 0.02
+    assert _cosine(out, ref_out) >= 0.99999
+
+
+def test_run_decode_fp8_kv_matches_reference() -> None:
+    require_sm12x()
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1, 1, 1, 1],
+        cache_seqlens=[64, 192, 256, 448],
+        page_size=64,
+        seed=91,
+    )
+    k_fp8, v_fp8, k_descale, v_descale = quantize_paged_kv_cache_e4m3(
+        k_cache, v_cache, page_table, cache_seqlens
+    )
+    out, _ = _run_eager(
+        q,
+        k_fp8,
+        v_fp8,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        mode="decode",
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    ref_out, _ = paged_attention_reference(
+        q,
+        k_fp8,
+        v_fp8,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        causal=True,
+    )
+    torch.cuda.synchronize()
+    assert (out - ref_out).abs().max().item() <= 0.06
+    assert _cosine(out, ref_out) >= 0.999
+
+
+def test_run_extend_matches_reference() -> None:
+    require_sm12x()
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[8, 16],
+        cache_seqlens=[128, 192],
+        page_size=64,
+        seed=57,
+    )
+    out, _ = _run_eager(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, mode="extend"
+    )
+    ref_out, _ = paged_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, causal=True
+    )
+    torch.cuda.synchronize()
+    assert (out - ref_out).abs().max().item() <= 0.02
+    assert _cosine(out, ref_out) >= 0.99999

--- a/tests/experimental/attention/test_sparse_mla.py
+++ b/tests/experimental/attention/test_sparse_mla.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""attention.sparse_mla: decode over top-k-selected tokens vs the in-tree
+pure-torch reference (packed NSA MLA cache layout), through the public
+plan -> bind -> run_decode lifecycle, including -1-padded selections.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.attention import sparse_mla
+from flashinfer.experimental.sm12x.attention._shared.mla.reference import (
+    pack_mla_kv_cache_reference,
+    sparse_mla_reference,
+)
+
+from ..conftest import require_sm12x
+
+NOPE_DIM = 512
+ROPE_DIM = 64
+HEAD_DIM = NOPE_DIM + ROPE_DIM
+V_HEAD_DIM = NOPE_DIM
+
+
+def _make_case(*, rows: int, heads: int, cache_tokens: int, width: int):
+    torch.manual_seed(20260716)
+    k_nope = (
+        torch.randn(cache_tokens, NOPE_DIM, device="cuda", dtype=torch.bfloat16) / 4
+    )
+    k_rope = (
+        torch.randn(cache_tokens, ROPE_DIM, device="cuda", dtype=torch.bfloat16) / 4
+    )
+    kv_cache = pack_mla_kv_cache_reference(k_nope, k_rope)
+    q_all = torch.randn(rows, heads, HEAD_DIM, device="cuda", dtype=torch.bfloat16) / 4
+
+    selected = torch.stack(
+        [
+            torch.randperm(cache_tokens, device="cuda")[:width].sort().values
+            for _ in range(rows)
+        ]
+    ).to(torch.int32)
+    cache_seqlens = torch.full((rows,), cache_tokens, dtype=torch.int32, device="cuda")
+    active = torch.full((rows,), width, dtype=torch.int32, device="cuda")
+    return q_all, kv_cache, selected, cache_seqlens, active
+
+
+def _run_public_decode(q_all, kv_cache, selected, cache_seqlens, active, *, width):
+    rows, heads, _ = q_all.shape
+    plan = sparse_mla.plan(
+        sparse_mla.Caps(
+            device=q_all.device,
+            num_q_heads=heads,
+            max_q_rows=rows,
+            max_width=width,
+            kv_dtype=torch.uint8,  # packed NSA byte cache (fp8+scale+rope)
+        )
+    )
+    spec = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=q_all.device)
+    binding = sparse_mla.bind(
+        plan,
+        scratch=scratch,
+        q=q_all,
+        selected_indices=selected,
+        cache_seqlens_int32=cache_seqlens,
+        nsa_cache_seqlens_int32=active,
+    )
+    sm_scale = HEAD_DIM**-0.5
+    out = sparse_mla.run_decode(
+        binding=binding,
+        kv_cache=kv_cache,
+        sm_scale=sm_scale,
+        v_head_dim=V_HEAD_DIM,
+    )
+    ref = sparse_mla_reference(
+        q_all=q_all,
+        kv_cache=kv_cache,
+        page_table_1=selected,
+        active_token_counts=active,
+        sm_scale=sm_scale,
+        v_head_dim=V_HEAD_DIM,
+    )
+    return out, ref
+
+
+def _assert_matches(out: torch.Tensor, ref: torch.Tensor) -> None:
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(out).all().item())
+    assert int(torch.count_nonzero(out).item()) > 0
+    cosine = torch.nn.functional.cosine_similarity(
+        out.float().flatten(), ref.float().flatten(), dim=0
+    )
+    assert float(cosine.item()) > 0.99, f"cosine {float(cosine.item()):.5f}"
+    torch.testing.assert_close(
+        out.float(), ref.to(out.dtype).float(), rtol=5e-2, atol=5e-2
+    )
+
+
+def test_run_decode_matches_reference() -> None:
+    require_sm12x()
+    q, kv, sel, lens, active = _make_case(rows=4, heads=16, cache_tokens=512, width=128)
+    out, ref = _run_public_decode(q, kv, sel, lens, active, width=128)
+    _assert_matches(out, ref)
+
+
+def test_run_decode_masks_padded_selection() -> None:
+    require_sm12x()
+    width = 128
+    q, kv, sel, lens, active = _make_case(
+        rows=4, heads=16, cache_tokens=512, width=width
+    )
+    # Invalidate the back half of every row's selection: pad with -1 and
+    # shrink the active counts to match; the kernel and reference must both
+    # attend only to the front half.
+    sel[:, width // 2 :] = -1
+    active.fill_(width // 2)
+    out, ref = _run_public_decode(q, kv, sel, lens, active, width=width)
+    _assert_matches(out, ref)

--- a/tests/experimental/attention/test_varlen.py
+++ b/tests/experimental/attention/test_varlen.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from ..conftest import require_sm12x as require_sm120
+
+
+def _require_contiguous_backend() -> torch.device:
+    device = require_sm120()
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cuda.bindings.driver")
+    return device
+
+
+def _run_attention_with_plan(
+    plan,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    softmax_scale: Optional[float] = None,
+    attention_sink_bias: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from flashinfer.experimental.sm12x.attention._shared.contiguous import (
+        sm12x_attention_forward,
+        plan_attention_scratch,
+    )
+
+    scratch_plan = plan_attention_scratch(plan)
+    spec = scratch_plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k=k,
+        v=v,
+        softmax_scale=softmax_scale,
+        attention_sink_bias=attention_sink_bias,
+    )
+    return sm12x_attention_forward(binding=binding)
+
+
+def _run_varlen_attention_with_plan(
+    plan,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    causal: Optional[bool] = None,
+    window_size: Optional[Tuple[int, int]] = None,
+    softmax_scale: Optional[float] = None,
+    attention_sink_bias: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from flashinfer.experimental.sm12x.attention._shared.contiguous import (
+        sm12x_varlen_attention_forward,
+        plan_varlen_attention_scratch,
+    )
+
+    scratch_plan = plan_varlen_attention_scratch(plan)
+    spec = scratch_plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=cu_seqlens,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        causal=causal,
+        window_size=window_size,
+        softmax_scale=softmax_scale,
+        attention_sink_bias=attention_sink_bias,
+    )
+    return sm12x_varlen_attention_forward(binding=binding)
+
+
+def _vision_reference_attention_segment(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    sinks: Optional[torch.Tensor],
+    num_kv_groups: int,
+    softmax_scale: float,
+    window_size: Tuple[int, int],
+) -> torch.Tensor:
+    output_dtype = q.dtype
+    q = q.float()
+    k = k.float()
+    v = v.float()
+
+    if num_kv_groups > 1:
+        k = k.repeat_interleave(num_kv_groups, dim=1)
+        v = v.repeat_interleave(num_kv_groups, dim=1)
+
+    q_len = q.shape[0]
+    k_len = k.shape[0]
+    scores = torch.einsum("qhd,khd->hqk", q, k) * softmax_scale
+
+    left, right = window_size
+    if left != -1 or right != -1:
+        q_pos = torch.arange(q_len, device=q.device).unsqueeze(1)
+        k_pos = torch.arange(k_len, device=q.device).unsqueeze(0)
+        q_aligned = q_pos + k_len - q_len
+        keep = torch.ones((q_len, k_len), dtype=torch.bool, device=q.device)
+        if left != -1:
+            keep &= k_pos >= q_aligned - left
+        if right != -1:
+            keep &= k_pos <= q_aligned + right
+        scores = scores.masked_fill(~keep.unsqueeze(0), float("-inf"))
+
+    if sinks is not None:
+        sink_logits = sinks.to(device=q.device, dtype=torch.float32).view(
+            q.shape[1], 1, 1
+        )
+        scores = torch.cat([scores, sink_logits.expand(q.shape[1], q_len, 1)], dim=-1)
+        attn_probs = F.softmax(scores, dim=-1, dtype=torch.float32)[..., :k_len]
+    else:
+        attn_probs = F.softmax(scores, dim=-1, dtype=torch.float32)
+
+    return torch.einsum("hqk,khd->qhd", attn_probs, v).to(dtype=output_dtype)
+
+
+def _vision_torch_ref_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    softmax_scale: Optional[float] = None,
+    window_size: Tuple[int, int] = (-1, -1),
+    s_aux: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if q.ndim != 3 or k.ndim != 3 or v.ndim != 3:
+        raise ValueError("q, k, and v must be packed rank-3 tensors")
+    if q.shape[1] % k.shape[1] != 0:
+        raise ValueError("q head count must be divisible by kv head count")
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(q.shape[-1])
+
+    offsets = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+    outputs = []
+    for start, end in zip(offsets[:-1], offsets[1:], strict=False):
+        outputs.append(
+            _vision_reference_attention_segment(
+                q[start:end],
+                k[start:end],
+                v[start:end],
+                sinks=s_aux,
+                num_kv_groups=q.shape[1] // k.shape[1],
+                softmax_scale=float(softmax_scale),
+                window_size=window_size,
+            )
+        )
+    if not outputs:
+        return torch.empty_like(q)
+    return torch.cat(outputs, dim=0)
+
+
+def _pack_rank4_segments(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if x.ndim != 4:
+        raise ValueError(f"expected rank-4 tensor, got rank {x.ndim}")
+    batch, seqlen = int(x.shape[0]), int(x.shape[1])
+    cu_seqlens = torch.arange(
+        0,
+        (batch + 1) * seqlen,
+        seqlen,
+        dtype=torch.int32,
+        device=x.device,
+    )
+    return x.reshape(batch * seqlen, *x.shape[2:]).contiguous(), cu_seqlens
+
+
+def _contiguous_ref_from_rank4(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    window_size: Tuple[int, int],
+    s_aux: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+) -> torch.Tensor:
+    q_packed, cu_seqlens = _pack_rank4_segments(q)
+    k_packed, k_cu_seqlens = _pack_rank4_segments(k)
+    v_packed, v_cu_seqlens = _pack_rank4_segments(v)
+    if not torch.equal(cu_seqlens, k_cu_seqlens) or not torch.equal(
+        cu_seqlens, v_cu_seqlens
+    ):
+        raise ValueError(
+            "torch_ref vision attention expects matching packed segment lengths"
+        )
+    out = _vision_torch_ref_attention(
+        q_packed,
+        k_packed,
+        v_packed,
+        cu_seqlens,
+        softmax_scale=softmax_scale,
+        window_size=window_size,
+        s_aux=s_aux,
+    )
+    return out.reshape(q.shape[0], q.shape[1], q.shape[2], v.shape[-1])
+
+
+def _make_gqa_inputs(
+    shape: tuple[int, int, int, int],
+    *,
+    kv_heads: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    seed: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+    batch, seqlen, q_heads, head_dim = shape
+    q = (
+        torch.randn(
+            batch,
+            seqlen,
+            q_heads,
+            head_dim,
+            generator=generator,
+            device=device,
+            dtype=dtype,
+        )
+        / 4
+    )
+    k = (
+        torch.randn(
+            batch,
+            seqlen,
+            kv_heads,
+            head_dim,
+            generator=generator,
+            device=device,
+            dtype=dtype,
+        )
+        / 4
+    )
+    v = (
+        torch.randn(
+            batch,
+            seqlen,
+            kv_heads,
+            head_dim,
+            generator=generator,
+            device=device,
+            dtype=dtype,
+        )
+        / 4
+    )
+    return q.contiguous(), k.contiguous(), v.contiguous()
+
+
+def _make_varlen_gqa_inputs(
+    lengths: tuple[int, ...],
+    *,
+    q_heads: int,
+    kv_heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    seed: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+    total = sum(lengths)
+    q = (
+        torch.randn(
+            total, q_heads, head_dim, generator=generator, device=device, dtype=dtype
+        )
+        / 4
+    )
+    k = (
+        torch.randn(
+            total, kv_heads, head_dim, generator=generator, device=device, dtype=dtype
+        )
+        / 4
+    )
+    v = (
+        torch.randn(
+            total, kv_heads, head_dim, generator=generator, device=device, dtype=dtype
+        )
+        / 4
+    )
+    offsets = [0]
+    for length in lengths:
+        offsets.append(offsets[-1] + int(length))
+    cu_seqlens = torch.tensor(offsets, dtype=torch.int32, device=device)
+    return q.contiguous(), k.contiguous(), v.contiguous(), cu_seqlens
+
+
+def _cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> float:
+    a_f = a.to(torch.float32).reshape(-1)
+    b_f = b.to(torch.float32).reshape(-1)
+    return torch.nn.functional.cosine_similarity(a_f, b_f, dim=0).item()
+
+
+def test_sglang_torch_ref_handles_local_window_gqa_and_sinks_on_cpu() -> None:
+    q, k, v = _make_gqa_inputs(
+        (2, 7, 4, 16),
+        kv_heads=2,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        seed=11,
+    )
+    sinks = torch.linspace(-0.5, 0.25, q.shape[2])
+
+    out = _contiguous_ref_from_rank4(
+        q,
+        k,
+        v,
+        window_size=(2, 1),
+        s_aux=sinks,
+    )
+    out_without_sinks = _contiguous_ref_from_rank4(
+        q,
+        k,
+        v,
+        window_size=(2, 1),
+    )
+
+    assert out.shape == q.shape
+    assert out.dtype == q.dtype
+    assert torch.isfinite(out).all()
+    assert not torch.allclose(out, out_without_sinks)
+
+
+@pytest.mark.parametrize(
+    ("causal", "window_size"),
+    [
+        (True, (-1, 0)),
+        (False, (-1, -1)),
+        (False, (8, 8)),
+    ],
+)
+@torch.inference_mode()
+def test_contiguous_attention_matches_sglang_torch_ref(
+    causal: bool,
+    window_size: Tuple[int, int],
+) -> None:
+    device = _require_contiguous_backend()
+    from flashinfer.experimental.sm12x.attention._shared.contiguous import (
+        clear_attention_caches,
+        create_attention_plan,
+    )
+
+    clear_attention_caches()
+    q, k, v = _make_gqa_inputs(
+        (1, 48, 4, 64),
+        kv_heads=2,
+        dtype=torch.bfloat16,
+        device=device,
+        seed=23 if causal else 29,
+    )
+
+    plan = create_attention_plan(q, k, v, causal=causal, window_size=window_size)
+    out, _lse = _run_attention_with_plan(
+        plan,
+        q,
+        k,
+        v,
+    )
+    torch.cuda.synchronize()
+
+    ref = _contiguous_ref_from_rank4(
+        q,
+        k,
+        v,
+        window_size=window_size,
+    )
+
+    assert (out - ref).abs().max().item() <= 0.03
+    assert _cosine_similarity(out, ref) >= 0.9999
+
+
+@torch.inference_mode()
+def test_varlen_contiguous_attention_matches_sglang_torch_ref_swa_gqa_and_sinks() -> (
+    None
+):
+    device = _require_contiguous_backend()
+    from flashinfer.experimental.sm12x.attention._shared.contiguous import (
+        clear_attention_caches,
+        create_varlen_attention_plan,
+    )
+
+    clear_attention_caches()
+    lengths = (5, 17, 9)
+    q, k, v, cu_seqlens = _make_varlen_gqa_inputs(
+        lengths,
+        q_heads=4,
+        kv_heads=2,
+        head_dim=64,
+        dtype=torch.bfloat16,
+        device=device,
+        seed=37,
+    )
+    window_size = (4, 3)
+    max_seqlen = max(lengths)
+    sinks = torch.linspace(
+        -0.25,
+        0.5,
+        q.shape[1],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    plan = create_varlen_attention_plan(
+        q,
+        k,
+        v,
+        cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+        causal=False,
+        window_size=window_size,
+        attention_sink_bias=sinks,
+    )
+    out, _lse = _run_varlen_attention_with_plan(
+        plan,
+        q,
+        k,
+        v,
+        cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+        causal=False,
+        window_size=window_size,
+        attention_sink_bias=sinks,
+    )
+    torch.cuda.synchronize()
+
+    ref = _vision_torch_ref_attention(
+        q,
+        k,
+        v,
+        cu_seqlens,
+        window_size=window_size,
+        s_aux=sinks,
+    )
+
+    assert (out - ref).abs().max().item() <= 0.035
+    assert _cosine_similarity(out, ref) >= 0.9998

--- a/tests/experimental/comm/test_pcie.py
+++ b/tests/experimental/comm/test_pcie.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.comm.pcie.pcie_oneshot import (
+    PCIeOneshotAllReduce,
+    PCIeOneshotAllReducePool,
+    parse_pcie_oneshot_max_size,
+)
+
+
+class _FakeExt:
+    def __init__(self):
+        self.init_calls = []
+        self.register_pcie_buffers_calls = []
+        self.register_buffer_calls = []
+        self.all_reduce_calls = []
+        self.all_reduce_fused_add_rms_norm_calls = []
+        self.dispose_calls = []
+        self.register_graph_buffers_calls = []
+        self.handle_bytes = [1, 2, 3]
+        self.offsets = [0, 64]
+
+    def init_custom_ar(self, signal_ptrs, rank_data, rank):
+        self.init_calls.append((tuple(signal_ptrs), rank_data.device.type, rank))
+        return 12345
+
+    def register_pcie_buffers(self, ptr, ptrs0, ptrs1):
+        self.register_pcie_buffers_calls.append((ptr, tuple(ptrs0), tuple(ptrs1)))
+
+    def register_buffer(self, ptr, peer_input_ptrs):
+        self.register_buffer_calls.append((ptr, tuple(peer_input_ptrs)))
+
+    def all_reduce(self, ptr, inp, out, reg_buffer, reg_buffer_bytes):
+        self.all_reduce_calls.append(
+            (
+                ptr,
+                int(inp.data_ptr()),
+                int(out.data_ptr()),
+                reg_buffer,
+                reg_buffer_bytes,
+            )
+        )
+        out.copy_(inp)
+
+    def all_reduce_fused_add_rms_norm(
+        self,
+        ptr,
+        inp,
+        residual,
+        weight,
+        out,
+        residual_out,
+        epsilon,
+        reg_buffer,
+        reg_buffer_bytes,
+    ):
+        self.all_reduce_fused_add_rms_norm_calls.append(
+            (
+                ptr,
+                int(inp.data_ptr()),
+                int(residual.data_ptr()),
+                int(weight.data_ptr()),
+                int(out.data_ptr()),
+                int(residual_out.data_ptr()),
+                epsilon,
+                reg_buffer,
+                reg_buffer_bytes,
+            )
+        )
+        residual_value = residual.clone()
+        residual_out.copy_(inp)
+        residual_out.add_(residual_value)
+        variance = residual_out.float().square().mean(dim=-1, keepdim=True)
+        normalized = residual_out.float() * torch.rsqrt(variance + epsilon)
+        out.copy_((normalized * weight.float()).to(out.dtype))
+
+    def dispose(self, ptr):
+        self.dispose_calls.append(ptr)
+
+    def meta_size(self):
+        return 256
+
+    def get_graph_buffer_ipc_meta(self, ptr):
+        return list(self.handle_bytes), list(self.offsets)
+
+    def register_graph_buffers(self, ptr, handles, offsets):
+        self.register_graph_buffers_calls.append((ptr, handles, offsets))
+
+
+def _make_runtime(
+    *,
+    rank=0,
+    world_size=2,
+    exchange_group=None,
+    max_size=8 * 1024 * 1024,
+    eager=False,
+    ext=None,
+    stream_affine=True,
+):
+    ext = ext or _FakeExt()
+    kwargs = {}
+    if eager:
+        kwargs["eager_buffer_ptrs0"] = tuple(range(200, 200 + world_size))
+        kwargs["eager_buffer_ptrs1"] = tuple(range(300, 300 + world_size))
+    return PCIeOneshotAllReduce(
+        rank=rank,
+        world_size=world_size,
+        device=torch.device("cpu"),
+        signal_ptrs=tuple(range(100, 100 + world_size)),
+        exchange_group=exchange_group,
+        max_size=max_size,
+        ext_module=ext,
+        stream_affine=stream_affine,
+        **kwargs,
+    )
+
+
+def test_parse_pcie_oneshot_max_size_accepts_auto_and_suffixes():
+    assert parse_pcie_oneshot_max_size(None) is None
+    assert parse_pcie_oneshot_max_size("auto") is None
+    assert parse_pcie_oneshot_max_size("64KB") == 64 * 1024
+    assert parse_pcie_oneshot_max_size("2m") == 2 * 1024 * 1024
+    assert parse_pcie_oneshot_max_size(4096) == 4096
+
+
+def test_register_buffer_is_idempotent_for_same_mapping():
+    runtime = _make_runtime()
+    ext = runtime._ext
+
+    runtime.register_buffer((111, 222))
+    runtime.register_buffer((111, 222))
+
+    assert ext.register_buffer_calls == [(12345, (111, 222))]
+
+
+def test_all_reduce_registers_explicit_peer_ptrs_once():
+    runtime = _make_runtime()
+    ext = runtime._ext
+    inp = torch.arange(8, dtype=torch.bfloat16)
+
+    out0 = runtime.all_reduce(inp, peer_input_ptrs=(inp.data_ptr(), 222))
+    out1 = runtime.all_reduce(inp, peer_input_ptrs=(inp.data_ptr(), 222))
+
+    assert torch.equal(out0, inp)
+    assert torch.equal(out1, inp)
+    assert ext.register_buffer_calls == [(12345, (inp.data_ptr(), 222))]
+    assert len(ext.all_reduce_calls) == 2
+
+
+def test_eager_buffers_allow_all_reduce_without_peer_ptrs():
+    runtime = _make_runtime(eager=True)
+    ext = runtime._ext
+    inp = torch.arange(8, dtype=torch.bfloat16)
+
+    out = runtime.all_reduce(inp)
+
+    assert torch.equal(out, inp)
+    assert ext.register_pcie_buffers_calls == [(12345, (200, 201), (300, 301))]
+    assert ext.register_buffer_calls == []
+    assert len(ext.all_reduce_calls) == 1
+
+
+def test_fused_add_rms_norm_returns_norm_and_residual_outputs():
+    runtime = _make_runtime(eager=True)
+    ext = runtime._ext
+    inp = torch.arange(16, dtype=torch.bfloat16).reshape(2, 8) / 8
+    residual = torch.linspace(-0.5, 0.5, 16, dtype=torch.bfloat16).reshape(2, 8)
+    weight = torch.linspace(0.75, 1.25, 8, dtype=torch.bfloat16)
+
+    out, residual_out = runtime.all_reduce_fused_add_rms_norm(
+        inp,
+        residual,
+        weight,
+        1e-6,
+    )
+
+    expected_residual = inp + residual
+    variance = expected_residual.float().square().mean(dim=-1, keepdim=True)
+    expected_out = (
+        expected_residual.float() * torch.rsqrt(variance + 1e-6) * weight.float()
+    ).to(torch.bfloat16)
+    torch.testing.assert_close(residual_out, expected_residual)
+    torch.testing.assert_close(out, expected_out)
+    assert len(ext.all_reduce_fused_add_rms_norm_calls) == 1
+
+
+def test_world_size_10_is_supported_by_eager_pool():
+    created = []
+
+    def make_channel(stream_key):
+        runtime = _make_runtime(rank=3, world_size=10, eager=True)
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeOneshotAllReducePool(
+        rank=3,
+        world_size=10,
+        device=torch.device("cpu"),
+        channel_factory=make_channel,
+    )
+
+    runtime = pool.for_stream()
+
+    assert runtime.world_size == 10
+    assert runtime._ext.init_calls == [
+        ((100, 101, 102, 103, 104, 105, 106, 107, 108, 109), "cpu", 3)
+    ]
+    assert runtime._ext.register_pcie_buffers_calls == [
+        (
+            12345,
+            (200, 201, 202, 203, 204, 205, 206, 207, 208, 209),
+            (300, 301, 302, 303, 304, 305, 306, 307, 308, 309),
+        )
+    ]
+    assert created == [(None, runtime)]

--- a/tests/experimental/comm/test_pcie_dcp_a2a.py
+++ b/tests/experimental/comm/test_pcie_dcp_a2a.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x.comm.pcie.pcie_dcp_a2a import (
+    PCIeDCPA2A,
+    _staging_layout,
+    lse_reduce_scatter_reference,
+)
+
+
+class _FakeExt:
+    def __init__(self) -> None:
+        self.init_calls = []
+        self.run_calls = []
+        self.dispose_calls = []
+
+    def init_dcp_a2a(
+        self,
+        signal_ptrs,
+        staging0_ptrs,
+        staging1_ptrs,
+        output_capacity_elems,
+        lse_offset,
+        lse_capacity,
+        rank,
+    ):
+        self.init_calls.append(
+            (
+                tuple(signal_ptrs),
+                tuple(staging0_ptrs),
+                tuple(staging1_ptrs),
+                output_capacity_elems,
+                lse_offset,
+                lse_capacity,
+                rank,
+            )
+        )
+        return 1234
+
+    def lse_reduce_scatter(
+        self,
+        pointer,
+        partial_output,
+        partial_lse,
+        out,
+        natural_log,
+        threads,
+        block_limit,
+    ):
+        self.run_calls.append(
+            (pointer, natural_log, threads, block_limit, tuple(partial_output.shape))
+        )
+        heads_per_rank = partial_output.shape[1] // 2
+        out.copy_(partial_output[:, :heads_per_rank])
+
+    def all_gather_heads(
+        self,
+        pointer,
+        local_input,
+        out,
+        threads,
+        block_limit,
+    ):
+        self.run_calls.append(
+            (
+                pointer,
+                "all_gather_heads",
+                threads,
+                block_limit,
+                tuple(local_input.shape),
+            )
+        )
+        out.copy_(torch.cat((local_input, local_input), dim=1))
+
+    def dispose(self, pointer):
+        self.dispose_calls.append(pointer)
+
+
+def _make_runtime(ext: _FakeExt | None = None) -> PCIeDCPA2A:
+    return PCIeDCPA2A(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        signal_ptrs=(100, 200),
+        staging0_ptrs=(300, 400),
+        staging1_ptrs=(500, 600),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        output_capacity_elems=4 * 32 * 64,
+        lse_offset=4 * 32 * 64 * 2,
+        lse_capacity=4 * 32,
+        ext_module=ext or _FakeExt(),
+    )
+
+
+def test_staging_layout_has_aligned_disjoint_slots():
+    layout = _staging_layout(
+        signal_bytes=12345,
+        world_size=2,
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=512,
+    )
+
+    assert layout.staging0_offset % 256 == 0
+    assert layout.staging1_offset == layout.staging0_offset + layout.slot_bytes
+    assert layout.lse_offset % 256 == 0
+    assert layout.slab_bytes == layout.staging1_offset + layout.slot_bytes
+    assert layout.output_capacity_elems >= 4 * 32 * 512
+    assert layout.lse_capacity >= 4 * 32
+
+    wider_query_layout = _staging_layout(
+        signal_bytes=12345,
+        world_size=2,
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=512,
+        query_head_dim=576,
+    )
+    assert wider_query_layout.output_capacity_elems >= 4 * 32 * 576
+    assert wider_query_layout.lse_offset > layout.lse_offset
+
+
+def test_reference_selects_destination_heads_and_combines_lse_weights():
+    outputs = torch.tensor(
+        [
+            [[[[1.0], [2.0], [10.0], [20.0]]]],
+            [[[[3.0], [4.0], [30.0], [40.0]]]],
+        ],
+        dtype=torch.float32,
+    ).reshape(2, 1, 4, 1)
+    lses = torch.tensor(
+        [
+            [[0.0, 0.0, 0.0, -torch.inf]],
+            [[0.0, -torch.inf, 0.0, -torch.inf]],
+        ]
+    )
+
+    rank0 = lse_reduce_scatter_reference(outputs, lses, 0)
+    rank1 = lse_reduce_scatter_reference(outputs, lses, 1)
+
+    torch.testing.assert_close(rank0, torch.tensor([[[2.0], [2.0]]]))
+    torch.testing.assert_close(rank1, torch.tensor([[[20.0], [0.0]]]))
+
+
+def test_runtime_validates_and_dispatches_to_extension():
+    ext = _FakeExt()
+    runtime = _make_runtime(ext)
+    partial_output = torch.arange(2 * 32 * 64, dtype=torch.bfloat16).reshape(2, 32, 64)
+    partial_lse = torch.zeros(2, 32, dtype=torch.float32)
+
+    out = runtime.lse_reduce_scatter(
+        partial_output,
+        partial_lse,
+        is_lse_base_on_e=False,
+        threads=256,
+        block_limit=32,
+    )
+
+    assert out.shape == (2, 16, 64)
+    assert torch.equal(out, partial_output[:, :16])
+    assert ext.run_calls == [(1234, False, 256, 32, (2, 32, 64))]
+
+    local_input = partial_output[:, :16].contiguous()
+    gathered = runtime.all_gather_heads(
+        local_input,
+        threads=64,
+        block_limit=16,
+    )
+    assert gathered.shape == partial_output.shape
+    assert torch.equal(gathered, torch.cat((local_input, local_input), dim=1))
+    assert ext.run_calls[-1] == (
+        1234,
+        "all_gather_heads",
+        64,
+        16,
+        (2, 16, 64),
+    )
+    runtime.close()
+    assert ext.dispose_calls == [1234]
+
+
+def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
+    runtime = _make_runtime()
+    good_output = torch.zeros(1, 32, 64, dtype=torch.bfloat16)
+    good_lse = torch.zeros(1, 32, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="float32"):
+        runtime.lse_reduce_scatter(good_output, good_lse.bfloat16())
+    with pytest.raises(ValueError, match="configured heads/head_dim"):
+        runtime.lse_reduce_scatter(good_output[:, :, :32], good_lse)
+    with pytest.raises(ValueError, match="exceeds configured capacity"):
+        runtime.lse_reduce_scatter(
+            torch.zeros(5, 32, 64, dtype=torch.bfloat16),
+            torch.zeros(5, 32, dtype=torch.float32),
+        )
+
+    with pytest.raises(ValueError, match="configured local heads/head_dim"):
+        runtime.all_gather_heads(good_output[:, :8])
+    with pytest.raises(ValueError, match="exceeds configured capacity"):
+        runtime.all_gather_heads(torch.zeros(5, 16, 64, dtype=torch.bfloat16))

--- a/tests/experimental/comm/test_pcie_twoshot.py
+++ b/tests/experimental/comm/test_pcie_twoshot.py
@@ -1,0 +1,202 @@
+"""Correctness + micro-benchmark for PCIe two-shot fp8 SP collectives.
+
+Run with torchrun on 2, 4 or 8 GPUs:
+
+    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.run \
+        --nproc-per-node=8 tests/distributed/test_pcie_twoshot.py
+"""
+
+import os
+import time
+
+import torch
+import torch.distributed as dist
+
+from flashinfer.experimental.sm12x.comm.pcie.pcie_twoshot import (
+    PCIeTwoShotSP,
+    quantize_per_row,
+)
+
+ROWS = 4096
+ROW_ELEMS = 6144
+
+
+def _partial(seed: int, rows: int, device: torch.device) -> torch.Tensor:
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    x = torch.randn(rows, ROW_ELEMS, generator=gen, dtype=torch.float32)
+    return x.to(device=device, dtype=torch.bfloat16)
+
+
+def _check_reduce_scatter(
+    pool: PCIeTwoShotSP, rank: int, world: int, step: int
+) -> None:
+    device = pool.device
+    payloads = []
+    scales = []
+    for r in range(world):
+        q, s = quantize_per_row(_partial(1000 * step + r, ROWS, device))
+        payloads.append(q)
+        scales.append(s)
+
+    out = pool.reduce_scatter_fp8(payloads[rank], scales[rank])
+
+    rows_per_rank = ROWS // world
+    lo, hi = rank * rows_per_rank, (rank + 1) * rows_per_rank
+    ref = torch.zeros(rows_per_rank, ROW_ELEMS, dtype=torch.float32, device=device)
+    for r in range(world):
+        ref += payloads[r][lo:hi].float() * scales[r][lo:hi, None]
+    torch.testing.assert_close(out.float(), ref, rtol=2e-2, atol=2e-2)
+
+
+def _check_all_gather(pool: PCIeTwoShotSP, rank: int, world: int, step: int) -> None:
+    device = pool.device
+    rows_per_rank = ROWS // world
+    shards = []
+    scales = []
+    for r in range(world):
+        q, s = quantize_per_row(_partial(5000 * step + r, rows_per_rank, device))
+        shards.append(q)
+        scales.append(s)
+
+    out = pool.all_gather_fp8(shards[rank], scales[rank])
+
+    ref = torch.cat(
+        [
+            (shards[r].float() * scales[r][:, None]).to(torch.bfloat16)
+            for r in range(world)
+        ]
+    )
+    assert torch.equal(out, ref), "all_gather must be exact (dequant only)"
+
+
+def _check_graph_capture(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
+    device = pool.device
+    rows_per_rank = ROWS // world
+    q_in = torch.zeros(ROWS, ROW_ELEMS, dtype=torch.float8_e4m3fn, device=device)
+    s_in = torch.zeros(ROWS, dtype=torch.float32, device=device)
+    rs_out = torch.empty(rows_per_rank, ROW_ELEMS, dtype=torch.bfloat16, device=device)
+    ag_q = torch.zeros(
+        rows_per_rank, ROW_ELEMS, dtype=torch.float8_e4m3fn, device=device
+    )
+    ag_s = torch.zeros(rows_per_rank, dtype=torch.float32, device=device)
+    ag_out = torch.empty(ROWS, ROW_ELEMS, dtype=torch.bfloat16, device=device)
+
+    graph = torch.cuda.CUDAGraph()
+    # Warmup on a side stream, then capture.
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
+        pool.all_gather_fp8(ag_q, ag_s, ag_out)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    with torch.cuda.graph(graph):
+        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
+        pool.all_gather_fp8(ag_q, ag_s, ag_out)
+
+    for step in (11, 12):
+        payloads, scales, shards, sscales = [], [], [], []
+        for r in range(world):
+            q, s = quantize_per_row(_partial(7000 * step + r, ROWS, device))
+            payloads.append(q)
+            scales.append(s)
+            qs, ss = quantize_per_row(_partial(9000 * step + r, ROWS // world, device))
+            shards.append(qs)
+            sscales.append(ss)
+        q_in.copy_(payloads[rank])
+        s_in.copy_(scales[rank])
+        ag_q.copy_(shards[rank])
+        ag_s.copy_(sscales[rank])
+        dist.barrier()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        rows_per_rank = ROWS // world
+        lo, hi = rank * rows_per_rank, (rank + 1) * rows_per_rank
+        ref = torch.zeros(rows_per_rank, ROW_ELEMS, dtype=torch.float32, device=device)
+        for r in range(world):
+            ref += payloads[r][lo:hi].float() * scales[r][lo:hi, None]
+        torch.testing.assert_close(rs_out.float(), ref, rtol=2e-2, atol=2e-2)
+        ag_ref = torch.cat(
+            [
+                (shards[r].float() * sscales[r][:, None]).to(torch.bfloat16)
+                for r in range(world)
+            ]
+        )
+        assert torch.equal(ag_out, ag_ref)
+
+
+def _bench(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
+    device = pool.device
+    rows_per_rank = ROWS // world
+    x = torch.randn(ROWS, ROW_ELEMS, dtype=torch.bfloat16, device=device)
+    q, s = quantize_per_row(x)
+    qs, ss = quantize_per_row(x[:rows_per_rank])
+    rs_out = torch.empty(rows_per_rank, ROW_ELEMS, dtype=torch.bfloat16, device=device)
+    ag_out = torch.empty(ROWS, ROW_ELEMS, dtype=torch.bfloat16, device=device)
+    nccl_rs_out = torch.empty(
+        rows_per_rank, ROW_ELEMS, dtype=torch.bfloat16, device=device
+    )
+    nccl_ag_out = torch.empty(ROWS, ROW_ELEMS, dtype=torch.bfloat16, device=device)
+    shard_bf16 = x[:rows_per_rank].contiguous()
+
+    def timeit(fn, iters=30) -> float:
+        for _ in range(5):
+            fn()
+        torch.cuda.synchronize()
+        dist.barrier()
+        start = time.perf_counter()
+        for _ in range(iters):
+            fn()
+        torch.cuda.synchronize()
+        return (time.perf_counter() - start) / iters * 1e6
+
+    results = {
+        "sm12x rs_fp8": timeit(lambda: pool.reduce_scatter_fp8(q, s, rs_out)),
+        "sm12x ag_fp8": timeit(lambda: pool.all_gather_fp8(qs, ss, ag_out)),
+        "nccl rs bf16": timeit(lambda: dist.reduce_scatter_tensor(nccl_rs_out, x)),
+        "nccl ag bf16": timeit(
+            lambda: dist.all_gather_into_tensor(nccl_ag_out, shard_bf16)
+        ),
+    }
+    if rank == 0:
+        payload_mb = ROWS * ROW_ELEMS / 1e6
+        print(
+            f"[{world} ranks, {ROWS}x{ROW_ELEMS}, payload {payload_mb:.0f} MB bf16-equiv]"
+        )
+        for name, us in results.items():
+            print(f"  {name:14s} {us:9.1f} us")
+
+
+def main() -> None:
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="nccl")
+    device = torch.device("cuda", local_rank)
+
+    pool = PCIeTwoShotSP.from_exchange_group(
+        exchange_group=dist.group.WORLD,
+        device=device,
+        max_rows=ROWS,
+        row_elems=ROW_ELEMS,
+    )
+
+    for step in range(4):  # exercises double-buffer slot alternation
+        _check_reduce_scatter(pool, rank, world, step)
+        _check_all_gather(pool, rank, world, step)
+    _check_graph_capture(pool, rank, world)
+    dist.barrier()
+    if rank == 0:
+        print("pcie_twoshot correctness OK")
+    _bench(pool, rank, world)
+
+    pool.close()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/experimental/conftest.py
+++ b/tests/experimental/conftest.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures/helpers for flashinfer.experimental tests.
+
+Keep this module importable without torch: the isolation/arch lint tests run
+in a stdlib-only CI job (with --confcutdir to skip the repo-root conftest).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def require_sm12x():
+    """Skip unless running on a consumer-Blackwell (SM120/SM121) GPU."""
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for experimental sm12x tests")
+    major, minor = torch.cuda.get_device_capability(torch.device("cuda"))
+    if major != 12 or minor not in (0, 1):
+        pytest.skip(f"SM12x (SM120/SM121) GPU required, found sm_{major}{minor}")
+    return torch.device("cuda")
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_seed():
+    try:
+        import torch
+    except ImportError:
+        yield
+        return
+    torch.manual_seed(42)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(42)
+    yield

--- a/tests/experimental/gemm/test_block_fp8_linear.py
+++ b/tests/experimental/gemm/test_block_fp8_linear.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""gemm.block_fp8_linear: quantized-reference parity + the planned lifecycle
+(plan -> bind -> run) replaying under CUDA-graph capture.
+
+Curated from b12x tests/test_gemm_block_fp8_linear.py; kernel-reuse and
+regime-policy tests stay in the b12x repo.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.gemm import block_fp8_linear as bfl
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+    dequantize_mxfp8_rows_torch,
+)
+
+from ..conftest import require_sm12x
+
+
+def _make_block_fp8_weight(
+    out_features: int, in_features: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    weight = (
+        torch.randn((out_features, in_features), device="cuda", dtype=torch.bfloat16)
+        / 8
+    ).to(torch.float8_e4m3fn)
+    scale_u8 = (
+        torch.arange(
+            (out_features // 128) * (in_features // 128),
+            device="cuda",
+            dtype=torch.int32,
+        )
+        % 3
+        + 126
+    ).to(torch.uint8)
+    scale = scale_u8.view(torch.float8_e8m0fnu).reshape(
+        out_features // 128, in_features // 128
+    )
+    return weight, scale
+
+
+def _reference(x: torch.Tensor, weight: torch.Tensor, scale: torch.Tensor):
+    x_q = bfl.quantize_input(x)
+    w_q = bfl.pack_weight(weight, scale)
+    x_deq = dequantize_mxfp8_rows_torch(x_q.values, x_q.scale_rows)
+    w_deq = dequantize_mxfp8_rows_torch(w_q.weight.values, w_q.weight.scale_rows)
+    return x_deq @ w_deq.T
+
+
+def test_run_matches_quantized_reference() -> None:
+    require_sm12x()
+    torch.manual_seed(20260523)
+
+    tokens, in_features, out_features = 7, 256, 384
+    x = (
+        torch.randn((tokens, in_features), device="cuda", dtype=torch.bfloat16) / 4
+    ).contiguous()
+    weight, scale = _make_block_fp8_weight(out_features, in_features)
+    packed = bfl.pack_weight(weight, scale)
+
+    actual = bfl.run(x, packed)
+    expected = _reference(x, weight, scale)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        actual.float(), expected.to(actual.dtype).float(), rtol=0, atol=0
+    )
+
+
+def test_plan_bind_run_replays_under_cuda_graph() -> None:
+    require_sm12x()
+    torch.manual_seed(20260526)
+
+    tokens, in_features, out_features = 1, 128, 256
+    x = (
+        torch.randn((tokens, in_features), device="cuda", dtype=torch.bfloat16) / 4
+    ).contiguous()
+    weight, scale = _make_block_fp8_weight(out_features, in_features)
+    packed = bfl.pack_weight(weight, scale)
+
+    plan = bfl.plan(
+        bfl.Caps(
+            device=x.device,
+            max_tokens=tokens,
+            in_features=in_features,
+            out_features=out_features,
+            output_dtype=x.dtype,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=x.device)
+        for shape, dtype in plan.shapes_and_dtypes()
+    )
+    output = torch.empty((tokens, out_features, 1), dtype=x.dtype, device=x.device)
+    binding = bfl.bind(
+        plan, scratch=scratch, source=x, packed_weight=packed, output=output
+    )
+
+    def run_once() -> torch.Tensor:
+        return bfl.run(binding=binding)
+
+    eager = run_once().clone()
+    torch.cuda.synchronize()
+
+    run_once()  # warm before capture
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = run_once()
+    for _ in range(3):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, eager, rtol=0, atol=0)

--- a/tests/experimental/gemm/test_blockscaled.py
+++ b/tests/experimental/gemm/test_blockscaled.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""gemm.blockscaled: NVFP4/MXFP8 dense block-scaled GEMM.
+
+Curated from b12x tests/test_gemm_stack.py: flashinfer-core cuDNN oracle
+parity (NVFP4), grouped MXFP8 per-batch scale correctness, and CUDA-graph
+replay. Exhaustive tile/support-matrix sweeps stay in the b12x repo.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x._lib import dense_gemm as dense_module
+from flashinfer.experimental.sm12x._lib.intrinsics import quantize_grouped_nvfp4_torch
+from flashinfer.experimental.sm12x._lib.utils import convert_sf_from_mma_layout
+from flashinfer.experimental.sm12x.gemm import blockscaled
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+    dequantize_mxfp8_rows_torch,
+    pack_fp8_block_scaled_weight_mxfp8,
+    quantize_mxfp8_rows_torch,
+)
+
+from ..conftest import require_sm12x
+
+
+def _require_cudnn_fp4_oracle():
+    """flashinfer core mm_fp4 (cuDNN backend) as the correctness oracle.
+
+    Tests may import both core and experimental; only package code is bound
+    by the isolation rule.
+    """
+    try:
+        from flashinfer.gemm import mm_fp4
+        from flashinfer.gemm.gemm_base import (
+            CUDNN_AVAILABLE,
+            _check_cudnn_fp4_availability,
+        )
+    except (ImportError, RuntimeError) as exc:
+        pytest.skip(f"flashinfer core mm_fp4 oracle unavailable: {exc}")
+    if not CUDNN_AVAILABLE:
+        pytest.skip("cuDNN Python bindings not installed")
+    try:
+        _check_cudnn_fp4_availability()
+    except RuntimeError as exc:
+        pytest.skip(f"cuDNN FP4 not available: {exc}")
+    return mm_fp4
+
+
+def _make_quantized_operand(
+    shape: tuple[int, int, int],
+    *,
+    dtype: torch.dtype,
+) -> tuple[tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    source = torch.randn(shape, device="cuda", dtype=dtype) / 4
+    row_counts = torch.full(
+        (shape[0],), shape[1], dtype=torch.int32, device=source.device
+    )
+    tensor_amax = source.abs().max().to(torch.float32)
+    global_scale = torch.tensor(
+        [torch.finfo(torch.float8_e4m3fn).max * 6.0 / tensor_amax],
+        dtype=torch.float32,
+        device=source.device,
+    )
+    packed, scales = quantize_grouped_nvfp4_torch(source, row_counts, global_scale)
+    return (packed, scales), global_scale
+
+
+def _mm_nvfp4(
+    lhs: tuple[torch.Tensor, torch.Tensor],
+    rhs: tuple[torch.Tensor, torch.Tensor],
+    lhs_scale: torch.Tensor,
+    rhs_scale: torch.Tensor,
+    *,
+    c_dtype: str = "bfloat16",
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    alpha = (1.0 / (lhs_scale[0] * rhs_scale[0])).view(1)
+    return blockscaled.mm(
+        lhs,
+        rhs,
+        out=out,
+        alpha=alpha,
+        ab_dtype="float4_e2m1fn",
+        sf_dtype="float8_e4m3fn",
+        c_dtype=c_dtype,
+        sf_vec_size=16,
+    )
+
+
+@pytest.mark.parametrize(
+    ("m", "n", "k", "c_dtype"),
+    [
+        (128, 128, 128, "bfloat16"),
+        (256, 512, 128, "bfloat16"),
+        (512, 256, 256, "bfloat16"),
+        (128, 128, 128, "float16"),
+    ],
+)
+def test_mm_nvfp4_matches_flashinfer_cudnn(m, n, k, c_dtype) -> None:
+    require_sm12x()
+    mm_fp4 = _require_cudnn_fp4_oracle()
+    torch.manual_seed(42)
+
+    lhs, lhs_scale = _make_quantized_operand((1, m, k), dtype=torch.bfloat16)
+    rhs, rhs_scale = _make_quantized_operand((1, n, k), dtype=torch.bfloat16)
+    alpha = (1.0 / (lhs_scale[0] * rhs_scale[0])).view(1)
+
+    actual = _mm_nvfp4(lhs, rhs, lhs_scale, rhs_scale, c_dtype=c_dtype)
+
+    packed_a, sfa = lhs
+    packed_b, sfb = rhs
+    oracle = mm_fp4(
+        packed_a[:, :, 0].contiguous(),
+        packed_b[:, :, 0].contiguous().T,
+        convert_sf_from_mma_layout(sfa, m=m, k=k, num_groups=1),
+        convert_sf_from_mma_layout(sfb, m=n, k=k, num_groups=1).T,
+        alpha,
+        torch.bfloat16 if c_dtype == "bfloat16" else torch.float16,
+        block_size=16,
+        use_8x4_sf_layout=False,
+        backend="cudnn",
+        use_nvfp4=True,
+    )
+
+    torch.testing.assert_close(actual[:, :, 0], oracle, rtol=0, atol=0)
+
+
+def test_mm_mxfp8_grouped_batches_use_their_own_scales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    require_sm12x()
+    torch.manual_seed(29)
+
+    # Real grouped WO-A geometry; force the shape-gated BK64 specialization so
+    # this compact test covers its packed-scale address arithmetic for L>1.
+    m, n, k = 64, 1024, 512
+    groups = 4
+    group_multipliers = torch.tensor(
+        [1.0, 2.0, 4.0, 0.5], device="cuda", dtype=torch.bfloat16
+    ).view(1, 1, groups)
+    a = torch.randn((m, k, groups), device="cuda", dtype=torch.bfloat16) / 4
+    a_q = quantize_mxfp8_rows_torch(a * group_multipliers)
+    b_values = (
+        torch.randn((groups * n, k), device="cuda", dtype=torch.bfloat16) / 32
+    ).to(torch.float8_e4m3fn)
+    b_scales = (
+        torch.tensor([1.0, 2.0, 4.0, 0.5], device="cuda", dtype=torch.float32)
+        .view(groups, 1, 1)
+        .expand(groups, n // 128, k // 128)
+        .reshape(groups * (n // 128), k // 128)
+        .contiguous()
+    )
+    b_q = pack_fp8_block_scaled_weight_mxfp8(
+        b_values, b_scales, m=n, k=k, num_groups=groups
+    )
+    assert not torch.equal(a_q.scale_rows[0], a_q.scale_rows[1])
+    assert not torch.equal(b_q.scale_rows[0], b_q.scale_rows[1])
+
+    monkeypatch.setattr(dense_module, "_select_mxfp8_tile_k", lambda *_: 64)
+    out = blockscaled.mm(
+        (a_q.values, a_q.scale_mma),
+        (b_q.values, b_q.scale_mma),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype="bfloat16",
+        sf_vec_size=32,
+        mma_tiler_mn=(128, 128),
+        expected_m=2048,
+        sfb_k_replicated=True,
+    )
+    a_deq = dequantize_mxfp8_rows_torch(a_q.values, a_q.scale_rows).to(torch.bfloat16)
+    b_deq = dequantize_mxfp8_rows_torch(b_q.values, b_q.scale_rows).to(torch.bfloat16)
+    ref = torch.einsum("mkl,nkl->mnl", a_deq, b_deq).to(torch.bfloat16)
+
+    torch.testing.assert_close(out, ref, rtol=0, atol=0)
+
+
+def test_mm_pair_replays_under_cuda_graph() -> None:
+    require_sm12x()
+    torch.manual_seed(1234)
+
+    gate_m, gate_n, gate_k = 32, 2048, 512
+    down_m, down_n, down_k = 32, 1024, 2048
+
+    gate_lhs, gate_ls = _make_quantized_operand(
+        (1, gate_m, gate_k), dtype=torch.bfloat16
+    )
+    gate_rhs, gate_rs = _make_quantized_operand(
+        (1, gate_n, gate_k), dtype=torch.bfloat16
+    )
+    down_lhs, down_ls = _make_quantized_operand(
+        (1, down_m, down_k), dtype=torch.bfloat16
+    )
+    down_rhs, down_rs = _make_quantized_operand(
+        (1, down_n, down_k), dtype=torch.bfloat16
+    )
+
+    eager_gate = _mm_nvfp4(gate_lhs, gate_rhs, gate_ls, gate_rs)
+    eager_down = _mm_nvfp4(down_lhs, down_rhs, down_ls, down_rs)
+    torch.cuda.synchronize()
+
+    graph_gate = torch.empty_like(eager_gate)
+    graph_down = torch.empty_like(eager_down)
+
+    # Prime compiled kernels before capture, matching the serving warmup path.
+    _mm_nvfp4(gate_lhs, gate_rhs, gate_ls, gate_rs)
+    _mm_nvfp4(down_lhs, down_rhs, down_ls, down_rs)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _mm_nvfp4(gate_lhs, gate_rhs, gate_ls, gate_rs, out=graph_gate)
+        _mm_nvfp4(down_lhs, down_rhs, down_ls, down_rs, out=graph_down)
+
+    for _ in range(3):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(graph_gate, eager_gate, rtol=0, atol=0)
+    torch.testing.assert_close(graph_down, eager_down, rtol=0, atol=0)

--- a/tests/experimental/gemm/test_mxfp8_linear.py
+++ b/tests/experimental/gemm/test_mxfp8_linear.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""gemm.mxfp8_linear: ModelOpt MXFP8 linear vs quantized reference, K-padding
+semantics, and CUDA-graph capture of the default fused path.
+
+Curated from b12x tests/test_gemm_mxfp8_linear.py (kept whole — it was
+already tight).
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x.gemm import block_fp8_linear as bfl
+from flashinfer.experimental.sm12x.gemm import mxfp8_linear
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+    dequantize_mxfp8_rows_torch,
+)
+
+from ..conftest import require_sm12x
+
+
+def require_mxf8_mma() -> None:
+    if not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
+        pytest.skip("CUTLASS DSL does not expose cute.nvgpu.warp.MmaMXF8Op")
+
+
+def _quantize_modelopt_mxfp8_rows(
+    source: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, width = map(int, source.shape)
+    chunks = width // 32
+    blocked = source.to(torch.float32).reshape(rows, chunks, 32)
+    max_abs = blocked.abs().amax(dim=-1)
+    safe = torch.where(max_abs > 0.0, max_abs / 448.0, torch.ones_like(max_abs))
+    scale_exp = torch.ceil(torch.log2(safe)).clamp(-127, 127)
+    scale_u8 = (scale_exp + 127).to(torch.uint8)
+    scale = scale_u8.view(torch.float8_e8m0fnu).to(torch.float32)
+    values = (
+        (blocked / scale[..., None])
+        .clamp(-448.0, 448.0)
+        .to(torch.float8_e4m3fn)
+        .reshape(rows, width)
+        .contiguous()
+    )
+    return values, scale_u8.contiguous()
+
+
+def _reference_from_packed(source: torch.Tensor, packed_weight) -> torch.Tensor:
+    rows, width = map(int, source.shape)
+    padded_width = int(packed_weight.padded_in_features)
+    if width != padded_width:
+        padded = source.new_zeros((rows, padded_width))
+        padded[:, :width] = source
+        source = padded.contiguous()
+    x_q = bfl.quantize_input(source)
+    x_deq = dequantize_mxfp8_rows_torch(x_q.values, x_q.scale_rows)
+    w_deq = dequantize_mxfp8_rows_torch(
+        packed_weight.weight.values, packed_weight.weight.scale_rows
+    )
+    return x_deq @ w_deq.T
+
+
+def _make_inputs(tokens: int, in_features: int, out_features: int):
+    source = (
+        torch.randn((tokens, in_features), device="cuda", dtype=torch.bfloat16) / 4
+    ).contiguous()
+    weight_bf16 = (
+        torch.randn((out_features, in_features), device="cuda", dtype=torch.bfloat16)
+        / 8
+    ).contiguous()
+    weight, weight_scale = _quantize_modelopt_mxfp8_rows(weight_bf16)
+    packed = mxfp8_linear.pack_weight(weight, weight_scale)
+    return source, weight_scale, packed
+
+
+def test_mm_matches_quantized_reference_small_n() -> None:
+    require_sm12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260614)
+
+    source, _, packed = _make_inputs(7, 128, 32)
+    actual = mxfp8_linear.mm(source, packed)
+    expected = _reference_from_packed(source, packed)
+    torch.cuda.synchronize()
+
+    assert actual.shape == (7, 32)
+    torch.testing.assert_close(
+        actual.float(), expected.to(actual.dtype).float(), rtol=0, atol=0
+    )
+
+
+def test_mm_pads_k32_to_dense_tile() -> None:
+    require_sm12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260615)
+
+    source, weight_scale, packed = _make_inputs(3, 160, 40)
+
+    assert packed.in_features == 160
+    assert packed.padded_in_features == 256
+    assert packed.weight.values.shape == (40, 256)
+    assert packed.weight.scale_rows.shape == (1, 40, 8)
+    torch.testing.assert_close(
+        packed.weight.scale_rows.view(torch.uint8)[0, :, :5], weight_scale
+    )
+    assert torch.all(packed.weight.scale_rows.view(torch.uint8)[0, :, 5:] == 127)
+
+    actual = mxfp8_linear.mm(source, packed)
+    expected = _reference_from_packed(source, packed)
+    torch.cuda.synchronize()
+
+    assert actual.shape == (3, 40)
+    torch.testing.assert_close(
+        actual.float(), expected.to(actual.dtype).float(), rtol=0, atol=0
+    )
+
+
+def test_mm_default_fused_path_captures_with_k_padding() -> None:
+    require_sm12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260616)
+
+    source, _, packed = _make_inputs(1, 160, 40)
+
+    eager = mxfp8_linear.mm(source, packed).clone()
+    torch.cuda.synchronize()
+
+    mxfp8_linear.mm(source, packed)  # warm before capture
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = mxfp8_linear.mm(source, packed)
+    for _ in range(3):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, eager, rtol=0, atol=0)

--- a/tests/experimental/gemm/test_wo_projection.py
+++ b/tests/experimental/gemm/test_wo_projection.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""gemm.wo_projection: planned lifecycle parity (plan -> bind -> run) against
+a quantized torch reference, plus the fused inverse-RoPE variant replaying
+under CUDA-graph capture with poisoned scale padding.
+
+Curated from b12x tests/test_gemm_wo_projection.py (1.2k lines upstream);
+split-GEMM leaves, packing round-trips, and byte-identity policy tests stay
+in the b12x repo.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.gemm import wo_projection as wo
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+    dequantize_mxfp8_rows_torch,
+    quantize_wo_projection_weights_mxfp8_torch,
+)
+
+from ..conftest import require_sm12x
+
+
+def test_plan_bind_run_singleton_group_matches_quantized_reference() -> None:
+    """TP8 collapses DSV4's eight output groups to one local WO group."""
+    require_sm12x()
+    torch.manual_seed(31005)
+
+    tokens, groups, group_width, rank, hidden = 3, 1, 512, 128, 128
+    x_tgd = (
+        torch.randn((tokens, groups, group_width), device="cuda", dtype=torch.bfloat16)
+        / 4
+    )
+    wo_a_grd = (
+        torch.randn((groups, rank, group_width), device="cuda", dtype=torch.bfloat16)
+        / group_width**0.5
+    )
+    wo_b_hgr = (
+        torch.randn((hidden, groups * rank), device="cuda", dtype=torch.bfloat16)
+        / (groups * rank) ** 0.5
+    )
+
+    weights = quantize_wo_projection_weights_mxfp8_torch(wo_a_grd, wo_b_hgr)
+    plan = wo.plan(
+        wo.Caps(
+            device=x_tgd.device,
+            max_tokens=tokens,
+            groups=groups,
+            group_width=group_width,
+            rank=rank,
+            hidden=hidden,
+            dtype=x_tgd.dtype,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=x_tgd.device)
+        for shape, dtype in plan.shapes_and_dtypes()
+    )
+    binding = wo.bind(
+        plan, scratch=scratch, source_tgd=x_tgd, weights=weights, expected_m=tokens
+    )
+    actual = wo.run(binding=binding)
+    torch.cuda.synchronize()
+
+    x_q = wo.quantize_input(x_tgd)
+    x_deq = dequantize_mxfp8_rows_torch(x_q.values, x_q.scale_rows)
+    wo_a_deq = dequantize_mxfp8_rows_torch(weights.wo_a.values, weights.wo_a.scale_rows)
+    tmp = (x_deq @ wo_a_deq.T).to(torch.bfloat16).unsqueeze(-1)
+    tmp_q = wo.quantize_input_b(tmp)
+    tmp_deq = dequantize_mxfp8_rows_torch(tmp_q.values, tmp_q.scale_rows)
+    wo_b_deq = dequantize_mxfp8_rows_torch(weights.wo_b.values, weights.wo_b.scale_rows)
+    expected = tmp_deq @ wo_b_deq.T
+
+    torch.testing.assert_close(actual, expected.to(actual.dtype), rtol=0, atol=0)
+
+
+def test_run_inv_rope_replays_under_graph_with_uninitialized_scale_padding() -> None:
+    require_sm12x()
+    torch.manual_seed(31007)
+
+    tokens = 1
+    groups = 2
+    heads_per_group = 4
+    nope_dim = 96
+    rope_dim = 32
+    head_dim = nope_dim + rope_dim
+    group_width = heads_per_group * head_dim
+    rank, hidden = 64, 128
+    o = (
+        torch.randn(
+            (tokens, groups * heads_per_group, head_dim),
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        / 4
+    ).contiguous()
+    positions = torch.zeros((tokens,), device="cuda", dtype=torch.long)
+    cos_sin_cache = torch.zeros((4, rope_dim), device="cuda", dtype=torch.float32)
+    cos_sin_cache[:, : rope_dim // 2] = 1
+    wo_a = (
+        torch.randn((groups, rank, group_width), device="cuda", dtype=torch.bfloat16)
+        / group_width**0.5
+    )
+    wo_b = (
+        torch.randn((hidden, groups * rank), device="cuda", dtype=torch.bfloat16)
+        / (groups * rank) ** 0.5
+    )
+    weights = quantize_wo_projection_weights_mxfp8_torch(wo_a, wo_b)
+
+    def run_once() -> torch.Tensor:
+        return wo.run_inv_rope(
+            o,
+            positions,
+            cos_sin_cache,
+            weights,
+            heads_per_group=heads_per_group,
+            nope_dim=nope_dim,
+            rope_dim=rope_dim,
+            expected_m=1,
+        )
+
+    # Warm all compilation/allocation before capture, then verify replay
+    # observes changed inputs without allocating or depending on stale scale
+    # padding.
+    run_once()
+    run_once()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run_once()
+    for _ in range(3):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    o.copy_(torch.randn_like(o) / 4)
+    graph.replay()
+    torch.cuda.synchronize()
+    replayed = captured.clone()
+    expected = run_once().clone()
+    torch.cuda.synchronize()
+
+    assert bool(torch.isfinite(replayed).all().item())
+    assert bool((replayed != 0).any().item())
+    torch.testing.assert_close(replayed, expected, rtol=0, atol=0)

--- a/tests/experimental/gemm/test_wo_projection_policy.py
+++ b/tests/experimental/gemm/test_wo_projection_policy.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import _should_use_exact_b16_wo
+
+
+def test_exact_b16_wo_is_spark_only() -> None:
+    assert _should_use_exact_b16_wo(tokens=16, sm_count=20)
+    assert not _should_use_exact_b16_wo(tokens=16, sm_count=188)
+    assert not _should_use_exact_b16_wo(tokens=8, sm_count=20)

--- a/tests/experimental/lint/test_arch_flags.py
+++ b/tests/experimental/lint/test_arch_flags.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Arch lint: experimental kernels may not target flagship datacenter archs.
+
+Proposal rule §1: experimental ops are for client GPU SKUs (SM12x).  This
+scan forbids SM90/SM100/SM103/SM110 arch spellings, gencode flags, capability
+helpers, and capability tuples anywhere under flashinfer/experimental/.
+
+Escape hatch for a legitimately needed mention (e.g. a comment explaining a
+ported heuristic): end the line with ``# arch-lint: allow``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+EXP = REPO / "flashinfer" / "experimental"
+
+ALLOW_MARKER = "arch-lint: allow"
+
+FORBIDDEN = [
+    re.compile(pattern)
+    for pattern in (
+        r"\bsm_?90a?\b",
+        r"\bsm_?100[af]?\b",
+        r"\bsm_?103a?\b",
+        r"\bsm_?110a?\b",
+        r"\bcompute_(90|100|103|110)\b",
+        r"is_sm(90|100|103|110)a?_supported",
+        r"\(\s*9\s*,\s*0\s*\)",
+        r"\(\s*10\s*,\s*[03]\s*\)",
+    )
+]
+
+
+def test_no_datacenter_arch_targets():
+    violations = []
+    for suffix in ("*.py", "*.cu", "*.cuh", "*.cpp", "*.h"):
+        for path in sorted(EXP.rglob(suffix)):
+            if "__pycache__" in path.parts:
+                continue
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                if ALLOW_MARKER in line:
+                    continue
+                for pattern in FORBIDDEN:
+                    if pattern.search(line):
+                        violations.append(
+                            f"  {path.relative_to(REPO)}:{lineno}: {line.strip()!r} "
+                            f"(matched {pattern.pattern!r})"
+                        )
+    assert not violations, (
+        "datacenter arch (SM90/SM100/SM103/SM110) references are forbidden in "
+        "flashinfer/experimental (rule §1); append '# arch-lint: allow' only "
+        "for justified mentions:\n" + "\n".join(violations)
+    )

--- a/tests/experimental/lint/test_isolation.py
+++ b/tests/experimental/lint/test_isolation.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Isolation lint: the structural guarantees of flashinfer.experimental.
+
+Two invariants, enforced statically (stdlib-only, no torch needed):
+
+1. Nothing under ``flashinfer/experimental/`` imports core flashinfer.
+   Experimental is self-sufficient (zero outbound imports), so core
+   refactors can never break it.
+2. Nothing in core ``flashinfer/`` imports (or names in a string literal)
+   ``flashinfer.experimental``.  This single check also proves that aot.py,
+   the jit-cache wheel, and the cubin wheel can never pick up experimental
+   code: their source sets are derived from core imports.
+
+Tests may import both worlds; only ``flashinfer/`` itself is scanned.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+PKG = REPO / "flashinfer"
+EXP = PKG / "experimental"
+
+_ESCAPES_PACKAGE = "<relative-import-escapes-repo>"
+
+
+def _iter_py(root: Path):
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def _import_targets(path: Path):
+    """Yield absolute dotted targets of every import, resolving relatives."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    pkg_parts = path.relative_to(REPO).parts[:-1]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0:
+                yield node.module or ""
+                continue
+            if node.level - 1 > len(pkg_parts):
+                yield _ESCAPES_PACKAGE
+                continue
+            base = ".".join(pkg_parts[: len(pkg_parts) - (node.level - 1)])
+            if node.module:
+                yield f"{base}.{node.module}" if base else node.module
+            else:
+                yield base
+
+
+def _fmt(violations: list[tuple[str, str]]) -> str:
+    return "\n".join(f"  {file}: {detail}" for file, detail in violations)
+
+
+def test_experimental_never_imports_core():
+    violations = []
+    for path in _iter_py(EXP):
+        rel = str(path.relative_to(REPO))
+        for target in _import_targets(path):
+            if target == _ESCAPES_PACKAGE:
+                violations.append((rel, "relative import escapes the repo root"))
+            elif target.startswith("flashinfer") and not target.startswith(
+                "flashinfer.experimental"
+            ):
+                violations.append((rel, f"imports core module {target!r}"))
+    assert not violations, (
+        "flashinfer/experimental must not import core flashinfer "
+        "(zero-outbound-imports rule):\n" + _fmt(violations)
+    )
+
+
+def test_core_never_imports_experimental():
+    literal = re.compile(r"""["']flashinfer\.experimental""")
+    violations = []
+    for path in _iter_py(PKG):
+        if path == EXP or EXP in path.parents:
+            continue
+        rel = str(path.relative_to(REPO))
+        for target in _import_targets(path):
+            if target.startswith("flashinfer.experimental"):
+                violations.append((rel, f"imports {target!r}"))
+        if literal.search(path.read_text()):
+            violations.append((rel, "references 'flashinfer.experimental' in a string"))
+    assert not violations, (
+        "core flashinfer must never import or reference flashinfer.experimental:\n"
+        + _fmt(violations)
+    )

--- a/tests/experimental/moe/test_ep_moe.py
+++ b/tests/experimental/moe/test_ep_moe.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""moe.ep_moe: two-rank expert-parallel partials must sum to the full fused
+MoE output (the strongest single consistency check across both moe ops), and
+a captured binding must observe changed routes on replay.
+
+Curated from b12x tests/test_ep_moe_api.py; scratch-sizing and contract
+validation unit tests stay in the b12x repo.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.moe import ep_moe
+
+from .._reference.helpers import run_tp_moe_fp4
+from ..conftest import require_sm12x
+from .test_fused_moe import make_modelopt_weights, prepare_experts
+
+
+def _run_ep_rank(
+    *,
+    a: torch.Tensor,
+    experts,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_map: torch.Tensor,
+):
+    prepared_map = ep_moe.prepare_expert_map(
+        expert_map,
+        local_num_experts=experts.num_experts,
+        global_num_experts=int(expert_map.numel()),
+        device=a.device,
+    )
+    plan = ep_moe.plan(
+        ep_moe.Caps(
+            max_tokens=int(a.shape[0]),
+            num_topk=int(topk_ids.shape[1]),
+            global_num_experts=int(expert_map.numel()),
+            device=a.device,
+            weight_plan=experts.plan,
+        )
+    )
+    scratch = torch.empty(
+        plan.scratch_specs()[0].shape, dtype=torch.uint8, device=a.device
+    )
+    output = torch.empty_like(a)
+    binding = ep_moe.bind(
+        plan,
+        scratch=scratch,
+        a=a,
+        experts=experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        expert_map=prepared_map,
+        output=output,
+    )
+    return ep_moe.run(binding=binding), binding
+
+
+def test_ep_rank_partials_sum_to_full_fused_moe() -> None:
+    require_sm12x()
+    torch.manual_seed(20260630)
+
+    global_e, hidden_size, intermediate_size = 7, 128, 128
+    m, topk = 24, 3
+    a = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+    weights = make_modelopt_weights(
+        experts=global_e, hidden_size=hidden_size, intermediate_size=intermediate_size
+    )
+    topk_ids = torch.randint(0, global_e, (m, topk), dtype=torch.int32, device="cuda")
+    topk_weights = torch.softmax(torch.randn(m, topk, device="cuda"), dim=-1)
+
+    global_experts = prepare_experts(a, weights, torch.arange(global_e))
+    expected = run_tp_moe_fp4(
+        a=a,
+        experts=global_experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        output=torch.empty_like(a),
+        quant_mode="w4a16",
+    )
+
+    partials = []
+    for rank in range(2):
+        global_ids = torch.arange(rank, global_e, 2)
+        local_experts = prepare_experts(a, weights, global_ids)
+        expert_map = torch.full((global_e,), -1, dtype=torch.int32, device="cuda")
+        expert_map[global_ids.to(device="cuda")] = torch.arange(
+            global_ids.numel(), dtype=torch.int32, device="cuda"
+        )
+        partial, _ = _run_ep_rank(
+            a=a,
+            experts=local_experts,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            expert_map=expert_map,
+        )
+        partials.append(partial.clone())
+
+    actual = partials[0] + partials[1]
+    torch.cuda.synchronize()
+    assert int(torch.count_nonzero(expected).item()) > 0
+    assert int(torch.count_nonzero(actual).item()) > 0
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.float().flatten(), expected.float().flatten(), dim=0
+    )
+    assert float(cosine.item()) > 0.999
+    torch.testing.assert_close(actual, expected, rtol=0.03, atol=0.03)
+
+
+def test_binding_replays_with_changed_routes_under_cuda_graph() -> None:
+    require_sm12x()
+    torch.manual_seed(20260631)
+
+    global_e, hidden_size, intermediate_size = 4, 128, 128
+    m, topk = 8, 2
+    a = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+    weights = make_modelopt_weights(
+        experts=global_e, hidden_size=hidden_size, intermediate_size=intermediate_size
+    )
+    global_ids = torch.tensor([0, 2])
+    experts = prepare_experts(a, weights, global_ids)
+    expert_map = torch.tensor([0, -1, 1, -1], dtype=torch.int32, device="cuda")
+    topk_ids = (
+        torch.tensor([[1, 3]], dtype=torch.int32, device="cuda")
+        .expand(m, -1)
+        .contiguous()
+    )
+    topk_weights = torch.full((m, topk), 0.5, dtype=torch.float32, device="cuda")
+
+    nonlocal_output, binding = _run_ep_rank(
+        a=a,
+        experts=experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        expert_map=expert_map,
+    )
+    torch.cuda.synchronize()
+    # No local expert routed -> partial must be exactly zero.
+    assert int(torch.count_nonzero(nonlocal_output).item()) == 0
+
+    topk_ids.copy_(
+        torch.tensor([[0, 1]], dtype=torch.int32, device="cuda").expand(m, -1)
+    )
+    binding.run()  # resolve all route-pack/GEMM variants before capture
+    graph = torch.cuda.CUDAGraph()
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        binding.run()
+
+    # Replay must observe route changes staged after capture.
+    topk_ids.copy_(
+        torch.tensor([[2, 3]], dtype=torch.int32, device="cuda").expand(m, -1)
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+    replayed = binding.output.clone()
+    binding.run()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(replayed, binding.output, rtol=0, atol=0)

--- a/tests/experimental/moe/test_execution_model.py
+++ b/tests/experimental/moe/test_execution_model.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""moe declarative execution model: MoESpec / ExecutionPlan planner contracts
+(CPU-only). Ported from b12x tests/test_moe_execution_model.py; exercises the
+public plan_weights/plan_execution verbs plus the _shared.execution vocabulary.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x.moe import fused_moe
+from flashinfer.experimental.sm12x.moe.fused_moe import _impl as tp_moe_impl
+from flashinfer.experimental.sm12x.moe._shared.execution import (
+    GemmEngine,
+    MoERegime,
+    OperandEncoding,
+    PreparedWeightLayout,
+    RouteLayout,
+    ScaleEncoding,
+    WorkAvailability,
+    WorkScheduler,
+    WeightPreparationTransform,
+    WeightStoragePolicy,
+    lower_moe_execution,
+    make_moe_spec,
+)
+
+plan_sm12x_fp4_moe_weights = fused_moe.plan_weights
+plan_tp_moe_execution = fused_moe.plan_execution
+
+
+def _weight_plan(
+    quant_modes: str | tuple[str, ...],
+    *,
+    source_format: str,
+    k: int = 128,
+    n: int = 128,
+    w4a16_layout: PreparedWeightLayout | None = None,
+):
+    return plan_sm12x_fp4_moe_weights(
+        quant_modes=quant_modes,
+        source_format=source_format,
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=32,
+        hidden_size=k,
+        intermediate_size=n,
+        w4a16_layout=w4a16_layout,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "quant_mode",
+        "source_format",
+        "activation_encoding",
+        "source_scale",
+        "compute_scale",
+    ),
+    [
+        (
+            "nvfp4",
+            "modelopt_nvfp4",
+            OperandEncoding.FP4_E2M1,
+            ScaleEncoding.E4M3_K16,
+            ScaleEncoding.E4M3_K16,
+        ),
+        (
+            "w4a8_nvfp4",
+            "modelopt_nvfp4",
+            OperandEncoding.MXFP8_E4M3,
+            ScaleEncoding.E4M3_K16,
+            ScaleEncoding.E8M0_K32_X_E4M3_K16_RESIDUAL,
+        ),
+        (
+            "w4a8_mx",
+            "fp4_e8m0_k32",
+            OperandEncoding.MXFP8_E4M3,
+            ScaleEncoding.E8M0_K32,
+            ScaleEncoding.E8M0_K32,
+        ),
+        (
+            "w4a16",
+            "compressed_tensors",
+            OperandEncoding.BF16,
+            ScaleEncoding.E4M3_K16,
+            ScaleEncoding.E4M3_K16,
+        ),
+    ],
+)
+def test_moe_spec_separates_source_and_compute_formats(
+    quant_mode: str,
+    source_format: str,
+    activation_encoding: OperandEncoding,
+    source_scale: ScaleEncoding,
+    compute_scale: ScaleEncoding,
+) -> None:
+    spec = make_moe_spec(
+        quant_mode=quant_mode,
+        source_format=source_format,
+        activation="silu",
+        io_dtype="bfloat16",
+        w13_layout="w13",
+    )
+
+    assert spec.activation_encoding is activation_encoding
+    assert spec.source_weight_scale is source_scale
+    assert spec.weight_scale is compute_scale
+
+
+def test_moe_spec_rejects_invalid_source_quant_pair() -> None:
+    with pytest.raises(ValueError, match="incompatible"):
+        make_moe_spec(
+            quant_mode="w4a8_mx",
+            source_format="modelopt_nvfp4",
+            activation="silu",
+            io_dtype="bfloat16",
+            w13_layout="w13",
+        )
+
+
+def test_same_w4a8_numerics_lower_to_queue_or_grid() -> None:
+    spec = make_moe_spec(
+        quant_mode="w4a8_mx",
+        source_format="fp4_e8m0_k32",
+        activation="silu",
+        io_dtype="bfloat16",
+        w13_layout="w13",
+    )
+
+    queued = lower_moe_execution(
+        spec,
+        regime=MoERegime.MATERIALIZED_FUSED,
+        scheduler=WorkScheduler.ATOMIC_QUEUE,
+        tile_m=32,
+        tile_n=128,
+    )
+    grid = lower_moe_execution(
+        spec,
+        regime=MoERegime.MATERIALIZED_FUSED,
+        scheduler=WorkScheduler.PERSISTENT_GRID,
+        tile_m=32,
+        tile_n=128,
+    )
+
+    assert queued.gemm_engine is GemmEngine.MXFP8_QMMA
+    assert grid.gemm_engine is GemmEngine.MXFP8_QMMA
+    assert queued.work_availability is WorkAvailability.PRECOMPUTED
+    assert queued.scheduler is WorkScheduler.ATOMIC_QUEUE
+    assert queued.uses_explicit_task_queue
+    assert queued.grid_addressable
+    assert grid.work_availability is WorkAvailability.PRECOMPUTED
+    assert grid.scheduler is WorkScheduler.PERSISTENT_GRID
+    assert grid.grid_addressable
+    assert grid.weight_layout is PreparedWeightLayout.QMMA_REPACKED
+    assert queued.weight_layout is PreparedWeightLayout.QMMA_REPACKED
+
+
+def test_materialized_fused_work_can_use_grid_or_load_balancing_queue() -> None:
+    spec = make_moe_spec(
+        quant_mode="nvfp4",
+        source_format="modelopt_nvfp4",
+        activation="silu",
+        io_dtype="bfloat16",
+        w13_layout="w13",
+    )
+
+    grid = lower_moe_execution(
+        spec,
+        regime=MoERegime.MATERIALIZED_FUSED,
+        scheduler=WorkScheduler.PERSISTENT_GRID,
+        tile_m=128,
+        tile_n=128,
+    )
+    queued = lower_moe_execution(
+        spec,
+        regime=MoERegime.MATERIALIZED_FUSED,
+        scheduler=WorkScheduler.ATOMIC_QUEUE,
+        tile_m=128,
+        tile_n=128,
+    )
+
+    assert grid.work_availability is WorkAvailability.PRECOMPUTED
+    assert queued.work_availability is WorkAvailability.PRECOMPUTED
+    assert grid.grid_addressable and queued.grid_addressable
+    assert not grid.uses_explicit_task_queue
+    assert queued.uses_explicit_task_queue
+    assert grid.gemm_engine is queued.gemm_engine is GemmEngine.NVFP4_MMA
+
+
+def test_workspace_plan_maps_kernel_family_to_execution_contract() -> None:
+    dynamic_weights = _weight_plan("nvfp4", source_format="modelopt_nvfp4")
+    dynamic = plan_tp_moe_execution(
+        num_tokens=64,
+        num_topk=4,
+        device=torch.device("cpu"),
+        weight_plan=dynamic_weights,
+        quant_mode="nvfp4",
+    )
+    w4a16_weights = _weight_plan("w4a16", source_format="fp4_e8m0_k32")
+    w4a16 = plan_tp_moe_execution(
+        num_tokens=64,
+        num_topk=4,
+        device=torch.device("cpu"),
+        weight_plan=w4a16_weights,
+        quant_mode="w4a16",
+    )
+
+    assert dynamic.implementation == "dynamic"
+    assert dynamic.execution.regime is MoERegime.MATERIALIZED_FUSED
+    assert dynamic.execution.route_layout is RouteLayout.APPEND_ONLY_EXPERT
+    assert dynamic.execution.work_availability is WorkAvailability.PRECOMPUTED
+    assert dynamic.execution.scheduler is WorkScheduler.ATOMIC_QUEUE
+    assert dynamic.execution.uses_explicit_task_queue
+    assert dynamic.execution.tile_m == 16
+    assert w4a16.implementation == "w4a16"
+    assert w4a16.spec.source_weight_scale is ScaleEncoding.E8M0_K32
+    assert w4a16.execution.route_layout is RouteLayout.SORTED_PADDED_EXPERT
+    assert w4a16.execution.scheduler is WorkScheduler.PERSISTENT_GRID
+    assert w4a16.execution.route_block_rows is not None
+
+
+def test_workspace_plan_uses_weight_plan_source_contract() -> None:
+    weights = _weight_plan(
+        "w4a8_mx",
+        source_format="fp4_e8m0_k32",
+        k=256,
+        n=128,
+    )
+    plan = plan_tp_moe_execution(
+        num_tokens=4,
+        num_topk=2,
+        device=torch.device("cpu"),
+        weight_plan=weights,
+        quant_mode="w4a8_mx",
+    )
+
+    assert plan.spec.source_format == "fp4_e8m0_k32"
+    assert plan.spec.source_weight_scale is ScaleEncoding.E8M0_K32
+
+
+def test_native_w4a8_m1_alone_selects_fixed_materialized_regime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M=1 specializes unified dynamic; neighboring decode sizes do not."""
+
+    monkeypatch.setenv("FLASHINFER_EXP_SM12X_DYNAMIC_WORK_SOURCE", "materialized_queue")
+    monkeypatch.setenv("FLASHINFER_EXP_SM12X_DYNAMIC_W4A8_MATERIALIZED", "1")
+    common = dict(
+        quant_mode="w4a8_mx",
+        activation="silu",
+        num_experts=256,
+        k=6144,
+        n=1024,
+        w4a8_repacked=True,
+        share_input_across_experts=True,
+        deterministic_output=False,
+    )
+
+    assert tp_moe_impl._w4a8_dynamic_materialized_enabled(
+        num_tokens=1,
+        routed_rows=8,
+        **common,
+    )
+    assert not tp_moe_impl._w4a8_dynamic_materialized_enabled(
+        num_tokens=2,
+        routed_rows=16,
+        **common,
+    )
+    assert not tp_moe_impl._w4a8_dynamic_materialized_enabled(
+        num_tokens=1,
+        routed_rows=8,
+        **(common | {"w4a8_repacked": False}),
+    )
+    assert not tp_moe_impl._w4a8_dynamic_materialized_enabled(
+        num_tokens=1,
+        routed_rows=40,
+        **common,
+    )
+
+
+def test_source_native_w4a16_and_nvfp4_share_one_allocation() -> None:
+    plan = _weight_plan(
+        ("nvfp4", "w4a16"),
+        source_format="modelopt_nvfp4",
+    )
+
+    assert plan.storage_policy is WeightStoragePolicy.KEEP_SOURCE
+    assert plan.transforms == {
+        WeightPreparationTransform.RUNTIME_ALPHAS,
+        WeightPreparationTransform.W4A16_NATIVE,
+    }
+    assert plan.required_weight_layout("nvfp4") is None
+    assert plan.required_weight_layout("w4a16") is PreparedWeightLayout.SOURCE_NATIVE
+
+
+def test_planner_rejects_source_plus_model_sized_repack() -> None:
+    with pytest.raises(ValueError, match="both source-native weights"):
+        _weight_plan(
+            ("nvfp4", "w4a16"),
+            source_format="modelopt_nvfp4",
+            w4a16_layout=PreparedWeightLayout.MMA_PACKED,
+        )
+
+
+def test_planner_rejects_two_incompatible_repacks() -> None:
+    with pytest.raises(ValueError, match="multiple incompatible model-sized"):
+        _weight_plan(
+            ("w4a8_mx", "w4a16"),
+            source_format="fp4_e8m0_k32",
+            k=256,
+            n=128,
+            w4a16_layout=PreparedWeightLayout.MMA_PACKED,
+        )
+
+
+def test_storage_policy_has_no_keep_both_state() -> None:
+    assert "keep_both" not in {policy.value for policy in WeightStoragePolicy}
+
+
+def test_non_128_aligned_e8m0_w4a16_shards_stay_source_native() -> None:
+    """2048/TP6 = 352 and 3072/TP16 = 192 have no packed tile configs; the
+    planner must route them through the native layout instead of failing at
+    kernel-config time. 128-aligned shards keep the packed fast path."""
+    for shard in (352, 192):
+        plan = _weight_plan("w4a16", source_format="fp4_e8m0_k32", n=shard)
+        assert WeightPreparationTransform.W4A16_NATIVE in plan.transforms
+        assert (
+            plan.required_weight_layout("w4a16") is PreparedWeightLayout.SOURCE_NATIVE
+        )
+
+    aligned = _weight_plan("w4a16", source_format="fp4_e8m0_k32", n=256)
+    assert WeightPreparationTransform.W4A16_PACKED in aligned.transforms
+    assert aligned.required_weight_layout("w4a16") is PreparedWeightLayout.MMA_PACKED

--- a/tests/experimental/moe/test_fused_moe.py
+++ b/tests/experimental/moe/test_fused_moe.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""moe.fused_moe: end-to-end W4A16 fused MoE under the serving contract.
+
+Numerical correctness is cross-checked in test_ep_moe.py (two-rank
+expert-parallel partials must sum to this op's full output). Here the planned
+lifecycle replays under CUDA-graph capture with kernel resolution frozen —
+zero compile-cache misses may occur inside the capture, per the warm ->
+freeze -> capture serving discipline.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import flashinfer.experimental.sm12x as sm12x
+from flashinfer.experimental.sm12x._lib.compiler import compile_cache_info
+from flashinfer.experimental.sm12x._lib.intrinsics import swizzle_block_scale
+
+from .._reference.helpers import make_tp_moe_fp4_binding, prepare_tp_moe_fp4_experts
+from ..conftest import require_sm12x
+
+
+def make_modelopt_weights(
+    *,
+    experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+) -> tuple[torch.Tensor, ...]:
+    w13 = torch.randint(
+        0,
+        256,
+        (experts, 2 * intermediate_size, hidden_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (experts, hidden_size, intermediate_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    w13_scale = swizzle_block_scale(
+        (
+            torch.rand(experts, 2 * intermediate_size, hidden_size // 16, device="cuda")
+            * 0.25
+            + 0.03125
+        ).to(torch.float8_e4m3fn)
+    )
+    w2_scale = swizzle_block_scale(
+        (
+            torch.rand(experts, hidden_size, intermediate_size // 16, device="cuda")
+            * 0.25
+            + 0.03125
+        ).to(torch.float8_e4m3fn)
+    )
+    w13_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
+    w2_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
+    return w13, w13_scale, w13_alpha, w2, w2_scale, w2_alpha
+
+
+def prepare_experts(
+    a: torch.Tensor,
+    weights: tuple[torch.Tensor, ...],
+    expert_ids: torch.Tensor,
+):
+    w13, w13_scale, w13_alpha, w2, w2_scale, w2_alpha = weights
+    selected = expert_ids.to(device=w13.device, dtype=torch.long)
+    local_e = int(selected.numel())
+    unit = torch.ones(local_e, dtype=torch.float32, device=a.device)
+    return prepare_tp_moe_fp4_experts(
+        a=a,
+        a1_gscale=unit,
+        w1_fp4=w13.index_select(0, selected).clone(),
+        w1_blockscale=w13_scale.index_select(0, selected).clone(),
+        w1_alphas=w13_alpha.index_select(0, selected).clone(),
+        a2_gscale=unit,
+        w2_fp4=w2.index_select(0, selected).clone(),
+        w2_blockscale=w2_scale.index_select(0, selected).clone(),
+        w2_alphas=w2_alpha.index_select(0, selected).clone(),
+        activation="silu",
+        quant_mode="w4a16",
+    )
+
+
+def test_run_w4a16_replays_under_cuda_graph_with_frozen_resolution() -> None:
+    require_sm12x()
+    torch.manual_seed(20260715)
+
+    from flashinfer.experimental.sm12x.moe import fused_moe
+
+    global_e, hidden_size, intermediate_size = 4, 128, 128
+    m, topk = 8, 2
+    a = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+    weights = make_modelopt_weights(
+        experts=global_e, hidden_size=hidden_size, intermediate_size=intermediate_size
+    )
+    experts = prepare_experts(a, weights, torch.arange(global_e))
+    topk_ids = torch.randint(0, global_e, (m, topk), dtype=torch.int32, device="cuda")
+    topk_weights = torch.softmax(torch.randn(m, topk, device="cuda"), dim=-1)
+
+    binding = make_tp_moe_fp4_binding(
+        a=a,
+        experts=experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        output=torch.empty_like(a),
+        quant_mode="w4a16",
+    )
+
+    eager = fused_moe.run(binding=binding).clone()
+    torch.cuda.synchronize()
+    assert int(torch.count_nonzero(eager).item()) > 0
+
+    fused_moe.run(binding=binding)  # resolve every kernel variant pre-capture
+    torch.cuda.synchronize()
+
+    misses_before = compile_cache_info()["compile_misses"]
+    sm12x.freeze_kernel_resolution("fused-moe graph capture test")
+    try:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = fused_moe.run(binding=binding)
+        for _ in range(3):
+            graph.replay()
+        torch.cuda.synchronize()
+    finally:
+        sm12x.unfreeze_kernel_resolution()
+
+    assert compile_cache_info()["compile_misses"] == misses_before, (
+        "no kernel may compile during or after warm capture"
+    )
+    torch.testing.assert_close(captured, eager, rtol=0, atol=0)

--- a/tests/experimental/moe/test_w4a16_hybrid_moe.py
+++ b/tests/experimental/moe/test_w4a16_hybrid_moe.py
@@ -1,0 +1,391 @@
+"""Parity tests for the two-tier hybrid W4A16 fused MoE kernel.
+
+The hybrid kernel runs one grid over a heterogeneous-quantization layer
+(tier 0 NVFP4 "packed" + tier 1 NF3 "nf3_2p1") using a global-expert
+descriptor map. Its oracle is the production serial path: one single-tier
+TC-decode launch per tier with the other tier's routes masked to -1 (the
+contract test_nf3_tc_decode_production_shape_with_tier_mask already covers),
+summed on the host. Identical prepared weights feed both paths, so any
+difference beyond FC2 atomic-accumulation ordering is a defect.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x._lib.intrinsics import swizzle_block_scale
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+    build_w4a16_tier_local_map,
+    compile_w4a16_fused_moe,
+    compile_w4a16_fused_moe_hybrid,
+    run_w4a16_moe,
+    run_w4a16_moe_hybrid,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.prepare import (
+    prepare_nf3_moe_weights,
+    prepare_w4a16_modelopt_nvfp4_weights,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+    make_w4a16_packed_buffers,
+)
+from .test_w4a16_nf3 import _round_to_e4m3_scale
+
+_DEVICE = torch.device("cuda")
+_DTYPE = torch.bfloat16
+_DEFAULT_MAX_SHARED_MEM = 101_376
+
+_HIDDEN = 6144
+_INTERMEDIATE = 512
+_TOPK = 8
+_CAPACITY_M = 4
+_TILE_CONFIG = (64, 256, 64, 256)
+_T0_EXPERTS = 4
+_T1_EXPERTS = 6
+_MAP_SLOTS = _T0_EXPERTS + _T1_EXPERTS
+_T0_GLOBAL_IDS = (0, 3, 5, 9)
+_T1_GLOBAL_IDS = (1, 2, 4, 6, 7, 8)
+
+
+def _device_limits() -> tuple[int, int]:
+    props = torch.cuda.get_device_properties(_DEVICE)
+    return int(props.multi_processor_count), int(
+        getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+    )
+
+
+def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:
+    scale = 0.05 + 0.2 * torch.rand(shape, device=_DEVICE)
+    return scale.to(torch.float8_e4m3fn)
+
+
+def _build_tier0_nvfp4():
+    w13_rows = 2 * _INTERMEDIATE
+    w13 = torch.randint(
+        0,
+        256,
+        (_T0_EXPERTS, w13_rows, _HIDDEN // 2),
+        dtype=torch.uint8,
+        device=_DEVICE,
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (_T0_EXPERTS, _HIDDEN, _INTERMEDIATE // 2),
+        dtype=torch.uint8,
+        device=_DEVICE,
+    )
+    w13_blockscale = swizzle_block_scale(
+        _positive_fp8((_T0_EXPERTS, w13_rows, _HIDDEN // 16))
+    )
+    w2_blockscale = swizzle_block_scale(
+        _positive_fp8((_T0_EXPERTS, _HIDDEN, _INTERMEDIATE // 16))
+    )
+    w13_global = (torch.rand(_T0_EXPERTS, device=_DEVICE) * 0.1 + 0.05).float()
+    w2_global = (torch.rand(_T0_EXPERTS, device=_DEVICE) * 0.1 + 0.05).float()
+    return prepare_w4a16_modelopt_nvfp4_weights(
+        w13,
+        w13_blockscale,
+        w13_global,
+        w2,
+        w2_blockscale,
+        w2_global,
+        activation="silu",
+        params_dtype=_DTYPE,
+    )
+
+
+def _build_tier1_nf3():
+    w13_rows = 2 * _INTERMEDIATE
+    w13_codes = torch.randint(
+        0, 8, (_T1_EXPERTS, w13_rows, _HIDDEN), dtype=torch.int32, device=_DEVICE
+    )
+    w2_codes = torch.randint(
+        0,
+        8,
+        (_T1_EXPERTS, _HIDDEN, _INTERMEDIATE),
+        dtype=torch.int32,
+        device=_DEVICE,
+    )
+    w13_scale = _round_to_e4m3_scale(
+        0.01 + 0.24 * torch.rand(_T1_EXPERTS, w13_rows, _HIDDEN // 32, device=_DEVICE)
+    )
+    w2_scale = _round_to_e4m3_scale(
+        0.01
+        + 0.24 * torch.rand(_T1_EXPERTS, _HIDDEN, _INTERMEDIATE // 32, device=_DEVICE)
+    )
+    return prepare_nf3_moe_weights(
+        w13_codes,
+        w13_scale,
+        w2_codes,
+        w2_scale,
+        activation="silu",
+        fc1_tile_n=_TILE_CONFIG[1],
+        fc2_tile_n=_TILE_CONFIG[3],
+        params_dtype=_DTYPE,
+    )
+
+
+def _tier_local_ids(global_ids: torch.Tensor, tier_globals: tuple[int, ...]):
+    """Map global route ids to tier-local ids, other-tier/invalid routes -> -1."""
+    lookup = {gid: local for local, gid in enumerate(tier_globals)}
+    local = torch.full_like(global_ids, -1)
+    for row in range(global_ids.shape[0]):
+        for col in range(global_ids.shape[1]):
+            gid = int(global_ids[row, col])
+            if gid in lookup:
+                local[row, col] = lookup[gid]
+    return local
+
+
+def _serial_reference(
+    x: torch.Tensor,
+    prepared_t0,
+    prepared_t1,
+    topk_weights: torch.Tensor,
+    global_ids: torch.Tensor,
+) -> torch.Tensor:
+    sms, max_shared_mem = _device_limits()
+    m = x.shape[0]
+    out = torch.zeros((m, _HIDDEN), dtype=_DTYPE, device=_DEVICE)
+    for prepared, tier_globals in (
+        (prepared_t0, _T0_GLOBAL_IDS),
+        (prepared_t1, _T1_GLOBAL_IDS),
+    ):
+        local_ids = _tier_local_ids(global_ids, tier_globals)
+        fused = compile_w4a16_fused_moe(
+            size_m=_CAPACITY_M,
+            hidden_size=_HIDDEN,
+            intermediate_size=_INTERMEDIATE,
+            num_experts=int(prepared.num_experts),
+            top_k=_TOPK,
+            activation="silu",
+            apply_router_weight_on_input=False,
+            zero_fc2_output=False,
+            moe_block_size=8,
+            max_m_blocks=_CAPACITY_M * _TOPK,
+            element_dtype="bf16",
+            fast_math=True,
+            sms=sms,
+            max_shared_mem=max_shared_mem,
+            weight_layout=prepared.weight_layout,
+            scale_format=prepared.scale_format,
+            w13_layout=getattr(prepared, "w13_layout", "packed"),
+            direct_topk_routes=True,
+            tc_decode_fused_sum=True,
+            force_tile_config=_TILE_CONFIG,
+        )
+        buffers = make_w4a16_packed_buffers(
+            prepared, m=_CAPACITY_M, topk=_TOPK, dtype=_DTYPE, device=_DEVICE
+        )
+        tier_out = run_w4a16_moe(
+            x,
+            prepared,
+            topk_weights,
+            local_ids,
+            activation="silu",
+            intermediate_cache13=buffers.intermediate_cache13,
+            intermediate_cache2=buffers.intermediate_cache2,
+            output=buffers.output[:m],
+            fc1_c_tmp=buffers.fc1_c_tmp,
+            fc2_c_tmp=buffers.fc2_c_tmp,
+            packed_route_indices=buffers.packed_route_indices,
+            block_expert_ids=buffers.block_expert_ids,
+            packed_route_count=buffers.packed_route_count,
+            fused_launch=fused,
+        )
+        torch.cuda.synchronize()
+        out += tier_out
+    return out
+
+
+def _run_hybrid(
+    x: torch.Tensor,
+    prepared_t0,
+    prepared_t1,
+    topk_weights: torch.Tensor,
+    global_ids: torch.Tensor,
+    *,
+    schedule_whole_tiles: bool,
+) -> torch.Tensor:
+    tier_local_map = build_w4a16_tier_local_map(
+        _T0_GLOBAL_IDS,
+        _T1_GLOBAL_IDS,
+        map_slots=_MAP_SLOTS,
+        device=_DEVICE,
+    )
+    buffers = make_w4a16_packed_buffers(
+        prepared_t0, m=_CAPACITY_M, topk=_TOPK, dtype=_DTYPE, device=_DEVICE
+    )
+    m = x.shape[0]
+    output = torch.full((m, _HIDDEN), float("nan"), dtype=_DTYPE, device=_DEVICE)
+    result = run_w4a16_moe_hybrid(
+        x,
+        prepared_t0,
+        prepared_t1,
+        topk_weights,
+        global_ids,
+        tier_local_map,
+        activation="silu",
+        intermediate_cache13=buffers.intermediate_cache13,
+        intermediate_cache2=buffers.intermediate_cache2,
+        output=output,
+        force_tile_config=_TILE_CONFIG,
+        size_m=_CAPACITY_M,
+        fc1_c_tmp=buffers.fc1_c_tmp,
+        fc2_c_tmp=buffers.fc2_c_tmp,
+        schedule_whole_tiles=schedule_whole_tiles,
+    )
+    torch.cuda.synchronize()
+    return result
+
+
+def _assert_parity(actual: torch.Tensor, expected: torch.Tensor, label: str) -> None:
+    got = actual.float()
+    ref = expected.float()
+    assert torch.isfinite(got).all(), f"{label}: nonfinite hybrid output"
+    denom = ref.abs().amax().clamp(min=1e-6)
+    rel = (got - ref).abs().amax() / denom
+    assert rel < 2e-2, f"{label}: rel err {float(rel):.5f} exceeds 2e-2"
+
+
+@pytest.fixture(scope="module")
+def hybrid_problem():
+    torch.manual_seed(20260718)
+    prepared_t0 = _build_tier0_nvfp4()
+    prepared_t1 = _build_tier1_nf3()
+    x = torch.randn(_CAPACITY_M, _HIDDEN, dtype=_DTYPE, device=_DEVICE) * 0.1
+    topk_weights = torch.softmax(
+        torch.randn(_CAPACITY_M, _TOPK, device=_DEVICE), dim=-1
+    )
+    return prepared_t0, prepared_t1, x, topk_weights
+
+
+def _global_ids_case(case: str) -> torch.Tensor:
+    generator = torch.Generator(device="cpu").manual_seed(hash(case) % (2**31))
+    if case == "mixed":
+        ids = torch.randint(
+            0, _MAP_SLOTS, (_CAPACITY_M, _TOPK), dtype=torch.int32, generator=generator
+        )
+    elif case == "all_tier0":
+        choices = torch.tensor(_T0_GLOBAL_IDS, dtype=torch.int32)
+        idx = torch.randint(
+            0, len(_T0_GLOBAL_IDS), (_CAPACITY_M, _TOPK), generator=generator
+        )
+        ids = choices[idx]
+    elif case == "all_tier1":
+        choices = torch.tensor(_T1_GLOBAL_IDS, dtype=torch.int32)
+        idx = torch.randint(
+            0, len(_T1_GLOBAL_IDS), (_CAPACITY_M, _TOPK), generator=generator
+        )
+        ids = choices[idx]
+    elif case == "with_invalid":
+        ids = torch.randint(
+            0, _MAP_SLOTS, (_CAPACITY_M, _TOPK), dtype=torch.int32, generator=generator
+        )
+        ids[0, 1] = -1
+        ids[1, 5] = -1
+        ids[3, 0] = -1
+    else:
+        raise AssertionError(case)
+    return ids.to(dtype=torch.int32, device=_DEVICE)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("case", ["mixed", "all_tier0", "all_tier1", "with_invalid"])
+def test_hybrid_matches_serial_two_launch(case: str, hybrid_problem) -> None:
+    prepared_t0, prepared_t1, x, topk_weights = hybrid_problem
+    global_ids = _global_ids_case(case)
+    expected = _serial_reference(x, prepared_t0, prepared_t1, topk_weights, global_ids)
+    actual = _run_hybrid(
+        x,
+        prepared_t0,
+        prepared_t1,
+        topk_weights,
+        global_ids,
+        schedule_whole_tiles=True,
+    )
+    _assert_parity(actual, expected, f"hybrid[{case}]")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_hybrid_split_k_schedule_matches_whole_tiles(hybrid_problem) -> None:
+    """The split-K tail schedule and the whole-tiles schedule are numerically
+    interchangeable through the same route-map emit hooks."""
+    prepared_t0, prepared_t1, x, topk_weights = hybrid_problem
+    global_ids = _global_ids_case("mixed")
+    expected = _serial_reference(x, prepared_t0, prepared_t1, topk_weights, global_ids)
+    actual = _run_hybrid(
+        x,
+        prepared_t0,
+        prepared_t1,
+        topk_weights,
+        global_ids,
+        schedule_whole_tiles=False,
+    )
+    _assert_parity(actual, expected, "hybrid[split_k]")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_hybrid_partial_batch(hybrid_problem) -> None:
+    """m < capacity: trailing route slots are ignored, output rows match."""
+    prepared_t0, prepared_t1, x, topk_weights = hybrid_problem
+    global_ids = _global_ids_case("mixed")
+    m = 1
+    expected = _serial_reference(
+        x[:m], prepared_t0, prepared_t1, topk_weights[:m], global_ids[:m]
+    )
+    actual = _run_hybrid(
+        x[:m],
+        prepared_t0,
+        prepared_t1,
+        topk_weights[:m],
+        global_ids[:m],
+        schedule_whole_tiles=True,
+    )
+    _assert_parity(actual, expected, "hybrid[m=1]")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_hybrid_glm_geometry_admits_without_spills() -> None:
+    """GLM-5.2 TP4 shard geometry: the combined two-decoder kernel must fit
+    without local-memory spills, or the decode win silently evaporates.
+
+    The exact shared-memory pin documents the production geometry; it should
+    only move with a deliberate smem layout change. Register/local assertions
+    are skipped when the compile came from the on-disk object cache (no
+    introspection surface) -- a fresh compile covers them.
+    """
+    sms, max_shared_mem = _device_limits()
+    hybrid = compile_w4a16_fused_moe_hybrid(
+        size_m=4,
+        hidden_size=6144,
+        intermediate_size=512,
+        tier0_num_experts=64,
+        tier1_num_experts=192,
+        top_k=8,
+        activation="silu",
+        map_slots=256,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        force_tile_config=(64, 256, 64, 256),
+    )
+    assert hybrid.shared_memory_bytes == 45_184
+    assert hybrid.blocks_per_sm == 1
+    assert hybrid.cta_threads == 256
+    if hybrid.registers_per_thread >= 0:
+        assert 1 <= hybrid.registers_per_thread <= 255
+        assert hybrid.local_memory_bytes == 0
+
+
+def test_tier_local_map_builder_rejects_bad_maps() -> None:
+    with pytest.raises(ValueError, match="mapped twice"):
+        build_w4a16_tier_local_map((0, 1), (1, 2), map_slots=4)
+    with pytest.raises(ValueError, match="outside"):
+        build_w4a16_tier_local_map((0, 5), (1,), map_slots=4)
+    table = build_w4a16_tier_local_map(_T0_GLOBAL_IDS, _T1_GLOBAL_IDS, map_slots=16)
+    assert table.numel() == 16
+    assert int(table[0]) == 0
+    assert int(table[1]) == (1 << 8) | 0
+    assert int(table[9]) == 3
+    assert int(table[10]) == -1

--- a/tests/experimental/moe/test_w4a16_nf3.py
+++ b/tests/experimental/moe/test_w4a16_nf3.py
@@ -1,0 +1,386 @@
+"""Numerical reference tests for the NF3 ("nf3_2p1") W4A16 MoE kernel path.
+
+Packs NF3 codes/scales with the production packer (prepare_nf3_moe_weights),
+compiles the fused MoE kernel with weight_layout="nf3_2p1", runs it through
+the production host entry (run_w4a16_moe), and compares against a pure-torch
+reference MoE built from the same dequantized weights. Covers both the
+TC-decode (small-M direct top-k, fused top-k sum) and route-packed paths.
+
+The tile_n coupling: the flat-span NF3 layout is packed for a specific CTA
+N-tile, so the test compiles the fused kernel FIRST, reads fc1_tile_n/fc2_tile_n
+back off the compile result, and packs with exactly those. The same
+(cached) kernel is then reused for the launch, so packing and kernel agree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.kernel import (
+    compile_w4a16_fused_moe,
+    run_w4a16_moe,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.prepare import (
+    _NF3_CODEBOOK,
+    prepare_nf3_moe_weights,
+)
+from flashinfer.experimental.sm12x.moe._shared.kernels.w4a16.host import (
+    make_w4a16_packed_buffers,
+    max_packed_route_slots,
+    select_route_block_size_m,
+)
+
+_DEVICE = torch.device("cuda")
+_DTYPE = torch.bfloat16
+_DEFAULT_MAX_SHARED_MEM = 101_376
+
+
+def _round_to_e4m3_scale(t_s: torch.Tensor) -> torch.Tensor:
+    """Round positive scales to 3 mantissa bits so the NF3 e4m3-style K/32 scale
+    encoding is lossless (real checkpoints already have <=3 mantissa bits, so the
+    kernel decode reproduces exactly these values -- the reference can then use
+    them directly)."""
+    t_s = t_s.to(torch.float32).clamp(min=2.0**-7)
+    e = torch.floor(torch.log2(t_s))
+    step = torch.pow(2.0, e - 3)
+    return torch.round(t_s / step) * step
+
+
+def _dequant(codes: torch.Tensor, t_s: torch.Tensor) -> torch.Tensor:
+    """[E, N, K] codes + [E, N, K//32] scales -> bf16 [E, N, K] weights, matching
+    the kernel: bf16 codebook value * (3-mantissa) scale, rounded to bf16."""
+    cb = torch.tensor(_NF3_CODEBOOK, dtype=torch.bfloat16, device=codes.device)
+    w = cb[codes.long()].to(torch.float32)  # [E, N, K] bf16-valued
+    scale = t_s.to(torch.float32).repeat_interleave(32, dim=2)  # [E, N, K]
+    return (w * scale).to(torch.bfloat16)
+
+
+def _reference_moe(
+    a: torch.Tensor,
+    w13_deq: torch.Tensor,
+    w2_deq: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    intermediate_size: int,
+) -> torch.Tensor:
+    m, hidden = a.shape
+    topk = topk_ids.shape[1]
+    out = torch.zeros((m, hidden), dtype=torch.float32, device=a.device)
+    a_f = a.to(torch.float32)
+    for t in range(m):
+        for k in range(topk):
+            e = int(topk_ids[t, k])
+            w13 = w13_deq[e].to(torch.float32)  # [2I, hidden]
+            fc1 = a_f[t] @ w13.T  # [2I]
+            gate = fc1[:intermediate_size]
+            up = fc1[intermediate_size:]
+            silu = gate * torch.sigmoid(gate)
+            act = (silu.to(torch.bfloat16) * up.to(torch.bfloat16)).to(torch.float32)
+            w2 = w2_deq[e].to(torch.float32)  # [hidden, I]
+            fc2 = act @ w2.T  # [hidden]
+            out[t] += float(topk_weights[t, k]) * fc2
+    return out
+
+
+def _build_problem(m: int, seed: int = 0):
+    torch.manual_seed(seed)
+    num_experts = 4
+    topk = 8
+    intermediate_size = 64
+    hidden = 256
+    w13_rows = 2 * intermediate_size  # 128
+
+    w13_codes = torch.randint(
+        0, 8, (num_experts, w13_rows, hidden), dtype=torch.int32, device=_DEVICE
+    )
+    w2_codes = torch.randint(
+        0,
+        8,
+        (num_experts, hidden, intermediate_size),
+        dtype=torch.int32,
+        device=_DEVICE,
+    )
+    w13_scale = _round_to_e4m3_scale(
+        0.01 + 0.24 * torch.rand(num_experts, w13_rows, hidden // 32, device=_DEVICE)
+    )
+    w2_scale = _round_to_e4m3_scale(
+        0.01
+        + 0.24
+        * torch.rand(num_experts, hidden, intermediate_size // 32, device=_DEVICE)
+    )
+    a = torch.randn(m, hidden, dtype=_DTYPE, device=_DEVICE) * 0.1
+    topk_ids = torch.randint(
+        0, num_experts, (m, topk), dtype=torch.int32, device=_DEVICE
+    )
+    topk_weights = torch.rand(m, topk, dtype=torch.float32, device=_DEVICE)
+    return dict(
+        num_experts=num_experts,
+        topk=topk,
+        intermediate_size=intermediate_size,
+        hidden=hidden,
+        w13_rows=w13_rows,
+        w13_codes=w13_codes,
+        w2_codes=w2_codes,
+        w13_scale=w13_scale,
+        w2_scale=w2_scale,
+        a=a,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+    )
+
+
+def _device_limits():
+    props = torch.cuda.get_device_properties(_DEVICE)
+    sms = int(props.multi_processor_count)
+    max_shared_mem = int(
+        getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+    )
+    return sms, max_shared_mem
+
+
+def _run_case(m: int, *, tc_decode: bool) -> None:
+    p = _build_problem(m, seed=1234 + m + (100 if tc_decode else 0))
+    sms, max_shared_mem = _device_limits()
+
+    if tc_decode:
+        block_size_m = 8
+        direct_topk = True
+        max_m_blocks = m * p["topk"]
+    else:
+        block_size_m = select_route_block_size_m(m, p["topk"], p["num_experts"])
+        direct_topk = False
+        route_slots = max_packed_route_slots(
+            m * p["topk"], block_size_m, p["num_experts"]
+        )
+        max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
+
+    fused = compile_w4a16_fused_moe(
+        size_m=m,
+        hidden_size=p["hidden"],
+        intermediate_size=p["intermediate_size"],
+        num_experts=p["num_experts"],
+        top_k=p["topk"],
+        activation="silu",
+        apply_router_weight_on_input=False,
+        zero_fc2_output=False,
+        moe_block_size=block_size_m,
+        max_m_blocks=int(max_m_blocks),
+        element_dtype="bf16",
+        fast_math=True,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        weight_layout="nf3_2p1",
+        scale_format="e4m3_k32",
+        w13_layout="w13",
+        direct_topk_routes=direct_topk,
+        tc_decode_fused_sum=tc_decode,
+    )
+
+    prepared = prepare_nf3_moe_weights(
+        p["w13_codes"],
+        p["w13_scale"],
+        p["w2_codes"],
+        p["w2_scale"],
+        activation="silu",
+        fc1_tile_n=int(fused.fc1_tile_n),
+        fc2_tile_n=int(fused.fc2_tile_n),
+        params_dtype=_DTYPE,
+    )
+
+    buffers = make_w4a16_packed_buffers(
+        prepared,
+        m=m,
+        topk=p["topk"],
+        dtype=_DTYPE,
+        device=_DEVICE,
+    )
+
+    out = run_w4a16_moe(
+        p["a"],
+        prepared,
+        p["topk_weights"],
+        p["topk_ids"],
+        activation="silu",
+        intermediate_cache13=buffers.intermediate_cache13,
+        intermediate_cache2=buffers.intermediate_cache2,
+        output=buffers.output,
+        fc1_c_tmp=buffers.fc1_c_tmp,
+        fc2_c_tmp=buffers.fc2_c_tmp,
+        packed_route_indices=buffers.packed_route_indices,
+        block_expert_ids=buffers.block_expert_ids,
+        packed_route_count=buffers.packed_route_count,
+        fused_launch=fused,
+    )
+    torch.cuda.synchronize()
+
+    w13_deq = _dequant(p["w13_codes"], p["w13_scale"])
+    w2_deq = _dequant(p["w2_codes"], p["w2_scale"])
+    ref = _reference_moe(
+        p["a"],
+        w13_deq,
+        w2_deq,
+        p["topk_ids"],
+        p["topk_weights"],
+        p["intermediate_size"],
+    )
+    got = out.to(torch.float32)
+    denom = ref.abs().amax().clamp(min=1e-6)
+    rel = (got - ref).abs().amax() / denom
+    tag = "tc_decode" if tc_decode else "packed_route"
+    assert rel < 2e-2, f"NF3 {tag} m={m} rel err {float(rel):.4f} exceeds 2e-2"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize(
+    ("m", "tc_decode"),
+    [
+        # Small-M decode path: fused top-k sum (tc_zero_output prologue) +
+        # direct top-k routes on the NF3 weights.
+        (1, True),
+        (5, True),
+        # Route-packed path + shared w4a16_topk_sum: the prefill-class NF3 GEMM.
+        (33, False),
+    ],
+)
+def test_nf3_matches_dequant_reference(m: int, tc_decode: bool) -> None:
+    _run_case(m, tc_decode=tc_decode)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_nf3_tc_decode_production_shape_with_tier_mask() -> None:
+    """Cover the GLM-5.2 TP4 hybrid contract used by the vLLM integration.
+
+    The serving path compiles one m=8 launch at pinned 256-wide tiles, reuses
+    it at m=1, and maps routes belonging to the other precision tier to -1.
+    """
+    torch.manual_seed(20260714)
+    m, capacity_m = 1, 8
+    num_experts, topk = 4, 8
+    hidden, intermediate = 6144, 512
+    w13_rows = 2 * intermediate
+
+    w13_codes = torch.randint(
+        0,
+        8,
+        (num_experts, w13_rows, hidden),
+        dtype=torch.int32,
+        device=_DEVICE,
+    )
+    w2_codes = torch.randint(
+        0,
+        8,
+        (num_experts, hidden, intermediate),
+        dtype=torch.int32,
+        device=_DEVICE,
+    )
+    w13_scale = _round_to_e4m3_scale(
+        0.01 + 0.24 * torch.rand(num_experts, w13_rows, hidden // 32, device=_DEVICE)
+    )
+    w2_scale = _round_to_e4m3_scale(
+        0.01
+        + 0.24 * torch.rand(num_experts, hidden, intermediate // 32, device=_DEVICE)
+    )
+    x = (torch.randn(m, hidden, device=_DEVICE) * 0.1).to(_DTYPE)
+    topk_ids = torch.tensor(
+        [[0, -1, 1, -1, 2, -1, 3, -1]], dtype=torch.int32, device=_DEVICE
+    )
+    topk_weights = torch.softmax(torch.randn(m, topk, device=_DEVICE), dim=-1)
+
+    sms, max_shared_mem = _device_limits()
+    fused = compile_w4a16_fused_moe(
+        size_m=capacity_m,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        num_experts=num_experts,
+        top_k=topk,
+        activation="silu",
+        apply_router_weight_on_input=False,
+        zero_fc2_output=False,
+        moe_block_size=8,
+        max_m_blocks=capacity_m * topk,
+        element_dtype="bf16",
+        fast_math=True,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        weight_layout="nf3_2p1",
+        scale_format="e4m3_k32",
+        w13_layout="w13",
+        direct_topk_routes=True,
+        tc_decode_fused_sum=True,
+        force_tile_config=(64, 256, 64, 256),
+    )
+    prepared = prepare_nf3_moe_weights(
+        w13_codes,
+        w13_scale,
+        w2_codes,
+        w2_scale,
+        activation="silu",
+        fc1_tile_n=256,
+        fc2_tile_n=256,
+        params_dtype=_DTYPE,
+    )
+    buffers = make_w4a16_packed_buffers(
+        prepared,
+        m=capacity_m,
+        topk=topk,
+        dtype=_DTYPE,
+        device=_DEVICE,
+    )
+    out = run_w4a16_moe(
+        x,
+        prepared,
+        topk_weights,
+        topk_ids,
+        activation="silu",
+        intermediate_cache13=buffers.intermediate_cache13,
+        intermediate_cache2=buffers.intermediate_cache2,
+        output=buffers.output[:m],
+        fc1_c_tmp=buffers.fc1_c_tmp,
+        fc2_c_tmp=buffers.fc2_c_tmp,
+        packed_route_indices=buffers.packed_route_indices,
+        block_expert_ids=buffers.block_expert_ids,
+        packed_route_count=buffers.packed_route_count,
+        fused_launch=fused,
+    )
+    torch.cuda.synchronize()
+
+    w13_deq = _dequant(w13_codes, w13_scale)
+    w2_deq = _dequant(w2_codes, w2_scale)
+    ref = torch.zeros((m, hidden), dtype=torch.float32, device=_DEVICE)
+    x_f = x.float()
+    for route in range(topk):
+        expert = int(topk_ids[0, route])
+        if expert < 0:
+            continue
+        fc1 = x_f[0] @ w13_deq[expert].float().T
+        gate, up = fc1[:intermediate], fc1[intermediate:]
+        act = (gate * torch.sigmoid(gate)).to(_DTYPE) * up.to(_DTYPE)
+        ref[0] += float(topk_weights[0, route]) * (
+            act.float() @ w2_deq[expert].float().T
+        )
+
+    denom = ref.abs().amax().clamp(min=1e-6)
+    rel = (out.float() - ref).abs().amax() / denom
+    assert rel < 2e-2, f"production-shape NF3 TC decode rel err {float(rel):.4f}"
+
+    mismatched = replace(prepared, fc1_tile_n=128)
+    with pytest.raises(RuntimeError, match="NF3 packing geometry"):
+        run_w4a16_moe(
+            x,
+            mismatched,
+            topk_weights,
+            topk_ids,
+            activation="silu",
+            intermediate_cache13=buffers.intermediate_cache13,
+            intermediate_cache2=buffers.intermediate_cache2,
+            output=buffers.output[:m],
+            fc1_c_tmp=buffers.fc1_c_tmp,
+            fc2_c_tmp=buffers.fc2_c_tmp,
+            packed_route_indices=buffers.packed_route_indices,
+            block_expert_ids=buffers.block_expert_ids,
+            packed_route_count=buffers.packed_route_count,
+            fused_launch=fused,
+        )

--- a/tests/experimental/norm/test_mhc.py
+++ b/tests/experimental/norm/test_mhc.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.experimental.sm12x.norm import mhc
+
+SM12XMHCScratchCaps = mhc.Caps
+sm12x_mhc_post = mhc.run_post
+sm12x_mhc_post_pre = mhc.run_post_pre
+plan_mhc_scratch = mhc.plan
+
+from ..conftest import require_sm12x as require_sm120
+
+
+def _mhc_pre_reference(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor,
+    *,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    y_dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    flat = residual.flatten(1).float()
+    mixes = F.linear(flat, fn) * torch.rsqrt(
+        flat.square().mean(dim=-1, keepdim=True) + rms_eps
+    )
+    pre = torch.sigmoid(mixes[:, :4] * scale[0] + bias[:4]) + hc_eps
+    post = 2 * torch.sigmoid(mixes[:, 4:8] * scale[1] + bias[4:8])
+    comb = mixes[:, 8:].view(-1, 4, 4) * scale[2] + bias[8:].view(4, 4)
+    comb = torch.softmax(comb, dim=-1) + hc_eps
+    comb = comb / (comb.sum(dim=-2, keepdim=True) + hc_eps)
+    for _ in range(sinkhorn_iters - 1):
+        comb = comb / (comb.sum(dim=-1, keepdim=True) + hc_eps)
+        comb = comb / (comb.sum(dim=-2, keepdim=True) + hc_eps)
+    y = (pre.unsqueeze(-1) * residual.float()).sum(dim=1)
+    y = y.to(residual.dtype if y_dtype is None else y_dtype)
+    return y, post, comb
+
+
+def _mhc_post_reference(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post: torch.Tensor,
+    comb: torch.Tensor,
+) -> torch.Tensor:
+    return (
+        post.unsqueeze(-1) * x.unsqueeze(1).float()
+        + (comb.unsqueeze(-1) * residual.unsqueeze(2).float()).sum(dim=1)
+    ).to(x.dtype)
+
+
+def _make_inputs(
+    *,
+    tokens: int,
+    hidden_size: int,
+    seed: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(seed)
+    residual = (
+        torch.randn((tokens, 4, hidden_size), generator=gen, dtype=torch.float32).to(
+            device
+        )
+        / 3
+    ).to(torch.bfloat16)
+    x = (
+        torch.randn((tokens, hidden_size), generator=gen, dtype=torch.float32).to(
+            device
+        )
+        / 4
+    ).to(torch.bfloat16)
+    fn = (
+        torch.randn((24, 4 * hidden_size), generator=gen, dtype=torch.float32).to(
+            device
+        )
+        / 64
+    )
+    scale = torch.randn((3,), generator=gen, dtype=torch.float32).to(device) / 3
+    bias = torch.randn((24,), generator=gen, dtype=torch.float32).to(device) / 5
+    return (
+        residual.contiguous(),
+        x.contiguous(),
+        fn.contiguous(),
+        scale.contiguous(),
+        bias.contiguous(),
+    )
+
+
+def _make_mhc_binding(
+    *,
+    tokens: int,
+    hidden_size: int,
+    device: torch.device,
+    split_k: int = 64,
+    expected_m: int | None = None,
+):
+    max_tokens = max(tokens, expected_m or tokens)
+    plan = plan_mhc_scratch(
+        SM12XMHCScratchCaps(
+            device=device,
+            max_tokens=max_tokens,
+            hidden_size=hidden_size,
+            split_k=split_k,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=device)
+        for shape, dtype in plan.shapes_and_dtypes()
+    )
+    return plan.bind(
+        scratch=scratch,
+        tokens=tokens,
+        expected_m=expected_m,
+        y=torch.empty((tokens, hidden_size), dtype=torch.bfloat16, device=device),
+        post=torch.empty((tokens, 4), dtype=torch.float32, device=device),
+        comb=torch.empty((tokens, 4, 4), dtype=torch.float32, device=device),
+        out=torch.empty((tokens, 4, hidden_size), dtype=torch.bfloat16, device=device),
+    )
+
+
+@pytest.mark.parametrize("tokens", [1, 3, 8])
+def test_sm12x_mhc_fused_post_pre_match_reference(tokens: int) -> None:
+    device = require_sm120()
+    hidden_size = 4096
+    residual, x, fn, scale, bias = _make_inputs(
+        tokens=tokens,
+        hidden_size=hidden_size,
+        seed=91_450 + tokens,
+        device=device,
+    )
+    binding = _make_mhc_binding(
+        tokens=tokens,
+        hidden_size=hidden_size,
+        device=device,
+    )
+    _, prev_post, prev_comb = _mhc_pre_reference(
+        residual,
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+    )
+    prev_post_arg = prev_post.contiguous()
+    if tokens == 3:
+        prev_post_arg = prev_post_arg.unsqueeze(-1).contiguous()
+
+    residual_cur, post, comb, y = sm12x_mhc_post_pre(
+        x,
+        residual,
+        prev_post_arg,
+        prev_comb.contiguous(),
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+        binding=binding,
+    )
+    torch.cuda.synchronize(device)
+
+    assert (
+        residual_cur.untyped_storage().data_ptr()
+        == binding.out.untyped_storage().data_ptr()
+    )
+    assert (
+        post.untyped_storage().data_ptr()
+        == binding.post_buffer.untyped_storage().data_ptr()
+    )
+    assert (
+        comb.untyped_storage().data_ptr()
+        == binding.comb_buffer.untyped_storage().data_ptr()
+    )
+    assert y.untyped_storage().data_ptr() == binding.y.untyped_storage().data_ptr()
+
+    residual_ref = _mhc_post_reference(x, residual, prev_post, prev_comb)
+    y_ref, post_ref, comb_ref = _mhc_pre_reference(
+        residual_ref,
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+    )
+    torch.testing.assert_close(residual_cur, residual_ref, rtol=0.0, atol=2e-2)
+    torch.testing.assert_close(y, y_ref, rtol=0.0, atol=8e-3)
+    scalar_atol = 2e-5 if tokens >= 8 else 1e-5
+    torch.testing.assert_close(post, post_ref, rtol=2e-6, atol=scalar_atol)
+    torch.testing.assert_close(comb, comb_ref, rtol=2e-6, atol=scalar_atol)
+
+
+@pytest.mark.parametrize("tokens", [1, 3])
+def test_sm12x_mhc_fused_post_pre_with_rmsnorm_match_reference(tokens: int) -> None:
+    device = require_sm120()
+    hidden_size = 4096
+    residual, x, fn, scale, bias = _make_inputs(
+        tokens=tokens,
+        hidden_size=hidden_size,
+        seed=91_470 + tokens,
+        device=device,
+    )
+    binding = _make_mhc_binding(
+        tokens=tokens,
+        hidden_size=hidden_size,
+        device=device,
+    )
+    norm_gen = torch.Generator(device="cpu")
+    norm_gen.manual_seed(91_471 + tokens)
+    norm_weight = (
+        torch.randn((hidden_size,), generator=norm_gen, dtype=torch.float32)
+        .to(device)
+        .to(torch.bfloat16)
+        .contiguous()
+    )
+    _, prev_post, prev_comb = _mhc_pre_reference(
+        residual,
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+    )
+
+    residual_cur, post, comb, y = sm12x_mhc_post_pre(
+        x,
+        residual,
+        prev_post.contiguous(),
+        prev_comb.contiguous(),
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+        binding=binding,
+        norm_weight=norm_weight,
+        norm_eps=1e-6,
+    )
+    torch.cuda.synchronize(device)
+
+    residual_ref = _mhc_post_reference(x, residual, prev_post, prev_comb)
+    # The fused post_pre kernel (like vLLM's TileLang kernel) computes the
+    # RMSNorm variance in fp32 from the collapsed activation -- not from the
+    # bf16-rounded activation -- so reference the variance from fp32 y too
+    # (matching vllm_y_max == fused_y_max in the benchmark). The activation
+    # itself is still bf16 (it is stored bf16 before the norm multiply).
+    y_raw_ref_fp32, post_ref, comb_ref = _mhc_pre_reference(
+        residual_ref,
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+        y_dtype=torch.float32,
+    )
+    rms_scale = torch.rsqrt(y_raw_ref_fp32.square().mean(dim=-1, keepdim=True) + 1e-6)
+    y_ref = (
+        y_raw_ref_fp32.to(torch.bfloat16).float() * rms_scale * norm_weight.float()
+    ).to(torch.bfloat16)
+    torch.testing.assert_close(residual_cur, residual_ref, rtol=0.0, atol=2e-2)
+    torch.testing.assert_close(y, y_ref, rtol=0.0, atol=6e-3)
+    torch.testing.assert_close(post, post_ref, rtol=2e-6, atol=1e-5)
+    torch.testing.assert_close(comb, comb_ref, rtol=2e-6, atol=4e-5)
+
+
+def test_sm12x_mhc_fused_post_pre_graph_capture() -> None:
+    device = require_sm120()
+    tokens = 2
+    hidden_size = 4096
+    residual, x, fn, scale, bias = _make_inputs(
+        tokens=tokens,
+        hidden_size=hidden_size,
+        seed=91_460,
+        device=device,
+    )
+    _, prev_post, prev_comb = _mhc_pre_reference(
+        residual,
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+    )
+    prev_post_arg = prev_post.contiguous()
+    prev_comb_arg = prev_comb.contiguous()
+    # CUDA graph capture requires caller-owned scratch (the partials buffer).
+    binding = _make_mhc_binding(
+        tokens=tokens,
+        hidden_size=hidden_size,
+        device=device,
+    )
+    residual_cur = binding.out
+    y = binding.y
+    post = binding.post_buffer
+    comb = binding.comb_buffer
+
+    def run() -> None:
+        sm12x_mhc_post_pre(
+            x,
+            residual,
+            prev_post_arg,
+            prev_comb_arg,
+            fn,
+            scale,
+            bias,
+            rms_eps=1e-6,
+            hc_eps=1e-6,
+            sinkhorn_iters=20,
+            binding=binding,
+        )
+
+    run()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    residual_ref = _mhc_post_reference(x, residual, prev_post, prev_comb)
+    y_ref, post_ref, comb_ref = _mhc_pre_reference(
+        residual_ref,
+        fn,
+        scale,
+        bias,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        sinkhorn_iters=20,
+    )
+    torch.testing.assert_close(residual_cur, residual_ref, rtol=0.0, atol=2e-2)
+    torch.testing.assert_close(y, y_ref, rtol=0.0, atol=4e-3)
+    torch.testing.assert_close(post, post_ref, rtol=2e-6, atol=1e-5)
+    torch.testing.assert_close(comb, comb_ref, rtol=2e-6, atol=1e-5)

--- a/tests/experimental/quantization/test_mxfp8.py
+++ b/tests/experimental/quantization/test_mxfp8.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""quantization.mxfp8: the standalone CuTe row quantizer writes the same
+bits as the packaged block-FP8 input-quant path (same underlying kernel via
+its opaque custom op), and dequantizes back close to the source.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x.gemm import block_fp8_linear as bfl
+from flashinfer.experimental.sm12x.gemm._shared.wo_mxfp8 import (
+    dequantize_mxfp8_rows_torch,
+)
+from flashinfer.experimental.sm12x.quantization import mxfp8
+
+from ..conftest import require_sm12x
+
+
+def test_quantize_rows_matches_packaged_path_and_dequantizes() -> None:
+    require_sm12x()
+    torch.manual_seed(20260715)
+
+    source = (
+        torch.randn((5, 256), device="cuda", dtype=torch.bfloat16) / 4
+    ).contiguous()
+
+    reference = bfl.quantize_input(source)
+    values = torch.empty_like(reference.values)
+    scale_rows = torch.empty_like(reference.scale_rows)
+    # The kernel writes only live-row lanes of the swizzled MMA scale tensor;
+    # the packaged path pre-fills the 128-row-tile padding with the neutral
+    # e8m0 1.0 (biased exponent 127). Match that so the compare stays bitwise.
+    scale_mma = torch.full_like(reference.scale_mma.view(torch.uint8), 127).view(
+        torch.float8_e8m0fnu
+    )
+
+    mxfp8.quantize_rows(source, values, scale_rows, scale_mma)
+    torch.cuda.synchronize()
+
+    assert torch.equal(values.view(torch.uint8), reference.values.view(torch.uint8))
+    assert torch.equal(
+        scale_rows.view(torch.uint8), reference.scale_rows.view(torch.uint8)
+    )
+    assert torch.equal(
+        scale_mma.view(torch.uint8), reference.scale_mma.view(torch.uint8)
+    )
+
+    deq = dequantize_mxfp8_rows_torch(values, scale_rows)
+    assert bool(torch.isfinite(deq).all().item())
+    assert (deq.float() - source.float()).abs().max().item() < 0.05

--- a/tests/experimental/quantization/test_nvfp4.py
+++ b/tests/experimental/quantization/test_nvfp4.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""quantization.nvfp4: the BF16 -> NVFP4 TMA tile quantizer matches the
+pure-torch grouped quantizer (the blockscaled GEMM tests' operand builder)
+bitwise on both packed values and MMA-layout scales.
+
+The op was dead at the original port baseline and revived by the CUTLASS
+DSL 4.6 migration.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flashinfer.experimental.sm12x._lib.intrinsics import quantize_grouped_nvfp4_torch
+from flashinfer.experimental.sm12x.quantization import nvfp4
+
+from ..conftest import require_sm12x
+
+
+def test_run_matches_torch_grouped_quantizer() -> None:
+    require_sm12x()
+    torch.manual_seed(20260720)
+
+    m, k = 256, 512
+    source = (torch.randn((m, k), device="cuda", dtype=torch.bfloat16) / 4).contiguous()
+    tensor_amax = source.abs().max().to(torch.float32)
+    global_scale = (torch.finfo(torch.float8_e4m3fn).max * 6.0 / tensor_amax).reshape(1)
+
+    row_counts = torch.full((1,), m, dtype=torch.int32, device="cuda")
+    ref_packed, ref_scale_view = quantize_grouped_nvfp4_torch(
+        source.unsqueeze(0), row_counts, global_scale
+    )
+    # Invert as_grouped_scale_view's logical permutation to recover the
+    # physical contiguous scale-storage contract the TMA kernel writes
+    # (mirrors b12x tests/test_bf16_to_fp4_tma.py).
+    ref_scales = ref_scale_view.permute(5, 2, 4, 0, 1, 3).contiguous().view(torch.uint8)
+
+    plan = nvfp4.plan(m, k)
+    outputs = nvfp4.allocate_outputs(plan)
+    nvfp4.run(plan=plan, x=source, global_scale=global_scale, outputs=outputs)
+    torch.cuda.synchronize()
+
+    actual_packed = outputs.packed_a_storage.view(-1)
+    expected_packed = ref_packed.contiguous().view(torch.uint8).view(-1)
+    assert actual_packed.numel() == expected_packed.numel()
+    assert int(torch.count_nonzero(actual_packed).item()) > 0
+    assert torch.equal(actual_packed, expected_packed)
+
+    actual_scales = outputs.scale_flat
+    expected_scales = ref_scales.view(-1)
+    assert actual_scales.numel() == expected_scales.numel()
+    assert torch.equal(actual_scales, expected_scales)

--- a/tests/experimental/test_import_hygiene.py
+++ b/tests/experimental/test_import_hygiene.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Import hygiene for flashinfer.experimental (runtime side of isolation).
+
+Each case runs in a fresh subprocess so module caches can't leak between
+assertions:
+
+1. ``import flashinfer`` alone never touches experimental and never warns.
+2. ``import flashinfer.experimental.sm12x`` works without a GPU, emits
+   exactly one FutureWarning, and is side-effect free: no cutlass/triton
+   import, no sm12x compiler import, no ``flashinfer_sm12x`` torch ops.
+3. The FutureWarning fires once per process (re-import stays silent), and
+   the freeze controls are callable from the namespace root.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("torch")
+
+
+def _run(code: str) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert proc.returncode == 0, (
+        f"subprocess failed\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+CORE_ONLY = """
+import json, sys, warnings
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    import flashinfer
+print(json.dumps({
+    "experimental_modules": sorted(
+        m for m in sys.modules if m.startswith("flashinfer.experimental")
+    ),
+    "experimental_warnings": [
+        str(w.message) for w in caught
+        if w.category is FutureWarning and "flashinfer.experimental" in str(w.message)
+    ],
+}))
+"""
+
+
+def test_core_import_never_touches_experimental():
+    data = _run(CORE_ONLY)
+    assert data["experimental_modules"] == []
+    assert data["experimental_warnings"] == []
+
+
+NAMESPACE_IMPORT = """
+import json, sys, warnings
+import flashinfer
+import torch
+
+before = set(sys.modules)
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    import flashinfer.experimental.sm12x as sm12x
+    ops = sm12x.list_ops()
+newly_loaded = sorted(set(sys.modules) - before)
+
+future_warnings = [
+    str(w.message) for w in caught
+    if w.category is FutureWarning and "flashinfer.experimental" in str(w.message)
+]
+
+with warnings.catch_warnings(record=True) as caught_again:
+    warnings.simplefilter("always")
+    import importlib
+    importlib.import_module("flashinfer.experimental")
+    importlib.import_module("flashinfer.experimental.sm12x")
+second_warnings = [
+    str(w.message) for w in caught_again
+    if w.category is FutureWarning and "flashinfer.experimental" in str(w.message)
+]
+
+sm12x.freeze_kernel_resolution("hygiene-test")
+frozen = sm12x.kernel_resolution_frozen()
+sm12x.unfreeze_kernel_resolution()
+
+torch_namespaces = {name.split("::")[0] for name in torch._C._dispatch_get_all_op_names()}
+
+print(json.dumps({
+    "n_future_warnings": len(future_warnings),
+    "n_second_warnings": len(second_warnings),
+    "newly_loaded_cutlass": [m for m in newly_loaded if m == "cutlass" or m.startswith("cutlass.")],
+    "newly_loaded_triton": [m for m in newly_loaded if m == "triton" or m.startswith("triton.")],
+    "compiler_loaded": "flashinfer.experimental.sm12x._lib.compiler" in sys.modules,
+    "intrinsics_loaded": "flashinfer.experimental.sm12x._lib.intrinsics" in sys.modules,
+    "n_ops": len(ops),
+    "torch_ops_registered": "flashinfer_sm12x" in torch_namespaces,
+    "freeze_roundtrip": frozen,
+}))
+"""
+
+
+def test_namespace_import_is_side_effect_free():
+    data = _run(NAMESPACE_IMPORT)
+    assert data["n_future_warnings"] == 1, "exactly one FutureWarning on first import"
+    assert data["n_second_warnings"] == 0, "re-import must not warn again"
+    assert data["newly_loaded_cutlass"] == [], "namespace import must not pull cutlass"
+    assert data["newly_loaded_triton"] == [], "namespace import must not pull triton"
+    assert not data["compiler_loaded"], "sm12x compiler must load on first op use only"
+    assert not data["intrinsics_loaded"], (
+        "kernel intrinsics must load on first op use only"
+    )
+    assert not data["torch_ops_registered"], "torch ops must register on op import only"
+    assert data["freeze_roundtrip"] is True
+    assert isinstance(data["n_ops"], int)
+
+
+QUIET_IMPORT = """
+import json, os, warnings
+os.environ["FLASHINFER_EXP_QUIET"] = "1"
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    import flashinfer.experimental.sm12x
+print(json.dumps({
+    "warnings": [
+        str(w.message) for w in caught
+        if w.category is FutureWarning and "flashinfer.experimental" in str(w.message)
+    ],
+}))
+"""
+
+
+def test_quiet_env_silences_future_warning():
+    data = _run(QUIET_IMPORT)
+    assert data["warnings"] == []

--- a/tests/experimental/test_registry.py
+++ b/tests/experimental/test_registry.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 FlashInfer team
+# SPDX-License-Identifier: Apache-2.0
+"""Registry contract: sm12x._OPS and the on-disk op directories stay in
+lockstep, and every op honors the META/__all__ shape (invariant #3)."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+
+REPO = Path(__file__).resolve().parents[2]
+SM12X_DIR = REPO / "flashinfer" / "experimental" / "sm12x"
+
+
+def _on_disk_ops() -> list[str]:
+    ops = []
+    for group_dir in sorted(SM12X_DIR.iterdir()):
+        if not group_dir.is_dir() or group_dir.name.startswith("_"):
+            continue
+        for op_dir in sorted(group_dir.iterdir()):
+            if not op_dir.is_dir() or op_dir.name.startswith("_"):
+                continue
+            ops.append(f"{group_dir.name}.{op_dir.name}")
+    return ops
+
+
+def _sm12x():
+    return importlib.import_module("flashinfer.experimental.sm12x")
+
+
+def test_registry_matches_disk():
+    sm12x = _sm12x()
+    assert sorted(sm12x._OPS) == _on_disk_ops(), (
+        "sm12x._OPS and the op directories under flashinfer/experimental/sm12x/ "
+        "must be in bijection; register new ops in _OPS"
+    )
+
+
+def test_list_ops_and_find_op():
+    sm12x = _sm12x()
+    metas = sm12x.list_ops()
+    assert len(metas) == len(sm12x._OPS)
+    for meta in metas:
+        assert sm12x.find_op(meta.qualname) is meta
+    with pytest.raises(KeyError):
+        sm12x.find_op("no_such.op")
+
+
+def test_every_op_meta_contract():
+    sm12x = _sm12x()
+    for meta in sm12x.list_ops():
+        module = importlib.import_module(
+            f"flashinfer.experimental.sm12x.{meta.qualname}"
+        )
+        assert isinstance(module.META, sm12x.OpMeta)
+        assert set(module.__all__) == set(meta.entry_points) | {"META"}, meta.qualname
+        assert "is_supported" in meta.entry_points, meta.qualname
+        assert meta.archs and set(meta.archs) <= {"sm120a", "sm121a"}, meta.qualname
+        assert meta.provenance.commit, f"{meta.qualname} missing provenance commit"
+        assert meta.test_path and (REPO / meta.test_path).is_file(), (
+            f"{meta.qualname} META.test_path {meta.test_path!r} does not exist"
+        )
+
+
+def test_clear_all_caches_never_forces_imports():
+    sm12x = _sm12x()
+    sm12x.clear_all_caches()  # must be a no-op / safe with nothing imported
+
+
+def test_every_op_api_resolves():
+    """Force-load every op's api and resolve every declared entry point.
+
+    Catches facade/alias typos without a GPU; needs cutlass (kernel modules
+    import it), so the CPU-only CI job skips this one.
+    """
+    pytest.importorskip("cutlass")
+    sm12x = _sm12x()
+    for meta in sm12x.list_ops():
+        module = importlib.import_module(
+            f"flashinfer.experimental.sm12x.{meta.qualname}"
+        )
+        for name in meta.entry_points:
+            assert getattr(module, name) is not None, f"{meta.qualname}.{name}"


### PR DESCRIPTION
## 📌 Description

  Reference implementation of the `flashinfer.experimental` proposal: an isolated,
  minimally-reviewed landing zone for consumer-GPU (SM12x) kernels, fenced off so it can
  never affect datacenter users — plus the first corpus to live in it.

  **What's inside** — `flashinfer.experimental.sm12x`, a curated port of the b12x
  CuTe-DSL kernel corpus (`lukealonso/b12x @ 6627d342`, CUTLASS DSL 4.6): 15 ops in 6 groups.

  | Group | Ops |
  |---|---|
  | `attention` | `paged` (decode/extend, FP8 KV, MSA block-sparse), `sparse_mla` (DSV4/GLM top-k  MLA + NVFP4 FP8-RoPE cache writer), `compressed_mla`, `nsa_indexer`, `varlen` |
  | `gemm` | `blockscaled` (NVFP4/MXFP4/MXFP8), `block_fp8_linear`, `mxfp8_linear`,
  `wo_projection` |
  | `moe` | `fused_moe` (nvfp4/mxfp4/w4a8/w4a16 + NF3 layouts), `ep_moe` |
  | `norm` / `quantization` / `comm` | `mhc`, `mxfp8`, `nvfp4`, `pcie` (PCIe collectives) |

  **Proposal rules, enforced by blocking CI lints rather than convention:**

  - **Isolation**: zero outbound imports (experimental never imports core; capability gating
    is vendored) and core never imports experimental — which also structurally proves
    `aot.py` / jit-cache / cubin wheels can never pick up experimental code.
  - **Arch restriction**: no SM90/SM100/SM103/SM110 targets anywhere in the tree.
  - **Side-effect-free namespace**: `import flashinfer.experimental.sm12x` pulls no
    cutlass/triton, registers no torch ops, and emits exactly one `FutureWarning`
    (`FLASHINFER_EXP_QUIET=1` silences). Kernels load on first op use.
  - **JIT only**: pure Python + JIT sources (raw `.cu` only inside `comm/pcie/`,
    registered as package-data per the existing `cute_dsl/sparse/blk64` precedent).

  **One grammar**: every op declares itself via a `META` header (entry points, dtypes,
  requirements, provenance, test path; `sm12x.list_ops()` enumerates), and stateful ops
  share one serving-grade lifecycle — `plan()` may allocate, `bind()` builds views only
  (never allocates), `run*()` is CUDA-graph-capture safe — with serving freeze controls
  at the arch root. See `flashinfer/experimental/README.md` for the full contract and
  the b12x → experimental migration map.

  **Core-facing footprint** (the part that needs real review, all in the first commit):
  mypy/pre-commit/ruff excludes for the experimental subtree, `nvidia-cutlass-dsl` floor
  `4.5.0 → 4.5.2` (experimental additionally runtime-gates itself at `>= 4.6.0` without
  constraining core installs), one package-data entry, and one new non-blocking CI
  workflow. Wheel grows ~1–1.5 MB compressed. Core code paths are untouched.

  ## 🔍 Related Issues

  <!-- TODO: link the flashinfer.experimental proposal / RFC discussion -->

  ## 🚀 Pull Request Checklist

  ### ✅ Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred  method).
  - [x] I have installed the hooks with `pre-commit install`.
  - [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported
  issues.

  ## 🧪 Tests

  - [x] Tests have been added or updated as needed.
  - [x] All tests are passing (`unittest`, etc.).

  `tests/experimental/`: 127 tests — structural lints (blocking, stdlib-only), subprocess
  import-hygiene, registry contract, and curated small-shape kernel tests (pure-torch
  references, flashinfer-core cuDNN `mm_fp4` oracle bitwise parity, CUDA-graph replays
  under frozen kernel resolution). All green on RTX PRO 6000 (SM120) with
  `nvidia-cutlass-dsl==4.6.0`; dense NVFP4 GEMM verified bitwise-identical to upstream
  b12x with perf ratio 1.000. GPU CI is templated but disabled until an SM12x runner
  exists — until then the GPU lane is a local runbook.

  ## Reviewer Notes

  - **Review model** (per the proposal): commit 1 (`experimental: scaffold …`) is the
    line-review target — namespace, rules, lints, CI, and the config edits. Commits 2–6
    are mechanical kernel drops whose review is "the lints are green, the tests exist and
    passed on SM120, provenance headers are present"; every ported file carries its
    upstream path + commit, and each op's `META.provenance` pins the source revision.
  - `torch.ops.flashinfer_sm12x.*` is a **private** integration namespace
    (torch.compile/graph tracing only); the documented Python API is the surface.
  - Known caveats are declared in-tree, not hidden: `attention.paged` decode graph replay
    is implemented but currently untested in-tree (upstream's replay tests are stale;
    noted in `META.notes`), and `attention.varlen` is marked reduced-assurance.
  - Pre-commit: `pre-commit run --all-files` is green. The four ported `.cu` files are
    excluded from clang-format (kept byte-faithful to upstream, matching the subtree's
    mypy/ruff exemptions); this change also repairs the hook's exclude regex, which was
    silently matching nothing (`(?x)` verbose mode ate the separator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added experimental SM12x attention (paged/varlen/sparse/compressed MLA), SM12x GEMM, MXFP8/NVFP4 quantization, fused MoE, mHC normalization, and PCIe collective operations.
  - Introduced planning/binding/scratch/workspace workflows with lazy-loading, cache management, and CUDA Graph-safe execution controls (including kernel-resolution freezing).
- **Documentation**
  - Expanded SM12x experimental guidance covering supported architectures, lifecycles, configuration, caching, and migration.
- **Tests**
  - Added extensive correctness/validation coverage (compile-cache, runtime patching, import hygiene/isolation, attention/MLA/MoE, GEMM, PCIe) and SM12x-focused CI checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->