### PR TITLE
docs(mamba): document checkpointing varlen arguments

### DIFF
--- a/flashinfer/mamba/checkpointing_ssu.py
+++ b/flashinfer/mamba/checkpointing_ssu.py
@@ -306,6 +306,15 @@ def checkpointing_ssu(
     d_split : Optional[int]
         Per-head DIM split factor.  This is only exposed for benchmarking.
         Do not use it cause it will make things slow.
+    cu_seqlens : Optional[torch.Tensor]
+        Cumulative sequence boundaries for packed variable-length input, as a
+        one-dimensional int32 CUDA tensor.  When provided, ``x`` must have
+        shape ``(1, total_tokens, nheads, dim)`` and ``max_seqlen`` is required.
+    max_seqlen : Optional[int]
+        Upper bound on every packed sequence length.  In variable-length mode
+        this is the JIT-specialized predicted-token count used to derive the
+        logical replay window from the ring-buffer size.  Must be ``None`` when
+        ``cu_seqlens`` is not provided.
     precompute_heads_per_cta : int
         Two-kernel PRECOMPUTE head-tiling: heads per precompute CTA.  0 (default) uses the
         launcher's co-residency heuristic; >0 overrides it (must divide nheads/ngroups,

--- a/flashinfer/mamba/checkpointing_ssu.py
+++ b/flashinfer/mamba/checkpointing_ssu.py
@@ -308,8 +308,10 @@ def checkpointing_ssu(
         Do not use it cause it will make things slow.
     cu_seqlens : Optional[torch.Tensor]
         Cumulative sequence boundaries for packed variable-length input, as a
-        one-dimensional int32 CUDA tensor.  When provided, ``x`` must have
-        shape ``(1, total_tokens, nheads, dim)`` and ``max_seqlen`` is required.
+        one-dimensional int32 CUDA tensor of shape ``(batch + 1,)``.  It must
+        start at 0, be monotonically nondecreasing, and end at ``total_tokens``.
+        When provided, ``x`` must have shape
+        ``(1, total_tokens, nheads, dim)`` and ``max_seqlen`` is required.
     max_seqlen : Optional[int]
         Upper bound on every packed sequence length.  In variable-length mode
         this is the JIT-specialized predicted-token count used to derive the


### PR DESCRIPTION
## Description

Document the two `checkpointing_ssu` arguments still reported by the documentation checker in #4061:

- `cu_seqlens`: packed variable-length boundaries, dtype/device requirements, and packed `x` shape
- `max_seqlen`: required per-sequence upper bound, JIT specialization/ring-window role, and fixed-length exclusion

The wording follows the wrapper validation and ring-buffer contract in the implementation. This is documentation-only and does not change runtime behavior.

## Validation

- `git diff --check`
- `pre-commit run --files flashinfer/mamba/checkpointing_ssu.py`
  - mypy passed
  - Ruff check/format passed
  - all remaining configured hooks passed

Addresses the remaining `checkpointing_ssu` argument-consistency finding in #4061.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified variable-length mode inputs for checkpointing.
  * Specified that packed sequence boundaries (`cu_seqlens`) use a 1D `int32` CUDA tensor of shape `(batch + 1,)`.
  * Updated required input shapes when sequence boundaries are provided, and clarified `max_seqlen` requirements (must be provided with boundaries, omitted otherwise).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->