### PR TITLE
fix(mnnvl): use SCM_RIGHTS fd exchange for POSIX-FD path instead of pidfd_getfd

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -530,41 +530,17 @@ class MnnvlMemory:  # type: ignore[no-redef]
         ):
             all_handles_data = comm.allgather(exported_fabric_handle.data)
         else:
-            all_handles_data = comm.allgather(exported_fabric_handle)
-            all_pids = comm.allgather(os.getpid())
-            libc = ctypes.CDLL(None, use_errno=True)
-            syscall = libc.syscall
-            SYS_pidfd_open = 434
-            SYS_pidfd_getfd = 438
-            pidfds = []
-            for pid in all_pids:
-                pidfd = syscall(SYS_pidfd_open, pid, 0)
-                if pidfd < 0:
-                    err = ctypes.get_errno()
-                    raise RuntimeError(
-                        f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
-                    )
-                pidfds.append(pidfd)
-
-            remote_fds = []
-            for pidfd, fd in zip(pidfds, all_handles_data, strict=True):
-                remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
-                if remote_fd < 0:
-                    err = ctypes.get_errno()
-                    error_msg = f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno {err}: {os.strerror(err)}."
-                    if err == 1:  # EPERM
-                        error_msg += (
-                            " Permission denied. If running in a container, try adding --cap-add=SYS_PTRACE "
-                            "to your docker run command."
-                        )
-                    else:
-                        error_msg += (
-                            " This may be due to kernel version (requires Linux 5.6+)."
-                        )
-                    raise RuntimeError(error_msg)
-                remote_fds.append(remote_fd)
-
-            all_handles_data = remote_fds
+            # POSIX-FD single-node path (x86 Blackwell/Hopper, no NVLink fabric
+            # cluster): exchange the CUDA VMM file descriptors via SCM_RIGHTS over
+            # a Unix socket, reusing PosixFDHandleExchanger -- the same mechanism
+            # SymmDeviceMemory already uses. This avoids pidfd_getfd, which needs
+            # PTRACE_MODE_ATTACH (CAP_SYS_PTRACE + a permissive yama ptrace_scope)
+            # and fails with EPERM inside a default-capability container.
+            exchanger = PosixFDHandleExchanger(comm, comm_rank, comm_size)
+            try:
+                all_handles_data = exchanger.allgather(exported_fabric_handle)
+            finally:
+                exchanger.close()
         # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501
         # can use buf = memoryview(data) to import if using plain buffer for data.
 

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -524,10 +524,11 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
             )
         )
