### PR TITLE
fix(moe_ep): fix two NIXL-EP combine deadlocks under real serving load

### DIFF
--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/handle.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/handle.py
@@ -70,8 +70,13 @@ class NixlEpHandle(Handle):
         """Forward to ``Buffer.low_latency_dispatch``."""
         x = params.x[0]  # MVP: single token tensor
         buf = self._fleet.buffer
-        async_finish = not self._staged
-        return_recv_hook = self._staged
+        # Always drive the Buffer with async_finish=False + a recv hook,
+        # mirroring vLLM's proven native nixl_ep path. The MVP's
+        # async_finish=True event does NOT guarantee the RDMA transfer has
+        # landed — it deadlocks combine under load (rank 0 never finishes
+        # sending, peers time out on "combine receive src_rank 0"). The hook
+        # is the actual completion barrier; run it now for the synchronous
+        # (non-staged) path, or defer it to complete() when staged (DBO).
         (
             recv_x,
             recv_count,
@@ -86,12 +91,18 @@ class NixlEpHandle(Handle):
             use_fp8=self._fleet.use_fp8,
             round_scale=self._fleet.use_ue8m0,
             use_ue8m0=self._fleet.use_ue8m0,
-            async_finish=async_finish,
-            return_recv_hook=return_recv_hook,
+            async_finish=False,
+            return_recv_hook=True,
         )
         self._nixl_handle = handle
-        self._event = event
-        self._recv_hook = hook
+        if self._staged:
+            self._event = event
+            self._recv_hook = hook
+        else:
+            if hook is not None:
+                hook()
+            self._event = None
+            self._recv_hook = None
         # recv_x is (fp8_tensor, scales) tuple when use_fp8 — surface both.
         if isinstance(recv_x, tuple):
             expert_tensors, expert_scales = recv_x[0], recv_x[1]
@@ -126,23 +137,33 @@ class NixlEpHandle(Handle):
             )
         topk_weights = tw.weights  # type: ignore[attr-defined]
         out_t: Optional[Any] = params.out
+        # async_finish=False + recv hook (see dispatch()): the async event
+        # path is unreliable in the NIXL MVP and hangs combine under load.
         result = buf.low_latency_combine(
             x,
             self._topk_ids,
             topk_weights,
             self._nixl_handle,
-            async_finish=not self._staged,
+            async_finish=False,
             zero_copy=False,
-            return_recv_hook=self._staged,
+            return_recv_hook=True,
             out=out_t,
         )
         # low_latency_combine returns (combined_x, event, hook).
         if isinstance(result, tuple):
             combined_x = result[0]
-            self._event = result[1] if len(result) > 1 else None
-            self._recv_hook = result[2] if len(result) > 2 else None
+            event = result[1] if len(result) > 1 else None
+            hook = result[2] if len(result) > 2 else None
         else:
-            combined_x = result
+            combined_x, event, hook = result, None, None
+        if self._staged:
+            self._event = event
+            self._recv_hook = hook
+        else:
+            if hook is not None:
+                hook()
+            self._event = None
+            self._recv_hook = None
         return CombineOutput(x=combined_x)
 
     # @flashinfer_api  # disabled per PR #3453 review

--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/handle.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/handle.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from .....algo_knobs import (
     AlgoKnob,
     HandleAlgoKnobSplitOperation,
     HandleAlgoKnobTopKWeights,
-    HandleAlgoKnobUserStream,
     _index_knobs,
 )
 from .....config import (
@@ -51,37 +49,21 @@ class NixlEpHandle(Handle):
             else params.topk_ids.to(topk_t)
         )
 
-        # Stream the Buffer kernels should run on: the user-stream knob wins,
-        # else the fleet's bootstrap stream; 0 = leave the current stream alone.
-        us = self._handle_knobs.get(HandleAlgoKnobUserStream)
-        self._stream = (
-            int(us.stream)  # type: ignore[attr-defined]
-            if us is not None
-            else int(fleet._bootstrap.stream or 0)
-        )
-        self._stream_obj = None  # lazily built torch.cuda.ExternalStream
+        # HandleAlgoKnobUserStream is intentionally NOT honored by wrapping the
+        # Buffer calls in a torch stream context. The NIXL Buffer takes no
+        # stream argument and manages its own CUDA streams/events for the async
+        # RDMA dispatch/combine completion; forcing its calls onto a foreign
+        # (External) stream breaks that completion signaling and DEADLOCKS the
+        # combine — rank 0 never pushes its combine data, so every peer times
+        # out on "combine receive src_rank 0" (observed end-to-end on B200
+        # DP8-EP decode). The Buffer must run on the natural current stream,
+        # which is exactly the stream vLLM/callers have current when they call
+        # dispatch/combine — so nothing is lost by ignoring the knob here.
 
         # State stashed by dispatch() for combine() + complete().
         self._nixl_handle = None
         self._event = None
         self._recv_hook = None
