### PR TITLE
feat(sm120): fused MoE (SwiGLU) via moe_gemm is_gated for cute SM120 groupwise GEMM

### DIFF
--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_op.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_op.cu
@@ -22,7 +22,8 @@
 void CutlassFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_scale,
                                      TensorView b_scale, TensorView m_indptr, TensorView out,
                                      std::string scale_major_mode, int64_t scale_granularity_m,
-                                     int64_t scale_granularity_n, int64_t scale_granularity_k) {
+                                     int64_t scale_granularity_n, int64_t scale_granularity_k,
+                                     int64_t is_gated) {
   TVM_FFI_ICHECK(scale_major_mode == "MN")
       << "Only scale_major_mode=\"MN\" is supported; got \"" << scale_major_mode << "\"";
 
@@ -62,13 +63,24 @@ void CutlassFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_sc
   int n = static_cast<int>(b.size(1));
   int k = static_cast<int>(b.size(2));
 
+  // Gated (fused SwiGLU) mode: b packs gate+up along N (b.size(1) == 2 * out_n); the kernel
+  // fuses SiLU(gate)*up so output N is halved. b_scale still spans the full b.size(1) weight
+  // dimension (SFB is over b.size(1)), so only out / runner shape_n use out_n.
+  bool gated = is_gated != 0;
+  if (gated) {
+    TVM_FFI_ICHECK_EQ(n % 2, 0)
+        << "gated (fused SwiGLU) moe requires even b.size(1) (gate+up); got " << n;
+  }
+  int out_n = gated ? n / 2 : n;
+
   TVM_FFI_ICHECK_GT(num_experts, 0) << "num_experts must be positive; got " << num_experts;
   TVM_FFI_ICHECK_EQ(a.size(1), k) << "a.size(1) (" << a.size(1) << ") must match b.size(2) (" << k
                                   << ")";
   TVM_FFI_ICHECK_EQ(out.size(0), total_rows)
       << "out.size(0) (" << out.size(0) << ") must match a.size(0) (" << total_rows << ")";
-  TVM_FFI_ICHECK_EQ(out.size(1), n)
-      << "out.size(1) (" << out.size(1) << ") must match b.size(1) (" << n << ")";
+  TVM_FFI_ICHECK_EQ(out.size(1), out_n)
+      << "out.size(1) (" << out.size(1) << ") must match output N (" << out_n
+      << (gated ? "; = b.size(1)/2 for gated" : "; = b.size(1)") << ")";
   TVM_FFI_ICHECK_EQ(m_indptr.size(0), num_experts + 1)
       << "m_indptr.size(0) (" << m_indptr.size(0) << ") must be num_experts + 1 ("
       << (num_experts + 1) << ")";
@@ -76,7 +88,7 @@ void CutlassFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_sc
   TVM_FFI_ICHECK_GT(k, 0) << "k must be positive; got k=" << k;
   TVM_FFI_ICHECK_GT(n, 0) << "n must be positive; got n=" << n;
   TVM_FFI_ICHECK_EQ(k % 16, 0) << "k must be multiple of 16; got k=" << k;
-  TVM_FFI_ICHECK_EQ(n % 16, 0) << "n must be multiple of 16; got n=" << n;
+  TVM_FFI_ICHECK_EQ(out_n % 16, 0) << "output N must be multiple of 16; got " << out_n;
 
   auto ceil_div = [](int64_t x, int64_t y) { return (x + y - 1) / y; };
   auto compute_padded_offset = [](int64_t offset, int64_t problem_idx) {
@@ -110,7 +122,7 @@ void CutlassFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_sc
   runner.moe_gemm_fp8_nt_groupwise(
       out.data_ptr(), static_cast<void const*>(a.data_ptr()),
       static_cast<void const*>(b.data_ptr()), static_cast<int32_t const*>(m_indptr.data_ptr()),
-      num_experts, total_rows, n, k, stream, static_cast<float const*>(a_scale.data_ptr()),
+      num_experts, total_rows, out_n, k, stream, static_cast<float const*>(a_scale.data_ptr()),
       static_cast<float const*>(b_scale.data_ptr()), static_cast<int>(scale_granularity_m),
-      static_cast<int>(scale_granularity_n), static_cast<int>(scale_granularity_k));
+      static_cast<int>(scale_granularity_n), static_cast<int>(scale_granularity_k), gated);
 }

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_op.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_op.cu
@@ -63,9 +63,10 @@ void CutlassFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_sc
   int n = static_cast<int>(b.size(1));
   int k = static_cast<int>(b.size(2));
 
-  // Gated (fused SwiGLU) mode: b packs gate+up along N (b.size(1) == 2 * out_n); the kernel
-  // fuses SiLU(gate)*up so output N is halved. b_scale still spans the full b.size(1) weight
-  // dimension (SFB is over b.size(1)), so only out / runner shape_n use out_n.
+  // Gated (fused SwiGLU) mode: b packs up in columns [0, N) and gate in [N, 2*N) along N
+  // (b.size(1) == 2 * out_n); the kernel fuses SiLU(gate)*up so output N is halved. b_scale
+  // still spans the full b.size(1) weight dimension (SFB is over b.size(1)), so only out /
+  // runner shape_n use out_n.
   bool gated = is_gated != 0;
   if (gated) {
     TVM_FFI_ICHECK_EQ(n % 2, 0)

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_op_jit_binding.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_op_jit_binding.cu
@@ -20,6 +20,7 @@
 void CutlassFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_scale,
                                      TensorView b_scale, TensorView m_indptr, TensorView out,
                                      std::string scale_major_mode, int64_t scale_granularity_m,
-                                     int64_t scale_granularity_n, int64_t scale_granularity_k);
+                                     int64_t scale_granularity_n, int64_t scale_granularity_k,
+                                     int64_t is_gated);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_gemm_fp8_nt_groupwise, CutlassFP8GroupwiseMoeGEMMSM120);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
@@ -20,6 +20,8 @@
 #include <stdexcept>
 
 #include "cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.h"
+#include "tvm_ffi_utils.h"
+#include "cute_sm120_mxfp8_groupwise/sm120_fused_moe/launch.cuh"
 #include "cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh"
 #include "cute_sm120_mxfp8_groupwise/sm120_blockscaling/launch.cuh"
 // clang-format on
@@ -39,8 +41,51 @@ CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType,
 static void check_scale_granularity_mnk(int scale_granularity_m, int scale_granularity_n,
                                         int scale_granularity_k) {
   if (scale_granularity_m != 1 || scale_granularity_n != 128 || scale_granularity_k != 128) {
-    throw std::runtime_error("unsupported FP8 scale granularity");
+    TVM_FFI_ICHECK(false) << "unsupported FP8 scale granularity";
   }
+}
+
+static int select_fp8_fused_moe_tile_m(int total_rows, int shape_n, int num_experts, int num_sms) {
+  int m_per_expert = num_experts > 0 ? (total_rows + num_experts - 1) / num_experts : 0;
+  auto tile_count = [&](int tile_m, int tile_n) {
+    int64_t num_m = (int64_t(m_per_expert) + tile_m - 1) / tile_m;
+    int64_t num_n = (int64_t(shape_n) + tile_n - 1) / tile_n;
+    return int64_t(num_experts) * num_m * num_n;
+  };
+
+  int64_t swapab_tiles = tile_count(8, 128);
+  int64_t m32_tiles = tile_count(32, 128);
+  int64_t m64_tiles = tile_count(64, 128);
+  int64_t m128_tiles = tile_count(128, 64);
+
+  if (shape_n % 128 == 0 &&
+      (m_per_expert <= 8 || (m32_tiles < num_sms / 2 && swapab_tiles <= num_sms))) {
+    return 8;
+  }
+  if (shape_n == 64) {
+    return m_per_expert <= 32 ? 32 : 128;
+  }
+  if (shape_n % 128 != 0) {
+    return 128;
+  }
+
+  int64_t m32_waves = (m32_tiles + num_sms - 1) / num_sms;
+  int64_t m64_waves = (m64_tiles + num_sms - 1) / num_sms;
+  int64_t m128_waves = (m128_tiles + num_sms - 1) / num_sms;
+
+  if (m64_waves >= m32_waves) {
+    if (m32_waves == 1 && m32_tiles < num_sms / 2) {
+      return 128;
+    }
+    return 32;
+  }
+  if (m128_waves < m64_waves) {
+    return 128;
+  }
+  if (m128_waves > m64_waves && m64_tiles <= int64_t(num_sms) * 8) {
+    return 64;
+  }
+  return 128;
 }
 
 static int select_fp8_flat_tile_m(int shape_m, int shape_n, int num_groups, int num_sms) {
@@ -96,6 +141,50 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
                           int scale_granularity_k) {
   check_scale_granularity_mnk(scale_granularity_m, scale_granularity_n, scale_granularity_k);
   gemm_fp8_nt_groupwise_impl(D, A, B, shape_m, shape_n, shape_k, SFA, SFB, stream);
+}
+
+template <typename ElementType, typename OutElementType, typename AccumElementType,
+          typename BlockScaleElementType>
+void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, BlockScaleElementType>::
+    fused_moe_fp8_nt_groupwise_impl(void* D, void const* A, void const* B,
+                                    int32_t const* token_offset, int num_experts, int total_rows,
+                                    int shape_n, int shape_k, cudaStream_t stream, float const* SFA,
+                                    float const* SFB) {
+  using KT_SWAPAB = sm120_blockscaling::SM120BlockScalingFusedMoeBuilder<128, 8, 128, 2, true>;
+  using KT_M32 = sm120_blockscaling::SM120BlockScalingFusedMoeBuilder<32, 128, 128, 2>;
+  using KT_M64 = sm120_blockscaling::SM120BlockScalingFusedMoeBuilder<64, 128, 128, 2>;
+  using KT_M128 = sm120_blockscaling::SM120BlockScalingFusedMoeBuilder<128, 64, 128, 2>;
+
+  auto ptr_A = reinterpret_cast<typename KT_M128::ElementA const*>(A);
+  auto ptr_B = reinterpret_cast<typename KT_M128::ElementB const*>(B);
+  auto ptr_SFA = reinterpret_cast<typename KT_M128::ElementScale const*>(SFA);
+  auto ptr_SFB = reinterpret_cast<typename KT_M128::ElementScale const*>(SFB);
+  auto ptr_D = reinterpret_cast<typename KT_M128::ElementD*>(D);
+
+  int num_sms = sm120_blockscaling::get_num_sms();
+  int tile_m = select_fp8_fused_moe_tile_m(total_rows, shape_n, num_experts, num_sms);
+
+  if (tile_m == 8) {
+    sm120_blockscaling::launch_fused_moe<KT_SWAPAB>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
+                                                    total_rows, shape_n, shape_k, num_experts,
+                                                    token_offset, num_sms, stream);
+    return;
+  }
+  if (tile_m == KT_M32::kTileM) {
+    sm120_blockscaling::launch_fused_moe<KT_M32>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
+                                                 shape_n, shape_k, num_experts, token_offset,
+                                                 num_sms, stream);
+    return;
+  }
+  if (tile_m == KT_M64::kTileM) {
+    sm120_blockscaling::launch_fused_moe<KT_M64>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
+                                                 shape_n, shape_k, num_experts, token_offset,
+                                                 num_sms, stream);
+    return;
+  }
+  sm120_blockscaling::launch_fused_moe<KT_M128>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
+                                                shape_n, shape_k, num_experts, token_offset,
+                                                num_sms, stream);
 }
 
 template <typename ElementType, typename OutElementType, typename AccumElementType,
@@ -251,10 +340,15 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
                               int num_experts, int total_rows, int shape_n, int shape_k,
                               cudaStream_t stream, float const* SFA, float const* SFB,
                               int scale_granularity_m, int scale_granularity_n,
-                              int scale_granularity_k) {
+                              int scale_granularity_k, bool is_gated) {
   check_scale_granularity_mnk(scale_granularity_m, scale_granularity_n, scale_granularity_k);
-  moe_gemm_fp8_nt_groupwise_impl(D, A, B, token_offset, num_experts, total_rows, shape_n, shape_k,
-                                 stream, SFA, SFB);
+  if (is_gated) {
+    fused_moe_fp8_nt_groupwise_impl(D, A, B, token_offset, num_experts, total_rows, shape_n,
+                                    shape_k, stream, SFA, SFB);
+  } else {
+    moe_gemm_fp8_nt_groupwise_impl(D, A, B, token_offset, num_experts, total_rows, shape_n, shape_k,
+                                   stream, SFA, SFB);
+  }
 }
 
 template <typename ElementType, typename OutElementType, typename AccumElementType,
@@ -280,7 +374,7 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
   int num_sms = sm120_blockscaling::get_num_sms();
   int m_per_expert = num_experts > 0 ? (total_rows / num_experts) : 0;
 
-  if (m_per_expert <= 8) {
+  if (m_per_expert <= 12) {
     sm120_blockscaling::launch_moe_gemm<KT_SWAPAB_N8>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
                                                       total_rows, shape_n, shape_k, num_experts,
                                                       token_offset, num_sms, stream);
@@ -288,7 +382,7 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
     sm120_blockscaling::launch_moe_gemm<KT_M32>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
                                                 shape_n, shape_k, num_experts, token_offset,
                                                 num_sms, stream);
-  } else if (m_per_expert <= 64) {
+  } else if (m_per_expert < 96 || (m_per_expert < 192 && shape_k <= 2048)) {
     sm120_blockscaling::launch_moe_gemm<KT_M64>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
                                                 shape_n, shape_k, num_experts, token_offset,
                                                 num_sms, stream);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
@@ -374,7 +374,16 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
   int num_sms = sm120_blockscaling::get_num_sms();
   int m_per_expert = num_experts > 0 ? (total_rows / num_experts) : 0;
 
-  if (m_per_expert <= 12) {
+  auto tile_count = [&](int tile_m, int tile_n) {
+    int64_t num_m = (int64_t(m_per_expert) + tile_m - 1) / tile_m;
+    int64_t num_n = (int64_t(shape_n) + tile_n - 1) / tile_n;
+    return int64_t(num_experts) * num_m * num_n;
+  };
+  int64_t swapab_tiles = tile_count(8, 128);
+  int64_t m32_tiles = tile_count(32, 128);
+
+  if (shape_n % 128 == 0 &&
+      (m_per_expert <= 8 || (m32_tiles < num_sms / 2 && swapab_tiles <= num_sms))) {
     sm120_blockscaling::launch_moe_gemm<KT_SWAPAB_N8>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
                                                       total_rows, shape_n, shape_k, num_experts,
                                                       token_offset, num_sms, stream);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.h
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.h
@@ -57,7 +57,7 @@ class CuteSm120Fp8GemmRunnerInterface {
                                          int max_shape_m, int shape_n, int shape_k,
                                          cudaStream_t stream, float const* SFA, float const* SFB,
                                          int scale_granularity_m = 1, int scale_granularity_n = 128,
-                                         int scale_granularity_k = 128) = 0;
+                                         int scale_granularity_k = 128, bool is_gated = false) = 0;
 
   virtual void group_gemm_fp8_nt_groupwise_contiguous(
       void* D, void const* A, void const* B, int32_t const* m_indices, int num_groups, int m,
@@ -95,7 +95,7 @@ class CuteSm120Fp8GemmRunner : public CuteSm120Fp8GemmRunnerInterface {
                                  int num_groups, int max_shape_m, int shape_n, int shape_k,
                                  cudaStream_t stream, float const* SFA, float const* SFB,
                                  int scale_granularity_m = 1, int scale_granularity_n = 128,
-                                 int scale_granularity_k = 128) override;
+                                 int scale_granularity_k = 128, bool is_gated = false) override;
 
   void group_gemm_fp8_nt_groupwise_contiguous(
       void* D, void const* A, void const* B, int32_t const* m_indices, int num_groups, int m,
@@ -121,6 +121,11 @@ class CuteSm120Fp8GemmRunner : public CuteSm120Fp8GemmRunnerInterface {
                                       int32_t const* token_offset, int num_groups, int max_shape_m,
                                       int shape_n, int shape_k, cudaStream_t stream,
                                       float const* SFA, float const* SFB);
+
+  void fused_moe_fp8_nt_groupwise_impl(void* D, void const* A, void const* B,
+                                       int32_t const* token_offset, int num_groups, int max_shape_m,
+                                       int shape_n, int shape_k, cudaStream_t stream,
+                                       float const* SFA, float const* SFB);
 
   void group_gemm_fp8_nt_groupwise_contiguous_impl(void* D, void const* A, void const* B,
                                                    int32_t const* m_indices, int num_groups, int m,

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_op.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_op.cu
@@ -21,7 +21,8 @@
 void CutlassMXFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_scale,
                                        TensorView b_scale, TensorView m_indptr, TensorView out,
                                        std::string scale_major_mode, int64_t scale_granularity_m,
-                                       int64_t scale_granularity_n, int64_t scale_granularity_k) {
+                                       int64_t scale_granularity_n, int64_t scale_granularity_k,
+                                       int64_t is_gated) {
   TVM_FFI_ICHECK(scale_major_mode == "MN")
       << "Only scale_major_mode=\"MN\" is supported; got \"" << scale_major_mode << "\"";
 
@@ -56,18 +57,29 @@ void CutlassMXFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_
   int n = static_cast<int>(b.size(1));
   int k = static_cast<int>(b.size(2));
 
+  // Gated (fused SwiGLU) mode: b packs gate+up along N (b.size(1) == 2 * out_n); the kernel
+  // fuses SiLU(gate)*up so output N is halved. b_scale still spans the full b.size(1) weight
+  // dimension (deduce_sfb_layout is over b.size(1)), so only out / runner shape_n use out_n.
+  bool gated = is_gated != 0;
+  if (gated) {
+    TVM_FFI_ICHECK_EQ(n % 2, 0)
+        << "gated (fused SwiGLU) moe requires even b.size(1) (gate+up); got " << n;
+  }
+  int out_n = gated ? n / 2 : n;
+
   TVM_FFI_ICHECK_EQ(a.size(1), k) << "a.size(1) (" << a.size(1) << ") must match b.size(2) (" << k
                                   << ")";
   TVM_FFI_ICHECK_EQ(out.size(0), total_rows)
       << "out.size(0) (" << out.size(0) << ") must match a.size(0) (" << total_rows << ")";
-  TVM_FFI_ICHECK_EQ(out.size(1), n)
-      << "out.size(1) (" << out.size(1) << ") must match b.size(1) (" << n << ")";
+  TVM_FFI_ICHECK_EQ(out.size(1), out_n)
+      << "out.size(1) (" << out.size(1) << ") must match output N (" << out_n
+      << (gated ? "; = b.size(1)/2 for gated" : "; = b.size(1)") << ")";
   TVM_FFI_ICHECK_EQ(m_indptr.size(0), num_experts + 1)
       << "m_indptr.size(0) (" << m_indptr.size(0) << ") must be num_experts + 1 ("
       << (num_experts + 1) << ")";
 
   TVM_FFI_ICHECK_EQ(k % 16, 0) << "k must be multiple of 16; got k=" << k;
-  TVM_FFI_ICHECK_EQ(n % 16, 0) << "n must be multiple of 16; got n=" << n;
+  TVM_FFI_ICHECK_EQ(out_n % 16, 0) << "output N must be multiple of 16; got " << out_n;
 
   auto ceil_div = [](int64_t x, int64_t y) { return (x + y - 1) / y; };
   auto align = [&](int64_t x, int64_t alignment) { return ceil_div(x, alignment) * alignment; };
@@ -118,6 +130,7 @@ void CutlassMXFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_
   runner.moe_gemm_mxfp8_nt_groupwise(
       out.data_ptr(), static_cast<void const*>(a.data_ptr()),
       static_cast<void const*>(b.data_ptr()), static_cast<int32_t const*>(m_indptr.data_ptr()),
-      num_experts, total_rows, n, k, stream, static_cast<int32_t const*>(a_scale.data_ptr()),
-      static_cast<int32_t const*>(b_scale.data_ptr()), static_cast<int>(scale_granularity_k));
+      num_experts, total_rows, out_n, k, stream, static_cast<int32_t const*>(a_scale.data_ptr()),
+      static_cast<int32_t const*>(b_scale.data_ptr()), static_cast<int>(scale_granularity_k),
+      gated);
 }

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_op.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_op.cu
@@ -57,9 +57,10 @@ void CutlassMXFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_
   int n = static_cast<int>(b.size(1));
   int k = static_cast<int>(b.size(2));
 
-  // Gated (fused SwiGLU) mode: b packs gate+up along N (b.size(1) == 2 * out_n); the kernel
-  // fuses SiLU(gate)*up so output N is halved. b_scale still spans the full b.size(1) weight
-  // dimension (deduce_sfb_layout is over b.size(1)), so only out / runner shape_n use out_n.
+  // Gated (fused SwiGLU) mode: b packs up in columns [0, N) and gate in [N, 2*N) along N
+  // (b.size(1) == 2 * out_n); the kernel fuses SiLU(gate)*up so output N is halved. b_scale
+  // still spans the full b.size(1) weight dimension (deduce_sfb_layout is over b.size(1)),
+  // so only out / runner shape_n use out_n.
   bool gated = is_gated != 0;
   if (gated) {
     TVM_FFI_ICHECK_EQ(n % 2, 0)

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_op_jit_binding.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_op_jit_binding.cu
@@ -20,6 +20,7 @@
 void CutlassMXFP8GroupwiseMoeGEMMSM120(TensorView a, TensorView b, TensorView a_scale,
                                        TensorView b_scale, TensorView m_indptr, TensorView out,
                                        std::string scale_major_mode, int64_t scale_granularity_m,
-                                       int64_t scale_granularity_n, int64_t scale_granularity_k);
+                                       int64_t scale_granularity_n, int64_t scale_granularity_k,
+                                       int64_t is_gated);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_gemm_mxfp8_nt_groupwise, CutlassMXFP8GroupwiseMoeGEMMSM120);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
@@ -18,10 +18,12 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <stdexcept>
 #include <cuda_runtime.h>
 #include "cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.h"
 #include "cutlass/gemm_coord.h"
 #include "tvm_ffi_utils.h"
+#include "cute_sm120_mxfp8_groupwise/sm120_fused_moe/launch.cuh"
 #include "cute_sm120_mxfp8_groupwise/sm120_blockscaled/builder.cuh"
 #include "cute_sm120_mxfp8_groupwise/sm120_blockscaled/kernel_impl.cuh"
 #include "cute_sm120_mxfp8_groupwise/sm120_blockscaled/launch.cuh"
@@ -42,6 +44,44 @@
   }
 
 namespace flashinfer::gemm::mxfp8_cute_sm120 {
+
+static int select_mxfp8_fused_moe_tile_m(int total_rows, int shape_n, int shape_k, int num_experts,
+                                         int num_sms) {
+  int m_per_expert = num_experts > 0 ? (total_rows + num_experts - 1) / num_experts : 0;
+  auto tile_count = [&](int tile_m, int tile_n) {
+    int64_t num_m = (int64_t(m_per_expert) + tile_m - 1) / tile_m;
+    int64_t num_n = (int64_t(shape_n) + tile_n - 1) / tile_n;
+    return int64_t(num_experts) * num_m * num_n;
+  };
+
+  int64_t swapab_tiles = tile_count(8, 128);
+  int64_t m32_tiles = tile_count(32, 128);
+  int64_t m64_tiles = tile_count(64, 128);
+  int64_t m128_tiles = tile_count(128, 64);
+  bool short_k = shape_k <= 2048;
+
+  if (m_per_expert <= 8 || (short_k && m32_tiles < num_sms / 2 && swapab_tiles <= num_sms)) {
+    return 8;
+  }
+
+  int64_t m32_waves = (m32_tiles + num_sms - 1) / num_sms;
+  int64_t m64_waves = (m64_tiles + num_sms - 1) / num_sms;
+  int64_t m128_waves = (m128_tiles + num_sms - 1) / num_sms;
+
+  if (m64_waves >= m32_waves) {
+    return 32;
+  }
+  if (m128_waves < m64_waves) {
+    return 128;
+  }
+  if (m128_waves > m64_waves) {
+    return 64;
+  }
+  if (short_k && m64_tiles < m128_tiles) {
+    return 64;
+  }
+  return 128;
+}
 
 template <typename ElementType, typename OutElementType, typename AccumElementType,
           typename BlockScaleElementType>
@@ -69,6 +109,58 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
   DISPATCH_GRAN_K(granK, GRAN_K, {
     gemm_mxfp8_nt_groupwise_impl<GRAN_K>(D, A, B, shape_m, shape_n, shape_k, SFA, SFB, stream);
   })
+}
+
+template <typename ElementType, typename OutElementType, typename AccumElementType,
+          typename BlockScaleElementType>
+template <int GranK>
+void CuteSm120Mxfp8GemmRunner<
+    ElementType, OutElementType, AccumElementType,
+    BlockScaleElementType>::fused_moe_mxfp8_nt_groupwise_impl(void* D, void const* A, void const* B,
+                                                              int32_t const* token_offset,
+                                                              int num_experts, int total_rows,
+                                                              int shape_n, int shape_k,
+                                                              cudaStream_t stream,
+                                                              int32_t const* SFA,
+                                                              int32_t const* SFB) {
+  int num_sms = sm120_blockscaled::get_num_sms();
+
+  using KT_SWAPAB = sm120_blockscaled::SM120BlockScaledFusedMoeBuilder<128, 8, 64, 4, GranK, true>;
+  using KT_M32 = sm120_blockscaled::SM120BlockScaledFusedMoeBuilder<32, 128, 64, 4, GranK>;
+  using KT_M64 =
+      sm120_blockscaled::SM120BlockScaledFusedMoeBuilder<64, 128, 64, 4, GranK, false, true>;
+  using KT_M128 = sm120_blockscaled::SM120BlockScaledFusedMoeBuilder<128, 64, 64, 4, GranK>;
+
+  auto ptr_A = reinterpret_cast<typename KT_M128::ElementA*>(const_cast<void*>(A));
+  auto ptr_B = reinterpret_cast<typename KT_M128::ElementB*>(const_cast<void*>(B));
+  auto ptr_SFA =
+      reinterpret_cast<typename KT_M128::SFConfig::ElementSFLoad*>(const_cast<int32_t*>(SFA));
+  auto ptr_SFB =
+      reinterpret_cast<typename KT_M128::SFConfig::ElementSFLoad*>(const_cast<int32_t*>(SFB));
+  auto ptr_D = reinterpret_cast<typename KT_M128::ElementD*>(D);
+
+  int tile_m = select_mxfp8_fused_moe_tile_m(total_rows, shape_n, shape_k, num_experts, num_sms);
+  if (tile_m == 8) {
+    sm120_blockscaled::launch_fused_moe<KT_SWAPAB>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
+                                                   total_rows, shape_n, shape_k, num_experts,
+                                                   token_offset, num_sms, stream);
+    return;
+  }
+  if (tile_m == KT_M32::kTileM) {
+    sm120_blockscaled::launch_fused_moe<KT_M32>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
+                                                shape_n, shape_k, num_experts, token_offset,
+                                                num_sms, stream);
+    return;
+  }
+  if (tile_m == KT_M64::kTileM) {
+    sm120_blockscaled::launch_fused_moe<KT_M64>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
+                                                shape_n, shape_k, num_experts, token_offset,
+                                                num_sms, stream);
+    return;
+  }
+  sm120_blockscaled::launch_fused_moe<KT_M128>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, total_rows,
+                                               shape_n, shape_k, num_experts, token_offset, num_sms,
+                                               stream);
 }
 
 template <typename ElementType, typename OutElementType, typename AccumElementType,
