### PR TITLE
fix(topk): converge CTA before publishing multi-CTA radix group barrier arrival

### DIFF
--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -60,16 +60,20 @@ inline size_t GetRadixTopKAvailableOrderedSmemBytes(size_t max_smem_per_block,
 
 // ==================== Multi-CTA Top-K Implementation ====================
 
-// Acquire/Release primitives for inter-CTA synchronization
+// Acquire/Release primitives for inter-CTA synchronization.
+// All of them carry a "memory" clobber: `asm volatile` alone only keeps the compiler from
+// reordering these statements against each other, it does not stop ordinary loads/stores (or
+// values cached in registers) from being moved across the fence, which would defeat the
+// acquire/release pairing these helpers exist to provide.
 __device__ __forceinline__ int ld_acquire(int* ptr) {
   int state = 0;
 
 #if (__CUDA_ARCH__ >= 700)
   // SM70 and newer use memory consistency qualifiers
   // Acquire pattern using acquire modifier
-  asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(ptr));
+  asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(ptr) : "memory");
 #else
-  asm volatile("ld.cg.global.b32 %0, [%1];\n" : "=r"(state) : "l"(ptr));
+  asm volatile("ld.cg.global.b32 %0, [%1];\n" : "=r"(state) : "l"(ptr) : "memory");
 #endif
 
   return state;
