### PR TITLE
fix: raise a clear error for old setuptools under --no-build-isolation

### DIFF
--- a/build_backend.py
+++ b/build_backend.py
@@ -1038,6 +1038,36 @@ def _prepare_for_sdist():
     _create_data_dir(use_symlinks=False)
 
 
+# `[build-system] requires` in pyproject.toml pins setuptools>=77, but that pin
+# is only fetched into a *fresh, isolated* build env. `--no-build-isolation`
+# (the flag CONTRIBUTING.md and CLAUDE.md both tell developers to pass) skips
+# that isolated env and hands every hook below straight to whatever setuptools
+# is already on the caller's PATH. An older one chokes on this file's PEP 639
+# short-form `license = "Apache-2.0"` deep inside distutils' own config
+# validation, raising a ValueError that never mentions setuptools at all
+# (flashinfer-ai/flashinfer#2544). Check the version ourselves, at the one
+# point every build hook funnels through, and say what's actually wrong.
+_MIN_SETUPTOOLS = "77"
+
+
+def _check_setuptools_version() -> None:
+    import setuptools
+
+    try:
+        from packaging.version import Version
+    except ImportError:
+        return  # packaging isn't installed; let setuptools raise its own error
+
+    if Version(setuptools.__version__) < Version(_MIN_SETUPTOOLS):
+        raise RuntimeError(
+            f"flashinfer requires setuptools>={_MIN_SETUPTOOLS} to build "
+            f"(found {setuptools.__version__}). This is normally installed "
+            "automatically, but --no-build-isolation uses your already-"
+            "installed setuptools instead of the pinned build dependency. "
+            f"Upgrade it first: python -m pip install -U 'setuptools>={_MIN_SETUPTOOLS}'"
+        )
+
+
 def get_requires_for_build_wheel(config_settings=None):
     _prepare_for_wheel()
     return []
@@ -1054,25 +1084,30 @@ def get_requires_for_build_editable(config_settings=None):
 
 
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    _check_setuptools_version()
     _prepare_for_wheel()
     return orig.prepare_metadata_for_build_wheel(metadata_directory, config_settings)
 
 
 def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+    _check_setuptools_version()
     _prepare_for_editable()
     return orig.prepare_metadata_for_build_editable(metadata_directory, config_settings)
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+    _check_setuptools_version()
     _prepare_for_editable()
     return orig.build_editable(wheel_directory, config_settings, metadata_directory)
 
 
 def build_sdist(sdist_directory, config_settings=None):
+    _check_setuptools_version()
     _prepare_for_sdist()
     return orig.build_sdist(sdist_directory, config_settings)
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    _check_setuptools_version()
     _prepare_for_wheel()
     return orig.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/test_build_backend_setuptools_guard.py
+++ b/test_build_backend_setuptools_guard.py
@@ -1,0 +1,39 @@
+"""Standalone test for build_backend.py's setuptools-version guard.
+
+Not under tests/: that suite's conftest.py imports torch and the fully built
+flashinfer package, which this pure PEP 517 build-hook check has no need of.
+Run directly: pytest test_build_backend_setuptools_guard.py
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+build_backend = importlib.import_module("build_backend")
+
+
+def _set_setuptools_version(monkeypatch, version):
+    # _check_setuptools_version() does `import setuptools` locally, so patching
+    # sys.modules is what that local import will actually see.
+    fake = types.SimpleNamespace(__version__=version)
+    monkeypatch.setitem(sys.modules, "setuptools", fake)
+
+
+def test_old_setuptools_raises_clear_error(monkeypatch):
+    _set_setuptools_version(monkeypatch, "65.5.0")
+    with pytest.raises(RuntimeError, match="setuptools>=77"):
+        build_backend._check_setuptools_version()
+
+
+def test_pinned_setuptools_passes(monkeypatch):
+    _set_setuptools_version(monkeypatch, "77.0.0")
+    build_backend._check_setuptools_version()  # must not raise
+
+
+def test_newer_setuptools_passes(monkeypatch):
+    _set_setuptools_version(monkeypatch, "79.0.1")
+    build_backend._check_setuptools_version()  # must not raise


### PR DESCRIPTION
## 📌 Description

`--no-build-isolation` (the flag CONTRIBUTING.md recommends for development) skips pip's normal
isolated build environment, so every PEP 517 hook in `build_backend.py` gets handed the caller's
already-installed setuptools instead of the `setuptools>=77` pinned in `[build-system] requires`.
An older setuptools chokes on this file's PEP 639 `license = "Apache-2.0"` field deep inside
distutils' own config validation and raises a `ValueError` that never mentions setuptools at all,
so the real cause (an outdated build tool) is invisible from the traceback.

This adds a `_check_setuptools_version()` guard, called at the top of every hook in
`build_backend.py` that delegates into setuptools (`prepare_metadata_for_build_wheel/editable`,
`build_wheel/editable/sdist`), which raises a `RuntimeError` naming the actual problem and the
fix (`pip install -U 'setuptools>=77'`) before the opaque error can surface.

I did not change the `pyproject.toml` license field itself: #2615 tried that (switching to the
PEP 621 table form) and self-closed it after `setuptools>=77` deprecates that form with a hard
2026-02-18 cutoff already passed, so it would trade one setuptools-version problem for another.

## 🔍 Related Issues

Fixes #2544

## Verification

Reproduced the exact failure from the issue in a clean `python:3.11-slim` container: installed
`setuptools==65.5.0`, ran the documented `pip install --no-build-isolation -e . -v`, and got the
identical `ValueError: invalid pyproject.toml config: project.license` traceback reported in the
issue. Confirmed the same command still fails the same way on unpatched `main`.

With the fix, the same setup now fails fast with the new `RuntimeError` message instead of the
opaque `ValueError`. A normal install with the repo's already-current setuptools (79.0.1) still
succeeds and `import flashinfer` works, so the guard does not affect the common case.

Added `test_build_backend_setuptools_guard.py` at the repo root (not under `tests/`, since that
suite's `conftest.py` requires torch and a full GPU build this pure build-hook check doesn't need)
covering the old/pinned/newer setuptools versions; it fails on unpatched `main` (the guard
function doesn't exist yet) and passes on this branch.

Not verified: behavior on setuptools versions between 65 and 77, and any interaction with the
NIXL/NCCL EP best-effort install steps under an isolated (non `--no-build-isolation`) build,
since those are unaffected by this change and out of scope for this fix.

## 🚀 Pull Request Checklist

- [x] I have installed `pre-commit` by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear compatibility check for builds using an existing setuptools installation.
  * Builds now provide an actionable upgrade message when setuptools is older than version 77.

* **Tests**
  * Added coverage for supported and unsupported setuptools versions to help ensure reliable build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->