### PR TITLE
feat: add optional normed-output (y_out) to add_rmsnorm_fp4quant

### DIFF
--- a/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
+++ b/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
@@ -35,10 +35,12 @@ from typing import Callable, Tuple, Union
 import cutlass
 import cutlass.cute as cute
 import torch
-from cutlass import Float32, Int32, Int64, Uint32, Uint8
+from cutlass import Float32, Int32, Int64, Uint32, Uint64, Uint8
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
 
 from ..api_logging import flashinfer_api
-from ..trace.templates.norm import add_rmsnorm_fp4quant_trace
+from ..trace.templates.norm import add_rmsnorm_fp4quant_trace_dispatch
 from ..utils import device_support_pdl
 from .fp4_common import (
     # Constants
@@ -60,6 +62,7 @@ from .fp4_common import (
     bfloat2_hmax2,
     bfloat2_hmax_to_f32,
     # FP8 and FP4 conversion
+    cvt_f32x2_to_half2,
     cvt_f32_to_e4m3,
     fp8_e4m3_to_f32_and_rcp,
     cvt_f32_to_ue8m0,
@@ -81,6 +84,67 @@ from .fp4_common import (
     load_f32_16_from_smem,
     compute_y_and_max_abs_f32,
 )
+
+
+# =============================================================================
+# Helpers for optional normed (bf16/fp16) output
+# =============================================================================
+
+
+@dsl_user_op
+def cvt_f32x2_to_bfloat2(a: Float32, b: Float32, *, loc=None, ip=None) -> Uint32:
+    """Pack two float32 values into a bfloat2 (uint32 containing two bf16 values).
+
+    Uses cvt.rn.bf16.f32 for each value, then packs into a single uint32.
+    Mirrors cvt_f32x2_to_half2 in fp4_common.py.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b16 h0, h1;
+                cvt.rn.bf16.f32 h0, $1;
+                cvt.rn.bf16.f32 h1, $2;
+                mov.b32 $0, {h0, h1};
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def _store_y_norm_16(
+    mN: cute.Tensor,
+    y_f32: cute.Tensor,
+    row_offset: Int32,
+    col_offset: Int32,
+    H: int,
+    is_fp16: bool,
+):
+    """Store 16 normalized float32 values as fp16/bf16 to global memory.
+
+    mN is a flat 1D tensor viewed as row-major (M, H). Uses 4x 64-bit stores
+    (each packing 4 16-bit elements).
+    """
+    for j in cutlass.range_constexpr(4):
+        if cutlass.const_expr(is_fp16):
+            lo = cvt_f32x2_to_half2(y_f32[4 * j], y_f32[4 * j + 1])
+            hi = cvt_f32x2_to_half2(y_f32[4 * j + 2], y_f32[4 * j + 3])
+        else:
+            lo = cvt_f32x2_to_bfloat2(y_f32[4 * j], y_f32[4 * j + 1])
+            hi = cvt_f32x2_to_bfloat2(y_f32[4 * j + 2], y_f32[4 * j + 3])
+        packed64 = (Uint64(hi) << Uint64(32)) | Uint64(lo)
+        ptr = get_ptr_as_int64(mN, row_offset * H + col_offset + Int32(4 * j))
+        st_global_u64(ptr, packed64)
 
 
 # =============================================================================
@@ -111,6 +175,7 @@ class AddRMSNormFP4QuantKernel:
         sm_version: int | None = None,
         scale_format: str | None = None,
         output_both_sf_layouts: bool = False,
+        output_norm: bool = False,
     ):
         self.dtype = dtype
         self.H = H
@@ -119,6 +184,7 @@ class AddRMSNormFP4QuantKernel:
         self.is_fp16 = is_fp16
         self.sm_version = sm_version if sm_version is not None else get_sm_version()
         self.output_both_sf_layouts = output_both_sf_layouts
+        self.output_norm = output_norm
 
         if scale_format is None:
             self.scale_format = "ue8m0" if block_size == 32 else "e4m3"
@@ -285,6 +351,7 @@ class AddRMSNormFP4QuantKernel:
         mY: cute.Tensor,
         mS: cute.Tensor,
         mS_unswizzled: cute.Tensor,
+        mYNorm: cute.Tensor,
         mGlobalScale: cute.Tensor,
         M: Int32,
         eps: Float32,
@@ -300,6 +367,8 @@ class AddRMSNormFP4QuantKernel:
         - mY: Output FP4 tensor, shape (M, H // 2), row-major (packed)
         - mS: Scale factor tensor, shape depends on swizzle mode
         - mS_unswizzled: Unswizzled scale factor tensor (used when output_both_sf_layouts=True)
+        - mYNorm: Optional normed output tensor, flat 1D view of (M, H), same dtype as
+          input (only written when output_norm=True; pass any dummy tensor otherwise)
         - mGlobalScale: Global scale tensor, shape (1,), float32
         """
 
@@ -319,6 +388,7 @@ class AddRMSNormFP4QuantKernel:
             mY,
             mS,
             mS_unswizzled,
+            mYNorm,
             mGlobalScale,
             M,
             eps,
@@ -345,6 +415,7 @@ class AddRMSNormFP4QuantKernel:
         mY: cute.Tensor,
         mS: cute.Tensor,
         mS_unswizzled: cute.Tensor,
+        mYNorm: cute.Tensor,
         mGlobalScale: cute.Tensor,
         M: Int32,
         eps: Float32,
@@ -639,6 +710,16 @@ class AddRMSNormFP4QuantKernel:
                             )
                             st_global_u64(out_ptr, packed64)
 
+                            if cutlass.const_expr(self.output_norm):
+                                _store_y_norm_16(
+                                    mYNorm,
+                                    y_f32,
+                                    actual_row_idx,
+                                    block_start,
+                                    H,
+                                    is_fp16,
+                                )
+
                         else:
                             # Global memory path (cluster mode) - use helper functions
                             # mR contains h = x + r, so load from mR
@@ -711,6 +792,16 @@ class AddRMSNormFP4QuantKernel:
                                 mY, actual_row_idx * (H // 2) + out_offset
                             )
                             st_global_u64(out_ptr, packed64)
+
+                            if cutlass.const_expr(self.output_norm):
+                                _store_y_norm_16(
+                                    mYNorm,
+                                    y_f32,
+                                    actual_row_idx,
+                                    block_start,
+                                    H,
+                                    is_fp16,
+                                )
 
                     else:
                         # block_size == 32 (MXFP4) - process in two chunks of 16
@@ -804,6 +895,24 @@ class AddRMSNormFP4QuantKernel:
                             fp4_ptr_1 = get_ptr_as_int64(mY, fp4_offset + Int32(8))
                             st_global_u64(fp4_ptr_0, packed64_c0)
                             st_global_u64(fp4_ptr_1, packed64_c1)
+
+                            if cutlass.const_expr(self.output_norm):
+                                _store_y_norm_16(
+                                    mYNorm,
+                                    y_f32_c0,
+                                    actual_row_idx,
+                                    block_start,
+                                    H,
+                                    is_fp16,
+                                )
+                                _store_y_norm_16(
+                                    mYNorm,
+                                    y_f32_c1,
+                                    actual_row_idx,
+                                    block_start + Int32(16),
+                                    H,
+                                    is_fp16,
+                                )
 
                         else:
                             # Global memory path (cluster mode) - use helper functions
@@ -900,6 +1009,24 @@ class AddRMSNormFP4QuantKernel:
                             st_global_u64(fp4_ptr_0, packed64_c0)
                             st_global_u64(fp4_ptr_1, packed64_c1)
 
+                            if cutlass.const_expr(self.output_norm):
+                                _store_y_norm_16(
+                                    mYNorm,
+                                    y_f32_c0,
+                                    actual_row_idx,
+                                    block_start,
+                                    H,
+                                    is_fp16,
+                                )
+                                _store_y_norm_16(
+                                    mYNorm,
+                                    y_f32_c1,
+                                    actual_row_idx,
+                                    block_start + Int32(16),
+                                    H,
+                                    is_fp16,
+                                )
+
         if enable_pdl:
             cute.arch.griddepcontrol_launch_dependents()
 
@@ -919,6 +1046,7 @@ def _get_compiled_kernel(
     is_sf_swizzled_layout: bool,
     output_both_sf_layouts: bool = False,
     enable_pdl: bool = False,
+    output_norm: bool = False,
 ) -> Callable:
     """
     Get a compiled kernel closure that takes torch.Tensor directly.
@@ -936,6 +1064,7 @@ def _get_compiled_kernel(
         sm_version=sm_version,
         scale_format=scale_format,
         output_both_sf_layouts=output_both_sf_layouts,
+        output_norm=output_norm,
     )
 
     # Use symbolic size for dynamic M dimension
@@ -982,6 +1111,14 @@ def _get_compiled_kernel(
         assumed_align=128,
     )
 
+    # Optional normed output tensor (flat 1D view of (M, hidden_size)).
+    # Uses an independent symbolic size so a small dummy tensor can be passed
+    # when output_norm=False (the kernel never touches it in that case).
+    sym_ynorm_size = cute.sym_int()
+    ynorm_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype, (sym_ynorm_size,), assumed_align=16
+    )
+
     # Create fake stream that uses environment stream at runtime
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
@@ -999,6 +1136,7 @@ def _get_compiled_kernel(
         y_fake,
         s_fake,
         s_unswizzled_fake,
+        ynorm_fake,
         global_scale_fake,
         Int32(1),  # Dummy M
         Float32(1e-6),  # Dummy eps
@@ -1014,6 +1152,7 @@ def _get_compiled_kernel(
         y: torch.Tensor,
         s: torch.Tensor,
         s_unswizzled: torch.Tensor,
+        y_norm: torch.Tensor,
         global_scale: torch.Tensor,
         M: int,
         eps: float,
@@ -1035,6 +1174,7 @@ def _get_compiled_kernel(
             y_uint8,
             s_tensor,
             s_unswizzled.contiguous(),
+            y_norm,
             global_scale,
             M,
             eps,
@@ -1043,7 +1183,7 @@ def _get_compiled_kernel(
     return tensor_api
 
 
-@flashinfer_api(trace=add_rmsnorm_fp4quant_trace)
+@flashinfer_api(trace=add_rmsnorm_fp4quant_trace_dispatch)
 def add_rmsnorm_fp4quant(
     input: torch.Tensor,
     residual: torch.Tensor,
@@ -1058,6 +1198,7 @@ def add_rmsnorm_fp4quant(
     output_both_sf_layouts: bool = False,
     block_scale_unswizzled: torch.Tensor | None = None,
     enable_pdl: bool | None = None,
+    y_out: torch.Tensor | None = None,
 ) -> Union[
     Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 ]:
@@ -1145,6 +1286,15 @@ def add_rmsnorm_fp4quant(
         device supports it (probed via :func:`device_support_pdl`). Pass
         ``False`` to force-disable. See
         https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
+    y_out : torch.Tensor, optional
+        Optional output tensor for the normed (pre-quantization) values
+        ``y = RMSNorm(input + residual) * weight`` in the input dtype
+        (fp16/bf16). Shape must be ``(batch_size, hidden_size)`` or matching
+        3D input, contiguous. **Written in place**; the return value of this
+        function is unchanged (same tuple arity as without ``y_out``).
+        When ``None`` (default), the normed values are not materialized and
+        the generated kernel is identical to the baseline (the presence of
+        ``y_out`` is a compile-time specialization).
 
     Returns
     -------
@@ -1275,6 +1425,28 @@ def add_rmsnorm_fp4quant(
     if global_scale is None:
         global_scale = torch.ones(1, dtype=torch.float32, device=input.device)
 
+    # Optional normed (bf16/fp16) output — compile-time specialization
+    output_norm = y_out is not None
+    weight_contig = weight.contiguous()
+    if output_norm:
+        assert y_out.dtype == dtype, (
+            f"y_out dtype {y_out.dtype} must match input dtype {dtype}"
+        )
+        assert y_out.device == input.device, (
+            f"y_out device {y_out.device} must match input device {input.device}"
+        )
+        assert y_out.is_contiguous(), "y_out must be contiguous"
+        assert y_out.shape == input.shape, (
+            f"y_out shape {tuple(y_out.shape)} must match the input shape "
+            f"{tuple(input.shape)} (same (batch, hidden) or 3D layout)"
+        )
+        assert y_out.data_ptr() % 16 == 0, "y_out must be 16-byte aligned"
+        y_norm_arg = y_out.view(-1)
+    else:
+        # Dummy tensor; the kernel never reads or writes it when
+        # output_norm=False (the store is compiled out).
+        y_norm_arg = weight_contig
+
     tensor_api = _get_compiled_kernel(
         hidden_size,
         block_size,
@@ -1284,14 +1456,16 @@ def add_rmsnorm_fp4quant(
         is_sf_swizzled_layout,
         output_both_sf_layouts,
         enable_pdl,
+        output_norm,
     )
     tensor_api(
         input_2d.contiguous(),
         residual_2d.contiguous(),
-        weight.contiguous(),
+        weight_contig,
         y_fp4_2d,
         block_scale_2d.view(torch.uint8),
         block_scale_unswizzled_2d.view(torch.uint8),
+        y_norm_arg,
         global_scale.contiguous(),
         batch_size,
         eps,

--- a/flashinfer/trace/templates/norm.py
+++ b/flashinfer/trace/templates/norm.py
@@ -882,7 +882,11 @@ add_rmsnorm_fp4quant_trace = TraceTemplate(
     name_prefix="add_rmsnorm_fp4quant",
     description=(
         "CuTe-DSL fused (residual + input) → RMSNorm → FP4 quantize. "
-        "Mutates the residual buffer in-place with the prenorm sum."
+        "Mutates the residual buffer in-place with the prenorm sum. "
+        "Note: the optional output variants of the runtime API "
+        "(``output_both_sf_layouts`` and ``y_out``) are not modeled by this "
+        "trace template — it captures the core FP4-quantize signature only; "
+        "dump/replay of those extra mutated buffers is unsupported."
     ),
     axes=_RMSNORM_FP4_AXES,
     inputs={
@@ -907,4 +911,26 @@ add_rmsnorm_fp4quant_trace = TraceTemplate(
 )
 add_rmsnorm_fp4quant_trace.axes["scalar"] = Var(
     description="global_scale tensor length (typically 1).",
+)
+
+
+def add_rmsnorm_fp4quant_trace_dispatch(save_dir=None, name=None, **kwargs):
+    """Select the trace template for ``add_rmsnorm_fp4quant``.
+
+    The static template models only the core FP4-quantize signature. The
+    optional output variants — ``y_out`` (an extra normed bf16/fp16 store)
+    and ``output_both_sf_layouts`` (a second scale-factor buffer) — add
+    mutated outputs the template does not represent. Refuse to emit a trace
+    for those calls (return ``None``) instead of silently dumping an
+    incomplete definition that dump/replay tooling would mis-handle.
+    """
+    if kwargs.get("y_out") is not None or kwargs.get("output_both_sf_layouts"):
+        return None
+    return add_rmsnorm_fp4quant_trace
+
+
+# Published so ``@flashinfer_api`` can auto-register the underlying template
+# for trace discovery even though the decorator receives the dispatch fn.
+add_rmsnorm_fp4quant_trace_dispatch.templates = (  # type: ignore[attr-defined]
+    add_rmsnorm_fp4quant_trace,
 )

--- a/tests/norm/test_add_rmsnorm_fp4_quant_cute_dsl.py
+++ b/tests/norm/test_add_rmsnorm_fp4_quant_cute_dsl.py
@@ -2211,5 +2211,431 @@ class TestOutputBothSFLayouts:
         )
 
 
+@cute_dsl_available
+@blackwell_required
+class TestYNormOutput:
+    """Optional normed-output (``y_out``).
+
+    When ``y_out`` is provided the kernel additionally stores the bf16/fp16
+    RMSNorm result (before quantization) so a single launch can feed both an
+    FP4 GEMM and a norm-precision consumer (e.g. an MoE router). The FP4
+    payload and scale-factor outputs must be unaffected by the extra store.
+    """
+
+    @pytest.mark.parametrize("batch_size", [1, 64])
+    @pytest.mark.parametrize("hidden_size", [256, 4096])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_y_out_matches_reference(self, batch_size, hidden_size, dtype):
+        """``y_out`` equals the reference RMSNorm(x+r)*weight in input dtype."""
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        torch.manual_seed(42)
+        block_size = 16
+        eps = 1e-6
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+
+        # Reference computed before the in-place residual update.
+        ref_norm = llama_rms_norm(x + r, weight, eps=eps)
+
+        y_out = torch.empty(batch_size, hidden_size, device="cuda", dtype=dtype)
+        add_rmsnorm_fp4quant(
+            x,
+            r,
+            weight,
+            eps=eps,
+            block_size=block_size,
+            y_out=y_out,
+        )
+
+        # Same rounding path as the reference (fp32 compute -> input dtype),
+        # so the stored norm should match within a couple of ULPs.
+        torch.testing.assert_close(
+            y_out.float(), ref_norm.float(), rtol=1e-2, atol=1e-2
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 64])
+    @pytest.mark.parametrize("hidden_size", [256, 2048])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_quant_outputs_unaffected_by_y_out(self, batch_size, hidden_size, dtype):
+        """FP4 payload and block scales are byte-identical with/without ``y_out``.
+
+        Uses the unswizzled (linear) scale-factor layout so the comparison is
+        padding-free and exact; the swizzled path with ``y_out`` is covered by
+        ``test_y_out_with_both_sf_layouts``.
+        """
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        torch.manual_seed(42)
+        block_size = 16
+        eps = 1e-6
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        global_scale = compute_global_scale(x, r, weight, eps=eps)
+
+        # Baseline (no y_out).
+        r_base = r.clone()
+        y_fp4_base = torch.empty(
+            batch_size, hidden_size // 2, device="cuda", dtype=torch.float4_e2m1fn_x2
+        )
+        sf_base = torch.empty(
+            batch_size,
+            hidden_size // block_size,
+            device="cuda",
+            dtype=torch.float8_e4m3fn,
+        )
+        add_rmsnorm_fp4quant(
+            x,
+            r_base,
+            weight,
+            y_fp4_base,
+            sf_base,
+            global_scale=global_scale,
+            eps=eps,
+            block_size=block_size,
+            is_sf_swizzled_layout=False,
+        )
+
+        # With y_out (fresh clones — residual is updated in place).
+        r_y = r.clone()
+        y_fp4_y = torch.empty(
+            batch_size, hidden_size // 2, device="cuda", dtype=torch.float4_e2m1fn_x2
+        )
+        sf_y = torch.empty(
+            batch_size,
+            hidden_size // block_size,
+            device="cuda",
+            dtype=torch.float8_e4m3fn,
+        )
+        y_out = torch.empty(batch_size, hidden_size, device="cuda", dtype=dtype)
+        add_rmsnorm_fp4quant(
+            x,
+            r_y,
+            weight,
+            y_fp4_y,
+            sf_y,
+            global_scale=global_scale,
+            eps=eps,
+            block_size=block_size,
+            is_sf_swizzled_layout=False,
+            y_out=y_out,
+        )
+
+        assert torch.equal(y_fp4_base.view(torch.uint8), y_fp4_y.view(torch.uint8)), (
+            "FP4 payload must be byte-identical with and without y_out"
+        )
+        assert torch.equal(sf_base.view(torch.uint8), sf_y.view(torch.uint8)), (
+            "Block scales must be byte-identical with and without y_out"
+        )
+        # Residual in-place update is also unaffected.
+        assert torch.equal(r_base, r_y)
+
+    @pytest.mark.parametrize("batch_size", [1, 16, 128])
+    @pytest.mark.parametrize("hidden_size", [512, 2048])
+    def test_y_out_with_both_sf_layouts(self, batch_size, hidden_size):
+        """``y_out`` composes with ``output_both_sf_layouts=True``."""
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        torch.manual_seed(42)
+        block_size = 16
+        eps = 1e-6
+        dtype = torch.bfloat16
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        ref_norm = llama_rms_norm(x + r, weight, eps=eps)
+
+        y_out = torch.empty(batch_size, hidden_size, device="cuda", dtype=dtype)
+        result = add_rmsnorm_fp4quant(
+            x,
+            r,
+            weight,
+            eps=eps,
+            block_size=block_size,
+            output_both_sf_layouts=True,
+            y_out=y_out,
+        )
+
+        # Tuple arity is still 3 (y_out is written in place, not returned).
+        assert len(result) == 3
+        torch.testing.assert_close(
+            y_out.float(), ref_norm.float(), rtol=1e-2, atol=1e-2
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 4])
+    @pytest.mark.parametrize("seq_len", [37])
+    @pytest.mark.parametrize("hidden_size", [256, 2048])
+    def test_y_out_3d(self, batch_size, seq_len, hidden_size):
+        """``y_out`` works with 3D (batch, seq, hidden) inputs."""
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        torch.manual_seed(42)
+        block_size = 16
+        eps = 1e-6
+        dtype = torch.bfloat16
+
+        x = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        ref_norm = llama_rms_norm(x + r, weight, eps=eps)
+
+        y_out = torch.empty(
+            batch_size, seq_len, hidden_size, device="cuda", dtype=dtype
+        )
+        add_rmsnorm_fp4quant(
+            x,
+            r,
+            weight,
+            eps=eps,
+            block_size=block_size,
+            y_out=y_out,
+        )
+
+        torch.testing.assert_close(
+            y_out.float(), ref_norm.float(), rtol=1e-2, atol=1e-2
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 64])
+    @pytest.mark.parametrize("hidden_size", [2048])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_y_out_is_not_global_scaled(self, batch_size, hidden_size, dtype):
+        """``y_out`` is the un-scaled RMSNorm, independent of ``global_scale``.
+
+        ``global_scale`` only affects the FP4 block-scale mapping, not the
+        normed value a router/shared-gate consumes. Guards against a future
+        change that stores the quant-scaled value into ``y_out``. Also checks
+        the FP4 payload still matches the baseline (no ``y_out``).
+        """
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        torch.manual_seed(42)
+        block_size = 16
+        eps = 1e-6
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        # A deliberately non-unit global scale.
+        global_scale = compute_global_scale(x, r, weight, eps=eps)
+        assert global_scale.item() != 1.0
+
+        ref_norm = llama_rms_norm(x + r, weight, eps=eps)
+
+        # Baseline FP4 (no y_out).
+        r_base = r.clone()
+        y_fp4_base = torch.empty(
+            batch_size, hidden_size // 2, device="cuda", dtype=torch.float4_e2m1fn_x2
+        )
+        sf_base = torch.empty(
+            batch_size,
+            hidden_size // block_size,
+            device="cuda",
+            dtype=torch.float8_e4m3fn,
+        )
+        add_rmsnorm_fp4quant(
+            x,
+            r_base,
+            weight,
+            y_fp4_base,
+            sf_base,
+            global_scale=global_scale,
+            eps=eps,
+            block_size=block_size,
+            is_sf_swizzled_layout=False,
+        )
+
+        # With y_out.
+        r_y = r.clone()
+        y_fp4_y = torch.empty_like(y_fp4_base)
+        sf_y = torch.empty_like(sf_base)
+        y_out = torch.empty(batch_size, hidden_size, device="cuda", dtype=dtype)
+        add_rmsnorm_fp4quant(
+            x,
+            r_y,
+            weight,
+            y_fp4_y,
+            sf_y,
+            global_scale=global_scale,
+            eps=eps,
+            block_size=block_size,
+            is_sf_swizzled_layout=False,
+            y_out=y_out,
+        )
+
+        # y_out is the plain RMSNorm (NOT multiplied by global_scale).
+        torch.testing.assert_close(
+            y_out.float(), ref_norm.float(), rtol=1e-2, atol=1e-2
+        )
+        # FP4 payload unaffected by the extra y_out store.
+        assert torch.equal(y_fp4_base.view(torch.uint8), y_fp4_y.view(torch.uint8))
+
+    @pytest.mark.parametrize("batch_size", [1, 64])
+    @pytest.mark.parametrize("hidden_size", [2048])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_y_out_mxfp4_block32(self, batch_size, hidden_size, dtype):
+        """``y_out`` under MXFP4 (block_size=32, UE8M0), which the kernel
+        handles with a distinct dual-chunk store path."""
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        torch.manual_seed(42)
+        block_size = 32  # MXFP4
+        eps = 1e-6
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        ref_norm = llama_rms_norm(x + r, weight, eps=eps)
+
+        # Baseline (no y_out).
+        r_base = r.clone()
+        y_fp4_base = torch.empty(
+            batch_size, hidden_size // 2, device="cuda", dtype=torch.float4_e2m1fn_x2
+        )
+        sf_base = torch.empty(
+            batch_size, hidden_size // block_size, device="cuda", dtype=torch.uint8
+        )
+        add_rmsnorm_fp4quant(
+            x,
+            r_base,
+            weight,
+            y_fp4_base,
+            sf_base,
+            eps=eps,
+            block_size=block_size,
+            scale_format="ue8m0",
+        )
+
+        # With y_out.
+        r_y = r.clone()
+        y_fp4_y = torch.empty_like(y_fp4_base)
+        sf_y = torch.empty_like(sf_base)
+        y_out = torch.empty(batch_size, hidden_size, device="cuda", dtype=dtype)
+        add_rmsnorm_fp4quant(
+            x,
+            r_y,
+            weight,
+            y_fp4_y,
+            sf_y,
+            eps=eps,
+            block_size=block_size,
+            scale_format="ue8m0",
+            y_out=y_out,
+        )
+
+        torch.testing.assert_close(
+            y_out.float(), ref_norm.float(), rtol=1e-2, atol=1e-2
+        )
+        assert torch.equal(y_fp4_base.view(torch.uint8), y_fp4_y.view(torch.uint8)), (
+            "MXFP4 FP4 payload must be byte-identical with and without y_out"
+        )
+        assert torch.equal(sf_base, sf_y), (
+            "MXFP4 block scales must be byte-identical with and without y_out"
+        )
+
+    def test_y_out_wrong_shape_same_numel_raises(self):
+        """A ``y_out`` with the right element count but wrong shape is rejected.
+
+        Regression guard for the shape check (was ``numel``-only): a router /
+        shared-gate consumer would misread a mis-shaped buffer.
+        """
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        batch_size, hidden_size = 16, 512
+        block_size = 16
+        eps = 1e-6
+        dtype = torch.bfloat16
+        torch.manual_seed(42)
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        # Same numel (16*512) but transposed shape.
+        y_out_bad = torch.empty(hidden_size, batch_size, device="cuda", dtype=dtype)
+        assert y_out_bad.numel() == batch_size * hidden_size
+
+        with pytest.raises(AssertionError):
+            add_rmsnorm_fp4quant(
+                x, r, weight, eps=eps, block_size=block_size, y_out=y_out_bad
+            )
+
+    def test_trace_refused_for_optional_output_variants(self):
+        """``fi_trace`` refuses (returns ``{}``) when the optional output
+        variants are active, since the trace template models only the core
+        FP4-quantize signature; the plain call still traces normally."""
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        batch_size, hidden_size = 16, 512
+        block_size = 16
+        eps = 1e-6
+        dtype = torch.bfloat16
+        torch.manual_seed(42)
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        y_out = torch.empty(batch_size, hidden_size, device="cuda", dtype=dtype)
+
+        fi_trace = getattr(add_rmsnorm_fp4quant, "fi_trace", None)
+        if fi_trace is None:
+            pytest.skip("fi_trace not attached (trace tooling unavailable)")
+
+        # Core signature traces normally (non-empty definition).
+        core = fi_trace(
+            input=x, residual=r.clone(), weight=weight, eps=eps, block_size=block_size
+        )
+        assert core and "inputs" in core
+
+        # y_out active -> refused.
+        assert (
+            fi_trace(
+                input=x,
+                residual=r.clone(),
+                weight=weight,
+                eps=eps,
+                block_size=block_size,
+                y_out=y_out,
+            )
+            == {}
+        )
+
+        # output_both_sf_layouts active -> refused.
+        assert (
+            fi_trace(
+                input=x,
+                residual=r.clone(),
+                weight=weight,
+                eps=eps,
+                block_size=block_size,
+                output_both_sf_layouts=True,
+            )
+            == {}
+        )
+
+    def test_y_out_dtype_mismatch_raises(self):
+        """``y_out`` with a dtype different from the input is rejected."""
+        from flashinfer.cute_dsl import add_rmsnorm_fp4quant
+
+        batch_size, hidden_size = 16, 512
+        block_size = 16
+        eps = 1e-6
+        dtype = torch.bfloat16
+        torch.manual_seed(42)
+
+        x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        r = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+        weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+        y_out = torch.empty(batch_size, hidden_size, device="cuda", dtype=torch.float16)
+
+        with pytest.raises(AssertionError):
+            add_rmsnorm_fp4quant(
+                x, r, weight, eps=eps, block_size=block_size, y_out=y_out
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

add_rmsnorm_fp4quant fuses add + RMSNorm + FP4 quantization into one CuTe-DSL kernel. It computes y = RMSNorm(residual + input) * weight and quantizes y to FP4, but the normed y never leaves registers — it's consumed only by the quantizer.

This is a problem when a second consumer needs y in its original precision. In a Qwen3-Next MoE layer, the post-attention norm feeds two readers at once:

the FP4 experts (want the FP4-quantized y), and
the router gate (wants y in bf16).
Today that forces two kernels — a separate fused_add_rmsnorm for the router plus a standalone fp4_quantize for the experts — reading the same normed tensor twice.

This PR adds an optional y_out tensor. When provided, the kernel also writes the normed bf16/fp16 y (one extra [M, H] store in the epilogue), so a single launch feeds both consumers. On Qwen3.6-35B-A3B-NVFP4 decode (B200) this collapses fused_add_rmsnorm + two FP4 quantizes into one kernel — roughly 8.4µs → 3.1µs per MoE layer per decode step.

✅ Key properties
Zero cost when unused. y_out=None is a compile-time specialization threaded through the JIT cache key, so the default path generates the identical kernel as before.
Non-invasive. The return-tuple arity is unchanged; y_out is written in place.
Numerically transparent. The FP4 payload, both scale-factor layouts, and the in-place residual update are byte-identical with and without y_out. y_out itself matches the fp32 reference within 1–2 ULPs, and is the un-scaled RMSNorm result (global_scale only affects the FP4 block scales, never y).
Small overhead when used. +0.19µs at M=4 (2.87µs → 3.06µs, CUDA-graph replay, PDL on) — just the extra store.

🧪 Tests
New TestYNormOutput class: correctness vs the fp32 reference, byte-identity of the FP4/scale/residual outputs with and without y_out, composition with output_both_sf_layouts, 3D inputs, MXFP4 (block_size=32), the global_scale ≠ 1 semantics, shape/dtype/device guards, and trace-dispatch refusal. 145 passed on B200.

📎 Notes
The trace template models only the core FP4-quantize signature, so a dispatch guard makes fi_trace refuse to emit a definition when y_out (or the pre-existing output_both_sf_layouts) is active, rather than silently dumping an incomplete one.
A full-file test run shows 96 unrelated failures in TestFusedVsSeparateFP4Quantize::test_mxfp4_fused_matches_separate; these are pre-existing on main (reproduced by reverting this kernel file) and untouched by this change — the edit is entirely guarded by y_out is not None.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `y_out` to `add_rmsnorm_fp4quant` to write `RMSNorm(x + residual) * weight` (unscaled) into a caller-provided FP16/BF16 tensor for both 2D and 3D inputs, including MXFP4 mode (block size 32).
  - `y_out` can be used alongside `output_both_sf_layouts` while preserving the existing FP4 payload, scale-factor outputs, and residual updates.

- **Documentation**
  - Updated tracing notes: trace/replay is not supported for `y_out` and `output_both_sf_layouts`.

- **Tests**
  - Added a dedicated test suite validating correctness, invariance vs baseline outputs, and argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->