### PR TITLE
test: compute mm_fp4 cosine similarity in fp32 to avoid bf16 rounding cliff

### DIFF
--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -103,7 +103,9 @@ def _test_mm_fp4(
                 skip_check=False,
             )
 
-        cos_sim = F.cosine_similarity(reference.reshape(-1), res.reshape(-1), dim=0)
+        cos_sim = F.cosine_similarity(
+            reference.float().reshape(-1), res.float().reshape(-1), dim=0
+        )
         assert cos_sim > 0.97
     except LibraryError as e:
         # TODO: Remove this check once cuDNN backend version is updated to 9.14.0


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

compute mm_fp4 cosine similarity in fp32 to avoid bf16 rounding cliff.

Example:

```python
import torch
t = torch.tensor(0.9702, dtype=torch.bfloat16)  # true value passes the threshold
print(t.item(), t > 0.97)   # 0.96875 False  <- spurious failure
f = torch.tensor(0.9702, dtype=torch.float32)    # metric computed in fp32 (the fix)
print(f.item(), f > 0.97)           # 0.9702 True   <- correct verdict
```

## 🔍 Related Issues

Contributes to #3824. Complements #3829, which fixes the other half of the flake (unseeded inputs); the two changes touch different lines and do not conflict.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical consistency in tensor similarity checks by ensuring values are compared using floating-point precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->