### PR TITLE
[GDN] improve sm100 GDN performance

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -160,13 +160,6 @@ def _wrap_tma(ret):
     return TmaInfo(ret[0], ret[1])
 
 
-from cutlass.utils import SmemAllocator, TmemAllocator
-
-try:
-    from cutlass.tensor_utils import LayoutEnum
-except ModuleNotFoundError:
-    from cutlass.utils import LayoutEnum
-
 from .gated_delta_net_tile_scheduler import (
     GDNTileSchedulerParams,
     GDNTileScheduler,
@@ -377,6 +370,7 @@ class GatedDeltaNetChunkedKernel:
     def can_implement(
         io_dtype,
         acc_dtype,
+        inverse_dtype,
         mma_tiler_qk,
         mma_tiler_qs,
         mma_tiler_qkv,
@@ -390,6 +384,10 @@ class GatedDeltaNetChunkedKernel:
         if acc_dtype != cutlass.Float32:
             raise testing.CantImplementError(
                 f"acc_dtype={acc_dtype} not supported; only Float32 is supported"
+            )
+        if inverse_dtype != io_dtype:
+            raise testing.CantImplementError(
+                f"inverse_dtype={inverse_dtype} must match io_dtype={io_dtype}"
             )
         if mma_tiler_qk != (64, 64, 128):
             raise testing.CantImplementError(
@@ -424,6 +422,7 @@ class GatedDeltaNetChunkedKernel:
         cu_seqlens: cute.Tensor,
         s_in: Optional[cute.Tensor],
         s_out: Optional[cute.Tensor],
+        s_indices: Optional[cute.Tensor],
         s_checkpoints: Optional[cute.Tensor],
         cu_checkpoints: Optional[cute.Tensor],
         checkpoint_every_n_tokens: cutlass.Int32,
@@ -821,9 +820,6 @@ class GatedDeltaNetChunkedKernel:
             )
         )
 
-        cumsumlog_smem_layout = cute.select(cumsumlog_smem_layout_staged, mode=[0])
-        beta_smem_layout = cute.select(beta_smem_layout_staged, mode=[0])
-
         o_smem_layout = cute.select(o_smem_layout_staged, mode=[0, 1])
         tma_o = _wrap_tma(
             cpasync.make_tiled_tma_atom(
@@ -868,6 +864,7 @@ class GatedDeltaNetChunkedKernel:
             cu_seqlens,
             s_in,
             s_out,
+            s_indices,
             s_checkpoints,
             cu_checkpoints,
             checkpoint_every_n_tokens,
@@ -892,7 +889,7 @@ class GatedDeltaNetChunkedKernel:
             grid=grid_shape,
             block=(self.threads_per_cta, 1, 1),
             cluster=self.cluster_shape_mnk,
-            smem=self.shared_storage.size_in_bytes(),
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
             stream=stream,
             min_blocks_per_mp=1,
         )
@@ -928,6 +925,7 @@ class GatedDeltaNetChunkedKernel:
         mS_init: Optional[cute.Tensor],
         # final state output (fp32) to GMEM; None if not stored
         mS_out: Optional[cute.Tensor],
+        mS_indices: Optional[cute.Tensor],
         mS_checkpoints: Optional[cute.Tensor],
         cu_checkpoints: Optional[cute.Tensor],
         checkpoint_every_n_tokens: cutlass.Int32,
@@ -1330,53 +1328,31 @@ class GatedDeltaNetChunkedKernel:
                 batch_start = cu_seqlens[batch_idx]
                 seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
                 num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
-                checkpoint_offset = 0
-                if cutlass.const_expr(self.enable_checkpoints):
-                    checkpoint_offset = cu_checkpoints[batch_idx]
-                if cutlass.const_expr(self.use_initial_state):
-                    kv_acc_producer = self._load_initial_state(
-                        tidx,
-                        mS_init,
-                        head_idx,
-                        batch_idx,
-                        tmem_ptr,
-                        tiled_mma_kv,
-                        kv_acc_producer,
+                if num_chunks_b > 0:
+                    checkpoint_offset = 0
+                    if cutlass.const_expr(self.enable_checkpoints):
+                        checkpoint_offset = cu_checkpoints[batch_idx]
+                    if cutlass.const_expr(self.use_initial_state):
+                        kv_acc_producer = self._load_initial_state(
+                            tidx,
+                            mS_init,
+                            mS_indices,
+                            head_idx,
+                            batch_idx,
+                            tmem_ptr,
+                            tiled_mma_kv,
+                            kv_acc_producer,
+                        )
+                    sV_pisl = self._transform_to_position_independent_layout(
+                        sV, v_smem_layout_staged.inner
                     )
-                sV_pisl = self._transform_to_position_independent_layout(
-                    sV, v_smem_layout_staged.inner
-                )
-                sO_pisl = self._transform_to_position_independent_layout(
-                    sO, o_smem_layout_staged.inner
-                )
-                num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
-                num_chunks_padded = num_pairs_b * 2
-                is_first_chunk = True
-                for chunk_iter in cutlass.range(num_chunks_padded):
-                    (
-                        load_v_consumer,
-                        load_gate_consumer,
-                        cg1_shared_acc_consumer,
-                        kv_acc_consumer,
-                        q_state_acc_consumer,
-                        kv_acc_producer,
-                        state_inp_ready_producer,
-                        vks_ready_producer,
-                        nv_ready_producer,
-                        decay_v_ready_producer,
-                        o_store_producer,
-                        checkpoint_offset,
-                    ) = self.compute_group_1_chunk(
-                        tidx,
-                        tmem_ptr,
-                        scale,
-                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
-                        (sV_pisl, sCumsumlog, sCumprod, sBeta, sO_pisl),
-                        (
-                            mS_checkpoints,
-                            checkpoint_offset,
-                            checkpoint_every_n_tokens,
-                        ),
+                    sO_pisl = self._transform_to_position_independent_layout(
+                        sO, o_smem_layout_staged.inner
+                    )
+                    num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
+                    num_chunks_padded = num_pairs_b * 2
+                    is_first_chunk = True
+                    for chunk_iter in cutlass.range(num_chunks_padded):
                         (
                             load_v_consumer,
                             load_gate_consumer,
@@ -1389,35 +1365,71 @@ class GatedDeltaNetChunkedKernel:
                             nv_ready_producer,
                             decay_v_ready_producer,
                             o_store_producer,
-                        ),
-                        (
-                            chunk_iter,
-                            num_pairs_b,
+                            checkpoint_offset,
+                        ) = self.compute_group_1_chunk(
+                            tidx,
+                            tmem_ptr,
+                            scale,
+                            (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                            (sV_pisl, sCumsumlog, sCumprod, sBeta, sO_pisl),
+                            (
+                                mS_checkpoints,
+                                checkpoint_offset,
+                                checkpoint_every_n_tokens,
+                            ),
+                            (
+                                load_v_consumer,
+                                load_gate_consumer,
+                                cg1_shared_acc_consumer,
+                                kv_acc_consumer,
+                                q_state_acc_consumer,
+                                kv_acc_producer,
+                                state_inp_ready_producer,
+                                vks_ready_producer,
+                                nv_ready_producer,
+                                decay_v_ready_producer,
+                                o_store_producer,
+                            ),
+                            (
+                                chunk_iter,
+                                num_pairs_b,
+                                head_idx,
+                                seqlen_b,
+                                is_first_chunk,
+                            ),
+                        )
+                        is_first_chunk = False
+                    if cutlass.const_expr(
+                        self.store_final_state or self.enable_checkpoints
+                    ):
+                        kv_acc_consumer = self._store_final_state(
+                            tidx,
+                            mS_out,
+                            mS_indices,
                             head_idx,
+                            batch_idx,
+                            tmem_ptr,
+                            tiled_mma_kv,
+                            kv_acc_consumer,
                             seqlen_b,
-                            is_first_chunk,
-                        ),
-                    )
-                    is_first_chunk = False
-                if cutlass.const_expr(
-                    self.store_final_state or self.enable_checkpoints
+                            mS_checkpoints,
+                            checkpoint_offset,
+                            checkpoint_every_n_tokens,
+                        )
+                    else:
+                        kv_acc_handle = kv_acc_consumer.wait_and_advance()
+                        kv_acc_handle.release()
+                elif cutlass.const_expr(
+                    self.store_final_state and self.use_initial_state
                 ):
-                    kv_acc_consumer = self._store_final_state(
+                    self._store_empty_final_state(
                         tidx,
+                        mS_init,
                         mS_out,
+                        mS_indices,
                         head_idx,
                         batch_idx,
-                        tmem_ptr,
-                        tiled_mma_kv,
-                        kv_acc_consumer,
-                        seqlen_b,
-                        mS_checkpoints,
-                        checkpoint_offset,
-                        checkpoint_every_n_tokens,
                     )
-                else:
-                    kv_acc_handle = kv_acc_consumer.wait_and_advance()
-                    kv_acc_handle.release()
 
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
@@ -1435,20 +1447,34 @@ class GatedDeltaNetChunkedKernel:
             cute.arch.setmaxregister_decrease(self.num_regs_other)
             tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
-            self.mma_cg0_issuer_warp(
-                tmem_ptr,
-                scheduler_params,
-                (bidx, bidy, bidz),
-                grid_dim,
-                cu_seqlens,
-                (tiled_mma_qk, tiled_mma_qkv),
-                (sQ, sK),
-                (
-                    cg0_shared_acc_producer,
-                    load_k_consumer,
-                    load_q_consumer,
-                ),
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
             )
+            work = scheduler.initial_work_tile_info()
+            while work.is_valid_tile:
+                batch_idx, _, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
+                for _pair_idx in cutlass.range(num_pairs_b):
+                    (
+                        cg0_shared_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                    ) = self.mma_cg0_pair(
+                        tmem_ptr,
+                        (tiled_mma_qk, tiled_mma_qkv),
+                        (sQ, sK),
+                        (
+                            cg0_shared_acc_producer,
+                            load_k_consumer,
+                            load_q_consumer,
+                        ),
+                    )
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+
+            cg0_shared_acc_producer.tail()
 
         # ==============================================================
         # CG1 MMA ISSUER (warp 10: KS/QS/NV/QKV/KV)
@@ -1457,28 +1483,107 @@ class GatedDeltaNetChunkedKernel:
             cute.arch.setmaxregister_decrease(self.num_regs_other)
             tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
-            self.mma_cg1_issuer_warp(
-                tmem_ptr,
-                scheduler_params,
-                (bidx, bidy, bidz),
-                grid_dim,
-                cu_seqlens,
-                (tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv),
-                (sQ, sK, sK_trans, sV, sAinv, sQk),
-                (
-                    cg1_shared_acc_producer,
-                    q_state_acc_producer,
-                    kv_acc_producer,
-                    load_k_consumer,
-                    load_q_consumer,
-                    a_inv_ready_consumer,
-                    qk_ready_consumer,
-                    state_inp_ready_consumer,
-                    vks_ready_consumer,
-                    nv_ready_consumer,
-                    decay_v_ready_consumer,
-                ),
+            scheduler = GDNTileScheduler.create(
+                scheduler_params, (bidx, bidy, bidz), grid_dim
             )
+            work = scheduler.initial_work_tile_info()
+            while work.is_valid_tile:
+                batch_idx, _, _ = work.tile_idx
+                batch_start = cu_seqlens[batch_idx]
+                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                num_chunks = cute.ceil_div(seqlen_b, self.b_t * 2) * 2
+
+                run_cg1_mma = num_chunks > 0
+                if cutlass.const_expr(self.use_initial_state):
+                    run_cg1_mma = True
+                if run_cg1_mma:
+                    first_loop_chunk = 0
+                    if cutlass.const_expr(not self.use_initial_state):
+                        (
+                            cg1_shared_acc_producer,
+                            q_state_acc_producer,
+                            kv_acc_producer,
+                            load_k_consumer,
+                            load_q_consumer,
+                            a_inv_ready_consumer,
+                            qk_ready_consumer,
+                            state_inp_ready_consumer,
+                            vks_ready_consumer,
+                            nv_ready_consumer,
+                            decay_v_ready_consumer,
+                        ) = self.mma_cg1_chunk(
+                            tmem_ptr,
+                            (
+                                tiled_mma_qs,
+                                tiled_mma_qkv,
+                                tiled_mma_qkv_ss,
+                                tiled_mma_kv,
+                            ),
+                            (sQ, sK, sK_trans, sV, sAinv, sQk),
+                            (
+                                cg1_shared_acc_producer,
+                                q_state_acc_producer,
+                                kv_acc_producer,
+                                load_k_consumer,
+                                load_q_consumer,
+                                a_inv_ready_consumer,
+                                qk_ready_consumer,
+                                state_inp_ready_consumer,
+                                vks_ready_consumer,
+                                nv_ready_consumer,
+                                decay_v_ready_consumer,
+                            ),
+                            True,
+                        )
+                        first_loop_chunk = 1
+
+                    for chunk_idx in cutlass.range(first_loop_chunk, num_chunks):
+                        is_first_chunk = False
+                        if cutlass.const_expr(self.use_initial_state):
+                            is_first_chunk = chunk_idx == 0
+                        (
+                            cg1_shared_acc_producer,
+                            q_state_acc_producer,
+                            kv_acc_producer,
+                            load_k_consumer,
+                            load_q_consumer,
+                            a_inv_ready_consumer,
+                            qk_ready_consumer,
+                            state_inp_ready_consumer,
+                            vks_ready_consumer,
+                            nv_ready_consumer,
+                            decay_v_ready_consumer,
+                        ) = self.mma_cg1_chunk(
+                            tmem_ptr,
+                            (
+                                tiled_mma_qs,
+                                tiled_mma_qkv,
+                                tiled_mma_qkv_ss,
+                                tiled_mma_kv,
+                            ),
+                            (sQ, sK, sK_trans, sV, sAinv, sQk),
+                            (
+                                cg1_shared_acc_producer,
+                                q_state_acc_producer,
+                                kv_acc_producer,
+                                load_k_consumer,
+                                load_q_consumer,
+                                a_inv_ready_consumer,
+                                qk_ready_consumer,
+                                state_inp_ready_consumer,
+                                vks_ready_consumer,
+                                nv_ready_consumer,
+                                decay_v_ready_consumer,
+                            ),
+                            is_first_chunk,
+                        )
+
+                scheduler.advance_to_next_work()
+                work = scheduler.get_current_work()
+
+            cg1_shared_acc_producer.tail()
+            q_state_acc_producer.tail()
+            kv_acc_producer.tail()
 
         # ==============================================================
         # TMA LOAD WARP (warp 9)
@@ -1511,41 +1616,58 @@ class GatedDeltaNetChunkedKernel:
                 num_pairs = 2
                 num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
                 num_chunks_b = num_pairs_b * num_pairs
-                num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
 
-                # Build bounded tensors: same ptr/strides, token dim capped to batch_end
-                bounded_q = cute.make_tensor(
-                    mQ.iterator,
-                    cute.make_layout(
-                        (batch_end, mQ.shape[1], mQ.shape[2]),
-                        stride=(mQ.stride[0], mQ.stride[1], mQ.stride[2]),
-                    ),
-                )
-                bounded_k = cute.make_tensor(
-                    mK.iterator,
-                    cute.make_layout(
-                        (batch_end, mK.shape[1], mK.shape[2]),
-                        stride=(mK.stride[0], mK.stride[1], mK.stride[2]),
-                    ),
-                )
-                bounded_v = cute.make_tensor(
-                    mV.iterator,
-                    cute.make_layout(
-                        (mV.shape[0], batch_end, mV.shape[2]),
-                        stride=(mV.stride[0], mV.stride[1], mV.stride[2]),
-                    ),
-                )
-                # Update K/Q/V descriptors
-                tensormap_manager.update_tensormap(
-                    (bounded_q, bounded_k, bounded_v),
-                    (tma_q.atom, tma_k.atom, tma_v.atom),
-                    (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
-                    self.tma_qkv_warp_id,
-                    (None, None, None),
-                )
+                # All warp roles skip empty workloads at the same granularity.
+                if num_chunks_b > 0:
+                    # Bounded descriptors zero-fill partial and padded chunks.
+                    bounded_q = cute.make_tensor(
+                        mQ.iterator,
+                        cute.make_layout(
+                            (batch_end, mQ.shape[1], mQ.shape[2]),
+                            stride=(mQ.stride[0], mQ.stride[1], mQ.stride[2]),
+                        ),
+                    )
+                    bounded_k = cute.make_tensor(
+                        mK.iterator,
+                        cute.make_layout(
+                            (batch_end, mK.shape[1], mK.shape[2]),
+                            stride=(mK.stride[0], mK.stride[1], mK.stride[2]),
+                        ),
+                    )
+                    bounded_v = cute.make_tensor(
+                        mV.iterator,
+                        cute.make_layout(
+                            (mV.shape[0], batch_end, mV.shape[2]),
+                            stride=(mV.stride[0], mV.stride[1], mV.stride[2]),
+                        ),
+                    )
+                    tensormap_manager.update_tensormap(
+                        (bounded_q, bounded_k, bounded_v),
+                        (tma_q.atom, tma_k.atom, tma_v.atom),
+                        (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
+                        self.tma_qkv_warp_id,
+                        (None, None, None),
+                    )
 
-                # Warp 9 now owns only the Q/K/V TMA stream.
-                for chunk_idx in cutlass.range(num_valid_chunks_b - 1):
+                    num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                    for chunk_idx in cutlass.range(num_valid_chunks_b - 1):
+                        chunk_offset = batch_start + chunk_idx * self.b_t
+                        load_q_producer, load_k_producer, load_v_producer = (
+                            self.tma_qkv_warp(
+                                (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
+                                (tma_q, tma_k, tma_v),
+                                (sQ, sK, sV),
+                                (load_q_producer, load_k_producer, load_v_producer),
+                                (chunk_offset, chunk_idx, batch_idx, head_idx),
+                                (
+                                    tensormap_manager,
+                                    tensormap_q_ptr,
+                                    tensormap_k_ptr,
+                                    tensormap_v_ptr,
+                                ),
+                            )
+                        )
+                    chunk_idx = num_valid_chunks_b - 1
                     chunk_offset = batch_start + chunk_idx * self.b_t
                     load_q_producer, load_k_producer, load_v_producer = (
                         self.tma_qkv_warp(
@@ -1562,40 +1684,23 @@ class GatedDeltaNetChunkedKernel:
                             ),
                         )
                     )
-                chunk_idx = num_valid_chunks_b - 1
-                chunk_offset = batch_start + chunk_idx * self.b_t
-                load_q_producer, load_k_producer, load_v_producer = self.tma_qkv_warp(
-                    (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
-                    (tma_q, tma_k, tma_v),
-                    (sQ, sK, sV),
-                    (load_q_producer, load_k_producer, load_v_producer),
-                    (chunk_offset, chunk_idx, batch_idx, head_idx),
-                    (
-                        tensormap_manager,
-                        tensormap_q_ptr,
-                        tensormap_k_ptr,
-                        tensormap_v_ptr,
-                    ),
-                )
-                # A padded second chunk keeps every consumer's two-chunk pair
-                # cadence aligned while gate/beta produce neutral values.
-                for chunk_idx in cutlass.range(num_valid_chunks_b, num_chunks_b):
-                    chunk_offset = batch_start + chunk_idx * self.b_t
-                    load_q_producer, load_k_producer, load_v_producer = (
-                        self.tma_qkv_warp(
-                            (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
-                            (tma_q, tma_k, tma_v),
-                            (sQ, sK, sV),
-                            (load_q_producer, load_k_producer, load_v_producer),
-                            (chunk_offset, chunk_idx, batch_idx, head_idx),
-                            (
-                                tensormap_manager,
-                                tensormap_q_ptr,
-                                tensormap_k_ptr,
-                                tensormap_v_ptr,
-                            ),
+                    for chunk_idx in cutlass.range(num_valid_chunks_b, num_chunks_b):
+                        chunk_offset = batch_start + chunk_idx * self.b_t
+                        load_q_producer, load_k_producer, load_v_producer = (
+                            self.tma_qkv_warp(
+                                (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
+                                (tma_q, tma_k, tma_v),
+                                (sQ, sK, sV),
+                                (load_q_producer, load_k_producer, load_v_producer),
+                                (chunk_offset, chunk_idx, batch_idx, head_idx),
+                                (
+                                    tensormap_manager,
+                                    tensormap_q_ptr,
+                                    tensormap_k_ptr,
+                                    tensormap_v_ptr,
+                                ),
+                            )
                         )
-                    )
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
 
@@ -1629,48 +1734,28 @@ class GatedDeltaNetChunkedKernel:
                 num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
                 num_chunks_b = num_pairs_b * num_pairs
 
-                # Build bounded O tensor: token dim capped to batch_end
-                num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
-                bounded_o = cute.make_tensor(
-                    mO.iterator,
-                    cute.make_layout(
-                        (mO.shape[0], batch_end, mO.shape[2]),
-                        stride=(mO.stride[0], mO.stride[1], mO.stride[2]),
-                    ),
-                )
-
-                # Update O descriptor independently
-                tensormap_manager.update_tensormap(
-                    (bounded_o,),
-                    (tma_o.atom,),
-                    (tensormap_o_ptr,),
-                    self.epilogue_warp_id,
-                    (None,),
-                )
-                tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
-
-                # Every valid work tile has at least one two-chunk pair.
-                for prefetch_idx in range(2):
-                    prefetch_offset = batch_start + prefetch_idx * self.b_t
-                    is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
-                    load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
-                        tidx,
-                        (mGate, mBeta),
-                        (sCumsumlog, sCumprod, sBeta),
-                        (load_gate_producer, load_beta_producer),
-                        (
-                            prefetch_offset,
-                            head_idx,
-                            is_last_tile,
-                            batch_end,
+                # Keep the fixed prefetch and zero-trip store loop under one
+                # guard. The wider scope lets the compiler share the dynamic
+                # chunk predicate without introducing divergent loop state.
+                if num_chunks_b > 0:
+                    num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                    bounded_o = cute.make_tensor(
+                        mO.iterator,
+                        cute.make_layout(
+                            (mO.shape[0], batch_end, mO.shape[2]),
+                            stride=(mO.stride[0], mO.stride[1], mO.stride[2]),
                         ),
                     )
+                    tensormap_manager.update_tensormap(
+                        (bounded_o,),
+                        (tma_o.atom,),
+                        (tensormap_o_ptr,),
+                        self.epilogue_warp_id,
+                        (None,),
+                    )
+                    tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
 
-                # Fill the remaining two lookahead stages together. Since the
-                # chunk count is even, chunks 2 and 3 are either both present
-                # or both absent.
-                if num_chunks_b > 2:
-                    for prefetch_idx in range(2, 4):
+                    for prefetch_idx in range(2):
                         prefetch_offset = batch_start + prefetch_idx * self.b_t
                         is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
                         load_gate_producer, load_beta_producer = (
@@ -1688,28 +1773,55 @@ class GatedDeltaNetChunkedKernel:
                             )
                         )
 
-                for chunk_idx in cutlass.range(num_chunks_b):
-                    prefetch_idx = chunk_idx + 4
-                    if prefetch_idx < num_chunks_b:
-                        prefetch_offset = batch_start + prefetch_idx * self.b_t
-                        is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
-                        load_gate_producer, load_beta_producer = (
-                            self.load_gate_beta_warp(
-                                tidx,
-                                (mGate, mBeta),
-                                (sCumsumlog, sCumprod, sBeta),
-                                (load_gate_producer, load_beta_producer),
-                                (prefetch_offset, head_idx, is_last_tile, batch_end),
+                    # Fill the remaining two lookahead stages together. Since the
+                    # chunk count is even, chunks 2 and 3 are either both present
+                    # or both absent.
+                    if num_chunks_b > 2:
+                        for prefetch_idx in range(2, 4):
+                            prefetch_offset = batch_start + prefetch_idx * self.b_t
+                            is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
+                            load_gate_producer, load_beta_producer = (
+                                self.load_gate_beta_warp(
+                                    tidx,
+                                    (mGate, mBeta),
+                                    (sCumsumlog, sCumprod, sBeta),
+                                    (load_gate_producer, load_beta_producer),
+                                    (
+                                        prefetch_offset,
+                                        head_idx,
+                                        is_last_tile,
+                                        batch_end,
+                                    ),
+                                )
                             )
+
+                    for chunk_idx in cutlass.range(num_chunks_b):
+                        prefetch_idx = chunk_idx + 4
+                        if prefetch_idx < num_chunks_b:
+                            prefetch_offset = batch_start + prefetch_idx * self.b_t
+                            is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
+                            load_gate_producer, load_beta_producer = (
+                                self.load_gate_beta_warp(
+                                    tidx,
+                                    (mGate, mBeta),
+                                    (sCumsumlog, sCumprod, sBeta),
+                                    (load_gate_producer, load_beta_producer),
+                                    (
+                                        prefetch_offset,
+                                        head_idx,
+                                        is_last_tile,
+                                        batch_end,
+                                    ),
+                                )
+                            )
+                        chunk_offset = batch_start + chunk_idx * self.b_t
+                        o_store_consumer = self.epilogue_warp(
+                            (sO,),
+                            (tma_o,),
+                            (o_store_consumer,),
+                            (head_idx, chunk_offset),
+                            (tensormap_manager, tensormap_o_ptr),
                         )
-                    chunk_offset = batch_start + chunk_idx * self.b_t
-                    o_store_consumer = self.epilogue_warp(
-                        (sO,),
-                        (tma_o,),
-                        (o_store_consumer,),
-                        (head_idx, chunk_offset),
-                        (tensormap_manager, tensormap_o_ptr),
-                    )
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
 
@@ -1760,7 +1872,6 @@ class GatedDeltaNetChunkedKernel:
         # Per-thread MMA slices (cta_v=0 for ONE-CTA mode).
         thr_mma_qk = tiled_mma_qk.get_slice(0)
         thr_mma_qkv_ss = tiled_mma_qkv_ss.get_slice(0)
-        thr_mma_kv = tiled_mma_kv.get_slice(0)
 
         # Tile shapes from the MMA tiler (128, 128, 128):
         #   mode[0,2] = (BT, DK) - M,K tile for A (Q) and for B (K) of tiled_mma_qk
@@ -1968,7 +2079,6 @@ class GatedDeltaNetChunkedKernel:
                 )
                 if lidx >= offset:
                     tGrGate[col] = tGrGate[col] + n
-        sum_v = 0.0
         for col in range(1, cute.size(tGrGate)):
             last_v = cute.arch.shuffle_sync(
                 tGrGate[col - 1],
@@ -2012,48 +2122,6 @@ class GatedDeltaNetChunkedKernel:
         beta_handle.commit()
 
         return load_gate_producer, load_beta_producer
-
-    @cute.jit
-    def mma_cg0_issuer_warp(
-        self,
-        tmem_ptr: cutlass.Int64,
-        scheduler_params: GDNTileSchedulerParams,
-        block_coord: tuple,
-        grid_dim: tuple,
-        cu_seqlens: cute.Tensor,
-        mma_args: tuple,
-        smem_args: tuple,
-        pipeline_args: tuple,
-    ):
-        """Issue the pair-level KK0/KK1/QK0/QK1 stream from warp 8."""
-        cg0_acc_producer, load_k_consumer, load_q_consumer = pipeline_args
-        scheduler = GDNTileScheduler.create(scheduler_params, block_coord, grid_dim)
-        work = scheduler.initial_work_tile_info()
-
-        while work.is_valid_tile:
-            batch_idx, _, _ = work.tile_idx
-            batch_start = cu_seqlens[batch_idx]
-            seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
-            num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
-            for pair_idx in cutlass.range(num_pairs_b):
-                (
-                    cg0_acc_producer,
-                    load_k_consumer,
-                    load_q_consumer,
-                ) = self.mma_cg0_pair(
-                    tmem_ptr,
-                    mma_args,
-                    smem_args,
-                    (
-                        cg0_acc_producer,
-                        load_k_consumer,
-                        load_q_consumer,
-                    ),
-                )
-            scheduler.advance_to_next_work()
-            work = scheduler.get_current_work()
-
-        cg0_acc_producer.tail()
 
     @cute.jit
     def mma_cg0_pair(
@@ -2154,118 +2222,6 @@ class GatedDeltaNetChunkedKernel:
         )
 
     @cute.jit
-    def mma_cg1_issuer_warp(
-        self,
-        tmem_ptr: cutlass.Int64,
-        scheduler_params: GDNTileSchedulerParams,
-        block_coord: tuple,
-        grid_dim: tuple,
-        cu_seqlens: cute.Tensor,
-        mma_args: tuple,
-        smem_args: tuple,
-        pipeline_args: tuple,
-    ):
-        """Issue the chunk-level state/output GEMM stream from warp 10."""
-        (
-            cg1_acc_producer,
-            q_state_acc_producer,
-            kv_acc_producer,
-            load_k_consumer,
-            load_q_consumer,
-            a_inv_ready_consumer,
-            qk_ready_consumer,
-            state_inp_ready_consumer,
-            vks_ready_consumer,
-            nv_ready_consumer,
-            decay_v_ready_consumer,
-        ) = pipeline_args
-        scheduler = GDNTileScheduler.create(scheduler_params, block_coord, grid_dim)
-        work = scheduler.initial_work_tile_info()
-        while work.is_valid_tile:
-            batch_idx, _, _ = work.tile_idx
-            batch_start = cu_seqlens[batch_idx]
-            seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
-            num_chunks = cute.ceil_div(seqlen_b, self.b_t * 2) * 2
-            first_loop_chunk = 0
-
-            if cutlass.const_expr(not self.use_initial_state):
-                (
-                    cg1_acc_producer,
-                    q_state_acc_producer,
-                    kv_acc_producer,
-                    load_k_consumer,
-                    load_q_consumer,
-                    a_inv_ready_consumer,
-                    qk_ready_consumer,
-                    state_inp_ready_consumer,
-                    vks_ready_consumer,
-                    nv_ready_consumer,
-                    decay_v_ready_consumer,
-                ) = self.mma_cg1_chunk(
-                    tmem_ptr,
-                    mma_args,
-                    smem_args,
-                    (
-                        cg1_acc_producer,
-                        q_state_acc_producer,
-                        kv_acc_producer,
-                        load_k_consumer,
-                        load_q_consumer,
-                        a_inv_ready_consumer,
-                        qk_ready_consumer,
-                        state_inp_ready_consumer,
-                        vks_ready_consumer,
-                        nv_ready_consumer,
-                        decay_v_ready_consumer,
-                    ),
-                    True,
-                )
-                first_loop_chunk = 1
-
-            for chunk_idx in cutlass.range(first_loop_chunk, num_chunks):
-                is_first_chunk = False
-                if cutlass.const_expr(self.use_initial_state):
-                    is_first_chunk = chunk_idx == 0
-                (
-                    cg1_acc_producer,
-                    q_state_acc_producer,
-                    kv_acc_producer,
-                    load_k_consumer,
-                    load_q_consumer,
-                    a_inv_ready_consumer,
-                    qk_ready_consumer,
-                    state_inp_ready_consumer,
-                    vks_ready_consumer,
-                    nv_ready_consumer,
-                    decay_v_ready_consumer,
-                ) = self.mma_cg1_chunk(
-                    tmem_ptr,
-                    mma_args,
-                    smem_args,
-                    (
-                        cg1_acc_producer,
-                        q_state_acc_producer,
-                        kv_acc_producer,
-                        load_k_consumer,
-                        load_q_consumer,
-                        a_inv_ready_consumer,
-                        qk_ready_consumer,
-                        state_inp_ready_consumer,
-                        vks_ready_consumer,
-                        nv_ready_consumer,
-                        decay_v_ready_consumer,
-                    ),
-                    is_first_chunk,
-                )
-
-            scheduler.advance_to_next_work()
-            work = scheduler.get_current_work()
-
-        cg1_acc_producer.tail()
-        q_state_acc_producer.tail()
-        kv_acc_producer.tail()
-
-    @cute.jit
     def mma_cg1_chunk(
         self,
         tmem_ptr: cutlass.Int64,
@@ -2275,7 +2231,7 @@ class GatedDeltaNetChunkedKernel:
         is_first_chunk: cutlass.Boolean,
     ) -> tuple:
         """Issue KS/QS/NV/QKV/KV for one chunk."""
-        tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv = mma_args
+        tiled_mma_qs, tiled_mma_qkv, _, tiled_mma_kv = mma_args
         sQ, sK, sK_trans, sV, sAinv, sQk = smem_args
         (
             cg1_acc_producer,
@@ -2350,14 +2306,13 @@ class GatedDeltaNetChunkedKernel:
         tCrAinv_B = tiled_mma_qkv.make_fragment_B(sAinv)
         tCrNv_B = tiled_mma_qkv.make_fragment_B(sQk)
         tCrKt_B = tiled_mma_kv.make_fragment_B(sK_trans)
-        tCrV_A_ss = tiled_mma_qkv_ss.make_fragment_A(sV)
         num_kphases_qs = cute.size(tCtStateInp, mode=[2])
         num_kphases_qkv = cute.size(tCrAinv_B, mode=[2])
         num_kphases_kv = cute.size(tCrKt_B, mode=[2])
 
         k_handle = load_k_consumer.wait_and_advance()
         q_handle = load_q_consumer.wait_and_advance()
-        valid_state = is_first_chunk == False
+        valid_state = is_first_chunk == False  # noqa: E712
         if cutlass.const_expr(self.use_initial_state):
             valid_state = True
 
@@ -2405,11 +2360,11 @@ class GatedDeltaNetChunkedKernel:
                 )
         else:
             for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
-                tiled_mma_qkv_ss.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
                 cute.gemm(
-                    tiled_mma_qkv_ss,
+                    tiled_mma_qkv,
                     tCtShared[None, None, None, nv_handle.index],
-                    tCrV_A_ss[None, None, kphase_idx, 0],
+                    tCtSharedInp[None, None, kphase_idx, 0],
                     tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
                     tCtShared[None, None, None, nv_handle.index],
                 )
@@ -2612,7 +2567,8 @@ class GatedDeltaNetChunkedKernel:
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
-        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
@@ -2810,7 +2766,7 @@ class GatedDeltaNetChunkedKernel:
         k_stage = k_release_handle.index
         q_stage = q_release_handle.index
 
-        valid_state = is_first_chunk == False
+        valid_state = is_first_chunk == False  # noqa: E712
         if cutlass.const_expr(self.use_initial_state):
             valid_state = True
 
@@ -2845,7 +2801,7 @@ class GatedDeltaNetChunkedKernel:
         load_q_releaser.advance()
 
         nv_handle = cg1_shared_acc_producer.acquire_and_advance()
-        vks_handle = vks_ready_consumer.wait_and_advance()
+        vks_ready_consumer.wait_and_advance()
         ainv_handle = a_inv_ready_consumer.wait_and_advance()
         if valid_state:
             for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
@@ -2902,7 +2858,7 @@ class GatedDeltaNetChunkedKernel:
 
         q_state_handle = q_state_acc_producer.acquire_and_advance()
         qkv_qk_handle = qk_ready_consumer.wait_and_advance()
-        qkv_nv_handle = nv_ready_consumer.wait_and_advance()
+        nv_ready_consumer.wait_and_advance()
         for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
             if valid_state:
                 tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, True)
@@ -2922,7 +2878,7 @@ class GatedDeltaNetChunkedKernel:
             if is_first_chunk:
                 kv_acc_producer.advance()
         kv_handle = kv_acc_producer.acquire_and_advance()
-        dv_handle = decay_v_ready_consumer.wait_and_advance()
+        decay_v_ready_consumer.wait_and_advance()
         for kphase_idx in cutlass.range(num_kphases_kv, unroll_full=True):
             if valid_state:
                 tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, True)
@@ -3031,7 +2987,6 @@ class GatedDeltaNetChunkedKernel:
             num_bits_per_copy=128,
         )
         tiled_ainv_r2s = cute.make_tiled_copy_D(atom_ainv_r2s, tiled_shared_t2r)
-        sAinv_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(sAinv)
         if cutlass.const_expr(self.inverse_dtype == self.io_dtype):
             sAinvCal_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
                 sAinvCal
@@ -3981,6 +3936,7 @@ class GatedDeltaNetChunkedKernel:
         self,
         tidx,
         mS_init,
+        mS_indices,
         head_idx,
         batch_idx,
         tmem_ptr,
@@ -4021,8 +3977,12 @@ class GatedDeltaNetChunkedKernel:
         tRT_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
         tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.state_dtype)
 
+        if cutlass.const_expr(mS_indices is not None):
+            state_row = mS_indices[batch_idx]
+        else:
+            state_row = batch_idx
         gS_init = cute.flat_divide(
-            mS_init[None, None, head_idx, batch_idx],
+            mS_init[None, None, head_idx, state_row],
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
         )[None, None, 0, 0]
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
@@ -4057,11 +4017,39 @@ class GatedDeltaNetChunkedKernel:
         return kv_acc_producer
 
     @cute.jit
+    def _store_empty_final_state(
+        self,
+        tidx,
+        mS_init,
+        mS_out,
+        mS_indices,
+        head_idx,
+        batch_idx,
+    ):
+        """Copy initial state to final state for a sequence containing no tokens."""
+        num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
+        cg1_tidx = tidx % num_threads_cg1
+        state_elements = self.mma_tiler_kv[0] * self.mma_tiler_kv[1]
+        if cutlass.const_expr(mS_indices is not None):
+            state_row = mS_indices[batch_idx]
+        else:
+            state_row = batch_idx
+        for linear_idx in cutlass.range(
+            cg1_tidx, state_elements, num_threads_cg1, unroll=1
+        ):
+            key_idx = linear_idx // self.mma_tiler_kv[0]
+            value_idx = linear_idx - key_idx * self.mma_tiler_kv[0]
+            mS_out[value_idx, key_idx, head_idx, state_row] = mS_init[
+                value_idx, key_idx, head_idx, state_row
+            ]
+
+    @cute.jit
     def _store_final_state(
         self,
         tidx,
         # full output-state GMEM tensor (DK, DV, (h_r, h_qv), B) fp32
         mS_out,
+        mS_indices,
         head_idx,
         batch_idx,
         tmem_ptr,
@@ -4110,11 +4098,10 @@ class GatedDeltaNetChunkedKernel:
         tTR_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.acc_dtype)
         tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
 
-        # Wait for last GEMM-7 to finish
+        # Wait for last GEMM-7 to finish.
         kv_acc_handle = kv_acc_consumer.wait_and_advance()
 
         for sub in cutlass.range(tTR_rState.shape[2]):
-            # Read state TMEM -> fp32 registers
             cute.copy(
                 tiled_state_t2r,
                 tTR_tCtState[None, 0, sub, kv_acc_handle.index],
@@ -4134,7 +4121,6 @@ class GatedDeltaNetChunkedKernel:
                             mS_checkpoints[None, None, head_idx, checkpoint_offset],
                             (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
                         )[None, None, 0, 0]
-
                         tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
                         cute.autovec_copy(
                             tRG_rState[None, 0, sub],
@@ -4142,8 +4128,12 @@ class GatedDeltaNetChunkedKernel:
                             l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
                         )
             if cutlass.const_expr(self.store_final_state):
+                if cutlass.const_expr(mS_indices is not None):
+                    state_row = mS_indices[batch_idx]
+                else:
+                    state_row = batch_idx
                 gS_out = cute.flat_divide(
-                    mS_out[None, None, head_idx, batch_idx],
+                    mS_out[None, None, head_idx, state_row],
                     (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
                 )[None, None, 0, 0]
                 tRG_tCgState = thr_state_t2r.partition_D(gS_out)
@@ -4327,9 +4317,7 @@ class GatedDeltaNetChunkedKernel:
             atom_shared_inp_r2t, tCtShared_inp_for_r2t
         )
         thr_shared_inp_r2t = tiled_shared_inp_r2t.get_slice(cg1_tidx)
-        tRT_tCcShared_inp = thr_shared_inp_r2t.partition_S(tCcShared_inp)
         tRT_tCtShared_inp = thr_shared_inp_r2t.partition_D(tCtShared_inp_mn_view)
-        tRT_rShared_inp = cute.make_rmem_tensor_like(tRT_tCcShared_inp, self.io_dtype)
 
         # Dedicated full-tile VKS r2t (separate atom so it can be tuned
         # independently of atom_shared_inp_r2t used by NV/decay_v writes).
@@ -4338,7 +4326,6 @@ class GatedDeltaNetChunkedKernel:
         )
         tiled_vks_r2t = tcgen05.make_tmem_copy(atom_vks_r2t, tCtShared_inp_for_r2t)
         thr_vks_r2t = tiled_vks_r2t.get_slice(cg1_tidx)
-        tRT_tCcVKS_inp = thr_vks_r2t.partition_S(tCcShared_inp)
         tRT_tCtVKS_inp = thr_vks_r2t.partition_D(tCtShared_inp_mn_view)
 
         qs_acc_shape = tiled_mma_qs.partition_shape_C(
@@ -4374,7 +4361,6 @@ class GatedDeltaNetChunkedKernel:
         tTR_rQS = cute.make_rmem_tensor_like(tTR_tCcQS, self.acc_dtype)
 
         tRT_tCcV = thr_shared_inp_r2t.partition_S(tCcShared_inp)
-        tRT_tCtV = thr_shared_inp_r2t.partition_D(tCtShared_inp_mn_view)
         atom_v_s2r = cute.make_copy_atom(
             cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
             self.io_dtype,
@@ -4412,7 +4398,7 @@ class GatedDeltaNetChunkedKernel:
         # Pair membership is derived from the caller-provided chunk index.
         is_pair_first = (chunk_iter & 1) == 0
 
-        valid_state = is_first_chunk == False
+        valid_state = is_first_chunk == False  # noqa: E712
         if cutlass.const_expr(self.use_initial_state):
             valid_state = True
             if is_pair_first:
@@ -4519,12 +4505,14 @@ class GatedDeltaNetChunkedKernel:
         v_handle = load_v_consumer.wait_and_advance()
         tRT_rV = cute.make_rmem_tensor_like(tRT_tCcV, self.io_dtype)
         tCrV = tiled_v_s2r.retile(tRT_rV)
-        if valid_state:
-            cute.copy(
-                tiled_v_s2r,
-                tCsV[None, None, None, v_handle.index],
-                tCrV,
-            )
+        # Always publish V through fixed TMEM slot 0. The SMEM V ring cursor
+        # survives persistent work boundaries, so a new work item cannot
+        # assume that its first V tile resides in SMEM stage 0.
+        cute.copy(
+            tiled_v_s2r,
+            tCsV[None, None, None, v_handle.index],
+            tCrV,
+        )
 
         if valid_state:
             ks_handle = cg1_shared_acc_consumer.wait_and_advance()
@@ -4539,12 +4527,12 @@ class GatedDeltaNetChunkedKernel:
             ks_handle.release()
             for k in cutlass.range(cute.size(tTR_rKS), vectorize=True):
                 tRT_rV[k] = tRT_rV[k] - tTR_rKS[k].to(self.io_dtype)
-            cute.copy(
-                tiled_vks_r2t,
-                tRT_rV,
-                tRT_tCtVKS_inp[None, None, None, 0],
-            )
-            cute.arch.fence_view_async_tmem_store()
+        cute.copy(
+            tiled_vks_r2t,
+            tRT_rV,
+            tRT_tCtVKS_inp[None, None, None, 0],
+        )
+        cute.arch.fence_view_async_tmem_store()
         vks_handle.commit()
 
         if valid_state:

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -160,6 +160,13 @@ def _wrap_tma(ret):
     return TmaInfo(ret[0], ret[1])
 
 
+from cutlass.utils import SmemAllocator, TmemAllocator
+
+try:
+    from cutlass.tensor_utils import LayoutEnum
+except ModuleNotFoundError:
+    from cutlass.utils import LayoutEnum
+
 from .gated_delta_net_tile_scheduler import (
     GDNTileSchedulerParams,
     GDNTileScheduler,
@@ -175,21 +182,22 @@ class GatedDeltaNetChunkedKernel:
     """
     Configuration and execution class for the Chunked GDN kernel.
 
-    Follows the same class-based structure:
+    Main responsibilities:
       - __init__    : warp IDs, barriers, tile shapes, SMEM/TMEM sizes
       - __call__    : @cute.jit host entry point (TMA setup, kernel launch)
       - kernel      : @cute.kernel device entry point (warp dispatch)
       - per-warp methods called from kernel's chunk loop
 
     Args:
-        io_dtype   : input/output dtype (Float16 or BFloat16)
+        io_dtype   : input/output dtype (Float16)
         acc_dtype  : accumulator dtype  (Float32)
-        BT         : chunk size / block tile  (64)
+        b_t        : fixed chunk size / block tile (64)
         DK         : key/query hidden dim     (128)
         DV         : value hidden dim         (128)
     """
 
     # TMA descriptor size in bytes
+    arch = "sm_100"
     bytes_per_tensormap = 128
     num_tensormaps = 4
 
@@ -206,6 +214,7 @@ class GatedDeltaNetChunkedKernel:
         num_sm: int,
         is_GQA: bool,
         use_initial_state: bool,
+        inverse_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         store_final_state: bool = True,
         enable_checkpoints: bool = False,
         is_persistent: bool = True,
@@ -220,6 +229,7 @@ class GatedDeltaNetChunkedKernel:
         self.max_active_clusters = max_active_clusters
         self.num_sm = num_sm
         self.is_GQA = is_GQA
+        self.inverse_dtype = inverse_dtype
         self.use_initial_state = use_initial_state
         self.store_final_state = store_final_state
         self.enable_checkpoints = enable_checkpoints
@@ -234,20 +244,32 @@ class GatedDeltaNetChunkedKernel:
         self.compute_group_1_warp_ids = [4, 5, 6, 7]
         self.mma_warp_id = 8
         self.tma_qkv_warp_id = 9
-        self.load_gate_beta_warp_id = 10
+        # The second issuer owns the five state/output GEMMs.
+        self.mma_cg1_warp_id = 10
         # store O
         self.epilogue_warp_id = 11
+        # The lightly loaded O epilogue warp also prefetches gate/beta.
+        self.load_gate_beta_warp_id = self.epilogue_warp_id
 
+        # Give the MMA/TMA/gate/epilogue warps enough registers to keep their
+        # pipeline handles resident. Fund the increase from CG1 first while
+        # preserving the existing 64,512-register CTA budget.
         self.num_regs_compute_group_0 = 224
         self.num_regs_compute_group_1 = 256
         self.num_regs_other = 24
+        if not self.use_initial_state:
+            # The peeled zero-state MMA carries more pipeline cursors.  Transfer
+            # twenty-four registers from each CG1 warp to each lightweight warp while
+            # retaining the same 64,512-register CTA allocation.
+            self.num_regs_compute_group_1 = 232
+            self.num_regs_other = 48
 
         self.threads_per_cta = 32 * (
             len(
                 (
                     self.mma_warp_id,
                     self.tma_qkv_warp_id,
-                    self.load_gate_beta_warp_id,
+                    self.mma_cg1_warp_id,
                     self.epilogue_warp_id,
                 )
             )
@@ -262,6 +284,7 @@ class GatedDeltaNetChunkedKernel:
         )
         self.occupancy = 1
         self.threads_per_warp = 32
+        self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
         # ------------------------------------------------------------------
         # Named barriers - only TmemAllocator requires a NamedBarrier;
@@ -274,6 +297,7 @@ class GatedDeltaNetChunkedKernel:
             * len(
                 (
                     self.mma_warp_id,
+                    self.mma_cg1_warp_id,
                     *self.compute_group_0_warp_ids,
                     *self.compute_group_1_warp_ids,
                 )
@@ -282,10 +306,6 @@ class GatedDeltaNetChunkedKernel:
         self.inverse_barrier = pipeline.NamedBarrier(
             barrier_id=2,
             num_threads=self.threads_per_warp * len(self.compute_group_0_warp_ids),
-        )
-        self.inverse_barrier_inner = pipeline.NamedBarrier(
-            barrier_id=3,
-            num_threads=self.threads_per_warp * 2,
         )
         self.init_state_store_barrier = pipeline.NamedBarrier(
             barrier_id=4,
@@ -296,16 +316,27 @@ class GatedDeltaNetChunkedKernel:
         # ------------------------------------------------------------------
         # SMEM sizes (bytes per stage) and stage counts
         # ------------------------------------------------------------------
-        self.smem_q_stages = 1
-        self.smem_k_stages = 2
-        self.smem_v_stages = 1
-        self.smem_ainv_stages = 1
-        self.smem_qk_stages = 1
-        self.smem_o_stages = 1
-        self.smem_group_order_stages = 1
-        # Cumulative gate buffers - placed last in SMEM
-        self.smem_gate_stages = 1
-        self.smem_beta_stages = 1
+        self.smem_q_stages = 2
+        # Four K stages let TMA make K3 available while K0 remains live for
+        # KV0, so the next pair's KK0/KK1 can be issued back-to-back.
+        self.smem_k_stages = 4
+        # Three V stages both break the double-KK lookahead dependency cycle
+        # and let TMA stay ahead while CG1 consumes the current pair.
+        self.smem_v_stages = 3
+        # Mid-pair KK lookahead overlaps next-pair inverse preparation with the
+        # current second chunk.  NV0 has released current Ainv0 by then, so the
+        # live set is current Ainv1 plus next Ainv0/1: three stages total.
+        self.smem_ainv_stages = 3
+        self.smem_qk_stages = 2
+        # Gate/beta work now shares the epilogue warp, so O uses two stages to
+        # avoid back-pressuring CG1 while the warp publishes the next gate.
+        self.smem_o_stages = 2
+        # Five resident stages preserve four chunks of gate/beta lookahead.
+        # Cumulative gate buffers are placed last in SMEM.
+        self.smem_gate_stages = 5
+        # Let the scalar producer enter the next pair after CG0 releases beta0
+        # instead of waiting for both current-pair beta stages.
+        self.smem_beta_stages = 5
 
         # ------------------------------------------------------------------
         # TMEM column offsets and buffer sizes (fp32, 32B per column)
@@ -314,7 +345,10 @@ class GatedDeltaNetChunkedKernel:
         self.tmem_q_state_acc_stages = 1
         self.tmem_state_inp_stages = 1
         self.tmem_shared_inp_stages = 2
-        self.tmem_shared_acc_stages = 2
+        # CG0 owns KK/QK and CG1 owns KS/NV.  Separate rings remove the
+        # cross-group ownership handoff from the shared-acc critical path.
+        self.tmem_cg0_shared_acc_stages = 2
+        self.tmem_cg1_shared_acc_stages = 1
 
         self.tmem_state_offset = 0
         self.tmem_q_state_offset = (
@@ -323,11 +357,14 @@ class GatedDeltaNetChunkedKernel:
         self.tmem_state_inp_offset = (
             self.tmem_q_state_offset + self.tmem_q_state_acc_stages * 64
         )
-        self.tmem_shared_acc_offset = (
+        self.tmem_cg0_shared_acc_offset = (
             self.tmem_state_inp_offset + self.tmem_state_inp_stages * 64
         )
+        self.tmem_cg1_shared_acc_offset = (
+            self.tmem_cg0_shared_acc_offset + self.tmem_cg0_shared_acc_stages * 64
+        )
         self.tmem_shared_inp_offset = (
-            self.tmem_shared_acc_offset + self.tmem_shared_acc_stages * 64
+            self.tmem_cg1_shared_acc_offset + self.tmem_cg1_shared_acc_stages * 64
         )
 
         self.buffer_align_bytes = 1024
@@ -387,7 +424,6 @@ class GatedDeltaNetChunkedKernel:
         cu_seqlens: cute.Tensor,
         s_in: Optional[cute.Tensor],
         s_out: Optional[cute.Tensor],
-        s_indices: Optional[cute.Tensor],
         s_checkpoints: Optional[cute.Tensor],
         cu_checkpoints: Optional[cute.Tensor],
         checkpoint_every_n_tokens: cutlass.Int32,
@@ -605,9 +641,23 @@ class GatedDeltaNetChunkedKernel:
         v_smem_layout_staged = sm100_utils.make_smem_layout_a(
             tiled_mma_qkv_ss, self.mma_tiler_qkv, self.io_dtype, self.smem_v_stages
         )
-        # A_inv is B operand for tiled_mma_qkv (GEMM 5: new_v: V @ A_inv);
+        # A_inv is B operand for tiled_mma_qkv (GEMM 5: new_v: V @ A_inv).
         ainv_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            tiled_mma_qkv, self.mma_tiler_qkv, self.io_dtype, self.smem_ainv_stages
+            tiled_mma_qkv,
+            self.mma_tiler_qkv,
+            self.io_dtype,
+            self.smem_ainv_stages,
+        )
+        ainv_cal_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma_qkv,
+            self.mma_tiler_qkv,
+            self.inverse_dtype,
+            self.smem_ainv_stages,
+        )
+        ainv_cal_smem_elements = (
+            0
+            if self.inverse_dtype == self.io_dtype
+            else cute.cosize(ainv_cal_smem_layout_staged)
         )
         # W_qkv is A operand for tiled_mma_qkv (GEMM 6: qkv: NV @ qk)
         qk_smem_layout_staged = sm100_utils.make_smem_layout_b(
@@ -616,7 +666,7 @@ class GatedDeltaNetChunkedKernel:
 
         o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
             self.io_dtype,
-            utils.LayoutEnum.from_tensor(o),
+            cutlass.utils.LayoutEnum.from_tensor(o),
             self.mma_tiler_qkv[:2],
             self.smem_o_stages,
         )
@@ -632,17 +682,17 @@ class GatedDeltaNetChunkedKernel:
         @cute.struct
         class SharedStorage:
             # Pipeline mbarriers - one entry per stage, 2 Int64 words per barrier
-            # TMA load warp -> MMA warp (K double-buffered)
+            # TMA load warp -> MMA warp (K is staged for next-chunk prefetch)
             load_k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_k_stages * 2]
             # TMA load warp -> MMA warp
             load_q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_q_stages * 2]
-            # TMA load warp -> MMA warp
+            # TMA load warp -> CG1 V-load signal
             load_v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.smem_v_stages * 2]
-            # TMA gate warp -> CG0/CG1
+            # Gate/beta load warp -> CG0/CG1
             load_gate_mbar_ptr: cute.struct.MemRange[
                 cutlass.Int64, self.smem_gate_stages * 2
             ]
-            # TMA beta warp -> CG0
+            # Gate/beta load warp -> CG0
             load_beta_mbar_ptr: cute.struct.MemRange[
                 cutlass.Int64, self.smem_beta_stages * 2
             ]
@@ -654,9 +704,13 @@ class GatedDeltaNetChunkedKernel:
             kv_acc_mbar_ptr: cute.struct.MemRange[
                 cutlass.Int64, self.tmem_kv_acc_stages * 2
             ]
-            # MMA warp -> CG0/CG1 (GEMM 1-6 done)
-            shared_acc_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.tmem_shared_acc_stages * 2
+            # MMA warp -> CG0 (KK/QK ready)
+            cg0_shared_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_cg0_shared_acc_stages * 2
+            ]
+            # MMA warp -> CG1 (KS/NV ready)
+            cg1_shared_acc_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.tmem_cg1_shared_acc_stages * 2
             ]
             # CG0 -> MMA warp (A_inv ready in SMEM)
             ainv_ready_mbar_ptr: cute.struct.MemRange[
@@ -669,17 +723,14 @@ class GatedDeltaNetChunkedKernel:
             state_inp_ready_mbar_ptr: cute.struct.MemRange[
                 cutlass.Int64, self.tmem_state_inp_stages * 2
             ]
-            # CG1 -> MMA warp (state input ready in SMEM)
-            shared_inp_ready_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.tmem_shared_inp_stages * 2
-            ]
+            # CG1 -> MMA warp: fixed-slot TMEM inputs.  The empty halves are
+            # unused because downstream accumulator-full signals prove reuse.
+            vks_ready_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            nv_ready_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            decay_v_ready_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
             # CG1 -> epilogue warp
             o_store_mbar_ptr: cute.struct.MemRange[
                 cutlass.Int64, self.smem_o_stages * 2
-            ]
-            # CG0 -> CG1 (group order)
-            group_order_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.smem_group_order_stages * 2
             ]
             # TMEM allocation token
             tmem_holding_buf: cutlass.Int32
@@ -697,11 +748,17 @@ class GatedDeltaNetChunkedKernel:
                 cute.struct.MemRange[self.io_dtype, cute.cosize(v_smem_layout_staged)],
                 self.buffer_align_bytes,
             ]
-            # A_inv result, then overwritten with fp16 NV
+            # A_inv result consumed by the next MMA; keep this in io_dtype.
             sAinv: cute.struct.Align[
                 cute.struct.MemRange[
                     self.io_dtype, cute.cosize(ainv_smem_layout_staged)
                 ],
+                self.buffer_align_bytes,
+            ]
+            # Optional inverse scratch buffer. Default inverse_dtype == io_dtype
+            # aliases sAinv and allocates no extra SMEM.
+            sAinvCal: cute.struct.Align[
+                cute.struct.MemRange[self.inverse_dtype, ainv_cal_smem_elements],
                 self.buffer_align_bytes,
             ]
             # W_qk scores
@@ -764,8 +821,8 @@ class GatedDeltaNetChunkedKernel:
             )
         )
 
-        cumsumlog_smem_layout = cute.select(cumsumlog_smem_layout_staged, mode=[0])  # noqa: F841
-        beta_smem_layout = cute.select(beta_smem_layout_staged, mode=[0])  # noqa: F841
+        cumsumlog_smem_layout = cute.select(cumsumlog_smem_layout_staged, mode=[0])
+        beta_smem_layout = cute.select(beta_smem_layout_staged, mode=[0])
 
         o_smem_layout = cute.select(o_smem_layout_staged, mode=[0, 1])
         tma_o = _wrap_tma(
@@ -811,7 +868,6 @@ class GatedDeltaNetChunkedKernel:
             cu_seqlens,
             s_in,
             s_out,
-            s_indices,
             s_checkpoints,
             cu_checkpoints,
             checkpoint_every_n_tokens,
@@ -823,6 +879,7 @@ class GatedDeltaNetChunkedKernel:
             cumsumlog_smem_layout_staged,
             beta_smem_layout_staged,
             ainv_smem_layout_staged,
+            ainv_cal_smem_layout_staged,
             qk_smem_layout_staged,
             o_smem_layout_staged,
             scheduler_params,
@@ -835,7 +892,7 @@ class GatedDeltaNetChunkedKernel:
             grid=grid_shape,
             block=(self.threads_per_cta, 1, 1),
             cluster=self.cluster_shape_mnk,
-            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
+            smem=self.shared_storage.size_in_bytes(),
             stream=stream,
             min_blocks_per_mp=1,
         )
@@ -871,9 +928,6 @@ class GatedDeltaNetChunkedKernel:
         mS_init: Optional[cute.Tensor],
         # final state output (fp32) to GMEM; None if not stored
         mS_out: Optional[cute.Tensor],
-        # optional (num_seqs,) int32 indirection into the state pool rows; None
-        # means identity (row == batch_idx), preserving legacy behavior
-        mS_indices: Optional[cute.Tensor],
         mS_checkpoints: Optional[cute.Tensor],
         cu_checkpoints: Optional[cute.Tensor],
         checkpoint_every_n_tokens: cutlass.Int32,
@@ -886,18 +940,19 @@ class GatedDeltaNetChunkedKernel:
         cumsumlog_smem_layout_staged: cute.Layout,
         beta_smem_layout_staged: cute.Layout,
         ainv_smem_layout_staged: cute.ComposedLayout,
+        ainv_cal_smem_layout_staged: cute.ComposedLayout,
         qk_smem_layout_staged: cute.ComposedLayout,
         o_smem_layout_staged: cute.ComposedLayout,
         # Scheduler
         scheduler_params: GDNTileSchedulerParams,
-        # TMA descriptor workspace in GMEM (one set of 5 slots per CTA)
-        # Slots: Q=0, K[0]=1, K[1]=2, V=3, O=4  (each slot = bytes_per_tensormap = 16xInt64)
+        # TMA descriptor workspace in GMEM (one q/k/v/o descriptor set per CTA)
+        # Slots: Q=0, K=1, V=2, O=3
         mQ,
         mK,
         mV,
         # used for TMA descriptor update
         mO,
-        # (num_ctas, 3+smem_k_stages, 16) Int64
+        # (num_ctas, num_tensormaps, bytes_per_tensormap) Int8 workspace
         tensormap_workspace: cute.Tensor,
     ):
         """
@@ -926,8 +981,8 @@ class GatedDeltaNetChunkedKernel:
             assert mS_out is None, "mS_out must be None if store_final_state is False"
 
         # ------------------------------------------------------------------
-        # TMA descriptor GMEM workspace - one set of 5 ptrs per CTA
-        # Slots: Q=0, K[0]=1, K[1]=2, V=3, O=4
+        # TMA descriptor GMEM workspace - one q/k/v/o descriptor set per CTA.
+        # Slots: Q=0, K=1, V=2, O=3.
         # ------------------------------------------------------------------
         cta_linear_idx = bidz * grid_dim[1] * grid_dim[0] + bidy * grid_dim[0] + bidx
 
@@ -967,10 +1022,17 @@ class GatedDeltaNetChunkedKernel:
         sV = storage.sV.get_tensor(
             v_smem_layout_staged.outer, swizzle=v_smem_layout_staged.inner
         )
-        # A_inverse / new_v  (A_inv written first, then overwritten with fp16 NV)
+        # A_inverse MMA input.
         sAinv = storage.sAinv.get_tensor(
             ainv_smem_layout_staged.outer, swizzle=ainv_smem_layout_staged.inner
         )
+        if cutlass.const_expr(self.inverse_dtype == self.io_dtype):
+            sAinvCal = sAinv
+        else:
+            sAinvCal = storage.sAinvCal.get_tensor(
+                ainv_cal_smem_layout_staged.outer,
+                swizzle=ainv_cal_smem_layout_staged.inner,
+            )
         # QK output / O store  (W_qk first, then O epilogue staging)
         sQk = storage.sQk.get_tensor(
             qk_smem_layout_staged.outer, swizzle=qk_smem_layout_staged.inner
@@ -990,10 +1052,10 @@ class GatedDeltaNetChunkedKernel:
             cpasync.prefetch_descriptor(tma_o.atom)
 
         # TMEM allocator object - CG1 will issue the actual allocation
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.utils.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
-            # Correction warp is the last one that accesses tmem
+            # CG1 owns allocation and is the last group to release TMEM state.
             allocator_warp_id=self.compute_group_1_warp_ids[0],
         )
 
@@ -1007,10 +1069,11 @@ class GatedDeltaNetChunkedKernel:
 
         # 1 thread (TMA issuer)
         cg_tma = _cg(len([self.tma_qkv_warp_id]))
-        # 1 warp (gate/beta ldg/ldgsts warp)
+        # 1 warp (gate/beta scalar load warp)
         cg_gate = _cg(self.threads_per_warp * len([self.load_gate_beta_warp_id]))
-        # 1 thread (UMMA issuer)
+        # One producer per result pipeline; K/Q are consumed by both issuers.
         cg_mma = _cg(len([self.mma_warp_id]))
+        cg_mma_both = _cg(len([self.mma_warp_id, self.mma_cg1_warp_id]))
         # 128 threads (CG0)
         cg_cg0 = _cg(self.threads_per_warp * len(self.compute_group_0_warp_ids))
         # 128 threads (CG1)
@@ -1025,11 +1088,11 @@ class GatedDeltaNetChunkedKernel:
         # 32 threads (epilogue warp)
         cg_epi = _cg(self.threads_per_warp * len([self.epilogue_warp_id]))
 
-        # TMA load -> MMA:  K (double-buffered), Q, V
+        # TMA load pipelines: K/Q feed MMA; V is signaled to CG1 for ALU work.
         load_k_producer, load_k_consumer = pipeline.PipelineTmaUmma.create(
             num_stages=self.smem_k_stages,
             producer_group=cg_tma,
-            consumer_group=cg_mma,
+            consumer_group=cg_mma_both,
             tx_count=self.tma_k_bytes,
             barrier_storage=storage.load_k_mbar_ptr.data_ptr(),
             defer_sync=True,
@@ -1038,7 +1101,7 @@ class GatedDeltaNetChunkedKernel:
         load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
             num_stages=self.smem_q_stages,
             producer_group=cg_tma,
-            consumer_group=cg_mma,
+            consumer_group=cg_mma_both,
             tx_count=self.tma_q_bytes,
             barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
             defer_sync=True,
@@ -1051,8 +1114,8 @@ class GatedDeltaNetChunkedKernel:
             barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
             defer_sync=True,
         ).make_participants()
-        # Gate warp (warp 10) -> CG0 / CG1:  gate/beta (PipelineAsync, software-signaled)
-        # ldg/ldgsts paths do not use TMA barriers; producer calls commit() after writes.
+        # Unified loader warp 9 -> CG0 / CG1: gate/beta (software-signaled)
+        # Scalar-load paths do not use TMA barriers; producer calls commit() after writes.
         load_gate_producer, load_gate_consumer = pipeline.PipelineAsync.create(
             num_stages=self.smem_gate_stages,
             producer_group=cg_gate,
@@ -1087,14 +1150,27 @@ class GatedDeltaNetChunkedKernel:
             defer_sync=True,
         ).make_participants()
 
-        # MMA warp -> CG0/CG1:  shared_acc
-        shared_acc_producer, shared_acc_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.tmem_shared_acc_stages,
-            producer_group=cg_mma,
-            consumer_group=cg_cg0,
-            barrier_storage=storage.shared_acc_mbar_ptr.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
+        # MMA warp -> CG0: KK/QK accumulator ring.
+        cg0_shared_acc_producer, cg0_shared_acc_consumer = (
+            pipeline.PipelineUmmaAsync.create(
+                num_stages=self.tmem_cg0_shared_acc_stages,
+                producer_group=cg_mma,
+                consumer_group=cg_cg0,
+                barrier_storage=storage.cg0_shared_acc_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
+
+        # MMA warp -> CG1: KS/NV accumulator ring.
+        cg1_shared_acc_producer, cg1_shared_acc_consumer = (
+            pipeline.PipelineUmmaAsync.create(
+                num_stages=self.tmem_cg1_shared_acc_stages,
+                producer_group=cg_mma,
+                consumer_group=cg_cg1,
+                barrier_storage=storage.cg1_shared_acc_mbar_ptr.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+        )
 
         # CG0 -> MMA warp:  a_inv_done
         a_inv_ready_producer, a_inv_ready_consumer = pipeline.PipelineAsyncUmma.create(
@@ -1114,7 +1190,7 @@ class GatedDeltaNetChunkedKernel:
             defer_sync=True,
         ).make_participants()
 
-        # CG1 -> MMA warp:  state_inp_ready
+        # CG1 -> MMA warp: state input.
         state_inp_ready_producer, state_inp_ready_consumer = (
             pipeline.PipelineAsyncUmma.create(
                 num_stages=self.tmem_state_inp_stages,
@@ -1125,13 +1201,27 @@ class GatedDeltaNetChunkedKernel:
             ).make_participants()
         )
 
-        # CG1 -> MMA warp:  shared_inp_ready
-        shared_inp_ready_producer, shared_inp_ready_consumer = (
+        # CG1 -> MMA warp: fixed-slot, ready-only input notifications.
+        vks_ready_producer, vks_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg1,
+            consumer_group=cg_mma,
+            barrier_storage=storage.vks_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        nv_ready_producer, nv_ready_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=cg_cg1,
+            consumer_group=cg_mma,
+            barrier_storage=storage.nv_ready_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        decay_v_ready_producer, decay_v_ready_consumer = (
             pipeline.PipelineAsyncUmma.create(
-                num_stages=self.tmem_shared_inp_stages,
+                num_stages=1,
                 producer_group=cg_cg1,
                 consumer_group=cg_mma,
-                barrier_storage=storage.shared_inp_ready_mbar_ptr.data_ptr(),
+                barrier_storage=storage.decay_v_ready_mbar_ptr.data_ptr(),
                 defer_sync=True,
             ).make_participants()
         )
@@ -1142,14 +1232,6 @@ class GatedDeltaNetChunkedKernel:
             producer_group=cg_cg1,
             consumer_group=cg_epi,
             barrier_storage=storage.o_store_mbar_ptr.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-
-        group_order_producer, group_order_consumer = pipeline.PipelineAsync.create(
-            num_stages=self.smem_group_order_stages,
-            producer_group=cg_cg0,
-            consumer_group=cg_cg1,
-            barrier_storage=storage.group_order_mbar_ptr.data_ptr(),
             defer_sync=True,
         ).make_participants()
 
@@ -1180,41 +1262,51 @@ class GatedDeltaNetChunkedKernel:
                 batch_idx, head_idx, _ = work.tile_idx
                 batch_start = cu_seqlens[batch_idx]
                 seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
-                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                num_pairs = 2
+                num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
 
                 sQk_pisl = self._transform_to_position_independent_layout(
                     sQk, qk_smem_layout_staged.inner
                 )
-                # First chunk: no previous state (S_prev = 0), skip GEMMs 3/4
-                for chunk_idx in cutlass.range(num_chunks_b):
+                sAinv_pisl = self._transform_to_position_independent_layout(
+                    sAinv, ainv_smem_layout_staged.inner
+                )
+                cg0_smem_args = (
+                    sCumsumlog,
+                    sBeta,
+                    sAinv_pisl,
+                    sAinvCal,
+                    sQk_pisl,
+                )
+                # Runtime first/last predicates keep one pair body in SASS instead
+                # of peeling a complete first-pair copy before the steady loop.
+                for pair_idx in cutlass.range(num_pairs_b):
                     (
                         load_gate_consumer,
                         load_beta_consumer,
-                        shared_acc_consumer,
+                        cg0_shared_acc_consumer,
                         a_inv_ready_producer,
                         qk_ready_producer,
-                        group_order_producer,
-                    ) = self.compute_group_0(
+                    ) = self.compute_group_0_pair(
                         tidx,
                         tmem_ptr,
                         scale,
                         (tiled_mma_qk,),
-                        (sCumsumlog, sBeta, sAinv, sQk_pisl),
+                        cg0_smem_args,
                         (
                             load_gate_consumer,
                             load_beta_consumer,
-                            shared_acc_consumer,
+                            cg0_shared_acc_consumer,
                             a_inv_ready_producer,
                             qk_ready_producer,
-                            group_order_producer,
                         ),
-                        (chunk_idx == 0,),
+                        (pair_idx == 0, pair_idx < num_pairs_b - 1),
                     )
+
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
             a_inv_ready_producer.tail()
             qk_ready_producer.tail()
-            group_order_producer.tail()
 
         # ==============================================================
         # COMPUTE WARP GROUP 1 (warps 4-7)
@@ -1224,8 +1316,8 @@ class GatedDeltaNetChunkedKernel:
             and warp_idx <= self.compute_group_1_warp_ids[-1]
         ):
             cute.arch.setmaxregister_increase(self.num_regs_compute_group_1)
-            # Total TMEM columns: state(128) + q_state_acc(128) + shared_acc(128x2) = 512
-            tmem.allocate(cute.arch.get_max_tmem_alloc_cols("sm_100"))
+            # Total TMEM columns: state + q_state_acc + shared_acc + input staging.
+            tmem.allocate(self.tmem_alloc_cols)
             tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
 
@@ -1239,127 +1331,93 @@ class GatedDeltaNetChunkedKernel:
                 seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
                 num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
                 checkpoint_offset = 0
+                if cutlass.const_expr(self.enable_checkpoints):
+                    checkpoint_offset = cu_checkpoints[batch_idx]
+                if cutlass.const_expr(self.use_initial_state):
+                    kv_acc_producer = self._load_initial_state(
+                        tidx,
+                        mS_init,
+                        head_idx,
+                        batch_idx,
+                        tmem_ptr,
+                        tiled_mma_kv,
+                        kv_acc_producer,
+                    )
                 sV_pisl = self._transform_to_position_independent_layout(
                     sV, v_smem_layout_staged.inner
                 )
                 sO_pisl = self._transform_to_position_independent_layout(
                     sO, o_smem_layout_staged.inner
                 )
-                if num_chunks_b > 0:
-                    if cutlass.const_expr(self.enable_checkpoints):
-                        checkpoint_offset = cu_checkpoints[batch_idx]
-                    if cutlass.const_expr(self.use_initial_state):
-                        kv_acc_producer = self._load_initial_state(
-                            tidx,
-                            mS_init,
-                            mS_indices,
-                            head_idx,
-                            batch_idx,
-                            tmem_ptr,
-                            tiled_mma_kv,
-                            kv_acc_producer,
-                        )
+                num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
+                num_chunks_padded = num_pairs_b * 2
+                is_first_chunk = True
+                for chunk_iter in cutlass.range(num_chunks_padded):
                     (
                         load_v_consumer,
                         load_gate_consumer,
-                        shared_acc_consumer,
+                        cg1_shared_acc_consumer,
                         kv_acc_consumer,
                         q_state_acc_consumer,
-                        group_order_consumer,
                         kv_acc_producer,
                         state_inp_ready_producer,
-                        shared_inp_ready_producer,
-                        o_store_producer,
-                        checkpoint_idx,
-                    ) = self.compute_group_1(
-                        tidx,
-                        tmem_ptr,
-                        scale,
-                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
-                        (
-                            sV_pisl,
-                            sCumsumlog,
-                            sCumprod,
-                            sBeta,
-                            sO_pisl,
-                        ),
-                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
-                        (
-                            load_v_consumer,
-                            load_gate_consumer,
-                            shared_acc_consumer,
-                            kv_acc_consumer,
-                            q_state_acc_consumer,
-                            group_order_consumer,
-                            kv_acc_producer,
-                            state_inp_ready_producer,
-                            shared_inp_ready_producer,
-                            o_store_producer,
-                        ),
-                        (True, 0, head_idx),
-                    )
-                for chunk_idx in cutlass.range(1, num_chunks_b):
-                    chunk_offset = batch_start + chunk_idx * self.b_t
-                    (
-                        load_v_consumer,
-                        load_gate_consumer,
-                        shared_acc_consumer,
-                        kv_acc_consumer,
-                        q_state_acc_consumer,
-                        group_order_consumer,
-                        kv_acc_producer,
-                        state_inp_ready_producer,
-                        shared_inp_ready_producer,
+                        vks_ready_producer,
+                        nv_ready_producer,
+                        decay_v_ready_producer,
                         o_store_producer,
                         checkpoint_offset,
-                    ) = self.compute_group_1(
+                    ) = self.compute_group_1_chunk(
                         tidx,
                         tmem_ptr,
                         scale,
                         (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                        (sV_pisl, sCumsumlog, sCumprod, sBeta, sO_pisl),
                         (
-                            sV_pisl,
-                            sCumsumlog,
-                            sCumprod,
-                            sBeta,
-                            sO_pisl,
-                        ),
-                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
-                        (
-                            load_v_consumer,
-                            load_gate_consumer,
-                            shared_acc_consumer,
-                            kv_acc_consumer,
-                            q_state_acc_consumer,
-                            group_order_consumer,
-                            kv_acc_producer,
-                            state_inp_ready_producer,
-                            shared_inp_ready_producer,
-                            o_store_producer,
-                        ),
-                        (False, chunk_idx, head_idx),
-                    )
-                if num_chunks_b > 0:
-                    if cutlass.const_expr(
-                        self.store_final_state or self.enable_checkpoints
-                    ):
-                        kv_acc_consumer = self._store_final_state(
-                            tidx,
-                            mS_out,
-                            mS_indices,
-                            head_idx,
-                            batch_idx,
-                            tmem_ptr,
-                            tiled_mma_kv,
-                            kv_acc_consumer,
-                            seqlen_b,
                             mS_checkpoints,
                             checkpoint_offset,
                             checkpoint_every_n_tokens,
-                        )
-                    else:
-                        kv_acc_handle = kv_acc_consumer.wait_and_advance()
-                        kv_acc_handle.release()
+                        ),
+                        (
+                            load_v_consumer,
+                            load_gate_consumer,
+                            cg1_shared_acc_consumer,
+                            kv_acc_consumer,
+                            q_state_acc_consumer,
+                            kv_acc_producer,
+                            state_inp_ready_producer,
+                            vks_ready_producer,
+                            nv_ready_producer,
+                            decay_v_ready_producer,
+                            o_store_producer,
+                        ),
+                        (
+                            chunk_iter,
+                            num_pairs_b,
+                            head_idx,
+                            seqlen_b,
+                            is_first_chunk,
+                        ),
+                    )
+                    is_first_chunk = False
+                if cutlass.const_expr(
+                    self.store_final_state or self.enable_checkpoints
+                ):
+                    kv_acc_consumer = self._store_final_state(
+                        tidx,
+                        mS_out,
+                        head_idx,
+                        batch_idx,
+                        tmem_ptr,
+                        tiled_mma_kv,
+                        kv_acc_consumer,
+                        seqlen_b,
+                        mS_checkpoints,
+                        checkpoint_offset,
+                        checkpoint_every_n_tokens,
+                    )
+                else:
+                    kv_acc_handle = kv_acc_consumer.wait_and_advance()
+                    kv_acc_handle.release()
 
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
@@ -1367,109 +1425,60 @@ class GatedDeltaNetChunkedKernel:
             tmem.relinquish_alloc_permit()
             tmem.free(tmem_ptr)
 
-            shared_inp_ready_producer.tail()
             o_store_producer.tail()
             state_inp_ready_producer.tail()
 
         # ==============================================================
-        # MMA WARP (warp 8)
+        # CG0 MMA ISSUER (warp 8: KK/QK)
         # ==============================================================
         elif warp_idx == self.mma_warp_id:
             cute.arch.setmaxregister_decrease(self.num_regs_other)
-
             tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
-            scheduler = GDNTileScheduler.create(
-                scheduler_params, (bidx, bidy, bidz), grid_dim
+            self.mma_cg0_issuer_warp(
+                tmem_ptr,
+                scheduler_params,
+                (bidx, bidy, bidz),
+                grid_dim,
+                cu_seqlens,
+                (tiled_mma_qk, tiled_mma_qkv),
+                (sQ, sK),
+                (
+                    cg0_shared_acc_producer,
+                    load_k_consumer,
+                    load_q_consumer,
+                ),
             )
-            work = scheduler.initial_work_tile_info()
-            while work.is_valid_tile:
-                batch_idx, head_idx, _ = work.tile_idx
-                batch_start = cu_seqlens[batch_idx]
-                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
-                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
-                # First chunk: no previous state (S_prev = 0), skip GEMMs 3/4.
-                chunk_offset = batch_start
-                if num_chunks_b > 0:
-                    (
-                        shared_acc_producer,
-                        q_state_acc_producer,
-                        kv_acc_producer,
-                        load_k_consumer,
-                        load_q_consumer,
-                        load_v_consumer,
-                        a_inv_ready_consumer,
-                        qk_ready_consumer,
-                        state_inp_ready_consumer,
-                        shared_inp_ready_consumer,
-                    ) = self.mma_warp(
-                        tmem_ptr,
-                        (
-                            tiled_mma_qk,
-                            tiled_mma_qs,
-                            tiled_mma_qkv,
-                            tiled_mma_qkv_ss,
-                            tiled_mma_kv,
-                        ),
-                        (sQ, sK, sK_trans, sV, sAinv, sQk),
-                        (
-                            shared_acc_producer,
-                            q_state_acc_producer,
-                            kv_acc_producer,
-                            load_k_consumer,
-                            load_q_consumer,
-                            load_v_consumer,
-                            a_inv_ready_consumer,
-                            qk_ready_consumer,
-                            state_inp_ready_consumer,
-                            shared_inp_ready_consumer,
-                        ),
-                        (True,),
-                    )
-                # Main loop: chunks 1..num_chunks_b-1 with previous state.
-                for chunk_idx in cutlass.range(1, num_chunks_b):  # noqa: B007
-                    (
-                        shared_acc_producer,
-                        q_state_acc_producer,
-                        kv_acc_producer,
-                        load_k_consumer,
-                        load_q_consumer,
-                        load_v_consumer,
-                        a_inv_ready_consumer,
-                        qk_ready_consumer,
-                        state_inp_ready_consumer,
-                        shared_inp_ready_consumer,
-                    ) = self.mma_warp(
-                        tmem_ptr,
-                        (
-                            tiled_mma_qk,
-                            tiled_mma_qs,
-                            tiled_mma_qkv,
-                            tiled_mma_qkv_ss,
-                            tiled_mma_kv,
-                        ),
-                        (sQ, sK, sK_trans, sV, sAinv, sQk),
-                        (
-                            shared_acc_producer,
-                            q_state_acc_producer,
-                            kv_acc_producer,
-                            load_k_consumer,
-                            load_q_consumer,
-                            load_v_consumer,
-                            a_inv_ready_consumer,
-                            qk_ready_consumer,
-                            state_inp_ready_consumer,
-                            shared_inp_ready_consumer,
-                        ),
-                        (False,),
-                    )
 
-                scheduler.advance_to_next_work()
-                work = scheduler.get_current_work()
-
-            shared_acc_producer.tail()
-            q_state_acc_producer.tail()
-            kv_acc_producer.tail()
+        # ==============================================================
+        # CG1 MMA ISSUER (warp 10: KS/QS/NV/QKV/KV)
+        # ==============================================================
+        elif warp_idx == self.mma_cg1_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            self.mma_cg1_issuer_warp(
+                tmem_ptr,
+                scheduler_params,
+                (bidx, bidy, bidz),
+                grid_dim,
+                cu_seqlens,
+                (tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv),
+                (sQ, sK, sK_trans, sV, sAinv, sQk),
+                (
+                    cg1_shared_acc_producer,
+                    q_state_acc_producer,
+                    kv_acc_producer,
+                    load_k_consumer,
+                    load_q_consumer,
+                    a_inv_ready_consumer,
+                    qk_ready_consumer,
+                    state_inp_ready_consumer,
+                    vks_ready_consumer,
+                    nv_ready_consumer,
+                    decay_v_ready_consumer,
+                ),
+            )
 
         # ==============================================================
         # TMA LOAD WARP (warp 9)
@@ -1499,7 +1508,10 @@ class GatedDeltaNetChunkedKernel:
                 batch_start = cu_seqlens[batch_idx]
                 batch_end = cu_seqlens[batch_idx + 1]
                 seqlen_b = batch_end - batch_start
-                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                num_pairs = 2
+                num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
+                num_chunks_b = num_pairs_b * num_pairs
+                num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
 
                 # Build bounded tensors: same ptr/strides, token dim capped to batch_end
                 bounded_q = cute.make_tensor(
@@ -1523,17 +1535,17 @@ class GatedDeltaNetChunkedKernel:
                         stride=(mV.stride[0], mV.stride[1], mV.stride[2]),
                     ),
                 )
-                if num_chunks_b > 0:
-                    # Update K/Q/V descriptors
-                    tensormap_manager.update_tensormap(
-                        (bounded_q, bounded_k, bounded_v),
-                        (tma_q.atom, tma_k.atom, tma_v.atom),
-                        (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
-                        self.tma_qkv_warp_id,
-                        (None, None, None),
-                    )
+                # Update K/Q/V descriptors
+                tensormap_manager.update_tensormap(
+                    (bounded_q, bounded_k, bounded_v),
+                    (tma_q.atom, tma_k.atom, tma_v.atom),
+                    (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
+                    self.tma_qkv_warp_id,
+                    (None, None, None),
+                )
 
-                for chunk_idx in cutlass.range(num_chunks_b):
+                # Warp 9 now owns only the Q/K/V TMA stream.
+                for chunk_idx in cutlass.range(num_valid_chunks_b - 1):
                     chunk_offset = batch_start + chunk_idx * self.b_t
                     load_q_producer, load_k_producer, load_v_producer = (
                         self.tma_qkv_warp(
@@ -1550,7 +1562,40 @@ class GatedDeltaNetChunkedKernel:
                             ),
                         )
                     )
-
+                chunk_idx = num_valid_chunks_b - 1
+                chunk_offset = batch_start + chunk_idx * self.b_t
+                load_q_producer, load_k_producer, load_v_producer = self.tma_qkv_warp(
+                    (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
+                    (tma_q, tma_k, tma_v),
+                    (sQ, sK, sV),
+                    (load_q_producer, load_k_producer, load_v_producer),
+                    (chunk_offset, chunk_idx, batch_idx, head_idx),
+                    (
+                        tensormap_manager,
+                        tensormap_q_ptr,
+                        tensormap_k_ptr,
+                        tensormap_v_ptr,
+                    ),
+                )
+                # A padded second chunk keeps every consumer's two-chunk pair
+                # cadence aligned while gate/beta produce neutral values.
+                for chunk_idx in cutlass.range(num_valid_chunks_b, num_chunks_b):
+                    chunk_offset = batch_start + chunk_idx * self.b_t
+                    load_q_producer, load_k_producer, load_v_producer = (
+                        self.tma_qkv_warp(
+                            (tiled_mma_qk, tiled_mma_qkv_ss, tiled_mma_kv),
+                            (tma_q, tma_k, tma_v),
+                            (sQ, sK, sV),
+                            (load_q_producer, load_k_producer, load_v_producer),
+                            (chunk_offset, chunk_idx, batch_idx, head_idx),
+                            (
+                                tensormap_manager,
+                                tensormap_q_ptr,
+                                tensormap_k_ptr,
+                                tensormap_v_ptr,
+                            ),
+                        )
+                    )
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
 
@@ -1558,49 +1603,6 @@ class GatedDeltaNetChunkedKernel:
             load_k_producer.tail()
             load_v_producer.tail()
 
-        # ==============================================================
-        # GATE/BETA LOAD WARP (warp 10)
-        # ==============================================================
-        if warp_idx == self.load_gate_beta_warp_id:
-            cute.arch.setmaxregister_decrease(self.num_regs_other)
-            scheduler = GDNTileScheduler.create(
-                scheduler_params, (bidx, bidy, bidz), grid_dim
-            )
-            work = scheduler.initial_work_tile_info()
-            while work.is_valid_tile:
-                batch_idx, head_idx, _ = work.tile_idx
-                batch_start = cu_seqlens[batch_idx]
-                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
-                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
-                batch_end = batch_start + seqlen_b
-                # Full tiles (all but the last): unconditional loads
-                for chunk_idx in cutlass.range(num_chunks_b - 1):
-                    chunk_offset = batch_start + chunk_idx * self.b_t
-                    load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
-                        tidx,
-                        (mGate, mBeta),
-                        (sCumsumlog, sCumprod, sBeta),
-                        (load_gate_producer, load_beta_producer),
-                        (chunk_offset, head_idx, False, batch_end),
-                    )
-                if num_chunks_b > 0:
-                    # Last tile: is_last_tile=True, valid_tokens derived inside
-                    load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
-                        tidx,
-                        (mGate, mBeta),
-                        (sCumsumlog, sCumprod, sBeta),
-                        (load_gate_producer, load_beta_producer),
-                        (
-                            batch_start + (num_chunks_b - 1) * self.b_t,
-                            head_idx,
-                            True,
-                            batch_end,
-                        ),
-                    )
-                scheduler.advance_to_next_work()
-                work = scheduler.get_current_work()
-            load_gate_producer.tail()
-            load_beta_producer.tail()
         # ==============================================================
         # EPILOGUE WARP (warp 11)
         # ==============================================================
@@ -1623,9 +1625,12 @@ class GatedDeltaNetChunkedKernel:
                 batch_start = cu_seqlens[batch_idx]
                 batch_end = cu_seqlens[batch_idx + 1]
                 seqlen_b = batch_end - batch_start
-                num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                num_pairs = 2
+                num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
+                num_chunks_b = num_pairs_b * num_pairs
 
                 # Build bounded O tensor: token dim capped to batch_end
+                num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
                 bounded_o = cute.make_tensor(
                     mO.iterator,
                     cute.make_layout(
@@ -1634,18 +1639,69 @@ class GatedDeltaNetChunkedKernel:
                     ),
                 )
 
-                if num_chunks_b > 0:
-                    # Update O descriptor independently
-                    tensormap_manager.update_tensormap(
-                        (bounded_o,),
-                        (tma_o.atom,),
-                        (tensormap_o_ptr,),
-                        self.epilogue_warp_id,
-                        (None,),
+                # Update O descriptor independently
+                tensormap_manager.update_tensormap(
+                    (bounded_o,),
+                    (tma_o.atom,),
+                    (tensormap_o_ptr,),
+                    self.epilogue_warp_id,
+                    (None,),
+                )
+                tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
+
+                # Every valid work tile has at least one two-chunk pair.
+                for prefetch_idx in range(2):
+                    prefetch_offset = batch_start + prefetch_idx * self.b_t
+                    is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
+                    load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
+                        tidx,
+                        (mGate, mBeta),
+                        (sCumsumlog, sCumprod, sBeta),
+                        (load_gate_producer, load_beta_producer),
+                        (
+                            prefetch_offset,
+                            head_idx,
+                            is_last_tile,
+                            batch_end,
+                        ),
                     )
-                    tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
+
+                # Fill the remaining two lookahead stages together. Since the
+                # chunk count is even, chunks 2 and 3 are either both present
+                # or both absent.
+                if num_chunks_b > 2:
+                    for prefetch_idx in range(2, 4):
+                        prefetch_offset = batch_start + prefetch_idx * self.b_t
+                        is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
+                        load_gate_producer, load_beta_producer = (
+                            self.load_gate_beta_warp(
+                                tidx,
+                                (mGate, mBeta),
+                                (sCumsumlog, sCumprod, sBeta),
+                                (load_gate_producer, load_beta_producer),
+                                (
+                                    prefetch_offset,
+                                    head_idx,
+                                    is_last_tile,
+                                    batch_end,
+                                ),
+                            )
+                        )
 
                 for chunk_idx in cutlass.range(num_chunks_b):
+                    prefetch_idx = chunk_idx + 4
+                    if prefetch_idx < num_chunks_b:
+                        prefetch_offset = batch_start + prefetch_idx * self.b_t
+                        is_last_tile = prefetch_idx >= num_valid_chunks_b - 1
+                        load_gate_producer, load_beta_producer = (
+                            self.load_gate_beta_warp(
+                                tidx,
+                                (mGate, mBeta),
+                                (sCumsumlog, sCumprod, sBeta),
+                                (load_gate_producer, load_beta_producer),
+                                (prefetch_offset, head_idx, is_last_tile, batch_end),
+                            )
+                        )
                     chunk_offset = batch_start + chunk_idx * self.b_t
                     o_store_consumer = self.epilogue_warp(
                         (sO,),
@@ -1656,6 +1712,9 @@ class GatedDeltaNetChunkedKernel:
                     )
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
+
+            load_gate_producer.tail()
+            load_beta_producer.tail()
 
     # -----------------------------------------------------------------------
     # Per-warp methods  (called from kernel's chunk loop)
@@ -1674,7 +1733,7 @@ class GatedDeltaNetChunkedKernel:
     ]:
         """Warp 9: load Q, K (double-buffered), V for the current chunk.
 
-        Pattern (following fmha.py / dense_gemm_persistent.py):
+        TMA load pattern:
           1. domain_offset the TMA tensor to (chunk_offset, head_idx, 0) so that
              the logical tile (0, ...) maps to the current chunk.
           2. flat_divide to obtain the tiled global view.
@@ -1701,7 +1760,7 @@ class GatedDeltaNetChunkedKernel:
         # Per-thread MMA slices (cta_v=0 for ONE-CTA mode).
         thr_mma_qk = tiled_mma_qk.get_slice(0)
         thr_mma_qkv_ss = tiled_mma_qkv_ss.get_slice(0)
-        thr_mma_kv = tiled_mma_kv.get_slice(0)  # noqa: F841
+        thr_mma_kv = tiled_mma_kv.get_slice(0)
 
         # Tile shapes from the MMA tiler (128, 128, 128):
         #   mode[0,2] = (BT, DK) - M,K tile for A (Q) and for B (K) of tiled_mma_qk
@@ -1814,12 +1873,12 @@ class GatedDeltaNetChunkedKernel:
         pipeline_args: tuple,
         work_args: tuple,
     ) -> tuple[pipeline.PipelineProducer, pipeline.PipelineProducer]:
-        """Warp 10: load gate[BT] and beta[BT] for the current chunk.
+        """Epilogue warp 11: load gate[BT] and beta[BT] for one chunk.
 
-        Gate is loaded via ldg (sync G->R), natural log applied in registers, then
+        Gate is loaded synchronously to registers, natural log applied there, then
         stored to sCumsumlog SMEM (stride-32 layout matching compute_group_0 reads).
 
-        Beta is loaded via ldgsts (async G->S, cp.async) into sBeta SMEM.
+        Beta is copied asynchronously from GMEM to sBeta SMEM.
 
         The last tile uses predicated copies: elements with linear index >= valid_tokens
         are out-of-bounds and receive neutral values (gate=1 -> ln=0, beta=0).
@@ -1849,7 +1908,7 @@ class GatedDeltaNetChunkedKernel:
         thread_layout = cute.make_layout((self.threads_per_warp,), stride=(1,))
         value_layout = cute.make_layout((1,), stride=(1,))
 
-        # Gate: sync G->R (ldg), apply ln + prefix sum, then R->S (sts)
+        # Gate: sync GMEM -> registers, apply ln + prefix sum, then registers -> SMEM
         atom_gate_g2r = cute.make_copy_atom(
             cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=32
         )
@@ -1857,11 +1916,9 @@ class GatedDeltaNetChunkedKernel:
             atom_gate_g2r, thread_layout, value_layout
         )
 
-        # Beta: async G->S (ldgsts / cp.async)
+        # Beta: async GMEM -> SMEM
         atom_beta_g2s = cute.make_copy_atom(
-            cute.nvgpu.cpasync.CopyG2SOp(
-                cache_mode=cute.nvgpu.cpasync.LoadCacheMode.ALWAYS
-            ),
+            cute.nvgpu.cpasync.CopyG2SOp(cache_mode=cute.nvgpu.LoadCacheMode.ALWAYS),
             cutlass.Float32,
             num_bits_per_copy=32,
         )
@@ -1879,25 +1936,22 @@ class GatedDeltaNetChunkedKernel:
         tBgBeta = thr_copy_beta_g2s.partition_S(gBeta)
         tBsBeta = thr_copy_beta_g2s.partition_D(sBeta)
 
-        gate_handle = load_gate_producer.acquire_and_advance()
-
         rGate = cute.make_rmem_tensor_like(tGgGate, self.acc_dtype)
         tGrGate = tiled_copy_gate_g2r.retile(rGate)
         rCumprod = cute.make_rmem_tensor_like(tGgGate, self.acc_dtype)
         tGrCumprod = tiled_copy_gate_g2r.retile(rCumprod)
 
-        # --- Predicate (last tile only): compute once, reuse for gate and beta ---
-        if cutlass.const_expr(is_last_tile):
-            valid_tokens = batch_end  # noqa: F841
-            tGcGate = thr_copy_gate_g2r.partition_S(cGate)
-            tGpGate = cute.make_rmem_tensor(
-                ((tGcGate.shape[0][1],), tGcGate.shape[1]), cutlass.Boolean
-            )
+        # --- Predicate (last/padded tile only): reuse for gate and beta ---
+        tGcGate = thr_copy_gate_g2r.partition_S(cGate)
+        tGpGate = cute.make_rmem_tensor(
+            ((tGcGate.shape[0][1],), tGcGate.shape[1]), cutlass.Boolean
+        )
+        if is_last_tile:
             for i in range(cute.size(tGpGate)):
                 tGpGate[i] = cute.elem_less(tGcGate[i][0], batch_end)
 
         # --- Gate load ---
-        if cutlass.const_expr(is_last_tile):
+        if is_last_tile:
             # OOB neutral: 1.0 -> log2 ~= 0.0 (no decay contribution)
             tGrGate.fill(1.0)
             cute.copy(tiled_copy_gate_g2r, tGgGate, tGrGate, pred=tGpGate)
@@ -1914,7 +1968,7 @@ class GatedDeltaNetChunkedKernel:
                 )
                 if lidx >= offset:
                     tGrGate[col] = tGrGate[col] + n
-        sum_v = 0.0  # noqa: F841
+        sum_v = 0.0
         for col in range(1, cute.size(tGrGate)):
             last_v = cute.arch.shuffle_sync(
                 tGrGate[col - 1],
@@ -1925,6 +1979,10 @@ class GatedDeltaNetChunkedKernel:
             tGrGate[col] += last_v
         for col in range(cute.size(tGrGate)):
             tGrCumprod[col] = cute.math.exp2(tGrGate[col], fastmath=True)
+
+        # Keep the gate stage available while the register-only prefix scan is
+        # running.  The stage is needed only when its SMEM writes begin.
+        gate_handle = load_gate_producer.acquire_and_advance()
         cute.copy(
             tiled_copy_gate_g2r, tGrGate, tGsCumsumlog[None, None, 0, gate_handle.index]
         )
@@ -1938,9 +1996,9 @@ class GatedDeltaNetChunkedKernel:
 
         # --- Beta load ---
         beta_handle = load_beta_producer.acquire_and_advance()
-        if cutlass.const_expr(is_last_tile):
+        if is_last_tile:
             # clear OOB slots before predicated cp.async
-            tBsBeta.fill(0.0)
+            tBsBeta[None, None, 0, beta_handle.index].fill(0.0)
             cute.copy(
                 tiled_copy_beta_g2s,
                 tBgBeta,
@@ -1956,7 +2014,593 @@ class GatedDeltaNetChunkedKernel:
         return load_gate_producer, load_beta_producer
 
     @cute.jit
-    def mma_warp(
+    def mma_cg0_issuer_warp(
+        self,
+        tmem_ptr: cutlass.Int64,
+        scheduler_params: GDNTileSchedulerParams,
+        block_coord: tuple,
+        grid_dim: tuple,
+        cu_seqlens: cute.Tensor,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+    ):
+        """Issue the pair-level KK0/KK1/QK0/QK1 stream from warp 8."""
+        cg0_acc_producer, load_k_consumer, load_q_consumer = pipeline_args
+        scheduler = GDNTileScheduler.create(scheduler_params, block_coord, grid_dim)
+        work = scheduler.initial_work_tile_info()
+
+        while work.is_valid_tile:
+            batch_idx, _, _ = work.tile_idx
+            batch_start = cu_seqlens[batch_idx]
+            seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+            num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
+            for pair_idx in cutlass.range(num_pairs_b):
+                (
+                    cg0_acc_producer,
+                    load_k_consumer,
+                    load_q_consumer,
+                ) = self.mma_cg0_pair(
+                    tmem_ptr,
+                    mma_args,
+                    smem_args,
+                    (
+                        cg0_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                    ),
+                )
+            scheduler.advance_to_next_work()
+            work = scheduler.get_current_work()
+
+        cg0_acc_producer.tail()
+
+    @cute.jit
+    def mma_cg0_pair(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+    ) -> tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Issue one pair's fixed KK0/KK1/QK0/QK1 sequence."""
+        tiled_mma_qk, tiled_mma_qkv = mma_args
+        sQ, sK = smem_args
+        (
+            cg0_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+        ) = pipeline_args
+
+        acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtAcc_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_cg0_shared_acc_stages)
+        )
+        tCtAcc = cute.make_tensor(
+            tmem_ptr + self.tmem_cg0_shared_acc_offset, tCtAcc_fake.layout
+        )
+        tCrK_A = tiled_mma_qk.make_fragment_A(sK)
+        tCrK_B = tiled_mma_qk.make_fragment_B(sK)
+        tCrQ_A = tiled_mma_qk.make_fragment_A(sQ)
+        num_kphases = cute.size(tCrK_A, mode=[2])
+
+        kk0_handle = cg0_acc_producer.acquire_and_advance()
+        k0_handle = load_k_consumer.wait_and_advance()
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qk,
+                tCtAcc[None, None, None, kk0_handle.index],
+                tCrK_A[None, None, kphase_idx, k0_handle.index],
+                tCrK_B[None, None, kphase_idx, k0_handle.index],
+                tCtAcc[None, None, None, kk0_handle.index],
+            )
+        kk0_handle.commit()
+
+        kk1_handle = cg0_acc_producer.acquire_and_advance()
+        k1_handle = load_k_consumer.wait_and_advance()
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qk,
+                tCtAcc[None, None, None, kk1_handle.index],
+                tCrK_A[None, None, kphase_idx, k1_handle.index],
+                tCrK_B[None, None, kphase_idx, k1_handle.index],
+                tCtAcc[None, None, None, kk1_handle.index],
+            )
+        kk1_handle.commit()
+
+        q0_handle = load_q_consumer.wait_and_advance()
+        qk0_handle = cg0_acc_producer.acquire_and_advance()
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qk,
+                tCtAcc[None, None, None, qk0_handle.index],
+                tCrQ_A[None, None, kphase_idx, q0_handle.index],
+                tCrK_B[None, None, kphase_idx, k0_handle.index],
+                tCtAcc[None, None, None, qk0_handle.index],
+            )
+        qk0_handle.commit()
+
+        q1_handle = load_q_consumer.wait_and_advance()
+        qk1_handle = cg0_acc_producer.acquire_and_advance()
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma_qk,
+                tCtAcc[None, None, None, qk1_handle.index],
+                tCrQ_A[None, None, kphase_idx, q1_handle.index],
+                tCrK_B[None, None, kphase_idx, k1_handle.index],
+                tCtAcc[None, None, None, qk1_handle.index],
+            )
+        qk1_handle.commit()
+
+        q0_handle.release()
+        q1_handle.release()
+        k0_handle.release()
+        k1_handle.release()
+
+        return (
+            cg0_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+        )
+
+    @cute.jit
+    def mma_cg1_issuer_warp(
+        self,
+        tmem_ptr: cutlass.Int64,
+        scheduler_params: GDNTileSchedulerParams,
+        block_coord: tuple,
+        grid_dim: tuple,
+        cu_seqlens: cute.Tensor,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+    ):
+        """Issue the chunk-level state/output GEMM stream from warp 10."""
+        (
+            cg1_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
+        ) = pipeline_args
+        scheduler = GDNTileScheduler.create(scheduler_params, block_coord, grid_dim)
+        work = scheduler.initial_work_tile_info()
+        while work.is_valid_tile:
+            batch_idx, _, _ = work.tile_idx
+            batch_start = cu_seqlens[batch_idx]
+            seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+            num_chunks = cute.ceil_div(seqlen_b, self.b_t * 2) * 2
+            first_loop_chunk = 0
+
+            if cutlass.const_expr(not self.use_initial_state):
+                (
+                    cg1_acc_producer,
+                    q_state_acc_producer,
+                    kv_acc_producer,
+                    load_k_consumer,
+                    load_q_consumer,
+                    a_inv_ready_consumer,
+                    qk_ready_consumer,
+                    state_inp_ready_consumer,
+                    vks_ready_consumer,
+                    nv_ready_consumer,
+                    decay_v_ready_consumer,
+                ) = self.mma_cg1_chunk(
+                    tmem_ptr,
+                    mma_args,
+                    smem_args,
+                    (
+                        cg1_acc_producer,
+                        q_state_acc_producer,
+                        kv_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                        a_inv_ready_consumer,
+                        qk_ready_consumer,
+                        state_inp_ready_consumer,
+                        vks_ready_consumer,
+                        nv_ready_consumer,
+                        decay_v_ready_consumer,
+                    ),
+                    True,
+                )
+                first_loop_chunk = 1
+
+            for chunk_idx in cutlass.range(first_loop_chunk, num_chunks):
+                is_first_chunk = False
+                if cutlass.const_expr(self.use_initial_state):
+                    is_first_chunk = chunk_idx == 0
+                (
+                    cg1_acc_producer,
+                    q_state_acc_producer,
+                    kv_acc_producer,
+                    load_k_consumer,
+                    load_q_consumer,
+                    a_inv_ready_consumer,
+                    qk_ready_consumer,
+                    state_inp_ready_consumer,
+                    vks_ready_consumer,
+                    nv_ready_consumer,
+                    decay_v_ready_consumer,
+                ) = self.mma_cg1_chunk(
+                    tmem_ptr,
+                    mma_args,
+                    smem_args,
+                    (
+                        cg1_acc_producer,
+                        q_state_acc_producer,
+                        kv_acc_producer,
+                        load_k_consumer,
+                        load_q_consumer,
+                        a_inv_ready_consumer,
+                        qk_ready_consumer,
+                        state_inp_ready_consumer,
+                        vks_ready_consumer,
+                        nv_ready_consumer,
+                        decay_v_ready_consumer,
+                    ),
+                    is_first_chunk,
+                )
+
+            scheduler.advance_to_next_work()
+            work = scheduler.get_current_work()
+
+        cg1_acc_producer.tail()
+        q_state_acc_producer.tail()
+        kv_acc_producer.tail()
+
+    @cute.jit
+    def mma_cg1_chunk(
+        self,
+        tmem_ptr: cutlass.Int64,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+        is_first_chunk: cutlass.Boolean,
+    ) -> tuple:
+        """Issue KS/QS/NV/QKV/KV for one chunk."""
+        tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv = mma_args
+        sQ, sK, sK_trans, sV, sAinv, sQk = smem_args
+        (
+            cg1_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
+        ) = pipeline_args
+
+        acc_shape = tiled_mma_qkv.partition_shape_C(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
+        )
+        tCtShared_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_cg1_shared_acc_stages)
+        )
+        tCtShared = cute.make_tensor(
+            tmem_ptr + self.tmem_cg1_shared_acc_offset, tCtShared_fake.layout
+        )
+
+        shared_inp_shape = tiled_mma_qkv.partition_shape_A(
+            (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
+        )
+        tCtSharedInp_fake = tiled_mma_qkv.make_fragment_A(
+            cute.append(shared_inp_shape, self.tmem_shared_inp_stages)
+        )
+        tCtSharedInp = cute.make_tensor(
+            cute.recast_ptr(
+                tmem_ptr + self.tmem_shared_inp_offset, dtype=self.io_dtype
+            ),
+            tCtSharedInp_fake.layout,
+        )
+
+        qs_acc_shape = tiled_mma_qs.partition_shape_C(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
+        )
+        tCtQState_fake = tiled_mma_qs.make_fragment_C(
+            cute.append(qs_acc_shape, self.tmem_q_state_acc_stages)
+        )
+        tCtQState = cute.make_tensor(
+            tmem_ptr + self.tmem_q_state_offset, tCtQState_fake.layout
+        )
+
+        state_acc_shape = tiled_mma_kv.partition_shape_C(
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
+        )
+        tCtState_fake = tiled_mma_kv.make_fragment_C(
+            cute.append(state_acc_shape, self.tmem_kv_acc_stages)
+        )
+        tCtState = cute.make_tensor(
+            tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
+        )
+
+        state_inp_shape = tiled_mma_qs.partition_shape_A(
+            (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
+        )
+        tCtStateInp_fake = tiled_mma_qs.make_fragment_A(
+            cute.append(state_inp_shape, self.tmem_state_inp_stages)
+        )
+        tCtStateInp = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + self.tmem_state_inp_offset, dtype=self.io_dtype),
+            tCtStateInp_fake.layout,
+        )
+
+        tCrK_B_qs = tiled_mma_qs.make_fragment_B(sK)
+        tCrQ_B_qs = tiled_mma_qs.make_fragment_B(sQ)
+        tCrAinv_B = tiled_mma_qkv.make_fragment_B(sAinv)
+        tCrNv_B = tiled_mma_qkv.make_fragment_B(sQk)
+        tCrKt_B = tiled_mma_kv.make_fragment_B(sK_trans)
+        tCrV_A_ss = tiled_mma_qkv_ss.make_fragment_A(sV)
+        num_kphases_qs = cute.size(tCtStateInp, mode=[2])
+        num_kphases_qkv = cute.size(tCrAinv_B, mode=[2])
+        num_kphases_kv = cute.size(tCrKt_B, mode=[2])
+
+        k_handle = load_k_consumer.wait_and_advance()
+        q_handle = load_q_consumer.wait_and_advance()
+        valid_state = is_first_chunk == False
+        if cutlass.const_expr(self.use_initial_state):
+            valid_state = True
+
+        if valid_state:
+            ks_handle = cg1_acc_producer.acquire_and_advance()
+            state_handle = state_inp_ready_consumer.wait_and_advance()
+            for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
+                tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qs,
+                    tCtShared[None, None, None, ks_handle.index],
+                    tCtStateInp[None, None, kphase_idx, state_handle.index],
+                    tCrK_B_qs[None, None, kphase_idx, k_handle.index],
+                    tCtShared[None, None, None, ks_handle.index],
+                )
+            ks_handle.commit()
+
+            qs_handle = q_state_acc_producer.acquire_and_advance()
+            for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
+                tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qs,
+                    tCtQState[None, None, None, qs_handle.index],
+                    tCtStateInp[None, None, kphase_idx, state_handle.index],
+                    tCrQ_B_qs[None, None, kphase_idx, q_handle.index],
+                    tCtQState[None, None, None, qs_handle.index],
+                )
+            qs_handle.commit()
+            state_handle.release()
+
+        q_handle.release()
+
+        nv_handle = cg1_acc_producer.acquire_and_advance()
+        vks_ready_consumer.wait_and_advance()
+        ainv_handle = a_inv_ready_consumer.wait_and_advance()
+        if valid_state:
+            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qkv,
+                    tCtShared[None, None, None, nv_handle.index],
+                    tCtSharedInp[None, None, kphase_idx, 0],
+                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                    tCtShared[None, None, None, nv_handle.index],
+                )
+        else:
+            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+                tiled_mma_qkv_ss.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qkv_ss,
+                    tCtShared[None, None, None, nv_handle.index],
+                    tCrV_A_ss[None, None, kphase_idx, 0],
+                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                    tCtShared[None, None, None, nv_handle.index],
+                )
+        nv_handle.commit()
+        ainv_handle.release()
+
+        q_state_handle = q_state_acc_producer.acquire_and_advance()
+        qk_handle = qk_ready_consumer.wait_and_advance()
+        nv_ready_consumer.wait_and_advance()
+        for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+            tiled_mma_qkv.set(
+                tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0)
+            )
+            cute.gemm(
+                tiled_mma_qkv,
+                tCtQState[None, None, None, q_state_handle.index],
+                tCtSharedInp[None, None, kphase_idx, 0],
+                tCrNv_B[None, None, kphase_idx, qk_handle.index],
+                tCtQState[None, None, None, q_state_handle.index],
+            )
+        qk_handle.release()
+        q_state_handle.commit()
+
+        if cutlass.const_expr(self.use_initial_state):
+            if is_first_chunk:
+                kv_acc_producer.advance()
+        kv_handle = kv_acc_producer.acquire_and_advance()
+        decay_v_ready_consumer.wait_and_advance()
+        for kphase_idx in cutlass.range(num_kphases_kv, unroll_full=True):
+            tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0))
+            cute.gemm(
+                tiled_mma_kv,
+                tCtState[None, None, None, kv_handle.index],
+                tCtSharedInp[None, None, kphase_idx, 1],
+                tCrKt_B[None, None, kphase_idx, k_handle.index],
+                tCtState[None, None, None, kv_handle.index],
+            )
+        kv_handle.commit()
+        k_handle.release()
+
+        return (
+            cg1_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
+        )
+
+    @cute.jit
+    def mma_issuer_warp(
+        self,
+        tmem_ptr: cutlass.Int64,
+        scheduler_params: GDNTileSchedulerParams,
+        block_coord: tuple,
+        grid_dim: tuple,
+        cu_seqlens: cute.Tensor,
+        mma_args: tuple,
+        smem_args: tuple,
+        pipeline_args: tuple,
+    ):
+        """Run the MMA issuer over its scheduler-owned work stream."""
+        (
+            cg0_shared_acc_producer,
+            cg1_shared_acc_producer,
+            q_state_acc_producer,
+            kv_acc_producer,
+            load_k_consumer,
+            load_q_consumer,
+            load_v_consumer,
+            a_inv_ready_consumer,
+            qk_ready_consumer,
+            state_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
+        ) = pipeline_args
+        load_k_releaser = load_k_consumer.clone()
+        load_q_releaser = load_q_consumer.clone()
+        scheduler = GDNTileScheduler.create(scheduler_params, block_coord, grid_dim)
+        work = scheduler.initial_work_tile_info()
+
+        while work.is_valid_tile:
+            batch_idx, _, _ = work.tile_idx
+            batch_start = cu_seqlens[batch_idx]
+            seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+            num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
+            num_chunks_padded = num_pairs_b * 2
+            first_loop_chunk = 0
+
+            if cutlass.const_expr(not self.use_initial_state):
+                (
+                    cg0_shared_acc_producer,
+                    cg1_shared_acc_producer,
+                    q_state_acc_producer,
+                    kv_acc_producer,
+                    load_k_consumer,
+                    load_k_releaser,
+                    load_q_consumer,
+                    load_q_releaser,
+                    load_v_consumer,
+                    a_inv_ready_consumer,
+                    qk_ready_consumer,
+                    state_inp_ready_consumer,
+                    vks_ready_consumer,
+                    nv_ready_consumer,
+                    decay_v_ready_consumer,
+                ) = self.mma_warp_chunk(
+                    tmem_ptr,
+                    mma_args,
+                    smem_args,
+                    (
+                        cg0_shared_acc_producer,
+                        cg1_shared_acc_producer,
+                        q_state_acc_producer,
+                        kv_acc_producer,
+                        load_k_consumer,
+                        load_k_releaser,
+                        load_q_consumer,
+                        load_q_releaser,
+                        load_v_consumer,
+                        a_inv_ready_consumer,
+                        qk_ready_consumer,
+                        state_inp_ready_consumer,
+                        vks_ready_consumer,
+                        nv_ready_consumer,
+                        decay_v_ready_consumer,
+                    ),
+                    (0, num_pairs_b, True),
+                )
+                first_loop_chunk = 1
+
+            for chunk_iter in cutlass.range(first_loop_chunk, num_chunks_padded):
+                loop_is_first_chunk = False
+                if cutlass.const_expr(self.use_initial_state):
+                    loop_is_first_chunk = chunk_iter == 0
+                (
+                    cg0_shared_acc_producer,
+                    cg1_shared_acc_producer,
+                    q_state_acc_producer,
+                    kv_acc_producer,
+                    load_k_consumer,
+                    load_k_releaser,
+                    load_q_consumer,
+                    load_q_releaser,
+                    load_v_consumer,
+                    a_inv_ready_consumer,
+                    qk_ready_consumer,
+                    state_inp_ready_consumer,
+                    vks_ready_consumer,
+                    nv_ready_consumer,
+                    decay_v_ready_consumer,
+                ) = self.mma_warp_chunk(
+                    tmem_ptr,
+                    mma_args,
+                    smem_args,
+                    (
+                        cg0_shared_acc_producer,
+                        cg1_shared_acc_producer,
+                        q_state_acc_producer,
+                        kv_acc_producer,
+                        load_k_consumer,
+                        load_k_releaser,
+                        load_q_consumer,
+                        load_q_releaser,
+                        load_v_consumer,
+                        a_inv_ready_consumer,
+                        qk_ready_consumer,
+                        state_inp_ready_consumer,
+                        vks_ready_consumer,
+                        nv_ready_consumer,
+                        decay_v_ready_consumer,
+                    ),
+                    (chunk_iter, num_pairs_b, loop_is_first_chunk),
+                )
+
+            scheduler.advance_to_next_work()
+            work = scheduler.get_current_work()
+
+        cg0_shared_acc_producer.tail()
+        cg1_shared_acc_producer.tail()
+        q_state_acc_producer.tail()
+        kv_acc_producer.tail()
+
+    @cute.jit
+    def mma_warp_chunk(
         self,
         tmem_ptr: cutlass.Int64,
         mma_args: tuple,
@@ -1964,6 +2608,8 @@ class GatedDeltaNetChunkedKernel:
         pipeline_args: tuple,
         work_args: tuple,
     ) -> tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