@@ -256,10 +348,16 @@ void CuteSm120Mxfp8GemmRunner<
                                                         int num_experts, int total_rows,
                                                         int shape_n, int shape_k,
                                                         cudaStream_t stream, int32_t const* SFA,
-                                                        int32_t const* SFB, int granK) {
+                                                        int32_t const* SFB, int granK,
+                                                        bool is_gated) {
   DISPATCH_GRAN_K(granK, GRAN_K, {
-    moe_gemm_mxfp8_nt_groupwise_impl<GRAN_K>(D, A, B, token_offset, num_experts, total_rows,
-                                             shape_n, shape_k, stream, SFA, SFB);
+    if (is_gated) {
+      fused_moe_mxfp8_nt_groupwise_impl<GRAN_K>(D, A, B, token_offset, num_experts, total_rows,
+                                                shape_n, shape_k, stream, SFA, SFB);
+    } else {
+      moe_gemm_mxfp8_nt_groupwise_impl<GRAN_K>(D, A, B, token_offset, num_experts, total_rows,
+                                               shape_n, shape_k, stream, SFA, SFB);
+    }
   })
 }
 

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.h
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.h
@@ -54,7 +54,8 @@ class CuteSm120Mxfp8GemmRunnerInterface {
                                            int32_t const* token_offset, int num_groups,
                                            int max_shape_m, int shape_n, int shape_k,
                                            cudaStream_t stream, int32_t const* SFA = nullptr,
-                                           int32_t const* SFB = nullptr, int granK = 128) = 0;
+                                           int32_t const* SFB = nullptr, int granK = 128,
+                                           bool is_gated = false) = 0;
 
   virtual void group_gemm_mxfp8_nt_groupwise_contiguous(
       void* D, void const* A, void const* B, int32_t const* m_indices, int num_groups, int m,
@@ -88,7 +89,7 @@ class CuteSm120Mxfp8GemmRunner : public CuteSm120Mxfp8GemmRunnerInterface {
                                    int32_t const* token_offset, int num_groups, int max_shape_m,
                                    int shape_n, int shape_k, cudaStream_t stream,
                                    int32_t const* SFA = nullptr, int32_t const* SFB = nullptr,
-                                   int granK = 128) override;
+                                   int granK = 128, bool is_gated = false) override;
 
   void group_gemm_mxfp8_nt_groupwise_contiguous(void* D, void const* A, void const* B,
                                                 int32_t const* m_indices, int num_groups, int m,
@@ -121,6 +122,13 @@ class CuteSm120Mxfp8GemmRunner : public CuteSm120Mxfp8GemmRunnerInterface {
                                         int max_shape_m, int shape_n, int shape_k,
                                         cudaStream_t stream, int32_t const* SFA,
                                         int32_t const* SFB);
+
+  template <int GranK>
+  void fused_moe_mxfp8_nt_groupwise_impl(void* D, void const* A, void const* B,
+                                         int32_t const* token_offset, int num_groups,
+                                         int max_shape_m, int shape_n, int shape_k,
+                                         cudaStream_t stream, int32_t const* SFA,
+                                         int32_t const* SFB);
 
   template <int GranK>
   void group_gemm_mxfp8_nt_groupwise_contiguous_impl(void* D, void const* A, void const* B,

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaled/kernel_impl.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaled/kernel_impl.cuh
@@ -42,9 +42,7 @@ struct SM120BlockScaledGemmKernel {
   static constexpr int MinBlocksPerMultiprocessor = 1;
 
   static constexpr sm120_common::GemmType kGemmType = KT::kGemmType;
-  using Scheduler =
-      std::conditional_t<KT::kSwapAB, sm120_common::Scheduler<kGemmType, KT::kTileN, KT::kTileM>,
-                         sm120_common::Scheduler<kGemmType, KT::kTileM, KT::kTileN>>;
+  using Scheduler = sm120_common::SelectedScheduler<kGemmType, KT::kSwapAB, KT::kTileM, KT::kTileN>;
   using ProblemShape = typename KT::ProblemShape;
 
   struct Params {
@@ -373,6 +371,8 @@ struct SM120BlockScaledGemmKernel {
 
   CUTE_DEVICE
   void operator()(Params const& params, char* smem_buf) {
+    static_assert(kGemmType != sm120_common::GemmType::MGroupedContiguousWithZeroPadding,
+                  "MGroupedContiguousWithZeroPadding launches SM120BlockScaledMoeGemmKernel");
     SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
     int warp_idx = cutlass::canonical_warp_idx_sync();
     int lane_predicate = cute::elect_one_sync();

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaled/launch.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaled/launch.cuh
@@ -24,6 +24,7 @@
 #include <cutlass/device_kernel.h>
 
 #include "kernel_impl.cuh"
+#include "moe_kernel_impl.cuh"
 // clang-format on
 
 namespace flashinfer::gemm::mxfp8_cute_sm120 {
@@ -90,7 +91,9 @@ void launch_moe_gemm(typename KT::ElementA* ptr_A, typename KT::ElementB* ptr_B,
                      typename KT::SFConfig::ElementSFLoad* ptr_SFB, typename KT::ElementD* ptr_D,
                      int M_padded, int N, int K, int num_experts, int32_t const* grouped_layout,
                      int num_sms, cudaStream_t stream = 0) {
-  using Kernel = SM120BlockScaledGemmKernel<KT>;
+  using Kernel =
+      std::conditional_t<KT::kGemmType == sm120_common::GemmType::MGroupedContiguousWithZeroPadding,
+                         SM120BlockScaledMoeGemmKernel<KT>, SM120BlockScaledGemmKernel<KT>>;
   auto args = make_launch_args<KT, Kernel>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, M_padded, N, K,
                                            grouped_layout);
   auto problem_shape = make_shape(M_padded, N, K, num_experts);

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaled/moe_kernel_impl.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaled/moe_kernel_impl.cuh
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// clang-format off
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+#include <cutlass/arch/barrier.h>
+#include <cutlass/cutlass.h>
+
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaled/kernel_impl.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_common/moe_scheduler.cuh"
+// clang-format on
+
+namespace flashinfer::gemm::mxfp8_cute_sm120 {
+namespace sm120_blockscaled {
+
+template <typename KT>
+struct SM120BlockScaledMoeGemmKernel : SM120BlockScaledGemmKernel<KT> {
+  using BaseKernel = SM120BlockScaledGemmKernel<KT>;
+  using Params = typename BaseKernel::Params;
+  using Scheduler = sm120_common::SelectedMoeScheduler<KT::kSwapAB, KT::kTileM, KT::kTileN>;
+
+  static_assert(KT::kGemmType == sm120_common::GemmType::MGroupedContiguousWithZeroPadding);
+  static_assert(KT::kUnionSmem,
+                "the dedicated scheduler warp reuses the idle epi warp; a "
+                "TmaStore instance needs an explicit scheduling decision");
+
+  static constexpr int kNumSchedStages = 2;
+  static constexpr int kNumSchedConsumers = KT::MMAConfig::kNumMathWarps + 2;
+
+  struct SharedStorage : BaseKernel::SharedStorage {
+    alignas(8) sm120_common::MoeSchedStorage<kNumSchedStages> sched;
+  };
+  static constexpr int kSmemSize = int(sizeof(SharedStorage));
+
+  CUTE_DEVICE
+  void operator()(Params const& params, char* smem_buf) {
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+    int warp_idx = cutlass::canonical_warp_idx_sync();
+    int lane_predicate = cute::elect_one_sync();
+    bool is_tma_thread = warp_idx == 0 && lane_predicate;
+
+    if (is_tma_thread) {
+      BaseKernel::prefetch_tma_descriptors(params);
+    }
+    __syncthreads();
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)store_full_mbar;
+    if (is_tma_thread) {
+#pragma unroll
+      for (uint32_t i = 0; i < KT::SFConfig::SF_Stages; ++i) {
+        sf_full_mbar[i].init(1);
+        sf_empty_mbar[i].init(KT::MMAConfig::kNumMathThreads);
+      }
+#pragma unroll
+      for (uint32_t i = 0; i < KT::AB_Stages; ++i) {
+        ab_full_mbar[i].init(1);
+        ab_empty_mbar[i].init(KT::MMAConfig::kNumMathThreads);
+      }
+      store_empty_mbar[0].init(KT::MMAConfig::kNumMathThreads);
+      shared_storage.sched.init_mbars(kNumSchedConsumers);
+      cutlass::arch::fence_barrier_init();
+    }
+    __syncthreads();
+
+    int32_t num_sf_cycles = sm120_common::math::ceil_div(
+        params.K, int(KT::SFConfig::PACK_NK * KT::SFConfig::SF_Stages));
+
+    if (warp_idx >= KT::MMAConfig::kNumMathWarps) {
+      constexpr int sched_warp_idx = KT::MMAConfig::kNumMathWarps;
+      constexpr int ab_warp_idx = sched_warp_idx + 1;
+      constexpr int sf_warp_idx = ab_warp_idx + 1;
+
+      if (warp_idx == sched_warp_idx) {
+        Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
+        sm120_common::MoeSchedProducer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        int32_t m_block_idx, n_block_idx;
+        while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+          sched_pipeline.publish(sm120_common::MoeWorkTile{
+              m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx),
+              scheduler.get_m_offset(), scheduler.get_m_boundary(), 1});
+        }
+        sched_pipeline.publish_sentinel();
+      }
+      if (warp_idx == ab_warp_idx) {
+        uint32_t ab_phase = 1;
+        uint32_t store_phase = 1;
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
+          if (lane_predicate) {
+            auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
+                tile.m_block, tile.n_block, tile.group);
+            BaseKernel::load_ab(params, shared_storage, blk_coord, tile.m_offset, num_sf_cycles,
+                                ab_phase, store_phase);
+          }
+        }
+      }
+      if (warp_idx == sf_warp_idx) {
+        uint32_t sf_phase = 1;
+        uint32_t store_phase = 1;
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
+          if (lane_predicate) {
+            auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
+                tile.m_block, tile.n_block, tile.group);
+            BaseKernel::load_sf(params, shared_storage, blk_coord, tile.m_offset, num_sf_cycles,
+                                sf_phase, store_phase);
+          }
+        }
+      }
+    } else {
+      uint32_t sf_phase = 0;
+      uint32_t ab_phase = 0;
+      int epi_stage = 0;
+      uint32_t se_phase[1] = {1};
+      sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                     lane_predicate};
+      sm120_common::MoeWorkTile tile;
+      while (sched_pipeline.get_next_tile(tile)) {
+        auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(tile.m_block,
+                                                                          tile.n_block, tile.group);
+        BaseKernel::mma(params, shared_storage, num_sf_cycles, tile.m_offset, tile.m_boundary,
+                        cute::get<0>(blk_coord), cute::get<1>(blk_coord), cute::get<2>(blk_coord),
+                        sf_phase, ab_phase, epi_stage, se_phase);
+      }
+    }
+  }
+};
+
+}  // namespace sm120_blockscaled
+}  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
@@ -95,7 +95,7 @@ struct SM120BlockScalingBuilder {
       TileM_ >= 64;
   static constexpr bool kUnionSmem = !kUseTmaStore && !kUseStagedR2G;
   static constexpr int AB_Stages = Stages_;
-  static constexpr uint32_t LoadRegisterRequirement = kUseStagedR2G ? 80 : 40;
+  static constexpr uint32_t LoadRegisterRequirement = kUseStagedR2G ? 88 : 40;
   static constexpr uint32_t MmaRegisterRequirement = kUseStagedR2G ? 208 : 232;
 
   static constexpr int kTileM = TileM_;

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/launch.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/launch.cuh
@@ -24,6 +24,7 @@
 #include <cutlass/device_kernel.h>
 
 #include "kernel_impl.cuh"
+#include "moe_kernel_impl.cuh"
 // clang-format on
 
 namespace flashinfer::gemm::mxfp8_cute_sm120 {
@@ -85,7 +86,9 @@ void launch_moe_gemm(typename KT::ElementA const* ptr_A, typename KT::ElementB c
                      typename KT::ElementScale const* ptr_SFB, typename KT::ElementD* ptr_D, int M,
                      int N, int K, int num_experts, int32_t const* grouped_layout, int num_sms,
                      cudaStream_t stream = 0) {
-  using Kernel = SM120BlockScalingGemmKernel<KT>;
+  using Kernel =
+      std::conditional_t<KT::kGemmType == sm120_common::GemmType::MGroupedContiguousWithZeroPadding,
+                         SM120BlockScalingMoeGemmKernel<KT>, SM120BlockScalingGemmKernel<KT>>;
   auto args =
       make_launch_args<KT, Kernel>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, M, N, K, grouped_layout);
   auto problem_shape = make_shape(M, N, K, num_experts);

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/moe_kernel_impl.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/moe_kernel_impl.cuh
@@ -25,120 +25,40 @@
 #include <cutlass/arch/barrier.h>
 #include <cutlass/cutlass.h>
 
-#include "cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh"
-#include "cute_sm120_mxfp8_groupwise/sm120_common/ab_tma_load.cuh"
-#include "cute_sm120_mxfp8_groupwise/sm120_common/epilogue.cuh"
-#include "cute_sm120_mxfp8_groupwise/sm120_common/math.cuh"
-#include "cute_sm120_mxfp8_groupwise/sm120_common/scheduler.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaling/kernel_impl.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_common/moe_scheduler.cuh"
 // clang-format on
 
 namespace flashinfer::gemm::mxfp8_cute_sm120 {
 namespace sm120_blockscaling {
 
-using namespace cute;
-
 template <typename KT>
-struct SM120BlockScalingGemmKernel {
-  static constexpr int kNumTMAThreads = 128;
-  static constexpr int kNumMathThreads = KT::MMAConfig::kNumMathThreads;
-  static constexpr int MaxThreadsPerBlock = kNumTMAThreads + kNumMathThreads;
-  static constexpr int MinBlocksPerMultiprocessor = 1;
-
-  static constexpr sm120_common::GemmType kGemmType = KT::kGemmType;
-  using Scheduler = sm120_common::SelectedScheduler<kGemmType, KT::kSwapAB, KT::kTileM, KT::kTileN>;
-  using ProblemShape = typename KT::ProblemShape;
-
-  struct Params {
-    typename KT::ABLoadConfig::TMA_A tma_load_a;
-    typename KT::ABLoadConfig::TMA_B tma_load_b;
-    typename KT::SfaTmaLoadConfig::TMA_SFA tma_load_sfa;
-    typename KT::ElementScale const* ptr_SFA;
-    typename KT::ElementScale const* ptr_SFB;
-    typename KT::TmaStoreConfig::TMA_D tma_store_d;
-    typename KT::ElementD* ptr_D;
-    int M;
-    int N;
-    int K;
-    int num_experts;
-    int32_t const* grouped_layout;
-  };
-
-  struct Arguments {
-    typename KT::ElementA const* ptr_A;
-    typename KT::ABLoadConfig::StrideA dA;
-    typename KT::ElementB const* ptr_B;
-    typename KT::ABLoadConfig::StrideB dB;
-    typename KT::ElementScale const* ptr_SFA;
-    typename KT::ElementScale const* ptr_SFB;
-    typename KT::ElementD* ptr_D;
-    int32_t const* grouped_layout;
-    typename KT::TmaStoreConfig::StrideD dD = {};
-  };
-
-  static Params to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args) {
-    auto [M, N, K, num_experts] = problem_shape;
-    auto [tma_load_a, tma_load_b] = sm120_common::utils::make_ab_tma_descriptors<KT>(
-        args.ptr_A, args.dA, args.ptr_B, args.dB, M, N, K, num_experts);
-
-    typename KT::SfaTmaLoadConfig::TMA_SFA tma_load_sfa{};
-    if constexpr (KT::kUseTmaSFA) {
-      tma_load_sfa = utils::make_sfa_tma_descriptor<KT>(args.ptr_SFA, M, N, K, num_experts);
-    }
-
-    typename KT::TmaStoreConfig::TMA_D tma_store_d{};
-    if constexpr (KT::kUseTmaStore) {
-      auto tensor_d =
-          make_tensor(make_gmem_ptr(args.ptr_D),
-                      sm120_common::utils::deduce_d_layout<KT::kSwapAB>(M, N, num_experts));
-      tma_store_d = make_tma_copy_C_sm90(typename KT::TmaStoreConfig::CopyOpS2G{}, tensor_d,
-                                         take<0, 2>(typename KT::TmaStoreConfig::SmemLayoutD{}),
-                                         typename KT::TmaStoreConfig::EpilogueTile_MN{});
-    }
-
-    return {tma_load_a,
-            tma_load_b,
-            tma_load_sfa,
-            args.ptr_SFA,
-            args.ptr_SFB,
-            tma_store_d,
-            args.ptr_D,
-            M,
-            N,
-            K,
-            num_experts,
-            args.grouped_layout};
-  }
-
-  static dim3 get_grid_shape(int num_sms) { return dim3(num_sms, 1, 1); }
-
-  static dim3 get_block_shape() { return dim3(MaxThreadsPerBlock, 1, 1); }
-
-  CUTE_DEVICE
-  static void prefetch_tma_descriptors(Params const& params) {
-    cute::prefetch_tma_descriptor(params.tma_load_a.get_tma_descriptor());
-    cute::prefetch_tma_descriptor(params.tma_load_b.get_tma_descriptor());
-    if constexpr (KT::kUseTmaSFA) {
-      cute::prefetch_tma_descriptor(params.tma_load_sfa.get_tma_descriptor());
-    }
-    if constexpr (KT::kUseTmaStore) {
-      cute::prefetch_tma_descriptor(params.tma_store_d.get_tma_descriptor());
-    }
-  }
-
-  using TensorStorage = std::conditional_t<KT::kUseTmaStore, typename KT::TensorStorageSplit,
-                                           typename KT::TensorStorageUnion>;
-  using BarrierStorage = typename KT::BarrierStorage;
-
-  struct SharedStorage {
-    TensorStorage tensors;
-    alignas(16) BarrierStorage barriers;
-  };
-
-  static constexpr int kSmemSize = int(sizeof(SharedStorage));
-
+struct SM120BlockScalingMoeGemmKernel : SM120BlockScalingGemmKernel<KT> {
+  using BaseKernel = SM120BlockScalingGemmKernel<KT>;
+  using Params = typename BaseKernel::Params;
+  using Scheduler = sm120_common::SelectedMoeScheduler<KT::kSwapAB, KT::kTileM, KT::kTileN>;
   using FullBarrier = typename KT::FullBarrier;
   using EmptyBarrier = typename KT::EmptyBarrier;
   using ProducerBarrierType = typename FullBarrier::ValueType;
+
+  static_assert(KT::kGemmType == sm120_common::GemmType::MGroupedContiguousWithZeroPadding);
+  static_assert(!KT::kUseTmaStore, "the barrier init chain omits the TmaStore stages");
+
+  // StagedR2G instances park the staged store warp on the first specialized
+  // warp, so their scheduler warp runs on the otherwise idle last specialized
+  // warp and the store warp joins the sched consumers.
+  static constexpr int kNumSchedStages = 2;
+  static constexpr int kNumSchedConsumers =
+      KT::MMAConfig::kNumMathWarps + (KT::kUseStagedR2G ? 3 : 2);
+
+  using TensorStorage = std::conditional_t<KT::kUseStagedR2G, typename KT::TensorStorageStagedR2G,
+                                           typename KT::TensorStorageUnion>;
+  struct SharedStorage {
+    TensorStorage tensors;
+    alignas(16) typename KT::BarrierStorage barriers;
+    alignas(8) sm120_common::MoeSchedStorage<kNumSchedStages> sched;
+  };
+  static constexpr int kSmemSize = int(sizeof(SharedStorage));
 
   CUTE_DEVICE
   static auto get_mbarriers(SharedStorage& shared_storage) {
@@ -227,83 +147,46 @@ struct SM120BlockScalingGemmKernel {
 
   template <typename BlkCoord>
   CUTE_DEVICE static void load_sf(Params const& params, SharedStorage& shared_storage,
-                                  BlkCoord const& blk_coord, int32_t m_offset, int32_t k_tile_count,
-                                  int& sf_stage, uint32_t& sf_phase, uint32_t& store_phase) {
+                                  BlkCoord const& blk_coord, int32_t m_offset, int32_t m_boundary,
+                                  int32_t k_tile_count, int& sf_stage, uint32_t& sf_phase,
+                                  uint32_t& store_phase) {
+    static_assert(KT::kSwapAB && KT::kGranN == 1);
     auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
-    constexpr bool kPerBatchAB = KT::kPerBatchAB;
-    constexpr bool kSwapAB = KT::kSwapAB;
-
-    int sfa_src_M = kSwapAB ? params.N : params.M;
-    int sfa_src_L = kSwapAB ? params.num_experts : (kPerBatchAB ? params.num_experts : 1);
-    int sfb_src_N = kSwapAB ? params.M : params.N;
-    int sfb_src_L = (kSwapAB && !kPerBatchAB) ? 1 : params.num_experts;
-    int sfa_real_M = sfa_src_M;
-    int sfb_real_N = sfb_src_N;
-    int32_t sfa_tile_idx = m_block_idx;
-    int32_t sfa_batch_idx = kSwapAB ? expert_idx : (kPerBatchAB ? expert_idx : 0);
-    int32_t sfb_tile_idx = n_block_idx;
-    int32_t sfb_batch_idx = (kSwapAB && !kPerBatchAB) ? 0 : expert_idx;
-    int32_t sf_m_offset = m_offset;
     int lane_idx = cutlass::canonical_lane_idx();
 
-    if constexpr (kSwapAB && KT::kFlat) {
-      static_assert(KT::kGranN == 1);
-      sfb_real_N = KT::SFConfig::get_tma_aligned_size(sfb_src_N);
-    }
+    int sfa_src_M = params.N;
+    int sfb_src_N = params.M;
+    int sfb_real_N = sm120_common::math::compute_padded_offset(sfb_src_N, params.num_experts);
+    int32_t sf_m_offset = sm120_common::math::compute_padded_offset(m_offset, expert_idx);
+
     auto sSFA = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA.begin()),
                             typename KT::SFConfig::SmemLayoutSFA{});
     auto sSFB = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB.begin()),
                             typename KT::SFConfig::SmemLayoutSFB{});
 
-    cute::Tensor mSFA_full =
-        make_tensor(make_gmem_ptr(params.ptr_SFA),
-                    KT::SFConfig::deduce_sfa_layout(sfa_real_M, sfb_real_N, params.K, sfa_src_L));
+    cute::Tensor mSFA = make_tensor(
+        make_gmem_ptr(params.ptr_SFA),
+        KT::SFConfig::deduce_sfa_layout(sfa_src_M, sfb_real_N, params.K, params.num_experts));
     cute::Tensor mSFB_full =
         make_tensor(make_gmem_ptr(params.ptr_SFB),
-                    KT::SFConfig::deduce_sfb_layout(sfa_real_M, sfb_real_N, params.K, sfb_src_L));
-    cute::Tensor cSFA_full = make_identity_tensor(mSFA_full.shape());
+                    KT::SFConfig::deduce_sfb_layout(sfa_src_M, sfb_real_N, params.K, 1));
+    cute::Tensor cSFA = make_identity_tensor(mSFA.shape());
     cute::Tensor cSFB_full = make_identity_tensor(mSFB_full.shape());
-
-    auto mSFA = [&] {
-      if constexpr (!kSwapAB && !KT::kFlat) {
-        return domain_offset(make_coord(m_offset / KT::kGranM, 0, 0), mSFA_full);
-      } else {
-        return mSFA_full;
-      }
-    }();
-    auto mSFB = [&] {
-      if constexpr (kSwapAB && !KT::kFlat) {
-        return domain_offset(make_coord(sf_m_offset / KT::kGranN, 0, 0), mSFB_full);
-      } else {
-        return mSFB_full;
-      }
-    }();
-    auto cSFA = [&] {
-      if constexpr (!kSwapAB && !KT::kFlat) {
-        return domain_offset(make_coord(m_offset / KT::kGranM, 0, 0), cSFA_full);
-      } else {
-        return cSFA_full;
-      }
-    }();
-    auto cSFB = [&] {
-      if constexpr (kSwapAB && !KT::kFlat) {
-        return domain_offset(make_coord(sf_m_offset / KT::kGranN, 0, 0), cSFB_full);
-      } else {
-        return cSFB_full;
-      }
-    }();
+    auto mSFB = domain_offset(make_coord(sf_m_offset / KT::kGranN, 0, 0), mSFB_full);
+    auto cSFB = domain_offset(make_coord(sf_m_offset / KT::kGranN, 0, 0), cSFB_full);
 
     int64_t scales_m = sm120_common::math::ceil_div(sfa_src_M, int(KT::kGranM));
-    int64_t scales_n = sm120_common::math::ceil_div(sfb_src_N, int(KT::kGranN));
+    int64_t scales_n = sf_m_offset / KT::kGranN +
+                       sm120_common::math::ceil_div(m_boundary - m_offset, int(KT::kGranN));
 
     cute::Tensor gSFA = local_tile(mSFA, make_tile(Int<KT::SFConfig::kTileScaleM>{}),
-                                   make_coord(sfa_tile_idx, _, sfa_batch_idx));
+                                   make_coord(m_block_idx, _, expert_idx));
     cute::Tensor coordSFA = local_tile(cSFA, make_tile(Int<KT::SFConfig::kTileScaleM>{}),
-                                       make_coord(sfa_tile_idx, _, sfa_batch_idx));
+                                       make_coord(m_block_idx, _, expert_idx));
     cute::Tensor gSFB = local_tile(mSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
-                                   make_coord(sfb_tile_idx, _, sfb_batch_idx));
+                                   make_coord(n_block_idx, _, Int<0>{}));
     cute::Tensor coordSFB = local_tile(cSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
-                                       make_coord(sfb_tile_idx, _, sfb_batch_idx));
+                                       make_coord(n_block_idx, _, Int<0>{}));
 
     TiledCopy scale_copy_a = make_tiled_copy(
         typename KT::SFConfig::SmemCopyAtomSFA{},
@@ -408,9 +291,6 @@ struct SM120BlockScalingGemmKernel {
                   int32_t expert_idx, int& read_stage, uint32_t& sf_phase, uint32_t& ab_phase,
                   int& epi_stage, uint32_t* se_phase) {
     int thread_idx = int(threadIdx.x);
-    (void)m_offset;
-    (void)m_boundary;
-    (void)m_block_idx;
     (void)n_block_idx;
     (void)expert_idx;
 
@@ -571,10 +451,11 @@ struct SM120BlockScalingGemmKernel {
     });
     rescale();
 
-    if constexpr (KT::kUseTmaStore) {
-      sm120_common::utils::epi_r2s<KT>(params, shared_storage, accum, thread_idx, epi_stage,
-                                       se_phase, store_full_mbar, store_empty_mbar);
-    } else if constexpr (KT::kFlat || (!KT::kFlat && KT::kSwapAB)) {
+    if constexpr (KT::kUseStagedR2G) {
+      sm120_common::utils::epi_staged_r2s<KT>(params, shared_storage, accum, thread_idx, m_offset,
+                                              m_boundary, m_block_idx, epi_stage, se_phase[0],
+                                              store_full_mbar, store_empty_mbar);
+    } else if constexpr (KT::kSwapAB) {
       sm120_common::utils::epi_pred_stg<KT>(params, accum, thread_idx, m_offset, m_boundary,
                                             m_block_idx, n_block_idx, store_empty_mbar);
     } else {
@@ -584,33 +465,15 @@ struct SM120BlockScalingGemmKernel {
     }
   }
 
-  template <typename BlkCoord>
-  CUTE_DEVICE static void store(Params const& params, SharedStorage& shared_storage,
-                                BlkCoord const& blk_coord, uint32_t* sf_phase, int& epi_stage) {
-    if constexpr (KT::kUseTmaStore) {
-      auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
-            store_empty_mbar] = get_mbarriers(shared_storage);
-      (void)ab_full_mbar;
-      (void)ab_empty_mbar;
-      (void)sf_full_mbar;
-      (void)sf_empty_mbar;
-      sm120_common::utils::tma_store<KT>(params, shared_storage, cute::get<0>(blk_coord),
-                                         cute::get<1>(blk_coord), cute::get<2>(blk_coord), sf_phase,
-                                         epi_stage, store_full_mbar, store_empty_mbar);
-    }
-  }
-
   CUTE_DEVICE
   void operator()(Params const& params, char* smem_buf) {
-    static_assert(kGemmType != sm120_common::GemmType::MGroupedContiguousWithZeroPadding,
-                  "MGroupedContiguousWithZeroPadding launches SM120BlockScalingMoeGemmKernel");
     SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
     int warp_idx = cutlass::canonical_warp_idx_sync();
     int lane_predicate = cute::elect_one_sync();
     bool is_tma_thread = warp_idx == 0 && lane_predicate;
 
     if (is_tma_thread) {
-      prefetch_tma_descriptors(params);
+      BaseKernel::prefetch_tma_descriptors(params);
     }
     __syncthreads();
 
@@ -627,15 +490,16 @@ struct SM120BlockScalingGemmKernel {
         ab_full_mbar[i].init(1);
         ab_empty_mbar[i].init(KT::MMAConfig::kNumMathThreads);
       }
-      if constexpr (KT::kUseTmaStore) {
+      if constexpr (KT::kUseStagedR2G) {
 #pragma unroll
-        for (uint32_t i = 0; i < KT::TmaStoreConfig::StagesD; ++i) {
+        for (uint32_t i = 0; i < KT::StagedR2GStoreConfig::StagesD; ++i) {
           store_full_mbar[i].init(KT::MMAConfig::kNumMathThreads);
-          store_empty_mbar[i].init(1);
+          store_empty_mbar[i].init(KT::StagedR2GStoreConfig::kNumStoreThreads);
         }
       } else if constexpr (KT::kUnionSmem) {
         store_empty_mbar[0].init(KT::MMAConfig::kNumMathThreads);
       }
+      shared_storage.sched.init_mbars(kNumSchedConsumers);
       cutlass::arch::fence_barrier_init();
     }
     __syncthreads();
@@ -644,59 +508,67 @@ struct SM120BlockScalingGemmKernel {
 
     if (warp_idx >= KT::MMAConfig::kNumMathWarps) {
       cutlass::arch::warpgroup_reg_dealloc<KT::LoadRegisterRequirement>();
-      constexpr int first_specialized_warp_idx = KT::MMAConfig::kNumMathWarps;
-      constexpr int tma_store_warp_idx = first_specialized_warp_idx;
-      constexpr int ab_warp_idx = first_specialized_warp_idx + 1;
-      constexpr int sf_warp_idx = first_specialized_warp_idx + 2;
+      constexpr int sched_warp_idx = KT::MMAConfig::kNumMathWarps;
+      constexpr int ab_warp_idx = sched_warp_idx + 1;
+      constexpr int sf_warp_idx = ab_warp_idx + 1;
+      constexpr int store_warp_idx = sf_warp_idx + 1;
 
       if (warp_idx == ab_warp_idx) {
         int ab_stage = 0;
         uint32_t ab_phase = 1;
         uint32_t store_phase = 1;
-        if (lane_predicate) {
-          Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
-          int32_t m_block_idx, n_block_idx;
-          while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
+          if (lane_predicate) {
             auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
-                m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx));
-            load_ab(params, shared_storage, blk_coord, scheduler.get_m_offset(), k_tile_count,
-                    ab_stage, ab_phase, store_phase);
+                tile.m_block, tile.n_block, tile.group);
+            load_ab(params, shared_storage, blk_coord, tile.m_offset, k_tile_count, ab_stage,
+                    ab_phase, store_phase);
           }
         }
-        __syncwarp();
       } else if (warp_idx == sf_warp_idx) {
         int sf_stage = 0;
         uint32_t sf_phase = 1;
         uint32_t store_phase = 1;
-        Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
-        int32_t m_block_idx, n_block_idx;
-        while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
           auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
-              m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx));
+              tile.m_block, tile.n_block, tile.group);
           if constexpr (KT::kUseTmaSFA) {
-            load_sf_tma(params, shared_storage, blk_coord, scheduler.get_m_offset(), k_tile_count,
-                        sf_stage, sf_phase, store_phase);
+            load_sf_tma(params, shared_storage, blk_coord, tile.m_offset, k_tile_count, sf_stage,
+                        sf_phase, store_phase);
           } else {
-            load_sf(params, shared_storage, blk_coord, scheduler.get_m_offset(), k_tile_count,
+            load_sf(params, shared_storage, blk_coord, tile.m_offset, tile.m_boundary, k_tile_count,
                     sf_stage, sf_phase, store_phase);
           }
         }
