### PR TITLE
fix(gdn): compile decode kernels for tensor device arch

### DIFF
--- a/flashinfer/gdn_kernels/cute_compile_utils.py
+++ b/flashinfer/gdn_kernels/cute_compile_utils.py
@@ -1,0 +1,32 @@
+"""Shared CuteDSL compile helpers for GDN decode kernels."""
+
+from __future__ import annotations
+
+import torch
+import cutlass.cute as cute
+
+
+def device_compute_capability(device: torch.device | str) -> tuple[int, int]:
+    """Return ``(major, minor)`` for ``device``, resolving index-less ``cuda``."""
+    d = torch.device(device)
+    if d.type == "cuda" and d.index is None:
+        d = torch.device("cuda", torch.cuda.current_device())
+    return torch.cuda.get_device_capability(d)
+
+
+def cute_compile_options(device: torch.device | str) -> tuple:
+    """Device-matched CuteDSL ``GPUArch`` options for ``device``.
+
+    Prefer the tensor's device over process ``current_device`` so multi-GPU
+    callers compile for the GPU that owns the inputs (flashinfer#3960, #4117).
+    """
+    major, minor = device_compute_capability(device)
+    # Match nvidia-cutlass-dsl gpu_arch_map: Hopper+ primary targets use "a".
+    if major >= 9:
+        return (cute.GPUArch(f"sm_{major}{minor}a"),)
+    return (cute.GPUArch(f"sm_{major}{minor}"),)
+
+
+def cute_compile(func, *args, device: torch.device | str, **kwargs):
+    """``cute.compile`` with ``GPUArch`` taken from ``device``."""
+    return cute.compile[cute_compile_options(device)](func, *args, **kwargs)

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -47,6 +47,8 @@ import cuda.bindings.driver as cuda
 import torch
 from cutlass.cute.runtime import from_dlpack
 
+from .cute_compile_utils import cute_compile, device_compute_capability
+
 
 def _mark_batch_dynamic(torch_t: torch.Tensor, *, assumed_align: int = 32):
     # mark_layout_dynamic accepts non-compact packed q/k/v (SGLang fused QKV).