@@ -1977,39 +2623,52 @@ class GatedDeltaNetChunkedKernel:
         pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
     ]:
-        """Warp 8: issue all 7 GEMMs in dependency order."""
+        """Warp 8: process one chunk from the caller-owned chunk stream.
+
+        The next KK0/KK1 are issued after current NV0 so their MMA latency
+        overlaps current QKV0/KV0 and chunk-1 work. CG0 and CG1 accumulators
+        use disjoint two-stage rings, so the lookahead cannot alias KS/NV.
+        """
         tiled_mma_qk, tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv = (
             mma_args
         )
         sQ, sK, sK_trans, sV, sAinv, sQk = smem_args
         (
-            shared_acc_producer,
+            cg0_shared_acc_producer,
+            cg1_shared_acc_producer,
             q_state_acc_producer,
             kv_acc_producer,
             load_k_consumer,
+            load_k_releaser,
             load_q_consumer,
+            load_q_releaser,
             load_v_consumer,
             a_inv_ready_consumer,
             qk_ready_consumer,
             state_inp_ready_consumer,
-            shared_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
         ) = pipeline_args
-        (is_first_chunk,) = work_args
-
-        valid_state = not is_first_chunk or self.use_initial_state
+        chunk_iter, num_pairs_b, is_first_chunk = work_args
 
         # ------------------------------------------------------------------