-        __syncwarp();
-      } else {
-        if constexpr (KT::kUseTmaStore) {
-          if (warp_idx == tma_store_warp_idx) {
-            uint32_t sf_phase[KT::TmaStoreConfig::StagesD] = {0};
-            int epi_stage = 0;
-            if (lane_predicate) {
-              Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
-              int32_t m_block_idx, n_block_idx;
-              while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
-                auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
-                    m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx));
-                store(params, shared_storage, blk_coord, sf_phase, epi_stage);
-              }
-            }
-            __syncwarp();
+      } else if (warp_idx == sched_warp_idx) {
+        Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
+        sm120_common::MoeSchedProducer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        int32_t m_block_idx, n_block_idx;
+        while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+          sched_pipeline.publish(sm120_common::MoeWorkTile{
+              m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx),
+              scheduler.get_m_offset(), scheduler.get_m_boundary(), 1});
+        }
+        sched_pipeline.publish_sentinel();
+      } else if constexpr (KT::kUseStagedR2G) {
+        if (warp_idx == store_warp_idx) {
+          uint32_t full_phase = 0;
+          int store_stage = 0;
+          int store_thread_idx = cutlass::canonical_lane_idx();
+          sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                         lane_predicate};
+          sm120_common::MoeWorkTile tile;
+          while (sched_pipeline.get_next_tile(tile)) {
+            sm120_common::utils::staged_r2g_store<KT>(
+                params, shared_storage, tile.m_offset, tile.m_boundary, tile.m_block, tile.n_block,
+                store_thread_idx, full_phase, store_stage, store_full_mbar, store_empty_mbar);
           }
         }
       }
