### PR TITLE
Update TRTLLM-GEN FMHA cubins

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "158f6fa11ef139a098cfddcdddce73ca99d164ad/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "e3a8eba02eb19f4485652f84f5095524350246b5/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "b368d003e8fdfe4b271bff7c788ac52ef789a81b/batched_gemm-da58956-b4ac80e/"
     )
@@ -157,7 +157,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "c2d9399b2537be785882354a4f9902ed6c03136c0ea341e201eac40c3923e1dc"
+        "03e0f29f970de40b0fd3c6025a16a39fb6c9af2a6549a63da73cf3da8494e658"
     )
     TRTLLM_GEN_BMM: str = (
         "d0178cd486be54e622386e88daba9c2aca654be7e6f3dcd1af7ecca3354492d2"


### PR DESCRIPTION
## Description

Updates the TRTLLM-GEN FMHA artifact pin to include the pipeline-stage-relative dynamic-page offset fix.

The previous kernels could index page offsets using the absolute head index instead of the pipeline-stage-relative head index. On SM100 with large virtual KV pages, this could select incorrect KV data and cause incorrect attention output, including severe accuracy degradation and runaway generation in vLLM speculative decoding workloads.

## Artifact provenance

- TRTLLM-GEN fix: f110422f
- Cubin-publishing MR: 163
- Artifact path: `e3a8eba02eb19f4485652f84f5095524350246b5/fmha/trtllm-gen/`
- `checksums.txt` SHA-256: `03e0f29f970de40b0fd3c6025a16a39fb6c9af2a6549a63da73cf3da8494e658`

## Validation

- Cubin build and public publishing pipeline passed.
- The published manifest was downloaded independently and its SHA-256 matches the value above.
- The kernel fix was validated with focused page-256 reproduction and full Tau2 MTP=5 testing.
- No FlashInfer API or ABI changes are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the TRTLLM generation asset location used by the artifact downloader.
  * Updated the associated SHA256 checksum used for post-download integrity verification to match the new asset source.
  * Improves accuracy of asset validation to ensure the correct model files are detected during setup and downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->