### PR TITLE
perf(moe): enable tiny-M NVFP4 autotuning on SM100

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1529,7 +1529,17 @@ def get_trtllm_moe_sm100_module():
             num_tokens = moe_inputs.hidden_states.shape[0]
 
             major, _ = get_compute_capability(moe_inputs.hidden_states.device)
-            if major == 10 and num_tokens * self.top_k < 2 * self.num_local_experts:
+            # Native NVFP4 tactics are valid at tiny M. Retain the guard
+            # conservatively for other dtypes, including the affected BF16 path.
+            is_nvfp4 = (
+                self.dtype_act == DtypeTrtllmGen.E2m1
+                and self.dtype_weights == DtypeTrtllmGen.E2m1
+            )
+            if (
+                major == 10
+                and not is_nvfp4
+                and num_tokens * self.top_k < 2 * self.num_local_experts
+            ):
                 return []
 
             has_gemm1_lora_delta = moe_inputs.gemm1_lora_delta is not None

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -35,7 +35,11 @@ from flashinfer.fused_moe import (
     trtllm_fp8_block_scale_routed_moe,
     WeightLayout,
 )
-from flashinfer.fused_moe.core import Fp8QuantizationType, MoEInputs
+from flashinfer.fused_moe.core import (
+    Fp8QuantizationType,
+    MoEInputs,
+    get_trtllm_moe_sm100_module,
+)
 from flashinfer.jit.fused_moe import gen_trtllm_gen_fused_moe_sm100_module
 from flashinfer.tllm_enums import DtypeTrtllmGen
 from flashinfer.utils import (
@@ -331,6 +335,56 @@ def _enumerate_valid_tactics(
             False,  # has_gemm1_lora_delta
         )
     )
+
+
+@pytest.mark.parametrize(
+    "dtype_act,dtype_weights,expect_tactics",
+    [
+        (DtypeTrtllmGen.E2m1, DtypeTrtllmGen.E2m1, True),
+        (DtypeTrtllmGen.Bfloat16, DtypeTrtllmGen.Bfloat16, False),
+    ],
+)
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8])
+def test_sm100_tiny_m_autotune_guard_is_dtype_scoped(
+    dtype_act: DtypeTrtllmGen,
+    dtype_weights: DtypeTrtllmGen,
+    expect_tactics: bool,
+    num_tokens: int,
+):
+    device = torch.device("cuda:0")
+    if get_compute_capability(device)[0] != 10:
+        pytest.skip("Only works on SM100 / SM103.")
+
+    top_k = 22
+    num_local_experts = 128
+    module = get_trtllm_moe_sm100_module()
+    runner = module.MoERunner(
+        top_k=top_k,
+        num_local_experts=num_local_experts,
+        dtype_act=dtype_act,
+        dtype_weights=dtype_weights,
+        fp8_quantization_type=Fp8QuantizationType.NoneFp8,
+        hidden_size=2048,
+        intermediate_size=5120,
+        activation_type=ActivationType.Swiglu.value,
+        use_shuffled_weight=True,
+        weight_layout=WeightLayout.MajorK,
+        num_experts=512,
+    )
+    # Tactic enumeration only needs the token count and device from hidden_states.
+    inputs = MoEInputs(
+        output=None,
+        routing_logits=None,
+        topk_ids=None,
+        expert_weights=None,
+        hidden_states=torch.empty(num_tokens, 1, device=device),
+        hidden_states_scale=None,
+        gemm1_lora_delta=None,
+        per_token_scale=None,
+    )
+
+    tactics = runner.get_valid_tactics(inputs.to_list(), None)
+    assert bool(tactics) == expect_tactics
 
 
 @pytest.mark.parametrize("quant_mode", ["NvFP4xNvFP4", "MxFP4xMxFP8", "MxFP4xBf16"])


### PR DESCRIPTION
## Description

PR #3837 disabled SM100 MoE tactic enumeration when the average tokens per local expert is below two. The reported TMA failure affects BF16, but the dtype-agnostic guard also disables valid native NVFP4 tactics.

Tiny-M NVFP4 calls therefore always use the fallback tactic. This PR restores tactic enumeration only for native E2M1 x E2M1 NVFP4; BF16 and every other dtype combination retain the safety guard.

## Performance

Measured on GB200 with the Nemotron-3 Ultra NVFP4 expert geometry: 128 local experts, top-k 22, H=2048, and I=5120. M=1/2 use one run and M=4/8 are means across two independent runs; every run contains 24 paired CUDA Graph blocks.

| Tokens | Fallback (us) | Autotuned (us) | Change |
|---:|---:|---:|---:|
| 1 | 32.80 | 31.45 | -4.10% |
| 2 | 50.97 | 49.87 | -2.16% |
| 4 | 69.16 | 68.48 | -1.00% |
| 8 | 85.32 | 84.63 | -0.81% |

On the one-node TP1/DP4/EP4 Ultra E2E workload, output throughput changed from 784.36 to 785.33 tokens/s (+0.12%) and mean TPOT changed from 15.710 to 15.732 ms (+0.14%; higher is worse). The two fresh-server blocks reversed sign, so the result is neutral within run-to-run noise and no E2E gain is claimed.

The observed one-time vLLM DP4 cold-start overhead for profiling the four additional buckets was approximately 24-26 seconds. Subsequent starts reused the tactic cache.

## Related issues

- #3837
- #4041
- vllm-project/vllm#46083

## Pre-commit checks

- [x] Ran `pre-commit` on the changed files.

## Tests

- [x] Added a focused SM100 dtype/boundary regression test.
- [x] `8 passed, 78 deselected` on GB200.
- [x] Exhaustively checked 1,056 tactics per shape at M=1/2/4/8; every result was finite, deterministic, and bit-identical to fallback.
- [x] Public-autotuner and CUDA Graph replay validation.

## Reviewer notes

This is a narrower alternative to #4041: it restores the validated NVFP4 path without re-enabling BF16 tiny-M tactic profiling.