-        # Build TMEM accumulator views
+        # Build TMEM accumulator views  (identical to mma_warp)
         # ------------------------------------------------------------------
-        # Shared acc (GEMMs 1/2/3/5/6) - 2 stages, layout from tiled_mma_qk
         acc_shape = tiled_mma_qkv.partition_shape_C(
             (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
         )
-        tCtAcc_fake = tiled_mma_qkv.make_fragment_C(
-            cute.append(acc_shape, self.tmem_shared_acc_stages)
+        tCtCg0Shared_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_cg0_shared_acc_stages)
         )
-        tCtShared = cute.make_tensor(
-            tmem_ptr + self.tmem_shared_acc_offset, tCtAcc_fake.layout
+        tCtCg0Shared = cute.make_tensor(
+            tmem_ptr + self.tmem_cg0_shared_acc_offset, tCtCg0Shared_fake.layout
+        )
+        tCtCg1Shared_fake = tiled_mma_qkv.make_fragment_C(
+            cute.append(acc_shape, self.tmem_cg1_shared_acc_stages)
+        )
+        tCtCg1Shared = cute.make_tensor(
+            tmem_ptr + self.tmem_cg1_shared_acc_offset, tCtCg1Shared_fake.layout
         )
 
         shared_inp_shape = tiled_mma_qkv.partition_shape_A(
@@ -2025,7 +2684,6 @@ class GatedDeltaNetChunkedKernel:
             tCtShared_inp_fake.layout,
         )
 
-        # q*state acc (GEMM 4 only) - 1 stage, layout from tiled_mma_qs
         qs_acc_shape = tiled_mma_qs.partition_shape_C(
             (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
         )
@@ -2036,7 +2694,6 @@ class GatedDeltaNetChunkedKernel:
             tmem_ptr + self.tmem_q_state_offset, tCtQState_fake.layout
         )
 
-        # state acc (GEMM 7 only) - 1 stage, layout from tiled_mma_kv
         state_acc_shape = tiled_mma_kv.partition_shape_C(
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
         )
@@ -2059,197 +2716,249 @@ class GatedDeltaNetChunkedKernel:
         )
 
         # ------------------------------------------------------------------
