### PR TITLE
perf(jit): prune arch gencode that dispatch can never load

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -697,9 +697,7 @@ def gen_all_modules(
         _ssu_ntokens = [1, 4, 6, 8]
         _ssu_cu_seqlens_dtypes = [torch.int32, torch.int64]
         _ssu_num_accepted_dtypes = [torch.int32, torch.int64]
-        # Default SSU MTP-simple module requires sm_80+ (uses cp.async).  If
-        # the AOT build target has no Ampere-or-newer arch, skip it silently.
-        if has_sm80 or has_sm90 or has_sm100:
+        if has_sm80:
             for dtype_combo, dim, dstate, ntokens, cs_dtype, na_dtype in product(
                 _ssu_dtype_combos,
                 _ssu_dims,
@@ -715,7 +713,7 @@ def gen_all_modules(
                         *dtype_combo, dim, dstate, ntokens, cs_dtype, na_dtype
                     )  # type: ignore[call-arg]
                 )
-        if has_sm90 or has_sm100:
+        if has_sm90:
             for dtype_combo, dim, dstate, ntokens, cs_dtype, na_dtype in product(
                 _ssu_dtype_combos,
                 _ssu_dims,
@@ -730,6 +728,7 @@ def gen_all_modules(
                         *dtype_combo, dim, dstate, ntokens, cs_dtype, na_dtype
                     )
                 )
+        if has_sm90 or has_sm100:
             jit_specs.append(gen_trtllm_utils_module())
         # FP4 KV cache quantization/dequantization
         jit_specs.append(gen_fp4_kv_dequantization_module())

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -572,7 +572,7 @@ def gen_gemm_sm100_module() -> JitSpec:
         write_if_different(dest_path, source)
 
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 11]
+        supported_major_versions=[10]
     )
     return gen_jit_spec(
         "gemm_sm100",

--- a/flashinfer/jit/mamba/selective_state_update.py
+++ b/flashinfer/jit/mamba/selective_state_update.py
@@ -168,13 +168,11 @@ def gen_selective_state_update_module(
         num_accepted_tokens_dtype,
         philox_rounds,
     )
-    # The MTP-simple kernel uses cp.async (sm_80+).  Restrict compilation to
-    # Ampere and newer; on pre-Ampere GPUs the JIT will raise
-    # "No supported CUDA architectures found" instead of failing in nvcc.
+    # The MTP-simple kernel uses cp.async (sm_80+); on pre-Ampere GPUs the
+    # JIT will raise "No supported CUDA architectures found" instead of
+    # failing in nvcc.
     compilation_context = CompilationContext()
-    nvcc_flags = compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[8, 9, 10, 11]
-    )
+    nvcc_flags = compilation_context.get_nvcc_flags_list(supported_major_versions=[8])
     return _gen_module(
         uri,
         state_dtype,
@@ -225,9 +223,7 @@ def gen_selective_state_update_sm90_module(
         + "_sm90"
     )
     compilation_context = CompilationContext()
-    nvcc_flags = compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[9, 10, 11]
-    )
+    nvcc_flags = compilation_context.get_nvcc_flags_list(supported_major_versions=[9])
     nvcc_flags += ["-DFLASHINFER_MAMBA_ENABLE_SM90"]
     return _gen_module(
         uri,

--- a/flashinfer/jit/xqa.py
+++ b/flashinfer/jit/xqa.py
@@ -95,7 +95,7 @@ def gen_xqa_module(
 
     compilation_context = CompilationContext()
     nvcc_flags = compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[9, 10, 11, 12]
+        supported_major_versions=[9, 10, 12]
     )
     sm_nvcc_flags = nvcc_flags
 


### PR DESCRIPTION
## 📌 Description

Follow-up to #3947, which removed compiled GPU code that SM12x devices can never run. This PR extends the same audit to the whole tree: every module's `supported_major_versions` list was checked against the dispatch logic that decides which module a GPU actually loads. Four lists still contained architectures whose GPUs can never load the module:

| module | change | why the removed entries are dead |
|---|---|---|
| mamba SSU base | `[8, 9, 10, 11]` → `[8]` | SM90 and newer GPUs always load the sm90 or sm100 variant instead |
| mamba SSU sm90 | `[9, 10, 11]` → `[9]` | SM100 and newer GPUs always load the sm100 variant |
| fp8 GEMM (`gemm_sm100`) | `[10, 11]` → `[10]` | every caller accepts SM100 only; SM110 gets an error before the module loads |
| xqa | `[9, 10, 11, 12]` → `[9, 10, 12]` | the xqa API rejects SM110 before the module can load |

`aot.py` gets a matching change: the two mamba modules are now prebuilt only for the build targets that load them (base for SM8x, sm90 variant for SM9x). This is required: after the prune, prebuilding the base module in a wheel with no SM8x target has no architecture left to compile for and fails the build.

### Result

This further removes about 587 MB of installed size from the cu130 aarch64 jit-cache wheel, on top of the ~1 GB removed by #3947:

| pruned GPU code | installed |
|---|---|
| mamba SSU base variants (48 modules) | 214 MB |
| mamba SSU sm90 variants (48 modules) | 267 MB |
| xqa (384 modules), SM110 code | 56 MB |
| fp8 GEMM (`gemm_sm100`), SM110 code | 50 MB |

The xqa and fp8 GEMM rows are SM110 code, which only exists in cu130 aarch64 wheels (the only build that targets SM110). The mamba rows apply to every wheel.

## 🔍 Related Issues

#3170 (cross-cutting item 10, extended beyond SM12x).

## 🧪 Tests

- A GPU-free dispatch simulation (45 cases): for every compute capability from 8.0 to 12.1, dispatch picks the expected module, and that module still compiles for the architecture. All pass on this branch. Removing a live entry on purpose makes exactly the matching case fail, which confirms the check can catch a bad prune.
- Runtime verification on H100 (SM90) and B200 (SM100), JIT-compiling this branch into a fresh cache. All affected suites pass: mamba SSU and xqa on both machines, and the `gemm_sm100` fp8 GEMM suite on B200. The cache afterwards holds only sm90 variants on H100 and only sm100 variants on B200, so dispatch never requested the pruned modules.
- `pre-commit run` on the changed files is clean.

## Reviewer Notes

- Two more dead entries (SM110 in the sm103 fp4 and cutlass bf16 GEMM modules) stay in place: those modules are not prebuilt into wheels, so keeping the entries costs nothing and future SM110 support there needs no list edit.
- The dead verdicts reflect today's dispatch. If a later change routes one of these architectures back (for example, Thor support in xqa), the entry must be re-added here.
- The audit also found the opposite mismatch: some modules do run on architectures that wheels never prebuild them for (several SM110-capable modules, and the trtllm-gen fused MoE on SM12x). Left unchanged, since adding prebuilds grows wheels and deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU architecture targeting for generated CUDA kernels.
  * Corrected architecture-specific generation for selective state update, GEMM, and XQA kernels.
  * Reduced compilation attempts for unsupported GPU architectures, improving build compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->