@@ -706,19 +578,16 @@ struct SM120BlockScalingGemmKernel {
       uint32_t sf_phase = 0;
       uint32_t ab_phase = 0;
       int epi_stage = 0;
-      uint32_t se_phase[KT::TmaStoreConfig::StagesD];
-#pragma unroll
-      for (int i = 0; i < KT::TmaStoreConfig::StagesD; ++i) {
-        se_phase[i] = 1;
-      }
-      Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
-      int32_t m_block_idx, n_block_idx;
-      while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
-        auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
-            m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx));
-        mma(params, shared_storage, k_tile_count, scheduler.get_m_offset(),
-            scheduler.get_m_boundary(), cute::get<0>(blk_coord), cute::get<1>(blk_coord),
-            cute::get<2>(blk_coord), read_stage, sf_phase, ab_phase, epi_stage, se_phase);
+      uint32_t se_phase[1] = {1};
+      sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                     lane_predicate};
+      sm120_common::MoeWorkTile tile;
+      while (sched_pipeline.get_next_tile(tile)) {
+        auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(tile.m_block,
+                                                                          tile.n_block, tile.group);
+        mma(params, shared_storage, k_tile_count, tile.m_offset, tile.m_boundary,
+            cute::get<0>(blk_coord), cute::get<1>(blk_coord), cute::get<2>(blk_coord), read_stage,
+            sf_phase, ab_phase, epi_stage, se_phase);
       }
     }
   }

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_common/epilogue.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_common/epilogue.cuh
@@ -105,7 +105,7 @@ struct Sm120BlockScaledTmaStoreConfig<kTileM, kTileN, ElementD, /*kEnabled=*/fal
 
 template <int kTileM, int kTileN, typename ElementD, bool kEnabled = true>
 struct Sm120BlockScaledStagedR2GStoreConfig {
-  static_assert((kTileM == 64 || kTileM == 128) && kTileN == 128);
+  static_assert((kTileM == 64 || kTileM == 128) && (kTileN == 64 || kTileN == 128));
 
   static constexpr int kEpiTileM = 64;
   static constexpr int kEpiTileN = 32;

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_common/moe_scheduler.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_common/moe_scheduler.cuh
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+// clang-format off
+#include <cstdint>
+#include <type_traits>
+
+#include <cutlass/arch/barrier.h>
+// clang-format on
+
+namespace flashinfer::gemm::mxfp8_cute_sm120 {
+namespace sm120_common {
+
+// Warp-cooperative tile scheduler for MGroupedContiguousWithZeroPadding.
+// Drop-in replacement for Scheduler<MGroupedContiguousWithZeroPadding>:
+// same grouped_layout contract (token_offset[E+1] int32 cumsum with leading 0),
+// same tile sequence, same get_* semantics. Each get_next_block resolves the
+// owning group with one coalesced 32-group window per round (lane-parallel
+// prefix sum + ballot) instead of a serial per-group dependent-load walk.
+// All 32 lanes of the calling warp must be active and converged.
+template <int BlockM, int BlockN>
+struct MoeScheduler {
+  int32_t shape_m;
+  int32_t shape_n;
+  int32_t num_groups;
+  int32_t num_n_blocks;
+  int32_t const* grouped_layout;
+
+  int32_t current_iter = -1;
+  int32_t current_group_idx = 0;
+  int32_t prev_psum_m = 0;
+  int32_t current_psum_m = 0;
+
+  int32_t window_base = 0;
+  int32_t window_start_block = 0;
+  int32_t lane_off = 0;
+  int32_t lane_next = 0;
+
+  __device__ __forceinline__ explicit MoeScheduler(int shape_m_, int shape_n_, int num_groups_,
+                                                   int32_t const* grouped_layout_)
+      : shape_m(shape_m_),
+        shape_n(shape_n_),
+        num_groups(num_groups_),
+        num_n_blocks((shape_n_ + BlockN - 1) / BlockN),
+        grouped_layout(grouped_layout_) {
+    load_window();
+  }
+
+  __device__ __forceinline__ void load_window() {
+    int32_t lane = threadIdx.x & 31;
+    int32_t g = window_base + lane;
+    lane_off = grouped_layout[g < num_groups ? g : num_groups];
+    lane_next = grouped_layout[g + 1 < num_groups ? g + 1 : num_groups];
+  }
+
+  __device__ __forceinline__ bool get_next_block(int32_t& m_block_idx, int32_t& n_block_idx) {
+    int64_t next_block_idx = static_cast<int64_t>(++current_iter) * gridDim.x + blockIdx.x;
+    int64_t target_m_block = next_block_idx / num_n_blocks;
+    n_block_idx = static_cast<int32_t>(next_block_idx % num_n_blocks);
+
+    int32_t lane = threadIdx.x & 31;
+    while (true) {
+      int32_t my_blocks = (lane_next - lane_off + BlockM - 1) / BlockM;
+      int32_t incl = my_blocks;
+#pragma unroll
+      for (int d = 1; d < 32; d <<= 1) {
+        int32_t up = __shfl_up_sync(0xffffffffu, incl, d);
+        if (lane >= d) {
+          incl += up;
+        }
+      }
+      int32_t window_total = __shfl_sync(0xffffffffu, incl, 31);
+
+      if (target_m_block < static_cast<int64_t>(window_start_block) + window_total) {
+        int32_t local = static_cast<int32_t>(target_m_block - window_start_block);
+        uint32_t owners = __ballot_sync(0xffffffffu, incl > local);
+        int32_t src = __ffs(owners) - 1;
+        current_group_idx = window_base + src;
+        prev_psum_m = __shfl_sync(0xffffffffu, lane_off, src);
+        current_psum_m = __shfl_sync(0xffffffffu, lane_next, src);
+        int32_t group_start = __shfl_sync(0xffffffffu, incl - my_blocks, src);
+        m_block_idx = local - group_start;
+        return true;
+      }
+      if (window_base + 32 >= num_groups) {
+        return false;
+      }
+      window_start_block += window_total;
+      window_base += 32;
+      load_window();
+    }
+  }
+
+  __device__ __forceinline__ int32_t get_m_offset() const { return prev_psum_m; }
+  __device__ __forceinline__ int32_t get_m_boundary() const { return current_psum_m; }
+  __device__ __forceinline__ int32_t get_expert_idx(int32_t = 0) const { return current_group_idx; }
+};
+
+// SwapAB-aware MoeScheduler selection shared by every ZeroPadding kernel
+// (moe and fused): logical tiles swap with the operands.
+template <bool kSwapAB, int TileM, int TileN>
+using SelectedMoeScheduler =
+    std::conditional_t<kSwapAB, MoeScheduler<TileN, TileM>, MoeScheduler<TileM, TileN>>;
+
+// Dedicated-scheduler-warp handoff: one warp runs MoeScheduler and publishes
+// every resolved tile into this SMEM pipeline; the consumer warps carry no
+// scheduler and drain stages until the valid == 0 end sentinel.
+struct MoeWorkTile {
+  int32_t m_block, n_block, group, m_offset, m_boundary, valid;
+};
+
+template <int Stages>
+struct MoeSchedStorage {
+  MoeWorkTile work[Stages];
+  alignas(8) uint64_t sched_full_mbar[Stages];
+  alignas(8) uint64_t sched_empty_mbar[Stages];
+
+  __device__ __forceinline__ cutlass::arch::ClusterBarrier* full_mbar(int sched_stage) {
+    return reinterpret_cast<cutlass::arch::ClusterBarrier*>(&sched_full_mbar[sched_stage]);
+  }
+  __device__ __forceinline__ cutlass::arch::ClusterBarrier* empty_mbar(int sched_stage) {
+    return reinterpret_cast<cutlass::arch::ClusterBarrier*>(&sched_empty_mbar[sched_stage]);
+  }
+  __device__ __forceinline__ void init_mbars(int num_consumers) {
+#pragma unroll
+    for (int i = 0; i < Stages; ++i) {
+      full_mbar(i)->init(1);
+      empty_mbar(i)->init(num_consumers);
+    }
+  }
+};
+
+// Producer view of the sched pipeline: the scheduler warp publishes one
+// MoeWorkTile per stage and closes the stream with the valid == 0 sentinel.
+template <int Stages>
+struct MoeSchedProducer {
+  MoeSchedStorage<Stages>& storage;
+  int lane_predicate;
+  uint32_t sched_iter = 0;
+
+  __device__ __forceinline__ void publish(MoeWorkTile const& tile) {
+    int sched_stage = sched_iter % Stages;
+    storage.empty_mbar(sched_stage)->wait(((sched_iter / Stages) & 1) ^ 1);
+    if (lane_predicate) {
+      storage.work[sched_stage] = tile;
+      storage.full_mbar(sched_stage)->arrive();
+    }
+    ++sched_iter;
+  }
+  __device__ __forceinline__ void publish_sentinel() {
+    int sched_stage = sched_iter % Stages;
+    storage.empty_mbar(sched_stage)->wait(((sched_iter / Stages) & 1) ^ 1);
+    if (lane_predicate) {
+      storage.work[sched_stage].valid = 0;
+      storage.full_mbar(sched_stage)->arrive();
+    }
+  }
+};
+
+// Consumer view: waits a stage, copies the tile into registers, then the
+// elected lane releases the stage before the caller starts working on it.
+// Returns false on the sentinel (which is never released).
+template <int Stages>
+struct MoeSchedConsumer {
+  MoeSchedStorage<Stages>& storage;
+  int lane_predicate;
+  uint32_t sched_iter = 0;
+
+  __device__ __forceinline__ bool get_next_tile(MoeWorkTile& tile) {
+    int sched_stage = sched_iter % Stages;
+    storage.full_mbar(sched_stage)->wait((sched_iter / Stages) & 1);
+    tile = storage.work[sched_stage];
+    // Every lane must own its register copy before the elected lane lets
+    // the producer overwrite the stage.
+    __syncwarp();
+    if (!tile.valid) {
+      return false;
+    }
+    if (lane_predicate) {
+      storage.empty_mbar(sched_stage)->arrive();
+    }
+    ++sched_iter;
+    return true;
+  }
+};
+
+}  // namespace sm120_common
+}  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_common/scheduler.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_common/scheduler.cuh
@@ -17,6 +17,7 @@
 #pragma once
 // clang-format off
 #include <cstdint>
+#include <type_traits>
 
 #include <cute/config.hpp>
 #include <cute/layout.hpp>
@@ -73,14 +74,12 @@ constexpr int get_num_1d_blocks_per_group() {
 
 template <GemmType kGemmType, int BlockM, int BlockN>
 struct Scheduler {
-  static_assert(
-      kGemmType == GemmType::Normal || kGemmType == GemmType::Batched ||
-          kGemmType == GemmType::MGroupedContiguous ||
-          kGemmType == GemmType::MGroupedContiguousWithPsumLayout ||
-          kGemmType == GemmType::MGroupedContiguousWithZeroPadding ||
-          kGemmType == GemmType::MGroupedMasked,
-      "Scheduler supports Normal, Batched, MGroupedContiguous, "
-      "MGroupedContiguousWithPsumLayout, MGroupedContiguousWithZeroPadding, MGroupedMasked.");
+  static_assert(kGemmType == GemmType::Normal || kGemmType == GemmType::Batched ||
+                    kGemmType == GemmType::MGroupedContiguous ||
+                    kGemmType == GemmType::MGroupedContiguousWithPsumLayout ||
+                    kGemmType == GemmType::MGroupedMasked,
+                "Scheduler supports Normal, Batched, MGroupedContiguous, "
+                "MGroupedContiguousWithPsumLayout, MGroupedMasked.");
 
   static constexpr int kNum1DBlocksPerGroup = get_num_1d_blocks_per_group<BlockM, BlockN>();
 
@@ -166,29 +165,6 @@ struct Scheduler {
       auto remain_blocks = next_block_idx - current_m_block_cumsum * num_n_blocks;
       get_swizzled_block_idx_local(remain_blocks, num_m_blocks, m_block_idx, n_block_idx);
       return true;
-    } else if constexpr (kGemmType == GemmType::MGroupedContiguousWithZeroPadding) {
-      // ZeroPadding MoE: unpadded raw grouped_layout interpreted as
-      // token_offset[E+1] int32 cumsum WITH leading 0 (= [0, m0, m0+m1, ..., M_total]),
-      // plain row-major (no L2 swizzle).
-      while (true) {
-        if (current_group_idx >= num_groups) return false;
-
-        prev_psum_m = grouped_layout[current_group_idx];
-        current_psum_m = grouped_layout[current_group_idx + 1];
-        int32_t shape_m_cur = current_psum_m - prev_psum_m;
-        num_m_blocks = (shape_m_cur + BlockM - 1) / BlockM;
-
-        int32_t next_cumsum = current_m_block_cumsum + num_m_blocks;
-        if (next_block_idx < next_cumsum * num_n_blocks) break;
-
-        ++current_group_idx;
-        current_m_block_cumsum = next_cumsum;
-      }
-
-      auto remain_blocks = next_block_idx - current_m_block_cumsum * num_n_blocks;
-      m_block_idx = remain_blocks / num_n_blocks;
-      n_block_idx = remain_blocks % num_n_blocks;
-      return true;
     } else if constexpr (kGemmType == GemmType::MGroupedMasked) {
       while (true) {
         // End of the task
@@ -231,6 +207,12 @@ struct Scheduler {
     return current_group_idx;
   }
 };
+
+// SwapAB-aware Scheduler selection shared by every non-ZeroPadding kernel:
+// logical tiles swap with the operands.
+template <GemmType kGemmType, bool kSwapAB, int TileM, int TileN>
+using SelectedScheduler = std::conditional_t<kSwapAB, Scheduler<kGemmType, TileN, TileM>,
+                                             Scheduler<kGemmType, TileM, TileN>>;
 
 }  // namespace sm120_common
 }  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/fp8_builder.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/fp8_builder.cuh
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// clang-format off
+#include <cstdint>
+#include <type_traits>
+
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh"
+// clang-format on
+
+namespace flashinfer::gemm::mxfp8_cute_sm120 {
+namespace sm120_blockscaling {
+
+using namespace cute;
+
+template <int TileM_ = 128, int TileN_ = 64, int TileK_ = 128, int Stages_ = 2,
+          bool SwapAB_ = false>
+struct SM120BlockScalingFusedMoeBuilder
+    : SM120BlockScalingBuilder<TileM_, TileN_, TileK_, Stages_, SwapAB_ ? 128 : 1,
+                               SwapAB_ ? 1 : 128, 128,
+                               sm120_common::GemmType::MGroupedContiguousWithZeroPadding, SwapAB_> {
+  using Base =
+      SM120BlockScalingBuilder<TileM_, TileN_, TileK_, Stages_, SwapAB_ ? 128 : 1,
+                               SwapAB_ ? 1 : 128, 128,
+                               sm120_common::GemmType::MGroupedContiguousWithZeroPadding, SwapAB_>;
+
+  using ElementA = typename Base::ElementA;
+  using ElementB = typename Base::ElementB;
+  using ElementScale = typename Base::ElementScale;
+  using ABLoadConfig = typename Base::ABLoadConfig;
+  using SFConfig = typename Base::SFConfig;
+  using StagedR2GStoreConfig = typename Base::StagedR2GStoreConfig;
+
+  static constexpr uint32_t LoadRegisterRequirement = Base::kUseStagedR2G ? 120 : 40;
+  static constexpr uint32_t MmaRegisterRequirement = Base::kUseStagedR2G ? 192 : 232;
+
+  struct SharedStorageLoadDefault : cute::aligned_struct<128, _0> {
+    alignas(1024)
+        cute::ArrayEngine<ElementA, cute::cosize_v<typename ABLoadConfig::SmemLayoutA>> smem_A;
+    alignas(1024)
+        cute::ArrayEngine<ElementB, cute::cosize_v<typename ABLoadConfig::SmemLayoutB>> smem_B_up;
+    alignas(1024)
+        cute::ArrayEngine<ElementB, cute::cosize_v<typename ABLoadConfig::SmemLayoutB>> smem_B_gate;
+    alignas(128)
+        cute::ArrayEngine<ElementScale, cute::cosize_v<typename SFConfig::SmemLayoutSFA>> smem_SFA;
+    cute::ArrayEngine<ElementScale, cute::cosize_v<typename SFConfig::SmemLayoutSFB>> smem_SFB_up;
+    cute::ArrayEngine<ElementScale, cute::cosize_v<typename SFConfig::SmemLayoutSFB>> smem_SFB_gate;
+  };
+
+  struct SharedStorageLoadSwapAB : cute::aligned_struct<128, _0> {
+    alignas(1024)
+        cute::ArrayEngine<ElementA, cute::cosize_v<typename ABLoadConfig::SmemLayoutA>> smem_A_up;
+    alignas(1024)
+        cute::ArrayEngine<ElementA, cute::cosize_v<typename ABLoadConfig::SmemLayoutA>> smem_A_gate;
+    alignas(1024)
+        cute::ArrayEngine<ElementB, cute::cosize_v<typename ABLoadConfig::SmemLayoutB>> smem_B;
+    cute::ArrayEngine<ElementScale, cute::cosize_v<typename SFConfig::SmemLayoutSFA>> smem_SFA_up;
+    cute::ArrayEngine<ElementScale, cute::cosize_v<typename SFConfig::SmemLayoutSFA>> smem_SFA_gate;
+    cute::ArrayEngine<ElementScale, cute::cosize_v<typename SFConfig::SmemLayoutSFB>> smem_SFB;
+  };
+
+  using SharedStorageLoad =
+      std::conditional_t<SwapAB_, SharedStorageLoadSwapAB, SharedStorageLoadDefault>;
+
+  union TensorStorageUnion {
+    SharedStorageLoad load;
+    typename Base::R2GStoreConfig::SharedStorageR2G store;
+  };
+
+  struct TensorStorageStagedR2G {
+    SharedStorageLoad load;
+    typename StagedR2GStoreConfig::SharedStorageStagedR2G store;
+  };
+};
+
+}  // namespace sm120_blockscaling
+}  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/fp8_kernel_impl.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/fp8_kernel_impl.cuh
@@ -1,0 +1,1037 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// clang-format off
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+#include <cutlass/arch/reg_reconfig.h>
+
+#include "cute_sm120_mxfp8_groupwise/sm120_fused_moe/fp8_builder.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaling/kernel_impl.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_common/moe_scheduler.cuh"
+// clang-format on
+
+namespace flashinfer::gemm::mxfp8_cute_sm120 {
+namespace sm120_blockscaling {
+
+using namespace cute;
+
+template <typename KT>
+struct SM120BlockScalingFusedMoeGemmKernel : SM120BlockScalingGemmKernel<KT> {
+  using BaseKernel = SM120BlockScalingGemmKernel<KT>;
+  using Scheduler = sm120_common::SelectedMoeScheduler<KT::kSwapAB, KT::kTileM, KT::kTileN>;
+  using ProblemShape = typename BaseKernel::ProblemShape;
+  static constexpr int kNumSchedStages = 2;
+  static constexpr int kNumSchedConsumers =
+      KT::MMAConfig::kNumMathWarps + (KT::kUseStagedR2G ? 3 : 2);
+  using TensorStorage = std::conditional_t<KT::kUseStagedR2G, typename KT::TensorStorageStagedR2G,
+                                           typename KT::TensorStorageUnion>;
+  struct SharedStorage {
+    TensorStorage tensors;
+    alignas(16) typename KT::BarrierStorage barriers;
+    alignas(8) sm120_common::MoeSchedStorage<kNumSchedStages> sched;
+  };
+  static constexpr int kSmemSize = int(sizeof(SharedStorage));
+  using FullBarrier = typename KT::FullBarrier;
+  using EmptyBarrier = typename KT::EmptyBarrier;
+  using ProducerBarrierType = typename FullBarrier::ValueType;
+  static constexpr bool kUseStagedR2G = KT::kUseStagedR2G;
+  static constexpr uint32_t TmaTransactionBytesAB =
+      KT::kSwapAB
+          ? 2 * KT::ABLoadConfig::TmaTransactionBytesA + KT::ABLoadConfig::TmaTransactionBytesB
+          : KT::ABLoadConfig::TmaTransactionBytesA + 2 * KT::ABLoadConfig::TmaTransactionBytesB;
+
+  static_assert(KT::kGemmType == sm120_common::GemmType::MGroupedContiguousWithZeroPadding);
+  static_assert(KT::SFConfig::SF_Stages == KT::AB_Stages);
+
+  struct Params {
+    typename KT::ABLoadConfig::TMA_A tma_load_a;
+    typename KT::ABLoadConfig::TMA_B tma_load_b;
+    typename KT::SfaTmaLoadConfig::TMA_SFA tma_load_sfa;
+    typename KT::ElementScale const* ptr_SFA;
+    typename KT::ElementScale const* ptr_SFB;
+    typename KT::ElementD* ptr_D;
+    int M;
+    int N;
+    int K;
+    int num_experts;
+    int32_t const* grouped_layout;
+  };
+
+  struct Arguments {
+    typename KT::ElementA const* ptr_A;
+    typename KT::ABLoadConfig::StrideA dA;
+    typename KT::ElementB const* ptr_B;
+    typename KT::ABLoadConfig::StrideB dB;
+    typename KT::ElementScale const* ptr_SFA;
+    typename KT::ElementScale const* ptr_SFB;
+    typename KT::ElementD* ptr_D;
+    int32_t const* grouped_layout;
+  };
+
+  static Params to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args) {
+    auto [M, N, K, num_experts] = problem_shape;
+    auto [tma_load_a, tma_load_b] = sm120_common::utils::make_ab_tma_descriptors<KT>(
+        args.ptr_A, args.dA, args.ptr_B, args.dB, M, 2 * N, K, num_experts);
+    typename KT::SfaTmaLoadConfig::TMA_SFA tma_load_sfa{};
+    if constexpr (KT::kUseTmaSFA) {
+      tma_load_sfa = utils::make_sfa_tma_descriptor<KT>(args.ptr_SFA, M, N, K, num_experts);
+    }
+    return {tma_load_a, tma_load_b, tma_load_sfa, args.ptr_SFA,       args.ptr_SFB, args.ptr_D, M,
+            N,          K,          num_experts,  args.grouped_layout};
+  }
+
+  CUTE_DEVICE
+  static auto get_mbarriers(SharedStorage& shared_storage) {
+    auto* ab_full_mbar = recast_ptr<FullBarrier>(&shared_storage.barriers.ab_full_mbar[0]);
+    auto* ab_empty_mbar = recast_ptr<EmptyBarrier>(&shared_storage.barriers.ab_empty_mbar[0]);
+    auto* sf_full_mbar = recast_ptr<FullBarrier>(&shared_storage.barriers.sf_full_mbar[0]);
+    auto* sf_empty_mbar = recast_ptr<EmptyBarrier>(&shared_storage.barriers.sf_empty_mbar[0]);
+    auto* store_full_mbar = recast_ptr<EmptyBarrier>(&shared_storage.barriers.store_full_mbar[0]);
+    auto* store_empty_mbar = recast_ptr<EmptyBarrier>(&shared_storage.barriers.store_empty_mbar[0]);
+    return cute::make_tuple(ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar,
+                            store_full_mbar, store_empty_mbar);
+  }
+
+  CUTE_DEVICE
+  static void prefetch_tma_descriptors(Params const& params) {
+    cute::prefetch_tma_descriptor(params.tma_load_a.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_b.get_tma_descriptor());
+    if constexpr (KT::kUseTmaSFA) {
+      cute::prefetch_tma_descriptor(params.tma_load_sfa.get_tma_descriptor());
+    }
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_ab(Params const& params, SharedStorage& shared_storage,
+                                  BlkCoord const& blk_coord, int32_t m_offset, int32_t k_tile_count,
+                                  int& ab_stage, uint32_t& ab_phase, uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    using X = Underscore;
+
+    auto mA_full = params.tma_load_a.get_tma_tensor(make_shape(params.M, params.K, 1));
+    auto mA = domain_offset(make_coord(m_offset, 0, 0), mA_full);
+    auto gA_mkl = local_tile(mA, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gA = gA_mkl(_, _, m_block_idx, _, Int<0>{});
+
+    auto mB =
+        params.tma_load_b.get_tma_tensor(make_shape(2 * params.N, params.K, params.num_experts));
+    auto mB_up = mB;
+    auto mB_gate = domain_offset(make_coord(params.N, 0, 0), mB);
+    auto gB_up_nkl =
+        local_tile(mB_up, typename KT::TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gB_gate_nkl =
+        local_tile(mB_gate, typename KT::TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gB_up = gB_up_nkl(_, _, n_block_idx, _, expert_idx);
+    auto gB_gate = gB_gate_nkl(_, _, n_block_idx, _, expert_idx);
+
+    auto block_tma_a = params.tma_load_a.get_slice(0);
+    auto block_tma_b = params.tma_load_b.get_slice(0);
+    auto tAgA = block_tma_a.partition_S(gA);
+    auto tBgB_up = block_tma_b.partition_S(gB_up);
+    auto tBgB_gate = block_tma_b.partition_S(gB_gate);
+
+    auto sA = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto sB_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto tAsA = block_tma_a.partition_D(sA);
+    auto tBsB_up = block_tma_b.partition_D(sB_up);
+    auto tBsB_gate = block_tma_b.partition_D(sB_gate);
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = get_mbarriers(shared_storage);
+    (void)sf_full_mbar;
+    (void)sf_empty_mbar;
+    (void)store_full_mbar;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count; ++k_tile_idx) {
+      ab_empty_mbar[ab_stage].wait(ab_phase);
+      auto& ab_full_barrier = ab_full_mbar[ab_stage];
+      ab_full_barrier.arrive_and_expect_tx(TmaTransactionBytesAB);
+      auto tma_copy_a = params.tma_load_a.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+      auto tma_copy_b = params.tma_load_b.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+      cute::copy(tma_copy_a, tAgA(_, _, _, k_tile_idx), tAsA(_, _, _, ab_stage));
+      cute::copy(tma_copy_b, tBgB_up(_, _, _, k_tile_idx), tBsB_up(_, _, _, ab_stage));
+      cute::copy(tma_copy_b, tBgB_gate(_, _, _, k_tile_idx), tBsB_gate(_, _, _, ab_stage));
+      ++ab_stage;
+      if (ab_stage == KT::AB_Stages) {
+        ab_stage = 0;
+        ab_phase ^= 1;
+      }
+    }
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_ab_swap(Params const& params, SharedStorage& shared_storage,
+                                       BlkCoord const& blk_coord, int32_t m_offset,
+                                       int32_t k_tile_count, int& ab_stage, uint32_t& ab_phase,
+                                       uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    using X = Underscore;
+
+    auto mA =
+        params.tma_load_a.get_tma_tensor(make_shape(2 * params.N, params.K, params.num_experts));
+    auto mA_up = mA;
+    auto mA_gate = domain_offset(make_coord(params.N, 0, 0), mA);
+    auto gA_up_mkl =
+        local_tile(mA_up, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gA_gate_mkl =
+        local_tile(mA_gate, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gA_up = gA_up_mkl(_, _, m_block_idx, _, expert_idx);
+    auto gA_gate = gA_gate_mkl(_, _, m_block_idx, _, expert_idx);
+
+    auto mB_full = params.tma_load_b.get_tma_tensor(make_shape(params.M, params.K, 1));
+    auto mB = domain_offset(make_coord(m_offset, 0, 0), mB_full);
+    auto gB_nkl = local_tile(mB, typename KT::TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gB = gB_nkl(_, _, n_block_idx, _, Int<0>{});
+
+    auto block_tma_a = params.tma_load_a.get_slice(0);
+    auto block_tma_b = params.tma_load_b.get_slice(0);
+    auto tAgA_up = block_tma_a.partition_S(gA_up);
+    auto tAgA_gate = block_tma_a.partition_S(gA_gate);
+    auto tBgB = block_tma_b.partition_S(gB);
+
+    auto sA_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sA_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto tAsA_up = block_tma_a.partition_D(sA_up);
+    auto tAsA_gate = block_tma_a.partition_D(sA_gate);
+    auto tBsB = block_tma_b.partition_D(sB);
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = get_mbarriers(shared_storage);
+    (void)sf_full_mbar;
+    (void)sf_empty_mbar;
+    (void)store_full_mbar;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count; ++k_tile_idx) {
+      ab_empty_mbar[ab_stage].wait(ab_phase);
+      auto& ab_full_barrier = ab_full_mbar[ab_stage];
+      ab_full_barrier.arrive_and_expect_tx(TmaTransactionBytesAB);
+      auto tma_copy_a = params.tma_load_a.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+      auto tma_copy_b = params.tma_load_b.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+      cute::copy(tma_copy_a, tAgA_up(_, _, _, k_tile_idx), tAsA_up(_, _, _, ab_stage));
+      cute::copy(tma_copy_a, tAgA_gate(_, _, _, k_tile_idx), tAsA_gate(_, _, _, ab_stage));
+      cute::copy(tma_copy_b, tBgB(_, _, _, k_tile_idx), tBsB(_, _, _, ab_stage));
+      ++ab_stage;
+      if (ab_stage == KT::AB_Stages) {
+        ab_stage = 0;
+        ab_phase ^= 1;
+      }
+    }
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_sf(Params const& params, SharedStorage& shared_storage,
+                                  BlkCoord const& blk_coord, int32_t m_offset, int32_t k_tile_count,
+                                  int& sf_stage, uint32_t& sf_phase, uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    (void)m_block_idx;
+    int lane_idx = cutlass::canonical_lane_idx();
+    int lane_predicate = cute::elect_one_sync();
+
+    auto tAgSFA = utils::tma_sfa_partition<KT>(params.tma_load_sfa, params.M, params.N, params.K,
+                                               params.num_experts, blk_coord, m_offset);
+    auto block_tma_sfa = params.tma_load_sfa.get_slice(0);
+
+    auto sSFA = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA.begin()),
+                            typename KT::SFConfig::SmemLayoutTmaSFA{});
+    auto tAsSFA = block_tma_sfa.partition_D(sSFA);
+
+    auto sfb_layout =
+        KT::SFConfig::deduce_sfb_layout(params.M, 2 * params.N, params.K, params.num_experts);
+    auto mSFB = make_tensor(make_gmem_ptr(params.ptr_SFB), sfb_layout);
+    auto cSFB = make_identity_tensor(mSFB.shape());
+    int n_offset = n_block_idx * KT::kTileN;
+    int sfb_up_n = n_offset / KT::kGranN;
+    int sfb_gate_n = (params.N + n_offset) / KT::kGranN;
+    auto gSFB_up = local_tile(mSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
+                              make_coord(sfb_up_n, _, expert_idx));
+    auto gSFB_gate = local_tile(mSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
+                                make_coord(sfb_gate_n, _, expert_idx));
+    auto coordSFB_up = local_tile(cSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
+                                  make_coord(sfb_up_n, _, expert_idx));
+    auto coordSFB_gate = local_tile(cSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
+                                    make_coord(sfb_gate_n, _, expert_idx));
+
+    auto sSFB_up = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_up.begin()),
+                               typename KT::SFConfig::SmemLayoutSFB{});
+    auto sSFB_gate = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_gate.begin()),
+                                 typename KT::SFConfig::SmemLayoutSFB{});
+    TiledCopy scale_copy_b = make_tiled_copy(
+        typename KT::SFConfig::SmemCopyAtomSFB{},
+        Layout<Shape<Int<KT::SFConfig::kNumScaleCopyThreads>>>{}, Layout<Shape<_1>>{});
+    auto thr_scale_copy_b = scale_copy_b.get_slice(lane_idx);
+    auto tBgSFB_up = thr_scale_copy_b.partition_S(gSFB_up);
+    auto tBgSFB_gate = thr_scale_copy_b.partition_S(gSFB_gate);
+    auto tBcSFB_up = thr_scale_copy_b.partition_S(coordSFB_up);
+    auto tBcSFB_gate = thr_scale_copy_b.partition_S(coordSFB_gate);
+    auto tBsSFB_up = thr_scale_copy_b.partition_D(sSFB_up);
+    auto tBsSFB_gate = thr_scale_copy_b.partition_D(sSFB_gate);
+    int64_t scales_n = sm120_common::math::ceil_div(2 * params.N, int(KT::kGranN));
+    auto tBpSFB_up = cute::lazy::transform(tBcSFB_up(_, _, 0), [&](auto const& coord) {
+      return lane_idx < KT::SFConfig::kTileScaleN && get<0>(coord) < scales_n;
+    });
+    auto tBpSFB_gate = cute::lazy::transform(tBcSFB_gate(_, _, 0), [&](auto const& coord) {
+      return lane_idx < KT::SFConfig::kTileScaleN && get<0>(coord) < scales_n;
+    });
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = get_mbarriers(shared_storage);
+    (void)ab_full_mbar;
+    (void)ab_empty_mbar;
+    (void)store_full_mbar;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count; ++k_tile_idx) {
+      sf_empty_mbar[sf_stage].wait(sf_phase);
+      auto& sf_full_barrier = sf_full_mbar[sf_stage];
+      if (lane_predicate) {
+        sf_full_barrier.arrive_and_expect_tx(KT::SfaTmaLoadConfig::TmaTransactionBytesSFA);
+        auto tma_copy_sfa =
+            params.tma_load_sfa.with(*recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+        cute::copy(tma_copy_sfa, tAgSFA(_, _, _, k_tile_idx), tAsSFA(_, _, _, sf_stage));
+      }
+      __syncwarp();
+      copy_if(scale_copy_b, tBpSFB_up, tBgSFB_up(_, _, k_tile_idx), tBsSFB_up(_, _, sf_stage));
+      copy_if(scale_copy_b, tBpSFB_gate, tBgSFB_gate(_, _, k_tile_idx),
+              tBsSFB_gate(_, _, sf_stage));
+      cutlass::arch::cpasync_barrier_arrive_noinc(
+          recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+      ++sf_stage;
+      if (sf_stage == KT::SFConfig::SF_Stages) {
+        sf_stage = 0;
+        sf_phase ^= 1;
+      }
+    }
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_sf_swap(Params const& params, SharedStorage& shared_storage,
+                                       BlkCoord const& blk_coord, int32_t m_offset,
+                                       int32_t m_boundary, int32_t k_tile_count, int& sf_stage,
+                                       uint32_t& sf_phase, uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    int lane_idx = cutlass::canonical_lane_idx();
+
+    auto sfa_layout =
+        KT::SFConfig::deduce_sfa_layout(2 * params.N, params.M, params.K, params.num_experts);
+    auto mSFA = make_tensor(make_gmem_ptr(params.ptr_SFA), sfa_layout);
+    auto cSFA = make_identity_tensor(mSFA.shape());
+    auto mSFA_up = mSFA;
+    auto mSFA_gate = domain_offset(make_coord(params.N / KT::kGranM, 0, 0), mSFA);
+    auto cSFA_up = cSFA;
+    auto cSFA_gate = domain_offset(make_coord(params.N / KT::kGranM, 0, 0), cSFA);
+    auto gSFA_up = local_tile(mSFA_up, make_tile(Int<KT::SFConfig::kTileScaleM>{}),
+                              make_coord(m_block_idx, _, expert_idx));
+    auto gSFA_gate = local_tile(mSFA_gate, make_tile(Int<KT::SFConfig::kTileScaleM>{}),
+                                make_coord(m_block_idx, _, expert_idx));
+    auto coordSFA_up = local_tile(cSFA_up, make_tile(Int<KT::SFConfig::kTileScaleM>{}),
+                                  make_coord(m_block_idx, _, expert_idx));
+    auto coordSFA_gate = local_tile(cSFA_gate, make_tile(Int<KT::SFConfig::kTileScaleM>{}),
+                                    make_coord(m_block_idx, _, expert_idx));
+
+    int32_t sfb_real_N = sm120_common::math::compute_padded_offset(params.M, params.num_experts);
+    int32_t sf_m_offset = sm120_common::math::compute_padded_offset(m_offset, expert_idx);
+    auto sfb_layout = KT::SFConfig::deduce_sfb_layout(2 * params.N, sfb_real_N, params.K, 1);
+    auto mSFB_full = make_tensor(make_gmem_ptr(params.ptr_SFB), sfb_layout);
+    auto cSFB_full = make_identity_tensor(mSFB_full.shape());
+    auto mSFB = domain_offset(make_coord(sf_m_offset / KT::kGranN, 0, 0), mSFB_full);
+    auto cSFB = domain_offset(make_coord(sf_m_offset / KT::kGranN, 0, 0), cSFB_full);
+    auto gSFB = local_tile(mSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
+                           make_coord(n_block_idx, _, Int<0>{}));
+    auto coordSFB = local_tile(cSFB, make_tile(Int<KT::SFConfig::kTileScaleN>{}),
+                               make_coord(n_block_idx, _, Int<0>{}));
+
+    auto sSFA_up = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_up.begin()),
+                               typename KT::SFConfig::SmemLayoutSFA{});
+    auto sSFA_gate = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_gate.begin()),
+                                 typename KT::SFConfig::SmemLayoutSFA{});
+    auto sSFB = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB.begin()),
+                            typename KT::SFConfig::SmemLayoutSFB{});
+
+    TiledCopy scale_copy_a = make_tiled_copy(
+        typename KT::SFConfig::SmemCopyAtomSFA{},
+        Layout<Shape<Int<KT::SFConfig::kNumScaleCopyThreads>>>{}, Layout<Shape<_1>>{});
+    TiledCopy scale_copy_b = make_tiled_copy(
+        typename KT::SFConfig::SmemCopyAtomSFB{},
+        Layout<Shape<Int<KT::SFConfig::kNumScaleCopyThreads>>>{}, Layout<Shape<_1>>{});
+    auto thr_scale_copy_a = scale_copy_a.get_slice(lane_idx);
+    auto thr_scale_copy_b = scale_copy_b.get_slice(lane_idx);
+    auto tAgSFA_up = thr_scale_copy_a.partition_S(gSFA_up);
+    auto tAgSFA_gate = thr_scale_copy_a.partition_S(gSFA_gate);
+    auto tAcSFA_up = thr_scale_copy_a.partition_S(coordSFA_up);
+    auto tAcSFA_gate = thr_scale_copy_a.partition_S(coordSFA_gate);
+    auto tAsSFA_up = thr_scale_copy_a.partition_D(sSFA_up);
+    auto tAsSFA_gate = thr_scale_copy_a.partition_D(sSFA_gate);
+    auto tBgSFB = thr_scale_copy_b.partition_S(gSFB);
+    auto tBcSFB = thr_scale_copy_b.partition_S(coordSFB);
+    auto tBsSFB = thr_scale_copy_b.partition_D(sSFB);
+
+    int64_t scales_m = sm120_common::math::ceil_div(2 * params.N, int(KT::kGranM));
+    int64_t scales_n = sf_m_offset / KT::kGranN +
+                       sm120_common::math::ceil_div(m_boundary - m_offset, int(KT::kGranN));
+    auto tApSFA_up = cute::lazy::transform(tAcSFA_up(_, _, 0), [&](auto const& coord) {
+      return lane_idx < KT::SFConfig::kTileScaleM && get<0>(coord) < scales_m;
+    });
+    auto tApSFA_gate = cute::lazy::transform(tAcSFA_gate(_, _, 0), [&](auto const& coord) {
+      return lane_idx < KT::SFConfig::kTileScaleM && get<0>(coord) < scales_m;
+    });
+    auto tBpSFB = cute::lazy::transform(tBcSFB(_, _, 0), [&](auto const& coord) {
+      return lane_idx < KT::SFConfig::kTileScaleN && get<0>(coord) < scales_n;
+    });
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = get_mbarriers(shared_storage);
+    (void)ab_full_mbar;
+    (void)ab_empty_mbar;
+    (void)store_full_mbar;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count; ++k_tile_idx) {
+      sf_empty_mbar[sf_stage].wait(sf_phase);
+      copy_if(scale_copy_a, tApSFA_up, tAgSFA_up(_, _, k_tile_idx), tAsSFA_up(_, _, sf_stage));
+      copy_if(scale_copy_a, tApSFA_gate, tAgSFA_gate(_, _, k_tile_idx),
+              tAsSFA_gate(_, _, sf_stage));
+      copy_if(scale_copy_b, tBpSFB, tBgSFB(_, _, k_tile_idx), tBsSFB(_, _, sf_stage));
+      cutlass::arch::cpasync_barrier_arrive_noinc(
+          recast_ptr<ProducerBarrierType>(&sf_full_mbar[sf_stage]));
+      ++sf_stage;
+      if (sf_stage == KT::SFConfig::SF_Stages) {
+        sf_stage = 0;
+        sf_phase ^= 1;
+      }
+    }
+  }
+
+  CUTE_DEVICE
+  static void mma_swap(Params const& params, SharedStorage& shared_storage, int32_t k_tile_count,
+                       int32_t m_offset, int32_t m_boundary, int32_t m_block_idx,
+                       int32_t n_block_idx, int& read_stage, uint32_t& sf_phase,
+                       uint32_t& ab_phase) {
+    int thread_idx = int(threadIdx.x);
+
+    auto sA_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sA_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+
+    typename KT::MMAConfig::TiledMma mma;
+    auto thr_mma = mma.get_thread_slice(thread_idx);
+    auto accum_up = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto accum_gate = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto tmp_accum = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto tCrA_up = thr_mma.partition_fragment_A(sA_up(_, _, Int<0>{}));
+    auto tCrA_gate = thr_mma.partition_fragment_A(sA_gate(_, _, Int<0>{}));
+    auto tCrB = thr_mma.partition_fragment_B(sB(_, _, Int<0>{}));
+    constexpr int K_BLOCK_MAX = decltype(size<2>(tCrA_up))::value;
+
+    auto s2r_copy_A = make_tiled_copy_A(typename KT::ABLoadConfig::SmemCopyAtomA{}, mma);
+    auto s2r_thr_copy_A = s2r_copy_A.get_thread_slice(thread_idx);
+    auto tXsA_up = s2r_thr_copy_A.partition_S(sA_up);
+    auto tXsA_gate = s2r_thr_copy_A.partition_S(sA_gate);
+    auto tXrA_up = s2r_thr_copy_A.retile_D(tCrA_up);
+    auto tXrA_gate = s2r_thr_copy_A.retile_D(tCrA_gate);
+    auto s2r_copy_B = make_tiled_copy_B(typename KT::ABLoadConfig::SmemCopyAtomB{}, mma);
+    auto s2r_thr_copy_B = s2r_copy_B.get_thread_slice(thread_idx);
+    auto tXsB = s2r_thr_copy_B.partition_S(sB);
+    auto tXrB = s2r_thr_copy_B.retile_D(tCrB);
+
+    auto sSFAViewAsC_up =
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_up.begin()),
+                    typename KT::SFConfig::SmemLayoutSFAViewAsC{});
+    auto sSFAViewAsC_gate =
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_gate.begin()),
+                    typename KT::SFConfig::SmemLayoutSFAViewAsC{});
+    auto sSFBViewAsC = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB.begin()),
+                                   typename KT::SFConfig::SmemLayoutSFBViewAsC{});
+    auto tCsSFAViewAsC_up = thr_mma.partition_C(sSFAViewAsC_up);
+    auto tCsSFAViewAsC_gate = thr_mma.partition_C(sSFAViewAsC_gate);
+    auto tCsSFBViewAsC = thr_mma.partition_C(sSFBViewAsC);
+    auto tCrSFAViewAsC_up =
+        make_tensor_like<typename KT::ElementScale>(tCsSFAViewAsC_up(_, _, _, Int<0>{}));
+    auto tCrSFAViewAsC_gate =
+        make_tensor_like<typename KT::ElementScale>(tCsSFAViewAsC_gate(_, _, _, Int<0>{}));
+    auto tCrSFBViewAsC_up =
+        make_tensor_like<typename KT::ElementScale>(tCsSFBViewAsC(_, _, _, Int<0>{}));
+    auto tCrSFBViewAsC_gate =
+        make_tensor_like<typename KT::ElementScale>(tCsSFBViewAsC(_, _, _, Int<0>{}));
+
+    clear(accum_up);
+    clear(accum_gate);
+    clear(tmp_accum);
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = get_mbarriers(shared_storage);
+    (void)store_full_mbar;
+
+    auto copy_ab_s2r = [&](auto k_block) {
+      cute::copy(s2r_copy_A, tXsA_up(_, _, k_block, read_stage), tXrA_up(_, _, k_block));
+      cute::copy(s2r_copy_A, tXsA_gate(_, _, k_block, read_stage), tXrA_gate(_, _, k_block));
+      cute::copy(s2r_copy_B, tXsB(_, _, k_block, read_stage), tXrB(_, _, k_block));
+    };
+    auto advance_read_stage = [&]() {
+      read_stage = (read_stage + 1) % KT::AB_Stages;
+      if (read_stage == 0) {
+        ab_phase ^= 1;
+        sf_phase ^= 1;
+      }
+    };
+    auto copy_scale_s2r = [&]() {
+      sf_full_mbar[read_stage].wait(sf_phase);
+      cute::copy(tCsSFAViewAsC_up(_, _, _, read_stage), tCrSFAViewAsC_up);
+      cute::copy(tCsSFAViewAsC_gate(_, _, _, read_stage), tCrSFAViewAsC_gate);
+      cute::copy(tCsSFBViewAsC(_, _, _, read_stage), tCrSFBViewAsC_up);
+      cute::copy(tCsSFBViewAsC(_, _, _, read_stage), tCrSFBViewAsC_gate);
+      sf_empty_mbar[read_stage].arrive();
+      typename KT::ElementScale scale_a_up = tCrSFAViewAsC_up.data()[0];
+      typename KT::ElementScale scale_a_gate = tCrSFAViewAsC_gate.data()[0];
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(tCrSFBViewAsC_up); ++i) {
+        tCrSFBViewAsC_up.data()[i] *= scale_a_up;
+        tCrSFBViewAsC_gate.data()[i] *= scale_a_gate;
+      }
+    };
+    auto rescale_up = [&]() {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(accum_up); ++i) {
+        accum_up(i) += tmp_accum(i) * tCrSFBViewAsC_up(i);
+        tmp_accum(i) = 0.0f;
+      }
+    };
+    auto rescale_gate = [&]() {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(accum_gate); ++i) {
+        accum_gate(i) += tmp_accum(i) * tCrSFBViewAsC_gate(i);
+        tmp_accum(i) = 0.0f;
+      }
+    };
+
+    copy_scale_s2r();
+    ab_full_mbar[read_stage].wait(ab_phase);
+    copy_ab_s2r(Int<0>{});
+
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count - 1; ++k_tile_idx) {
+      cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+        constexpr int k_block_idx = decltype(k_block)::value;
+        if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+          copy_ab_s2r(Int<k_block_idx + 1>{});
+        }
+        cute::gemm(mma, tCrA_up(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+      });
+      rescale_up();
+
+      cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+        cute::gemm(mma, tCrA_gate(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+      });
+      ab_empty_mbar[read_stage].arrive();
+      advance_read_stage();
+      ab_full_mbar[read_stage].wait(ab_phase);
+      copy_ab_s2r(Int<0>{});
+      rescale_gate();
+      copy_scale_s2r();
+    }
+
+    cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+      constexpr int k_block_idx = decltype(k_block)::value;
+      if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+        copy_ab_s2r(Int<k_block_idx + 1>{});
+      }
+      cute::gemm(mma, tCrA_up(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+    });
+    rescale_up();
+
+    cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+      cute::gemm(mma, tCrA_gate(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+    });
+    ab_empty_mbar[read_stage].arrive();
+    advance_read_stage();
+    rescale_gate();
+
+    cutlass::arch::NamedBarrier::sync(KT::MMAConfig::kNumMathThreads, 0);
+    CUTE_UNROLL
+    for (int i = 0; i < size(accum_gate); ++i) {
+      tmp_accum(i) = __expf(-accum_gate(i));
+    }
+    CUTE_UNROLL
+    for (int i = 0; i < size(accum_gate); ++i) {
+      accum_gate(i) = accum_gate(i) / (1.0f + tmp_accum(i));
+    }
+    CUTE_UNROLL
+    for (int i = 0; i < size(accum_up); ++i) {
+      accum_up(i) *= accum_gate(i);
+    }
+    sm120_common::utils::epi_pred_stg<KT>(params, accum_up, thread_idx, m_offset, m_boundary,
+                                          m_block_idx, n_block_idx, store_empty_mbar);
+  }
+
+  CUTE_DEVICE
+  static void mma(Params const& params, SharedStorage& shared_storage, int32_t k_tile_count,
+                  int32_t m_offset, int32_t m_boundary, int32_t m_block_idx, int32_t n_block_idx,
+                  int32_t expert_idx, int& read_stage, uint32_t& sf_phase, uint32_t& ab_phase,
+                  int& epi_stage, uint32_t& se_phase) {
+    int thread_idx = int(threadIdx.x);
+
+    auto sA = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto sB_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+
+    typename KT::MMAConfig::TiledMma mma;
+    auto thr_mma = mma.get_thread_slice(thread_idx);
+    auto accum_up = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto accum_gate = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto tmp_accum = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    clear(accum_up);
+    clear(accum_gate);
+    clear(tmp_accum);
+
+    auto tCrA = thr_mma.partition_fragment_A(sA(_, _, Int<0>{}));
+    auto tCrB = thr_mma.partition_fragment_B(sB_up(_, _, Int<0>{}));
+    constexpr int K_BLOCK_MAX = decltype(size<2>(tCrA))::value;
+    auto s2r_copy_A = make_tiled_copy_A(typename KT::ABLoadConfig::SmemCopyAtomA{}, mma);
+    auto s2r_thr_copy_A = s2r_copy_A.get_thread_slice(thread_idx);
+    auto tXsA = s2r_thr_copy_A.partition_S(sA);
+    auto tXrA = s2r_thr_copy_A.retile_D(tCrA);
+    auto s2r_copy_B = make_tiled_copy_B(typename KT::ABLoadConfig::SmemCopyAtomB{}, mma);
+    auto s2r_thr_copy_B = s2r_copy_B.get_thread_slice(thread_idx);
+    auto tXsB_up = s2r_thr_copy_B.partition_S(sB_up);
+    auto tXsB_gate = s2r_thr_copy_B.partition_S(sB_gate);
+    auto tXrB = s2r_thr_copy_B.retile_D(tCrB);
+
+    auto sSFAViewAsC = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA.begin()),
+                                   typename KT::SFConfig::SmemLayoutSFAViewAsC{});
+    auto sSFBViewAsC_up =
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_up.begin()),
+                    typename KT::SFConfig::SmemLayoutSFBViewAsC{});
+    auto sSFBViewAsC_gate =
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_gate.begin()),
+                    typename KT::SFConfig::SmemLayoutSFBViewAsC{});
+    auto tCsSFAViewAsC = thr_mma.partition_C(sSFAViewAsC);
+    auto tCsSFBViewAsC_up = thr_mma.partition_C(sSFBViewAsC_up);
+    auto tCsSFBViewAsC_gate = thr_mma.partition_C(sSFBViewAsC_gate);
+    auto tCrSFAViewAsC_up =
+        make_tensor_like<typename KT::ElementScale>(tCsSFAViewAsC(_, _, _, Int<0>{}));
+    auto tCrSFAViewAsC_gate =
+        make_tensor_like<typename KT::ElementScale>(tCsSFAViewAsC(_, _, _, Int<0>{}));
+    auto tCrSFBViewAsC_up =
+        make_tensor_like<typename KT::ElementScale>(tCsSFBViewAsC_up(_, _, _, Int<0>{}));
+    auto tCrSFBViewAsC_gate =
+        make_tensor_like<typename KT::ElementScale>(tCsSFBViewAsC_gate(_, _, _, Int<0>{}));
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = get_mbarriers(shared_storage);
+
+    auto rescale_up = [&]() {
+      if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN == 1) {
+        typename KT::ElementScale scale_ab = tCrSFAViewAsC_up.data()[0];
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_up); ++i) {
+          accum_up(i) += tmp_accum(i) * scale_ab;
+          tmp_accum(i) = 0.0f;
+        }
+      }
+      if constexpr (KT::SFConfig::kTileScaleM > 1 && KT::SFConfig::kTileScaleN == 1) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_up); ++i) {
+          accum_up(i) += tmp_accum(i) * tCrSFAViewAsC_up(i);
+          tmp_accum(i) = 0.0f;
+        }
+      }
+      if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN > 1) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_up); ++i) {
+          accum_up(i) += tmp_accum(i) * tCrSFBViewAsC_up(i);
+          tmp_accum(i) = 0.0f;
+        }
+      }
+      if constexpr (KT::SFConfig::kTileScaleM > 1 && KT::SFConfig::kTileScaleN > 1) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_up); ++i) {
+          accum_up(i) += tmp_accum(i) * tCrSFAViewAsC_up(i) * tCrSFBViewAsC_up(i);
+          tmp_accum(i) = 0.0f;
+        }
+      }
+    };
+    auto rescale_gate = [&]() {
+      if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN == 1) {
+        typename KT::ElementScale scale_ab = tCrSFAViewAsC_gate.data()[0];
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_gate); ++i) {
+          accum_gate(i) += tmp_accum(i) * scale_ab;
+          tmp_accum(i) = 0.0f;
+        }
+      }
+      if constexpr (KT::SFConfig::kTileScaleM > 1 && KT::SFConfig::kTileScaleN == 1) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_gate); ++i) {
+          accum_gate(i) += tmp_accum(i) * tCrSFAViewAsC_gate(i);
+          tmp_accum(i) = 0.0f;
+        }
+      }
+      if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN > 1) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_gate); ++i) {
+          accum_gate(i) += tmp_accum(i) * tCrSFBViewAsC_gate(i);
+          tmp_accum(i) = 0.0f;
+        }
+      }
+      if constexpr (KT::SFConfig::kTileScaleM > 1 && KT::SFConfig::kTileScaleN > 1) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(accum_gate); ++i) {
+          accum_gate(i) += tmp_accum(i) * tCrSFAViewAsC_gate(i) * tCrSFBViewAsC_gate(i);
+          tmp_accum(i) = 0.0f;
+        }
+      }
+    };
+    auto tXsA_stage = tXsA(_, _, _, read_stage);
+    auto tXsB_up_stage = tXsB_up(_, _, _, read_stage);
+    auto tXsB_gate_stage = tXsB_gate(_, _, _, read_stage);
+    auto copy_scale_s2r = [&]() {
+      cute::copy(tCsSFAViewAsC(_, _, _, read_stage), tCrSFAViewAsC_up);
+      cute::copy(tCsSFAViewAsC(_, _, _, read_stage), tCrSFAViewAsC_gate);
+      cute::copy(tCsSFBViewAsC_up(_, _, _, read_stage), tCrSFBViewAsC_up);
+      cute::copy(tCsSFBViewAsC_gate(_, _, _, read_stage), tCrSFBViewAsC_gate);
+      if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN == 1) {
+        tCrSFAViewAsC_up.data()[0] *= tCrSFBViewAsC_up.data()[0];
+        tCrSFAViewAsC_gate.data()[0] *= tCrSFBViewAsC_gate.data()[0];
+      }
+      if constexpr (KT::SFConfig::kTileScaleM > 1 && KT::SFConfig::kTileScaleN == 1) {
+        typename KT::ElementScale scale_b_up = tCrSFBViewAsC_up.data()[0];
+        typename KT::ElementScale scale_b_gate = tCrSFBViewAsC_gate.data()[0];
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(tCrSFAViewAsC_up); ++i) {
+          tCrSFAViewAsC_up.data()[i] *= scale_b_up;
+          tCrSFAViewAsC_gate.data()[i] *= scale_b_gate;
+        }
+      }
+      if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN > 1) {
+        typename KT::ElementScale scale_a_up = tCrSFAViewAsC_up.data()[0];
+        typename KT::ElementScale scale_a_gate = tCrSFAViewAsC_gate.data()[0];
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(tCrSFBViewAsC_up); ++i) {
+          tCrSFBViewAsC_up.data()[i] *= scale_a_up;
+          tCrSFBViewAsC_gate.data()[i] *= scale_a_gate;
+        }
+      }
+    };
+    auto copy_up_s2r = [&](auto k_block) {
+      cute::copy(s2r_copy_A, tXsA_stage(_, _, k_block), tXrA(_, _, k_block));
+      cute::copy(s2r_copy_B, tXsB_up_stage(_, _, k_block), tXrB(_, _, k_block));
+    };
+    auto copy_gate_s2r = [&](auto k_block) {
+      cute::copy(s2r_copy_B, tXsB_gate_stage(_, _, k_block), tXrB(_, _, k_block));
+    };
+    auto advance_read_stage = [&]() {
+      ++read_stage;
+      if (read_stage == KT::AB_Stages) {
+        read_stage = 0;
+        ab_phase ^= 1;
+        sf_phase ^= 1;
+      }
+      tXsA_stage = tXsA(_, _, _, read_stage);
+      tXsB_up_stage = tXsB_up(_, _, _, read_stage);
+      tXsB_gate_stage = tXsB_gate(_, _, _, read_stage);
+    };
+
+    sf_full_mbar[read_stage].wait(sf_phase);
+    copy_scale_s2r();
+    sf_empty_mbar[read_stage].arrive();
+    ab_full_mbar[read_stage].wait(ab_phase);
+    copy_up_s2r(Int<0>{});
+
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count - 1; ++k_tile_idx) {
+      cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+        constexpr int k_block_idx = decltype(k_block)::value;
+        if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+          copy_up_s2r(Int<k_block_idx + 1>{});
+        }
+        cute::gemm(mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+      });
+      rescale_up();
+
+      copy_gate_s2r(Int<0>{});
+      cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+        constexpr int k_block_idx = decltype(k_block)::value;
+        if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+          copy_gate_s2r(Int<k_block_idx + 1>{});
+        } else {
+          ab_empty_mbar[read_stage].arrive();
+          advance_read_stage();
+          ab_full_mbar[read_stage].wait(ab_phase);
+          copy_up_s2r(Int<0>{});
+        }
+        cute::gemm(mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+      });
+      rescale_gate();
+
+      sf_full_mbar[read_stage].wait(sf_phase);
+      copy_scale_s2r();
+      sf_empty_mbar[read_stage].arrive();
+    }
+
+    cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+      constexpr int k_block_idx = decltype(k_block)::value;
+      if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+        copy_up_s2r(Int<k_block_idx + 1>{});
+      }
+      cute::gemm(mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+    });
+    rescale_up();
+
+    copy_gate_s2r(Int<0>{});
+    cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+      constexpr int k_block_idx = decltype(k_block)::value;
+      if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+        copy_gate_s2r(Int<k_block_idx + 1>{});
+      } else {
+        ab_empty_mbar[read_stage].arrive();
+        advance_read_stage();
+      }
+      cute::gemm(mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tmp_accum);
+    });
+    if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN == 1) {
+      typename KT::ElementScale scale_ab = tCrSFAViewAsC_gate.data()[0];
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(accum_gate); ++i) {
+        accum_gate(i) += tmp_accum(i) * scale_ab;
+        tmp_accum(i) = __expf(-accum_gate(i));
+      }
+    }
+    if constexpr (KT::SFConfig::kTileScaleM > 1 && KT::SFConfig::kTileScaleN == 1) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(accum_gate); ++i) {
+        accum_gate(i) += tmp_accum(i) * tCrSFAViewAsC_gate(i);
+        tmp_accum(i) = __expf(-accum_gate(i));
+      }
+    }
+    if constexpr (KT::SFConfig::kTileScaleM == 1 && KT::SFConfig::kTileScaleN > 1) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(accum_gate); ++i) {
+        accum_gate(i) += tmp_accum(i) * tCrSFBViewAsC_gate(i);
+        tmp_accum(i) = __expf(-accum_gate(i));
+      }
+    }
+    if constexpr (KT::SFConfig::kTileScaleM > 1 && KT::SFConfig::kTileScaleN > 1) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(accum_gate); ++i) {
+        accum_gate(i) += tmp_accum(i) * tCrSFAViewAsC_gate(i) * tCrSFBViewAsC_gate(i);
+        tmp_accum(i) = __expf(-accum_gate(i));
+      }
+    }
+
+    CUTE_UNROLL
+    for (int i = 0; i < size(accum_gate); ++i) {
+      accum_gate(i) = accum_gate(i) / (1.0f + tmp_accum(i));
+    }
+
+    CUTE_UNROLL
+    for (int i = 0; i < size(accum_up); ++i) {
+      accum_up(i) *= accum_gate(i);
+    }
+    if constexpr (kUseStagedR2G) {
+      sm120_common::utils::epi_staged_r2s<KT>(params, shared_storage, accum_up, thread_idx,
+                                              m_offset, m_boundary, m_block_idx, epi_stage,
+                                              se_phase, store_full_mbar, store_empty_mbar);
+    } else {
+      sm120_common::utils::epi_pred_r2g<KT>(params, shared_storage, accum_up, thread_idx, m_offset,
+                                            m_boundary, m_block_idx, n_block_idx, expert_idx,
+                                            store_empty_mbar);
+    }
+  }
+
+  CUTE_DEVICE
+  void operator()(Params const& params, char* smem_buf) {
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+    int warp_idx = cutlass::canonical_warp_idx_sync();
+    int lane_predicate = cute::elect_one_sync();
+    bool is_tma_thread = warp_idx == 0 && lane_predicate;
+
+    if (is_tma_thread) {
+      prefetch_tma_descriptors(params);
+    }
+    __syncthreads();
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = get_mbarriers(shared_storage);
+    if (is_tma_thread) {
+      cute::for_each(cute::make_int_sequence<KT::AB_Stages>{}, [&](auto stage) {
+        ab_full_mbar[stage].init(1);
+        ab_empty_mbar[stage].init(KT::MMAConfig::kNumMathThreads);
+      });
+      cute::for_each(cute::make_int_sequence<KT::SFConfig::SF_Stages>{}, [&](auto stage) {
+        sf_full_mbar[stage].init(KT::kNumProducerThreadEvents);
+        sf_empty_mbar[stage].init(KT::MMAConfig::kNumMathThreads);
+      });
+      if constexpr (kUseStagedR2G) {
+        cute::for_each(cute::make_int_sequence<KT::StagedR2GStoreConfig::StagesD>{},
+                       [&](auto stage) {
+                         store_full_mbar[stage].init(KT::MMAConfig::kNumMathThreads);
+                         store_empty_mbar[stage].init(KT::StagedR2GStoreConfig::kNumStoreThreads);
+                       });
+      } else {
+        store_empty_mbar[0].init(KT::MMAConfig::kNumMathThreads);
+      }
+      shared_storage.sched.init_mbars(kNumSchedConsumers);
+      cutlass::arch::fence_barrier_init();
+    }
+    __syncthreads();
+
+    int32_t k_tile_count = sm120_common::math::ceil_div(params.K, int(KT::kTileK));
+
+    if (warp_idx >= KT::MMAConfig::kNumMathWarps) {
+      cutlass::arch::warpgroup_reg_dealloc<KT::LoadRegisterRequirement>();
+      constexpr int sched_warp_idx = KT::MMAConfig::kNumMathWarps;
+      constexpr int ab_warp_idx = sched_warp_idx + 1;
+      constexpr int sf_warp_idx = ab_warp_idx + 1;
+      constexpr int store_warp_idx = sf_warp_idx + 1;
+
+      if (warp_idx == ab_warp_idx) {
+        int ab_stage = 0;
+        uint32_t ab_phase = 1;
+        uint32_t store_phase = 1;
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
+          if (lane_predicate) {
+            auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
+                tile.m_block, tile.n_block, tile.group);
+            if constexpr (KT::kSwapAB) {
+              load_ab_swap(params, shared_storage, blk_coord, tile.m_offset, k_tile_count, ab_stage,
+                           ab_phase, store_phase);
+            } else {
+              load_ab(params, shared_storage, blk_coord, tile.m_offset, k_tile_count, ab_stage,
+                      ab_phase, store_phase);
+            }
+          }
+        }
+      } else if (warp_idx == sf_warp_idx) {
+        int sf_stage = 0;
+        uint32_t sf_phase = 1;
+        uint32_t store_phase = 1;
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
+          auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
+              tile.m_block, tile.n_block, tile.group);
+          if constexpr (KT::kSwapAB) {
+            load_sf_swap(params, shared_storage, blk_coord, tile.m_offset, tile.m_boundary,
+                         k_tile_count, sf_stage, sf_phase, store_phase);
+          } else {
+            load_sf(params, shared_storage, blk_coord, tile.m_offset, k_tile_count, sf_stage,
+                    sf_phase, store_phase);
+          }
+        }
+      } else if (warp_idx == sched_warp_idx) {
+        Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
+        sm120_common::MoeSchedProducer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        int32_t m_block_idx;
+        int32_t n_block_idx;
+        while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+          sched_pipeline.publish(sm120_common::MoeWorkTile{
+              m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx),
+              scheduler.get_m_offset(), scheduler.get_m_boundary(), 1});
+        }
+        sched_pipeline.publish_sentinel();
+      } else if constexpr (kUseStagedR2G) {
+        if (warp_idx == store_warp_idx) {
+          uint32_t full_phase = 0;
+          int store_stage = 0;
+          int store_thread_idx = cutlass::canonical_lane_idx();
+          sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                         lane_predicate};
+          sm120_common::MoeWorkTile tile;
+          while (sched_pipeline.get_next_tile(tile)) {
+            sm120_common::utils::staged_r2g_store<KT>(
+                params, shared_storage, tile.m_offset, tile.m_boundary, tile.m_block, tile.n_block,
+                store_thread_idx, full_phase, store_stage, store_full_mbar, store_empty_mbar);
+          }
+        }
+      }
+    } else {
+      cutlass::arch::warpgroup_reg_alloc<KT::MmaRegisterRequirement>();
+      int read_stage = 0;
+      uint32_t sf_phase = 0;
+      uint32_t ab_phase = 0;
+      int epi_stage = 0;
+      uint32_t se_phase = 1;
+      sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                     lane_predicate};
+      sm120_common::MoeWorkTile tile;
+      while (sched_pipeline.get_next_tile(tile)) {
+        auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(tile.m_block,
+                                                                          tile.n_block, tile.group);
+        if constexpr (KT::kSwapAB) {
+          mma_swap(params, shared_storage, k_tile_count, tile.m_offset, tile.m_boundary,
+                   get<0>(blk_coord), get<1>(blk_coord), read_stage, sf_phase, ab_phase);
+        } else {
+          mma(params, shared_storage, k_tile_count, tile.m_offset, tile.m_boundary,
+              get<0>(blk_coord), get<1>(blk_coord), get<2>(blk_coord), read_stage, sf_phase,
+              ab_phase, epi_stage, se_phase);
+        }
+      }
+    }
+  }
+};
+
+}  // namespace sm120_blockscaling
+}  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/launch.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/launch.cuh
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// clang-format off
+#include "cute_sm120_mxfp8_groupwise/sm120_fused_moe/fp8_kernel_impl.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_fused_moe/mxfp8_kernel_impl.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaled/launch.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaling/launch.cuh"
+// clang-format on
+
+namespace flashinfer::gemm::mxfp8_cute_sm120 {
+namespace sm120_blockscaled {
+
+template <typename KT>
+void launch_fused_moe(typename KT::ElementA* ptr_A, typename KT::ElementB* ptr_B,
+                      typename KT::SFConfig::ElementSFLoad* ptr_SFA,
+                      typename KT::SFConfig::ElementSFLoad* ptr_SFB, typename KT::ElementD* ptr_D,
+                      int M, int N, int K, int num_experts, int32_t const* grouped_layout,
+                      int num_sms, cudaStream_t stream = 0) {
+  using Kernel = SM120BlockScaledFusedMoeGemmKernel<KT>;
+  auto args = make_launch_args<KT, Kernel>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, M, 2 * N, K,
+                                           grouped_layout);
+  auto problem_shape = make_shape(M, N, K, num_experts);
+  launch_kernel<Kernel>(Kernel::to_underlying_arguments(problem_shape, args), num_sms, stream);
+}
+
+}  // namespace sm120_blockscaled
+
+namespace sm120_blockscaling {
+
+template <typename KT>
+void launch_fused_moe(typename KT::ElementA const* ptr_A, typename KT::ElementB const* ptr_B,
+                      typename KT::ElementScale const* ptr_SFA,
+                      typename KT::ElementScale const* ptr_SFB, typename KT::ElementD* ptr_D, int M,
+                      int N, int K, int num_experts, int32_t const* grouped_layout, int num_sms,
+                      cudaStream_t stream = 0) {
+  using Kernel = SM120BlockScalingFusedMoeGemmKernel<KT>;
+  auto args = make_launch_args<KT, Kernel>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D, M, 2 * N, K,
+                                           grouped_layout);
+  auto problem_shape = make_shape(M, N, K, num_experts);
+  launch_kernel<Kernel>(Kernel::to_underlying_arguments(problem_shape, args), num_sms, stream);
+}
+
+}  // namespace sm120_blockscaling
+}  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/mxfp8_builder.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/mxfp8_builder.cuh
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// clang-format off
+#include <cstdint>
+#include <type_traits>
+
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaled/builder.cuh"
+// clang-format on
+
+namespace flashinfer::gemm::mxfp8_cute_sm120 {
+namespace sm120_blockscaled {
+
+using namespace cute;
+
+template <int TileM_ = 128, int TileN_ = 64, int TileK_ = 128, int Stages_ = 2, int GranK_ = 128,
+          bool SwapAB_ = false, bool UseStagedR2G_ = false>
+struct SM120BlockScaledFusedMoeBuilder
+    : SM120BlockScaledBuilder<TileM_, TileN_, TileK_, Stages_, GranK_,
+                              sm120_common::GemmType::MGroupedContiguousWithZeroPadding, SwapAB_> {
+  using Base =
+      SM120BlockScaledBuilder<TileM_, TileN_, TileK_, Stages_, GranK_,
+                              sm120_common::GemmType::MGroupedContiguousWithZeroPadding, SwapAB_>;
+
+  static_assert(GranK_ == 32 || GranK_ == 128);
+
+  using ElementA = typename Base::ElementA;
+  using ElementB = typename Base::ElementB;
+  using ABLoadConfig = typename Base::ABLoadConfig;
+  using SFConfig = typename Base::SFConfig;
+  using MMAConfig = typename Base::MMAConfig;
+  using R2GStoreConfig = typename Base::R2GStoreConfig;
+  using FullBarrier = typename Base::FullBarrier;
+  using EmptyBarrier = typename Base::EmptyBarrier;
+
+  static constexpr bool kUseStagedR2G = UseStagedR2G_;
+  static constexpr bool kUnionSmem = !kUseStagedR2G;
+  static constexpr uint32_t LoadRegisterRequirement = kUseStagedR2G ? 120 : 56;
+  static constexpr uint32_t MmaRegisterRequirement = kUseStagedR2G ? 192 : 224;
+
+  static_assert(!Base::kUseTmaStore);
+
+  using StagedR2GStoreConfig =
+      sm120_common::Sm120BlockScaledStagedR2GStoreConfig<TileM_, TileN_, typename Base::ElementD,
+                                                         kUseStagedR2G>;
+  static constexpr int kNumStoreMbar = StagedR2GStoreConfig::StagesD;
+
+  struct SharedStorageLoadDefault : cute::aligned_struct<128, _0> {
+    alignas(1024)
+        cute::ArrayEngine<ElementA, cute::cosize_v<typename ABLoadConfig::SmemLayoutA>> smem_A;
+    alignas(1024)
+        cute::ArrayEngine<ElementB, cute::cosize_v<typename ABLoadConfig::SmemLayoutB>> smem_B_up;
+    alignas(1024)
+        cute::ArrayEngine<ElementB, cute::cosize_v<typename ABLoadConfig::SmemLayoutB>> smem_B_gate;
+    cute::ArrayEngine<typename SFConfig::ElementSFLoad,
+                      cute::cosize_v<typename SFConfig::SmemLayoutSFA>>
+        smem_SFA;
+    cute::ArrayEngine<typename SFConfig::ElementSFLoad,
+                      cute::cosize_v<typename SFConfig::SmemLayoutSFB>>
+        smem_SFB_up;
+    cute::ArrayEngine<typename SFConfig::ElementSFLoad,
+                      cute::cosize_v<typename SFConfig::SmemLayoutSFB>>
+        smem_SFB_gate;
+  };
+
+  struct SharedStorageLoadSwapAB : cute::aligned_struct<128, _0> {
+    alignas(1024)
+        cute::ArrayEngine<ElementA, cute::cosize_v<typename ABLoadConfig::SmemLayoutA>> smem_A_up;
+    alignas(1024)
+        cute::ArrayEngine<ElementA, cute::cosize_v<typename ABLoadConfig::SmemLayoutA>> smem_A_gate;
+    alignas(1024)
+        cute::ArrayEngine<ElementB, cute::cosize_v<typename ABLoadConfig::SmemLayoutB>> smem_B;
+    cute::ArrayEngine<typename SFConfig::ElementSFLoad,
+                      cute::cosize_v<typename SFConfig::SmemLayoutSFA>>
+        smem_SFA_up;
+    cute::ArrayEngine<typename SFConfig::ElementSFLoad,
+                      cute::cosize_v<typename SFConfig::SmemLayoutSFA>>
+        smem_SFA_gate;
+    cute::ArrayEngine<typename SFConfig::ElementSFLoad,
+                      cute::cosize_v<typename SFConfig::SmemLayoutSFB>>
+        smem_SFB;
+  };
+
+  using SharedStorageLoad =
+      std::conditional_t<SwapAB_, SharedStorageLoadSwapAB, SharedStorageLoadDefault>;
+
+  struct BarrierStorage {
+    FullBarrier ab_full_mbar[Base::AB_Stages];
+    EmptyBarrier ab_empty_mbar[Base::AB_Stages];
+    FullBarrier sf_full_mbar[Base::SFConfig::SF_Stages];
+    EmptyBarrier sf_empty_mbar[Base::SFConfig::SF_Stages];
+    EmptyBarrier store_full_mbar[kNumStoreMbar];
+    EmptyBarrier store_empty_mbar[kNumStoreMbar];
+  };
+
+  union TensorStorageUnionDefault {
+    SharedStorageLoad load;
+    typename R2GStoreConfig::SharedStorageR2G store;
+  };
+
+  struct TensorStorageSplit {
+    SharedStorageLoad load;
+    typename StagedR2GStoreConfig::SharedStorageStagedR2G store;
+  };
+
+  using TensorStorageUnion =
+      std::conditional_t<kUseStagedR2G, TensorStorageSplit, TensorStorageUnionDefault>;
+};
+
+}  // namespace sm120_blockscaled
+}  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/mxfp8_kernel_impl.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_fused_moe/mxfp8_kernel_impl.cuh
@@ -1,0 +1,898 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// clang-format off
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+#include <cutlass/arch/reg_reconfig.h>
+#include <cutlass/epilogue/thread/activation.h>
+
+#include "cute_sm120_mxfp8_groupwise/sm120_fused_moe/mxfp8_builder.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_blockscaled/kernel_impl.cuh"
+#include "cute_sm120_mxfp8_groupwise/sm120_common/moe_scheduler.cuh"
+// clang-format on
+
+namespace flashinfer::gemm::mxfp8_cute_sm120 {
+namespace sm120_blockscaled {
+
+using namespace cute;
+
+template <typename KT>
+struct SM120BlockScaledFusedMoeGemmKernel : SM120BlockScaledGemmKernel<KT> {
+  using BaseKernel = SM120BlockScaledGemmKernel<KT>;
+  using Scheduler = sm120_common::SelectedMoeScheduler<KT::kSwapAB, KT::kTileM, KT::kTileN>;
+  using ProblemShape = typename BaseKernel::ProblemShape;
+  static constexpr int kNumSchedStages = 2;
+  static constexpr int kNumSchedConsumers =
+      KT::MMAConfig::kNumMathWarps + (KT::kUseStagedR2G ? 3 : 2);
+  struct SharedStorage : BaseKernel::SharedStorage {
+    alignas(8) sm120_common::MoeSchedStorage<kNumSchedStages> sched;
+  };
+  static constexpr int kSmemSize = int(sizeof(SharedStorage));
+  using FullBarrier = typename KT::FullBarrier;
+  using ProducerBarrierType = typename FullBarrier::ValueType;
+  static constexpr bool kUseStagedR2G = KT::kUseStagedR2G;
+  static constexpr uint32_t TmaTransactionBytesAB =
+      KT::kSwapAB
+          ? 2 * KT::ABLoadConfig::TmaTransactionBytesA + KT::ABLoadConfig::TmaTransactionBytesB
+          : KT::ABLoadConfig::TmaTransactionBytesA + 2 * KT::ABLoadConfig::TmaTransactionBytesB;
+  static constexpr uint32_t TmaTransactionBytesSF =
+      KT::kSwapAB ? 2 * KT::SFConfig::TmaTransactionBytesSFA + KT::SFConfig::TmaTransactionBytesSFB
+                  : KT::SFConfig::TmaTransactionBytesSFA + 2 * KT::SFConfig::TmaTransactionBytesSFB;
+
+  struct Params {
+    typename KT::ABLoadConfig::TMA_A tma_load_a;
+    typename KT::ABLoadConfig::TMA_B tma_load_b;
+    typename KT::SFConfig::TMA_SFA tma_load_sfa;
+    typename KT::SFConfig::TMA_SFB tma_load_sfb;
+    typename KT::ElementD* ptr_D;
+    int M;
+    int N;
+    int K;
+    int num_experts;
+    int32_t const* grouped_layout;
+  };
+
+  struct Arguments {
+    typename KT::ElementA* ptr_A;
+    typename KT::ABLoadConfig::StrideA dA;
+    typename KT::ElementB* ptr_B;
+    typename KT::ABLoadConfig::StrideB dB;
+    typename KT::SFConfig::ElementSFLoad* ptr_SFA;
+    typename KT::SFConfig::ElementSFLoad* ptr_SFB;
+    typename KT::ElementD* ptr_D;
+    int32_t const* grouped_layout;
+  };
+
+  static Params to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args) {
+    auto [M, N, K, num_experts] = problem_shape;
+    auto [tma_load_a, tma_load_b] = sm120_common::utils::make_ab_tma_descriptors<KT>(
+        args.ptr_A, args.dA, args.ptr_B, args.dB, M, 2 * N, K, num_experts);
+    auto [tma_load_sfa, tma_load_sfb] =
+        utils::make_sf_tma_descriptors<KT>(args.ptr_SFA, args.ptr_SFB, M, 2 * N, K, num_experts);
+    return {tma_load_a, tma_load_b, tma_load_sfa, tma_load_sfb,       args.ptr_D, M,
+            N,          K,          num_experts,  args.grouped_layout};
+  }
+
+  CUTE_DEVICE
+  static void prefetch_tma_descriptors(Params const& params) {
+    cute::prefetch_tma_descriptor(params.tma_load_a.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_b.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_sfa.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_sfb.get_tma_descriptor());
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_ab(Params const& params, SharedStorage& shared_storage,
+                                  BlkCoord const& blk_coord, int32_t m_offset,
+                                  int32_t num_sf_cycles, uint32_t& ab_phase,
+                                  uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    using X = Underscore;
+
+    auto mA_full = params.tma_load_a.get_tma_tensor(make_shape(params.M, params.K, 1));
+    auto mA = domain_offset(make_coord(m_offset, 0, 0), mA_full);
+    auto gA_mkl = local_tile(mA, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gA = gA_mkl(_, _, m_block_idx, _, Int<0>{});
+
+    auto mB =
+        params.tma_load_b.get_tma_tensor(make_shape(2 * params.N, params.K, params.num_experts));
+    auto mB_up = mB;
+    auto mB_gate = domain_offset(make_coord(params.N, 0, 0), mB);
+    auto gB_up_nkl =
+        local_tile(mB_up, typename KT::TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gB_gate_nkl =
+        local_tile(mB_gate, typename KT::TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gB_up = gB_up_nkl(_, _, n_block_idx, _, expert_idx);
+    auto gB_gate = gB_gate_nkl(_, _, n_block_idx, _, expert_idx);
+
+    auto block_tma_a = params.tma_load_a.get_slice(0);
+    auto block_tma_b = params.tma_load_b.get_slice(0);
+    auto tAgA = block_tma_a.partition_S(gA);
+    auto tBgB_up = block_tma_b.partition_S(gB_up);
+    auto tBgB_gate = block_tma_b.partition_S(gB_gate);
+
+    auto sA = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto sB_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto tAsA = block_tma_a.partition_D(sA);
+    auto tBsB_up = block_tma_b.partition_D(sB_up);
+    auto tBsB_gate = block_tma_b.partition_D(sB_gate);
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)sf_full_mbar;
+    (void)sf_empty_mbar;
+    (void)store_full_mbar;
+
+    int32_t k_tile_count =
+        num_sf_cycles * KT::SFConfig::SF_Stages * KT::SFConfig::kNumTileKPerPackSF;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count; k_tile_idx += KT::AB_Stages) {
+      cute::for_each(cute::make_int_sequence<KT::AB_Stages>{}, [&](auto write_stage) {
+        ab_empty_mbar[write_stage].wait(ab_phase);
+        auto& ab_full_barrier = ab_full_mbar[write_stage];
+        ab_full_barrier.arrive_and_expect_tx(TmaTransactionBytesAB);
+        auto tma_copy_a =
+            params.tma_load_a.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+        cute::copy(tma_copy_a, tAgA(_, _, _, k_tile_idx + write_stage), tAsA(_, _, _, write_stage));
+        auto tma_copy_b =
+            params.tma_load_b.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+        cute::copy(tma_copy_b, tBgB_up(_, _, _, k_tile_idx + write_stage),
+                   tBsB_up(_, _, _, write_stage));
+        cute::copy(tma_copy_b, tBgB_gate(_, _, _, k_tile_idx + write_stage),
+                   tBsB_gate(_, _, _, write_stage));
+      });
+      ab_phase ^= 1;
+    }
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_ab_swap(Params const& params, SharedStorage& shared_storage,
+                                       BlkCoord const& blk_coord, int32_t m_offset,
+                                       int32_t num_sf_cycles, uint32_t& ab_phase,
+                                       uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    using X = Underscore;
+
+    auto mA =
+        params.tma_load_a.get_tma_tensor(make_shape(2 * params.N, params.K, params.num_experts));
+    auto mA_up = mA;
+    auto mA_gate = domain_offset(make_coord(params.N, 0, 0), mA);
+    auto gA_up_mkl =
+        local_tile(mA_up, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gA_gate_mkl =
+        local_tile(mA_gate, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gA_up = gA_up_mkl(_, _, m_block_idx, _, expert_idx);
+    auto gA_gate = gA_gate_mkl(_, _, m_block_idx, _, expert_idx);
+
+    auto mB_full = params.tma_load_b.get_tma_tensor(make_shape(params.M, params.K, 1));
+    auto mB = domain_offset(make_coord(m_offset, 0, 0), mB_full);
+    auto gB_nkl = local_tile(mB, typename KT::TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gB = gB_nkl(_, _, n_block_idx, _, Int<0>{});
+
+    auto block_tma_a = params.tma_load_a.get_slice(0);
+    auto block_tma_b = params.tma_load_b.get_slice(0);
+    auto tAgA_up = block_tma_a.partition_S(gA_up);
+    auto tAgA_gate = block_tma_a.partition_S(gA_gate);
+    auto tBgB = block_tma_b.partition_S(gB);
+
+    auto sA_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sA_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto tAsA_up = block_tma_a.partition_D(sA_up);
+    auto tAsA_gate = block_tma_a.partition_D(sA_gate);
+    auto tBsB = block_tma_b.partition_D(sB);
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)sf_full_mbar;
+    (void)sf_empty_mbar;
+    (void)store_full_mbar;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    int32_t k_tile_count =
+        num_sf_cycles * KT::SFConfig::SF_Stages * KT::SFConfig::kNumTileKPerPackSF;
+    for (int32_t k_tile_idx = 0; k_tile_idx < k_tile_count; k_tile_idx += KT::AB_Stages) {
+      cute::for_each(cute::make_int_sequence<KT::AB_Stages>{}, [&](auto write_stage) {
+        ab_empty_mbar[write_stage].wait(ab_phase);
+        auto& ab_full_barrier = ab_full_mbar[write_stage];
+        ab_full_barrier.arrive_and_expect_tx(TmaTransactionBytesAB);
+        auto tma_copy_a =
+            params.tma_load_a.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+        cute::copy(tma_copy_a, tAgA_up(_, _, _, k_tile_idx + write_stage),
+                   tAsA_up(_, _, _, write_stage));
+        cute::copy(tma_copy_a, tAgA_gate(_, _, _, k_tile_idx + write_stage),
+                   tAsA_gate(_, _, _, write_stage));
+        auto tma_copy_b =
+            params.tma_load_b.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+        cute::copy(tma_copy_b, tBgB(_, _, _, k_tile_idx + write_stage), tBsB(_, _, _, write_stage));
+      });
+      ab_phase ^= 1;
+    }
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_sf(Params const& params, SharedStorage& shared_storage,
+                                  BlkCoord const& blk_coord, int32_t m_offset,
+                                  int32_t num_sf_cycles, uint32_t& sf_phase,
+                                  uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    using X = Underscore;
+
+    auto sf_shape = make_shape(params.M, 2 * params.N, params.K, 1);
+    auto sfa_layout = KT::SFConfig::deduce_sfa_layout(sf_shape, params.num_experts);
+    auto mSFA_full = params.tma_load_sfa.get_tma_tensor(shape(sfa_layout));
+    int32_t sf_m_offset = sm120_common::math::compute_padded_offset(m_offset, expert_idx);
+    auto mSFA = domain_offset(make_coord(sf_m_offset, 0, 0), mSFA_full);
+    auto gSFA_mkl = local_tile(mSFA, typename KT::SFConfig::ScaleTileShape{}, make_coord(_, _, _),
+                               Step<_1, X, _1>{});
+    auto gSFA = gSFA_mkl(_, _, m_block_idx, _, Int<0>{});
+
+    auto sfb_shape = make_shape(params.M, 2 * params.N, params.K, params.num_experts);
+    auto sfb_layout = KT::SFConfig::deduce_sfb_layout(sfb_shape, params.num_experts);
+    auto mSFB = params.tma_load_sfb.get_tma_tensor(shape(sfb_layout));
+    auto mSFB_up = mSFB;
+    auto mSFB_gate = domain_offset(make_coord(params.N, 0, 0), mSFB);
+    auto gSFB_up_nkl = local_tile(mSFB_up, typename KT::SFConfig::ScaleTileShape{},
+                                  make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gSFB_gate_nkl = local_tile(mSFB_gate, typename KT::SFConfig::ScaleTileShape{},
+                                    make_coord(_, _, _), Step<X, _1, _1>{});
+    auto gSFB_up = gSFB_up_nkl(_, _, n_block_idx, _, expert_idx);
+    auto gSFB_gate = gSFB_gate_nkl(_, _, n_block_idx, _, expert_idx);
+
+    auto block_tma_sfa = params.tma_load_sfa.get_slice(0);
+    auto block_tma_sfb = params.tma_load_sfb.get_slice(0);
+    auto tAgSFA = block_tma_sfa.partition_S(gSFA);
+    auto tBgSFB_up = block_tma_sfb.partition_S(gSFB_up);
+    auto tBgSFB_gate = block_tma_sfb.partition_S(gSFB_gate);
+
+    auto sSFA = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA.begin()),
+                    typename KT::SFConfig::SmemLayoutSFA{}));
+    auto sSFB_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_up.begin()),
+                    typename KT::SFConfig::SmemLayoutSFB{}));
+    auto sSFB_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_gate.begin()),
+                    typename KT::SFConfig::SmemLayoutSFB{}));
+    auto tAsSFA = block_tma_sfa.partition_D(sSFA);
+    auto tBsSFB_up = block_tma_sfb.partition_D(sSFB_up);
+    auto tBsSFB_gate = block_tma_sfb.partition_D(sSFB_gate);
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)ab_full_mbar;
+    (void)ab_empty_mbar;
+    (void)store_full_mbar;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    for (int32_t sf_cycle = 0; sf_cycle < num_sf_cycles; ++sf_cycle) {
+      cute::for_each(cute::make_int_sequence<KT::SFConfig::SF_Stages>{}, [&](auto sf_stage) {
+        sf_empty_mbar[sf_stage].wait(sf_phase);
+        auto& sf_full_barrier = sf_full_mbar[sf_stage];
+        sf_full_barrier.arrive_and_expect_tx(TmaTransactionBytesSF);
+        auto tma_copy_sfa =
+            params.tma_load_sfa.with(*recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+        auto tma_copy_sfb =
+            params.tma_load_sfb.with(*recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+        int32_t sf_tile_idx = sf_cycle * KT::SFConfig::SF_Stages + sf_stage;
+        cute::copy(tma_copy_sfa, tAgSFA(_, _, _, sf_tile_idx), tAsSFA(_, _, _, sf_stage));
+        cute::copy(tma_copy_sfb, tBgSFB_up(_, _, _, sf_tile_idx), tBsSFB_up(_, _, _, sf_stage));
+        cute::copy(tma_copy_sfb, tBgSFB_gate(_, _, _, sf_tile_idx), tBsSFB_gate(_, _, _, sf_stage));
+      });
+      sf_phase ^= 1;
+    }
+  }
+
+  template <typename BlkCoord>
+  CUTE_DEVICE static void load_sf_swap(Params const& params, SharedStorage& shared_storage,
+                                       BlkCoord const& blk_coord, int32_t m_offset,
+                                       int32_t num_sf_cycles, uint32_t& sf_phase,
+                                       uint32_t& store_phase) {
+    auto [m_block_idx, n_block_idx, expert_idx] = blk_coord;
+    using X = Underscore;
+
+    auto sf_shape = make_shape(2 * params.N, params.M, params.K, params.num_experts);
+    auto sfa_layout = KT::SFConfig::deduce_sfa_layout(sf_shape, params.num_experts);
+    auto mSFA = params.tma_load_sfa.get_tma_tensor(shape(sfa_layout));
+    auto mSFA_up = mSFA;
+    auto mSFA_gate = domain_offset(make_coord(params.N, 0, 0), mSFA);
+    auto gSFA_up_mkl = local_tile(mSFA_up, typename KT::SFConfig::ScaleTileShape{},
+                                  make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gSFA_gate_mkl = local_tile(mSFA_gate, typename KT::SFConfig::ScaleTileShape{},
+                                    make_coord(_, _, _), Step<_1, X, _1>{});
+    auto gSFA_up = gSFA_up_mkl(_, _, m_block_idx, _, expert_idx);
+    auto gSFA_gate = gSFA_gate_mkl(_, _, m_block_idx, _, expert_idx);
+
+    auto sfb_layout = KT::SFConfig::deduce_sfb_layout(
+        make_shape(2 * params.N, params.M, params.K, 1), params.num_experts);
+    auto mSFB_full = params.tma_load_sfb.get_tma_tensor(shape(sfb_layout));
+    int32_t sf_m_offset = sm120_common::math::compute_padded_offset(m_offset, expert_idx);
+    auto mSFB = domain_offset(make_coord(sf_m_offset, 0, 0), mSFB_full);
+    auto gSFB_nkl = local_tile(mSFB, typename KT::SFConfig::ScaleTileShape{}, make_coord(_, _, _),
+                               Step<X, _1, _1>{});
+    auto gSFB = gSFB_nkl(_, _, n_block_idx, _, Int<0>{});
+
+    auto block_tma_sfa = params.tma_load_sfa.get_slice(0);
+    auto block_tma_sfb = params.tma_load_sfb.get_slice(0);
+    auto tAgSFA_up = block_tma_sfa.partition_S(gSFA_up);
+    auto tAgSFA_gate = block_tma_sfa.partition_S(gSFA_gate);
+    auto tBgSFB = block_tma_sfb.partition_S(gSFB);
+
+    auto sSFA_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_up.begin()),
+                    typename KT::SFConfig::SmemLayoutSFA{}));
+    auto sSFA_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_gate.begin()),
+                    typename KT::SFConfig::SmemLayoutSFA{}));
+    auto sSFB = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB.begin()),
+                    typename KT::SFConfig::SmemLayoutSFB{}));
+    auto tAsSFA_up = block_tma_sfa.partition_D(sSFA_up);
+    auto tAsSFA_gate = block_tma_sfa.partition_D(sSFA_gate);
+    auto tBsSFB = block_tma_sfb.partition_D(sSFB);
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)ab_full_mbar;
+    (void)ab_empty_mbar;
+    (void)store_full_mbar;
+
+    if constexpr (KT::kUnionSmem) {
+      store_empty_mbar[0].wait(store_phase);
+      store_phase ^= 1;
+    }
+
+    for (int32_t sf_cycle = 0; sf_cycle < num_sf_cycles; ++sf_cycle) {
+      cute::for_each(cute::make_int_sequence<KT::SFConfig::SF_Stages>{}, [&](auto sf_stage) {
+        sf_empty_mbar[sf_stage].wait(sf_phase);
+        auto& sf_full_barrier = sf_full_mbar[sf_stage];
+        sf_full_barrier.arrive_and_expect_tx(TmaTransactionBytesSF);
+        auto tma_copy_sfa =
+            params.tma_load_sfa.with(*recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+        auto tma_copy_sfb =
+            params.tma_load_sfb.with(*recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+        int32_t sf_tile_idx = sf_cycle * KT::SFConfig::SF_Stages + sf_stage;
+        cute::copy(tma_copy_sfa, tAgSFA_up(_, _, _, sf_tile_idx), tAsSFA_up(_, _, _, sf_stage));
+        cute::copy(tma_copy_sfa, tAgSFA_gate(_, _, _, sf_tile_idx), tAsSFA_gate(_, _, _, sf_stage));
+        cute::copy(tma_copy_sfb, tBgSFB(_, _, _, sf_tile_idx), tBsSFB(_, _, _, sf_stage));
+      });
+      sf_phase ^= 1;
+    }
+  }
+
+  CUTE_DEVICE
+  static void mma_swap(Params const& params, SharedStorage& shared_storage, int32_t num_sf_cycles,
+                       int32_t m_offset, int32_t m_boundary, int32_t m_block_idx,
+                       int32_t n_block_idx, uint32_t& sf_phase, uint32_t& ab_phase) {
+    int thread_idx = int(threadIdx.x);
+
+    auto sA_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sA_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto sSFA_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_up.begin()),
+                    typename KT::SFConfig::SmemLayoutSFA{}));
+    auto sSFA_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA_gate.begin()),
+                    typename KT::SFConfig::SmemLayoutSFA{}));
+    auto sSFB = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB.begin()),
+                    typename KT::SFConfig::SmemLayoutSFB{}));
+
+    typename KT::MMAConfig::TiledMma mma;
+    auto thr_mma = mma.get_thread_slice(thread_idx);
+    auto accum_up = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto accum_gate = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto tCrA_up = thr_mma.partition_fragment_A(sA_up(_, _, Int<0>{}));
+    auto tCrA_gate = thr_mma.partition_fragment_A(sA_gate(_, _, Int<0>{}));
+    auto tCrB = thr_mma.partition_fragment_B(sB(_, _, Int<0>{}));
+    constexpr int K_BLOCK_MAX = decltype(size<2>(tCrA_up))::value;
+
+    auto s2r_copy_A = make_tiled_copy_A(typename KT::ABLoadConfig::SmemCopyAtomA{}, mma);
+    auto s2r_thr_copy_A = s2r_copy_A.get_thread_slice(thread_idx);
+    auto tXsA_up = s2r_thr_copy_A.partition_S(sA_up);
+    auto tXsA_gate = s2r_thr_copy_A.partition_S(sA_gate);
+    auto tXrA_up = s2r_thr_copy_A.retile_D(tCrA_up);
+    auto tXrA_gate = s2r_thr_copy_A.retile_D(tCrA_gate);
+    auto s2r_copy_B = make_tiled_copy_B(typename KT::ABLoadConfig::SmemCopyAtomB{}, mma);
+    auto s2r_thr_copy_B = s2r_copy_B.get_thread_slice(thread_idx);
+    auto tXsB = s2r_thr_copy_B.partition_S(sB);
+    auto tXrB = s2r_thr_copy_B.retile_D(tCrB);
+
+    auto s2r_copy_SFA = make_tiled_copy_impl(typename KT::SFConfig::SmemCopyAtomSF{},
+                                             KT::SFConfig::get_layoutSFA_TV(mma),
+                                             make_shape(size<0>(tile_shape(mma)), _1{}));
+    auto s2r_thr_copy_SFA = s2r_copy_SFA.get_thread_slice(thread_idx);
+    auto tXsSFA_up = s2r_thr_copy_SFA.partition_S(sSFA_up);
+    auto tXsSFA_gate = s2r_thr_copy_SFA.partition_S(sSFA_gate);
+    auto tCrSFA_up = KT::SFConfig::partition_fragment_SFA(sSFA_up(_, _, Int<0>{}), thr_mma);
+    auto tCrSFA_gate = KT::SFConfig::partition_fragment_SFA(sSFA_gate(_, _, Int<0>{}), thr_mma);
+    auto tXrSFA_up = s2r_thr_copy_SFA.retile_D(tCrSFA_up);
+    auto tXrSFA_gate = s2r_thr_copy_SFA.retile_D(tCrSFA_gate);
+    auto tCrSFA_up_frg = KT::SFConfig::transform_fragment_for_qmma(tCrSFA_up);
+    auto tCrSFA_gate_frg = KT::SFConfig::transform_fragment_for_qmma(tCrSFA_gate);
+
+    auto s2r_copy_SFB = make_tiled_copy_impl(typename KT::SFConfig::SmemCopyAtomSF{},
+                                             KT::SFConfig::get_layoutSFB_TV(mma),
+                                             make_shape(size<1>(tile_shape(mma)), _1{}));
+    auto s2r_thr_copy_SFB = s2r_copy_SFB.get_thread_slice(thread_idx);
+    auto tXsSFB = s2r_thr_copy_SFB.partition_S(sSFB);
+    auto tCrSFB = KT::SFConfig::partition_fragment_SFB(sSFB(_, _, Int<0>{}), thr_mma);
+    auto tXrSFB = s2r_thr_copy_SFB.retile_D(tCrSFB);
+    auto tCrSFB_frg = KT::SFConfig::transform_fragment_for_qmma(tCrSFB);
+
+    clear(accum_up);
+    clear(accum_gate);
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)store_full_mbar;
+
+    int ab_read_stage = 0;
+    int sf_read_stage = 0;
+
+    auto copy_ab_s2r = [&](auto k_block) {
+      cute::copy(s2r_copy_A, tXsA_up(_, _, k_block, ab_read_stage), tXrA_up(_, _, k_block));
+      cute::copy(s2r_copy_A, tXsA_gate(_, _, k_block, ab_read_stage), tXrA_gate(_, _, k_block));
+      cute::copy(s2r_copy_B, tXsB(_, _, k_block, ab_read_stage), tXrB(_, _, k_block));
+    };
+    auto advance_ab_read_stage = [&]() {
+      ab_read_stage = (ab_read_stage + 1) % KT::AB_Stages;
+      ab_phase ^= uint32_t(ab_read_stage == 0);
+    };
+    auto copy_sf_s2r = [&]() {
+      if constexpr (KT::SFConfig::SF_Stages == 1) {
+        sf_full_mbar[0].wait(sf_phase);
+        cute::copy(s2r_copy_SFA, tXsSFA_up(_, _, _, Int<0>{}), tXrSFA_up);
+        cute::copy(s2r_copy_SFA, tXsSFA_gate(_, _, _, Int<0>{}), tXrSFA_gate);
+        cute::copy(s2r_copy_SFB, tXsSFB(_, _, _, Int<0>{}), tXrSFB);
+        sf_empty_mbar[0].arrive();
+        sf_phase ^= 1;
+      } else {
+        sf_full_mbar[sf_read_stage].wait(sf_phase);
+        cute::copy(s2r_copy_SFA, tXsSFA_up(_, _, _, sf_read_stage), tXrSFA_up);
+        cute::copy(s2r_copy_SFA, tXsSFA_gate(_, _, _, sf_read_stage), tXrSFA_gate);
+        cute::copy(s2r_copy_SFB, tXsSFB(_, _, _, sf_read_stage), tXrSFB);
+        sf_empty_mbar[sf_read_stage].arrive();
+        sf_read_stage = (sf_read_stage + 1) % KT::SFConfig::SF_Stages;
+        sf_phase ^= uint32_t(sf_read_stage == 0);
+      }
+    };
+
+    copy_sf_s2r();
+    ab_full_mbar[ab_read_stage].wait(ab_phase);
+    copy_ab_s2r(Int<0>{});
+
+    int32_t sf_pack_count = num_sf_cycles * KT::SFConfig::SF_Stages;
+    for (int32_t sf_pack_idx = 0; sf_pack_idx < sf_pack_count - 1; ++sf_pack_idx) {
+      cute::for_each(
+          cute::make_int_sequence<KT::SFConfig::kNumTileKPerPackSF>{}, [&](auto k_in_sf) {
+            cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+              constexpr int k_block_idx = decltype(k_block)::value;
+              if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+                copy_ab_s2r(Int<k_block_idx + 1>{});
+              } else {
+                ab_empty_mbar[ab_read_stage].arrive();
+                advance_ab_read_stage();
+                ab_full_mbar[ab_read_stage].wait(ab_phase);
+                copy_ab_s2r(Int<0>{});
+              }
+              cute::gemm(
+                  mma,
+                  make_zip_tensor(tCrA_up(_, _, k_block), tCrSFA_up_frg(_, _, k_block, k_in_sf)),
+                  make_zip_tensor(tCrB(_, _, k_block), tCrSFB_frg(_, _, k_block, k_in_sf)),
+                  accum_up);
+              cute::gemm(mma,
+                         make_zip_tensor(tCrA_gate(_, _, k_block),
+                                         tCrSFA_gate_frg(_, _, k_block, k_in_sf)),
+                         make_zip_tensor(tCrB(_, _, k_block), tCrSFB_frg(_, _, k_block, k_in_sf)),
+                         accum_gate);
+            });
+          });
+
+      copy_sf_s2r();
+    }
+
+    cute::for_each(cute::make_int_sequence<KT::SFConfig::kNumTileKPerPackSF>{}, [&](auto k_in_sf) {
+      constexpr bool is_last_k_tile =
+          decltype(k_in_sf)::value == KT::SFConfig::kNumTileKPerPackSF - 1;
+      cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+        constexpr int k_block_idx = decltype(k_block)::value;
+        if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+          copy_ab_s2r(Int<k_block_idx + 1>{});
+        } else {
+          ab_empty_mbar[ab_read_stage].arrive();
+          advance_ab_read_stage();
+          if constexpr (!is_last_k_tile) {
+            ab_full_mbar[ab_read_stage].wait(ab_phase);
+            copy_ab_s2r(Int<0>{});
+          }
+        }
+        cute::gemm(
+            mma, make_zip_tensor(tCrA_up(_, _, k_block), tCrSFA_up_frg(_, _, k_block, k_in_sf)),
+            make_zip_tensor(tCrB(_, _, k_block), tCrSFB_frg(_, _, k_block, k_in_sf)), accum_up);
+        cute::gemm(
+            mma, make_zip_tensor(tCrA_gate(_, _, k_block), tCrSFA_gate_frg(_, _, k_block, k_in_sf)),
+            make_zip_tensor(tCrB(_, _, k_block), tCrSFB_frg(_, _, k_block, k_in_sf)), accum_gate);
+      });
+    });
+
+    cutlass::arch::NamedBarrier::sync(KT::MMAConfig::kNumMathThreads, 0);
+    CUTE_UNROLL
+    for (int i = 0; i < size(accum_up); ++i) {
+      float gate = accum_gate(i);
+      accum_up(i) *= gate / (1.0f + __expf(-gate));
+    }
+    sm120_common::utils::epi_pred_stg<KT>(params, accum_up, thread_idx, m_offset, m_boundary,
+                                          m_block_idx, n_block_idx, store_empty_mbar);
+  }
+
+  CUTE_DEVICE
+  static void mma(Params const& params, SharedStorage& shared_storage, int32_t num_sf_cycles,
+                  int32_t m_offset, int32_t m_boundary, int32_t m_block_idx, int32_t n_block_idx,
+                  int32_t expert_idx, uint32_t& sf_phase, uint32_t& ab_phase, int& epi_stage,
+                  uint32_t& se_phase) {
+    int thread_idx = int(threadIdx.x);
+    typename KT::MMAConfig::TiledMma mma;
+    auto thr_mma = mma.get_thread_slice(thread_idx);
+    auto accum_up = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    auto accum_gate = partition_fragment_C(mma, take<0, 2>(typename KT::TileShape{}));
+    clear(accum_up);
+    clear(accum_gate);
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)store_full_mbar;
+
+    auto sA = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutA{}));
+    auto sB_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_up.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto sB_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B_gate.begin()),
+                    typename KT::ABLoadConfig::SmemLayoutB{}));
+    auto sSFA = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA.begin()),
+                    typename KT::SFConfig::SmemLayoutSFA{}));
+    auto sSFB_up = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_up.begin()),
+                    typename KT::SFConfig::SmemLayoutSFB{}));
+    auto sSFB_gate = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB_gate.begin()),
+                    typename KT::SFConfig::SmemLayoutSFB{}));
+
+    auto tCrA = thr_mma.partition_fragment_A(sA(_, _, Int<0>{}));
+    auto tCrB_up = thr_mma.partition_fragment_B(sB_up(_, _, Int<0>{}));
+    auto tCrB_gate = thr_mma.partition_fragment_B(sB_gate(_, _, Int<0>{}));
+    constexpr int K_BLOCK_MAX = decltype(size<2>(tCrA))::value;
+
+    auto s2r_copy_A = make_tiled_copy_A(typename KT::ABLoadConfig::SmemCopyAtomA{}, mma);
+    auto s2r_thr_copy_A = s2r_copy_A.get_thread_slice(thread_idx);
+    auto tXsA = s2r_thr_copy_A.partition_S(sA);
+    auto tXrA = s2r_thr_copy_A.retile_D(tCrA);
+    auto s2r_copy_B = make_tiled_copy_B(typename KT::ABLoadConfig::SmemCopyAtomB{}, mma);
+    auto s2r_thr_copy_B = s2r_copy_B.get_thread_slice(thread_idx);
+    auto tXsB_up = s2r_thr_copy_B.partition_S(sB_up);
+    auto tXsB_gate = s2r_thr_copy_B.partition_S(sB_gate);
+    auto tXrB_up = s2r_thr_copy_B.retile_D(tCrB_up);
+    auto tXrB_gate = s2r_thr_copy_B.retile_D(tCrB_gate);
+
+    auto s2r_copy_SFA = make_tiled_copy_impl(typename KT::SFConfig::SmemCopyAtomSF{},
+                                             KT::SFConfig::get_layoutSFA_TV(mma),
+                                             make_shape(size<0>(tile_shape(mma)), _1{}));
+    auto s2r_thr_copy_SFA = s2r_copy_SFA.get_thread_slice(thread_idx);
+    auto tXsSFA = s2r_thr_copy_SFA.partition_S(sSFA);
+    auto tCrSFA = KT::SFConfig::partition_fragment_SFA(sSFA(_, _, Int<0>{}), thr_mma);
+    auto tXrSFA = s2r_thr_copy_SFA.retile_D(tCrSFA);
+    auto tCrSFA_frg = KT::SFConfig::transform_fragment_for_qmma(tCrSFA);
+
+    auto s2r_copy_SFB = make_tiled_copy_impl(typename KT::SFConfig::SmemCopyAtomSF{},
+                                             KT::SFConfig::get_layoutSFB_TV(mma),
+                                             make_shape(size<1>(tile_shape(mma)), _1{}));
+    auto s2r_thr_copy_SFB = s2r_copy_SFB.get_thread_slice(thread_idx);
+    auto tXsSFB_up = s2r_thr_copy_SFB.partition_S(sSFB_up);
+    auto tXsSFB_gate = s2r_thr_copy_SFB.partition_S(sSFB_gate);
+    auto tCrSFB_up = KT::SFConfig::partition_fragment_SFB(sSFB_up(_, _, Int<0>{}), thr_mma);
+    auto tCrSFB_gate = KT::SFConfig::partition_fragment_SFB(sSFB_gate(_, _, Int<0>{}), thr_mma);
+    auto tXrSFB_up = s2r_thr_copy_SFB.retile_D(tCrSFB_up);
+    auto tXrSFB_gate = s2r_thr_copy_SFB.retile_D(tCrSFB_gate);
+    auto tCrSFB_up_frg = KT::SFConfig::transform_fragment_for_qmma(tCrSFB_up);
+    auto tCrSFB_gate_frg = KT::SFConfig::transform_fragment_for_qmma(tCrSFB_gate);
+
+    int ab_read_stage = 0;
+    int sf_read_stage = 0;
+
+    auto copy_ab_s2r = [&](auto k_block) {
+      cute::copy(s2r_copy_A, tXsA(_, _, k_block, ab_read_stage), tXrA(_, _, k_block));
+      cute::copy(s2r_copy_B, tXsB_up(_, _, k_block, ab_read_stage), tXrB_up(_, _, k_block));
+      cute::copy(s2r_copy_B, tXsB_gate(_, _, k_block, ab_read_stage), tXrB_gate(_, _, k_block));
+    };
+    auto advance_ab_read_stage = [&]() {
+      ab_read_stage = (ab_read_stage + 1) % KT::AB_Stages;
+      ab_phase ^= uint32_t(ab_read_stage == 0);
+    };
+    auto copy_sf_s2r = [&]() {
+      if constexpr (KT::SFConfig::SF_Stages == 1) {
+        sf_full_mbar[0].wait(sf_phase);
+        cute::copy(s2r_copy_SFA, tXsSFA(_, _, _, Int<0>{}), tXrSFA);
+        cute::copy(s2r_copy_SFB, tXsSFB_up(_, _, _, Int<0>{}), tXrSFB_up);
+        cute::copy(s2r_copy_SFB, tXsSFB_gate(_, _, _, Int<0>{}), tXrSFB_gate);
+        sf_empty_mbar[0].arrive();
+        sf_phase ^= 1;
+      } else {
+        sf_full_mbar[sf_read_stage].wait(sf_phase);
+        cute::copy(s2r_copy_SFA, tXsSFA(_, _, _, sf_read_stage), tXrSFA);
+        cute::copy(s2r_copy_SFB, tXsSFB_up(_, _, _, sf_read_stage), tXrSFB_up);
+        cute::copy(s2r_copy_SFB, tXsSFB_gate(_, _, _, sf_read_stage), tXrSFB_gate);
+        sf_empty_mbar[sf_read_stage].arrive();
+        sf_read_stage = (sf_read_stage + 1) % KT::SFConfig::SF_Stages;
+        sf_phase ^= uint32_t(sf_read_stage == 0);
+      }
+    };
+
+    copy_sf_s2r();
+    ab_full_mbar[ab_read_stage].wait(ab_phase);
+    copy_ab_s2r(Int<0>{});
+
+    int32_t sf_pack_count = num_sf_cycles * KT::SFConfig::SF_Stages;
+    for (int32_t sf_pack_idx = 0; sf_pack_idx < sf_pack_count - 1; ++sf_pack_idx) {
+      cute::for_each(
+          cute::make_int_sequence<KT::SFConfig::kNumTileKPerPackSF>{}, [&](auto k_in_sf) {
+            cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+              constexpr int k_block_idx = decltype(k_block)::value;
+              if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+                copy_ab_s2r(Int<k_block_idx + 1>{});
+              } else {
+                ab_empty_mbar[ab_read_stage].arrive();
+                advance_ab_read_stage();
+                ab_full_mbar[ab_read_stage].wait(ab_phase);
+                copy_ab_s2r(Int<0>{});
+              }
+              cute::gemm(
+                  mma, make_zip_tensor(tCrA(_, _, k_block), tCrSFA_frg(_, _, k_block, k_in_sf)),
+                  make_zip_tensor(tCrB_up(_, _, k_block), tCrSFB_up_frg(_, _, k_block, k_in_sf)),
+                  accum_up);
+              cute::gemm(mma,
+                         make_zip_tensor(tCrA(_, _, k_block), tCrSFA_frg(_, _, k_block, k_in_sf)),
+                         make_zip_tensor(tCrB_gate(_, _, k_block),
+                                         tCrSFB_gate_frg(_, _, k_block, k_in_sf)),
+                         accum_gate);
+            });
+          });
+
+      copy_sf_s2r();
+    }
+
+    cute::for_each(cute::make_int_sequence<KT::SFConfig::kNumTileKPerPackSF>{}, [&](auto k_in_sf) {
+      constexpr bool is_last_k_tile =
+          decltype(k_in_sf)::value == KT::SFConfig::kNumTileKPerPackSF - 1;
+      cute::for_each(cute::make_int_sequence<K_BLOCK_MAX>{}, [&](auto k_block) {
+        constexpr int k_block_idx = decltype(k_block)::value;
+        if constexpr (k_block_idx + 1 < K_BLOCK_MAX) {
+          copy_ab_s2r(Int<k_block_idx + 1>{});
+        } else {
+          ab_empty_mbar[ab_read_stage].arrive();
+          advance_ab_read_stage();
+          if constexpr (!is_last_k_tile) {
+            ab_full_mbar[ab_read_stage].wait(ab_phase);
+            copy_ab_s2r(Int<0>{});
+          }
+        }
+        cute::gemm(mma, make_zip_tensor(tCrA(_, _, k_block), tCrSFA_frg(_, _, k_block, k_in_sf)),
+                   make_zip_tensor(tCrB_up(_, _, k_block), tCrSFB_up_frg(_, _, k_block, k_in_sf)),
+                   accum_up);
+        cute::gemm(
+            mma, make_zip_tensor(tCrA(_, _, k_block), tCrSFA_frg(_, _, k_block, k_in_sf)),
+            make_zip_tensor(tCrB_gate(_, _, k_block), tCrSFB_gate_frg(_, _, k_block, k_in_sf)),
+            accum_gate);
+      });
+    });
+
+    cutlass::arch::NamedBarrier::sync(KT::MMAConfig::kNumMathThreads, 0);
+    cutlass::epilogue::thread::SiLu<float> cutlass_silu;
+    CUTE_UNROLL
+    for (int i = 0; i < size(accum_up); ++i) {
+      accum_up(i) *= cutlass_silu(accum_gate(i));
+    }
+    if constexpr (kUseStagedR2G) {
+      sm120_common::utils::epi_staged_r2s<KT>(params, shared_storage, accum_up, thread_idx,
+                                              m_offset, m_boundary, m_block_idx, epi_stage,
+                                              se_phase, store_full_mbar, store_empty_mbar);
+    } else {
+      sm120_common::utils::epi_pred_r2g<KT>(params, shared_storage, accum_up, thread_idx, m_offset,
+                                            m_boundary, m_block_idx, n_block_idx, expert_idx,
+                                            store_empty_mbar);
+    }
+  }
+
+  CUTE_DEVICE
+  void operator()(Params const& params, char* smem_buf) {
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+    int warp_idx = cutlass::canonical_warp_idx_sync();
+    int lane_predicate = cute::elect_one_sync();
+    bool is_tma_thread = warp_idx == 0 && lane_predicate;
+
+    if (is_tma_thread) {
+      prefetch_tma_descriptors(params);
+    }
+    __syncthreads();
+
+    auto [ab_full_mbar, ab_empty_mbar, sf_full_mbar, sf_empty_mbar, store_full_mbar,
+          store_empty_mbar] = BaseKernel::get_mbarriers(shared_storage);
+    (void)store_full_mbar;
+    if (is_tma_thread) {
+      cute::for_each(cute::make_int_sequence<KT::AB_Stages>{}, [&](auto stage) {
+        ab_full_mbar[stage].init(1);
+        ab_empty_mbar[stage].init(KT::MMAConfig::kNumMathThreads);
+      });
+      cute::for_each(cute::make_int_sequence<KT::SFConfig::SF_Stages>{}, [&](auto stage) {
+        sf_full_mbar[stage].init(1);
+        sf_empty_mbar[stage].init(KT::MMAConfig::kNumMathThreads);
+      });
+      if constexpr (kUseStagedR2G) {
+        cute::for_each(cute::make_int_sequence<KT::StagedR2GStoreConfig::StagesD>{},
+                       [&](auto stage) {
+                         store_full_mbar[stage].init(KT::MMAConfig::kNumMathThreads);
+                         store_empty_mbar[stage].init(KT::StagedR2GStoreConfig::kNumStoreThreads);
+                       });
+      } else {
+        store_empty_mbar[0].init(KT::MMAConfig::kNumMathThreads);
+      }
+      shared_storage.sched.init_mbars(kNumSchedConsumers);
+      cutlass::arch::fence_barrier_init();
+    }
+    __syncthreads();
+
+    int32_t num_sf_cycles = sm120_common::math::ceil_div(
+        params.K, int(KT::SFConfig::PACK_NK * KT::SFConfig::SF_Stages));
+
+    if (warp_idx >= KT::MMAConfig::kNumMathWarps) {
+      cutlass::arch::warpgroup_reg_dealloc<KT::LoadRegisterRequirement>();
+      constexpr int sched_warp_idx = KT::MMAConfig::kNumMathWarps;
+      constexpr int ab_warp_idx = sched_warp_idx + 1;
+      constexpr int sf_warp_idx = ab_warp_idx + 1;
+      constexpr int store_warp_idx = sf_warp_idx + 1;
+
+      if (warp_idx == ab_warp_idx) {
+        uint32_t ab_phase = 1;
+        uint32_t store_phase = 1;
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
+          if (lane_predicate) {
+            auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
+                tile.m_block, tile.n_block, tile.group);
+            if constexpr (KT::kSwapAB) {
+              load_ab_swap(params, shared_storage, blk_coord, tile.m_offset, num_sf_cycles,
+                           ab_phase, store_phase);
+            } else {
+              load_ab(params, shared_storage, blk_coord, tile.m_offset, num_sf_cycles, ab_phase,
+                      store_phase);
+            }
+          }
+        }
+      } else if (warp_idx == sf_warp_idx) {
+        uint32_t sf_phase = 1;
+        uint32_t store_phase = 1;
+        sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        sm120_common::MoeWorkTile tile;
+        while (sched_pipeline.get_next_tile(tile)) {
+          if (lane_predicate) {
+            auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(
+                tile.m_block, tile.n_block, tile.group);
+            if constexpr (KT::kSwapAB) {
+              load_sf_swap(params, shared_storage, blk_coord, tile.m_offset, num_sf_cycles,
+                           sf_phase, store_phase);
+            } else {
+              load_sf(params, shared_storage, blk_coord, tile.m_offset, num_sf_cycles, sf_phase,
+                      store_phase);
+            }
+          }
+        }
+      } else if (warp_idx == sched_warp_idx) {
+        Scheduler scheduler(params.M, params.N, params.num_experts, params.grouped_layout);
+        sm120_common::MoeSchedProducer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                       lane_predicate};
+        int32_t m_block_idx;
+        int32_t n_block_idx;
+        while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+          sched_pipeline.publish(sm120_common::MoeWorkTile{
+              m_block_idx, n_block_idx, scheduler.get_expert_idx(m_block_idx),
+              scheduler.get_m_offset(), scheduler.get_m_boundary(), 1});
+        }
+        sched_pipeline.publish_sentinel();
+      } else if constexpr (kUseStagedR2G) {
+        if (warp_idx == store_warp_idx) {
+          int store_thread_idx = cutlass::canonical_lane_idx();
+          int store_stage = 0;
+          uint32_t full_phase = 0;
+          sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                         lane_predicate};
+          sm120_common::MoeWorkTile tile;
+          while (sched_pipeline.get_next_tile(tile)) {
+            sm120_common::utils::staged_r2g_store<KT>(
+                params, shared_storage, tile.m_offset, tile.m_boundary, tile.m_block, tile.n_block,
+                store_thread_idx, full_phase, store_stage, store_full_mbar, store_empty_mbar);
+          }
+        }
+      }
+    } else {
+      cutlass::arch::warpgroup_reg_alloc<KT::MmaRegisterRequirement>();
+      uint32_t sf_phase = 0;
+      uint32_t ab_phase = 0;
+      int epi_stage = 0;
+      uint32_t se_phase = 1;
+      sm120_common::MoeSchedConsumer<kNumSchedStages> sched_pipeline{shared_storage.sched,
+                                                                     lane_predicate};
+      sm120_common::MoeWorkTile tile;
+      while (sched_pipeline.get_next_tile(tile)) {
+        auto blk_coord = sm120_common::utils::make_blk_coord<KT::kSwapAB>(tile.m_block,
+                                                                          tile.n_block, tile.group);
+        if constexpr (KT::kSwapAB) {
+          mma_swap(params, shared_storage, num_sf_cycles, tile.m_offset, tile.m_boundary,
+                   get<0>(blk_coord), get<1>(blk_coord), sf_phase, ab_phase);
+        } else {
+          mma(params, shared_storage, num_sf_cycles, tile.m_offset, tile.m_boundary,
+              get<0>(blk_coord), get<1>(blk_coord), get<2>(blk_coord), sf_phase, ab_phase,
+              epi_stage, se_phase);
+        }
+      }
+    }
+  }
+};
+
+}  // namespace sm120_blockscaled
+}  // namespace flashinfer::gemm::mxfp8_cute_sm120