-        # Pre-create operand fragments (stage dim preserved; sliced at GEMM time)
-        # tiled_mma_qk operands (GEMMs 1, 2)
-        # K as A for GEMM 1 (kk)
+        # Pre-create operand fragments
+        # ------------------------------------------------------------------
         tCrK_A = tiled_mma_qk.make_fragment_A(sK)
-        # K as B for GEMMs 1+2 (kk, qk)
         tCrK_B = tiled_mma_qk.make_fragment_B(sK)
-        # Q as A for GEMM 2 (qk)
         tCrQ_A = tiled_mma_qk.make_fragment_A(sQ)
-        # tiled_mma_qs operands (GEMMs 3, 4)
-        # K as A for GEMM 3 (k*state)
         tCrS_A = tCtState_inp
-        # Q as A for GEMM 4 (q*state)
         tCrQ_B_qs = tiled_mma_qs.make_fragment_B(sQ)
-        # S_prev as B for GEMMs 3+4
         tCrK_B_qs = tiled_mma_qs.make_fragment_B(sK)
-        # tiled_mma_qkv operands (GEMMs 5, 6)
-        # V-KS as A for GEMM 5
-        if cutlass.const_expr(valid_state):
-            tCrV_A = tCtShared_inp
-        else:
-            tCrV_A = tiled_mma_qkv_ss.make_fragment_A(sV)
-        # A_inv as B for GEMM 5
         tCrAinv_B = tiled_mma_qkv.make_fragment_B(sAinv)
-
-        # W_qkv as A for GEMM 6
         tCrQkv_A = tCtShared_inp
-        # NV as B for GEMM 6
         tCrNv_B = tiled_mma_qkv.make_fragment_B(sQk)
-        # tiled_mma_kv operands (GEMM 7)
-        # delta as A for GEMM 7
         tCrDecayV_A = tCtShared_inp
-        # K^T as B for GEMM 7
         tCrKt_B = tiled_mma_kv.make_fragment_B(sK_trans)
 
-        # ---- GEMM 1: kk  (K @ K^T -> shared acc) ----------------------------
-        # Both A and B are K; valid because tiled_mma_qk has K-major for both operands.
-        k_handle = load_k_consumer.wait_and_advance()
-        kk_handle = shared_acc_producer.acquire_and_advance()
+        # The first no-state pair reads V directly from SMEM; later pairs read
+        # the state-corrected VKS operand from TMEM.
+        tCrV_A_0_ss = tiled_mma_qkv_ss.make_fragment_A(sV)
 
         num_kphases = cute.size(tCrK_A, mode=[2])
-        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-            cute.gemm(
-                tiled_mma_qk,
-                tCtShared[None, None, None, kk_handle.index],
-                tCrK_A[None, None, kphase_idx, k_handle.index],
-                tCrK_B[None, None, kphase_idx, k_handle.index],
-                tCtShared[None, None, None, kk_handle.index],
-            )
+        num_kphases_qs = cute.size(tCrS_A, mode=[2])
+        num_kphases_qkv = cute.size(tCrAinv_B, mode=[2])
+        num_kphases_kv = cute.size(tCrKt_B, mode=[2])
 
-        # Signal W_kk ready -> CG0 kk_epi
-        kk_handle.commit()
+        # Pair membership is derived from the caller-provided chunk index.
+        is_pair_first = (chunk_iter & 1) == 0
+        has_next_pair = chunk_iter < num_pairs_b * 2 - 2
 
