### PR TITLE
feat(xqa): ragged Q and per-row sliding-window masking for speculative decode

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -202,7 +202,14 @@ def parse_attention_args(line, parser):
         "--causal",
         action="store_true",
         default=False,
-        help="Causal masking. Note: not padding masking. Only used for prefill tests.",
+        help=(
+            "Causal masking. Note: not padding masking. Used for prefill tests, and "
+            "for the speculative-decode draft block (--s_qo > 1) in decode tests: "
+            "with --causal, draft token i attends to draft tokens j <= i (standard "
+            "speculative decoding); without it, every draft token attends to all "
+            "draft tokens (no causal masking within the draft block, e.g. "
+            "DFlash-style drafters). The KV prefix is always fully visible."
+        ),
     )
     parser.add_argument(
         "--random_actual_seq_len",
@@ -284,21 +291,31 @@ def sample_actual_seq_lens(max_seqlen, batch_size, device, random_actual_seq_len
     return actual_seq_lens
 
 
-def generate_speculative_causal_mask(batch_size, q_seq_len, device):
+def generate_speculative_mask(batch_size, q_seq_len, device, mask_mode="causal"):
     """
-    Generate a packed causal mask for speculative decode chunks (q_len > 1).
+    Generate a packed draft-block mask for speculative decode chunks (q_len > 1).
 
     Returned shape is [batch_size, q_seq_len, num_packed_masks_per_token * 2]
     with dtype uint16, where num_packed_masks_per_token = ceil(q_seq_len / 32).
-    Each query row i encodes allowed attention to draft-token columns j <= i
-    (strictly lower-triangular with diagonal) and masks out j > i.
+    With mask_mode="causal", each query row i encodes allowed attention to
+    draft-token columns j <= i (strictly lower-triangular with diagonal) and
+    masks out j > i. With mask_mode="full", every draft token attends to all
+    draft tokens (no causal masking within the draft block, e.g. DFlash-style
+    drafters); the KV prefix is always fully visible in both modes.
     The innermost dimension stores packed bits (uint32 words reinterpreted as
     uint16), matching the mask layout expected by decode APIs.
     """
     num_packed_masks_per_token = (q_seq_len + 31) // 32
     q_indices = torch.arange(q_seq_len, device=device, dtype=torch.int32).unsqueeze(1)
     kv_indices = torch.arange(q_seq_len, device=device, dtype=torch.int32).unsqueeze(0)
-    causal_bool_mask = kv_indices <= q_indices
+    if mask_mode == "causal":
+        causal_bool_mask = kv_indices <= q_indices
+    elif mask_mode == "full":
+        causal_bool_mask = torch.ones(
+            q_seq_len, q_seq_len, device=device, dtype=torch.bool
+        )
+    else:
+        raise ValueError(f"Unsupported spec-decode mask mode: {mask_mode}")
 
     padded_seq_len = num_packed_masks_per_token * 32
     if padded_seq_len > q_seq_len:
@@ -380,6 +397,8 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
     batch_size = args.batch_size
     s_qo = args.s_qo
     speculative_decode = s_qo > 1
+    # For speculative decode, --causal selects the draft-block mask.
+    causal = args.causal
     s_kv = args.s_kv
     num_qo_heads = args.num_qo_heads
     num_kv_heads = args.num_kv_heads
@@ -437,6 +456,13 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
     if "auto" in backends and speculative_decode:
         print("[INFO] auto backend is disabled for speculative decode. Skipping.")
         backends.remove("auto")
+
+    if speculative_decode and not causal and "trtllm-gen" in backends:
+        print(
+            "[WARNING] trtllm-gen wrapper backend applies implicit causal masking to "
+            "the draft block and ignores the non-causal (DFlash) mask; refcheck "
+            "against trtllm-native may mismatch."
+        )
 
     # Storage for timing results and outputs
     backend_times = {backend: [] for backend in backends}
@@ -568,7 +594,9 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
         * (s_qo * num_qo_heads * head_dim_qk)
     ).long()  # For cuDNN
     speculative_mask = (
-        generate_speculative_causal_mask(batch_size, s_qo, device)
+        generate_speculative_mask(
+            batch_size, s_qo, device, "causal" if causal else "full"
+        )
         if speculative_decode
         else None
     )
@@ -852,7 +880,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
                 cur_res["num_kv_heads"] = num_kv_heads
                 cur_res["head_dim_qk"] = head_dim_qk
                 cur_res["head_dim_vo"] = head_dim_vo
-                cur_res["causal"] = False
+                cur_res["causal"] = causal if speculative_decode else False
                 cur_res["q_dtype"] = q_dtype
                 cur_res["kv_dtype"] = kv_dtype
                 cur_res["avg_actual_seq_len"] = avg_seq_len_kv

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -202,13 +202,19 @@ def parse_attention_args(line, parser):
         "--causal",
         action="store_true",
         default=False,
+        help="Causal masking. Note: not padding masking. Only used for prefill tests.",
+    )
+    parser.add_argument(
+        "--spec_dec_mask",
+        type=str,
+        choices=["causal", "full"],
+        default="causal",
         help=(
-            "Causal masking. Note: not padding masking. Used for prefill tests, and "
-            "for the speculative-decode draft block (--s_qo > 1) in decode tests: "
-            "with --causal, draft token i attends to draft tokens j <= i (standard "
-            "speculative decoding); without it, every draft token attends to all "
-            "draft tokens (no causal masking within the draft block, e.g. "
-            "DFlash-style drafters). The KV prefix is always fully visible."
+            "Draft-block mask for speculative decode (--s_qo > 1) in decode tests. "
+            "'causal': draft token i attends to draft tokens j <= i (standard "
+            "speculative decoding, the default). 'full': every draft token attends "
+            "to all draft tokens (e.g. DFlash-style drafters). The KV prefix is "
+            "always fully visible."
         ),
     )
     parser.add_argument(
@@ -292,18 +298,12 @@ def sample_actual_seq_lens(max_seqlen, batch_size, device, random_actual_seq_len
 
 
 def generate_speculative_mask(batch_size, q_seq_len, device, mask_mode="causal"):
-    """
-    Generate a packed draft-block mask for speculative decode chunks (q_len > 1).
+    """Packed draft-block mask for speculative decode (q_len > 1).
 
-    Returned shape is [batch_size, q_seq_len, num_packed_masks_per_token * 2]
-    with dtype uint16, where num_packed_masks_per_token = ceil(q_seq_len / 32).
-    With mask_mode="causal", each query row i encodes allowed attention to
-    draft-token columns j <= i (strictly lower-triangular with diagonal) and
-    masks out j > i. With mask_mode="full", every draft token attends to all
-    draft tokens (no causal masking within the draft block, e.g. DFlash-style
-    drafters); the KV prefix is always fully visible in both modes.
-    The innermost dimension stores packed bits (uint32 words reinterpreted as
-    uint16), matching the mask layout expected by decode APIs.
+    mask_mode "causal": draft token i attends to draft tokens j <= i;
+    "full": every draft token attends to all draft tokens. The KV prefix is
+    always fully visible. Returns [batch_size, q_seq_len,
+    ceil(q_seq_len / 32) * 2] uint16 (bit-packed, as decode APIs expect).
     """
     num_packed_masks_per_token = (q_seq_len + 31) // 32
     q_indices = torch.arange(q_seq_len, device=device, dtype=torch.int32).unsqueeze(1)
@@ -397,8 +397,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
     batch_size = args.batch_size
     s_qo = args.s_qo
     speculative_decode = s_qo > 1
-    # For speculative decode, --causal selects the draft-block mask.
-    causal = args.causal
+    spec_dec_mask_mode = args.spec_dec_mask
     s_kv = args.s_kv
     num_qo_heads = args.num_qo_heads
     num_kv_heads = args.num_kv_heads
@@ -457,7 +456,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
         print("[INFO] auto backend is disabled for speculative decode. Skipping.")
         backends.remove("auto")
 
-    if speculative_decode and not causal and "trtllm-gen" in backends:
+    if speculative_decode and spec_dec_mask_mode == "full" and "trtllm-gen" in backends:
         print(
             "[WARNING] trtllm-gen wrapper backend applies implicit causal masking to "
             "the draft block and ignores the non-causal (DFlash) mask; refcheck "
@@ -594,9 +593,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
         * (s_qo * num_qo_heads * head_dim_qk)
     ).long()  # For cuDNN
     speculative_mask = (
-        generate_speculative_mask(
-            batch_size, s_qo, device, "causal" if causal else "full"
-        )
+        generate_speculative_mask(batch_size, s_qo, device, spec_dec_mask_mode)
         if speculative_decode
         else None
     )
@@ -880,7 +877,9 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
                 cur_res["num_kv_heads"] = num_kv_heads
                 cur_res["head_dim_qk"] = head_dim_qk
                 cur_res["head_dim_vo"] = head_dim_vo
-                cur_res["causal"] = causal if speculative_decode else False
+                cur_res["causal"] = (
+                    spec_dec_mask_mode == "causal" if speculative_decode else False
+                )
                 cur_res["q_dtype"] = q_dtype
                 cur_res["kv_dtype"] = kv_dtype
                 cur_res["avg_actual_seq_len"] = avg_seq_len_kv

--- a/csrc/flashinfer_xqa_binding.cu
+++ b/csrc/flashinfer_xqa_binding.cu
@@ -36,8 +36,8 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
                  tvm::ffi::Optional<TensorView> vSfCacheVLLM, TensorView kvCachePageList,
                  int64_t maxSeqLen, TensorView seqLen, int64_t batchSize, double kvCacheScale,
                  tvm::ffi::Optional<TensorView> kvScaleTensor, int64_t qSeqLen,
-                 tvm::ffi::Optional<TensorView> mask, TensorView semaphores, TensorView scratch,
-                 bool enable_pdl);
+                 tvm::ffi::Optional<TensorView> qCuSeqLens, tvm::ffi::Optional<TensorView> mask,
+                 TensorView semaphores, TensorView scratch, bool enable_pdl);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(xqa_wrapper, xqa_wrapper);
 

--- a/csrc/xqa/mha.cu
+++ b/csrc/xqa/mha.cu
@@ -465,7 +465,12 @@ using WarpAcc = WarpAccT<warpTile.y, warpTile.x>;
 __device__ inline void applyMaskFromInput(Warp const& warp, WarpAcc& acc, MaskType const* mask,
                                           uint32_t rowOffset, uint32_t nbValidCols,
                                           uint32_t qSeqLen, uint32_t actualQSeqLen,
-                                          uint32_t headGrpSize) {
+                                          uint32_t headGrpSize
+#if SLIDING_WINDOW
+                                          ,
+                                          uint32_t tileTokenBeg, int32_t winBegBase
+#endif
+) {
   uint32_t const idxInQuad = laneId() % 4;
   uint32_t const idxQuad = laneId() / 4;
   // Packed mask is aligned with 32 bits (2 uint16_t).
@@ -477,6 +482,14 @@ __device__ inline void applyMaskFromInput(Warp const& warp, WarpAcc& acc, MaskTy
     for (uint32_t i = 0; i < InstAcc::rows; i++) {
       uint32_t const tokenRow =
           min((rowOffset + instM * m + idxQuad + i * 8) / headGrpSize, actualQSeqLen - 1);
+#if SLIDING_WINDOW
+      // Per-row sliding window begin (inclusive): draft row r sits at position
+      // cacheSeqLen - actualQSeqLen + r, so winBegBase = cacheSeqLen -
+      // actualQSeqLen + 1 - slidingWinSize and this row's window starts at
+      // winBegBase + tokenRow. Callers pass a large negative winBegBase to
+      // disable window masking.
+      int32_t const rowWinBeg = winBegBase + int32_t(tokenRow);
+#endif
 #pragma unroll
       for (uint32_t mask_n = 0; mask_n < acc.cols / MMAS_N_PER_MASK; mask_n++) {
         uint32_t const firstCol = instN * mask_n * MMAS_N_PER_MASK + InstAcc::cols * idxInQuad;
@@ -507,7 +520,13 @@ __device__ inline void applyMaskFromInput(Warp const& warp, WarpAcc& acc, MaskTy
                 col + actualQSeqLen < nbValidCols
                     ? true
                     : packedMask & (1u << ((col + actualQSeqLen - nbValidCols) - maskPosStart));
-            acc(m, n)(i, j) = maskFlag && col < nbValidCols ? acc(m, n)(i, j) : safeInitRowMax;
+#if SLIDING_WINDOW
+            bool const inWindow = int32_t(tileTokenBeg + col) >= rowWinBeg;
+#else
+            constexpr bool inWindow = true;
+#endif
+            acc(m, n)(i, j) =
+                maskFlag && inWindow && col < nbValidCols ? acc(m, n)(i, j) : safeInitRowMax;
           }
         }
       }
@@ -1736,7 +1755,20 @@ CUBIN_EXPORT __global__
   uint32_t const cacheSeqLen = getCacheSeqLen<usePagedKVCache>(cacheList, idxReq);
 #if SLIDING_WINDOW
   bool const rtIsReallySliding = (cacheSeqLen > slidingWinSize);
+#if SPEC_DEC && !IS_SPEC_DEC_TREE
+  // Per-row sliding window for linear (non-tree) spec-dec: draft row r sits at
+  // position cacheSeqLen - actualQSeqLen + r, so its window begins at that
+  // position + 1 - slidingWinSize. Whole leading tiles are skipped only up to
+  // the window begin of the earliest row handled by this CTA; the per-row
+  // window edge is masked exactly in applyMaskFromInput.
+  int32_t const specDecWinBegBase =
+      int32_t(cacheSeqLen - actualQSeqLen + 1) - int32_t(slidingWinSize);
+  uint32_t const ctaTokenRowBeg = min(idxHeadTokenInGrp / headGrpSize, actualQSeqLen - 1);
+  int32_t const ctaWinBeg = specDecWinBegBase + int32_t(ctaTokenRowBeg);
+  uint32_t const nbTotalSkipTokens = (rtIsReallySliding && ctaWinBeg > 0) ? uint32_t(ctaWinBeg) : 0;
+#else
   uint32_t const nbTotalSkipTokens = rtIsReallySliding ? cacheSeqLen - slidingWinSize : 0;
+#endif
 #else
   constexpr bool rtIsReallySliding = false;
   constexpr uint32_t nbTotalSkipTokens = 0;
@@ -2023,11 +2055,31 @@ CUBIN_EXPORT __global__
       // masking
       uint32_t const warpTileTokenBeg = ctaTile.x * seqIter + warpTile.x * warpIdx.x;
 #if SPEC_DEC
-      if (seqIter >= nbSeqItersWithoutMask) {
+#if SLIDING_WINDOW && !IS_SPEC_DEC_TREE
+      // Tiles below the last row's window begin (cacheSeqLen - slidingWinSize)
+      // need the per-row window edge mask; tiles fully below this CTA's
+      // first-row window begin were already skipped via nbSkipLeadingTiles.
+      bool const needWinEdgeMask =
+          rtIsReallySliding && (ctaTile.x * seqIter < cacheSeqLen - slidingWinSize);
+      int32_t const winBegBase = rtIsReallySliding ? specDecWinBegBase : int32_t(-(1 << 30));
+#else
+      constexpr bool needWinEdgeMask = false;
+#if SLIDING_WINDOW
+      // Tree-structured draft tokens have no row-indexed positions; keep the
+      // legacy tile-granular window skip without a per-row edge mask.
+      int32_t const winBegBase = -(1 << 30);
+#endif
+#endif
+      if (seqIter >= nbSeqItersWithoutMask || needWinEdgeMask) {
         uint32_t const nbValidCols =
             (warpTileTokenBeg < cacheSeqLen ? cacheSeqLen - warpTileTokenBeg : 0U);
         applyMaskFromInput(warp, acc, mask, idxHeadTokenInGrp, nbValidCols, qSeqLen, actualQSeqLen,
-                           headGrpSize);
+                           headGrpSize
+#if SLIDING_WINDOW
+                           ,
+                           warpTileTokenBeg, winBegBase
+#endif
+        );
       }
 #else
       bool const isFirstIter = (seqIter == nbSkipLeadingTiles);

--- a/csrc/xqa/mha.cu
+++ b/csrc/xqa/mha.cu
@@ -483,11 +483,8 @@ __device__ inline void applyMaskFromInput(Warp const& warp, WarpAcc& acc, MaskTy
       uint32_t const tokenRow =
           min((rowOffset + instM * m + idxQuad + i * 8) / headGrpSize, actualQSeqLen - 1);
 #if SLIDING_WINDOW
-      // Per-row sliding window begin (inclusive): draft row r sits at position
-      // cacheSeqLen - actualQSeqLen + r, so winBegBase = cacheSeqLen -
-      // actualQSeqLen + 1 - slidingWinSize and this row's window starts at
-      // winBegBase + tokenRow. Callers pass a large negative winBegBase to
-      // disable window masking.
+      // Per-row window begin (inclusive); see winBegBase at the call site.
+      // Callers disable window masking with a large negative winBegBase.
       int32_t const rowWinBeg = winBegBase + int32_t(tokenRow);
 #endif
 #pragma unroll
@@ -1605,6 +1602,12 @@ CUBIN_EXPORT __global__
   // Same as idxReq * qSeqLen if all sequences all the same.
   // Take different beams as different requests/sequences currently.
   uint32_t const reqSeqOffset = variableQSeqLen ? uint32_t(qCuSeqLens[idxReq]) : (qSeqLen * idxReq);
+  // A ragged request may have 0 draft tokens (all rejected). It owns no rows
+  // and min(row, actualQSeqLen - 1) would underflow, so exit before any
+  // barrier/semaphore interaction (uniform across the request's CTAs).
+  if (variableQSeqLen && actualQSeqLen == 0) {
+    return;
+  }
 
   uint32_t const nbVHeads = nbKHeads;
   uint32_t const nbQHeads = nbKHeads * headGrpSize;
@@ -1756,11 +1759,10 @@ CUBIN_EXPORT __global__
 #if SLIDING_WINDOW
   bool const rtIsReallySliding = (cacheSeqLen > slidingWinSize);
 #if SPEC_DEC && !IS_SPEC_DEC_TREE
-  // Per-row sliding window for linear (non-tree) spec-dec: draft row r sits at
-  // position cacheSeqLen - actualQSeqLen + r, so its window begins at that
-  // position + 1 - slidingWinSize. Whole leading tiles are skipped only up to
-  // the window begin of the earliest row handled by this CTA; the per-row
-  // window edge is masked exactly in applyMaskFromInput.
+  // Linear (non-tree) spec-dec: draft row r sits at position
+  // cacheSeqLen - actualQSeqLen + r, so each row's window begins at
+  // winBegBase + r. Skip whole leading tiles only up to the earliest row
+  // handled by this CTA; applyMaskFromInput masks the per-row edge exactly.
   int32_t const specDecWinBegBase =
       int32_t(cacheSeqLen - actualQSeqLen + 1) - int32_t(slidingWinSize);
   uint32_t const ctaTokenRowBeg = min(idxHeadTokenInGrp / headGrpSize, actualQSeqLen - 1);
@@ -2065,8 +2067,8 @@ CUBIN_EXPORT __global__
 #else
       constexpr bool needWinEdgeMask = false;
 #if SLIDING_WINDOW
-      // Tree-structured draft tokens have no row-indexed positions; keep the
-      // legacy tile-granular window skip without a per-row edge mask.
+      // Tree-structured draft tokens have no row-indexed positions, so only
+      // the tile-granular window skip applies; no per-row edge mask.
       int32_t const winBegBase = -(1 << 30);
 #endif
 #endif

--- a/csrc/xqa/xqa_wrapper.cu
+++ b/csrc/xqa/xqa_wrapper.cu
@@ -57,8 +57,8 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
                  Optional<TensorView> kSfCacheVLLM, Optional<TensorView> vSfCacheVLLM,
                  TensorView kvCachePageList, int64_t maxSeqLen, TensorView seqLen,
                  int64_t batchSize, double kvCacheScale, Optional<TensorView> kvScaleTensor,
-                 int64_t qSeqLen, Optional<TensorView> mask, TensorView semaphores,
-                 TensorView scratch, bool enable_pdl) {
+                 int64_t qSeqLen, Optional<TensorView> qCuSeqLens, Optional<TensorView> mask,
+                 TensorView semaphores, TensorView scratch, bool enable_pdl) {
   auto stream = get_stream(output.device());
   float const* attentionSinksPtr =
       attentionSinks.has_value() ? reinterpret_cast<float const*>(attentionSinks.value().data_ptr())
@@ -87,6 +87,12 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
 #if SPEC_DEC
   MaskType const* maskPtr =
       mask.has_value() ? reinterpret_cast<MaskType const*>(mask.value().data_ptr()) : nullptr;
+  // Optional ragged Q: cumulative draft lengths [batchSize + 1]; when set,
+  // qSeqLen is the max draft length and q/mask/output are packed by qCuSeqLens.
+  SeqLenDataType const* qCuSeqLensPtr =
+      qCuSeqLens.has_value()
+          ? reinterpret_cast<SeqLenDataType const*>(qCuSeqLens.value().data_ptr())
+          : nullptr;
 #endif
 
   void* kSfCachePtr = kSfCacheVLLM.has_value() ? kSfCacheVLLM.value().data_ptr() : nullptr;
@@ -106,7 +112,7 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
         reinterpret_cast<KVCachePageIndex const*>(kvCachePageList.data_ptr()), maxSeqLen,
         reinterpret_cast<uint32_t const*>(seqLen.data_ptr()), batchSize, kvCacheScale, kvScalePtr,
 #if SPEC_DEC
-        qSeqLen, nullptr, maskPtr,
+        qSeqLen, qCuSeqLensPtr, maskPtr,
 #endif
         reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
         reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl, kv_stride_page, kv_stride_token,
@@ -131,7 +137,7 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
                       maxSeqLen, reinterpret_cast<uint32_t const*>(seqLen.data_ptr()), batchSize,
                       kvCacheScale, kvScalePtr,
 #if SPEC_DEC
-                      qSeqLen, nullptr, maskPtr,
+                      qSeqLen, qCuSeqLensPtr, maskPtr,
 #endif
                       reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
                       reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl, kv_stride_page,

--- a/csrc/xqa/xqa_wrapper.cu
+++ b/csrc/xqa/xqa_wrapper.cu
@@ -100,6 +100,11 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
 
 #if USE_SM90_MHA
   if (run_sm90_fp8_mha) {
+#if SPEC_DEC
+    // mha_sm90.cu's qCuSeqLens path is unvalidated; fail loudly.
+    TVM_FFI_ICHECK(qCuSeqLensPtr == nullptr)
+        << "ragged Q (q_cu_seq_lens) is not supported on the SM90 fp8 MHA path";
+#endif
     launchHopperF8MHAFlashInfer(
         multiProcessorCount, nbKHeads, slidingWinSize, qScale, qScalePtr,
         reinterpret_cast<OutputHead*>(output.data_ptr()),

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3539,12 +3539,14 @@ def xqa_batch_decode_with_kv_cache(
     kv_cache_sf: Union[
         torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]
     ] = None,
+    q_cu_seq_lens: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Parameters
     ----------
     query : torch.Tensor
-        query tensor with shape [num_tokens, num_heads, head_dim], num_tokens = batch_size * q_len_per_request
+        query tensor with shape [num_tokens, num_heads, head_dim], num_tokens = batch_size * q_len_per_request,
+        or sum of per-request draft lengths when :attr:`q_cu_seq_lens` is given (ragged Q)
 
     kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         If kv_cache is a single tensor, it should be a tensor with shape [num_pages, 1 or 2, page_size, num_kv_heads, head_dim] if :attr:`kv_layout` is ``NHD``,
@@ -3596,10 +3598,17 @@ def xqa_batch_decode_with_kv_cache(
         output scale factor for fp8 output.
 
     mask : Optional[torch.Tensor] = None
-        causal attention mask for xqa speculative decoding.
+        draft-block attention mask for xqa speculative decoding.
 
     kv_cache_sf : Optional[torch.Tensor] = None
         KV cache scaling factors. Must provide when NVFP4 KV cache is used.
+
+    q_cu_seq_lens : Optional[torch.Tensor] = None
+        cumulative draft lengths [batch_size + 1] (int32, on device) enabling
+        ragged Q: requests may have different draft lengths. When given,
+        query/out stay packed as [total_q_tokens, num_heads, head_dim],
+        q_len_per_req must be the maximum draft length, and mask rows are
+        packed by the same cumulative offsets.
 
     Returns
     -------
@@ -3657,17 +3666,29 @@ def xqa_batch_decode_with_kv_cache(
     kv_scale_value = bmm2_scale * o_scale
     q_scale_value = bmm1_scale / kv_scale_value * (head_dim**0.5)
 
-    if q_len_per_req > 1:
-        batch_size = query.shape[0] // q_len_per_req
-        query = query.view(batch_size, q_len_per_req, query.shape[1], query.shape[2])
-    query_new = query.unsqueeze(1)
+    if q_cu_seq_lens is not None:
+        # Ragged Q: query stays packed as [total_q_tokens, num_heads, head_dim]
+        # and q_len_per_req is the max draft length across the batch.
+        assert q_len_per_req > 1, (
+            "q_cu_seq_lens requires q_len_per_req to be the max draft length (> 1)"
+        )
+        query_new = query
+        out_shape_ref = query
+    else:
+        if q_len_per_req > 1:
+            batch_size = query.shape[0] // q_len_per_req
+            query = query.view(
+                batch_size, q_len_per_req, query.shape[1], query.shape[2]
+            )
+        query_new = query.unsqueeze(1)
+        out_shape_ref = query
     seq_lens_new = seq_lens.unsqueeze(1)
     sinks_new = sinks.reshape(num_kv_heads, -1) if sinks is not None else None
 
-    # Ensure 4D output for xqa
+    # Ensure 4D output for xqa (packed 3D stays as-is for ragged Q)
     if out is None:
-        out = torch.empty_like(query)
-    out_4d = out.unsqueeze(1)
+        out = torch.empty_like(out_shape_ref)
+    out_new = out if q_cu_seq_lens is not None else out.unsqueeze(1)
 
     xqa(
         query_new,
@@ -3675,7 +3696,7 @@ def xqa_batch_decode_with_kv_cache(
         v_cache,
         block_tables,
         seq_lens_new,
-        out_4d,
+        out_new,
         scratch,
         semaphore,
         num_kv_heads,
@@ -3691,6 +3712,7 @@ def xqa_batch_decode_with_kv_cache(
         enable_pdl=enable_pdl,
         rcp_out_scale=1.0 / o_scale,
         q_seq_len=q_len_per_req,
+        q_cu_seq_lens=q_cu_seq_lens,
         mask=mask,
     )
 

--- a/flashinfer/jit/xqa.py
+++ b/flashinfer/jit/xqa.py
@@ -40,6 +40,7 @@ def gen_xqa_module(
     use_sliding_window: bool,
     output_dtype: torch.dtype,
     q_seq_len: int = 1,
+    use_ragged_q: bool = False,
 ) -> JitSpec:
     if input_dtype == torch.float16:
         flag_input_dtype = ["-DINPUT_FP16=1", "-DDTYPE=__half"]
@@ -85,11 +86,19 @@ def gen_xqa_module(
 
     if q_seq_len > 1:
         use_spec_dec = True
-        if q_seq_len * head_group_ratio <= 32:
+        # The SPEC_Q_SEQ_LEN (SWAP_AB) specialization requires a uniform q
+        # length across the batch, so it must be skipped for ragged Q.
+        if q_seq_len * head_group_ratio <= 32 and not use_ragged_q:
             flag_spec_dec = ["-DSPEC_DEC=1", f"-DSPEC_Q_SEQ_LEN={q_seq_len}"]
         else:
             flag_spec_dec = ["-DSPEC_DEC=1"]
+        # The xqa() mask API indexes draft tokens by row position (linear
+        # chains, causal or full/DFlash masks), not tree structures. Non-tree
+        # mode enables exact per-row sliding-window masking in spec-dec.
+        flag_spec_dec.append("-DIS_SPEC_DEC_TREE=0")
     else:
+        if use_ragged_q:
+            raise ValueError("use_ragged_q requires q_seq_len > 1 (speculative decode)")
         flag_spec_dec = ["-DSPEC_DEC=0"]
         use_spec_dec = False
 
@@ -117,8 +126,9 @@ def gen_xqa_module(
     else:
         flag_sm90_mha = ["-DUSE_SM90_MHA=0"]
 
+    ragged_suffix = "_ragged_q" if use_ragged_q else ""
     return gen_jit_spec(
-        f"xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}",
+        f"xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}{ragged_suffix}",
         sources,
         extra_cuda_cflags=xqa_nvcc_flags
         + sm_nvcc_flags

--- a/flashinfer/jit/xqa.py
+++ b/flashinfer/jit/xqa.py
@@ -93,8 +93,7 @@ def gen_xqa_module(
         else:
             flag_spec_dec = ["-DSPEC_DEC=1"]
         # The xqa() mask API indexes draft tokens by row position (linear
-        # chains, causal or full/DFlash masks), not tree structures. Non-tree
-        # mode enables exact per-row sliding-window masking in spec-dec.
+        # chains only); non-tree mode enables per-row sliding-window masking.
         flag_spec_dec.append("-DIS_SPEC_DEC_TREE=0")
     else:
         if use_ragged_q:
@@ -126,7 +125,10 @@ def gen_xqa_module(
     else:
         flag_sm90_mha = ["-DUSE_SM90_MHA=0"]
 
-    ragged_suffix = "_ragged_q" if use_ragged_q else ""
+    # Suffix the URI only when ragged Q actually changes the compile flags
+    # (i.e. it suppressed the SPEC_Q_SEQ_LEN specialization above).
+    ragged_changes_flags = use_ragged_q and q_seq_len * head_group_ratio <= 32
+    ragged_suffix = "_ragged_q" if ragged_changes_flags else ""
     return gen_jit_spec(
         f"xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}{ragged_suffix}",
         sources,

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -2765,6 +2765,16 @@ xqa_batch_decode_trace = TraceTemplate(
         "bmm2_scale": Scalar(
             "float32", optional=True, description="Scale applied after softmax @ V."
         ),
+        "q_cu_seq_lens": Tensor(
+            ["len_indptr"],
+            dtype="int32",
+            optional=True,
+            description=(
+                "Cumulative per-request draft lengths [batch_size + 1] for "
+                "ragged speculative decode; query stays packed as "
+                "[num_tokens, num_heads, head_dim]."
+            ),
+        ),
     },
     outputs={
         "output": Tensor(["num_tokens", "num_heads", "head_dim"], dtype_from="query"),

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -42,6 +42,7 @@ def get_xqa_module(
     use_sliding_window: bool,
     output_dtype: torch.dtype,
     q_seq_len: int,
+    use_ragged_q: bool = False,
 ):
     module = gen_xqa_module(
         input_dtype,
@@ -52,6 +53,7 @@ def get_xqa_module(
         use_sliding_window,
         output_dtype,
         q_seq_len,
+        use_ragged_q,
     ).build_and_load()
 
     if q_seq_len > 1:
@@ -59,8 +61,11 @@ def get_xqa_module(
     else:
         use_spec_dec = False
 
+    ragged_suffix = "_ragged_q" if use_ragged_q else ""
+    op_name = f"flashinfer::xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}{ragged_suffix}"
+
     @register_custom_op(
-        f"flashinfer::xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}",
+        op_name,
         mutates_args=("output", "workspace_buffer"),
     )
     def xqa(
@@ -86,6 +91,7 @@ def get_xqa_module(
         workspace_buffer: torch.Tensor,
         enable_pdl: bool,
         q_seq_len: int,
+        q_cu_seq_lens: Optional[torch.Tensor],
         mask: Optional[torch.Tensor],
     ) -> None:
         module.xqa_wrapper(
@@ -110,15 +116,14 @@ def get_xqa_module(
             1.0 if isinstance(kv_scale, torch.Tensor) else kv_scale,
             None if isinstance(kv_scale, float) else kv_scale,
             q_seq_len,
+            q_cu_seq_lens,
             mask,
             semaphores,
             workspace_buffer,
             enable_pdl,
         )
 
-    @register_fake_op(
-        f"flashinfer::xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}"
-    )
+    @register_fake_op(op_name)
     def _fake_xqa(
         run_sm90_fp8_mha: bool,
         sm_count: int,
@@ -142,6 +147,7 @@ def get_xqa_module(
         workspace_buffer: torch.Tensor,
         enable_pdl: bool,
         q_seq_len: int,
+        q_cu_seq_lens: Optional[torch.Tensor],
         mask: Optional[torch.Tensor],
     ) -> None:
         pass
@@ -174,6 +180,7 @@ def xqa(
     q_seq_len: int = 1,
     mask: Optional[torch.Tensor] = None,
     *,
+    q_cu_seq_lens: Optional[torch.Tensor] = None,
     k_sf_cache: Optional[torch.Tensor] = None,
     v_sf_cache: Optional[torch.Tensor] = None,
 ) -> None:
@@ -231,6 +238,10 @@ def xqa(
         Scale factor for KV cache.
     sliding_win_size : int, default=0
         Sliding window size for attention. If 0, no sliding window is used.
+        With speculative decoding (``q_seq_len > 1``), the window is applied
+        per draft row, assuming draft tokens occupy consecutive positions at
+        the end of the sequence (linear chains, causal or full masks);
+        tree-structured drafts are not supported with sliding window.
     kv_layout : str, default="NHD"
         The layout of the KV cache. Can be either ``NHD`` or ``HND``.
     sm_count : Optional[int], default=None
@@ -243,16 +254,27 @@ def xqa(
         Reciprocal of output scale factor.
     q_seq_len : int, default=1
         Query sequence length. When > 1, enables speculative decoding mode.
+        With ragged Q (``q_cu_seq_lens`` set), this is the maximum draft
+        length across the batch.
     mask : Optional[torch.Tensor], default=None
-        Causal attention mask for speculative decoding mode (when ``q_seq_len > 1``).
-        Shape: ``[batch_size, q_seq_len, mask_size_per_row]`` where
-        ``mask_size_per_row = ((q_seq_len + 31) // 32) * 2``.
+        Draft-block attention mask for speculative decoding mode (when
+        ``q_seq_len > 1``). Shape: ``[batch_size, q_seq_len,
+        mask_size_per_row]`` where ``mask_size_per_row = ((q_seq_len + 31) //
+        32) * 2``, or ``[total_q_tokens, mask_size_per_row]`` with ragged Q,
+        where each request's rows cover its own draft length.
         Data type should be torch.uint16 (bit-packed format, aligned to 32 bits).
+    q_cu_seq_lens : Optional[torch.Tensor], default=None
+        Cumulative draft lengths ``[batch_size + 1]`` (torch.int32 or
+        torch.uint32, on device) enabling ragged Q: requests may have
+        different draft lengths (each >= 1). When set, ``q`` and ``output``
+        are packed as ``[total_q_tokens, num_q_heads, head_dim]``,
+        ``q_seq_len`` must be the maximum draft length, and ``mask`` rows are
+        packed by the same cumulative offsets.
 
     Note
     ----
     The function automatically infers several parameters from tensor shapes:
-    - batch_size from q.shape[0]
+    - batch_size from q.shape[0] (or seq_lens.shape[0] with ragged Q)
     - num_q_heads from q.shape[-2]
     - head_dim from q.shape[-1]
     - input_dtype from q.dtype
@@ -266,8 +288,20 @@ def xqa(
 
     enable_pdl = enable_pdl if enable_pdl is not None else device_support_pdl(q.device)
 
+    use_ragged_q = q_cu_seq_lens is not None
+    if use_ragged_q:
+        assert q_seq_len > 1, "q_cu_seq_lens requires q_seq_len > 1 (the max draft len)"
+        assert q.dim() == 3, (
+            "With q_cu_seq_lens, q must be packed as "
+            f"[total_q_tokens, num_q_heads, head_dim], got {q.dim()}D"
+        )
+        assert q_cu_seq_lens.dtype in (torch.int32, torch.uint32), (
+            "q_cu_seq_lens must be int32 or uint32"
+        )
+        assert output.shape == q.shape, "Output must match packed ragged q shape"
+
     # Infer parameters from tensors
-    batch_size = q.shape[0]
+    batch_size = seq_lens.shape[0] if use_ragged_q else q.shape[0]
     num_q_heads = q.shape[-2]
     head_dim = q.shape[-1]
 
@@ -326,6 +360,7 @@ def xqa(
         use_sliding_window,
         output.dtype,
         q_seq_len,
+        use_ragged_q,
     )
 
     if q_seq_len > 1:
@@ -356,6 +391,7 @@ def xqa(
         workspace_buffer,
         enable_pdl,
         q_seq_len,
+        q_cu_seq_lens,
         mask,
     )
 

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -44,7 +44,7 @@ def get_xqa_module(
     q_seq_len: int,
     use_ragged_q: bool = False,
 ):
-    module = gen_xqa_module(
+    spec = gen_xqa_module(
         input_dtype,
         kv_cache_dtype,
         page_size,
@@ -54,15 +54,10 @@ def get_xqa_module(
         output_dtype,
         q_seq_len,
         use_ragged_q,
-    ).build_and_load()
-
-    if q_seq_len > 1:
-        use_spec_dec = True
-    else:
-        use_spec_dec = False
-
-    ragged_suffix = "_ragged_q" if use_ragged_q else ""
-    op_name = f"flashinfer::xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}{ragged_suffix}"
+    )
+    # Reuse the JIT module URI so the two names can never drift apart.
+    op_name = f"flashinfer::{spec.name}"
+    module = spec.build_and_load()
 
     @register_custom_op(
         op_name,
@@ -266,10 +261,11 @@ def xqa(
     q_cu_seq_lens : Optional[torch.Tensor], default=None
         Cumulative draft lengths ``[batch_size + 1]`` (torch.int32 or
         torch.uint32, on device) enabling ragged Q: requests may have
-        different draft lengths (each >= 1). When set, ``q`` and ``output``
-        are packed as ``[total_q_tokens, num_q_heads, head_dim]``,
-        ``q_seq_len`` must be the maximum draft length, and ``mask`` rows are
-        packed by the same cumulative offsets.
+        different draft lengths, including 0 for a request with no draft
+        tokens this step. When set, ``q`` and ``output`` are packed as
+        ``[total_q_tokens, num_q_heads, head_dim]``, ``q_seq_len`` must be
+        the maximum draft length, and ``mask`` rows are packed by the same
+        cumulative offsets.
 
     Note
     ----
@@ -298,7 +294,18 @@ def xqa(
         assert q_cu_seq_lens.dtype in (torch.int32, torch.uint32), (
             "q_cu_seq_lens must be int32 or uint32"
         )
+        assert q_cu_seq_lens.is_cuda, (
+            "q_cu_seq_lens must be a device tensor; the kernel dereferences its "
+            "pointer on the GPU"
+        )
+        assert q_cu_seq_lens.numel() == seq_lens.shape[0] + 1, (
+            f"q_cu_seq_lens must have batch_size + 1 = {seq_lens.shape[0] + 1} "
+            f"entries, got {q_cu_seq_lens.numel()}"
+        )
         assert output.shape == q.shape, "Output must match packed ragged q shape"
+        # Not checked (needs a device sync): entries non-decreasing, each
+        # length <= q_seq_len, last entry == q.shape[0]. Violations return
+        # garbage rows rather than raising.
 
     # Infer parameters from tensors
     batch_size = seq_lens.shape[0] if use_ragged_q else q.shape[0]
@@ -351,6 +358,10 @@ def xqa(
     if get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12]:
         raise RuntimeError("XQA is only supported on SM90, SM100, SM120/SM121 GPUs")
 
+    # Ragged Q only changes the build when it suppresses the SPEC_Q_SEQ_LEN
+    # specialization; otherwise reuse the uniform module (a separate cache
+    # entry would re-register the same torch op name and fail).
+    ragged_build = use_ragged_q and q_seq_len * head_group_ratio <= 32
     xqa_module = get_xqa_module(
         q.dtype,
         k_cache.dtype,
@@ -360,7 +371,7 @@ def xqa(
         use_sliding_window,
         output.dtype,
         q_seq_len,
-        use_ragged_q,
+        ragged_build,
     )
 
     if q_seq_len > 1:

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -265,7 +265,7 @@ def xqa(
         tokens this step. When set, ``q`` and ``output`` are packed as
         ``[total_q_tokens, num_q_heads, head_dim]``, ``q_seq_len`` must be
         the maximum draft length, and ``mask`` rows are packed by the same
-        cumulative offsets.
+        cumulative offsets. Not supported on the SM90 fp8 MHA path.
 
     Note
     ----
@@ -297,6 +297,12 @@ def xqa(
         assert q_cu_seq_lens.is_cuda, (
             "q_cu_seq_lens must be a device tensor; the kernel dereferences its "
             "pointer on the GPU"
+        )
+        assert q_cu_seq_lens.device == q.device, (
+            f"q_cu_seq_lens must be on {q.device}, got {q_cu_seq_lens.device}"
+        )
+        assert q_cu_seq_lens.dim() == 1 and q_cu_seq_lens.is_contiguous(), (
+            "q_cu_seq_lens must be a contiguous 1-D tensor"
         )
         assert q_cu_seq_lens.numel() == seq_lens.shape[0] + 1, (
             f"q_cu_seq_lens must have batch_size + 1 = {seq_lens.shape[0] + 1} "

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -237,6 +237,8 @@ def xqa(
         per draft row, assuming draft tokens occupy consecutive positions at
         the end of the sequence (linear chains, causal or full masks);
         tree-structured drafts are not supported with sliding window.
+        On SM90 with fp8 KV cache, speculative decode with a sliding window
+        runs on the generic kernel rather than the Hopper fp8 kernel.
     kv_layout : str, default="NHD"
         The layout of the KV cache. Can be either ``NHD`` or ``HND``.
     sm_count : Optional[int], default=None
@@ -265,7 +267,8 @@ def xqa(
         tokens this step. When set, ``q`` and ``output`` are packed as
         ``[total_q_tokens, num_q_heads, head_dim]``, ``q_seq_len`` must be
         the maximum draft length, and ``mask`` rows are packed by the same
-        cumulative offsets. Not supported on the SM90 fp8 MHA path.
+        cumulative offsets. On SM90 with fp8 KV cache, ragged Q runs on the
+        generic kernel rather than the Hopper fp8 kernel.
 
     Note
     ----
@@ -384,6 +387,10 @@ def xqa(
         assert mask is not None, "Mask is required for speculative decoding"
         if sinks is not None:
             run_sm90_fp8_mha = False  # TODO: mha_sm90.cu has precision issue if sinks and speculative decoding are used simultaneously
+        if use_ragged_q or use_sliding_window:
+            # mha_sm90.cu rejects ragged Q, and its spec-dec sliding-window
+            # path mis-masks full draft masks; use the generic kernel.
+            run_sm90_fp8_mha = False
 
     xqa_module.xqa(
         run_sm90_fp8_mha,

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -330,13 +330,14 @@ def get_last_page_len(seq_lens, page_size):
     return last_page_len
 
 
-def generate_causal_mask(
+def generate_spec_dec_mask(
     batch_size: int,
     q_seq_len: int,
     device: torch.device,
+    mask_mode: str = "causal",
 ) -> torch.Tensor:
     """
-    Generate causal attention mask for speculative decoding.
+    Generate a packed draft-block attention mask for speculative decoding.
 
     Parameters
     ----------
@@ -346,11 +347,16 @@ def generate_causal_mask(
         Query sequence length (number of speculative decoding tokens)
     device : torch.device
         Target device for the mask tensor
+    mask_mode : str
+        "causal": draft token i attends to draft tokens j <= i (standard
+        speculative decoding). "full": every draft token attends to all draft
+        tokens (no causal masking within the draft block, e.g. DFlash-style
+        drafters). The KV prefix is always fully visible in both modes.
 
     Returns
     -------
     torch.Tensor
-        Causal mask with shape [batch_size, q_seq_len, mask_size_per_row]
+        Mask with shape [batch_size, q_seq_len, mask_size_per_row]
         where mask_size_per_row = divUp(q_seq_len, 32) * 2 (in uint16_t units).
         Data type: torch.uint16
 
@@ -360,7 +366,14 @@ def generate_causal_mask(
     q_indices = torch.arange(q_seq_len, device=device, dtype=torch.int32).unsqueeze(1)
     kv_indices = torch.arange(q_seq_len, device=device, dtype=torch.int32).unsqueeze(0)
 
-    causal_bool_mask = kv_indices <= q_indices
+    if mask_mode == "causal":
+        causal_bool_mask = kv_indices <= q_indices
+    elif mask_mode == "full":
+        causal_bool_mask = torch.ones(
+            q_seq_len, q_seq_len, device=device, dtype=torch.bool
+        )
+    else:
+        raise ValueError(f"Unsupported spec-decode mask mode: {mask_mode}")
 
     padded_seq_len = num_packed_masks_per_token * 32
     if padded_seq_len > q_seq_len:
@@ -422,6 +435,7 @@ def generate_causal_mask(
 @pytest.mark.parametrize("enable_sink", [True, False])
 @pytest.mark.parametrize("max_in_kv_len", [110])
 @pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
 def test_xqa_batch_decode(
     batch_size,
     q_len_per_req,
@@ -436,11 +450,17 @@ def test_xqa_batch_decode(
     enable_sink,
     max_in_kv_len,
     kv_layout,
+    spec_dec_mask_mode,
 ):
     """Test xqa_batch_decode_with_kv_cache function.
 
-    This test supports both NHD and HND layouts.
+    This test supports both NHD and HND layouts. For speculative decode
+    (q_len_per_req > 1), both draft-block mask modes are covered: "causal"
+    (standard speculative decoding) and "full" (no causal masking within the
+    draft block, e.g. DFlash-style drafters).
     """
+    if q_len_per_req == 1 and spec_dec_mask_mode == "full":
+        pytest.skip("Mask is unused for q_len_per_req == 1")
 
     # Set up test parameters
     torch.manual_seed(0)
@@ -494,6 +514,10 @@ def test_xqa_batch_decode(
         "q_data_type": ref_q.dtype,
         "window_left": window_left,
     }
+    # With a "full" draft-block mask, every draft token attends to the whole
+    # sequence (prefix + all draft tokens); since seq_lens include the draft
+    # tokens, that is exactly non-causal prefill over the paged KV cache.
+    ref_causal = spec_dec_mask_mode == "causal"
     if not enable_sink:
         if q_len_per_req == 1:
             wrapper_ref = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
@@ -514,7 +538,7 @@ def test_xqa_batch_decode(
                     "paged_kv_indices": plan_params_prefill.pop("indices"),
                     "paged_kv_last_page_len": plan_params_prefill.pop("last_page_len"),
                     "head_dim_qk": plan_params_prefill.pop("head_dim"),
-                    "causal": True,
+                    "causal": ref_causal,
                     "logits_soft_cap": 0.0,
                 }
             )
@@ -537,7 +561,7 @@ def test_xqa_batch_decode(
             v_flat,
             sink,
             window_left,
-            True,
+            ref_causal if q_len_per_req > 1 else True,
             sm_scale,
             mode="varlen",
             batch_size=batch_size,
@@ -546,7 +570,9 @@ def test_xqa_batch_decode(
         )
 
     if q_len_per_req > 1:
-        mask = generate_causal_mask(batch_size, q_len_per_req, GPU_DEVICE)
+        mask = generate_spec_dec_mask(
+            batch_size, q_len_per_req, GPU_DEVICE, spec_dec_mask_mode
+        )
     else:
         mask = None
 
@@ -571,6 +597,251 @@ def test_xqa_batch_decode(
     )
 
     # Verification
+    torch.testing.assert_close(
+        output.float(),
+        output_ref.float() / o_scale,
+        rtol=1e-1 if kv_dtype == "fp8" else 1e-2,
+        atol=1e-1 if kv_dtype == "fp8" else 1e-2,
+    )
+
+
+@pytest.mark.skipif(
+    get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12],
+    reason="XQA is only supported on SM90, SM100, SM120/SM121 GPUs",
+)
+@pytest.mark.parametrize(
+    "batch_size,q_len_per_req,page_size,num_kv_heads,head_grp_size",
+    [
+        (4, 2, 32, 2, 4),
+        (4, 4, 64, 4, 2),
+        (4, 5, 16, 2, 8),
+    ],
+)
+@pytest.mark.parametrize("window_left", [63, 127])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    [
+        ("bf16", "bf16", "bf16"),
+        ("bf16", "fp8", "bf16"),
+    ],
+)
+@pytest.mark.parametrize("enable_sink", [True, False])
+@pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
+def test_xqa_batch_decode_spec_dec_sliding_window(
+    batch_size,
+    q_len_per_req,
+    page_size,
+    num_kv_heads,
+    head_grp_size,
+    window_left,
+    q_dtype,
+    kv_dtype,
+    o_dtype,
+    enable_sink,
+    spec_dec_mask_mode,
+):
+    """Speculative decode with a sliding window that actually truncates
+    (kv_len >> window), unlike the main test where window_left exceeds every
+    sequence length. This exercises the per-row window-edge masking in the
+    spec-dec kernel; tile-granular or shared-anchor windowing fails it.
+    """
+    test_xqa_batch_decode(
+        batch_size=batch_size,
+        q_len_per_req=q_len_per_req,
+        page_size=page_size,
+        num_kv_heads=num_kv_heads,
+        head_grp_size=head_grp_size,
+        window_left=window_left,
+        q_dtype=q_dtype,
+        o_dtype=o_dtype,
+        kv_dtype=kv_dtype,
+        enable_pdl=None,
+        enable_sink=enable_sink,
+        max_in_kv_len=300,
+        kv_layout="NHD",
+        spec_dec_mask_mode=spec_dec_mask_mode,
+    )
+
+
+def generate_ragged_spec_dec_mask(
+    q_lens: torch.Tensor,
+    max_q_len: int,
+    device: torch.device,
+    mask_mode: str = "causal",
+) -> torch.Tensor:
+    """Packed draft-block mask for ragged speculative decoding.
+
+    Rows are packed by cumulative draft lengths: request i contributes
+    q_lens[i] rows, each spanning its own q_lens[i] draft columns. Row
+    stride is sized by max_q_len: [total_q_tokens, divUp(max_q_len,32)*2]
+    uint16.
+    """
+    num_packed_masks_per_token = (max_q_len + 31) // 32
+    padded = num_packed_masks_per_token * 32
+    rows = []
+    for q_len in q_lens.tolist():
+        q_indices = torch.arange(q_len, device=device, dtype=torch.int32).view(-1, 1)
+        kv_indices = torch.arange(padded, device=device, dtype=torch.int32).view(1, -1)
+        if mask_mode == "causal":
+            m = (kv_indices <= q_indices) & (kv_indices < q_len)
+        elif mask_mode == "full":
+            m = (kv_indices < q_len).expand(q_len, -1)
+        else:
+            raise ValueError(f"Unsupported spec-decode mask mode: {mask_mode}")
+        rows.append(m)
+    bool_mask = torch.cat(rows, dim=0).view(-1, num_packed_masks_per_token, 32)
+    bit_positions = torch.tensor(
+        [1 << i for i in range(32)], device=device, dtype=torch.int64
+    )
+    mask_uint32 = (
+        (bool_mask.to(torch.int64) * bit_positions).sum(dim=-1).to(torch.uint32)
+    ).contiguous()
+    return mask_uint32.view(torch.uint16)
+
+
+@pytest.mark.skipif(
+    get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12],
+    reason="XQA is only supported on SM90, SM100, SM120/SM121 GPUs",
+)
+@pytest.mark.parametrize(
+    "q_lens_pattern,page_size,num_kv_heads,head_grp_size",
+    [
+        # max_q_len * head_grp_size <= 32: single token block per group
+        ((1, 3, 2, 4), 32, 2, 4),
+        # max_q_len * head_grp_size > 32: multiple token blocks per group,
+        # short requests leave whole blocks with zero valid rows
+        ((5, 1, 3, 2), 16, 2, 8),
+    ],
+)
+@pytest.mark.parametrize("window_left", [-1, 127])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    [
+        ("bf16", "bf16", "bf16"),
+        ("bf16", "fp8", "bf16"),
+    ],
+)
+@pytest.mark.parametrize("enable_sink", [True, False])
+@pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
+def test_xqa_batch_decode_ragged_q(
+    q_lens_pattern,
+    page_size,
+    num_kv_heads,
+    head_grp_size,
+    window_left,
+    q_dtype,
+    kv_dtype,
+    o_dtype,
+    enable_sink,
+    spec_dec_mask_mode,
+):
+    """Ragged speculative decode: per-request draft lengths via q_cu_seq_lens,
+    with q packed as [total_q_tokens, num_heads, head_dim]."""
+    torch.manual_seed(0)
+    head_dim = 128
+    max_in_kv_len = 300
+    batch_size = len(q_lens_pattern)
+    num_qo_heads = num_kv_heads * head_grp_size
+    max_q_len = max(q_lens_pattern)
+
+    q_lens = torch.tensor(q_lens_pattern, dtype=torch.int32)
+    in_kv_lens = torch.randint(0, max_in_kv_len + 1, (batch_size,), dtype=torch.int)
+    in_kv_lens[-1] = max_in_kv_len
+    seq_lens = q_lens + in_kv_lens
+
+    q, q_scale, ref_q = create_query_tensor(q_lens, num_qo_heads, head_dim, q_dtype)
+    q_indptr = generate_cumsum_lens(q_lens)
+
+    kv_cache, k_scale, v_scale, _, _, ref_kv_cache = create_kv_cache(
+        batch_size,
+        seq_lens,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        kv_dtype,
+        q_dtype,
+        "NHD",
+    )
+    page_table, all_page_ids, page_per_seq = create_page_table(
+        batch_size, seq_lens, page_size
+    )
+    kv_indptr = generate_cumsum_lens(page_per_seq)
+    kv_last_page_len = get_last_page_len(seq_lens, page_size)
+
+    workspace_buffer, workspace_buffer_ref = create_workspace_buffers(GPU_DEVICE)
+    out, o_scale = create_output(q, o_dtype)
+    sm_scale = float(1.0 / (head_dim**0.5))
+
+    ref_causal = spec_dec_mask_mode == "causal"
+    if not enable_sink:
+        wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+            workspace_buffer_ref, "NHD"
+        )
+        wrapper_ref.plan(
+            qo_indptr=q_indptr,
+            paged_kv_indptr=kv_indptr,
+            paged_kv_indices=all_page_ids,
+            paged_kv_last_page_len=kv_last_page_len.to(GPU_DEVICE),
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim,
+            page_size=page_size,
+            causal=ref_causal,
+            logits_soft_cap=0.0,
+            pos_encoding_mode="NONE",
+            kv_data_type=ref_kv_cache.dtype,
+            q_data_type=ref_q.dtype,
+            window_left=window_left,
+        )
+        output_ref = wrapper_ref.run(ref_q, ref_kv_cache)
+        sink = None
+    else:
+        k_flat, v_flat, kv_indptr_tokens = flatten_paged_kv(
+            ref_kv_cache,
+            page_table,
+            seq_lens.to(GPU_DEVICE),
+            page_size,
+            kv_last_page_len,
+            "NHD",
+        )
+        sink = torch.rand(num_qo_heads, device=GPU_DEVICE, dtype=torch.float32) * 5
+        output_ref = sink_attention_unified(
+            ref_q,
+            k_flat,
+            v_flat,
+            sink,
+            window_left,
+            ref_causal,
+            sm_scale,
+            mode="varlen",
+            batch_size=batch_size,
+            qo_indptr=q_indptr,
+            kv_indptr=kv_indptr_tokens,
+        )
+
+    mask = generate_ragged_spec_dec_mask(
+        q_lens, max_q_len, GPU_DEVICE, spec_dec_mask_mode
+    )
+
+    output = flashinfer.decode.xqa_batch_decode_with_kv_cache(
+        q.contiguous(),
+        kv_cache,
+        workspace_buffer,
+        page_table,
+        seq_lens.to(GPU_DEVICE),
+        torch.max(seq_lens).item(),
+        q_scale * k_scale * sm_scale,  # bmm1_scale
+        v_scale / o_scale,  # bmm2_scale
+        window_left,
+        out=out,
+        sinks=sink,
+        kv_layout="NHD",
+        q_len_per_req=max_q_len,
+        o_scale=o_scale,
+        mask=mask,
+        q_cu_seq_lens=q_indptr,
+    )
+
     torch.testing.assert_close(
         output.float(),
         output_ref.float() / o_scale,
@@ -617,6 +888,7 @@ def test_xqa_batch_decode(
 # stride by the factor-2 stacking. This exercises the dedicated sf_stride_*
 # plumbing and regresses if the kernel falls back to the data-cache strides.
 @pytest.mark.parametrize("sf_layout", ["stacked", "separate"])
+@pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
 def test_xqa_batch_decode_nvfp4_kv(
     batch_size,
     q_len_per_req,
@@ -632,11 +904,14 @@ def test_xqa_batch_decode_nvfp4_kv(
     max_in_kv_len,
     kv_layout,
     sf_layout,
+    spec_dec_mask_mode,
 ):
     """Test xqa_batch_decode_with_kv_cache function.
 
     This test supports both NHD and HND layouts.
     """
+    if q_len_per_req == 1 and spec_dec_mask_mode == "full":
+        pytest.skip("Mask is unused for q_len_per_req == 1")
 
     # Set up test parameters
     torch.manual_seed(0)
@@ -724,7 +999,7 @@ def test_xqa_batch_decode_nvfp4_kv(
                     "paged_kv_indices": plan_params_prefill.pop("indices"),
                     "paged_kv_last_page_len": plan_params_prefill.pop("last_page_len"),
                     "head_dim_qk": plan_params_prefill.pop("head_dim"),
-                    "causal": True,
+                    "causal": spec_dec_mask_mode == "causal",
                     "logits_soft_cap": 0.0,
                 }
             )
@@ -747,7 +1022,7 @@ def test_xqa_batch_decode_nvfp4_kv(
             v_flat,
             sink,
             window_left,
-            True,
+            spec_dec_mask_mode == "causal" if q_len_per_req > 1 else True,
             sm_scale,
             mode="varlen",
             batch_size=batch_size,
@@ -756,7 +1031,9 @@ def test_xqa_batch_decode_nvfp4_kv(
         )
 
     if q_len_per_req > 1:
-        mask = generate_causal_mask(batch_size, q_len_per_req, GPU_DEVICE)
+        mask = generate_spec_dec_mask(
+            batch_size, q_len_per_req, GPU_DEVICE, spec_dec_mask_mode
+        )
     else:
         mask = None
 

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -417,6 +417,9 @@ def generate_spec_dec_mask(
         (4, 1, 32, 2, 5),
         (128, 1, 64, 2, 6),
         (256, 1, 64, 4, 8),
+        # Nemotron 3.5 Nano shape: 32 q heads / 2 kv heads (group ratio 16)
+        (4, 1, 32, 2, 16),
+        (4, 4, 32, 2, 16),
     ],
 )
 @pytest.mark.parametrize("window_left", [-1, 127])
@@ -615,6 +618,8 @@ def test_xqa_batch_decode(
         (4, 2, 32, 2, 4),
         (4, 4, 64, 4, 2),
         (4, 5, 16, 2, 8),
+        # Nemotron 3.5 Nano shape: 32 q heads / 2 kv heads (group ratio 16)
+        (4, 4, 32, 2, 16),
     ],
 )
 @pytest.mark.parametrize("window_left", [63, 127])
@@ -711,6 +716,8 @@ def generate_ragged_spec_dec_mask(
         # max_q_len * head_grp_size > 32: multiple token blocks per group,
         # short requests leave whole blocks with zero valid rows
         ((5, 1, 3, 2), 16, 2, 8),
+        # Nemotron 3.5 Nano shape: 32 q heads / 2 kv heads (group ratio 16)
+        ((1, 4, 2, 3), 32, 2, 16),
     ],
 )
 @pytest.mark.parametrize("window_left", [-1, 127])

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -336,30 +336,12 @@ def generate_spec_dec_mask(
     device: torch.device,
     mask_mode: str = "causal",
 ) -> torch.Tensor:
-    """
-    Generate a packed draft-block attention mask for speculative decoding.
+    """Packed draft-block attention mask for speculative decoding.
 
-    Parameters
-    ----------
-    batch_size : int
-        Batch size
-    q_seq_len : int
-        Query sequence length (number of speculative decoding tokens)
-    device : torch.device
-        Target device for the mask tensor
-    mask_mode : str
-        "causal": draft token i attends to draft tokens j <= i (standard
-        speculative decoding). "full": every draft token attends to all draft
-        tokens (no causal masking within the draft block, e.g. DFlash-style
-        drafters). The KV prefix is always fully visible in both modes.
-
-    Returns
-    -------
-    torch.Tensor
-        Mask with shape [batch_size, q_seq_len, mask_size_per_row]
-        where mask_size_per_row = divUp(q_seq_len, 32) * 2 (in uint16_t units).
-        Data type: torch.uint16
-
+    mask_mode "causal": draft token i attends to draft tokens j <= i;
+    "full": every draft token attends to all draft tokens. The KV prefix is
+    always fully visible. Returns [batch_size, q_seq_len,
+    divUp(q_seq_len, 32) * 2] uint16.
     """
     num_packed_masks_per_token = (q_seq_len + 31) // 32
 
@@ -417,7 +399,7 @@ def generate_spec_dec_mask(
         (4, 1, 32, 2, 5),
         (128, 1, 64, 2, 6),
         (256, 1, 64, 4, 8),
-        # Nemotron 3.5 Nano shape: 32 q heads / 2 kv heads (group ratio 16)
+        # 32 q heads / 2 kv heads (group ratio 16)
         (4, 1, 32, 2, 16),
         (4, 4, 32, 2, 16),
     ],
@@ -455,13 +437,7 @@ def test_xqa_batch_decode(
     kv_layout,
     spec_dec_mask_mode,
 ):
-    """Test xqa_batch_decode_with_kv_cache function.
-
-    This test supports both NHD and HND layouts. For speculative decode
-    (q_len_per_req > 1), both draft-block mask modes are covered: "causal"
-    (standard speculative decoding) and "full" (no causal masking within the
-    draft block, e.g. DFlash-style drafters).
-    """
+    """Test xqa_batch_decode_with_kv_cache across layouts and mask modes."""
     if q_len_per_req == 1 and spec_dec_mask_mode == "full":
         pytest.skip("Mask is unused for q_len_per_req == 1")
 
@@ -618,7 +594,7 @@ def test_xqa_batch_decode(
         (4, 2, 32, 2, 4),
         (4, 4, 64, 4, 2),
         (4, 5, 16, 2, 8),
-        # Nemotron 3.5 Nano shape: 32 q heads / 2 kv heads (group ratio 16)
+        # 32 q heads / 2 kv heads (group ratio 16)
         (4, 4, 32, 2, 16),
     ],
 )
@@ -632,6 +608,14 @@ def test_xqa_batch_decode(
 )
 @pytest.mark.parametrize("enable_sink", [True, False])
 @pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
+@pytest.mark.parametrize(
+    "max_in_kv_len",
+    [
+        300,
+        # long context engages the multi-block (split-KV) path
+        30000,
+    ],
+)
 def test_xqa_batch_decode_spec_dec_sliding_window(
     batch_size,
     q_len_per_req,
@@ -644,6 +628,7 @@ def test_xqa_batch_decode_spec_dec_sliding_window(
     o_dtype,
     enable_sink,
     spec_dec_mask_mode,
+    max_in_kv_len,
 ):
     """Speculative decode with a sliding window that actually truncates
     (kv_len >> window), unlike the main test where window_left exceeds every
@@ -662,7 +647,7 @@ def test_xqa_batch_decode_spec_dec_sliding_window(
         kv_dtype=kv_dtype,
         enable_pdl=None,
         enable_sink=enable_sink,
-        max_in_kv_len=300,
+        max_in_kv_len=max_in_kv_len,
         kv_layout="NHD",
         spec_dec_mask_mode=spec_dec_mask_mode,
     )
@@ -716,8 +701,11 @@ def generate_ragged_spec_dec_mask(
         # max_q_len * head_grp_size > 32: multiple token blocks per group,
         # short requests leave whole blocks with zero valid rows
         ((5, 1, 3, 2), 16, 2, 8),
-        # Nemotron 3.5 Nano shape: 32 q heads / 2 kv heads (group ratio 16)
+        # 32 q heads / 2 kv heads (group ratio 16)
         ((1, 4, 2, 3), 32, 2, 16),
+        # zero-length draft: a request whose drafts were all rejected owns no
+        # query rows and must be skipped without touching its neighbors' masks
+        ((5, 0, 3, 2), 16, 2, 8),
     ],
 )
 @pytest.mark.parametrize("window_left", [-1, 127])
