### PR TITLE
Use the fast flashinfer quant for MegaMOE

### DIFF
--- a/flashinfer/moe_ep/backends/mega/kernel/mxfp8_cutedsl/staging.py
+++ b/flashinfer/moe_ep/backends/mega/kernel/mxfp8_cutedsl/staging.py
@@ -31,9 +31,9 @@ def stage_mega_moe_inputs(
     from .....kernel_src.cutedsl_megamoe import (
         Mxfp8BlockSize,
         ceil_div,
-        mxfp8_quantize_per_block_32,
         round_up,
     )
+    from flashinfer.quantization.fp8_quantization import mxfp8_quantize
 
     num_tokens, hidden = hidden_states.shape
     if num_tokens == 0:
@@ -43,9 +43,12 @@ def stage_mega_moe_inputs(
     if topk_weights.shape != topk_ids.shape:
         raise ValueError("topk_weights and topk_ids must have the same shape.")
 
-    data_dtype = _mxfp8_data_dtype(kind)
-    activation_fp32 = hidden_states.to(torch.float32)
-    q, sf = mxfp8_quantize_per_block_32(activation_fp32, data_dtype)
+    q, sf = mxfp8_quantize(
+        hidden_states,
+        is_sf_swizzled_layout=False,
+        alignment=32,
+        backend="cuda",
+    )
 
     hidden_sf_cols = ceil_div(hidden, Mxfp8BlockSize)
     hidden_sf_cols_padded = round_up(hidden_sf_cols, 4)
@@ -57,7 +60,11 @@ def stage_mega_moe_inputs(
 
     x_fp8[:num_tokens].view(torch.uint8).copy_(q.view(torch.uint8))
     x_sf[:num_tokens].zero_()
-    x_sf[:num_tokens, :hidden_sf_cols].view(torch.uint8).copy_(sf.view(torch.uint8))
+    # fused mxfp8_quantize returns SF as a 1-D flat (num_tokens*hidden/32,) uint8 tensor
+    # (linear layout) — reshape to [num_tokens, hidden_sf_cols] before copying.
+    x_sf[:num_tokens, :hidden_sf_cols].view(torch.uint8).copy_(
+        sf.view(torch.uint8).reshape(num_tokens, hidden_sf_cols)
+    )
     topk_idx_out[:num_tokens].copy_(topk_ids)
     topk_weights_out[:num_tokens].copy_(topk_weights)
 

--- a/flashinfer/moe_ep/backends/mega/kernel/nvfp4_cutedsl/staging.py
+++ b/flashinfer/moe_ep/backends/mega/kernel/nvfp4_cutedsl/staging.py
@@ -24,9 +24,9 @@ def stage_mega_moe_inputs(
     from .....kernel_src.cutedsl_megamoe import (
         Nvfp4BlockSize,
         ceil_div,
-        nvfp4_quantize_per_block_16,
         round_up,
     )
+    from flashinfer.quantization.fp4_quantization import fp4_quantize
 
     num_tokens, hidden = hidden_states.shape
     if num_tokens == 0:
@@ -36,8 +36,16 @@ def stage_mega_moe_inputs(
     if topk_weights.shape != topk_ids.shape:
         raise ValueError("topk_weights and topk_ids must have the same shape.")
 
-    activation_fp32 = hidden_states.to(torch.float32)
-    q, sf = nvfp4_quantize_per_block_16(activation_fp32, norm_const)
+    global_scale = torch.full(
+        (1,), float(norm_const), dtype=torch.float32, device=hidden_states.device
+    )
+    q, sf = fp4_quantize(
+        hidden_states,
+        global_scale=global_scale,
+        sf_vec_size=16,
+        sf_use_ue8m0=False,
+        is_sf_swizzled_layout=False,
+    )
 
     hidden_sf_cols = ceil_div(hidden, Nvfp4BlockSize)
     hidden_sf_cols_padded = round_up(hidden_sf_cols, 4)
@@ -47,9 +55,9 @@ def stage_mega_moe_inputs(
             f"{hidden_sf_cols_padded}."
         )
 
-    x_nvfp4[:num_tokens].copy_(q)
+    x_nvfp4[:num_tokens].view(torch.uint8).copy_(q)
     x_sf[:num_tokens].zero_()
-    x_sf[:num_tokens, :hidden_sf_cols].copy_(sf)
+    x_sf[:num_tokens, :hidden_sf_cols].view(torch.uint8).copy_(sf)
     topk_idx_out[:num_tokens].copy_(topk_ids)
     topk_weights_out[:num_tokens].copy_(topk_weights)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MXFP8 activation quantization during mixture-of-experts processing.
  * Corrected scale-factor layout handling for staged MXFP8 inputs.
  * Updated NVFP4 quantization and output copying to improve compatibility with expected buffer formats.
  * Preserved accurate quantized data when writing FP8 and FP4 inputs to processing buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->