### PR TITLE
test(logging): isolate module reimports

### DIFF
--- a/flashinfer/api_logging.py
+++ b/flashinfer/api_logging.py
@@ -172,6 +172,7 @@ def _install_cuda_graph_dump_autoflush() -> None:
             _logger.error(f"flush_graph_dumps ({reason}) failed: {exc}")
 
     atexit.register(_do_flush, "atexit")
+    _install_cuda_graph_dump_autoflush._atexit_callback = _do_flush  # type: ignore[attr-defined]
 
     # SIGTERM handler that flushes then chains to whatever was previously
     # registered (sglang's launcher installs its own; preserve it).
@@ -192,15 +193,63 @@ def _install_cuda_graph_dump_autoflush() -> None:
 
     with contextlib.suppress(ValueError, OSError):
         signal.signal(signal.SIGTERM, _sigterm_flush)
+        _install_cuda_graph_dump_autoflush._sigterm_handler = _sigterm_flush  # type: ignore[attr-defined]
+        _install_cuda_graph_dump_autoflush._previous_sigterm_handler = (  # type: ignore[attr-defined]
+            _prev_sigterm
+        )
+
+
+def _restore_cuda_graph_dump_autoflush() -> None:
+    """Unregister process hooks installed for level-10 graph dumping.
+
+    Normal applications keep these hooks for the lifetime of the process.
+    Tests that reimport :mod:`flashinfer.api_logging` need an explicit teardown
+    so old module instances do not retain atexit callbacks or SIGTERM handlers.
+    """
+    try:
+        import atexit
+        import signal
+    except Exception:  # pragma: no cover
+        return
+
+    callback = getattr(_install_cuda_graph_dump_autoflush, "_atexit_callback", None)
+    if callback is not None:
+        atexit.unregister(callback)
+
+    sigterm_handler = getattr(
+        _install_cuda_graph_dump_autoflush, "_sigterm_handler", None
+    )
+    previous_sigterm_handler = getattr(
+        _install_cuda_graph_dump_autoflush,
+        "_previous_sigterm_handler",
+        None,
+    )
+    if (
+        sigterm_handler is not None
+        and signal.getsignal(signal.SIGTERM) is sigterm_handler
+    ):
+        with contextlib.suppress(ValueError, OSError):
+            signal.signal(signal.SIGTERM, previous_sigterm_handler)
+
+    for attr in (
+        "_atexit_callback",
+        "_sigterm_handler",
+        "_previous_sigterm_handler",
+        "_done",
+    ):
+        with contextlib.suppress(AttributeError):
+            delattr(_install_cuda_graph_dump_autoflush, attr)
 
 
 def _restore_cuda_graph_hooks() -> None:
