### PR TITLE
feat(gdn): index GDN prefill state pool via state_indices (SM100/SM103)

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -387,6 +387,7 @@ class GatedDeltaNetChunkedKernel:
         cu_seqlens: cute.Tensor,
         s_in: Optional[cute.Tensor],
         s_out: Optional[cute.Tensor],
+        s_indices: Optional[cute.Tensor],
         s_checkpoints: Optional[cute.Tensor],
         cu_checkpoints: Optional[cute.Tensor],
         checkpoint_every_n_tokens: cutlass.Int32,
@@ -810,6 +811,7 @@ class GatedDeltaNetChunkedKernel:
             cu_seqlens,
             s_in,
             s_out,
+            s_indices,
             s_checkpoints,
             cu_checkpoints,
             checkpoint_every_n_tokens,
@@ -869,6 +871,9 @@ class GatedDeltaNetChunkedKernel:
         mS_init: Optional[cute.Tensor],
         # final state output (fp32) to GMEM; None if not stored
         mS_out: Optional[cute.Tensor],
+        # optional (num_seqs,) int32 indirection into the state pool rows; None
+        # means identity (row == batch_idx), preserving legacy behavior
+        mS_indices: Optional[cute.Tensor],
         mS_checkpoints: Optional[cute.Tensor],
         cu_checkpoints: Optional[cute.Tensor],
         checkpoint_every_n_tokens: cutlass.Int32,