-        # ---- GEMM 2: qk  (Q @ K^T -> shared acc) ----------------------------
-        # K is still held (k_handle not yet released).
-        q_handle = load_q_consumer.wait_and_advance()
-        qk_handle = shared_acc_producer.acquire_and_advance()
+        # Both KK/QK accumulators must precede chunk 0 because CG0 builds
+        # the pair inverse from KK0/KK1 before MMA can consume Ainv0.
+        if is_pair_first:
+            k0_cursor = load_k_releaser.clone()
+            k0_ready_handle = k0_cursor.current_handle()
+            k1_cursor = k0_cursor.clone()
+            k1_cursor.advance()
+            k1_ready_handle = k1_cursor.current_handle()
 
-        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-            cute.gemm(
-                tiled_mma_qk,
-                tCtShared[None, None, None, qk_handle.index],
-                tCrQ_A[None, None, kphase_idx, q_handle.index],
-                tCrK_B[None, None, kphase_idx, k_handle.index],
-                tCtShared[None, None, None, qk_handle.index],
-            )
+            if is_first_chunk:
+                kk0_handle = cg0_shared_acc_producer.acquire_and_advance()
+                k0_ready_handle = load_k_consumer.wait_and_advance()
+                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                    tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                    cute.gemm(
+                        tiled_mma_qk,
+                        tCtCg0Shared[None, None, None, kk0_handle.index],
+                        tCrK_A[None, None, kphase_idx, k0_ready_handle.index],
+                        tCrK_B[None, None, kphase_idx, k0_ready_handle.index],
+                        tCtCg0Shared[None, None, None, kk0_handle.index],
+                    )
+                kk0_handle.commit()
 
-        # Signal W_qk ready -> CG0 qk_epi
-        qk_handle.commit()
+                kk1_handle = cg0_shared_acc_producer.acquire_and_advance()
+                k1_ready_handle = load_k_consumer.wait_and_advance()
+                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                    tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                    cute.gemm(
+                        tiled_mma_qk,
+                        tCtCg0Shared[None, None, None, kk1_handle.index],
+                        tCrK_A[None, None, kphase_idx, k1_ready_handle.index],
+                        tCrK_B[None, None, kphase_idx, k1_ready_handle.index],
+                        tCtCg0Shared[None, None, None, kk1_handle.index],
+                    )
+                kk1_handle.commit()
 
-        # ---- GEMM 3: k*state  (K @ S_prev -> shared acc) --------------------
-        # ---- GEMM 4: q*state  (Q @ S_prev -> tmem_q_state) ------------------
-        # Skipped on the first chunk when use_initial_state is False (S_prev = 0, outputs are zero).
+            qk0_handle = cg0_shared_acc_producer.acquire_and_advance()
+            q0_ready_handle = load_q_consumer.wait_and_advance()
+            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qk,
+                    tCtCg0Shared[None, None, None, qk0_handle.index],
+                    tCrQ_A[None, None, kphase_idx, q0_ready_handle.index],
+                    tCrK_B[None, None, kphase_idx, k0_ready_handle.index],
+                    tCtCg0Shared[None, None, None, qk0_handle.index],
+                )
+            qk0_handle.commit()
+
+            qk1_handle = cg0_shared_acc_producer.acquire_and_advance()
+            q1_ready_handle = load_q_consumer.wait_and_advance()
+            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qk,
+                    tCtCg0Shared[None, None, None, qk1_handle.index],
+                    tCrQ_A[None, None, kphase_idx, q1_ready_handle.index],
+                    tCrK_B[None, None, kphase_idx, k1_ready_handle.index],
+                    tCtCg0Shared[None, None, None, qk1_handle.index],
+                )
+            qk1_handle.commit()
+
+        k_release_handle = load_k_releaser.current_handle()
+        q_release_handle = load_q_releaser.current_handle()
+        k_stage = k_release_handle.index
+        q_stage = q_release_handle.index
+
+        valid_state = is_first_chunk == False
+        if cutlass.const_expr(self.use_initial_state):
+            valid_state = True
+
         if valid_state:
-            s_handle = state_inp_ready_consumer.wait_and_advance()
-            ks_handle = shared_acc_producer.acquire_and_advance()
-
-            num_kphases_qs = cute.size(tCrS_A, mode=[2])
+            ks_handle = cg1_shared_acc_producer.acquire_and_advance()
+            state_handle = state_inp_ready_consumer.wait_and_advance()
             for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
                 tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
                 cute.gemm(
                     tiled_mma_qs,
-                    tCtShared[None, None, None, ks_handle.index],
-                    tCrS_A[None, None, kphase_idx, s_handle.index],
-                    tCrK_B_qs[None, None, kphase_idx, k_handle.index],
-                    tCtShared[None, None, None, ks_handle.index],
+                    tCtCg1Shared[None, None, None, ks_handle.index],
+                    tCrS_A[None, None, kphase_idx, state_handle.index],
+                    tCrK_B_qs[None, None, kphase_idx, k_stage],
+                    tCtCg1Shared[None, None, None, ks_handle.index],
                 )
             ks_handle.commit()
 
-            q_state_acc_handle = q_state_acc_producer.acquire_and_advance()
-            # S_prev still loaded (same s_handle.index as GEMM 3).
-            num_kphases_qs = cute.size(tCrS_A, mode=[2])
+            qs_handle = q_state_acc_producer.acquire_and_advance()
             for kphase_idx in cutlass.range(num_kphases_qs, unroll_full=True):
                 tiled_mma_qs.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
                 cute.gemm(
                     tiled_mma_qs,
-                    tCtQState[None, None, None, q_state_acc_handle.index],
-                    tCrS_A[None, None, kphase_idx, s_handle.index],
-                    tCrQ_B_qs[None, None, kphase_idx, q_handle.index],
-                    tCtQState[None, None, None, q_state_acc_handle.index],
+                    tCtQState[None, None, None, qs_handle.index],
+                    tCrS_A[None, None, kphase_idx, state_handle.index],
+                    tCrQ_B_qs[None, None, kphase_idx, q_stage],
+                    tCtQState[None, None, None, qs_handle.index],
                 )
-            q_state_acc_handle.commit()
-            # Release state SMEM (S_prev fully consumed by GEMMs 3 + 4).
-            s_handle.release()
+            qs_handle.commit()
+            state_handle.release()
 
-        q_handle.release()
+        q_release_handle.release()
+        load_q_releaser.advance()
 
-        # ---- GEMM 5: new_v  (A_inv @ (V-KS) -> shared acc) ------------------
-        # A_inv from CG0 (a_inv_ready); V-KS from CG1 (v_ks_ready, stored in sV).
-        vks_handle = shared_inp_ready_consumer.wait_and_advance()
+        nv_handle = cg1_shared_acc_producer.acquire_and_advance()
+        vks_handle = vks_ready_consumer.wait_and_advance()
         ainv_handle = a_inv_ready_consumer.wait_and_advance()
-        nv_handle = shared_acc_producer.acquire_and_advance()
-
-        num_kphases_qkv = cute.size(tCrAinv_B, mode=[2])
-        cur_tiled_mma_qkv = tiled_mma_qkv if valid_state else tiled_mma_qkv_ss
-        for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
-            cur_tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-            cute.gemm(
-                cur_tiled_mma_qkv,
-                tCtShared[None, None, None, nv_handle.index],
-                tCrV_A[None, None, kphase_idx, vks_handle.index],
-                tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
-                tCtShared[None, None, None, nv_handle.index],
-            )
-
+        if valid_state:
+            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qkv,
+                    tCtCg1Shared[None, None, None, nv_handle.index],
+                    tCtShared_inp[None, None, kphase_idx, 0],
+                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                    tCtCg1Shared[None, None, None, nv_handle.index],
+                )
+        else:
+            for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
+                tiled_mma_qkv_ss.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qkv_ss,
+                    tCtCg1Shared[None, None, None, nv_handle.index],
+                    tCrV_A_0_ss[None, None, kphase_idx, 0],
+                    tCrAinv_B[None, None, kphase_idx, ainv_handle.index],
+                    tCtCg1Shared[None, None, None, nv_handle.index],
+                )
         nv_handle.commit()
         ainv_handle.release()
-        vks_handle.release()
 
-        # ---- GEMM 6: qkv  (W_qkv @ NV -> q * state acc) ------------------------
-        # W_qkv from CG0 (qk_ready, stored in sQk); NV from CG1 (new_v_ready, stored in sNv).
+        # Preserve the mid-pair lookahead after NV0. The two successor KKs
+        # are explicit operations, not a nested pair/chunk loop.
+        if is_pair_first:
+            if has_next_pair:
+                pf_kk0_handle = cg0_shared_acc_producer.acquire_and_advance()
+                pf_k0_handle = load_k_consumer.wait_and_advance()
+                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                    tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                    cute.gemm(
+                        tiled_mma_qk,
+                        tCtCg0Shared[None, None, None, pf_kk0_handle.index],
+                        tCrK_A[None, None, kphase_idx, pf_k0_handle.index],
+                        tCrK_B[None, None, kphase_idx, pf_k0_handle.index],
+                        tCtCg0Shared[None, None, None, pf_kk0_handle.index],
+                    )
+                pf_kk0_handle.commit()
+
+                pf_kk1_handle = cg0_shared_acc_producer.acquire_and_advance()
+                pf_k1_handle = load_k_consumer.wait_and_advance()
+                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                    tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                    cute.gemm(
+                        tiled_mma_qk,
+                        tCtCg0Shared[None, None, None, pf_kk1_handle.index],
+                        tCrK_A[None, None, kphase_idx, pf_k1_handle.index],
+                        tCrK_B[None, None, kphase_idx, pf_k1_handle.index],
+                        tCtCg0Shared[None, None, None, pf_kk1_handle.index],
+                    )
+                pf_kk1_handle.commit()
+
+        q_state_handle = q_state_acc_producer.acquire_and_advance()
         qkv_qk_handle = qk_ready_consumer.wait_and_advance()
-        qkv_nv_handle = shared_inp_ready_consumer.wait_and_advance()
-        q_state_acc_handle = q_state_acc_producer.acquire_and_advance()
-
-        num_kphases_qkv = cute.size(tCrQkv_A, mode=[2])
+        qkv_nv_handle = nv_ready_consumer.wait_and_advance()
         for kphase_idx in cutlass.range(num_kphases_qkv, unroll_full=True):
-            tiled_mma_qkv.set(
-                tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0)
-            )
+            if valid_state:
+                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, True)
+            else:
+                tiled_mma_qkv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
             cute.gemm(
                 tiled_mma_qkv,
-                tCtQState[None, None, None, q_state_acc_handle.index],
-                tCrQkv_A[None, None, kphase_idx, qkv_nv_handle.index],
+                tCtQState[None, None, None, q_state_handle.index],
+                tCrQkv_A[None, None, kphase_idx, 0],
                 tCrNv_B[None, None, kphase_idx, qkv_qk_handle.index],
-                tCtQState[None, None, None, q_state_acc_handle.index],
+                tCtQState[None, None, None, q_state_handle.index],
             )
-
         qkv_qk_handle.release()
-        qkv_nv_handle.release()
-        q_state_acc_handle.commit()
+        q_state_handle.commit()
 
-        # ---- GEMM 7: kv_update  (K^T @ delta -> state TMEM) ---------------------
-        # delta from CG1 (decay_v_ready, stored in sDecayV); K^T reuses k_handle slot.
-        # First chunk: zero-init on kphase 0. Subsequent chunks: always accumulate.
-        if cutlass.const_expr(self.use_initial_state and is_first_chunk):
-            kv_acc_producer.advance()
-        kv_acc_handle = kv_acc_producer.acquire_and_advance()
-        dv_handle = shared_inp_ready_consumer.wait_and_advance()
-
-        num_kphases_kv = cute.size(tCrKt_B, mode=[2])
+        if cutlass.const_expr(self.use_initial_state):
+            if is_first_chunk:
+                kv_acc_producer.advance()
+        kv_handle = kv_acc_producer.acquire_and_advance()
+        dv_handle = decay_v_ready_consumer.wait_and_advance()
         for kphase_idx in cutlass.range(num_kphases_kv, unroll_full=True):
-            tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0))
+            if valid_state:
+                tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, True)
+            else:
+                tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
             cute.gemm(
                 tiled_mma_kv,
-                tCtState[None, None, None, kv_acc_handle.index],
-                tCrDecayV_A[None, None, kphase_idx, dv_handle.index],
-                tCrKt_B[None, None, kphase_idx, k_handle.index],
-                tCtState[None, None, None, kv_acc_handle.index],
+                tCtState[None, None, None, kv_handle.index],
+                tCrDecayV_A[None, None, kphase_idx, 1],
+                tCrKt_B[None, None, kphase_idx, k_stage],
+                tCtState[None, None, None, kv_handle.index],
             )
-        kv_acc_handle.commit()
-        dv_handle.release()
-        # K SMEM slot now free for next chunk
-        k_handle.release()
+        kv_handle.commit()
+        k_release_handle.release()
+        load_k_releaser.advance()
 
-        return (  # type: ignore[return-value]
-            shared_acc_producer,
+        return (
+            cg0_shared_acc_producer,
+            cg1_shared_acc_producer,
             q_state_acc_producer,
             kv_acc_producer,
             load_k_consumer,
+            load_k_releaser,
             load_q_consumer,
+            load_q_releaser,
             load_v_consumer,
             a_inv_ready_consumer,
             qk_ready_consumer,
             state_inp_ready_consumer,
-            shared_inp_ready_consumer,
+            vks_ready_consumer,
+            nv_ready_consumer,
+            decay_v_ready_consumer,
         )
 
     @cute.jit
-    def compute_group_0(
+    def compute_group_0_pair(
         self,
         tidx: cutlass.Int32,
         tmem_ptr: cutlass.Int64,
@@ -2264,31 +2973,30 @@ class GatedDeltaNetChunkedKernel:
         pipeline.PipelineConsumer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
-        pipeline.PipelineProducer,
-        pipeline.PipelineProducer,
     ]:
-        """Warps 0-3: T-pairwise, kk_epi, inverse, qk_epi."""
+        """Warps 0-3: reuse one T-pairwise calculation across KK and QK.
+
+        The first pair completes both inverses before QK. A steady pair consumes
+        the prefetched KK0/KK1 from CG0's private ring, then reuses the same T
+        registers for QK0/QK1 before publishing both inverses.
+        """
         (tiled_mma_qk,) = mma_args
-        sCumsumlog, sBeta, sAinv, sQk = smem_args
+        sCumsumlog, sBeta, sAinv, sAinvCal, sQk = smem_args
         (
             load_gate_consumer,
             load_beta_consumer,
-            shared_acc_consumer,
+            cg0_shared_acc_consumer,
             a_inv_ready_producer,
             qk_ready_producer,
-            group_order_producer,
         ) = pipeline_args
-        (is_first_chunk,) = work_args
+        _, _ = work_args
 
         # ------------------------------------------------------------------
-        # Preamble: per-thread ID within CG0 and TMEM copy setup
+        # Preamble: identical to compute_group_0
         # ------------------------------------------------------------------
-        # Local thread ID within CG0 (0..127)
         num_threads_cg0 = self.threads_per_warp * len(self.compute_group_0_warp_ids)
         cg0_tidx = tidx % num_threads_cg0
 
-        # Build TMEM tensor view of shared_acc (both stages):
-        #   shape = (per_thread_acc_shape..., tmem_shared_acc_stages)
         tAcc_shape = tiled_mma_qk.partition_shape_C(
             (self.mma_tiler_qk[0], self.mma_tiler_qk[1])
         )
@@ -2297,301 +3005,405 @@ class GatedDeltaNetChunkedKernel:
             tAcc_wo_stages.iterator,
             cute.flat_product(
                 tAcc_wo_stages.layout,
-                cute.make_layout((self.tmem_shared_acc_stages,), stride=(1,)),
+                cute.make_layout((self.tmem_cg0_shared_acc_stages,), stride=(1,)),
             ),
         )
         tStS_staged = cute.make_tensor(
-            tmem_ptr + self.tmem_shared_acc_offset, tAcc.layout
+            tmem_ptr + self.tmem_cg0_shared_acc_offset, tAcc.layout
         )
-        tStS_staged_mn_view = self.transform_partitioned_tensor_layout(tStS_staged)
+        tStS_staged_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tStS_staged
+        )
         cS = cute.make_identity_tensor((self.mma_tiler_qk[0], self.mma_tiler_qk[1]))
-        # TMEM load copy atom and tiled copy (loads fp32 accum from TMEM -> registers)
         tStS_for_t2r = tStS_staged[(None, None), 0, 0, 0]
         atom_shared_t2r = cute.make_copy_atom(
-            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+            tcgen05.copy.Ld16x32bx2Op(tcgen05.copy.Repetition(16)), self.acc_dtype
         )
         tiled_shared_t2r = tcgen05.make_tmem_copy(atom_shared_t2r, tStS_for_t2r)
         thr_shared_t2r = tiled_shared_t2r.get_slice(cg0_tidx)
 
-        # Per-thread TMEM source (staged).
-        # tTR_tStS shape: (A, B, NUM_SUBS, NUM_STAGES)
-        # Each subtile is tTR_tStS[None, None, sub, stage] with shape (A, B).
         tTR_tStS = thr_shared_t2r.partition_S(tStS_staged_mn_view)
         tTR_tScS = thr_shared_t2r.partition_D(cS)
 
-        sub_tile_size = 32
-
-        # SMEM store copies: fp32 registers -> fp16 SMEM (A-operands for GEMM 5 and 6).
-        # make_tiled_copy_D mirrors tmem_tiled_copy's thread-value mapping so the
-        # register layout from the TMEM load aligns with the SMEM destination partition.
         atom_ainv_r2s = cute.make_copy_atom(
-            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+            cute.nvgpu.CopyUniversalOp(),
             self.io_dtype,
+            num_bits_per_copy=128,
         )
         tiled_ainv_r2s = cute.make_tiled_copy_D(atom_ainv_r2s, tiled_shared_t2r)
-        sAinv_mn_view = self.transform_partitioned_tensor_layout(sAinv)
-        thr_ainv_r2s = tiled_ainv_r2s.get_slice(cg0_tidx)
-        tCsAI = thr_ainv_r2s.partition_D(sAinv_mn_view)
-
-        atom_ainv_s2r = cute.make_copy_atom(
-            cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
-            self.io_dtype,
-        )
-        tiled_ainv_s2r = cute.make_tiled_copy_D(atom_ainv_s2r, tiled_shared_t2r)
-        thr_ainv_s2r = tiled_ainv_s2r.get_slice(cg0_tidx)
+        sAinv_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(sAinv)
+        if cutlass.const_expr(self.inverse_dtype == self.io_dtype):
+            sAinvCal_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+                sAinvCal
+            )
+            tiled_ainv_cal_r2s = tiled_ainv_r2s
+            tCsAICal = tiled_ainv_cal_r2s.get_slice(cg0_tidx).partition_D(
+                sAinvCal_mn_view
+            )
+        else:
+            atom_ainv_cal_r2s = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.inverse_dtype,
+                num_bits_per_copy=128,
+            )
+            tiled_ainv_cal_r2s = cute.make_tiled_copy_D(
+                atom_ainv_cal_r2s, tiled_shared_t2r
+            )
+            sAinvCal_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+                sAinvCal
+            )
+            tCsAICal = tiled_ainv_cal_r2s.get_slice(cg0_tidx).partition_D(
+                sAinvCal_mn_view
+            )
 
         atom_qk_r2s = cute.make_copy_atom(
-            cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+            cute.nvgpu.CopyUniversalOp(),
             self.io_dtype,
+            num_bits_per_copy=128,
         )
         tiled_qk_r2s = cute.make_tiled_copy_D(atom_qk_r2s, tiled_shared_t2r)
-        sQk_mn_view = self.transform_partitioned_tensor_layout(sQk)
+        sQk_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(sQk)
         tCsQK = tiled_qk_r2s.get_slice(cg0_tidx).partition_D(sQk_mn_view)
-
         # ------------------------------------------------------------------
-        # Step 1: T-pairwise - wait for cumsumlog, compute T row, release
-        #   sCumsumlog[t] = sum_{l=0}^{t} log(gate_l)  (prefix sum done by gate warp)
-        #   T[i,j]        = exp(cumsumlog[i] - cumsumlog[j])  for i>=j, else 0
-        #
-        #   The gate warp (warp 10) stores the inclusive prefix sum directly into
-        #   sCumsumlog before committing the gate pipeline handle, so CG0 can read
-        #   the final cumsumlog values immediately after wait_and_advance().
+        # Step 1a: T-pairwise for sub-chunk 0
         # ------------------------------------------------------------------
-        gate_handle = load_gate_consumer.wait_and_advance()
+        gate0_handle = load_gate_consumer.wait_and_advance()
+        sCumsumlog0 = sCumsumlog[None, 0, gate0_handle.index]
+        row_coord = tTR_tScS[0][0]
+        row_cumsumlog0 = sCumsumlog0[row_coord]
+        tGrCumsumlog_0 = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
+        gate1_handle = load_gate_consumer.wait_and_advance()
+        sCumsumlog1 = sCumsumlog[None, 0, gate1_handle.index]
+        row_cumsumlog1 = sCumsumlog1[row_coord]
+        tGrCumsumlog_1 = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
 
-        # Pre-compute T[i,*] for all columns into registers BEFORE waiting for TMEM.
-        # This overlaps the 128 exp2f calls with the MMA warp's GEMMs so that
-        # kk_epi and qk_epi only need a register multiply - no SMEM reads in the
-        # hot loop.  Register cost: BT fp32 = 128 regs (live until after qk_epi).
-        #   tGrT[j] = exp2(cumsumlog[i] - cumsumlog[j])  for i >= j, else 0.0
-        #   where i = cg0_tidx (this thread's row), j = k (col, compile-time).
-        rCumsumlog = cute.make_rmem_tensor((2, 16), self.acc_dtype)
-        tGrCumsumlog = thr_shared_t2r.partition_D(rCumsumlog)
+        # The triangular predicate is identical for both chunks in the pair.
+        # Compute the two named register fragments together so the predicate
+        # and element traversal are emitted once without dynamic RMEM indexing.
         for k in cutlass.range_constexpr(cute.size(tTR_tScS)):
             coord = tTR_tScS[k]
