### PR TITLE
fix(moe): skip unsafe SM12x MXFP8xMXFP4 profiling

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -632,7 +632,17 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             use_wfp4afp8_humming=use_wfp4afp8_humming,
         )
 
-        if profile_ids is None:
+        # The SM12x CUTLASS profiler cannot currently construct valid TMA
+        # inputs for MXFP8 activations with packed MXFP4 weights. Profiling
+        # these tactics can leave the CUDA context in an illegal-instruction
+        # state (see #4049), while the normal fallback path is valid.
+        skip_unsafe_mxfp8_mxfp4_profiling = (
+            backend in ("120", "121")
+            and use_mxfp8_act_scaling
+            and fc1_expert_weights.dtype == torch.int64
+        )
+
+        if profile_ids is None and not skip_unsafe_mxfp8_mxfp4_profiling:
             tuner = AutoTuner.get()
             MoERunner.refine_tuning_config(tune_max_num_tokens)
 
@@ -667,12 +677,20 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
                 ],
                 gemm_idx=2,
             )
-        else:
+        elif profile_ids is not None:
             if len(profile_ids) != 2:
                 raise ValueError(
                     "profile_ids must contain [gemm1_profile, gemm2_profile]"
                 )
             gemm_tactic_1, gemm_tactic_2 = profile_ids
+        else:
+            if AutoTuner.get().is_tuning_mode:
+                logger.warning_once(
+                    "[AutoTuner]: Skipping SM12x MXFP8xMXFP4 fused-MoE profiling "
+                    "because it can leave the CUDA context unusable (see #4049). "
+                    "Using fallback tactics."
+                )
+            gemm_tactic_1, gemm_tactic_2 = -1, -1
 
         run_moe = (
             moe_runner.fused_moe_runner.run_moe_min_latency

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -1498,6 +1498,9 @@ def dequant_mxfp8_batches(
 @pytest.mark.parametrize(
     ("alpha", "beta", "limit"), [(None, None, None), (0.5, 0.0, 7.0), (1.702, 1.0, 7.0)]
 )
+# use_autotune=True covers #4049: SM12x must fall back without launching
+# the unsafe MXFP8xMXFP4 CUTLASS profiler.
+@pytest.mark.parametrize("use_autotune", [False, True])
 @pytest.mark.skipif(
     torch.cuda.get_device_capability()[0] not in [10, 11, 12],
     reason="MXFP8xMXFP4 is only supported on SM100, SM110 and SM120/SM121",
@@ -1512,6 +1515,7 @@ def test_moe_mxfp8_mxfp4(
     alpha,
     beta,
     limit,
+    use_autotune,
 ):
     """
     Test MoE with MXFP8 activations and MXFP4 weights.
@@ -1562,21 +1566,22 @@ def test_moe_mxfp8_mxfp4(
         beta_t = None
 
     # Call cutlass_fused_moe with MXFP8 activations and MXFP4 weights
-    _ = fused_moe.cutlass_fused_moe(
-        mxfp8_x,
-        selected_experts.to(torch.int),
-        routing_weights,
-        mxfp4_w1.contiguous().view(torch.long),
-        mxfp4_w2.contiguous().view(torch.long),
-        otype,
-        swiglu_alpha=alpha_t,
-        swiglu_limit=limit_t,
-        swiglu_beta=beta_t,
-        quant_scales=quant_scales,
-        input_sf=mxfp8_x_sf,
-        use_mxfp8_act_scaling=True,
-        output=flash_output,
-    )
+    with autotune(True) if use_autotune else nullcontext():
+        _ = fused_moe.cutlass_fused_moe(
+            mxfp8_x,
+            selected_experts.to(torch.int),
+            routing_weights,
+            mxfp4_w1.contiguous().view(torch.long),
+            mxfp4_w2.contiguous().view(torch.long),
+            otype,
+            swiglu_alpha=alpha_t,
+            swiglu_limit=limit_t,
+            swiglu_beta=beta_t,
+            quant_scales=quant_scales,
+            input_sf=mxfp8_x_sf,
+            use_mxfp8_act_scaling=True,
+            output=flash_output,
+        )
 
     dq_mxfp8_x = (
         mxfp8_dequantize_host(


### PR DESCRIPTION
## 📌 Description

Avoid automatic CUTLASS tactic profiling for the SM120/SM121 MXFP8-activation × packed-MXFP4-weight fused-MoE path.

On current `main`, all 20 GEMM1 tactics fail for this path on SM121, and six of them leave the CUDA context in an illegal-instruction state. The normal fallback tactic remains valid and passes the existing numerical checks, so this change:

- selects fallback tactics only for automatic SM12x MXFP8×MXFP4 profiling;
- preserves explicit `profile_ids` behavior;
- emits a one-time warning when tuning mode requests this unsafe profile;
- exercises both normal and autotune-enabled execution in the existing MXFP8×MXFP4 test.

This is intentionally a safety fallback, not a claim that the unsupported profiler tactics are fixed.

## 🔍 Related Issues

Closes #4049

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Targeted result: `pre-commit run --files flashinfer/fused_moe/core.py tests/moe/test_trtllm_cutlass_fused_moe.py` passes all applicable hooks, including mypy and Ruff.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

GPU validation after rebasing onto current `main`:

```text
python -m pytest -q tests/moe/test_trtllm_cutlass_fused_moe.py::test_moe_mxfp8_mxfp4
12 passed, 3 warnings in 75.76s
```

Environment: NVIDIA GB10 (SM121), CUDA 13.x container, FlashInfer built from this source checkout.

## Reviewer Notes

Please review the narrow dtype/backend guard and whether warning only in tuning mode is the preferred UX. Explicit tactic IDs remain untouched.

AI-assisted contribution disclosure: Codex assisted with reproduction, per-tactic isolation, implementation, and validation. The issue discussion and this PR include the concrete environment and test results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for MXFP8 activation and packed MXFP4 weight configurations on supported hardware.
  * Unsafe autotuning paths are now skipped, preventing potential execution issues and using a safe fallback instead.
  * Invalid profiling configuration input now produces a clear validation error.

* **Tests**
  * Expanded coverage to verify both autotuned and non-autotuned execution for the affected MoE configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->