--- a/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
@@ -85,6 +85,7 @@ def moe_gemm_fp8_nt_groupwise(
     backend: Literal["cute"] = "cute",
     out: Optional[torch.Tensor] = None,
     out_dtype: Optional[torch.dtype] = None,
+    is_gated: bool = False,
 ) -> torch.Tensor:
     r"""Perform grouped GEMM with FP8 inputs in zero-padding mode using groupwise
     float32 scaling. Currently only supported on NVIDIA RTX PRO 6000 Blackwell (SM120)
@@ -141,6 +142,11 @@ def moe_gemm_fp8_nt_groupwise(
     out_dtype: Optional[torch.dtype]
         The data type of the output tensor. Currently only ``torch.bfloat16`` is supported.
 
+    is_gated: bool
+        If ``True``, run fused gate+up SwiGLU: ``b`` packs gate and up projections along N
+        (``b.shape[1] == 2 * out_n``) and the kernel fuses ``SiLU(gate) * up`` so the output
+        N is ``b.shape[1] // 2``. Defaults to ``False`` (plain grouped GEMM).
+
     Returns
     -------
     out: torch.Tensor
@@ -171,9 +177,12 @@ def moe_gemm_fp8_nt_groupwise(
             f"Only out_dtype=torch.bfloat16 is supported; got {out_dtype}"
         )
 
+    # Gated (fused SwiGLU): b packs gate+up along N (b.shape[1] == 2 * out_n); the kernel
+    # fuses SiLU(gate)*up so the output N is halved.
     n = b.shape[1]
+    out_n = n // 2 if is_gated else n
     if out is None:
-        out = torch.empty((a.shape[0], n), dtype=out_dtype, device=a.device)
+        out = torch.empty((a.shape[0], out_n), dtype=out_dtype, device=a.device)
 
     get_gemm_sm120_module_cute_fp8().moe_gemm_fp8_nt_groupwise(
         a,
@@ -186,5 +195,6 @@ def moe_gemm_fp8_nt_groupwise(
         scale_granularity_mnk[0],
         scale_granularity_mnk[1],
         scale_granularity_mnk[2],
+        is_gated,
     )
     return out

--- a/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
@@ -143,7 +143,8 @@ def moe_gemm_fp8_nt_groupwise(
         The data type of the output tensor. Currently only ``torch.bfloat16`` is supported.
 
     is_gated: bool
-        If ``True``, run fused gate+up SwiGLU: ``b`` packs gate and up projections along N
+        If ``True``, run fused gate+up SwiGLU: ``b`` packs the up projection in columns
+        ``[0, N)`` and the gate projection in ``[N, 2*N)`` along N
         (``b.shape[1] == 2 * out_n``) and the kernel fuses ``SiLU(gate) * up`` so the output
         N is ``b.shape[1] // 2``. Defaults to ``False`` (plain grouped GEMM).
 
@@ -177,8 +178,8 @@ def moe_gemm_fp8_nt_groupwise(
             f"Only out_dtype=torch.bfloat16 is supported; got {out_dtype}"
         )
 
-    # Gated (fused SwiGLU): b packs gate+up along N (b.shape[1] == 2 * out_n); the kernel
-    # fuses SiLU(gate)*up so the output N is halved.
+    # Gated (fused SwiGLU): b packs up in columns [0, N) and gate in [N, 2*N) along N
+    # (b.shape[1] == 2 * out_n); the kernel fuses SiLU(gate)*up so the output N is halved.
     n = b.shape[1]
     out_n = n // 2 if is_gated else n
     if out is None:

--- a/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
@@ -104,6 +104,7 @@ def moe_gemm_mxfp8_nt_groupwise(
     backend: Literal["cute"] = "cute",
     out: Optional[torch.Tensor] = None,
     out_dtype: Optional[torch.dtype] = None,
+    is_gated: bool = False,
 ) -> torch.Tensor:
     r"""Perform grouped GEMM with MXFP8 inputs in zero-padding mode using groupwise UE8M0
     scaling. Currently only supported on NVIDIA RTX PRO 6000 Blackwell (SM120) architecture.
