### PR TITLE
fix(gemm): enforce bmm_fp8 tensorwide scale contract

### DIFF
--- a/csrc/bmm_fp8.cu
+++ b/csrc/bmm_fp8.cu
@@ -20,11 +20,29 @@
 
 #include "tvm_ffi_utils.h"
 
+namespace {
+
+void check_tensorwide_scale(TensorView scale, TensorView operand, char const* scale_name,
+                            char const* operand_name) {
+  CHECK_CUDA(scale);
+  TVM_FFI_ICHECK_EQ(scale.dtype(), dl_float32) << scale_name << " must be float32";
+  TVM_FFI_ICHECK_EQ(scale.numel(), 1)
+      << scale_name << " must contain exactly one tensorwide scale value";
+  TVM_FFI_ICHECK_EQ(scale.device().device_type, operand.device().device_type)
+      << scale_name << " and " << operand_name << " must be on the same device";
+  TVM_FFI_ICHECK_EQ(scale.device().device_id, operand.device().device_id)
+      << scale_name << " and " << operand_name << " must be on the same device";
+}
+
+}  // namespace
+
 void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, TensorView B_scale,
              TensorView workspace_buffer, int64_t cublas_handle) {
   CHECK_CUDA(A);
   CHECK_CUDA(B);
   CHECK_CUDA(D);
+  check_tensorwide_scale(A_scale, A, "A_scale", "A");
+  check_tensorwide_scale(B_scale, B, "B_scale", "B");
   CHECK_DIM(3, A);
   CHECK_DIM(3, B);
   CHECK_DIM(3, D);
@@ -69,6 +87,8 @@ int64_t bmm_fp8_get_algos(TensorView A, TensorView B, TensorView D, TensorView A
   CHECK_CUDA(A);
   CHECK_CUDA(B);
   CHECK_CUDA(D);
+  check_tensorwide_scale(A_scale, A, "A_scale", "A");
+  check_tensorwide_scale(B_scale, B, "B_scale", "B");
   CHECK_DIM(3, A);
   CHECK_DIM(3, B);
   CHECK_DIM(3, D);
@@ -110,6 +130,8 @@ void bmm_fp8_run_with_algo(TensorView A, TensorView B, TensorView D, TensorView 
   CHECK_CUDA(A);
   CHECK_CUDA(B);
   CHECK_CUDA(D);
+  check_tensorwide_scale(A_scale, A, "A_scale", "A");
+  check_tensorwide_scale(B_scale, B, "B_scale", "B");
   CHECK_DIM(3, A);
   CHECK_DIM(3, B);
   CHECK_DIM(3, D);

--- a/csrc/fp8_gemm_cutlass.cu
+++ b/csrc/fp8_gemm_cutlass.cu
@@ -90,6 +90,14 @@ void fp8_bmm_impl(TensorView mat1, TensorView mat2, TensorView scale_a, TensorVi
   CHECK_INPUT(mat2);
   CHECK_INPUT(scale_a);
   CHECK_INPUT(scale_b);
+  TVM_FFI_ICHECK_EQ(scale_a.dtype(), dl_float32) << "scale_a must be float32";
+  TVM_FFI_ICHECK_EQ(scale_b.dtype(), dl_float32) << "scale_b must be float32";
+  TVM_FFI_ICHECK_EQ(scale_a.numel(), 1)
+      << "scale_a must contain exactly one tensorwide scale value";
+  TVM_FFI_ICHECK_EQ(scale_b.numel(), 1)
+      << "scale_b must contain exactly one tensorwide scale value";
+  CHECK_DEVICE(scale_a, mat1);
+  CHECK_DEVICE(scale_b, mat2);
 
   int mat2_k_scale = 1;
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6697,6 +6697,24 @@ def _check_bmm_fp8_problem_size(
     backend: Literal["cudnn", "cublas", "cutlass", "auto"] = "cublas",
 ):
     _validate_fp8_output_dtype(dtype)
+    for scale, operand, scale_name, operand_name in (
+        (A_scale, A, "A_scale", "A"),
+        (B_scale, B, "B_scale", "B"),
+    ):
+        if scale.numel() != 1:
+            raise ValueError(
+                f"{scale_name} must contain exactly one tensorwide scale value, "
+                f"but got {scale.numel()} values"
+            )
+        if scale.dtype != torch.float32:
+            raise ValueError(
+                f"{scale_name} must be a float32 tensor, but got {scale.dtype}"
+            )
+        if scale.device != operand.device:
+            raise ValueError(
+                f"{scale_name} must be on the same device as {operand_name}, "
+                f"but got {scale.device} and {operand.device}"
+            )
     return True
 
 
@@ -6760,10 +6778,12 @@ def bmm_fp8(
         Mat2 tensor, shape (b, k, n), should be column major, fp8 e4m3 or fp8 e5m2.
 
     A_scale: torch.Tensor
-        Scale tensor for A, float.
+        Tensorwide scale for A. Must contain exactly one float32 value on the
+        same CUDA device as A.
 
     B_scale: torch.Tensor
-        Scale tensor for B, float.
+        Tensorwide scale for B. Must contain exactly one float32 value on the
+        same CUDA device as B.
 
     dtype: torch.dtype
         out dtype, bf16 or fp16.
@@ -6779,6 +6799,11 @@ def bmm_fp8(
     -------
     out: torch.Tensor
         Out tensor, shape (b, m, n), bf16 or fp16.
+
+    Notes
+    -----
+    This API supports tensorwide scaling only. Use
+    :func:`gemm_fp8_nt_groupwise` for groupwise FP8 scaling.
 
     Examples
     --------

--- a/tests/gemm/test_bmm_fp8.py
+++ b/tests/gemm/test_bmm_fp8.py
@@ -7,6 +7,107 @@ from flashinfer.utils import get_compute_capability
 from tests.utils_fp8 import to_float8
 
 
+@pytest.fixture
+def bmm_fp8_inputs():
+    input_fp8 = torch.randn((1, 16, 64), device="cuda", dtype=torch.float16).to(
+        torch.float8_e4m3fn
+    )
+    mat2_fp8 = (
+        torch.randn((1, 64, 64), device="cuda", dtype=torch.float16)
+        .to(torch.float8_e4m3fn)
+        .transpose(-2, -1)
+    )
+    scale = torch.ones((), device="cuda", dtype=torch.float32)
+    return input_fp8, mat2_fp8, scale
+
+
+@pytest.mark.parametrize("scale_name", ["A_scale", "B_scale"])
+@pytest.mark.parametrize(
+    ("invalid_scale", "error"),
+    [
+        (
+            lambda: torch.ones((1, 2, 1), device="cuda", dtype=torch.float32),
+            "must contain exactly one tensorwide scale value",
+        ),
+        (
+            lambda: torch.ones((), device="cuda", dtype=torch.float16),
+            "must be a float32 tensor",
+        ),
+        (
+            lambda: torch.ones((), device="cpu", dtype=torch.float32),
+            "must be on the same device",
+        ),
+    ],
+)
+def test_bmm_fp8_rejects_invalid_tensorwide_scale(
+    bmm_fp8_inputs, scale_name, invalid_scale, error
+):
+    input_fp8, mat2_fp8, valid_scale = bmm_fp8_inputs
+    scales = {"A_scale": valid_scale, "B_scale": valid_scale}
+    scales[scale_name] = invalid_scale()
+
+    with pytest.raises(ValueError, match=error):
+        bmm_fp8(
+            input_fp8,
+            mat2_fp8,
+            scales["A_scale"],
+            scales["B_scale"],
+            torch.bfloat16,
+            backend="cublas",
+        )
+
+
+@pytest.mark.parametrize(
+    ("invalid_scale", "error"),
+    [
+        (
+            lambda: torch.ones((2,), device="cuda", dtype=torch.float32),
+            "must contain exactly one tensorwide scale value",
+        ),
+        (
+            lambda: torch.ones((), device="cuda", dtype=torch.float16),
+            "must be float32",
+        ),
+        (
+            lambda: torch.ones((), device="cpu", dtype=torch.float32),
+            "must be a CUDA tensor",
+        ),
+    ],
+)
+def test_bmm_fp8_cublas_ffi_rejects_invalid_tensorwide_scale(
+    bmm_fp8_inputs, invalid_scale, error
+):
+    input_fp8, mat2_fp8, valid_scale = bmm_fp8_inputs
+
+    with pytest.raises(RuntimeError, match=error):
+        bmm_fp8(
+            input_fp8,
+            mat2_fp8,
+            invalid_scale(),
+            valid_scale,
+            torch.bfloat16,
+            backend="cublas",
+            skip_check=True,
+        )
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (1, 1, 1)])
+def test_bmm_fp8_accepts_single_value_scale_shapes(bmm_fp8_inputs, shape):
+    input_fp8, mat2_fp8, _ = bmm_fp8_inputs
+    scale = torch.ones(shape, device="cuda", dtype=torch.float32)
+
+    result = bmm_fp8(
+        input_fp8,
+        mat2_fp8,
+        scale,
+        scale,
+        torch.bfloat16,
+        backend="cublas",
+    )
+
+    assert result.shape == (1, 16, 64)
+
+
 @pytest.mark.parametrize("b", [1, 16])
 @pytest.mark.parametrize("m", [1, 48, 128])
 @pytest.mark.parametrize("n", [64, 80, 10304])

--- a/tests/gemm/test_bmm_fp8.py
+++ b/tests/gemm/test_bmm_fp8.py
@@ -57,6 +57,7 @@ def test_bmm_fp8_rejects_invalid_tensorwide_scale(
         )
 
 
+@pytest.mark.parametrize("scale_name", ["A_scale", "B_scale"])
 @pytest.mark.parametrize(
     ("invalid_scale", "error"),
     [
@@ -75,16 +76,18 @@ def test_bmm_fp8_rejects_invalid_tensorwide_scale(
     ],
 )
 def test_bmm_fp8_cublas_ffi_rejects_invalid_tensorwide_scale(
-    bmm_fp8_inputs, invalid_scale, error
+    bmm_fp8_inputs, scale_name, invalid_scale, error
 ):
     input_fp8, mat2_fp8, valid_scale = bmm_fp8_inputs
+    scales = {"A_scale": valid_scale, "B_scale": valid_scale}
+    scales[scale_name] = invalid_scale()
 
     with pytest.raises(RuntimeError, match=error):
         bmm_fp8(
             input_fp8,
             mat2_fp8,
-            invalid_scale(),
-            valid_scale,
+            scales["A_scale"],
+            scales["B_scale"],
             torch.bfloat16,
             backend="cublas",
             skip_check=True,


### PR DESCRIPTION
## Summary

- reject `bmm_fp8` scales unless each contains exactly one float32 value on the operand's CUDA device
- mirror the dtype, cardinality, and device checks at the cuBLASLt and SM100 CUTLASS FFI boundaries before `float*` casts
- document the tensorwide contract and point groupwise callers to `gemm_fp8_nt_groupwise`
- cover invalid scales, accepted one-value shapes, and the FFI checks

## Root cause

The common `bmm_fp8` checker only validated the output dtype. Backend selection therefore accepted arbitrary scale shapes, dtypes, and devices; the cuBLASLt and SM100 CUTLASS bindings then cast the storage to `float*`. On current `main`, an `A_scale` with shape `(1, 2, 1)` ran successfully instead of failing before dispatch.

## Validation

- `12 passed` for the focused tensorwide-scale and FFI regression cases on GB10 / SM121
- existing cuBLAS FP8 BMM representative case: `1 passed`
- `pre-commit run --files ...`: all configured hooks passed
- cuBLAS FFI checks were exercised through `skip_check=True`; the SM100 CUTLASS boundary was not hardware-executed locally

Fixes #4052.

Disclosure: code navigation and test orchestration were AI-assisted; the reproducer, implementation, and GPU results above were independently run and checked against this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for FP8 tensorwide scale inputs, including dtype, device, and single-value requirements.
  * Improved error handling for invalid scale inputs across FP8 matrix multiplication execution paths.

* **Documentation**
  * Clarified that FP8 BMM supports tensorwide scaling only.
  * Documented accepted scale formats and guidance for groupwise scaling.

* **Tests**
  * Added coverage for invalid scale shapes, dtypes, and devices.
  * Verified support for scalar and single-value scale shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->