-            tGrCumsumlog[k] = (
+            is_lower = row_coord >= coord[1]
+            tGrCumsumlog_0[k] = (
                 cute.math.exp2(
-                    sCumsumlog[coord[0]] - sCumsumlog[coord[1]], fastmath=True
+                    row_cumsumlog0 - sCumsumlog0[coord[1]],
+                    fastmath=True,
                 )
-                if coord[0] >= coord[1]
+                if is_lower
                 else 0.0
             )
-        gate_handle.release()
+            tGrCumsumlog_1[k] = (
+                cute.math.exp2(
+                    row_cumsumlog1 - sCumsumlog1[coord[1]],
+                    fastmath=True,
+                )
+                if is_lower
+                else 0.0
+            )
+        gate0_handle.release()
+        gate1_handle.release()
 
-        # Wait for beta ready (used in both kk_epi and qk_epi scaling)
-        beta_handle = load_beta_consumer.wait_and_advance()
-
-        rBeta = cute.make_rmem_tensor((2,), self.acc_dtype)
-        rBeta = cute.make_tensor(
-            rBeta.iterator,
-            cute.flat_product(rBeta.layout, cute.make_layout((16,), stride=(0,))),
-        )
-        tGrBeta = thr_shared_t2r.partition_D(rBeta)
-        for k in cutlass.range_constexpr(cute.size(tTR_tScS)):
-            coord = tTR_tScS[k]
-            tGrBeta[k] = sBeta[coord[0], 0, beta_handle.index]
-
+        beta0_handle = load_beta_consumer.wait_and_advance()
+        tGrBeta_0 = sBeta[tTR_tScS[0][0], 0, beta0_handle.index]
+        beta1_handle = load_beta_consumer.wait_and_advance()
+        tGrBeta_1 = sBeta[tTR_tScS[0][0], 0, beta1_handle.index]
         # ------------------------------------------------------------------
-        # Step 2: kk_epi - load W_kk (GEMM 1 result from TMEM), scale -> M_kk
-        #   Depends on: shared_acc stage 0 (MMA warp GEMM 1 kk done)
-        #   W_kk[i,j] *= T[i,j] * beta[i]  where T[i,j] = exp2(cumsumlog[i]-cumsumlog[j])
-        #   TMEM load is split into num_kk_subs subtiles (each covering kk_sub_size cols).
+        # Step 2: kk_epi0 + kk_epi1
+        # Consume both KK accumulators first so their inverse can overlap the
+        # following QK0/QK1 MMA issues in the two shared-acc stages.
         # ------------------------------------------------------------------
-        # Acquire sAinvNv slot, fence, signal
-        ainv_handle = a_inv_ready_producer.acquire_and_advance()
-        # Acquire sQkOstore slot, write W_qkv (fp16), fence, signal
-        qk_ready_handle = qk_ready_producer.acquire_and_advance()
-        group_order_handle = group_order_producer.acquire_and_advance()
-        kk_handle = shared_acc_consumer.wait_and_advance()
+        ainv0_handle = a_inv_ready_producer.acquire_and_advance()
 
-        # tStS_for_t2r = tStS_staged[(None, None), 0, 0, kk_handle.index]
-        # tTR_tStS = thr_shared_t2r.partition_S(tStS_for_t2r)
-        # tKKrKK: full-size register buffer for M_kk (inverse step), filled subtile by subtile.
-        # tKKrKK[j] = M_kk[cg0_tidx, j] after the loop (thread owns its full row).
-        # SMEM write is deferred to the inverse step (row-major layout, below).
         tKKrKK = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
-
-        tKKrKK_out = cute.make_rmem_tensor_like(tKKrKK, self.io_dtype)
-        tCrAI = tiled_ainv_r2s.retile(tKKrKK_out)
+        tKKrKK_out_cal = cute.make_rmem_tensor_like(tKKrKK, self.inverse_dtype)
+        tCrAICal = tiled_ainv_cal_r2s.retile(tKKrKK_out_cal)
+        kk0_handle = cg0_shared_acc_consumer.wait_and_advance()
         for sub in cutlass.range(tKKrKK.shape[2]):
             cute.copy(
                 tiled_shared_t2r,
-                tTR_tStS[None, 0, sub, kk_handle.index],
+                tTR_tStS[None, 0, sub, kk0_handle.index],
                 tKKrKK[None, 0, sub],
             )
-            for k in cutlass.range(sub_tile_size):
+        cute.arch.fence_view_async_tmem_load()
+        kk0_handle.release()
+        for sub in cutlass.range(tKKrKK.shape[2]):
+            for k in cutlass.range(
+                cute.size(tGrCumsumlog_0.shape[0]),
+                vectorize=True,
+                unroll_full=True,
+            ):
                 tKKrKK[k, 0, sub] = (
-                    tKKrKK[k, 0, sub] * tGrCumsumlog[k, 0, sub] * tGrBeta[k, 0, sub]
+                    tKKrKK[k, 0, sub] * tGrCumsumlog_0[k, 0, sub] * tGrBeta_0
                 )
-            tKKrKK_out[None, 0, sub].store(
-                tKKrKK[None, 0, sub].load().to(self.io_dtype)
+            tKKrKK_out_cal[None, 0, sub].store(
+                tKKrKK[None, 0, sub].load().to(self.inverse_dtype)
             )
             cute.copy(
-                tiled_ainv_r2s,
-                tCrAI[None, 0, sub],
-                tCsAI[None, 0, sub, ainv_handle.index],
+                tiled_ainv_cal_r2s,
+                tCrAICal[None, 0, sub],
+                tCsAICal[None, 0, sub, ainv0_handle.index],
             )
-        # Release shared_acc stage 0 (CG1 also releases its side - collective barrier)
-        kk_handle.release()
 
-        # ------------------------------------------------------------------
-        # Step 3: qk_epi - load W_qk (GEMM 2 result from TMEM), scale -> W_qkv
-        #   Depends on: shared_acc stage 1 (MMA warp GEMM 2 qk done)
-        #   W_qk[i,j] *= T[i,j] * scale  where T[i,j] = exp2(cumsumlog[i]-cumsumlog[j])
-        #   Same subtile structure as kk_epi (num_kk_subs / kk_sub_size reused).
-        #   Done before inverse so that qk_ready signals GEMM 6 early, letting the
-        #   MMA warp run GEMM 6 in parallel with the inverse computation below.
-        # ------------------------------------------------------------------
-        qk_handle = shared_acc_consumer.wait_and_advance()
+        ainv1_handle = a_inv_ready_producer.acquire_and_advance()
+        kk1_handle = cg0_shared_acc_consumer.wait_and_advance()
+        for sub in cutlass.range(tKKrKK.shape[2]):
+            cute.copy(
+                tiled_shared_t2r,
+                tTR_tStS[None, 0, sub, kk1_handle.index],
+                tKKrKK[None, 0, sub],
+            )
+        cute.arch.fence_view_async_tmem_load()
+        kk1_handle.release()
+        for sub in cutlass.range(tKKrKK.shape[2]):
+            for k in cutlass.range(
+                cute.size(tGrCumsumlog_1.shape[0]),
+                vectorize=True,
+                unroll_full=True,
+            ):
+                tKKrKK[k, 0, sub] = (
+                    tKKrKK[k, 0, sub] * tGrCumsumlog_1[k, 0, sub] * tGrBeta_1
+                )
+            tKKrKK_out_cal[None, 0, sub].store(
+                tKKrKK[None, 0, sub].load().to(self.inverse_dtype)
+            )
+            cute.copy(
+                tiled_ainv_cal_r2s,
+                tCrAICal[None, 0, sub],
+                tCsAICal[None, 0, sub, ainv1_handle.index],
+            )
 
-        tStS_for_t2r = tStS_staged[(None, None), 0, 0, qk_handle.index]
-        # tTR_tStS = thr_shared_t2r.partition_S(tStS_for_t2r)
+        self._partial_pair_inverse(tidx, sAinvCal, ainv0_handle, ainv1_handle)
+        self._finish_pair_inverse(
+            tidx,
+            (sBeta, sAinv, sAinvCal),
+            (tiled_shared_t2r, tTR_tScS),
+            (ainv0_handle, ainv1_handle, beta0_handle, beta1_handle),
+        )
 
-        # tQKrQK: full-size register buffer for W_qkv (SMEM write), filled subtile by subtile.
+        qk0_ready_handle = qk_ready_producer.acquire_and_advance()
+        qk0_handle = cg0_shared_acc_consumer.wait_and_advance()
         tQKrQK = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
-
-        # Convert fp32 tQKrQK -> fp16 and store to sQk, one subtile at a time.
         tQKrQK_out = cute.make_rmem_tensor_like(tQKrQK, self.io_dtype)
         tCrQK = tiled_qk_r2s.retile(tQKrQK_out)
         for sub in cutlass.range(tQKrQK.shape[2]):
             cute.copy(
                 tiled_shared_t2r,
-                tTR_tStS[None, 0, sub, qk_handle.index],
+                tTR_tStS[None, 0, sub, qk0_handle.index],
                 tQKrQK[None, 0, sub],
             )
-            for k in cutlass.range(sub_tile_size):
-                tQKrQK[k, 0, sub] = tQKrQK[k, 0, sub] * tGrCumsumlog[k, 0, sub] * scale
+            for k in cutlass.range(
+                cute.size(tGrCumsumlog_0.shape[0]), vectorize=True, unroll_full=True
+            ):
+                tQKrQK[k, 0, sub] = (
+                    tQKrQK[k, 0, sub] * tGrCumsumlog_0[k, 0, sub] * scale
+                )
             tQKrQK_out[None, 0, sub].store(
                 tQKrQK[None, 0, sub].load().to(self.io_dtype)
             )
             cute.copy(
-                tiled_qk_r2s, tCrQK[None, 0, sub], tCsQK[None, 0, sub, qk_handle.index]
+                tiled_qk_r2s,
+                tCrQK[None, 0, sub],
+                tCsQK[None, 0, sub, qk0_ready_handle.index],
             )
         cute.arch.fence_view_async_shared()
-        # Release shared_acc stage 1
-        qk_handle.release()
-        group_order_handle.commit()
-
-        qk_ready_handle.commit()
-
-        # Advance past shared_acc stages used by GEMMs 3/4 (K*State, Q*State).
-        # These stages form a collective barrier with CG1; CG0 must advance
-        # even though it does not read the results, so CG1 can proceed.
-        # First chunk without valid state skips GEMM 4 (Q*State), so only
-        # one advance is needed instead of two.
-        shared_acc_consumer.advance()
-        valid_state = not is_first_chunk or self.use_initial_state
-        if valid_state:
-            shared_acc_consumer.advance()
+        cute.arch.fence_view_async_tmem_load()
+        qk0_handle.release()
+        qk0_ready_handle.commit()
 
         # ------------------------------------------------------------------
-        # Step 4: inverse - compute A_inv = (I + M_kk)^{-1}, write to sAinvNv
-        #   Done after qk_epi so the inverse computation overlaps with GEMM 6
-        #   (qkv) running in the MMA warp.
+        # Step 3: qk_epi1
         # ------------------------------------------------------------------
+        qk1_ready_handle = qk_ready_producer.acquire_and_advance()
+        qk1_handle = cg0_shared_acc_consumer.wait_and_advance()
 
-        # -- Hierarchical blockwise inverse: A_inv = (I + M_kk)^{-1} ----------
-        # Thread cg0_tidx owns row cg0_tidx of the BTxBT matrix.
-        # sAinv is reinterpreted as row-major (BTxBT) fp16 for the algorithm;
-        # the MMA-ready A-operand layout is written back via tiled_store_ainv after.
-        # NOTE: assumes io_dtype == Float16 (algorithm uses fp16 SMEM + fp32 accumulators).
+        for sub in cutlass.range(tQKrQK.shape[2]):
+            cute.copy(
+                tiled_shared_t2r,
+                tTR_tStS[None, 0, sub, qk1_handle.index],
+                tQKrQK[None, 0, sub],
+            )
+            for k in cutlass.range(
+                cute.size(tGrCumsumlog_1.shape[0]), vectorize=True, unroll_full=True
+            ):
+                tQKrQK[k, 0, sub] = (
+                    tQKrQK[k, 0, sub] * tGrCumsumlog_1[k, 0, sub] * scale
+                )
+            tQKrQK_out[None, 0, sub].store(
+                tQKrQK[None, 0, sub].load().to(self.io_dtype)
+            )
+            cute.copy(
+                tiled_qk_r2s,
+                tCrQK[None, 0, sub],
+                tCsQK[None, 0, sub, qk1_ready_handle.index],
+            )
+        cute.arch.fence_view_async_shared()
+        cute.arch.fence_view_async_tmem_load()
+        qk1_handle.release()
+        qk1_ready_handle.commit()
+
+        return (
+            load_gate_consumer,
+            load_beta_consumer,
+            cg0_shared_acc_consumer,
+            a_inv_ready_producer,
+            qk_ready_producer,
+        )
+
+    @cute.jit
+    def _partial_pair_inverse(
+        self,
+        tidx: cutlass.Int32,
+        sAinvCal: cute.Tensor,
+        ainv0_handle,
+        ainv1_handle,
+    ):
+        """Invert 8x8 diagonal blocks and build the 16x16 corrections."""
+        num_threads_cg0 = self.threads_per_warp * len(self.compute_group_0_warp_ids)
+        cg0_tidx = tidx % num_threads_cg0
+        warp_id = cg0_tidx // 32
+        lane_id = cg0_tidx % 32
+        inverse_group = warp_id // 2
+        inverse_local_warp = warp_id % 2
+        sAinvCal_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            sAinvCal
+        )
+        sA0Work = sAinvCal_mn_view[None, None, ainv0_handle.index]
+        sA1Work = sAinvCal_mn_view[None, None, ainv1_handle.index]
+        # Three stages can wrap between the two pair handles, so XOR is invalid.
+        inverse_stage = ainv0_handle.index
+        if inverse_group == 1:
+            inverse_stage = ainv1_handle.index
+        sAWork = sAinvCal_mn_view[None, None, inverse_stage]
+
+        sM_8x8 = cute.flat_divide(sAWork, (8, 8))
+        self.inverse_barrier.arrive_and_wait()
+        idx_8x8 = (inverse_local_warp * self.threads_per_warp + lane_id) // 8
+        self._invert_diagonal_NxN(sM_8x8[None, None, idx_8x8, idx_8x8], cg0_tidx, 8)
+        self.inverse_barrier.arrive_and_wait()
+
+        sM0_16x16 = cute.flat_divide(sA0Work, (16, 16))
+        sM1_16x16 = cute.flat_divide(sA1Work, (16, 16))
+        self._blockwise_diagonal_8x8_to_16x16(
+            sM0_16x16[None, None, warp_id, warp_id], lane_id
+        )
+        self._blockwise_diagonal_8x8_to_16x16(
+            sM1_16x16[None, None, warp_id, warp_id], lane_id
+        )
+        self.inverse_barrier.arrive_and_wait()
+
+    @cute.jit
+    def _finish_pair_inverse(
+        self,
+        tidx: cutlass.Int32,
+        smem_args: tuple,
+        copy_args: tuple,
+        handle_args: tuple,
+    ):
+        """Invert and publish two prepared A-inverse stages in parallel."""
+        sBeta, sAinv, sAinvCal = smem_args
+        tiled_shared_t2r, tTR_tScS = copy_args
+        ainv0_handle, ainv1_handle, beta0_handle, beta1_handle = handle_args
+
+        num_threads_cg0 = self.threads_per_warp * len(self.compute_group_0_warp_ids)
+        cg0_tidx = tidx % num_threads_cg0
         warp_id = cg0_tidx // 32
         lane_id = cg0_tidx % 32
 
-        sA = sAinv_mn_view[None, None, ainv_handle.index]
-        # Stage 1: Gauss-Jordan inversion of BT//8 = 16 diagonal 8x8 blocks.
-        sM_8x8 = cute.flat_divide(sA, (8, 8))
-        self.inverse_barrier.arrive_and_wait()
-        if warp_id < 2:
-            self._invert_diagonal_NxN(
-                sM_8x8[None, None, cg0_tidx // 8, cg0_tidx // 8], cg0_tidx, 8
-            )
-        self.inverse_barrier.arrive_and_wait()
+        sAinv_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(sAinv)
+        sAinvCal_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            sAinvCal
+        )
+        inverse_group = warp_id // 2
+        inverse_local_warp = warp_id % 2
+        inverse_stage = ainv0_handle.index
+        if inverse_group == 1:
+            inverse_stage = ainv1_handle.index
+        sAWork = sAinvCal_mn_view[None, None, inverse_stage]
 
-        # Stage 2: off-diagonal correction 8x8 -> 16x16.
-        # 8 diagonal 16x16 tiles; each warp handles 2 tiles sequentially.
-        sM_16x16 = cute.flat_divide(sA, (16, 16))
-        self._blockwise_diagonal_8x8_to_16x16(
-            sM_16x16[None, None, warp_id, warp_id], lane_id
+        # Resume after the partial inverse: 16x16 -> 32x32 -> 64x64.
+        sM_32x32 = cute.flat_divide(sAWork, (32, 32))
+        self._blockwise_diagonal_16x16_to_32x32(
+            sM_32x32[None, None, inverse_local_warp, inverse_local_warp], lane_id
+        )
+        self.inverse_barrier.arrive_and_wait()
+        sM_64x64 = cute.flat_divide(sAWork, (64, 64))
+        self._blockwise_diagonal_32x32_to_64x64(
+            sM_64x64[None, None, 0, 0], inverse_local_warp, lane_id
         )
         self.inverse_barrier.arrive_and_wait()
 
-        # Stage 3: off-diagonal correction 16x16 -> 32x32.
-        # 4 diagonal 32x32 tiles; one tile per warp.
-        sM_32x32 = cute.flat_divide(sA, (32, 32))
-        if warp_id < 2:
-            self._blockwise_diagonal_16x16_to_32x32(
-                sM_32x32[None, None, warp_id, warp_id], lane_id
-            )
-        self.inverse_barrier.arrive_and_wait()
-
-        # Stage 4: off-diagonal correction 32x32 -> 64x64.
-        # 2 diagonal 64x64 tiles; warps 0,1 on tile 0, warps 2,3 on tile 1.
-        sM_64x64 = cute.flat_divide(sA, (64, 64))
-        if warp_id < 2:
-            self._blockwise_diagonal_32x32_to_64x64(
-                sM_64x64[None, None, warp_id // 2, warp_id // 2], warp_id, lane_id
-            )
-        self.inverse_barrier.arrive_and_wait()
-
-        # sAinv_rm now contains A_inv = (I + M_kk)^{-1} in row-major fp16 layout.
-
-        # Apply beta column-scaling: A_inv[i,j] *= beta[j]  (equivalent to A_inv @ diag(beta))
-        tCsAI = thr_ainv_s2r.partition_S(sAinv_mn_view)
-        tCsAI = tCsAI[None, None, None, ainv_handle.index]
-        tCrAI = cute.make_rmem_tensor_like(tCsAI, self.io_dtype)
-        tCrAI_acc = cute.make_rmem_tensor_like(tCrAI, self.acc_dtype)
-        rBeta = cute.make_rmem_tensor((16,), self.acc_dtype)
-        rBeta = cute.make_tensor(
-            rBeta.iterator,
-            cute.flat_product(cute.make_layout((2,), stride=(0,)), rBeta.layout),
+        # Apply beta column scaling and publish both stages to the MMA warp.
+        atom_ainv_s2r = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self.io_dtype, num_bits_per_copy=128
         )
-        tKKrBeta = thr_ainv_s2r.partition_D(rBeta)
+        tiled_ainv_s2r = cute.make_tiled_copy_D(atom_ainv_s2r, tiled_shared_t2r)
+        thr_ainv_s2r = tiled_ainv_s2r.get_slice(cg0_tidx)
+        if cutlass.const_expr(self.inverse_dtype == self.io_dtype):
+            tiled_ainv_cal_s2r = tiled_ainv_s2r
+            thr_ainv_cal_s2r = thr_ainv_s2r
+        else:
+            atom_ainv_cal_s2r = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.inverse_dtype,
+                num_bits_per_copy=128,
+            )
+            tiled_ainv_cal_s2r = cute.make_tiled_copy_D(
+                atom_ainv_cal_s2r, tiled_shared_t2r
+            )
+            thr_ainv_cal_s2r = tiled_ainv_cal_s2r.get_slice(cg0_tidx)
+        tKKrBeta = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
+
+        tCsAI0 = thr_ainv_s2r.partition_S(sAinv_mn_view)[
+            None, None, None, ainv0_handle.index
+        ]
+        tCsAI0Cal = thr_ainv_cal_s2r.partition_S(sAinvCal_mn_view)[
+            None, None, None, ainv0_handle.index
+        ]
+        tCrAI0 = cute.make_rmem_tensor_like(tCsAI0, self.io_dtype)
+        tCrAI0Acc = cute.make_rmem_tensor_like(tCrAI0, self.acc_dtype)
+        tCrAI0Cal = cute.make_rmem_tensor_like(tCsAI0Cal, self.inverse_dtype)
         for k in cutlass.range(cute.size(tTR_tScS)):
             coord = tTR_tScS[k]
-            tKKrBeta[k] = sBeta[coord[1], 0, beta_handle.index]
-        cute.copy(
-            tiled_ainv_s2r,
-            tCsAI,
-            tCrAI,
-        )
-
-        tCrAI_acc.store(tCrAI.load().to(self.acc_dtype))
-        for k in cutlass.range(cute.size(tCrAI)):
-            tCrAI_acc[k] = tCrAI_acc[k] * tKKrBeta[k]
-        tCrAI.store(tCrAI_acc.load().to(self.io_dtype))
-        cute.copy(
-            tiled_ainv_r2s,
-            tCrAI,
-            tCsAI,
-        )
-
-        # Fence SMEM writes and signal A_inv ready to MMA warp (GEMM 5 can start)
+            tKKrBeta[k] = sBeta[coord[1], 0, beta0_handle.index]
+        cute.copy(tiled_ainv_cal_s2r, tCsAI0Cal, tCrAI0Cal)
+        tCrAI0Acc.store(tCrAI0Cal.load().to(self.acc_dtype))
+        for k in cutlass.range(cute.size(tCrAI0), vectorize=True, unroll_full=True):
+            tCrAI0Acc[k] = tCrAI0Acc[k] * tKKrBeta[k]
+        tCrAI0.store(tCrAI0Acc.load().to(self.io_dtype))
+        cute.copy(tiled_ainv_s2r, tCrAI0, tCsAI0)
         cute.arch.fence_view_async_shared()
+        ainv0_handle.commit()
+        beta0_handle.release()
 
-        ainv_handle.commit()
-
-        # Release beta pipeline (beta fully consumed by this chunk)
-        beta_handle.release()
-
-        return (  # type: ignore[return-value]
-            load_gate_consumer,
-            load_beta_consumer,
-            shared_acc_consumer,
-            a_inv_ready_producer,
-            qk_ready_producer,
-            group_order_producer,
-        )
+        tCsAI1 = thr_ainv_s2r.partition_S(sAinv_mn_view)[
+            None, None, None, ainv1_handle.index
+        ]
+        tCsAI1Cal = thr_ainv_cal_s2r.partition_S(sAinvCal_mn_view)[
+            None, None, None, ainv1_handle.index
+        ]
+        tCrAI1 = cute.make_rmem_tensor_like(tCsAI1, self.io_dtype)
+        tCrAI1Acc = cute.make_rmem_tensor_like(tCrAI1, self.acc_dtype)
+        tCrAI1Cal = cute.make_rmem_tensor_like(tCsAI1Cal, self.inverse_dtype)
+        for k in cutlass.range(cute.size(tTR_tScS)):
+            coord = tTR_tScS[k]
+            tKKrBeta[k] = sBeta[coord[1], 0, beta1_handle.index]
+        cute.copy(tiled_ainv_cal_s2r, tCsAI1Cal, tCrAI1Cal)
+        tCrAI1Acc.store(tCrAI1Cal.load().to(self.acc_dtype))
+        for k in cutlass.range(cute.size(tCrAI1), vectorize=True, unroll_full=True):
+            tCrAI1Acc[k] = tCrAI1Acc[k] * tKKrBeta[k]
+        tCrAI1.store(tCrAI1Acc.load().to(self.io_dtype))
+        cute.copy(tiled_ainv_s2r, tCrAI1, tCsAI1)
+        cute.arch.fence_view_async_shared()
+        ainv1_handle.commit()
+        beta1_handle.release()
 
     # ------------------------------------------------------------------
-    # Hierarchical blockwise inverse helpers (ported from gdn_inverse_verify.py)
-    # Compute X = (I + M)^{-1} for a 128x128 unit lower-triangular matrix in-place
-    # on a row-major fp16 SMEM buffer.  5-stage algorithm:
-    #   Stage 1: Gauss-Jordan inversion of 16 diagonal 8x8 blocks (warp shuffle)
+    # Hierarchical blockwise inverse helpers.
+    # Compute X = (I + M)^{-1} for a 64x64 unit lower-triangular matrix in-place
+    # on a row-major SMEM buffer.  4-stage algorithm:
+    #   Stage 1: Gauss-Jordan inversion of 8 diagonal 8x8 blocks (warp shuffle)
     #   Stage 2: 8x8 -> 16x16 via warp MMA  (SM80_16x8x8)
     #   Stage 3: 16x16 -> 32x32 via warp MMA (SM80_16x8x16)
     #   Stage 4: 32x32 -> 64x64 via warp MMA, 2 warps per 64x64 tile
-    #   Stage 5: 64x64 -> 128x128 via warp MMA, 4 warps on full matrix
     # ------------------------------------------------------------------
 
     def _make_acc_tensor_into_a_view(self, acc: cute.Tensor) -> cute.Tensor:
@@ -2615,19 +3427,34 @@ class GatedDeltaNetChunkedKernel:
         )
         return cute.make_tensor(acc.iterator, acc_layout_a)
 
+    def _convert_f32_fragment_to_tf32_operand(
+        self, fragment: cute.Tensor
+    ) -> cute.Tensor:
+        fragment_values = fragment.load()
+        fragment_tf32 = cute.make_rmem_tensor_like(fragment, cutlass.Int32)
+        for i in range(cute.size(fragment)):
+            fragment_tf32[i] = cute.arch.cvt_f32_tf32(fragment_values[i])
+        return fragment_tf32
+
+    def _assume_tensor_iterator_alignment(
+        self, tensor: cute.Tensor, alignment: int
+    ) -> cute.Tensor:
+        return cute.make_tensor(tensor.iterator.align(alignment), tensor.layout)
+
     @cute.jit
     def _invert_diagonal_NxN(self, mat_NxN, tidx, N: int = 8):
-        """Stage 1: Gauss-Jordan inversion of one diagonal NxN block in-place (fp16 SMEM).
+        """Stage 1: Gauss-Jordan inversion of one diagonal NxN block in-place.
 
         Each thread owns one row (tidx_in_group = tidx % N).
         Uses warp shuffle to broadcast pivot values; no __syncthreads inside.
         N-1 pivot steps, compile-time unrolled.
         """
         tidx_in_group = tidx % N
-        row_f16 = cute.make_rmem_tensor((N,), self.io_dtype)
-        cute.autovec_copy(mat_NxN[tidx_in_group, None], row_f16)
-        row = cute.make_rmem_tensor_like(row_f16, self.acc_dtype)
-        row.store(row_f16.load().to(cutlass.Float32))
+        row_storage = cute.make_rmem_tensor((N,), mat_NxN.element_type)
+        cute.autovec_copy(mat_NxN[tidx_in_group, None], row_storage)
+        row = cute.make_rmem_tensor_like(row_storage, self.acc_dtype)
+        row.store(row_storage.load().to(cutlass.Float32))
+
         for i in cutlass.range_constexpr(N):
             row[i] = 1.0 if tidx_in_group == i else row[i]
         for src_row in cutlass.range_constexpr(N - 1):
@@ -2641,8 +3468,8 @@ class GatedDeltaNetChunkedKernel:
                 )
             row[src_row] = row_scale if tidx_in_group > src_row else row[src_row]
 
-        row_f16.store(row.load().to(self.io_dtype))
-        cute.autovec_copy(row_f16, mat_NxN[tidx_in_group, None])
+        row_storage.store(row.load().to(mat_NxN.element_type))
+        cute.autovec_copy(row_storage, mat_NxN[tidx_in_group, None])
 
     @cute.jit
     def _blockwise_diagonal_8x8_to_16x16(self, mat_16x16, lane_id):
@@ -2652,40 +3479,76 @@ class GatedDeltaNetChunkedKernel:
         correction block: C <-- -D^{-1} C A^{-1}.
         MMA: SM80_16x8x8_F32F16F16F32_TN, single warp.  D^{-1} broadcast 8x8 -> 16x8.
         """
-        mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
-            self.io_dtype, self.acc_dtype, (16, 8, 8)
-        )
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            mma_atom = cute.nvgpu.warp.MmaTF32Op((16, 8, 8))
+        else:
+            mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
+                mat_16x16.element_type, self.acc_dtype, (16, 8, 8)
+            )
         tiled_mma = cute.make_tiled_mma(mma_atom, cute.make_layout((1, 1, 1)))
         thr_mma = tiled_mma.get_slice(lane_id)
 
-        D_tiled_copy = cute.make_tiled_copy_A(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=False),
-                mat_16x16.element_type,
-            ),
-            tiled_mma,
-        )
-        C_tiled_copy = cute.make_tiled_copy_B(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=True),
-                mat_16x16.element_type,
-            ),
-            tiled_mma,
-        )
-        A_tiled_copy = cute.make_tiled_copy_B(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=True),
-                mat_16x16.element_type,
-            ),
-            tiled_mma,
-        )
-        O_tiled_copy = cute.make_tiled_copy_C(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=1, transpose=False),
-                mat_16x16.element_type,
-            ),
-            tiled_mma,
-        )
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            D_tiled_copy = cute.make_tiled_copy_A(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=False),
+                    cutlass.Float32,
+                ),
+                tiled_mma,
+            )
+            C_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=32,
+                ),
+                tiled_mma,
+            )
+            A_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=32,
+                ),
+                tiled_mma,
+            )
+            O_tiled_copy = cute.make_tiled_copy_C(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=64,
+                ),
+                tiled_mma,
+            )
+        else:
+            D_tiled_copy = cute.make_tiled_copy_A(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=False),
+                    mat_16x16.element_type,
+                ),
+                tiled_mma,
+            )
+            C_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=True),
+                    mat_16x16.element_type,
+                ),
+                tiled_mma,
+            )
+            A_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=1, transpose=True),
+                    mat_16x16.element_type,
+                ),
+                tiled_mma,
+            )
+            O_tiled_copy = cute.make_tiled_copy_C(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=1, transpose=False),
+                    mat_16x16.element_type,
+                ),
+                tiled_mma,
+            )
 
         D_thr_copy = D_tiled_copy.get_slice(lane_id)
         C_thr_copy = C_tiled_copy.get_slice(lane_id)
@@ -2704,52 +3567,101 @@ class GatedDeltaNetChunkedKernel:
             sDinv.iterator,
             cute.logical_product(sDinv.layout, (cute.make_layout((2,), stride=(0,)),)),
         )
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            sDinv_m_bcast = self._assume_tensor_iterator_alignment(sDinv_m_bcast, 16)
         sO_m_bcast = cute.make_tensor(
             sO.iterator,
             cute.logical_product(sO.layout, (cute.make_layout((2,), stride=(0,)),)),
         )
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            sO_m_bcast = self._assume_tensor_iterator_alignment(sO_m_bcast, 16)
 
         tOrDinv = tiled_mma.make_fragment_A(thr_mma.partition_A(sDinv_m_bcast))
         tOrC = tiled_mma.make_fragment_B(thr_mma.partition_B(sC))
         tOrAinv = tiled_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            tOrDinv_load = cute.make_rmem_tensor_like(tOrDinv, cutlass.Float32)
+            tOrC_load = cute.make_rmem_tensor_like(tOrC, cutlass.Float32)
+            tOrAinv_load = cute.make_rmem_tensor_like(tOrAinv, cutlass.Float32)
+        else:
+            tOrDinv_load = tOrDinv
+            tOrC_load = tOrC
+            tOrAinv_load = tOrAinv
         tDCrDC = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 8)))
         tOrO = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 8)))
 
         tOsDinv = D_thr_copy.partition_S(sDinv_m_bcast)
-        tOsDinv = cute.logical_divide(tOsDinv, (tOsDinv.shape[0], None, None))
-        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
-        tOrDinv_cv = cute.logical_divide(tOrDinv_cv, (tOrDinv_cv.shape[0], None, None))
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv_load)
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            tOsDinv = self._assume_tensor_iterator_alignment(tOsDinv, 16)
+        if cutlass.const_expr(mat_16x16.element_type != cutlass.Float32):
+            tOsDinv = cute.logical_divide(tOsDinv, (tOsDinv.shape[0], None, None))
+            tOrDinv_cv = cute.logical_divide(
+                tOrDinv_cv, (tOrDinv_cv.shape[0], None, None)
+            )
         tOsC = C_thr_copy.partition_S(sC)
-        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOrC_cv = C_thr_copy.retile(tOrC_load)
         tOsAinv = A_thr_copy.partition_S(sAinv)
-        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv_load)
         tOsO = O_thr_copy.partition_D(sO_m_bcast)
+        tOsO_full = tOsO
         tOsO = cute.logical_divide(tOsO, (tOsO.shape[0], None, None))
         tOrO_cv = O_thr_copy.retile(tOrO)
+        tOrO_cv_full = tOrO_cv
         tOrO_cv = cute.logical_divide(tOrO_cv, (tOrO_cv.shape[0], None, None))
-        cute.copy(
-            D_tiled_copy,
-            tOsDinv[(None, 0), None, None],
-            tOrDinv_cv[(None, 0), None, None],
-        )
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            cute.copy(D_tiled_copy, tOsDinv, tOrDinv_cv)
+        else:
+            cute.copy(
+                D_tiled_copy,
+                tOsDinv[(None, 0), None, None],
+                tOrDinv_cv[(None, 0), None, None],
+            )
         cute.copy(C_tiled_copy, tOsC, tOrC_cv)
-        tDCrDC.fill(0.0)
-        cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
-        tDCrDC.store(-tDCrDC.load())
+        if cutlass.const_expr(mat_16x16.element_type == cutlass.Float32):
+            tOrDinv = self._convert_f32_fragment_to_tf32_operand(tOrDinv_load)
+            tOrC = self._convert_f32_fragment_to_tf32_operand(tOrC_load)
+            tDCrDC.fill(0.0)
+            cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
 
-        tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
-        tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, self.io_dtype)
-        tOrDC.store(tDCrDC_a.load().to(self.io_dtype))
+            tDCrDC_cv = O_thr_copy.retile(tDCrDC)
+            tDCrDC_store = cute.make_rmem_tensor_like(tDCrDC_cv, cutlass.Float32)
+            tDCrDC_store.store(cutlass.Float32(0.0) - tDCrDC_cv.load())
+            cute.copy(O_tiled_copy, tDCrDC_store, tOsO_full)
+            cute.arch.sync_warp()
 
-        cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
-        tOrO.fill(0.0)
-        cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+            tOsDC = D_thr_copy.partition_S(sO_m_bcast)
+            tOrDC_load = cute.make_rmem_tensor_like(tOrDinv_load, cutlass.Float32)
+            tOrDC_cv = D_thr_copy.retile(tOrDC_load)
+            tOsDC = self._assume_tensor_iterator_alignment(tOsDC, 16)
+            cute.copy(D_tiled_copy, tOsDC, tOrDC_cv)
+            tOrDC = self._convert_f32_fragment_to_tf32_operand(tOrDC_load)
 
-        tOrO_cv_cvt = cute.make_rmem_tensor_like(
-            tOrO_cv[(None, 0), None, None], self.io_dtype
-        )
-        tOrO_cv_cvt.store(tOrO_cv[(None, 0), None, None].load().to(self.io_dtype))
-        cute.copy(O_tiled_copy, tOrO_cv_cvt, tOsO[(None, 0), None, None])
+            cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+            tOrAinv = self._convert_f32_fragment_to_tf32_operand(tOrAinv_load)
+            tOrO.fill(0.0)
+            cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+
+            cute.copy(O_tiled_copy, tOrO_cv_full, tOsO_full)
+        else:
+            tDCrDC.fill(0.0)
+            cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
+            tDCrDC.store(cutlass.Float32(0.0) - tDCrDC.load())
+            tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
+            tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, mat_16x16.element_type)
+            tOrDC.store(tDCrDC_a.load().to(mat_16x16.element_type))
+
+            cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+            tOrO.fill(0.0)
+            cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+
+            tOrO_cv_cvt = cute.make_rmem_tensor_like(
+                tOrO_cv[(None, 0), None, None], mat_16x16.element_type
+            )
+            tOrO_cv_cvt.store(
+                tOrO_cv[(None, 0), None, None].load().to(mat_16x16.element_type)
+            )
+            cute.copy(O_tiled_copy, tOrO_cv_cvt, tOsO[(None, 0), None, None])
 
     @cute.jit
     def _blockwise_diagonal_16x16_to_32x32(self, mat_32x32, lane_id):