@@ -161,6 +162,11 @@ def moe_gemm_mxfp8_nt_groupwise(
     out_dtype: Optional[torch.dtype]
         The data type of the output tensor. Currently only ``torch.bfloat16`` is supported.
 
+    is_gated: bool
+        If ``True``, run fused gate+up SwiGLU: ``b`` packs gate and up projections along N
+        (``b.shape[1] == 2 * out_n``) and the kernel fuses ``SiLU(gate) * up`` so the output
+        N is ``b.shape[1] // 2``. Defaults to ``False`` (plain grouped GEMM).
+
     Returns
     -------
     out: torch.Tensor
@@ -191,9 +197,12 @@ def moe_gemm_mxfp8_nt_groupwise(
             f"Only out_dtype=torch.bfloat16 is supported; got {out_dtype}"
         )
 
+    # Gated (fused SwiGLU): b packs gate+up along N (b.shape[1] == 2 * out_n); the kernel
+    # fuses SiLU(gate)*up so the output N is halved.
     n = b.shape[1]
+    out_n = n // 2 if is_gated else n
     if out is None:
-        out = torch.empty((a.shape[0], n), dtype=out_dtype, device=a.device)
+        out = torch.empty((a.shape[0], out_n), dtype=out_dtype, device=a.device)
 
     get_gemm_sm120_module_cute_mxfp8().moe_gemm_mxfp8_nt_groupwise(
         a,
@@ -206,5 +215,6 @@ def moe_gemm_mxfp8_nt_groupwise(
         scale_granularity_mnk[0],
         scale_granularity_mnk[1],
         scale_granularity_mnk[2],
+        is_gated,
     )
     return out

--- a/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
@@ -163,7 +163,8 @@ def moe_gemm_mxfp8_nt_groupwise(
         The data type of the output tensor. Currently only ``torch.bfloat16`` is supported.
 
     is_gated: bool
-        If ``True``, run fused gate+up SwiGLU: ``b`` packs gate and up projections along N
+        If ``True``, run fused gate+up SwiGLU: ``b`` packs the up projection in columns
+        ``[0, N)`` and the gate projection in ``[N, 2*N)`` along N
         (``b.shape[1] == 2 * out_n``) and the kernel fuses ``SiLU(gate) * up`` so the output
         N is ``b.shape[1] // 2``. Defaults to ``False`` (plain grouped GEMM).
 
@@ -197,8 +198,8 @@ def moe_gemm_mxfp8_nt_groupwise(
             f"Only out_dtype=torch.bfloat16 is supported; got {out_dtype}"
         )
 
-    # Gated (fused SwiGLU): b packs gate+up along N (b.shape[1] == 2 * out_n); the kernel
-    # fuses SiLU(gate)*up so the output N is halved.
+    # Gated (fused SwiGLU): b packs up in columns [0, N) and gate in [N, 2*N) along N
+    # (b.shape[1] == 2 * out_n); the kernel fuses SiLU(gate)*up so the output N is halved.
     n = b.shape[1]
     out_n = n // 2 if is_gated else n
     if out is None:

--- a/tests/grouped_mm/test_cute_sm120_fp8.py
+++ b/tests/grouped_mm/test_cute_sm120_fp8.py
@@ -22,12 +22,17 @@ from typing import Tuple
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 from flashinfer.grouped_mm import moe_gemm_fp8_nt_groupwise
 from flashinfer.testing.utils import per_block_cast_to_fp8, per_token_cast_to_fp8
 from flashinfer.utils import is_sm120a_supported
 
 CALC_DIFF_THRESHOLD = 1e-3
+# Gated (fused SwiGLU) uses a looser tolerance: the fp8 GEMM output is 2N (gate+up),
+# whose e4m3 quantization diff (~1.5e-3) dominates and is independent of the SwiGLU
+# fusion (verified: non-gated GEMM + torch SiLU gives the same diff).
+GATED_CALC_DIFF_THRESHOLD = 2e-3
 
 
 def skip_if_not_sm120():
@@ -79,7 +84,7 @@ def per_token_cast_to_fp8_for_moe_gemm(
     return x_fp8, padded
 
 
-def make_inputs(m_per_expert_list, n, k):
+def make_inputs(m_per_expert_list, n, k, is_gated=False):
     torch.random.manual_seed(0)
     num_experts = len(m_per_expert_list)
     offsets = [0]
@@ -87,9 +92,12 @@ def make_inputs(m_per_expert_list, n, k):
         offsets.append(offsets[-1] + m_pe)
     total_rows = offsets[-1]
 
+    # Gated (fused SwiGLU): b packs up (first n) + gate (second n) along N (2*n);
+    # output N stays n after up * SiLU(gate).
+    weight_n = 2 * n if is_gated else n
     a = torch.randn((total_rows, k), dtype=torch.bfloat16, device="cuda")
     b = torch.randn(
-        (num_experts, n, k), dtype=torch.bfloat16, device="cuda"
+        (num_experts, weight_n, k), dtype=torch.bfloat16, device="cuda"
     ) / math.sqrt(k)
     m_indptr = torch.tensor(offsets, dtype=torch.int32, device="cuda")
 
@@ -97,7 +105,11 @@ def make_inputs(m_per_expert_list, n, k):
     for i in range(num_experts):
         start, end = offsets[i], offsets[i + 1]
         if start < end:
-            ref[start:end] = a[start:end] @ b[i].t()
+            if is_gated:
+                gate_up = a[start:end] @ b[i].t()  # [rows, 2*n]
+                ref[start:end] = gate_up[:, :n] * F.silu(gate_up[:, n:])
+            else:
+                ref[start:end] = a[start:end] @ b[i].t()
 
     a_fp8, a_scale = per_token_cast_to_fp8_for_moe_gemm(a, m_indptr)
     b_fp8_list, b_sf_list = [], []
@@ -121,6 +133,20 @@ def test_moe_gemm_fp8_nt_groupwise(num_experts, rows_per_expert, n, k):
     out = moe_gemm_fp8_nt_groupwise(a, b, a_scale, b_scale, m_indptr)
     diff = calc_diff(out.float(), ref.float())
     assert diff < CALC_DIFF_THRESHOLD, f"calc_diff={diff:.6e}"
+
+
+@pytest.mark.parametrize("num_experts", [4, 8])
+@pytest.mark.parametrize("rows_per_expert", [1, 8, 192, 1024])
+@pytest.mark.parametrize("n,k", [(4096, 7168), (7168, 4096)])
+def test_moe_gemm_fp8_nt_groupwise_gated(num_experts, rows_per_expert, n, k):
+    skip_if_not_sm120()
+    a, b, a_scale, b_scale, m_indptr, ref = make_inputs(
+        [rows_per_expert] * num_experts, n, k, is_gated=True
+    )
+    out = moe_gemm_fp8_nt_groupwise(a, b, a_scale, b_scale, m_indptr, is_gated=True)
+    assert out.shape == (ref.shape[0], n)
+    diff = calc_diff(out.float(), ref.float())
+    assert diff < GATED_CALC_DIFF_THRESHOLD, f"gated calc_diff={diff:.6e}"
 
 
 @pytest.mark.parametrize(

--- a/tests/grouped_mm/test_cute_sm120_mxfp8.py
+++ b/tests/grouped_mm/test_cute_sm120_mxfp8.py
@@ -329,6 +329,97 @@ def test_moe_gemm_mxfp8_nt_groupwise(
     assert cos_sim > COS_SIM_THRESHOLD, f"cos_sim={cos_sim:.4f} < {COS_SIM_THRESHOLD}"
 
 
+@pytest.mark.parametrize("num_groups", [2, 4])
+@pytest.mark.parametrize("rows_per_group", [1, 8, 64, 128])
+@pytest.mark.parametrize("n,k", [(4096, 7168), (7168, 4096)])
+@pytest.mark.parametrize("k_gran", [32, 128])
+@pytest.mark.parametrize("is_weight_scale_float", [True, False])
+def test_moe_gemm_mxfp8_nt_groupwise_gated(
+    num_groups, rows_per_group, n, k, k_gran, is_weight_scale_float
+):
+    # Gated (fused SwiGLU): b packs up (first n) + gate (second n) along N (2*n);
+    # the kernel fuses up * SiLU(gate), so the output N is n.
+    skip_if_not_sm120()
+    torch.random.manual_seed(0)
+    out_dtype = torch.bfloat16
+    token_num = rows_per_group * num_groups
+
+    a = torch.randn((token_num, k), dtype=torch.bfloat16, device="cuda")
+    b = torch.randn(
+        (num_groups, 2 * n, k), dtype=torch.bfloat16, device="cuda"
+    ) / math.sqrt(k)
+    m_indptr = torch.tensor(
+        [i * rows_per_group for i in range(num_groups + 1)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    a_fp8, a_sf = per_token_cast_to_mxfp8_for_moe_gemm(a, m_indptr, gran_k=k_gran)
+
+    a_deq = torch.zeros_like(a)
+    for j in range(num_groups):
+        start = int(m_indptr[j].item())
+        end = int(m_indptr[j + 1].item())
+        a_j_fp8, a_j_sf_ue8m0 = per_token_cast_to_fp8(
+            a[start:end], use_ue8m0=True, gran_k=k_gran
+        )
+        a_deq[start:end] = per_token_dequant_from_fp8(
+            a_j_fp8, a_j_sf_ue8m0, gran_k=k_gran, dtype=a.dtype
+        )
+
+    b_fp8_list, b_sf_ue8m0_list = [], []
+    for i in range(num_groups):
+        if is_weight_scale_float:
+            b_i_fp8, b_i_sf = per_block_cast_to_fp8(b[i], use_ue8m0=True, gran_k=k_gran)
+        else:
+            b_i_fp8_raw, b_i_sf_fp32 = per_block_cast_to_fp8(
+                b[i], use_ue8m0=False, gran_k=k_gran
+            )
+            b_i_fp8, b_i_sf = per_block_resmooth_to_ue8m0(
+                b_i_fp8_raw, b_i_sf_fp32, gran_k=k_gran
+            )
+        b_fp8_list.append(b_i_fp8)
+        b_sf_ue8m0_list.append(b_i_sf)
+    b_fp8 = torch.stack(b_fp8_list, dim=0)
+    b_sf_ue8m0 = torch.stack(b_sf_ue8m0_list, dim=0)
+    b_sf = transform_sf_into_required_layout(
+        b_sf_ue8m0,
+        mn=2 * n,
+        k=k,
+        recipe=(k_gran, k_gran),
+        num_groups=num_groups,
+        is_sfa=False,
+    )
+    b_deq = per_block_dequant_from_fp8(b_fp8, b_sf_ue8m0, gran_k=k_gran, dtype=b.dtype)
+
+    ref = torch.zeros(token_num, n, dtype=out_dtype, device="cuda")
+    for j in range(num_groups):
+        start = int(m_indptr[j].item())
+        end = int(m_indptr[j + 1].item())
+        gate_up = a_deq[start:end] @ b_deq[j].t()  # [rows, 2*n]
+        up = gate_up[:, :n]
+        gate = gate_up[:, n:]
+        ref[start:end] = (up * F.silu(gate)).to(out_dtype)
+
+    out = moe_gemm_mxfp8_nt_groupwise(
+        a_fp8,
+        b_fp8,
+        a_sf,
+        b_sf,
+        m_indptr,
+        scale_granularity_mnk=(1, 1, k_gran),
+        out_dtype=out_dtype,
+        is_gated=True,
+    )
+    assert out.shape == (token_num, n)
+    cos_sim = F.cosine_similarity(
+        out.reshape(-1).float(), ref.reshape(-1).float(), dim=0
+    ).item()
+    assert cos_sim > COS_SIM_THRESHOLD, (
+        f"gated cos_sim={cos_sim:.4f} < {COS_SIM_THRESHOLD}"
+    )
+
+
 @pytest.mark.parametrize("bad_scale", ["a_m", "a_k", "b_expert", "b_n", "b_k"])
 def test_moe_gemm_mxfp8_nt_groupwise_rejects_bad_scale_shape(bad_scale):
     skip_if_not_sm120()


### PR DESCRIPTION
## 📌 Description

Adds **fused MoE FC1** (GEMM1 + SwiGLU in a single kernel) and a **warp-cooperative MoE scheduler** to the SM120 CuTe groupwise MoE GEMM entry. Fusion is exposed via an `is_gated` flag on the existing `moe_gemm_{fp8,mxfp8}_nt_groupwise` API. Follow-up to #3562 (MXFP8) and #3891 (FP8), sharing the same in-tree kernel package and JIT module.

With `is_gated=True` the kernel reads the `2I` gate+up weight (up in the first `I` columns of N, gate in the second), applies `up * SiLU(gate)` in the epilogue, and writes the `I`-wide activated output — fusing away the `2I` intermediate global write+read and the separate activation launch.

**Entry**: `flashinfer.grouped_mm.moe_gemm_{fp8,mxfp8}_nt_groupwise(a, b, a_scale, b_scale, m_indptr, scale_granularity_mnk, out=None, is_gated=False)`. `is_gated=True` requires even `b.size(1)` and halves output N to `I`.

## Benchmark 1: fused vs unfused

- **fused** = `moe_gemm_*_nt_groupwise(..., is_gated=True)` — GEMM1 + SwiGLU in one kernel.
- **unfused** = `moe_gemm_*_nt_groupwise(..., is_gated=False)` producing the `2I` gate+up, then a standalone Triton SwiGLU.
- CUPTI kernel-level, warmup 20 + 50-iter median, exclusive serial. Quant / scale-transform / routing / output allocation are outside the timed window; the unfused window covers GEMM + SwiGLU back-to-back.
- **Δ = fusion speedup = `(unfused_us / fused_us − 1) × 100%`** (positive = fused faster). FP8 and MXFP8 reported separately.

FC1 shapes: **Qwen3.5-35B** (E=256, K=2048, 2I=1024) · **Qwen3-235B** (E=128, K=4096, 2I=3072) · **DeepSeek-V3** (E=256, K=7168, 2I=4096). DeepSeek-V3 tops out at MPE=512, the other two at 1024.

### RTX PRO 6000 Blackwell Server Edition (SM120a, 188 SM)

#### Qwen3.5-35B

| MPE | fp8 fused (µs) | fp8 unfused (µs) | fp8 Δ | mxfp8 fused (µs) | mxfp8 unfused (µs) | mxfp8 Δ |
|---|---|---|---|---|---|---|
| 1 | 415.7 | 417.2 | +0.4% | 425.9 | 428.9 | +0.7% |
| 4 | 418.9 | 420.7 | +0.4% | 427.9 | 432.8 | +1.1% |
| 8 | 422.2 | 424.6 | +0.6% | 430.2 | 437.0 | +1.6% |
| 16 | 431.2 | 433.4 | +0.5% | 436.1 | 445.2 | +2.1% |
| 32 | 444.1 | 447.8 | +0.8% | 443.8 | 459.3 | +3.5% |
| 64 | 457.0 | 480.7 | +5.2% | 461.4 | 490.4 | +6.3% |
| 128 | 486.1 | 544.5 | +12.0% | 494.4 | 555.2 | +12.3% |
| 256 | 552.9 | 694.9 | +25.7% | 567.0 | 708.0 | +24.9% |
| 1024 | 1568.5 | 2087.1 | +33.1% | 1555.9 | 2089.5 | +34.3% |

#### Qwen3-235B

| MPE | fp8 fused (µs) | fp8 unfused (µs) | fp8 Δ | mxfp8 fused (µs) | mxfp8 unfused (µs) | mxfp8 Δ |
|---|---|---|---|---|---|---|
| 1 | 1127.5 | 1117.2 | -0.9% | 1159.9 | 1155.0 | -0.4% |
| 4 | 1133.3 | 1125.4 | -0.7% | 1164.7 | 1164.0 | -0.1% |
| 8 | 1137.5 | 1133.3 | -0.4% | 1166.9 | 1173.7 | +0.6% |
| 16 | 1148.1 | 1153.2 | +0.4% | 1180.5 | 1192.6 | +1.0% |
| 32 | 1164.1 | 1177.4 | +1.2% | 1189.9 | 1213.6 | +2.0% |
| 64 | 1194.3 | 1231.9 | +3.1% | 1220.9 | 1259.1 | +3.1% |
| 128 | 1235.5 | 1338.1 | +8.3% | 1261.7 | 1365.8 | +8.3% |
| 256 | 1329.5 | 1557.9 | +17.2% | 1369.7 | 1590.5 | +16.1% |
| 1024 | 4859.1 | 5462.0 | +12.4% | 5021.2 | 5705.6 | +13.6% |

#### DeepSeek-V3

| MPE | fp8 fused (µs) | fp8 unfused (µs) | fp8 Δ | mxfp8 fused (µs) | mxfp8 unfused (µs) | mxfp8 Δ |
|---|---|---|---|---|---|---|
| 1 | 4984.5 | 4969.1 | -0.3% | 5176.4 | 5179.1 | +0.1% |
| 4 | 5001.5 | 4999.3 | -0.0% | 5195.6 | 5219.7 | +0.5% |
| 8 | 5019.1 | 5031.8 | +0.3% | 5210.7 | 5254.8 | +0.8% |
| 16 | 5079.4 | 5119.5 | +0.8% | 5252.0 | 5328.3 | +1.5% |
| 32 | 5128.5 | 5211.5 | +1.6% | 5294.0 | 5413.6 | +2.3% |
| 64 | 5337.5 | 5437.7 | +1.9% | 5386.0 | 5621.7 | +4.4% |
| 128 | 5467.0 | 5788.3 | +5.9% | 5665.0 | 5974.9 | +5.5% |
| 256 | 6817.4 | 7261.4 | +6.5% | 6493.9 | 7089.9 | +9.2% |
| 512 | 13300.1 | 13823.2 | +3.9% | 12227.7 | 13102.6 | +7.2% |

### RTX PRO 5000 Blackwell (SM120a, 110 SM)

#### Qwen3.5-35B

| MPE | fp8 fused (µs) | fp8 unfused (µs) | fp8 Δ | mxfp8 fused (µs) | mxfp8 unfused (µs) | mxfp8 Δ |
|---|---|---|---|---|---|---|
| 1 | 455.3 | 465.1 | +2.2% | 471.4 | 477.5 | +1.3% |
| 4 | 468.1 | 475.4 | +1.6% | 483.1 | 492.2 | +1.9% |
| 8 | 475.6 | 481.2 | +1.2% | 496.0 | 499.4 | +0.7% |
| 16 | 486.6 | 488.7 | +0.4% | 503.7 | 507.4 | +0.7% |
| 32 | 497.3 | 503.9 | +1.3% | 512.8 | 521.7 | +1.7% |
| 64 | 525.7 | 549.7 | +4.6% | 540.0 | 577.2 | +6.9% |
| 128 | 573.1 | 633.3 | +10.5% | 600.7 | 652.4 | +8.6% |
| 256 | 706.4 | 862.8 | +22.1% | 714.5 | 873.1 | +22.2% |
| 1024 | 2790.3 | 3457.5 | +23.9% | 2817.7 | 3368.1 | +19.5% |

#### Qwen3-235B

| MPE | fp8 fused (µs) | fp8 unfused (µs) | fp8 Δ | mxfp8 fused (µs) | mxfp8 unfused (µs) | mxfp8 Δ |
|---|---|---|---|---|---|---|
| 1 | 1354.6 | 1366.7 | +0.9% | 1420.4 | 1406.5 | -1.0% |
| 4 | 1373.0 | 1377.1 | +0.3% | 1438.3 | 1426.4 | -0.8% |
| 8 | 1380.4 | 1381.6 | +0.1% | 1444.6 | 1436.1 | -0.6% |
| 16 | 1399.2 | 1397.4 | -0.1% | 1454.8 | 1449.8 | -0.3% |
| 32 | 1411.9 | 1410.7 | -0.1% | 1466.3 | 1468.7 | +0.2% |
| 64 | 1462.5 | 1469.2 | +0.5% | 1492.5 | 1544.5 | +3.5% |
| 128 | 1492.8 | 1639.3 | +9.8% | 1548.5 | 1694.6 | +9.4% |
| 256 | 2017.4 | 2323.8 | +15.2% | 2116.8 | 2342.8 | +10.7% |
| 1024 | 8278.5 | 9218.5 | +11.4% | 8306.9 | 9258.2 | +11.5% |

#### DeepSeek-V3

| MPE | fp8 fused (µs) | fp8 unfused (µs) | fp8 Δ | mxfp8 fused (µs) | mxfp8 unfused (µs) | mxfp8 Δ |
|---|---|---|---|---|---|---|
| 1 | 6241.2 | 6235.1 | -0.1% | 6487.4 | 6451.4 | -0.6% |
| 4 | 6254.4 | 6254.3 | -0.0% | 6499.1 | 6481.9 | -0.3% |
| 8 | 6269.1 | 6290.3 | +0.3% | 6512.7 | 6510.1 | -0.0% |
| 16 | 6337.1 | 6366.4 | +0.5% | 6555.2 | 6596.9 | +0.6% |
| 32 | 6380.8 | 6442.6 | +1.0% | 6597.4 | 6682.0 | +1.3% |
| 64 | 6885.3 | 6726.1 | -2.3% | 6701.6 | 6894.7 | +2.9% |
| 128 | 7021.1 | 7308.6 | +4.1% | 7061.2 | 7408.3 | +4.9% |
| 256 | 10298.8 | 10741.8 | +4.3% | 10245.9 | 10829.9 | +5.7% |
| 512 | 20201.4 | 20958.2 | +3.7% | 19835.6 | 21038.7 | +6.1% |

Fusion is neutral (occasionally slightly negative) at decode — small MPE, where FC1 grouped GEMM is weight-bandwidth / per-expert-tile-schedule bound and the `2I` intermediate round-trip is negligible against the GEMM floor — and grows with token count at prefill. Peak gain scales inversely with K: **Qwen3.5-35B (K=2048) > Qwen3-235B (K=4096) > DeepSeek-V3 (K=7168)** (up to +34% / +17% / +9% on the 6000; +24% / +15% / +6% on the 5000). FP8 and MXFP8 track closely.

## Benchmark 2: cooperative MoE scheduler (new `sm120_common/moe_scheduler.cuh`)

The ZeroPadding token→tile map was previously resolved by a per-lane linear scan (base of #3891). This PR replaces it with a warp-cooperative scan (coalesced 32-group load + `shfl` prefix-sum + `ballot`, isomorphic to the CUTLASS SM90 group scheduler), selected per `GemmType` — non-ZeroPadding paths are SASS-unchanged.

Decode-shaped microbenchmark on RTX PRO 6000 Blackwell Server Edition (M=1 token × topk=8, E=256, GranK=32; `contig` = padding-free upper bound), 4-arm NCU on one binary:

| scheduler | GEMM1 (N=1024, K=2048) | GEMM2 (N=2048, K=512) |
|---|---|---|
| linear scan (prev, #3891) | 30.70 µs (+109% vs ideal) | 26.44 µs (+193%) |
| **cooperative (this PR)** | **17.45 µs (+18.9%)** | **10.77 µs (+19.5%)** |
| **speedup vs linear scan** | **+76%** | **+146%** |

Scheduler global-load traffic drops **7.1×** (963,840 → 136,256 LSU sectors) and instructions 5×↓ (7.9M → 1.6M), bringing decode scheduler overhead from ~2–3× the padding-free ideal to within ~20%. At E≤64 both schedulers are within ~2–3% of ideal; large-M (prefill) and non-ZeroPadding shapes are unchanged (paired benchmark ≤0.42%, no regression).

## 🔍 Related Issues

Follow-up to #3562 (MXFP8 MoE GEMM entry) and #3891 (FP8 MoE GEMM entry) — same in-tree kernel package.

## 🧪 Tests

`tests/grouped_mm/test_cute_sm120_{fp8,mxfp8}.py` — adds gated (SwiGLU) correctness cells for both dtypes, against a per-expert bf16 GEMM + reference-SwiGLU baseline (FP8 `calc_diff < 2e-3`, MXFP8 `cos_sim > 0.99`). The `cute::Tensor` qualification in the blockscaling headers keeps existing non-gated coverage bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional gated MoE GEMM support for FP8 and MXFP8 workloads via `is_gated`.
  * Enables fused SwiGLU gate+up computation with reduced output width and stricter shape validation for packed gate/up inputs.
  * Improved SM120 MoE execution/tiling for gated workloads.

* **Bug Fixes**
  * Tightened gated-mode dimension and alignment checks (including updated multiple-of-16 validation).

* **Tests**
  * Added gated correctness coverage for FP8 and MXFP8 MoE GEMM, including relaxed numerical tolerance where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->