### PR TITLE
fix(cudnn): correct mixed-dtype prefill output

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -806,7 +806,9 @@ def cudnn_batch_prefill_with_kv_cache(
     out : Optional[torch.Tensor]
         Pre-allocated output tensor, shape
         ``(total_qo_tokens, num_heads_qo, head_dim_vo)``.  Allocated internally
-        when ``None``.
+        when ``None``.  When supplied it must match that shape, be contiguous, be
+        on the same device as ``q``, and have dtype ``o_data_type`` (or ``q.dtype``
+        when ``o_data_type`` is ``None``); otherwise ``ValueError`` is raised.
     lse : Optional[torch.Tensor]
         Pre-allocated LSE tensor, shape
         ``(batch_size, max_token_per_sequence, num_heads_qo)``.  Allocated

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -890,9 +890,18 @@ def cudnn_batch_prefill_with_kv_cache(
     if o_data_type is None:
         o_data_type = q.dtype
 
+    out_shape = (num_tokens, h_qo, d_vo)
     if out is None:
-        out_shape = (num_tokens, h_qo, d_vo)
         out = torch.empty(out_shape, device=q.device, dtype=o_data_type)
+    else:
+        if out.shape != out_shape:
+            raise ValueError(f"out must have shape {out_shape}, got {tuple(out.shape)}")
+        if out.dtype != o_data_type:
+            raise ValueError(f"out must have dtype {o_data_type}, got {out.dtype}")
+        if out.device != q.device:
+            raise ValueError(f"out must be on device {q.device}, got {out.device}")
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
 
     if batch_offsets_units == "tokens":
         # Convenience feature to allow user to set just batch_offsets_{q,k} if desired.
@@ -902,6 +911,21 @@ def cudnn_batch_prefill_with_kv_cache(
             batch_offsets_v = batch_offsets_k
 
     if CUDNN_AVAILABLE and backend != "cubin":
+        # cuDNN 9.20/9.24 on SM89 silently miscompute mixed HALF/BFLOAT16 O
+        # descriptors. Keep SDPA's O in the input dtype and make the API
+        # conversion explicit instead of relying on backend conversion.
+        needs_output_cast = (
+            q.dtype in (torch.float16, torch.bfloat16)
+            and o_data_type in (torch.float16, torch.bfloat16)
+            and o_data_type != q.dtype
+        )
+        cudnn_out = (
+            torch.empty(out_shape, device=q.device, dtype=q.dtype)
+            if needs_output_cast
+            else out
+        )
+        cudnn_o_data_type = q.dtype if needs_output_cast else o_data_type
+
         # The cuDNN graph declares packed q/out with THD nominal strides
         # (batch stride == one token), which is only addressable through ragged
         # offsets. Without them the graph is well-formed but reads/writes batch
@@ -932,9 +956,9 @@ def cudnn_batch_prefill_with_kv_cache(
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
-            out=out,
+            out=cudnn_out,
             lse=lse,
-            o_data_type=o_data_type,
+            o_data_type=cudnn_o_data_type,
         )
 
         if batch_offsets_units == "tokens":
@@ -978,7 +1002,7 @@ def cudnn_batch_prefill_with_kv_cache(
                 batch_offsets_v = apply_multiplier(batch_offsets_v, h_kv * d_vo)
                 batch_offsets_stats = apply_multiplier(batch_offsets_stats, h_qo)
 
-        return _batch_prefill_with_kv_cache(
+        cudnn_out, lse = _batch_prefill_with_kv_cache(
             **run_kwargs,
             batch_offsets_q=batch_offsets_q,
             batch_offsets_o=batch_offsets_o,
@@ -986,6 +1010,9 @@ def cudnn_batch_prefill_with_kv_cache(
             batch_offsets_v=batch_offsets_v,
             batch_offsets_stats=batch_offsets_stats,
         )
+        if needs_output_cast:
+            out.copy_(cudnn_out)
+        return out, lse
     else:
         if actual_seq_lens_q is None or actual_seq_lens_kv is None:
             raise ValueError(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3857,9 +3857,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         # For NVFP4 KV (uint8 packed), v last dim is head_dim//2; use q head_dim for output
         out_head_dim = q.shape[-1] if kv_cache_sf is not None else v.shape[-1]
+        # Preserve the existing BF16 default for FP8 while honoring an
+        # explicitly planned FP16/BF16 output dtype.
+        out_dtype = self._cached_o_data_type
+        if q.dtype.itemsize == 1 and out_dtype == q.dtype:
+            out_dtype = torch.bfloat16
         if out is None:
-            # when input dtype is fp8, we need to use bf16 output
-            out_dtype = torch.bfloat16 if q.dtype.itemsize == 1 else q.dtype
             out = torch.empty(
                 q.shape[:-1] + (out_head_dim,),
                 dtype=out_dtype,
@@ -3869,7 +3872,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             check_shape_dtype_device(
                 out,
                 q.shape[:-1] + (out_head_dim,),
-                self._cached_o_data_type,
+                out_dtype,
                 q.device,
                 "out",
             )
@@ -4018,6 +4021,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 is_cuda_graph_compatible=self._use_cuda_graph,
                 out=out,
                 lse=lse,
+                o_data_type=out_dtype,
             )
 
             return (out, lse) if return_lse else out

--- a/tests/attention/test_cudnn_prefill_output_dtype.py
+++ b/tests/attention/test_cudnn_prefill_output_dtype.py
@@ -1,0 +1,262 @@
+import math
+
+import pytest
+import torch
+
+from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
+from flashinfer.cudnn import prefill as cudnn_prefill
+from flashinfer.prefill import BatchPrefillWithRaggedKVCacheWrapper
+
+
+Q_TOKENS = 32
+KV_TOKENS = 48
+NUM_HEADS = 4
+HEAD_DIM = 128
+
+
+def _require_cudnn():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if not cudnn_prefill.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package is not available")
+
+
+def _inputs(dtype):
+    torch.manual_seed(20260725)
+    q = torch.randn(Q_TOKENS, NUM_HEADS, HEAD_DIM, device="cuda", dtype=dtype)
+    k = torch.randn(KV_TOKENS, NUM_HEADS, HEAD_DIM, device="cuda", dtype=dtype)
+    v = torch.randn(KV_TOKENS, NUM_HEADS, HEAD_DIM, device="cuda", dtype=dtype)
+    return q, k, v
+
+
+def _reference(q, k, v, causal=False):
+    scores = torch.einsum("qhd,khd->hqk", q.float(), k.float()) / math.sqrt(HEAD_DIM)
+    if causal:
+        q_positions = torch.arange(Q_TOKENS, device=q.device)[:, None]
+        kv_positions = torch.arange(KV_TOKENS, device=q.device)[None, :]
+        mask = kv_positions > q_positions + KV_TOKENS - Q_TOKENS
+        scores.masked_fill_(mask.unsqueeze(0), float("-inf"))
+    probabilities = torch.softmax(scores, dim=-1)
+    return torch.einsum("hqk,khd->qhd", probabilities, v.float())
+
+
+def _direct_call(
+    input_dtype,
+    output_dtype=None,
+    *,
+    out=None,
+    causal=False,
+    return_lse=False,
+    is_cuda_graph_compatible=False,
+):
+    q, k, v = _inputs(input_dtype)
+    seq_q = torch.tensor([Q_TOKENS], device="cuda", dtype=torch.int32).view(1, 1, 1, 1)
+    seq_kv = torch.tensor([KV_TOKENS], device="cuda", dtype=torch.int32).view(
+        1, 1, 1, 1
+    )
+    workspace = torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.int8)
+    result, lse = cudnn_batch_prefill_with_kv_cache(
+        q,
+        k,
+        v,
+        1.0 / math.sqrt(HEAD_DIM),
+        workspace,
+        max_token_per_sequence=Q_TOKENS,
+        max_sequence_kv=KV_TOKENS,
+        actual_seq_lens_q=seq_q,
+        actual_seq_lens_kv=seq_kv,
+        causal=causal,
+        return_lse=return_lse,
+        out=out,
+        o_data_type=output_dtype,
+        is_cuda_graph_compatible=is_cuda_graph_compatible,
+    )
+    return result, lse, (q, k, v)
+
+
+@pytest.mark.parametrize(
+    "input_dtype,output_dtype",
+    [
+        (torch.bfloat16, torch.bfloat16),
+        (torch.bfloat16, torch.float16),
+        (torch.float16, torch.float16),
+        (torch.float16, torch.bfloat16),
+    ],
+)
+def test_cudnn_prefill_output_dtype(input_dtype, output_dtype):
+    _require_cudnn()
+    output, _, inputs = _direct_call(input_dtype, output_dtype)
+
+    assert output.dtype == output_dtype
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(
+        output.float(), _reference(*inputs), atol=1e-2, rtol=1e-2
+    )
+
+
+def test_cudnn_prefill_default_output_dtype_matches_input():
+    _require_cudnn()
+    implicit, _, _ = _direct_call(torch.bfloat16)
+    explicit, _, _ = _direct_call(torch.bfloat16, torch.bfloat16)
+
+    assert implicit.dtype == torch.bfloat16
+    assert torch.equal(implicit, explicit)
+
+
+@pytest.mark.parametrize(
+    "input_dtype,output_dtype",
+    [
+        (torch.bfloat16, torch.float16),
+        (torch.float16, torch.bfloat16),
+    ],
+)
+def test_cudnn_prefill_mixed_dtype_preallocated_output(input_dtype, output_dtype):
+    _require_cudnn()
+    out = torch.empty(Q_TOKENS, NUM_HEADS, HEAD_DIM, device="cuda", dtype=output_dtype)
+    output, _, inputs = _direct_call(input_dtype, output_dtype, out=out)
+
+    assert output is out
+    torch.testing.assert_close(
+        output.float(), _reference(*inputs), atol=1e-2, rtol=1e-2
+    )
+
+
+def test_cudnn_prefill_validates_preallocated_output():
+    _require_cudnn()
+    expected_shape = (Q_TOKENS, NUM_HEADS, HEAD_DIM)
+
+    wrong_shape = torch.empty(
+        Q_TOKENS - 1, NUM_HEADS, HEAD_DIM, device="cuda", dtype=torch.float16
+    )
+    with pytest.raises(ValueError, match="out must have shape"):
+        _direct_call(torch.bfloat16, torch.float16, out=wrong_shape)
+
+    wrong_dtype = torch.empty(expected_shape, device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="out must have dtype"):
+        _direct_call(torch.bfloat16, torch.float16, out=wrong_dtype)
+
+    wrong_device = torch.empty(expected_shape, device="cpu", dtype=torch.float16)
+    with pytest.raises(ValueError, match="out must be on device"):
+        _direct_call(torch.bfloat16, torch.float16, out=wrong_device)
+
+    noncontiguous = torch.empty(
+        Q_TOKENS, NUM_HEADS, HEAD_DIM * 2, device="cuda", dtype=torch.float16
+    )[..., ::2]
+    with pytest.raises(ValueError, match="out must be contiguous"):
+        _direct_call(torch.bfloat16, torch.float16, out=noncontiguous)
+
+
+@pytest.mark.parametrize(
+    "input_dtype,output_dtype",
+    [
+        (torch.bfloat16, torch.float16),
+        (torch.float16, torch.bfloat16),
+    ],
+)
+def test_cudnn_ragged_prefill_honors_planned_output_dtype(input_dtype, output_dtype):
+    _require_cudnn()
+    q, k, v = _inputs(input_dtype)
+    workspace = torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.int8)
+    wrapper = BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cudnn"
+    )
+    q_indptr = torch.tensor([0, q.numel()], device="cuda", dtype=torch.int32)
+    k_indptr = torch.tensor([0, k.numel()], device="cuda", dtype=torch.int32)
+    v_indptr = torch.tensor([0, v.numel()], device="cuda", dtype=torch.int32)
+    o_indptr = torch.tensor(
+        [0, Q_TOKENS * NUM_HEADS * HEAD_DIM],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    wrapper.plan(
+        q_indptr,
+        k_indptr,
+        NUM_HEADS,
+        NUM_HEADS,
+        HEAD_DIM,
+        causal=False,
+        q_data_type=input_dtype,
+        kv_data_type=input_dtype,
+        o_data_type=output_dtype,
+        seq_lens=torch.tensor([KV_TOKENS], device="cuda", dtype=torch.int32),
+        seq_lens_q=torch.tensor([Q_TOKENS], device="cuda", dtype=torch.int32),
+        max_token_per_sequence=Q_TOKENS,
+        max_sequence_kv=KV_TOKENS,
+        v_indptr=v_indptr,
+        o_indptr=o_indptr,
+    )
+
+    output = wrapper.run(q, k, v)
+
+    assert output.dtype == output_dtype
+    torch.testing.assert_close(
+        output.float(), _reference(q, k, v), atol=1e-2, rtol=1e-2
+    )
+
+
+def test_cudnn_prefill_mixed_dtype_preserves_causal_lse_path():
+    _require_cudnn()
+    output, lse, inputs = _direct_call(
+        torch.bfloat16,
+        torch.float16,
+        causal=True,
+        return_lse=True,
+    )
+
+    assert lse is not None
+    assert torch.isfinite(lse).all()
+    torch.testing.assert_close(
+        output.float(), _reference(*inputs, causal=True), atol=1e-2, rtol=1e-2
+    )
+
+
+@pytest.mark.parametrize(
+    "input_dtype,output_dtype",
+    [
+        (torch.bfloat16, torch.float16),
+        (torch.float16, torch.bfloat16),
+    ],
+)
+def test_cudnn_prefill_mixed_dtype_cuda_graph(input_dtype, output_dtype):
+    _require_cudnn()
+    q, k, v = _inputs(input_dtype)
+    expected = _reference(q, k, v)
+    seq_q = torch.tensor([Q_TOKENS], device="cuda", dtype=torch.int32).view(1, 1, 1, 1)
+    seq_kv = torch.tensor([KV_TOKENS], device="cuda", dtype=torch.int32).view(
+        1, 1, 1, 1
+    )
+    workspace = torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.int8)
+    out = torch.empty(Q_TOKENS, NUM_HEADS, HEAD_DIM, device="cuda", dtype=output_dtype)
+
+    def run():
+        cudnn_batch_prefill_with_kv_cache(
+            q,
+            k,
+            v,
+            1.0 / math.sqrt(HEAD_DIM),
+            workspace,
+            max_token_per_sequence=Q_TOKENS,
+            max_sequence_kv=KV_TOKENS,
+            actual_seq_lens_q=seq_q,
+            actual_seq_lens_kv=seq_kv,
+            causal=False,
+            return_lse=False,
+            out=out,
+            o_data_type=output_dtype,
+            is_cuda_graph_compatible=True,
+        )
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            run()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out.float(), expected, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
## 📌 Description

`cudnn_batch_prefill_with_kv_cache` accepts an output dtype independent of the input dtype. On an RTX 4070 Laptop GPU, cold BF16 → FP16 and FP16 → BF16 calls returned the requested dtype but incorrect values.

### Mechanism

The same failure reproduces in a direct cuDNN frontend SDPA graph when the O descriptor uses the other 16-bit dtype, so it is independent of FlashInfer's graph cache. The ragged wrapper also cached its planned output dtype without propagating it to the cuDNN call.

### Fix

- For mixed BF16/FP16 requests, run cuDNN with O in the input dtype and copy/cast into the requested output.
- Validate caller-provided output shape, dtype, device, and layout before execution.
- Allocate and propagate the planned output dtype in the ragged wrapper.

Same-dtype, FP8, and cubin paths do not enter the new conversion branch.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

RTX 4070 Laptop, SM89, PyTorch 2.13.0+cu130, cuDNN frontend 1.26.0, backend 9.20.0 (also checked with backend 9.24.0.43):

- BF16 → FP16 max error: 1.3858262 before, 0.0040065 after
- FP16 → BF16 max error: 7.4553275 before, 0.0041705 after
- focused output-dtype tests: 13 passed
- token-indptr cuDNN prefill tests: 65 passed, 65 capability-skipped
- paged causal/noncausal × LSE on/off: 8 passed
- `pre-commit run --all-files`: passed in a clean Linux clone

The full `tests/attention -k cudnn` matrix was not completed locally. Its largest cases exceed the 8 GB GPU, and an unrelated FA2 reference JIT failure blocks some selected cases.

## Reviewer Notes

The temporary output and extra copy are used only for mixed BF16/FP16 requests. Same-dtype, FP8, and cubin execution are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit output data type selection for cuDNN prefill, including mixed FP16/BF16 inputs and outputs.
  * Ragged prefill now consistently honors the configured output data type.

* **Bug Fixes**
  * Improved mixed-precision compatibility and output handling.
  * Added validation for output shape, dtype, device, and memory layout.
  * Preserved correct behavior for causal attention, log-sum-exp results, and CUDA graph replay.

* **Tests**
  * Added comprehensive coverage for output types, validation, mixed-precision execution, and graph replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->