@@ -1247,6 +1252,7 @@ class GatedDeltaNetChunkedKernel:
                         kv_acc_producer = self._load_initial_state(
                             tidx,
                             mS_init,
+                            mS_indices,
                             head_idx,
                             batch_idx,
                             tmem_ptr,
@@ -1340,6 +1346,7 @@ class GatedDeltaNetChunkedKernel:
                         kv_acc_consumer = self._store_final_state(
                             tidx,
                             mS_out,
+                            mS_indices,
                             head_idx,
                             batch_idx,
                             tmem_ptr,
@@ -2938,6 +2945,7 @@ class GatedDeltaNetChunkedKernel:
         self,
         tidx,
         mS_init,
+        mS_indices,
         head_idx,
         batch_idx,
         tmem_ptr,
@@ -2976,8 +2984,15 @@ class GatedDeltaNetChunkedKernel:
         tRT_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
         tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.state_dtype)
 
+        # Optional indexed (pool) access: read the recurrent-state row by an
+        # indirection index instead of the sequence-order batch_idx. Loaded
+        # once per work tile (per (batch_idx, head_idx)) as an Int32 scalar.
+        if cutlass.const_expr(mS_indices is not None):
+            state_row = mS_indices[batch_idx]
+        else:
+            state_row = batch_idx
         gS_init = cute.flat_divide(
-            mS_init[None, None, head_idx, batch_idx],
+            mS_init[None, None, head_idx, state_row],
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
         )[None, None, 0, 0]
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
@@ -3017,6 +3032,7 @@ class GatedDeltaNetChunkedKernel:
         tidx,
         # full output-state GMEM tensor (DK, DV, (h_r, h_qv), B) fp32
         mS_out,
+        mS_indices,
         head_idx,
         batch_idx,
         tmem_ptr,
@@ -3066,6 +3082,15 @@ class GatedDeltaNetChunkedKernel:
         # Wait for last GEMM-7 to finish
         kv_acc_handle = kv_acc_consumer.wait_and_advance()
 
+        # Optional indexed (pool) access: write the recurrent-state row by an
+        # indirection index instead of the sequence-order batch_idx. Loaded
+        # once per work tile (per (batch_idx, head_idx)) as an Int32 scalar and
+        # reused across the sub loop below.
+        if cutlass.const_expr(mS_indices is not None):
+            state_row = mS_indices[batch_idx]
+        else:
+            state_row = batch_idx
+
         for sub in cutlass.range(tTR_rState.shape[2]):
             # Read state TMEM -> fp32 registers
             cute.copy(
@@ -3097,7 +3122,7 @@ class GatedDeltaNetChunkedKernel:
                     )
             if cutlass.const_expr(self.store_final_state):
                 gS_out = cute.flat_divide(
-                    mS_out[None, None, head_idx, batch_idx],
+                    mS_out[None, None, head_idx, state_row],
                     (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
                 )[None, None, 0, 0]
                 tRG_tCgState = thr_state_t2r.partition_D(gS_out)

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -57,6 +57,7 @@ def _get_compiled_cache(
     use_initial_state: bool,
     store_final_state: bool,
     enable_checkpoints: bool,
+    use_state_indices: bool,
 ):
     """Return a mutable dict that lazily stores the compiled kernel."""
     return {}
@@ -91,6 +92,38 @@ def _cutlass_state_dtype(torch_dtype: torch.dtype):
         )
 
 
+def _mark_state_layout(s_cute, use_state_indices: bool, DK: int) -> None:
+    """Mark the recurrent-state tensor layout for compilation.
+
+    Packed mode (``use_state_indices=False``): the caller passes a compact
+    ``[num_seqs, H, V, K]`` state, so we keep the original marking that both
+    makes the layout dynamic (stride-1 K dim auto-deduced) and attaches a
+    ``divisibility=DK`` hint on the K dim for wider vectorized state copies.
+
+    Pool/indexed mode (``use_state_indices=True``): the caller passes its real
+    SSM state pool ``[N_pool, H, V, K]`` whose dim-0 (slot) stride is padded by
+    the mamba conv+ssm cache packing, i.e. ``stride[0] > H*V*K`` -> the layout is
+    NON-COMPACT. ``mark_compact_shape_dynamic`` asserts a compact layout and
+    raises ``RuntimeError: The stride_order is not consistent with the layout``.
+    ``mark_layout_dynamic()`` alone pins the single stride-1 dim (mode 3 = K) to
+    stride 1 and carries every other stride (including the padded dim-0) through
+    as a dynamic runtime value. The kernel addresses the state purely via
+    ``s.stride[...]`` (reshape at ~475-497 and ``mS_init/mS_out[..., state_row]``),
+    so a padded dim-0 stride is handled correctly. cutlass-dsl offers no way to
+    attach a divisibility hint without also requiring compactness, so this path
+    drops the ``divisibility=DK`` hint; the stride-1 K dim is retained, so the
+    128x128 state autovec copy still vectorizes (possibly a narrower vector).
+    That copy is a negligible fraction of the kernel, so correctness is kept
+    with no meaningful perf cost.
+    """
+    if use_state_indices:
+        s_cute.mark_layout_dynamic()
+    else:
+        s_cute.mark_layout_dynamic().mark_compact_shape_dynamic(
+            mode=3, stride_order=(0, 1, 2, 3), divisibility=DK
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -110,6 +143,7 @@ def chunk_gated_delta_rule_sm100(
     checkpoint_every_n_tokens: int = 0,
     cu_checkpoints: Optional[torch.Tensor] = None,
     output_checkpoints: Optional[torch.Tensor] = None,
+    state_indices: Optional[torch.Tensor] = None,
 ) -> None:
     """Execute the Blackwell chunked GDN prefill kernel.
 
@@ -151,6 +185,8 @@ def chunk_gated_delta_rule_sm100(
     _initial_state = initial_state if use_initial_state else None
     B = cu_seqlens.size(0) - 1
     _output_state = output_state if store_final_state else None
+    use_state_indices = state_indices is not None
+    _state_indices = state_indices if use_state_indices else None
 
     cache = _get_compiled_cache(
         str(q.dtype),
@@ -161,6 +197,7 @@ def chunk_gated_delta_rule_sm100(
         use_initial_state,
         store_final_state,
         enable_checkpoints,
+        use_state_indices,
     )
 
     if "compiled" not in cache:
@@ -217,16 +254,18 @@ def chunk_gated_delta_rule_sm100(
         s_in_cute = None
         if use_initial_state:
             s_in_cute = from_dlpack(_initial_state, assumed_align=16)
-            s_in_cute.mark_layout_dynamic().mark_compact_shape_dynamic(
-                mode=3, stride_order=(0, 1, 2, 3), divisibility=DK
-            )
+            _mark_state_layout(s_in_cute, use_state_indices, DK)
 
         s_out_cute = None
         if store_final_state:
             s_out_cute = from_dlpack(_output_state, assumed_align=16)
-            s_out_cute.mark_layout_dynamic().mark_compact_shape_dynamic(
-                mode=3, stride_order=(0, 1, 2, 3), divisibility=DK
-            )
+            _mark_state_layout(s_out_cute, use_state_indices, DK)
+
+        s_indices_cute = None
+        if use_state_indices:
+            s_indices_cute = from_dlpack(
+                _state_indices, assumed_align=4
+            ).mark_layout_dynamic()
 
         s_checkpoints_cute = None
         cu_checkpoints_cute = None
@@ -258,6 +297,7 @@ def chunk_gated_delta_rule_sm100(
             cu_seqlens_cute,
             s_in_cute,
             s_out_cute,
+            s_indices_cute,
             s_checkpoints_cute,
             cu_checkpoints_cute,
             checkpoint_every_n_tokens,
@@ -293,6 +333,7 @@ def chunk_gated_delta_rule_sm100(
         cu_seqlens,
         _initial_state,
         _output_state,
+        _state_indices,
         output_checkpoints,
         cu_checkpoints,
         checkpoint_every_n_tokens,

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -117,6 +117,7 @@ def chunk_gated_delta_rule(
     checkpoint_cu_starts: Optional[torch.Tensor] = None,
     checkpoint_every_n_tokens: int = 0,
     use_cp: Literal["auto"] | bool = "auto",
+    state_indices: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated Delta Rule (GDN) attention for prefill.
 
@@ -146,11 +147,15 @@ def chunk_gated_delta_rule(
         Scale factor for the attention scores.  Defaults to
         ``1 / sqrt(head_size)`` when ``None``.
     initial_state : torch.Tensor, optional
-        Initial KV state of shape
+        Initial KV state. Packed, sequence-ordered shape
         ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be
         float32 on SM90/SM120.  The SM100 path also accepts bfloat16,
         float16, float8_e4m3fn, and float8_e5m2.  Starts from zero state
-        when ``None``.
+        when ``None``.  When ``state_indices`` is given (SM100/SM103 only),
+        this is instead the state **pool** ``[N_pool, num_sab_heads,
+        head_size, head_size]`` and sequence ``i`` reads its initial state
+        from row ``state_indices[i]``; the pool may be non-compact (padded
+        first-dimension stride, inner ``[H, V, K]`` block contiguous).
     output_final_state : bool
         Whether to output the final state.  Default: ``False``.
     cu_seqlens : torch.Tensor
@@ -169,11 +174,16 @@ def chunk_gated_delta_rule(
         max(num_q_heads, num_v_heads)``.  Allocated automatically when
         ``None``.
     output_state : torch.Tensor, optional
-        Pre-allocated output state tensor of shape ``[num_seqs,
-        num_sab_heads, head_size, head_size]``.  Must be float32 on
-        SM90/SM120.  The SM100 path also accepts bfloat16, float16,
+        Pre-allocated output state tensor. Packed, sequence-ordered shape
+        ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be float32
+        on SM90/SM120.  The SM100 path also accepts bfloat16, float16,
         float8_e4m3fn, and float8_e5m2.  Required when
-        ``output_final_state=True``.
+        ``output_final_state=True``.  When ``state_indices`` is given it is
+        instead the output state **pool** ``[N_pool, ...]`` and sequence
+        ``i``'s final state is written to row ``state_indices[i]`` (in place
+        when ``output_state is initial_state``); it must be provided by the
+        caller (auto-allocation is rejected, since a compact ``[num_seqs, ...]``
+        buffer would be indexed out of bounds by the pool slot ids).
     state_checkpoints : torch.Tensor, optional
         Pre-allocated checkpoint tensor of shape ``[total_checkpoints,
         num_sab_heads, head_size, head_size]``.  Must be float32 on
@@ -194,6 +204,23 @@ def chunk_gated_delta_rule(
         low-parallelism heuristics match. ``"auto"`` enables conservative
         routing, ``True`` requires CP support, and ``False`` disables CP.
         Default: ``"auto"``.
+    state_indices : torch.Tensor, optional
+        Int32 tensor of shape ``[num_seqs]`` (SM100/SM103 only). When provided,
+        ``initial_state`` and ``output_state`` are treated as a state pool whose
+        first dimension is indexed by these slot ids rather than laid out in
+        sequence order: sequence ``i`` reads its initial state from row
+        ``state_indices[i]`` and writes its final state back to the same row
+        (in place when ``output_state is initial_state``). This lets callers
+        that keep a paged/indexed state pool avoid gathering the active rows
+        into a packed buffer and scattering the result back. The pool may be
+        non-compact (padded first-dimension stride). ``None`` (default) keeps
+        the packed, sequence-ordered layout.
+
+        The ids **must be unique**: as with any indexed scatter, two sequences
+        sharing a slot id would concurrently write the same pool row across
+        work tiles, leaving that row's final state nondeterministic. Uniqueness
+        is a caller precondition (not checked at launch, to avoid a per-call
+        host sync); the caller's slot allocator is expected to guarantee it.
 
 
     Returns
@@ -202,7 +229,10 @@ def chunk_gated_delta_rule(
         When ``output_final_state=False``, the output tensor of shape
         ``[total_seq_len, num_o_heads, head_size]``.  Otherwise a tuple
         ``(output, final_state)`` where ``final_state`` has shape
-        ``[num_seqs, num_sab_heads, head_size, head_size]``.
+        ``[num_seqs, num_sab_heads, head_size, head_size]`` — or, when
+        ``state_indices`` is given, the state pool ``[N_pool, ...]`` itself
+        (i.e. ``output_state``), whose rows named by ``state_indices`` now
+        hold the updated final states.
 
     Notes
     -----
@@ -312,7 +342,28 @@ def chunk_gated_delta_rule(
     cp_heuristic_matches = _arch_major in (9, 12) and should_use_cp_host(
         num_seqs * num_sab_heads, _sm_count, _device_name
     )
-    if use_cp is True or (use_cp == "auto" and cp_heuristic_matches):
+    will_use_cp = use_cp is True or (use_cp == "auto" and cp_heuristic_matches)
+    if state_indices is not None:
+        # Indexed state-pool I/O is only implemented in the SM100/SM103 non-CP
+        # CuTe-DSL kernel. Reject it on every other dispatch path (SM90, SM120,
+        # or CP) rather than silently ignoring it and reading/writing the state
+        # in packed, sequence-ordered layout.
+        if _arch_major != 10 or will_use_cp:
+            raise NotImplementedError(
+                "state_indices is only supported on the SM100/SM103 GDN prefill "
+                f"kernel (non-CP); got compute-capability major {_arch_major}, "
+                f"use_cp={use_cp!r}."
+            )
+        # The kernel writes each final state to output_state[state_indices[i]],
+        # so a compact [num_seqs, ...] auto-allocation would be indexed out of
+        # bounds by arbitrary pool slot ids. Require the caller to pass the pool.
+        if output_final_state and output_state is None:
+            raise ValueError(
+                "state_indices requires an explicit output_state pool sized like "
+                "the state pool ([N_pool, H, V, K]); refusing to auto-allocate a "
+                "compact [num_seqs, ...] tensor that would be indexed out of bounds."
+            )
+    if will_use_cp:
         cp_rejection_reason = _cp_delta_rule_rejection_reason(
             arch_major=_arch_major,
             q=q,
@@ -433,6 +484,7 @@ def chunk_gated_delta_rule(
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             cu_checkpoints=_cu_checkpoints,
             output_checkpoints=state_checkpoints,
+            state_indices=state_indices,
         )
     elif _arch_major == 12:
         # SM120 Blackwell path (CuTe DSL kernel)

--- a/tests/gdn/test_prefill_state_indices.py
+++ b/tests/gdn/test_prefill_state_indices.py
@@ -1,0 +1,212 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+import pytest
+
+from flashinfer.utils import is_sm100a_supported
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
+
+
+def _skip_if_not_sm100():
+    device = torch.device("cuda")
+    if not is_sm100a_supported(device):
+        pytest.skip("state_indices GDN prefill path requires SM100/SM103 (Blackwell)")
+    cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
+    if cuda_major < 13:
+        pytest.skip(f"SM100 GDN prefill requires CUDA 13+, got {torch.version.cuda}")
+
+
+def _make_inputs(seq_lens, H, D, dtype, device, seed):
+    torch.manual_seed(seed)
+    total = sum(seq_lens)
+    num_seqs = len(seq_lens)
+    cu_seqlens = torch.tensor(
+        [0, *torch.cumsum(torch.tensor(seq_lens), 0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    q = (
+        F.normalize(
+            torch.randn(total, H, D, dtype=torch.float32, device=device), dim=-1
+        )
+        .to(dtype)
+        .contiguous()
+    )
+    k = (
+        F.normalize(
+            torch.randn(total, H, D, dtype=torch.float32, device=device), dim=-1
+        )
+        .to(dtype)
+        .contiguous()
+    )
+    v = torch.randn(total, H, D, dtype=dtype, device=device).contiguous()
+    # FlashInfer consumes linear-space alpha = exp(log_g)
+    g_log = -F.softplus(
+        torch.randn(total, H, dtype=torch.float32, device=device) * 0.5 - 2.0
+    )
+    g = torch.exp(g_log).contiguous()
+    beta = torch.rand(total, H, dtype=torch.float32, device=device).contiguous()
+    init_state = torch.randn(num_seqs, H, D, D, dtype=dtype, device=device).contiguous()
+    return q, k, v, g, beta, cu_seqlens, init_state
+
+
+def _run(q, k, v, g, beta, cu_seqlens, initial_state, output_state, state_indices):
+    total, H, D = q.shape
+    out = torch.empty(total, H, D, dtype=q.dtype, device=q.device)
+    output, final = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        None,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=False,
+        output=out,
+        output_state=output_state,
+        state_indices=state_indices,
+    )
+    return output, final
+
+
+def _make_pool(init_state, perm, n_pool, pad, dtype, device):
+    """Build a state pool holding init_state[i] at row perm[i].
+
+    ``pad > 0`` gives the pool a padded (non-compact) *first-dimension* stride
+    while keeping the inner ``[H, V, K]`` block fully contiguous -- exactly
+    TRT-LLM's mamba cache layout, where conv+ssm are packed per slot so only the
+    per-slot (dim-0) stride is padded. Built via ``as_strided`` over flat storage
+    so the padding lands only between slots, not inside the state block.
+    """
+    _, H, D, _ = init_state.shape
+    if pad == 0:
+        pool = torch.zeros(n_pool, H, D, D, dtype=dtype, device=device)
+    else:
+        slot_stride = H * D * D + pad  # usable state block + inter-slot padding
+        storage = torch.zeros(n_pool * slot_stride, dtype=dtype, device=device)
+        pool = storage.as_strided((n_pool, H, D, D), (slot_stride, D * D, D, 1))
+        assert not pool.is_contiguous()  # dim-0 stride padded
+        assert pool.stride()[1:] == (D * D, D, 1)  # inner [H, V, K] contiguous
+    for i, r in enumerate(perm):
+        pool[r] = init_state[i]
+    return pool
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[128], [256], [128, 192, 64], [64, 512]],
+)
+@pytest.mark.parametrize("H", [16, 32])
+@pytest.mark.parametrize("pad", [0, 96])  # 0 = compact pool, 96 = non-compact
+def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad):
+    """A pool + state_indices in-place update must match the packed,
+    sequence-ordered baseline bitwise (the kernel math is identical; only the
+    addressed gmem row differs)."""
+    _skip_if_not_sm100()
+    device = torch.device("cuda")
+    D = 128
+    num_seqs = len(seq_lens)
+    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
+        seq_lens, H, D, dtype, device, seed=0
+    )
+
+    # (a) packed baseline, no state_indices
+    out_state_a = torch.empty(num_seqs, H, D, D, dtype=dtype, device=device)
+    output_a, final_a = _run(
+        q, k, v, g, beta, cu_seqlens, init_state.clone(), out_state_a, None
+    )
+    torch.cuda.synchronize()
+
+    # (b) indexed pool, in-place output_state == initial_state
+    n_pool = num_seqs + 5
+    perm = [(i * 3 + 2) % n_pool for i in range(num_seqs)]
+    assert len(set(perm)) == num_seqs  # distinct slots
+    pool = _make_pool(init_state, perm, n_pool, pad, dtype, device)
+    idx = torch.tensor(perm, dtype=torch.int32, device=device)
+    output_b, _ = _run(q, k, v, g, beta, cu_seqlens, pool, pool, idx)
+    torch.cuda.synchronize()
+
+    assert not torch.isnan(output_b).any()
+    assert torch.equal(output_a, output_b), "output differs from packed baseline"
+    # final states landed in the indexed pool rows
+    assert torch.equal(final_a, pool[perm]), "final state differs from baseline"
+
+    # untouched pool rows stay zero (only requested rows written)
+    untouched = [r for r in range(n_pool) if r not in perm]
+    assert torch.equal(pool[untouched], torch.zeros_like(pool[untouched]))
+
+
+def test_prefill_state_indices_requires_output_state_pool():
+    """With state_indices set, output_state must be a caller-provided pool: an
+    auto-allocated compact [num_seqs, ...] tensor would be indexed out of bounds
+    by the pool slot ids, so output_state=None must be rejected."""
+    _skip_if_not_sm100()
+    device = torch.device("cuda")
+    H, D = 16, 128
+    seq_lens = [128, 64]
+    num_seqs = len(seq_lens)
+    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
+        seq_lens, H, D, torch.bfloat16, device, seed=2
+    )
+    n_pool = num_seqs + 3
+    perm = list(range(num_seqs))
+    pool = _make_pool(init_state, perm, n_pool, 0, torch.bfloat16, device)
+    idx = torch.tensor(perm, dtype=torch.int32, device=device)
+    out = torch.empty(sum(seq_lens), H, D, dtype=torch.bfloat16, device=device)
+    # On the supported SM100/SM103 path this must be the output_state ValueError,
+    # not NotImplementedError (which would mean the kernel was wrongly rejected).
+    with pytest.raises(ValueError, match="explicit output_state pool"):
+        chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            None,
+            initial_state=pool,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=False,
+            output=out,
+            output_state=None,  # must be rejected when state_indices is set
+            state_indices=idx,
+        )
+
+
+def test_prefill_state_indices_none_is_default():
+    """state_indices=None must reproduce the packed path exactly (default)."""
+    _skip_if_not_sm100()
+    device = torch.device("cuda")
+    H, D = 16, 128
+    seq_lens = [128, 192]
+    num_seqs = len(seq_lens)
+    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
+        seq_lens, H, D, torch.bfloat16, device, seed=1
+    )
+    s1 = torch.empty(num_seqs, H, D, D, dtype=torch.bfloat16, device=device)
+    o1, f1 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s1, None)
+    s2 = torch.empty(num_seqs, H, D, D, dtype=torch.bfloat16, device=device)
+    o2, f2 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s2, None)
+    torch.cuda.synchronize()
+    assert torch.equal(o1, o2)
+    assert torch.equal(f1, f2)


### PR DESCRIPTION


<!-- .github/pull_request_template.md -->

## 📌 Description
Add an optional state_indices argument to chunk_gated_delta_rule. On the SM100/SM103 Blackwell kernel, when provided, initial_state and output_state are treated as a state pool whose first dimension is indexed by these slot ids: sequence i reads its initial state from row state_indices[i] and writes its final state back to the same row (in place when output_state is initial_state). The pool may be non-compact (padded first-dimension stride). This lets callers with a paged/indexed state pool skip gathering the active rows into a packed buffer and scattering the result back; state_indices=None keeps the packed, sequence-ordered layout unchanged.
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional indexed recurrent-state pooling for Gated Delta Net prefill on Blackwell-class hardware (SM100/SM103), using a per-sequence `state_indices` tensor.
  * Behavior is unchanged when `state_indices` is omitted.
* **Bug Fixes**
  * Improved correctness and safety for pooled-state execution: unsupported dispatch paths now error, and pooled output-final-state requires an explicit `output_state`.
* **Tests**
  * Added GPU-gated coverage validating pooled vs packed outputs/final states, input/output-state requirements, and default behavior when `state_indices=None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->