@@ -2759,42 +3671,78 @@ class GatedDeltaNetChunkedKernel:
         MMA: SM80_16x8x16_F32F16F16F32_TN, TileShape (16,16,16), single warp.
         make_acc_into_op ratio=2: A-frag atom size (8) / C-frag atom size (4).
         """
-        mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
-            self.io_dtype, self.acc_dtype, (16, 8, 16)
-        )
+        if cutlass.const_expr(mat_32x32.element_type == cutlass.Float32):
+            mma_atom = cute.nvgpu.warp.MmaTF32Op((16, 8, 8))
+        else:
+            mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
+                mat_32x32.element_type, self.acc_dtype, (16, 8, 16)
+            )
         tiled_mma = cute.make_tiled_mma(
             mma_atom, cute.make_layout((1, 1, 1)), permutation_mnk=(16, 16, 16)
         )
         thr_mma = tiled_mma.get_slice(lane_id)
 
-        D_tiled_copy = cute.make_tiled_copy_A(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
-                mat_32x32.element_type,
-            ),
-            tiled_mma,
-        )
-        C_tiled_copy = cute.make_tiled_copy_B(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
-                mat_32x32.element_type,
-            ),
-            tiled_mma,
-        )
-        A_tiled_copy = cute.make_tiled_copy_B(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
-                mat_32x32.element_type,
-            ),
-            tiled_mma,
-        )
-        O_tiled_copy = cute.make_tiled_copy_C(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
-                mat_32x32.element_type,
-            ),
-            tiled_mma,
-        )
+        if cutlass.const_expr(mat_32x32.element_type == cutlass.Float32):
+            D_tiled_copy = cute.make_tiled_copy_A(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                    cutlass.Float32,
+                ),
+                tiled_mma,
+            )
+            C_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=32,
+                ),
+                tiled_mma,
+            )
+            A_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=32,
+                ),
+                tiled_mma,
+            )
+            O_tiled_copy = cute.make_tiled_copy_C(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=64,
+                ),
+                tiled_mma,
+            )
+        else:
+            D_tiled_copy = cute.make_tiled_copy_A(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                    mat_32x32.element_type,
+                ),
+                tiled_mma,
+            )
+            C_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                    mat_32x32.element_type,
+                ),
+                tiled_mma,
+            )
+            A_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                    mat_32x32.element_type,
+                ),
+                tiled_mma,
+            )
+            O_tiled_copy = cute.make_tiled_copy_C(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                    mat_32x32.element_type,
+                ),
+                tiled_mma,
+            )
 
         D_thr_copy = D_tiled_copy.get_slice(lane_id)
         C_thr_copy = C_tiled_copy.get_slice(lane_id)
@@ -2812,29 +3760,55 @@ class GatedDeltaNetChunkedKernel:
         tOrDinv = tiled_mma.make_fragment_A(thr_mma.partition_A(sDinv))
         tOrC = tiled_mma.make_fragment_B(thr_mma.partition_B(sC))
         tOrAinv = tiled_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        if cutlass.const_expr(mat_32x32.element_type == cutlass.Float32):
+            tOrDinv_load = cute.make_rmem_tensor_like(tOrDinv, cutlass.Float32)
+            tOrC_load = cute.make_rmem_tensor_like(tOrC, cutlass.Float32)
+            tOrAinv_load = cute.make_rmem_tensor_like(tOrAinv, cutlass.Float32)
+        else:
+            tOrDinv_load = tOrDinv
+            tOrC_load = tOrC
+            tOrAinv_load = tOrAinv
         tDCrDC = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 16)))
         tOrO = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 16)))
 
         tOsDinv = D_thr_copy.partition_S(sDinv)
-        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv_load)
         tOsC = C_thr_copy.partition_S(sC)
-        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOrC_cv = C_thr_copy.retile(tOrC_load)
         tOsAinv = A_thr_copy.partition_S(sAinv)
-        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv_load)
         tOsO = O_thr_copy.partition_D(sO)
         tOrO_cv = O_thr_copy.retile(tOrO)
 
         cute.copy(D_tiled_copy, tOsDinv, tOrDinv_cv)
         cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        if cutlass.const_expr(mat_32x32.element_type == cutlass.Float32):
+            tOrDinv = self._convert_f32_fragment_to_tf32_operand(tOrDinv_load)
+            tOrC = self._convert_f32_fragment_to_tf32_operand(tOrC_load)
         tDCrDC.fill(0.0)
         cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
-        tDCrDC.store(-tDCrDC.load())
 
-        tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
-        tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, mat_32x32.element_type)
-        tOrDC.store(tDCrDC_a.load().to(mat_32x32.element_type))
+        if cutlass.const_expr(mat_32x32.element_type == cutlass.Float32):
+            tDCrDC_cv = O_thr_copy.retile(tDCrDC)
+            tDCrDC_store = cute.make_rmem_tensor_like(tDCrDC_cv, cutlass.Float32)
+            tDCrDC_store.store(cutlass.Float32(0.0) - tDCrDC_cv.load())
+            cute.copy(O_tiled_copy, tDCrDC_store, tOsO)
+            cute.arch.sync_warp()
+
+            tOsDC = D_thr_copy.partition_S(sO)
+            tOrDC_load = cute.make_rmem_tensor_like(tOrDinv_load, cutlass.Float32)
+            tOrDC_cv = D_thr_copy.retile(tOrDC_load)
+            cute.copy(D_tiled_copy, tOsDC, tOrDC_cv)
+            tOrDC = self._convert_f32_fragment_to_tf32_operand(tOrDC_load)
+        else:
+            tDCrDC.store(-tDCrDC.load())
+            tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
+            tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, mat_32x32.element_type)
+            tOrDC.store(tDCrDC_a.load().to(mat_32x32.element_type))
 
         cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        if cutlass.const_expr(mat_32x32.element_type == cutlass.Float32):
+            tOrAinv = self._convert_f32_fragment_to_tf32_operand(tOrAinv_load)
         tOrO.fill(0.0)
         cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
 
@@ -2843,49 +3817,85 @@ class GatedDeltaNetChunkedKernel:
         cute.copy(O_tiled_copy, tOrO_cv_cvt, tOsO)
 
     @cute.jit
-    def _blockwise_diagonal_32x32_to_64x64(self, mat_64x64, warp_id, lane_id):
+    def _blockwise_diagonal_32x32_to_64x64(self, mat_64x64, local_warp_id, lane_id):
         """Stage 4: off-diagonal correction for one 64x64 diagonal tile (32x32 -> 64x64).
 
-        4 warps collaborate (warp_id in {0,1,2,3}); x = warp_id//2, y = warp_id%2.
+        Two warps collaborate, each owning one 16x32 slice of the bottom-left block.
         MMA: SM80_16x8x16 TileShape (16,32,32), permutation_mnk=(16,32,32).
         Ends with sync_threads() to protect the sO write from races.
         """
-        mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
-            self.io_dtype, self.acc_dtype, (16, 8, 16)
-        )
+        if cutlass.const_expr(mat_64x64.element_type == cutlass.Float32):
+            mma_atom = cute.nvgpu.warp.MmaTF32Op((16, 8, 8))
+        else:
+            mma_atom = cute.nvgpu.warp.MmaF16BF16Op(
+                mat_64x64.element_type, self.acc_dtype, (16, 8, 16)
+            )
         tiled_mma = cute.make_tiled_mma(
             mma_atom, cute.make_layout((1, 1, 1)), permutation_mnk=(16, 32, 32)
         )
         thr_mma = tiled_mma.get_slice(lane_id)
 
-        D_tiled_copy = cute.make_tiled_copy_A(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
-                mat_64x64.element_type,
-            ),
-            tiled_mma,
-        )
-        C_tiled_copy = cute.make_tiled_copy_B(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
-                mat_64x64.element_type,
-            ),
-            tiled_mma,
-        )
-        A_tiled_copy = cute.make_tiled_copy_B(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
-                mat_64x64.element_type,
-            ),
-            tiled_mma,
-        )
-        O_tiled_copy = cute.make_tiled_copy_C(
-            cute.make_copy_atom(
-                cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
-                mat_64x64.element_type,
-            ),
-            tiled_mma,
-        )
+        if cutlass.const_expr(mat_64x64.element_type == cutlass.Float32):
+            D_tiled_copy = cute.make_tiled_copy_A(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                    cutlass.Float32,
+                ),
+                tiled_mma,
+            )
+            C_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=32,
+                ),
+                tiled_mma,
+            )
+            A_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=32,
+                ),
+                tiled_mma,
+            )
+            O_tiled_copy = cute.make_tiled_copy_C(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.Float32,
+                    num_bits_per_copy=64,
+                ),
+                tiled_mma,
+            )
+        else:
+            D_tiled_copy = cute.make_tiled_copy_A(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                    mat_64x64.element_type,
+                ),
+                tiled_mma,
+            )
+            C_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                    mat_64x64.element_type,
+                ),
+                tiled_mma,
+            )
+            A_tiled_copy = cute.make_tiled_copy_B(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
+                    mat_64x64.element_type,
+                ),
+                tiled_mma,
+            )
+            O_tiled_copy = cute.make_tiled_copy_C(
+                cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(num_matrices=4, transpose=False),
+                    mat_64x64.element_type,
+                ),
+                tiled_mma,
+            )
 
         D_thr_copy = D_tiled_copy.get_slice(lane_id)
         C_thr_copy = C_tiled_copy.get_slice(lane_id)
@@ -2897,47 +3907,73 @@ class GatedDeltaNetChunkedKernel:
         sC_full = mat_32x32_2x2[None, None, 1, 0]
         sAinv_full = mat_32x32_2x2[None, None, 0, 0]
 
-        sDinv = cute.flat_divide(sDinv_full, (16, 32))[None, None, warp_id % 2, 0]
+        sDinv = cute.flat_divide(sDinv_full, (16, 32))[None, None, local_warp_id, 0]
         sC = cute.make_tensor(
             sC_full.iterator, cute.select(sC_full.layout, mode=[1, 0])
         )
         sAinv = cute.make_tensor(
             sAinv_full.iterator, cute.select(sAinv_full.layout, mode=[1, 0])
         )
-        sO = cute.flat_divide(sC_full, (16, 32))[None, None, warp_id % 2, 0]
+        sO = cute.flat_divide(sC_full, (16, 32))[None, None, local_warp_id, 0]
 
         tOrDinv = tiled_mma.make_fragment_A(thr_mma.partition_A(sDinv))
         tOrC = tiled_mma.make_fragment_B(thr_mma.partition_B(sC))
         tOrAinv = tiled_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        if cutlass.const_expr(mat_64x64.element_type == cutlass.Float32):
+            tOrDinv_load = cute.make_rmem_tensor_like(tOrDinv, cutlass.Float32)
+            tOrC_load = cute.make_rmem_tensor_like(tOrC, cutlass.Float32)
+            tOrAinv_load = cute.make_rmem_tensor_like(tOrAinv, cutlass.Float32)
+        else:
+            tOrDinv_load = tOrDinv
+            tOrC_load = tOrC
+            tOrAinv_load = tOrAinv
         tDCrDC = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 32)))
         tOrO = tiled_mma.make_fragment_C(tiled_mma.partition_shape_C((16, 32)))
 
         tOsDinv = D_thr_copy.partition_S(sDinv)
-        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv_load)
         tOsC = C_thr_copy.partition_S(sC)
-        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOrC_cv = C_thr_copy.retile(tOrC_load)
         tOsAinv = A_thr_copy.partition_S(sAinv)
-        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv_load)
         tOsO = O_thr_copy.partition_D(sO)
         tOrO_cv = O_thr_copy.retile(tOrO)
 
         cute.copy(D_tiled_copy, tOsDinv, tOrDinv_cv)
         cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        if cutlass.const_expr(mat_64x64.element_type == cutlass.Float32):
+            tOrDinv = self._convert_f32_fragment_to_tf32_operand(tOrDinv_load)
+            tOrC = self._convert_f32_fragment_to_tf32_operand(tOrC_load)
         tDCrDC.fill(0.0)
         cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
-        tDCrDC.store(-tDCrDC.load())
 
-        tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
-        tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, mat_64x64.element_type)
-        tOrDC.store(tDCrDC_a.load().to(mat_64x64.element_type))
+        if cutlass.const_expr(mat_64x64.element_type == cutlass.Float32):
+            tDCrDC_cv = O_thr_copy.retile(tDCrDC)
+            tDCrDC_store = cute.make_rmem_tensor_like(tDCrDC_cv, cutlass.Float32)
+            tDCrDC_store.store(cutlass.Float32(0.0) - tDCrDC_cv.load())
+            cute.copy(O_tiled_copy, tDCrDC_store, tOsO)
+            self.inverse_barrier.arrive_and_wait()
+
+            tOsDC = D_thr_copy.partition_S(sO)
+            tOrDC_load = cute.make_rmem_tensor_like(tOrDinv_load, cutlass.Float32)
+            tOrDC_cv = D_thr_copy.retile(tOrDC_load)
+            cute.copy(D_tiled_copy, tOsDC, tOrDC_cv)
+            tOrDC = self._convert_f32_fragment_to_tf32_operand(tOrDC_load)
+        else:
+            tDCrDC.store(-tDCrDC.load())
+            tDCrDC_a = self._make_acc_tensor_into_a_view(tDCrDC)
+            tOrDC = cute.make_rmem_tensor_like(tDCrDC_a, mat_64x64.element_type)
+            tOrDC.store(tDCrDC_a.load().to(mat_64x64.element_type))
 
         cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        if cutlass.const_expr(mat_64x64.element_type == cutlass.Float32):
+            tOrAinv = self._convert_f32_fragment_to_tf32_operand(tOrAinv_load)
         tOrO.fill(0.0)
         cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
 
         tOrO_cv_cvt = cute.make_rmem_tensor_like(tOrO_cv, mat_64x64.element_type)
         tOrO_cv_cvt.store(tOrO_cv.load().to(mat_64x64.element_type))
-        self.inverse_barrier_inner.arrive_and_wait()
+        self.inverse_barrier.arrive_and_wait()
         cute.copy(O_tiled_copy, tOrO_cv_cvt, tOsO)
 
     @cute.jit
@@ -2945,7 +3981,6 @@ class GatedDeltaNetChunkedKernel:
         self,
         tidx,
         mS_init,
-        mS_indices,
         head_idx,
         batch_idx,
         tmem_ptr,
@@ -2955,7 +3990,7 @@ class GatedDeltaNetChunkedKernel:
         """Load S_init from GMEM into state TMEM (fp32).
 
         Two steps:
