### PR TITLE
perf(test): bulk-precompile XQA decode kernels to cut test wall time ~4x

### DIFF
--- a/tests/attention/conftest.py
+++ b/tests/attention/conftest.py
@@ -55,38 +55,46 @@ def pytest_collection_modifyitems(session, config, items):
     if not xqa_items:
         return
 
+    # --collect-only enumerates tests without running them, so don't pre-build.
+    if config.getoption("--collect-only"):
+        return
+
     from flashinfer.jit.core import build_jit_specs
     from flashinfer.jit.xqa import gen_xqa_module
 
-    specs = {}
-    for it in xqa_items:
-        cs = getattr(it, "callspec", None)
-        if cs is None:
-            continue
-        kwargs = _executed_xqa_uri(cs.params)
-        if kwargs is None:
-            continue
-        try:
-            spec = gen_xqa_module(**kwargs)
-        except ValueError as e:
-            logger.debug("xqa-prebuild: skipping unsupported config %s: %s", kwargs, e)
-            continue
-        specs[spec.name] = spec
-
-    specs = list(specs.values())
-    if not specs:
-        return
-
     reporter = config.pluginmanager.getplugin("terminalreporter")
-    if reporter:
-        reporter.write_line(
-            f"[xqa-prebuild] compiling {len(specs)} XQA kernels in parallel..."
-        )
 
-    # Any failure here (e.g. compilation failure) must not abort collection
-    # for the whole suite. Fall back to the normal per-test first-touch JIT path,
-    # where a genuinely broken kernel surfaces as its own test failure instead.
+    # The whole prebuild is a best-effort optimization. Any failure here must not
+    # abort collection for the entire suite.
     try:
+        specs = {}
+        for it in xqa_items:
+            cs = getattr(it, "callspec", None)
+            if cs is None:
+                continue
+            kwargs = _executed_xqa_uri(cs.params)
+            if kwargs is None:
+                continue
+            try:
+                spec = gen_xqa_module(**kwargs)
+            except ValueError as e:
+                # Per-config unsupported (bad dtype/page_size/head_dim): skip just
+                # this config and keep prebuilding the rest.
+                logger.debug(
+                    "xqa-prebuild: skipping unsupported config %s: %s", kwargs, e
+                )
+                continue
+            specs[spec.name] = spec
+
+        specs = list(specs.values())
+        if not specs:
+            return
+
+        if reporter:
+            reporter.write_line(
+                f"[xqa-prebuild] compiling {len(specs)} XQA kernels in parallel..."
+            )
+
         # One ninja graph, built in parallel; skip_prebuilt reuses anything already AOT'd.
         build_jit_specs(specs, verbose=False)
 

--- a/tests/attention/conftest.py
+++ b/tests/attention/conftest.py
@@ -1,0 +1,104 @@
+"""
+Conftest file for attention tests.
+
+Current features:
+1.  Bulk-precompile XQA decode kernels before the test file
+``test_trtllm_gen_attention_decode_xqa.py`` runs. Bulk-precompile avoids
+sequential compilation of kernels that can occupy 95% of the test's wall time.
+"""
+
+import os
+
+import pytest
+import torch
+
+_XQA_FILE = "test_trtllm_gen_attention_decode_xqa.py"
+
+_DT = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp8": torch.float8_e4m3fn}
+
+
+def _executed_xqa_uri(p):
+    """Return gen_xqa_module kwargs for an executed xqa case, or None if the
+    case is skipped by the backend guards (mirrors the test's pytest.skip logic)."""
+    q, kv, o = p["q_dtype"], p["kv_dtype"], p["o_dtype"]
+    if p.get("non_contiguous_query"):
+        return None  # xqa: no non-contiguous query
+    if p.get("skips_softmax"):
+        return None  # xqa: no skips_softmax
+    if not p.get("uses_shared_paged_kv_idx", True):
+        return None  # xqa: needs shared page indices
+    if q == "fp8":
+        return None  # xqa: only fp16/bf16 query
+    if o == "nvfp4" or kv == "nvfp4":
+        return None  # xqa: unsupported
+    return dict(
+        input_dtype=_DT[q],
+        kv_cache_dtype=_DT[kv],
+        page_size=p["page_size"],
+        head_dim=p["head_dim"],
+        head_group_ratio=p["head_grp_size"],
+        use_sliding_window=(p["window_left"] != -1),
+        output_dtype=_DT[o],
+        q_seq_len=p["q_len_per_req"],
+    )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(session, config, items):
+    # trylast: run after -k/-m deselection so we only build kernels for cases
+    # that will actually execute.
+    xqa_items = [it for it in items if it.nodeid.split("::")[0].endswith(_XQA_FILE)]
+    if not xqa_items:
+        return
+
+    from flashinfer.jit.core import build_jit_specs
+    from flashinfer.jit.xqa import gen_xqa_module
+
+    specs = {}
+    for it in xqa_items:
+        cs = getattr(it, "callspec", None)
+        if cs is None:
+            continue
+        kwargs = _executed_xqa_uri(cs.params)
+        if kwargs is None:
+            continue
+        try:
+            spec = gen_xqa_module(**kwargs)
+        except Exception:
+            continue  # unsupported config the test would also skip
+        specs[spec.name] = spec
+
+    specs = list(specs.values())
+    if not specs:
+        return
+
+    reporter = config.pluginmanager.getplugin("terminalreporter")
+    if reporter:
+        reporter.write_line(
+            f"[xqa-prebuild] compiling {len(specs)} XQA kernels in parallel..."
+        )
+
+    # One ninja graph, built in parallel; skip_prebuilt reuses anything already AOT'd.
+    build_jit_specs(specs, verbose=False)
+
+    # Stage each freshly-built .so into the AOT path so build_and_load loads it
+    # directly (no per-module ninja dependency scan at test time).
+    staged = 0
+    for s in specs:
+        src = s.jit_library_path
+        dst = s.aot_path
+        if dst.exists() or not src.exists():
+            continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.link(src, dst)  # hardlink: instant, same filesystem
+        except OSError:
+            import shutil
+
+            shutil.copy2(src, dst)
+        staged += 1
+
+    if reporter:
+        reporter.write_line(
+            f"[xqa-prebuild] staged {staged} kernels into AOT dir; test will load-only."
+        )