@@ -3129,8 +3131,10 @@ def gated_delta_rule_mtp_wide_vec(
     else:
         pool_size_key = pool_size
         pool_slot_stride = tuple(int(s) for s in initial_state_source.stride())
+    cc = device_compute_capability(q.device)
     cache_key = (
         "v3_mtp_bf16_tiled_dynB",
+        cc,
         T_val,
         H_val,
         HV_val,
@@ -3203,7 +3207,7 @@ def gated_delta_rule_mtp_wide_vec(
         )
 
         _compiled_kernels_wide_vec[cache_key] = {
-            "compiled": cute.compile(
+            "compiled": cute_compile(
                 _run_wide_vec,
                 h_,
                 inter_,
@@ -3239,6 +3243,7 @@ def gated_delta_rule_mtp_wide_vec(
                 per_token_pool_scatter,
                 per_token_pool_scatter_flat,
                 stream,
+                device=q.device,
                 options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
             # Per-B default tensors (B-dependent shapes; can't be shared
@@ -3408,8 +3413,10 @@ def gated_delta_rule_t1_wide_vec(
     else:
         pool_size_key = pool_size
         pool_slot_stride = tuple(int(s) for s in initial_state_source.stride())
+    cc = device_compute_capability(q.device)
     cache_key = (
         "v3_mtp_bf16_tiled_dynB",
+        cc,
         T_val,
         H_val,
         HV_val,
@@ -3464,7 +3471,7 @@ def gated_delta_rule_t1_wide_vec(
         h0_out_idx_ = h0_idx_
 
         _compiled_kernels_wide_vec[cache_key] = {
-            "compiled": cute.compile(
+            "compiled": cute_compile(
                 _run_wide_vec_t1,
                 h_,
                 inter_,
@@ -3493,6 +3500,7 @@ def gated_delta_rule_t1_wide_vec(
                 use_packed_fma,
                 same_pool,
                 stream,
+                device=q.device,
                 options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
             # Per-B default tensors (B-dependent shapes — see batch-dynamic
@@ -3773,8 +3781,10 @@ def gated_delta_rule_mtp(
     else:
         pool_size_key = pool_size
         pool_slot_stride = tuple(int(s) for s in initial_state_source.stride())
+    cc = device_compute_capability(q.device)
     cache_key = (
         "mtp_bf16_dynB",
+        cc,
         T,
         H,
         HV,
@@ -3847,7 +3857,7 @@ def gated_delta_rule_mtp(
         )
 
         _compiled_kernels_mtp[cache_key] = {
-            "compiled": cute.compile(
+            "compiled": cute_compile(
                 run_gdn_decode_bf16state_mtp_ilp4,
                 h_,
                 inter_,
@@ -3882,6 +3892,7 @@ def gated_delta_rule_mtp(
                 per_token_pool_scatter,
                 per_token_pool_scatter_flat,
                 stream,
+                device=q.device,
                 options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
             # Per-B default tensors (B-dependent shapes — see batch-dynamic

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -46,6 +46,8 @@ import cutlass.cute as cute
 from cutlass.cute.runtime import from_dlpack
 import cuda.bindings.driver as cuda
 
+from .cute_compile_utils import cute_compile, device_compute_capability
+
 # ============================================================================
 # Global configuration for MTP (Multiple Token Processing) version
 # ============================================================================
@@ -2496,6 +2498,8 @@ def run_gdn_verify_kernel_mtp_inline(
 
 @functools.cache
 def _get_compiled_mtp_kernel(
+    cc_major: int,
+    cc_minor: int,
     T: int,
     H: int,
     HV: int,
@@ -2521,6 +2525,8 @@ def _get_compiled_mtp_kernel(
 
 @functools.cache
 def _get_compiled_mtp_kernel_inline(
+    cc_major: int,
+    cc_minor: int,
     T: int,
     H: int,
     HV: int,
@@ -2608,8 +2614,8 @@ def run_mtp_decode(
     # Dispatch between inline kernel and warp-specialized kernel based on CTA work units
     _, _, ilp_rows, use_smem_v = get_mtp_config(B, T, HV, V, disable_state_update)
     use_inline_kernel = (B * HV) <= 128
-    major, _ = torch.cuda.get_device_capability(q.device)
-    use_packed_fma = major >= 10  # SM100+ (Blackwell) supports packed F32x2
+    cc = device_compute_capability(q.device)
+    use_packed_fma = cc[0] >= 10  # SM100+ (Blackwell) supports packed F32x2
 
     per_token_pool_scatter = ssm_state_indices is not None
 
@@ -2625,6 +2631,8 @@ def run_mtp_decode(
 
     if use_inline_kernel:
         inline_cache_key = (
+            cc[0],
+            cc[1],
             T,
             H,
             HV,
@@ -2647,6 +2655,8 @@ def run_mtp_decode(
         cache = _get_compiled_mtp_kernel_inline(*inline_cache_key)
     else:
         warp_cache_key = (
+            cc[0],
+            cc[1],
             T,
             H,
             HV,
@@ -2748,7 +2758,7 @@ def run_mtp_decode(
         ).mark_layout_dynamic()
 
         if use_inline_kernel:
-            compiled = cute.compile(
+            compiled = cute_compile(
                 run_gdn_verify_kernel_mtp_inline,
                 h0_source_tensor,
                 intermediate_states_tensor,
@@ -2785,10 +2795,11 @@ def run_mtp_decode(
                 use_packed_fma=use_packed_fma,
                 per_token_pool_scatter=per_token_pool_scatter,
                 stream=stream,
+                device=q.device,
                 options="--enable-tvm-ffi --generate-line-info",
             )
         else:
-            compiled = cute.compile(
+            compiled = cute_compile(
                 run_gdn_verify_kernel_mtp,
                 h0_source_tensor,
                 intermediate_states_tensor,
@@ -2825,6 +2836,7 @@ def run_mtp_decode(
                 use_packed_fma=use_packed_fma,
                 per_token_pool_scatter=per_token_pool_scatter,
                 stream=stream,
+                device=q.device,
                 options="--enable-tvm-ffi --generate-line-info",
             )
         cache["compiled"] = compiled

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -29,6 +29,8 @@ from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.runtime import from_dlpack
 import cuda.bindings.driver as cuda
 
+from .cute_compile_utils import cute_compile, device_compute_capability
+
 # ============================================================================
 # Constants for NONTRANSPOSE version ([pool, HV, K, V])
 # ============================================================================
@@ -677,6 +679,8 @@ def run_gdn_decode_kernel_big_batch_nontranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel_nontranspose(
+    cc_major: int,
+    cc_minor: int,
     use_small_batch: bool,
     T: int,
     H: int,
@@ -722,7 +726,20 @@ def run_nontranspose_decode(
         use_qk_l2norm: Whether to apply L2 normalization.
     """
     use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
-    cache_key = (use_small_batch, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
+    cc = device_compute_capability(q.device)
+    cache_key = (
+        cc[0],
+        cc[1],
+        use_small_batch,
+        T,
+        H,
+        HV,
+        K,
+        V,
+        q.dtype,
+        scale,
+        use_qk_l2norm,
+    )
     cache = _get_compiled_decode_kernel_nontranspose(*cache_key)
 
     aux_map = cache.setdefault("aux", {})
@@ -763,7 +780,7 @@ def run_nontranspose_decode(
         ).mark_layout_dynamic()
 
         # Use TVM FFI to reduce runtime overhead
-        compiled = cute.compile(
+        compiled = cute_compile(
             run_func,
             cu_seqlens_tensor,
             q_tensor,
@@ -787,6 +804,7 @@ def run_nontranspose_decode(
             use_initial_state=True,
             use_qk_l2norm=use_qk_l2norm,
             stream=stream,
+            device=q.device,
             options="--enable-tvm-ffi",
         )
         cache["compiled"] = compiled

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -28,6 +28,8 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.runtime import from_dlpack
+
+from .cute_compile_utils import cute_compile, device_compute_capability
 import cuda.bindings.driver as cuda
 
 # ============================================================================
@@ -896,6 +898,8 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel(
+    cc_major: int,
+    cc_minor: int,
     T: int,
     H: int,
     HV: int,
@@ -960,7 +964,10 @@ def run_pretranspose_decode(
         stride0, stride1, stride2, stride3 = tuple(int(x) for x in h0_source.stride())
     else:
         pool_size = stride0 = stride1 = stride2 = stride3 = 0
+    cc = device_compute_capability(q.device)
     cache_key = (
+        cc[0],
+        cc[1],
         T,
         H,
         HV,
@@ -1028,7 +1035,7 @@ def run_pretranspose_decode(
         run_func = run_gdn_decode_kernel_small_batch_pretranspose
 
         # Use TVM FFI to reduce runtime overhead
-        compiled = cute.compile(
+        compiled = cute_compile(
             run_func,
             h0_source_tensor,
             A_log_tensor,
@@ -1055,6 +1062,7 @@ def run_pretranspose_decode(
             use_pool_indexing=use_pool_indexing,
             is_varlen=False,
             stream=stream,
+            device=q.device,
             options="--enable-tvm-ffi",
         )
         cache["compiled"] = compiled


### PR DESCRIPTION
## Summary
- Add `cute_compile_utils.py` with shared helpers to compile CuteDSL kernels for the GPU that owns the input tensors (not `torch.cuda.current_device()`).
- Wire pretranspose, nontranspose, MTP, and bf16-state decode kernels to use explicit `GPUArch` (`sm_{maj}{min}a` for Hopper+) and include compute capability in JIT cache keys.

## Motivation
Multi-GPU callers can compile a cubin for the wrong GPU when tensors live on a non-default device. This hardens the remaining GDN **decode** kernels that still used bare `cute.compile(...)`.

## Relationship to other PRs
- **Independent of #4117** — that PR fixes the WY output-only kernel (`cute.experimental` → `cute` + SM121 Core enum issue in #3995). This PR does not touch `gdn_decode_bf16_wy_output_only.py`.
- Same general pattern as #3960 (prefill SM121 targeting), applied to decode kernels.

## Test plan
- [x] H100 smoke: `test_decode_kernel_basic_pretranspose[bfloat16-1-16-16-32-128-1.0-True-True]`
- [x] H100 smoke: `test_decode_kernel_basic_nontranspose[bfloat16-1-16-16-32-128-1.0-True-True]`
- [ ] Spark / multi-GPU verification (optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GDN decode kernel compatibility across different GPU architectures.
  * Prevented cached compiled kernels from being reused on incompatible GPUs.
  * Automatically selects device-specific compilation settings for supported hardware.
  * Updated multiple GDN decode paths, including BF16, MTP, transpose, and non-transpose workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->