-          1. GMEM state dtype -> registers
+          1. GMEM fp32 -> registers
           2. registers -> state TMEM (fp32), signal kv_acc so MMA can start GEMM 7
         """
         num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
@@ -2971,7 +4006,9 @@ class GatedDeltaNetChunkedKernel:
         tCtState = cute.make_tensor(
             tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
         )
-        tCtState_mn_view = self.transform_partitioned_tensor_layout(tCtState)
+        tCtState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState
+        )
         state_r2t_atom = cute.make_copy_atom(
             tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
         )
@@ -2984,27 +4021,20 @@ class GatedDeltaNetChunkedKernel:
         tRT_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
         tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.state_dtype)
 
-        # Optional indexed (pool) access: read the recurrent-state row by an
-        # indirection index instead of the sequence-order batch_idx. Loaded
-        # once per work tile (per (batch_idx, head_idx)) as an Int32 scalar.
-        if cutlass.const_expr(mS_indices is not None):
-            state_row = mS_indices[batch_idx]
-        else:
-            state_row = batch_idx
         gS_init = cute.flat_divide(
-            mS_init[None, None, head_idx, state_row],
+            mS_init[None, None, head_idx, batch_idx],
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
         )[None, None, 0, 0]
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
         kv_acc_handle = kv_acc_producer.acquire_and_advance()
-        for sub in cutlass.range(tRT_tCrState.shape[2]):
-            # 1. Load S_init GMEM -> state dtype registers
+        for sub in cutlass.range(tGR_tCrState.shape[2]):
+            # 1. Load S_init state_dtype GMEM -> state_dtype registers
             cute.autovec_copy(
                 tGR_tCgState[None, 0, sub],
                 tGR_tCrState[None, 0, sub],
                 l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
             )
-            if cutlass.const_expr(self.state_dtype != self.acc_dtype):
+            if cutlass.const_expr(self.acc_dtype != self.state_dtype):
                 tRT_tCrState[None, 0, sub].store(
                     tGR_tCrState[None, 0, sub].load().to(self.acc_dtype)
                 )
@@ -3032,7 +4062,6 @@ class GatedDeltaNetChunkedKernel:
         tidx,
         # full output-state GMEM tensor (DK, DV, (h_r, h_qv), B) fp32
         mS_out,
-        mS_indices,
         head_idx,
         batch_idx,
         tmem_ptr,
@@ -3062,7 +4091,9 @@ class GatedDeltaNetChunkedKernel:
         tCtState = cute.make_tensor(
             tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
         )
-        tCtState_mn_view = self.transform_partitioned_tensor_layout(tCtState)
+        tCtState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState
+        )
         tCcState = cute.make_identity_tensor(
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
         )
@@ -3082,15 +4113,6 @@ class GatedDeltaNetChunkedKernel:
         # Wait for last GEMM-7 to finish
         kv_acc_handle = kv_acc_consumer.wait_and_advance()
 
-        # Optional indexed (pool) access: write the recurrent-state row by an
-        # indirection index instead of the sequence-order batch_idx. Loaded
-        # once per work tile (per (batch_idx, head_idx)) as an Int32 scalar and
-        # reused across the sub loop below.
-        if cutlass.const_expr(mS_indices is not None):
-            state_row = mS_indices[batch_idx]
-        else:
-            state_row = batch_idx
-
         for sub in cutlass.range(tTR_rState.shape[2]):
             # Read state TMEM -> fp32 registers
             cute.copy(
@@ -3098,7 +4120,7 @@ class GatedDeltaNetChunkedKernel:
                 tTR_tCtState[None, 0, sub, kv_acc_handle.index],
                 tTR_rState[None, 0, sub],
             )
-            if cutlass.const_expr(self.state_dtype != self.acc_dtype):
+            if cutlass.const_expr(self.acc_dtype != self.state_dtype):
                 tRG_rState[None, 0, sub].store(
                     tTR_rState[None, 0, sub].load().to(self.state_dtype)
                 )
@@ -3106,36 +4128,35 @@ class GatedDeltaNetChunkedKernel:
                 tRG_rState = tTR_rState
             if cutlass.const_expr(self.enable_checkpoints):
                 if seqlen_b % checkpoint_every_n_tokens == 0:
-                    gS_checkpoints = cute.make_tensor(
-                        mS_checkpoints[
-                            None, None, head_idx, checkpoint_offset
-                        ].iterator,
-                        cute.make_ordered_layout(
-                            (self.mma_tiler_kv[0], self.mma_tiler_kv[1]), order=(1, 0)
-                        ),
-                    )
-                    tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
-                    cute.autovec_copy(
-                        tRG_rState[None, 0, sub],
-                        tSgCheckpoints[None, 0, sub],
-                        l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
-                    )
+                    num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
+                    if num_valid_chunks_b % 2 == 0:
+                        gS_checkpoints = cute.flat_divide(
+                            mS_checkpoints[None, None, head_idx, checkpoint_offset],
+                            (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+                        )[None, None, 0, 0]
+
+                        tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
+                        cute.autovec_copy(
+                            tRG_rState[None, 0, sub],
+                            tSgCheckpoints[None, 0, sub],
+                            l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                        )
             if cutlass.const_expr(self.store_final_state):
                 gS_out = cute.flat_divide(
-                    mS_out[None, None, head_idx, state_row],
+                    mS_out[None, None, head_idx, batch_idx],
                     (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
                 )[None, None, 0, 0]
                 tRG_tCgState = thr_state_t2r.partition_D(gS_out)
                 cute.autovec_copy(
-                    tRG_rState,
-                    tRG_tCgState,
+                    tRG_rState[None, 0, sub],
+                    tRG_tCgState[None, 0, sub],
                     l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
                 )
         kv_acc_handle.release()
         return kv_acc_consumer
 
     @cute.jit
-    def compute_group_1(
+    def compute_group_1_chunk(
         self,
         tidx: cutlass.Int32,
         tmem_ptr: cutlass.Int64,
@@ -3151,36 +4172,39 @@ class GatedDeltaNetChunkedKernel:
         pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
-        pipeline.PipelineConsumer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
         pipeline.PipelineProducer,
+        cutlass.Int32,
     ]:
-        """Warps 4-7: kv_decay_v, v-k*state, state*q_epi, new_v_epi, qkv_epilogue, kv_update_epi."""
+        """Warps 4-7: process one chunk from the caller-owned chunk stream."""
         sV, sCumsumlog, sCumprod, sBeta, sO = smem_args
         mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens = checkpoint_args
         (
             load_v_consumer,
             load_gate_consumer,
-            shared_acc_consumer,
+            cg1_shared_acc_consumer,
             kv_acc_consumer,
             q_state_acc_consumer,
-            group_order_consumer,
             kv_acc_producer,
             state_inp_ready_producer,
-            shared_inp_ready_producer,
+            vks_ready_producer,
+            nv_ready_producer,
+            decay_v_ready_producer,
             o_store_producer,
         ) = pipeline_args
         tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv = mma_args
-        (is_first_chunk, chunk_idx, head_idx) = work_args
+        chunk_iter, num_pairs_b, head_idx, seqlen_b, is_first_chunk = work_args
 
+        # ------------------------------------------------------------------
+        # Preamble (identical to compute_group_1)
+        # ------------------------------------------------------------------
         num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
         cg1_tidx = tidx % num_threads_cg1
 
-        # -- State TMEM tensor (DKxDV, layout from tiled_mma_kv) --------------
         state_acc_shape = tiled_mma_kv.partition_shape_C(
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
         )
@@ -3190,7 +4214,9 @@ class GatedDeltaNetChunkedKernel:
         tCtState = cute.make_tensor(
             tmem_ptr + self.tmem_state_offset, tCtState_fake.layout
         )
-        tCtState_mn_view = self.transform_partitioned_tensor_layout(tCtState)
+        tCtState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState
+        )
         tCcState = cute.make_identity_tensor(
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1])
         )
@@ -3221,7 +4247,9 @@ class GatedDeltaNetChunkedKernel:
             cute.recast_ptr(tmem_ptr + self.tmem_state_inp_offset, dtype=self.io_dtype),
             tCtState_inp_fake.layout,
         )
-        tCtState_inp_mn_view = self.transform_partitioned_tensor_layout(tCtState_inp)
+        tCtState_inp_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtState_inp
+        )
         tCcState_inp = cute.make_identity_tensor(
             (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
         )
@@ -3237,21 +4265,20 @@ class GatedDeltaNetChunkedKernel:
         tRT_tCtState_inp = thr_state_inp_r2t.partition_D(tCtState_inp_mn_view)
         tRT_rState_inp = cute.make_rmem_tensor_like(tRT_tCcState_inp, self.io_dtype)
 
-        # -- Shared acc TMEM tensor (BTxDV, layout from tiled_mma_qkv) ----------
-        # Needed for v-k*state (K*S, stage 0) and new_v_epi (NV, stage 1).
-        # qkv_epilogue reads O_intra from q_state TMEM, not from this buffer.
         qkv_acc_shape = tiled_mma_qkv.partition_shape_C(
             (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
         )
         tCtShared_fake = tiled_mma_qkv.make_fragment_C(qkv_acc_shape)
         tCtShared = cute.make_tensor(
-            tmem_ptr + self.tmem_shared_acc_offset,
+            tmem_ptr + self.tmem_cg1_shared_acc_offset,
             cute.flat_product(
-                tCtShared_fake.layout, cute.make_layout((self.tmem_shared_acc_stages,))
+                tCtShared_fake.layout,
+                cute.make_layout((self.tmem_cg1_shared_acc_stages,)),
             ),
         )
-        tCtShared_mn_view = self.transform_partitioned_tensor_layout(tCtShared)
-        # use qk here to construct shared as it has the biggest tiler (BT, BT)
+        tCtShared_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtShared
+        )
         tCcShared = cute.make_identity_tensor(
             (self.mma_tiler_qkv[0], self.mma_tiler_qkv[1])
         )
@@ -3263,6 +4290,16 @@ class GatedDeltaNetChunkedKernel:
         thr_shared_t2r = tiled_shared_t2r.get_slice(cg1_tidx)
         tTR_tCtShared = thr_shared_t2r.partition_S(tCtShared_mn_view)
         tTR_tCcShared = thr_shared_t2r.partition_D(tCcShared)
+
+        # Dedicated full-tile KS t2r (separate atom so it can be tuned
+        # independently of atom_shared_t2r used by NV/decay_v reads).
+        atom_ks_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
+        )
+        tiled_ks_t2r = tcgen05.make_tmem_copy(atom_ks_t2r, tCtShared_for_t2r)
+        thr_ks_t2r = tiled_ks_t2r.get_slice(cg1_tidx)
+        tTR_tCtKS = thr_ks_t2r.partition_S(tCtShared_mn_view)
+        tTR_tCcKS = thr_ks_t2r.partition_D(tCcShared)
 
         qkv_inp_shape = tiled_mma_qkv.partition_shape_A(
             (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
@@ -3276,7 +4313,9 @@ class GatedDeltaNetChunkedKernel:
             ),
             tCtShared_inp_fake.layout,
         )
-        tCtShared_inp_mn_view = self.transform_partitioned_tensor_layout(tCtShared_inp)
+        tCtShared_inp_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtShared_inp
+        )
         tCcShared_inp = cute.make_identity_tensor(
             (self.mma_tiler_qkv[0], self.mma_tiler_qkv[2])
         )
@@ -3290,10 +4329,18 @@ class GatedDeltaNetChunkedKernel:
         thr_shared_inp_r2t = tiled_shared_inp_r2t.get_slice(cg1_tidx)
         tRT_tCcShared_inp = thr_shared_inp_r2t.partition_S(tCcShared_inp)
         tRT_tCtShared_inp = thr_shared_inp_r2t.partition_D(tCtShared_inp_mn_view)
-        tRT_rShared_inp = cute.make_rmem_tensor_like(tRT_tCcShared_inp, self.io_dtype)  # noqa: F841
+        tRT_rShared_inp = cute.make_rmem_tensor_like(tRT_tCcShared_inp, self.io_dtype)
 
-        # -- Q-state TMEM tensor (BTxDV, layout from tiled_mma_qs) --------------
-        # Used by state*q_epi (scale Q*S result) and qkv_epilogue (read final O).
+        # Dedicated full-tile VKS r2t (separate atom so it can be tuned
+        # independently of atom_shared_inp_r2t used by NV/decay_v writes).
+        atom_vks_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x128bOp(tcgen05.copy.Repetition(8)), self.io_dtype
+        )
+        tiled_vks_r2t = tcgen05.make_tmem_copy(atom_vks_r2t, tCtShared_inp_for_r2t)
+        thr_vks_r2t = tiled_vks_r2t.get_slice(cg1_tidx)
+        tRT_tCcVKS_inp = thr_vks_r2t.partition_S(tCcShared_inp)
+        tRT_tCtVKS_inp = thr_vks_r2t.partition_D(tCtShared_inp_mn_view)
+
         qs_acc_shape = tiled_mma_qs.partition_shape_C(
             (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
         )
@@ -3303,7 +4350,9 @@ class GatedDeltaNetChunkedKernel:
         tCtQState = cute.make_tensor(
             tmem_ptr + self.tmem_q_state_offset, tCtQState_fake.layout
         )
-        tCtQState_mn_view = self.transform_partitioned_tensor_layout(tCtQState)
+        tCtQState_mn_view = utils.gemm.sm100.transform_partitioned_tensor_layout(
+            tCtQState
+        )
         tCcQState = cute.make_identity_tensor(
             (self.mma_tiler_qs[0], self.mma_tiler_qs[1])
         )
@@ -3324,12 +4373,8 @@ class GatedDeltaNetChunkedKernel:
         tRT_tCtQS = thr_qs_r2t.partition_D(tCtQState_mn_view)
         tTR_rQS = cute.make_rmem_tensor_like(tTR_tCcQS, self.acc_dtype)
 
-        # -- SMEM V tiled copy: sV has domain (DV, BT); threads over BT (dim 1) --
-        # Thread cg1_tidx owns all DV features for BT token cg1_tidx.
-        # Beta scaling: sBeta[cg1_tidx] - one scalar per thread.
-
         tRT_tCcV = thr_shared_inp_r2t.partition_S(tCcShared_inp)
-        tRT_tCtV = thr_shared_inp_r2t.partition_D(tCtShared_inp_mn_view)  # noqa: F841
+        tRT_tCtV = thr_shared_inp_r2t.partition_D(tCtShared_inp_mn_view)
         atom_v_s2r = cute.make_copy_atom(
             cute.nvgpu.warp.LdMatrix8x8x16bOp(num_matrices=4, transpose=True),
             self.io_dtype,
@@ -3340,8 +4385,6 @@ class GatedDeltaNetChunkedKernel:
         )
         thr_v_s2r = tiled_v_s2r.get_slice(cg1_tidx)
 
-        # -- SMEM store: fp32 TMEM (tiled_mma_qs layout) -> fp16 sO --
-        # Used by qkv_epilogue to write final O result.
         atom_o_t2r = cute.make_copy_atom(
             tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)), self.acc_dtype
         )
@@ -3358,173 +4401,171 @@ class GatedDeltaNetChunkedKernel:
         tCsO = thr_o_r2s.partition_D(sO)
 
         sub_tile_size = 32
+        max_coord = tTR_tCcShared[cute.size(tTR_tCcShared) - 1]
 
-        gate_handle = load_gate_consumer.wait_and_advance()
-
-        cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_handle.index]
-
-        valid_state = not is_first_chunk or self.use_initial_state
-        if cutlass.const_expr(valid_state):
-            if cutlass.const_expr(self.use_initial_state):
-                kv_acc_producer.advance()
-            # Wait for previous chunk's GEMM 7 to finish writing dS.
-            # This also serialises the TMEM read-modify-write vs GEMM 7.
-            kv_handle = kv_acc_consumer.wait_and_advance()
-
-            state_inp_ready_handle = state_inp_ready_producer.acquire_and_advance()
-            for sub in cutlass.range(tRT_rState_inp.shape[2]):
-                cute.copy(
-                    tiled_state_t2r,
-                    tTR_tCtState[None, 0, sub, kv_handle.index],
-                    tTR_rState[None, 0, sub],
-                )
-                if cutlass.const_expr(self.enable_checkpoints and not is_first_chunk):
-                    if (self.b_t * chunk_idx) % checkpoint_every_n_tokens == 0:
-                        gS_checkpoints = cute.make_tensor(
-                            mS_checkpoints[
-                                None, None, head_idx, checkpoint_offset
-                            ].iterator,
-                            cute.make_ordered_layout(
-                                (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
-                                order=(1, 0),
-                            ),
-                        )
-                        tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
-                        if cutlass.const_expr(self.state_dtype != self.acc_dtype):
-                            tRG_rState[None, 0, sub].store(
-                                tTR_rState[None, 0, sub].load().to(self.state_dtype)
-                            )
-                        else:
-                            tRG_rState = tTR_rState
-                        cute.autovec_copy(
-                            tRG_rState[None, 0, sub],
-                            tSgCheckpoints[None, 0, sub],
-                            l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
-                        )
-
-                tRT_rState_inp[None, 0, sub].store(
-                    tTR_rState[None, 0, sub].load().to(self.io_dtype)
-                )
-                cute.copy(
-                    tiled_state_inp_r2t,
-                    tRT_rState_inp[None, 0, sub],
-                    tRT_tCtState_inp[None, 0, sub, state_inp_ready_handle.index],
-                )
-            cute.arch.fence_view_async_tmem_store()
-            state_inp_ready_handle.commit()
-
-            # Load S_prev -> scale by Phi -> write Phi*S_prev back to same TMEM slot.
-            for sub in cutlass.range(tTR_rState.shape[2]):
-                for k in cutlass.range(sub_tile_size, vectorize=True):
-                    tTR_rState[k, 0, sub] = tTR_rState[k, 0, sub] * cumprod_total
-                cute.copy(
-                    tiled_state_r2t,
-                    tTR_rState[None, 0, sub],
-                    tRT_tCtState[None, 0, sub, kv_handle.index],
-                )
-            if cutlass.const_expr(self.enable_checkpoints and not is_first_chunk):
-                if (self.b_t * chunk_idx) % checkpoint_every_n_tokens == 0:
-                    checkpoint_offset += 1
-            cute.arch.fence_view_async_tmem_store()
-
-            # Release slot - MMA can now acquire it for this chunk's GEMM 7
-            # (which accumulates dS on top of Phi*S_prev).
-            kv_handle.release()
-
-        # wait for kk and qk epilogue to finish
-        shared_acc_consumer.advance()
-        shared_acc_consumer.advance()
+        sV_vt_view = utils.gemm.sm100.transform_partitioned_tensor_layout(sV)
+        tCsV = thr_v_s2r.partition_S(sV_vt_view)
 
         rCumprod = cute.make_rmem_tensor((1, cute.size(tTR_tCcShared)), self.acc_dtype)
         tGrCumprod = thr_shared_t2r.partition_D(rCumprod)
+        tGrDecayScale = cute.make_rmem_tensor_like(tTR_tCcShared, self.acc_dtype)
+        # Pair membership is derived from the caller-provided chunk index.
+        is_pair_first = (chunk_iter & 1) == 0
+
+        valid_state = is_first_chunk == False
+        if cutlass.const_expr(self.use_initial_state):
+            valid_state = True
+            if is_pair_first:
+                kv_acc_producer.advance()
+                kv_acc_producer.advance()
+
+        # Only the total decay is needed to finish the state update.  Defer
+        # the per-row gate work until the previous state has been published
+        # and decayed, keeping its register fragment in one contiguous region.
+        gate_handle = load_gate_consumer.wait_and_advance()
+        cumprod_total = sCumprod[max_coord[1], 0, gate_handle.index]
+
+        kv_prev_handle = kv_acc_consumer.current_handle()
+        if valid_state:
+            kv_prev_handle = kv_acc_consumer.wait_and_advance()
+            # No empty-stage wait is needed before reusing state_inp.  For the
+            # first publication the stage is initialized empty.  Thereafter,
+            # CG1 reaches this point only after waiting for the preceding NewV;
+            # the MMA warp releases state_inp before publishing that NewV.
+            state_inp_handle = state_inp_ready_producer.current_handle()
+            state_inp_ready_producer.advance()
+            cute.copy(
+                tiled_state_t2r,
+                tTR_tCtState[None, 0, None, kv_prev_handle.index],
+                tTR_rState[None, 0, None],
+            )
+            tRT_rState_inp[None, 0, None].store(
+                tTR_rState[None, 0, None].load().to(self.io_dtype)
+            )
+            cute.copy(
+                tiled_state_inp_r2t,
+                tRT_rState_inp[None, 0, None],
+                tRT_tCtState_inp[None, 0, None, state_inp_handle.index],
+            )
+            cute.arch.fence_view_async_tmem_store()
+            state_inp_handle.commit()
+            checkpoint_token = self.b_t * chunk_iter
+            if cutlass.const_expr(self.enable_checkpoints):
+                if checkpoint_token > 0:
+                    if checkpoint_token <= seqlen_b:
+                        if checkpoint_token % checkpoint_every_n_tokens == 0:
+                            gS_checkpoints = cute.flat_divide(
+                                mS_checkpoints[
+                                    None,
+                                    None,
+                                    head_idx,
+                                    checkpoint_offset,
+                                ],
+                                (
+                                    self.mma_tiler_kv[0],
+                                    self.mma_tiler_kv[1],
+                                ),
+                            )[None, None, 0, 0]
+                            tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
+                            if cutlass.const_expr(self.state_dtype != self.acc_dtype):
+                                tRG_rState[None, 0, None].store(
+                                    tTR_rState[None, 0, None]
+                                    .load()
+                                    .to(self.state_dtype)
+                                )
+                            else:
+                                tRG_rState = tTR_rState
+                            cute.autovec_copy(
+                                tRG_rState[None, 0, None],
+                                tSgCheckpoints[None, 0, None],
+                                l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                            )
+            for k in cutlass.range(cute.size(tTR_rState), vectorize=True):
+                tTR_rState[k] = tTR_rState[k] * cumprod_total
+            cute.copy(
+                tiled_state_r2t,
+                tTR_rState[None, 0, None],
+                tRT_tCtState[None, 0, None, kv_prev_handle.index],
+            )
+            if cutlass.const_expr(self.enable_checkpoints):
+                if checkpoint_token > 0:
+                    if checkpoint_token <= seqlen_b:
+                        if checkpoint_token % checkpoint_every_n_tokens == 0:
+                            checkpoint_offset += 1
+            cute.arch.fence_view_async_tmem_store()
+            kv_prev_handle.release()
         for k in cutlass.range_constexpr(cute.size(tTR_tCcShared)):
             coord = tTR_tCcShared[k]
             tGrCumprod[k] = sCumprod[coord[1], 0, gate_handle.index]
-        rDecayScale = cute.make_rmem_tensor(
-            (1, cute.size(tTR_tCcShared)), self.acc_dtype
-        )
-        tGrDecayScale = thr_shared_t2r.partition_D(rDecayScale)
         last_cumsumlog = sCumsumlog[self.b_t - 1, 0, gate_handle.index]
-        for k in cutlass.range_constexpr(cute.size(tTR_tCcShared)):
-            coord = tTR_tCcShared[k]
-            tGrDecayScale[k] = cute.math.exp2(
-                last_cumsumlog - sCumsumlog[coord[1], 0, gate_handle.index],
-                fastmath=True,
+        for k in cutlass.range_constexpr(0, cute.size(tTR_tCcShared), 2):
+            coord0 = tTR_tCcShared[k]
+            coord1 = tTR_tCcShared[k + 1]
+            decay_diff = cute.arch.add_packed_f32x2(
+                (last_cumsumlog, last_cumsumlog),
+                (
+                    -sCumsumlog[coord0[1], 0, gate_handle.index],
+                    -sCumsumlog[coord1[1], 0, gate_handle.index],
+                ),
+                ftz=False,
+                rnd="rn",
             )
+            tGrDecayScale[k] = cute.math.exp2(decay_diff[0], fastmath=True)
+            tGrDecayScale[k + 1] = cute.math.exp2(decay_diff[1], fastmath=True)
         gate_handle.release()
-        # ---- v - k*state  (ALU) -----------------------------------------------
-        # delta[bt, dv] = V[bt, dv] - (K*S)[bt, dv]
-        # Beta is fused into A_beta in CG0; no beta scaling here.
-        # Thread cg1_tidx owns all DV elements for token bt=cg1_tidx.
-        # Write fp16 delta to sV (GEMM 5 via v_ks_ready) and sStateDv (GEMM 7 via decay_v_ready).
-        vks_handle = shared_inp_ready_producer.acquire_and_advance()
+
+        vks_handle = vks_ready_producer.current_handle()
+        vks_ready_producer.advance()
         v_handle = load_v_consumer.wait_and_advance()
-
-        if cutlass.const_expr(valid_state):
-            # Load V[*, cg1_tidx] from sV SMEM into registers
-
-            tTR_rKS = cute.make_rmem_tensor_like(tTR_tCcShared, self.acc_dtype)
-            sV_vt_view = self.transform_partitioned_tensor_layout(sV)
-            tCsV = thr_v_s2r.partition_S(sV_vt_view)
-
-            tRT_rV = cute.make_rmem_tensor_like(tRT_tCcV, self.io_dtype)
-            tCrV = tiled_v_s2r.retile(tRT_rV)
-            cute.copy(tiled_v_s2r, tCsV[None, None, None, v_handle.index], tCrV)
-            group_order_handle = group_order_consumer.wait_and_advance()
-            # Wait for GEMM 3 (K*S) result in shared_acc
-            ks_acc_handle = shared_acc_consumer.wait_and_advance()
+        tRT_rV = cute.make_rmem_tensor_like(tRT_tCcV, self.io_dtype)
+        tCrV = tiled_v_s2r.retile(tRT_rV)
+        if valid_state:
             cute.copy(
-                tiled_shared_t2r,
-                tTR_tCtShared[None, None, None, ks_acc_handle.index],
+                tiled_v_s2r,
+                tCsV[None, None, None, v_handle.index],
+                tCrV,
+            )
+
+        if valid_state:
+            ks_handle = cg1_shared_acc_consumer.wait_and_advance()
+            tTR_rKS = cute.make_rmem_tensor_like(tTR_tCcKS, self.acc_dtype)
+            cute.copy(
+                tiled_ks_t2r,
+                tTR_tCtKS[None, None, None, ks_handle.index],
                 tTR_rKS,
             )
             for k in cutlass.range(cute.size(tTR_rKS), vectorize=True):
                 tTR_rKS[k] = tTR_rKS[k] * tGrCumprod[k]
-            ks_acc_handle.release()
+            ks_handle.release()
             for k in cutlass.range(cute.size(tTR_rKS), vectorize=True):
                 tRT_rV[k] = tRT_rV[k] - tTR_rKS[k].to(self.io_dtype)
             cute.copy(
-                tiled_shared_inp_r2t,
+                tiled_vks_r2t,
                 tRT_rV,
-                tRT_tCtShared_inp[None, None, None, vks_handle.index],
+                tRT_tCtVKS_inp[None, None, None, 0],
             )
             cute.arch.fence_view_async_tmem_store()
-        else:
-            group_order_handle = group_order_consumer.wait_and_advance()
         vks_handle.commit()
 
-        # ---- state*q_epi (ALU) ------------------------------------------------
-        # Scale Q*S_prev cross-chunk contribution: QS[bt, *] *= cumprod[bt]
-        # Thread cg1_tidx owns token bt=cg1_tidx -> scalar multiply by cur_cumprod.
-        # Write scaled result back to same q_state TMEM slot so GEMM 6 accumulates on top.
-        if cutlass.const_expr(valid_state):
+        if valid_state:
             qs_handle = q_state_acc_consumer.wait_and_advance()
-            for sub in cutlass.range(tTR_rQS.shape[1]):
-                cute.copy(
-                    tiled_qs_t2r,
-                    tTR_tCtQS[None, sub, 0, qs_handle.index],
-                    tTR_rQS[None, sub, 0],
-                )
-                for k in cutlass.range(sub_tile_size, vectorize=True):
-                    tTR_rQS[k, sub, 0] = (
-                        tTR_rQS[k, sub, 0] * tGrCumprod[k, sub, 0] * scale
-                    )
-                cute.copy(
-                    tiled_qs_r2t,
-                    tTR_rQS[None, sub, 0],
-                    tRT_tCtQS[None, sub, 0, qs_handle.index],
-                )
+            cute.copy(
+                tiled_qs_t2r,
+                tTR_tCtQS[None, None, 0, qs_handle.index],
+                tTR_rQS[None, None, 0],
+            )
+            for k in cutlass.range(cute.size(tTR_rQS), vectorize=True):
+                tTR_rQS[k] = tTR_rQS[k] * tGrCumprod[k] * scale
+            cute.copy(
+                tiled_qs_r2t,
+                tTR_rQS[None, None, 0],
+                tRT_tCtQS[None, None, 0, qs_handle.index],
+            )
             cute.arch.fence_view_async_tmem_store()
-
             qs_handle.release()
 
-        # ---- new_v_epi --------------------------------------------------------
-        # NV = A_inv @ delta (GEMM 5 result) in shared_acc TMEM; fp32 -> fp16 -> sAinvNv.
-        nv_handle = shared_acc_consumer.wait_and_advance()
-        sV_vt_view = self.transform_partitioned_tensor_layout(sV)
+        nv_handle = cg1_shared_acc_consumer.wait_and_advance()
         v_handle.release()
-        nv_ready_handle = shared_inp_ready_producer.acquire_and_advance()
-
         tTR_rNv = cute.make_rmem_tensor_like(tTR_tCcShared, self.acc_dtype)
         tTR_rNv_inp = cute.make_rmem_tensor_like(tTR_rNv, self.io_dtype)
         for sub in cutlass.range(tTR_rNv.shape[1]):
@@ -3536,70 +4577,69 @@ class GatedDeltaNetChunkedKernel:
             tTR_rNv_inp[None, sub, 0].store(
                 tTR_rNv[None, sub, 0].load().to(self.io_dtype)
             )
-            cute.copy(
-                tiled_shared_inp_r2t,
-                tTR_rNv_inp[None, sub, 0],
-                tRT_tCtShared_inp[None, sub, 0, nv_ready_handle.index],
-            )
-        cute.arch.fence_view_async_tmem_store()
         nv_handle.release()
-        nv_ready_handle.commit()
 
-        # Write decay_scale * delta to sStateDv -> GEMM 7 B-operand
-        # -- kv_decay_v: S_prev *= Phi = exp(cumsumlog[BT-1]) ------------------
-        # Always wait for gate (collective barrier shared with CG0).
-        decay_v_handle = shared_inp_ready_producer.acquire_and_advance()
         tTR_rDv = tTR_rNv
-        tRT_rDv_inp = cute.make_rmem_tensor_like(tTR_rDv, self.io_dtype)
         for sub in cutlass.range(tTR_rDv.shape[1]):
             for k in cutlass.range(sub_tile_size, vectorize=True):
                 tTR_rDv[k, sub, 0] = tTR_rDv[k, sub, 0] * tGrDecayScale[k, sub, 0]
-            tRT_rDv_inp[None, sub, 0].store(
+
+        nv_ready_handle = nv_ready_producer.current_handle()
+        nv_ready_producer.advance()
+        decay_v_ready_handle = decay_v_ready_producer.current_handle()
+        decay_v_ready_producer.advance()
+        # Both chunks publish NV for GEMM6/QKV before decayV for GEMM7/KV.
+        for sub in cutlass.range(tTR_rDv.shape[1]):
+            cute.copy(
+                tiled_shared_inp_r2t,
+                tTR_rNv_inp[None, sub, 0],
+                tRT_tCtShared_inp[None, sub, 0, 0],
+            )
+            tTR_rNv_inp[None, sub, 0].store(
                 tTR_rDv[None, sub, 0].load().to(self.io_dtype)
             )
             cute.copy(
                 tiled_shared_inp_r2t,
-                tRT_rDv_inp[None, sub, 0],
-                tRT_tCtShared_inp[None, sub, 0, decay_v_handle.index],
+                tTR_rNv_inp[None, sub, 0],
+                tRT_tCtShared_inp[None, sub, 0, 1],
             )
         cute.arch.fence_view_async_tmem_store()
-        decay_v_handle.commit()
+        nv_ready_handle.commit()
+        decay_v_ready_handle.commit()
 
-        # ---- qkv_epilogue -----------------------------------------------------
-        # GEMM 6 accumulated W_qkv@NV into q_state TMEM on top of the scaled Q*S.
-        # q_state_acc second wait (same 1-stage pipeline, wraps back to stage 0).
+        # Drain this chunk's output at the end of the same chunk.  This keeps
+        # O ownership uniform and removes the first/last pending-output cases.
         o_handle = o_store_producer.acquire_and_advance()
-        qs_handle2 = q_state_acc_consumer.wait_and_advance()
-
+        o_qs_handle = q_state_acc_consumer.wait_and_advance()
         tTR_tOrO = cute.make_rmem_tensor_like(tTR_tOcO, self.acc_dtype)
         tTR_rO_out = cute.make_rmem_tensor_like(tTR_tOrO, self.io_dtype)
         tRS_tOrO = tiled_o_r2s.retile(tTR_rO_out)
         cute.copy(
             tiled_o_t2r,
-            tTR_tOtO[None, None, None, qs_handle2.index],
+            tTR_tOtO[None, None, None, o_qs_handle.index],
             tTR_tOrO,
         )
-        group_order_handle.release()
         tTR_rO_out.store(tTR_tOrO.load().to(self.io_dtype))
-        cute.copy(tiled_o_r2s, tRS_tOrO, tCsO[None, None, None, o_handle.index])
+        cute.copy(
+            tiled_o_r2s,
+            tRS_tOrO,
+            tCsO[None, None, None, o_handle.index],
+        )
         cute.arch.fence_view_async_shared()
-        qs_handle2.release()
-
-        # O in sQkOstore ready for epilogue warp TMA store
+        o_qs_handle.release()
         o_handle.commit()
 
-        # ---- kv_update_epi ----------------------------------------------------
-        # None, do state update at the beginning of the next chunk.
-        return (  # type: ignore[return-value]
+        return (
             load_v_consumer,
             load_gate_consumer,
-            shared_acc_consumer,
+            cg1_shared_acc_consumer,
             kv_acc_consumer,
             q_state_acc_consumer,
-            group_order_consumer,
             kv_acc_producer,
             state_inp_ready_producer,
-            shared_inp_ready_producer,
+            vks_ready_producer,
+            nv_ready_producer,
+            decay_v_ready_producer,
             o_store_producer,
             checkpoint_offset,
         )
@@ -3670,45 +4710,6 @@ class GatedDeltaNetChunkedKernel:
 
         return o_store_consumer
 
-    def transform_partitioned_tensor_layout(self, tensor: cute.Tensor) -> cute.Tensor:
-        """
-        Transform MMA layout from ((MMA_ATOM_M, MMA_ATOM_N), MMA_M, MMA_N, ...rest)
-        to ((MMA_ATOM_M, MMA_M), (MMA_ATOM_N, MMA_N), ...rest).
-
-        This groups MMA_ATOM_M with MMA_M and MMA_ATOM_N with MMA_N.
-
-        :param tensor: Input tensor with layout ((MMA_ATOM_M, MMA_ATOM_N), MMA_M, MMA_N, ...rest)
-        :type tensor: cute.Tensor
-        :return: Transformed tensor with layout ((MMA_ATOM_M, MMA_M), (MMA_ATOM_N, MMA_N), ...rest)
-        :rtype: cute.Tensor
-        """
-        layout = tensor.layout
-        # Save original layout in case it is a composed layout
-        stored_layout = layout
-
-        if isinstance(stored_layout, cute.ComposedLayout):
-            # For composed layouts, we only modify the outer layout
-            layout = layout.outer
-
-        shape = layout.shape
-        stride = layout.stride
-
-        # Build new shape: ((shape[0][0], shape[1]), (shape[0][1], shape[2]), ...rest)
-        new_shape = ((shape[0][0], shape[1]), (shape[0][1], shape[2]), *shape[3:])
-
-        # Build new stride: ((stride[0][0], stride[1]), (stride[0][1], stride[2]), ...rest)
-        new_stride = ((stride[0][0], stride[1]), (stride[0][1], stride[2]), *stride[3:])
-
-        new_layout = cute.make_layout(shape=new_shape, stride=new_stride)
-
-        if isinstance(stored_layout, cute.ComposedLayout):
-            # Recreate the composed layout
-            new_layout = cute.make_composed_layout(
-                stored_layout.inner, stored_layout.offset, new_layout
-            )
-
-        return cute.make_tensor(tensor.iterator, new_layout)
-
     @cute.jit
     def _transform_to_position_independent_layout(
         self, tensor: cute.Tensor, swizzle_inner: cute.Swizzle
@@ -3758,3 +4759,8 @@ class GatedDeltaNetChunkedKernel:
             ),
         )
         return workspace
+
+
+# ---------------------------------------------------------------------------
+# Test / validation entry point
+# ---------------------------------------------------------------------------

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -207,6 +207,10 @@ def chunk_gated_delta_rule_sm100(
 
         gdn = GatedDeltaNetChunkedKernel(
             io_dtype=io_dtype,
+            # The kernel requires the triangular-inverse dtype to match io_dtype
+            # (asserted in its __init__); pass io_dtype so bf16 uses the same
+            # validated path as fp16 instead of the default Float16.
+            inverse_dtype=io_dtype,
             acc_dtype=cutlass.Float32,
             state_dtype=state_dtype,
             mma_tiler_qk=(64, 64, 128),
@@ -304,7 +308,7 @@ def chunk_gated_delta_rule_sm100(
             scale,
             workspace_cute,
             stream,
-            options="--enable-tvm-ffi --opt-level 2",
+            options="--enable-tvm-ffi --opt-level 3",
         )
 
         cache["compiled"] = compiled


### PR DESCRIPTION
## What

Optimizes the Blackwell SM100 chunk-stream Gated Delta Net (GDN) prefill kernel.
Coauthored by @guangyunh-nv @jhjpark 

## Test environment

- **GPU:** NVIDIA B300 SXM6 AC — Blackwell (SM100)
- **Compile:** `--enable-tvm-ffi --opt-level 3`
- **Dtype:** bf16 in/out, fp32 state + accumulation
- **Benchmark:** `benchmarks/bench_gdn_prefill.py`, 2 warmup + 8 timed iters, CUDA graph
- **Baseline ("pre-PR"):** the initial functional port of this kernel (`--opt-level 2`)

## Performance

120 configurations (8 head configs x 15 sequence configs). **Median 1.25x** speedup
(range 1.07x-1.32x). No regressions (every config is faster than the baseline).

<details>
<summary>Full 120-configuration results (h_qk/h_v, seqlen, pre-PR ms, this-PR ms, speedup)</summary>

| h_qk/h_v | seqlen | pre-PR (ms) | this PR (ms) | speedup |
|---|---|---|---|---|
| 2/8 | 1x65536 | 2.352 | 1.827 | 1.29x |
| 2/8 | 1x32768 | 1.184 | 0.923 | 1.28x |
| 2/8 | 1x16384 | 0.601 | 0.470 | 1.28x |
| 2/8 | 1x8192 | 0.311 | 0.242 | 1.28x |
| 2/8 | 1x4096 | 0.165 | 0.129 | 1.28x |
| 2/8 | 1x2048 | 0.091 | 0.069 | 1.31x |
| 2/8 | 6144+2048 | 0.237 | 0.187 | 1.27x |
| 2/8 | 4096+4096 | 0.165 | 0.131 | 1.26x |
| 2/8 | 2048+6144 | 0.237 | 0.187 | 1.27x |
| 2/8 | 1024+7168 | 0.274 | 0.215 | 1.27x |
| 2/8 | 2048x4 | 0.093 | 0.074 | 1.25x |
| 2/8 | 1024x8 | 0.057 | 0.047 | 1.22x |
| 2/8 | 8192x8 | 0.315 | 0.246 | 1.28x |
| 2/8 | 8192x16 | 0.317 | 0.248 | 1.28x |
| 2/8 | 8192x32 | 0.627 | 0.490 | 1.28x |
| 4/16 | 1x65536 | 2.349 | 1.830 | 1.28x |
| 4/16 | 1x32768 | 1.185 | 0.925 | 1.28x |
| 4/16 | 1x16384 | 0.602 | 0.471 | 1.28x |
| 4/16 | 1x8192 | 0.311 | 0.245 | 1.27x |
| 4/16 | 1x4096 | 0.165 | 0.131 | 1.26x |
| 4/16 | 1x2048 | 0.092 | 0.074 | 1.25x |
| 4/16 | 6144+2048 | 0.238 | 0.189 | 1.26x |
| 4/16 | 4096+4096 | 0.166 | 0.133 | 1.25x |
| 4/16 | 2048+6144 | 0.239 | 0.188 | 1.27x |
| 4/16 | 1024+7168 | 0.276 | 0.216 | 1.27x |
| 4/16 | 2048x4 | 0.094 | 0.077 | 1.23x |
| 4/16 | 1024x8 | 0.060 | 0.050 | 1.21x |
| 4/16 | 8192x8 | 0.317 | 0.249 | 1.27x |
| 4/16 | 8192x16 | 0.626 | 0.493 | 1.27x |
| 4/16 | 8192x32 | 1.235 | 1.031 | 1.20x |
| 8/32 | 1x65536 | 2.361 | 1.836 | 1.29x |
| 8/32 | 1x32768 | 1.190 | 0.928 | 1.28x |
| 8/32 | 1x16384 | 0.605 | 0.475 | 1.27x |
| 8/32 | 1x8192 | 0.312 | 0.247 | 1.26x |
| 8/32 | 1x4096 | 0.166 | 0.133 | 1.24x |
| 8/32 | 1x2048 | 0.092 | 0.075 | 1.24x |
| 8/32 | 6144+2048 | 0.240 | 0.191 | 1.26x |
| 8/32 | 4096+4096 | 0.167 | 0.134 | 1.24x |
| 8/32 | 2048+6144 | 0.241 | 0.190 | 1.27x |
| 8/32 | 1024+7168 | 0.278 | 0.218 | 1.28x |
| 8/32 | 2048x4 | 0.097 | 0.079 | 1.23x |
| 8/32 | 1024x8 | 0.113 | 0.094 | 1.20x |
| 8/32 | 8192x8 | 0.628 | 0.508 | 1.24x |
| 8/32 | 8192x16 | 1.242 | 1.033 | 1.20x |
| 8/32 | 8192x32 | 2.185 | 1.933 | 1.13x |
| 16/64 | 1x65536 | 2.383 | 1.835 | 1.30x |
| 16/64 | 1x32768 | 1.202 | 0.927 | 1.30x |
| 16/64 | 1x16384 | 0.611 | 0.473 | 1.29x |
| 16/64 | 1x8192 | 0.316 | 0.247 | 1.28x |
| 16/64 | 1x4096 | 0.168 | 0.133 | 1.26x |
| 16/64 | 1x2048 | 0.094 | 0.077 | 1.23x |
| 16/64 | 6144+2048 | 0.243 | 0.192 | 1.26x |
| 16/64 | 4096+4096 | 0.171 | 0.137 | 1.26x |
| 16/64 | 2048+6144 | 0.244 | 0.192 | 1.27x |
| 16/64 | 1024+7168 | 0.281 | 0.220 | 1.27x |
| 16/64 | 2048x4 | 0.186 | 0.152 | 1.23x |
| 16/64 | 1024x8 | 0.219 | 0.185 | 1.19x |
| 16/64 | 8192x8 | 1.246 | 1.034 | 1.21x |
| 16/64 | 8192x16 | 2.189 | 1.930 | 1.13x |
| 16/64 | 8192x32 | 4.404 | 4.001 | 1.10x |
| 16/32 | 1x65536 | 2.364 | 1.839 | 1.29x |
| 16/32 | 1x32768 | 1.192 | 0.930 | 1.28x |
| 16/32 | 1x16384 | 0.605 | 0.475 | 1.27x |
| 16/32 | 1x8192 | 0.312 | 0.247 | 1.26x |
| 16/32 | 1x4096 | 0.166 | 0.134 | 1.24x |
| 16/32 | 1x2048 | 0.092 | 0.075 | 1.23x |
| 16/32 | 6144+2048 | 0.240 | 0.191 | 1.25x |
| 16/32 | 4096+4096 | 0.167 | 0.134 | 1.25x |
| 16/32 | 2048+6144 | 0.241 | 0.191 | 1.27x |
| 16/32 | 1024+7168 | 0.278 | 0.219 | 1.27x |
| 16/32 | 2048x4 | 0.097 | 0.080 | 1.21x |
| 16/32 | 1024x8 | 0.112 | 0.095 | 1.18x |
| 16/32 | 8192x8 | 0.629 | 0.499 | 1.26x |
| 16/32 | 8192x16 | 1.244 | 1.065 | 1.17x |
| 16/32 | 8192x32 | 2.190 | 1.990 | 1.10x |
| 16/48 | 1x65536 | 2.335 | 1.832 | 1.27x |
| 16/48 | 1x32768 | 1.177 | 0.927 | 1.27x |
| 16/48 | 1x16384 | 0.599 | 0.473 | 1.27x |
| 16/48 | 1x8192 | 0.310 | 0.246 | 1.26x |
| 16/48 | 1x4096 | 0.165 | 0.133 | 1.25x |
| 16/48 | 1x2048 | 0.092 | 0.075 | 1.23x |
| 16/48 | 6144+2048 | 0.239 | 0.191 | 1.25x |
| 16/48 | 4096+4096 | 0.168 | 0.134 | 1.25x |
| 16/48 | 2048+6144 | 0.240 | 0.190 | 1.26x |
| 16/48 | 1024+7168 | 0.277 | 0.219 | 1.27x |
| 16/48 | 2048x4 | 0.184 | 0.150 | 1.23x |
| 16/48 | 1024x8 | 0.165 | 0.138 | 1.19x |
| 16/48 | 8192x8 | 0.930 | 0.780 | 1.19x |
| 16/48 | 8192x16 | 1.852 | 1.566 | 1.18x |
| 16/48 | 8192x32 | 3.393 | 3.059 | 1.11x |
| 16/16 | 1x65536 | 2.377 | 1.836 | 1.29x |
| 16/16 | 1x32768 | 1.198 | 0.928 | 1.29x |
| 16/16 | 1x16384 | 0.608 | 0.473 | 1.29x |
| 16/16 | 1x8192 | 0.314 | 0.246 | 1.28x |
| 16/16 | 1x4096 | 0.167 | 0.132 | 1.26x |
| 16/16 | 1x2048 | 0.092 | 0.074 | 1.25x |
| 16/16 | 6144+2048 | 0.240 | 0.189 | 1.27x |
| 16/16 | 4096+4096 | 0.168 | 0.132 | 1.27x |
| 16/16 | 2048+6144 | 0.242 | 0.189 | 1.28x |
| 16/16 | 1024+7168 | 0.279 | 0.217 | 1.28x |
| 16/16 | 2048x4 | 0.095 | 0.076 | 1.24x |
| 16/16 | 1024x8 | 0.060 | 0.050 | 1.20x |
| 16/16 | 8192x8 | 0.319 | 0.252 | 1.27x |
| 16/16 | 8192x16 | 0.632 | 0.507 | 1.25x |
| 16/16 | 8192x32 | 1.243 | 1.107 | 1.12x |
| 32/32 | 1x65536 | 2.398 | 1.844 | 1.30x |
| 32/32 | 1x32768 | 1.209 | 0.932 | 1.30x |
| 32/32 | 1x16384 | 0.614 | 0.476 | 1.29x |
| 32/32 | 1x8192 | 0.316 | 0.247 | 1.28x |
| 32/32 | 1x4096 | 0.168 | 0.133 | 1.26x |
| 32/32 | 1x2048 | 0.093 | 0.075 | 1.24x |
| 32/32 | 6144+2048 | 0.242 | 0.191 | 1.27x |
| 32/32 | 4096+4096 | 0.168 | 0.134 | 1.25x |
| 32/32 | 2048+6144 | 0.242 | 0.191 | 1.27x |
| 32/32 | 1024+7168 | 0.280 | 0.219 | 1.28x |
| 32/32 | 2048x4 | 0.098 | 0.080 | 1.22x |
| 32/32 | 1024x8 | 0.113 | 0.096 | 1.18x |
| 32/32 | 8192x8 | 0.634 | 0.537 | 1.18x |
| 32/32 | 8192x16 | 1.254 | 1.114 | 1.13x |
| 32/32 | 8192x32 | 2.238 | 2.097 | 1.07x |


## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Blackwell prefill reliability across padded and partial chunks.
  * Corrected final-state handling for sequences with no tokens.
  * Improved state loading and storing for Blackwell layouts.
  * Enhanced numerical handling for inverse calculations and edge cases.

* **Performance**
  * Reworked kernel processing and staging to improve execution efficiency.
  * Optimized compilation settings for faster runtime performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->