@@ -730,6 +718,14 @@ def generate_ragged_spec_dec_mask(
 )
 @pytest.mark.parametrize("enable_sink", [True, False])
 @pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
+@pytest.mark.parametrize(
+    "max_in_kv_len",
+    [
+        300,
+        # long context engages the multi-block (split-KV) path
+        30000,
+    ],
+)
 def test_xqa_batch_decode_ragged_q(
     q_lens_pattern,
     page_size,
@@ -741,12 +737,12 @@ def test_xqa_batch_decode_ragged_q(
     o_dtype,
     enable_sink,
     spec_dec_mask_mode,
+    max_in_kv_len,
 ):
     """Ragged speculative decode: per-request draft lengths via q_cu_seq_lens,
     with q packed as [total_q_tokens, num_heads, head_dim]."""
     torch.manual_seed(0)
     head_dim = 128
-    max_in_kv_len = 300
     batch_size = len(q_lens_pattern)
     num_qo_heads = num_kv_heads * head_grp_size
     max_q_len = max(q_lens_pattern)


### PR DESCRIPTION
## 📌 Description

XQA is the FlashInfer decode kernel used on SM120/121 for models with attention sinks (#4070). Serving those models with speculative decoding runs the draft-verification step through XQA as well, and two gaps blocked that:

- Every request in a batch had to verify the same number of draft tokens. The kernel indexes queries and masks through cumulative lengths internally, but the argument was never exposed.
- Sliding-window masking computed one window start from the last draft token's position and applied it to the whole draft block. Each draft token sits at its own position, so this masked out KV that the earlier draft tokens should still attend to.

Fixes:

- Plumb `q_cu_seq_lens` through the wrapper and Python API so each request can verify a different number of draft tokens, with host-side input validation. The SM90 fp8 path rejects ragged Q rather than run an unvalidated path.
- Compute the window per draft row: whole KV tiles are skipped conservatively, and the exact per-row edge is masked in the kernel.
- Extend tests and the benchmark to cover both draft-block mask modes (causal and full, selected with `--spec_dec_mask`), long contexts (split-KV path), zero-length drafts, and GQA group ratio 16.

Kernel changes and investigation by @bkryu.

## 📈 Performance

The table shows XQA's speedup over each baseline, measured as kernel time with CUPTI at batch size 1 with head_dim 128, 32 query heads over 2 KV heads, and a bf16 KV cache. Each cell gives the speedup at context lengths 1k, 4k, and 32k. The column m is the number of query tokens per request: m=1 is plain decode, and m=4 or 8 is draft-block verification in speculative decode. Each baseline is measured under full attention and under sliding-window attention with a 1024-token window (SWA 1024).

Baselines:

- vLLM's Triton unified-attention kernel, sinks enabled on both sides.
- FlashInfer fa2 wrappers, sinks disabled on both sides (fa2 has no sink support).

| GPU | m | vs Triton, full attn | vs Triton, SWA 1024 | vs fa2, full attn | vs fa2, SWA 1024 |
|---|---|---|---|---|---|
| GB10 | 1 | 1.7 / 0.9 / 1.1 | 1.5 / 1.2 / 2.3 | 0.8 / 0.9 / 1.0 | 0.9 / 0.7 / 0.8 |
| GB10 | 4 | 1.2 / 2.2 / 5.0 | 1.2 / 1.2 / 1.2 | 2.7 / 1.4 / 1.2 | 2.3 / 1.9 / 1.9 |
| GB10 | 8 | 1.1 / 1.8 / 4.0 | 1.2 / 1.1 / 0.9 | 1.8 / 1.4 / 1.0 | 2.5 / 2.1 / 1.5 |
| RTX PRO 6000 | 1 | 3.0 / 2.4 / 3.2 | 3.3 / 3.0 / 3.6 | 1.0 / 0.8 / 0.8 | 1.0 / 1.0 / 0.6 |
| RTX PRO 6000 | 4 | 2.1 / 6.0 / 18.0 | 1.9 / 1.9 / 1.2 | 3.7 / 2.3 / 1.5 | 2.7 / 3.0 / 2.1 |
| RTX PRO 6000 | 8 | 2.1 / 5.5 / 14.2 | 1.8 / 2.0 / 1.0 | 3.3 / 2.4 / 1.1 | 2.8 / 2.8 / 1.6 |

## 🔍 Related Issues

#4070 (attention sinks on SM120/121).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/attention/test_xqa_batch_decode.py` passes on SM120 (RTX 5080, RTX PRO 6000) and SM121 (GB10). Outputs cross-checked against an independent reference kernel up to 64k context.

## Reviewer Notes

- Speculative-decode builds now assume the draft tokens form a linear chain rather than a tree (the `IS_SPEC_DEC_TREE` compile flag flips from 1 to 0). This is deliberate: the per-row window needs each draft token's sequence position, and only a linear chain defines one. The assumption only matters in sliding-window builds, and tree-shaped drafts never worked correctly with sliding windows, so no working caller changes behavior.
- Not validated on SM90/SM100 hardware. The changed paths are spec-dec only, and the SM90 fp8 wrapper rejects ragged explicitly; CI runs the tests on those arches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ragged-Q speculative decoding support via optional `q_cu_seq_lens`.
  - Introduced configurable speculative draft attention masking with `--spec_dec_mask` (`causal`/`full`), including trace support.
  - Extended JIT/custom-op pathways to support ragged-Q specialization.

- **Bug Fixes**
  - Improved speculative decoding masking for sliding-window cases and fixed an empty-query edge case for ragged requests.

- **Tests**
  - Expanded coverage for ragged-Q, `causal`/`full` mask modes, sliding-window behavior, and KV cache variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->