### PR TITLE
fix(profiler): report unsupported MLA devices before JIT

### DIFF
--- a/profiler/mla.py
+++ b/profiler/mla.py
@@ -19,12 +19,36 @@ import argparse
 import torch
 
 import flashinfer
-from flashinfer.profiler import export_to_perfetto_trace
+
+
+def _check_mla_profiler_support(backend):
+    if backend != "fa3":
+        raise ValueError(
+            "Intra-kernel MLA profiling is only implemented for the FA3 backend, "
+            f"got backend={backend!r}."
+        )
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "Intra-kernel MLA profiling requires an NVIDIA Hopper GPU, but CUDA "
+            "is not available."
+        )
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    major, minor = torch.cuda.get_device_capability(device)
+    if major != 9:
+        raise RuntimeError(
+            "Intra-kernel MLA profiling with the FA3 backend requires an NVIDIA "
+            f"Hopper GPU (compute capability 9.x); found "
+            f"{torch.cuda.get_device_name(device)} (compute capability {major}.{minor})."
+        )
 
 
 def profile_deepseek_mla_decode(
     batch_size, seq_len, num_heads, profiler_buffer_size, backend
 ):
+    _check_mla_profiler_support(backend)
+    from flashinfer.profiler import export_to_perfetto_trace
+
     head_dim_ckv = 512
     head_dim_kpe = 64
     page_size = 1


### PR DESCRIPTION
## 📌 Description

The MLA intra-kernel profiler uses the FA3 implementation, whose instrumentation is currently available only for NVIDIA Hopper GPUs. On unsupported devices such as A100 or RTX 3090, the example previously continued into optional dependency loading, tensor allocation, or JIT compilation before failing with an indirect error.

This change:

- validates that the requested backend is `fa3`;
- reports when CUDA is unavailable;
- rejects non-Hopper devices with the detected GPU name and compute capability; and
- delays importing `tg4perfetto` until after the environment check succeeds.

Unsupported devices now fail immediately with an actionable message, without allocating profiler tensors or starting JIT compilation.

## 🔍 Related Issues

Fixes #1452

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files`.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] The full test suite is passing.

Targeted validation:

- `python -m py_compile profiler/mla.py`
- mocked unsupported backend, unavailable CUDA, and SM90 pass-through checks
- RTX 3090 negative-path run using GPU 5, which reported compute capability 8.6 and the Hopper requirement before importing `tg4perfetto`
- `pre-commit run --files profiler/mla.py`
- `git diff --check`

## Reviewer Notes

The unsupported-device path was validated on an RTX 3090. The supported Hopper path was not run on physical SM90 hardware; an SM90 pass-through was validated with mocked device capability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer validation when MLA profiling is requested with an unsupported backend or hardware configuration.
  * Profiling now reports descriptive errors when CUDA is unavailable or the required NVIDIA Hopper GPU is not detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->