### PR TITLE
feat: add sm100 cp delta rule prefill

### DIFF
--- a/flashinfer/gdn_kernels/__init__.py
+++ b/flashinfer/gdn_kernels/__init__.py
@@ -71,9 +71,10 @@ except (ImportError, RuntimeError):
     get_mtp_config = None  # type: ignore
 
 try:
-    from .blackwell import chunk_gated_delta_rule_sm100
+    from .blackwell import chunk_gated_delta_rule_sm100, cp_delta_rule_dsl_sm100
 except (ImportError, RuntimeError):
     chunk_gated_delta_rule_sm100 = None  # type: ignore
+    cp_delta_rule_dsl_sm100 = None  # type: ignore
 
 try:
     from .delta_rule_dsl import (
@@ -104,5 +105,6 @@ __all__ = [
     "chunk_gated_delta_rule_sm100",
     "chunk_gated_delta_rule_sm120",
     "cp_delta_rule_dsl_sm90",
+    "cp_delta_rule_dsl_sm100",
     "cp_delta_rule_dsl_sm120",
 ]

--- a/flashinfer/gdn_kernels/blackwell/__init__.py
+++ b/flashinfer/gdn_kernels/blackwell/__init__.py
@@ -10,6 +10,12 @@ try:
 except (ImportError, RuntimeError):
     chunk_gated_delta_rule_sm100 = None  # type: ignore
 
+try:
+    from .gdn_cp_prefill import cp_delta_rule_dsl_sm100
+except (ImportError, RuntimeError):
+    cp_delta_rule_dsl_sm100 = None  # type: ignore
+
 __all__ = [
     "chunk_gated_delta_rule_sm100",
+    "cp_delta_rule_dsl_sm100",
 ]

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -1514,3 +1514,526 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
             )
         else:
             cute.arch.setmaxregister_decrease(self.num_regs_other)
+
+
+class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
+    """Fix CP states with a TF32 UTCMMA recurrence and an FP32 TMEM accumulator."""
+
+    def __init__(
+        self,
+        rows_per_cta: int = 64,
+        needs_initial_state: bool = False,
+        store_final_state: bool = False,
+        initial_state_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        state_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        cu_seqlens_dtype: Type[cutlass.Numeric] = cutlass.Int32,
+        use_state_indices: bool = False,
+        store_initial_state: bool = False,
+    ):
+        self.needs_initial_state   = needs_initial_state
+        self.store_final_state     = store_final_state
+        self.initial_state_dtype   = initial_state_dtype
+        self.state_dtype           = state_dtype
+        self.cu_seqlens_dtype      = cu_seqlens_dtype
+        self.use_state_indices     = use_state_indices
+        self.store_initial_state   = store_initial_state
+        self.acc_dtype             = cutlass.Float32
+        self.mma_dtype             = cutlass.TFloat32
+        self.D                     = 128
+        if rows_per_cta not in (64, 128):
+            raise ValueError(f"rows_per_cta must be 64 or 128, got {rows_per_cta}")
+        self.rows_per_cta          = rows_per_cta
+        self.row_ctas              = self.D // rows_per_cta
+        self.m_stage               = 1
+        self.n_stage               = 1
+        self.threads_per_cta       = 256
+        self.compute_warp_group_id = 0
+        self.mma_warp_id           = 4
+        self.tma_warp_id           = 5
+        self.num_regs_compute      = 120 if rows_per_cta == 64 else 256
+        self.num_regs_other        = 32
+        self.cta_group             = tcgen05.CtaGroup.ONE
+        self.tmem_acc_offset       = 0
+        self.tmem_opd_offset       = 128
+        self.tmem_alloc_barrier    = pipeline.NamedBarrier(barrier_id=1, num_threads=160)
+        self.manual_cache_key(
+            "rows_per_cta", "row_ctas", "needs_initial_state", "store_final_state",
+            "initial_state_dtype", "state_dtype",
+            "cu_seqlens_dtype", "use_state_indices", "store_initial_state", "m_stage", "n_stage",
+            "num_regs_compute", "num_regs_other",
+        )
+
+    @cute.jit
+    def load_tensor_tma(
+        self, tma_atom, tma_tensor, sTensor, tensor_pipeline, head_idx, chunk_idx,
+        row_cta_idx: cutlass.Int32, is_transfer: bool,
+    ):
+        handle = tensor_pipeline.acquire_and_advance()
+        sTensor_stage = sTensor[None, None, handle.index]
+        mTensor = tma_tensor[None, None, head_idx, chunk_idx]
+        if cutlass.const_expr(is_transfer):
+            gTensor = cute.zipped_divide(mTensor, (self.D, self.D))[((None, None), (0, 0))]
+        else:
+            gTensor = cute.zipped_divide(mTensor, (self.rows_per_cta, self.D))[
+                ((None, None), (row_cta_idx, 0))
+            ]
+        tTsT, tTgT = cpasync.tma_partition(
+            tma_atom, 0, cute.make_layout(1), cute.group_modes(sTensor_stage, 0, 2), cute.group_modes(gTensor, 0, 2)
+        )
+        cute.copy(tma_atom, tTgT, tTsT, tma_bar_ptr=handle.barrier)
+        return tensor_pipeline
+
+    @cute.jit
+    def make_tmem_tensor(self, tmem_ptr: cutlass.Int64, tiled_mma):
+        acc_shape = tiled_mma.partition_shape_C((self.rows_per_cta, self.D))
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, 1))
+        tCtAcc = cute.make_tensor(tmem_ptr + self.tmem_acc_offset, tCtAcc_fake.layout)
+        return tCtAcc
+
+    @cute.jit
+    def make_tmem_operand(self, tmem_ptr: cutlass.Int64, tiled_mma):
+        opd_shape = tiled_mma.partition_shape_A((self.rows_per_cta, self.D))
+        tCtOpd_fake = tiled_mma.make_fragment_A(cute.append(opd_shape, 1))
+        return cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_opd_offset, dtype=self.mma_dtype),
+            tCtOpd_fake.layout,
+        )
+
+    @cute.jit
+    def copy_tensor_to_acc(
+        self,
+        tiled_mma,
+        tCtAcc: cute.Tensor,
+        src: cute.Tensor,
+        tidx: cutlass.Int32,
+        convert_src: bool,
+        stage: cutlass.Int32,
+    ):
+        tCtAcc_mn = utils.gemm.sm100.transform_partitioned_tensor_layout(tCtAcc)
+        cAcc = cute.make_identity_tensor((self.rows_per_cta, self.D))
+        if cutlass.const_expr(self.rows_per_cta == 128):
+            atom_r2t = cute.make_copy_atom(
+                tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+            )
+        else:
+            atom_r2t = cute.make_copy_atom(
+                tcgen05.copy.St16x32bx2Op(tcgen05.copy.Repetition(16)), self.acc_dtype
+            )
+        tiled_r2t = tcgen05.make_tmem_copy(atom_r2t, tCtAcc_mn[None, None, 0])
+        thr_r2t = tiled_r2t.get_slice(tidx)
+        tRT_cAcc = thr_r2t.partition_S(cAcc)
+        tRT_tAcc = thr_r2t.partition_D(tCtAcc_mn)
+        tRT_src = thr_r2t.partition_S(src)
+        tRT_rAcc = cute.make_rmem_tensor_like(tRT_cAcc, self.acc_dtype)
+        for sub in cutlass.range(cute.size(tRT_rAcc, mode=[2]), unroll_full=True):
+            if cutlass.const_expr(convert_src):
+                tRT_rAcc[None, 0, sub].store(tRT_src[None, 0, sub].load().to(self.acc_dtype))
+            else:
+                cute.autovec_copy(tRT_src[None, 0, sub], tRT_rAcc[None, 0, sub])
+            cute.copy(tiled_r2t, tRT_rAcc[None, 0, sub], tRT_tAcc[None, 0, sub, stage])
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def convert_acc_to_opd(
+        self, tiled_mma, tCtAcc: cute.Tensor, tCtOpd: cute.Tensor, tidx: cutlass.Int32
+    ):
+        tCtAcc_mn = utils.gemm.sm100.transform_partitioned_tensor_layout(tCtAcc)
+        tCtOpd_mn = utils.gemm.sm100.transform_partitioned_tensor_layout(tCtOpd)
+        cAcc = cute.make_identity_tensor((self.rows_per_cta, self.D))
+        if cutlass.const_expr(self.rows_per_cta == 128):
+            atom_t2r = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+            )
+            atom_r2t = cute.make_copy_atom(
+                tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.mma_dtype
+            )
+        else:
+            atom_t2r = cute.make_copy_atom(
+                tcgen05.copy.Ld16x32bx2Op(tcgen05.copy.Repetition(16)), self.acc_dtype
+            )
+            atom_r2t = cute.make_copy_atom(
+                tcgen05.copy.St16x32bx2Op(tcgen05.copy.Repetition(16)), self.mma_dtype
+            )
+        tiled_t2r = tcgen05.make_tmem_copy(atom_t2r, tCtAcc_mn[None, None, 0])
+        tiled_r2t = tcgen05.make_tmem_copy(atom_r2t, tCtOpd_mn[None, None, 0])
+        thr_t2r = tiled_t2r.get_slice(tidx)
+        thr_r2t = tiled_r2t.get_slice(tidx)
+        tTR_tAcc = thr_t2r.partition_S(tCtAcc_mn)
+        tTR_cAcc = thr_t2r.partition_D(cAcc)
+        tRT_tOpd = thr_r2t.partition_D(tCtOpd_mn)
+        tTR_rAcc = cute.make_rmem_tensor_like(tTR_cAcc, self.acc_dtype)
+        tRT_rOpd = cute.make_rmem_tensor_like(tTR_cAcc, self.mma_dtype)
+
+        for iter_m in cutlass.range(cute.size(tTR_rAcc, mode=[1]), unroll_full=True):
+            for iter_n in cutlass.range(cute.size(tTR_rAcc, mode=[2]), unroll_full=True):
+                cute.copy(tiled_t2r, tTR_tAcc[None, iter_m, iter_n, 0], tTR_rAcc[None, iter_m, iter_n])
+                tRT_rOpd[None, iter_m, iter_n].store(
+                    tTR_rAcc[None, iter_m, iter_n].load().to(self.mma_dtype)
+                )
+                cute.copy(
+                    tiled_r2t, tRT_rOpd[None, iter_m, iter_n],
+                    tRT_tOpd[None, iter_m, iter_n, 0],
+                )
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def store_acc(
+        self,
+        tiled_mma,
+        tCtAcc: cute.Tensor,
+        tidx: cutlass.Int32,
+        gFixedState: cute.Tensor,
+        gOutputState: cute.Tensor,
+        store_output: bool,
+        stage: cutlass.Int32,
+    ):
+        tCtAcc_mn = utils.gemm.sm100.transform_partitioned_tensor_layout(tCtAcc)
+        cAcc = cute.make_identity_tensor((self.rows_per_cta, self.D))
+        if cutlass.const_expr(self.rows_per_cta == 128):
+            atom_t2r = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+            )
+        else:
+            atom_t2r = cute.make_copy_atom(
+                tcgen05.copy.Ld16x32bx2Op(tcgen05.copy.Repetition(16)), self.acc_dtype
+            )
+        tiled_t2r = tcgen05.make_tmem_copy(atom_t2r, tCtAcc_mn[None, None, 0])
+        thr_t2r = tiled_t2r.get_slice(tidx)
+        tTR_tAcc = thr_t2r.partition_S(tCtAcc_mn)
+        tTR_cAcc = thr_t2r.partition_D(cAcc)
+        tTR_gFixedState = thr_t2r.partition_D(gFixedState)
+        tTR_gFixedState = cute.make_tensor(
+            tTR_gFixedState.iterator.align(16), tTR_gFixedState.layout
+        )
+        tTR_rAcc = cute.make_rmem_tensor_like(tTR_cAcc, self.acc_dtype)
+        if cutlass.const_expr(store_output):
+            tTR_gOutputState = thr_t2r.partition_D(gOutputState)
+            tTR_gOutputState = cute.make_tensor(
+                tTR_gOutputState.iterator.align(16), tTR_gOutputState.layout
+            )
+            tTR_rOutput = cute.make_rmem_tensor_like(tTR_cAcc, self.state_dtype)
+        for sub in cutlass.range(cute.size(tTR_rAcc, mode=[2]), unroll_full=True):
+            cute.copy(tiled_t2r, tTR_tAcc[None, 0, sub, stage], tTR_rAcc[None, 0, sub])
+            cute.autovec_copy(tTR_rAcc[None, 0, sub], tTR_gFixedState[None, 0, sub])
+            if cutlass.const_expr(store_output):
+                tTR_rOutput[None, 0, sub].store(tTR_rAcc[None, 0, sub].load().to(self.state_dtype))
+                cute.autovec_copy(tTR_rOutput[None, 0, sub], tTR_gOutputState[None, 0, sub])
+
+    @cute.jit
+    def run_compute_role(
+        self,
+        tiled_mma,
+        tmem_ptr,
+        sN,
+        n_consumer,
+        mma_ready_producer,
+        mma_done_consumer,
+        gInitialState,
+        gInitialStateWorkspace,
+        gFixedState,
+        gOutputState,
+        chunk_start,
+        num_chunks,
+        tidx,
+    ):
+        tCtAcc = self.make_tmem_tensor(tmem_ptr, tiled_mma)
+        tCtOpd = self.make_tmem_operand(tmem_ptr, tiled_mma)
+        start = cutlass.Int32(0)
+        state_stage = cutlass.Int32(0)
+        if cutlass.const_expr(self.needs_initial_state):
+            self.copy_tensor_to_acc(
+                tiled_mma, tCtAcc, gInitialState, tidx,
+                self.initial_state_dtype != self.acc_dtype, state_stage,
+            )
+            if cutlass.const_expr(self.store_initial_state):
+                self.store_acc(
+                    tiled_mma, tCtAcc, tidx, gInitialStateWorkspace, gOutputState, False, state_stage
+                )
+        else:
+            start = cutlass.Int32(1)
+            n_init_handle = n_consumer.wait_and_advance()
+            self.copy_tensor_to_acc(
+                tiled_mma, tCtAcc, sN[None, None, n_init_handle.index], tidx, False, state_stage,
+            )
+            self.store_acc(
+                tiled_mma, tCtAcc, tidx, gFixedState[None, None, chunk_start],
+                gOutputState, False, state_stage,
+            )
+            n_init_handle.release()
+
+        for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
+            self.convert_acc_to_opd(tiled_mma, tCtAcc, tCtOpd, tidx)
+            n_handle = n_consumer.wait_and_advance()
+            ready_handle = mma_ready_producer.acquire_and_advance()
+            self.copy_tensor_to_acc(
+                tiled_mma, tCtAcc, sN[None, None, n_handle.index], tidx, False, state_stage
+            )
+            ready_handle.commit()
+            n_handle.release()
+            done_handle = mma_done_consumer.wait_and_advance()
+            self.store_acc(
+                tiled_mma, tCtAcc, tidx, gFixedState[None, None, chunk_start + chunk_idx],
+                gOutputState, False, state_stage,
+            )
+            done_handle.release()
+        if cutlass.const_expr(self.store_final_state):
+            self.store_acc(
+                tiled_mma, tCtAcc, tidx, gFixedState[None, None, chunk_start + num_chunks - 1],
+                gOutputState, True, state_stage,
+            )
+
+    @cute.jit
+    def run_mma_role(
+        self, tiled_mma, tmem_ptr, sM, m_consumer, mma_ready_consumer,
+        mma_done_producer, num_iters, tidx
+    ):
+        tCtAcc = self.make_tmem_tensor(tmem_ptr, tiled_mma)
+        tCrS = self.make_tmem_operand(tmem_ptr, tiled_mma)
+        tCrM = tiled_mma.make_fragment_B(sM)
+        for _iter_idx in cutlass.range(num_iters, unroll=1):
+            m_handle = m_consumer.wait_and_advance()
+            ready_handle = mma_ready_consumer.wait_and_advance()
+            done_handle = mma_done_producer.acquire_and_advance()
+            for kphase in cutlass.range(cute.size(tCrS, mode=[2]), unroll_full=True):
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                cute.gemm(
+                    tiled_mma, tCtAcc[None, None, None, 0],
+                    tCrS[None, None, kphase, 0],
+                    tCrM[None, None, kphase, m_handle.index],
+                    tCtAcc[None, None, None, 0],
+                )
+            done_handle.commit()
+            ready_handle.release()
+            m_handle.release()
+
+    @cute.jit
+    def __call__(
+        self,
+        g_transfer_t: cute.Tensor,
+        g_local_state_t: cute.Tensor,
+        g_initial_state_t: cute.Tensor,
+        g_initial_state_workspace_t: cute.Tensor,
+        g_fixed_state_t: cute.Tensor,
+        g_output_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        stream,
+    ):
+        tiled_mma = cute.make_tiled_mma(
+            tcgen05.MmaTF32Op(
+                (self.rows_per_cta, 64, 8), self.cta_group, tcgen05.OperandSource.TMEM,
+                OperandMajorMode.K, OperandMajorMode.MN,
+            )
+        )
+        m_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma, (self.rows_per_cta, self.D, self.D), self.acc_dtype, self.m_stage
+        )
+        n_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma, (self.rows_per_cta, self.D, self.D), self.acc_dtype, self.n_stage,
+            is_k_major=True,
+        )
+        m_semantic_layout = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_layout(m_layout)
+        n_semantic_layout = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_layout(n_layout)
+        tma_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        m_tma_layout = cute.slice_(m_semantic_layout, (None, None, 0))
+        n_tma_layout = cute.slice_(n_semantic_layout, (None, None, 0))
+        tma_m = cpasync.make_tiled_tma_atom(tma_op, g_transfer_t, m_tma_layout, (self.D, self.D))
+        tma_n = cpasync.make_tiled_tma_atom(
+            tma_op, g_local_state_t, n_tma_layout, (self.rows_per_cta, self.D)
+        )
+        tma_atom_m, tma_tensor_m = tma_m
+        tma_atom_n, tma_tensor_n = tma_n
+        self.tma_m_bytes = cute.size(m_tma_layout) * 4
+        self.tma_n_bytes = cute.size(n_tma_layout) * 4
+
+        @cute.struct
+        class SharedStorage:
+            m_mbar: cute.struct.MemRange[cutlass.Int64, self.m_stage * 2]
+            n_mbar: cute.struct.MemRange[cutlass.Int64, self.n_stage * 2]
+            mma_ready_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            mma_done_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            tmem_holding_buf: cutlass.Int32
+            sM: cute.struct.Align[cute.struct.MemRange[self.acc_dtype, cute.cosize(m_layout)], 1024]
+            sN: cute.struct.Align[cute.struct.MemRange[self.acc_dtype, cute.cosize(n_layout)], 1024]
+
+        self.shared_storage = SharedStorage
+        self.kernel(
+            tiled_mma, tma_atom_m, tma_tensor_m, tma_atom_n, tma_tensor_n,
+            g_initial_state_t, g_initial_state_workspace_t, g_fixed_state_t, g_output_state_t,
+            g_state_indices_t, g_cu_seqlens, m_layout, n_layout, chunk_len,
+            total_cp_chunks, num_seqs, num_heads,
+        ).launch(
+            grid=(num_seqs * num_heads * self.row_ctas, 1, 1), block=(self.threads_per_cta, 1, 1),
+            max_number_threads=(self.threads_per_cta, 1, 1),
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
+            stream=stream, min_blocks_per_mp=2 if self.rows_per_cta == 64 else 1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma,
+        tma_atom_m,
+        tma_tensor_m,
+        tma_atom_n,
+        tma_tensor_n,
+        g_initial_state_t,
+        g_initial_state_workspace_t,
+        g_fixed_state_t,
+        g_output_state_t,
+        g_state_indices_t,
+        g_cu_seqlens,
+        m_layout,
+        n_layout,
+        chunk_len,
+        total_cp_chunks,
+        num_seqs,
+        num_heads,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        bx, _, _ = cute.arch.block_idx()
+        row_cta_idx = bx % self.row_ctas
+        head_seq_idx = bx // self.row_ctas
+        head_idx = head_seq_idx % num_heads
+        seq_idx = head_seq_idx // num_heads
+        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
+        num_chunks = chunks_for_len(seq_end - seq_start, chunk_len)
+        chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
+        start = cutlass.Int32(0) if cutlass.const_expr(self.needs_initial_state) else cutlass.Int32(1)
+        num_iters = num_chunks - start
+
+        allocator = utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+        sM = storage.sM.get_tensor(m_layout.outer, swizzle=m_layout.inner)
+        sN = storage.sN.get_tensor(n_layout.outer, swizzle=n_layout.inner)
+        sM_tma = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_tensor_layout(sM)
+        sN_tma = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_tensor_layout(sN)
+        cg_tma = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        cg_mma = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        cg_compute = pipeline.CooperativeGroup(pipeline.Agent.Thread, 128)
+        cg_compute_tma = pipeline.CooperativeGroup(pipeline.Agent.Thread, 4)
+        m_producer, m_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.m_stage, producer_group=cg_tma, consumer_group=cg_mma,
+            tx_count=self.tma_m_bytes, barrier_storage=storage.m_mbar.data_ptr(), defer_sync=True,
+        ).make_participants()
+        n_producer, n_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.n_stage, producer_group=cg_tma, consumer_group=cg_compute_tma,
+            tx_count=self.tma_n_bytes, barrier_storage=storage.n_mbar.data_ptr(), defer_sync=True,
+            enable_multicast_signaling=False,
+        ).make_participants()
+        mma_ready_producer, mma_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1, producer_group=cg_compute, consumer_group=cg_mma,
+            barrier_storage=storage.mma_ready_mbar.data_ptr(), defer_sync=True,
+        ).make_participants()
+        mma_done_producer, mma_done_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=1, producer_group=cg_mma, consumer_group=cg_compute,
+            barrier_storage=storage.mma_done_mbar.data_ptr(), defer_sync=True,
+        ).make_participants()
+        pipeline.pipeline_init_arrive(cluster_shape_mn=cute.make_layout((1, 1)), is_relaxed=True)
+        pipeline.pipeline_init_wait(cluster_shape_mn=cute.make_layout((1, 1)))
+
+        out_layout = cute.make_layout(
+            (self.D, self.D, num_heads, total_cp_chunks),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        gFixedState = cute.make_tensor(g_fixed_state_t.iterator.align(128), out_layout)
+        gFixedStateCta = cute.local_tile(
+            gFixedState[None, None, head_idx, None],
+            (self.rows_per_cta, self.D, total_cp_chunks), (row_cta_idx, 0, 0),
+        )
+        state_layout = cute.make_layout(
+            (self.D, self.D, num_heads, num_seqs),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        state_row = seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_row = cutlass.Int32(g_state_indices_t[seq_idx])
+        if cutlass.const_expr(self.needs_initial_state):
+            if cutlass.const_expr(self.use_state_indices):
+                initial_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
+                    stride=(g_initial_state_t.stride[2], g_initial_state_t.stride[3], g_initial_state_t.stride[1], g_initial_state_t.stride[0]),
+                )
+                gInitialStateTensor = cute.make_tensor(g_initial_state_t.iterator, initial_layout)
+            else:
+                gInitialStateTensor = cute.make_tensor(g_initial_state_t.iterator, state_layout)
+            gInitialState = cute.local_tile(
+                gInitialStateTensor[None, None, head_idx, state_row],
+                (self.rows_per_cta, self.D), (row_cta_idx, 0),
+            )
+            gInitialStateWorkspaceTensor = cute.make_tensor(g_initial_state_workspace_t.iterator, state_layout)
+            gInitialStateWorkspace = cute.local_tile(
+                gInitialStateWorkspaceTensor[None, None, head_idx, seq_idx],
+                (self.rows_per_cta, self.D), (row_cta_idx, 0),
+            )
+        else:
+            gInitialState = gFixedStateCta[None, None, chunk_start]
+            gInitialStateWorkspace = gInitialState
+        if cutlass.const_expr(self.store_final_state):
+            if cutlass.const_expr(self.use_state_indices):
+                output_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_output_state_t.shape[0]),
+                    stride=(g_output_state_t.stride[2], g_output_state_t.stride[3], g_output_state_t.stride[1], g_output_state_t.stride[0]),
+                )
+                gOutputStateTensor = cute.make_tensor(g_output_state_t.iterator, output_layout)
+            else:
+                gOutputStateTensor = cute.make_tensor(g_output_state_t.iterator, state_layout)
+            gOutputState = cute.local_tile(
+                gOutputStateTensor[None, None, head_idx, state_row],
+                (self.rows_per_cta, self.D), (row_cta_idx, 0),
+            )
+        else:
+            gOutputState = gFixedStateCta[None, None, chunk_start]
+
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr, barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=0,
+        )
+        tmem.allocate(256)
+        if warp_idx <= self.mma_warp_id:
+            tmem.wait_for_alloc()
+        if num_chunks == 0:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            if warp_idx == self.compute_warp_group_id:
+                tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+                tmem.relinquish_alloc_permit()
+                tmem.free(tmem_ptr)
+        elif warp_idx >= self.compute_warp_group_id and warp_idx < self.compute_warp_group_id + 4:
+            cute.arch.setmaxregister_increase(self.num_regs_compute)
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            self.run_compute_role(
+                tiled_mma, tmem_ptr, sN_tma, n_consumer, mma_ready_producer, mma_done_consumer,
+                gInitialState, gInitialStateWorkspace, gFixedStateCta,
+                gOutputState, chunk_start, num_chunks, tidx,
+            )
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)
+        elif warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            self.run_mma_role(
+                tiled_mma, tmem_ptr, sM, m_consumer, mma_ready_consumer,
+                mma_done_producer, num_iters, tidx
+            )
+        elif warp_idx == self.tma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            cpasync.prefetch_descriptor(tma_atom_m)
+            cpasync.prefetch_descriptor(tma_atom_n)
+            for chunk_idx in cutlass.range(num_chunks, unroll=1):
+                n_producer = self.load_tensor_tma(
+                    tma_atom_n, tma_tensor_n, sN_tma, n_producer, head_idx,
+                    chunk_start + chunk_idx, row_cta_idx, False,
+                )
+                if chunk_idx >= start:
+                    m_producer = self.load_tensor_tma(
+                        tma_atom_m, tma_tensor_m, sM_tma, m_producer, head_idx,
+                        chunk_start + chunk_idx, row_cta_idx, True,
+                    )
+        else:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -1951,9 +1951,9 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             (self.D, self.D, num_heads, num_seqs),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
-        state_row = seq_idx
+        state_idx = seq_idx
         if cutlass.const_expr(self.use_state_indices):
-            state_row = cutlass.Int32(g_state_indices_t[seq_idx])
+            state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
             if cutlass.const_expr(self.use_state_indices):
                 initial_layout = cute.make_layout(
@@ -1964,7 +1964,7 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             else:
                 gInitialStateTensor = cute.make_tensor(g_initial_state_t.iterator, state_layout)
             gInitialState = cute.local_tile(
-                gInitialStateTensor[None, None, head_idx, state_row],
+                gInitialStateTensor[None, None, head_idx, state_idx],
                 (self.rows_per_cta, self.D), (row_cta_idx, 0),
             )
             gInitialStateWorkspaceTensor = cute.make_tensor(g_initial_state_workspace_t.iterator, state_layout)
@@ -1985,7 +1985,7 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             else:
                 gOutputStateTensor = cute.make_tensor(g_output_state_t.iterator, state_layout)
             gOutputState = cute.local_tile(
-                gOutputStateTensor[None, None, head_idx, state_row],
+                gOutputStateTensor[None, None, head_idx, state_idx],
                 (self.rows_per_cta, self.D), (row_cta_idx, 0),
             )
         else:

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -1530,56 +1530,78 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         use_state_indices: bool = False,
         store_initial_state: bool = False,
     ):
-        self.needs_initial_state   = needs_initial_state
-        self.store_final_state     = store_final_state
-        self.initial_state_dtype   = initial_state_dtype
-        self.state_dtype           = state_dtype
-        self.cu_seqlens_dtype      = cu_seqlens_dtype
-        self.use_state_indices     = use_state_indices
-        self.store_initial_state   = store_initial_state
-        self.acc_dtype             = cutlass.Float32
-        self.mma_dtype             = cutlass.TFloat32
-        self.D                     = 128
+        self.needs_initial_state = needs_initial_state
+        self.store_final_state = store_final_state
+        self.initial_state_dtype = initial_state_dtype
+        self.state_dtype = state_dtype
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.use_state_indices = use_state_indices
+        self.store_initial_state = store_initial_state
+        self.acc_dtype = cutlass.Float32
+        self.mma_dtype = cutlass.TFloat32
+        self.D = 128
         if rows_per_cta not in (64, 128):
             raise ValueError(f"rows_per_cta must be 64 or 128, got {rows_per_cta}")
-        self.rows_per_cta          = rows_per_cta
-        self.row_ctas              = self.D // rows_per_cta
+        self.rows_per_cta = rows_per_cta
+        self.row_ctas = self.D // rows_per_cta
         # A second M stage hides the exposed UTC64 TMA load; UTC128 is unchanged by it.
-        self.m_stage               = 2 if rows_per_cta == 64 else 1
-        self.n_stage               = 1
-        self.threads_per_cta       = 256
+        self.m_stage = 2 if rows_per_cta == 64 else 1
+        self.n_stage = 1
+        self.threads_per_cta = 256
         self.compute_warp_group_id = 0
-        self.mma_warp_id           = 4
-        self.tma_warp_id           = 5
-        self.num_regs_compute      = 120 if rows_per_cta == 64 else 256
-        self.num_regs_other        = 32
-        self.cta_group             = tcgen05.CtaGroup.ONE
-        self.tmem_acc_offset       = 0
-        self.tmem_opd_offset       = 128
-        self.tmem_alloc_barrier    = pipeline.NamedBarrier(barrier_id=1, num_threads=160)
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.num_regs_compute = 120 if rows_per_cta == 64 else 256
+        self.num_regs_other = 32
+        self.cta_group = tcgen05.CtaGroup.ONE
+        self.tmem_acc_offset = 0
+        self.tmem_opd_offset = 128
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=160)
         self.manual_cache_key(
-            "rows_per_cta", "row_ctas", "needs_initial_state", "store_final_state",
-            "initial_state_dtype", "state_dtype",
-            "cu_seqlens_dtype", "use_state_indices", "store_initial_state", "m_stage", "n_stage",
-            "num_regs_compute", "num_regs_other",
+            "rows_per_cta",
+            "row_ctas",
+            "needs_initial_state",
+            "store_final_state",
+            "initial_state_dtype",
+            "state_dtype",
+            "cu_seqlens_dtype",
+            "use_state_indices",
+            "store_initial_state",
+            "m_stage",
+            "n_stage",
+            "num_regs_compute",
+            "num_regs_other",
         )
 
     @cute.jit
     def load_tensor_tma(
-        self, tma_atom, tma_tensor, sTensor, tensor_pipeline, head_idx, chunk_idx,
-        row_cta_idx: cutlass.Int32, is_transfer: bool,
+        self,
+        tma_atom,
+        tma_tensor,
+        sTensor,
+        tensor_pipeline,
+        head_idx,
+        chunk_idx,
+        row_cta_idx: cutlass.Int32,
+        is_transfer: bool,
     ):
         handle = tensor_pipeline.acquire_and_advance()
         sTensor_stage = sTensor[None, None, handle.index]
         mTensor = tma_tensor[None, None, head_idx, chunk_idx]
         if cutlass.const_expr(is_transfer):
-            gTensor = cute.zipped_divide(mTensor, (self.D, self.D))[((None, None), (0, 0))]
+            gTensor = cute.zipped_divide(mTensor, (self.D, self.D))[
+                ((None, None), (0, 0))
+            ]
         else:
             gTensor = cute.zipped_divide(mTensor, (self.rows_per_cta, self.D))[
                 ((None, None), (row_cta_idx, 0))
             ]
         tTsT, tTgT = cpasync.tma_partition(
-            tma_atom, 0, cute.make_layout(1), cute.group_modes(sTensor_stage, 0, 2), cute.group_modes(gTensor, 0, 2)
+            tma_atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sTensor_stage, 0, 2),
+            cute.group_modes(gTensor, 0, 2),
         )
         cute.copy(tma_atom, tTgT, tTsT, tma_bar_ptr=handle.barrier)
         return tensor_pipeline
@@ -1628,7 +1650,9 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         tRT_rAcc = cute.make_rmem_tensor_like(tRT_cAcc, self.acc_dtype)
         for sub in cutlass.range(cute.size(tRT_rAcc, mode=[2]), unroll_full=True):
             if cutlass.const_expr(convert_src):
-                tRT_rAcc[None, 0, sub].store(tRT_src[None, 0, sub].load().to(self.acc_dtype))
+                tRT_rAcc[None, 0, sub].store(
+                    tRT_src[None, 0, sub].load().to(self.acc_dtype)
+                )
             else:
                 cute.autovec_copy(tRT_src[None, 0, sub], tRT_rAcc[None, 0, sub])
             cute.copy(tiled_r2t, tRT_rAcc[None, 0, sub], tRT_tAcc[None, 0, sub, stage])
@@ -1666,13 +1690,20 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         tRT_rOpd = cute.make_rmem_tensor_like(tTR_cAcc, self.mma_dtype)
 
         for iter_m in cutlass.range(cute.size(tTR_rAcc, mode=[1]), unroll_full=True):
-            for iter_n in cutlass.range(cute.size(tTR_rAcc, mode=[2]), unroll_full=True):
-                cute.copy(tiled_t2r, tTR_tAcc[None, iter_m, iter_n, 0], tTR_rAcc[None, iter_m, iter_n])
+            for iter_n in cutlass.range(
+                cute.size(tTR_rAcc, mode=[2]), unroll_full=True
+            ):
+                cute.copy(
+                    tiled_t2r,
+                    tTR_tAcc[None, iter_m, iter_n, 0],
+                    tTR_rAcc[None, iter_m, iter_n],
+                )
                 tRT_rOpd[None, iter_m, iter_n].store(
                     tTR_rAcc[None, iter_m, iter_n].load().to(self.mma_dtype)
                 )
                 cute.copy(
-                    tiled_r2t, tRT_rOpd[None, iter_m, iter_n],
+                    tiled_r2t,
+                    tRT_rOpd[None, iter_m, iter_n],
                     tRT_tOpd[None, iter_m, iter_n, 0],
                 )
         cute.arch.fence_view_async_tmem_store()
@@ -1717,8 +1748,12 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             cute.copy(tiled_t2r, tTR_tAcc[None, 0, sub, stage], tTR_rAcc[None, 0, sub])
             cute.autovec_copy(tTR_rAcc[None, 0, sub], tTR_gFixedState[None, 0, sub])
             if cutlass.const_expr(store_output):
-                tTR_rOutput[None, 0, sub].store(tTR_rAcc[None, 0, sub].load().to(self.state_dtype))
-                cute.autovec_copy(tTR_rOutput[None, 0, sub], tTR_gOutputState[None, 0, sub])
+                tTR_rOutput[None, 0, sub].store(
+                    tTR_rAcc[None, 0, sub].load().to(self.state_dtype)
+                )
+                cute.autovec_copy(
+                    tTR_rOutput[None, 0, sub], tTR_gOutputState[None, 0, sub]
+                )
 
     @cute.jit
     def run_compute_role(
@@ -1743,22 +1778,42 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         state_stage = cutlass.Int32(0)
         if cutlass.const_expr(self.needs_initial_state):
             self.copy_tensor_to_acc(
-                tiled_mma, tCtAcc, gInitialState, tidx,
-                self.initial_state_dtype != self.acc_dtype, state_stage,
+                tiled_mma,
+                tCtAcc,
+                gInitialState,
+                tidx,
+                self.initial_state_dtype != self.acc_dtype,
+                state_stage,
             )
             if cutlass.const_expr(self.store_initial_state):
                 self.store_acc(
-                    tiled_mma, tCtAcc, tidx, gInitialStateWorkspace, gOutputState, False, state_stage
+                    tiled_mma,
+                    tCtAcc,
+                    tidx,
+                    gInitialStateWorkspace,
+                    gOutputState,
+                    False,
+                    state_stage,
                 )
         else:
             start = cutlass.Int32(1)
             n_init_handle = n_consumer.wait_and_advance()
             self.copy_tensor_to_acc(
-                tiled_mma, tCtAcc, sN[None, None, n_init_handle.index], tidx, False, state_stage,
+                tiled_mma,
+                tCtAcc,
+                sN[None, None, n_init_handle.index],
+                tidx,
+                False,
+                state_stage,
             )
             self.store_acc(
-                tiled_mma, tCtAcc, tidx, gFixedState[None, None, chunk_start],
-                gOutputState, False, state_stage,
+                tiled_mma,
+                tCtAcc,
+                tidx,
+                gFixedState[None, None, chunk_start],
+                gOutputState,
+                False,
+                state_stage,
             )
             n_init_handle.release()
 
@@ -1767,26 +1822,48 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             n_handle = n_consumer.wait_and_advance()
             ready_handle = mma_ready_producer.acquire_and_advance()
             self.copy_tensor_to_acc(
-                tiled_mma, tCtAcc, sN[None, None, n_handle.index], tidx, False, state_stage
+                tiled_mma,
+                tCtAcc,
+                sN[None, None, n_handle.index],
+                tidx,
+                False,
+                state_stage,
             )
             ready_handle.commit()
             n_handle.release()
             done_handle = mma_done_consumer.wait_and_advance()
             self.store_acc(
-                tiled_mma, tCtAcc, tidx, gFixedState[None, None, chunk_start + chunk_idx],
-                gOutputState, False, state_stage,
+                tiled_mma,
+                tCtAcc,
+                tidx,
+                gFixedState[None, None, chunk_start + chunk_idx],
+                gOutputState,
+                False,
+                state_stage,
             )
             done_handle.release()
         if cutlass.const_expr(self.store_final_state):
             self.store_acc(
-                tiled_mma, tCtAcc, tidx, gFixedState[None, None, chunk_start + num_chunks - 1],
-                gOutputState, True, state_stage,
+                tiled_mma,
+                tCtAcc,
+                tidx,
+                gFixedState[None, None, chunk_start + num_chunks - 1],
+                gOutputState,
+                True,
+                state_stage,
             )
 
     @cute.jit
     def run_mma_role(
-        self, tiled_mma, tmem_ptr, sM, m_consumer, mma_ready_consumer,
-        mma_done_producer, num_iters, tidx
+        self,
+        tiled_mma,
+        tmem_ptr,
+        sM,
+        m_consumer,
+        mma_ready_consumer,
+        mma_done_producer,
+        num_iters,
+        tidx,
     ):
         tCtAcc = self.make_tmem_tensor(tmem_ptr, tiled_mma)
         tCrS = self.make_tmem_operand(tmem_ptr, tiled_mma)
@@ -1798,7 +1875,8 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             for kphase in cutlass.range(cute.size(tCrS, mode=[2]), unroll_full=True):
                 tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
                 cute.gemm(
-                    tiled_mma, tCtAcc[None, None, None, 0],
+                    tiled_mma,
+                    tCtAcc[None, None, None, 0],
                     tCrS[None, None, kphase, 0],
                     tCrM[None, None, kphase, m_handle.index],
                     tCtAcc[None, None, None, 0],
@@ -1826,23 +1904,35 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
     ):
         tiled_mma = cute.make_tiled_mma(
             tcgen05.MmaTF32Op(
-                (self.rows_per_cta, 64, 8), self.cta_group, tcgen05.OperandSource.TMEM,
-                OperandMajorMode.K, OperandMajorMode.MN,
+                (self.rows_per_cta, 64, 8),
+                self.cta_group,
+                tcgen05.OperandSource.TMEM,
+                OperandMajorMode.K,
+                OperandMajorMode.MN,
             )
         )
         m_layout = sm100_utils.make_smem_layout_b(
             tiled_mma, (self.rows_per_cta, self.D, self.D), self.acc_dtype, self.m_stage
         )
         n_layout = sm100_utils.make_smem_layout_a(
-            tiled_mma, (self.rows_per_cta, self.D, self.D), self.acc_dtype, self.n_stage,
+            tiled_mma,
+            (self.rows_per_cta, self.D, self.D),
+            self.acc_dtype,
+            self.n_stage,
             is_k_major=True,
         )
-        m_semantic_layout = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_layout(m_layout)
-        n_semantic_layout = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_layout(n_layout)
+        m_semantic_layout = (
+            CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_layout(m_layout)
+        )
+        n_semantic_layout = (
+            CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_layout(n_layout)
+        )
         tma_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
         m_tma_layout = cute.slice_(m_semantic_layout, (None, None, 0))
         n_tma_layout = cute.slice_(n_semantic_layout, (None, None, 0))
-        tma_m = cpasync.make_tiled_tma_atom(tma_op, g_transfer_t, m_tma_layout, (self.D, self.D))
+        tma_m = cpasync.make_tiled_tma_atom(
+            tma_op, g_transfer_t, m_tma_layout, (self.D, self.D)
+        )
         tma_n = cpasync.make_tiled_tma_atom(
             tma_op, g_local_state_t, n_tma_layout, (self.rows_per_cta, self.D)
         )
@@ -1858,20 +1948,39 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             mma_ready_mbar: cute.struct.MemRange[cutlass.Int64, 2]
             mma_done_mbar: cute.struct.MemRange[cutlass.Int64, 2]
             tmem_holding_buf: cutlass.Int32
-            sM: cute.struct.Align[cute.struct.MemRange[self.acc_dtype, cute.cosize(m_layout)], 1024]
-            sN: cute.struct.Align[cute.struct.MemRange[self.acc_dtype, cute.cosize(n_layout)], 1024]
+            sM: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(m_layout)], 1024
+            ]
+            sN: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(n_layout)], 1024
+            ]
 
         self.shared_storage = SharedStorage
         self.kernel(
-            tiled_mma, tma_atom_m, tma_tensor_m, tma_atom_n, tma_tensor_n,
-            g_initial_state_t, g_initial_state_workspace_t, g_fixed_state_t, g_output_state_t,
-            g_state_indices_t, g_cu_seqlens, m_layout, n_layout, chunk_len,
-            total_cp_chunks, num_seqs, num_heads,
+            tiled_mma,
+            tma_atom_m,
+            tma_tensor_m,
+            tma_atom_n,
+            tma_tensor_n,
+            g_initial_state_t,
+            g_initial_state_workspace_t,
+            g_fixed_state_t,
+            g_output_state_t,
+            g_state_indices_t,
+            g_cu_seqlens,
+            m_layout,
+            n_layout,
+            chunk_len,
+            total_cp_chunks,
+            num_seqs,
+            num_heads,
         ).launch(
-            grid=(num_seqs * num_heads * self.row_ctas, 1, 1), block=(self.threads_per_cta, 1, 1),
+            grid=(num_seqs * num_heads * self.row_ctas, 1, 1),
+            block=(self.threads_per_cta, 1, 1),
             max_number_threads=(self.threads_per_cta, 1, 1),
             smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
-            stream=stream, min_blocks_per_mp=1,
+            stream=stream,
+            min_blocks_per_mp=1,
         )
 
     @cute.kernel
@@ -1906,37 +2015,61 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
         num_chunks = chunks_for_len(seq_end - seq_start, chunk_len)
         chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
-        start = cutlass.Int32(0) if cutlass.const_expr(self.needs_initial_state) else cutlass.Int32(1)
+        start = (
+            cutlass.Int32(0)
+            if cutlass.const_expr(self.needs_initial_state)
+            else cutlass.Int32(1)
+        )
         num_iters = num_chunks - start
 
         allocator = utils.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sM = storage.sM.get_tensor(m_layout.outer, swizzle=m_layout.inner)
         sN = storage.sN.get_tensor(n_layout.outer, swizzle=n_layout.inner)
-        sM_tma = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_tensor_layout(sM)
-        sN_tma = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_tensor_layout(sN)
+        sM_tma = (
+            CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_tensor_layout(sM)
+        )
+        sN_tma = (
+            CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_tensor_layout(sN)
+        )
         cg_tma = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
         cg_mma = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
         cg_compute = pipeline.CooperativeGroup(pipeline.Agent.Thread, 128)
         cg_compute_tma = pipeline.CooperativeGroup(pipeline.Agent.Thread, 4)
         m_producer, m_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.m_stage, producer_group=cg_tma, consumer_group=cg_mma,
-            tx_count=self.tma_m_bytes, barrier_storage=storage.m_mbar.data_ptr(), defer_sync=True,
+            num_stages=self.m_stage,
+            producer_group=cg_tma,
+            consumer_group=cg_mma,
+            tx_count=self.tma_m_bytes,
+            barrier_storage=storage.m_mbar.data_ptr(),
+            defer_sync=True,
         ).make_participants()
         n_producer, n_consumer = pipeline.PipelineTmaAsync.create(
-            num_stages=self.n_stage, producer_group=cg_tma, consumer_group=cg_compute_tma,
-            tx_count=self.tma_n_bytes, barrier_storage=storage.n_mbar.data_ptr(), defer_sync=True,
+            num_stages=self.n_stage,
+            producer_group=cg_tma,
+            consumer_group=cg_compute_tma,
+            tx_count=self.tma_n_bytes,
+            barrier_storage=storage.n_mbar.data_ptr(),
+            defer_sync=True,
             enable_multicast_signaling=False,
         ).make_participants()
         mma_ready_producer, mma_ready_consumer = pipeline.PipelineAsyncUmma.create(
-            num_stages=1, producer_group=cg_compute, consumer_group=cg_mma,
-            barrier_storage=storage.mma_ready_mbar.data_ptr(), defer_sync=True,
+            num_stages=1,
+            producer_group=cg_compute,
+            consumer_group=cg_mma,
+            barrier_storage=storage.mma_ready_mbar.data_ptr(),
+            defer_sync=True,
         ).make_participants()
         mma_done_producer, mma_done_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=1, producer_group=cg_mma, consumer_group=cg_compute,
-            barrier_storage=storage.mma_done_mbar.data_ptr(), defer_sync=True,
+            num_stages=1,
+            producer_group=cg_mma,
+            consumer_group=cg_compute,
+            barrier_storage=storage.mma_done_mbar.data_ptr(),
+            defer_sync=True,
         ).make_participants()
-        pipeline.pipeline_init_arrive(cluster_shape_mn=cute.make_layout((1, 1)), is_relaxed=True)
+        pipeline.pipeline_init_arrive(
+            cluster_shape_mn=cute.make_layout((1, 1)), is_relaxed=True
+        )
         pipeline.pipeline_init_wait(cluster_shape_mn=cute.make_layout((1, 1)))
 
         out_layout = cute.make_layout(
@@ -1946,7 +2079,8 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         gFixedState = cute.make_tensor(g_fixed_state_t.iterator.align(128), out_layout)
         gFixedStateCta = cute.local_tile(
             gFixedState[None, None, head_idx, None],
-            (self.rows_per_cta, self.D, total_cp_chunks), (row_cta_idx, 0, 0),
+            (self.rows_per_cta, self.D, total_cp_chunks),
+            (row_cta_idx, 0, 0),
         )
         state_layout = cute.make_layout(
             (self.D, self.D, num_heads, num_seqs),
@@ -1959,19 +2093,32 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             if cutlass.const_expr(self.use_state_indices):
                 initial_layout = cute.make_layout(
                     (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
-                    stride=(g_initial_state_t.stride[2], g_initial_state_t.stride[3], g_initial_state_t.stride[1], g_initial_state_t.stride[0]),
+                    stride=(
+                        g_initial_state_t.stride[2],
+                        g_initial_state_t.stride[3],
+                        g_initial_state_t.stride[1],
+                        g_initial_state_t.stride[0],
+                    ),
                 )
-                gInitialStateTensor = cute.make_tensor(g_initial_state_t.iterator, initial_layout)
+                gInitialStateTensor = cute.make_tensor(
+                    g_initial_state_t.iterator, initial_layout
+                )
             else:
-                gInitialStateTensor = cute.make_tensor(g_initial_state_t.iterator, state_layout)
+                gInitialStateTensor = cute.make_tensor(
+                    g_initial_state_t.iterator, state_layout
+                )
             gInitialState = cute.local_tile(
                 gInitialStateTensor[None, None, head_idx, state_idx],
-                (self.rows_per_cta, self.D), (row_cta_idx, 0),
+                (self.rows_per_cta, self.D),
+                (row_cta_idx, 0),
             )
-            gInitialStateWorkspaceTensor = cute.make_tensor(g_initial_state_workspace_t.iterator, state_layout)
+            gInitialStateWorkspaceTensor = cute.make_tensor(
+                g_initial_state_workspace_t.iterator, state_layout
+            )
             gInitialStateWorkspace = cute.local_tile(
                 gInitialStateWorkspaceTensor[None, None, head_idx, seq_idx],
-                (self.rows_per_cta, self.D), (row_cta_idx, 0),
+                (self.rows_per_cta, self.D),
+                (row_cta_idx, 0),
             )
         else:
             gInitialState = gFixedStateCta[None, None, chunk_start]
@@ -1980,20 +2127,31 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             if cutlass.const_expr(self.use_state_indices):
                 output_layout = cute.make_layout(
                     (self.D, self.D, num_heads, g_output_state_t.shape[0]),
-                    stride=(g_output_state_t.stride[2], g_output_state_t.stride[3], g_output_state_t.stride[1], g_output_state_t.stride[0]),
+                    stride=(
+                        g_output_state_t.stride[2],
+                        g_output_state_t.stride[3],
+                        g_output_state_t.stride[1],
+                        g_output_state_t.stride[0],
+                    ),
                 )
-                gOutputStateTensor = cute.make_tensor(g_output_state_t.iterator, output_layout)
+                gOutputStateTensor = cute.make_tensor(
+                    g_output_state_t.iterator, output_layout
+                )
             else:
-                gOutputStateTensor = cute.make_tensor(g_output_state_t.iterator, state_layout)
+                gOutputStateTensor = cute.make_tensor(
+                    g_output_state_t.iterator, state_layout
+                )
             gOutputState = cute.local_tile(
                 gOutputStateTensor[None, None, head_idx, state_idx],
-                (self.rows_per_cta, self.D), (row_cta_idx, 0),
+                (self.rows_per_cta, self.D),
+                (row_cta_idx, 0),
             )
         else:
             gOutputState = gFixedStateCta[None, None, chunk_start]
 
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf.ptr, barrier_for_retrieve=self.tmem_alloc_barrier,
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=0,
         )
         tmem.allocate(256)
@@ -2005,13 +2163,26 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
                 tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
                 tmem.relinquish_alloc_permit()
                 tmem.free(tmem_ptr)
-        elif warp_idx >= self.compute_warp_group_id and warp_idx < self.compute_warp_group_id + 4:
+        elif (
+            warp_idx >= self.compute_warp_group_id
+            and warp_idx < self.compute_warp_group_id + 4
+        ):
             cute.arch.setmaxregister_increase(self.num_regs_compute)
             tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
             self.run_compute_role(
-                tiled_mma, tmem_ptr, sN_tma, n_consumer, mma_ready_producer, mma_done_consumer,
-                gInitialState, gInitialStateWorkspace, gFixedStateCta,
-                gOutputState, chunk_start, num_chunks, tidx,
+                tiled_mma,
+                tmem_ptr,
+                sN_tma,
+                n_consumer,
+                mma_ready_producer,
+                mma_done_consumer,
+                gInitialState,
+                gInitialStateWorkspace,
+                gFixedStateCta,
+                gOutputState,
+                chunk_start,
+                num_chunks,
+                tidx,
             )
             tmem.relinquish_alloc_permit()
             tmem.free(tmem_ptr)
@@ -2019,8 +2190,14 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             cute.arch.setmaxregister_decrease(self.num_regs_other)
             tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
             self.run_mma_role(
-                tiled_mma, tmem_ptr, sM, m_consumer, mma_ready_consumer,
-                mma_done_producer, num_iters, tidx
+                tiled_mma,
+                tmem_ptr,
+                sM,
+                m_consumer,
+                mma_ready_consumer,
+                mma_done_producer,
+                num_iters,
+                tidx,
             )
         elif warp_idx == self.tma_warp_id:
             cute.arch.setmaxregister_decrease(self.num_regs_other)
@@ -2028,13 +2205,25 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             cpasync.prefetch_descriptor(tma_atom_n)
             for chunk_idx in cutlass.range(num_chunks, unroll=1):
                 n_producer = self.load_tensor_tma(
-                    tma_atom_n, tma_tensor_n, sN_tma, n_producer, head_idx,
-                    chunk_start + chunk_idx, row_cta_idx, False,
+                    tma_atom_n,
+                    tma_tensor_n,
+                    sN_tma,
+                    n_producer,
+                    head_idx,
+                    chunk_start + chunk_idx,
+                    row_cta_idx,
+                    False,
                 )
                 if chunk_idx >= start:
                     m_producer = self.load_tensor_tma(
-                        tma_atom_m, tma_tensor_m, sM_tma, m_producer, head_idx,
-                        chunk_start + chunk_idx, row_cta_idx, True,
+                        tma_atom_m,
+                        tma_tensor_m,
+                        sM_tma,
+                        m_producer,
+                        head_idx,
+                        chunk_start + chunk_idx,
+                        row_cta_idx,
+                        True,
                     )
         else:
             cute.arch.setmaxregister_decrease(self.num_regs_other)

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -1,0 +1,1516 @@
+"""Native tcgen05 context-parallel GDN kernels for Blackwell SM100."""
+
+from typing import Type
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.cute.nvgpu import OperandMajorMode, cpasync, tcgen05
+
+from ..delta_rule_dsl.alpha import AlphaProcessor
+from ..delta_rule_dsl.custom_compile_cache import KeyedCompileMixin
+from ..delta_rule_dsl.varlen_helper import (
+    chunks_for_len,
+    varlen_chunk_idx,
+    varlen_chunk_valid_len,
+)
+
+
+class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
+    """Compute local CP transfer/state while keeping both recurrences in TMEM."""
+
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        cu_seqlens_dtype: Type[cutlass.Numeric] = cutlass.Int32,
+    ):
+        self.dtype = dtype
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.acc_dtype = cutlass.Float32
+        self.BLK = 64
+        self.D = 128
+
+        self.k_stage = 3
+        self.v_stage = 3
+        self.t_stage = 3
+        self.alpha_stage = 4
+        self.x_stage = 2
+
+        self.compute_group_0_warp_ids = [0, 1, 2, 3]
+        self.compute_group_1_warp_ids = [4, 5, 6, 7]
+        self.transfer_mma_warp_id = 8
+        self.tma_warp_id = 9
+        self.alpha_warp_id = 10
+        self.state_mma_warp_id = 11
+        self.threads_per_cta = 384
+
+        self.cta_group = tcgen05.CtaGroup.ONE
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.tmem_m_offset = 0
+        self.tmem_n_offset = 128
+        self.tmem_scratch_offset = 256
+        self.tmem_m_inp_offset = 320
+        self.tmem_n_inp_offset = 384
+        self.tmem_x_y_acc_offset = 448
+
+        self.num_regs_compute = 216
+        self.num_regs_mma = 72
+        self.num_regs_other = 24
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=32
+            * (
+                len(self.compute_group_0_warp_ids)
+                + len(self.compute_group_1_warp_ids)
+                + 2
+            ),
+        )
+        self.tmem_dealloc_barrier = pipeline.NamedBarrier(barrier_id=2, num_threads=1)
+        self.manual_cache_key(
+            "dtype",
+            "cu_seqlens_dtype",
+            "acc_dtype",
+            "BLK",
+            "D",
+            "k_stage",
+            "v_stage",
+            "t_stage",
+            "alpha_stage",
+            "x_stage",
+        )
+
+    @staticmethod
+    def transform_partitioned_layout(layout):
+        stored_layout = layout
+        if isinstance(layout, cute.ComposedLayout):
+            layout = layout.outer
+        shape = layout.shape
+        stride = layout.stride
+        new_layout = cute.make_layout(
+            ((shape[0][0], shape[1]), (shape[0][1], shape[2]), *shape[3:]),
+            stride=((stride[0][0], stride[1]), (stride[0][1], stride[2]), *stride[3:]),
+        )
+        if isinstance(stored_layout, cute.ComposedLayout):
+            new_layout = cute.make_composed_layout(
+                stored_layout.inner, stored_layout.offset, new_layout
+            )
+        return new_layout
+
+    @staticmethod
+    def transform_partitioned_tensor_layout(tensor: cute.Tensor) -> cute.Tensor:
+        new_layout = CPDeltaRuleMNPrecomputeUtcmma1Sm100.transform_partitioned_layout(
+            tensor.layout
+        )
+        return cute.make_tensor(tensor.iterator, new_layout)
+
+    @cute.jit
+    def load_alpha_block(
+        self,
+        g_alpha: cute.Tensor,
+        sAlpha: cute.Tensor,
+        tok_offset: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        blk: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        alpha_stage: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        lane = tidx % 32
+        sAlpha_stage = sAlpha[None, None, alpha_stage]
+        for i in cutlass.range_constexpr(2):
+            row = lane + i * 32
+            tok = blk * self.BLK + row
+            alpha = cutlass.Float32(1.0)
+            if tok < chunk_len:
+                alpha = cutlass.Float32(
+                    g_alpha[(tok_offset + tok) * num_heads + head_idx]
+                )
+            sAlpha_stage[row, AlphaProcessor.CUMSUM_LOG] = alpha
+
+    @cute.jit
+    def mask_alpha_oob_block(
+        self,
+        sAlpha: cute.Tensor,
+        blk: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        alpha_stage: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        lane = tidx % 32
+        sAlpha_stage = sAlpha[None, None, alpha_stage]
+        for i in cutlass.range_constexpr(2):
+            row = lane + i * 32
+            tok = blk * self.BLK + row
+            if tok >= chunk_len:
+                sAlpha_stage[row, AlphaProcessor.CUMPROD_NEG_END_RCP] = cutlass.Float32(
+                    0.0
+                )
+
+    @cute.jit
+    def load_tensor_block_tma_sm100(
+        self,
+        tma_atom,
+        tma_tensor,
+        sTensor,
+        tensor_pipeline,
+        tok_offset,
+        t_block_start,
+        head_idx,
+        blk,
+        is_transfer: bool,
+        cta_coord,
+        cta_layout,
+    ):
+        handle = tensor_pipeline.acquire_and_advance()
+        sTensor_stage = sTensor[None, None, handle.index]
+        if cutlass.const_expr(is_transfer):
+            mTensor = tma_tensor[None, None, head_idx, t_block_start + blk]
+            gTensor = cute.zipped_divide(mTensor, (self.BLK, self.BLK))[
+                ((None, None), (0, 0))
+            ]
+        else:
+            mTensor = cute.domain_offset(
+                (0, tok_offset + blk * self.BLK), tma_tensor[None, None, head_idx]
+            )
+            gTensor = cute.zipped_divide(mTensor, (self.D, self.BLK))[
+                ((None, None), (0, 0))
+            ]
+        tTsT, tTgT = cpasync.tma_partition(
+            tma_atom,
+            cta_coord,
+            cta_layout,
+            cute.group_modes(sTensor_stage, 0, 2),
+            cute.group_modes(gTensor, 0, 2),
+        )
+        cute.copy(tma_atom, tTgT, tTsT, tma_bar_ptr=handle.barrier)
+        return tensor_pipeline
+
+    @cute.jit
+    def run_load_alpha_role_sm100(
+        self,
+        g_alpha,
+        sAlpha,
+        alpha_producer,
+        tok_offset,
+        head_idx,
+        chunk_len,
+        num_blocks,
+        num_heads,
+        tidx,
+    ):
+        for blk in cutlass.range(num_blocks, unroll=1):
+            handle = alpha_producer.acquire_and_advance()
+            cute.arch.fence_view_async_shared()
+            self.load_alpha_block(
+                g_alpha,
+                sAlpha,
+                tok_offset,
+                head_idx,
+                blk,
+                chunk_len,
+                num_heads,
+                handle.index,
+                tidx,
+            )
+            AlphaProcessor().run(
+                sAlpha[None, None, handle.index], cutlass.Float32(1.0), True
+            )
+            self.mask_alpha_oob_block(sAlpha, blk, chunk_len, handle.index, tidx)
+            cute.arch.fence_view_async_shared()
+            handle.commit()
+        return alpha_producer
+
+    @cute.jit
+    def _initialize_tmem_matrix(
+        self,
+        tmem_ptr: cutlass.Int64,
+        offset: int,
+        tiled_mma,
+        tidx: cutlass.Int32,
+        identity: bool,
+    ):
+        acc_shape = tiled_mma.partition_shape_C((self.D, self.D))
+        tCtC_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, 1))
+        tCtC = cute.make_tensor(tmem_ptr + offset, tCtC_fake.layout)
+        tCtC_mn = self.transform_partitioned_tensor_layout(tCtC)
+        cC = cute.make_identity_tensor((self.D, self.D))
+        atom_r2t = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        tiled_r2t = tcgen05.make_tmem_copy(atom_r2t, tCtC[(None, None), 0, 0, 0])
+        thr_r2t = tiled_r2t.get_slice(tidx)
+        tRT_cC = thr_r2t.partition_S(cC)
+        tRT_tC = thr_r2t.partition_D(tCtC_mn)
+        rC = cute.make_rmem_tensor_like(tRT_cC, self.acc_dtype)
+        for i in cutlass.range(cute.size(rC), unroll_full=True):
+            row, col = tRT_cC[i]
+            rC[i] = (
+                cutlass.Float32(1.0)
+                if cutlass.const_expr(identity) and row == col
+                else cutlass.Float32(0.0)
+            )
+        for sub in cutlass.range(cute.size(rC, mode=[2]), unroll_full=True):
+            cute.copy(tiled_r2t, rC[None, 0, sub], tRT_tC[None, 0, sub, 0])
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def _scale_tmem_matrix(
+        self,
+        tmem_ptr: cutlass.Int64,
+        offset: int,
+        tiled_mma,
+        tidx: cutlass.Int32,
+        scale: cutlass.Float32,
+    ):
+        acc_shape = tiled_mma.partition_shape_C((self.D, self.D))
+        tCtC_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, 1))
+        tCtC = cute.make_tensor(tmem_ptr + offset, tCtC_fake.layout)
+        tCtC_mn = self.transform_partitioned_tensor_layout(tCtC)
+        cC = cute.make_identity_tensor((self.D, self.D))
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        atom_r2t = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        tiled_t2r = tcgen05.make_tmem_copy(atom_t2r, tCtC[(None, None), 0, 0, 0])
+        tiled_r2t = tcgen05.make_tmem_copy(atom_r2t, tCtC[(None, None), 0, 0, 0])
+        thr_t2r = tiled_t2r.get_slice(tidx)
+        thr_r2t = tiled_r2t.get_slice(tidx)
+        tTR_tC = thr_t2r.partition_S(tCtC_mn)
+        tTR_cC = thr_t2r.partition_D(cC)
+        tRT_tC = thr_r2t.partition_D(tCtC_mn)
+        rC = cute.make_rmem_tensor_like(tTR_cC, self.acc_dtype)
+        for sub in cutlass.range(cute.size(rC, mode=[2]), unroll_full=True):
+            cute.copy(tiled_t2r, tTR_tC[None, 0, sub, 0], rC[None, 0, sub])
+            for i in cutlass.range(cute.size(rC, mode=[0]), vectorize=True):
+                rC[i, 0, sub] = rC[i, 0, sub] * scale
+            cute.copy(tiled_r2t, rC[None, 0, sub], tRT_tC[None, 0, sub, 0])
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def _store_tmem_matrix(
+        self,
+        tmem_ptr: cutlass.Int64,
+        offset: int,
+        tiled_mma,
+        tidx: cutlass.Int32,
+        gC: cute.Tensor,
+    ):
+        acc_shape = tiled_mma.partition_shape_C((self.D, self.D))
+        tCtC_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, 1))
+        tCtC = cute.make_tensor(tmem_ptr + offset, tCtC_fake.layout)
+        tCtC_mn = self.transform_partitioned_tensor_layout(tCtC)
+        cC = cute.make_identity_tensor((self.D, self.D))
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        tiled_t2r = tcgen05.make_tmem_copy(atom_t2r, tCtC[(None, None), 0, 0, 0])
+        thr_t2r = tiled_t2r.get_slice(tidx)
+        tTR_tC = thr_t2r.partition_S(tCtC_mn)
+        tTR_cC = thr_t2r.partition_D(cC)
+        tCgC = thr_t2r.partition_D(gC)
+        tCgC = cute.make_tensor(tCgC.iterator.align(16), tCgC.layout)
+        rC = cute.make_rmem_tensor_like(tTR_cC, self.acc_dtype)
+        atom_r2g = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self.acc_dtype, num_bits_per_copy=128
+        )
+        for sub in cutlass.range(cute.size(rC, mode=[2]), unroll_full=True):
+            cute.copy(tiled_t2r, tTR_tC[None, 0, sub, 0], rC[None, 0, sub])
+            cute.copy(atom_r2g, rC[None, 0, sub], tCgC[None, 0, sub])
+
+    @cute.jit
+    def _materialize_x(
+        self,
+        tmem_ptr: cutlass.Int64,
+        tiled_mma_x,
+        tidx: cutlass.Int32,
+        sX: cute.Tensor,
+        x_stage: cutlass.Int32,
+    ):
+        acc_shape = tiled_mma_x.partition_shape_C((self.D, self.BLK))
+        tCtX_fake = tiled_mma_x.make_fragment_C(cute.append(acc_shape, 1))
+        tCtX = cute.make_tensor(tmem_ptr + self.tmem_x_y_acc_offset, tCtX_fake.layout)
+        tCtX_mn = self.transform_partitioned_tensor_layout(tCtX)
+        cX = cute.make_identity_tensor((self.D, self.BLK))
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_t2r = tcgen05.make_tmem_copy(atom_t2r, tCtX[(None, None), 0, 0, 0])
+        thr_t2r = tiled_t2r.get_slice(tidx)
+        tTR_tX = thr_t2r.partition_S(tCtX_mn)
+        tTR_cX = thr_t2r.partition_D(cX)
+        rX = cute.make_rmem_tensor_like(tTR_cX, self.acc_dtype)
+        sX_mn = self.transform_partitioned_tensor_layout(sX[None, None, None, x_stage])
+        rX_out = cute.make_rmem_tensor_like(tTR_cX, self.dtype)
+        atom_x_r2s = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=True),
+            self.dtype,
+        )
+        tiled_x_r2s = cute.make_tiled_copy_D(atom_x_r2s, tiled_t2r)
+        thr_x_r2s = tiled_x_r2s.get_slice(tidx)
+        tXsX = thr_x_r2s.partition_D(sX_mn)
+        tXsX = cute.make_tensor(tXsX.iterator.align(16), tXsX.layout)
+        tXrX = tiled_x_r2s.retile(rX_out)
+        for iter_m in cutlass.range(cute.size(rX, mode=[1]), unroll_full=True):
+            for iter_n in cutlass.range(cute.size(rX, mode=[2]), unroll_full=True):
+                cute.copy(
+                    tiled_t2r,
+                    tTR_tX[None, iter_m, iter_n, 0],
+                    rX[None, iter_m, iter_n],
+                )
+                rX_out[None, iter_m, iter_n].store(
+                    rX[None, iter_m, iter_n].load().to(self.dtype)
+                )
+                cute.copy(
+                    tiled_x_r2s,
+                    tXrX[None, iter_m, iter_n],
+                    tXsX[None, iter_m, iter_n],
+                )
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def _convert_matrix_to_z_input(
+        self,
+        tmem_ptr: cutlass.Int64,
+        src_offset: int,
+        dst_offset: int,
+        tiled_mma_update,
+        tiled_mma_z,
+        tidx: cutlass.Int32,
+    ):
+        src_shape = tiled_mma_update.partition_shape_C((self.D, self.D))
+        tCtSrc_fake = tiled_mma_update.make_fragment_C(cute.append(src_shape, 1))
+        tCtSrc = cute.make_tensor(tmem_ptr + src_offset, tCtSrc_fake.layout)
+        tCtSrc_mn = self.transform_partitioned_tensor_layout(tCtSrc)
+        cSrc = cute.make_identity_tensor((self.D, self.D))
+        src_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        src_copy = tcgen05.make_tmem_copy(src_atom, tCtSrc[(None, None), 0, 0, 0])
+        src_thr = src_copy.get_slice(tidx)
+        tTR_tSrc = src_thr.partition_S(tCtSrc_mn)
+        tTR_cSrc = src_thr.partition_D(cSrc)
+        rSrc = cute.make_rmem_tensor_like(tTR_cSrc, self.acc_dtype)
+
+        dst_shape = tiled_mma_z.partition_shape_A((self.D, self.D))
+        tCtDst_fake = tiled_mma_z.make_fragment_A(cute.append(dst_shape, 1))
+        tCtDst = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + dst_offset, dtype=self.dtype), tCtDst_fake.layout
+        )
+        tCtDst_mn = self.transform_partitioned_tensor_layout(tCtDst)
+        cDst = cute.make_identity_tensor((self.D, self.D))
+        dst_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(16)), self.dtype
+        )
+        dst_copy = tcgen05.make_tmem_copy(dst_atom, tCtDst_mn[None, None, 0])
+        dst_thr = dst_copy.get_slice(tidx)
+        tRT_cDst = dst_thr.partition_S(cDst)
+        tRT_tDst = dst_thr.partition_D(tCtDst_mn)
+        rDst = cute.make_rmem_tensor_like(tRT_cDst, self.dtype)
+
+        for iter_m in cutlass.range(cute.size(rSrc, mode=[1]), unroll_full=True):
+            for iter_n in cutlass.range(cute.size(rSrc, mode=[2]), unroll_full=True):
+                cute.copy(
+                    src_copy,
+                    tTR_tSrc[None, iter_m, iter_n, 0],
+                    rSrc[None, iter_m, iter_n],
+                )
+                rDst[None, iter_m, iter_n].store(
+                    rSrc[None, iter_m, iter_n].load().to(self.dtype)
+                )
+                cute.copy(
+                    dst_copy,
+                    rDst[None, iter_m, iter_n],
+                    tRT_tDst[None, iter_m, iter_n, 0],
+                )
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def _convert_scratch_to_update_input(
+        self,
+        tmem_ptr: cutlass.Int64,
+        dst_offset: int,
+        tiled_mma_x,
+        tiled_mma_update,
+        tidx: cutlass.Int32,
+    ):
+        src_shape = tiled_mma_x.partition_shape_C((self.D, self.BLK))
+        tCtSrc_fake = tiled_mma_x.make_fragment_C(cute.append(src_shape, 1))
+        tCtSrc = cute.make_tensor(
+            tmem_ptr + self.tmem_scratch_offset, tCtSrc_fake.layout
+        )
+        tCtSrc_mn = self.transform_partitioned_tensor_layout(tCtSrc)
+        cSrc = cute.make_identity_tensor((self.D, self.BLK))
+        src_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        src_copy = tcgen05.make_tmem_copy(src_atom, tCtSrc[(None, None), 0, 0, 0])
+        src_thr = src_copy.get_slice(tidx)
+        tTR_tSrc = src_thr.partition_S(tCtSrc_mn)
+        tTR_cSrc = src_thr.partition_D(cSrc)
+        rSrc = cute.make_rmem_tensor_like(tTR_cSrc, self.acc_dtype)
+
+        dst_shape = tiled_mma_update.partition_shape_A((self.D, self.BLK))
+        tCtDst_fake = tiled_mma_update.make_fragment_A(cute.append(dst_shape, 1))
+        tCtDst = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + dst_offset, dtype=self.dtype), tCtDst_fake.layout
+        )
+        tCtDst_mn = self.transform_partitioned_tensor_layout(tCtDst)
+        cDst = cute.make_identity_tensor((self.D, self.BLK))
+        dst_atom = cute.make_copy_atom(
+            tcgen05.copy.St16x128bOp(tcgen05.copy.Repetition(8)), self.dtype
+        )
+        dst_copy = tcgen05.make_tmem_copy(dst_atom, tCtDst_mn[None, None, 0])
+        dst_thr = dst_copy.get_slice(tidx)
+        tRT_cDst = dst_thr.partition_S(cDst)
+        tRT_tDst = dst_thr.partition_D(tCtDst_mn)
+        rDst = cute.make_rmem_tensor_like(tRT_cDst, self.dtype)
+
+        for iter_m in cutlass.range(cute.size(rSrc, mode=[1]), unroll_full=True):
+            for iter_n in cutlass.range(cute.size(rSrc, mode=[2]), unroll_full=True):
+                cute.copy(
+                    src_copy,
+                    tTR_tSrc[None, iter_m, iter_n, 0],
+                    rSrc[None, iter_m, iter_n],
+                )
+                rDst[None, iter_m, iter_n].store(
+                    rSrc[None, iter_m, iter_n].load().to(self.dtype)
+                )
+                cute.copy(
+                    dst_copy,
+                    rDst[None, iter_m, iter_n],
+                    tRT_tDst[None, iter_m, iter_n, 0],
+                )
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def _process_y(
+        self,
+        tmem_ptr: cutlass.Int64,
+        tiled_mma_x,
+        tidx: cutlass.Int32,
+        sV: cute.Tensor,
+        sAlpha: cute.Tensor,
+        v_stage: cutlass.Int32,
+        alpha_stage: cutlass.Int32,
+        block_coeff: cutlass.Float32,
+        tiled_mma_update,
+    ):
+        acc_shape = tiled_mma_x.partition_shape_C((self.D, self.BLK))
+        tCtY_fake = tiled_mma_x.make_fragment_C(cute.append(acc_shape, 1))
+        tCtY = cute.make_tensor(tmem_ptr + self.tmem_x_y_acc_offset, tCtY_fake.layout)
+        tCtY_mn = self.transform_partitioned_tensor_layout(tCtY)
+        cY = cute.make_identity_tensor((self.D, self.BLK))
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_t2r = tcgen05.make_tmem_copy(atom_t2r, tCtY[(None, None), 0, 0, 0])
+        thr_t2r = tiled_t2r.get_slice(tidx)
+        tTR_tY = thr_t2r.partition_S(tCtY_mn)
+        tTR_cY = thr_t2r.partition_D(cY)
+        rY = cute.make_rmem_tensor_like(tTR_cY, self.acc_dtype)
+        sAlpha_blk = sAlpha[None, None, alpha_stage]
+
+        dst_shape = tiled_mma_update.partition_shape_A((self.D, self.BLK))
+        tCtDst_fake = tiled_mma_update.make_fragment_A(cute.append(dst_shape, 1))
+        tCtDst = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_n_inp_offset, dtype=self.dtype),
+            tCtDst_fake.layout,
+        )
+        tCtDst_mn = self.transform_partitioned_tensor_layout(tCtDst)
+        cDst = cute.make_identity_tensor((self.D, self.BLK))
+        dst_atom = cute.make_copy_atom(
+            tcgen05.copy.St16x128bOp(tcgen05.copy.Repetition(8)), self.dtype
+        )
+        dst_copy = tcgen05.make_tmem_copy(dst_atom, tCtDst_mn[None, None, 0])
+        dst_thr = dst_copy.get_slice(tidx)
+        tRT_cDst = dst_thr.partition_S(cDst)
+        tRT_tDst = dst_thr.partition_D(tCtDst_mn)
+        rDst = cute.make_rmem_tensor_like(tRT_cDst, self.dtype)
+        rV = cute.make_rmem_tensor_like(tRT_cDst, self.dtype)
+        atom_v_s2r = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+            self.dtype,
+        )
+        tiled_v_s2r = cute.make_tiled_copy_S(atom_v_s2r, dst_copy)
+        thr_v_s2r = tiled_v_s2r.get_slice(tidx)
+        tVsV = thr_v_s2r.partition_S(sV)
+        tVrV = tiled_v_s2r.retile(rV)
+        for iter_m in cutlass.range(cute.size(rY, mode=[1]), unroll_full=True):
+            for iter_n in cutlass.range(cute.size(rY, mode=[2]), unroll_full=True):
+                cute.copy(
+                    tiled_t2r,
+                    tTR_tY[None, iter_m, iter_n, 0],
+                    rY[None, iter_m, iter_n],
+                )
+                cute.copy(
+                    tiled_v_s2r,
+                    tVsV[None, iter_m, iter_n, v_stage],
+                    tVrV[None, iter_m, iter_n],
+                )
+                for i in cutlass.range(cute.size(rY, mode=[0]), unroll_full=True):
+                    _, token = tTR_cY[i, iter_m, iter_n]
+                    rY[i, iter_m, iter_n] = (
+                        block_coeff * rY[i, iter_m, iter_n]
+                        + cutlass.Float32(rV[i, iter_m, iter_n])
+                        * sAlpha_blk[token, AlphaProcessor.CUMPROD_NEG_END_RCP]
+                    )
+                rDst[None, iter_m, iter_n].store(
+                    rY[None, iter_m, iter_n].load().to(self.dtype)
+                )
+                cute.copy(
+                    dst_copy,
+                    rDst[None, iter_m, iter_n],
+                    tRT_tDst[None, iter_m, iter_n, 0],
+                )
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def run_transfer_mma_role(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        k_consumer,
+        math_pipelines: tuple,
+        num_blocks: cutlass.Int32,
+    ):
+        tiled_mma_z, tiled_mma_update, tiled_mma_update_ss = mma_args
+        sK, sK_trans, sX = smem_args
+        (
+            m_init_consumer,
+            x_ready_consumer,
+            m_in_consumer,
+            z_acc_producer,
+            z_ready_consumer,
+            m_acc_producer,
+        ) = math_pipelines
+
+        m_init_consumer.wait_and_advance().release()
+
+        z_shape = tiled_mma_z.partition_shape_C((self.D, self.BLK))
+        tCtScratch_fake = tiled_mma_z.make_fragment_C(cute.append(z_shape, 1))
+        tCtScratch = cute.make_tensor(
+            tmem_ptr + self.tmem_scratch_offset, tCtScratch_fake.layout
+        )
+        update_shape = tiled_mma_update.partition_shape_C((self.D, self.D))
+        tCtUpdate_fake = tiled_mma_update.make_fragment_C(cute.append(update_shape, 1))
+        tCtM = cute.make_tensor(tmem_ptr + self.tmem_m_offset, tCtUpdate_fake.layout)
+
+        z_inp_shape = tiled_mma_z.partition_shape_A((self.D, self.D))
+        tCtZInp_fake = tiled_mma_z.make_fragment_A(cute.append(z_inp_shape, 1))
+        tCtMInp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_m_inp_offset, dtype=self.dtype),
+            tCtZInp_fake.layout,
+        )
+        update_inp_shape = tiled_mma_update.partition_shape_A((self.D, self.BLK))
+        tCtUpdateInp_fake = tiled_mma_update.make_fragment_A(
+            cute.append(update_inp_shape, 1)
+        )
+        tCtZInp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_m_inp_offset, dtype=self.dtype),
+            tCtUpdateInp_fake.layout,
+        )
+
+        tCrM_Z = tCtMInp
+        tCrK_ZY = tiled_mma_z.make_fragment_B(sK_trans)
+        tCrZ_Update = tCtZInp
+        tCrX_Update = tiled_mma_update.make_fragment_B(sX)
+        tCrK_Update = tiled_mma_update_ss.make_fragment_A(sK)
+
+        for blk in cutlass.range(num_blocks, unroll=1):
+            k_handle = k_consumer.wait_and_advance()
+            if blk > 0:
+                m_in_handle = m_in_consumer.wait_and_advance()
+                for kphase in cutlass.range(
+                    cute.size(tCrM_Z, mode=[2]), unroll_full=True
+                ):
+                    tiled_mma_z.set(tcgen05.Field.ACCUMULATE, kphase != 0)
+                    cute.gemm(
+                        tiled_mma_z,
+                        tCtScratch[None, None, None, 0],
+                        tCrM_Z[None, None, kphase, 0],
+                        tCrK_ZY[None, None, kphase, k_handle.index],
+                        tCtScratch[None, None, None, 0],
+                    )
+                z_handle = z_acc_producer.acquire_and_advance()
+                z_handle.commit()
+                z_ready_consumer.wait_and_advance().release()
+                m_in_handle.release()
+
+            x_ready_handle = x_ready_consumer.wait_and_advance()
+            m_handle = m_acc_producer.acquire_and_advance()
+            for kphase in cutlass.range(
+                cute.size(tCrX_Update, mode=[2]), unroll_full=True
+            ):
+                tiled_mma_update.set(tcgen05.Field.ACCUMULATE, True)
+                if blk == 0:
+                    tiled_mma_update_ss.set(tcgen05.Field.ACCUMULATE, True)
+                    cute.gemm(
+                        tiled_mma_update_ss,
+                        tCtM[None, None, None, m_handle.index],
+                        tCrK_Update[None, None, kphase, k_handle.index],
+                        tCrX_Update[None, None, kphase, x_ready_handle.index],
+                        tCtM[None, None, None, m_handle.index],
+                    )
+                else:
+                    cute.gemm(
+                        tiled_mma_update,
+                        tCtM[None, None, None, m_handle.index],
+                        tCrZ_Update[None, None, kphase, 0],
+                        tCrX_Update[None, None, kphase, x_ready_handle.index],
+                        tCtM[None, None, None, m_handle.index],
+                    )
+            m_handle.commit()
+            x_ready_handle.release()
+            k_handle.release()
+
+    @cute.jit
+    def run_state_mma_role(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        load_pipelines: tuple,
+        math_pipelines: tuple,
+        num_blocks: cutlass.Int32,
+    ):
+        tiled_mma_x, tiled_mma_y, tiled_mma_update = mma_args
+        sK, sK_trans, sT, sX = smem_args
+        k_consumer, t_consumer = load_pipelines
+        (
+            n_init_consumer,
+            x_acc_producer,
+            x_ready_consumer,
+            n_in_consumer,
+            y_acc_producer,
+            y_ready_consumer,
+            n_acc_producer,
+        ) = math_pipelines
+
+        n_init_consumer.wait_and_advance().release()
+
+        x_shape = tiled_mma_x.partition_shape_C((self.D, self.BLK))
+        tCtX_fake = tiled_mma_x.make_fragment_C(cute.append(x_shape, 1))
+        tCtX = cute.make_tensor(tmem_ptr + self.tmem_x_y_acc_offset, tCtX_fake.layout)
+        y_shape = tiled_mma_y.partition_shape_C((self.D, self.BLK))
+        tCtY_fake = tiled_mma_y.make_fragment_C(cute.append(y_shape, 1))
+        tCtY = cute.make_tensor(tmem_ptr + self.tmem_x_y_acc_offset, tCtY_fake.layout)
+        update_shape = tiled_mma_update.partition_shape_C((self.D, self.D))
+        tCtUpdate_fake = tiled_mma_update.make_fragment_C(cute.append(update_shape, 1))
+        tCtN = cute.make_tensor(tmem_ptr + self.tmem_n_offset, tCtUpdate_fake.layout)
+
+        y_inp_shape = tiled_mma_y.partition_shape_A((self.D, self.D))
+        tCtYInp_fake = tiled_mma_y.make_fragment_A(cute.append(y_inp_shape, 1))
+        tCtNInp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_n_inp_offset, dtype=self.dtype),
+            tCtYInp_fake.layout,
+        )
+        update_inp_shape = tiled_mma_update.partition_shape_A((self.D, self.BLK))
+        tCtUpdateInp_fake = tiled_mma_update.make_fragment_A(
+            cute.append(update_inp_shape, 1)
+        )
+        tCtYInp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_n_inp_offset, dtype=self.dtype),
+            tCtUpdateInp_fake.layout,
+        )
+
+        tCrK_X = tiled_mma_x.make_fragment_A(sK)
+        tCrT_X = tiled_mma_x.make_fragment_B(sT)
+        tCrN_Y = tCtNInp
+        tCrK_Y = tiled_mma_y.make_fragment_B(sK_trans)
+        tCrY_Update = tCtYInp
+        tCrX_Update = tiled_mma_update.make_fragment_B(sX)
+
+        for _ in cutlass.range(num_blocks, unroll=1):
+            k_handle = k_consumer.wait_and_advance()
+            t_handle = t_consumer.wait_and_advance()
+            x_handle = x_acc_producer.acquire_and_advance()
+            for kphase in cutlass.range(cute.size(tCrK_X, mode=[2]), unroll_full=True):
+                tiled_mma_x.set(tcgen05.Field.ACCUMULATE, kphase != 0)
+                cute.gemm(
+                    tiled_mma_x,
+                    tCtX[None, None, None, x_handle.index],
+                    tCrK_X[None, None, kphase, k_handle.index],
+                    tCrT_X[None, None, kphase, t_handle.index],
+                    tCtX[None, None, None, x_handle.index],
+                )
+            x_handle.commit()
+            t_handle.release()
+            x_ready_handle = x_ready_consumer.wait_and_advance()
+
+            n_in_handle = n_in_consumer.wait_and_advance()
+            y_handle = y_acc_producer.acquire_and_advance()
+            for kphase in cutlass.range(cute.size(tCrN_Y, mode=[2]), unroll_full=True):
+                tiled_mma_y.set(tcgen05.Field.ACCUMULATE, kphase != 0)
+                cute.gemm(
+                    tiled_mma_y,
+                    tCtY[None, None, None, y_handle.index],
+                    tCrN_Y[None, None, kphase, 0],
+                    tCrK_Y[None, None, kphase, k_handle.index],
+                    tCtY[None, None, None, y_handle.index],
+                )
+            y_handle.commit()
+            n_in_handle.release()
+            k_handle.release()
+
+            y_ready_consumer.wait_and_advance().release()
+            n_handle = n_acc_producer.acquire_and_advance()
+            for kphase in cutlass.range(
+                cute.size(tCrX_Update, mode=[2]), unroll_full=True
+            ):
+                tiled_mma_update.set(tcgen05.Field.ACCUMULATE, True)
+                cute.gemm(
+                    tiled_mma_update,
+                    tCtN[None, None, None, n_handle.index],
+                    tCrY_Update[None, None, kphase, 0],
+                    tCrX_Update[None, None, kphase, x_ready_handle.index],
+                    tCtN[None, None, None, n_handle.index],
+                )
+            n_handle.commit()
+            x_ready_handle.release()
+
+    @cute.jit
+    def run_compute_group_0(
+        self,
+        tidx: cutlass.Int32,
+        tmem_ptr: cutlass.Int64,
+        tiled_mma_x,
+        tiled_mma_z,
+        tiled_mma_update,
+        sX: cute.Tensor,
+        sAlpha: cute.Tensor,
+        alpha_consumer,
+        math_pipelines: tuple,
+        num_blocks: cutlass.Int32,
+        gM: cute.Tensor,
+    ):
+        (
+            m_init_producer,
+            x_acc_consumer,
+            x_ready_producer,
+            m_in_producer,
+            z_acc_consumer,
+            z_ready_producer,
+            m_acc_consumer,
+            done_producer,
+        ) = math_pipelines
+        self._initialize_tmem_matrix(
+            tmem_ptr, self.tmem_m_offset, tiled_mma_update, tidx, True
+        )
+        m_init_producer.acquire_and_advance().commit()
+        for blk in cutlass.range(num_blocks, unroll=1):
+            alpha_handle = alpha_consumer.wait_and_advance()
+            x_handle = x_acc_consumer.wait_and_advance()
+            x_ready_handle = x_ready_producer.acquire_and_advance()
+            self._materialize_x(tmem_ptr, tiled_mma_x, tidx, sX, x_ready_handle.index)
+            x_handle.release()
+            x_ready_handle.commit()
+
+            if blk > 0:
+                self._convert_matrix_to_z_input(
+                    tmem_ptr,
+                    self.tmem_m_offset,
+                    self.tmem_m_inp_offset,
+                    tiled_mma_update,
+                    tiled_mma_z,
+                    tidx,
+                )
+                m_in_producer.acquire_and_advance().commit()
+                z_handle = z_acc_consumer.wait_and_advance()
+                self._convert_scratch_to_update_input(
+                    tmem_ptr,
+                    self.tmem_m_inp_offset,
+                    tiled_mma_x,
+                    tiled_mma_update,
+                    tidx,
+                )
+                z_handle.release()
+                z_ready_producer.acquire_and_advance().commit()
+
+            # OOB alpha is one, so the final row is gamma_end for full and tail blocks.
+            block_coeff = cutlass.Float32(
+                sAlpha[self.BLK - 1, AlphaProcessor.CUMPROD, alpha_handle.index]
+            )
+            m_handle = m_acc_consumer.wait_and_advance()
+            self._scale_tmem_matrix(
+                tmem_ptr, self.tmem_m_offset, tiled_mma_update, tidx, block_coeff
+            )
+            m_handle.release()
+            alpha_handle.release()
+        self._store_tmem_matrix(
+            tmem_ptr, self.tmem_m_offset, tiled_mma_update, tidx, gM
+        )
+        done_producer.acquire_and_advance().commit()
+
+    @cute.jit
+    def run_compute_group_1(
+        self,
+        tidx: cutlass.Int32,
+        tmem_ptr: cutlass.Int64,
+        tiled_mma_x,
+        tiled_mma_z,
+        tiled_mma_update,
+        sV: cute.Tensor,
+        sAlpha: cute.Tensor,
+        v_consumer,
+        alpha_consumer,
+        math_pipelines: tuple,
+        num_blocks: cutlass.Int32,
+        gN: cute.Tensor,
+    ):
+        (
+            n_init_producer,
+            n_in_producer,
+            y_acc_consumer,
+            y_ready_producer,
+            n_acc_consumer,
+            done_consumer,
+        ) = math_pipelines
+        self._initialize_tmem_matrix(
+            tmem_ptr, self.tmem_n_offset, tiled_mma_update, tidx, False
+        )
+        n_init_producer.acquire_and_advance().commit()
+        for _ in cutlass.range(num_blocks, unroll=1):
+            v_handle = v_consumer.wait_and_advance()
+            alpha_handle = alpha_consumer.wait_and_advance()
+            self._convert_matrix_to_z_input(
+                tmem_ptr,
+                self.tmem_n_offset,
+                self.tmem_n_inp_offset,
+                tiled_mma_update,
+                tiled_mma_z,
+                tidx,
+            )
+            n_in_producer.acquire_and_advance().commit()
+            y_handle = y_acc_consumer.wait_and_advance()
+            block_coeff = cutlass.Float32(
+                sAlpha[self.BLK - 1, AlphaProcessor.CUMPROD, alpha_handle.index]
+            )
+            self._process_y(
+                tmem_ptr,
+                tiled_mma_x,
+                tidx,
+                sV,
+                sAlpha,
+                v_handle.index,
+                alpha_handle.index,
+                block_coeff,
+                tiled_mma_update,
+            )
+            y_handle.release()
+            self._scale_tmem_matrix(
+                tmem_ptr, self.tmem_n_offset, tiled_mma_update, tidx, block_coeff
+            )
+            cute.arch.fence_view_async_tmem_store()
+            y_ready_producer.acquire_and_advance().commit()
+            n_acc_consumer.wait_and_advance().release()
+            v_handle.release()
+            alpha_handle.release()
+        self._store_tmem_matrix(
+            tmem_ptr, self.tmem_n_offset, tiled_mma_update, tidx, gN
+        )
+        done_consumer.wait_and_advance().release()
+
+    @cute.jit
+    def __call__(
+        self,
+        g_k: cute.Tensor,
+        g_v: cute.Tensor,
+        g_t: cute.Tensor,
+        g_alpha: cute.Tensor,
+        g_transfer_t: cute.Tensor,
+        g_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        max_cp_chunks_per_seq: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        stream,
+    ):
+        def make_mma(mnk, source_a, a_major, b_major):
+            op = tcgen05.MmaF16BF16Op(
+                self.dtype,
+                self.acc_dtype,
+                (mnk[0], mnk[1], 16),
+                self.cta_group,
+                source_a,
+                a_major,
+                b_major,
+            )
+            return cute.make_tiled_mma(op)
+
+        tiled_mma_x = make_mma(
+            (self.D, self.BLK, self.BLK),
+            tcgen05.OperandSource.SMEM,
+            OperandMajorMode.MN,
+            OperandMajorMode.K,
+        )
+        tiled_mma_z = make_mma(
+            (self.D, self.BLK, self.D),
+            tcgen05.OperandSource.TMEM,
+            OperandMajorMode.K,
+            OperandMajorMode.K,
+        )
+        tiled_mma_y = make_mma(
+            (self.D, self.BLK, self.D),
+            tcgen05.OperandSource.TMEM,
+            OperandMajorMode.K,
+            OperandMajorMode.K,
+        )
+        tiled_mma_m_update = make_mma(
+            (self.D, self.D, self.BLK),
+            tcgen05.OperandSource.TMEM,
+            OperandMajorMode.K,
+            OperandMajorMode.MN,
+        )
+        tiled_mma_n_update = make_mma(
+            (self.D, self.D, self.BLK),
+            tcgen05.OperandSource.TMEM,
+            OperandMajorMode.K,
+            OperandMajorMode.MN,
+        )
+        tiled_mma_m_update_ss = make_mma(
+            (self.D, self.D, self.BLK),
+            tcgen05.OperandSource.SMEM,
+            OperandMajorMode.MN,
+            OperandMajorMode.MN,
+        )
+        k_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma_x, (self.D, self.BLK, self.BLK), self.dtype, self.k_stage
+        )
+        k_trans_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma_z, (self.D, self.BLK, self.D), self.dtype, self.k_stage
+        )
+        v_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma_x, (self.D, self.BLK, self.BLK), self.dtype, self.v_stage
+        )
+        t_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma_x, (self.D, self.BLK, self.BLK), self.dtype, self.t_stage
+        )
+        x_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma_m_update, (self.D, self.D, self.BLK), self.dtype, self.x_stage
+        )
+        k_semantic_layout = self.transform_partitioned_layout(k_layout)
+        v_semantic_layout = self.transform_partitioned_layout(v_layout)
+        t_semantic_layout = self.transform_partitioned_layout(t_layout)
+        alpha_layout = cute.make_layout(
+            (self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage)
+        )
+
+        # The physical cluster is laid out along grid-x. Model that rank as a
+        # logical N coordinate so K/T/V are broadcast rather than partitioned.
+        cluster_layout_vmnk = cute.make_layout((1, 1, 1, 1))
+        tma_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        k_tma_layout = cute.slice_(k_semantic_layout, (None, None, 0))
+        v_tma_layout = cute.slice_(v_semantic_layout, (None, None, 0))
+        t_tma_layout = cute.slice_(t_semantic_layout, (None, None, 0))
+        tma_k = cpasync.make_tiled_tma_atom(
+            tma_op, g_k, k_tma_layout, (self.D, self.BLK)
+        )
+        tma_v = cpasync.make_tiled_tma_atom(
+            tma_op, g_v, v_tma_layout, (self.D, self.BLK)
+        )
+        tma_t = cpasync.make_tiled_tma_atom(
+            tma_op, g_t, t_tma_layout, (self.BLK, self.BLK)
+        )
+        tma_atom_k, tma_tensor_k = tma_k
+        tma_atom_v, tma_tensor_v = tma_v
+        tma_atom_t, tma_tensor_t = tma_t
+        dtype_bytes = self.dtype.width // 8
+        self.tma_k_bytes = cute.size(k_tma_layout) * dtype_bytes
+        self.tma_v_bytes = cute.size(v_tma_layout) * dtype_bytes
+        self.tma_t_bytes = cute.size(t_tma_layout) * dtype_bytes
+
+        @cute.struct
+        class SharedStorage:
+            load_k_mbar: cute.struct.MemRange[cutlass.Int64, self.k_stage * 2]
+            load_v_mbar: cute.struct.MemRange[cutlass.Int64, self.v_stage * 2]
+            load_t_mbar: cute.struct.MemRange[cutlass.Int64, self.t_stage * 2]
+            alpha_mbar: cute.struct.MemRange[cutlass.Int64, self.alpha_stage * 2]
+            m_init_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            n_init_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            x_acc_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            x_ready_mbar: cute.struct.MemRange[cutlass.Int64, self.x_stage * 2]
+            m_in_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            n_in_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            z_acc_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            z_ready_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            m_acc_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            y_acc_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            y_ready_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            n_acc_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            done_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            tmem_holding_buf: cutlass.Int32
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(k_layout)], 1024
+            ]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(v_layout)], 1024
+            ]
+            sT: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(t_layout)], 1024
+            ]
+            sX: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(x_layout)], 1024
+            ]
+            sAlpha: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(alpha_layout)], 16
+            ]
+
+        self.shared_storage = SharedStorage  # type: ignore[assignment]
+        self.kernel(
+            tiled_mma_x,
+            tiled_mma_z,
+            tiled_mma_y,
+            tiled_mma_m_update,
+            tiled_mma_n_update,
+            tiled_mma_m_update_ss,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_t,
+            tma_tensor_t,
+            g_alpha,
+            g_transfer_t,
+            g_state_t,
+            g_cu_seqlens,
+            k_layout,
+            k_trans_layout,
+            v_layout,
+            t_layout,
+            x_layout,
+            alpha_layout,
+            cluster_layout_vmnk,
+            chunk_len,
+            num_k_heads,
+            num_v_heads,
+            num_sab_heads,
+            total_cp_chunks,
+            num_seqs,
+        ).launch(
+            grid=(
+                num_sab_heads * max_cp_chunks_per_seq,
+                num_seqs,
+                1,
+            ),
+            block=(self.threads_per_cta, 1, 1),
+            cluster=self.cluster_shape_mnk,
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma_x,
+        tiled_mma_z,
+        tiled_mma_y,
+        tiled_mma_m_update,
+        tiled_mma_n_update,
+        tiled_mma_m_update_ss,
+        tma_atom_k,
+        tma_tensor_k,
+        tma_atom_v,
+        tma_tensor_v,
+        tma_atom_t,
+        tma_tensor_t,
+        g_alpha,
+        g_transfer_t,
+        g_state_t,
+        g_cu_seqlens,
+        k_layout,
+        k_trans_layout,
+        v_layout,
+        t_layout,
+        x_layout,
+        alpha_layout,
+        cluster_layout_vmnk,
+        chunk_len,
+        num_k_heads,
+        num_v_heads,
+        num_sab_heads,
+        total_cp_chunks,
+        num_seqs,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        bx, seq_idx, _ = cute.arch.block_idx()
+        sab_head_idx = bx % num_sab_heads
+        chunk_idx_in_seq = bx // num_sab_heads
+        k_head_idx = sab_head_idx * num_k_heads // num_sab_heads
+        v_head_idx = sab_head_idx * num_v_heads // num_sab_heads
+        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_cp_chunks = chunks_for_len(seq_len, chunk_len)
+        is_valid_chunk = chunk_idx_in_seq < num_cp_chunks
+
+        tok_offset = seq_start + chunk_idx_in_seq * chunk_len
+        cp_chunk_idx = varlen_chunk_idx(seq_idx, seq_start, chunk_idx_in_seq, chunk_len)
+        valid_chunk_len = varlen_chunk_valid_len(seq_len, chunk_idx_in_seq, chunk_len)
+        num_blocks = cute.ceil_div(valid_chunk_len, self.BLK)
+        t_blocks_per_cp_chunk = cute.ceil_div(chunk_len, self.BLK)
+        t_block_start = varlen_chunk_idx(
+            seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK
+        )
+
+        allocator = utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+        sK = storage.sK.get_tensor(k_layout.outer, swizzle=k_layout.inner)
+        sK_trans = storage.sK.get_tensor(
+            k_trans_layout.outer, swizzle=k_trans_layout.inner
+        )
+        sV = storage.sV.get_tensor(v_layout.outer, swizzle=v_layout.inner)
+        sT = storage.sT.get_tensor(t_layout.outer, swizzle=t_layout.inner)
+        sX = storage.sX.get_tensor(x_layout.outer, swizzle=x_layout.inner)
+        sK_tma = self.transform_partitioned_tensor_layout(sK)
+        sV_tma = self.transform_partitioned_tensor_layout(sV)
+        sT_tma = self.transform_partitioned_tensor_layout(sT)
+        sAlpha = storage.sAlpha.get_tensor(alpha_layout)
+
+        def cg(num_threads):
+            return pipeline.CooperativeGroup(pipeline.Agent.Thread, num_threads)
+
+        cg_tma = cg(1)
+        cg_mma = cg(1)
+        cg_mma_both = cg(2)
+        cg_alpha = cg(32)
+        cg_cg0 = cg(128)
+        cg_cg1 = cg(128)
+        cg_cg1_v = cg(4)
+        cg_both = cg(256)
+        load_k_pipeline = pipeline.PipelineTmaUmma.create(
+            num_stages=self.k_stage,
+            producer_group=cg_tma,
+            consumer_group=cg_mma_both,
+            tx_count=self.tma_k_bytes,
+            barrier_storage=storage.load_k_mbar.data_ptr(),
+            defer_sync=True,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            mcast_mode_mn=(1, 0),
+        )
+        load_k_producer = load_k_pipeline.make_producer()
+        load_k_transfer_consumer = load_k_pipeline.make_consumer()
+        load_k_state_consumer = load_k_pipeline.make_consumer()
+        load_t_producer, load_t_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.t_stage,
+            producer_group=cg_tma,
+            consumer_group=cg_mma,
+            tx_count=self.tma_t_bytes,
+            barrier_storage=storage.load_t_mbar.data_ptr(),
+            defer_sync=True,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            mcast_mode_mn=(1, 0),
+        ).make_participants()
+        load_v_producer, load_v_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.v_stage,
+            producer_group=cg_tma,
+            consumer_group=cg_cg1_v,
+            tx_count=self.tma_v_bytes,
+            barrier_storage=storage.load_v_mbar.data_ptr(),
+            defer_sync=True,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            mcast_mode_mn=(1, 0),
+            enable_multicast_signaling=False,
+        ).make_participants()
+        alpha_pipeline = pipeline.PipelineAsync.create(
+            num_stages=self.alpha_stage,
+            producer_group=cg_alpha,
+            consumer_group=cg_both,
+            barrier_storage=storage.alpha_mbar.data_ptr(),
+            defer_sync=True,
+        )
+        alpha_producer = alpha_pipeline.make_producer()
+        alpha_m_consumer = alpha_pipeline.make_consumer()
+        alpha_n_consumer = alpha_pipeline.make_consumer()
+        m_init_producer, m_init_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma,
+            barrier_storage=storage.m_init_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        n_init_producer, n_init_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg1,
+            consumer_group=cg_mma,
+            barrier_storage=storage.n_init_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        x_acc_producer, x_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=cg_mma,
+            consumer_group=cg_cg0,
+            barrier_storage=storage.x_acc_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        x_ready_pipeline = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.x_stage,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma_both,
+            barrier_storage=storage.x_ready_mbar.data_ptr(),
+            defer_sync=True,
+        )
+        x_ready_producer = x_ready_pipeline.make_producer()
+        x_ready_m_consumer = x_ready_pipeline.make_consumer()
+        x_ready_n_consumer = x_ready_pipeline.make_consumer()
+        m_in_producer, m_in_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma,
+            barrier_storage=storage.m_in_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        n_in_producer, n_in_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg1,
+            consumer_group=cg_mma,
+            barrier_storage=storage.n_in_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        z_acc_producer, z_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=cg_mma,
+            consumer_group=cg_cg0,
+            barrier_storage=storage.z_acc_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        z_ready_producer, z_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma,
+            barrier_storage=storage.z_ready_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        m_acc_producer, m_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=cg_mma,
+            consumer_group=cg_cg0,
+            barrier_storage=storage.m_acc_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        y_acc_producer, y_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=cg_mma,
+            consumer_group=cg_cg1,
+            barrier_storage=storage.y_acc_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        y_ready_producer, y_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg1,
+            consumer_group=cg_mma,
+            barrier_storage=storage.y_ready_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        n_acc_producer, n_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=cg_mma,
+            consumer_group=cg_cg1,
+            barrier_storage=storage.n_acc_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        done_producer, done_consumer = pipeline.PipelineAsync.create(
+            num_stages=1,
+            producer_group=cg_cg0,
+            consumer_group=cg_cg1,
+            barrier_storage=storage.done_mbar.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        pipeline.pipeline_init_arrive(
+            cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True
+        )
+        pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.compute_group_1_warp_ids[0],
+        )
+        tmem.allocate(cute.arch.get_max_tmem_alloc_cols("sm_100"))
+
+        out_layout = cute.make_layout(
+            (self.D, self.D, num_sab_heads, total_cp_chunks),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_sab_heads),
+        )
+        mM = cute.make_tensor(g_transfer_t.iterator, out_layout)
+        mN = cute.make_tensor(g_state_t.iterator, out_layout)
+        gM = mM[None, None, sab_head_idx, cp_chunk_idx]
+        gN = mN[None, None, sab_head_idx, cp_chunk_idx]
+
+        tensor_cta_coord = 0
+        tensor_cta_layout = cute.make_layout(1)
+        participates_in_tmem = (
+            warp_idx <= self.transfer_mma_warp_id or warp_idx == self.state_mma_warp_id
+        )
+
+        if not is_valid_chunk:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            if participates_in_tmem:
+                tmem.wait_for_alloc()
+            if warp_idx == self.compute_group_1_warp_ids[0]:
+                tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+                tmem.relinquish_alloc_permit()
+                tmem.free(tmem_ptr)
+        elif is_valid_chunk and warp_idx >= 0 and warp_idx <= 3:
+            cute.arch.setmaxregister_increase(self.num_regs_compute)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            self.run_compute_group_0(
+                tidx,
+                tmem_ptr,
+                tiled_mma_x,
+                tiled_mma_z,
+                tiled_mma_m_update,
+                sX,
+                sAlpha,
+                alpha_m_consumer,
+                (
+                    m_init_producer,
+                    x_acc_consumer,
+                    x_ready_producer,
+                    m_in_producer,
+                    z_acc_consumer,
+                    z_ready_producer,
+                    m_acc_consumer,
+                    done_producer,
+                ),
+                num_blocks,
+                gM,
+            )
+        elif is_valid_chunk and warp_idx >= 4 and warp_idx <= 7:
+            cute.arch.setmaxregister_increase(self.num_regs_compute)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            self.run_compute_group_1(
+                tidx % 128,
+                tmem_ptr,
+                tiled_mma_x,
+                tiled_mma_y,
+                tiled_mma_n_update,
+                sV_tma,
+                sAlpha,
+                load_v_consumer,
+                alpha_n_consumer,
+                (
+                    n_init_producer,
+                    n_in_producer,
+                    y_acc_consumer,
+                    y_ready_producer,
+                    n_acc_consumer,
+                    done_consumer,
+                ),
+                num_blocks,
+                gN,
+            )
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)
+        elif is_valid_chunk and warp_idx == self.transfer_mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_mma)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_v)
+            cpasync.prefetch_descriptor(tma_atom_t)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            self.run_transfer_mma_role(
+                tmem_ptr,
+                (tiled_mma_z, tiled_mma_m_update, tiled_mma_m_update_ss),
+                (sK, sK_trans, sX),
+                load_k_transfer_consumer,
+                (
+                    m_init_consumer,
+                    x_ready_m_consumer,
+                    m_in_consumer,
+                    z_acc_producer,
+                    z_ready_consumer,
+                    m_acc_producer,
+                ),
+                num_blocks,
+            )
+        elif is_valid_chunk and warp_idx == self.state_mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_mma)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            self.run_state_mma_role(
+                tmem_ptr,
+                (tiled_mma_x, tiled_mma_y, tiled_mma_n_update),
+                (sK, sK_trans, sT, sX),
+                (load_k_state_consumer, load_t_consumer),
+                (
+                    n_init_consumer,
+                    x_acc_producer,
+                    x_ready_n_consumer,
+                    n_in_consumer,
+                    y_acc_producer,
+                    y_ready_consumer,
+                    n_acc_producer,
+                ),
+                num_blocks,
+            )
+        elif is_valid_chunk and warp_idx == self.tma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            for blk in cutlass.range(num_blocks, unroll=1):
+                load_k_producer = self.load_tensor_block_tma_sm100(
+                    tma_atom_k,
+                    tma_tensor_k,
+                    sK_tma,
+                    load_k_producer,
+                    tok_offset,
+                    t_block_start,
+                    k_head_idx,
+                    blk,
+                    False,
+                    tensor_cta_coord,
+                    tensor_cta_layout,
+                )
+                load_v_producer = self.load_tensor_block_tma_sm100(
+                    tma_atom_v,
+                    tma_tensor_v,
+                    sV_tma,
+                    load_v_producer,
+                    tok_offset,
+                    t_block_start,
+                    v_head_idx,
+                    blk,
+                    False,
+                    tensor_cta_coord,
+                    tensor_cta_layout,
+                )
+                load_t_producer = self.load_tensor_block_tma_sm100(
+                    tma_atom_t,
+                    tma_tensor_t,
+                    sT_tma,
+                    load_t_producer,
+                    tok_offset,
+                    t_block_start,
+                    sab_head_idx,
+                    blk,
+                    True,
+                    tensor_cta_coord,
+                    tensor_cta_layout,
+                )
+        elif is_valid_chunk and warp_idx == self.alpha_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            alpha_producer = self.run_load_alpha_role_sm100(
+                g_alpha,
+                sAlpha,
+                alpha_producer,
+                tok_offset,
+                sab_head_idx,
+                valid_chunk_len,
+                num_blocks,
+                num_sab_heads,
+                tidx,
+            )
+        else:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -1544,7 +1544,8 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             raise ValueError(f"rows_per_cta must be 64 or 128, got {rows_per_cta}")
         self.rows_per_cta          = rows_per_cta
         self.row_ctas              = self.D // rows_per_cta
-        self.m_stage               = 1
+        # A second M stage hides the exposed UTC64 TMA load; UTC128 is unchanged by it.
+        self.m_stage               = 2 if rows_per_cta == 64 else 1
         self.n_stage               = 1
         self.threads_per_cta       = 256
         self.compute_warp_group_id = 0
@@ -1870,7 +1871,7 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             grid=(num_seqs * num_heads * self.row_ctas, 1, 1), block=(self.threads_per_cta, 1, 1),
             max_number_threads=(self.threads_per_cta, 1, 1),
             smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
-            stream=stream, min_blocks_per_mp=2 if self.rows_per_cta == 64 else 1,
+            stream=stream, min_blocks_per_mp=1,
         )
 
     @cute.kernel

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -2320,11 +2320,11 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, mS_init.element_type)
 
         if cutlass.const_expr(mS_indices is not None):
-            state_row = mS_indices[batch_idx]
+            state_idx = mS_indices[batch_idx]
         else:
-            state_row = batch_idx
+            state_idx = batch_idx
         gS_init = cute.flat_divide(
-            mS_init[None, None, head_idx, state_row],
+            mS_init[None, None, head_idx, state_idx],
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
         )[None, None, 0, 0]
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
@@ -2444,11 +2444,11 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                         )
             if cutlass.const_expr(self.store_final_state):
                 if cutlass.const_expr(mS_indices is not None):
-                    state_row = mS_indices[batch_idx]
+                    state_idx = mS_indices[batch_idx]
                 else:
-                    state_row = batch_idx
+                    state_idx = batch_idx
                 gS_out = cute.flat_divide(
-                    mS_out[None, None, head_idx, state_row],
+                    mS_out[None, None, head_idx, state_idx],
                     (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
                 )[None, None, 0, 0]
                 tRG_tCgState = thr_state_t2r.partition_D(gS_out)

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -1,0 +1,3265 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Context-parallel Gated Delta Net prefill kernel for Blackwell SM100.
+
+Each CTA processes one CP chunk as a recurrence of 64-token blocks. It follows
+the optimized non-CP SM100 state pipeline, but replaces the KK and hierarchical
+inverse path with a TMA load of the signed, beta-folded inverse produced by CP
+preprocessing. CG0 applies the gate sandwich and publishes the same A-inverse
+operand contract consumed by the common recurrence.
+
+Warp assignments (12 warps):
+  warps 0-3 : transform T and materialize gamma-scaled QK
+  warps 4-7 : recurrent state and output epilogues
+  warp 8    : issue paired QK UTCMMA
+  warp 9    : TMA load Q, K, V, and T
+  warp 10   : issue state/output UTCMMA
+  warp 11   : preprocess gates and store O
+"""
+
+import math
+from typing import Optional, Type, Tuple
+
+import cuda.bindings.driver as cuda
+
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+from cutlass.utils import TensorMapManager, TensorMapUpdateMode
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.cute.testing as testing
+
+# ---------------------------------------------------------------------------
+# cutlass-dsl 4.4.2 compatibility: TmaInfo was removed; make_tiled_tma_atom_*
+# now returns a plain (CopyAtom, Tensor) tuple instead of TmaInfo.
+# ---------------------------------------------------------------------------
+try:
+    from cutlass.cute.nvgpu.cpasync import TmaInfo
+except ImportError:
+    from cutlass.base_dsl import (
+        extract_mlir_values as _emv,
+        new_from_mlir_values as _nfmv,
+        extract_mlir_attributes as _ema,
+        get_mlir_types as _gmt,
+    )
+
+    class TmaInfo:  # type: ignore[no-redef]
+        """Compatibility shim replacing cpasync.TmaInfo for cutlass-dsl >= 4.4.2."""
+
+        def __init__(self, atom, tma_tensor, smem_layout=None):
+            self._atom = atom
+            self._tma_tensor = tma_tensor
+
+        @property
+        def atom(self):
+            return self._atom
+
+        @property
+        def tma_tensor(self):
+            return self._tma_tensor
+
+        def __extract_mlir_values__(self):
+            return _emv(self._atom) + _emv(self._tma_tensor)
+
+        def __extract_mlir_attributes__(self):
+            return _ema(self._atom) + _ema(self._tma_tensor)
+
+        def __new_from_mlir_values__(self, values):
+            n = len(_gmt(self._atom))
+            return TmaInfo(
+                _nfmv(self._atom, values[:n]),
+                _nfmv(self._tma_tensor, values[n:]),
+            )
+
+        def __iter__(self):
+            yield self._atom
+            yield self._tma_tensor
+
+        def __getitem__(self, i):
+            return (self._atom, self._tma_tensor)[i]
+
+        def __len__(self):
+            return 2
+
+
+def _wrap_tma(ret):
+    """Wrap make_tiled_tma_atom_* return value in TmaInfo if not already."""
+    if isinstance(ret, TmaInfo):
+        return ret
+    # 4.4.2: returns (CopyAtom, Tensor) tuple
+    return TmaInfo(ret[0], ret[1])
+
+
+from ..delta_rule_dsl.varlen_helper import (
+    chunks_for_len,
+    varlen_chunk_idx,
+    varlen_chunk_valid_len,
+)
+from ..delta_rule_dsl.custom_compile_cache import KeyedCompileMixin
+
+
+# ---------------------------------------------------------------------------
+# Combined configuration + execution class
+# ---------------------------------------------------------------------------
+
+
+class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
+    """
+    Configuration and execution class for the Chunked GDN kernel.
+
+    Main responsibilities:
+      - __init__    : warp IDs, barriers, tile shapes, SMEM/TMEM sizes
+      - __call__    : @cute.jit host entry point (TMA setup, kernel launch)
+      - kernel      : @cute.kernel device entry point (warp dispatch)
+      - per-warp methods called from kernel's chunk loop
+
+    Args:
+        io_dtype   : input/output dtype (Float16)
+        acc_dtype  : accumulator dtype  (Float32)
+        b_t        : fixed chunk size / block tile (64)
+        DK         : key/query hidden dim     (128)
+        DV         : value hidden dim         (128)
+    """
+
+    # TMA descriptor size in bytes
+    arch = "sm_100"
+    bytes_per_tensormap = 128
+    num_tensormaps = 5
+
+    def __init__(
+        self,
+        io_dtype: Type[cutlass.Numeric],
+        acc_dtype: Type[cutlass.Numeric],
+        state_dtype: Type[cutlass.Numeric],
+        mma_tiler_qk: Tuple[int, int, int],
+        mma_tiler_qs: Tuple[int, int, int],
+        mma_tiler_qkv: Tuple[int, int, int],
+        mma_tiler_kv: Tuple[int, int, int],
+        max_active_clusters: int,
+        num_sm: int,
+        is_GQA: bool,
+        head_ratio: int,
+        use_initial_state: bool,
+        store_final_state: bool = True,
+        enable_checkpoints: bool = False,
+        is_persistent: bool = True,
+        cu_seqlens_dtype: Type[cutlass.Numeric] = cutlass.Int32,
+    ):
+        self.io_dtype = io_dtype
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.acc_dtype = acc_dtype
+        self.state_dtype = state_dtype
+        self.mma_tiler_qk = mma_tiler_qk
+        self.mma_tiler_qs = mma_tiler_qs
+        self.mma_tiler_qkv = mma_tiler_qkv
+        self.mma_tiler_kv = mma_tiler_kv
+        self.max_active_clusters = max_active_clusters
+        self.num_sm = num_sm
+        self.is_GQA = is_GQA
+        self.head_ratio = head_ratio
+        self.needs_initial_state = use_initial_state
+        # Every CP CTA receives an explicit state, either the user-provided
+        # initial state, zero, or the fixed-up state from the previous CP chunk.
+        self.use_initial_state = True
+        self.store_final_state = store_final_state
+        self.enable_checkpoints = False
+        self.is_persistent = False
+
+        # ------------------------------------------------------------------
+        # Warp assignments  (12 warps total)
+        # ------------------------------------------------------------------
+        # Precomputed-T transform and QK epilogue.
+        self.compute_group_0_warp_ids = [0, 1, 2, 3]
+        # Recurrent state and output epilogues.
+        self.compute_group_1_warp_ids = [4, 5, 6, 7]
+        self.mma_warp_id = 8
+        self.tma_qkv_warp_id = 9
+        # The second issuer owns the five state/output GEMMs.
+        self.mma_cg1_warp_id = 10
+        # store O
+        self.epilogue_warp_id = 11
+        # The lightly loaded O epilogue warp also preprocesses gate.
+        self.gate_warp_id = self.epilogue_warp_id
+
+        # Give the MMA/TMA/gate/epilogue warps enough registers to keep their
+        # pipeline handles resident. Fund the increase from CG1 first while
+        # preserving the existing 64,512-register CTA budget.
+        self.num_regs_compute_group_0 = 224
+        self.num_regs_compute_group_1 = 256
+        self.num_regs_other = 24
+        if not self.use_initial_state:
+            # The peeled zero-state MMA carries more pipeline cursors.  Transfer
+            # twenty-four registers from each CG1 warp to each lightweight warp while
+            # retaining the same 64,512-register CTA allocation.
+            self.num_regs_compute_group_1 = 232
+            self.num_regs_other = 48
+
+        self.threads_per_cta = 32 * (
+            len(
+                (
+                    self.mma_warp_id,
+                    self.tma_qkv_warp_id,
+                    self.mma_cg1_warp_id,
+                    self.epilogue_warp_id,
+                )
+            )
+            + len(self.compute_group_0_warp_ids)
+            + len(self.compute_group_1_warp_ids)
+        )
+
+        self.use_2cta_instrs = False
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+        self.occupancy = 1
+        self.threads_per_warp = 32
+        self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
+
+        # ------------------------------------------------------------------
+        # Named barriers - only TmemAllocator requires a NamedBarrier;
+        # all other inter-warp synchronization uses mbarrier-based pipelines
+        # created inside kernel().
+        # ------------------------------------------------------------------
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_warp
+            * len(
+                (
+                    self.mma_warp_id,
+                    self.mma_cg1_warp_id,
+                    *self.compute_group_0_warp_ids,
+                    *self.compute_group_1_warp_ids,
+                )
+            ),
+        )
+        self.t_store_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_warp * len(self.compute_group_0_warp_ids),
+        )
+        self.init_state_store_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.threads_per_warp * len(self.compute_group_1_warp_ids),
+        )
+        self.manual_cache_key(
+            "io_dtype",
+            "cu_seqlens_dtype",
+            "acc_dtype",
+            "state_dtype",
+            "mma_tiler_qk",
+            "mma_tiler_qs",
+            "mma_tiler_qkv",
+            "mma_tiler_kv",
+            "is_GQA",
+            "head_ratio",
+            "needs_initial_state",
+            "store_final_state",
+        )
+
+    def _setup_attributes(self):
+        # ------------------------------------------------------------------
+        # SMEM sizes (bytes per stage) and stage counts
+        # ------------------------------------------------------------------
+        self.smem_q_stages = 2
+        # CP does not issue KK, so three K stages cover the QK/CG1 consumers.
+        self.smem_k_stages = 3
+        # Three V stages let TMA stay ahead while CG1 consumes the current pair.
+        self.smem_v_stages = 3
+        self.smem_t_stages = 2
+        # Current Ainv1 and the next pair's two transformed T tiles can coexist.
+        self.smem_ainv_stages = 3
+        self.smem_qk_stages = 2
+        # Gate work shares the epilogue warp, so O uses two stages to
+        # avoid back-pressuring CG1 while the warp publishes the next gate.
+        self.smem_o_stages = 2
+        # Five resident stages preserve four chunks of gate lookahead.
+        # Cumulative gate buffers are placed last in SMEM.
+        self.smem_gate_stages = 5
+
+        # ------------------------------------------------------------------
+        # TMEM column offsets and buffer sizes (fp32, 32B per column)
+        # ------------------------------------------------------------------
+        self.tmem_kv_acc_stages = 1
+        self.tmem_q_state_acc_stages = 1
+        self.tmem_state_inp_stages = 1
+        self.tmem_shared_inp_stages = 2
+        # CG0 owns QK and CG1 owns KS/NV. Separate rings remove the
+        # cross-group ownership handoff from the shared-acc critical path.
+        self.tmem_cg0_shared_acc_stages = 2
+        self.tmem_cg1_shared_acc_stages = 1
+
+        self.tmem_state_offset = 0
+        self.tmem_q_state_offset = (
+            self.tmem_state_offset + self.tmem_kv_acc_stages * 128
+        )
+        self.tmem_state_inp_offset = (
+            self.tmem_q_state_offset + self.tmem_q_state_acc_stages * 64
+        )
+        self.tmem_cg0_shared_acc_offset = (
+            self.tmem_state_inp_offset + self.tmem_state_inp_stages * 64
+        )
+        self.tmem_cg1_shared_acc_offset = (
+            self.tmem_cg0_shared_acc_offset + self.tmem_cg0_shared_acc_stages * 64
+        )
+        self.tmem_shared_inp_offset = (
+            self.tmem_cg1_shared_acc_offset + self.tmem_cg1_shared_acc_stages * 64
+        )
+        self.buffer_align_bytes = 1024
+
+    # -----------------------------------------------------------------------
+    # Capability check
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def can_implement(
+        io_dtype,
+        acc_dtype,
+        mma_tiler_qk,
+        mma_tiler_qs,
+        mma_tiler_qkv,
+        mma_tiler_kv,
+    ):
+        """Raise CantImplementError if this configuration is not supported."""
+        if io_dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            raise testing.CantImplementError(
+                f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported"
+            )
+        if acc_dtype != cutlass.Float32:
+            raise testing.CantImplementError(
+                f"acc_dtype={acc_dtype} not supported; only Float32 is supported"
+            )
+        if mma_tiler_qk != (64, 64, 128):
+            raise testing.CantImplementError(
+                f"mma_tiler_qk={mma_tiler_qk} not supported; only (64, 64, 128) is supported"
+            )
+        if mma_tiler_qs != (128, 64, 128):
+            raise testing.CantImplementError(
+                f"mma_tiler_qs={mma_tiler_qs} not supported; only (128, 64, 128) is supported"
+            )
+        if mma_tiler_qkv != (128, 64, 64):
+            raise testing.CantImplementError(
+                f"mma_tiler_qkv={mma_tiler_qkv} not supported; only (128, 64, 64) is supported"
+            )
+        if mma_tiler_kv != (128, 128, 64):
+            raise testing.CantImplementError(
+                f"mma_tiler_kv={mma_tiler_kv} not supported; only (128, 128, 64) is supported"
+            )
+
+    # -----------------------------------------------------------------------
+    # Host entry point
+    # -----------------------------------------------------------------------
+
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        gate: cute.Tensor,
+        t: cute.Tensor,
+        o: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        fixed_state: cute.Tensor,
+        initial_state: Optional[cute.Tensor],
+        state_out: cute.Tensor,
+        cp_chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        max_cp_chunks_per_seq: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        scale: cutlass.Float32,
+        tensormap_workspace: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        # chunk size
+        self.b_t = 64
+        h_q = q.shape[1]
+        h_v = v.shape[1]
+        self._setup_attributes()
+
+        if cutlass.const_expr(self.is_GQA):
+            h_r = h_q // h_v
+            h_qv = h_v
+            q = cute.make_tensor(
+                q.iterator,
+                cute.make_layout(
+                    (q.shape[0], q.shape[2], (h_r, h_v)),
+                    stride=(q.stride[0], q.stride[2], (q.stride[1], h_r * q.stride[1])),
+                ),
+            )
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_r, h_v)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+                ),
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_r, h_v)),
+                    stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
+                ),
+            )
+        else:
+            h_r = h_v // h_q
+            h_qv = h_q
+            q = cute.make_tensor(
+                q.iterator,
+                cute.make_layout(
+                    (q.shape[0], q.shape[2], (h_r, h_q)),
+                    stride=(q.stride[0], q.stride[2], (0, q.stride[1])),
+                ),
+            )
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_r, h_q)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+                ),
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_r, h_q)),
+                    stride=(v.stride[2], v.stride[0], (v.stride[1], h_r * v.stride[1])),
+                ),
+            )
+
+        gate = cute.make_tensor(
+            gate.iterator,
+            cute.make_layout(
+                (gate.shape[0], (h_r, h_qv)),
+                stride=(gate.stride[0], (gate.stride[1], h_r * gate.stride[1])),
+            ),
+        )
+        t = cute.make_tensor(
+            t.iterator,
+            cute.make_layout(
+                (t.shape[0], t.shape[1], (h_r, h_qv), t.shape[3]),
+                stride=(
+                    t.stride[0],
+                    t.stride[1],
+                    (t.stride[2], h_r * t.stride[2]),
+                    t.stride[3],
+                ),
+            ),
+        )
+        o = cute.make_tensor(
+            o.iterator,
+            cute.make_layout(
+                (o.shape[2], o.shape[0], (h_r, h_qv)),
+                stride=(o.stride[2], o.stride[0], (o.stride[1], h_r * o.stride[1])),
+            ),
+        )
+        fixed_state = cute.make_tensor(
+            fixed_state.iterator,
+            cute.make_layout(
+                (
+                    fixed_state.shape[2],
+                    fixed_state.shape[3],
+                    (h_r, h_qv),
+                    fixed_state.shape[0],
+                ),
+                stride=(
+                    fixed_state.stride[2],
+                    fixed_state.stride[3],
+                    (fixed_state.stride[1], h_r * fixed_state.stride[1]),
+                    fixed_state.stride[0],
+                ),
+            ),
+        )
+        if cutlass.const_expr(initial_state is not None):
+            initial_state = cute.make_tensor(
+                initial_state.iterator,
+                cute.make_layout(
+                    (
+                        initial_state.shape[2],
+                        initial_state.shape[3],
+                        (h_r, h_qv),
+                        initial_state.shape[0],
+                    ),
+                    stride=(
+                        initial_state.stride[2],
+                        initial_state.stride[3],
+                        (initial_state.stride[1], h_r * initial_state.stride[1]),
+                        initial_state.stride[0],
+                    ),
+                ),
+            )
+        state_out = cute.make_tensor(
+            state_out.iterator,
+            cute.make_layout(
+                (
+                    state_out.shape[2],
+                    state_out.shape[3],
+                    (h_r, h_qv),
+                    state_out.shape[0],
+                ),
+                stride=(
+                    state_out.stride[2],
+                    state_out.stride[3],
+                    (state_out.stride[1], h_r * state_out.stride[1]),
+                    state_out.stride[0],
+                ),
+            ),
+        )
+
+        # ------------------------------------------------------------------
+        # Build tiled MMAs  (one per logical GEMM group, differing in operand major modes)
+        # ------------------------------------------------------------------
+        def _mma_op(mma_tiler, a_major, b_major, OperandSourceA):
+            # Derive MMA atom (M, N) from the first two dims of the tile shape;
+            # K=16 is the hardware fp16 atom depth (fixed for SM100 tcgen05).
+            return tcgen05.MmaF16BF16Op(
+                self.io_dtype,
+                self.acc_dtype,
+                (mma_tiler[0], mma_tiler[1], 16),
+                self.cta_group,
+                OperandSourceA,
+                a_major,
+                b_major,
+            )
+
+        # QK = Q @ K.T.
+        tiled_mma_qk = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qk,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.SMEM,
+            )
+        )
+        # K/Q applied to the recurrent state.
+        tiled_mma_qs = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qs,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.TMEM,
+            )
+        )
+        # New-V correction and intra-block output.
+        tiled_mma_qkv = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qkv,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.TMEM,
+            )
+        )
+        # for v_smem_layout_staged
+        tiled_mma_qkv_ss = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qkv,
+                OperandMajorMode.MN,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.SMEM,
+            )
+        )
+        # Recurrent state update.
+        tiled_mma_kv = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_kv,
+                OperandMajorMode.K,
+                OperandMajorMode.MN,
+                tcgen05.OperandSource.TMEM,
+            )
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (tiled_mma_qk.thr_id.shape,),
+        )
+
+        # ------------------------------------------------------------------
+        # SMEM layouts - computed before SharedStorage so cosize() is available
+        # ------------------------------------------------------------------
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        tma_store_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+
+        # Q and K are the A and B operands of QK.
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma_qk, self.mma_tiler_qk, self.io_dtype, self.smem_q_stages
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qk, self.mma_tiler_qk, self.io_dtype, self.smem_k_stages
+        )
+        k_trans_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_kv, self.mma_tiler_kv, self.io_dtype, self.smem_k_stages
+        )
+        # V is the A operand of the new-V correction.
+        v_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma_qkv_ss, self.mma_tiler_qkv, self.io_dtype, self.smem_v_stages
+        )
+        # A_inv is the B operand of the new-V correction.
+        ainv_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qkv,
+            self.mma_tiler_qkv,
+            self.io_dtype,
+            self.smem_ainv_stages,
+        )
+        t_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qkv,
+            self.mma_tiler_qkv,
+            self.io_dtype,
+            self.smem_t_stages,
+        )
+        # QK is the B operand of the intra-block output update.
+        qk_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qkv, self.mma_tiler_qkv, self.io_dtype, self.smem_qk_stages
+        )
+
+        o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.io_dtype,
+            cutlass.utils.LayoutEnum.from_tensor(o),
+            self.mma_tiler_qkv[:2],
+            self.smem_o_stages,
+        )
+        # Gate scalar arrays (1D Float32, flat layout - no swizzle needed)
+        cumsumlog_smem_layout_staged = cute.make_layout(
+            (self.b_t, 1, self.smem_gate_stages)
+        )
+
+        # ------------------------------------------------------------------
+        # Shared memory struct  (defined here to capture layout cosizes)
+        # ------------------------------------------------------------------
+        @cute.struct
+        class SharedStorage:
+            # Pipeline mbarriers - one entry per stage, 2 Int64 words per barrier
+            # TMA load warp -> MMA warp (K is staged for next-chunk prefetch)
+            load_k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_k_stages * 2]
+            # TMA load warp -> MMA warp
+            load_q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_q_stages * 2]
+            # TMA load warp -> CG1 V-load signal
+            load_v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_v_stages * 2]
+            # Gate load warp -> CG0/CG1.
+            load_gate_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_gate_stages * 2
+            ]
+            # TMA T load -> CG0
+            load_t_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_t_stages * 2]
+            # MMA warp -> CG1 (Q*state acc ready in TMEM)
+            q_state_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_q_state_acc_stages * 2
+            ]
+            # MMA warp -> CG1 (state update done).
+            kv_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_kv_acc_stages * 2
+            ]
+            # MMA warp -> CG0 (QK ready).
+            cg0_shared_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_cg0_shared_acc_stages * 2
+            ]
+            # MMA warp -> CG1 (KS/NV ready)
+            cg1_shared_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_cg1_shared_acc_stages * 2
+            ]
+            # CG0 -> MMA warp (A_inv ready in SMEM)
+            ainv_ready_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_ainv_stages * 2
+            ]
+            # CG0 -> MMA warp (QK ready in SMEM)
+            qk_ready_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_qk_stages * 2
+            ]
+            state_inp_ready_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_state_inp_stages * 2
+            ]
+            # CG1 -> MMA warp: fixed-slot TMEM inputs.  The empty halves are
+            # unused because downstream accumulator-full signals prove reuse.
+            vks_ready_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            nv_ready_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            decay_v_ready_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            # CG1 -> epilogue warp
+            o_store_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_o_stages * 2
+            ]
+            # TMEM allocation token
+            tmem_holding_buf: cutlass.Int32
+            # SMEM tensor buffers (aligned, in SMEM layout order)
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(q_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(k_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(v_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sT: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(t_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # A_inv result consumed by the next MMA; keep this in io_dtype.
+            sAinv: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.io_dtype, cute.cosize(ainv_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # W_qk scores
+            sQk: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(qk_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sO: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(o_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # Cumulative gate scalars - placed last in SMEM
+            cumsumlog: cute.struct.MemRange[
+                cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)
+            ]
+            cumprod: cute.struct.MemRange[
+                cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # ------------------------------------------------------------------
+        # Build TMA atoms
+        # ------------------------------------------------------------------
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
+        t_smem_layout = cute.select(t_smem_layout_staged, mode=[0, 1, 2])
+
+        tma_q = _wrap_tma(
+            cute.nvgpu.make_tiled_tma_atom_A(
+                tma_load_op,
+                q,
+                q_smem_layout,
+                self.mma_tiler_qk,
+                tiled_mma_qk,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_k = _wrap_tma(
+            cute.nvgpu.make_tiled_tma_atom_B(
+                tma_load_op,
+                k,
+                k_smem_layout,
+                self.mma_tiler_qk,
+                tiled_mma_qk,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_v = _wrap_tma(
+            cute.nvgpu.make_tiled_tma_atom_A(
+                tma_load_op,
+                v,
+                v_smem_layout,
+                self.mma_tiler_qkv,
+                tiled_mma_qkv_ss,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_t = _wrap_tma(
+            cute.nvgpu.make_tiled_tma_atom_B(
+                tma_load_op,
+                t,
+                t_smem_layout,
+                self.mma_tiler_qkv,
+                tiled_mma_qkv,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+
+        o_smem_layout = cute.select(o_smem_layout_staged, mode=[0, 1])
+        tma_o = _wrap_tma(
+            cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                o,
+                o_smem_layout,
+                self.mma_tiler_qkv[:2],
+            )
+        )
+
+        self.tma_q_bytes = cute.size_in_bytes(self.io_dtype, q_smem_layout)
+        self.tma_k_bytes = cute.size_in_bytes(self.io_dtype, k_smem_layout)
+        self.tma_v_bytes = cute.size_in_bytes(self.io_dtype, v_smem_layout)
+        self.tma_t_bytes = cute.size_in_bytes(self.io_dtype, t_smem_layout)
+        self.tma_o_bytes = cute.size_in_bytes(self.io_dtype, o_smem_layout)
+
+        # ------------------------------------------------------------------
+        # Launch
+        # ------------------------------------------------------------------
+        grid_shape = (h_r * h_qv * max_cp_chunks_per_seq, num_seqs, 1)
+
+        self.kernel(
+            tiled_mma_qk,
+            tiled_mma_qs,
+            tiled_mma_qkv,
+            tiled_mma_qkv_ss,
+            tiled_mma_kv,
+            tma_q,
+            tma_k,
+            tma_v,
+            tma_t,
+            gate,
+            tma_o,
+            cu_seqlens,
+            fixed_state,
+            initial_state,
+            state_out,
+            cp_chunk_len,
+            h_r * h_qv,
+            scale,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            k_trans_smem_layout_staged,
+            v_smem_layout_staged,
+            cumsumlog_smem_layout_staged,
+            t_smem_layout_staged,
+            ainv_smem_layout_staged,
+            qk_smem_layout_staged,
+            o_smem_layout_staged,
+            q,
+            k,
+            v,
+            t,
+            o,
+            tensormap_workspace,
+        ).launch(
+            grid=grid_shape,
+            block=(self.threads_per_cta, 1, 1),
+            cluster=self.cluster_shape_mnk,
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.jit
+    def get_cp_work(
+        self,
+        cu_seqlens: cute.Tensor,
+        seq_idx: cutlass.Int32,
+        flat_work_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        cp_chunk_len: cutlass.Int32,
+    ):
+        head_idx = flat_work_idx % num_sab_heads
+        chunk_idx = flat_work_idx // num_sab_heads
+        seq_start = cutlass.Int32(cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_cp_chunks = chunks_for_len(seq_len, cp_chunk_len)
+        valid_chunk_len = cutlass.Int32(0)
+        if chunk_idx < num_cp_chunks:
+            valid_chunk_len = varlen_chunk_valid_len(seq_len, chunk_idx, cp_chunk_len)
+        tok_offset = seq_start + chunk_idx * cp_chunk_len
+        cp_chunk_idx = varlen_chunk_idx(seq_idx, seq_start, chunk_idx, cp_chunk_len)
+        t_blocks_per_cp_chunk = cute.ceil_div(cp_chunk_len, self.b_t)
+        t_block_start = varlen_chunk_idx(
+            seq_idx, seq_start, chunk_idx * t_blocks_per_cp_chunk, self.b_t
+        )
+        return (
+            head_idx,
+            chunk_idx,
+            tok_offset,
+            valid_chunk_len,
+            num_cp_chunks,
+            cp_chunk_idx,
+            t_block_start,
+        )
+
+    # -----------------------------------------------------------------------
+    # Device kernel
+    # -----------------------------------------------------------------------
+
+    @cute.kernel
+    def kernel(
+        self,
+        # Tiled MMAs (one per logical GEMM group)
+        # QK.
+        tiled_mma_qk: cute.TiledMma,
+        # K/Q applied to state.
+        tiled_mma_qs: cute.TiledMma,
+        # New-V correction and intra-block output.
+        tiled_mma_qkv: cute.TiledMma,
+        # New-V correction with an SMEM V operand.
+        tiled_mma_qkv_ss: cute.TiledMma,
+        # State update.
+        tiled_mma_kv: cute.TiledMma,
+        # TMA descriptors and cute tensors
+        tma_q: TmaInfo,
+        tma_k: TmaInfo,
+        tma_v: TmaInfo,
+        tma_t: TmaInfo,
+        mGate: cute.Tensor,
+        tma_o: TmaInfo,
+        cu_seqlens: cute.Tensor,
+        mFixedState: cute.Tensor,
+        mInitialState: Optional[cute.Tensor],
+        mStateOut: cute.Tensor,
+        cp_chunk_len: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        scale: cutlass.Float32,
+        # SMEM staged layouts (needed to view shared_storage tensor buffers)
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        k_trans_smem_layout_staged: cute.ComposedLayout,
+        v_smem_layout_staged: cute.ComposedLayout,
+        cumsumlog_smem_layout_staged: cute.Layout,
+        t_smem_layout_staged: cute.ComposedLayout,
+        ainv_smem_layout_staged: cute.ComposedLayout,
+        qk_smem_layout_staged: cute.ComposedLayout,
+        o_smem_layout_staged: cute.ComposedLayout,
+        # TMA descriptor workspace in GMEM (one q/k/v/t/o descriptor set per CTA).
+        mQ,
+        mK,
+        mV,
+        mT,
+        # used for TMA descriptor update
+        mO,
+        # (num_ctas, num_tensormaps, bytes_per_tensormap) Int8 workspace
+        tensormap_workspace: cute.Tensor,
+    ):
+        """
+        Process one explicitly mapped CP chunk for one sequence and SAB head.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        bidx, bidy, bidz = cute.arch.block_idx()
+        grid_dim = cute.arch.grid_dim()
+
+        if cutlass.const_expr(self.needs_initial_state):
+            assert mInitialState is not None, (
+                "mInitialState must be provided if needs_initial_state is True"
+            )
+        else:
+            assert mInitialState is None, (
+                "mInitialState must be None if needs_initial_state is False"
+            )
+
+        (
+            head_idx,
+            cp_chunk_idx_in_seq,
+            chunk_start,
+            chunk_len,
+            num_cp_chunks,
+            cp_chunk_idx,
+            t_block_start,
+        ) = self.get_cp_work(cu_seqlens, bidy, bidx, num_sab_heads, cp_chunk_len)
+        # ------------------------------------------------------------------
+        # TMA descriptor GMEM workspace - one q/k/v/o descriptor set per CTA.
+        # Slots: Q=0, K=1, V=2, T=3, O=4.
+        # ------------------------------------------------------------------
+        cta_linear_idx = bidz * grid_dim[1] * grid_dim[0] + bidy * grid_dim[0] + bidx
+
+        tensormap_manager = TensorMapManager(
+            TensorMapUpdateMode.GMEM, self.bytes_per_tensormap
+        )
+
+        tensormap_workspace = self.initialize_workspace(tensormap_workspace, grid_dim)
+        tensormap_q_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 0, None)].iterator
+        )
+        tensormap_k_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 1, None)].iterator
+        )
+        tensormap_v_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 2, None)].iterator
+        )
+        tensormap_o_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 4, None)].iterator
+        )
+
+        # ------------------------------------------------------------------
+        # 1. Allocate SMEM / TMEM, prefetch TMA descriptors
+        # ------------------------------------------------------------------
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        sQ = storage.sQ.get_tensor(
+            q_smem_layout_staged.outer, swizzle=q_smem_layout_staged.inner
+        )
+        sK = storage.sK.get_tensor(
+            k_smem_layout_staged.outer, swizzle=k_smem_layout_staged.inner
+        )
+        sK_trans = storage.sK.get_tensor(
+            k_trans_smem_layout_staged.outer, swizzle=k_trans_smem_layout_staged.inner
+        )
+        sV = storage.sV.get_tensor(
+            v_smem_layout_staged.outer, swizzle=v_smem_layout_staged.inner
+        )
+        sT = storage.sT.get_tensor(
+            t_smem_layout_staged.outer, swizzle=t_smem_layout_staged.inner
+        )
+        # A_inverse MMA input.
+        sAinv = storage.sAinv.get_tensor(
+            ainv_smem_layout_staged.outer, swizzle=ainv_smem_layout_staged.inner
+        )
+        # QK output / O store  (W_qk first, then O epilogue staging)
+        sQk = storage.sQk.get_tensor(
+            qk_smem_layout_staged.outer, swizzle=qk_smem_layout_staged.inner
+        )
+        sO = storage.sO.get_tensor(
+            o_smem_layout_staged.outer, swizzle=o_smem_layout_staged.inner
+        )
+        # Gate scalar arrays (1D Float32, flat - no swizzle)
+        sCumsumlog = storage.cumsumlog.get_tensor(cumsumlog_smem_layout_staged)
+        sCumprod = storage.cumprod.get_tensor(cumsumlog_smem_layout_staged)
+
+        if warp_idx == self.mma_warp_id:
+            cpasync.prefetch_descriptor(tma_q.atom)
+            cpasync.prefetch_descriptor(tma_k.atom)
+            cpasync.prefetch_descriptor(tma_v.atom)
+            cpasync.prefetch_descriptor(tma_t.atom)
+            cpasync.prefetch_descriptor(tma_o.atom)
+
+        # TMEM allocator object - CG1 will issue the actual allocation
+        tmem = cutlass.utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            # CG1 owns allocation and is the last group to release TMEM state.
+            allocator_warp_id=self.compute_group_1_warp_ids[0],
+        )
+
+        # ------------------------------------------------------------------
+        # mbarrier-based pipelines
+        # Each pipeline is created by all threads; barrier_storage points into SMEM.
+        # defer_sync=True means pipeline_init_arrive() flushes all at once below.
+        # ------------------------------------------------------------------
+        def _cg(num_threads):
+            return pipeline.CooperativeGroup(pipeline.Agent.Thread, num_threads)
+
+        # 1 thread (TMA issuer)
+        cg_tma = _cg(len([self.tma_qkv_warp_id]))
+        # 1 warp (gate scalar load warp).
+        cg_gate = _cg(self.threads_per_warp * len([self.gate_warp_id]))
+        # One producer per result pipeline; K/Q are consumed by both issuers.
+        cg_mma = _cg(len([self.mma_warp_id]))
+        cg_mma_both = _cg(len([self.mma_warp_id, self.mma_cg1_warp_id]))
+        # 128 threads (CG0)
+        cg_cg0 = _cg(self.threads_per_warp * len(self.compute_group_0_warp_ids))
+        # One elected thread per CG0 warp releases each TMA T stage.
+        cg_cg0_t = _cg(len(self.compute_group_0_warp_ids))
+        # 128 threads (CG1)
+        cg_cg1 = _cg(self.threads_per_warp * len(self.compute_group_1_warp_ids))
+        # 4 threads (one per CG1 warp, used for V load signaling)
+        cg_cg1_v = _cg(len(self.compute_group_1_warp_ids))
+        # 256 threads (CG0 + CG1)
+        cg_both = _cg(
+            self.threads_per_warp * len(self.compute_group_0_warp_ids)
+            + self.threads_per_warp * len(self.compute_group_1_warp_ids)
+        )
+        # 32 threads (epilogue warp)
+        cg_epi = _cg(self.threads_per_warp * len([self.epilogue_warp_id]))
+
+        # TMA load pipelines: K/Q feed MMA; V is signaled to CG1 for ALU work.
+        load_k_producer, load_k_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.smem_k_stages,
+            producer_group=cg_tma,
+            consumer_group=cg_mma_both,
+            tx_count=self.tma_k_bytes,
+            barrier_storage=storage.load_k_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.smem_q_stages,
+            producer_group=cg_tma,
+            consumer_group=cg_mma_both,
+            tx_count=self.tma_q_bytes,
+            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        load_v_producer, load_v_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.smem_v_stages,
+            producer_group=cg_tma,
+            consumer_group=cg_cg1_v,
+            tx_count=self.tma_v_bytes,
+            barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        # Gate producer -> CG0 / CG1 (software-signaled).
+        # Scalar-load paths do not use TMA barriers; producer calls commit() after writes.
+        load_gate_producer, load_gate_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.smem_gate_stages,
+            producer_group=cg_gate,
+            consumer_group=cg_both,
+            barrier_storage=storage.load_gate_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        load_t_producer, load_t_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.smem_t_stages,
+            producer_group=cg_tma,
+            consumer_group=cg_cg0_t,
+            tx_count=self.tma_t_bytes,
+            barrier_storage=storage.load_t_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # MMA warp -> CG1:  kv_acc
+        kv_acc_producer, kv_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.tmem_kv_acc_stages,
+            producer_group=cg_mma,
+            consumer_group=cg_cg1,
+            barrier_storage=storage.kv_acc_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # MMA warp -> CG1:  q_state_acc
+        q_state_acc_producer, q_state_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.tmem_q_state_acc_stages,
+            producer_group=cg_mma,
+            consumer_group=cg_cg1,
+            barrier_storage=storage.q_state_acc_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # QK issuer -> CG0 accumulator ring.
+        cg0_shared_acc_producer, cg0_shared_acc_consumer = (
+            pipeline.PipelineUmmaAsync.create(
+                num_stages=self.tmem_cg0_shared_acc_stages,
+                producer_group=cg_mma,
+                consumer_group=cg_cg0,
+                barrier_storage=storage.cg0_shared_acc_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
+
+        # MMA warp -> CG1: KS/NV accumulator ring.
+        cg1_shared_acc_producer, cg1_shared_acc_consumer = (
+            pipeline.PipelineUmmaAsync.create(
+                num_stages=self.tmem_cg1_shared_acc_stages,
+                producer_group=cg_mma,
+                consumer_group=cg_cg1,
+                barrier_storage=storage.cg1_shared_acc_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
+
+        # CG0 -> MMA warp:  a_inv_done
+        a_inv_ready_producer, a_inv_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.smem_ainv_stages,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma,
+            barrier_storage=storage.ainv_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # CG0 -> MMA warp:  qk_done
+        qk_ready_producer, qk_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.smem_qk_stages,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma,
+            barrier_storage=storage.qk_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # CG1 -> MMA warp: state input.
+        state_inp_ready_producer, state_inp_ready_consumer = (
+            pipeline.PipelineAsyncUmma.create(
+                num_stages=self.tmem_state_inp_stages,
+                producer_group=cg_cg1,
+                consumer_group=cg_mma,
+                barrier_storage=storage.state_inp_ready_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
+
+        # CG1 -> MMA warp: fixed-slot, ready-only input notifications.
+        vks_ready_producer, vks_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg1,
+            consumer_group=cg_mma,
+            barrier_storage=storage.vks_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        nv_ready_producer, nv_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg1,
+            consumer_group=cg_mma,
+            barrier_storage=storage.nv_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        decay_v_ready_producer, decay_v_ready_consumer = (
+            pipeline.PipelineAsyncUmma.create(
+                num_stages=1,
+                producer_group=cg_cg1,
+                consumer_group=cg_mma,
+                barrier_storage=storage.decay_v_ready_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
+
+        # CG1 -> epilogue warp:  output_ready
+        o_store_producer, o_store_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.smem_o_stages,
+            producer_group=cg_cg1,
+            consumer_group=cg_epi,
+            barrier_storage=storage.o_store_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        pipeline_init_arrive(is_relaxed=True)
+
+        pipeline_init_wait()
+
+        num_pairs = 2
+        num_pairs_b = cute.ceil_div(chunk_len, self.b_t * num_pairs)
+        num_chunks_b = num_pairs_b * num_pairs
+        num_valid_chunks_b = cute.ceil_div(chunk_len, self.b_t)
+        chunk_end = chunk_start + chunk_len
+
+        # COMPUTE WARP GROUP 0 (warps 0-3): T transform and QK epilogue.
+        if (
+            warp_idx >= self.compute_group_0_warp_ids[0]
+            and warp_idx <= self.compute_group_0_warp_ids[-1]
+        ):
+            cute.arch.setmaxregister_increase(self.num_regs_compute_group_0)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            sQk_pisl = self._transform_to_position_independent_layout(
+                sQk, qk_smem_layout_staged.inner
+            )
+            sAinv_pisl = self._transform_to_position_independent_layout(
+                sAinv, ainv_smem_layout_staged.inner
+            )
+            for pair_idx in cutlass.range(num_pairs_b):
+                (
+                    load_gate_consumer,
+                    load_t_consumer,
+                    cg0_shared_acc_consumer,
+                    a_inv_ready_producer,
+                    qk_ready_producer,
+                ) = self.compute_group_0_pair_cp(
+                    tidx,
+                    tmem_ptr,
+                    scale,
+                    (tiled_mma_qk,),
+                    (sCumsumlog, sT, sAinv_pisl, sQk_pisl),
+                    (
+                        load_gate_consumer,
+                        load_t_consumer,
+                        cg0_shared_acc_consumer,
+                        a_inv_ready_producer,
+                        qk_ready_producer,
+                    ),
+                    (pair_idx, num_pairs_b, num_valid_chunks_b, chunk_len),
+                )
+            a_inv_ready_producer.tail()
+            qk_ready_producer.tail()
+
+        # COMPUTE WARP GROUP 1 (warps 4-7): recurrent state and output.
+        if (
+            warp_idx >= self.compute_group_1_warp_ids[0]
+            and warp_idx <= self.compute_group_1_warp_ids[-1]
+        ):
+            cute.arch.setmaxregister_increase(self.num_regs_compute_group_1)
+            tmem.allocate(self.tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            if chunk_len > 0:
+                kv_acc_producer = self._load_cp_initial_state(
+                    tidx,
+                    mFixedState,
+                    mInitialState,
+                    head_idx,
+                    bidy,
+                    cp_chunk_idx_in_seq,
+                    cp_chunk_idx,
+                    tmem_ptr,
+                    tiled_mma_kv,
+                    kv_acc_producer,
+                )
+                sV_pisl = self._transform_to_position_independent_layout(
+                    sV, v_smem_layout_staged.inner
+                )
+                sO_pisl = self._transform_to_position_independent_layout(
+                    sO, o_smem_layout_staged.inner
+                )
+                checkpoint_offset = 0
+                is_first_chunk = True
+                for chunk_idx in cutlass.range(num_chunks_b):
+                    (
+                        load_v_consumer,
+                        load_gate_consumer,
+                        cg1_shared_acc_consumer,
+                        kv_acc_consumer,
+                        q_state_acc_consumer,
+                        kv_acc_producer,
+                        state_inp_ready_producer,
+                        vks_ready_producer,
+                        nv_ready_producer,
+                        decay_v_ready_producer,
+                        o_store_producer,
+                        checkpoint_offset,
+                    ) = self.compute_group_1_chunk(
+                        tidx,
+                        tmem_ptr,
+                        scale,
+                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                        (sV_pisl, sCumsumlog, sCumprod, sCumprod, sO_pisl),
+                        (mStateOut, checkpoint_offset, cutlass.Int32(0)),
+                        (
+                            load_v_consumer,
+                            load_gate_consumer,
+                            cg1_shared_acc_consumer,
+                            kv_acc_consumer,
+                            q_state_acc_consumer,
+                            kv_acc_producer,
+                            state_inp_ready_producer,
+                            vks_ready_producer,
+                            nv_ready_producer,
+                            decay_v_ready_producer,
+                            o_store_producer,
+                        ),
+                        (chunk_idx, num_pairs_b, head_idx, chunk_len, is_first_chunk),
+                    )
+                    is_first_chunk = False
+
+                if cp_chunk_idx_in_seq == num_cp_chunks - 1:
+                    kv_acc_consumer = self._store_final_state(
+                        tidx,
+                        mStateOut,
+                        None,
+                        head_idx,
+                        bidy,
+                        tmem_ptr,
+                        tiled_mma_kv,
+                        kv_acc_consumer,
+                        chunk_len,
+                        mStateOut,
+                        cutlass.Int32(0),
+                        cutlass.Int32(0),
+                    )
+                else:
+                    kv_acc_handle = kv_acc_consumer.wait_and_advance()
+                    kv_acc_handle.release()
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)
+            o_store_producer.tail()
+            state_inp_ready_producer.tail()
+
+        # CG0 MMA ISSUER (warp 8): paired QK.
+        elif warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            for _pair_idx in cutlass.range(num_pairs_b):
+                (
+                    cg0_shared_acc_producer,
+                    load_k_consumer,
+                    load_q_consumer,
+                ) = self.mma_cg0_pair_cp(
+                    tmem_ptr,
+                    (tiled_mma_qk, tiled_mma_qkv),
+                    (sQ, sK),
+                    (
+                        cg0_shared_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                    ),
+                )
+            cg0_shared_acc_producer.tail()
+
+        # CG1 MMA ISSUER (warp 10): KS/QS/NV/QKV/KV.
+        elif warp_idx == self.mma_cg1_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            for chunk_idx in cutlass.range(num_chunks_b):
+                (
+                    cg1_shared_acc_producer,
+                    q_state_acc_producer,
+                    kv_acc_producer,
+                    load_k_consumer,
+                    load_q_consumer,
+                    a_inv_ready_consumer,
+                    qk_ready_consumer,
+                    state_inp_ready_consumer,
+                    vks_ready_consumer,
+                    nv_ready_consumer,
+                    decay_v_ready_consumer,
+                ) = self.mma_cg1_chunk(
+                    tmem_ptr,
+                    (
+                        tiled_mma_qs,
+                        tiled_mma_qkv,
+                        tiled_mma_qkv_ss,
+                        tiled_mma_kv,
+                    ),
+                    (sQ, sK, sK_trans, sV, sAinv, sQk),
+                    (
+                        cg1_shared_acc_producer,
+                        q_state_acc_producer,
+                        kv_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                        a_inv_ready_consumer,
+                        qk_ready_consumer,
+                        state_inp_ready_consumer,
+                        vks_ready_consumer,
+                        nv_ready_consumer,
+                        decay_v_ready_consumer,
+                    ),
+                    chunk_idx == 0,
+                )
+            cg1_shared_acc_producer.tail()
+            q_state_acc_producer.tail()
+            kv_acc_producer.tail()
+
+        # TMA LOAD WARP (warp 9): Q/K/V and precomputed T.
+        elif warp_idx == self.tma_qkv_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tensormap_manager.init_tensormap_from_atom(
+                tma_q.atom, tensormap_q_ptr, self.tma_qkv_warp_id
+            )
+            tensormap_manager.init_tensormap_from_atom(
+                tma_k.atom, tensormap_k_ptr, self.tma_qkv_warp_id
+            )
+            tensormap_manager.init_tensormap_from_atom(
+                tma_v.atom, tensormap_v_ptr, self.tma_qkv_warp_id
+            )
+            tensormap_manager.fence_tensormap_initialization()
+            bounded_q = cute.make_tensor(
+                mQ.iterator,
+                cute.make_layout(
+                    (chunk_end, mQ.shape[1], mQ.shape[2]),
+                    stride=(mQ.stride[0], mQ.stride[1], mQ.stride[2]),
+                ),
+            )
+            bounded_k = cute.make_tensor(
+                mK.iterator,
+                cute.make_layout(
+                    (chunk_end, mK.shape[1], mK.shape[2]),
+                    stride=(mK.stride[0], mK.stride[1], mK.stride[2]),
+                ),
+            )
+            bounded_v = cute.make_tensor(
+                mV.iterator,
+                cute.make_layout(
+                    (mV.shape[0], chunk_end, mV.shape[2]),
+                    stride=(mV.stride[0], mV.stride[1], mV.stride[2]),
+                ),
+            )
+            tensormap_manager.update_tensormap(
+                (bounded_q, bounded_k, bounded_v),
+                (tma_q.atom, tma_k.atom, tma_v.atom),
+                (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
+                self.tma_qkv_warp_id,
+                (None, None, None),
+            )
+            for chunk_idx in cutlass.range(num_chunks_b):
+                chunk_offset = chunk_start + chunk_idx * self.b_t
+                load_q_producer, load_k_producer, load_v_producer = self.tma_qkv_warp(
+                    (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
+                    (tma_q, tma_k, tma_v),
+                    (sQ, sK, sV),
+                    (load_q_producer, load_k_producer, load_v_producer),
+                    (chunk_offset, chunk_idx, bidy, head_idx),
+                    (
+                        tensormap_manager,
+                        tensormap_q_ptr,
+                        tensormap_k_ptr,
+                        tensormap_v_ptr,
+                    ),
+                )
+                t_chunk_idx = chunk_idx
+                if chunk_idx >= num_valid_chunks_b:
+                    t_chunk_idx = num_valid_chunks_b - 1
+                load_t_producer = self.tma_t_warp(
+                    tiled_mma_qkv,
+                    tma_t,
+                    sT,
+                    load_t_producer,
+                    t_block_start + t_chunk_idx,
+                    head_idx,
+                )
+            load_q_producer.tail()
+            load_k_producer.tail()
+            load_v_producer.tail()
+            load_t_producer.tail()
+
+        # EPILOGUE WARP (warp 11): gate preprocessing and O store.
+        if warp_idx == self.epilogue_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tensormap_manager.init_tensormap_from_atom(
+                tma_o.atom, tensormap_o_ptr, self.epilogue_warp_id
+            )
+            tensormap_manager.fence_tensormap_initialization()
+            bounded_o = cute.make_tensor(
+                mO.iterator,
+                cute.make_layout(
+                    (mO.shape[0], chunk_end, mO.shape[2]),
+                    stride=(mO.stride[0], mO.stride[1], mO.stride[2]),
+                ),
+            )
+            tensormap_manager.update_tensormap(
+                (bounded_o,),
+                (tma_o.atom,),
+                (tensormap_o_ptr,),
+                self.epilogue_warp_id,
+                (None,),
+            )
+            tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
+
+            if chunk_len > 0:
+                num_gate_prefetch = 4
+                for prefetch_idx in range(2):
+                    load_gate_producer = self.load_gate_warp(
+                        tidx,
+                        mGate,
+                        (sCumsumlog, sCumprod),
+                        load_gate_producer,
+                        (
+                            chunk_start + prefetch_idx * self.b_t,
+                            head_idx,
+                            prefetch_idx >= num_valid_chunks_b - 1,
+                            chunk_end,
+                        ),
+                    )
+                if num_chunks_b > 2:
+                    for prefetch_idx in range(2, num_gate_prefetch):
+                        load_gate_producer = self.load_gate_warp(
+                            tidx,
+                            mGate,
+                            (sCumsumlog, sCumprod),
+                            load_gate_producer,
+                            (
+                                chunk_start + prefetch_idx * self.b_t,
+                                head_idx,
+                                prefetch_idx >= num_valid_chunks_b - 1,
+                                chunk_end,
+                            ),
+                        )
+                for chunk_idx in cutlass.range(num_chunks_b):
+                    prefetch_idx = chunk_idx + num_gate_prefetch
+                    if prefetch_idx < num_chunks_b:
+                        load_gate_producer = self.load_gate_warp(
+                            tidx,
+                            mGate,
+                            (sCumsumlog, sCumprod),
+                            load_gate_producer,
+                            (
+                                chunk_start + prefetch_idx * self.b_t,
+                                head_idx,
+                                prefetch_idx >= num_valid_chunks_b - 1,
+                                chunk_end,
+                            ),
+                        )
+                    o_store_consumer = self.epilogue_warp(
+                        (sO,),
+                        (tma_o,),
+                        (o_store_consumer,),
+                        (head_idx, chunk_start + chunk_idx * self.b_t),
+                        (tensormap_manager, tensormap_o_ptr),
+                    )
+            load_gate_producer.tail()
+
+    # ------------------------------------------------------------------
+    # Per-warp methods  (called from kernel's chunk loop)
+    @cute.jit
+    def tma_t_warp(
+        self,
+        tiled_mma_qkv: cute.TiledMma,
+        tma_t: TmaInfo,
+        sT: cute.Tensor,
+        load_t_producer: pipeline.PipelineProducer,
+        t_block_idx: cutlass.Int32,
+        head_idx: cutlass.Int32,
+    ) -> pipeline.PipelineProducer:
+        """Load one signed, beta-folded T tile into its MMA-B SMEM layout."""
+        t_handle = load_t_producer.acquire_and_advance()
+        mT = tma_t.tma_tensor[None, None, head_idx, t_block_idx]
+        gT = cute.flat_divide(
+            mT,
+            (self.b_t, self.b_t),
+        )
+        tCgT = tiled_mma_qkv.get_slice(0).partition_B(gT)
+        tTsT, tTgT = cpasync.tma_partition(
+            tma_t.atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sT, 0, 3),
+            cute.group_modes(tCgT, 0, 3),
+        )
+        cute.copy(
+            tma_t.atom,
+            tTgT[(None, 0, 0)],
+            tTsT[(None, t_handle.index)],
+            tma_bar_ptr=t_handle.barrier,
+        )
+        return load_t_producer
+
+    @cute.jit
+    def load_gate_warp(
+        self,
+        tidx: cutlass.Int32,
+        gate: cute.Tensor,
+        smem_args: tuple,
+        load_gate_producer: pipeline.PipelineProducer,
+        work_args: tuple,
+    ) -> pipeline.PipelineProducer:
+        """Warp 10: load and prefix-process gate[BT] for the current chunk.
+
+        Gate is loaded via ldg (sync G->R), then preprocessed into cumsum-log
+        and cumprod channels in SMEM.
+
+        The last tile uses predicated copies: elements with linear index >= valid_tokens
+        are out-of-bounds and receive the neutral gate value one.
+
+        Thread tidx (lane 0..31) owns positions tidx, tidx+32, tidx+64, tidx+96.
+        """
+        sCumsumlog, sCumprod = smem_args
+        chunk_offset, head_idx, is_last_tile, batch_end = work_args
+
+        # lane index
+        lidx = tidx % self.threads_per_warp
+
+        gGate = cute.domain_offset((chunk_offset,), gate[None, head_idx])
+        cGate = cute.domain_offset(
+            (chunk_offset,), cute.make_identity_tensor(gate[None, head_idx].shape)
+        )
+        gGate = cute.flat_divide(gGate, (self.b_t,))[None, 0]
+        cGate = cute.flat_divide(cGate, (self.b_t,))[None, 0]
+
+        # Tiled copy: 1D thread/value layouts; partition_S/D handle element mapping.
+        # thread_layout (32,): each of the 32 lanes maps to one row of the b_t tile.
+        # value_layout  (4,) : each lane owns 4 elements strided by threads_per_warp.
+        thread_layout = cute.make_layout((self.threads_per_warp,), stride=(1,))
+        value_layout = cute.make_layout((1,), stride=(1,))
+
+        # Gate: sync G->R (ldg), apply ln + prefix sum, then R->S (sts)
+        atom_gate_g2r = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=32
+        )
+        tiled_copy_gate_g2r = cute.make_tiled_copy_tv(
+            atom_gate_g2r, thread_layout, value_layout
+        )
+
+        # Per-thread partitions (1D tensors; no manual 2D reshaping needed)
+        thr_copy_gate_g2r = tiled_copy_gate_g2r.get_slice(lidx)
+        tGgGate = thr_copy_gate_g2r.partition_S(gGate)
+        tGsCumsumlog = thr_copy_gate_g2r.partition_D(sCumsumlog)
+        tGsCumprod = thr_copy_gate_g2r.partition_D(sCumprod)
+
+        gate_handle = load_gate_producer.acquire_and_advance()
+
+        rGate = cute.make_rmem_tensor_like(tGgGate, self.acc_dtype)
+        tGrGate = tiled_copy_gate_g2r.retile(rGate)
+        rCumprod = cute.make_rmem_tensor_like(tGgGate, self.acc_dtype)
+        tGrCumprod = tiled_copy_gate_g2r.retile(rCumprod)
+
+        # Compute the tail predicate once for the gate tile.
+        tGcGate = thr_copy_gate_g2r.partition_S(cGate)
+        tGpGate = cute.make_rmem_tensor(
+            ((tGcGate.shape[0][1],), tGcGate.shape[1]), cutlass.Boolean
+        )
+        if is_last_tile:
+            valid_tokens = batch_end  # noqa: F841
+            for i in range(cute.size(tGpGate)):
+                tGpGate[i] = cute.elem_less(tGcGate[i][0], batch_end)
+
+        # --- Gate load ---
+        if is_last_tile:
+            # OOB neutral: 1.0 -> log2 ~= 0.0 (no decay contribution)
+            tGrGate.fill(1.0)
+            cute.copy(tiled_copy_gate_g2r, tGgGate, tGrGate, pred=tGpGate)
+        else:
+            cute.copy(tiled_copy_gate_g2r, tGgGate, tGrGate)
+
+        # --- log2 + warp-wide inclusive prefix sum + SMEM store (always) ---
+        for i in range(cute.size(tGrGate)):
+            tGrGate[i] = cute.math.log2(tGrGate[i] + 1e-10, fastmath=True)
+        for offset in [1, 2, 4, 8, 16]:
+            for col in range(cute.size(tGrGate)):
+                n = cute.arch.shuffle_sync_up(
+                    tGrGate[col], offset, mask=0xFFFFFFFF, mask_and_clamp=0
+                )
+                if lidx >= offset:
+                    tGrGate[col] = tGrGate[col] + n
+        sum_v = 0.0  # noqa: F841
+        for col in range(1, cute.size(tGrGate)):
+            last_v = cute.arch.shuffle_sync(
+                tGrGate[col - 1],
+                self.threads_per_warp - 1,
+                mask=0xFFFFFFFF,
+                mask_and_clamp=self.threads_per_warp - 1,
+            )
+            tGrGate[col] += last_v
+        for col in range(cute.size(tGrGate)):
+            tGrCumprod[col] = cute.math.exp2(tGrGate[col], fastmath=True)
+        cute.copy(
+            tiled_copy_gate_g2r, tGrGate, tGsCumsumlog[None, None, 0, gate_handle.index]
+        )
+        cute.copy(
+            tiled_copy_gate_g2r,
+            tGrCumprod,
+            tGsCumprod[None, None, 0, gate_handle.index],
+        )
+        gate_handle.commit()
+
+        return load_gate_producer
+
+    @cute.jit
+    def mma_cg0_warp(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Warp 8: issue Q @ K.T for the CP score path."""
+        tiled_mma_qk, tiled_mma_qkv = mma_args
+        sQ, sK = smem_args
+        shared_acc_producer, load_k_consumer, load_q_consumer = pipeline_args
+
+        acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtAcc_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_cg0_shared_acc_stages)
+        )
+        tCtShared = cute.make_tensor(
+            tmem_ptr + self.tmem_cg0_shared_acc_offset, tCtAcc_fake.layout
+        )
+
+        tCrK_B = tiled_mma_qk.make_fragment_B(sK)
+        tCrQ_A = tiled_mma_qk.make_fragment_A(sQ)
+
+        k_handle = load_k_consumer.wait_and_advance()
+        q_handle = load_q_consumer.wait_and_advance()
+        qk_handle = shared_acc_producer.acquire_and_advance()
+        num_kphases = cute.size(tCrQ_A, mode=[2])
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qk,
+                tCtShared[None, None, None, qk_handle.index],
+                tCrQ_A[None, None, kphase_idx, q_handle.index],
+                tCrK_B[None, None, kphase_idx, k_handle.index],
+                tCtShared[None, None, None, qk_handle.index],
+            )
+        qk_handle.commit()
+        q_handle.release()
+        k_handle.release()
+
+        return shared_acc_producer, load_k_consumer, load_q_consumer
+
+    @cute.jit
+    def compute_group_0_cp(
+        self,
+        tidx: cutlass.Int32,
+        tmem_ptr: cutlass.Int64,
+        scale: cutlass.Float32,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ):
+        """Materialize gamma-scaled QK and signed-T operands for tcgen05."""
+        (tiled_mma_qk,) = mma_args
+        sCumsumlog, sT, sAinv, sQk = smem_args
+        (
+            load_gate_consumer,
+            load_t_consumer,
+            aux_acc_consumer,
+            t_ready_producer,
+            qk_ready_producer,
+        ) = pipeline_args
+        is_final_block, valid_tokens = work_args
+
+        num_threads_cg0 = self.threads_per_warp * len(self.compute_group_0_warp_ids)
+        cg0_tidx = tidx % num_threads_cg0
+        tAcc_shape = tiled_mma_qk.partition_shape_C(
+            (self.mma_tiler_qk[0], self.mma_tiler_qk[1])
+        )
+        tAcc = tiled_mma_qk.make_fragment_C(tAcc_shape)
+        tAcc = cute.make_tensor(
+            tAcc.iterator,
+            cute.flat_product(
+                tAcc.layout,
+                cute.make_layout((self.tmem_cg0_shared_acc_stages,), stride=(1,)),
+            ),
+        )
+        tStS = cute.make_tensor(tmem_ptr + self.tmem_cg0_shared_acc_offset, tAcc.layout)
+        tStS_mn = self.transform_partitioned_tensor_layout(tStS)
+        cS = cute.make_identity_tensor((self.mma_tiler_qk[0], self.mma_tiler_qk[1]))
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_t2r = tcgen05.make_tmem_copy(atom_t2r, tStS[(None, None), 0, 0, 0])
+        thr_t2r = tiled_t2r.get_slice(cg0_tidx)
+        tTR_tStS = thr_t2r.partition_S(tStS_mn)
+        tTR_cS = thr_t2r.partition_D(cS)
+
+        sT_mn = self.transform_partitioned_tensor_layout(sT)
+        sAinv_mn = self.transform_partitioned_tensor_layout(sAinv)
+
+        gate_handle = load_gate_consumer.wait_and_advance()
+        t_handle = load_t_consumer.wait_and_advance()
+        t_ready_handle = t_ready_producer.acquire_and_advance()
+        copy_mma = cute.make_tiled_mma(
+            cute.nvgpu.warp.MmaF16BF16Op(self.io_dtype, self.acc_dtype, (16, 8, 16)),
+            cute.make_layout((4, 1, 1)),
+            permutation_mnk=(self.b_t, self.b_t, 16),
+        )
+        atom_t_s2r = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+            self.io_dtype,
+        )
+        tiled_t_s2r = cute.make_tiled_copy_C(atom_t_s2r, copy_mma)
+        thr_t_s2r = tiled_t_s2r.get_slice(cg0_tidx)
+        tTsT = thr_t_s2r.partition_S(sT_mn)
+        rT = cute.make_rmem_tensor(
+            copy_mma.partition_shape_C((self.b_t, self.b_t)),
+            self.io_dtype,
+        )
+        tTrT = thr_t_s2r.retile(rT)
+        cute.copy(
+            tiled_t_s2r,
+            tTsT[None, None, None, t_handle.index],
+            tTrT,
+        )
+
+        cT = cute.make_identity_tensor((self.b_t, self.b_t))
+        tTcT = thr_t_s2r.partition_D(cT)
+        tTcT = thr_t_s2r.retile(tTcT)
+        for i in cutlass.range_constexpr(cute.size(tTrT)):
+            t, s = tTcT[i]
+            pred = s >= t
+            if is_final_block:
+                pred = pred and s < valid_tokens and t < valid_tokens
+            gamma = cutlass.Float32(0.0)
+            if pred:
+                gamma = cute.math.exp2(
+                    sCumsumlog[s, 0, gate_handle.index]
+                    - sCumsumlog[t, 0, gate_handle.index],
+                    fastmath=True,
+                )
+            tTrT[i] = self.io_dtype(-gamma * cutlass.Float32(tTrT[i]))
+
+        sAinv_t = cute.make_tensor(
+            sAinv_mn.iterator,
+            cute.select(sAinv_mn.layout, mode=[1, 0, 2]),
+        )
+        atom_t_r2s = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=True),
+            self.io_dtype,
+        )
+        tiled_t_r2s = cute.make_tiled_copy_C(atom_t_r2s, copy_mma)
+        thr_t_r2s = tiled_t_r2s.get_slice(cg0_tidx)
+        tTsAinv = thr_t_r2s.partition_D(sAinv_t)
+        tTsAinv = cute.make_tensor(tTsAinv.iterator.align(16), tTsAinv.layout)
+        tTrT_r2s = thr_t_r2s.retile(rT)
+        cute.copy(
+            tiled_t_r2s,
+            tTrT_r2s,
+            tTsAinv[None, None, None, t_ready_handle.index],
+        )
+        cute.arch.fence_view_async_shared()
+        self.t_store_barrier.arrive_and_wait()
+        t_handle.release()
+        t_ready_handle.commit()
+
+        qk_ready_handle = qk_ready_producer.acquire_and_advance()
+        qk_handle = aux_acc_consumer.wait_and_advance()
+        tQKrQK = cute.make_rmem_tensor_like(tTR_cS, self.acc_dtype)
+        tQKrQK_out = cute.make_rmem_tensor_like(tQKrQK, self.io_dtype)
+        atom_qk_r2s = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+            self.io_dtype,
+        )
+        tiled_qk_r2s = cute.make_tiled_copy_D(atom_qk_r2s, tiled_t2r)
+        tQsQK = tiled_qk_r2s.get_slice(cg0_tidx).partition_D(
+            self.transform_partitioned_tensor_layout(sQk)
+        )
+        tQrQK = tiled_qk_r2s.retile(tQKrQK_out)
+        for sub in cutlass.range_constexpr(tQKrQK.shape[2]):
+            cute.copy(
+                tiled_t2r,
+                tTR_tStS[None, 0, sub, qk_handle.index],
+                tQKrQK[None, 0, sub],
+            )
+            for i in cutlass.range(32):
+                s, t = tTR_cS[i, 0, sub]
+                pred = s >= t
+                if is_final_block:
+                    pred = pred and s < valid_tokens and t < valid_tokens
+                gamma = cutlass.Float32(0.0)
+                if pred:
+                    gamma = cute.math.exp2(
+                        sCumsumlog[s, 0, gate_handle.index]
+                        - sCumsumlog[t, 0, gate_handle.index],
+                        fastmath=True,
+                    )
+                tQKrQK_out[i, 0, sub] = self.io_dtype(tQKrQK[i, 0, sub] * gamma * scale)
+            cute.copy(
+                tiled_qk_r2s,
+                tQrQK[None, 0, sub],
+                tQsQK[None, 0, sub, qk_ready_handle.index],
+            )
+        cute.arch.fence_view_async_shared()
+        qk_handle.release()
+        qk_ready_handle.commit()
+        gate_handle.release()
+        return (
+            load_gate_consumer,
+            load_t_consumer,
+            aux_acc_consumer,
+            t_ready_producer,
+            qk_ready_producer,
+        )
+
+    def transform_partitioned_tensor_layout(self, tensor: cute.Tensor) -> cute.Tensor:
+        """
+        Transform MMA layout from ((MMA_ATOM_M, MMA_ATOM_N), MMA_M, MMA_N, ...rest)
+        to ((MMA_ATOM_M, MMA_M), (MMA_ATOM_N, MMA_N), ...rest).
+
+        This groups MMA_ATOM_M with MMA_M and MMA_ATOM_N with MMA_N.
+
+        :param tensor: Input tensor with layout ((MMA_ATOM_M, MMA_ATOM_N), MMA_M, MMA_N, ...rest)
+        :type tensor: cute.Tensor
+        :return: Transformed tensor with layout ((MMA_ATOM_M, MMA_M), (MMA_ATOM_N, MMA_N), ...rest)
+        :rtype: cute.Tensor
+        """
+        layout = tensor.layout
+        # Save original layout in case it is a composed layout
+        stored_layout = layout
+
+        if isinstance(stored_layout, cute.ComposedLayout):
+            # For composed layouts, we only modify the outer layout
+            layout = layout.outer
+
+        shape = layout.shape
+        stride = layout.stride
+
+        # Build new shape: ((shape[0][0], shape[1]), (shape[0][1], shape[2]), ...rest)
+        new_shape = ((shape[0][0], shape[1]), (shape[0][1], shape[2]), *shape[3:])
+
+        # Build new stride: ((stride[0][0], stride[1]), (stride[0][1], stride[2]), ...rest)
+        new_stride = ((stride[0][0], stride[1]), (stride[0][1], stride[2]), *stride[3:])
+
+        new_layout = cute.make_layout(shape=new_shape, stride=new_stride)
+
+        if isinstance(stored_layout, cute.ComposedLayout):
+            # Recreate the composed layout
+            new_layout = cute.make_composed_layout(
+                stored_layout.inner, stored_layout.offset, new_layout
+            )
+
+        return cute.make_tensor(tensor.iterator, new_layout)
+
+    # -----------------------------------------------------------------------
+    @cute.jit
+    def mma_cg0_pair_cp(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+    ):
+        for _ in range(2):
+            pipeline_args = self.mma_cg0_warp(
+                tmem_ptr,
+                mma_args,
+                smem_args,
+                pipeline_args,
+                (),
+            )
+        return pipeline_args
+
+    @cute.jit
+    def compute_group_0_pair_cp(
+        self,
+        tidx: cutlass.Int32,
+        tmem_ptr: cutlass.Int64,
+        scale: cutlass.Float32,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ):
+        pair_idx, _, num_valid_chunks, chunk_len = work_args
+        for chunk_in_pair in range(2):
+            chunk_idx = pair_idx * 2 + chunk_in_pair
+            valid_tokens = chunk_len - chunk_idx * self.b_t
+            pipeline_args = self.compute_group_0_cp(
+                tidx,
+                tmem_ptr,
+                scale,
+                mma_args,
+                smem_args,
+                pipeline_args,
+                (chunk_idx >= num_valid_chunks - 1, valid_tokens),
+            )
+        return pipeline_args
+
+    @cute.jit
+    def tma_qkv_warp(
+        self,
+        mma_args: tuple,
+        tma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+        tensormap_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineProducer, pipeline.PipelineProducer, pipeline.PipelineProducer
+    ]:
+        """Warp 9: load Q, K (double-buffered), V for the current chunk.
+
+        TMA load pattern:
+          1. domain_offset the TMA tensor to (chunk_offset, head_idx, 0) so that
+             the logical tile (0, ...) maps to the current chunk.
+          2. flat_divide to obtain the tiled global view.
+          3. thr_mma.partition_{A,B} to get the TMA-compatible per-thread view.
+          4. cpasync.tma_partition -> (tXsX, tXgX) SMEM/global pairs.
+          5. acquire pipeline stage, issue cute.copy, signal mbarrier.
+
+        Note on head coordinate: head_idx is the flat KV-head index in [0, h_qv).
+        For the hierarchical head layout (h_r, h_qv) with h_r having stride 0
+        (broadcast), the flat index maps correctly as long as head_idx < h_qv.
+        """
+        tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv = mma_args
+        tma_q, tma_k, tma_v = tma_args
+        sQ, sK, sV = smem_args
+        load_q_producer, load_k_producer, load_v_producer = pipeline_args
+        chunk_offset, chunk_idx, batch_idx, head_idx = work_args
+        tensormap_manager, tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr = (
+            tensormap_args
+        )
+
+        # Single-CTA mode: no multicast, cta_v = 0.
+        cta_layout = cute.make_layout(1)
+
+        # Per-thread MMA slices (cta_v=0 for ONE-CTA mode).
+        thr_mma_qk = tiled_mma_qk.get_slice(0)
+        thr_mma_qkv_ss = tiled_mma_qkv_ss.get_slice(0)
+
+        # Tile shapes from the MMA tiler (128, 128, 128):
+        #   mode[0,2] = (BT, DK) - M,K tile for A (Q) and for B (K) of tiled_mma_qk
+        #   mode[1,2] = (BT, DV) - tile shape for loading V (B operand in GEMMs 5/6)
+        # (BT, DK)
+        qk_tile = cute.select(self.mma_tiler_qk, mode=[0, 2])
+        # (DV, BT)
+        v_tile = cute.select(self.mma_tiler_qkv, mode=[0, 2])
+
+        # ------------------------------------------------------------------
+        # K  (B operand of GEMM-kk / GEMM-qk, double-buffered)
+        # Tensor shape: (total_tokens, H_hier, DK)
+        # TMA tile:     (BT, DK)
+        # ------------------------------------------------------------------
+        mK = cute.domain_offset(
+            (chunk_offset, cutlass.Int32(0)), tma_k.tma_tensor[None, None, head_idx]
+        )
+        # (..., num_k_tiles, ...)
+        gK = cute.flat_divide(mK, qk_tile)
+        tCgK = thr_mma_qk.partition_B(gK)
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_k.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sK, 0, 3),
+            cute.group_modes(tCgK, 0, 3),
+        )
+
+        # Load K for the current chunk into the next available pipeline stage.
+        k_handle = load_k_producer.acquire_and_advance()
+        if chunk_idx == 0:
+            tensormap_manager.fence_tensormap_update(tensormap_k_ptr)
+
+        cute.copy(
+            tma_k.atom,
+            tKgK[(None, 0, 0)],
+            tKsK[(None, k_handle.index)],
+            tma_bar_ptr=k_handle.barrier,
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_k_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        # ------------------------------------------------------------------
+        # Q  (A operand of GEMM-qk, single-buffered)
+        # ------------------------------------------------------------------
+        mQ = cute.domain_offset(
+            (chunk_offset, cutlass.Int32(0)), tma_q.tma_tensor[None, None, head_idx]
+        )
+        gQ = cute.flat_divide(mQ, qk_tile)
+        tCgQ = thr_mma_qk.partition_A(gQ)
+        tQsQ, tQgQ = cpasync.tma_partition(
+            tma_q.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sQ, 0, 3),
+            cute.group_modes(tCgQ, 0, 3),
+        )
+
+        q_handle = load_q_producer.acquire_and_advance()
+        if chunk_idx == 0:
+            tensormap_manager.fence_tensormap_update(tensormap_q_ptr)
+        cute.copy(
+            tma_q.atom,
+            tQgQ[(None, 0, 0)],
+            tQsQ[(None, q_handle.index)],
+            tma_bar_ptr=q_handle.barrier,
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_q_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        # ------------------------------------------------------------------
+        # V  (B operand of GEMM-new_v / GEMM-qkv, single-buffered)
+        # ------------------------------------------------------------------
+        mV = cute.domain_offset(
+            (cutlass.Int32(0), chunk_offset), tma_v.tma_tensor[None, None, head_idx]
+        )
+        gV = cute.flat_divide(mV, v_tile)
+        tCgV = thr_mma_qkv_ss.partition_A(gV)
+        tVsV, tVgV = cpasync.tma_partition(
+            tma_v.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sV, 0, 3),
+            cute.group_modes(tCgV, 0, 3),
+        )
+
+        v_handle = load_v_producer.acquire_and_advance()
+        if chunk_idx == 0:
+            tensormap_manager.fence_tensormap_update(tensormap_v_ptr)
+        cute.copy(
+            tma_v.atom,
+            tVgV[(None, 0, 0)],
+            tVsV[(None, v_handle.index)],
+            tma_bar_ptr=v_handle.barrier,
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_v_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        return load_q_producer, load_k_producer, load_v_producer
+
+    @cute.jit
+    def _load_cp_initial_state(
+        self,
+        tidx,
+        mFixedState,
+        mInitialState,
+        head_idx,
+        seq_idx,
+        cp_chunk_idx_in_seq,
+        cp_chunk_idx,
+        tmem_ptr,
+        tiled_mma_kv,
+        kv_acc_producer,
+    ):
+        if cutlass.const_expr(self.needs_initial_state):
+            if cp_chunk_idx_in_seq > 0:
+                kv_acc_producer = self._load_initial_state(
+                    tidx,
+                    mFixedState,
+                    None,
+                    head_idx,
+                    cp_chunk_idx - 1,
+                    tmem_ptr,
+                    tiled_mma_kv,
+                    kv_acc_producer,
+                )
+            else:
+                kv_acc_producer = self._load_initial_state(
+                    tidx,
+                    mInitialState,
+                    None,
+                    head_idx,
+                    seq_idx,
+                    tmem_ptr,
+                    tiled_mma_kv,
+                    kv_acc_producer,
+                )
+        else:
+            if cp_chunk_idx_in_seq > 0:
+                kv_acc_producer = self._load_initial_state(
+                    tidx,
+                    mFixedState,
+                    None,
+                    head_idx,
+                    cp_chunk_idx - 1,
+                    tmem_ptr,
+                    tiled_mma_kv,
+                    kv_acc_producer,
+                )
+            else:
+                kv_acc_producer = self._zero_initial_state(
+                    tidx, tmem_ptr, tiled_mma_kv, kv_acc_producer
+                )
+        return kv_acc_producer
+
+    @cute.jit
+    def _zero_initial_state(self, tidx, tmem_ptr, tiled_mma_kv, kv_acc_producer):
+        num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
+        cg1_tidx = tidx % num_threads_cg1
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+        tCtState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState
+        )
+        state_r2t_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        cState = cute.make_identity_tensor((self.mma_tiler_kv[0], self.mma_tiler_kv[1]))
+        tiled_state_r2t = tcgen05.make_tmem_copy(
+            state_r2t_atom, tCtState[(None, None), 0, 0, 0]
+        )
+        thr_state_r2t = tiled_state_r2t.get_slice(cg1_tidx)
+        tRT_tCtState = thr_state_r2t.partition_D(tCtState_mn_view)
+        tRT_tCcState = thr_state_r2t.partition_S(cState)
+        rState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
+        rState.fill(0.0)
+
+        kv_acc_handle = kv_acc_producer.acquire_and_advance()
+        for sub in cutlass.range(rState.shape[2]):
+            cute.copy(
+                tiled_state_r2t,
+                rState[None, 0, sub],
+                tRT_tCtState[None, 0, sub, kv_acc_handle.index],
+            )
+        cute.arch.fence_view_async_tmem_store()
+        self.init_state_store_barrier.arrive_and_wait()
+        if cg1_tidx == 0:
+            cute.arch.mbarrier_arrive(kv_acc_handle.barrier)
+        return kv_acc_producer
+
+    @cute.jit
+    def _load_initial_state(
+        self,
+        tidx,
+        mS_init,
+        mS_indices,
+        head_idx,
+        batch_idx,
+        tmem_ptr,
+        tiled_mma_kv,
+        kv_acc_producer,
+    ) -> pipeline.PipelineProducer:
+        """Load S_init from GMEM into state TMEM (fp32).
+
+        Two steps:
+          1. GMEM fp32 -> registers
+          2. registers -> state TMEM (fp32), then signal the state-update issuer
+        """
+        num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
+        cg1_tidx = tidx % num_threads_cg1
+
+        # Build state TMEM store copy (registers -> state TMEM)
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+        tCtState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState
+        )
+        state_r2t_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        cState = cute.make_identity_tensor((self.mma_tiler_kv[0], self.mma_tiler_kv[1]))
+        tCtState_for_r2t = tCtState[(None, None), 0, 0, 0]
+        tiled_state_r2t = tcgen05.make_tmem_copy(state_r2t_atom, tCtState_for_r2t)
+        thr_state_r2t = tiled_state_r2t.get_slice(cg1_tidx)
+        tRT_tCtState = thr_state_r2t.partition_D(tCtState_mn_view)
+        tRT_tCcState = thr_state_r2t.partition_S(cState)
+        tRT_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
+        tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.state_dtype)
+
+        if cutlass.const_expr(mS_indices is not None):
+            state_row = mS_indices[batch_idx]
+        else:
+            state_row = batch_idx
+        gS_init = cute.flat_divide(
+            mS_init[None, None, head_idx, state_row],
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+        )[None, None, 0, 0]
+        tGR_tCgState = thr_state_r2t.partition_S(gS_init)
+        kv_acc_handle = kv_acc_producer.acquire_and_advance()
+        for sub in cutlass.range(tGR_tCrState.shape[2]):
+            # 1. Load S_init state_dtype GMEM -> state_dtype registers
+            cute.autovec_copy(
+                tGR_tCgState[None, 0, sub],
+                tGR_tCrState[None, 0, sub],
+                l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+            )
+            if cutlass.const_expr(self.acc_dtype != self.state_dtype):
+                tRT_tCrState[None, 0, sub].store(
+                    tGR_tCrState[None, 0, sub].load().to(self.acc_dtype)
+                )
+            else:
+                tRT_tCrState = tGR_tCrState
+
+            # 2. fp32 registers -> state TMEM; the state update accumulates on top.
+            cute.copy(
+                tiled_state_r2t,
+                tRT_tCrState[None, 0, sub],
+                tRT_tCtState[None, 0, sub, kv_acc_handle.index],
+            )
+        cute.arch.fence_view_async_tmem_store()
+
+        # Manually sync before committing - CG1 is not the MMA warp so uses mbarrier_arrive.
+        self.init_state_store_barrier.arrive_and_wait()
+        if cg1_tidx == 0:
+            cute.arch.mbarrier_arrive(kv_acc_handle.barrier)
+
+        return kv_acc_producer
+
+    @cute.jit
+    def _store_final_state(
+        self,
+        tidx,
+        # full output-state GMEM tensor (DK, DV, (h_r, h_qv), B) fp32
+        mS_out,
+        mS_indices,
+        head_idx,
+        batch_idx,
+        tmem_ptr,
+        tiled_mma_kv,
+        # MMA -> CG1 consumer; waited+released inside this method
+        kv_acc_consumer,
+        seqlen_b,
+        mS_checkpoints,
+        checkpoint_offset,
+        checkpoint_every_n_tokens,
+    ):
+        """Store final recurrent state from TMEM (fp32) to GMEM mS_out.
+
+        Waits for the last GEMM-7 (kv_acc) to complete, reads state TMEM -> registers,
+        writes registers -> GMEM fp32, then releases the consumer handle.
+        """
+        num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
+        cg1_tidx = tidx % num_threads_cg1
+
+        # Build state TMEM layout (mirrors compute_group_1 setup)
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+        tCtState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState
+        )
+        tCcState = cute.make_identity_tensor(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+
+        # TMEM -> registers  (Ld32x32b)
+        atom_state_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        tCtState_for_t2r = tCtState[(None, None), 0, 0, 0]
+        tiled_state_t2r = tcgen05.make_tmem_copy(atom_state_t2r, tCtState_for_t2r)
+        thr_state_t2r = tiled_state_t2r.get_slice(cg1_tidx)
+        tTR_tCtState = thr_state_t2r.partition_S(tCtState_mn_view)
+        tTR_tCcState = thr_state_t2r.partition_D(tCcState)
+        tTR_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.acc_dtype)
+        tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
+
+        # Wait for last GEMM-7 to finish.
+        kv_acc_handle = kv_acc_consumer.wait_and_advance()
+
+        for sub in cutlass.range(tTR_rState.shape[2]):
+            cute.copy(
+                tiled_state_t2r,
+                tTR_tCtState[None, 0, sub, kv_acc_handle.index],
+                tTR_rState[None, 0, sub],
+            )
+            if cutlass.const_expr(self.acc_dtype != self.state_dtype):
+                tRG_rState[None, 0, sub].store(
+                    tTR_rState[None, 0, sub].load().to(self.state_dtype)
+                )
+            else:
+                tRG_rState = tTR_rState
+            if cutlass.const_expr(self.enable_checkpoints):
+                if seqlen_b % checkpoint_every_n_tokens == 0:
+                    num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                    if num_valid_chunks_b % 2 == 0:
+                        gS_checkpoints = cute.flat_divide(
+                            mS_checkpoints[None, None, head_idx, checkpoint_offset],
+                            (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+                        )[None, None, 0, 0]
+                        tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
+                        cute.autovec_copy(
+                            tRG_rState[None, 0, sub],
+                            tSgCheckpoints[None, 0, sub],
+                            l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                        )
+            if cutlass.const_expr(self.store_final_state):
+                if cutlass.const_expr(mS_indices is not None):
+                    state_row = mS_indices[batch_idx]
+                else:
+                    state_row = batch_idx
+                gS_out = cute.flat_divide(
+                    mS_out[None, None, head_idx, state_row],
+                    (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+                )[None, None, 0, 0]
+                tRG_tCgState = thr_state_t2r.partition_D(gS_out)
+                cute.autovec_copy(
+                    tRG_rState[None, 0, sub],
+                    tRG_tCgState[None, 0, sub],
+                    l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                )
+        kv_acc_handle.release()
+        return kv_acc_consumer
+
+    @cute.jit
+    def mma_cg1_chunk(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        is_first_chunk: cutlass.Boolean,
+    ) -> tuple:
+        """Issue KS/QS/NV/QKV/KV for one chunk."""
+        tiled_mma_qs, tiled_mma_qkv, _, tiled_mma_kv = mma_args
+        sQ, sK, sK_trans, sV, sAinv, sQk = smem_args
+        (
+            cg1_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
+        ) = pipeline_args
+
+        acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtShared_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_cg1_shared_acc_stages)
+        )
+        tCtShared = cute.make_tensor(
+            tmem_ptr + self.tmem_cg1_shared_acc_offset, tCtShared_fake.layout
+        )
+
+        shared_inp_shape = tiled_mma_qkv.partition_shape_A(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
+        )
+        tCtSharedInp_fake = tiled_mma_qkv.make_fragment_A(
+            cute.append(shared_inp_shape, self.tmem_shared_inp_stages)
+        )
+        tCtSharedInp = cute.make_tensor(
+            cute.recast_ptr(
+                tmem_ptr + self.tmem_shared_inp_offset, dtype=self.io_dtype
+            ),
+            tCtSharedInp_fake.layout,
+        )
+
+        qs_acc_shape = tiled_mma_qs.partition_shape_C(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
+        )
+        tCtQState_fake = tiled_mma_qs.make_fragment_C(
+            cute.append(qs_acc_shape, self.tmem_q_state_acc_stages)
+        )
+        tCtQState = cute.make_tensor(
+            tmem_ptr + self.tmem_q_state_offset, tCtQState_fake.layout
+        )
+
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+
+        state_inp_shape = tiled_mma_qs.partition_shape_A(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
+        )
+        tCtStateInp_fake = tiled_mma_qs.make_fragment_A(
+            cute.append(state_inp_shape, self.tmem_state_inp_stages)
+        )
+        tCtStateInp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_state_inp_offset, dtype=self.io_dtype),
+            tCtStateInp_fake.layout,
+        )
+
+        tCrK_B_qs = tiled_mma_qs.make_fragment_B(sK)
+        tCrQ_B_qs = tiled_mma_qs.make_fragment_B(sQ)
+        tCrAinv_B = tiled_mma_qkv.make_fragment_B(sAinv)
+        tCrNv_B = tiled_mma_qkv.make_fragment_B(sQk)
+        tCrKt_B = tiled_mma_kv.make_fragment_B(sK_trans)
+        num_kphases_qs = cute.size(tCtStateInp, mode=[2])
+        num_kphases_qkv = cute.size(tCrAinv_B, mode=[2])
+        num_kphases_kv = cute.size(tCrKt_B, mode=[2])
+
+        k_handle = load_k_consumer.wait_and_advance()
+        q_handle = load_q_consumer.wait_and_advance()
+        valid_state = is_first_chunk == False  # noqa: E712
+        if cutlass.const_expr(self.use_initial_state):
+            valid_state = True
+
+        if valid_state:
+            ks_handle = cg1_acc_producer.acquire_and_advance()
+            state_handle = state_inp_ready_consumer.wait_and_advance()
+            for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
+                tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qs,
+                    tCtShared[None, None, None, ks_handle.index],
+                    tCtStateInp[None, None, kphase_idx, state_handle.index],
+                    tCrK_B_qs[None, None, kphase_idx, k_handle.index],
+                    tCtShared[None, None, None, ks_handle.index],
+                )
+            ks_handle.commit()
+
+            qs_handle = q_state_acc_producer.acquire_and_advance()
+            for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
+                tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qs,
+                    tCtQState[None, None, None, qs_handle.index],
+                    tCtStateInp[None, None, kphase_idx, state_handle.index],
+                    tCrQ_B_qs[None, None, kphase_idx, q_handle.index],
+                    tCtQState[None, None, None, qs_handle.index],
+                )
+            qs_handle.commit()
+            state_handle.release()
+
+        q_handle.release()
+
+        nv_handle = cg1_acc_producer.acquire_and_advance()
+        vks_ready_consumer.wait_and_advance()
+        ainv_handle = a_inv_ready_consumer.wait_and_advance()
+        if valid_state:
+            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qkv,
+                    tCtShared[None, None, None, nv_handle.index],
+                    tCtSharedInp[None, None, kphase_idx, 0],
+                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                    tCtShared[None, None, None, nv_handle.index],
+                )
+        else:
+            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qkv,
+                    tCtShared[None, None, None, nv_handle.index],
+                    tCtSharedInp[None, None, kphase_idx, 0],
+                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                    tCtShared[None, None, None, nv_handle.index],
+                )
+        nv_handle.commit()
+        ainv_handle.release()
+
+        q_state_handle = q_state_acc_producer.acquire_and_advance()
+        qk_handle = qk_ready_consumer.wait_and_advance()
+        nv_ready_consumer.wait_and_advance()
+        for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+            tiled_mma_qkv.set(
+                tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0)
+            )
+            cute.gemm(
+                tiled_mma_qkv,
+                tCtQState[None, None, None, q_state_handle.index],
+                tCtSharedInp[None, None, kphase_idx, 0],
+                tCrNv_B[None, None, kphase_idx, qk_handle.index],
+                tCtQState[None, None, None, q_state_handle.index],
+            )
+        qk_handle.release()
+        q_state_handle.commit()
+
+        if cutlass.const_expr(self.use_initial_state):
+            if is_first_chunk:
+                kv_acc_producer.advance()
+        kv_handle = kv_acc_producer.acquire_and_advance()
+        decay_v_ready_consumer.wait_and_advance()
+        for kphase_idx in cutlass.range(num_kphases_kv, unroll_full=True):
+            tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0))
+            cute.gemm(
+                tiled_mma_kv,
+                tCtState[None, None, None, kv_handle.index],
+                tCtSharedInp[None, None, kphase_idx, 1],
+                tCrKt_B[None, None, kphase_idx, k_handle.index],
+                tCtState[None, None, None, kv_handle.index],
+            )
+        kv_handle.commit()
+        k_handle.release()
+
+        return (
+            cg1_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
+        )
+
+    @cute.jit
+    def compute_group_1_chunk(
+        self,
+        tidx: cutlass.Int32,
+        tmem_ptr: cutlass.Int64,
+        scale: cutlass.Float32,
+        mma_args: tuple,
+        smem_args: tuple,
+        checkpoint_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        cutlass.Int32,
+    ]:
+        """Warps 4-7: process one chunk from the caller-owned chunk stream."""
+        sV, sCumsumlog, sCumprod, sBeta, sO = smem_args
+        mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens = checkpoint_args
+        (
+            load_v_consumer,
+            load_gate_consumer,
+            cg1_shared_acc_consumer,
+            kv_acc_consumer,
+            q_state_acc_consumer,
+            kv_acc_producer,
+            state_inp_ready_producer,
+            vks_ready_producer,
+            nv_ready_producer,
+            decay_v_ready_producer,
+            o_store_producer,
+        ) = pipeline_args
+        tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv = mma_args
+        chunk_iter, num_pairs_b, head_idx, seqlen_b, is_first_chunk = work_args
+
+        # ------------------------------------------------------------------
+        # Preamble (identical to compute_group_1)
+        # ------------------------------------------------------------------
+        num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
+        cg1_tidx = tidx % num_threads_cg1
+
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+        tCtState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState
+        )
+        tCcState = cute.make_identity_tensor(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        atom_state_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        atom_state_r2t = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        tCtState_for_t2r = tCtState[(None, None), 0, 0, 0]
+        tiled_state_t2r = tcgen05.make_tmem_copy(atom_state_t2r, tCtState_for_t2r)
+        tiled_state_r2t = tcgen05.make_tmem_copy(atom_state_r2t, tCtState_for_t2r)
+        thr_state_t2r = tiled_state_t2r.get_slice(cg1_tidx)
+        thr_state_r2t = tiled_state_r2t.get_slice(cg1_tidx)
+        tTR_tCtState = thr_state_t2r.partition_S(tCtState_mn_view)
+        tTR_tCcState = thr_state_t2r.partition_D(tCcState)
+        tRT_tCtState = thr_state_r2t.partition_D(tCtState_mn_view)
+        tTR_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.acc_dtype)
+        tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
+
+        state_inp_shape = tiled_mma_qs.partition_shape_A(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
+        )
+        tCtState_inp_fake = tiled_mma_qs.make_fragment_A(
+            cute.append(state_inp_shape, self.tmem_state_inp_stages)
+        )
+        tCtState_inp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_state_inp_offset, dtype=self.io_dtype),
+            tCtState_inp_fake.layout,
+        )
+        tCtState_inp_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState_inp
+        )
+        tCcState_inp = cute.make_identity_tensor(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
+        )
+        atom_state_inp_r2t = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(16)), self.io_dtype
+        )
+        tCtState_inp_for_r2t = tCtState_inp_mn_view[None, None, 0]
+        tiled_state_inp_r2t = tcgen05.make_tmem_copy(
+            atom_state_inp_r2t, tCtState_inp_for_r2t
+        )
+        thr_state_inp_r2t = tiled_state_inp_r2t.get_slice(cg1_tidx)
+        tRT_tCcState_inp = thr_state_inp_r2t.partition_S(tCcState_inp)
+        tRT_tCtState_inp = thr_state_inp_r2t.partition_D(tCtState_inp_mn_view)
+        tRT_rState_inp = cute.make_rmem_tensor_like(tRT_tCcState_inp, self.io_dtype)
+
+        qkv_acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtShared_fake = tiled_mma_qkv.make_fragment_C(qkv_acc_shape)
+        tCtShared = cute.make_tensor(
+            tmem_ptr + self.tmem_cg1_shared_acc_offset,
+            cute.flat_product(
+                tCtShared_fake.layout,
+                cute.make_layout((self.tmem_cg1_shared_acc_stages,)),
+            ),
+        )
+        tCtShared_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtShared
+        )
+        tCcShared = cute.make_identity_tensor(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        atom_shared_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tCtShared_for_t2r = tCtShared[(None, None), 0, 0, 0]
+        tiled_shared_t2r = tcgen05.make_tmem_copy(atom_shared_t2r, tCtShared_for_t2r)
+        thr_shared_t2r = tiled_shared_t2r.get_slice(cg1_tidx)
+        tTR_tCtShared = thr_shared_t2r.partition_S(tCtShared_mn_view)
+        tTR_tCcShared = thr_shared_t2r.partition_D(tCcShared)
+
+        # Dedicated full-tile KS t2r (separate atom so it can be tuned
+        # independently of atom_shared_t2r used by NV/decay_v reads).
+        atom_ks_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_ks_t2r = tcgen05.make_tmem_copy(atom_ks_t2r, tCtShared_for_t2r)
+        thr_ks_t2r = tiled_ks_t2r.get_slice(cg1_tidx)
+        tTR_tCtKS = thr_ks_t2r.partition_S(tCtShared_mn_view)
+        tTR_tCcKS = thr_ks_t2r.partition_D(tCcShared)
+
+        qkv_inp_shape = tiled_mma_qkv.partition_shape_A(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
+        )
+        tCtShared_inp_fake = tiled_mma_qkv.make_fragment_A(
+            cute.append(qkv_inp_shape, self.tmem_shared_inp_stages)
+        )
+        tCtShared_inp = cute.make_tensor(
+            cute.recast_ptr(
+                tmem_ptr + self.tmem_shared_inp_offset, dtype=self.io_dtype
+            ),
+            tCtShared_inp_fake.layout,
+        )
+        tCtShared_inp_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtShared_inp
+        )
+        tCcShared_inp = cute.make_identity_tensor(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
+        )
+        atom_shared_inp_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x128bOp(tcgen05.copy.Repetition(8)), self.io_dtype
+        )
+        tCtShared_inp_for_r2t = tCtShared_inp_mn_view[None, None, 0]
+        tiled_shared_inp_r2t = tcgen05.make_tmem_copy(
+            atom_shared_inp_r2t, tCtShared_inp_for_r2t
+        )
+        thr_shared_inp_r2t = tiled_shared_inp_r2t.get_slice(cg1_tidx)
+        tRT_tCtShared_inp = thr_shared_inp_r2t.partition_D(tCtShared_inp_mn_view)
+
+        # Dedicated full-tile VKS r2t (separate atom so it can be tuned
+        # independently of atom_shared_inp_r2t used by NV/decay_v writes).
+        atom_vks_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x128bOp(tcgen05.copy.Repetition(8)), self.io_dtype
+        )
+        tiled_vks_r2t = tcgen05.make_tmem_copy(atom_vks_r2t, tCtShared_inp_for_r2t)
+        thr_vks_r2t = tiled_vks_r2t.get_slice(cg1_tidx)
+        tRT_tCtVKS_inp = thr_vks_r2t.partition_D(tCtShared_inp_mn_view)
+
+        qs_acc_shape = tiled_mma_qs.partition_shape_C(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
+        )
+        tCtQState_fake = tiled_mma_qs.make_fragment_C(
+            cute.append(qs_acc_shape, self.tmem_q_state_acc_stages)
+        )
+        tCtQState = cute.make_tensor(
+            tmem_ptr + self.tmem_q_state_offset, tCtQState_fake.layout
+        )
+        tCtQState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtQState
+        )
+        tCcQState = cute.make_identity_tensor(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
+        )
+        atom_qs_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        atom_qs_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tCtQState_for_t2r = tCtQState[(None, None), 0, 0, 0]
+        tiled_qs_t2r = tcgen05.make_tmem_copy(atom_qs_t2r, tCtQState_for_t2r)
+        tCtQState_for_r2t = tCtQState[(None, None), 0, 0, 0]
+        tiled_qs_r2t = tcgen05.make_tmem_copy(atom_qs_r2t, tCtQState_for_r2t)
+        thr_qs_t2r = tiled_qs_t2r.get_slice(cg1_tidx)
+        thr_qs_r2t = tiled_qs_r2t.get_slice(cg1_tidx)
+        tTR_tCtQS = thr_qs_t2r.partition_S(tCtQState_mn_view)
+        tTR_tCcQS = thr_qs_t2r.partition_D(tCcQState)
+        tRT_tCtQS = thr_qs_r2t.partition_D(tCtQState_mn_view)
+        tTR_rQS = cute.make_rmem_tensor_like(tTR_tCcQS, self.acc_dtype)
+
+        tRT_tCcV = thr_shared_inp_r2t.partition_S(tCcShared_inp)
+        atom_v_s2r = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+            self.io_dtype,
+        )
+        tiled_v_s2r = cute.make_tiled_copy_S(
+            atom_v_s2r,
+            tiled_shared_inp_r2t,
+        )
+        thr_v_s2r = tiled_v_s2r.get_slice(cg1_tidx)
+
+        atom_o_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_o_t2r = tcgen05.make_tmem_copy(atom_o_t2r, tCtQState_for_t2r)
+        thr_o_t2r = tiled_o_t2r.get_slice(cg1_tidx)
+        tTR_tOtO = thr_o_t2r.partition_S(tCtQState_mn_view)
+        tTR_tOcO = thr_o_t2r.partition_D(tCcQState)
+        atom_o_r2s = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=True),
+            self.io_dtype,
+        )
+        tiled_o_r2s = cute.make_tiled_copy_D(atom_o_r2s, tiled_o_t2r)
+        thr_o_r2s = tiled_o_r2s.get_slice(cg1_tidx)
+        tCsO = thr_o_r2s.partition_D(sO)
+
+        sub_tile_size = 32
+        sV_vt_view = utils.gemm.sm100.transform_partitioned_tensor_layout(sV)
+        tCsV = thr_v_s2r.partition_S(sV_vt_view)
+
+        rCumprod = cute.make_rmem_tensor((1, cute.size(tTR_tCcShared)), self.acc_dtype)
+        tGrCumprod = thr_shared_t2r.partition_D(rCumprod)
+        tGrDecayScale = cute.make_rmem_tensor_like(tTR_tCcShared, self.acc_dtype)
+        # Pair membership is derived from the caller-provided chunk index.
+        is_pair_first = (chunk_iter & 1) == 0
+
+        valid_state = is_first_chunk == False  # noqa: E712
+        if cutlass.const_expr(self.use_initial_state):
+            valid_state = True
+            if is_pair_first:
+                kv_acc_producer.advance()
+                kv_acc_producer.advance()
+
+        # Only the total decay is needed to finish the state update.  Defer
+        # the per-row gate work until the previous state has been published
+        # and decayed, keeping its register fragment in one contiguous region.
+        gate_handle = load_gate_consumer.wait_and_advance()
+        # valid_len = max(0, min(self.b_t, seqlen_b - chunk_iter * self.b_t))
+        # gamma_end = 1.0 if valid_len == 0 else sCumprod[valid_len - 1, 0, gate_handle.index]
+        # OOB alpha is padded with 1 before the prefix scan, so the last physical slot equals gamma_end.
+        cumprod_total = sCumprod[self.b_t - 1, 0, gate_handle.index]
+
+        kv_prev_handle = kv_acc_consumer.current_handle()
+        if valid_state:
+            kv_prev_handle = kv_acc_consumer.wait_and_advance()
+            # No empty-stage wait is needed before reusing state_inp.  For the
+            # first publication the stage is initialized empty.  Thereafter,
+            # CG1 reaches this point only after waiting for the preceding NewV;
+            # the MMA warp releases state_inp before publishing that NewV.
+            state_inp_handle = state_inp_ready_producer.current_handle()
+            state_inp_ready_producer.advance()
+            cute.copy(
+                tiled_state_t2r,
+                tTR_tCtState[None, 0, None, kv_prev_handle.index],
+                tTR_rState[None, 0, None],
+            )
+            tRT_rState_inp[None, 0, None].store(
+                tTR_rState[None, 0, None].load().to(self.io_dtype)
+            )
+            cute.copy(
+                tiled_state_inp_r2t,
+                tRT_rState_inp[None, 0, None],
+                tRT_tCtState_inp[None, 0, None, state_inp_handle.index],
+            )
+            cute.arch.fence_view_async_tmem_store()
+            state_inp_handle.commit()
+            checkpoint_token = self.b_t * chunk_iter
+            if cutlass.const_expr(self.enable_checkpoints):
+                if checkpoint_token > 0:
+                    if checkpoint_token <= seqlen_b:
+                        if checkpoint_token % checkpoint_every_n_tokens == 0:
+                            gS_checkpoints = cute.flat_divide(
+                                mS_checkpoints[
+                                    None,
+                                    None,
+                                    head_idx,
+                                    checkpoint_offset,
+                                ],
+                                (
+                                    self.mma_tiler_kv[0],
+                                    self.mma_tiler_kv[1],
+                                ),
+                            )[None, None, 0, 0]
+                            tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
+                            if cutlass.const_expr(self.state_dtype != self.acc_dtype):
+                                tRG_rState[None, 0, None].store(
+                                    tTR_rState[None, 0, None]
+                                    .load()
+                                    .to(self.state_dtype)
+                                )
+                            else:
+                                tRG_rState = tTR_rState
+                            cute.autovec_copy(
+                                tRG_rState[None, 0, None],
+                                tSgCheckpoints[None, 0, None],
+                                l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                            )
+            for k in cutlass.range(cute.size(tTR_rState), vectorize=True):
+                tTR_rState[k] = tTR_rState[k] * cumprod_total
+            cute.copy(
+                tiled_state_r2t,
+                tTR_rState[None, 0, None],
+                tRT_tCtState[None, 0, None, kv_prev_handle.index],
+            )
+            if cutlass.const_expr(self.enable_checkpoints):
+                if checkpoint_token > 0:
+                    if checkpoint_token <= seqlen_b:
+                        if checkpoint_token % checkpoint_every_n_tokens == 0:
+                            checkpoint_offset += 1
+            cute.arch.fence_view_async_tmem_store()
+            kv_prev_handle.release()
+        for k in cutlass.range_constexpr(cute.size(tTR_tCcShared)):
+            coord = tTR_tCcShared[k]
+            tGrCumprod[k] = sCumprod[coord[1], 0, gate_handle.index]
+        last_cumsumlog = sCumsumlog[self.b_t - 1, 0, gate_handle.index]
+        for k in cutlass.range_constexpr(0, cute.size(tTR_tCcShared), 2):
+            coord0 = tTR_tCcShared[k]
+            coord1 = tTR_tCcShared[k + 1]
+            decay_diff = cute.arch.add_packed_f32x2(
+                (last_cumsumlog, last_cumsumlog),
+                (
+                    -sCumsumlog[coord0[1], 0, gate_handle.index],
+                    -sCumsumlog[coord1[1], 0, gate_handle.index],
+                ),
+                ftz=False,
+                rnd="rn",
+            )
+            tGrDecayScale[k] = cute.math.exp2(decay_diff[0], fastmath=True)
+            tGrDecayScale[k + 1] = cute.math.exp2(decay_diff[1], fastmath=True)
+        gate_handle.release()
+
+        vks_handle = vks_ready_producer.current_handle()
+        vks_ready_producer.advance()
+        v_handle = load_v_consumer.wait_and_advance()
+        tRT_rV = cute.make_rmem_tensor_like(tRT_tCcV, self.io_dtype)
+        tCrV = tiled_v_s2r.retile(tRT_rV)
+        # Always publish V through fixed TMEM slot 0. The SMEM V ring cursor
+        # survives persistent work boundaries, so a new work item cannot
+        # assume that its first V tile resides in SMEM stage 0.
+        cute.copy(
+            tiled_v_s2r,
+            tCsV[None, None, None, v_handle.index],
+            tCrV,
+        )
+
+        if valid_state:
+            ks_handle = cg1_shared_acc_consumer.wait_and_advance()
+            tTR_rKS = cute.make_rmem_tensor_like(tTR_tCcKS, self.acc_dtype)
+            cute.copy(
+                tiled_ks_t2r,
+                tTR_tCtKS[None, None, None, ks_handle.index],
+                tTR_rKS,
+            )
+            for k in cutlass.range(cute.size(tTR_rKS), vectorize=True):
+                tTR_rKS[k] = tTR_rKS[k] * tGrCumprod[k]
+            ks_handle.release()
+            for k in cutlass.range(cute.size(tTR_rKS), vectorize=True):
+                tRT_rV[k] = tRT_rV[k] - tTR_rKS[k].to(self.io_dtype)
+        cute.copy(
+            tiled_vks_r2t,
+            tRT_rV,
+            tRT_tCtVKS_inp[None, None, None, 0],
+        )
+        cute.arch.fence_view_async_tmem_store()
+        vks_handle.commit()
+
+        if valid_state:
+            qs_handle = q_state_acc_consumer.wait_and_advance()
+            cute.copy(
+                tiled_qs_t2r,
+                tTR_tCtQS[None, None, 0, qs_handle.index],
+                tTR_rQS[None, None, 0],
+            )
+            for k in cutlass.range(cute.size(tTR_rQS), vectorize=True):
+                tTR_rQS[k] = tTR_rQS[k] * tGrCumprod[k] * scale
+            cute.copy(
+                tiled_qs_r2t,
+                tTR_rQS[None, None, 0],
+                tRT_tCtQS[None, None, 0, qs_handle.index],
+            )
+            cute.arch.fence_view_async_tmem_store()
+            qs_handle.release()
+
+        nv_handle = cg1_shared_acc_consumer.wait_and_advance()
+        v_handle.release()
+        tTR_rNv = cute.make_rmem_tensor_like(tTR_tCcShared, self.acc_dtype)
+        tTR_rNv_inp = cute.make_rmem_tensor_like(tTR_rNv, self.io_dtype)
+        for sub in cutlass.range(tTR_rNv.shape[1]):
+            cute.copy(
+                tiled_shared_t2r,
+                tTR_tCtShared[None, sub, 0, nv_handle.index],
+                tTR_rNv[None, sub, 0],
+            )
+            tTR_rNv_inp[None, sub, 0].store(
+                tTR_rNv[None, sub, 0].load().to(self.io_dtype)
+            )
+        nv_handle.release()
+
+        tTR_rDv = tTR_rNv
+        for sub in cutlass.range(tTR_rDv.shape[1]):
+            for k in cutlass.range(sub_tile_size, vectorize=True):
+                tTR_rDv[k, sub, 0] = tTR_rDv[k, sub, 0] * tGrDecayScale[k, sub, 0]
+
+        nv_ready_handle = nv_ready_producer.current_handle()
+        nv_ready_producer.advance()
+        decay_v_ready_handle = decay_v_ready_producer.current_handle()
+        decay_v_ready_producer.advance()
+        # Both chunks publish NV for GEMM6/QKV before decayV for GEMM7/KV.
+        for sub in cutlass.range(tTR_rDv.shape[1]):
+            cute.copy(
+                tiled_shared_inp_r2t,
+                tTR_rNv_inp[None, sub, 0],
+                tRT_tCtShared_inp[None, sub, 0, 0],
+            )
+            tTR_rNv_inp[None, sub, 0].store(
+                tTR_rDv[None, sub, 0].load().to(self.io_dtype)
+            )
+            cute.copy(
+                tiled_shared_inp_r2t,
+                tTR_rNv_inp[None, sub, 0],
+                tRT_tCtShared_inp[None, sub, 0, 1],
+            )
+        cute.arch.fence_view_async_tmem_store()
+        nv_ready_handle.commit()
+        decay_v_ready_handle.commit()
+
+        # Drain this chunk's output at the end of the same chunk.  This keeps
+        # O ownership uniform and removes the first/last pending-output cases.
+        o_handle = o_store_producer.acquire_and_advance()
+        o_qs_handle = q_state_acc_consumer.wait_and_advance()
+        tTR_tOrO = cute.make_rmem_tensor_like(tTR_tOcO, self.acc_dtype)
+        tTR_rO_out = cute.make_rmem_tensor_like(tTR_tOrO, self.io_dtype)
+        tRS_tOrO = tiled_o_r2s.retile(tTR_rO_out)
+        cute.copy(
+            tiled_o_t2r,
+            tTR_tOtO[None, None, None, o_qs_handle.index],
+            tTR_tOrO,
+        )
+        tTR_rO_out.store(tTR_tOrO.load().to(self.io_dtype))
+        cute.copy(
+            tiled_o_r2s,
+            tRS_tOrO,
+            tCsO[None, None, None, o_handle.index],
+        )
+        cute.arch.fence_view_async_shared()
+        o_qs_handle.release()
+        o_handle.commit()
+
+        return (
+            load_v_consumer,
+            load_gate_consumer,
+            cg1_shared_acc_consumer,
+            kv_acc_consumer,
+            q_state_acc_consumer,
+            kv_acc_producer,
+            state_inp_ready_producer,
+            vks_ready_producer,
+            nv_ready_producer,
+            decay_v_ready_producer,
+            o_store_producer,
+            checkpoint_offset,
+        )
+
+    @cute.jit
+    def epilogue_warp(
+        self,
+        smem_args,
+        tma_args,
+        pipeline_args,
+        work_args,
+        tensormap_args,
+    ) -> pipeline.PipelineConsumer:
+        """Warp 11: TMA bulk-store O from SMEM staging buffer to global memory.
+
+        Steps:
+          1. Wait for CG1 to signal O is ready in sO (via o_store_consumer).
+          2. Domain-offset the TMA tensor to (chunk_offset, head_idx), flat-divide
+             into tiles, tma_partition -> (tOsO, tOgO).
+          3. Issue TMA S2G bulk copy using the per-work-tile updated descriptor.
+          4. Commit the async group and wait for the store to land in GMEM.
+          5. Release the pipeline slot back to CG1.
+        """
+        (sO,) = smem_args
+        (tma_o,) = tma_args
+        (o_store_consumer,) = pipeline_args
+        head_idx, chunk_offset = work_args
+        tensormap_manager, tensormap_o_ptr = tensormap_args
+
+        o_handle = o_store_consumer.wait_and_advance()
+
+        cta_layout = cute.make_layout(1)
+        # (BT, DV)
+        o_tile = cute.select(self.mma_tiler_qkv, mode=[0, 1])
+
+        # Position global O tile at current chunk / head
+        mO = cute.domain_offset(
+            (cutlass.Int32(0), chunk_offset),
+            tma_o.tma_tensor[None, None, head_idx],
+        )
+        # (BT, DV, num_o_tiles, ...)
+        gO = cute.flat_divide(mO, o_tile)
+
+        # TMA partition: tOsO = SMEM source, tOgO = GMEM destination
+        tOsO, tOgO = cpasync.tma_partition(
+            tma_o.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sO, 0, 2),
+            cute.group_modes(gO, 0, 2),
+        )
+
+        # TMA bulk store SMEM -> GMEM using the descriptor updated per work tile
+        cute.copy(
+            tma_o.atom,
+            tOsO[(None, o_handle.index)],
+            tOgO[(None, 0, 0)],
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_o_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        # Wait for the store to complete before releasing the SMEM slot
+        cute.arch.cp_async_bulk_commit_group()
+        cute.arch.cp_async_bulk_wait_group(0)
+
+        o_handle.release()
+
+        return o_store_consumer
+
+    @cute.jit
+    def _transform_to_position_independent_layout(
+        self, tensor: cute.Tensor, swizzle_inner: cute.Swizzle
+    ) -> cute.Tensor:
+        wo_swizzle_iter = cute.recast_ptr(tensor.iterator, swizzle_=None)
+        pisl_swizzle_base = int(math.log2(self.io_dtype.width)) - 1
+        pisl_swizzle = cute.make_swizzle(
+            swizzle_inner.num_bits, pisl_swizzle_base, swizzle_inner.num_shift
+        )
+        tensor_pisl = cute.make_composed_layout(pisl_swizzle, 0, tensor.layout)
+        return cute.make_tensor(wo_swizzle_iter, tensor_pisl)
+
+    @staticmethod
+    def get_workspace_size(num_sm: int, B: int, HQ: int, HV: int, is_persistent: bool):
+        # q, k, v, o
+        if is_persistent:
+            return (
+                CPDeltaRulePrefillTcgen05Sm100.bytes_per_tensormap
+                * CPDeltaRulePrefillTcgen05Sm100.num_tensormaps
+                * num_sm
+            )
+        HO = HQ if HQ >= HV else HV
+        return (
+            CPDeltaRulePrefillTcgen05Sm100.bytes_per_tensormap
+            * CPDeltaRulePrefillTcgen05Sm100.num_tensormaps
+            * (B * HO)
+        )
+
+    @cute.jit
+    def initialize_workspace(
+        self, workspace: cute.Tensor, grid_dim: Tuple[int, int, int]
+    ):
+        workspace = cute.make_tensor(
+            workspace.iterator,
+            cute.make_layout(
+                (
+                    grid_dim[0] * grid_dim[1] * grid_dim[2],
+                    CPDeltaRulePrefillTcgen05Sm100.num_tensormaps,
+                    CPDeltaRulePrefillTcgen05Sm100.bytes_per_tensormap,
+                ),
+                stride=(
+                    CPDeltaRulePrefillTcgen05Sm100.num_tensormaps
+                    * CPDeltaRulePrefillTcgen05Sm100.bytes_per_tensormap,
+                    CPDeltaRulePrefillTcgen05Sm100.bytes_per_tensormap,
+                    1,
+                ),
+            ),
+        )
+        return workspace
+
+
+# ---------------------------------------------------------------------------
+# Test / validation entry point
+# ---------------------------------------------------------------------------

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -516,23 +516,26 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                     ),
                 ),
             )
-        state_out = cute.make_tensor(
-            state_out.iterator,
-            cute.make_layout(
-                (
-                    state_out.shape[2],
-                    state_out.shape[3],
-                    (h_r, h_qv),
-                    state_out.shape[0],
+        if cutlass.const_expr(self.store_final_state):
+            state_out = cute.make_tensor(
+                state_out.iterator,
+                cute.make_layout(
+                    (
+                        state_out.shape[2],
+                        state_out.shape[3],
+                        (h_r, h_qv),
+                        state_out.shape[0],
+                    ),
+                    stride=(
+                        state_out.stride[2],
+                        state_out.stride[3],
+                        (state_out.stride[1], h_r * state_out.stride[1]),
+                        state_out.stride[0],
+                    ),
                 ),
-                stride=(
-                    state_out.stride[2],
-                    state_out.stride[3],
-                    (state_out.stride[1], h_r * state_out.stride[1]),
-                    state_out.stride[0],
-                ),
-            ),
-        )
+            )
+        else:
+            state_out = fixed_state
 
         # ------------------------------------------------------------------
         # Build tiled MMAs  (one per logical GEMM group, differing in operand major modes)
@@ -2314,7 +2317,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         tRT_tCtState = thr_state_r2t.partition_D(tCtState_mn_view)
         tRT_tCcState = thr_state_r2t.partition_S(cState)
         tRT_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
-        tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.state_dtype)
+        tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, mS_init.element_type)
 
         if cutlass.const_expr(mS_indices is not None):
             state_row = mS_indices[batch_idx]
@@ -2333,7 +2336,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                 tGR_tCrState[None, 0, sub],
                 l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
             )
-            if cutlass.const_expr(self.acc_dtype != self.state_dtype):
+            if cutlass.const_expr(self.acc_dtype != mS_init.element_type):
                 tRT_tCrState[None, 0, sub].store(
                     tGR_tCrState[None, 0, sub].load().to(self.acc_dtype)
                 )

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -2587,26 +2587,15 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         nv_handle = cg1_acc_producer.acquire_and_advance()
         vks_ready_consumer.wait_and_advance()
         ainv_handle = a_inv_ready_consumer.wait_and_advance()
-        if valid_state:
-            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
-                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-                cute.gemm(
-                    tiled_mma_qkv,
-                    tCtShared[None, None, None, nv_handle.index],
-                    tCtSharedInp[None, None, kphase_idx, 0],
-                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
-                    tCtShared[None, None, None, nv_handle.index],
-                )
-        else:
-            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
-                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-                cute.gemm(
-                    tiled_mma_qkv,
-                    tCtShared[None, None, None, nv_handle.index],
-                    tCtSharedInp[None, None, kphase_idx, 0],
-                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
-                    tCtShared[None, None, None, nv_handle.index],
-                )
+        for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+            tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qkv,
+                tCtShared[None, None, None, nv_handle.index],
+                tCtSharedInp[None, None, kphase_idx, 0],
+                tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                tCtShared[None, None, None, nv_handle.index],
+            )
         nv_handle.commit()
         ainv_handle.release()
 

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -1,0 +1,945 @@
+"""Context-parallel GDN prefill kernels for Blackwell SM100."""
+
+import functools
+import math
+
+import torch
+import cutlass
+import cutlass.cute as cute
+
+from ...utils import (
+    _get_cache_buf,
+    get_compute_capability,
+    get_device_name,
+    get_device_sm_count,
+)
+from ..delta_rule_dsl.custom_compile_cache import cached_compile, get_cached_compile
+from ..delta_rule_dsl.delta_rule_cp_sm120 import (
+    CPDeltaRuleFixupHmmaSm120,
+    CPDeltaRuleFixupSimtSm120,
+    CPDeltaRuleTPrecomputeSm120,
+)
+from ..delta_rule_dsl.delta_rule_sm120 import _FullyFusedDeltaRuleSm120
+from ..delta_rule_dsl.varlen_helper import (
+    CP_CHUNK_LEN_GRANULARITY,
+    choose_cp_chunk_len_host,
+    max_num_chunks_host,
+    workspace_num_chunks_host,
+)
+from .gated_delta_net_cp import CPDeltaRuleMNPrecomputeUtcmma1Sm100
+from .gated_delta_net_cp_prefill import CPDeltaRulePrefillTcgen05Sm100
+
+
+@functools.cache
+def _blackwell_compile_options(device: torch.device):
+    major, minor = get_compute_capability(device)
+    if major != 10:
+        raise RuntimeError(
+            f"SM100 CP delta rule requires a compute 10.x device, got {major}.{minor}"
+        )
+    return cute.EnableTVMFFI(True), cute.GPUArch(f"sm_{major}{minor}a")
+
+
+def _get_cp_workspace(name, shape, dtype, device):
+    nbytes = math.prod(shape) * dtype.itemsize
+    return _get_cache_buf(name, nbytes, device)[:nbytes].view(dtype).view(shape)
+
+
+class CPDeltaRuleTPrecomputeSm100(CPDeltaRuleTPrecomputeSm120):
+    """SM100 specialization of the architecture-portable T precompute body."""
+
+
+def _cu_seqlens_dtype(dtype):
+    try:
+        return {torch.int32: cutlass.Int32, torch.int64: cutlass.Int64}[dtype]
+    except KeyError as err:
+        raise RuntimeError(
+            f"cu_seqlens must have dtype torch.int32 or torch.int64, got {dtype}"
+        ) from err
+
+
+@functools.cache
+def _get_t_precompute_kernel(kernel_dtype, cu_seqlens_dtype):
+    return CPDeltaRuleTPrecomputeSm100(
+        kernel_dtype, cu_seqlens_dtype=cu_seqlens_dtype
+    )
+
+
+def cp_delta_rule_t_precompute_dsl_sm100(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    max_seqlen: int | None = None,
+    *,
+    _skip_check: bool = False,
+    _device=None,
+    _stream=None,
+):
+    """Precompute signed, beta-folded CP T tiles on SM100."""
+    import cuda.bindings.driver as cuda_driver
+
+    device = k.device if _device is None else _device
+    if not _skip_check:
+        if k.ndim != 3:
+            raise RuntimeError(
+                f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}"
+            )
+        if beta.ndim != 2 or beta.shape[0] != k.shape[0]:
+            raise RuntimeError(
+                f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}"
+            )
+        if total_seqlen != k.shape[0]:
+            raise RuntimeError(
+                f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}"
+            )
+        _cu_seqlens_dtype(cu_seqlens.dtype)
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided")
+    if not _skip_check and max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+    _, num_k_heads, d = k.shape
+    num_sab_heads = beta.shape[1]
+    if not _skip_check:
+        if num_sab_heads < num_k_heads or num_sab_heads % num_k_heads != 0:
+            raise RuntimeError(
+                "beta heads must be a positive multiple of k heads, "
+                f"got beta heads={num_sab_heads} and k heads={num_k_heads}"
+            )
+        if d != 128:
+            raise RuntimeError(
+                f"CPDeltaRuleTPrecomputeSm100 only supports D=128, got {d}"
+            )
+        if k.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError(
+                f"CPDeltaRuleTPrecomputeSm100 only supports fp16/bf16 inputs, got {k.dtype}"
+            )
+        if beta.dtype != torch.float32:
+            raise RuntimeError(f"beta must have dtype torch.float32, got {beta.dtype}")
+        for name, tensor in (("k", k), ("beta", beta)):
+            if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+
+    total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
+    max_t_blocks_per_seq = max_num_chunks_host(max_seqlen, 64)
+    t = _get_cp_workspace(
+        "gdn_cp_sm100_t",
+        (total_t_blocks, num_sab_heads, 64, 64),
+        k.dtype,
+        device,
+    )
+    if total_t_blocks == 0:
+        return t
+    k_tma = k.as_strided((d, total_seqlen, num_k_heads), (1, num_k_heads * d, d))
+    kernel_dtype = {torch.float16: cutlass.Float16, torch.bfloat16: cutlass.BFloat16}[
+        k.dtype
+    ]
+    stream = (
+        _stream
+        if _stream is not None
+        else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
+    )
+
+    kernel = _get_t_precompute_kernel(
+        kernel_dtype, _cu_seqlens_dtype(cu_seqlens.dtype)
+    )
+    compile_options = _blackwell_compile_options(device)
+    compiled = get_cached_compile(kernel, compile_options)
+    if compiled is None:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
+        kernel_args = (
+            from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+            from_dlpack(beta.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(t.view(-1), assumed_align=128).mark_layout_dynamic(),
+            from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+            cutlass.Int32(num_k_heads),
+            cutlass.Int32(num_sab_heads),
+            cutlass.Int32(total_t_blocks),
+            cutlass.Int32(max_t_blocks_per_seq),
+            cutlass.Int32(num_seqs),
+            stream,
+        )
+        compiled = cached_compile(kernel, *kernel_args, compile_options=compile_options)
+    compiled(
+        k_tma,
+        beta.reshape(-1),
+        t.view(-1),
+        cu_seqlens,
+        num_k_heads,
+        num_sab_heads,
+        total_t_blocks,
+        max_t_blocks_per_seq,
+        num_seqs,
+        stream,
+    )
+    return t
+
+
+@functools.cache
+def _get_mn_precompute_kernel(kernel_dtype, cu_seqlens_dtype):
+    return CPDeltaRuleMNPrecomputeUtcmma1Sm100(kernel_dtype, cu_seqlens_dtype)
+
+
+def cp_delta_rule_mn_precompute_dsl_sm100(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    t: torch.Tensor,
+    alpha: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    cp_chunk_len: int = 4096,
+    max_seqlen: int | None = None,
+    *,
+    _skip_check: bool = False,
+    _device=None,
+    _stream=None,
+):
+    """Precompute local transfer and state workspaces on SM100."""
+    import cuda.bindings.driver as cuda_driver
+
+    device = k.device if _device is None else _device
+    if not _skip_check:
+        if k.ndim != 3:
+            raise RuntimeError(
+                f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}"
+            )
+        if v.ndim != 3 or v.shape[0] != k.shape[0] or v.shape[2] != k.shape[2]:
+            raise RuntimeError(
+                f"v must have shape (total_seqlen, num_v_heads, D), got {tuple(v.shape)}"
+            )
+        if alpha.ndim != 2 or alpha.shape[0] != k.shape[0]:
+            raise RuntimeError(
+                f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}"
+            )
+        if total_seqlen != k.shape[0]:
+            raise RuntimeError(
+                f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}"
+            )
+        if cp_chunk_len % 64 != 0:
+            raise RuntimeError(
+                f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
+            )
+        _cu_seqlens_dtype(cu_seqlens.dtype)
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided")
+    if not _skip_check and max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+    _, num_k_heads, d = k.shape
+    num_v_heads = v.shape[1]
+    num_sab_heads = alpha.shape[1]
+    if not _skip_check:
+        if num_sab_heads < num_k_heads or num_sab_heads % num_k_heads != 0:
+            raise RuntimeError(
+                "alpha heads must be a positive multiple of k heads, "
+                f"got alpha heads={num_sab_heads} and k heads={num_k_heads}"
+            )
+        if num_sab_heads < num_v_heads or num_sab_heads % num_v_heads != 0:
+            raise RuntimeError(
+                "alpha heads must be a positive multiple of v heads, "
+                f"got alpha heads={num_sab_heads} and v heads={num_v_heads}"
+            )
+    total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
+    if not _skip_check and t.shape != (total_t_blocks, num_sab_heads, 64, 64):
+        raise RuntimeError(
+            f"t must have shape {(total_t_blocks, num_sab_heads, 64, 64)}, got {tuple(t.shape)}"
+        )
+    total_cp_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
+    if not _skip_check:
+        if d != 128:
+            raise RuntimeError(
+                f"CPDeltaRuleMNPrecomputeSm100 only supports D=128, got {d}"
+            )
+        if k.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError(
+                f"CPDeltaRuleMNPrecomputeSm100 only supports fp16/bf16 inputs, got {k.dtype}"
+            )
+        if v.dtype != k.dtype or t.dtype != k.dtype:
+            raise RuntimeError(
+                f"v/t dtypes must match k dtype, got k={k.dtype}, v={v.dtype}, t={t.dtype}"
+            )
+        if alpha.dtype != torch.float32:
+            raise RuntimeError(
+                f"alpha must have dtype torch.float32, got {alpha.dtype}"
+            )
+        for name, tensor in (("k", k), ("v", v), ("t", t), ("alpha", alpha)):
+            if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+
+    max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
+    k_tma = k.as_strided((d, total_seqlen, num_k_heads), (1, num_k_heads * d, d))
+    v_tma = v.as_strided((d, total_seqlen, num_v_heads), (1, num_v_heads * d, d))
+    t_tma = t.as_strided(
+        (64, 64, num_sab_heads, total_t_blocks),
+        (64, 1, 64 * 64, num_sab_heads * 64 * 64),
+    )
+    workspace_shape = (total_cp_chunks, num_sab_heads, d, d)
+    transfer_t = _get_cp_workspace(
+        "gdn_cp_sm100_local_transfer", workspace_shape, torch.float32, device
+    )
+    state_t = _get_cp_workspace(
+        "gdn_cp_sm100_local_state", workspace_shape, torch.float32, device
+    )
+    if total_cp_chunks == 0:
+        return transfer_t, state_t
+
+    kernel_dtype = {torch.float16: cutlass.Float16, torch.bfloat16: cutlass.BFloat16}[
+        k.dtype
+    ]
+    stream = (
+        _stream
+        if _stream is not None
+        else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
+    )
+    kernel = _get_mn_precompute_kernel(
+        kernel_dtype, _cu_seqlens_dtype(cu_seqlens.dtype)
+    )
+    compile_options = _blackwell_compile_options(device)
+    compiled = get_cached_compile(kernel, compile_options)
+    if compiled is None:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
+        kernel_args = (
+            from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+            from_dlpack(v_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+            from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
+            from_dlpack(alpha.view(-1), assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(transfer_t.view(-1), assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(state_t.view(-1), assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+            cutlass.Int32(cp_chunk_len),
+            cutlass.Int32(num_k_heads),
+            cutlass.Int32(num_v_heads),
+            cutlass.Int32(num_sab_heads),
+            cutlass.Int32(total_cp_chunks),
+            cutlass.Int32(max_cp_chunks_per_seq),
+            cutlass.Int32(num_seqs),
+            stream,
+        )
+        compiled = cached_compile(kernel, *kernel_args, compile_options=compile_options)
+    compiled(
+        k_tma,
+        v_tma,
+        t_tma,
+        alpha.view(-1),
+        transfer_t.view(-1),
+        state_t.view(-1),
+        cu_seqlens,
+        cp_chunk_len,
+        num_k_heads,
+        num_v_heads,
+        num_sab_heads,
+        total_cp_chunks,
+        max_cp_chunks_per_seq,
+        num_seqs,
+        stream,
+    )
+    return transfer_t, state_t
+
+
+class CPDeltaRuleFixupSm100(CPDeltaRuleFixupSimtSm120):
+    """SM100 specialization of the register-prefetched SIMT fixup body."""
+
+
+class CPDeltaRuleFixupHmmaSm100(CPDeltaRuleFixupHmmaSm120):
+    """SM100 specialization of the HMMA fixup fallback."""
+
+
+@functools.cache
+def _get_fixup_kernel(needs_initial_state, kernel_kind, cu_seqlens_dtype):
+    if kernel_kind == "simt_row4":
+        return CPDeltaRuleFixupSm100(
+            needs_initial_state, 4, cu_seqlens_dtype=cu_seqlens_dtype
+        )
+    if kernel_kind == "simt_row8":
+        return CPDeltaRuleFixupSm100(
+            needs_initial_state, 8, cu_seqlens_dtype=cu_seqlens_dtype
+        )
+    if kernel_kind == "hmma":
+        return CPDeltaRuleFixupHmmaSm100(
+            needs_initial_state, cu_seqlens_dtype=cu_seqlens_dtype
+        )
+    raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
+
+
+def cp_delta_rule_fixup_dsl_sm100(
+    local_transfer: torch.Tensor,
+    local_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    cp_chunk_len: int = 4096,
+    initial_state: torch.Tensor | None = None,
+    *,
+    _skip_check: bool = False,
+    _kernel_kind: str | None = None,
+    _device=None,
+    _stream=None,
+):
+    """Fix SM100 CP chunk states into global chunk-boundary states."""
+    import cuda.bindings.driver as cuda_driver
+
+    device = local_transfer.device if _device is None else _device
+    if not _skip_check:
+        if local_transfer.ndim != 4:
+            raise RuntimeError(
+                "local_transfer must have shape (num_chunks, num_heads, DimV, DimK), "
+                f"got {tuple(local_transfer.shape)}"
+            )
+        if local_state.shape != local_transfer.shape:
+            raise RuntimeError(
+                "local_state shape must match local_transfer shape, "
+                f"got {tuple(local_state.shape)} and {tuple(local_transfer.shape)}"
+            )
+        if local_transfer.shape[-2:] != (128, 128):
+            raise RuntimeError(
+                f"CPDeltaRuleFixupSm100 only supports D=128, got {tuple(local_transfer.shape[-2:])}"
+            )
+        if local_transfer.dtype != torch.float32 or local_state.dtype != torch.float32:
+            raise RuntimeError(
+                "CPDeltaRuleFixupSm100 only supports float32 inputs, "
+                f"got {local_transfer.dtype} and {local_state.dtype}"
+            )
+        if initial_state is not None:
+            expected_initial_state_shape = (
+                cu_seqlens.shape[0] - 1,
+                local_transfer.shape[1],
+                128,
+                128,
+            )
+            if initial_state.shape != expected_initial_state_shape:
+                raise RuntimeError(
+                    f"initial_state must have shape {expected_initial_state_shape}, got {tuple(initial_state.shape)}"
+                )
+            if initial_state.dtype != torch.float32:
+                raise RuntimeError(
+                    f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
+                )
+        for name, tensor in (
+            ("local_transfer", local_transfer),
+            ("local_state", local_state),
+            ("initial_state", initial_state),
+        ):
+            if tensor is not None and not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+
+    total_cp_chunks, num_heads, _, d = local_transfer.shape
+    if not _skip_check:
+        if cp_chunk_len <= 0:
+            raise RuntimeError(f"cp_chunk_len must be positive, got {cp_chunk_len}")
+        _cu_seqlens_dtype(cu_seqlens.dtype)
+        expected_chunks = workspace_num_chunks_host(
+            cu_seqlens, cp_chunk_len, total_seqlen
+        )
+        if expected_chunks != total_cp_chunks:
+            raise RuntimeError(
+                "local_transfer/local_state first dim must equal "
+                f"chunk_bound(num_seqs, total_seqlen, cp_chunk_len)={expected_chunks}, got {total_cp_chunks}"
+            )
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+
+    fixed_state = _get_cp_workspace(
+        "gdn_cp_sm100_fixed_state", local_state.shape, local_state.dtype, device
+    )
+    if total_cp_chunks == 0:
+        return fixed_state
+
+    local_transfer_tma = local_transfer.as_strided(
+        (d, d, num_heads, total_cp_chunks), (d, 1, d * d, num_heads * d * d)
+    )
+    local_state_tma = local_state.as_strided(
+        (d, d, num_heads, total_cp_chunks), (d, 1, d * d, num_heads * d * d)
+    )
+    stream = (
+        _stream
+        if _stream is not None
+        else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
+    )
+    needs_initial_state = initial_state is not None
+    if _kernel_kind is None:
+        if num_heads <= 8:
+            _kernel_kind = "simt_row4"
+        elif num_heads <= 16:
+            _kernel_kind = "simt_row8"
+        else:
+            _kernel_kind = "hmma"
+    kernel = _get_fixup_kernel(
+        needs_initial_state, _kernel_kind, _cu_seqlens_dtype(cu_seqlens.dtype)
+    )
+    compile_options = _blackwell_compile_options(device)
+    compiled = get_cached_compile(kernel, compile_options)
+    if compiled is None:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
+        initial_state_cute = (
+            from_dlpack(
+                initial_state.reshape(-1), assumed_align=16
+            ).mark_layout_dynamic()
+            if needs_initial_state
+            else None
+        )
+        kernel_args = (
+            from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(
+                leading_dim=1
+            ),
+            from_dlpack(local_state_tma, assumed_align=128).mark_layout_dynamic(
+                leading_dim=1
+            ),
+            initial_state_cute,
+            from_dlpack(
+                fixed_state.reshape(-1), assumed_align=128
+            ).mark_layout_dynamic(),
+            from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+            cutlass.Int32(cp_chunk_len),
+            cutlass.Int32(total_cp_chunks),
+            cutlass.Int32(num_seqs),
+            cutlass.Int32(num_heads),
+            stream,
+        )
+        compiled = cached_compile(kernel, *kernel_args, compile_options=compile_options)
+    compiled(
+        local_transfer_tma,
+        local_state_tma,
+        initial_state.reshape(-1) if needs_initial_state else None,
+        fixed_state.reshape(-1),
+        cu_seqlens,
+        cp_chunk_len,
+        total_cp_chunks,
+        num_seqs,
+        num_heads,
+        stream,
+    )
+    return fixed_state
+
+
+@functools.cache
+def _get_prefill_kernel(
+    kernel_dtype,
+    num_sm,
+    is_gqa,
+    head_ratio,
+    needs_initial_state,
+    cu_seqlens_dtype,
+):
+    return CPDeltaRulePrefillTcgen05Sm100(
+        io_dtype=kernel_dtype,
+        acc_dtype=cutlass.Float32,
+        state_dtype=cutlass.Float32,
+        mma_tiler_qk=(64, 64, 128),
+        mma_tiler_qs=(128, 64, 128),
+        mma_tiler_qkv=(128, 64, 64),
+        mma_tiler_kv=(128, 128, 64),
+        max_active_clusters=num_sm,
+        num_sm=num_sm,
+        is_GQA=is_gqa,
+        head_ratio=head_ratio,
+        use_initial_state=needs_initial_state,
+        store_final_state=True,
+        enable_checkpoints=False,
+        is_persistent=False,
+        cu_seqlens_dtype=cu_seqlens_dtype,
+    )
+
+
+def cp_delta_rule_prefill_dsl_sm100(
+    o: torch.Tensor,
+    state: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    t: torch.Tensor,
+    fixed_state: torch.Tensor,
+    alpha: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    cp_chunk_len: int = 4096,
+    max_seqlen: int | None = None,
+    initial_state: torch.Tensor | None = None,
+    *,
+    _skip_check: bool = False,
+    _device=None,
+    _stream=None,
+):
+    """Run CP main prefill with precomputed T and fixed-up chunk states on SM100."""
+    import cuda.bindings.driver as cuda_driver
+
+    device = q.device if _device is None else _device
+    if not _skip_check:
+        if q.ndim != 3:
+            raise RuntimeError(
+                f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}"
+            )
+        if k.ndim != 3 or v.ndim != 3 or o.ndim != 3:
+            raise RuntimeError(
+                "k, v, and o must have shape (total_seqlen, num_heads, D), "
+                f"got k={tuple(k.shape)}, v={tuple(v.shape)}, o={tuple(o.shape)}"
+            )
+        if (
+            k.shape[0] != q.shape[0]
+            or v.shape[0] != q.shape[0]
+            or o.shape[0] != q.shape[0]
+        ):
+            raise RuntimeError("q, k, v, and o must have the same total_seqlen")
+        if (
+            k.shape[2] != q.shape[2]
+            or v.shape[2] != q.shape[2]
+            or o.shape[2] != q.shape[2]
+        ):
+            raise RuntimeError("q, k, v, and o must have the same D")
+        if total_seqlen != q.shape[0]:
+            raise RuntimeError(
+                f"total_seqlen must match q.shape[0], got {total_seqlen} and {q.shape[0]}"
+            )
+        if cp_chunk_len % 64 != 0:
+            raise RuntimeError(
+                f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
+            )
+        _cu_seqlens_dtype(cu_seqlens.dtype)
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided")
+    _, num_q_heads, d = q.shape
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
+    total_cp_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
+    if not _skip_check:
+        if d != 128:
+            raise RuntimeError(f"CPDeltaRulePrefillSm100 only supports D=128, got {d}")
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError(
+                f"CPDeltaRulePrefillSm100 only supports fp16/bf16 inputs, got {q.dtype}"
+            )
+        if (
+            k.dtype != q.dtype
+            or v.dtype != q.dtype
+            or o.dtype != q.dtype
+            or t.dtype != q.dtype
+        ):
+            raise RuntimeError("q/k/v/o/t dtypes must match")
+        if alpha.dtype != torch.float32:
+            raise RuntimeError(
+                f"alpha must have dtype torch.float32, got {alpha.dtype}"
+            )
+        if o.shape != (total_seqlen, num_sab_heads, d):
+            raise RuntimeError(
+                f"o must have shape {(total_seqlen, num_sab_heads, d)}, got {tuple(o.shape)}"
+            )
+        if t.shape != (total_t_blocks, num_sab_heads, 64, 64):
+            raise RuntimeError(
+                f"t must have shape {(total_t_blocks, num_sab_heads, 64, 64)}, got {tuple(t.shape)}"
+            )
+        expected_workspace_shape = (total_cp_chunks, num_sab_heads, d, d)
+        expected_state_shape = (num_seqs, num_sab_heads, d, d)
+        if (
+            fixed_state.shape != expected_workspace_shape
+            or state.shape != expected_state_shape
+        ):
+            raise RuntimeError(
+                f"fixed_state/state must have shapes {expected_workspace_shape} and {expected_state_shape}"
+            )
+        if initial_state is not None and initial_state.shape != expected_state_shape:
+            raise RuntimeError(
+                f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+            )
+        if not _FullyFusedDeltaRuleSm120.can_implement(
+            num_q_heads, num_k_heads, num_v_heads, d, q.element_size()
+        ):
+            raise RuntimeError(
+                "q/v heads must be positive multiples of k heads, "
+                f"got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
+            )
+        for name, tensor in (
+            ("q", q),
+            ("k", k),
+            ("v", v),
+            ("t", t),
+            ("fixed_state", fixed_state),
+            ("initial_state", initial_state),
+            ("alpha", alpha),
+            ("o", o),
+            ("state", state),
+        ):
+            if tensor is not None and not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+    if total_cp_chunks == 0:
+        return
+
+    max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
+    t_tma = t.as_strided(
+        (64, 64, num_sab_heads, total_t_blocks),
+        (64, 1, 64 * 64, num_sab_heads * 64 * 64),
+    )
+    kernel_dtype = {torch.float16: cutlass.Float16, torch.bfloat16: cutlass.BFloat16}[
+        q.dtype
+    ]
+    stream = (
+        _stream
+        if _stream is not None
+        else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
+    )
+    needs_initial_state = initial_state is not None
+    num_sm = get_device_sm_count(device)
+    is_gqa = num_q_heads >= num_v_heads
+    head_ratio = num_q_heads // num_v_heads if is_gqa else num_v_heads // num_q_heads
+    kernel = _get_prefill_kernel(
+        kernel_dtype,
+        num_sm,
+        is_gqa,
+        head_ratio,
+        needs_initial_state,
+        _cu_seqlens_dtype(cu_seqlens.dtype),
+    )
+    compile_options = _blackwell_compile_options(device)
+    workspace_size = (
+        num_seqs
+        * num_sab_heads
+        * max_cp_chunks_per_seq
+        * CPDeltaRulePrefillTcgen05Sm100.num_tensormaps
+        * CPDeltaRulePrefillTcgen05Sm100.bytes_per_tensormap
+    )
+    tensormaps_t = _get_cache_buf(
+        "gdn_cp_sm100_prefill_tensormaps", workspace_size, device
+    )[:workspace_size]
+    compiled = get_cached_compile(kernel, compile_options)
+    if compiled is None:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
+        kernel_args = (
+            from_dlpack(q, assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(k, assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(v, assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(alpha, assumed_align=16).mark_layout_dynamic(leading_dim=1),
+            from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
+            from_dlpack(o, assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+            from_dlpack(fixed_state, assumed_align=16).mark_layout_dynamic(),
+            (
+                from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic()
+                if needs_initial_state
+                else None
+            ),
+            from_dlpack(state, assumed_align=16).mark_layout_dynamic(),
+            cutlass.Int32(cp_chunk_len),
+            cutlass.Int32(total_cp_chunks),
+            cutlass.Int32(max_cp_chunks_per_seq),
+            cutlass.Int32(num_seqs),
+            cutlass.Float32(scale),
+            from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic(),
+            stream,
+        )
+        compiled = cached_compile(kernel, *kernel_args, compile_options=compile_options)
+    compiled(
+        q,
+        k,
+        v,
+        alpha,
+        t_tma,
+        o,
+        cu_seqlens,
+        fixed_state,
+        initial_state if needs_initial_state else None,
+        state,
+        cp_chunk_len,
+        total_cp_chunks,
+        max_cp_chunks_per_seq,
+        num_seqs,
+        scale,
+        tensormaps_t,
+        stream,
+    )
+
+
+def cp_delta_rule_dsl_sm100(
+    o: torch.Tensor,
+    state: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    alpha: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float,
+    *,
+    initial_state: torch.Tensor | None = None,
+    max_seqlen: int | None = None,
+    cp_chunk_len: int | None = None,
+    cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
+):
+    """Run the context-parallel delta-rule prefill pipeline on SM100."""
+    import cuda.bindings.driver as cuda_driver
+
+    # Fetch launch metadata once and reuse it across the four kernel wrappers.
+    device = q.device
+    device_name = get_device_name(device)
+    device_capability = get_compute_capability(device)
+    num_sms = get_device_sm_count(device)
+    stream = cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
+
+    total_seqlen = q.shape[0]
+    num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None and num_seqs == 1:
+        max_seqlen = total_seqlen
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided when num_seqs != 1")
+    if max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+    if cp_chunk_len is None:
+        num_heads = max(q.shape[1], v.shape[1])
+        cp_chunk_len = choose_cp_chunk_len_host(
+            max_seqlen,
+            num_heads,
+            num_sms,
+            chunk_len_granularity=cp_chunk_len_granularity,
+            device_capability=device_capability,
+            total_seqlen=total_seqlen,
+            device_name=device_name,
+        )
+    if q.ndim != 3:
+        raise RuntimeError(
+            f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}"
+        )
+    if k.ndim != 3 or v.ndim != 3 or o.ndim != 3:
+        raise RuntimeError(
+            "k, v, and o must have shape (total_seqlen, num_heads, D), "
+            f"got k={tuple(k.shape)}, v={tuple(v.shape)}, o={tuple(o.shape)}"
+        )
+    if (
+        k.shape[0] != total_seqlen
+        or v.shape[0] != total_seqlen
+        or o.shape[0] != total_seqlen
+    ):
+        raise RuntimeError("q, k, v, and o must have the same total_seqlen")
+    if k.shape[2] != q.shape[2] or v.shape[2] != q.shape[2] or o.shape[2] != q.shape[2]:
+        raise RuntimeError("q, k, v, and o must have the same D")
+    if alpha.shape != beta.shape or alpha.shape[0] != total_seqlen:
+        raise RuntimeError(
+            "alpha and beta must have shape (total_seqlen, num_sab_heads), "
+            f"got alpha={tuple(alpha.shape)} and beta={tuple(beta.shape)}"
+        )
+    if cp_chunk_len % 64 != 0:
+        raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+    _cu_seqlens_dtype(cu_seqlens.dtype)
+    if not cu_seqlens.is_contiguous():
+        raise RuntimeError("cu_seqlens must be contiguous")
+
+    _, num_q_heads, d = q.shape
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    if o.shape[1] != num_sab_heads or alpha.shape[1] != num_sab_heads:
+        raise RuntimeError(
+            f"o/alpha/beta heads must equal max(q heads, v heads)={num_sab_heads}"
+        )
+    if not _FullyFusedDeltaRuleSm120.can_implement(
+        num_q_heads, num_k_heads, num_v_heads, d, q.element_size()
+    ):
+        raise RuntimeError(
+            "CPDeltaRuleSm100 only supports GQA/GVA head counts, "
+            f"got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
+        )
+    expected_state_shape = (num_seqs, num_sab_heads, d, d)
+    if state.shape != expected_state_shape:
+        raise RuntimeError(
+            f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
+        )
+    if initial_state is not None and initial_state.shape != expected_state_shape:
+        raise RuntimeError(
+            f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+        )
+    if d != 128:
+        raise RuntimeError(f"CPDeltaRuleSm100 only supports D=128, got {d}")
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise RuntimeError(
+            f"CPDeltaRuleSm100 only supports fp16/bf16 inputs, got {q.dtype}"
+        )
+    if k.dtype != q.dtype or v.dtype != q.dtype or o.dtype != q.dtype:
+        raise RuntimeError("q/k/v/o dtypes must match")
+    if alpha.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise RuntimeError("alpha and beta must have dtype torch.float32")
+    if state.dtype != torch.float32 or (
+        initial_state is not None and initial_state.dtype != torch.float32
+    ):
+        raise RuntimeError("state and initial_state must have dtype torch.float32")
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("alpha", alpha),
+        ("beta", beta),
+        ("o", o),
+        ("state", state),
+        ("initial_state", initial_state),
+    ):
+        if tensor is not None and not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+
+    with torch.cuda.nvtx.range("cp_delta_rule_sm100"):
+        t = cp_delta_rule_t_precompute_dsl_sm100(
+            k,
+            beta,
+            cu_seqlens,
+            total_seqlen,
+            max_seqlen=max_seqlen,
+            _skip_check=True,
+            _device=device,
+            _stream=stream,
+        )
+        local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm100(
+            k,
+            v,
+            t,
+            alpha,
+            cu_seqlens,
+            total_seqlen,
+            cp_chunk_len=cp_chunk_len,
+            max_seqlen=max_seqlen,
+            _skip_check=True,
+            _device=device,
+            _stream=stream,
+        )
+        fixed_state = cp_delta_rule_fixup_dsl_sm100(
+            local_transfer,
+            local_state,
+            cu_seqlens,
+            total_seqlen,
+            cp_chunk_len=cp_chunk_len,
+            initial_state=initial_state,
+            _skip_check=True,
+            _device=device,
+            _stream=stream,
+        )
+        cp_delta_rule_prefill_dsl_sm100(
+            o,
+            state,
+            q,
+            k,
+            v,
+            t,
+            fixed_state,
+            alpha,
+            scale,
+            cu_seqlens,
+            total_seqlen,
+            cp_chunk_len=cp_chunk_len,
+            max_seqlen=max_seqlen,
+            initial_state=initial_state,
+            _skip_check=True,
+            _device=device,
+            _stream=stream,
+        )

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -26,9 +26,12 @@ from ..delta_rule_dsl.varlen_helper import (
     max_num_chunks_host,
     workspace_num_chunks_host,
 )
-from .gated_delta_net_cp import CPDeltaRuleMNPrecomputeUtcmma1Sm100
+from .gated_delta_net_cp import (
+    CPDeltaRuleFixupUtcmmaSm100,
+    CPDeltaRuleMNPrecomputeUtcmma1Sm100,
+)
 from .gated_delta_net_cp_prefill import CPDeltaRulePrefillTcgen05Sm100
-from .gdn_prefill import _cutlass_state_dtype
+from .gdn_prefill import _cutlass_state_dtype, _mark_state_layout
 
 
 @functools.cache
@@ -360,34 +363,52 @@ def _get_fixup_kernel(
     store_final_state,
     initial_state_dtype,
     output_state_dtype,
+    use_state_indices,
     kernel_kind,
     cu_seqlens_dtype,
 ):
     if kernel_kind == "simt_row4":
         return CPDeltaRuleFixupSm100(
-            needs_initial_state,
-            4,
-            store_final_state,
-            initial_state_dtype,
-            output_state_dtype,
-            cu_seqlens_dtype,
+            needs_initial_state=needs_initial_state,
+            rows_per_cta=4,
+            store_final_state=store_final_state,
+            initial_state_dtype=initial_state_dtype,
+            state_dtype=output_state_dtype,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            use_state_indices=use_state_indices,
+            store_initial_state=needs_initial_state,
         )
     if kernel_kind == "simt_row8":
         return CPDeltaRuleFixupSm100(
-            needs_initial_state,
-            8,
-            store_final_state,
-            initial_state_dtype,
-            output_state_dtype,
-            cu_seqlens_dtype,
+            needs_initial_state=needs_initial_state,
+            rows_per_cta=8,
+            store_final_state=store_final_state,
+            initial_state_dtype=initial_state_dtype,
+            state_dtype=output_state_dtype,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            use_state_indices=use_state_indices,
+            store_initial_state=needs_initial_state,
         )
     if kernel_kind == "hmma":
         return CPDeltaRuleFixupHmmaSm100(
-            needs_initial_state,
-            store_final_state,
-            initial_state_dtype,
-            output_state_dtype,
-            cu_seqlens_dtype,
+            needs_initial_state=needs_initial_state,
+            store_final_state=store_final_state,
+            initial_state_dtype=initial_state_dtype,
+            state_dtype=output_state_dtype,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            use_state_indices=use_state_indices,
+            store_initial_state=needs_initial_state,
+        )
+    if kernel_kind in ("utcmma", "utcmma64", "utcmma128"):
+        return CPDeltaRuleFixupUtcmmaSm100(
+            rows_per_cta=128 if kernel_kind == "utcmma128" else 64,
+            needs_initial_state=needs_initial_state,
+            store_final_state=store_final_state,
+            initial_state_dtype=initial_state_dtype,
+            state_dtype=output_state_dtype,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            use_state_indices=use_state_indices,
+            store_initial_state=needs_initial_state,
         )
     raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
 
@@ -400,6 +421,8 @@ def cp_delta_rule_fixup_dsl_sm100(
     cp_chunk_len: int = 4096,
     initial_state: torch.Tensor | None = None,
     output_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+    initial_state_workspace: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
     _kernel_kind: str | None = None,
@@ -430,31 +453,37 @@ def cp_delta_rule_fixup_dsl_sm100(
                 "CPDeltaRuleFixupSm100 only supports float32 inputs, "
                 f"got {local_transfer.dtype} and {local_state.dtype}"
             )
+        use_state_indices = state_indices is not None
         for name, tensor in (("initial_state", initial_state), ("output_state", output_state)):
             if tensor is not None:
-                if tensor.shape != (
-                    cu_seqlens.shape[0] - 1,
-                    local_transfer.shape[1],
-                    128,
-                    128,
+                expected_tail = (local_transfer.shape[1], 128, 128)
+                if tuple(tensor.shape[1:]) != expected_tail or (
+                    not use_state_indices and tensor.shape[0] != cu_seqlens.shape[0] - 1
                 ):
                     raise RuntimeError(
                         f"{name} must have shape "
-                        f"{(cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128)}, "
-                        f"got {tuple(tensor.shape)}"
+                        f"{('[N_pool]' if use_state_indices else f'[{cu_seqlens.shape[0] - 1}]')}"
+                        f" + {expected_tail}, got {tuple(tensor.shape)}"
                     )
                 if tensor.dtype not in (torch.float32, torch.bfloat16, torch.float16):
                     raise RuntimeError(
                         f"{name} must have dtype float32, bfloat16, or float16, got {tensor.dtype}"
                     )
+        if use_state_indices:
+            if state_indices.dtype != torch.int32 or state_indices.shape != (cu_seqlens.shape[0] - 1,):
+                raise RuntimeError(
+                    f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and dtype int32"
+                )
         for name, tensor in (
             ("local_transfer", local_transfer),
             ("local_state", local_state),
-            ("initial_state", initial_state),
-            ("output_state", output_state),
+            ("state_indices", state_indices),
         ):
             if tensor is not None and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
+        for name, tensor in (("initial_state", initial_state), ("output_state", output_state)):
+            if tensor is not None and tensor.stride()[1:] != (128 * 128, 128, 1):
+                raise RuntimeError(f"{name} must be contiguous in its inner [H, V, K] modes")
 
     total_cp_chunks, num_heads, _, d = local_transfer.shape
     if not _skip_check:
@@ -476,11 +505,18 @@ def cp_delta_rule_fixup_dsl_sm100(
     fixed_state = _get_cp_workspace(
         "gdn_cp_sm100_fixed_state", local_state.shape, local_state.dtype, device
     )
+    if initial_state is not None and initial_state_workspace is None:
+        initial_state_workspace = _get_cp_workspace(
+            "gdn_cp_sm100_initial_state",
+            (num_seqs, num_heads, d, d),
+            torch.float32,
+            device,
+        )
     if total_cp_chunks == 0:
         return fixed_state
 
     local_transfer_tma = local_transfer.as_strided(
-        (d, d, num_heads, total_cp_chunks), (d, 1, d * d, num_heads * d * d)
+        (d, d, num_heads, total_cp_chunks), (1, d, d * d, num_heads * d * d)
     )
     local_state_tma = local_state.as_strided(
         (d, d, num_heads, total_cp_chunks), (d, 1, d * d, num_heads * d * d)
@@ -492,6 +528,7 @@ def cp_delta_rule_fixup_dsl_sm100(
     )
     needs_initial_state = initial_state is not None
     store_final_state = output_state is not None
+    use_state_indices = state_indices is not None
     initial_state_dtype = _cutlass_state_dtype(
         initial_state.dtype if needs_initial_state else torch.float32
     )
@@ -500,17 +537,23 @@ def cp_delta_rule_fixup_dsl_sm100(
     )
     if _kernel_kind is None:
         num_parallel_states = num_seqs * num_heads
-        if num_heads <= 8:
-            _kernel_kind = "simt_row4" if num_parallel_states <= 8 else "simt_row8"
-        elif num_heads <= 16:
-            _kernel_kind = "simt_row8"
+        num_sms = get_device_sm_count(device)
+        # SIMT4 sustains two CTAs/SM. UTC64 and UTC128 launch D/rows_per_cta
+        # CTAs per state, so UTC64 switches out when its two-CTA grid exceeds one wave.
+        simt_row4_one_wave_states = num_sms * 2 // (d // 4)
+        utcmma64_one_wave_states = num_sms // (d // 64)
+        if num_parallel_states <= simt_row4_one_wave_states:
+            _kernel_kind = "simt_row4"
+        elif num_parallel_states <= utcmma64_one_wave_states:
+            _kernel_kind = "utcmma64"
         else:
-            _kernel_kind = "hmma"
+            _kernel_kind = "utcmma128"
     kernel = _get_fixup_kernel(
         needs_initial_state,
         store_final_state,
         initial_state_dtype,
         output_state_dtype,
+        use_state_indices,
         _kernel_kind,
         _cu_seqlens_dtype(cu_seqlens.dtype),
     )
@@ -520,29 +563,35 @@ def cp_delta_rule_fixup_dsl_sm100(
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
             *args, **{**kwargs, "enable_tvm_ffi": True}
         )
-        initial_state_cute = (
-            from_dlpack(
-                initial_state.reshape(-1), assumed_align=16
-            ).mark_layout_dynamic()
+        initial_state_cute = None
+        if needs_initial_state:
+            initial_state_cute = from_dlpack(initial_state, assumed_align=16)
+            _mark_state_layout(initial_state_cute, use_state_indices, d)
+        initial_state_workspace_cute = (
+            from_dlpack(initial_state_workspace.reshape(-1), assumed_align=16).mark_layout_dynamic()
             if needs_initial_state
             else None
         )
+        output_state_cute = None
+        if store_final_state:
+            output_state_cute = from_dlpack(output_state, assumed_align=16)
+            _mark_state_layout(output_state_cute, use_state_indices, d)
         kernel_args = (
             from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(
-                leading_dim=1
+                leading_dim=0
             ),
             from_dlpack(local_state_tma, assumed_align=128).mark_layout_dynamic(
                 leading_dim=1
             ),
             initial_state_cute,
+            initial_state_workspace_cute,
             from_dlpack(
                 fixed_state.reshape(-1), assumed_align=128
             ).mark_layout_dynamic(),
+            output_state_cute,
             (
-                from_dlpack(
-                    output_state.reshape(-1), assumed_align=16
-                ).mark_layout_dynamic()
-                if store_final_state
+                from_dlpack(state_indices, assumed_align=4).mark_layout_dynamic()
+                if use_state_indices
                 else None
             ),
             from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
@@ -556,9 +605,11 @@ def cp_delta_rule_fixup_dsl_sm100(
     compiled(
         local_transfer_tma,
         local_state_tma,
-        initial_state.reshape(-1) if needs_initial_state else None,
+        initial_state if needs_initial_state else None,
+        initial_state_workspace.reshape(-1) if needs_initial_state else None,
         fixed_state.reshape(-1),
-        output_state.reshape(-1) if store_final_state else None,
+        output_state if store_final_state else None,
+        state_indices if use_state_indices else None,
         cu_seqlens,
         cp_chunk_len,
         total_cp_chunks,
@@ -696,10 +747,11 @@ def cp_delta_rule_prefill_dsl_sm100(
             raise RuntimeError(
                 f"fixed_state must have shape {expected_workspace_shape}, got {tuple(fixed_state.shape)}"
             )
-        if initial_state is not None and initial_state.shape != expected_state_shape:
-            raise RuntimeError(
-                f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
-            )
+        if initial_state is not None:
+            if initial_state.shape != expected_state_shape:
+                raise RuntimeError(
+                    f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+                )
         if not _FullyFusedDeltaRuleSm120.can_implement(
             num_q_heads, num_k_heads, num_v_heads, d, q.element_size()
         ):
@@ -713,12 +765,13 @@ def cp_delta_rule_prefill_dsl_sm100(
             ("v", v),
             ("t", t),
             ("fixed_state", fixed_state),
-            ("initial_state", initial_state),
             ("alpha", alpha),
             ("o", o),
         ):
             if tensor is not None and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
+        if initial_state is not None and initial_state.stride()[1:] != (d * d, d, 1):
+            raise RuntimeError("initial_state must be contiguous in its inner [H, V, K] modes")
     if total_cp_chunks == 0:
         return
 
@@ -766,6 +819,10 @@ def cp_delta_rule_prefill_dsl_sm100(
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
             *args, **{**kwargs, "enable_tvm_ffi": True}
         )
+        initial_state_cute = None
+        if needs_initial_state:
+            initial_state_cute = from_dlpack(initial_state, assumed_align=16)
+            _mark_state_layout(initial_state_cute, False, d)
         kernel_args = (
             from_dlpack(q, assumed_align=16).mark_layout_dynamic(),
             from_dlpack(k, assumed_align=16).mark_layout_dynamic(),
@@ -775,11 +832,7 @@ def cp_delta_rule_prefill_dsl_sm100(
             from_dlpack(o, assumed_align=16).mark_layout_dynamic(),
             from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
             from_dlpack(fixed_state, assumed_align=16).mark_layout_dynamic(),
-            (
-                from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic()
-                if needs_initial_state
-                else None
-            ),
+            initial_state_cute,
             None,
             cutlass.Int32(cp_chunk_len),
             cutlass.Int32(total_cp_chunks),
@@ -823,6 +876,7 @@ def cp_delta_rule_dsl_sm100(
     scale: float,
     *,
     initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
     max_seqlen: int | None = None,
     cp_chunk_len: int | None = None,
     cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
@@ -901,13 +955,30 @@ def cp_delta_rule_dsl_sm100(
             f"got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
         )
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
-    if state is not None and state.shape != expected_state_shape:
+    use_state_indices = state_indices is not None
+    if state is not None and (
+        (not use_state_indices and state.shape != expected_state_shape)
+        or (use_state_indices and tuple(state.shape[1:]) != expected_state_shape[1:])
+    ):
         raise RuntimeError(
-            f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
+            f"state must have shape "
+            f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+            f"got {tuple(state.shape)}"
         )
-    if initial_state is not None and initial_state.shape != expected_state_shape:
+    if initial_state is not None and (
+        (not use_state_indices and initial_state.shape != expected_state_shape)
+        or (use_state_indices and tuple(initial_state.shape[1:]) != expected_state_shape[1:])
+    ):
         raise RuntimeError(
-            f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+            f"initial_state must have shape "
+            f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+            f"got {tuple(initial_state.shape)}"
+        )
+    if use_state_indices and (
+        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+    ):
+        raise RuntimeError(
+            f"state_indices must have shape {(num_seqs,)} and dtype int32"
         )
     if d != 128:
         raise RuntimeError(f"CPDeltaRuleSm100 only supports D=128, got {d}")
@@ -935,11 +1006,13 @@ def cp_delta_rule_dsl_sm100(
         ("alpha", alpha),
         ("beta", beta),
         ("o", o),
-        ("state", state),
-        ("initial_state", initial_state),
+        ("state_indices", state_indices),
     ):
         if tensor is not None and not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
+    for name, tensor in (("state", state), ("initial_state", initial_state)):
+        if tensor is not None and tensor.stride()[1:] != (d * d, d, 1):
+            raise RuntimeError(f"{name} must be contiguous in its inner [H, V, K] modes")
 
     with torch.cuda.nvtx.range("cp_delta_rule_sm100"):
         t = cp_delta_rule_t_precompute_dsl_sm100(
@@ -965,6 +1038,14 @@ def cp_delta_rule_dsl_sm100(
             _device=device,
             _stream=stream,
         )
+        initial_state_workspace = None
+        if initial_state is not None:
+            initial_state_workspace = _get_cp_workspace(
+                "gdn_cp_sm100_initial_state",
+                (num_seqs, num_sab_heads, d, d),
+                torch.float32,
+                device,
+            )
         fixed_state = cp_delta_rule_fixup_dsl_sm100(
             local_transfer,
             local_state,
@@ -973,6 +1054,8 @@ def cp_delta_rule_dsl_sm100(
             cp_chunk_len=cp_chunk_len,
             initial_state=initial_state,
             output_state=state,
+            state_indices=state_indices,
+            initial_state_workspace=initial_state_workspace,
             _skip_check=True,
             _device=device,
             _stream=stream,
@@ -990,7 +1073,7 @@ def cp_delta_rule_dsl_sm100(
             total_seqlen,
             cp_chunk_len=cp_chunk_len,
             max_seqlen=max_seqlen,
-            initial_state=initial_state,
+            initial_state=initial_state_workspace,
             _skip_check=True,
             _device=device,
             _stream=stream,

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -499,8 +499,9 @@ def cp_delta_rule_fixup_dsl_sm100(
         output_state.dtype if store_final_state else torch.float32
     )
     if _kernel_kind is None:
+        num_parallel_states = num_seqs * num_heads
         if num_heads <= 8:
-            _kernel_kind = "simt_row4"
+            _kernel_kind = "simt_row4" if num_parallel_states <= 8 else "simt_row8"
         elif num_heads <= 16:
             _kernel_kind = "simt_row8"
         else:
@@ -853,6 +854,7 @@ def cp_delta_rule_dsl_sm100(
             chunk_len_granularity=cp_chunk_len_granularity,
             device_capability=device_capability,
             total_seqlen=total_seqlen,
+            num_seqs=num_seqs,
             device_name=device_name,
         )
     if q.ndim != 3:

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -64,9 +64,7 @@ def _cu_seqlens_dtype(dtype):
 
 @functools.cache
 def _get_t_precompute_kernel(kernel_dtype, cu_seqlens_dtype):
-    return CPDeltaRuleTPrecomputeSm100(
-        kernel_dtype, cu_seqlens_dtype=cu_seqlens_dtype
-    )
+    return CPDeltaRuleTPrecomputeSm100(kernel_dtype, cu_seqlens_dtype=cu_seqlens_dtype)
 
 
 def cp_delta_rule_t_precompute_dsl_sm100(
@@ -147,9 +145,7 @@ def cp_delta_rule_t_precompute_dsl_sm100(
         else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
     )
 
-    kernel = _get_t_precompute_kernel(
-        kernel_dtype, _cu_seqlens_dtype(cu_seqlens.dtype)
-    )
+    kernel = _get_t_precompute_kernel(kernel_dtype, _cu_seqlens_dtype(cu_seqlens.dtype))
     compile_options = _blackwell_compile_options(device)
     compiled = get_cached_compile(kernel, compile_options)
     if compiled is None:
@@ -454,7 +450,10 @@ def cp_delta_rule_fixup_dsl_sm100(
                 f"got {local_transfer.dtype} and {local_state.dtype}"
             )
         use_state_indices = state_indices is not None
-        for name, tensor in (("initial_state", initial_state), ("output_state", output_state)):
+        for name, tensor in (
+            ("initial_state", initial_state),
+            ("output_state", output_state),
+        ):
             if tensor is not None:
                 expected_tail = (local_transfer.shape[1], 128, 128)
                 if tuple(tensor.shape[1:]) != expected_tail or (
@@ -470,7 +469,9 @@ def cp_delta_rule_fixup_dsl_sm100(
                         f"{name} must have dtype float32, bfloat16, or float16, got {tensor.dtype}"
                     )
         if use_state_indices:
-            if state_indices.dtype != torch.int32 or state_indices.shape != (cu_seqlens.shape[0] - 1,):
+            if state_indices.dtype != torch.int32 or state_indices.shape != (
+                cu_seqlens.shape[0] - 1,
+            ):
                 raise RuntimeError(
                     f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and dtype int32"
                 )
@@ -481,9 +482,14 @@ def cp_delta_rule_fixup_dsl_sm100(
         ):
             if tensor is not None and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
-        for name, tensor in (("initial_state", initial_state), ("output_state", output_state)):
+        for name, tensor in (
+            ("initial_state", initial_state),
+            ("output_state", output_state),
+        ):
             if tensor is not None and tensor.stride()[1:] != (128 * 128, 128, 1):
-                raise RuntimeError(f"{name} must be contiguous in its inner [H, V, K] modes")
+                raise RuntimeError(
+                    f"{name} must be contiguous in its inner [H, V, K] modes"
+                )
 
     total_cp_chunks, num_heads, _, d = local_transfer.shape
     if not _skip_check:
@@ -568,7 +574,9 @@ def cp_delta_rule_fixup_dsl_sm100(
             initial_state_cute = from_dlpack(initial_state, assumed_align=16)
             _mark_state_layout(initial_state_cute, use_state_indices, d)
         initial_state_workspace_cute = (
-            from_dlpack(initial_state_workspace.reshape(-1), assumed_align=16).mark_layout_dynamic()
+            from_dlpack(
+                initial_state_workspace.reshape(-1), assumed_align=16
+            ).mark_layout_dynamic()
             if needs_initial_state
             else None
         )
@@ -784,7 +792,9 @@ def cp_delta_rule_prefill_dsl_sm100(
         if state is not None and state.stride()[1:] != (d * d, d, 1):
             raise RuntimeError("state must be contiguous in its inner [H, V, K] modes")
         if initial_state is not None and initial_state.stride()[1:] != (d * d, d, 1):
-            raise RuntimeError("initial_state must be contiguous in its inner [H, V, K] modes")
+            raise RuntimeError(
+                "initial_state must be contiguous in its inner [H, V, K] modes"
+            )
         if (
             state is not None
             and initial_state is not None
@@ -814,7 +824,13 @@ def cp_delta_rule_prefill_dsl_sm100(
     num_sm = get_device_sm_count(device)
     is_gqa = num_q_heads >= num_v_heads
     head_ratio = num_q_heads // num_v_heads if is_gqa else num_v_heads // num_q_heads
-    state_dtype = state.dtype if store_final_state else initial_state.dtype if needs_initial_state else torch.float32
+    state_dtype = (
+        state.dtype
+        if store_final_state
+        else initial_state.dtype
+        if needs_initial_state
+        else torch.float32
+    )
     kernel = _get_prefill_kernel(
         kernel_dtype,
         _cutlass_state_dtype(state_dtype),
@@ -993,7 +1009,10 @@ def cp_delta_rule_dsl_sm100(
         )
     if initial_state is not None and (
         (not use_state_indices and initial_state.shape != expected_state_shape)
-        or (use_state_indices and tuple(initial_state.shape[1:]) != expected_state_shape[1:])
+        or (
+            use_state_indices
+            and tuple(initial_state.shape[1:]) != expected_state_shape[1:]
+        )
     ):
         raise RuntimeError(
             f"initial_state must have shape "
@@ -1038,7 +1057,9 @@ def cp_delta_rule_dsl_sm100(
             raise RuntimeError(f"{name} must be contiguous")
     for name, tensor in (("state", state), ("initial_state", initial_state)):
         if tensor is not None and tensor.stride()[1:] != (d * d, d, 1):
-            raise RuntimeError(f"{name} must be contiguous in its inner [H, V, K] modes")
+            raise RuntimeError(
+                f"{name} must be contiguous in its inner [H, V, K] modes"
+            )
 
     with torch.cuda.nvtx.range("cp_delta_rule_sm100"):
         t = cp_delta_rule_t_precompute_dsl_sm100(

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -28,6 +28,7 @@ from ..delta_rule_dsl.varlen_helper import (
 )
 from .gated_delta_net_cp import CPDeltaRuleMNPrecomputeUtcmma1Sm100
 from .gated_delta_net_cp_prefill import CPDeltaRulePrefillTcgen05Sm100
+from .gdn_prefill import _cutlass_state_dtype
 
 
 @functools.cache
@@ -354,18 +355,39 @@ class CPDeltaRuleFixupHmmaSm100(CPDeltaRuleFixupHmmaSm120):
 
 
 @functools.cache
-def _get_fixup_kernel(needs_initial_state, kernel_kind, cu_seqlens_dtype):
+def _get_fixup_kernel(
+    needs_initial_state,
+    store_final_state,
+    initial_state_dtype,
+    output_state_dtype,
+    kernel_kind,
+    cu_seqlens_dtype,
+):
     if kernel_kind == "simt_row4":
         return CPDeltaRuleFixupSm100(
-            needs_initial_state, 4, cu_seqlens_dtype=cu_seqlens_dtype
+            needs_initial_state,
+            4,
+            store_final_state,
+            initial_state_dtype,
+            output_state_dtype,
+            cu_seqlens_dtype,
         )
     if kernel_kind == "simt_row8":
         return CPDeltaRuleFixupSm100(
-            needs_initial_state, 8, cu_seqlens_dtype=cu_seqlens_dtype
+            needs_initial_state,
+            8,
+            store_final_state,
+            initial_state_dtype,
+            output_state_dtype,
+            cu_seqlens_dtype,
         )
     if kernel_kind == "hmma":
         return CPDeltaRuleFixupHmmaSm100(
-            needs_initial_state, cu_seqlens_dtype=cu_seqlens_dtype
+            needs_initial_state,
+            store_final_state,
+            initial_state_dtype,
+            output_state_dtype,
+            cu_seqlens_dtype,
         )
     raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
 
@@ -377,6 +399,7 @@ def cp_delta_rule_fixup_dsl_sm100(
     total_seqlen: int,
     cp_chunk_len: int = 4096,
     initial_state: torch.Tensor | None = None,
+    output_state: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
     _kernel_kind: str | None = None,
@@ -407,25 +430,28 @@ def cp_delta_rule_fixup_dsl_sm100(
                 "CPDeltaRuleFixupSm100 only supports float32 inputs, "
                 f"got {local_transfer.dtype} and {local_state.dtype}"
             )
-        if initial_state is not None:
-            expected_initial_state_shape = (
-                cu_seqlens.shape[0] - 1,
-                local_transfer.shape[1],
-                128,
-                128,
-            )
-            if initial_state.shape != expected_initial_state_shape:
-                raise RuntimeError(
-                    f"initial_state must have shape {expected_initial_state_shape}, got {tuple(initial_state.shape)}"
-                )
-            if initial_state.dtype != torch.float32:
-                raise RuntimeError(
-                    f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
-                )
+        for name, tensor in (("initial_state", initial_state), ("output_state", output_state)):
+            if tensor is not None:
+                if tensor.shape != (
+                    cu_seqlens.shape[0] - 1,
+                    local_transfer.shape[1],
+                    128,
+                    128,
+                ):
+                    raise RuntimeError(
+                        f"{name} must have shape "
+                        f"{(cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128)}, "
+                        f"got {tuple(tensor.shape)}"
+                    )
+                if tensor.dtype not in (torch.float32, torch.bfloat16, torch.float16):
+                    raise RuntimeError(
+                        f"{name} must have dtype float32, bfloat16, or float16, got {tensor.dtype}"
+                    )
         for name, tensor in (
             ("local_transfer", local_transfer),
             ("local_state", local_state),
             ("initial_state", initial_state),
+            ("output_state", output_state),
         ):
             if tensor is not None and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
@@ -465,6 +491,13 @@ def cp_delta_rule_fixup_dsl_sm100(
         else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
     )
     needs_initial_state = initial_state is not None
+    store_final_state = output_state is not None
+    initial_state_dtype = _cutlass_state_dtype(
+        initial_state.dtype if needs_initial_state else torch.float32
+    )
+    output_state_dtype = _cutlass_state_dtype(
+        output_state.dtype if store_final_state else torch.float32
+    )
     if _kernel_kind is None:
         if num_heads <= 8:
             _kernel_kind = "simt_row4"
@@ -473,7 +506,12 @@ def cp_delta_rule_fixup_dsl_sm100(
         else:
             _kernel_kind = "hmma"
     kernel = _get_fixup_kernel(
-        needs_initial_state, _kernel_kind, _cu_seqlens_dtype(cu_seqlens.dtype)
+        needs_initial_state,
+        store_final_state,
+        initial_state_dtype,
+        output_state_dtype,
+        _kernel_kind,
+        _cu_seqlens_dtype(cu_seqlens.dtype),
     )
     compile_options = _blackwell_compile_options(device)
     compiled = get_cached_compile(kernel, compile_options)
@@ -499,6 +537,13 @@ def cp_delta_rule_fixup_dsl_sm100(
             from_dlpack(
                 fixed_state.reshape(-1), assumed_align=128
             ).mark_layout_dynamic(),
+            (
+                from_dlpack(
+                    output_state.reshape(-1), assumed_align=16
+                ).mark_layout_dynamic()
+                if store_final_state
+                else None
+            ),
             from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
             cutlass.Int32(cp_chunk_len),
             cutlass.Int32(total_cp_chunks),
@@ -512,6 +557,7 @@ def cp_delta_rule_fixup_dsl_sm100(
         local_state_tma,
         initial_state.reshape(-1) if needs_initial_state else None,
         fixed_state.reshape(-1),
+        output_state.reshape(-1) if store_final_state else None,
         cu_seqlens,
         cp_chunk_len,
         total_cp_chunks,
@@ -525,6 +571,7 @@ def cp_delta_rule_fixup_dsl_sm100(
 @functools.cache
 def _get_prefill_kernel(
     kernel_dtype,
+    state_dtype,
     num_sm,
     is_gqa,
     head_ratio,
@@ -534,7 +581,7 @@ def _get_prefill_kernel(
     return CPDeltaRulePrefillTcgen05Sm100(
         io_dtype=kernel_dtype,
         acc_dtype=cutlass.Float32,
-        state_dtype=cutlass.Float32,
+        state_dtype=state_dtype,
         mma_tiler_qk=(64, 64, 128),
         mma_tiler_qs=(128, 64, 128),
         mma_tiler_qkv=(128, 64, 64),
@@ -544,7 +591,7 @@ def _get_prefill_kernel(
         is_GQA=is_gqa,
         head_ratio=head_ratio,
         use_initial_state=needs_initial_state,
-        store_final_state=True,
+        store_final_state=False,
         enable_checkpoints=False,
         is_persistent=False,
         cu_seqlens_dtype=cu_seqlens_dtype,
@@ -553,7 +600,6 @@ def _get_prefill_kernel(
 
 def cp_delta_rule_prefill_dsl_sm100(
     o: torch.Tensor,
-    state: torch.Tensor,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -645,12 +691,9 @@ def cp_delta_rule_prefill_dsl_sm100(
             )
         expected_workspace_shape = (total_cp_chunks, num_sab_heads, d, d)
         expected_state_shape = (num_seqs, num_sab_heads, d, d)
-        if (
-            fixed_state.shape != expected_workspace_shape
-            or state.shape != expected_state_shape
-        ):
+        if fixed_state.shape != expected_workspace_shape:
             raise RuntimeError(
-                f"fixed_state/state must have shapes {expected_workspace_shape} and {expected_state_shape}"
+                f"fixed_state must have shape {expected_workspace_shape}, got {tuple(fixed_state.shape)}"
             )
         if initial_state is not None and initial_state.shape != expected_state_shape:
             raise RuntimeError(
@@ -672,7 +715,6 @@ def cp_delta_rule_prefill_dsl_sm100(
             ("initial_state", initial_state),
             ("alpha", alpha),
             ("o", o),
-            ("state", state),
         ):
             if tensor is not None and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
@@ -698,6 +740,9 @@ def cp_delta_rule_prefill_dsl_sm100(
     head_ratio = num_q_heads // num_v_heads if is_gqa else num_v_heads // num_q_heads
     kernel = _get_prefill_kernel(
         kernel_dtype,
+        _cutlass_state_dtype(
+            initial_state.dtype if needs_initial_state else torch.float32
+        ),
         num_sm,
         is_gqa,
         head_ratio,
@@ -734,7 +779,7 @@ def cp_delta_rule_prefill_dsl_sm100(
                 if needs_initial_state
                 else None
             ),
-            from_dlpack(state, assumed_align=16).mark_layout_dynamic(),
+            None,
             cutlass.Int32(cp_chunk_len),
             cutlass.Int32(total_cp_chunks),
             cutlass.Int32(max_cp_chunks_per_seq),
@@ -754,7 +799,7 @@ def cp_delta_rule_prefill_dsl_sm100(
         cu_seqlens,
         fixed_state,
         initial_state if needs_initial_state else None,
-        state,
+        None,
         cp_chunk_len,
         total_cp_chunks,
         max_cp_chunks_per_seq,
@@ -767,7 +812,7 @@ def cp_delta_rule_prefill_dsl_sm100(
 
 def cp_delta_rule_dsl_sm100(
     o: torch.Tensor,
-    state: torch.Tensor,
+    state: torch.Tensor | None,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -854,7 +899,7 @@ def cp_delta_rule_dsl_sm100(
             f"got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
         )
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
-    if state.shape != expected_state_shape:
+    if state is not None and state.shape != expected_state_shape:
         raise RuntimeError(
             f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
         )
@@ -872,10 +917,15 @@ def cp_delta_rule_dsl_sm100(
         raise RuntimeError("q/k/v/o dtypes must match")
     if alpha.dtype != torch.float32 or beta.dtype != torch.float32:
         raise RuntimeError("alpha and beta must have dtype torch.float32")
-    if state.dtype != torch.float32 or (
-        initial_state is not None and initial_state.dtype != torch.float32
-    ):
-        raise RuntimeError("state and initial_state must have dtype torch.float32")
+    for name, tensor in (("state", state), ("initial_state", initial_state)):
+        if tensor is not None and tensor.dtype not in (
+            torch.float32,
+            torch.bfloat16,
+            torch.float16,
+        ):
+            raise RuntimeError(
+                f"{name} must have dtype float32, bfloat16, or float16, got {tensor.dtype}"
+            )
     for name, tensor in (
         ("q", q),
         ("k", k),
@@ -920,13 +970,13 @@ def cp_delta_rule_dsl_sm100(
             total_seqlen,
             cp_chunk_len=cp_chunk_len,
             initial_state=initial_state,
+            output_state=state,
             _skip_check=True,
             _device=device,
             _stream=stream,
         )
         cp_delta_rule_prefill_dsl_sm100(
             o,
-            state,
             q,
             k,
             v,

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -628,6 +628,7 @@ def _get_prefill_kernel(
     is_gqa,
     head_ratio,
     needs_initial_state,
+    store_final_state,
     cu_seqlens_dtype,
 ):
     return CPDeltaRulePrefillTcgen05Sm100(
@@ -643,7 +644,7 @@ def _get_prefill_kernel(
         is_GQA=is_gqa,
         head_ratio=head_ratio,
         use_initial_state=needs_initial_state,
-        store_final_state=False,
+        store_final_state=store_final_state,
         enable_checkpoints=False,
         is_persistent=False,
         cu_seqlens_dtype=cu_seqlens_dtype,
@@ -652,6 +653,7 @@ def _get_prefill_kernel(
 
 def cp_delta_rule_prefill_dsl_sm100(
     o: torch.Tensor,
+    state: torch.Tensor | None,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -747,6 +749,15 @@ def cp_delta_rule_prefill_dsl_sm100(
             raise RuntimeError(
                 f"fixed_state must have shape {expected_workspace_shape}, got {tuple(fixed_state.shape)}"
             )
+        if state is not None:
+            if state.shape != expected_state_shape:
+                raise RuntimeError(
+                    f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
+                )
+            if state.dtype not in (torch.float32, torch.bfloat16, torch.float16):
+                raise RuntimeError(
+                    f"state must have dtype float32, bfloat16, or float16, got {state.dtype}"
+                )
         if initial_state is not None:
             if initial_state.shape != expected_state_shape:
                 raise RuntimeError(
@@ -770,8 +781,18 @@ def cp_delta_rule_prefill_dsl_sm100(
         ):
             if tensor is not None and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
+        if state is not None and state.stride()[1:] != (d * d, d, 1):
+            raise RuntimeError("state must be contiguous in its inner [H, V, K] modes")
         if initial_state is not None and initial_state.stride()[1:] != (d * d, d, 1):
             raise RuntimeError("initial_state must be contiguous in its inner [H, V, K] modes")
+        if (
+            state is not None
+            and initial_state is not None
+            and state.dtype != initial_state.dtype
+        ):
+            raise RuntimeError(
+                f"state and initial_state dtypes must match, got {state.dtype} and {initial_state.dtype}"
+            )
     if total_cp_chunks == 0:
         return
 
@@ -789,18 +810,19 @@ def cp_delta_rule_prefill_dsl_sm100(
         else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
     )
     needs_initial_state = initial_state is not None
+    store_final_state = state is not None
     num_sm = get_device_sm_count(device)
     is_gqa = num_q_heads >= num_v_heads
     head_ratio = num_q_heads // num_v_heads if is_gqa else num_v_heads // num_q_heads
+    state_dtype = state.dtype if store_final_state else initial_state.dtype if needs_initial_state else torch.float32
     kernel = _get_prefill_kernel(
         kernel_dtype,
-        _cutlass_state_dtype(
-            initial_state.dtype if needs_initial_state else torch.float32
-        ),
+        _cutlass_state_dtype(state_dtype),
         num_sm,
         is_gqa,
         head_ratio,
         needs_initial_state,
+        store_final_state,
         _cu_seqlens_dtype(cu_seqlens.dtype),
     )
     compile_options = _blackwell_compile_options(device)
@@ -823,6 +845,10 @@ def cp_delta_rule_prefill_dsl_sm100(
         if needs_initial_state:
             initial_state_cute = from_dlpack(initial_state, assumed_align=16)
             _mark_state_layout(initial_state_cute, False, d)
+        state_cute = None
+        if store_final_state:
+            state_cute = from_dlpack(state, assumed_align=16)
+            _mark_state_layout(state_cute, False, d)
         kernel_args = (
             from_dlpack(q, assumed_align=16).mark_layout_dynamic(),
             from_dlpack(k, assumed_align=16).mark_layout_dynamic(),
@@ -833,7 +859,7 @@ def cp_delta_rule_prefill_dsl_sm100(
             from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
             from_dlpack(fixed_state, assumed_align=16).mark_layout_dynamic(),
             initial_state_cute,
-            None,
+            state_cute,
             cutlass.Int32(cp_chunk_len),
             cutlass.Int32(total_cp_chunks),
             cutlass.Int32(max_cp_chunks_per_seq),
@@ -853,7 +879,7 @@ def cp_delta_rule_prefill_dsl_sm100(
         cu_seqlens,
         fixed_state,
         initial_state if needs_initial_state else None,
-        None,
+        state if store_final_state else None,
         cp_chunk_len,
         total_cp_chunks,
         max_cp_chunks_per_seq,
@@ -1062,6 +1088,7 @@ def cp_delta_rule_dsl_sm100(
         )
         cp_delta_rule_prefill_dsl_sm100(
             o,
+            None,
             q,
             k,
             v,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/alpha.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/alpha.py
@@ -10,6 +10,7 @@ class AlphaProcessor:
     CUMSUM_LOG = 0
     CUMPROD = 1
     CUMPROD_SCALE = 2
+    CUMPROD_END_RCP = 2
     CUMPROD_NEG_END_RCP = 2
     NUM_CHANNELS = 3
 
@@ -19,6 +20,7 @@ class AlphaProcessor:
         vecs: cute.Tensor,
         scale: cutlass.Float32,
         channel2_neg_end_rcp: cutlass.Constexpr = False,
+        channel2_end_rcp: cutlass.Constexpr = False,
     ):
         WARP_SIZE = 32
         blk_q = cute.size(vecs.shape[0])
@@ -45,7 +47,7 @@ class AlphaProcessor:
             carry = cute.arch.shuffle_sync(frag[i - 1], 31)
             frag[i] = frag[i] + carry
 
-        if cutlass.const_expr(channel2_neg_end_rcp):
+        if cutlass.const_expr(channel2_neg_end_rcp or channel2_end_rcp):
             end_log = cute.arch.shuffle_sync(frag[num_iters - 1], 31)
         for i in cutlass.range_constexpr(num_iters):
             vecs_32[lane_id, i, AlphaProcessor.CUMSUM_LOG] = frag[i]
@@ -55,5 +57,9 @@ class AlphaProcessor:
                 vecs_32[
                     lane_id, i, AlphaProcessor.CUMPROD_NEG_END_RCP
                 ] = -cute.math.exp2(end_log - frag[i], fastmath=True)
+            elif cutlass.const_expr(channel2_end_rcp):
+                vecs_32[lane_id, i, AlphaProcessor.CUMPROD_END_RCP] = cute.math.exp2(
+                    end_log - frag[i], fastmath=True
+                )
             else:
                 vecs_32[lane_id, i, AlphaProcessor.CUMPROD_SCALE] = cumprod * scale

--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import tempfile
 import warnings
@@ -94,11 +95,15 @@ class KeyedCompileMixin:
         return compile_key
 
 
+@functools.cache
+def _compile_options_tuple_key(options):
+    return tuple((type(option), option.value) for option in options)
+
+
 def _compile_options_key(options):
     if options is None:
         return None
-    options = _as_options_tuple(options)
-    return tuple((type(option), option.value) for option in options)
+    return _compile_options_tuple_key(_as_options_tuple(options))
 
 
 def _option_value(options, option_type):
@@ -176,3 +181,8 @@ def cached_compile(func, *args, compile_options=None, **kwargs):
         _in_mem_compile_cache[cache_key] = compiled_fn
 
     return compiled_fn
+
+
+def get_cached_compile(func, compile_options=None):
+    cache_key = (func._get_compile_key(), _compile_options_key(compile_options))
+    return _in_mem_compile_cache.get(cache_key)

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -1750,9 +1750,15 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
     def __init__(
         self,
         needs_initial_state: bool = False,
+        store_final_state: bool = False,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
     ):
         self.needs_initial_state = needs_initial_state
+        self.store_final_state = store_final_state
+        self.initial_state_dtype = initial_state_dtype
+        self.state_dtype = state_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.D = 128
         self.rows_per_cta = 64
@@ -1769,6 +1775,9 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         self.use_3xtf32 = False
         self.manual_cache_key(
             "needs_initial_state",
+            "store_final_state",
+            "initial_state_dtype",
+            "state_dtype",
             "cu_seqlens_dtype",
             "D",
             "rows_per_cta",
@@ -1843,6 +1852,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         n_consumer_state,
         gFixedState: cute.Tensor,
         gInitialState: cute.Tensor,
+        gOutputState: cute.Tensor,
         num_chunks: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
         chunk_start: cutlass.Int32,
@@ -1890,10 +1900,18 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
                 (16, self.D),
                 (global_row_base // 16, 0),
             )
+        if cutlass.const_expr(self.store_final_state):
+            gOutputState_warp = cute.local_tile(
+                gOutputState[None, None, head_idx, seq_idx],
+                (16, self.D),
+                (global_row_base // 16, 0),
+            )
         tSMsN = thr_copy_C.partition_S(sN_warp)
         tSMgFixedState = thr_store_C.partition_D(gFixedState_warp)
         if cutlass.const_expr(self.needs_initial_state):
             tSMgInitialState = thr_copy_C.partition_S(gInitialState_warp)
+        if cutlass.const_expr(self.store_final_state):
+            tSMgOutputState = thr_store_C.partition_D(gOutputState_warp)
 
         start = cutlass.Int32(0)
         if cutlass.const_expr(not self.needs_initial_state):
@@ -1920,7 +1938,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             start = cutlass.Int32(0)
 
             # init tSMrState from initial_state
-            cute.autovec_copy(tSMgInitialState, tSMrState_cv)
+            tSMrState_cv.store(tSMgInitialState.load().to(cutlass.Float32))
 
         for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
             TF32.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)
@@ -1964,6 +1982,12 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
                 tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start + chunk_idx
             )
 
+        if cutlass.const_expr(self.store_final_state):
+            tSMrOutputState = cute.make_rmem_tensor_like(tSMrState, self.state_dtype)
+            tSMrOutputState.store(tSMrState.load().to(self.state_dtype))
+            tSMrOutputState_store = thr_store_C.retile(tSMrOutputState)
+            cute.autovec_copy(tSMrOutputState_store, tSMgOutputState)
+
         return m_consumer_state, n_consumer_state
 
     @cute.jit
@@ -1973,6 +1997,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
+        g_output_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2008,6 +2033,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             g_local_state_t,
             g_initial_state_t,
             g_fixed_state_t,
+            g_output_state_t,
             g_cu_seqlens,
             chunk_len,
             total_cp_chunks,
@@ -2028,6 +2054,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
+        g_output_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2090,6 +2117,10 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             )
         else:
             gInitialState = gFixedState
+        if cutlass.const_expr(self.store_final_state):
+            gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
+        else:
+            gOutputState = gFixedState
 
         copy_atom = cute.make_copy_atom(
             cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=128
@@ -2252,6 +2283,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
                     n_consumer_state,
                     gFixedState,
                     gInitialState,
+                    gOutputState,
                     num_chunks,
                     total_cp_chunks,
                     chunk_start,
@@ -2267,9 +2299,15 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         self,
         needs_initial_state: bool = False,
         rows_per_cta: int = 4,
+        store_final_state: bool = False,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
     ):
         self.needs_initial_state = needs_initial_state
+        self.store_final_state = store_final_state
+        self.initial_state_dtype = initial_state_dtype
+        self.state_dtype = state_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.D = 128
         self.rows_per_cta = rows_per_cta
@@ -2280,6 +2318,9 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         self.registers_per_thread = 256
         self.manual_cache_key(
             "needs_initial_state",
+            "store_final_state",
+            "initial_state_dtype",
+            "state_dtype",
             "cu_seqlens_dtype",
             "D",
             "rows_per_cta",
@@ -2302,7 +2343,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         start = cutlass.Int32(0)
         if cutlass.const_expr(self.needs_initial_state):
             for i in cutlass.range_constexpr(self.rows_per_cta):
-                sState[i, col] = gInitialState[i, col]
+                sState[i, col] = gInitialState[i, col].to(cutlass.Float32)
         else:
             start = cutlass.Int32(1)
             for i in cutlass.range_constexpr(self.rows_per_cta):
@@ -2431,6 +2472,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
+        g_output_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2452,6 +2494,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             g_local_state_t,
             g_initial_state_t,
             g_fixed_state_t,
+            g_output_state_t,
             g_cu_seqlens,
             chunk_len,
             total_cp_chunks,
@@ -2472,6 +2515,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
+        g_output_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2520,6 +2564,13 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             )
         else:
             gInitialState = gFixedState
+        if cutlass.const_expr(self.store_final_state):
+            gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
+            gOutputState_cta = cute.local_tile(
+                gOutputState[None, None, head_idx, seq_idx],
+                (self.rows_per_cta, self.D),
+                (row_cta_idx, 0),
+            )
 
         sState = storage.smem_state.get_tensor(state_layout)
         gTransfer_head = gTransfer[None, None, head_idx, None]
@@ -2565,6 +2616,9 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
                 col,
                 start,
             )
+            if cutlass.const_expr(self.store_final_state):
+                for i in cutlass.range_constexpr(self.rows_per_cta):
+                    gOutputState_cta[i, col] = sState[i, col].to(self.state_dtype)
         gFixedState_gap = cute.domain_offset((0, 0, gap_start), gFixedState_cta)
         self.zero_invalid_slots(gFixedState_gap, gap_end - gap_start, col)
 
@@ -2707,6 +2761,7 @@ def cp_delta_rule_fixup_dsl_sm120(
         ),
         initial_state_cute,
         from_dlpack(fixed_state.reshape(-1), assumed_align=128).mark_layout_dynamic(),
+        None,
         from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
         cutlass.Int32(cp_chunk_len),
         cutlass.Int32(total_cp_chunks),

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -1956,7 +1956,14 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             # init tSMrState from initial_state
             tSMrState_cv.store(tSMgInitialState.load().to(cutlass.Float32))
             if cutlass.const_expr(self.store_initial_state):
-                cute.copy(tiled_store_C, tSMrState_store, tSMgInitialStateWorkspace)
+                tSMrInitialState = cute.make_tensor(
+                    tSMrState_store.iterator.align(8), tSMrState_store.layout
+                )
+                tSMgInitialStateWorkspace = cute.make_tensor(
+                    tSMgInitialStateWorkspace.iterator.align(8),
+                    tSMgInitialStateWorkspace.layout,
+                )
+                cute.autovec_copy(tSMrInitialState, tSMgInitialStateWorkspace)
 
         for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
             TF32.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -1925,7 +1925,9 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         if cutlass.const_expr(self.needs_initial_state):
             tSMgInitialState = thr_copy_C.partition_S(gInitialState_warp)
         if cutlass.const_expr(self.store_initial_state):
-            tSMgInitialStateWorkspace = thr_store_C.partition_D(gInitialStateWorkspace_warp)
+            tSMgInitialStateWorkspace = thr_store_C.partition_D(
+                gInitialStateWorkspace_warp
+            )
         if cutlass.const_expr(self.store_final_state):
             tSMgOutputState = thr_store_C.partition_D(gOutputState_warp)
 
@@ -2156,9 +2158,13 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
                         g_initial_state_t.stride[0],
                     ),
                 )
-                gInitialState = cute.make_tensor(g_initial_state_t.iterator, initial_state_layout)
+                gInitialState = cute.make_tensor(
+                    g_initial_state_t.iterator, initial_state_layout
+                )
             else:
-                gInitialState = cute.make_tensor(g_initial_state_t.iterator, fixed_state_layout)
+                gInitialState = cute.make_tensor(
+                    g_initial_state_t.iterator, fixed_state_layout
+                )
         else:
             gInitialState = gFixedState
         if cutlass.const_expr(self.store_final_state):
@@ -2172,9 +2178,13 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
                         g_output_state_t.stride[0],
                     ),
                 )
-                gOutputState = cute.make_tensor(g_output_state_t.iterator, output_state_layout)
+                gOutputState = cute.make_tensor(
+                    g_output_state_t.iterator, output_state_layout
+                )
             else:
-                gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
+                gOutputState = cute.make_tensor(
+                    g_output_state_t.iterator, fixed_state_layout
+                )
         else:
             gOutputState = gFixedState
         if cutlass.const_expr(self.store_initial_state):
@@ -2652,9 +2662,13 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
                         g_initial_state_t.stride[0],
                     ),
                 )
-                gInitialState = cute.make_tensor(g_initial_state_t.iterator, initial_state_layout)
+                gInitialState = cute.make_tensor(
+                    g_initial_state_t.iterator, initial_state_layout
+                )
             else:
-                gInitialState = cute.make_tensor(g_initial_state_t.iterator, fixed_state_layout)
+                gInitialState = cute.make_tensor(
+                    g_initial_state_t.iterator, fixed_state_layout
+                )
         else:
             gInitialState = gFixedState
         if cutlass.const_expr(self.store_final_state):
@@ -2668,9 +2682,13 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
                         g_output_state_t.stride[0],
                     ),
                 )
-                gOutputState = cute.make_tensor(g_output_state_t.iterator, output_state_layout)
+                gOutputState = cute.make_tensor(
+                    g_output_state_t.iterator, output_state_layout
+                )
             else:
-                gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
+                gOutputState = cute.make_tensor(
+                    g_output_state_t.iterator, fixed_state_layout
+                )
             gOutputState_cta = cute.local_tile(
                 gOutputState[None, None, head_idx, state_idx],
                 (self.rows_per_cta, self.D),

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -63,13 +63,17 @@ class CPDeltaRuleTPrecomputeSm120(KeyedCompileMixin):
         self,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
     ):
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.cu_seqlens_dtype = cu_seqlens_dtype
         self.inverse_dtype = cutlass.Float16
         self.BLK = 64
         self.D = 128
-        self.manual_cache_key("dtype", "acc_dtype", "inverse_dtype", "BLK", "D")
+        self.manual_cache_key(
+            "dtype", "acc_dtype", "cu_seqlens_dtype", "inverse_dtype", "BLK", "D"
+        )
 
     @cute.jit
     def load_k_tile_tma(
@@ -1743,8 +1747,13 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         LOAD = 0
         MATH = 1
 
-    def __init__(self, needs_initial_state: bool = False):
+    def __init__(
+        self,
+        needs_initial_state: bool = False,
+        cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
+    ):
         self.needs_initial_state = needs_initial_state
+        self.cu_seqlens_dtype = cu_seqlens_dtype
         self.D = 128
         self.rows_per_cta = 64
         self.row_ctas = 2
@@ -1760,6 +1769,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         self.use_3xtf32 = False
         self.manual_cache_key(
             "needs_initial_state",
+            "cu_seqlens_dtype",
             "D",
             "rows_per_cta",
             "row_ctas",
@@ -2257,8 +2267,10 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         self,
         needs_initial_state: bool = False,
         rows_per_cta: int = 4,
+        cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
     ):
         self.needs_initial_state = needs_initial_state
+        self.cu_seqlens_dtype = cu_seqlens_dtype
         self.D = 128
         self.rows_per_cta = rows_per_cta
         self.row_ctas = self.D // self.rows_per_cta
@@ -2268,6 +2280,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         self.registers_per_thread = 256
         self.manual_cache_key(
             "needs_initial_state",
+            "cu_seqlens_dtype",
             "D",
             "rows_per_cta",
             "row_ctas",

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -1754,12 +1754,16 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
+        use_state_indices: bool = False,
+        store_initial_state: bool = False,
     ):
         self.needs_initial_state = needs_initial_state
         self.store_final_state = store_final_state
         self.initial_state_dtype = initial_state_dtype
         self.state_dtype = state_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.use_state_indices = use_state_indices
+        self.store_initial_state = store_initial_state
         self.D = 128
         self.rows_per_cta = 64
         self.row_ctas = 2
@@ -1779,6 +1783,8 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             "initial_state_dtype",
             "state_dtype",
             "cu_seqlens_dtype",
+            "use_state_indices",
+            "store_initial_state",
             "D",
             "rows_per_cta",
             "row_ctas",
@@ -1852,11 +1858,13 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         n_consumer_state,
         gFixedState: cute.Tensor,
         gInitialState: cute.Tensor,
+        gInitialStateWorkspace: cute.Tensor,
         gOutputState: cute.Tensor,
         num_chunks: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
         chunk_start: cutlass.Int32,
         seq_idx: cutlass.Int32,
+        state_idx: cutlass.Int32,
         head_idx: cutlass.Int32,
         row_cta_idx: cutlass.Int32,
         math_tidx: cutlass.Int32,
@@ -1896,13 +1904,19 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         )
         if cutlass.const_expr(self.needs_initial_state):
             gInitialState_warp = cute.local_tile(
-                gInitialState[None, None, head_idx, seq_idx],
+                gInitialState[None, None, head_idx, state_idx],
+                (16, self.D),
+                (global_row_base // 16, 0),
+            )
+        if cutlass.const_expr(self.store_initial_state):
+            gInitialStateWorkspace_warp = cute.local_tile(
+                gInitialStateWorkspace[None, None, head_idx, seq_idx],
                 (16, self.D),
                 (global_row_base // 16, 0),
             )
         if cutlass.const_expr(self.store_final_state):
             gOutputState_warp = cute.local_tile(
-                gOutputState[None, None, head_idx, seq_idx],
+                gOutputState[None, None, head_idx, state_idx],
                 (16, self.D),
                 (global_row_base // 16, 0),
             )
@@ -1910,6 +1924,8 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         tSMgFixedState = thr_store_C.partition_D(gFixedState_warp)
         if cutlass.const_expr(self.needs_initial_state):
             tSMgInitialState = thr_copy_C.partition_S(gInitialState_warp)
+        if cutlass.const_expr(self.store_initial_state):
+            tSMgInitialStateWorkspace = thr_store_C.partition_D(gInitialStateWorkspace_warp)
         if cutlass.const_expr(self.store_final_state):
             tSMgOutputState = thr_store_C.partition_D(gOutputState_warp)
 
@@ -1939,6 +1955,8 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
 
             # init tSMrState from initial_state
             tSMrState_cv.store(tSMgInitialState.load().to(cutlass.Float32))
+            if cutlass.const_expr(self.store_initial_state):
+                cute.copy(tiled_store_C, tSMrState_store, tSMgInitialStateWorkspace)
 
         for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
             TF32.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)
@@ -1996,8 +2014,10 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_initial_state_workspace_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_output_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2032,8 +2052,10 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             g_transfer_t,
             g_local_state_t,
             g_initial_state_t,
+            g_initial_state_workspace_t,
             g_fixed_state_t,
             g_output_state_t,
+            g_state_indices_t,
             g_cu_seqlens,
             chunk_len,
             total_cp_chunks,
@@ -2053,8 +2075,10 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_initial_state_workspace_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_output_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2111,16 +2135,47 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             (self.D, self.D, num_heads, num_seqs),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
+        state_idx = seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
-            gInitialState = cute.make_tensor(
-                g_initial_state_t.iterator, fixed_state_layout
-            )
+            if cutlass.const_expr(self.use_state_indices):
+                initial_state_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
+                    stride=(
+                        g_initial_state_t.stride[2],
+                        g_initial_state_t.stride[3],
+                        g_initial_state_t.stride[1],
+                        g_initial_state_t.stride[0],
+                    ),
+                )
+                gInitialState = cute.make_tensor(g_initial_state_t.iterator, initial_state_layout)
+            else:
+                gInitialState = cute.make_tensor(g_initial_state_t.iterator, fixed_state_layout)
         else:
             gInitialState = gFixedState
         if cutlass.const_expr(self.store_final_state):
-            gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
+            if cutlass.const_expr(self.use_state_indices):
+                output_state_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_output_state_t.shape[0]),
+                    stride=(
+                        g_output_state_t.stride[2],
+                        g_output_state_t.stride[3],
+                        g_output_state_t.stride[1],
+                        g_output_state_t.stride[0],
+                    ),
+                )
+                gOutputState = cute.make_tensor(g_output_state_t.iterator, output_state_layout)
+            else:
+                gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
         else:
             gOutputState = gFixedState
+        if cutlass.const_expr(self.store_initial_state):
+            gInitialStateWorkspace = cute.make_tensor(
+                g_initial_state_workspace_t.iterator, fixed_state_layout
+            )
+        else:
+            gInitialStateWorkspace = gFixedState
 
         copy_atom = cute.make_copy_atom(
             cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=128
@@ -2283,11 +2338,13 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
                     n_consumer_state,
                     gFixedState,
                     gInitialState,
+                    gInitialStateWorkspace,
                     gOutputState,
                     num_chunks,
                     total_cp_chunks,
                     chunk_start,
                     seq_idx,
+                    state_idx,
                     head_idx,
                     row_cta_idx,
                     math_tidx,
@@ -2303,12 +2360,16 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
+        use_state_indices: bool = False,
+        store_initial_state: bool = False,
     ):
         self.needs_initial_state = needs_initial_state
         self.store_final_state = store_final_state
         self.initial_state_dtype = initial_state_dtype
         self.state_dtype = state_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.use_state_indices = use_state_indices
+        self.store_initial_state = store_initial_state
         self.D = 128
         self.rows_per_cta = rows_per_cta
         self.row_ctas = self.D // self.rows_per_cta
@@ -2322,6 +2383,8 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             "initial_state_dtype",
             "state_dtype",
             "cu_seqlens_dtype",
+            "use_state_indices",
+            "store_initial_state",
             "D",
             "rows_per_cta",
             "row_ctas",
@@ -2338,12 +2401,16 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         gFixedState: cute.Tensor,
         gLocalState: cute.Tensor,
         gInitialState: cute.Tensor,
+        gInitialStateWorkspace: cute.Tensor,
         col: cutlass.Int32,
     ) -> cutlass.Int32:
         start = cutlass.Int32(0)
         if cutlass.const_expr(self.needs_initial_state):
             for i in cutlass.range_constexpr(self.rows_per_cta):
-                sState[i, col] = gInitialState[i, col].to(cutlass.Float32)
+                value = gInitialState[i, col].to(cutlass.Float32)
+                sState[i, col] = value
+                if cutlass.const_expr(self.store_initial_state):
+                    gInitialStateWorkspace[i, col] = value
         else:
             start = cutlass.Int32(1)
             for i in cutlass.range_constexpr(self.rows_per_cta):
@@ -2471,8 +2538,10 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_initial_state_workspace_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_output_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2493,8 +2562,10 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             g_transfer_t,
             g_local_state_t,
             g_initial_state_t,
+            g_initial_state_workspace_t,
             g_fixed_state_t,
             g_output_state_t,
+            g_state_indices_t,
             g_cu_seqlens,
             chunk_len,
             total_cp_chunks,
@@ -2514,8 +2585,10 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_initial_state_workspace_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_output_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
@@ -2558,19 +2631,55 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             (self.D, self.D, num_heads, num_seqs),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
+        state_idx = seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
-            gInitialState = cute.make_tensor(
-                g_initial_state_t.iterator, fixed_state_layout
-            )
+            if cutlass.const_expr(self.use_state_indices):
+                initial_state_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
+                    stride=(
+                        g_initial_state_t.stride[2],
+                        g_initial_state_t.stride[3],
+                        g_initial_state_t.stride[1],
+                        g_initial_state_t.stride[0],
+                    ),
+                )
+                gInitialState = cute.make_tensor(g_initial_state_t.iterator, initial_state_layout)
+            else:
+                gInitialState = cute.make_tensor(g_initial_state_t.iterator, fixed_state_layout)
         else:
             gInitialState = gFixedState
         if cutlass.const_expr(self.store_final_state):
-            gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
+            if cutlass.const_expr(self.use_state_indices):
+                output_state_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_output_state_t.shape[0]),
+                    stride=(
+                        g_output_state_t.stride[2],
+                        g_output_state_t.stride[3],
+                        g_output_state_t.stride[1],
+                        g_output_state_t.stride[0],
+                    ),
+                )
+                gOutputState = cute.make_tensor(g_output_state_t.iterator, output_state_layout)
+            else:
+                gOutputState = cute.make_tensor(g_output_state_t.iterator, fixed_state_layout)
             gOutputState_cta = cute.local_tile(
-                gOutputState[None, None, head_idx, seq_idx],
+                gOutputState[None, None, head_idx, state_idx],
                 (self.rows_per_cta, self.D),
                 (row_cta_idx, 0),
             )
+        if cutlass.const_expr(self.store_initial_state):
+            gInitialStateWorkspace = cute.make_tensor(
+                g_initial_state_workspace_t.iterator, fixed_state_layout
+            )
+            gInitialStateWorkspace_cta = cute.local_tile(
+                gInitialStateWorkspace[None, None, head_idx, seq_idx],
+                (self.rows_per_cta, self.D),
+                (row_cta_idx, 0),
+            )
+        else:
+            gInitialStateWorkspace_cta = gFixedState
 
         sState = storage.smem_state.get_tensor(state_layout)
         gTransfer_head = gTransfer[None, None, head_idx, None]
@@ -2589,7 +2698,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         gFixedState_seq = cute.domain_offset((0, 0, chunk_start), gFixedState_cta)
         if cutlass.const_expr(self.needs_initial_state):
             gInitialState_cta = cute.local_tile(
-                gInitialState[None, None, head_idx, seq_idx],
+                gInitialState[None, None, head_idx, state_idx],
                 (self.rows_per_cta, self.D),
                 (row_cta_idx, 0),
             )
@@ -2604,6 +2713,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
                 gFixedState_seq,
                 gLocalState_seq,
                 gInitialState_cta,
+                gInitialStateWorkspace_cta,
                 col,
             )
             cute.arch.sync_threads()
@@ -2760,7 +2870,9 @@ def cp_delta_rule_fixup_dsl_sm120(
             leading_dim=1
         ),
         initial_state_cute,
+        None,
         from_dlpack(fixed_state.reshape(-1), assumed_align=128).mark_layout_dynamic(),
+        None,
         None,
         from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
         cutlass.Int32(cp_chunk_len),

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -2925,6 +2925,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         needs_initial_state: bool = False,
+        store_final_state: bool = True,
     ):
         self.needs_alpha = True
         self.dtype = dtype
@@ -2933,6 +2934,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         self.BLK_KV = 64
         self.D = 128
         self.needs_initial_state = needs_initial_state
+        self.store_final_state = store_final_state
         self.q_stage = 1
         self.k_stage = 1
         self.v_stage = 1
@@ -2944,6 +2946,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         self.manual_cache_key(
             "needs_alpha",
             "needs_initial_state",
+            "store_final_state",
             "dtype",
             "acc_dtype",
             "BLK_Q",
@@ -4202,8 +4205,9 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                 scale,
                 wg_idx,
             )
-        if store_state:
-            self.kv_store(tKVrKV, gStateKV, kv_thr_mma)
+        if cutlass.const_expr(self.store_final_state):
+            if store_state:
+                self.kv_store(tKVrKV, gStateKV, kv_thr_mma)
 
     @cute.jit
     def __call__(
@@ -4792,7 +4796,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
 
 def cp_delta_rule_prefill_dsl_sm120(
     o: torch.Tensor,
-    state: torch.Tensor,
+    state: torch.Tensor | None,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -4891,14 +4895,14 @@ def cp_delta_rule_prefill_dsl_sm120(
             )
         expected_fixed_state_shape = (total_cp_chunks, num_sab_heads, d, d)
         expected_state_shape = (num_seqs, num_sab_heads, d, d)
-        if (
-            fixed_state.shape != expected_fixed_state_shape
-            or state.shape != expected_state_shape
+        if fixed_state.shape != expected_fixed_state_shape or (
+            state is not None and state.shape != expected_state_shape
         ):
             raise RuntimeError(
                 "fixed_state/state must have shapes "
                 f"{expected_fixed_state_shape} and {expected_state_shape}, "
-                f"got {tuple(fixed_state.shape)} and {tuple(state.shape)}"
+                f"got {tuple(fixed_state.shape)} and "
+                f"{None if state is None else tuple(state.shape)}"
             )
         if initial_state is not None and initial_state.shape != expected_state_shape:
             raise RuntimeError(
@@ -4991,14 +4995,18 @@ def cp_delta_rule_prefill_dsl_sm120(
         )
 
     needs_initial_state = initial_state is not None
+    store_final_state = state is not None
     initial_state_cute = (
         from_dlpack(initial_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
         if needs_initial_state
         else None
     )
     kernel = CPDeltaRulePrefillSm120(
-        kernel_dtype, needs_initial_state=needs_initial_state
+        kernel_dtype,
+        needs_initial_state=needs_initial_state,
+        store_final_state=store_final_state,
     )
+    state_arg = state if store_final_state else fixed_state
     kernel_args = (
         from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
         from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
@@ -5006,7 +5014,7 @@ def cp_delta_rule_prefill_dsl_sm120(
         from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
         from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
         from_dlpack(alpha.reshape(-1), assumed_align=16).mark_layout_dynamic(),
-        from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(state_arg.reshape(-1), assumed_align=16).mark_layout_dynamic(),
         from_dlpack(fixed_state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
         initial_state_cute,
         from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic(),
@@ -5030,7 +5038,7 @@ def cp_delta_rule_prefill_dsl_sm120(
 
 def cp_delta_rule_dsl_sm120(
     o: torch.Tensor,
-    state: torch.Tensor,
+    state: torch.Tensor | None,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -5123,7 +5131,7 @@ def cp_delta_rule_dsl_sm120(
             f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
         )
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
-    if state.shape != expected_state_shape:
+    if state is not None and state.shape != expected_state_shape:
         raise RuntimeError(
             f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
         )

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -2708,9 +2708,11 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         needs_initial_state: bool = False,
+        store_final_state: bool = True,
     ):
         super().__init__(True, False, True, False, dtype, acc_dtype)
         self.needs_initial_state = needs_initial_state
+        self.store_final_state = store_final_state
         self.t_stage = 2
         self.manual_cache_key(
             "needs_alpha",
@@ -2718,6 +2720,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             "needs_init_state",
             "needs_checkpointing",
             "needs_initial_state",
+            "store_final_state",
             "dtype",
             "acc_dtype",
             "inverse_dtype",
@@ -3324,8 +3327,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 scale,
                 wg_idx,
             )
-        if store_state:
-            self.kv_store(tKVrKV, gStateKV, kv_tiled_mma, math_tidx)
+        if cutlass.const_expr(self.store_final_state):
+            if store_state:
+                self.kv_store(tKVrKV, gStateKV, kv_tiled_mma, math_tidx)
 
     @cute.jit
     def __call__(
@@ -3898,7 +3902,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
 
 def cp_delta_rule_prefill_dsl_sm90(
     o: torch.Tensor,
-    state: torch.Tensor,
+    state: torch.Tensor | None,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -3997,14 +4001,14 @@ def cp_delta_rule_prefill_dsl_sm90(
             )
         expected_fixed_state_shape = (total_cp_chunks, num_sab_heads, d, d)
         expected_state_shape = (num_seqs, num_sab_heads, d, d)
-        if (
-            fixed_state.shape != expected_fixed_state_shape
-            or state.shape != expected_state_shape
+        if fixed_state.shape != expected_fixed_state_shape or (
+            state is not None and state.shape != expected_state_shape
         ):
             raise RuntimeError(
                 "fixed_state/state must have shapes "
                 f"{expected_fixed_state_shape} and {expected_state_shape}, "
-                f"got {tuple(fixed_state.shape)} and {tuple(state.shape)}"
+                f"got {tuple(fixed_state.shape)} and "
+                f"{None if state is None else tuple(state.shape)}"
             )
         if initial_state is not None and initial_state.shape != expected_state_shape:
             raise RuntimeError(
@@ -4097,14 +4101,18 @@ def cp_delta_rule_prefill_dsl_sm90(
         )
 
     needs_initial_state = initial_state is not None
+    store_final_state = state is not None
     initial_state_cute = (
         from_dlpack(initial_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
         if needs_initial_state
         else None
     )
     kernel = CPDeltaRulePrefillSm90(
-        kernel_dtype, needs_initial_state=needs_initial_state
+        kernel_dtype,
+        needs_initial_state=needs_initial_state,
+        store_final_state=store_final_state,
     )
+    state_arg = state if store_final_state else fixed_state
     kernel_args = (
         from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
         from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
@@ -4112,7 +4120,7 @@ def cp_delta_rule_prefill_dsl_sm90(
         from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
         from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
         from_dlpack(alpha.reshape(-1), assumed_align=16).mark_layout_dynamic(),
-        from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(state_arg.reshape(-1), assumed_align=16).mark_layout_dynamic(),
         from_dlpack(fixed_state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
         initial_state_cute,
         from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic(),
@@ -4138,7 +4146,7 @@ def cp_delta_rule_prefill_dsl_sm90(
 
 def cp_delta_rule_dsl_sm90(
     o: torch.Tensor,
-    state: torch.Tensor,
+    state: torch.Tensor | None,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -4231,7 +4239,7 @@ def cp_delta_rule_dsl_sm90(
             f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
         )
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
-    if state.shape != expected_state_shape:
+    if state is not None and state.shape != expected_state_shape:
         raise RuntimeError(
             f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
         )

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -12,14 +12,7 @@ CP_DEFAULT_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR = 1
 CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_NUMERATOR = 1
 CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR = 2
 CP_SM120_SHORT_HEURISTIC_MAX_HEADS = 16
-# (minimum average sequence length, threshold numerator, threshold denominator,
-# maximum number of sequences).
-# CP wins when non-CP parallel work is below the corresponding fraction of SMs.
-CP_SM100_PARALLELISM_TIERS = (
-    (4096, 1, 8, 1),
-    (8192, 1, 8, 2),
-    (16384, 2, 9, 2),
-)
+CP_SM100_PARALLELISM_THRESHOLD_DENOMINATOR = 4
 CP_HBM_PARALLELISM_THRESHOLD_NUMERATOR = 1
 CP_HBM_PARALLELISM_THRESHOLD_DENOMINATOR = 2
 CP_GDDR_PARALLELISM_THRESHOLD_NUMERATOR = 1
@@ -99,8 +92,6 @@ def should_use_cp_host(
     num_sms: int,
     device_name: str,
     device_capability: tuple[int, int] | None = None,
-    total_seqlen: int | None = None,
-    num_seqs: int | None = None,
 ) -> bool:
     """Return whether a public wrapper should dispatch to the CP path.
 
@@ -108,22 +99,8 @@ def should_use_cp_host(
     output/state heads. CP is selected only when that parallelism is strictly
     below the card-specific threshold.
     """
-    if (
-        device_capability is not None
-        and device_capability[0] == 10
-        and total_seqlen is not None
-        and num_seqs is not None
-    ):
-        avg_seqlen = _ceil_div(total_seqlen, num_seqs)
-        for min_avg_seqlen, threshold_num, threshold_den, max_num_seqs in reversed(
-            CP_SM100_PARALLELISM_TIERS
-        ):
-            if avg_seqlen >= min_avg_seqlen:
-                return (
-                    num_seqs <= max_num_seqs
-                    and num_parallel_work * threshold_den < num_sms * threshold_num
-                )
-        return False
+    if device_capability is not None and device_capability[0] == 10:
+        return num_parallel_work * CP_SM100_PARALLELISM_THRESHOLD_DENOMINATOR < num_sms
 
     threshold_num, threshold_den = cp_parallelism_threshold_host(device_name)
     return num_parallel_work * threshold_den < num_sms * threshold_num

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -113,13 +113,14 @@ def choose_cp_chunk_len_host(
     chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
     device_capability: tuple[int, int] | None = None,
     total_seqlen: int | None = None,
+    num_seqs: int = 1,
     device_name: str = "",
 ) -> int:
     """Choose a CP chunk length for the CP workspace kernels.
 
-    The TTFT path is usually one long sequence. For that case, MN precompute
-    launches `ceil_div(max_seqlen, chunk_len) * num_heads` CTAs. Pick the
-    smallest granularity-aligned chunk length whose CTA count is at most one wave.
+    MN precompute launches one CTA per sequence chunk and state head. Pick the
+    smallest granularity-aligned chunk length whose safely bounded CTA count is
+    at most one wave.
     """
     assert chunk_len_granularity % 64 == 0
     if total_seqlen is None:
@@ -146,10 +147,26 @@ def choose_cp_chunk_len_host(
                 balanced_chunk_len += 1
             return max(BLK, _round_up(balanced_chunk_len, BLK))
 
-    # target for one wave of CTAs
+    # Target one wave of MN CTAs. Account for the known longest sequence, then
+    # safely bound the chunks contributed by all remaining uneven sequences.
     target_chunks = max(1, num_sms // num_heads)
-    min_chunk_len = _ceil_div(max_seqlen, target_chunks)
-    return _round_up(min_chunk_len, chunk_len_granularity)
+    remaining_seqlen = max(0, total_seqlen - max_seqlen)
+    remaining_seqs = max(0, num_seqs - 1)
+
+    def chunk_bound_for_len(chunk_len: int) -> int:
+        return _ceil_div(max_seqlen, chunk_len) + chunk_bound_host(
+            remaining_seqs, remaining_seqlen, chunk_len
+        )
+
+    lo = 1
+    hi = max(1, _ceil_div(max_seqlen, chunk_len_granularity))
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if chunk_bound_for_len(mid * chunk_len_granularity) <= target_chunks:
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo * chunk_len_granularity
 
 
 @cute.jit

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -12,6 +12,14 @@ CP_DEFAULT_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR = 1
 CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_NUMERATOR = 1
 CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR = 2
 CP_SM120_SHORT_HEURISTIC_MAX_HEADS = 16
+# (minimum average sequence length, threshold numerator, threshold denominator,
+# maximum number of sequences).
+# CP wins when non-CP parallel work is below the corresponding fraction of SMs.
+CP_SM100_PARALLELISM_TIERS = (
+    (4096, 1, 8, 1),
+    (8192, 1, 8, 2),
+    (16384, 2, 9, 2),
+)
 CP_HBM_PARALLELISM_THRESHOLD_NUMERATOR = 1
 CP_HBM_PARALLELISM_THRESHOLD_DENOMINATOR = 2
 CP_GDDR_PARALLELISM_THRESHOLD_NUMERATOR = 1
@@ -86,13 +94,37 @@ def cp_short_workload_ratio_host(
     )
 
 
-def should_use_cp_host(num_parallel_work: int, num_sms: int, device_name: str) -> bool:
+def should_use_cp_host(
+    num_parallel_work: int,
+    num_sms: int,
+    device_name: str,
+    device_capability: tuple[int, int] | None = None,
+    total_seqlen: int | None = None,
+    num_seqs: int | None = None,
+) -> bool:
     """Return whether a public wrapper should dispatch to the CP path.
 
     `num_parallel_work` is the non-CP kernel parallelism, typically batch times
     output/state heads. CP is selected only when that parallelism is strictly
     below the card-specific threshold.
     """
+    if (
+        device_capability is not None
+        and device_capability[0] == 10
+        and total_seqlen is not None
+        and num_seqs is not None
+    ):
+        avg_seqlen = _ceil_div(total_seqlen, num_seqs)
+        for min_avg_seqlen, threshold_num, threshold_den, max_num_seqs in reversed(
+            CP_SM100_PARALLELISM_TIERS
+        ):
+            if avg_seqlen >= min_avg_seqlen:
+                return (
+                    num_seqs <= max_num_seqs
+                    and num_parallel_work * threshold_den < num_sms * threshold_num
+                )
+        return False
+
     threshold_num, threshold_den = cp_parallelism_threshold_host(device_name)
     return num_parallel_work * threshold_den < num_sms * threshold_num
 

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import math
 import warnings
-from typing import Literal, Optional, Union, Tuple
+from typing import Callable, Literal, Optional, Tuple, Union, cast
 import torch
 
 from .api_logging import flashinfer_api
@@ -425,12 +425,14 @@ def chunk_gated_delta_rule(
                     total_seq_len, num_sab_heads, dtype=torch.float32, device=device
                 )
             )
-            cp_delta_rule_dsl = {
-                9: cp_delta_rule_dsl_sm90,
-                10: cp_delta_rule_dsl_sm100,
-                12: cp_delta_rule_dsl_sm120,
-            }[_arch_major]
-            assert cp_delta_rule_dsl is not None
+            cp_delta_rule_dsl = cast(
+                Callable[..., None],
+                {
+                    9: cp_delta_rule_dsl_sm90,
+                    10: cp_delta_rule_dsl_sm100,
+                    12: cp_delta_rule_dsl_sm120,
+                }[_arch_major],
+            )
             state_indices_kwargs = (
                 {"state_indices": state_indices} if state_indices is not None else {}
             )

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -349,8 +349,6 @@ def chunk_gated_delta_rule(
         _sm_count,
         _device_name,
         device_capability=_device_capability,
-        total_seqlen=total_seq_len,
-        num_seqs=num_seqs,
     )
     will_use_cp = use_cp is True or (use_cp == "auto" and cp_heuristic_matches)
     if state_indices is not None:

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -395,7 +395,7 @@ def chunk_gated_delta_rule(
                 stacklevel=2,
             )
         else:
-            if output_state is None:
+            if output_final_state and output_state is None:
                 output_state = torch.empty(
                     (num_seqs, num_sab_heads, head_size, head_size),
                     dtype=torch.float32,

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -431,6 +431,9 @@ def chunk_gated_delta_rule(
                 12: cp_delta_rule_dsl_sm120,
             }[_arch_major]
             assert cp_delta_rule_dsl is not None
+            state_indices_kwargs = (
+                {"state_indices": state_indices} if state_indices is not None else {}
+            )
             cp_delta_rule_dsl(
                 output,
                 output_state,
@@ -442,8 +445,8 @@ def chunk_gated_delta_rule(
                 cu_seqlens,
                 _scale,
                 initial_state=initial_state,
-                state_indices=state_indices,
                 max_seqlen=total_seq_len,
+                **state_indices_kwargs,
             )
             if output_final_state:
                 return output, output_state

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -59,6 +59,7 @@ def _cp_delta_rule_rejection_reason(
     checkpoint_every_n_tokens: int,
     state_checkpoints: Optional[torch.Tensor],
     checkpoint_cu_starts: Optional[torch.Tensor],
+    state_indices: Optional[torch.Tensor],
 ) -> Optional[str]:
     if arch_major == 9:
         if cp_delta_rule_dsl_sm90 is None:
@@ -94,12 +95,20 @@ def _cp_delta_rule_rejection_reason(
         ("k", k),
         ("v", v),
         ("output", output),
-        ("initial_state", initial_state),
     ):
         if tensor is None:
             continue
         if not tensor.is_contiguous():
             return f"CP delta rule requires {name} to be contiguous"
+    if initial_state is not None:
+        if state_indices is None and not initial_state.is_contiguous():
+            return "CP delta rule requires initial_state to be contiguous"
+        if state_indices is not None and initial_state.stride()[1:] != (
+            initial_state.shape[2] * initial_state.shape[3],
+            initial_state.shape[3],
+            1,
+        ):
+            return "CP delta rule requires initial_state to be contiguous in [H, V, K]"
     return None
 
 
@@ -356,7 +365,7 @@ def chunk_gated_delta_rule(
         # CuTe-DSL kernel. Reject it on every other dispatch path (SM90, SM120,
         # or CP) rather than silently ignoring it and reading/writing the state
         # in packed, sequence-ordered layout.
-        if _arch_major != 10 or will_use_cp:
+        if _arch_major != 10:
             raise NotImplementedError(
                 "state_indices is only supported on the SM100/SM103 GDN prefill "
                 f"kernel (non-CP); got compute-capability major {_arch_major}, "
@@ -384,6 +393,7 @@ def chunk_gated_delta_rule(
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             state_checkpoints=state_checkpoints,
             checkpoint_cu_starts=checkpoint_cu_starts,
+            state_indices=state_indices,
         )
         if cp_rejection_reason is not None:
             if use_cp is True:
@@ -432,6 +442,7 @@ def chunk_gated_delta_rule(
                 cu_seqlens,
                 _scale,
                 initial_state=initial_state,
+                state_indices=state_indices,
                 max_seqlen=total_seq_len,
             )
             if output_final_state:

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -21,12 +21,13 @@ import torch
 
 from .api_logging import flashinfer_api
 from .trace.templates.gdn import gdn_prefill_trace
-from .utils import get_compute_capability, get_device_sm_count
+from .utils import get_compute_capability, get_device_name, get_device_sm_count
 from .gdn_kernels import (
     chunk_gated_delta_rule_sm90,
     chunk_gated_delta_rule_sm100,
     chunk_gated_delta_rule_sm120,
     cp_delta_rule_dsl_sm90,
+    cp_delta_rule_dsl_sm100,
     cp_delta_rule_dsl_sm120,
 )
 from .gdn_kernels.delta_rule_dsl.varlen_helper import should_use_cp_host
@@ -62,11 +63,14 @@ def _cp_delta_rule_rejection_reason(
     if arch_major == 9:
         if cp_delta_rule_dsl_sm90 is None:
             return "CP delta rule SM90 DSL kernel is unavailable"
+    elif arch_major == 10:
+        if cp_delta_rule_dsl_sm100 is None:
+            return "CP delta rule SM100 DSL kernel is unavailable"
     elif arch_major == 12:
         if cp_delta_rule_dsl_sm120 is None:
             return "CP delta rule SM120 DSL kernel is unavailable"
     else:
-        return "CP delta rule is currently implemented only for SM90 and SM120"
+        return "CP delta rule is currently implemented only for SM90, SM100, and SM120"
     if (
         checkpoint_every_n_tokens > 0
         or state_checkpoints is not None
@@ -337,10 +341,16 @@ def chunk_gated_delta_rule(
 
     _sm_count = get_device_sm_count(device)
     _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
-    _arch_major = get_compute_capability(device)[0]
-    _device_name = torch.cuda.get_device_properties(device).name
-    cp_heuristic_matches = _arch_major in (9, 12) and should_use_cp_host(
-        num_seqs * num_sab_heads, _sm_count, _device_name
+    _device_capability = get_compute_capability(device)
+    _arch_major = _device_capability[0]
+    _device_name = get_device_name(device)
+    cp_heuristic_matches = _arch_major in (9, 10, 12) and should_use_cp_host(
+        num_seqs * num_sab_heads,
+        _sm_count,
+        _device_name,
+        device_capability=_device_capability,
+        total_seqlen=total_seq_len,
+        num_seqs=num_seqs,
     )
     will_use_cp = use_cp is True or (use_cp == "auto" and cp_heuristic_matches)
     if state_indices is not None:
@@ -407,9 +417,11 @@ def chunk_gated_delta_rule(
                     total_seq_len, num_sab_heads, dtype=torch.float32, device=device
                 )
             )
-            cp_delta_rule_dsl = (
-                cp_delta_rule_dsl_sm90 if _arch_major == 9 else cp_delta_rule_dsl_sm120
-            )
+            cp_delta_rule_dsl = {
+                9: cp_delta_rule_dsl_sm90,
+                10: cp_delta_rule_dsl_sm100,
+                12: cp_delta_rule_dsl_sm120,
+            }[_arch_major]
             assert cp_delta_rule_dsl is not None
             cp_delta_rule_dsl(
                 output,
@@ -419,7 +431,7 @@ def chunk_gated_delta_rule(
                 v,
                 _g,
                 _beta,
-                cu_seqlens.to(torch.int64),
+                cu_seqlens,
                 _scale,
                 initial_state=initial_state,
                 max_seqlen=total_seq_len,

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -49,6 +49,7 @@ def _format_dtype_list(dtypes: tuple[torch.dtype, ...]) -> str:
 def _cp_delta_rule_rejection_reason(
     *,
     arch_major: int,
+    cuda_major: int,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -65,6 +66,8 @@ def _cp_delta_rule_rejection_reason(
         if cp_delta_rule_dsl_sm90 is None:
             return "CP delta rule SM90 DSL kernel is unavailable"
     elif arch_major == 10:
+        if cuda_major < 13:
+            return "CP delta rule SM100 requires CUDA 13 or newer"
         if cp_delta_rule_dsl_sm100 is None:
             return "CP delta rule SM100 DSL kernel is unavailable"
     elif arch_major == 12:
@@ -383,6 +386,7 @@ def chunk_gated_delta_rule(
     if will_use_cp:
         cp_rejection_reason = _cp_delta_rule_rejection_reason(
             arch_major=_arch_major,
+            cuda_major=_cuda_major,
             q=q,
             k=k,
             v=v,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -278,10 +278,16 @@ def canonicalize_torch_dtype(dtype: Union[torch.dtype, str]) -> torch.dtype:
 
 
 @functools.cache
+def get_device_properties(device: torch.device):
+    return torch.cuda.get_device_properties(device)
+
+
+@functools.cache
 def get_compute_capability(device: torch.device) -> Tuple[int, int]:
     if device.type != "cuda":
         raise ValueError("device must be a cuda device")
-    return torch.cuda.get_device_capability(device.index)
+    properties = get_device_properties(device)
+    return properties.major, properties.minor
 
 
 @functools.cache
@@ -326,7 +332,7 @@ def get_gpu_memory_bandwidth(device: torch.device) -> float:
 
 @functools.cache
 def get_shared_bytes_per_block_optin(device: torch.device) -> int:
-    cap = torch.cuda.get_device_properties(device.index)
+    cap = get_device_properties(device)
     return cap.shared_memory_per_block_optin
 
 
@@ -830,7 +836,12 @@ def round_up(x: int, y: int) -> int:
 
 @functools.cache
 def get_device_sm_count(device: torch.device) -> int:
-    return torch.cuda.get_device_properties(device).multi_processor_count
+    return get_device_properties(device).multi_processor_count
+
+
+@functools.cache
+def get_device_name(device: torch.device) -> str:
+    return get_device_properties(device).name
 
 
 def get_device_index(device: torch.device) -> int:

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -982,3 +982,76 @@ def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
 
     torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
     torch.testing.assert_close(our_state, ref_state, atol=4e-2, rtol=4e-2)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("seq_lens", [[128], [256, 64]])
+def test_sm100_cp_delta_rule_external_state_dtype(
+    qkv_factory,
+    state_dtype,
+    seq_lens,
+    seed=int(os.environ.get("SEED", "0")),
+):
+    device = torch.device("cuda")
+    if not is_sm100a_supported(device):
+        pytest.skip("typed CP state requires SM100/SM103")
+    _seed_all(seed)
+    dtype = torch.bfloat16
+    head_size = 128
+    num_heads = 1
+    num_seqs = len(seq_lens)
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+
+    with device:
+        q, k, v = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype
+        )
+        initial_state = (
+            torch.randn(num_seqs, num_heads, head_size, head_size) * 0.01
+        ).to(state_dtype)
+    q = q.contiguous()
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_heads, 0.99, device)
+    beta = _make_gates(total_seqlen, num_heads, 0.99, device)
+    our_o = torch.empty_like(q)
+    ref_o = torch.empty_like(q)
+    our_state = torch.empty_like(initial_state)
+    ref_state = torch.empty_like(initial_state)
+
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        1.0,
+        initial_state,
+        True,
+        cu_seqlens,
+        False,
+        output=our_o,
+        output_state=our_state,
+        use_cp=True,
+    )
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        1.0,
+        initial_state,
+        True,
+        cu_seqlens,
+        False,
+        output=ref_o,
+        output_state=ref_state,
+        use_cp=False,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
+    torch.testing.assert_close(our_state, ref_state, atol=4e-2, rtol=4e-2)

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -64,8 +64,6 @@ else:
 
 from flashinfer.gdn_kernels.delta_rule_dsl.varlen_helper import (
     chunk_bound_host,
-    choose_cp_chunk_len_host,
-    should_use_cp_host,
     workspace_num_chunks_host,
 )
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
@@ -106,99 +104,6 @@ def _make_gates(total_seqlen, num_heads, baseline, device):
         + (1.0 - baseline)
         * torch.rand(total_seqlen, num_heads, dtype=torch.float32, device=device)
     ).contiguous()
-
-
-@pytest.mark.parametrize(
-    "parallel_work, total_seqlen, num_seqs, expected",
-    [
-        (8, 1536, 1, False),
-        (8, 2048, 1, False),
-        (16, 4095, 1, False),
-        (16, 4096, 1, True),
-        (16, 8192 * 2, 2, True),
-        (16, 8192 * 3, 3, False),
-        (16, 8192, 1, True),
-        (24, 16383, 1, False),
-        (24, 16384, 1, True),
-        (32, 16384, 1, True),
-        (32, 32768 * 2, 2, True),
-        (32, 32768 * 3, 3, False),
-        (33, 65536, 1, False),
-    ],
-)
-def test_sm100_cp_dispatch_heuristic(parallel_work, total_seqlen, num_seqs, expected):
-    assert (
-        should_use_cp_host(
-            parallel_work,
-            148,
-            "NVIDIA B300 SXM6 AC",
-            device_capability=(10, 3),
-            total_seqlen=total_seqlen,
-            num_seqs=num_seqs,
-        )
-        is expected
-    )
-
-
-@pytest.mark.parametrize(
-    "max_seqlen, num_heads, expected",
-    [
-        (2048, 8, 384),
-        (4096, 8, 512),
-        (6144, 8, 512),
-        (8192, 8, 512),
-        (16384, 4, 512),
-        (32768, 4, 1024),
-        (32768, 2, 512),
-        (65536, 2, 1024),
-        (65536, 1, 512),
-        (262144, 1, 2048),
-        (16384, 8, 1024),
-        (8192, 16, 1024),
-    ],
-)
-def test_sm100_cp_chunk_balance(max_seqlen, num_heads, expected):
-    assert (
-        choose_cp_chunk_len_host(
-            max_seqlen,
-            num_heads,
-            148,
-            device_capability=(10, 3),
-            total_seqlen=max_seqlen,
-            device_name="NVIDIA B300 SXM6 AC",
-        )
-        == expected
-    )
-
-
-def test_other_arch_cp_heuristics_are_unchanged():
-    assert should_use_cp_host(
-        73,
-        148,
-        "NVIDIA H100 80GB HBM3",
-        device_capability=(9, 0),
-        total_seqlen=128,
-        num_seqs=1,
-    )
-    assert not should_use_cp_host(
-        74,
-        148,
-        "NVIDIA H100 80GB HBM3",
-        device_capability=(9, 0),
-        total_seqlen=65536,
-        num_seqs=1,
-    )
-    assert (
-        choose_cp_chunk_len_host(
-            8192,
-            8,
-            148,
-            device_capability=(9, 0),
-            total_seqlen=8192,
-            device_name="NVIDIA H100 80GB HBM3",
-        )
-        == 512
-    )
 
 
 @torch.inference_mode()

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -39,7 +39,12 @@ if torch.cuda.is_available() and is_sm90a_supported(torch.device("cuda")):
         cp_delta_rule_prefill_dsl_sm90 as cp_delta_rule_prefill_dsl,
         cp_delta_rule_t_precompute_dsl_sm90 as cp_delta_rule_t_precompute_dsl,
     )
-elif torch.cuda.is_available() and is_sm100a_supported(torch.device("cuda")):
+elif (
+    torch.cuda.is_available()
+    and is_sm100a_supported(torch.device("cuda"))
+    and torch.version.cuda is not None
+    and int(torch.version.cuda.split(".")[0]) >= 13
+):
     from flashinfer.gdn_kernels.blackwell.gdn_cp_prefill import (
         cp_delta_rule_dsl_sm100 as cp_delta_rule_dsl,
         cp_delta_rule_fixup_dsl_sm100 as cp_delta_rule_fixup_dsl,
@@ -77,11 +82,14 @@ FIXUP_KERNEL_KINDS = ["simt_row4", "simt_row8", "hmma"]
 def _skip_if_cp_unsupported():
     """Skip test if context parallelism is unsupported."""
     device = torch.device("cuda")
-    if not (
-        is_sm90a_supported(device)
-        or is_sm100a_supported(device)
-        or is_sm12x_supported(device)
-    ):
+    if is_sm100a_supported(device):
+        cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
+        if cuda_major < 13:
+            pytest.skip(
+                f"SM100 CP GDN prefill requires CUDA 13+, got {torch.version.cuda}"
+            )
+        return
+    if not (is_sm90a_supported(device) or is_sm12x_supported(device)):
         pytest.skip("CP GDN prefill requires SM90, SM100, or SM12x")
 
 
@@ -996,6 +1004,7 @@ def test_sm100_cp_delta_rule_external_state_dtype(
     device = torch.device("cuda")
     if not is_sm100a_supported(device):
         pytest.skip("typed CP state requires SM100/SM103")
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     dtype = torch.bfloat16
     head_size = 128

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -25,7 +25,11 @@ import torch
 
 from .reference_delta_rule import exclusive_cumsum
 from . import reference_delta_rule as reference
-from flashinfer.utils import is_sm90a_supported, is_sm12x_supported
+from flashinfer.utils import (
+    is_sm90a_supported,
+    is_sm100a_supported,
+    is_sm12x_supported,
+)
 
 if torch.cuda.is_available() and is_sm90a_supported(torch.device("cuda")):
     from flashinfer.gdn_kernels.delta_rule_dsl.delta_rule_cp_sm90 import (
@@ -34,6 +38,14 @@ if torch.cuda.is_available() and is_sm90a_supported(torch.device("cuda")):
         cp_delta_rule_mn_precompute_dsl_sm90 as cp_delta_rule_mn_precompute_dsl,
         cp_delta_rule_prefill_dsl_sm90 as cp_delta_rule_prefill_dsl,
         cp_delta_rule_t_precompute_dsl_sm90 as cp_delta_rule_t_precompute_dsl,
+    )
+elif torch.cuda.is_available() and is_sm100a_supported(torch.device("cuda")):
+    from flashinfer.gdn_kernels.blackwell.gdn_cp_prefill import (
+        cp_delta_rule_dsl_sm100 as cp_delta_rule_dsl,
+        cp_delta_rule_fixup_dsl_sm100 as cp_delta_rule_fixup_dsl,
+        cp_delta_rule_mn_precompute_dsl_sm100 as cp_delta_rule_mn_precompute_dsl,
+        cp_delta_rule_prefill_dsl_sm100 as cp_delta_rule_prefill_dsl,
+        cp_delta_rule_t_precompute_dsl_sm100 as cp_delta_rule_t_precompute_dsl,
     )
 elif torch.cuda.is_available() and is_sm12x_supported(torch.device("cuda")):
     from flashinfer.gdn_kernels.delta_rule_dsl.delta_rule_cp_sm120 import (
@@ -52,6 +64,8 @@ else:
 
 from flashinfer.gdn_kernels.delta_rule_dsl.varlen_helper import (
     chunk_bound_host,
+    choose_cp_chunk_len_host,
+    should_use_cp_host,
     workspace_num_chunks_host,
 )
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
@@ -65,8 +79,12 @@ FIXUP_KERNEL_KINDS = ["simt_row4", "simt_row8", "hmma"]
 def _skip_if_cp_unsupported():
     """Skip test if context parallelism is unsupported."""
     device = torch.device("cuda")
-    if not (is_sm90a_supported(device) or is_sm12x_supported(device)):
-        pytest.skip("CP GDN prefill requires SM90 or SM12x")
+    if not (
+        is_sm90a_supported(device)
+        or is_sm100a_supported(device)
+        or is_sm12x_supported(device)
+    ):
+        pytest.skip("CP GDN prefill requires SM90, SM100, or SM12x")
 
 
 def _seed_all(seed):
@@ -88,6 +106,99 @@ def _make_gates(total_seqlen, num_heads, baseline, device):
         + (1.0 - baseline)
         * torch.rand(total_seqlen, num_heads, dtype=torch.float32, device=device)
     ).contiguous()
+
+
+@pytest.mark.parametrize(
+    "parallel_work, total_seqlen, num_seqs, expected",
+    [
+        (8, 1536, 1, False),
+        (8, 2048, 1, False),
+        (16, 4095, 1, False),
+        (16, 4096, 1, True),
+        (16, 8192 * 2, 2, True),
+        (16, 8192 * 3, 3, False),
+        (16, 8192, 1, True),
+        (24, 16383, 1, False),
+        (24, 16384, 1, True),
+        (32, 16384, 1, True),
+        (32, 32768 * 2, 2, True),
+        (32, 32768 * 3, 3, False),
+        (33, 65536, 1, False),
+    ],
+)
+def test_sm100_cp_dispatch_heuristic(parallel_work, total_seqlen, num_seqs, expected):
+    assert (
+        should_use_cp_host(
+            parallel_work,
+            148,
+            "NVIDIA B300 SXM6 AC",
+            device_capability=(10, 3),
+            total_seqlen=total_seqlen,
+            num_seqs=num_seqs,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "max_seqlen, num_heads, expected",
+    [
+        (2048, 8, 384),
+        (4096, 8, 512),
+        (6144, 8, 512),
+        (8192, 8, 512),
+        (16384, 4, 512),
+        (32768, 4, 1024),
+        (32768, 2, 512),
+        (65536, 2, 1024),
+        (65536, 1, 512),
+        (262144, 1, 2048),
+        (16384, 8, 1024),
+        (8192, 16, 1024),
+    ],
+)
+def test_sm100_cp_chunk_balance(max_seqlen, num_heads, expected):
+    assert (
+        choose_cp_chunk_len_host(
+            max_seqlen,
+            num_heads,
+            148,
+            device_capability=(10, 3),
+            total_seqlen=max_seqlen,
+            device_name="NVIDIA B300 SXM6 AC",
+        )
+        == expected
+    )
+
+
+def test_other_arch_cp_heuristics_are_unchanged():
+    assert should_use_cp_host(
+        73,
+        148,
+        "NVIDIA H100 80GB HBM3",
+        device_capability=(9, 0),
+        total_seqlen=128,
+        num_seqs=1,
+    )
+    assert not should_use_cp_host(
+        74,
+        148,
+        "NVIDIA H100 80GB HBM3",
+        device_capability=(9, 0),
+        total_seqlen=65536,
+        num_seqs=1,
+    )
+    assert (
+        choose_cp_chunk_len_host(
+            8192,
+            8,
+            148,
+            device_capability=(9, 0),
+            total_seqlen=8192,
+            device_name="NVIDIA H100 80GB HBM3",
+        )
+        == 512
+    )
 
 
 @torch.inference_mode()
@@ -289,7 +400,13 @@ def test_cp_delta_rule_t_precompute_varlen_tail_is_projected(
 @pytest.mark.parametrize("gate_baseline", [0.9, 0.99, 0.9995])
 @pytest.mark.parametrize(
     "seq_lens, cp_chunk_len",
-    [([64, 192], 64), ([128, 200], 128), ([1024, 3000], 1024), ([96, 64, 192], 128)],
+    [
+        ([64, 192], 64),
+        ([128, 200], 128),
+        ([192], 192),
+        ([1024, 3000], 1024),
+        ([96, 64, 192], 128),
+    ],
 )
 def test_cp_delta_rule_mn_precompute(
     qkv_factory,
@@ -707,6 +824,7 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
         (torch.bfloat16, [2048], 1024, 1, 1, 1, 0.99, 1.0),
         (torch.bfloat16, [4096], 2048, 2, 1, 1, 0.9995, 1.0),
         (torch.float16, [2049], 1024, 1, 1, 1, 0.99, "auto"),
+        (torch.float16, [8193], 2048, 1, 1, 1, 0.99, "auto"),
         (torch.bfloat16, [1536, 257], 1024, 1, 1, 2, 0.99, 1.0),
     ],
 )
@@ -908,7 +1026,7 @@ def test_cp_delta_rule_e2e(
         ref_o = ref_o.to(dtype)
         atol_o = 2e-2
         rtol_o = 2e-2
-        atol_state = 5e-3
+        atol_state = 1e-2
         rtol_state = 5e-3
     else:
         atol_o = 5e-3
@@ -922,7 +1040,7 @@ def test_cp_delta_rule_e2e(
 
 @torch.inference_mode()
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
-@pytest.mark.parametrize("seq_lens", [[128], [256, 64]])
+@pytest.mark.parametrize("seq_lens", [[128], [256, 64], [2048]])
 def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
     qkv_factory,
     dtype,

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -51,8 +51,12 @@ def _skip_if_unsupported():
 def _skip_if_cp_unsupported():
     """Skip test if context parallelism is unsupported."""
     device = torch.device("cuda")
-    if not (is_sm90a_supported(device) or is_sm12x_supported(device)):
-        pytest.skip("CP GDN prefill requires SM90 or SM12x")
+    if not (
+        is_sm90a_supported(device)
+        or is_sm100a_supported(device)
+        or is_sm12x_supported(device)
+    ):
+        pytest.skip("CP GDN prefill requires SM90, SM100, or SM12x")
 
 
 def _skip_if_not_sm100():

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -51,11 +51,14 @@ def _skip_if_unsupported():
 def _skip_if_cp_unsupported():
     """Skip test if context parallelism is unsupported."""
     device = torch.device("cuda")
-    if not (
-        is_sm90a_supported(device)
-        or is_sm100a_supported(device)
-        or is_sm12x_supported(device)
-    ):
+    if is_sm100a_supported(device):
+        cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
+        if cuda_major < 13:
+            pytest.skip(
+                f"SM100 CP GDN prefill requires CUDA 13+, got {torch.version.cuda}"
+            )
+        return
+    if not (is_sm90a_supported(device) or is_sm12x_supported(device)):
         pytest.skip("CP GDN prefill requires SM90, SM100, or SM12x")
 
 

--- a/tests/gdn/test_prefill_state_indices.py
+++ b/tests/gdn/test_prefill_state_indices.py
@@ -67,7 +67,18 @@ def _make_inputs(seq_lens, H, D, dtype, device, seed):
     return q, k, v, g, beta, cu_seqlens, init_state
 
 
-def _run(q, k, v, g, beta, cu_seqlens, initial_state, output_state, state_indices):
+def _run(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    cu_seqlens,
+    initial_state,
+    output_state,
+    state_indices,
+    use_cp,
+):
     total, H, D = q.shape
     out = torch.empty(total, H, D, dtype=q.dtype, device=q.device)
     output, final = chunk_gated_delta_rule(
@@ -84,6 +95,7 @@ def _run(q, k, v, g, beta, cu_seqlens, initial_state, output_state, state_indice
         output=out,
         output_state=output_state,
         state_indices=state_indices,
+        use_cp=use_cp,
     )
     return output, final
 
@@ -118,7 +130,8 @@ def _make_pool(init_state, perm, n_pool, pad, dtype, device):
 )
 @pytest.mark.parametrize("H", [16, 32])
 @pytest.mark.parametrize("pad", [0, 96])  # 0 = compact pool, 96 = non-compact
-def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad):
+@pytest.mark.parametrize("use_cp", [False, True])
+def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad, use_cp):
     """A pool + state_indices in-place update must match the packed,
     sequence-ordered baseline bitwise (the kernel math is identical; only the
     addressed gmem row differs)."""
@@ -133,7 +146,16 @@ def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad):
     # (a) packed baseline, no state_indices
     out_state_a = torch.empty(num_seqs, H, D, D, dtype=dtype, device=device)
     output_a, final_a = _run(
-        q, k, v, g, beta, cu_seqlens, init_state.clone(), out_state_a, None
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        init_state.clone(),
+        out_state_a,
+        None,
+        use_cp,
     )
     torch.cuda.synchronize()
 
@@ -143,7 +165,7 @@ def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad):
     assert len(set(perm)) == num_seqs  # distinct slots
     pool = _make_pool(init_state, perm, n_pool, pad, dtype, device)
     idx = torch.tensor(perm, dtype=torch.int32, device=device)
-    output_b, _ = _run(q, k, v, g, beta, cu_seqlens, pool, pool, idx)
+    output_b, _ = _run(q, k, v, g, beta, cu_seqlens, pool, pool, idx, use_cp)
     torch.cuda.synchronize()
 
     assert not torch.isnan(output_b).any()
@@ -193,7 +215,8 @@ def test_prefill_state_indices_requires_output_state_pool():
         )
 
 
-def test_prefill_state_indices_none_is_default():
+@pytest.mark.parametrize("use_cp", [False, True])
+def test_prefill_state_indices_none_is_default(use_cp):
     """state_indices=None must reproduce the packed path exactly (default)."""
     _skip_if_not_sm100()
     device = torch.device("cuda")
@@ -204,9 +227,9 @@ def test_prefill_state_indices_none_is_default():
         seq_lens, H, D, torch.bfloat16, device, seed=1
     )
     s1 = torch.empty(num_seqs, H, D, D, dtype=torch.bfloat16, device=device)
-    o1, f1 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s1, None)
+    o1, f1 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s1, None, use_cp)
     s2 = torch.empty(num_seqs, H, D, D, dtype=torch.bfloat16, device=device)
-    o2, f2 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s2, None)
+    o2, f2 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s2, None, use_cp)
     torch.cuda.synchronize()
     assert torch.equal(o1, o2)
     assert torch.equal(f1, f2)


### PR DESCRIPTION
## 📌 Description

This PR adds cp impl for delta rule.

## 🔍 Related Issues

- [x] https://github.com/flashinfer-ai/flashinfer/issues/3491

## 🚀 Pull Request Checklist
### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

```
GPU: NVIDIA B300 SXM6 AC [Blackwell (SM100)]
Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128

Heads            Seqlens           h_qk  h_v    FI Blackwell (SM100)   TFLOPS  FLA/Triton   Speedup
---------------------------------------------------------------------------------------------------
397B/122B TP8    1x65536              2    8                  0.343ms   100.2      2.065ms     6.02x +
397B/122B TP8    1x32768              2    8                  0.213ms    80.7      1.048ms     4.92x +
397B/122B TP8    1x16384              2    8                  0.148ms    58.2      0.531ms     3.60x +
397B/122B TP8    1x8192               2    8                  0.114ms    37.5      0.269ms     2.35x +
397B/122B TP8    1x4096               2    8                  0.084ms    25.5      0.147ms     1.74x +
397B/122B TP8    1x2048               2    8                  0.070ms    15.4      0.087ms     1.25x +
397B/122B TP8    6144+2048            2    8                  0.110ms    39.0      0.223ms     2.03x +
397B/122B TP8    4096+4096            2    8                  0.102ms    42.0      0.176ms     1.73x +
397B/122B TP8    2048+6144            2    8                  0.109ms    39.6      0.223ms     2.06x +
397B/122B TP8    1024+7168            2    8                  0.114ms    37.8      0.247ms     2.17x +
397B/122B TP8    2048x4               2    8                  0.113ms    38.1      0.130ms     1.15x +
397B/122B TP8    1024x8               2    8                  0.046ms    92.9      0.117ms     2.53x +
397B/122B TP8    8192x8               2    8                  0.241ms   142.7      0.781ms     3.25x +
397B/122B TP8    8192x16              2    8                  0.244ms   281.1      1.546ms     6.32x +
397B/122B TP8    8192x32              2    8                  0.499ms   275.5      3.055ms     6.12x +

397B/122B TP4    1x65536              4   16                  0.569ms   120.7      2.595ms     4.56x +
397B/122B TP4    1x32768              4   16                  0.326ms   105.3      1.303ms     3.99x +
397B/122B TP4    1x16384              4   16                  0.195ms    87.9      0.670ms     3.43x +
397B/122B TP4    1x8192               4   16                  0.130ms    66.2      0.342ms     2.63x +
397B/122B TP4    1x4096               4   16                  0.097ms    44.2      0.178ms     1.83x +
397B/122B TP4    1x2048               4   16                  0.077ms    27.8      0.101ms     1.31x +
397B/122B TP4    6144+2048            4   16                  0.132ms    65.0      0.295ms     2.23x +
397B/122B TP4    4096+4096            4   16                  0.129ms    66.7      0.247ms     1.92x +
397B/122B TP4    2048+6144            4   16                  0.133ms    64.5      0.294ms     2.21x +
397B/122B TP4    1024+7168            4   16                  0.134ms    64.1      0.319ms     2.38x +
397B/122B TP4    2048x4               4   16                  0.074ms   115.5      0.213ms     2.87x +
397B/122B TP4    1024x8               4   16                  0.049ms   174.3      0.218ms     4.42x +
397B/122B TP4    8192x8               4   16                  0.243ms   282.4      1.555ms     6.39x +
397B/122B TP4    8192x16              4   16                  0.495ms   277.6      3.089ms     6.24x +
397B/122B TP4    8192x32              4   16                  1.024ms   268.5      5.928ms     5.79x +

397B/122B TP2    1x65536              8   32                  1.124ms   122.2      3.663ms     3.26x +
397B/122B TP2    1x32768              8   32                  0.585ms   117.5      1.827ms     3.13x +
397B/122B TP2    1x16384              8   32                  0.321ms   107.0      0.927ms     2.89x +
397B/122B TP2    1x8192               8   32                  0.189ms    91.0      0.481ms     2.55x +
397B/122B TP2    1x4096               8   32                  0.123ms    70.1      0.249ms     2.03x +
397B/122B TP2    1x2048               8   32                  0.089ms    48.5      0.132ms     1.49x +
397B/122B TP2    6144+2048            8   32                  0.186ms    92.6      0.448ms     2.42x +
397B/122B TP2    4096+4096            8   32                  0.130ms   131.7      0.415ms     3.18x +
397B/122B TP2    2048+6144            8   32                  0.186ms    92.3      0.472ms     2.54x +
397B/122B TP2    1024+7168            8   32                  0.214ms    80.4      0.500ms     2.34x +
397B/122B TP2    2048x4               8   32                  0.078ms   221.1      0.420ms     5.40x +
397B/122B TP2    1024x8               8   32                  0.093ms   184.0      0.426ms     4.56x +
397B/122B TP2    8192x8               8   32                  0.509ms   269.8      3.125ms     6.13x +
397B/122B TP2    8192x16              8   32                  1.032ms   266.5      6.020ms     5.84x +
397B/122B TP2    8192x32              8   32                  1.962ms   280.3     12.018ms     6.13x +

397B/122B TP1    1x65536             16   64                  1.796ms   153.0      6.251ms     3.48x +
397B/122B TP1    1x32768             16   64                  0.908ms   151.4      3.096ms     3.41x +
397B/122B TP1    1x16384             16   64                  0.464ms   148.2      1.564ms     3.37x +
397B/122B TP1    1x8192              16   64                  0.242ms   142.0      0.797ms     3.29x +
397B/122B TP1    1x4096              16   64                  0.131ms   131.0      0.417ms     3.18x +
397B/122B TP1    1x2048              16   64                  0.075ms   114.9      0.218ms     2.92x +
397B/122B TP1    6144+2048           16   64                  0.188ms   182.5      0.799ms     4.24x +
397B/122B TP1    4096+4096           16   64                  0.134ms   256.8      0.801ms     5.98x +
397B/122B TP1    2048+6144           16   64                  0.189ms   182.0      0.803ms     4.25x +
397B/122B TP1    1024+7168           16   64                  0.216ms   159.2      0.804ms     3.73x +
397B/122B TP1    2048x4              16   64                  0.150ms   229.4      0.805ms     5.38x +
397B/122B TP1    1024x8              16   64                  0.184ms   187.2      0.792ms     4.32x +
397B/122B TP1    8192x8              16   64                  1.027ms   267.6      5.998ms     5.84x +
397B/122B TP1    8192x16             16   64                  1.958ms   280.8     12.012ms     6.13x +
397B/122B TP1    8192x32             16   64                  4.042ms   272.0     24.021ms     5.94x +

35B/9B/4B TP1    1x65536             16   32                  1.143ms   120.3      3.667ms     3.21x +
35B/9B/4B TP1    1x32768             16   32                  0.590ms   116.6      1.827ms     3.10x +
35B/9B/4B TP1    1x16384             16   32                  0.323ms   106.3      0.927ms     2.87x +
35B/9B/4B TP1    1x8192              16   32                  0.190ms    90.3      0.481ms     2.53x +
35B/9B/4B TP1    1x4096              16   32                  0.124ms    69.0      0.249ms     2.00x +
35B/9B/4B TP1    1x2048              16   32                  0.090ms    47.8      0.132ms     1.47x +
35B/9B/4B TP1    6144+2048           16   32                  0.186ms    92.2      0.448ms     2.40x +
35B/9B/4B TP1    4096+4096           16   32                  0.131ms   130.9      0.416ms     3.16x +
35B/9B/4B TP1    2048+6144           16   32                  0.187ms    91.9      0.473ms     2.53x +
35B/9B/4B TP1    1024+7168           16   32                  0.215ms    80.1      0.502ms     2.34x +
35B/9B/4B TP1    2048x4              16   32                  0.078ms   218.9      0.419ms     5.34x +
35B/9B/4B TP1    1024x8              16   32                  0.094ms   181.9      0.426ms     4.51x +
35B/9B/4B TP1    8192x8              16   32                  0.508ms   270.5      3.122ms     6.14x +
35B/9B/4B TP1    8192x16             16   32                  1.057ms   260.0      6.018ms     5.69x +
35B/9B/4B TP1    8192x32             16   32                  2.022ms   271.9     12.009ms     5.94x +

27B TP1          1x65536             16   48                  1.756ms   117.4      5.071ms     2.89x +
27B TP1          1x32768             16   48                  0.897ms   114.9      2.520ms     2.81x +
27B TP1          1x16384             16   48                  0.461ms   111.7      1.274ms     2.76x +
27B TP1          1x8192              16   48                  0.241ms   107.1      0.657ms     2.73x +
27B TP1          1x4096              16   48                  0.130ms    99.0      0.341ms     2.62x +
27B TP1          1x2048              16   48                  0.074ms    87.5      0.189ms     2.56x +
27B TP1          6144+2048           16   48                  0.187ms   138.2      0.597ms     3.20x +
27B TP1          4096+4096           16   48                  0.131ms   196.3      0.660ms     5.03x +
27B TP1          2048+6144           16   48                  0.186ms   138.3      0.664ms     3.56x +
27B TP1          1024+7168           16   48                  0.214ms   120.5      0.666ms     3.11x +
27B TP1          2048x4              16   48                  0.148ms   173.9      0.605ms     4.08x +
27B TP1          1024x8              16   48                  0.139ms   185.1      0.613ms     4.41x +
27B TP1          8192x8              16   48                  0.789ms   261.2      4.573ms     5.79x +
27B TP1          8192x16             16   48                  1.580ms   261.0      8.926ms     5.65x +
27B TP1          8192x32             16   48                  3.119ms   264.4     17.624ms     5.65x +

2B/0.8B TP1      1x65536             16   16                  0.588ms   116.8      2.594ms     4.41x +
2B/0.8B TP1      1x32768             16   16                  0.332ms   103.6      1.303ms     3.93x +
2B/0.8B TP1      1x16384             16   16                  0.199ms    86.5      0.669ms     3.37x +
2B/0.8B TP1      1x8192              16   16                  0.132ms    64.9      0.342ms     2.58x +
2B/0.8B TP1      1x4096              16   16                  0.099ms    43.4      0.178ms     1.80x +
2B/0.8B TP1      1x2048              16   16                  0.078ms    27.4      0.101ms     1.29x +
2B/0.8B TP1      6144+2048           16   16                  0.136ms    63.0      0.294ms     2.16x +
2B/0.8B TP1      4096+4096           16   16                  0.133ms    64.5      0.247ms     1.85x +
2B/0.8B TP1      2048+6144           16   16                  0.136ms    63.2      0.294ms     2.17x +
2B/0.8B TP1      1024+7168           16   16                  0.137ms    62.6      0.319ms     2.32x +
2B/0.8B TP1      2048x4              16   16                  0.075ms   114.3      0.213ms     2.84x +
2B/0.8B TP1      1024x8              16   16                  0.051ms   170.1      0.218ms     4.31x +
2B/0.8B TP1      8192x8              16   16                  0.252ms   272.9      1.555ms     6.18x +
2B/0.8B TP1      8192x16             16   16                  0.534ms   257.2      3.086ms     5.78x +
2B/0.8B TP1      8192x32             16   16                  1.114ms   246.7      5.926ms     5.32x +

Sym h32          1x65536             32   32                  1.170ms   117.5      3.671ms     3.14x +
Sym h32          1x32768             32   32                  0.594ms   115.7      1.826ms     3.08x +
Sym h32          1x16384             32   32                  0.325ms   105.7      0.927ms     2.85x +
Sym h32          1x8192              32   32                  0.192ms    89.6      0.481ms     2.51x +
Sym h32          1x4096              32   32                  0.126ms    68.1      0.249ms     1.97x +
Sym h32          1x2048              32   32                  0.092ms    46.9      0.132ms     1.44x +
Sym h32          6144+2048           32   32                  0.187ms    92.0      0.448ms     2.40x +
Sym h32          4096+4096           32   32                  0.131ms   130.8      0.415ms     3.16x +
Sym h32          2048+6144           32   32                  0.188ms    91.5      0.473ms     2.52x +
Sym h32          1024+7168           32   32                  0.215ms    80.0      0.502ms     2.34x +
Sym h32          2048x4              32   32                  0.079ms   216.1      0.420ms     5.28x +
Sym h32          1024x8              32   32                  0.095ms   180.0      0.426ms     4.46x +
Sym h32          8192x8              32   32                  0.510ms   269.3      3.122ms     6.12x +
Sym h32          8192x16             32   32                  1.120ms   245.5      6.021ms     5.38x +
Sym h32          8192x32             32   32                  2.117ms   259.7     12.018ms     5.68x +
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Blackwell SM100 support for context-parallel Gated Delta Net prefill and delta-rule processing.
  - Added automatic kernel selection, optimized execution, improved chunk sizing, and compiled-kernel reuse.
  - Added optional initial and final state handling, including indexed states and varied state data types.
  - Exposed Blackwell functionality through the public API.
  - Improved device capability detection.

- **Tests**
  - Added SM100 coverage for dispatch, end-to-end processing, state handling, and data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->