-
-    def _stream_ctx(self):
-        """Context manager redirecting Buffer kernels to the bound stream.
-
-        The NIXL ``Buffer`` API takes no stream argument (unlike nccl.ep) and
-        launches on torch's current stream, so honoring
-        :class:`HandleAlgoKnobUserStream` means swapping the current stream
-        around each call. ``complete()`` runs under the same context so the
-        event wait / recv hook targets that stream too.
-        """
-        if not self._stream:
-            return contextlib.nullcontext()
-        import torch
-
-        if self._stream_obj is None:
-            self._stream_obj = torch.cuda.ExternalStream(self._stream)
-        return torch.cuda.stream(self._stream_obj)
 
     # @flashinfer_api  # disabled per PR #3453 review
     def dispatch(self, params: DispatchInputParams) -> DispatchOutput:
@@ -90,24 +72,23 @@ class NixlEpHandle(Handle):
         buf = self._fleet.buffer
         async_finish = not self._staged
         return_recv_hook = self._staged
-        with self._stream_ctx():
-            (
-                recv_x,
-                recv_count,
-                handle,
-                event,
-                hook,
-            ) = buf.low_latency_dispatch(
-                x,
-                self._topk_ids,
-                self._fleet.params.max_tokens_per_rank,
-                self._fleet.params.num_experts,
-                use_fp8=self._fleet.use_fp8,
-                round_scale=self._fleet.use_ue8m0,
-                use_ue8m0=self._fleet.use_ue8m0,
-                async_finish=async_finish,
-                return_recv_hook=return_recv_hook,
-            )
+        (
+            recv_x,
+            recv_count,
+            handle,
+            event,
+            hook,
+        ) = buf.low_latency_dispatch(
+            x,
+            self._topk_ids,
+            self._fleet.params.max_tokens_per_rank,
+            self._fleet.params.num_experts,
+            use_fp8=self._fleet.use_fp8,
+            round_scale=self._fleet.use_ue8m0,
+            use_ue8m0=self._fleet.use_ue8m0,
+            async_finish=async_finish,
+            return_recv_hook=return_recv_hook,
+        )
         self._nixl_handle = handle
         self._event = event
         self._recv_hook = hook
@@ -145,17 +126,16 @@ class NixlEpHandle(Handle):
             )
         topk_weights = tw.weights  # type: ignore[attr-defined]
         out_t: Optional[Any] = params.out
-        with self._stream_ctx():
-            result = buf.low_latency_combine(
-                x,
-                self._topk_ids,
-                topk_weights,
-                self._nixl_handle,
-                async_finish=not self._staged,
-                zero_copy=False,
-                return_recv_hook=self._staged,
-                out=out_t,
-            )
+        result = buf.low_latency_combine(
+            x,
+            self._topk_ids,
+            topk_weights,
+            self._nixl_handle,
+            async_finish=not self._staged,
+            zero_copy=False,
+            return_recv_hook=self._staged,
+            out=out_t,
+        )
         # low_latency_combine returns (combined_x, event, hook).
         if isinstance(result, tuple):
             combined_x = result[0]
@@ -168,12 +148,11 @@ class NixlEpHandle(Handle):
     # @flashinfer_api  # disabled per PR #3453 review
     def complete(self) -> None:
         """Wait on the staged event or invoke the deferred recv hook."""
-        with self._stream_ctx():
-            if self._recv_hook is not None:
-                self._recv_hook()
-                self._recv_hook = None
-            elif self._event is not None:
-                self._event.current_stream_wait()
+        if self._recv_hook is not None:
+            self._recv_hook()
+            self._recv_hook = None
+        elif self._event is not None:
+            self._event.current_stream_wait()
 
     def destroy(self) -> None:
         self._nixl_handle = None

--- a/tests/moe_ep/nixl_ep/test_fleet_mock.py
+++ b/tests/moe_ep/nixl_ep/test_fleet_mock.py
@@ -337,7 +337,11 @@ def test_dispatch_fp8_surfaces_scales(patched_loader, fake_buffer_cls):
     fake_buffer_cls.instances.clear()
 
 
