### PR TITLE
fix(trtllm-gen): select dynamic-page decode kernels for MHA (numHeadsQPerKv == 1)

### DIFF
--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -387,7 +387,7 @@ class TllmGenFmhaKernel {
 
   inline bool useDynamicNumTokensPerPage(RunnerParams const& params) const {
     return isPagedKv(params.mQkvLayout) && !isSparseMla(params.mSparseMlaType) &&
-           params.mNumHeadsQPerKv > 1 && params.mHeadDimQk == params.mHeadDimV &&
+           params.mHeadDimQk == params.mHeadDimV &&
            params.mNumTokensPerPage >= kDynamicNumTokensPerPageThreshold;
   }
 

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1541,11 +1541,13 @@ def test_trtllm_batch_decode_long_sequence_length(
 @pytest.mark.parametrize("q_len_per_req", [1, 2])
 @pytest.mark.parametrize("window_left", [-1, 127])
 @pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
-def test_trtllm_batch_decode_dynamic_page_size_gqa(
+@pytest.mark.parametrize("head_grp_size", [1, 5])
+def test_trtllm_batch_decode_dynamic_page_size(
     page_size: int,
     q_len_per_req: int,
     window_left: int,
     uses_shared_paged_kv_idx: bool,
+    head_grp_size: int,
 ) -> None:
     _skip_if_not_blackwell()
     _test_trtllm_batch_decode(
@@ -1555,7 +1557,7 @@ def test_trtllm_batch_decode_dynamic_page_size_gqa(
         q_len_per_req=q_len_per_req,
         page_size=page_size,
         num_kv_heads=2,
-        head_grp_size=5,
+        head_grp_size=head_grp_size,
         window_left=window_left,
         q_dtype="bf16",
         o_dtype="bf16",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

trtllm-gen paged decode had no kernel for MHA (`num_qo_heads == num_kv_heads`) with `page_size >= 128`, failing with `Missing TRTLLM-GEN kernel (decode): ... tileSizeQ=8, ... numTokensPerPage=128, dynamicNumTokensPerPage=0`.

Root cause: `useDynamicNumTokensPerPage` in `fmhaKernels.cuh` gated the dynamic numTokensPerPage decode kernels to `mNumHeadsQPerKv > 1`, so MHA fell through to static kernel selection — where the shipped cubin set stops at `numTokensPerPage=64`. The dynamic-page `tileSizeQ=8` cubins that cover the MHA shape already exist in the inventory for every dtype combination (bf16/fp16/e4m3 Q/KV, all O dtypes) and both mask types, so no new cubins are needed — this PR just drops the `> 1` term from the gate.

The dropped term is redundant as a validity check: the launcher already rejects `num_qo_heads % num_kv_heads != 0`, so the ratio is always >= 1, and the decode tileSizeQ selection (`mNumHeadsQPerKv <= 8 ? 8 : 16`) maps group 1 to the existing Q8 kernels.

Why this matters: MiniMax-M3 + EAGLE3 speculative decoding hits this cell unavoidably — the target's sparse attention mandates KV page size 128, and the published EAGLE3 draft model is MHA (64/64 heads, head_dim 128) sharing the deployment page size. Engines currently pin the drafter to a non-trtllm-gen backend as a workaround (e.g. vLLM recipes set `"attention_backend": "FLASH_ATTN"` for the draft).

Validation on B200 (SM100): the extended `test_trtllm_batch_decode_dynamic_page_size` passes all 64 cases — head_grp_size {1, 5} x page_size {128, 256, 512, 1024} x q_len_per_req {1, 2} x window_left {-1, 127} x uses_shared_paged_kv_idx {True, False} — i.e. all 32 new MHA cells pass against the reference, and the 32 pre-existing GQA cells confirm no regression. The previously failing MHA x page-128 decode matches the reference with the same max error as neighboring passing cells (0.002 in a standalone bf16 check).

## 🔍 Related Issues

Fixes #4094

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- This header originates from TensorRT-LLM's trtllm-gen kernels; if it is periodically synced from there, this fix may also need to land upstream (or be preserved on the next sync).
- `test_trtllm_batch_decode_dynamic_page_size_gqa` was renamed to `test_trtllm_batch_decode_dynamic_page_size` with `head_grp_size` parametrized as {1, 5} — flagging in case anything filters CI by the old test name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic page-size selection for attention decoding across additional query-to-key/value head configurations.
  * Expanded dynamic page-size coverage to include both standard and grouped-query attention scenarios.

* **Tests**
  * Added parameterized validation for multiple head grouping sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->