### PR TITLE
Fix CUDA graph capture crash in NVFP4 quantize's scale-tensor construction

### DIFF
--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -1799,8 +1799,8 @@ def nvfp4_quantize_cute_dsl(
             global_scale.float().reshape(1).contiguous().to(input.device)
         )
     else:
-        global_scale_tensor = torch.tensor(
-            [float(global_scale)], dtype=torch.float32, device=input.device
+        global_scale_tensor = torch.full(
+            (1,), float(global_scale), dtype=torch.float32, device=input.device
         )
 
     num_sm = get_num_sm(input.device)
@@ -2032,8 +2032,8 @@ def silu_and_mul_nvfp4_quantize_cute_dsl(
             global_scale.float().reshape(1).contiguous().to(input.device)
         )
     else:
-        global_scale_tensor = torch.tensor(
-            [float(global_scale)], dtype=torch.float32, device=input.device
+        global_scale_tensor = torch.full(
+            (1,), float(global_scale), dtype=torch.float32, device=input.device
         )
 
     num_sm = get_num_sm(input.device)
@@ -2202,8 +2202,8 @@ def nvfp4_quantize_per_token_cute_dsl(
             global_scale_inv.float().reshape(1).contiguous().to(input.device)
         )
     else:
-        global_scale_inv_tensor = torch.tensor(
-            [float(global_scale_inv)], dtype=torch.float32, device=input.device
+        global_scale_inv_tensor = torch.full(
+            (1,), float(global_scale_inv), dtype=torch.float32, device=input.device
         )
 
     num_sf_blocks_per_row = k // NVFP4_SF_VEC_SIZE


### PR DESCRIPTION
torch.tensor([float(x)], device="cuda") still stages through an implicit unpinned CPU tensor before copying to the GPU, which torch.cuda.graph() forbids ("Cannot copy between CPU and CUDA tensors during CUDA graph capture unless the CPU tensor is pinned"). Hit via sglang's flashinfer_trtllm MoE path calling nvfp4_quantize(..., per_token_activation=True, backend="cute-dsl") during prefill CUDA graph capture.

torch.full materializes the tensor with a device-side fill kernel, no host staging, so it's capture-safe. Applied to all three call sites in this file that build a scalar global-scale tensor from a Python float (nvfp4_quantize_cute_dsl, silu_and_mul_nvfp4_quantize_cute_dsl, nvfp4_quantize_per_token_cute_dsl).

Verified directly: torch.tensor(...) raises the capture error under torch.cuda.graph(), torch.full(...) doesn't. Ran nvfp4_quantize(..., backend="cute-dsl", per_token_activation=True) end-to-end inside a real CUDA graph capture + replay on SM103 — fails before this change, produces correct-shaped finite output after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVFP4 quantization when scale values are provided as scalar inputs.
  * Ensured generated scale tensors consistently use the expected shape, data type, and device placement across supported quantization operations.
  * Improved reliability for fused activation-and-quantization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->