-def test_user_stream_knob_redirects_dispatch(patched_loader, fake_buffer_cls):
+def test_user_stream_knob_accepted_but_not_redirected(patched_loader, fake_buffer_cls):
+    """The user-stream knob is accepted without error but must NOT wrap the
+    Buffer calls in a foreign stream context: doing so breaks NIXL's async
+    RDMA completion and deadlocks combine. NIXL runs on the current stream.
+    """
     import torch
 
     _skip_unless_ep_capable()
@@ -354,15 +358,19 @@ def test_user_stream_knob_redirects_dispatch(patched_loader, fake_buffer_cls):
     fleet = _make_fleet(create_fleet, BootstrapConfig, FleetParams)
     topk = torch.zeros(64, 4, dtype=torch.int64, device="cuda")
     side_stream = torch.cuda.Stream()
+    # Passing the knob must not raise and must not switch the active stream.
     h = fleet.create_handle(
         HandleParams(topk_ids=topk),
         algo_knobs=[HandleAlgoKnobUserStream(stream=side_stream.cuda_stream)],
     )
     x = torch.randn(64, 4096, dtype=torch.bfloat16, device="cuda")
+    default_stream = torch.cuda.current_stream().cuda_stream
     _ = h.dispatch(DispatchInputParams(x=[x]))
 
     disp = next(c for c in fake_buffer_cls.instances[-1].calls if c[0] == "dispatch")
-    assert disp[3]["stream"] == side_stream.cuda_stream
+    # The Buffer saw the CURRENT stream, not the side stream from the knob.
+    assert disp[3]["stream"] == default_stream
+    assert disp[3]["stream"] != side_stream.cuda_stream
 
     fake_buffer_cls.instances.clear()
 


### PR DESCRIPTION
## 📌 Description

Follow-up to #4075 (merged). Two fixes to the `flashinfer.moe_ep` **NIXL-EP** LL transport that #4075 did not include — both are combine-phase deadlocks that only surface under real DP-EP serving load, not in the single-shot multirank roundtrip test. Found while integrating `flashinfer_ep_nixl` into vLLM (vllm-project/vllm#47948).

Symptom in both cases: worker rank 0 stops sending its combine data, every peer times out on `NIXL-EP timeout for combine receive ... src_rank 0`, and the EP group hangs.

### 1. Don't wrap NIXL Buffer calls in a user-stream context (`3272f338`)
Honoring `HandleAlgoKnobUserStream` by running dispatch/combine/complete inside `torch.cuda.stream(ExternalStream(...))` breaks the NIXL Buffer's own async RDMA completion signaling. The Buffer takes no stream argument and manages its own streams; it must run on the natural current stream. Drop the wrapper — the knob is a no-op for nixl_ep (unlike nccl_ep, which binds the stream explicitly).

### 2. Drive dispatch/combine synchronously — `async_finish=False` + recv hook (`b848e0ae`)
The NIXL MVP's `async_finish=True` completion event does not guarantee the RDMA transfer landed, so under load the combine data isn't ready when peers read it. vLLM's native `nixl_ep` backend avoids this with `async_finish=False` + explicit recv hook — the proven path. Match it: `async_finish=False, return_recv_hook=True`, drain the hook synchronously on the non-staged path (defer to `complete()` only when staged/DBO).

Fix 1 cleared short sequences; fix 2 was needed for large token counts.

## 🧪 Tests

Validated end-to-end on **B200 DP8-EP** (Qwen3-30B-A3B, DP8 + EP) via the `flashinfer_ep_nixl` vLLM backend:
- **Before:** 2048-prefill / 2048-decode / GSM8K hang (109–112 `combine receive src_rank 0` timeouts). **After:** all complete.
- GSM8K 5-shot **0.848 / 0.891** (flex/strict); throughput (sum of 8 ranks) **9,617 / 23,370 / 5,911** tok/s for 128/128 · 2048/128 · 128/2048 — competitive with NCCL-EP LL.
- Mock suite updated for the no-stream-redirect contract; pre-commit clean.

The single-shot multirank roundtrip still passes but doesn't exercise this — the deadlocks are load-dependent (~256-prompt sustained load), which is why #4075 didn't catch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NIXL dispatch and combine completion handling for more reliable asynchronous communication.
  * Ensured operations consistently use the caller’s active CUDA stream.
  * Added safer handling for varying completion responses.

* **Tests**
  * Updated coverage to verify dispatch uses the current CUDA stream rather than a configured side stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->