-        if (
+        is_posix_fd = (
             allocation_prop.requestedHandleTypes
-            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-        ):
+            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+        if not is_posix_fd:
             all_handles_data = comm.allgather(exported_fabric_handle.data)
         else:
             # POSIX-FD single-node path (x86 Blackwell/Hopper, no NVLink fabric
@@ -539,6 +540,13 @@ class MnnvlMemory:  # type: ignore[no-redef]
             exchanger = PosixFDHandleExchanger(comm, comm_rank, comm_size)
             try:
                 all_handles_data = exchanger.allgather(exported_fabric_handle)
+            except OSError as e:
+                raise RuntimeError(
+                    "MNNVL POSIX-FD handle exchange failed. This path requires all "
+                    "ranks to run on one node and share a network namespace (the "
+                    "handles are passed over an abstract-namespace AF_UNIX socket). "
+                    f"Original error: {e!r}"
+                ) from e
             finally:
                 exchanger.close()
         # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501
@@ -575,6 +583,20 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 )
 
             checkCudaErrors(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
+
+            if is_posix_fd:
+                # SCM_RIGHTS installed a local dup of each peer's fd, and the CUDA
+                # import above holds its own reference to the allocation, so close
+                # the fd now (also the ring's iteration-0 self-dup for
+                # i == comm_rank). Leaving them open leaks fds and pins the
+                # physical allocation until process exit (cuMemRelease only frees
+                # once all shareable handles are closed).
+                os.close(remote_handle_data)
+
+        if is_posix_fd:
+            # The exported fd was dup'd into the kernel at sendmsg time; drop the
+            # local reference so this rank's allocation isn't self-pinned.
+            os.close(exported_fabric_handle)
 
         ptr = MnnvlMemory.current_start_address + MnnvlMemory.current_mem_offset
         stride = MnnvlMemory.current_rank_stride
@@ -725,6 +747,11 @@ class IpcSocket:
         Returns:
             int: Received file descriptor
         """
+        # Bound the wait: the sender issues its send microseconds after a shared
+        # barrier, so a peer that never sends (died / wrong namespace) would
+        # otherwise hang recv_fd forever. A generous timeout only fires on a
+        # genuine failure and surfaces it as socket.timeout instead of a deadlock.
+        self.sock.settimeout(120)
         # Receive message with ancillary data
         # Maximum size for ancillary data containing one fd
         fds = array.array("i")

--- a/tests/comm/conftest.py
+++ b/tests/comm/conftest.py
@@ -29,51 +29,19 @@ def pytest_sessionfinish(session, exitstatus):
 Shared test utilities for comm tests.
 """
 
-import ctypes
-import os
-
 from flashinfer.comm.mnnvl import MnnvlMemory
 
 
-def _check_pidfd_permissions() -> bool:
-    """Check if pidfd_getfd syscall is available and permitted.
-
-    This is required for MNNVL in containers - the SYS_PTRACE capability
-    must be available for cross-process file descriptor sharing.
-    """
-    try:
-        libc = ctypes.CDLL(None, use_errno=True)
-        syscall = libc.syscall
-        SYS_pidfd_open = 434
-        SYS_pidfd_getfd = 438
-
-        # Try to open our own process and get our own fd
-        my_pid = os.getpid()
-        pidfd = syscall(SYS_pidfd_open, my_pid, 0)
-        if pidfd < 0:
-            return False
-
-        # Try pidfd_getfd on stdin (fd=0) - this tests the permission
-        # We don't actually need the result, just checking if it's permitted
-        test_fd = syscall(SYS_pidfd_getfd, pidfd, 0, 0)
-        os.close(pidfd)
-
-        if test_fd < 0:
-            err = ctypes.get_errno()
-            if err == 1:  # EPERM - permission denied (container issue)
-                return False
-            # Other errors (like EBADF) are OK - permission check passed
-        else:
-            os.close(test_fd)
-
-        return True
-    except Exception:
-        return False
-
-
 def mnnvl_available() -> bool:
-    """Check if MNNVL is fully available (hardware + container permissions)."""
-    return MnnvlMemory.supports_mnnvl() and _check_pidfd_permissions()
+    """Check if MNNVL is available on this host (all-NVLink-up hardware).
+
+    The POSIX-FD handle exchange no longer needs CAP_SYS_PTRACE / pidfd_getfd
+    (it uses SCM_RIGHTS over an abstract-namespace socket), so a container
+    capability probe is intentionally not part of this gate -- MNNVL tests must
+    run in default-capability containers, the exact scenario the exchange fix
+    enables.
+    """
+    return MnnvlMemory.supports_mnnvl()
 
 
 def pytest_addoption(parser):

--- a/tests/comm/test_posix_fd_exchanger.py
+++ b/tests/comm/test_posix_fd_exchanger.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2024 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU-only coverage for PosixFDHandleExchanger (the SCM_RIGHTS fd exchange that
+MnnvlMemory's POSIX-FD path depends on). No GPU or NVLink required: each rank
+shares a memfd tagged with its rank and we assert the gathered fds map to the
+correct source ranks -- catching any ring-ordering or indexing regression.
+"""
+import os
+
+import pytest
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from flashinfer.comm.mnnvl import PosixFDHandleExchanger, TorchDistBackend
+
+
+def _worker(rank: int, world: int, init_method: str, q):
+    tag = f"rank-{rank}".encode()
+    try:
+        dist.init_process_group(
+            "gloo", rank=rank, world_size=world, init_method=init_method
+        )
+        # A memfd whose contents identify this rank; shareable via SCM_RIGHTS.
+        local_fd = os.memfd_create(f"posixfd-test-{rank}", 0)
+        os.write(local_fd, tag)
+
+        exchanger = PosixFDHandleExchanger(TorchDistBackend(), rank, world)
+        try:
+            gathered = exchanger.allgather(local_fd)
+        finally:
+            exchanger.close()
+
+        # gathered[src] must be a local fd referring to rank `src`'s memfd.
+        ok = True
+        for src, rfd in enumerate(gathered):
+            if os.pread(rfd, 32, 0) != f"rank-{src}".encode():
+                ok = False
+            os.close(rfd)
+        os.close(local_fd)
+        q.put((rank, ok, None))
+    except Exception as e:  # noqa: BLE001 - report to parent for a clean assert
+        q.put((rank, False, repr(e)))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world", [1, 2, 4])
+def test_posix_fd_exchanger_allgather(world: int):
+    if not hasattr(os, "memfd_create"):
+        pytest.skip("memfd_create requires Linux + Python >= 3.8")
+    ctx = mp.get_context("spawn")
+    q = ctx.Queue()
+    init_method = f"tcp://127.0.0.1:{29600 + world}"
+    procs = [
+        ctx.Process(target=_worker, args=(r, world, init_method, q))
+        for r in range(world)
+    ]
+    for p in procs:
+        p.start()
+    try:
+        outs = [q.get(timeout=120) for _ in range(world)]
+    finally:
+        for p in procs:
+            p.join(timeout=30)
+            if p.is_alive():
+                p.terminate()
+    for rank, ok, err in sorted(outs):
+        assert ok, f"rank {rank} fd-exchange failed: {err}"


### PR DESCRIPTION
<!-- PR title: fix(mnnvl): use SCM_RIGHTS fd exchange for the POSIX-FD path instead of pidfd_getfd -->

## Problem

`MnnvlMemory.open_mnnvl_memory` has two handle-exchange paths, selected in `get_allocation_prop` by CPU arch:
- **aarch64** (GB200/GB300) → `CU_MEM_HANDLE_TYPE_FABRIC`
- **x86_64** (B200/B300, Hopper) → `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`

The POSIX-FD path imports peer ranks' CUDA VMM file descriptors via `pidfd_open` / **`pidfd_getfd`**, which require `PTRACE_MODE_ATTACH`. Inside a **default-capability container** this fails:

```
RuntimeError: pidfd_getfd(pidfd=..., fd=...) failed with errno 1: Operation not permitted.
  ... try adding --cap-add=SYS_PTRACE to your docker run command.
```

Two independent kernel gates block `pidfd_getfd` without `CAP_SYS_PTRACE`:
1. Docker's **default seccomp** profile returns `EPERM` for `pidfd_getfd`.
2. **yama `ptrace_scope=1`** forbids sibling→sibling ptrace (worker ranks are siblings).

So every consumer of `MnnvlMemory` on x86 (decode-CP all-to-all, MoE all-to-all) needs `--cap-add=SYS_PTRACE` — which many managed/hardened container platforms disallow.

## Fix

Reuse the **`PosixFDHandleExchanger`** (`IpcSocket` + `SCM_RIGHTS` over a Unix domain socket) that already exists in this file and is already used by `SymmDeviceMemory`. Passing fds via `SCM_RIGHTS` needs **no ptrace** — it works under the default seccomp profile and any `ptrace_scope`, with no added capability. The FABRIC path (aarch64) is unchanged.

```python
# before: pidfd_open + pidfd_getfd loop (needs CAP_SYS_PTRACE)
# after:
exchanger = PosixFDHandleExchanger(comm, comm_rank, comm_size)
try:
    all_handles_data = exchanger.allgather(exported_fabric_handle)
finally:
    exchanger.close()
```

This is why `SymmDeviceMemory` (e.g. the trtllm MNNVL all-reduce fusion) already runs on x86 Blackwell in a default container, while `MnnvlMemory` consumers do not — this change brings `MnnvlMemory` to the same, cap-free mechanism.

## Verification (8×B200, x86, single node, Docker, default caps, yama ptrace_scope=1)

Real serving run (DeepSeek-V2-Lite, tp4 = dcp4, SGLang `--dcp-comm-backend fi_a2a`, which allocates the MNNVL decode-CP workspace via `MnnvlMemory`):

| case | flags | result |
|---|---|---|
| stock flashinfer | no `--cap-add` | ❌ `pidfd_getfd ... errno 1: Operation not permitted` at workspace init |
| stock flashinfer | `--cap-add=SYS_PTRACE` | ✅ boots, GSM8K 0.66 |
| **this patch** | **no `--cap-add`** | ✅ **boots, GSM8K 0.66** |

(NCCL `a2a` baseline boots without any flag, GSM8K 0.63 — confirms DCP itself is fine; only the MNNVL fd exchange was gated.)

(A standalone multi-process `MnnvlMemory` alloc repro reproduces the same matrix and is available on request.)

## Notes
- Also fixes the FlashInfer MNNVL MoE all-to-all (`trtllm_moe_alltoall`, same `MnnvlMemory`) in default containers.
- No behavior change on aarch64 NVL72 (FABRIC path untouched).
- The x86 POSIX-FD path now additionally calls `comm.bcast` and `comm.barrier` (the old pidfd loop needed only `comm.allgather`). `MPIBackend` and `TorchDistBackend` implement both; a custom duck-typed `CommBackend` must too.
- POSIX-FD fds are closed after import (no fd leak, no allocation pinned past `close_mnnvl_memory`); the exchange raises an actionable error / times out instead of hanging on a misconfig. CPU-only coverage added in `tests/comm/test_posix_fd_exchanger.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-FABRIC memory handle exchange to use a POSIX FD passing approach for better compatibility and reliability.
  * Added clearer error messaging for single-node/network-namespace requirements.
  * Ensured file-descriptor cleanup to avoid leaks and potential hangs during FD receiving.
* **Tests**
  * Added a CPU-only distributed test covering POSIX FD exchanger rank-to-descriptor correctness across multiple world sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->