@@ -81,8 +85,8 @@ __device__ __forceinline__ void red_release(int* ptr, int val) {
   // Release pattern using acq_rel fence + relaxed modifier
   // (The fence also releases data that was weakly-written by other threads prior to the last
   // syncthreads)
-  asm volatile("fence.acq_rel.gpu;\n");
-  asm volatile("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(ptr), "r"(val));
+  asm volatile("fence.acq_rel.gpu;\n" ::: "memory");
+  asm volatile("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(ptr), "r"(val) : "memory");
 #else
   __threadfence();
   atomicAdd(ptr, val);
@@ -93,8 +97,8 @@ __device__ __forceinline__ void st_release(int* ptr, int val) {
 #if (__CUDA_ARCH__ >= 700)
   // SM70 and newer use memory consistency qualifiers
   // Release pattern: fence + release store
-  asm volatile("fence.acq_rel.gpu;\n");
-  asm volatile("st.release.gpu.global.b32 [%0], %1;\n" : : "l"(ptr), "r"(val));
+  asm volatile("fence.acq_rel.gpu;\n" ::: "memory");
+  asm volatile("st.release.gpu.global.b32 [%0], %1;\n" : : "l"(ptr), "r"(val) : "memory");
 #else
   __threadfence();
   atomicExch(ptr, val);
@@ -166,6 +170,19 @@ inline RadixDeterministicCollectScratch* MaybeGetRadixDeterministicCollectScratc
  * Each CTA contributes exactly one arrival via tx==0, then waits until the
  * group-wide arrival counter reaches the current phase target.
  *
+ * The leading __syncthreads() is load-bearing: red_release's fence.acq_rel.gpu only makes the
+ * *other* threads' prior writes visible to peer CTAs when those writes are separated from the
+ * fence by a block-wide convergence point (the syncthreads + thread-0 fence idiom documented on
+ * red_release above). Callers reach this barrier straight out of all-thread write loops --
+ * accumulating into state->histogram, clearing the next round's histogram, or writing the
+ * collected index block -- so without it tx0 can publish its arrival while the rest of the CTA
+ * still has stores in flight. A peer CTA then passes the barrier and consumes data that was
+ * never written: an undercounted histogram yields a wrong pivot, and in the collect paths the
+ * peer reads uninitialized index slots and dereferences them (e.g. src_page_entry[row_start +
+ * idx]), which faults. RadixGroupResetStateLastCTA already converges for exactly this reason.
+ * The sync is free in practice: wait_ge ends with a __syncthreads(), so the trailing one is
+ * simply moved to the front.
+ *
  * \param state Per-group radix row state that owns the arrival counter
  * \param barrier_phase Current software-barrier phase for this CTA group
  * \param ctas_per_group Number of CTAs participating in the group barrier
@@ -173,13 +190,13 @@ inline RadixDeterministicCollectScratch* MaybeGetRadixDeterministicCollectScratc
  */
 __device__ __forceinline__ void AdvanceRadixGroupBarrier(RadixRowState* state, int& barrier_phase,
                                                          uint32_t ctas_per_group, uint32_t tx) {
+  __syncthreads();
   if (tx == 0) {
     red_release(&state->arrival_counter, 1);
   }
   int target = (barrier_phase + 1) * ctas_per_group;
   wait_ge(&state->arrival_counter, target, tx);
   barrier_phase++;
-  __syncthreads();
 }
 
 /*!

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -620,6 +620,52 @@ def test_top_k_renorm_probs_mixed_k_persistent_loop(dtype):
             )
 
 
+@pytest.mark.parametrize("k", [128, 1024])
+def test_top_k_renorm_probs_multi_cta_pivot_stability(k):
+    """Repeatedly run the multi-CTA path and require the exact top-k set every time.
+
+    Rows are permutations of a strictly increasing ramp, so every probability in a row is
+    distinct and the kept set is unambiguous -- no tie tolerance is needed and any deviation
+    is a real error.
+
+    This targets the cross-CTA group barrier: each CTA accumulates its slice of the round
+    histogram from all of its threads, then thread 0 marks arrival. If the CTA is not
+    converged before that mark, a peer CTA can read the group histogram while stores are
+    still in flight, undercount a bucket, and settle on a pivot that disagrees with its
+    peers -- which shows up here as a kept set that is not exactly the top k. The race is
+    timing-dependent, hence the repeat loop.
+    """
+    batch_size = 64
+    vocab_size = 128 * 1024  # large enough to force ctas_per_group > 1
+    num_trials = 20
+    device = "cuda:0"
+
+    generator = torch.Generator(device=device).manual_seed(42)
+    ramp = torch.arange(1, vocab_size + 1, device=device, dtype=torch.float32)
+    perm = torch.argsort(
+        torch.rand((batch_size, vocab_size), device=device, generator=generator), dim=-1
+    )
+    probs = ramp[perm]
+    probs /= probs.sum(dim=-1, keepdim=True)
+
+    threshold = torch.topk(probs, k, dim=-1).values[:, -1]
+    expected_mask = probs >= threshold.unsqueeze(-1)
+    assert torch.all(expected_mask.sum(dim=-1) == k)
+
+    for trial in range(num_trials):
+        renorm_probs = flashinfer.sampling.top_k_renorm_probs(probs, k)
+
+        mask = renorm_probs > 0
+        mismatched = (mask != expected_mask).any(dim=-1).nonzero().flatten()
+        assert mismatched.numel() == 0, (
+            f"trial {trial}: rows {mismatched.tolist()[:8]} kept the wrong set "
+            f"(kept counts {mask.sum(dim=-1)[mismatched].tolist()[:8]}, expected {k})"
+        )
+
+        sums = renorm_probs.float().sum(dim=-1)
+        torch.testing.assert_close(sums, torch.ones_like(sums), rtol=1e-3, atol=1e-3)
+
+
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("k", [10, 100, 500])


### PR DESCRIPTION
## 📌 Description

`AdvanceRadixGroupBarrier` lets thread 0 publish the CTA's arrival on `state->arrival_counter` **without first converging the block**:

```cpp
__device__ __forceinline__ void AdvanceRadixGroupBarrier(RadixRowState* state, int& barrier_phase,
                                                         uint32_t ctas_per_group, uint32_t tx) {
  if (tx == 0) {
    red_release(&state->arrival_counter, 1);   // <-- no __syncthreads() before this
  }
  ...
}
```

`red_release`'s `fence.acq_rel.gpu` only makes the *other* threads' prior writes visible to peer CTAs when those writes are separated from the fence by a `__syncthreads()`. That is exactly what the helper's own comment says ("the fence also releases data that was weakly-written by other threads prior to the last syncthreads"), and it is why `RadixGroupResetStateLastCTA` (added in #3615) converges before its release-ordered exit mark:

https://github.com/flashinfer-ai/flashinfer/blob/main/include/flashinfer/topk.cuh#L209-L216

The barrier itself never got the same treatment, and every hot call site reaches it straight out of an all-thread write loop with no intervening sync:

| Call site | Writes in flight when tx0 signals |
|---|---|
| `RadixSelectOneRound`, `RadixSelectFromSharedMemory` | `atomicAdd(&current_hist[i], ...)` from all threads, plus the leading CTA's `next_hist[i] = 0` clears |
| `RadixCollectIndices` | the CTA's block of collected `> pivot` indices |
| `RadixTopKPageTableTransformKernel` | `row_output[pos]`, which peers read back after the barrier |

Consequences, in increasing severity:

1. A peer CTA passes the barrier and reads `state->histogram` while a sibling's `atomicAdd`s are still landing → **undercounted bucket → the CTAs of a group settle on different pivots** → wrong top-k / wrong renormalization.
2. The leading CTA's `next_hist[i] = 0` clears can land *after* a peer has already accumulated into that buffer for the following round, **erasing counts that were already contributed**.
3. In the collect paths the peer reads **uninitialized** index slots and dereferences them — `src_page_entry[row_start + idx]` with a garbage `idx` is an out-of-bounds global read. That is a real illegal access, and it matches the `FAULT_PDE ACCESS_TYPE_VIRT_READ` MMU fault / Xid 31 reported in #4126.

This is timing-dependent, so it shows up as an occasional coredump or silently wrong sampling rather than a deterministic failure — consistent with #4126 not reproducing under a small standalone repro while faulting in production.

### The fix

Converge at the top of the barrier. `wait_ge` already ends with a `__syncthreads()`, so the trailing one is dropped and **the number of block syncs per barrier is unchanged** — this is not a new sync, it is a misplaced one moved to where it is load-bearing.

```diff
 __device__ __forceinline__ void AdvanceRadixGroupBarrier(RadixRowState* state, int& barrier_phase,
                                                          uint32_t ctas_per_group, uint32_t tx) {
+  __syncthreads();
   if (tx == 0) {
     red_release(&state->arrival_counter, 1);
   }
   int target = (barrier_phase + 1) * ctas_per_group;
   wait_ge(&state->arrival_counter, target, tx);
   barrier_phase++;
-  __syncthreads();
 }
```

Fixing it in the helper covers all ten call sites at once, including the two that were already correct by accident (the ones preceded by a `__syncthreads()` or by thread-0-only writes).

Secondly, `ld_acquire` / `red_release` / `st_release` gain the `"memory"` clobber that `atom_add_release` already carries. `asm volatile` only orders these statements against each other; it does not stop the compiler from moving ordinary loads and stores across the fence, or from keeping a value in a register across it, which defeats the acquire/release pairing these helpers exist to provide.

## 🔍 Related Issues

- Fixes #4126 (`RadixTopKRenormProbKernel_MultiCTA` coredump on B300 / sm_103)
- Same subsystem as #3610 / #3615; that PR made the *exit* path converge, this one does the same for the barrier

Note that #3618 (the per-device `row_states_buffer` cache key being shared across concurrent streams) is still open and orthogonal — it is a second way the same state words can be corrupted. This PR does not address it, since the allocation strategy there is a maintainer call.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

`tests/utils/test_sampling.py::test_top_k_renorm_probs_multi_cta_pivot_stability` builds rows that are permutations of a strictly increasing ramp, so every probability in a row is distinct and the kept set is unambiguous — no tie tolerance, any deviation is a real error. `vocab_size = 128 * 1024` forces `ctas_per_group > 1`, and the check is repeated because the race is timing-dependent.

**I do not have a Blackwell (or any multi-CTA-capable) GPU to run this on**, so the test is unverified on hardware and I have left the "all tests passing" box unchecked rather than claim otherwise. The fix itself is by inspection against the memory model and against the idiom already documented in this file. Would appreciate a maintainer running `tests/utils/test_sampling.py` and `tests/utils/test_topk.py` on the affected setup — and, if @bleedingfight still has the failing deployment, confirming the coredump stops.

## Reviewer Notes

- Worth double-checking my reading of the two "correct by accident" call sites — `RadixSelectFromSharedMemory`'s initial barrier (preceded by `__syncthreads()`) and the `sum_topk` barriers in the renorm/mask kernels (preceded by thread-0-only writes). Those were already safe; the change is a no-op for them beyond the sync being moved.
- The `"memory"` clobbers are strictly a hardening change and could be split out if you would rather keep this PR to the one-line ordering fix.
- Separately, and not touched here: `row_idx * vocab_size` in these kernels is computed in `uint32_t`, which overflows past ~26k rows at a 163840 vocab. Happy to file that separately if it is not already known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Top-K synchronization and memory ordering for more reliable multi-CTA sampling results.
  * Fixed potential instability when selecting and renormalizing large top-k probability sets.

* **Tests**
  * Added coverage for deterministic top-k selection and probability normalization across multiple runs and larger k values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->