--- a/tests/attention/conftest.py
+++ b/tests/attention/conftest.py
@@ -7,10 +7,14 @@ Current features:
 sequential compilation of kernels that can occupy 95% of the test's wall time.
 """
 
+import contextlib
+import logging
 import os
 
 import pytest
 import torch
+
+logger = logging.getLogger(__name__)
 
 _XQA_FILE = "test_trtllm_gen_attention_decode_xqa.py"
 
@@ -64,8 +68,9 @@ def pytest_collection_modifyitems(session, config, items):
             continue
         try:
             spec = gen_xqa_module(**kwargs)
-        except Exception:
-            continue  # unsupported config the test would also skip
+        except ValueError as e:
+            logger.debug("xqa-prebuild: skipping unsupported config %s: %s", kwargs, e)
+            continue
         specs[spec.name] = spec
 
     specs = list(specs.values())
@@ -78,25 +83,50 @@ def pytest_collection_modifyitems(session, config, items):
             f"[xqa-prebuild] compiling {len(specs)} XQA kernels in parallel..."
         )
 
-    # One ninja graph, built in parallel; skip_prebuilt reuses anything already AOT'd.
-    build_jit_specs(specs, verbose=False)
+    # Any failure here (e.g. compilation failure) must not abort collection
+    # for the whole suite. Fall back to the normal per-test first-touch JIT path,
+    # where a genuinely broken kernel surfaces as its own test failure instead.
+    try:
+        # One ninja graph, built in parallel; skip_prebuilt reuses anything already AOT'd.
+        build_jit_specs(specs, verbose=False)
 
-    # Stage each freshly-built .so into the AOT path so build_and_load loads it
-    # directly (no per-module ninja dependency scan at test time).
-    staged = 0
-    for s in specs:
-        src = s.jit_library_path
-        dst = s.aot_path
-        if dst.exists() or not src.exists():
-            continue
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            os.link(src, dst)  # hardlink: instant, same filesystem
-        except OSError:
-            import shutil
+        # Stage each freshly-built .so into the AOT path so build_and_load loads it
+        # directly (no per-module ninja dependency scan at test time).
+        staged = 0
+        for s in specs:
+            src = s.jit_library_path
+            dst = s.aot_path
+            if dst.exists() or not src.exists():
+                continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.link(src, dst)  # hardlink: atomic + instant, same filesystem
+            except FileExistsError:
+                continue  # another worker staged it first; nothing to do
+            except OSError:
+                # Cross-filesystem (or link unsupported): copy to a temp file in
+                # the destination dir, then atomically rename into place so a
+                # concurrent worker never observes a partially written .so.
+                import shutil
+                import tempfile
 
-            shutil.copy2(src, dst)
-        staged += 1
+                fd, tmp = tempfile.mkstemp(dir=str(dst.parent), suffix=".tmp")
+                os.close(fd)
+                try:
+                    shutil.copy2(src, tmp)
+                    os.replace(tmp, dst)  # atomic on the same filesystem
+                except OSError:
+                    with contextlib.suppress(OSError):
+                        os.unlink(tmp)
+                    continue
+            staged += 1
+    except Exception as e:
+        if reporter:
+            reporter.write_line(
+                f"[xqa-prebuild] prebuild failed ({e!r}); falling back to "
+                "per-test JIT compilation."
+            )
+        return
 
     if reporter:
         reporter.write_line(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

`tests/attention/test_trtllm_gen_attention_decode_xqa.py` takes **40+ minutes** in CI where profiling shows the wall time is ~95% JIT compilation, not kernel execution. 

The file's parametrize matrix expands to cases that map to 408 unique XQA kernel compilations, all of which occur serially, one at a time. Each compilation takes around 5 seconds. 

Current PR adds a `tests/attention/conftest.py` that, right before the xqa test file runs, enumerates the exact kernels the collected cases will need and builds them **all in a single parallel `ninja` invocation** via `flashinfer.jit.build_jit_specs`, then stages the artifacts so the tests load them directly instead of recompiling.

**Measured on GB10 / SM121, cold cache (full file):**

| | Wall time |
|---|---|
| Before (serial first-touch compile) | ~40 min `4896 passed, 66912 skipped, 2 warnings in 2305.72s (0:38:25)` |
| After (parallel prebuild + load-only) | **628 s (10:28)** — `4896 passed, 66912 skipped ... in (0:10:28)` |

The parallel build compiles all 408 kernels in ~4.6 min (0.67 s/kernel amortized vs 5.9 s serial); the rest is unchanged test execution. No behavior change — same pass/skip counts.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved attention test startup time by bulk-precompiling supported FlashInfer XQA decode kernels during pytest collection.
  * Reduced repeated compilation overhead by compiling a deduplicated set of module specs in parallel.
  * Added optional progress/status reporting when terminal output is available.
  * Improved robustness by staging built artifacts ahead of runtime using safe atomic moves/hardlinks, reusing existing files when possible, and falling back to normal JIT behavior if bulk setup encounters any issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->