### PR TITLE
fix(cudnn): key prefill graphs by tensor descriptors

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -67,6 +67,18 @@ def _create_cudnn_handle(stream: torch.cuda.Stream):
     return _cudnn_handle
 
 
+def _tensor_descriptor_signature(
+    tensor: Optional[torch.Tensor], *, ignore_leading_dim: bool = False
+):
+    """Return hashable metadata used to build a cuDNN tensor descriptor."""
+    if tensor is None:
+        return None
+    shape = tuple(tensor.shape)
+    if ignore_leading_dim and tensor.dim() == 3:
+        shape = shape[1:]
+    return tensor.dim(), tensor.dtype, tensor.device, shape, tuple(tensor.stride())
+
+
 # Tensor ids
 class UIDs(Enum):
     RESERVED_INVALID_UID = 0
@@ -140,12 +152,20 @@ def _sdpa_prefill_key_fn(
         h_qo, d_qk = q.shape[1], q.shape[3]
 
     if v_cache.dim() == 3:
-        h_kv, d_vo = k_cache.shape[1], k_cache.shape[2]
-    elif k_cache.dim() == 4:
-        h_kv, d_vo = k_cache.shape[1], k_cache.shape[3]
+        h_kv, d_vo = v_cache.shape[1], v_cache.shape[2]
+    elif v_cache.dim() == 4:
+        h_kv, d_vo = v_cache.shape[1], v_cache.shape[3]
 
+    block_tables_signature = None
     if block_tables is not None:
         page_size = k_cache.shape[2]
+        nd_block_tables = block_tables.reshape(
+            block_tables.shape[0], 1, block_tables.shape[1], 1
+        )
+        block_tables_signature = _tensor_descriptor_signature(nd_block_tables)
+
+    if o_data_type is None:
+        o_data_type = q.dtype
 
     key = (
         graph_b,
@@ -167,6 +187,20 @@ def _sdpa_prefill_key_fn(
         # (see _build_prefill_graph); omitting it here silently replays a
         # stale-scale graph for any same-shape call with a different scale.
         scale,
+        o_data_type,
+        _tensor_descriptor_signature(q, ignore_leading_dim=True),
+        _tensor_descriptor_signature(k_cache, ignore_leading_dim=True),
+        _tensor_descriptor_signature(v_cache, ignore_leading_dim=True),
+        _tensor_descriptor_signature(actual_seq_lens_q),
+        _tensor_descriptor_signature(actual_seq_lens_kv),
+        _tensor_descriptor_signature(cu_seq_lens_q),
+        _tensor_descriptor_signature(cu_seq_lens_kv),
+        block_tables_signature,
+        _tensor_descriptor_signature(batch_offsets_q),
+        _tensor_descriptor_signature(batch_offsets_o),
+        _tensor_descriptor_signature(batch_offsets_k),
+        _tensor_descriptor_signature(batch_offsets_v),
+        _tensor_descriptor_signature(batch_offsets_stats),
     )
     return key
 

--- a/tests/attention/test_cudnn_graph_cache_key.py
+++ b/tests/attention/test_cudnn_graph_cache_key.py
@@ -12,7 +12,8 @@ not a perf detail.
 
 This test runs the same shape twice with two scales and checks each result
 against an independent torch reference; without the key fix the second
-iteration fails.
+iteration fails.  The descriptor-metadata tests below apply the same cache-
+identity invariant to metadata baked into cuDNN tensor descriptors.
 """
 
 import math
@@ -55,6 +56,161 @@ def _reference(q, k, v, q_lens, kv_lens, scale, causal):
         qo_off += lq
         kv_off += lkv
     return torch.cat(outs)
+
+
+def _prefill_key(
+    *,
+    q=None,
+    k=None,
+    v=None,
+    scale=0.1,
+    out_dtype=None,
+    offsets=None,
+    block_tables=None,
+    out=None,
+    lse=None,
+):
+    q = torch.empty(8, 4, 128) if q is None else q
+    k = torch.empty(8, 2, 128) if k is None else k
+    v = torch.empty(8, 2, 128) if v is None else v
+    seq = torch.empty(2, 1, 1, 1, dtype=torch.int32)
+    return cudnn_prefill._sdpa_prefill_key_fn(
+        q,
+        k,
+        v,
+        scale,
+        max_token_seq_q=4,
+        max_sequence_kv=4,
+        actual_seq_lens_q=seq,
+        actual_seq_lens_kv=seq,
+        block_tables=block_tables,
+        bottom_right_causal_mask=False,
+        batch_offsets_q=offsets,
+        out=out,
+        lse=lse,
+        o_data_type=out_dtype,
+    )
+
+
+def test_cudnn_prefill_output_dtype_in_graph_cache_key():
+    assert _prefill_key(out_dtype=None) == _prefill_key(out_dtype=torch.float32)
+    assert _prefill_key(out_dtype=torch.bfloat16) != _prefill_key(
+        out_dtype=torch.float16
+    )
+
+
+def test_cudnn_prefill_tensor_descriptors_in_graph_cache_key():
+    contiguous = torch.empty(8, 2, 128)
+    strided = torch.empty(16, 2, 128)[::2, :, :]
+    assert contiguous.shape == strided.shape
+    assert contiguous.stride() != strided.stride()
+    assert _prefill_key(k=contiguous) != _prefill_key(k=strided)
+
+    assert _prefill_key(v=torch.empty(8, 2, 128, dtype=torch.float32)) != _prefill_key(
+        v=torch.empty(8, 2, 128, dtype=torch.bfloat16)
+    )
+
+
+def test_cudnn_prefill_value_dimension_comes_from_v():
+    q = torch.empty(8, 4, 192)
+    k = torch.empty(8, 2, 192)
+    key_128 = _prefill_key(q=q, k=k, v=torch.empty(8, 2, 128))
+    key_64 = _prefill_key(q=q, k=k, v=torch.empty(8, 2, 64))
+    assert key_128[9] == 128
+    assert key_64[9] == 64
+    assert key_128 != key_64
+
+
+def test_cudnn_prefill_optional_descriptor_signature_is_stable():
+    contiguous = torch.empty(3, dtype=torch.int32)
+    same_metadata = torch.ones(3, dtype=torch.int32)
+    strided = torch.empty(6, dtype=torch.int32)[::2]
+    assert _prefill_key(offsets=contiguous) == _prefill_key(offsets=same_metadata)
+    assert _prefill_key(offsets=contiguous) != _prefill_key(offsets=strided)
+
+    block_tables = torch.zeros(2, 3, dtype=torch.int32)
+    paged_k = torch.empty(6, 2, 4, 128)
+    paged_v = torch.empty_like(paged_k)
+    assert _prefill_key(
+        k=paged_k, v=paged_v, block_tables=block_tables
+    ) == _prefill_key(
+        k=paged_k,
+        v=paged_v,
+        block_tables=torch.ones_like(block_tables),
+    )
+    assert _prefill_key(
+        k=paged_k, v=paged_v, block_tables=block_tables
+    ) != _prefill_key(
+        k=paged_k,
+        v=paged_v,
+        block_tables=torch.zeros(2, 4, dtype=torch.int32),
+    )
+    hash(_prefill_key(offsets=contiguous))
+
+
+def test_cudnn_prefill_graph_key_preserves_descriptor_reuse():
+    key_a = _prefill_key(
+        q=torch.zeros(8, 4, 128),
+        k=torch.zeros(8, 2, 128),
+        v=torch.zeros(8, 2, 128),
+        out=torch.empty(8, 4, 128),
+        lse=torch.empty(2, 4, 4),
+    )
+    key_b = _prefill_key(
+        q=torch.ones(16, 4, 128),
+        k=torch.ones(32, 2, 128),
+        v=torch.ones(32, 2, 128),
+        out=torch.empty(99),
+        lse=torch.empty(1),
+    )
+    assert key_a == key_b
+
+
+def test_cudnn_prefill_attention_scale_remains_in_graph_cache_key():
+    assert _prefill_key(scale=0.1) != _prefill_key(scale=0.2)
+
+
+def test_cudnn_prefill_stride_in_graph_cache_key():
+    device = "cuda:0"
+    _skip_if_unsupported(device)
+
+    torch.manual_seed(1)
+    batch_size, num_heads, head_dim = 1, 4, 128
+    q_lens = torch.tensor([16], dtype=torch.int32, device=device)
+    kv_lens = torch.tensor([24], dtype=torch.int32, device=device)
+    q = torch.randn(
+        int(q_lens.sum()), num_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+    k_strided = torch.randn(
+        int(kv_lens.sum()) * 2,
+        num_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )[::2, :, :]
+    k_contiguous = k_strided.contiguous()
+    assert k_contiguous.shape == k_strided.shape
+    assert k_contiguous.stride() != k_strided.stride()
+    v = torch.randn_like(k_contiguous)
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    scale = 1.0 / math.sqrt(head_dim)
+    ref = _reference(q, k_strided, v, q_lens, kv_lens, scale, causal=False)
+
+    for k in (k_contiguous, k_strided):
+        out, _ = cudnn_batch_prefill_with_kv_cache(
+            q,
+            k,
+            v,
+            scale,
+            workspace,
+            max_token_per_sequence=16,
+            max_sequence_kv=24,
+            actual_seq_lens_q=q_lens.view(batch_size, 1, 1, 1),
+            actual_seq_lens_kv=kv_lens.view(batch_size, 1, 1, 1),
+            causal=False,
+            return_lse=False,
+        )
+        torch.testing.assert_close(out.float(), ref, atol=2e-2, rtol=2e-2)
 
 
 def test_cudnn_prefill_scale_in_graph_cache_key():


### PR DESCRIPTION
## 📌 Description

The cuDNN prefill graph cache did not distinguish tensors with the same shape but different strides. On an RTX 4070 Laptop GPU, a contiguous K call followed by a same-value, token-strided K call reused the first graph and returned incorrect output (1.8754 maximum error against an FP32 PyTorch reference).

cuDNN bakes tensor descriptor metadata into the compiled graph. This patch:

- adds the dtype, device, shape, and stride metadata used to build the Q/K/V and optional tensor descriptors to the cache key;
- normalizes the output dtype the same way as the graph builder;
- derives `h_kv` and `d_vo` from V, matching the graph builder.

Pointers, tensor values, caller-provided output/LSE buffers, and the dynamic packed-token count remain outside the key, so calls with the same graph descriptors still reuse the cached graph.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

RTX 4070 Laptop GPU, SM89, cuDNN 9.20.0:

- same-shape K stride regression: maximum error 1.8754 before, 0.00424 after;
- `pytest -q tests/attention/test_cudnn_graph_cache_key.py`: 9 passed;
- `pytest -q tests/attention/test_cudnn_prefill_token_indptr.py`: 65 passed, 65 skipped;
- paged prefill with causal/noncausal, LSE on/off, and repeated calls: 8 passed;
- `pre-commit run --all-files`: passed.

I did not complete the full `tests/attention -k cudnn` run locally because its largest cases do not fit on the laptop's 8 GB GPU. I tested mixed BF16/FP16 output at the key level only: a cold mixed-output call is already incorrect with cuDNN 9.20 on this GPU, so it cannot serve as a runtime regression for this cache fix.

## Reviewer Notes

The added key fields are limited to metadata used when building cuDNN tensor descriptors. Calls with identical descriptor metadata still share a cache entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cuDNN SDPA attention graph-cache correctness by making cache keys account for output data type, tensor layouts/strides/shapes/devices, and attention scale so different configurations no longer reuse stale graphs.
  * Fixed value-dimension derivation for prefill so KV sizing is consistent with the value cache.
  * Ensured cache reuse only occurs when tensor descriptors and relevant metadata are truly equivalent (including optional offset signatures and block tables).

* **Tests**
  * Added regression tests asserting cache-key uniqueness/reuse for output dtype, descriptor changes, scale, offsets stability, and block-table content.
  * Added CUDA-dependent stride coverage comparing cuDNN prefill results against a reference implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->