### PR TITLE
fix(mamba): cast int64 state stride for TMA descriptor init-lists

### DIFF
--- a/include/flashinfer/mamba/invoke_selective_state_update_mtp.cuh
+++ b/include/flashinfer/mamba/invoke_selective_state_update_mtp.cuh
@@ -130,7 +130,7 @@ void invokeSelectiveStateUpdateMTP(SelectiveStateMTPParams& params, SSUAlgorithm
           auto state_tensor = tma::buildNdDescriptor(
               typeid(state_t),
               /*shapes*/ {DSTATE, DIM, params.nheads, params.state_cache_size},
-              /*strides*/ {1, DSTATE, DSTATE * DIM, params.state_stride_batch},
+              /*strides*/ {1, DSTATE, DSTATE * DIM, (uint64_t)params.state_stride_batch},
               /*tiles*/ {DSTATE, DIM, 1, 1}, params.state);
 
           auto B_tensor = tma::buildNdDescriptor(
@@ -206,7 +206,7 @@ void invokeSelectiveStateUpdateMTP(SelectiveStateMTPParams& params, SSUAlgorithm
           auto state_tensor = tma::buildNdDescriptor(
               typeid(state_t),
               /*shapes*/ {DSTATE, DIM, params.nheads, params.state_cache_size},
-              /*strides*/ {1, DSTATE, DSTATE * DIM, params.state_stride_batch},
+              /*strides*/ {1, DSTATE, DSTATE * DIM, (uint64_t)params.state_stride_batch},
               /*tiles*/ {DSTATE_PAD, TMA_STATE_ROWS, 1, 1}, params.state);
 
           // B/C: tile by DSTATE_PAD to match padded smem layout.

--- a/include/flashinfer/mamba/kernel_selective_state_update_stp.cuh
+++ b/include/flashinfer/mamba/kernel_selective_state_update_stp.cuh
@@ -1283,11 +1283,11 @@ void invokeSelectiveStateUpdate(SelectiveStateUpdateParams& params, SSUAlgorithm
     dim3 block(warpSize, numWarps);
     dim3 grid(params.batch, params.nheads);
 
-    auto state_tensor =
-        tma::buildNdDescriptor(typeid(state_t),
-                               /*shapes*/ {DSTATE, DIM, params.nheads, params.state_cache_size},
-                               /*strides*/ {1, DSTATE, DSTATE * DIM, params.state_stride_batch},
-                               /*tiles*/ {DSTATE, rowsPerStage, 1, 1}, params.state);
+    auto state_tensor = tma::buildNdDescriptor(
+        typeid(state_t),
+        /*shapes*/ {DSTATE, DIM, params.nheads, params.state_cache_size},
+        /*strides*/ {1, DSTATE, DSTATE * DIM, static_cast<uint64_t>(params.state_stride_batch)},
+        /*tiles*/ {DSTATE, rowsPerStage, 1, 1}, params.state);
 
     using sram_t = SharedStorageVertical<input_t, weight_t, matrixA_t, state_t, state_scale_t,
                                          rowsPerStage, DIM, DSTATE, numStages>;
@@ -1319,11 +1319,11 @@ void invokeSelectiveStateUpdate(SelectiveStateUpdateParams& params, SSUAlgorithm
       dim3 block(warpSize, numWarps);
       dim3 grid(params.batch, params.nheads);
 
-      auto state_tensor =
-          tma::buildNdDescriptor(typeid(state_t),
-                                 /*shapes*/ {DSTATE, DIM, params.nheads, params.state_cache_size},
-                                 /*strides*/ {1, DSTATE, DSTATE * DIM, params.state_stride_batch},
-                                 /*tiles*/ {stageCols, DIM, 1, 1}, params.state);
+      auto state_tensor = tma::buildNdDescriptor(
+          typeid(state_t),
+          /*shapes*/ {DSTATE, DIM, params.nheads, params.state_cache_size},
+          /*strides*/ {1, DSTATE, DSTATE * DIM, static_cast<uint64_t>(params.state_stride_batch)},
+          /*tiles*/ {stageCols, DIM, 1, 1}, params.state);
       static_assert(DSTATE % stageCols == 0 && DSTATE >= stageCols);
 
       using sram_t = SharedStorageHorizontal<input_t, weight_t, matrixA_t, state_t, DIM, DSTATE,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->                                                                                                          
                                                                                                                                                   
## 📌 Descriptionn                                                                                                                                  
                                                                                                                                                   
`gen_selective_state_update_sm90_module` does not compile. Since the runtime                                                                       
dispatcher selects exactly that module for every GPU with `sm_major >= 9`                                                                          
([`flashinfer/mamba/selective_state_update.py`](https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/mamba/selective_state_update.py)),
Mamba SSU cannot be built on Hopper at all — via JIT or AOT.                                                                                       
                                                                                                                                                   
### Root cause                                                                                                                                     
                                                                                                                                                   
`SelectiveStateUpdateParams::state_stride_batch` is `int64_t`:                                                                                     
                                                                                                                                                   
```cpp                                                                                                                                             
// include/flashinfer/mamba/selective_state_update.cuh:55                                                                                          
int64_t x_stride_batch{}, dt_stride_batch{}, B_stride_batch{}, C_stride_batch{},                                                                   
    out_stride_batch{}, z_stride_batch{}, state_stride_batch{}, state_scale_stride_batch{};                                                        
```                                                                                                                                                
                                                                                                                                                   
but `buildNdDescriptor` takes `std::vector<uint64_t>`:                                                                                             
                                                                                                                                                   
```cpp                                                                                                                                             
// include/flashinfer/mamba/create_tensor_map.cuh:15                                                                                               
inline CUtensorMap buildNdDescriptor(                                                                                                              
    std::type_info const& dtype, std::vector<uint64_t> const& shapes,                                                                              
    std::vector<uint64_t> const& strides, std::vector<int32_t> const& tileShapes, ...);                                                            
```                                                                                                                                                
                                                                                                                                                   
Because the parameter is a `std::vector`, the braced argument forms an                                                                             
`std::initializer_list<uint64_t>`, and a narrowing conversion in a list                                                                            
initializer is **ill-formed** — a hard error, not a warning. Neither                                                                               
`-Wno-narrowing` nor `--diag-suppress` can demote it. (On an ordinary                                                                              
aggregate nvcc would emit only `warning #2361-D`.)                                                                                                 
                                                                                                                                                   
### Affected sites                                                                                                                                 
                                                                                                                                                   
| File | Lines | Guard |                                                                                                                           
|---|---|---|                                                                                                                                      
| `mamba/kernel_selective_state_update_stp.cuh` | 1289, 1325 | `FLASHINFER_MAMBA_ENABLE_SM90` |                                                    
| `mamba/invoke_selective_state_update_mtp.cuh` | 133, 209 | `FLASHINFER_MAMBA_ENABLE_SM100` |                                                     
                                                                                                                                                   
The arch guards are why this went unnoticed: the default (sm_80) module never                                                                      
instantiates these branches. Related: #3775 reports that                                                                                           
`gen_selective_state_update_sm100_module` is never registered in `aot.py`,                                                                         
so the Blackwell path is not exercised either.                                                                                                     
                                                                                                                                                   
Note the inconsistency this fixes — in the very same MTP function, the B, C                                                                        
and x descriptors already cast their strides, and only the state descriptor                                                                        
was missed:         


                                                                                                                       
```cpp                                                                                                                 
auto state_tensor = ... {1, DSTATE, DSTATE * DIM, params.state_stride_batch},       // no cast                         
auto B_tensor     = ... {1, (uint64_t)DSTATE, (uint64_t)params.B_stride_mtp, ...},  // cast                            
```                                                                                                                    
                                                                                                                       
Introduced in b7404d06 (#2444, Feb 2026).                                                                              
                                                                                                                       
## 🔍 Related Issues                                                                                                    
                                                                                                                       
Related to #3775 (SM100 SSU module not registered for AOT). Precedent: #1586.                                          
                                                                                                                       
## 🚀 Pull Request Checklist                                                                                            
                                                                                                                       
### ✅ Pre-commit Checks                                                                                                
                                                                                                                       
- [x] I have installed `pre-commit` by running `pip install pre-commit`.                                               
- [x] I have installed the hooks with `pre-commit install`.                                                            
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.                   
                                                                                                                       
## 🧪 Tests                                                                                                             
                                                                                                                       
- [ ] Tests have been added or updated as needed.                                                                      
- [x] All tests are passing (`unittest`, etc.).                                                                        
                                                                                                                       
No new test: this is a compile-time fix, and the existing SSU tests cover the                                          
runtime behaviour once the module builds. Reproduced with an **unmodified**                                            
`csrc/selective_state_update_kernel_inst.cu` and a config rendered from the                                            
first AOT dtype combo in `aot.py` (bf16 state/input/weight, f32 matrixA,                                               
int64 stateIndex, `DIM=64`, `DSTATE=128`):                                                                             
                                                                                                                       
```console                                                                                                             
$ nvcc -std=c++17 -arch=sm_90a -DFLASHINFER_MAMBA_ENABLE_SM90 \                                                        
       -Iinclude -I. -c selective_state_update_kernel_inst.cu                                                          
kernel_selective_state_update_stp.cuh(1289): error: invalid narrowing conversion from "signed long" to "unsigned long" 
kernel_selective_state_update_stp.cuh(1325): error: invalid narrowing conversion from "signed long" to "unsigned long" 
2 errors detected.                                                                                                     
                                                                                                                       
$ nvcc -std=c++17 -arch=sm_100a -DFLASHINFER_MAMBA_ENABLE_SM90 -DFLASHINFER_MAMBA_ENABLE_SM100 ...                     
   ... 4 errors detected. (the two above, plus mtp 133 and 209)                                                        
```                                                                                                                    
                                                                                                                       
Identical on CUDA 12.8, 12.9, 13.0 and 13.3, so this is not a toolkit                                                  
regression. After this change both configurations produce zero narrowing                                               
diagnostics.                                                                                                           
                                                                                                                       
## Reviewer Notes                                                                                                      
                                                                                                                       
Purely a type fix; no behavioural change — `state_stride_batch` is a byte/element                                      
stride that is always non-negative, so the value round-trips. Each site uses the                                       
cast style of its surrounding code (`static_cast` in `*_stp.cuh`, C-style in                                           
`*_mtp.cuh` to match the adjacent B/C/x descriptors). Formatting is whatever                                           
`clang-format` 19.1.1 produced.                                                                                        
                                                                                                                       
It may be worth adding a compile-only CI job that builds                                                               
`gen_selective_state_update_sm90_module`, since nothing today catches this.                                                                                                                                                                           

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability for selective state update operations by ensuring tensor batch strides are passed using the correct numeric format.
  * Applied the fix across supported vertical and horizontal execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->