### PR TITLE
Rework GDN SM100

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked_sm90_pipeline.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked_sm90_pipeline.py
@@ -1,0 +1,3942 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Chunked Gated Delta Net (GDN) prefill kernel for Blackwell SM100.
+
+Algorithm overview (per chunk c, tokens [cC, (c+1)C)):
+  Inputs : Q[BT,DK], K[BT,DK], V[BT,DV], gate[BT] (scalar gate), beta[BT] (scalar LR)
+  State  : S_prev[DK,DV]  (recurrent state, held in registers)
+
+  Preprocessing (compute warp group 0):
+    cumsumlog[t]     = sum_{l=0}^{t} log(gate_l)              cumulative log of gates
+    cumprod[t]       = exp(cumsumlog[t])                       cumulative product of gates
+    T_pairwise[i,j]  = cumprod[i] / cumprod[j]  (i>=j)       inter-token transfer weights
+    (stored in registers; 64 regs/thread)
+
+  GEMM 1 - kk   : W_kk[BT,BT]  = K  @ K^T       (lower-triangular intra scores)
+  GEMM 2 - qk   : W_qk[BT,BT]  = Q  @ K^T       (output attention scores)
+  GEMM 3 - k*state : KS[BT,DV] = K  @ S_prev    (key applied to state)
+  GEMM 4 - q*state : QS[BT,DV] = Q  @ S_prev    (inter-chunk output, before T scaling)
+  GEMM 5 - new v   : NV[BT,DV] = A_inv @ delta   (corrected value vectors)
+                      where A_inv = (I + M_kk)^{-1},  M_kk[i,j] = T[i,j]*beta[i]*W_kk[i,j]  (lower-tri, hierarchical blockwise inverse)
+  GEMM 6 - qkv  : O_intra[BT,DV] = W_qkv @ NV   (intra-chunk output)
+                   where W_qkv = T*beta*W_qk (scaled qk scores)
+  GEMM 7 - kv update : dS[DK,DV] = K^T @ delta       (state update, BT contraction)
+                        where delta[BT,DV] = V - KS    (delta rule residuals, after decay)
+
+  Epilogue:
+    O[BT,DV]  = O_intra + T_col * QS             (combine intra + inter)
+    S_next    = cumprod[BT-1] * S_prev + dS        (update register state)
+
+SMEM staging:
+  Buffer                           Stages
+  q                                3
+  k                                3
+  v                                3
+  A_inverse                        2
+  QK output                        2
+  O store                          1
+  cumsumlog / cumprod / scaled     4
+  beta                             3
+
+TMEM layout (512 columns):
+  Buffer                                      Columns  Stages
+  state increment                              128      1
+  q*state / output acc                           64      1
+  kk / qk acc                                    64      2
+  k*state / new_v acc                            64      2
+  state / delta / new_v input                    64      1      <-- lifetime-aliased
+
+Warp assignments (16 warps = 512 threads):
+  warps 0-3     : compute group 0 - T-pairwise, kk_epi, qk_epi, inverse
+  warps 4-7     : compute group 1 - left  State half, low token-half epilogues
+  warps 8-11    : compute group 2 - right State half, high token-half epilogues
+  warp  12      : CG0 MMA issuer - issues GEMMs 1-2
+  warp  13      : CG1 MMA issuer - issues GEMMs 3-7
+  warp  14      : unified loader - loads k, q, v, gate, beta
+  warp  15      : epilogue warp - stores O to global memory
+
+Implemented per-chunk dependency sequence (steady-state chunk c):
+
+  CG0:
+  warps 0-3  : make T -> wait G1, kk_epi -> wait G2, qk_epi, Wqkv.commit
+                -> inverse, Ainv.commit -> next chunk
+  CG1/2:
+  warps 4-11 : each maintains one State half and one token half:
+                S(c-1) -> state_inp.commit and Phi*S(c-1) -> wait G3 -> delta.commit
+                -> scale G4 -> wait G5, NV.commit -> decay_NV.commit -> wait G6 -> O.commit
+
+  W12 issuer : wait K -> G1:KK -> wait Q -> G2:QK -> advance G3/G5 slots -> next chunk
+  W13 issuer : wait state_inp -> G3:K*S -> G4:Q*S -> wait delta, reserve G5, wait Ainv -> G5
+                -> wait Wqkv and NV -> G6:output -> wait decay_NV -> G7:dS -> S(c)
+  W14 loader : load K/Q/V, gate, beta
+  W15 store  : wait O -> TMA store
+
+The diagram shows dependency order, not equal-duration boxes. In particular:
+  * G1/G2 and G3/G5 use independent two-stage TMEM rings, so CG0 can run ahead without waiting
+    for the recurrent State path.
+  * Ainv and Wqkv use independent two-stage SMEM rings. W13 first waits for delta(c), reserves the
+    G5 accumulator slot, and only then waits for Ainv(c), delaying Ainv consumption as far as possible.
+  * state_inp and shared_inp alias the same 64 columns. They are reused serially for S(c-1),
+    delta(c), NV(c), and decay_NV(c). Both State groups wait for G4 to release state_inp before
+    overwriting their half with delta(c); the GEMM7 state-increment accumulator remains disjoint.
+
+Cross-chunk steady state (each arrow is a dependency, horizontal position is only ordering):
+
+  W12 / CG0      [G1,G2,epi,inverse](c) ---- [G1,G2,epi,inverse](c+1) ---- [ ... ]
+                         |       |                      |       |
+                         |       +-- Ainv(c)            |       +-- Ainv(c+1)
+                         +---------- Wqkv(c)            +---------- Wqkv(c+1)
+  W13 / CG1+CG2     [G3,G4,G5,G6,G7](c) ---------- [G3,G4,G5,G6,G7](c+1) ----------
+                               |                                  |
+  recurrent state             S(c) ----------------------------> S(c+1)
+
+Both State groups remain recurrent through G7(c) -> S(c) -> G3/G4(c+1). CG0 has no state
+dependency and can run ahead until either the two-stage Ainv/Wqkv rings or the four-stage
+shared_acc ring applies backpressure.
+"""
+
+import math
+from typing import Optional, Type, Tuple
+
+import cuda.bindings.driver as cuda
+
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+from cutlass.utils import TensorMapManager, TensorMapUpdateMode
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.cute.testing as testing
+
+# ---------------------------------------------------------------------------
+# cutlass-dsl 4.4.2 compatibility: TmaInfo was removed; make_tiled_tma_atom_*
+# now returns a plain (CopyAtom, Tensor) tuple instead of TmaInfo.
+# ---------------------------------------------------------------------------
+try:
+    from cutlass.cute.nvgpu.cpasync import TmaInfo
+except ImportError:
+    from cutlass.base_dsl import (
+        extract_mlir_values as _emv,
+        new_from_mlir_values as _nfmv,
+        extract_mlir_attributes as _ema,
+        get_mlir_types as _gmt,
+    )
+
+    class TmaInfo:  # type: ignore[no-redef]
+        """Compatibility shim replacing cpasync.TmaInfo for cutlass-dsl >= 4.4.2."""
+
+        def __init__(self, atom, tma_tensor, smem_layout=None):
+            self._atom = atom
+            self._tma_tensor = tma_tensor
+
+        @property
+        def atom(self):
+            return self._atom
+
+        @property
+        def tma_tensor(self):
+            return self._tma_tensor
+
+        def __extract_mlir_values__(self):
+            return _emv(self._atom) + _emv(self._tma_tensor)
+
+        def __extract_mlir_attributes__(self):
+            return _ema(self._atom) + _ema(self._tma_tensor)
+
+        def __new_from_mlir_values__(self, values):
+            n = len(_gmt(self._atom))
+            return TmaInfo(
+                _nfmv(self._atom, values[:n]),
+                _nfmv(self._tma_tensor, values[n:]),
+            )
+
+        def __iter__(self):
+            yield self._atom
+            yield self._tma_tensor
+
+        def __getitem__(self, i):
+            return (self._atom, self._tma_tensor)[i]
+
+        def __len__(self):
+            return 2
+
+
+def _wrap_tma(ret):
+    """Wrap make_tiled_tma_atom_* return value in TmaInfo if not already."""
+    if isinstance(ret, TmaInfo):
+        return ret
+    # 4.4.2: returns (CopyAtom, Tensor) tuple
+    return TmaInfo(ret[0], ret[1])
+
+
+from .gated_delta_net_tile_scheduler import (
+    GDNTileSchedulerParams,
+    GDNTileScheduler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Combined configuration + execution class
+# ---------------------------------------------------------------------------
+
+
+class GatedDeltaNetChunkedSm90PipelineKernel:
+    """
+    Configuration and execution class for the Chunked GDN kernel.
+
+    Follows the same class-based structure:
+      - __init__    : warp IDs, barriers, tile shapes, SMEM/TMEM sizes
+      - __call__    : @cute.jit host entry point (TMA setup, kernel launch)
+      - kernel      : @cute.kernel device entry point (warp dispatch)
+      - per-warp methods called from kernel's chunk loop
+
+    Args:
+        io_dtype   : input/output dtype (Float16 or BFloat16)
+        acc_dtype  : accumulator dtype  (Float32)
+        BT         : chunk size / block tile  (64)
+        DK         : key/query hidden dim     (128)
+        DV         : value hidden dim         (128)
+    """
+
+    # TMA descriptor size in bytes
+    bytes_per_tensormap = 128
+    num_tensormaps = 4
+
+    def __init__(
+        self,
+        io_dtype: Type[cutlass.Numeric],
+        acc_dtype: Type[cutlass.Numeric],
+        state_dtype: Type[cutlass.Numeric],
+        mma_tiler_qk: Tuple[int, int, int],
+        mma_tiler_qs: Tuple[int, int, int],
+        mma_tiler_qkv: Tuple[int, int, int],
+        mma_tiler_kv: Tuple[int, int, int],
+        max_active_clusters: int,
+        num_sm: int,
+        is_GQA: bool,
+        use_initial_state: bool,
+        store_final_state: bool = True,
+        enable_checkpoints: bool = False,
+        is_persistent: bool = True,
+        order_state_groups: bool = False,
+    ):
+        self.io_dtype = io_dtype
+        self.acc_dtype = acc_dtype
+        self.state_dtype = state_dtype
+        self.mma_tiler_qk = mma_tiler_qk
+        self.mma_tiler_qs = mma_tiler_qs
+        self.mma_tiler_qkv = mma_tiler_qkv
+        self.mma_tiler_kv = mma_tiler_kv
+        self.max_active_clusters = max_active_clusters
+        self.num_sm = num_sm
+        self.is_GQA = is_GQA
+        self.use_initial_state = use_initial_state
+        self.store_final_state = store_final_state
+        self.enable_checkpoints = enable_checkpoints
+        self.is_persistent = is_persistent
+        self.order_state_groups = order_state_groups
+
+        # ------------------------------------------------------------------
+        # Warp assignments  (16 warps total)
+        # ------------------------------------------------------------------
+        # T-pairwise / kk_epi / qk_epi / inverse
+        self.compute_group_0_warp_ids = [0, 1, 2, 3]
+        # Left State half plus low token-half epilogues.
+        self.compute_group_1_warp_ids = [4, 5, 6, 7]
+        # Right State half plus high token-half epilogues.
+        self.compute_group_2_warp_ids = [8, 9, 10, 11]
+        self.mma_cg0_warp_id = 12
+        self.mma_cg1_warp_id = 13
+        self.load_warp_id = 14
+        # store O
+        self.epilogue_warp_id = 15
+
+        self.num_regs_compute_group_0 = 104
+        self.num_regs_compute_group_1 = 176
+        self.num_regs_compute_group_2 = 176
+        self.num_regs_other = 48
+
+        self.threads_per_cta = 32 * (
+            len(
+                (
+                    self.mma_cg0_warp_id,
+                    self.mma_cg1_warp_id,
+                    self.load_warp_id,
+                    self.epilogue_warp_id,
+                )
+            )
+            + len(self.compute_group_0_warp_ids)
+            + len(self.compute_group_1_warp_ids)
+            + len(self.compute_group_2_warp_ids)
+        )
+
+        self.use_2cta_instrs = False
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+        self.occupancy = 1
+        self.threads_per_warp = 32
+
+        # ------------------------------------------------------------------
+        # Named barriers for TMEM allocation, inverse/state exchange, and the
+        # ordering handoff between the two TCGEN05 issuer warps. Other inter-warp
+        # synchronization uses mbarrier-based pipelines created inside kernel().
+        # ------------------------------------------------------------------
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_warp
+            * len(
+                (
+                    self.mma_cg0_warp_id,
+                    self.mma_cg1_warp_id,
+                    *self.compute_group_0_warp_ids,
+                    *self.compute_group_1_warp_ids,
+                    *self.compute_group_2_warp_ids,
+                )
+            ),
+        )
+        self.inverse_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_warp * len(self.compute_group_0_warp_ids),
+        )
+        self.inverse_barrier_inner = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=self.threads_per_warp * 2,
+        )
+        num_threads_state = self.threads_per_warp * len(self.compute_group_1_warp_ids)
+        self.state_order_barrier_0 = pipeline.NamedBarrier(
+            barrier_id=4, num_threads=num_threads_state * 2
+        )
+        self.state_order_barrier_1 = pipeline.NamedBarrier(
+            barrier_id=5, num_threads=num_threads_state * 2
+        )
+
+    @cute.jit
+    def _state_order_wait(self, half_idx):
+        if cutlass.const_expr(half_idx == 0):
+            self.state_order_barrier_0.arrive_and_wait()
+        else:
+            self.state_order_barrier_1.arrive_and_wait()
+
+    @cute.jit
+    def _state_order_notify(self, half_idx):
+        if cutlass.const_expr(half_idx == 0):
+            self.state_order_barrier_1.arrive()
+        else:
+            self.state_order_barrier_0.arrive()
+
+    def _setup_attributes(self):
+        # ------------------------------------------------------------------
+        # SMEM sizes (bytes per stage) and stage counts
+        # ------------------------------------------------------------------
+        self.smem_q_stages = 3
+        self.smem_k_stages = 3
+        self.smem_v_stages = 3
+        self.smem_ainv_stages = 2
+        self.smem_qk_stages = 2
+        self.smem_o_stages = 1
+        # Keep the preprocessed gate channels far enough ahead of both state groups.
+        self.smem_gate_stages = 4
+        self.smem_beta_stages = 3
+
+        # ------------------------------------------------------------------
+        # TMEM column offsets and buffer sizes (fp32, 32B per column)
+        # ------------------------------------------------------------------
+        self.tmem_kv_acc_stages = 1
+        self.tmem_q_state_acc_stages = 1
+        self.tmem_state_inp_stages = 1
+        self.tmem_shared_inp_stages = 1
+        self.tmem_aux_acc_stages = 2
+        self.tmem_state_acc_stages = 2
+
+        self.tmem_state_offset = 0
+        self.tmem_q_state_offset = (
+            self.tmem_state_offset + self.tmem_kv_acc_stages * 128
+        )
+        self.tmem_aux_acc_offset = (
+            self.tmem_q_state_offset + self.tmem_q_state_acc_stages * 64
+        )
+        self.tmem_state_acc_offset = (
+            self.tmem_aux_acc_offset + self.tmem_aux_acc_stages * 64
+        )
+        self.tmem_state_inp_offset = (
+            self.tmem_state_acc_offset + self.tmem_state_acc_stages * 64
+        )
+        self.tmem_shared_inp_offset = self.tmem_state_inp_offset
+
+        self.buffer_align_bytes = 1024
+
+    # -----------------------------------------------------------------------
+    # Capability check
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def can_implement(
+        io_dtype,
+        acc_dtype,
+        mma_tiler_qk,
+        mma_tiler_qs,
+        mma_tiler_qkv,
+        mma_tiler_kv,
+    ):
+        """Raise CantImplementError if this configuration is not supported."""
+        if io_dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            raise testing.CantImplementError(
+                f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported"
+            )
+        if acc_dtype != cutlass.Float32:
+            raise testing.CantImplementError(
+                f"acc_dtype={acc_dtype} not supported; only Float32 is supported"
+            )
+        if mma_tiler_qk != (64, 64, 128):
+            raise testing.CantImplementError(
+                f"mma_tiler_qk={mma_tiler_qk} not supported; only (64, 64, 128) is supported"
+            )
+        if mma_tiler_qs != (128, 64, 128):
+            raise testing.CantImplementError(
+                f"mma_tiler_qs={mma_tiler_qs} not supported; only (128, 64, 128) is supported"
+            )
+        if mma_tiler_qkv != (128, 64, 64):
+            raise testing.CantImplementError(
+                f"mma_tiler_qkv={mma_tiler_qkv} not supported; only (128, 64, 64) is supported"
+            )
+        if mma_tiler_kv != (128, 128, 64):
+            raise testing.CantImplementError(
+                f"mma_tiler_kv={mma_tiler_kv} not supported; only (128, 128, 64) is supported"
+            )
+
+    # -----------------------------------------------------------------------
+    # Host entry point
+    # -----------------------------------------------------------------------
+
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        gate: cute.Tensor,
+        beta: cute.Tensor,
+        o: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        s_in: Optional[cute.Tensor],
+        s_out: Optional[cute.Tensor],
+        s_checkpoints: Optional[cute.Tensor],
+        cu_checkpoints: Optional[cute.Tensor],
+        checkpoint_every_n_tokens: cutlass.Int32,
+        scale: cutlass.Float32,
+        tensormap_workspace: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        # chunk size
+        self.b_t = 64
+        h_q = q.shape[1]
+        h_v = v.shape[1]
+        batch_size = cu_seqlens.shape[0] - 1
+
+        self._setup_attributes()
+
+        if cutlass.const_expr(self.is_GQA):
+            h_r = h_q // h_v
+            h_qv = h_v
+            q = cute.make_tensor(
+                q.iterator,
+                cute.make_layout(
+                    (q.shape[0], q.shape[2], (h_r, h_v)),
+                    stride=(q.stride[0], q.stride[2], (q.stride[1], h_r * q.stride[1])),
+                ),
+            )
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_r, h_v)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+                ),
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_r, h_v)),
+                    stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
+                ),
+            )
+        else:
+            h_r = h_v // h_q
+            h_qv = h_q
+            q = cute.make_tensor(
+                q.iterator,
+                cute.make_layout(
+                    (q.shape[0], q.shape[2], (h_r, h_q)),
+                    stride=(q.stride[0], q.stride[2], (0, q.stride[1])),
+                ),
+            )
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_r, h_q)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+                ),
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_r, h_q)),
+                    stride=(v.stride[2], v.stride[0], (v.stride[1], h_r * v.stride[1])),
+                ),
+            )
+
+        gate = cute.make_tensor(
+            gate.iterator,
+            cute.make_layout(
+                (gate.shape[0], (h_r, h_qv)),
+                stride=(gate.stride[0], (gate.stride[1], h_r * gate.stride[1])),
+            ),
+        )
+        beta = cute.make_tensor(
+            beta.iterator,
+            cute.make_layout(
+                (beta.shape[0], (h_r, h_qv)),
+                stride=(beta.stride[0], (beta.stride[1], h_r * beta.stride[1])),
+            ),
+        )
+        o = cute.make_tensor(
+            o.iterator,
+            cute.make_layout(
+                (o.shape[2], o.shape[0], (h_r, h_qv)),
+                stride=(o.stride[2], o.stride[0], (o.stride[1], h_r * o.stride[1])),
+            ),
+        )
+        if cutlass.const_expr(s_in is not None):
+            s_in = cute.make_tensor(
+                s_in.iterator,
+                cute.make_layout(
+                    (s_in.shape[2], s_in.shape[3], (h_r, h_qv), s_in.shape[0]),
+                    stride=(
+                        s_in.stride[2],
+                        s_in.stride[3],
+                        (s_in.stride[1], h_r * s_in.stride[1]),
+                        s_in.stride[0],
+                    ),
+                ),
+            )
+        if cutlass.const_expr(s_out is not None):
+            s_out = cute.make_tensor(
+                s_out.iterator,
+                cute.make_layout(
+                    (s_out.shape[2], s_out.shape[3], (h_r, h_qv), s_out.shape[0]),
+                    stride=(
+                        s_out.stride[2],
+                        s_out.stride[3],
+                        (s_out.stride[1], h_r * s_out.stride[1]),
+                        s_out.stride[0],
+                    ),
+                ),
+            )
+        if cutlass.const_expr(self.enable_checkpoints):
+            s_checkpoints = cute.make_tensor(
+                s_checkpoints.iterator,
+                cute.make_layout(
+                    (
+                        s_checkpoints.shape[2],
+                        s_checkpoints.shape[3],
+                        (h_r, h_qv),
+                        s_checkpoints.shape[0],
+                    ),
+                    stride=(
+                        s_checkpoints.stride[2],
+                        s_checkpoints.stride[3],
+                        (s_checkpoints.stride[1], h_r * s_checkpoints.stride[1]),
+                        s_checkpoints.stride[0],
+                    ),
+                ),
+            )
+
+        # ------------------------------------------------------------------
+        # Build tiled MMAs  (one per logical GEMM group, differing in operand major modes)
+        # ------------------------------------------------------------------
+        def _mma_op(mma_tiler, a_major, b_major, OperandSourceA):
+            # Derive MMA atom (M, N) from the first two dims of the tile shape;
+            # K=16 is the hardware fp16 atom depth (fixed for SM100 tcgen05).
+            return tcgen05.MmaF16BF16Op(
+                self.io_dtype,
+                self.acc_dtype,
+                (mma_tiler[0], mma_tiler[1], 16),
+                self.cta_group,
+                OperandSourceA,
+                a_major,
+                b_major,
+            )
+
+        # GEMM 1 (kk: K@K^T) + GEMM 2 (qk: Q@K^T)          - KK-major: A=K, B=K
+        tiled_mma_qk = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qk,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.SMEM,
+            )
+        )
+        # GEMM 3 (k*state: K@S) + GEMM 4 (q*state: Q@S)     - KN-major: A=K, B=MN
+        tiled_mma_qs = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qs,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.TMEM,
+            )
+        )
+        # GEMM 5 (new_v: A_inv@V) + GEMM 6 (qkv: W_qkv@NV)  - KN-major: A=K, B=MN
+        tiled_mma_qkv = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qkv,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.TMEM,
+            )
+        )
+        # for v_smem_layout_staged
+        tiled_mma_qkv_ss = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_qkv,
+                OperandMajorMode.MN,
+                OperandMajorMode.K,
+                tcgen05.OperandSource.SMEM,
+            )
+        )
+        # GEMM 7 (kv_update: K^T@delta -> dS)                    - MN-major: A=MN, B=MN
+        tiled_mma_kv = cute.make_tiled_mma(
+            _mma_op(
+                self.mma_tiler_kv,
+                OperandMajorMode.K,
+                OperandMajorMode.MN,
+                tcgen05.OperandSource.TMEM,
+            )
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (tiled_mma_qk.thr_id.shape,),
+        )
+
+        # ------------------------------------------------------------------
+        # SMEM layouts - computed before SharedStorage so cosize() is available
+        # ------------------------------------------------------------------
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        tma_store_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+
+        # Q is A operand for tiled_mma_qk (GEMM 2: qk), K is B operand (GEMM 1+2: kk/qk)
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma_qk, self.mma_tiler_qk, self.io_dtype, self.smem_q_stages
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qk, self.mma_tiler_qk, self.io_dtype, self.smem_k_stages
+        )
+        k_trans_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_kv, self.mma_tiler_kv, self.io_dtype, self.smem_k_stages
+        )
+        # V is A operand for tiled_mma_qkv (GEMM 5: new_v: V @ A_inv)
+        v_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma_qkv_ss, self.mma_tiler_qkv, self.io_dtype, self.smem_v_stages
+        )
+        # A_inv is B operand for tiled_mma_qkv (GEMM 5: new_v: V @ A_inv);
+        ainv_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qkv, self.mma_tiler_qkv, self.io_dtype, self.smem_ainv_stages
+        )
+        # W_qkv is A operand for tiled_mma_qkv (GEMM 6: qkv: NV @ qk)
+        qk_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qkv, self.mma_tiler_qkv, self.io_dtype, self.smem_qk_stages
+        )
+
+        o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.io_dtype,
+            utils.LayoutEnum.from_tensor(o),
+            self.mma_tiler_qkv[:2],
+            self.smem_o_stages,
+        )
+        # Gate scalar arrays (1D Float32, flat layout - no swizzle needed)
+        cumsumlog_smem_layout_staged = cute.make_layout(
+            (self.b_t, 1, self.smem_gate_stages)
+        )
+        beta_smem_layout_staged = cute.make_layout((self.b_t, 1, self.smem_beta_stages))
+
+        # ------------------------------------------------------------------
+        # Shared memory struct  (defined here to capture layout cosizes)
+        # ------------------------------------------------------------------
+        @cute.struct
+        class SharedStorage:
+            # Pipeline mbarriers - one entry per stage, 2 Int64 words per barrier
+            # Unified load warp -> both MMA issuers
+            load_k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_k_stages * 2]
+            # Unified load warp -> both MMA issuers
+            load_q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_q_stages * 2]
+            # Unified load warp -> both State groups
+            load_v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_v_stages * 2]
+            # Unified load warp -> CG0 and both State groups
+            load_gate_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_gate_stages * 2
+            ]
+            # Gate/beta load warp -> CG0
+            load_beta_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_beta_stages * 2
+            ]
+            # State MMA issuer -> both State groups (Q*state acc ready in TMEM)
+            q_state_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_q_state_acc_stages * 2
+            ]
+            # State MMA issuer -> both State groups (GEMM 7 done)
+            kv_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_kv_acc_stages * 2
+            ]
+            # Auxiliary MMA issuer -> CG0 (KK/QK accumulator ready)
+            aux_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_aux_acc_stages * 2
+            ]
+            # State MMA issuer -> both State groups (SK/NewV accumulator ready)
+            state_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_state_acc_stages * 2
+            ]
+            # CG0 -> State MMA issuer (A_inv ready in SMEM)
+            ainv_ready_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_ainv_stages * 2
+            ]
+            # CG0 -> State MMA issuer (QK ready in SMEM)
+            qk_ready_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_qk_stages * 2
+            ]
+            state_inp_ready_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_state_inp_stages * 2
+            ]
+            # Both State groups -> MMA warp (state input ready in TMEM)
+            shared_inp_ready_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_shared_inp_stages * 2
+            ]
+            # Both State groups -> epilogue warp
+            o_store_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.smem_o_stages * 2
+            ]
+            # TMEM allocation token
+            tmem_holding_buf: cutlass.Int32
+            # SMEM tensor buffers (aligned, in SMEM layout order)
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(q_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(k_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(v_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # A_inv result, then overwritten with fp16 NV
+            sAinv: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.io_dtype, cute.cosize(ainv_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # W_qk scores
+            sQk: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(qk_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sO: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(o_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # Cumulative gate scalars - placed last in SMEM
+            cumsumlog: cute.struct.MemRange[
+                cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)
+            ]
+            cumprod: cute.struct.MemRange[
+                cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)
+            ]
+            cumprod_scale: cute.struct.MemRange[
+                cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)
+            ]
+            beta: cute.struct.MemRange[
+                cutlass.Float32, cute.cosize(beta_smem_layout_staged)
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # ------------------------------------------------------------------
+        # Build TMA atoms
+        # ------------------------------------------------------------------
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
+
+        tma_q = _wrap_tma(
+            cute.nvgpu.make_tiled_tma_atom_A(
+                tma_load_op,
+                q,
+                q_smem_layout,
+                self.mma_tiler_qk,
+                tiled_mma_qk,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_k = _wrap_tma(
+            cute.nvgpu.make_tiled_tma_atom_B(
+                tma_load_op,
+                k,
+                k_smem_layout,
+                self.mma_tiler_qk,
+                tiled_mma_qk,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_v = _wrap_tma(
+            cute.nvgpu.make_tiled_tma_atom_A(
+                tma_load_op,
+                v,
+                v_smem_layout,
+                self.mma_tiler_qkv,
+                tiled_mma_qkv_ss,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+
+        cumsumlog_smem_layout = cute.select(cumsumlog_smem_layout_staged, mode=[0])  # noqa: F841
+        beta_smem_layout = cute.select(beta_smem_layout_staged, mode=[0])  # noqa: F841
+
+        o_smem_layout = cute.select(o_smem_layout_staged, mode=[0, 1])
+        tma_o = _wrap_tma(
+            cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                o,
+                o_smem_layout,
+                self.mma_tiler_qkv[:2],
+            )
+        )
+
+        self.tma_q_bytes = cute.size_in_bytes(self.io_dtype, q_smem_layout)
+        self.tma_k_bytes = cute.size_in_bytes(self.io_dtype, k_smem_layout)
+        self.tma_v_bytes = cute.size_in_bytes(self.io_dtype, v_smem_layout)
+        self.tma_o_bytes = cute.size_in_bytes(self.io_dtype, o_smem_layout)
+
+        # ------------------------------------------------------------------
+        # Launch
+        # ------------------------------------------------------------------
+        scheduler_params = GDNTileSchedulerParams(
+            num_seqs=batch_size,
+            num_q_heads=h_q,
+            num_v_heads=h_v,
+            is_GQA=self.is_GQA,
+            is_persistent=self.is_persistent,
+        )
+        grid_shape = GDNTileScheduler.get_grid_shape(
+            scheduler_params, self.max_active_clusters
+        )
+
+        self.kernel(
+            tiled_mma_qk,
+            tiled_mma_qs,
+            tiled_mma_qkv,
+            tiled_mma_qkv_ss,
+            tiled_mma_kv,
+            tma_q,
+            tma_k,
+            tma_v,
+            gate,
+            beta,
+            tma_o,
+            cu_seqlens,
+            s_in,
+            s_out,
+            s_checkpoints,
+            cu_checkpoints,
+            checkpoint_every_n_tokens,
+            scale,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            k_trans_smem_layout_staged,
+            v_smem_layout_staged,
+            cumsumlog_smem_layout_staged,
+            beta_smem_layout_staged,
+            ainv_smem_layout_staged,
+            qk_smem_layout_staged,
+            o_smem_layout_staged,
+            scheduler_params,
+            q,
+            k,
+            v,
+            o,
+            tensormap_workspace,
+        ).launch(
+            grid=grid_shape,
+            block=(self.threads_per_cta, 1, 1),
+            cluster=self.cluster_shape_mnk,
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    # -----------------------------------------------------------------------
+    # Device kernel
+    # -----------------------------------------------------------------------
+
+    @cute.kernel
+    def kernel(
+        self,
+        # Tiled MMAs (one per logical GEMM group)
+        # GEMM 1 (kk) + GEMM 2 (qk)
+        tiled_mma_qk: cute.TiledMma,
+        # GEMM 3 (k*state) + GEMM 4 (q*state)
+        tiled_mma_qs: cute.TiledMma,
+        # GEMM 5 (new_v) + GEMM 6 (qkv)
+        tiled_mma_qkv: cute.TiledMma,
+        # GEMM 5 (new_v: A_inv@V) first tile
+        tiled_mma_qkv_ss: cute.TiledMma,
+        # GEMM 7 (kv_update)
+        tiled_mma_kv: cute.TiledMma,
+        # TMA descriptors and cute tensors
+        tma_q: TmaInfo,
+        tma_k: TmaInfo,
+        tma_v: TmaInfo,
+        mGate: cute.Tensor,
+        mBeta: cute.Tensor,
+        tma_o: TmaInfo,
+        # (B+1,)  int32  cumulative seq lengths
+        cu_seqlens: cute.Tensor,
+        # initial state (fp32) from GMEM; None if not used
+        mS_init: Optional[cute.Tensor],
+        # final state output (fp32) to GMEM; None if not stored
+        mS_out: Optional[cute.Tensor],
+        mS_checkpoints: Optional[cute.Tensor],
+        cu_checkpoints: Optional[cute.Tensor],
+        checkpoint_every_n_tokens: cutlass.Int32,
+        scale: cutlass.Float32,
+        # SMEM staged layouts (needed to view shared_storage tensor buffers)
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        k_trans_smem_layout_staged: cute.ComposedLayout,
+        v_smem_layout_staged: cute.ComposedLayout,
+        cumsumlog_smem_layout_staged: cute.Layout,
+        beta_smem_layout_staged: cute.Layout,
+        ainv_smem_layout_staged: cute.ComposedLayout,
+        qk_smem_layout_staged: cute.ComposedLayout,
+        o_smem_layout_staged: cute.ComposedLayout,
+        # Scheduler
+        scheduler_params: GDNTileSchedulerParams,
+        # TMA descriptor workspace in GMEM (one set of 5 slots per CTA)
+        # Slots: Q=0, K[0]=1, K[1]=2, V=3, O=4  (each slot = bytes_per_tensormap = 16xInt64)
+        mQ,
+        mK,
+        mV,
+        # used for TMA descriptor update
+        mO,
+        # (num_ctas, 3+smem_k_stages, 16) Int64
+        tensormap_workspace: cute.Tensor,
+    ):
+        """
+        Main GDN chunked kernel.
+
+        Warp specialization is the outermost control flow: each warp role owns
+        its own persistent tile-scheduler loop, iterating over (batch, head)
+        tiles and then over chunks within each tile.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group_idx = cute.arch.make_warp_uniform(warp_idx // 4)
+        bidx, bidy, bidz = cute.arch.block_idx()
+        grid_dim = cute.arch.grid_dim()
+
+        if cutlass.const_expr(self.use_initial_state):
+            assert mS_init is not None, (
+                "mS_init must be provided if use_initial_state is True"
+            )
+        else:
+            assert mS_init is None, "mS_init must be None if use_initial_state is False"
+        if cutlass.const_expr(self.store_final_state):
+            assert mS_out is not None, (
+                "mS_out must be provided if store_final_state is True"
+            )
+        else:
+            assert mS_out is None, "mS_out must be None if store_final_state is False"
+
+        # ------------------------------------------------------------------
+        # TMA descriptor GMEM workspace - one set of 5 ptrs per CTA
+        # Slots: Q=0, K[0]=1, K[1]=2, V=3, O=4
+        # ------------------------------------------------------------------
+        cta_linear_idx = bidz * grid_dim[1] * grid_dim[0] + bidy * grid_dim[0] + bidx
+
+        tensormap_manager = TensorMapManager(
+            TensorMapUpdateMode.GMEM, self.bytes_per_tensormap
+        )
+
+        tensormap_workspace = self.initialize_workspace(tensormap_workspace, grid_dim)
+        tensormap_q_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 0, None)].iterator
+        )
+        tensormap_k_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 1, None)].iterator
+        )
+        tensormap_v_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 2, None)].iterator
+        )
+        tensormap_o_ptr = tensormap_manager.get_tensormap_ptr(
+            tensormap_workspace[(cta_linear_idx, 3, None)].iterator
+        )
+
+        # ------------------------------------------------------------------
+        # 1. Allocate SMEM / TMEM, prefetch TMA descriptors
+        # ------------------------------------------------------------------
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        sQ = storage.sQ.get_tensor(
+            q_smem_layout_staged.outer, swizzle=q_smem_layout_staged.inner
+        )
+        sK = storage.sK.get_tensor(
+            k_smem_layout_staged.outer, swizzle=k_smem_layout_staged.inner
+        )
+        sK_trans = storage.sK.get_tensor(
+            k_trans_smem_layout_staged.outer, swizzle=k_trans_smem_layout_staged.inner
+        )
+        sV = storage.sV.get_tensor(
+            v_smem_layout_staged.outer, swizzle=v_smem_layout_staged.inner
+        )
+        # A_inverse / new_v  (A_inv written first, then overwritten with fp16 NV)
+        sAinv = storage.sAinv.get_tensor(
+            ainv_smem_layout_staged.outer, swizzle=ainv_smem_layout_staged.inner
+        )
+        # QK output / O store  (W_qk first, then O epilogue staging)
+        sQk = storage.sQk.get_tensor(
+            qk_smem_layout_staged.outer, swizzle=qk_smem_layout_staged.inner
+        )
+        sO = storage.sO.get_tensor(
+            o_smem_layout_staged.outer, swizzle=o_smem_layout_staged.inner
+        )
+        # Gate scalar arrays (1D Float32, flat - no swizzle)
+        sCumsumlog = storage.cumsumlog.get_tensor(cumsumlog_smem_layout_staged)
+        sCumprod = storage.cumprod.get_tensor(cumsumlog_smem_layout_staged)
+        sCumprodScale = storage.cumprod_scale.get_tensor(cumsumlog_smem_layout_staged)
+        sBeta = storage.beta.get_tensor(beta_smem_layout_staged)
+
+        if warp_idx == self.mma_cg0_warp_id:
+            cpasync.prefetch_descriptor(tma_q.atom)
+            cpasync.prefetch_descriptor(tma_k.atom)
+            cpasync.prefetch_descriptor(tma_v.atom)
+            cpasync.prefetch_descriptor(tma_o.atom)
+
+        # TMEM allocator object - CG1 will issue the actual allocation
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            # Correction warp is the last one that accesses tmem
+            allocator_warp_id=self.compute_group_1_warp_ids[0],
+        )
+
+        # ------------------------------------------------------------------
+        # mbarrier-based pipelines
+        # Each pipeline is created by all threads; barrier_storage points into SMEM.
+        # defer_sync=True means pipeline_init_arrive() flushes all at once below.
+        # ------------------------------------------------------------------
+        def _cg(num_threads):
+            return pipeline.CooperativeGroup(pipeline.Agent.Thread, num_threads)
+
+        # 1 thread (TMA issuer)
+        cg_tma = _cg(len([self.load_warp_id]))
+        # 1 warp (gate/beta ldg/sts path of the unified load warp)
+        cg_gate = _cg(self.threads_per_warp * len([self.load_warp_id]))
+        # One thread per UMMA issuer; both consume Q and K.
+        cg_mma_cg0 = _cg(len([self.mma_cg0_warp_id]))
+        cg_mma_cg1 = _cg(len([self.mma_cg1_warp_id]))
+        cg_mma_both = _cg(len([self.mma_cg0_warp_id, self.mma_cg1_warp_id]))
+        # 128 threads (CG0)
+        cg_cg0 = _cg(self.threads_per_warp * len(self.compute_group_0_warp_ids))
+        # Both fixed State halves.
+        cg_state = _cg(
+            self.threads_per_warp
+            * (len(self.compute_group_1_warp_ids) + len(self.compute_group_2_warp_ids))
+        )
+        # One thread per State warp, used for V load signaling.
+        cg_state_v = _cg(
+            len(self.compute_group_1_warp_ids) + len(self.compute_group_2_warp_ids)
+        )
+        # CG0 plus both State halves.
+        cg_both = _cg(
+            self.threads_per_warp * len(self.compute_group_0_warp_ids)
+            + self.threads_per_warp
+            * (len(self.compute_group_1_warp_ids) + len(self.compute_group_2_warp_ids))
+        )
+        # 32 threads (epilogue warp)
+        cg_epi = _cg(self.threads_per_warp * len([self.epilogue_warp_id]))
+
+        # Unified load warp -> MMA: K, Q, V.
+        load_k_producer, load_k_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.smem_k_stages,
+            producer_group=cg_tma,
+            consumer_group=cg_mma_both,
+            tx_count=self.tma_k_bytes,
+            barrier_storage=storage.load_k_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.smem_q_stages,
+            producer_group=cg_tma,
+            consumer_group=cg_mma_both,
+            tx_count=self.tma_q_bytes,
+            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        load_v_producer, load_v_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.smem_v_stages,
+            producer_group=cg_tma,
+            consumer_group=cg_state_v,
+            tx_count=self.tma_v_bytes,
+            barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        # Unified load warp -> CG0 / State groups: gate/beta (PipelineAsync, software-signaled).
+        # ldg/ldgsts paths do not use TMA barriers; producer calls commit() after writes.
+        load_gate_producer, load_gate_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.smem_gate_stages,
+            producer_group=cg_gate,
+            consumer_group=cg_both,
+            barrier_storage=storage.load_gate_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        load_beta_producer, load_beta_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.smem_beta_stages,
+            producer_group=cg_gate,
+            consumer_group=cg_cg0,
+            barrier_storage=storage.load_beta_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # MMA warp -> both State groups: kv_acc
+        kv_acc_producer, kv_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.tmem_kv_acc_stages,
+            producer_group=cg_mma_cg1,
+            consumer_group=cg_state,
+            barrier_storage=storage.kv_acc_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # MMA warp -> both State groups: q_state_acc
+        q_state_acc_producer, q_state_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.tmem_q_state_acc_stages,
+            producer_group=cg_mma_cg1,
+            consumer_group=cg_state,
+            barrier_storage=storage.q_state_acc_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # Auxiliary MMA warp -> CG0: KK/QK accumulators.
+        aux_acc_producer, aux_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.tmem_aux_acc_stages,
+            producer_group=cg_mma_cg0,
+            consumer_group=cg_cg0,
+            barrier_storage=storage.aux_acc_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # State MMA warp -> both State groups: SK/NewV accumulators.
+        state_acc_producer, state_acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.tmem_state_acc_stages,
+            producer_group=cg_mma_cg1,
+            consumer_group=cg_state,
+            barrier_storage=storage.state_acc_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # CG0 -> MMA warp:  a_inv_done
+        a_inv_ready_producer, a_inv_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.smem_ainv_stages,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma_cg1,
+            barrier_storage=storage.ainv_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # CG0 -> MMA warp:  qk_done
+        qk_ready_producer, qk_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.smem_qk_stages,
+            producer_group=cg_cg0,
+            consumer_group=cg_mma_cg1,
+            barrier_storage=storage.qk_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # Both State groups -> MMA warp: state_inp_ready
+        state_inp_ready_producer, state_inp_ready_consumer = (
+            pipeline.PipelineAsyncUmma.create(
+                num_stages=self.tmem_state_inp_stages,
+                producer_group=cg_state,
+                consumer_group=cg_mma_cg1,
+                barrier_storage=storage.state_inp_ready_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
+
+        # Both State groups -> MMA warp: shared_inp_ready
+        shared_inp_ready_producer, shared_inp_ready_consumer = (
+            pipeline.PipelineAsyncUmma.create(
+                num_stages=self.tmem_shared_inp_stages,
+                producer_group=cg_state,
+                consumer_group=cg_mma_cg1,
+                barrier_storage=storage.shared_inp_ready_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
+
+        # Both State groups -> epilogue warp: output_ready
+        o_store_producer, o_store_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.smem_o_stages,
+            producer_group=cg_state,
+            consumer_group=cg_epi,
+            barrier_storage=storage.o_store_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+
+        # Seed the ordered State-group handoff so the left half owns the first copy phase.
+        if cutlass.const_expr(self.order_state_groups):
+            if warp_group_idx == 2:
+                self.state_order_barrier_0.arrive()
+
+        pipeline_init_arrive(is_relaxed=True)
+
+        pipeline_init_wait()
+
+        if warp_group_idx == 3:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+
+        # ------------------------------------------------------------------
+        # 2. Warp specialization - each warp role owns its own scheduler loop
+        # ------------------------------------------------------------------
+
+        # ==============================================================
+        # COMPUTE WARP GROUP 0 (warps 0-3)
+        # ==============================================================
+        if (
+            warp_idx >= self.compute_group_0_warp_ids[0]
+            and warp_idx <= self.compute_group_0_warp_ids[-1]
+        ):
+            cute.arch.setmaxregister_decrease(self.num_regs_compute_group_0)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
+            )
+            work = scheduler.initial_work_tile_info()
+            while work.is_valid_tile:
+                batch_idx, head_idx, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+
+                sQk_pisl = self._transform_to_position_independent_layout(
+                    sQk, qk_smem_layout_staged.inner
+                )
+                # First chunk: no previous state (S_prev = 0), skip GEMMs 3/4
+                for chunk_idx in cutlass.range(num_chunks_b):
+                    (
+                        load_gate_consumer,
+                        load_beta_consumer,
+                        aux_acc_consumer,
+                        a_inv_ready_producer,
+                        qk_ready_producer,
+                    ) = self.compute_group_0(
+                        tidx,
+                        tmem_ptr,
+                        scale,
+                        (tiled_mma_qk,),
+                        (sCumsumlog, sBeta, sAinv, sQk_pisl),
+                        (
+                            load_gate_consumer,
+                            load_beta_consumer,
+                            aux_acc_consumer,
+                            a_inv_ready_producer,
+                            qk_ready_producer,
+                        ),
+                        (chunk_idx == 0,),
+                    )
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+            a_inv_ready_producer.tail()
+            qk_ready_producer.tail()
+
+        # ==============================================================
+        # COMPUTE WARP GROUP 1 (warps 4-7)
+        # ==============================================================
+        if (
+            warp_idx >= self.compute_group_1_warp_ids[0]
+            and warp_idx <= self.compute_group_1_warp_ids[-1]
+        ):
+            cute.arch.setmaxregister_increase(self.num_regs_compute_group_1)
+            # The layouts use all 512 TMEM columns.
+            tmem.allocate(cute.arch.get_max_tmem_alloc_cols("sm_100"))
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            _, _, _, _, tTR_cState, _, _, _ = self._state_half_tmem_copies(
+                tidx, tmem_ptr, tiled_mma_kv, tiled_mma_qs, 0
+            )
+            rState = cute.make_rmem_tensor_like(tTR_cState, self.acc_dtype)
+
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
+            )
+            work = scheduler.initial_work_tile_info()
+            while work.is_valid_tile:
+                batch_idx, head_idx, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                checkpoint_offset = 0
+                sV_pisl = self._transform_to_position_independent_layout(
+                    sV, v_smem_layout_staged.inner
+                )
+                sO_pisl = self._transform_to_position_independent_layout(
+                    sO, o_smem_layout_staged.inner
+                )
+                if num_chunks_b > 0:
+                    if cutlass.const_expr(self.enable_checkpoints):
+                        checkpoint_offset = cu_checkpoints[batch_idx]
+                    self._initialize_state_half(
+                        tidx,
+                        mS_init,
+                        head_idx,
+                        batch_idx,
+                        tmem_ptr,
+                        tiled_mma_kv,
+                        tiled_mma_qs,
+                        rState,
+                        0,
+                    )
+                    (
+                        load_v_consumer,
+                        load_gate_consumer,
+                        state_acc_consumer,
+                        kv_acc_consumer,
+                        q_state_acc_consumer,
+                        kv_acc_producer,
+                        state_inp_ready_producer,
+                        shared_inp_ready_producer,
+                        o_store_producer,
+                        checkpoint_offset,
+                        rState,
+                    ) = self.compute_state_group(
+                        tidx,
+                        tmem_ptr,
+                        rState,
+                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                        (
+                            sV_pisl,
+                            sCumsumlog,
+                            sCumprod,
+                            sCumprodScale,
+                            sBeta,
+                            sO_pisl,
+                        ),
+                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
+                        (
+                            load_v_consumer,
+                            load_gate_consumer,
+                            state_acc_consumer,
+                            kv_acc_consumer,
+                            q_state_acc_consumer,
+                            kv_acc_producer,
+                            state_inp_ready_producer,
+                            shared_inp_ready_producer,
+                            o_store_producer,
+                        ),
+                        (True, 0, head_idx),
+                        0,
+                    )
+                for chunk_idx in cutlass.range(1, num_chunks_b):
+                    (
+                        load_v_consumer,
+                        load_gate_consumer,
+                        state_acc_consumer,
+                        kv_acc_consumer,
+                        q_state_acc_consumer,
+                        kv_acc_producer,
+                        state_inp_ready_producer,
+                        shared_inp_ready_producer,
+                        o_store_producer,
+                        checkpoint_offset,
+                        rState,
+                    ) = self.compute_state_group(
+                        tidx,
+                        tmem_ptr,
+                        rState,
+                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                        (
+                            sV_pisl,
+                            sCumsumlog,
+                            sCumprod,
+                            sCumprodScale,
+                            sBeta,
+                            sO_pisl,
+                        ),
+                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
+                        (
+                            load_v_consumer,
+                            load_gate_consumer,
+                            state_acc_consumer,
+                            kv_acc_consumer,
+                            q_state_acc_consumer,
+                            kv_acc_producer,
+                            state_inp_ready_producer,
+                            shared_inp_ready_producer,
+                            o_store_producer,
+                        ),
+                        (False, chunk_idx, head_idx),
+                        0,
+                    )
+                if num_chunks_b > 0:
+                    self._store_state_half(
+                        tidx,
+                        mS_out,
+                        mS_checkpoints,
+                        head_idx,
+                        batch_idx,
+                        checkpoint_offset,
+                        checkpoint_every_n_tokens,
+                        seqlen_b,
+                        tmem_ptr,
+                        tiled_mma_kv,
+                        tiled_mma_qs,
+                        rState,
+                        0,
+                    )
+
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)
+
+            shared_inp_ready_producer.tail()
+            o_store_producer.tail()
+            state_inp_ready_producer.tail()
+
+        # ==============================================================
+        # COMPUTE WARP GROUP 2 (warps 8-11): right State / high token half
+        # ==============================================================
+        elif (
+            warp_idx >= self.compute_group_2_warp_ids[0]
+            and warp_idx <= self.compute_group_2_warp_ids[-1]
+        ):
+            cute.arch.setmaxregister_increase(self.num_regs_compute_group_2)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            _, _, _, _, tTR_cState, _, _, _ = self._state_half_tmem_copies(
+                tidx, tmem_ptr, tiled_mma_kv, tiled_mma_qs, 1
+            )
+            rState = cute.make_rmem_tensor_like(tTR_cState, self.acc_dtype)
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
+            )
+            work = scheduler.initial_work_tile_info()
+            while work.is_valid_tile:
+                batch_idx, head_idx, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                checkpoint_offset = 0
+                sV_pisl = self._transform_to_position_independent_layout(
+                    sV, v_smem_layout_staged.inner
+                )
+                sO_pisl = self._transform_to_position_independent_layout(
+                    sO, o_smem_layout_staged.inner
+                )
+                if num_chunks_b > 0:
+                    if cutlass.const_expr(self.enable_checkpoints):
+                        checkpoint_offset = cu_checkpoints[batch_idx]
+                    self._initialize_state_half(
+                        tidx,
+                        mS_init,
+                        head_idx,
+                        batch_idx,
+                        tmem_ptr,
+                        tiled_mma_kv,
+                        tiled_mma_qs,
+                        rState,
+                        1,
+                    )
+                    (
+                        load_v_consumer,
+                        load_gate_consumer,
+                        state_acc_consumer,
+                        kv_acc_consumer,
+                        q_state_acc_consumer,
+                        kv_acc_producer,
+                        state_inp_ready_producer,
+                        shared_inp_ready_producer,
+                        o_store_producer,
+                        checkpoint_offset,
+                        rState,
+                    ) = self.compute_state_group(
+                        tidx,
+                        tmem_ptr,
+                        rState,
+                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                        (
+                            sV_pisl,
+                            sCumsumlog,
+                            sCumprod,
+                            sCumprodScale,
+                            sBeta,
+                            sO_pisl,
+                        ),
+                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
+                        (
+                            load_v_consumer,
+                            load_gate_consumer,
+                            state_acc_consumer,
+                            kv_acc_consumer,
+                            q_state_acc_consumer,
+                            kv_acc_producer,
+                            state_inp_ready_producer,
+                            shared_inp_ready_producer,
+                            o_store_producer,
+                        ),
+                        (True, 0, head_idx),
+                        1,
+                    )
+                for chunk_idx in cutlass.range(1, num_chunks_b):
+                    (
+                        load_v_consumer,
+                        load_gate_consumer,
+                        state_acc_consumer,
+                        kv_acc_consumer,
+                        q_state_acc_consumer,
+                        kv_acc_producer,
+                        state_inp_ready_producer,
+                        shared_inp_ready_producer,
+                        o_store_producer,
+                        checkpoint_offset,
+                        rState,
+                    ) = self.compute_state_group(
+                        tidx,
+                        tmem_ptr,
+                        rState,
+                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                        (
+                            sV_pisl,
+                            sCumsumlog,
+                            sCumprod,
+                            sCumprodScale,
+                            sBeta,
+                            sO_pisl,
+                        ),
+                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
+                        (
+                            load_v_consumer,
+                            load_gate_consumer,
+                            state_acc_consumer,
+                            kv_acc_consumer,
+                            q_state_acc_consumer,
+                            kv_acc_producer,
+                            state_inp_ready_producer,
+                            shared_inp_ready_producer,
+                            o_store_producer,
+                        ),
+                        (False, chunk_idx, head_idx),
+                        1,
+                    )
+                if num_chunks_b > 0:
+                    self._store_state_half(
+                        tidx,
+                        mS_out,
+                        mS_checkpoints,
+                        head_idx,
+                        batch_idx,
+                        checkpoint_offset,
+                        checkpoint_every_n_tokens,
+                        seqlen_b,
+                        tmem_ptr,
+                        tiled_mma_kv,
+                        tiled_mma_qs,
+                        rState,
+                        1,
+                    )
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+            shared_inp_ready_producer.tail()
+            o_store_producer.tail()
+            state_inp_ready_producer.tail()
+
+        # ==============================================================
+        # CG0 MMA ISSUER (warp 12): GEMMs 1-2
+        # ==============================================================
+        elif warp_idx == self.mma_cg0_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
+            )
+            work = scheduler.initial_work_tile_info()
+            while work.is_valid_tile:
+                batch_idx, head_idx, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                if num_chunks_b > 0:
+                    (
+                        aux_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                    ) = self.mma_cg0_warp(
+                        tmem_ptr,
+                        (tiled_mma_qk, tiled_mma_qkv),
+                        (sQ, sK),
+                        (aux_acc_producer, load_k_consumer, load_q_consumer),
+                        (True,),
+                    )
+                for chunk_idx in cutlass.range(1, num_chunks_b):  # noqa: B007
+                    (
+                        aux_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                    ) = self.mma_cg0_warp(
+                        tmem_ptr,
+                        (tiled_mma_qk, tiled_mma_qkv),
+                        (sQ, sK),
+                        (aux_acc_producer, load_k_consumer, load_q_consumer),
+                        (False,),
+                    )
+
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+            aux_acc_producer.tail()
+
+        # ==============================================================
+        # CG1 MMA ISSUER (warp 13): GEMMs 3-7
+        # ==============================================================
+        elif warp_idx == self.mma_cg1_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
+            )
+            work = scheduler.initial_work_tile_info()
+            v_stage_idx = cutlass.Int32(0)
+            while work.is_valid_tile:
+                batch_idx, head_idx, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                if num_chunks_b > 0:
+                    (
+                        state_acc_producer,
+                        q_state_acc_producer,
+                        kv_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                        load_v_consumer,
+                        a_inv_ready_consumer,
+                        qk_ready_consumer,
+                        state_inp_ready_consumer,
+                        shared_inp_ready_consumer,
+                    ) = self.mma_cg1_warp(
+                        tmem_ptr,
+                        (tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv),
+                        (sQ, sK, sK_trans, sV, sAinv, sQk),
+                        (
+                            state_acc_producer,
+                            q_state_acc_producer,
+                            kv_acc_producer,
+                            load_k_consumer,
+                            load_q_consumer,
+                            load_v_consumer,
+                            a_inv_ready_consumer,
+                            qk_ready_consumer,
+                            state_inp_ready_consumer,
+                            shared_inp_ready_consumer,
+                        ),
+                        (True, v_stage_idx),
+                    )
+                    v_stage_idx = (v_stage_idx + 1) % self.smem_v_stages
+                for chunk_idx in cutlass.range(1, num_chunks_b):  # noqa: B007
+                    (
+                        state_acc_producer,
+                        q_state_acc_producer,
+                        kv_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                        load_v_consumer,
+                        a_inv_ready_consumer,
+                        qk_ready_consumer,
+                        state_inp_ready_consumer,
+                        shared_inp_ready_consumer,
+                    ) = self.mma_cg1_warp(
+                        tmem_ptr,
+                        (tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv),
+                        (sQ, sK, sK_trans, sV, sAinv, sQk),
+                        (
+                            state_acc_producer,
+                            q_state_acc_producer,
+                            kv_acc_producer,
+                            load_k_consumer,
+                            load_q_consumer,
+                            load_v_consumer,
+                            a_inv_ready_consumer,
+                            qk_ready_consumer,
+                            state_inp_ready_consumer,
+                            shared_inp_ready_consumer,
+                        ),
+                        (False, v_stage_idx),
+                    )
+                    v_stage_idx = (v_stage_idx + 1) % self.smem_v_stages
+
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+
+            state_acc_producer.tail()
+            q_state_acc_producer.tail()
+            kv_acc_producer.tail()
+
+        # ==============================================================
+        # UNIFIED LOAD WARP (warp 14)
+        # ==============================================================
+        elif warp_idx == self.load_warp_id:
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
+            )
+            work = scheduler.initial_work_tile_info()
+
+            # Init base descriptors once into GMEM (copies embedded atom descriptor)
+            if work.is_valid_tile:
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_q.atom, tensormap_q_ptr, self.load_warp_id
+                )
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_k.atom, tensormap_k_ptr, self.load_warp_id
+                )
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_v.atom, tensormap_v_ptr, self.load_warp_id
+                )
+                tensormap_manager.fence_tensormap_initialization()
+
+            while work.is_valid_tile:
+                batch_idx, head_idx, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                batch_end = cu_seqlens[batch_idx + 1]
+                seqlen_b = batch_end - batch_start
+                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+
+                # Build bounded tensors: same ptr/strides, token dim capped to batch_end
+                bounded_q = cute.make_tensor(
+                    mQ.iterator,
+                    cute.make_layout(
+                        (batch_end, mQ.shape[1], mQ.shape[2]),
+                        stride=(mQ.stride[0], mQ.stride[1], mQ.stride[2]),
+                    ),
+                )
+                bounded_k = cute.make_tensor(
+                    mK.iterator,
+                    cute.make_layout(
+                        (batch_end, mK.shape[1], mK.shape[2]),
+                        stride=(mK.stride[0], mK.stride[1], mK.stride[2]),
+                    ),
+                )
+                bounded_v = cute.make_tensor(
+                    mV.iterator,
+                    cute.make_layout(
+                        (mV.shape[0], batch_end, mV.shape[2]),
+                        stride=(mV.stride[0], mV.stride[1], mV.stride[2]),
+                    ),
+                )
+                if num_chunks_b > 0:
+                    # Update K/Q/V descriptors
+                    tensormap_manager.update_tensormap(
+                        (bounded_q, bounded_k, bounded_v),
+                        (tma_q.atom, tma_k.atom, tma_v.atom),
+                        (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
+                        self.load_warp_id,
+                        (None, None, None),
+                    )
+
+                # Full tiles: load K, Q, V, gate, and beta in order.
+                for chunk_idx in cutlass.range(num_chunks_b - 1):
+                    chunk_offset = batch_start + chunk_idx * self.b_t
+                    load_q_producer, load_k_producer, load_v_producer = (
+                        self.tma_qkv_warp(
+                            (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
+                            (tma_q, tma_k, tma_v),
+                            (sQ, sK, sV),
+                            (load_q_producer, load_k_producer, load_v_producer),
+                            (chunk_offset, chunk_idx, batch_idx, head_idx),
+                            (
+                                tensormap_manager,
+                                tensormap_q_ptr,
+                                tensormap_k_ptr,
+                                tensormap_v_ptr,
+                            ),
+                        )
+                    )
+                    load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
+                        tidx,
+                        (mGate, mBeta),
+                        (sCumsumlog, sCumprod, sCumprodScale, sBeta),
+                        (load_gate_producer, load_beta_producer),
+                        (chunk_offset, head_idx, False, batch_end, scale),
+                    )
+
+                if num_chunks_b > 0:
+                    chunk_idx = num_chunks_b - 1
+                    chunk_offset = batch_start + chunk_idx * self.b_t
+                    load_q_producer, load_k_producer, load_v_producer = (
+                        self.tma_qkv_warp(
+                            (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
+                            (tma_q, tma_k, tma_v),
+                            (sQ, sK, sV),
+                            (load_q_producer, load_k_producer, load_v_producer),
+                            (chunk_offset, chunk_idx, batch_idx, head_idx),
+                            (
+                                tensormap_manager,
+                                tensormap_q_ptr,
+                                tensormap_k_ptr,
+                                tensormap_v_ptr,
+                            ),
+                        )
+                    )
+                    load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
+                        tidx,
+                        (mGate, mBeta),
+                        (sCumsumlog, sCumprod, sCumprodScale, sBeta),
+                        (load_gate_producer, load_beta_producer),
+                        (chunk_offset, head_idx, True, batch_end, scale),
+                    )
+
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+
+            load_q_producer.tail()
+            load_k_producer.tail()
+            load_v_producer.tail()
+            load_gate_producer.tail()
+            load_beta_producer.tail()
+
+        # ==============================================================
+        # EPILOGUE WARP (warp 15)
+        # ==============================================================
+        if warp_idx == self.epilogue_warp_id:
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
+            )
+            work = scheduler.initial_work_tile_info()
+
+            # Init O descriptor once into GMEM
+            if work.is_valid_tile:
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_o.atom, tensormap_o_ptr, self.epilogue_warp_id
+                )
+                tensormap_manager.fence_tensormap_initialization()
+
+            while work.is_valid_tile:
+                batch_idx, head_idx, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                batch_end = cu_seqlens[batch_idx + 1]
+                seqlen_b = batch_end - batch_start
+                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+
+                # Build bounded O tensor: token dim capped to batch_end
+                bounded_o = cute.make_tensor(
+                    mO.iterator,
+                    cute.make_layout(
+                        (mO.shape[0], batch_end, mO.shape[2]),
+                        stride=(mO.stride[0], mO.stride[1], mO.stride[2]),
+                    ),
+                )
+
+                if num_chunks_b > 0:
+                    # Update O descriptor independently
+                    tensormap_manager.update_tensormap(
+                        (bounded_o,),
+                        (tma_o.atom,),
+                        (tensormap_o_ptr,),
+                        self.epilogue_warp_id,
+                        (None,),
+                    )
+                    tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
+
+                for chunk_idx in cutlass.range(num_chunks_b):
+                    chunk_offset = batch_start + chunk_idx * self.b_t
+                    o_store_consumer = self.epilogue_warp(
+                        (sO,),
+                        (tma_o,),
+                        (o_store_consumer,),
+                        (head_idx, chunk_offset),
+                        (tensormap_manager, tensormap_o_ptr),
+                    )
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+
+    # -----------------------------------------------------------------------
+    # Per-warp methods  (called from kernel's chunk loop)
+    # -----------------------------------------------------------------------
+    @cute.jit
+    def tma_qkv_warp(
+        self,
+        mma_args: tuple,
+        tma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+        tensormap_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineProducer, pipeline.PipelineProducer, pipeline.PipelineProducer
+    ]:
+        """Unified load warp: load K, Q, and V for the current chunk.
+
+        Pattern (following fmha.py / dense_gemm_persistent.py):
+          1. domain_offset the TMA tensor to (chunk_offset, head_idx, 0) so that
+             the logical tile (0, ...) maps to the current chunk.
+          2. flat_divide to obtain the tiled global view.
+          3. thr_mma.partition_{A,B} to get the TMA-compatible per-thread view.
+          4. cpasync.tma_partition -> (tXsX, tXgX) SMEM/global pairs.
+          5. acquire pipeline stage, issue cute.copy, signal mbarrier.
+
+        Note on head coordinate: head_idx is the flat KV-head index in [0, h_qv).
+        For the hierarchical head layout (h_r, h_qv) with h_r having stride 0
+        (broadcast), the flat index maps correctly as long as head_idx < h_qv.
+        """
+        tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv = mma_args
+        tma_q, tma_k, tma_v = tma_args
+        sQ, sK, sV = smem_args
+        load_q_producer, load_k_producer, load_v_producer = pipeline_args
+        chunk_offset, chunk_idx, batch_idx, head_idx = work_args
+        tensormap_manager, tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr = (
+            tensormap_args
+        )
+
+        # Single-CTA mode: no multicast, cta_v = 0.
+        cta_layout = cute.make_layout(1)
+
+        # Per-thread MMA slices (cta_v=0 for ONE-CTA mode).
+        thr_mma_qk = tiled_mma_qk.get_slice(0)
+        thr_mma_qkv_ss = tiled_mma_qkv_ss.get_slice(0)
+        thr_mma_kv = tiled_mma_kv.get_slice(0)  # noqa: F841
+
+        # Tile shapes from the MMA tiler (128, 128, 128):
+        #   mode[0,2] = (BT, DK) - M,K tile for A (Q) and for B (K) of tiled_mma_qk
+        #   mode[1,2] = (BT, DV) - tile shape for loading V (B operand in GEMMs 5/6)
+        # (BT, DK)
+        qk_tile = cute.select(self.mma_tiler_qk, mode=[0, 2])
+        # (DV, BT)
+        v_tile = cute.select(self.mma_tiler_qkv, mode=[0, 2])
+
+        # ------------------------------------------------------------------
+        # K  (B operand of GEMM-kk / GEMM-qk, multi-stage buffered)
+        # Tensor shape: (total_tokens, H_hier, DK)
+        # TMA tile:     (BT, DK)
+        # ------------------------------------------------------------------
+        mK = cute.domain_offset(
+            (chunk_offset, cutlass.Int32(0)), tma_k.tma_tensor[None, None, head_idx]
+        )
+        # (..., num_k_tiles, ...)
+        gK = cute.flat_divide(mK, qk_tile)
+        tCgK = thr_mma_qk.partition_B(gK)
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_k.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sK, 0, 3),
+            cute.group_modes(tCgK, 0, 3),
+        )
+
+        # Load K for the current chunk into the next available pipeline stage.
+        k_handle = load_k_producer.acquire_and_advance()
+        if chunk_idx == 0:
+            tensormap_manager.fence_tensormap_update(tensormap_k_ptr)
+
+        cute.copy(
+            tma_k.atom,
+            tKgK[(None, 0, 0)],
+            tKsK[(None, k_handle.index)],
+            tma_bar_ptr=k_handle.barrier,
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_k_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        # ------------------------------------------------------------------
+        # Q  (A operand of GEMM-qk, multi-stage buffered)
+        # ------------------------------------------------------------------
+        mQ = cute.domain_offset(
+            (chunk_offset, cutlass.Int32(0)), tma_q.tma_tensor[None, None, head_idx]
+        )
+        gQ = cute.flat_divide(mQ, qk_tile)
+        tCgQ = thr_mma_qk.partition_A(gQ)
+        tQsQ, tQgQ = cpasync.tma_partition(
+            tma_q.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sQ, 0, 3),
+            cute.group_modes(tCgQ, 0, 3),
+        )
+
+        q_handle = load_q_producer.acquire_and_advance()
+        if chunk_idx == 0:
+            tensormap_manager.fence_tensormap_update(tensormap_q_ptr)
+        cute.copy(
+            tma_q.atom,
+            tQgQ[(None, 0, 0)],
+            tQsQ[(None, q_handle.index)],
+            tma_bar_ptr=q_handle.barrier,
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_q_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        # ------------------------------------------------------------------
+        # V  (B operand of GEMM-new_v / GEMM-qkv, multi-stage buffered)
+        # ------------------------------------------------------------------
+        mV = cute.domain_offset(
+            (cutlass.Int32(0), chunk_offset), tma_v.tma_tensor[None, None, head_idx]
+        )
+        gV = cute.flat_divide(mV, v_tile)
+        tCgV = thr_mma_qkv_ss.partition_A(gV)
+        tVsV, tVgV = cpasync.tma_partition(
+            tma_v.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sV, 0, 3),
+            cute.group_modes(tCgV, 0, 3),
+        )
+
+        v_handle = load_v_producer.acquire_and_advance()
+        if chunk_idx == 0:
+            tensormap_manager.fence_tensormap_update(tensormap_v_ptr)
+        cute.copy(
+            tma_v.atom,
+            tVgV[(None, 0, 0)],
+            tVsV[(None, v_handle.index)],
+            tma_bar_ptr=v_handle.barrier,
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_v_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        return load_q_producer, load_k_producer, load_v_producer
+
+    @cute.jit
+    def load_gate_beta_warp(
+        self,
+        tidx: cutlass.Int32,
+        gmem_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ) -> tuple[pipeline.PipelineProducer, pipeline.PipelineProducer]:
+        """Warp 14: load gate[BT] and beta[BT] for the current chunk.
+
+        Gate is loaded via ldg (sync G->R), then preprocessed into cumsum-log,
+        cumprod, and cumprod*scale channels in SMEM.
+
+        Beta is loaded through registers and stored into sBeta SMEM.
+
+        The last tile uses predicated copies: elements with linear index >= valid_tokens
+        are out-of-bounds and receive neutral values (gate=1 -> ln=0, beta=0).
+
+        Thread tidx (lane 0..31) owns positions tidx, tidx+32, tidx+64, tidx+96.
+        """
+        gate, beta = gmem_args
+        sCumsumlog, sCumprod, sCumprodScale, sBeta = smem_args
+        load_gate_producer, load_beta_producer = pipeline_args
+        chunk_offset, head_idx, is_last_tile, batch_end, scale = work_args
+
+        # lane index
+        lidx = tidx % self.threads_per_warp
+
+        gGate = cute.domain_offset((chunk_offset,), gate[None, head_idx])
+        cGate = cute.domain_offset(
+            (chunk_offset,), cute.make_identity_tensor(gate[None, head_idx].shape)
+        )
+        gBeta = cute.domain_offset((chunk_offset,), beta[None, head_idx])
+        gGate = cute.flat_divide(gGate, (self.b_t,))[None, 0]
+        cGate = cute.flat_divide(cGate, (self.b_t,))[None, 0]
+        gBeta = cute.flat_divide(gBeta, (self.b_t,))[None, 0]
+
+        # Tiled copy: 1D thread/value layouts; partition_S/D handle element mapping.
+        # thread_layout (32,): each of the 32 lanes maps to one row of the b_t tile.
+        # value_layout  (4,) : each lane owns 4 elements strided by threads_per_warp.
+        thread_layout = cute.make_layout((self.threads_per_warp,), stride=(1,))
+        value_layout = cute.make_layout((1,), stride=(1,))
+
+        # Gate: sync G->R (ldg), apply ln + prefix sum, then R->S (sts)
+        atom_gate_g2r = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=32
+        )
+        tiled_copy_gate_g2r = cute.make_tiled_copy_tv(
+            atom_gate_g2r, thread_layout, value_layout
+        )
+
+        # Beta: sync G->R, then R->S.
+        atom_beta = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=32
+        )
+        tiled_copy_beta = cute.make_tiled_copy_tv(
+            atom_beta, thread_layout, value_layout
+        )
+
+        # Per-thread partitions (1D tensors; no manual 2D reshaping needed)
+        thr_copy_gate_g2r = tiled_copy_gate_g2r.get_slice(lidx)
+        tGgGate = thr_copy_gate_g2r.partition_S(gGate)
+        tGsCumsumlog = thr_copy_gate_g2r.partition_D(sCumsumlog)
+        tGsCumprod = thr_copy_gate_g2r.partition_D(sCumprod)
+        tGsCumprodScale = thr_copy_gate_g2r.partition_D(sCumprodScale)
+
+        thr_copy_beta = tiled_copy_beta.get_slice(lidx)
+        tBgBeta = thr_copy_beta.partition_S(gBeta)
+        tBsBeta = thr_copy_beta.partition_D(sBeta)
+
+        gate_handle = load_gate_producer.acquire_and_advance()
+        beta_handle = load_beta_producer.acquire_and_advance()
+
+        rGate = cute.make_rmem_tensor_like(tGgGate, self.acc_dtype)
+        tGrGate = tiled_copy_gate_g2r.retile(rGate)
+        rCumprod = cute.make_rmem_tensor_like(tGgGate, self.acc_dtype)
+        tGrCumprod = tiled_copy_gate_g2r.retile(rCumprod)
+        rBeta = cute.make_rmem_tensor_like(tBgBeta, self.acc_dtype)
+        tBrBeta = tiled_copy_beta.retile(rBeta)
+
+        # --- Predicate (last tile only): compute once, reuse for gate and beta ---
+        if cutlass.const_expr(is_last_tile):
+            valid_tokens = batch_end  # noqa: F841
+            tGcGate = thr_copy_gate_g2r.partition_S(cGate)
+            tGpGate = cute.make_rmem_tensor(
+                ((tGcGate.shape[0][1],), tGcGate.shape[1]), cutlass.Boolean
+            )
+            for i in range(cute.size(tGpGate)):
+                tGpGate[i] = cute.elem_less(tGcGate[i][0], batch_end)
+
+        # --- Gate load ---
+        if cutlass.const_expr(is_last_tile):
+            # OOB neutral: 1.0 -> log2 ~= 0.0 (no decay contribution)
+            tGrGate.fill(1.0)
+            cute.copy(tiled_copy_gate_g2r, tGgGate, tGrGate, pred=tGpGate)
+        else:
+            cute.copy(tiled_copy_gate_g2r, tGgGate, tGrGate)
+
+        # Issue beta before consuming gate so both independent LDG streams can overlap.
+        if cutlass.const_expr(is_last_tile):
+            tBrBeta.fill(0.0)
+            cute.copy(tiled_copy_beta, tBgBeta, tBrBeta, pred=tGpGate)
+        else:
+            cute.copy(tiled_copy_beta, tBgBeta, tBrBeta)
+
+        # --- log2 + warp-wide inclusive prefix sum + SMEM store (always) ---
+        for i in range(cute.size(tGrGate)):
+            tGrGate[i] = cute.math.log2(tGrGate[i] + 1e-10, fastmath=True)
+        for offset in [1, 2, 4, 8, 16]:
+            for col in range(cute.size(tGrGate)):
+                n = cute.arch.shuffle_sync_up(
+                    tGrGate[col], offset, mask=0xFFFFFFFF, mask_and_clamp=0
+                )
+                if lidx >= offset:
+                    tGrGate[col] = tGrGate[col] + n
+        sum_v = 0.0  # noqa: F841
+        for col in range(1, cute.size(tGrGate)):
+            last_v = cute.arch.shuffle_sync(
+                tGrGate[col - 1],
+                self.threads_per_warp - 1,
+                mask=0xFFFFFFFF,
+                mask_and_clamp=self.threads_per_warp - 1,
+            )
+            tGrGate[col] += last_v
+        for col in range(cute.size(tGrGate)):
+            tGrCumprod[col] = cute.math.exp2(tGrGate[col], fastmath=True)
+        cute.copy(
+            tiled_copy_gate_g2r, tGrGate, tGsCumsumlog[None, None, 0, gate_handle.index]
+        )
+        cute.copy(
+            tiled_copy_gate_g2r,
+            tGrCumprod,
+            tGsCumprod[None, None, 0, gate_handle.index],
+        )
+        # Reuse the cumprod fragment so the extra channel does not extend the
+        # producer's register live range.
+        for col in range(cute.size(tGrCumprod)):
+            tGrCumprod[col] = tGrCumprod[col] * scale
+        cute.copy(
+            tiled_copy_gate_g2r,
+            tGrCumprod,
+            tGsCumprodScale[None, None, 0, gate_handle.index],
+        )
+
+        gate_handle.commit()
+
+        cute.copy(tiled_copy_beta, tBrBeta, tBsBeta[None, None, 0, beta_handle.index])
+        beta_handle.commit()
+
+        return load_gate_producer, load_beta_producer
+
+    @cute.jit
+    def mma_cg0_warp(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Warp 12: issue GEMMs 1-2 for compute group 0."""
+        tiled_mma_qk, tiled_mma_qkv = mma_args
+        sQ, sK = smem_args
+        shared_acc_producer, load_k_consumer, load_q_consumer = pipeline_args
+
+        acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtAcc_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_aux_acc_stages)
+        )
+        tCtShared = cute.make_tensor(
+            tmem_ptr + self.tmem_aux_acc_offset, tCtAcc_fake.layout
+        )
+
+        tCrK_A = tiled_mma_qk.make_fragment_A(sK)
+        tCrK_B = tiled_mma_qk.make_fragment_B(sK)
+        tCrQ_A = tiled_mma_qk.make_fragment_A(sQ)
+
+        # GEMM 1: K @ K^T -> W_kk.
+        k_handle = load_k_consumer.wait_and_advance()
+        kk_handle = shared_acc_producer.acquire_and_advance()
+        num_kphases = cute.size(tCrK_A, mode=[2])
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qk,
+                tCtShared[None, None, None, kk_handle.index],
+                tCrK_A[None, None, kphase_idx, k_handle.index],
+                tCrK_B[None, None, kphase_idx, k_handle.index],
+                tCtShared[None, None, None, kk_handle.index],
+            )
+        kk_handle.commit()
+
+        # GEMM 2: Q @ K^T -> W_qk.
+        q_handle = load_q_consumer.wait_and_advance()
+        qk_handle = shared_acc_producer.acquire_and_advance()
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qk,
+                tCtShared[None, None, None, qk_handle.index],
+                tCrQ_A[None, None, kphase_idx, q_handle.index],
+                tCrK_B[None, None, kphase_idx, k_handle.index],
+                tCtShared[None, None, None, qk_handle.index],
+            )
+        qk_handle.commit()
+        q_handle.release()
+        k_handle.release()
+
+        return shared_acc_producer, load_k_consumer, load_q_consumer
+
+    @cute.jit
+    def mma_cg1_warp(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Warp 13: issue GEMMs 3-7 for compute group 1."""
+        tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv = mma_args
+        sQ, sK, sK_trans, sV, sAinv, sQk = smem_args
+        (
+            shared_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            load_v_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            shared_inp_ready_consumer,
+        ) = pipeline_args
+        is_first_chunk, v_stage_idx = work_args
+
+        valid_state = not is_first_chunk or self.use_initial_state
+
+        # ------------------------------------------------------------------
+        # Build TMEM accumulator views
+        # ------------------------------------------------------------------
+        # Dedicated two-stage state accumulator ring for G3/G5. G1/G2 use a
+        # separate two-stage ring and therefore progress independently.
+        acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtAcc_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_state_acc_stages)
+        )
+        tCtShared = cute.make_tensor(
+            tmem_ptr + self.tmem_state_acc_offset, tCtAcc_fake.layout
+        )
+
+        shared_inp_shape = tiled_mma_qkv.partition_shape_A(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
+        )
+        tCtShared_inp_fake = tiled_mma_qkv.make_fragment_A(
+            cute.append(shared_inp_shape, self.tmem_shared_inp_stages)
+        )
+        tCtShared_inp = cute.make_tensor(
+            cute.recast_ptr(
+                tmem_ptr + self.tmem_shared_inp_offset, dtype=self.io_dtype
+            ),
+            tCtShared_inp_fake.layout,
+        )
+
+        # q*state acc (GEMM 4 only) - 1 stage, layout from tiled_mma_qs
+        qs_acc_shape = tiled_mma_qs.partition_shape_C(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
+        )
+        tCtQState_fake = tiled_mma_qs.make_fragment_C(
+            cute.append(qs_acc_shape, self.tmem_q_state_acc_stages)
+        )
+        tCtQState = cute.make_tensor(
+            tmem_ptr + self.tmem_q_state_offset, tCtQState_fake.layout
+        )
+
+        # state acc (GEMM 7 only) - 1 stage, layout from tiled_mma_kv
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+
+        state_inp_shape = tiled_mma_qs.partition_shape_A(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
+        )
+        tCtState_inp_fake = tiled_mma_qs.make_fragment_A(
+            cute.append(state_inp_shape, self.tmem_state_inp_stages)
+        )
+        tCtState_inp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_state_inp_offset, dtype=self.io_dtype),
+            tCtState_inp_fake.layout,
+        )
+
+        # ------------------------------------------------------------------
+        # Pre-create operand fragments (stage dim preserved; sliced at GEMM time).
+        # K as A for GEMM 3 (k*state)
+        tCrS_A = tCtState_inp
+        # Q as A for GEMM 4 (q*state)
+        tCrQ_B_qs = tiled_mma_qs.make_fragment_B(sQ)
+        # S_prev as B for GEMMs 3+4
+        tCrK_B_qs = tiled_mma_qs.make_fragment_B(sK)
+        # tiled_mma_qkv operands (GEMMs 5, 6)
+        # V-KS as A for GEMM 5
+        if cutlass.const_expr(valid_state):
+            tCrV_A = tCtShared_inp
+        else:
+            tCrV_A = tiled_mma_qkv_ss.make_fragment_A(sV)
+        # A_inv as B for GEMM 5
+        tCrAinv_B = tiled_mma_qkv.make_fragment_B(sAinv)
+
+        # W_qkv as A for GEMM 6
+        tCrQkv_A = tCtShared_inp
+        # NV as B for GEMM 6
+        tCrNv_B = tiled_mma_qkv.make_fragment_B(sQk)
+        # tiled_mma_kv operands (GEMM 7)
+        # delta as A for GEMM 7
+        tCrDecayV_A = tCtShared_inp
+        # K^T as B for GEMM 7
+        tCrKt_B = tiled_mma_kv.make_fragment_B(sK_trans)
+
+        k_handle = load_k_consumer.wait_and_advance()
+        q_handle = load_q_consumer.wait_and_advance()
+
+        # ---- GEMM 3: k*state  (K @ S_prev -> shared acc) --------------------
+        # ---- GEMM 4: q*state  (Q @ S_prev -> tmem_q_state) ------------------
+        # Skipped on the first chunk when use_initial_state is False (S_prev = 0, outputs are zero).
+        if valid_state:
+            s_handle = state_inp_ready_consumer.wait_and_advance()
+            ks_handle = shared_acc_producer.acquire_and_advance()
+
+            num_kphases_qs = cute.size(tCrS_A, mode=[2])
+            for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
+                tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qs,
+                    tCtShared[None, None, None, ks_handle.index],
+                    tCrS_A[None, None, kphase_idx, s_handle.index],
+                    tCrK_B_qs[None, None, kphase_idx, k_handle.index],
+                    tCtShared[None, None, None, ks_handle.index],
+                )
+            ks_handle.commit()
+
+            q_state_acc_handle = q_state_acc_producer.acquire_and_advance()
+            # S_prev still loaded (same s_handle.index as GEMM 3).
+            num_kphases_qs = cute.size(tCrS_A, mode=[2])
+            for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
+                tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qs,
+                    tCtQState[None, None, None, q_state_acc_handle.index],
+                    tCrS_A[None, None, kphase_idx, s_handle.index],
+                    tCrQ_B_qs[None, None, kphase_idx, q_handle.index],
+                    tCtQState[None, None, None, q_state_acc_handle.index],
+                )
+            q_state_acc_handle.commit()
+            # Release state SMEM (S_prev fully consumed by GEMMs 3 + 4).
+            s_handle.release()
+
+        q_handle.release()
+
+        # ---- GEMM 5: new_v  (A_inv @ (V-KS) -> shared acc) ------------------
+        # A_inv from CG0 (a_inv_ready); V-KS from CG1 (v_ks_ready, stored in sV).
+        vks_handle = shared_inp_ready_consumer.wait_and_advance()
+        nv_handle = shared_acc_producer.acquire_and_advance()
+        ainv_handle = a_inv_ready_consumer.wait_and_advance()
+
+        num_kphases_qkv = cute.size(tCrAinv_B, mode=[2])
+        cur_tiled_mma_qkv = tiled_mma_qkv if valid_state else tiled_mma_qkv_ss
+        v_operand_stage = vks_handle.index if valid_state else v_stage_idx
+        for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+            cur_tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                cur_tiled_mma_qkv,
+                tCtShared[None, None, None, nv_handle.index],
+                tCrV_A[None, None, kphase_idx, v_operand_stage],
+                tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                tCtShared[None, None, None, nv_handle.index],
+            )
+
+        nv_handle.commit()
+        ainv_handle.release()
+        vks_handle.release()
+
+        # ---- GEMM 6: qkv  (W_qkv @ NV -> q * state acc) ------------------------
+        # W_qkv from CG0 (qk_ready, stored in sQk); NV from CG1 (new_v_ready, stored in sNv).
+        qkv_qk_handle = qk_ready_consumer.wait_and_advance()
+        qkv_nv_handle = shared_inp_ready_consumer.wait_and_advance()
+        q_state_acc_handle = q_state_acc_producer.acquire_and_advance()
+
+        num_kphases_qkv = cute.size(tCrQkv_A, mode=[2])
+        for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+            tiled_mma_qkv.set(
+                tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0)
+            )
+            cute.gemm(
+                tiled_mma_qkv,
+                tCtQState[None, None, None, q_state_acc_handle.index],
+                tCrQkv_A[None, None, kphase_idx, qkv_nv_handle.index],
+                tCrNv_B[None, None, kphase_idx, qkv_qk_handle.index],
+                tCtQState[None, None, None, q_state_acc_handle.index],
+            )
+
+        qkv_qk_handle.release()
+        qkv_nv_handle.release()
+        q_state_acc_handle.commit()
+
+        # ---- GEMM 7: kv_update  (K^T @ delta -> state-increment TMEM) -----------
+        # delta from CG1 (decay_v_ready, stored in sDecayV); K^T reuses k_handle slot.
+        kv_acc_handle = kv_acc_producer.acquire_and_advance()
+        dv_handle = shared_inp_ready_consumer.wait_and_advance()
+
+        num_kphases_kv = cute.size(tCrKt_B, mode=[2])
+        for kphase_idx in cutlass.range(num_kphases_kv, unroll_full=True):
+            tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_kv,
+                tCtState[None, None, None, kv_acc_handle.index],
+                tCrDecayV_A[None, None, kphase_idx, dv_handle.index],
+                tCrKt_B[None, None, kphase_idx, k_handle.index],
+                tCtState[None, None, None, kv_acc_handle.index],
+            )
+        kv_acc_handle.commit()
+        dv_handle.release()
+        # K SMEM slot now free for next chunk
+        k_handle.release()
+
+        return (  # type: ignore[return-value]
+            shared_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            load_v_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            shared_inp_ready_consumer,
+        )
+
+    @cute.jit
+    def compute_group_0(
+        self,
+        tidx: cutlass.Int32,
+        tmem_ptr: cutlass.Int64,
+        scale: cutlass.Float32,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+    ]:
+        """Warps 0-3: T-pairwise, kk_epi, inverse, qk_epi."""
+        (tiled_mma_qk,) = mma_args
+        sCumsumlog, sBeta, sAinv, sQk = smem_args
+        (
+            load_gate_consumer,
+            load_beta_consumer,
+            shared_acc_consumer,
+            a_inv_ready_producer,
+            qk_ready_producer,
+        ) = pipeline_args
+        (is_first_chunk,) = work_args
+
+        # ------------------------------------------------------------------
+        # Preamble: per-thread ID within CG0 and TMEM copy setup
+        # ------------------------------------------------------------------
+        # Local thread ID within CG0 (0..127)
+        num_threads_cg0 = self.threads_per_warp * len(self.compute_group_0_warp_ids)
+        cg0_tidx = tidx % num_threads_cg0
+
+        # Build TMEM tensor view of shared_acc (both stages):
+        #   shape = (per_thread_acc_shape..., tmem_aux_acc_stages)
+        tAcc_shape = tiled_mma_qk.partition_shape_C(
+            (self.mma_tiler_qk[0], self.mma_tiler_qk[1])
+        )
+        tAcc_wo_stages = tiled_mma_qk.make_fragment_C(tAcc_shape)
+        tAcc = cute.make_tensor(
+            tAcc_wo_stages.iterator,
+            cute.flat_product(
+                tAcc_wo_stages.layout,
+                cute.make_layout((self.tmem_aux_acc_stages,), stride=(1,)),
+            ),
+        )
+        tStS_staged = cute.make_tensor(tmem_ptr + self.tmem_aux_acc_offset, tAcc.layout)
+        tStS_staged_mn_view = self.transform_partitioned_tensor_layout(tStS_staged)
+        cS = cute.make_identity_tensor((self.mma_tiler_qk[0], self.mma_tiler_qk[1]))
+        # TMEM load copy atom and tiled copy (loads fp32 accum from TMEM -> registers)
+        tStS_for_t2r = tStS_staged[(None, None), 0, 0, 0]
+        atom_shared_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_shared_t2r = tcgen05.make_tmem_copy(atom_shared_t2r, tStS_for_t2r)
+        thr_shared_t2r = tiled_shared_t2r.get_slice(cg0_tidx)
+
+        # Per-thread TMEM source (staged).
+        # tTR_tStS shape: (A, B, NUM_SUBS, NUM_STAGES)
+        # Each subtile is tTR_tStS[None, None, sub, stage] with shape (A, B).
+        tTR_tStS = thr_shared_t2r.partition_S(tStS_staged_mn_view)
+        tTR_tScS = thr_shared_t2r.partition_D(cS)
+
+        sub_tile_size = 32
+
+        # SMEM store copies: fp32 registers -> fp16 SMEM (A-operands for GEMM 5 and 6).
+        # make_tiled_copy_D mirrors tmem_tiled_copy's thread-value mapping so the
+        # register layout from the TMEM load aligns with the SMEM destination partition.
+        atom_ainv_r2s = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+            self.io_dtype,
+        )
+        tiled_ainv_r2s = cute.make_tiled_copy_D(atom_ainv_r2s, tiled_shared_t2r)
+        sAinv_mn_view = self.transform_partitioned_tensor_layout(sAinv)
+        thr_ainv_r2s = tiled_ainv_r2s.get_slice(cg0_tidx)
+        tCsAI = thr_ainv_r2s.partition_D(sAinv_mn_view)
+
+        atom_ainv_s2r = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+            self.io_dtype,
+        )
+        tiled_ainv_s2r = cute.make_tiled_copy_D(atom_ainv_s2r, tiled_shared_t2r)
+        thr_ainv_s2r = tiled_ainv_s2r.get_slice(cg0_tidx)
+
+        atom_qk_r2s = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+            self.io_dtype,
+        )
+        tiled_qk_r2s = cute.make_tiled_copy_D(atom_qk_r2s, tiled_shared_t2r)
+        sQk_mn_view = self.transform_partitioned_tensor_layout(sQk)
+        thr_qk_r2s = tiled_qk_r2s.get_slice(cg0_tidx)
+
+        # ------------------------------------------------------------------
+        # Step 1: T-pairwise - wait for cumsumlog, compute T row, release
+        #   sCumsumlog[t] = sum_{l=0}^{t} log(gate_l)  (prefix sum done by gate warp)
+        #   T[i,j]        = exp(cumsumlog[i] - cumsumlog[j])  for i>=j, else 0
+        #
+        #   The unified loader (warp 14) stores the inclusive prefix sum directly into
+        #   sCumsumlog before committing the gate pipeline handle, so CG0 can read
+        #   the final cumsumlog values immediately after wait_and_advance().
+        # ------------------------------------------------------------------
+        gate_handle = load_gate_consumer.wait_and_advance()
+        beta_handle = load_beta_consumer.wait_and_advance()
+
+        rBeta = cute.make_rmem_tensor((2,), self.acc_dtype)
+        rBeta = cute.make_tensor(
+            rBeta.iterator,
+            cute.flat_product(rBeta.layout, cute.make_layout((16,), stride=(0,))),
+        )
+        tGrBeta = thr_shared_t2r.partition_D(rBeta)
+
+        # Pre-compute T before waiting for TMEM so exp2 overlaps the MMA warp's GEMMs.
+        # Mask T in a separate pass; the explicit packed epilogues remain unconditional.
+        #   tGrT[j] = exp2(cumsumlog[i] - cumsumlog[j])
+        #   where i = cg0_tidx (this thread's row), j = k (col, compile-time).
+        rCumsumlog = cute.make_rmem_tensor((2, 16), self.acc_dtype)
+        tGrCumsumlog = thr_shared_t2r.partition_D(rCumsumlog)
+        tGrCumsumlog_s = cute.make_rmem_tensor_like(tGrCumsumlog)
+        tGrCumsumlog_t = cute.make_rmem_tensor_like(tGrCumsumlog)
+        for k in cutlass.range_constexpr(cute.size(tTR_tScS)):
+            s, t = tTR_tScS[k]
+            tGrBeta[k] = sBeta[s, 0, beta_handle.index]
+            tGrCumsumlog_s[k] = sCumsumlog[s, 0, gate_handle.index]
+            tGrCumsumlog_t[k] = sCumsumlog[t, 0, gate_handle.index]
+        for k in cutlass.range_constexpr(cute.size(tTR_tScS)):
+            tGrCumsumlog[k] = cute.math.exp2(
+                tGrCumsumlog_s[k] - tGrCumsumlog_t[k],
+                fastmath=True,
+            )
+        # The flattened TMEM fragment repeats the same 32-value coordinate pattern twice. For j = k % 32:
+        #   row = 16 * warp + lane // 4 + 8 * ((j // 2) % 2)
+        #   col = 2 * (lane % 4) + j % 2 + 8 * (j // 4)
+        # Rearrange row >= col so masking needs no online coordinate materialization.
+        lane_id = cg0_tidx % self.threads_per_warp
+        row_col_offset = (
+            16 * (cg0_tidx // self.threads_per_warp) + lane_id // 4 - 2 * (lane_id % 4)
+        )
+        for k in cutlass.range_constexpr(cute.size(tTR_tScS)):
+            j = k % sub_tile_size
+            threshold = (j % 2) + 8 * (j // 4) - 8 * ((j // 2) % 2)
+            tGrCumsumlog[k] = tGrCumsumlog[k] if row_col_offset >= threshold else 0.0
+        gate_handle.release()
+
+        # ------------------------------------------------------------------
+        # Step 2: kk_epi - W_kk[i,j] *= T[i,j] * beta[i] using packed multiplies
+        # ------------------------------------------------------------------
+        # Acquire sAinvNv slot, fence, signal
+        ainv_handle = a_inv_ready_producer.acquire_and_advance()
+        # Acquire sQkOstore slot, write W_qkv (fp16), fence, signal
+        qk_ready_handle = qk_ready_producer.acquire_and_advance()
+        kk_handle = shared_acc_consumer.wait_and_advance()
+
+        tKKrKK = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
+        tKKrKK_out = cute.make_rmem_tensor_like(tKKrKK, self.io_dtype)
+        tCrAI = tiled_ainv_r2s.retile(tKKrKK_out)
+        for sub in cutlass.range(tKKrKK.shape[2]):
+            cute.copy(
+                tiled_shared_t2r,
+                tTR_tStS[None, 0, sub, kk_handle.index],
+                tKKrKK[None, 0, sub],
+            )
+            for k in cutlass.range_constexpr(0, sub_tile_size, 2):
+                tKKrKK[k, 0, sub], tKKrKK[k + 1, 0, sub] = cute.arch.mul_packed_f32x2(
+                    (tKKrKK[k, 0, sub], tKKrKK[k + 1, 0, sub]),
+                    (tGrCumsumlog[k, 0, sub], tGrCumsumlog[k + 1, 0, sub]),
+                )
+                tKKrKK[k, 0, sub], tKKrKK[k + 1, 0, sub] = cute.arch.mul_packed_f32x2(
+                    (tKKrKK[k, 0, sub], tKKrKK[k + 1, 0, sub]),
+                    (tGrBeta[k, 0, sub], tGrBeta[k + 1, 0, sub]),
+                )
+            tKKrKK_out[None, 0, sub].store(
+                tKKrKK[None, 0, sub].load().to(self.io_dtype)
+            )
+            cute.copy(
+                tiled_ainv_r2s,
+                tCrAI[None, 0, sub],
+                tCsAI[None, 0, sub, ainv_handle.index],
+            )
+        kk_handle.release()
+
+        # ------------------------------------------------------------------
+        # Step 3: qk_epi - W_qk[i,j] *= T[i,j] * scale using packed multiplies
+        # ------------------------------------------------------------------
+        qk_handle = shared_acc_consumer.wait_and_advance()
+        tQKrQK = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
+        tQKrQK_out = cute.make_rmem_tensor_like(tQKrQK, self.io_dtype)
+        tCrQK = tiled_qk_r2s.retile(tQKrQK_out)
+        tCsQK = thr_qk_r2s.partition_D(sQk_mn_view[None, None, qk_ready_handle.index])
+        for sub in cutlass.range(tQKrQK.shape[2]):
+            cute.copy(
+                tiled_shared_t2r,
+                tTR_tStS[None, 0, sub, qk_handle.index],
+                tQKrQK[None, 0, sub],
+            )
+            for k in cutlass.range_constexpr(0, sub_tile_size, 2):
+                tQKrQK[k, 0, sub], tQKrQK[k + 1, 0, sub] = cute.arch.mul_packed_f32x2(
+                    (tQKrQK[k, 0, sub], tQKrQK[k + 1, 0, sub]),
+                    (tGrCumsumlog[k, 0, sub], tGrCumsumlog[k + 1, 0, sub]),
+                )
+                tQKrQK[k, 0, sub], tQKrQK[k + 1, 0, sub] = cute.arch.mul_packed_f32x2(
+                    (tQKrQK[k, 0, sub], tQKrQK[k + 1, 0, sub]),
+                    (scale, scale),
+                )
+            tQKrQK_out[None, 0, sub].store(
+                tQKrQK[None, 0, sub].load().to(self.io_dtype)
+            )
+            cute.copy(tiled_qk_r2s, tCrQK[None, 0, sub], tCsQK[None, 0, sub])
+        cute.arch.fence_view_async_shared()
+        qk_handle.release()
+        qk_ready_handle.commit()
+
+        # ------------------------------------------------------------------
+        # Step 4: inverse - compute A_inv = (I + M_kk)^{-1}, write to sAinvNv
+        #   Done after qk_epi so the inverse computation overlaps with GEMM 6
+        #   (qkv) running in the MMA warp.
+        # ------------------------------------------------------------------
+
+        # -- Hierarchical blockwise inverse: A_inv = (I + M_kk)^{-1} ----------
+        # Thread cg0_tidx owns row cg0_tidx of the BTxBT matrix.
+        # sAinv is reinterpreted as row-major (BTxBT) fp16 for the algorithm;
+        # the MMA-ready A-operand layout is written back via tiled_store_ainv after.
+        # NOTE: assumes io_dtype == Float16 (algorithm uses fp16 SMEM + fp32 accumulators).
+        warp_id = cg0_tidx // 32
+        lane_id = cg0_tidx % 32
+
+        sA = sAinv_mn_view[None, None, ainv_handle.index]
+        # Stage 1: Gauss-Jordan inversion of BT//8 = 16 diagonal 8x8 blocks.
+        sM_8x8 = cute.flat_divide(sA, (8, 8))
+        self.inverse_barrier.arrive_and_wait()
+        if warp_id < 2:
+            self._invert_diagonal_NxN(
+                sM_8x8[None, None, cg0_tidx // 8, cg0_tidx // 8], cg0_tidx, 8
+            )
+        self.inverse_barrier.arrive_and_wait()
+
+        # Stage 2: off-diagonal correction 8x8 -> 16x16.
+        # 8 diagonal 16x16 tiles; each warp handles 2 tiles sequentially.
+        sM_16x16 = cute.flat_divide(sA, (16, 16))
+        self._blockwise_diagonal_8x8_to_16x16(
+            sM_16x16[None, None, warp_id, warp_id], lane_id
+        )
+        self.inverse_barrier.arrive_and_wait()
+
+        # Stage 3: off-diagonal correction 16x16 -> 32x32.
+        # 4 diagonal 32x32 tiles; one tile per warp.
+        sM_32x32 = cute.flat_divide(sA, (32, 32))
+        if warp_id < 2:
+            self._blockwise_diagonal_16x16_to_32x32(
+                sM_32x32[None, None, warp_id, warp_id], lane_id
+            )
+        self.inverse_barrier.arrive_and_wait()
+
+        # Stage 4: off-diagonal correction 32x32 -> 64x64.
+        # 2 diagonal 64x64 tiles; warps 0,1 on tile 0, warps 2,3 on tile 1.
+        sM_64x64 = cute.flat_divide(sA, (64, 64))
+        if warp_id < 2:
+            self._blockwise_diagonal_32x32_to_64x64(
+                sM_64x64[None, None, warp_id // 2, warp_id // 2], warp_id, lane_id
+            )
+        self.inverse_barrier.arrive_and_wait()
+
+        # sAinv_rm now contains A_inv = (I + M_kk)^{-1} in row-major fp16 layout.
+
+        # Apply beta column-scaling: A_inv[i,j] *= beta[j]  (equivalent to A_inv @ diag(beta))
+        tCsAI = thr_ainv_s2r.partition_S(sAinv_mn_view)
+        tCsAI = tCsAI[None, None, None, ainv_handle.index]
+        tCrAI = cute.make_rmem_tensor_like(tCsAI, self.io_dtype)
+        tCrAI_acc = cute.make_rmem_tensor_like(tCrAI, self.acc_dtype)
+        rBeta = cute.make_rmem_tensor((16,), self.acc_dtype)
+        rBeta = cute.make_tensor(
+            rBeta.iterator,
+            cute.flat_product(cute.make_layout((2,), stride=(0,)), rBeta.layout),
+        )
+        tKKrBeta = thr_ainv_s2r.partition_D(rBeta)
+        for k in cutlass.range(cute.size(tTR_tScS)):
+            coord = tTR_tScS[k]
+            tKKrBeta[k] = sBeta[coord[1], 0, beta_handle.index]
+        cute.copy(
+            tiled_ainv_s2r,
+            tCsAI,
+            tCrAI,
+        )
+
+        tCrAI_acc.store(tCrAI.load().to(self.acc_dtype))
+        for k in cutlass.range(cute.size(tCrAI)):
+            tCrAI_acc[k] = tCrAI_acc[k] * tKKrBeta[k]
+        tCrAI.store(tCrAI_acc.load().to(self.io_dtype))
+        cute.copy(
+            tiled_ainv_r2s,
+            tCrAI,
+            tCsAI,
+        )
+
+        # Fence SMEM writes and signal A_inv ready to MMA warp (GEMM 5 can start)
+        cute.arch.fence_view_async_shared()
+
+        ainv_handle.commit()
+
+        # Release beta pipeline (beta fully consumed by this chunk)
+        beta_handle.release()
+
+        return (  # type: ignore[return-value]
+            load_gate_consumer,
+            load_beta_consumer,
+            shared_acc_consumer,
+            a_inv_ready_producer,
+            qk_ready_producer,
+        )
+
+    # ------------------------------------------------------------------
+    # Hierarchical blockwise inverse helpers (ported from gdn_inverse_verify.py)
+    # Compute X = (I + M)^{-1} for a 128x128 unit lower-triangular matrix in-place
+    # on a row-major fp16 SMEM buffer.  5-stage algorithm:
+    #   Stage 1: Gauss-Jordan inversion of 16 diagonal 8x8 blocks (warp shuffle)
+    #   Stage 2: 8x8 -> 16x16 via warp MMA  (SM80_16x8x8)
+    #   Stage 3: 16x16 -> 32x32 via warp MMA (SM80_16x8x16)
+    #   Stage 4: 32x32 -> 64x64 via warp MMA, 2 warps per 64x64 tile
+    #   Stage 5: 64x64 -> 128x128 via warp MMA, 4 warps on full matrix
+    # ------------------------------------------------------------------
+
+    def _make_acc_tensor_into_a_view(self, acc: cute.Tensor) -> cute.Tensor:
+        """Reinterpret accumulator tensor as an A-operand tensor for the next MMA.
+
+        For SM80_16x8x8 (ratio=1) the layout is unchanged; for SM80_16x8x16 (ratio=2)
+        the C-frag atom size differs from the A-frag atom size and requires a reshape.
+        """
+        acc_layout_divided = cute.logical_divide(acc.layout, (None, None, 2))
+        acc_layout_a = cute.make_layout(
+            (
+                (acc_layout_divided.shape[0], acc_layout_divided.shape[2][0]),
+                acc_layout_divided.shape[1],
+                acc_layout_divided.shape[2][1],
+            ),
+            stride=(
+                (acc_layout_divided.stride[0], acc_layout_divided.stride[2][0]),
+                acc_layout_divided.stride[1],
+                acc_layout_divided.stride[2][1],
+            ),
+        )
+        return cute.make_tensor(acc.iterator, acc_layout_a)
+
+    @cute.jit
+    def _invert_diagonal_NxN(self, mat_NxN, tidx, N: int = 8):
+        """Stage 1: Gauss-Jordan inversion of one diagonal NxN block in-place (fp16 SMEM).
+
+        Each thread owns one row (tidx_in_group = tidx % N).
+        Uses warp shuffle to broadcast pivot values; no __syncthreads inside.
+        N-1 pivot steps, compile-time unrolled.
+        """
+        tidx_in_group = tidx % N
+        row_f16 = cute.make_rmem_tensor((N,), self.io_dtype)
+        cute.autovec_copy(mat_NxN[tidx_in_group, None], row_f16)
+        row = cute.make_rmem_tensor_like(row_f16, self.acc_dtype)
+        row.store(row_f16.load().to(cutlass.Float32))
+        for i in cutlass.range_constexpr(N):
+            row[i] = 1.0 if tidx_in_group == i else row[i]
+        for src_row in cutlass.range_constexpr(N - 1):
+            # Inactive rows use zero scale so adjacent columns can share one
+            # unconditional SM100 FFMA2 without divergent control flow.
+            row_scale = -row[src_row] if tidx_in_group > src_row else 0.0
+            for i in cutlass.range_constexpr(0, src_row - src_row % 2, 2):
+                row_bcast_0 = cute.arch.shuffle_sync(
+                    row[i], src_row, mask=0xFFFFFFFF, mask_and_clamp=0b1100000011111
+                )
+                row_bcast_1 = cute.arch.shuffle_sync(
+                    row[i + 1], src_row, mask=0xFFFFFFFF, mask_and_clamp=0b1100000011111
+                )
+                row[i], row[i + 1] = cute.arch.fma_packed_f32x2(
+                    (row_scale, row_scale),
+                    (row_bcast_0, row_bcast_1),
+                    (row[i], row[i + 1]),
+                )
+            if src_row % 2 == 1:
+                i = src_row - 1
+                row_bcast = cute.arch.shuffle_sync(
+                    row[i], src_row, mask=0xFFFFFFFF, mask_and_clamp=0b1100000011111
+                )
+                row[i] = row[i] + row_scale * row_bcast
+            row[src_row] = row_scale if tidx_in_group > src_row else row[src_row]
+
+        row_f16.store(row.load().to(self.io_dtype))
+        cute.autovec_copy(row_f16, mat_NxN[tidx_in_group, None])
+
+    @cute.jit
+    def _blockwise_diagonal_8x8_to_16x16(self, mat_16x16, lane_id):
+        """Stage 2: off-diagonal correction for one 16x16 diagonal tile (8x8 -> 16x16).
+
+        After Stage 1 each diagonal 8x8 is inverted.  Computes the bottom-left 8x8
+        correction block: C <-- -D^{-1} C A^{-1}.
+        MMA: SM80_16x8x8_F32F16F16F32_TN, single warp.  D^{-1} broadcast 8x8 -> 16x8.
+        """
+        mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
+            self.io_dtype, self.acc_dtype, (16, 8, 8)
+        )
+        tiled_mma = cute.make_tiled_mma(mma_atom, cute.make_layout((1, 1, 1)))
+        thr_mma = tiled_mma.get_slice(lane_id)
+
+        D_tiled_copy = cute.make_tiled_copy_A(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=False),
+                mat_16x16.element_type,
+            ),
+            tiled_mma,
+        )
+        C_tiled_copy = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=True),
+                mat_16x16.element_type,
+            ),
+            tiled_mma,
+        )
+        A_tiled_copy = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=True),
+                mat_16x16.element_type,
+            ),
+            tiled_mma,
+        )
+        O_tiled_copy = cute.make_tiled_copy_C(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=1, transpose=False),
+                mat_16x16.element_type,
+            ),
+            tiled_mma,
+        )
+
+        D_thr_copy = D_tiled_copy.get_slice(lane_id)
+        C_thr_copy = C_tiled_copy.get_slice(lane_id)
+        A_thr_copy = A_tiled_copy.get_slice(lane_id)
+        O_thr_copy = O_tiled_copy.get_slice(lane_id)
+
+        mat_8x8_2x2 = cute.flat_divide(mat_16x16, (8, 8))
+        sDinv = mat_8x8_2x2[None, None, 1, 1]
+        sC = mat_8x8_2x2[None, None, 1, 0]
+        sC = cute.make_tensor(sC.iterator, cute.select(sC.layout, mode=[1, 0]))
+        sAinv = mat_8x8_2x2[None, None, 0, 0]
+        sAinv = cute.make_tensor(sAinv.iterator, cute.select(sAinv.layout, mode=[1, 0]))
+        sO = mat_8x8_2x2[None, None, 1, 0]
+
+        sDinv_m_bcast = cute.make_tensor(
+            sDinv.iterator,
+            cute.logical_product(sDinv.layout, (cute.make_layout((2,), stride=(0,)),)),
+        )
+        sO_m_bcast = cute.make_tensor(
+            sO.iterator,
+            cute.logical_product(sO.layout, (cute.make_layout((2,), stride=(0,)),)),
+        )
+
+        tOrDinv = tiled_mma.make_fragment_A(thr_mma.partition_A(sDinv_m_bcast))
+        tOrC = tiled_mma.make_fragment_B(thr_mma.partition_B(sC))
+        tOrAinv = tiled_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        tDCrDC = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 8)))
+        tOrO = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 8)))
+
+        tOsDinv = D_thr_copy.partition_S(sDinv_m_bcast)
+        tOsDinv = cute.logical_divide(tOsDinv, (tOsDinv.shape[0], None, None))
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOrDinv_cv = cute.logical_divide(tOrDinv_cv, (tOrDinv_cv.shape[0], None, None))
+        tOsC = C_thr_copy.partition_S(sC)
+        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOsAinv = A_thr_copy.partition_S(sAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOsO = O_thr_copy.partition_D(sO_m_bcast)
+        tOsO = cute.logical_divide(tOsO, (tOsO.shape[0], None, None))
+        tOrO_cv = O_thr_copy.retile(tOrO)
+        tOrO_cv = cute.logical_divide(tOrO_cv, (tOrO_cv.shape[0], None, None))
+        cute.copy(
+            D_tiled_copy,
+            tOsDinv[(None, 0), None, None],
+            tOrDinv_cv[(None, 0), None, None],
+        )
+        cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        tDCrDC.fill(0.0)
+        cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
+        tDCrDC.store(-tDCrDC.load())
+
+        tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
+        tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, self.io_dtype)
+        tOrDC.store(tDCrDC_a.load().to(self.io_dtype))
+
+        cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        tOrO.fill(0.0)
+        cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+
+        tOrO_cv_cvt = cute.make_rmem_tensor_like(
+            tOrO_cv[(None, 0), None, None], self.io_dtype
+        )
+        tOrO_cv_cvt.store(tOrO_cv[(None, 0), None, None].load().to(self.io_dtype))
+        cute.copy(O_tiled_copy, tOrO_cv_cvt, tOsO[(None, 0), None, None])
+
+    @cute.jit
+    def _blockwise_diagonal_16x16_to_32x32(self, mat_32x32, lane_id):
+        """Stage 3: off-diagonal correction for one 32x32 diagonal tile (16x16 -> 32x32).
+
+        After Stage 2 each diagonal 16x16 is inverted.  Computes C <-- -D^{-1} C A^{-1}.
+        MMA: SM80_16x8x16_F32F16F16F32_TN, TileShape (16,16,16), single warp.
+        make_acc_into_op ratio=2: A-frag atom size (8) / C-frag atom size (4).
+        """
+        mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
+            self.io_dtype, self.acc_dtype, (16, 8, 16)
+        )
+        tiled_mma = cute.make_tiled_mma(
+            mma_atom, cute.make_layout((1, 1, 1)), permutation_mnk=(16, 16, 16)
+        )
+        thr_mma = tiled_mma.get_slice(lane_id)
+
+        D_tiled_copy = cute.make_tiled_copy_A(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                mat_32x32.element_type,
+            ),
+            tiled_mma,
+        )
+        C_tiled_copy = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                mat_32x32.element_type,
+            ),
+            tiled_mma,
+        )
+        A_tiled_copy = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                mat_32x32.element_type,
+            ),
+            tiled_mma,
+        )
+        O_tiled_copy = cute.make_tiled_copy_C(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                mat_32x32.element_type,
+            ),
+            tiled_mma,
+        )
+
+        D_thr_copy = D_tiled_copy.get_slice(lane_id)
+        C_thr_copy = C_tiled_copy.get_slice(lane_id)
+        A_thr_copy = A_tiled_copy.get_slice(lane_id)
+        O_thr_copy = O_tiled_copy.get_slice(lane_id)
+
+        mat_16x16_2x2 = cute.flat_divide(mat_32x32, (16, 16))
+        sDinv = mat_16x16_2x2[None, None, 1, 1]
+        sC = mat_16x16_2x2[None, None, 1, 0]
+        sC = cute.make_tensor(sC.iterator, cute.select(sC.layout, mode=[1, 0]))
+        sAinv = mat_16x16_2x2[None, None, 0, 0]
+        sAinv = cute.make_tensor(sAinv.iterator, cute.select(sAinv.layout, mode=[1, 0]))
+        sO = mat_16x16_2x2[None, None, 1, 0]
+
+        tOrDinv = tiled_mma.make_fragment_A(thr_mma.partition_A(sDinv))
+        tOrC = tiled_mma.make_fragment_B(thr_mma.partition_B(sC))
+        tOrAinv = tiled_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        tDCrDC = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 16)))
+        tOrO = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 16)))
+
+        tOsDinv = D_thr_copy.partition_S(sDinv)
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOsC = C_thr_copy.partition_S(sC)
+        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOsAinv = A_thr_copy.partition_S(sAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOsO = O_thr_copy.partition_D(sO)
+        tOrO_cv = O_thr_copy.retile(tOrO)
+
+        cute.copy(D_tiled_copy, tOsDinv, tOrDinv_cv)
+        cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        tDCrDC.fill(0.0)
+        cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
+        tDCrDC.store(-tDCrDC.load())
+
+        tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
+        tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, mat_32x32.element_type)
+        tOrDC.store(tDCrDC_a.load().to(mat_32x32.element_type))
+
+        cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        tOrO.fill(0.0)
+        cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+
+        tOrO_cv_cvt = cute.make_rmem_tensor_like(tOrO_cv, mat_32x32.element_type)
+        tOrO_cv_cvt.store(tOrO_cv.load().to(mat_32x32.element_type))
+        cute.copy(O_tiled_copy, tOrO_cv_cvt, tOsO)
+
+    @cute.jit
+    def _blockwise_diagonal_32x32_to_64x64(self, mat_64x64, warp_id, lane_id):
+        """Stage 4: off-diagonal correction for one 64x64 diagonal tile (32x32 -> 64x64).
+
+        4 warps collaborate (warp_id in {0,1,2,3}); x = warp_id//2, y = warp_id%2.
+        MMA: SM80_16x8x16 TileShape (16,32,32), permutation_mnk=(16,32,32).
+        Ends with sync_threads() to protect the sO write from races.
+        """
+        mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
+            self.io_dtype, self.acc_dtype, (16, 8, 16)
+        )
+        tiled_mma = cute.make_tiled_mma(
+            mma_atom, cute.make_layout((1, 1, 1)), permutation_mnk=(16, 32, 32)
+        )
+        thr_mma = tiled_mma.get_slice(lane_id)
+
+        D_tiled_copy = cute.make_tiled_copy_A(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                mat_64x64.element_type,
+            ),
+            tiled_mma,
+        )
+        C_tiled_copy = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                mat_64x64.element_type,
+            ),
+            tiled_mma,
+        )
+        A_tiled_copy = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                mat_64x64.element_type,
+            ),
+            tiled_mma,
+        )
+        O_tiled_copy = cute.make_tiled_copy_C(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                mat_64x64.element_type,
+            ),
+            tiled_mma,
+        )
+
+        D_thr_copy = D_tiled_copy.get_slice(lane_id)
+        C_thr_copy = C_tiled_copy.get_slice(lane_id)
+        A_thr_copy = A_tiled_copy.get_slice(lane_id)
+        O_thr_copy = O_tiled_copy.get_slice(lane_id)
+
+        mat_32x32_2x2 = cute.flat_divide(mat_64x64, (32, 32))
+        sDinv_full = mat_32x32_2x2[None, None, 1, 1]
+        sC_full = mat_32x32_2x2[None, None, 1, 0]
+        sAinv_full = mat_32x32_2x2[None, None, 0, 0]
+
+        sDinv = cute.flat_divide(sDinv_full, (16, 32))[None, None, warp_id % 2, 0]
+        sC = cute.make_tensor(
+            sC_full.iterator, cute.select(sC_full.layout, mode=[1, 0])
+        )
+        sAinv = cute.make_tensor(
+            sAinv_full.iterator, cute.select(sAinv_full.layout, mode=[1, 0])
+        )
+        sO = cute.flat_divide(sC_full, (16, 32))[None, None, warp_id % 2, 0]
+
+        tOrDinv = tiled_mma.make_fragment_A(thr_mma.partition_A(sDinv))
+        tOrC = tiled_mma.make_fragment_B(thr_mma.partition_B(sC))
+        tOrAinv = tiled_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        tDCrDC = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 32)))
+        tOrO = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 32)))
+
+        tOsDinv = D_thr_copy.partition_S(sDinv)
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOsC = C_thr_copy.partition_S(sC)
+        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOsAinv = A_thr_copy.partition_S(sAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOsO = O_thr_copy.partition_D(sO)
+        tOrO_cv = O_thr_copy.retile(tOrO)
+
+        cute.copy(D_tiled_copy, tOsDinv, tOrDinv_cv)
+        cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        tDCrDC.fill(0.0)
+        cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
+        tDCrDC.store(-tDCrDC.load())
+
+        tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
+        tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, mat_64x64.element_type)
+        tOrDC.store(tDCrDC_a.load().to(mat_64x64.element_type))
+
+        cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        tOrO.fill(0.0)
+        cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+
+        tOrO_cv_cvt = cute.make_rmem_tensor_like(tOrO_cv, mat_64x64.element_type)
+        tOrO_cv_cvt.store(tOrO_cv.load().to(mat_64x64.element_type))
+        self.inverse_barrier_inner.arrive_and_wait()
+        cute.copy(O_tiled_copy, tOrO_cv_cvt, tOsO)
+
+    @cute.jit
+    def _state_half_tmem_copies(
+        self, tidx, tmem_ptr, tiled_mma_kv, tiled_mma_qs, half_idx
+    ):
+        state_tidx = tidx % 128
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+        tCtState_mn = self.transform_partitioned_tensor_layout(tCtState)
+        tCtState_half = cute.local_tile(tCtState_mn, (128, 64), (0, half_idx, None))
+        cState_half = cute.local_tile(
+            cute.make_identity_tensor((128, 128)), (128, 64), (0, half_idx)
+        )
+        state_t2r_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(16)), self.acc_dtype
+        )
+        state_r2t_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(16)), self.acc_dtype
+        )
+        tiled_state_t2r = tcgen05.make_tmem_copy(
+            state_t2r_atom, tCtState_half[None, None, 0]
+        )
+        tiled_state_r2t = tcgen05.make_tmem_copy(
+            state_r2t_atom, tCtState_half[None, None, 0]
+        )
+        thr_state_t2r = tiled_state_t2r.get_slice(state_tidx)
+        thr_state_r2t = tiled_state_r2t.get_slice(state_tidx)
+        tTR_tState = thr_state_t2r.partition_S(tCtState_half)
+        tTR_cState = thr_state_t2r.partition_D(cState_half)
+        tRT_tState = thr_state_r2t.partition_D(tCtState_half)
+
+        state_inp_shape = tiled_mma_qs.partition_shape_A(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
+        )
+        tCtStateInp_fake = tiled_mma_qs.make_fragment_A(
+            cute.append(state_inp_shape, self.tmem_state_inp_stages)
+        )
+        tCtStateInp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_state_inp_offset, dtype=self.io_dtype),
+            tCtStateInp_fake.layout,
+        )
+        tCtStateInp_mn = self.transform_partitioned_tensor_layout(tCtStateInp)
+        tCtStateInp_half = cute.local_tile(
+            tCtStateInp_mn, (128, 64), (0, half_idx, None)
+        )
+        cStateInp_half = cute.local_tile(
+            cute.make_identity_tensor((128, 128)), (128, 64), (0, half_idx)
+        )
+        state_inp_r2t_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(8)), self.io_dtype
+        )
+        tiled_state_inp_r2t = tcgen05.make_tmem_copy(
+            state_inp_r2t_atom, tCtStateInp_half[None, None, 0]
+        )
+        thr_state_inp_r2t = tiled_state_inp_r2t.get_slice(state_tidx)
+        tRT_cStateInp = thr_state_inp_r2t.partition_S(cStateInp_half)
+        tRT_tStateInp = thr_state_inp_r2t.partition_D(tCtStateInp_half)
+        return (
+            tiled_state_t2r,
+            tiled_state_r2t,
+            tiled_state_inp_r2t,
+            tTR_tState,
+            tTR_cState,
+            tRT_tState,
+            tRT_cStateInp,
+            tRT_tStateInp,
+        )
+
+    @cute.jit
+    def _initialize_state_half(
+        self,
+        tidx,
+        mS_init,
+        head_idx,
+        batch_idx,
+        tmem_ptr,
+        tiled_mma_kv,
+        tiled_mma_qs,
+        rState,
+        half_idx,
+    ):
+        (
+            _,
+            tiled_state_r2t,
+            _,
+            _,
+            tTR_cState,
+            _,
+            _,
+            _,
+        ) = self._state_half_tmem_copies(
+            tidx, tmem_ptr, tiled_mma_kv, tiled_mma_qs, half_idx
+        )
+        if cutlass.const_expr(self.use_initial_state):
+            thr_state_r2t = tiled_state_r2t.get_slice(tidx % 128)
+            gState = cute.local_tile(
+                mS_init[None, None, head_idx, batch_idx], (128, 64), (0, half_idx)
+            )
+            tRgState = thr_state_r2t.partition_S(gState)
+            rStateG = cute.make_rmem_tensor_like(tTR_cState, self.state_dtype)
+            for sub in cutlass.range(rState.shape[2]):
+                cute.autovec_copy(tRgState[None, 0, sub], rStateG[None, 0, sub])
+                rState[None, 0, sub].store(
+                    rStateG[None, 0, sub].load().to(self.acc_dtype)
+                )
+        else:
+            rState.fill(0.0)
+
+    @cute.jit
+    def _store_state_half(
+        self,
+        tidx,
+        mS_out,
+        mS_checkpoints,
+        head_idx,
+        batch_idx,
+        checkpoint_offset,
+        checkpoint_every_n_tokens,
+        seqlen_b,
+        tmem_ptr,
+        tiled_mma_kv,
+        tiled_mma_qs,
+        rState,
+        half_idx,
+    ):
+        (
+            tiled_state_t2r,
+            _,
+            _,
+            _,
+            tTR_cState,
+            _,
+            _,
+            _,
+        ) = self._state_half_tmem_copies(
+            tidx, tmem_ptr, tiled_mma_kv, tiled_mma_qs, half_idx
+        )
+        thr_state_t2r = tiled_state_t2r.get_slice(tidx % 128)
+        rStateG = cute.make_rmem_tensor_like(tTR_cState, self.state_dtype)
+        if cutlass.const_expr(self.state_dtype != self.acc_dtype):
+            rStateG.store(rState.load().to(self.state_dtype))
+        else:
+            rStateG = rState
+
+        if cutlass.const_expr(self.enable_checkpoints):
+            if seqlen_b % checkpoint_every_n_tokens == 0:
+                gCheckpoint = cute.make_tensor(
+                    mS_checkpoints[None, None, head_idx, checkpoint_offset].iterator,
+                    cute.make_ordered_layout((128, 128), order=(1, 0)),
+                )
+                gCheckpoint = cute.local_tile(gCheckpoint, (128, 64), (0, half_idx))
+                tSgCheckpoint = thr_state_t2r.partition_D(gCheckpoint)
+                for sub in cutlass.range(rStateG.shape[2]):
+                    cute.autovec_copy(
+                        rStateG[None, 0, sub],
+                        tSgCheckpoint[None, 0, sub],
+                        l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                    )
+        if cutlass.const_expr(self.store_final_state):
+            gState = cute.local_tile(
+                mS_out[None, None, head_idx, batch_idx], (128, 64), (0, half_idx)
+            )
+            tSgState = thr_state_t2r.partition_D(gState)
+            for sub in cutlass.range(rStateG.shape[2]):
+                cute.autovec_copy(
+                    rStateG[None, 0, sub],
+                    tSgState[None, 0, sub],
+                    l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                )
+
+    @cute.jit
+    def compute_state_group(
+        self,
+        tidx: cutlass.Int32,
+        tmem_ptr: cutlass.Int64,
+        rState: cute.Tensor,
+        mma_args: tuple,
+        smem_args: tuple,
+        checkpoint_args: tuple,
+        pipeline_args: tuple,
+        work_args: tuple,
+        half_idx,
+    ):
+        """Maintain one State half and process the corresponding token-feature half."""
+        sV, sCumsumlog, sCumprod, sCumprodScale, sBeta, sO = smem_args
+        mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens = checkpoint_args
+        (
+            load_v_consumer,
+            load_gate_consumer,
+            shared_acc_consumer,
+            kv_acc_consumer,
+            q_state_acc_consumer,
+            kv_acc_producer,
+            state_inp_ready_producer,
+            shared_inp_ready_producer,
+            o_store_producer,
+        ) = pipeline_args
+        tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv = mma_args
+        (is_first_chunk, chunk_idx, head_idx) = work_args
+
+        num_threads_state_group = self.threads_per_warp * len(
+            self.compute_group_1_warp_ids
+        )
+        state_group_tidx = tidx % num_threads_state_group
+
+        # -- State half (V x K view, split along K) --------------------------
+        (
+            tiled_state_t2r,
+            tiled_state_r2t,
+            tiled_state_inp_r2t,
+            tTR_tCtState,
+            tTR_tCcState,
+            tRT_tCtState,
+            tRT_tCcState_inp,
+            tRT_tCtState_inp,
+        ) = self._state_half_tmem_copies(
+            tidx, tmem_ptr, tiled_mma_kv, tiled_mma_qs, half_idx
+        )
+        thr_state_t2r = tiled_state_t2r.get_slice(state_group_tidx)
+        tTR_rState = rState
+        tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
+
+        # -- Shared acc TMEM tensor (BTxDV, layout from tiled_mma_qkv) ----------
+        # Needed for the G3 K*S and G5 new-V pipeline slots.
+        # qkv_epilogue reads O_intra from q_state TMEM, not from this buffer.
+        qkv_acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtShared_fake = tiled_mma_qkv.make_fragment_C(qkv_acc_shape)
+        tCtShared = cute.make_tensor(
+            tmem_ptr + self.tmem_state_acc_offset,
+            cute.flat_product(
+                tCtShared_fake.layout, cute.make_layout((self.tmem_state_acc_stages,))
+            ),
+        )
+        tCtShared_mn_view = self.transform_partitioned_tensor_layout(tCtShared)
+        tCcShared = cute.make_identity_tensor(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        atom_shared_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_shared_t2r = tcgen05.make_tmem_copy(
+            atom_shared_t2r, tCtShared[(None, None), 0, 0, 0]
+        )
+        thr_shared_t2r = tiled_shared_t2r.get_slice(state_group_tidx)
+        tTR_tCtShared = thr_shared_t2r.partition_S(tCtShared_mn_view)
+        tTR_tCcShared = thr_shared_t2r.partition_D(tCcShared)
+
+        qkv_inp_shape = tiled_mma_qkv.partition_shape_A(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
+        )
+        tCtShared_inp_fake = tiled_mma_qkv.make_fragment_A(
+            cute.append(qkv_inp_shape, self.tmem_shared_inp_stages)
+        )
+        tCtShared_inp = cute.make_tensor(
+            cute.recast_ptr(
+                tmem_ptr + self.tmem_shared_inp_offset, dtype=self.io_dtype
+            ),
+            tCtShared_inp_fake.layout,
+        )
+        tCtShared_inp_mn_view = self.transform_partitioned_tensor_layout(tCtShared_inp)
+        tCcShared_inp = cute.make_identity_tensor(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
+        )
+        atom_shared_inp_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x128bOp(tcgen05.copy.Repetition(8)), self.io_dtype
+        )
+        tiled_shared_inp_r2t = tcgen05.make_tmem_copy(
+            atom_shared_inp_r2t, tCtShared_inp_mn_view[None, None, 0]
+        )
+        thr_shared_inp_r2t = tiled_shared_inp_r2t.get_slice(state_group_tidx)
+        tRT_tCcShared_inp = thr_shared_inp_r2t.partition_S(tCcShared_inp)
+        tRT_tCtShared_inp = thr_shared_inp_r2t.partition_D(tCtShared_inp_mn_view)
+        tRT_rShared_inp = cute.make_rmem_tensor_like(tRT_tCcShared_inp, self.io_dtype)  # noqa: F841
+
+        # -- Q-state TMEM tensor (BTxDV, layout from tiled_mma_qs) --------------
+        # Used by state*q_epi (scale Q*S result) and qkv_epilogue (read final O).
+        qs_acc_shape = tiled_mma_qs.partition_shape_C(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
+        )
+        tCtQState_fake = tiled_mma_qs.make_fragment_C(
+            cute.append(qs_acc_shape, self.tmem_q_state_acc_stages)
+        )
+        tCtQState = cute.make_tensor(
+            tmem_ptr + self.tmem_q_state_offset, tCtQState_fake.layout
+        )
+        tCtQState_mn_view = self.transform_partitioned_tensor_layout(tCtQState)
+        tCcQState = cute.make_identity_tensor(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
+        )
+        atom_qs_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        atom_qs_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_qs_t2r = tcgen05.make_tmem_copy(
+            atom_qs_t2r, tCtQState[(None, None), 0, 0, 0]
+        )
+        tiled_qs_r2t = tcgen05.make_tmem_copy(
+            atom_qs_r2t, tCtQState[(None, None), 0, 0, 0]
+        )
+        thr_qs_t2r = tiled_qs_t2r.get_slice(state_group_tidx)
+        thr_qs_r2t = tiled_qs_r2t.get_slice(state_group_tidx)
+        tTR_tCtQS = thr_qs_t2r.partition_S(tCtQState_mn_view)
+        tTR_tCcQS = thr_qs_t2r.partition_D(tCcQState)
+        tRT_tCtQS = thr_qs_r2t.partition_D(tCtQState_mn_view)
+        # -- SMEM V tiled copy: sV has domain (DV, BT) ----------------------
+        tRT_tCcV = thr_shared_inp_r2t.partition_S(tCcShared_inp)
+        atom_v_s2r = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+            self.io_dtype,
+        )
+        tiled_v_s2r = cute.make_tiled_copy_S(atom_v_s2r, tiled_shared_inp_r2t)
+        thr_v_s2r = tiled_v_s2r.get_slice(state_group_tidx)
+        sV_vt_view = self.transform_partitioned_tensor_layout(sV)
+        tCsV = thr_v_s2r.partition_S(sV_vt_view)
+
+        # -- SMEM store: fp32 TMEM (tiled_mma_qs layout) -> fp16 sO --
+        # Used by qkv_epilogue to write final O result.
+        atom_o_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(4)), self.acc_dtype
+        )
+        tCtQState_o = cute.local_tile(tCtQState_mn_view, (128, 32), (0, half_idx, None))
+        tCcQState_o = cute.local_tile(
+            cute.make_identity_tensor((128, 64)), (128, 32), (0, half_idx)
+        )
+        sO_half = cute.local_tile(sO, (128, 32), (0, half_idx, None))
+        tiled_o_t2r = tcgen05.make_tmem_copy(atom_o_t2r, tCtQState_o[None, None, 0])
+        thr_o_t2r = tiled_o_t2r.get_slice(state_group_tidx)
+        tTR_tOtO = thr_o_t2r.partition_S(tCtQState_o)
+        tTR_tOcO = thr_o_t2r.partition_D(tCcQState_o)
+        atom_o_r2s = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=2, transpose=True),
+            self.io_dtype,
+        )
+        tiled_o_r2s = cute.make_tiled_copy_D(atom_o_r2s, tiled_o_t2r)
+        thr_o_r2s = tiled_o_r2s.get_slice(state_group_tidx)
+        tCsO = thr_o_r2s.partition_D(sO_half)
+
+        token_half_size = cute.size(tTR_tCcShared, mode=[0])
+        state_sub_tile_size = cute.size(tTR_rState, mode=[0])
+
+        gate_handle = load_gate_consumer.wait_and_advance()
+
+        cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_handle.index]
+
+        valid_state = not is_first_chunk or self.use_initial_state
+        if cutlass.const_expr(valid_state):
+            state_inp_ready_handle = state_inp_ready_producer.acquire_and_advance()
+            tRT_rState_inp = cute.make_rmem_tensor_like(
+                tRT_tCcState_inp[None, 0, 0], self.io_dtype
+            )
+            for sub in cutlass.range(tRT_tCcState_inp.shape[2]):
+                if cutlass.const_expr(self.enable_checkpoints and not is_first_chunk):
+                    if (self.b_t * chunk_idx) % checkpoint_every_n_tokens == 0:
+                        gS_checkpoints = cute.make_tensor(
+                            mS_checkpoints[
+                                None, None, head_idx, checkpoint_offset
+                            ].iterator,
+                            cute.make_ordered_layout(
+                                (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+                                order=(1, 0),
+                            ),
+                        )
+                        gS_checkpoints = cute.local_tile(
+                            gS_checkpoints, (128, 64), (0, half_idx)
+                        )
+                        tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
+                        if cutlass.const_expr(self.state_dtype != self.acc_dtype):
+                            tRG_rState[None, 0, sub].store(
+                                tTR_rState[None, 0, sub].load().to(self.state_dtype)
+                            )
+                        else:
+                            tRG_rState = tTR_rState
+                        cute.autovec_copy(
+                            tRG_rState[None, 0, sub],
+                            tSgCheckpoints[None, 0, sub],
+                            l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                        )
+
+                tRT_rState_inp.store(tTR_rState[None, 0, sub].load().to(self.io_dtype))
+                cute.copy(
+                    tiled_state_inp_r2t,
+                    tRT_rState_inp,
+                    tRT_tCtState_inp[None, 0, sub, state_inp_ready_handle.index],
+                )
+            cute.arch.fence_view_async_tmem_store()
+            state_inp_ready_handle.commit()
+
+            # Keep the recurrent state in registers and apply the block decay in place.
+            for sub in cutlass.range(tTR_rState.shape[2]):
+                for k in cutlass.range(state_sub_tile_size, vectorize=True):
+                    tTR_rState[k, 0, sub] = tTR_rState[k, 0, sub] * cumprod_total
+            if cutlass.const_expr(self.enable_checkpoints and not is_first_chunk):
+                if (self.b_t * chunk_idx) % checkpoint_every_n_tokens == 0:
+                    checkpoint_offset += 1
+            cute.arch.fence_view_async_tmem_store()
+        tTR_cShared_half = tTR_tCcShared[None, half_idx, 0]
+        rCumprod = cute.make_rmem_tensor_like(tTR_cShared_half, self.acc_dtype)
+        for k in cutlass.range(token_half_size, unroll_full=True):
+            coord = tTR_cShared_half[k]
+            rCumprod[k] = sCumprod[coord[1], 0, gate_handle.index]
+        # ---- v - k*state  (ALU) -----------------------------------------------
+        # delta[bt, dv] = V[bt, dv] - (K*S)[bt, dv]
+        # Beta is fused into A_beta in CG0; no beta scaling here.
+        # Write fp16 delta to sV (GEMM 5 via v_ks_ready) and sStateDv (GEMM 7 via decay_v_ready).
+        vks_handle = shared_inp_ready_producer.acquire_and_advance()
+        v_handle = load_v_consumer.wait_and_advance()
+
+        if cutlass.const_expr(valid_state):
+            ks_acc_handle = shared_acc_consumer.wait_and_advance()
+            # State input aliases shared input. Wait for G4 to release it before
+            # publishing delta for G5.
+            state_inp_ready_producer.acquire()
+            tTR_rKS = cute.make_rmem_tensor_like(tTR_cShared_half, self.acc_dtype)
+            tRT_rV_half = cute.make_rmem_tensor_like(
+                tRT_tCcV[None, half_idx, 0], self.io_dtype
+            )
+            # Retile expects the full logical destination. Broadcast the half-sized storage over the
+            # feature-half and singleton modes, then copy only the half owned by this State group.
+            tRT_rV_cv = cute.make_tensor(
+                tRT_rV_half.iterator,
+                cute.append(
+                    cute.append(
+                        tRT_rV_half.layout, cute.make_layout((2,), stride=(0,))
+                    ),
+                    cute.make_layout((1,), stride=(0,)),
+                ),
+            )
+            tCrV = tiled_v_s2r.retile(tRT_rV_cv)
+            if cutlass.const_expr(self.order_state_groups):
+                self._state_order_wait(half_idx)
+            cute.copy(
+                tiled_v_s2r,
+                tCsV[None, half_idx, 0, v_handle.index],
+                tCrV[None, half_idx, 0],
+            )
+            cute.copy(
+                tiled_shared_t2r,
+                tTR_tCtShared[None, half_idx, 0, ks_acc_handle.index],
+                tTR_rKS,
+            )
+            if cutlass.const_expr(self.order_state_groups):
+                self._state_order_notify(half_idx)
+            for k in cutlass.range(token_half_size, vectorize=True):
+                tTR_rKS[k] = tTR_rKS[k] * rCumprod[k]
+                tRT_rV_half[k] = tRT_rV_half[k] - tTR_rKS[k].to(self.io_dtype)
+            cute.copy(
+                tiled_shared_inp_r2t,
+                tRT_rV_half,
+                tRT_tCtShared_inp[None, half_idx, 0, vks_handle.index],
+            )
+            cute.arch.fence_view_async_tmem_store()
+            ks_acc_handle.release()
+        vks_handle.commit()
+
+        # ---- state*q_epi (ALU) ------------------------------------------------
+        # Scale Q*S_prev cross-chunk contribution: QS[bt, *] *= cumprod[bt]
+        # Write scaled result back to same q_state TMEM slot so GEMM 6 accumulates on top.
+        if cutlass.const_expr(valid_state):
+            qs_handle = q_state_acc_consumer.wait_and_advance()
+            tTR_rQS = cute.make_rmem_tensor_like(
+                tTR_tCcQS[None, half_idx, 0], self.acc_dtype
+            )
+            for k in cutlass.range(token_half_size, unroll_full=True):
+                coord = tTR_cShared_half[k]
+                rCumprod[k] = sCumprodScale[coord[1], 0, gate_handle.index]
+            cute.copy(
+                tiled_qs_t2r,
+                tTR_tCtQS[None, half_idx, 0, qs_handle.index],
+                tTR_rQS,
+            )
+            for k in cutlass.range(token_half_size, vectorize=True):
+                tTR_rQS[k] = tTR_rQS[k] * rCumprod[k]
+            cute.copy(
+                tiled_qs_r2t,
+                tTR_rQS,
+                tRT_tCtQS[None, half_idx, 0, qs_handle.index],
+            )
+            cute.arch.fence_view_async_tmem_store()
+
+            qs_handle.release()
+        rDecayScale = cute.make_rmem_tensor_like(tTR_cShared_half, self.acc_dtype)
+        last_cumsumlog = sCumsumlog[self.b_t - 1, 0, gate_handle.index]
+        for k in cutlass.range(token_half_size, unroll_full=True):
+            coord = tTR_cShared_half[k]
+            rDecayScale[k] = cute.math.exp2(
+                last_cumsumlog - sCumsumlog[coord[1], 0, gate_handle.index],
+                fastmath=True,
+            )
+        gate_handle.release()
+
+        # ---- new_v_epi --------------------------------------------------------
+        # NV = A_inv @ delta (GEMM 5 result) in shared_acc TMEM; fp32 -> fp16 -> sAinvNv.
+        nv_handle = shared_acc_consumer.wait_and_advance()
+        v_handle.release()
+        nv_ready_handle = shared_inp_ready_producer.acquire_and_advance()
+
+        tTR_rNv = cute.make_rmem_tensor_like(tTR_cShared_half, self.acc_dtype)
+        tTR_rNv_inp = cute.make_rmem_tensor_like(tTR_rNv, self.io_dtype)
+        cute.copy(
+            tiled_shared_t2r,
+            tTR_tCtShared[None, half_idx, 0, nv_handle.index],
+            tTR_rNv,
+        )
+        tTR_rNv_inp.store(tTR_rNv.load().to(self.io_dtype))
+        cute.copy(
+            tiled_shared_inp_r2t,
+            tTR_rNv_inp,
+            tRT_tCtShared_inp[None, half_idx, 0, nv_ready_handle.index],
+        )
+        cute.arch.fence_view_async_tmem_store()
+        nv_handle.release()
+        nv_ready_handle.commit()
+
+        # Write decay_scale * delta to sStateDv -> GEMM 7 B-operand
+        # -- kv_decay_v: S_prev *= Phi = exp(cumsumlog[BT-1]) ------------------
+        # Always wait for gate (collective barrier shared with CG0).
+        decay_v_handle = shared_inp_ready_producer.acquire_and_advance()
+        tTR_rDv = tTR_rNv
+        tRT_rDv_inp = cute.make_rmem_tensor_like(tTR_rDv, self.io_dtype)
+        for k in cutlass.range(token_half_size, vectorize=True):
+            tTR_rDv[k] = tTR_rDv[k] * rDecayScale[k]
+        tRT_rDv_inp.store(tTR_rDv.load().to(self.io_dtype))
+        cute.copy(
+            tiled_shared_inp_r2t,
+            tRT_rDv_inp,
+            tRT_tCtShared_inp[None, half_idx, 0, decay_v_handle.index],
+        )
+        cute.arch.fence_view_async_tmem_store()
+        decay_v_handle.commit()
+
+        # ---- qkv_epilogue -----------------------------------------------------
+        # GEMM 6 accumulated W_qkv@NV into q_state TMEM on top of the scaled Q*S.
+        # q_state_acc second wait (same 1-stage pipeline, wraps back to stage 0).
+        qs_handle2 = q_state_acc_consumer.wait_and_advance()
+        o_handle = o_store_producer.acquire_and_advance()
+        tTR_tOrO = cute.make_rmem_tensor_like(tTR_tOcO, self.acc_dtype)
+        tTR_rO_out = cute.make_rmem_tensor_like(tTR_tOrO, self.io_dtype)
+        tRS_tOrO = tiled_o_r2s.retile(tTR_rO_out)
+        cute.copy(
+            tiled_o_t2r,
+            tTR_tOtO[None, None, None, qs_handle2.index],
+            tTR_tOrO,
+        )
+        tTR_rO_out.store(tTR_tOrO.load().to(self.io_dtype))
+        cute.copy(tiled_o_r2s, tRS_tOrO, tCsO[None, None, None, o_handle.index])
+        cute.arch.fence_view_async_shared()
+        o_handle.commit()
+        qs_handle2.release()
+
+        # ---- kv_update_epi ----------------------------------------------------
+        # Add the current chunk's state increment to the register-resident state.
+        kv_handle = kv_acc_consumer.wait_and_advance()
+        tTR_rStateInc = cute.make_rmem_tensor_like(
+            tTR_tCcState[None, 0, 0], self.acc_dtype
+        )
+        for sub in cutlass.range(tTR_rState.shape[2]):
+            cute.copy(
+                tiled_state_t2r,
+                tTR_tCtState[None, 0, sub, kv_handle.index],
+                tTR_rStateInc,
+            )
+            for k in cutlass.range(state_sub_tile_size, vectorize=True):
+                tTR_rState[k, 0, sub] = tTR_rState[k, 0, sub] + tTR_rStateInc[k]
+        kv_handle.release()
+        return (  # type: ignore[return-value]
+            load_v_consumer,
+            load_gate_consumer,
+            shared_acc_consumer,
+            kv_acc_consumer,
+            q_state_acc_consumer,
+            kv_acc_producer,
+            state_inp_ready_producer,
+            shared_inp_ready_producer,
+            o_store_producer,
+            checkpoint_offset,
+            tTR_rState,
+        )
+
+    @cute.jit
+    def epilogue_warp(
+        self,
+        smem_args,
+        tma_args,
+        pipeline_args,
+        work_args,
+        tensormap_args,
+    ) -> pipeline.PipelineConsumer:
+        """Warp 15: TMA bulk-store O from SMEM staging buffer to global memory.
+
+        Steps:
+          1. Wait for both State groups to signal O is ready in sO.
+          2. Domain-offset the TMA tensor to (chunk_offset, head_idx), flat-divide
+             into tiles, tma_partition -> (tOsO, tOgO).
+          3. Issue TMA S2G bulk copy using the per-work-tile updated descriptor.
+          4. Commit the async group and wait for the store to land in GMEM.
+          5. Release the pipeline slot back to both State groups.
+        """
+        (sO,) = smem_args
+        (tma_o,) = tma_args
+        (o_store_consumer,) = pipeline_args
+        head_idx, chunk_offset = work_args
+        tensormap_manager, tensormap_o_ptr = tensormap_args
+
+        o_handle = o_store_consumer.wait_and_advance()
+
+        cta_layout = cute.make_layout(1)
+        # (BT, DV)
+        o_tile = cute.select(self.mma_tiler_qkv, mode=[0, 1])
+
+        # Position global O tile at current chunk / head
+        mO = cute.domain_offset(
+            (cutlass.Int32(0), chunk_offset),
+            tma_o.tma_tensor[None, None, head_idx],
+        )
+        # (BT, DV, num_o_tiles, ...)
+        gO = cute.flat_divide(mO, o_tile)
+
+        # TMA partition: tOsO = SMEM source, tOgO = GMEM destination
+        tOsO, tOgO = cpasync.tma_partition(
+            tma_o.atom,
+            0,
+            cta_layout,
+            cute.group_modes(sO, 0, 2),
+            cute.group_modes(gO, 0, 2),
+        )
+
+        # TMA bulk store SMEM -> GMEM using the descriptor updated per work tile
+        cute.copy(
+            tma_o.atom,
+            tOsO[(None, o_handle.index)],
+            tOgO[(None, 0, 0)],
+            tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                tensormap_o_ptr, cute.AddressSpace.generic
+            ),
+        )
+
+        # Wait for the store to complete before releasing the SMEM slot
+        cute.arch.cp_async_bulk_commit_group()
+        cute.arch.cp_async_bulk_wait_group(0)
+
+        o_handle.release()
+
+        return o_store_consumer
+
+    def transform_partitioned_tensor_layout(self, tensor: cute.Tensor) -> cute.Tensor:
+        """
+        Transform MMA layout from ((MMA_ATOM_M, MMA_ATOM_N), MMA_M, MMA_N, ...rest)
+        to ((MMA_ATOM_M, MMA_M), (MMA_ATOM_N, MMA_N), ...rest).
+
+        This groups MMA_ATOM_M with MMA_M and MMA_ATOM_N with MMA_N.
+
+        :param tensor: Input tensor with layout ((MMA_ATOM_M, MMA_ATOM_N), MMA_M, MMA_N, ...rest)
+        :type tensor: cute.Tensor
+        :return: Transformed tensor with layout ((MMA_ATOM_M, MMA_M), (MMA_ATOM_N, MMA_N), ...rest)
+        :rtype: cute.Tensor
+        """
+        layout = tensor.layout
+        # Save original layout in case it is a composed layout
+        stored_layout = layout
+
+        if isinstance(stored_layout, cute.ComposedLayout):
+            # For composed layouts, we only modify the outer layout
+            layout = layout.outer
+
+        shape = layout.shape
+        stride = layout.stride
+
+        # Build new shape: ((shape[0][0], shape[1]), (shape[0][1], shape[2]), ...rest)
+        new_shape = ((shape[0][0], shape[1]), (shape[0][1], shape[2]), *shape[3:])
+
+        # Build new stride: ((stride[0][0], stride[1]), (stride[0][1], stride[2]), ...rest)
+        new_stride = ((stride[0][0], stride[1]), (stride[0][1], stride[2]), *stride[3:])
+
+        new_layout = cute.make_layout(shape=new_shape, stride=new_stride)
+
+        if isinstance(stored_layout, cute.ComposedLayout):
+            # Recreate the composed layout
+            new_layout = cute.make_composed_layout(
+                stored_layout.inner, stored_layout.offset, new_layout
+            )
+
+        return cute.make_tensor(tensor.iterator, new_layout)
+
+    @cute.jit
+    def _transform_to_position_independent_layout(
+        self, tensor: cute.Tensor, swizzle_inner: cute.Swizzle
+    ) -> cute.Tensor:
+        wo_swizzle_iter = cute.recast_ptr(tensor.iterator, swizzle_=None)
+        pisl_swizzle_base = int(math.log2(self.io_dtype.width)) - 1
+        pisl_swizzle = cute.make_swizzle(
+            swizzle_inner.num_bits, pisl_swizzle_base, swizzle_inner.num_shift
+        )
+        tensor_pisl = cute.make_composed_layout(pisl_swizzle, 0, tensor.layout)
+        return cute.make_tensor(wo_swizzle_iter, tensor_pisl)
+
+    @staticmethod
+    def get_workspace_size(num_sm: int, B: int, HQ: int, HV: int, is_persistent: bool):
+        # q, k, v, o
+        if is_persistent:
+            return (
+                GatedDeltaNetChunkedSm90PipelineKernel.bytes_per_tensormap
+                * GatedDeltaNetChunkedSm90PipelineKernel.num_tensormaps
+                * num_sm
+            )
+        HO = HQ if HQ >= HV else HV
+        return (
+            GatedDeltaNetChunkedSm90PipelineKernel.bytes_per_tensormap
+            * GatedDeltaNetChunkedSm90PipelineKernel.num_tensormaps
+            * (B * HO)
+        )
+
+    @cute.jit
+    def initialize_workspace(
+        self, workspace: cute.Tensor, grid_dim: Tuple[int, int, int]
+    ):
+        workspace = cute.make_tensor(
+            workspace.iterator,
+            cute.make_layout(
+                (
+                    grid_dim[0] * grid_dim[1] * grid_dim[2],
+                    GatedDeltaNetChunkedSm90PipelineKernel.num_tensormaps,
+                    GatedDeltaNetChunkedSm90PipelineKernel.bytes_per_tensormap,
+                ),
+                stride=(
+                    GatedDeltaNetChunkedSm90PipelineKernel.num_tensormaps
+                    * GatedDeltaNetChunkedSm90PipelineKernel.bytes_per_tensormap,
+                    GatedDeltaNetChunkedSm90PipelineKernel.bytes_per_tensormap,
+                    1,
+                ),
+            ),
+        )
+        return workspace

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -26,7 +26,8 @@ State layout: ``[N, H, V, K]``.
 """
 
 import functools
-from typing import Optional
+import os
+from typing import Any, Optional
 
 import torch
 
@@ -38,6 +39,9 @@ from cutlass.cute.runtime import from_dlpack
 from flashinfer.cute_dsl.utils import get_num_sm
 
 from .gated_delta_net_chunked import GatedDeltaNetChunkedKernel
+from .gated_delta_net_chunked_sm90_pipeline import (
+    GatedDeltaNetChunkedSm90PipelineKernel,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -57,6 +61,8 @@ def _get_compiled_cache(
     use_initial_state: bool,
     store_final_state: bool,
     enable_checkpoints: bool,
+    pipeline_variant: str,
+    order_state_groups: bool,
 ):
     """Return a mutable dict that lazily stores the compiled kernel."""
     return {}
@@ -138,6 +144,17 @@ def chunk_gated_delta_rule_sm100(
     store_final_state = output_state is not None
     enable_checkpoints = checkpoint_every_n_tokens > 0
     io_dtype = _cutlass_io_dtype(q.dtype)
+    pipeline_variant = os.environ.get("FLASHINFER_GDN_SM100_PIPELINE", "native")
+    kernel_cls: Any
+    if pipeline_variant == "native":
+        kernel_cls = GatedDeltaNetChunkedKernel
+    elif pipeline_variant == "sm90":
+        kernel_cls = GatedDeltaNetChunkedSm90PipelineKernel
+    else:
+        raise ValueError(
+            "FLASHINFER_GDN_SM100_PIPELINE must be 'native' or 'sm90', "
+            f"got {pipeline_variant!r}"
+        )
 
     # Auto-detect state dtype from initial_state, default to float32
     if initial_state is not None:
@@ -151,6 +168,11 @@ def chunk_gated_delta_rule_sm100(
     _initial_state = initial_state if use_initial_state else None
     B = cu_seqlens.size(0) - 1
     _output_state = output_state if store_final_state else None
+    num_sm = get_num_sm(q.device)
+    num_work_tiles = B * (HQ if is_GQA else HV)
+    # The ordered State groups help when every CTA owns exactly one recurrent
+    # work tile. Sparse or multi-wave grids retain the original barrier-free body.
+    order_state_groups = pipeline_variant == "sm90" and num_work_tiles == num_sm
 
     cache = _get_compiled_cache(
         str(q.dtype),
@@ -161,14 +183,15 @@ def chunk_gated_delta_rule_sm100(
         use_initial_state,
         store_final_state,
         enable_checkpoints,
+        pipeline_variant,
+        order_state_groups,
     )
 
     if "compiled" not in cache:
         # --- First call: compile the kernel ---
-        num_sm = get_num_sm(q.device)
         max_active_clusters = num_sm
 
-        gdn = GatedDeltaNetChunkedKernel(
+        kernel_kwargs = dict(
             io_dtype=io_dtype,
             acc_dtype=cutlass.Float32,
             state_dtype=state_dtype,
@@ -184,6 +207,9 @@ def chunk_gated_delta_rule_sm100(
             enable_checkpoints=enable_checkpoints,
             is_persistent=True,
         )
+        if pipeline_variant == "sm90":
+            kernel_kwargs["order_state_groups"] = order_state_groups
+        gdn = kernel_cls(**kernel_kwargs)
 
         # Convert PyTorch tensors to CuTe tensors for compilation.
         # Token dimension (dim 0) must be dynamic to handle varying seq lengths.
@@ -239,9 +265,7 @@ def chunk_gated_delta_rule_sm100(
                 cu_checkpoints, assumed_align=4
             ).mark_layout_dynamic()
 
-        workspace_size = GatedDeltaNetChunkedKernel.get_workspace_size(
-            num_sm, B, HQ, HV, True
-        )
+        workspace_size = kernel_cls.get_workspace_size(num_sm, B, HQ, HV, True)
         workspace = torch.empty(workspace_size, dtype=torch.int8, device=q.device)
         workspace_cute = from_dlpack(workspace, assumed_align=16)
 
@@ -269,14 +293,14 @@ def chunk_gated_delta_rule_sm100(
 
         cache["compiled"] = compiled
         cache["num_sm"] = num_sm
+        cache["kernel_cls"] = kernel_cls
 
     # --- Execute ---
     compiled = cache["compiled"]
     num_sm = cache["num_sm"]
+    kernel_cls = cache["kernel_cls"]
 
-    workspace_size = GatedDeltaNetChunkedKernel.get_workspace_size(
-        num_sm, B, HQ, HV, True
-    )
+    workspace_size = kernel_cls.get_workspace_size(num_sm, B, HQ, HV, True)
     ws_key = f"workspace_{q.device.index}"
     if ws_key not in cache or cache[ws_key].size(0) < workspace_size:
         cache[ws_key] = torch.empty(workspace_size, dtype=torch.int8, device=q.device)


### PR DESCRIPTION
## 📌 Description

This PR introduce a new GDN pipeline for SM100. This design is not targeting for merging at the moment.

It is a largely "replicated" sm90 pipeline on sm100, HGMMA REG inputs are substitued with UTCMMA TMEM inputs, as follows

```
1. CG_aux, WG0

tKK = mma(sK, sK)
tQK = mma(sQ, sK)
tKK -> rKK, mask(rKK) -> sKK, sKK = beta(inv(sKK)) NOTE: T is sKK, aka, share buffer
tQK -> rQK, mask(rQK) -> sQK

single tKK and tQK, double buffer sKK and sQK buffer

2. CG_state, WG1+WG2, State accumulator in reg

tSK = mma(tState_opd, K), initial iter special
tO = mma(tState_opd, Q)
tSK -> rSK, sV -> rV, rV-rSK -> tV, or sV is TMEM pressure, tV allows us to release sV early.
tNewV = mma(tV, sKK)
tO += mma(NewV, sQK)
decay -> tState_acc, NOTE: this can be moved to much earlier part, we needs more experiments to properly place it.
tNewV -> rNewV, decay(rNewV) -> tNewV
tState_inc = mma(tNewV, sK)
tState_inc -> rState_inc, rState_acc += rState_inc
rState_acc -> tState_opd, if has next iter.

tState_opd and tState_inc share the same TMEM buffer, because they cannot present simutaneously.

3. other, 1WG

w0: CG_aux   UTCMMA issuer, in MMA order
w1: CG_state UTCMMA issuer, in MMA order
w2: K/Q/V, beta, alpah loader
w3: O store

(in V x K view)
WG1 for left part of State 
WG2 for right part of State
This is because lane to TMEM is physical. 

Some other variable, V and SK maybe also left-right splitted to load balance WG1 and WG2.

```

## 🔍 Related Issues

## 🚀 Pull Request Checklist
### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes
```
problem_size                          | h_qk  | h_v |    new    |    main   | speedup
397B/122B TP8        1x65536          |     2 |   8 |   2.028ms |   2.357ms |  1.16x
397B/122B TP8        1x32768          |     2 |   8 |   1.017ms |   1.191ms |  1.17x
397B/122B TP8        1x16384          |     2 |   8 |   0.515ms |   0.600ms |  1.17x
397B/122B TP8        1x8192           |     2 |   8 |   0.263ms |   0.309ms |  1.17x
397B/122B TP8        1x4096           |     2 |   8 |   0.138ms |   0.164ms |  1.19x
397B/122B TP8        1x2048           |     2 |   8 |   0.076ms |   0.091ms |  1.20x
397B/122B TP8        6144+2048        |     2 |   8 |   0.201ms |   0.236ms |  1.17x
397B/122B TP8        4096+4096        |     2 |   8 |   0.138ms |   0.165ms |  1.20x
397B/122B TP8        2048+6144        |     2 |   8 |   0.200ms |   0.237ms |  1.18x
397B/122B TP8        1024+7168        |     2 |   8 |   0.233ms |   0.273ms |  1.17x
397B/122B TP8        2048x4           |     2 |   8 |   0.077ms |   0.092ms |  1.19x
397B/122B TP8        1024x8           |     2 |   8 |   0.046ms |   0.058ms |  1.26x
397B/122B TP8        8192x8           |     2 |   8 |   0.266ms |   0.311ms |  1.17x
397B/122B TP8        8192x16          |     2 |   8 |   0.276ms |   0.312ms |  1.13x
397B/122B TP8        8192x32          |     2 |   8 |   0.552ms |   0.619ms |  1.12x

397B/122B TP4        1x65536          |     4 |  16 |   1.958ms |   2.354ms |  1.20x
397B/122B TP4        1x32768          |     4 |  16 |   0.988ms |   1.178ms |  1.19x
397B/122B TP4        1x16384          |     4 |  16 |   0.503ms |   0.598ms |  1.19x
397B/122B TP4        1x8192           |     4 |  16 |   0.260ms |   0.309ms |  1.19x
397B/122B TP4        1x4096           |     4 |  16 |   0.137ms |   0.165ms |  1.20x
397B/122B TP4        1x2048           |     4 |  16 |   0.076ms |   0.093ms |  1.22x
397B/122B TP4        6144+2048        |     4 |  16 |   0.199ms |   0.238ms |  1.20x
397B/122B TP4        4096+4096        |     4 |  16 |   0.140ms |   0.165ms |  1.18x
397B/122B TP4        2048+6144        |     4 |  16 |   0.201ms |   0.235ms |  1.17x
397B/122B TP4        1024+7168        |     4 |  16 |   0.231ms |   0.271ms |  1.17x
397B/122B TP4        2048x4           |     4 |  16 |   0.078ms |   0.093ms |  1.19x
397B/122B TP4        1024x8           |     4 |  16 |   0.048ms |   0.059ms |  1.23x
397B/122B TP4        8192x8           |     4 |  16 |   0.274ms |   0.313ms |  1.14x
397B/122B TP4        8192x16          |     4 |  16 |   0.553ms |   0.619ms |  1.12x
397B/122B TP4        8192x32          |     4 |  16 |   1.097ms |   1.228ms |  1.12x

397B/122B TP2        1x65536          |     8 |  32 |   1.976ms |   2.339ms |  1.18x
397B/122B TP2        1x32768          |     8 |  32 |   0.995ms |   1.178ms |  1.18x
397B/122B TP2        1x16384          |     8 |  32 |   0.506ms |   0.599ms |  1.18x
397B/122B TP2        1x8192           |     8 |  32 |   0.261ms |   0.310ms |  1.19x
397B/122B TP2        1x4096           |     8 |  32 |   0.139ms |   0.164ms |  1.18x
397B/122B TP2        1x2048           |     8 |  32 |   0.076ms |   0.091ms |  1.20x
397B/122B TP2        6144+2048        |     8 |  32 |   0.201ms |   0.238ms |  1.18x
397B/122B TP2        4096+4096        |     8 |  32 |   0.140ms |   0.166ms |  1.19x
397B/122B TP2        2048+6144        |     8 |  32 |   0.200ms |   0.238ms |  1.19x
397B/122B TP2        1024+7168        |     8 |  32 |   0.230ms |   0.274ms |  1.19x
397B/122B TP2        2048x4           |     8 |  32 |   0.080ms |   0.095ms |  1.19x
397B/122B TP2        1024x8           |     8 |  32 |   0.090ms |   0.111ms |  1.23x
397B/122B TP2        8192x8           |     8 |  32 |   0.551ms |   0.621ms |  1.13x
397B/122B TP2        8192x16          |     8 |  32 |   1.099ms |   1.229ms |  1.12x
397B/122B TP2        8192x32          |     8 |  32 |   2.104ms |   2.281ms |  1.08x

397B/122B TP1        1x65536          |    16 |  64 |   1.999ms |   2.364ms |  1.18x
397B/122B TP1        1x32768          |    16 |  64 |   1.010ms |   1.197ms |  1.19x
397B/122B TP1        1x16384          |    16 |  64 |   0.514ms |   0.603ms |  1.17x
397B/122B TP1        1x8192           |    16 |  64 |   0.265ms |   0.311ms |  1.17x
397B/122B TP1        1x4096           |    16 |  64 |   0.140ms |   0.166ms |  1.19x
397B/122B TP1        1x2048           |    16 |  64 |   0.078ms |   0.093ms |  1.19x
397B/122B TP1        6144+2048        |    16 |  64 |   0.204ms |   0.239ms |  1.17x
397B/122B TP1        4096+4096        |    16 |  64 |   0.145ms |   0.167ms |  1.15x
397B/122B TP1        2048+6144        |    16 |  64 |   0.205ms |   0.240ms |  1.17x
397B/122B TP1        1024+7168        |    16 |  64 |   0.235ms |   0.277ms |  1.18x
397B/122B TP1        2048x4           |    16 |  64 |   0.155ms |   0.183ms |  1.18x
397B/122B TP1        1024x8           |    16 |  64 |   0.172ms |   0.215ms |  1.25x
397B/122B TP1        8192x8           |    16 |  64 |   1.099ms |   1.246ms |  1.13x
397B/122B TP1        8192x16          |    16 |  64 |   2.096ms |   2.293ms |  1.09x
397B/122B TP1        8192x32          |    16 |  64 |   4.290ms |   4.594ms |  1.07x

35B/9B/4B TP1        1x65536          |    16 |  32 |   1.982ms |   2.335ms |  1.18x
35B/9B/4B TP1        1x32768          |    16 |  32 |   1.000ms |   1.177ms |  1.18x
35B/9B/4B TP1        1x16384          |    16 |  32 |   0.509ms |   0.599ms |  1.18x
35B/9B/4B TP1        1x8192           |    16 |  32 |   0.263ms |   0.309ms |  1.17x
35B/9B/4B TP1        1x4096           |    16 |  32 |   0.140ms |   0.164ms |  1.17x
35B/9B/4B TP1        1x2048           |    16 |  32 |   0.077ms |   0.092ms |  1.19x
35B/9B/4B TP1        6144+2048        |    16 |  32 |   0.202ms |   0.238ms |  1.18x
35B/9B/4B TP1        4096+4096        |    16 |  32 |   0.142ms |   0.166ms |  1.17x
35B/9B/4B TP1        2048+6144        |    16 |  32 |   0.201ms |   0.239ms |  1.19x
35B/9B/4B TP1        1024+7168        |    16 |  32 |   0.231ms |   0.275ms |  1.19x
35B/9B/4B TP1        2048x4           |    16 |  32 |   0.083ms |   0.095ms |  1.14x
35B/9B/4B TP1        1024x8           |    16 |  32 |   0.091ms |   0.110ms |  1.21x
35B/9B/4B TP1        8192x8           |    16 |  32 |   0.560ms |   0.621ms |  1.11x
35B/9B/4B TP1        8192x16          |    16 |  32 |   1.131ms |   1.244ms |  1.10x
35B/9B/4B TP1        8192x32          |    16 |  32 |   2.167ms |   2.328ms |  1.07x

27B TP1              1x65536          |    16 |  48 |   1.993ms |   2.358ms |  1.18x
27B TP1              1x32768          |    16 |  48 |   1.010ms |   1.185ms |  1.17x
27B TP1              1x16384          |    16 |  48 |   0.513ms |   0.601ms |  1.17x
27B TP1              1x8192           |    16 |  48 |   0.264ms |   0.310ms |  1.17x
27B TP1              1x4096           |    16 |  48 |   0.140ms |   0.165ms |  1.18x
27B TP1              1x2048           |    16 |  48 |   0.077ms |   0.092ms |  1.19x
27B TP1              6144+2048        |    16 |  48 |   0.203ms |   0.239ms |  1.18x
27B TP1              4096+4096        |    16 |  48 |   0.142ms |   0.166ms |  1.17x
27B TP1              2048+6144        |    16 |  48 |   0.202ms |   0.238ms |  1.18x
27B TP1              1024+7168        |    16 |  48 |   0.233ms |   0.275ms |  1.18x
27B TP1              2048x4           |    16 |  48 |   0.152ms |   0.183ms |  1.20x
27B TP1              1024x8           |    16 |  48 |   0.133ms |   0.163ms |  1.23x
27B TP1              8192x8           |    16 |  48 |   0.842ms |   0.924ms |  1.10x
27B TP1              8192x16          |    16 |  48 |   1.665ms |   1.864ms |  1.12x
27B TP1              8192x32          |    16 |  48 |   3.282ms |   3.553ms |  1.08x

2B/0.8B TP1          1x65536          |    16 |  16 |   1.924ms |   2.358ms |  1.23x
2B/0.8B TP1          1x32768          |    16 |  16 |   0.967ms |   1.189ms |  1.23x
2B/0.8B TP1          1x16384          |    16 |  16 |   0.492ms |   0.604ms |  1.23x
2B/0.8B TP1          1x8192           |    16 |  16 |   0.255ms |   0.312ms |  1.22x
2B/0.8B TP1          1x4096           |    16 |  16 |   0.135ms |   0.166ms |  1.23x
2B/0.8B TP1          1x2048           |    16 |  16 |   0.075ms |   0.092ms |  1.23x
2B/0.8B TP1          6144+2048        |    16 |  16 |   0.195ms |   0.239ms |  1.23x
2B/0.8B TP1          4096+4096        |    16 |  16 |   0.138ms |   0.167ms |  1.21x
2B/0.8B TP1          2048+6144        |    16 |  16 |   0.197ms |   0.238ms |  1.21x
2B/0.8B TP1          1024+7168        |    16 |  16 |   0.227ms |   0.275ms |  1.21x
2B/0.8B TP1          2048x4           |    16 |  16 |   0.079ms |   0.094ms |  1.19x
2B/0.8B TP1          1024x8           |    16 |  16 |   0.050ms |   0.059ms |  1.18x
2B/0.8B TP1          8192x8           |    16 |  16 |   0.281ms |   0.317ms |  1.13x
2B/0.8B TP1          8192x16          |    16 |  16 |   0.580ms |   0.635ms |  1.09x
2B/0.8B TP1          8192x32          |    16 |  16 |   1.165ms |   1.273ms |  1.09x

Sym h32              1x65536          |    32 |  32 |   1.934ms |   2.373ms |  1.23x
Sym h32              1x32768          |    32 |  32 |   0.973ms |   1.193ms |  1.23x
Sym h32              1x16384          |    32 |  32 |   0.496ms |   0.607ms |  1.22x
Sym h32              1x8192           |    32 |  32 |   0.258ms |   0.313ms |  1.21x
Sym h32              1x4096           |    32 |  32 |   0.138ms |   0.167ms |  1.21x
Sym h32              1x2048           |    32 |  32 |   0.077ms |   0.093ms |  1.21x
Sym h32              6144+2048        |    32 |  32 |   0.199ms |   0.241ms |  1.21x
Sym h32              4096+4096        |    32 |  32 |   0.140ms |   0.168ms |  1.20x
Sym h32              2048+6144        |    32 |  32 |   0.199ms |   0.240ms |  1.21x
Sym h32              1024+7168        |    32 |  32 |   0.229ms |   0.277ms |  1.21x
Sym h32              2048x4           |    32 |  32 |   0.084ms |   0.096ms |  1.14x
Sym h32              1024x8           |    32 |  32 |   0.093ms |   0.112ms |  1.20x
Sym h32              8192x8           |    32 |  32 |   0.584ms |   0.636ms |  1.09x
Sym h32              8192x16          |    32 |  32 |   1.171ms |   1.268ms |  1.08x
Sym h32              8192x32          |    32 |  32 |   2.248ms |   2.407ms |  1.07x
```