### PR TITLE
test(sm103): fix FP4 autotuner cache inspection

### DIFF
--- a/tests/gemm/test_mm_fp4_sm103.py
+++ b/tests/gemm/test_mm_fp4_sm103.py
@@ -77,17 +77,16 @@ def test_mm_fp4_sm103_cutlass_epilogue() -> None:
 
             if not selected_tactic_checked:
                 matching_entries = [
-                    (key, runner_id, tactic)
-                    for key, (runner_id, tactic, _) in tuner.profiling_cache.items()
+                    (key, tactic)
+                    for key, (tactic, _) in tuner.profiling_cache.items()
                     if key.custom_op == "fp4_gemm" and key.nearest_profile[0][0] == m
                 ]
                 assert len(matching_entries) == 1, (
                     "expected one fp4_gemm autotuner entry for the exact M bucket, "
                     f"got {matching_entries}"
                 )
-                key, runner_id, tactic = matching_entries[0]
+                key, tactic = matching_entries[0]
                 assert key.runner_class_name == "CutlassFp4GemmRunner"
-                assert runner_id == 0
                 assert tactic in _NATIVE_K768_TACTICS, (
                     f"autotuner selected generic tactic {tactic}; expected a native "
                     "SM103 K768 tactic"
@@ -197,15 +196,14 @@ def test_mm_fp4_sm103_generic_alignment_dispatch() -> None:
 
                 if not selected_tactic_checked:
                     matching_entries = [
-                        (key, runner_id, tactic)
-                        for key, (runner_id, tactic, _) in tuner.profiling_cache.items()
+                        (key, tactic)
+                        for key, (tactic, _) in tuner.profiling_cache.items()
                         if key.custom_op == "fp4_gemm"
                         and key.nearest_profile[0][0] == m
                     ]
                     assert len(matching_entries) == 1
-                    key, runner_id, tactic = matching_entries[0]
+                    key, tactic = matching_entries[0]
                     assert key.runner_class_name == "CutlassFp4GemmRunner"
-                    assert runner_id == 0
                     if first_alignment == "aligned":
                         assert tactic in _GENERIC_K128_K256_TACTICS
                     selected_tactic_checked = True


### PR DESCRIPTION
## 📌 Description

Update the SM103 `mm_fp4` tests to match the current in-memory
`AutoTuner.profiling_cache` schema.

PR #4004 changed each cache value from
`(runner_id, tactic, profile)` to `(tactic, profile)`, because the runner is
identified by `ProfilingCacheKey`. The tests added by PR #4063 still unpacked
the legacy three-item value and therefore raised:

```text
ValueError: not enough values to unpack (expected 3, got 2)
```

This change:

- unpacks `(tactic, profile)` in both SM103 test cases;
- continues to validate the selected runner through
  `key.runner_class_name`;
- preserves the native K768 and generic K128/K256 tactic-family assertions.

This is a test-only change; no GEMM, dispatch, or autotuner production code is
modified.

## 🔍 Related Issues

- Follow-up to #4063
- Cache schema change: #4004

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Targeted checks completed:

- `ruff check tests/gemm/test_mm_fp4_sm103.py`
- `ruff format --check tests/gemm/test_mm_fp4_sm103.py`
- `git diff --check`

## 🧪 Tests

- [x] Tests have been updated as needed.
- [x] All targeted tests are passing.

```text
pytest -q tests/gemm/test_mm_fp4_sm103.py -vv
2 passed, 2 warnings in 5.70s
```

Tested on NVIDIA B300 / SM103.

## Reviewer Notes

The runner index is intentionally no longer asserted. It is not stored in
`profiling_cache`; the test already verifies the runner identity using
`ProfilingCacheKey.runner_class_name`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated SM103 FP4 GEMM correctness tests to reflect the current profiling cache format.
  * Preserved validation that the selected runner is `CutlassFp4GemmRunner`.
  * Removed obsolete checks for a runner ID that is no longer part of the cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