-    """Restore CUDA graph methods wrapped by api_logging.
+    """Restore process and CUDA graph hooks installed by api_logging.
 
     Primarily useful when tests reload this module with different environment
     variables in the same process. In normal use these hooks live for the
     process lifetime.
     """
+    _restore_cuda_graph_dump_autoflush()
+
     with contextlib.suppress(Exception):
         graph_cls = torch.cuda.CUDAGraph
         current = graph_cls.replay

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import atexit
+import json
 import os
+import signal
 import sys
 import tempfile
-import json
 from enum import Enum
 from pathlib import Path
 
@@ -188,6 +190,28 @@ class TestAPILogging:
             assert "inf_count=" in log_contents
         finally:
             Path(log_file).unlink(missing_ok=True)
+
+    def test_restore_unregisters_level_10_process_hooks(self, monkeypatch):
+        """Reload teardown removes callbacks and restores the prior SIGTERM hook."""
+        self.setup_logging(level=10)
+        module = sys.modules["flashinfer.api_logging"]
+        installer = module._install_cuda_graph_dump_autoflush
+        callback = installer._atexit_callback
+        sigterm_handler = installer._sigterm_handler
+        previous_sigterm_handler = installer._previous_sigterm_handler
+        unregistered = []
+        original_unregister = atexit.unregister
+
+        with monkeypatch.context() as context:
+            context.setattr(atexit, "unregister", unregistered.append)
+            module._restore_cuda_graph_hooks()
+
+        original_unregister(callback)
+
+        assert unregistered == [callback]
+        assert signal.getsignal(signal.SIGTERM) is previous_sigterm_handler
+        assert signal.getsignal(signal.SIGTERM) is not sigterm_handler
+        assert not hasattr(installer, "_done")
 
     def test_enum_logging(self):
         """Test that enum values are logged with name and value."""

--- a/tests/utils/test_logging_replay.py
+++ b/tests/utils/test_logging_replay.py
@@ -38,9 +38,68 @@ from tests.utils_fp8 import to_float8
 
 def _clean_flashinfer_modules():
     """Remove flashinfer modules from sys.modules."""
+    api_logging = sys.modules.get("flashinfer.api_logging")
+    if api_logging is not None and hasattr(api_logging, "_restore_cuda_graph_hooks"):
+        api_logging._restore_cuda_graph_hooks()
+
     modules_to_delete = [k for k in sys.modules.keys() if k.startswith("flashinfer")]
     for module in modules_to_delete:
         del sys.modules[module]
+
+
+def _restore_flashinfer_modules(original_modules):
+    _clean_flashinfer_modules()
+    sys.modules.update(original_modules)
+
+    api_logging = original_modules.get("flashinfer.api_logging")
+    if api_logging is not None:
+        api_logging._install_cuda_graph_dump_autoflush()
+        api_logging._install_cuda_graph_hooks()
+
+
+@pytest.fixture(autouse=True)
+def preserve_flashinfer_modules():
+    """Keep logging reimports from changing module identities for other tests.
+
+    Pytest imports test modules during collection, so other tests may retain
+    classes and enum members from the initially imported FlashInfer modules.
+    The logging tests intentionally reimport FlashInfer to exercise
+    environment-controlled decorators. Restore the exact module objects that
+    existed before each test so those collected references remain coherent.
+    """
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith("flashinfer")
+    }
+
+    yield
+
+    _restore_flashinfer_modules(original_modules)
+
+
+def test_flashinfer_module_restore_preserves_collected_enum_identity():
+    """A logging reimport must not invalidate classes retained at collection."""
+    from flashinfer.logits_processor.types import TensorType
+
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith("flashinfer")
+    }
+    original_tensor_type = TensorType
+
+    _clean_flashinfer_modules()
+    from flashinfer.logits_processor.types import TensorType as reloaded_tensor_type
+
+    assert reloaded_tensor_type is not original_tensor_type
+
+    _restore_flashinfer_modules(original_modules)
+
+    assert (
+        sys.modules["flashinfer.logits_processor.types"].TensorType
+        is original_tensor_type
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## 📌 Description

Level-10 logging replay tests deliberately remove and reimport every
`flashinfer.*` module. During full-directory collection, other test modules
retain classes and enum members from the original modules. The reimport
therefore creates a second set of enum identities, producing errors such as
`Softmax can only be applied to LOGITS, got LOGITS` in otherwise unrelated
tests.

This change:

- snapshots and restores the exact `flashinfer.*` module objects around each
  logging replay test;
- tears down Level-10 `atexit`, `SIGTERM`, and CUDA graph hooks before a
  reload, then reinstalls the original module's hooks;
- adds regressions for enum identity preservation and process-hook cleanup.

## 🔍 Related Issues

Fixes #3802.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files`.

Targeted pre-commit checks pass for all changed files.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] The affected tests are passing.

- `tests/utils/test_logging.py`: 21 passed
- issue reproducer (logging replay followed by logits processor): 1 passed,
  1 skipped
- logging replay followed by the full logits processor file: 591 passed,
  13 skipped

## Reviewer Notes

The full GPU replay file does not compile in this local CUDA 13.0 environment
because current `main` uses `cuda::fast_mod_div` in `fastdiv.cuh`; that failure
is independent of this patch. The cross-file identity reproducer and the
affected logits suite both pass after the fix.
