### PR TITLE
fix: Add missing nvfp4 sizing branch in getProfilerWorkspaces

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4719,15 +4719,19 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
       (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
   size_t quant_5_size = 0;
   size_t quant_6_size = 0;
-  if (is_native_wfp4afp8_family || is_nvfp4_quant) {
-    quant_1_size = sizeof(float);
-    quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-    quant_3_size = num_experts_per_node * sizeof(float);
-    quant_4_size = sizeof(float);
-    quant_5_size = getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-    quant_6_size = num_experts_per_node * sizeof(float);
+  if (is_native_wfp4afp8_family) {
+    if (is_nvfp4_quant) {
+      quant_1_size = sizeof(float);
+      quant_2_size =
+          getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
+          sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+      quant_3_size = num_experts_per_node * sizeof(float);
+      quant_4_size = sizeof(float);
+      quant_5_size =
+          getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
+          sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+      quant_6_size = num_experts_per_node * sizeof(float);
+    }
   } else if (is_sm90_wfp4afp8_family) {
     quant_1_size = sizeof(float);
     quant_2_size =

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4714,11 +4714,6 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
   // FP4 sizes
   bool const use_humming_pre_mma = isHummingPreMmaScaleMode();
   size_t const fp8_mxfp4_token_scale_size = num_expanded_tokens * sizeof(float);
-  // Plain NVFP4 x NVFP4 (act nvfp4 + weight nvfp4). Before #3738 this was sized
-  // by the broad `is_fp4_w_quant` block; that block was replaced by the two
-  // Wfp4Afp8 branches below (both require FP8 activation, mDType == kFP8), which
-  // dropped coverage for the nvfp4-activation case and left quant_1..6 sized 0,
-  // tripping the TLLM_CHECK in prepare()'s FP4 consumer branch (nvbug 6469722).
   // The sizes are identical to the is_native_wfp4afp8_family branch.
   bool const is_nvfp4_quant =
       mSM >= 100 && (mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4714,7 +4714,6 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
   // FP4 sizes
   bool const use_humming_pre_mma = isHummingPreMmaScaleMode();
   size_t const fp8_mxfp4_token_scale_size = num_expanded_tokens * sizeof(float);
-  // The sizes are identical to the is_native_wfp4afp8_family branch.
   bool const is_nvfp4_quant =
       mSM >= 100 && (mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
       (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4719,19 +4719,24 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
       (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
   size_t quant_5_size = 0;
   size_t quant_6_size = 0;
-  if (is_native_wfp4afp8_family) {
-    if (is_nvfp4_quant) {
-      quant_1_size = sizeof(float);
-      quant_2_size =
-          getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
-          sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-      quant_3_size = num_experts_per_node * sizeof(float);
-      quant_4_size = sizeof(float);
-      quant_5_size =
-          getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
-          sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-      quant_6_size = num_experts_per_node * sizeof(float);
-    }
+  if (is_nvfp4_quant) {
+    quant_1_size = sizeof(float);
+    quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
+                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+    quant_3_size = num_experts_per_node * sizeof(float);
+    quant_4_size = sizeof(float);
+    quant_5_size = getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
+                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+    quant_6_size = num_experts_per_node * sizeof(float);
+  } else if (is_native_wfp4afp8_family) {
+    quant_1_size = sizeof(float);
+    quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
+                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+    quant_3_size = num_experts_per_node * sizeof(float);
+    quant_4_size = sizeof(float);
+    quant_5_size = getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
+                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+    quant_6_size = num_experts_per_node * sizeof(float);
   } else if (is_sm90_wfp4afp8_family) {
     quant_1_size = sizeof(float);
     quant_2_size =

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4714,9 +4714,18 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
   // FP4 sizes
   bool const use_humming_pre_mma = isHummingPreMmaScaleMode();
   size_t const fp8_mxfp4_token_scale_size = num_expanded_tokens * sizeof(float);
+  // Plain NVFP4 x NVFP4 (act nvfp4 + weight nvfp4). Before #3738 this was sized
+  // by the broad `is_fp4_w_quant` block; that block was replaced by the two
+  // Wfp4Afp8 branches below (both require FP8 activation, mDType == kFP8), which
+  // dropped coverage for the nvfp4-activation case and left quant_1..6 sized 0,
+  // tripping the TLLM_CHECK in prepare()'s FP4 consumer branch (nvbug 6469722).
+  // The sizes are identical to the is_native_wfp4afp8_family branch.
+  bool const is_nvfp4_quant =
+      mSM >= 100 && (mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
+      (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
   size_t quant_5_size = 0;
   size_t quant_6_size = 0;
-  if (is_native_wfp4afp8_family) {
+  if (is_native_wfp4afp8_family || is_nvfp4_quant) {
     quant_1_size = sizeof(float);
     quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
                    sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The FlashInfer perf-CI on B300 crashes when autotuning the CUTLASS NVFP4 fused-MoE with Assertion failed: 
`quant_1 && … && quant_6 at cutlass_fused_moe_kernels.cuh:5034.` The failure is confined to the autotuner's tactic-profiler (GemmProfilerBackend), which fabricates its own scratch scale-factor buffers quant_1..6 to time GEMM candidates in isolation — the real MoE forward builds its quant params from the caller's actual tensors and is unaffected. 

[PR3738](https://github.com/flashinfer-ai/flashinfer/pull/3738) refactored the profiler's FP4 workspace-sizing, replacing the broad `is_fp4_w_quant` branch (which covered every FP4-weight case) with two narrower branches, `is_native_wfp4afp8_family` and `is_sm90_wfp4afp8_family`, both of which require FP8 activation (`mDType == kFP8`). Plain NVFP4×NVFP4 has FP4/INT64 activation, so it matched neither branch, leaving all six quant_* buffers sized 0 → null pointers → the assertion. 

The fix restores NVFP4 coverage by adding an `is_nvfp4_quant` predicate (`mSM>=100 && mDType∈{kFP4,kINT64} && mWType∈{kFP4,kINT64}`) and adding an additional sizing branch, whose buffer sizes are byte-for-byte identical to the removed `is_fp4_w_quant` block. 

Verified on a B300: the previously-crashing repro now completes autotuning (gemm1/gemm2 21/21 each) and benchmarks cleanly.



## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profiler workspace sizing for NVFP4 (FP4 quantization) workloads by applying the correct FP4/NVFP4-specific scaling layout.
  * Ensured these updated sizing rules take precedence only for the intended FP4 + INT64 quantization configuration, preventing unintended overrides in other quantization families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->