### PR TITLE
fix(gemm): report a failed cuDNN tactic as unsupported during profiling (not silent tactic=-1)

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -48,6 +48,7 @@ from ..autotuner import (
     OptimizationProfile,
     TunableRunner,
     TuningConfig,
+    is_in_profile_measurement,
 )
 from ..fused_moe.utils import (
     get_hybrid_num_tokens_buckets,
@@ -2393,6 +2394,17 @@ def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
                 plan_index = candidate_plan_index
                 break
         if plan_index < 0:
+            # During autotuner profiling a requested tactic that resolves to
+            # no built plan must be reported as FAILED, not silently timed as
+            # tactic=-1 (raised in #3707 review; else the default's timing is
+            # attributed to the requested tactic and a tactic that never ran
+            # can win).  Serving keeps the warn+fallback for robustness.
+            if is_in_profile_measurement():
+                raise RuntimeError(
+                    "cuDNN GEMM engine/knob tactic matched no built execution "
+                    "plan during profiling; reporting as unsupported instead "
+                    "of silently using tactic=-1."
+                )
             warnings.warn(
                 "cuDNN GEMM engine/knob tactic did not match any built execution "
                 "plan; falling back to default tactic=-1.",
@@ -2402,6 +2414,12 @@ def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
         plan_index = tactic
 
     if plan_index >= graph.get_execution_plan_count():
+        if is_in_profile_measurement():
+            raise RuntimeError(
+                f"cuDNN GEMM plan index {plan_index} is out of range "
+                f"({graph.get_execution_plan_count()} plans) during profiling; "
+                f"reporting as unsupported instead of silently using tactic=-1."
+            )
         warnings.warn(
             f"cuDNN GEMM plan index {plan_index} is out of range "
             f"(execution plan count: {graph.get_execution_plan_count()}); "
@@ -3605,6 +3623,14 @@ def _cudnn_gemm_fp8_runner():
                         tactic=tactic,
                     )
             except Exception as exc:
+                # During autotuner profiling, report the failed tactic as
+                # unsupported (the autotuner marks it inf and disqualifies it)
+                # instead of silently timing tactic=-1 -- otherwise the
+                # fallback's time is attributed to the requested tactic and a
+                # tactic that never ran can win (raised in #3707 review).
+                # Serving keeps the warn+fallback for robustness.
+                if is_in_profile_measurement():
+                    raise
                 warnings.warn(
                     "cuDNN fp8 GEMM tactic failed; falling back to default "
                     f"tactic=-1. ({exc})",
@@ -4121,6 +4147,14 @@ def _cudnn_gemm_bf16_runner(
                 else:
                     _cudnn_gemm_bf16(workspace_buffer, a, b, bias, out, tactic=tactic)
             except Exception as exc:
+                # During autotuner profiling, report the failed tactic as
+                # unsupported (the autotuner marks it inf and disqualifies it)
+                # instead of silently timing tactic=-1 -- otherwise the
+                # fallback's time is attributed to the requested tactic and a
+                # tactic that never ran can win (raised in #3707 review).
+                # Serving keeps the warn+fallback for robustness.
+                if is_in_profile_measurement():
+                    raise
                 warnings.warn(
                     "cuDNN bf16 GEMM tactic failed; falling back to default "
                     f"tactic=-1. ({exc})",
@@ -5052,6 +5086,14 @@ def _cudnn_mm_mxfp8_runner():
                         tactic=tactic,
                     )
             except Exception as exc:
+                # During autotuner profiling, report the failed tactic as
+                # unsupported (the autotuner marks it inf and disqualifies it)
+                # instead of silently timing tactic=-1 -- otherwise the
+                # fallback's time is attributed to the requested tactic and a
+                # tactic that never ran can win (raised in #3707 review).
+                # Serving keeps the warn+fallback for robustness.
+                if is_in_profile_measurement():
+                    raise
                 warnings.warn(
                     "cuDNN mxfp8 GEMM tactic failed; falling back to default "
                     f"tactic=-1. ({exc})",
@@ -5524,6 +5566,14 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                         tactic=tactic,
                     )
             except Exception as exc:
+                # During autotuner profiling, report the failed tactic as
+                # unsupported (the autotuner marks it inf and disqualifies it)
+                # instead of silently timing tactic=-1 -- otherwise the
+                # fallback's time is attributed to the requested tactic and a
+                # tactic that never ran can win (raised in #3707 review).
+                # Serving keeps the warn+fallback for robustness.
+                if is_in_profile_measurement():
+                    raise
                 warnings.warn(
                     "cuDNN fp4 GEMM tactic failed; falling back to default "
                     f"tactic=-1. ({exc})",
@@ -8915,6 +8965,14 @@ def _cudnn_gemm_mxfp8_runner():
                         tactic=tactic,
                     )
             except Exception as exc:
+                # During autotuner profiling, report the failed tactic as
+                # unsupported (the autotuner marks it inf and disqualifies it)
+                # instead of silently timing tactic=-1 -- otherwise the
+                # fallback's time is attributed to the requested tactic and a
+                # tactic that never ran can win (raised in #3707 review).
+                # Serving keeps the warn+fallback for robustness.
+                if is_in_profile_measurement():
+                    raise
                 warnings.warn(
                     "cuDNN mxfp8 GEMM tactic failed; falling back to default "
                     f"tactic=-1. ({exc})",

--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -15,6 +15,7 @@ from ..autotuner import (
     OptimizationProfile,
     TunableRunner,
     TuningConfig,
+    is_in_profile_measurement,
 )
 from ..fused_moe.utils import (
     get_hybrid_num_tokens_buckets,
@@ -505,6 +506,11 @@ def _cudnn_bf16_fp4_runner(tuning_config):
                         tactic=tactic,
                     )
             except Exception as exc:
+                # During autotuner profiling, report the failed tactic as
+                # unsupported (marked inf) instead of silently timing
+                # tactic=-1 -- see the note in gemm_base.py (#3707 review).
+                if is_in_profile_measurement():
+                    raise
                 warnings.warn(
                     "cuDNN bf16-fp4 GEMM tactic failed; falling back to default "
                     f"tactic=-1. ({exc})",

--- a/tests/autotuner/test_cudnn_profiling_fallback.py
+++ b/tests/autotuner/test_cudnn_profiling_fallback.py
@@ -1,0 +1,63 @@
+"""A cuDNN GEMM tactic that cannot be used must be reported as FAILED during
+autotuner profiling (so the autotuner disqualifies it), while still falling
+back to tactic=-1 outside profiling for serving robustness.
+
+Regression for the silent-fallback-during-profiling issue raised in the
+#3707 review: otherwise the fallback's timing is attributed to the requested
+tactic and a tactic that never ran can win the autotune.
+"""
+
+import warnings
+
+import pytest
+import torch
+
+from flashinfer.autotuner.autotuner import _profile_measurement_scope
+from flashinfer.utils import get_compute_capability
+
+
+def _fp8_inputs(m=8, n=4096, k=4096):
+    from tests.utils_fp8 import to_float8
+
+    a = torch.randn([1, m, k], device="cuda", dtype=torch.bfloat16)
+    b = torch.randn([1, n, k], device="cuda", dtype=torch.bfloat16).transpose(-2, -1)
+    a8, a_scale = to_float8(a)
+    b8, b_scale = to_float8(b)
+    out = torch.empty([1, m, n], device="cuda", dtype=torch.bfloat16)
+    ws = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)
+    return [a8, b8, a_scale, b_scale, out, ws]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_cudnn_fp8_tactic_failure_raises_in_profiling_but_falls_back_serving():
+    if get_compute_capability(torch.device("cuda"))[0] < 9:
+        pytest.skip("cuDNN FP8 GEMM requires SM90+")
+    from flashinfer.gemm.gemm_base import (
+        _check_cudnn_availability,
+        _cudnn_gemm_fp8_runner,
+    )
+
+    try:
+        _check_cudnn_availability()
+    except Exception:
+        pytest.skip("cuDNN not available")
+
+    runner = _cudnn_gemm_fp8_runner()
+    inputs = _fp8_inputs()
+    bad_tactic = 9999  # out-of-range plan index -> deterministic fallback path
+
+    # Serving (not profiling): warn + fall back to -1 + produce a valid result.
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        runner.forward(inputs, tactic=bad_tactic)
+        assert any("falling back to default tactic=-1" in str(x.message) for x in w)
+    torch.cuda.synchronize()
+    assert torch.isfinite(inputs[4]).all()
+
+    # Profiling: the failed tactic must raise so the autotuner marks it inf,
+    # rather than silently timing the fallback under the requested tactic.
+    with (
+        pytest.raises(RuntimeError, match="during profiling"),
+        _profile_measurement_scope(),
+    ):
+        runner.forward(inputs, tactic=bad_tactic)


### PR DESCRIPTION
## 📌 Description

The cuDNN GEMM runners (FP8 / BF16 / FP4 / MXFP8 / BF16×FP4) silently execute `tactic=-1` when a requested tactic can't be used — both when resolving an engine/knob tactic to a plan index (no match / out-of-range) and when a tactic errors at execute time. That is correct for **serving** robustness, but during **autotuner profiling** it attributes the fallback's timing to the *requested* tactic. Consequences:

- a tactic that never actually ran can win the autotune (it's timed as the fast default);
- a genuinely faster tactic can be masked by the default's time;
- the tuner then persists a "winner" that always falls back at serving — violating *serve what was tuned*, and `validate_tactic`-style checks can't catch it because the tactic "works" (via fallback).

## Fix

Report a failed tactic as **unsupported** during profiling (re-raise), so the autotuner marks it `inf` and disqualifies it; keep the warn-and-fall-back path for serving. The profiling scope is already detectable via `is_in_profile_measurement()`, and `choose_one` already turns a raised tactic into `inf` + skip — so this is a small per-site change, not an autotuner rework.

8 sites: 2 in the tactic→plan_index resolver (`_get_cudnn_plan_index_for_tactic`: no-match, out-of-range) + 6 runner-forward `except` clauses (fp8/bf16/mxfp8×2/fp4 in `gemm_base.py`, bf16×fp4 in `gemm_bf16_fp4_cudnn.py`).

## 🔍 Related Issues

Raised in the #3707 review ("Do not treat a failed tactic's fallback execution as a successful tactic during profiling") and deferred there — the concern at the time was that it "would require a relatively broad autotuner change." Re-examined: `is_in_profile_measurement()` has existed since #3252 (before #3707), and the autotuner already marks a raised tactic `inf`, so the change is local to the runner fallback sites. Independently re-surfaced during a CUDA-graph-compatibility audit of the autotuner-v2 work (#3861).

## 🧪 Tests

`tests/autotuner/test_cudnn_profiling_fallback.py` (GPU, SM90+): an out-of-range tactic on the real cuDNN FP8 runner **warns + falls back + produces valid output** outside profiling, and **raises** (so it's disqualified) inside a `_profile_measurement_scope()`. Verified on SM100. Serving behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cuDNN GEMM autotuning by correctly marking failed or unsupported tactics during profiling.
  * Preserved serving behavior by warning and falling back to a default tactic when execution fails.

* **Tests**
  * Added coverage validating distinct tactic-failure behavior during profiling and serving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->