### PR TITLE
fix: in CuTe DSL FMHA and FMHA_BS kernels, allow configuring skip-rescale threshold

### DIFF
--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -388,8 +388,8 @@ def cute_dsl_fmha_ragged_prefill(
         The actual threshold = scale_factor / max_kv_len, then converted to log2 domain.
         None or 0 disables skip-softmax.
     skip_rescale_threshold : float
-        Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
-        >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
+        Skip-correction threshold: >0 enables skip-correction when row_max is not updated;
+        it allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
     """
     total_q, H_q, D = q.shape
     total_kv, H_k, _ = k.shape

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -330,6 +330,7 @@ def cute_dsl_fmha_ragged_prefill(
     max_kv_len: Optional[int] = None,
     kernel_fn=None,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
+    skip_rescale_threshold: float = 8.0,
     enable_pdl: bool = False,
 ) -> None:
     """Run DSL FMHA prefill kernel on ragged (variable-length) tensors.
@@ -386,6 +387,9 @@ def cute_dsl_fmha_ragged_prefill(
         Threshold scale factor for skip-softmax sparsity (https://arxiv.org/abs/2512.12087).
         The actual threshold = scale_factor / max_kv_len, then converted to log2 domain.
         None or 0 disables skip-softmax.
+    skip_rescale_threshold : float
+        Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
+        >1 allows skipping at new_row_max < X * row_max.
     """
     total_q, H_q, D = q.shape
     total_kv, H_k, _ = k.shape
@@ -409,6 +413,8 @@ def cute_dsl_fmha_ragged_prefill(
         try:
             if k.dtype != v.dtype:
                 raise RuntimeError("Separate dtype_qk / dtype_vo requires JIT")
+            if skip_rescale_threshold != 8.0:
+                raise RuntimeError("non-default skip_rescale_threshold requires JIT")
             if window_left != -1 or window_right != -1:
                 # The exported artifact matrix has no window axis: every
                 # prebuilt variant is traced with window_size_left=None (and
@@ -454,6 +460,7 @@ def cute_dsl_fmha_ragged_prefill(
                 q.device,
                 has_window_left=window_left != -1,
                 has_window_right=is_causal or window_right != -1,
+                skip_rescale_threshold=skip_rescale_threshold,
             )
             # JIT kernels are compiled with --enable-tvm-ffi; the CuTe-native branch
             # would not accept them.

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -389,7 +389,7 @@ def cute_dsl_fmha_ragged_prefill(
         None or 0 disables skip-softmax.
     skip_rescale_threshold : float
         Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
-        >1 allows skipping at new_row_max < X * row_max.
+        >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
     """
     total_q, H_q, D = q.shape
     total_kv, H_k, _ = k.shape

--- a/flashinfer/attention/cute_dsl/fmha_blockscaled.py
+++ b/flashinfer/attention/cute_dsl/fmha_blockscaled.py
@@ -55,6 +55,7 @@ def cute_dsl_fmha_blockscaled_prefill(
     scale_v: float | torch.Tensor = 1.0,
     scale_o: float | torch.Tensor = 1.0,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
+    skip_rescale_threshold: float = 8.0,
     enable_pdl: bool = False,
 ) -> None:
     """Batched (non-varlen) block-scaled prefill via the JIT-compiled trtllm kernel.
@@ -91,6 +92,7 @@ def cute_dsl_fmha_blockscaled_prefill(
         use_skip,
         enable_pdl,
         q.device,
+        skip_rescale_threshold=skip_rescale_threshold,
     )
 
     if sm_scale is None:

--- a/flashinfer/cute_dsl/attention/fmha/compile.py
+++ b/flashinfer/cute_dsl/attention/fmha/compile.py
@@ -81,6 +81,7 @@ def compile_cute_dsl_fmha_kernel(
     device: torch.device,
     has_window_left: bool = False,
     has_window_right=None,
+    skip_rescale_threshold: float = 8.0,
 ):
     """Compile (and cache) the trtllm FMHA kernel for a static config.
 
@@ -117,6 +118,7 @@ def compile_cute_dsl_fmha_kernel(
         mask_type=_mask_type(has_window_left or has_window_right),
         enable_ex2_emulation=enable_ex2_emulation,
         enable_skip_correction=True,
+        skip_rescale_threshold=skip_rescale_threshold,
         use_tma_store=False,  # varlen -> STG
     )
 
@@ -221,6 +223,7 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
     enable_skip_softmax: bool,
     use_pdl: bool,
     device: torch.device,
+    skip_rescale_threshold: float = 8.0,
 ):
     """Compile (and cache) the trtllm block-scaled FMHA kernel (batched, non-varlen)."""
     from .fmha_blockscaled import BlackwellFusedMultiHeadBlockScaledAttentionForward
@@ -241,6 +244,7 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
         enable_skip_correction=True,
         qk_sf_vec_size=sf_vec,
         use_tma_store=True,  # non-varlen
+        skip_rescale_threshold=skip_rescale_threshold,
     )
 
     sym_b = cute.sym_int()

--- a/flashinfer/cute_dsl/attention/fmha/fmha.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha.py
@@ -118,6 +118,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         enable_ex2_emulation: bool,
         enable_skip_correction: bool,
         use_tma_store: bool = True,
+        skip_rescale_threshold: float = 8.0,
     ):
         """Initializes the configuration for a Blackwell Fused Multi-Head Attention (FMHA) kernel.
 
@@ -142,6 +143,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             - window_size_left/right: Sliding window size for attention masking
             - enable_ex2_emulation: Whether to enable exp2 emulation
             - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
+            - skip_rescale_threshold: Skip-correction threshold: =1 enables skip-correction when row_max is not updated
+                                      ; >1 allows skipping at new_row_max < X * row_max.
 
         :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
         :type qk_acc_dtype: Type[cutlass.Numeric]
@@ -190,6 +193,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.is_persistent = is_persistent
         self.mask_type = mask_type
         self.enable_skip_correction = enable_skip_correction
+        self.rescale_threshold = skip_rescale_threshold if enable_skip_correction else 0.0
         self.enable_ex2_emulation = enable_ex2_emulation
         self.use_tma_store = use_tma_store
 
@@ -333,14 +337,14 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.mma_softmax_stage = 1
         self.epi_stage = 2
 
-        # Tunable parameters
-        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
         # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
         # more of E4M3's [0, 448] range, improving quantization precision.
         # Derived from rescale_threshold to guarantee P*2^offset <= 448.
         self.p_fp8_prescale_log2 = max(0.0, math.floor(math.log2(448) - self.rescale_threshold))
         # ln(2) * offset correction for LSE when pre-scale is active
         self.p_fp8_prescale_lse_correction = self.p_fp8_prescale_log2 * math.log(2)
+
+        # Tunable parameters
         # For most cases, seq barrier is needed to help keep the pipeline stable
         # But sometimes, compiler will schedule the barrier at an unexpected place
         # if it hurts perf a lot, try to quickly fix it by disabling seq barrier

--- a/flashinfer/cute_dsl/attention/fmha/fmha.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha.py
@@ -143,8 +143,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             - window_size_left/right: Sliding window size for attention masking
             - enable_ex2_emulation: Whether to enable exp2 emulation
             - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
-            - skip_rescale_threshold: Skip-correction threshold: =1 enables skip-correction when row_max is not updated
-                                      ; >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
+            - skip_rescale_threshold: Skip-correction threshold: >0 enables skip-correction when row_max is not updated
+                                      ; it allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
 
         :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
         :type qk_acc_dtype: Type[cutlass.Numeric]

--- a/flashinfer/cute_dsl/attention/fmha/fmha.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha.py
@@ -144,7 +144,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             - enable_ex2_emulation: Whether to enable exp2 emulation
             - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
             - skip_rescale_threshold: Skip-correction threshold: =1 enables skip-correction when row_max is not updated
-                                      ; >1 allows skipping at new_row_max < X * row_max.
+                                      ; >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
 
         :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
         :type qk_acc_dtype: Type[cutlass.Numeric]

--- a/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
@@ -214,6 +214,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
         enable_skip_correction: bool,
         qk_sf_vec_size: int,
         use_tma_store: bool = True,
+        skip_rescale_threshold: float = 8.0,
     ):
         """Initializes the configuration for a Blackwell Fused Multi-Head Attention (FMHA) kernel.
 
@@ -238,6 +239,8 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
             - window_size_left/right: Sliding window size for attention masking
             - enable_ex2_emulation: Whether to enable exp2 emulation
             - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
+            - skip_rescale_threshold: Skip-correction threshold: =1 enables skip-correction when row_max is not updated
+                                      ; >1 allows skipping at new_row_max < X * row_max.
 
         :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
         :type qk_acc_dtype: Type[cutlass.Numeric]
@@ -290,6 +293,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
         self.is_persistent = is_persistent
         self.mask_type = mask_type
         self.enable_skip_correction = enable_skip_correction
+        self.rescale_threshold = skip_rescale_threshold if enable_skip_correction else 0.0
         self.enable_ex2_emulation = enable_ex2_emulation
         self.qk_sf_vec_size = qk_sf_vec_size
         self.qk_mma_inst_bits_k = 256
@@ -448,14 +452,14 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
         self.mma_softmax_stage = 1
         self.epi_stage = 2
 
-        # Tunable parameters
-        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
         # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
         # more of E4M3's [0, 448] range, improving quantization precision.
         # Derived from rescale_threshold to guarantee P*2^offset <= 448.
         self.p_fp8_prescale_log2 = max(0.0, math.floor(math.log2(448) - self.rescale_threshold))
         # ln(2) * offset correction for LSE when pre-scale is active
         self.p_fp8_prescale_lse_correction = self.p_fp8_prescale_log2 * math.log(2)
+
+        # Tunable parameters
         # For most cases, seq barrier is needed to help keep the pipeline stable
         # But sometimes, compiler will schedule the barrier at an unexpected place
         # if it hurts perf a lot, try to quickly fix it by disabling seq barrier

--- a/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
@@ -240,7 +240,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
             - enable_ex2_emulation: Whether to enable exp2 emulation
             - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
             - skip_rescale_threshold: Skip-correction threshold: =1 enables skip-correction when row_max is not updated
-                                      ; >1 allows skipping at new_row_max < X * row_max.
+                                      ; >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
 
         :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
         :type qk_acc_dtype: Type[cutlass.Numeric]

--- a/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
@@ -239,8 +239,8 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
             - window_size_left/right: Sliding window size for attention masking
             - enable_ex2_emulation: Whether to enable exp2 emulation
             - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
-            - skip_rescale_threshold: Skip-correction threshold: =1 enables skip-correction when row_max is not updated
-                                      ; >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
+            - skip_rescale_threshold: Skip-correction threshold: >0 enables skip-correction when row_max is not updated
+                                      ; it allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
 
         :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
         :type qk_acc_dtype: Type[cutlass.Numeric]

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3787,7 +3787,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
         skip_rescale_threshold : float
             Cute DSL Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
-            >1 allows skipping at new_row_max < X * row_max.
+            >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
         kv_cache_sf : Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]
             Per-block scale factors for NVFP4 KV input.  Accepts either a single
             packed scale tensor or a ``(k_scales, v_scales)`` tuple matching the
@@ -4522,7 +4522,7 @@ def trtllm_ragged_attention_deepseek(
         The actual threshold value equals the provided threshold_scale_factor divided by the context length.
     skip_rescale_threshold : float
         Cute DSL Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
-        >1 allows skipping at new_row_max < X * row_max.
+        >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
     out : Optional[torch.Tensor]
         output tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1], value.shape[2]]
     lse : Optional[torch.Tensor]

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3493,8 +3493,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             _sm_scale = (
                 sm_scale if sm_scale is not None else 1.0 / math.sqrt(head_dim_qk)
             )
-            # Variant-less head-128 dense/causal plans route to the trtllm
-            # CuTe DSL FMHA kernel (prebuilt artifacts).  Sliding-window
+            # Variant-less head-128 dense/causal plans route to the standalone
+            # CuTe DSL FMHA runner (prebuilt artifacts or JIT). Sliding-window
             # plans use the modular cute-dsl path, which measures faster on
             # windows (banded masks skip dead work) for every V dtype —
             # mixed V (e.g. fp8 V with bf16 Q/K) forces the FMHA path onto
@@ -3508,8 +3508,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._cute_dsl_fmha_plan = {
                     "qo_indptr": qo_indptr,
                     "kv_indptr": kv_indptr,
-                    "seq_lens": k_lens.to(torch.int32),
-                    "batch_size": qo_indptr.shape[0] - 1,
                     "max_q_len": int(q_lens.max().item()),
                     "max_kv_len": int(k_lens.max().item()),
                     "sm_scale": _sm_scale,
@@ -3690,6 +3688,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         sm_scale: Optional[float] = None,
         rope_scale: Optional[float] = None,
         rope_theta: Optional[float] = None,
+        skip_rescale_threshold: float = 8.0,
     ) -> torch.Tensor:
         r"""Warning: This function is deprecated, please use :meth:`run` instead."""
         self._causal = causal
@@ -3700,7 +3699,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
-        return self.run(q, k, v)
+        return self.run(q, k, v, skip_rescale_threshold=skip_rescale_threshold)
 
     @overload
     def run(
@@ -3713,6 +3712,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[False] = False,
         enable_pdl: Optional[bool] = None,
+        skip_rescale_threshold: float = 8.0,
         kv_cache_sf: Optional[
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         ] = None,
@@ -3729,6 +3729,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[True] = True,
         enable_pdl: Optional[bool] = None,
+        skip_rescale_threshold: float = 8.0,
         kv_cache_sf: Optional[
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         ] = None,
@@ -3749,6 +3750,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         lse: Optional[torch.Tensor] = None,
         return_lse: bool = False,
         enable_pdl: Optional[bool] = None,
+        skip_rescale_threshold: float = 8.0,
         kv_cache_sf: Optional[
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         ] = None,
@@ -3783,6 +3785,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         enable_pdl : bool
             Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
+        skip_rescale_threshold : float
+            Cute DSL Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
+            >1 allows skipping at new_row_max < X * row_max.
         kv_cache_sf : Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]
             Per-block scale factors for NVFP4 KV input.  Accepts either a single
             packed scale tensor or a ``(k_scales, v_scales)`` tuple matching the
@@ -3933,33 +3938,33 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             # enable_pdl is a launch-latency hint: forwarded on the FMHA
             # route below; the modular kernel has no PDL support.
             if self._cute_dsl_use_fmha:
-                # Delegate dense/causal plans to the trtllm CuTe DSL FMHA
-                # kernel (mixed V dtype included: it JIT-compiles
-                # separate-V-dtype variants).  Windowed plans stay on the
-                # modular path for every V dtype.
+                # Dense/causal plans invoke the shared CuTe DSL FMHA runner
+                # directly, keeping this FlashInfer wrapper independent from
+                # the TRT-LLM attention entry point. Mixed V dtypes and
+                # non-default rescale thresholds JIT-compile distinct kernels.
+                from .attention.cute_dsl.fmha import cute_dsl_fmha_ragged_prefill
+
                 p = self._cute_dsl_fmha_plan
-                return trtllm_ragged_attention_deepseek(
-                    query=q,
-                    key=k,
-                    value=v,
-                    workspace_buffer=self._float_workspace_buffer,
-                    seq_lens=p["seq_lens"],
-                    max_q_len=p["max_q_len"],
-                    max_kv_len=p["max_kv_len"],
-                    bmm1_scale=p["sm_scale"],
-                    bmm2_scale=1.0,
-                    o_sf_scale=1.0,
-                    batch_size=p["batch_size"],
-                    window_left=p["window_left"],
-                    cum_seq_lens_q=p["qo_indptr"],
-                    cum_seq_lens_kv=p["kv_indptr"],
-                    enable_pdl=enable_pdl,
+                cute_dsl_fmha_ragged_prefill(
+                    q=q,
+                    k=k,
+                    v=v,
+                    o=out,
+                    qo_indptr=p["qo_indptr"],
+                    kv_indptr=p["kv_indptr"],
                     is_causal=p["causal"],
-                    return_lse=return_lse,
-                    out=out,
-                    lse=lse,
-                    backend="cute-dsl",
+                    sm_scale=p["sm_scale"],
+                    window_left=p["window_left"],
+                    lse=lse if return_lse else None,
+                    max_qo_len=p["max_q_len"],
+                    max_kv_len=p["max_kv_len"],
+                    skip_rescale_threshold=skip_rescale_threshold,
+                    enable_pdl=enable_pdl,
                 )
+                if return_lse:
+                    assert lse is not None
+                    return out, lse
+                return out
             if return_lse:
                 # Standard-path modular kernel computes LSE natively; the
                 # wrapper raises NotImplementedError for attention variants.
@@ -4454,6 +4459,7 @@ def trtllm_ragged_attention_deepseek(
     return_lse: bool,
     attention_sinks: Optional[torch.Tensor] = None,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
+    skip_rescale_threshold: float = 8.0,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     sage_attn_sfs: Tuple[
@@ -4514,6 +4520,9 @@ def trtllm_ragged_attention_deepseek(
         If no value is provided, then standard attention is used.
         Setting the threshold to a higher value generally increases kernel performance at the cost of accuracy degradation.
         The actual threshold value equals the provided threshold_scale_factor divided by the context length.
+    skip_rescale_threshold : float
+        Cute DSL Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
+        >1 allows skipping at new_row_max < X * row_max.
     out : Optional[torch.Tensor]
         output tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1], value.shape[2]]
     lse : Optional[torch.Tensor]
@@ -4632,6 +4641,7 @@ def trtllm_ragged_attention_deepseek(
             max_qo_len=max_q_len,
             max_kv_len=max_kv_len,
             skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+            skip_rescale_threshold=skip_rescale_threshold,
             enable_pdl=enable_pdl,
         )
     else:

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3786,8 +3786,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
         skip_rescale_threshold : float
-            Cute DSL Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
-            >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
+            Cute DSL Skip-correction threshold: >0 enables skip-correction when row_max is not updated;
+            it allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
         kv_cache_sf : Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]
             Per-block scale factors for NVFP4 KV input.  Accepts either a single
             packed scale tensor or a ``(k_scales, v_scales)`` tuple matching the
@@ -4521,8 +4521,8 @@ def trtllm_ragged_attention_deepseek(
         Setting the threshold to a higher value generally increases kernel performance at the cost of accuracy degradation.
         The actual threshold value equals the provided threshold_scale_factor divided by the context length.
     skip_rescale_threshold : float
-        Cute DSL Skip-correction threshold: =1 enables skip-correction when row_max is not updated;
-        >1 allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
+        Cute DSL Skip-correction threshold: >0 enables skip-correction when row_max is not updated;
+        it allows skipping at (new_row_max - row_max) * scale_sm * log2e < X.
     out : Optional[torch.Tensor]
         output tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1], value.shape[2]]
     lse : Optional[torch.Tensor]

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Frontend tests for the `cute-dsl` backend routed to the trtllm JIT FMHA kernel.
+"""Frontend tests for APIs backed by the shared CuTe DSL FMHA runner.
 
 Covers entry points:
-* `trtllm_ragged_attention_deepseek(backend="cute-dsl")` — the shared low-level API.
-* `BatchPrefillWithRaggedKVCacheWrapper(backend="cute-dsl")` — delegates to the former
-  for standard attention, falls back to prefill.py for ALiBi / soft-cap.
+* `trtllm_ragged_attention_deepseek(backend="cute-dsl")` — the TRT-LLM API entry.
+* `BatchPrefillWithRaggedKVCacheWrapper(backend="cute-dsl")` — independently calls
+  the runner for standard attention and uses modular prefill for ALiBi / soft-cap.
 """
 
 import math
@@ -78,15 +78,15 @@ def _make_qkv(total_q, total_kv, Hq, Hk, dtype_qk, dtype_vo, Dqk, Dvo):
 
 
 @pytest.mark.parametrize(
-    "dtype_qk,dtype_vo,Dqk,Dvo",
+    "dtype_qk,dtype_vo,Dqk,Dvo,skip_rescale_threshold",
     [
-        (torch.bfloat16, torch.bfloat16, 128, 128),
-        (torch.bfloat16, torch.float8_e4m3fn, 128, 128),
-        (torch.float8_e4m3fn, torch.float8_e4m3fn, 128, 128),
-        (torch.float8_e4m3fn, torch.float8_e4m3fn, 192, 128),  # MLA
+        (torch.bfloat16, torch.bfloat16, 128, 128, 1.0),
+        (torch.bfloat16, torch.float8_e4m3fn, 128, 128, 8.0),
+        (torch.float8_e4m3fn, torch.float8_e4m3fn, 128, 128, 8.0),
+        (torch.float8_e4m3fn, torch.float8_e4m3fn, 192, 128, 8.0),  # MLA
     ],
 )
-def test_deepseek_cute_dsl(dtype_qk, dtype_vo, Dqk, Dvo):
+def test_deepseek_cute_dsl(dtype_qk, dtype_vo, Dqk, Dvo, skip_rescale_threshold):
     torch.manual_seed(0)
     b, s, H = 2, 256, 8
     qo = _indptr([s] * b)
@@ -115,10 +115,11 @@ def test_deepseek_cute_dsl(dtype_qk, dtype_vo, Dqk, Dvo):
         enable_pdl=False,
         is_causal=False,
         return_lse=False,
+        skip_rescale_threshold=skip_rescale_threshold,
         backend="cute-dsl",
     )
     ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=False)
-    atol = 4e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
+    atol = 5e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
     torch.testing.assert_close(o.float(), ref.float(), atol=atol, rtol=atol)
 
 
@@ -152,7 +153,7 @@ def test_batch_prefill_cute_dsl(dtype_qk, dtype_vo, causal):
     w.plan(qo, kv, Hq, Hk, D, causal=causal, q_data_type=dtype_qk)
     o = w.run(q, k, v)
     ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=causal)
-    atol = 4e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
+    atol = 5e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
     torch.testing.assert_close(o.float(), ref.float(), atol=atol, rtol=atol)
 
     # LSE is now supported for standard attention.
@@ -161,7 +162,8 @@ def test_batch_prefill_cute_dsl(dtype_qk, dtype_vo, causal):
     assert lse.shape == (total, Hq)
 
 
-def test_cute_dsl_jit_case(monkeypatch):
+@pytest.mark.parametrize("skip_rescale_threshold", [8.0, 1.0])
+def test_cute_dsl_jit_case(monkeypatch, skip_rescale_threshold):
     """When the cubin variant is unavailable, cute_dsl_fmha_ragged_prefill must
     JIT-compile the kernel and still produce correct results.
     """
@@ -194,13 +196,14 @@ def test_cute_dsl_jit_case(monkeypatch):
         sm_scale=sm,
         max_qo_len=s,
         max_kv_len=s,
+        skip_rescale_threshold=skip_rescale_threshold,
     )
     ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=False)
     torch.testing.assert_close(o.float(), ref.float(), atol=3e-2, rtol=3e-2)
 
 
 def test_batch_prefill_cute_dsl_alibi():
-    """ALiBi is unsupported by the trtllm kernel; must use prefill.py instead."""
+    """ALiBi is unsupported by the FMHA runner; use modular prefill instead."""
     torch.manual_seed(0)
     b, s, H, D = 2, 256, 8, 128
     qo = _indptr([s] * b)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The parameter configures the behavior of skip-correlation:
- 0.0 disables skip-correlation
- 1.0 allows skip-corr in the same form as FA3 (skips only when row_max is not updated)
- 8.0 (default if skip-correlation is enabled) allows skipping row_max update thus correlation as well if new_row_max < 8.0 old_row_max.

**Why making it configurable?**
- Because we saw a Cosmos3-Edge's accuracy getting affected by the default 8.0 value if P&V are quantized to FP8. We wanted to allow skip-correction for higher performance, but we also (occasionally) need to prevent the `skip_rescale_threshold->p_fp8_prescale_log2` chain from hurting P-matrix's accuracy.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable `skip_rescale_threshold` support for standard and block-scaled CuTe DSL attention, with a default of `8.0`.
  - Extended prefill APIs to accept and apply the threshold across supported execution paths.
  - Added automatic fallback compilation when a requested threshold is not available in a prebuilt kernel.

- **Tests**
  - Expanded coverage for threshold variations, float8, MLA, and forced compilation scenarios.
  - Updated numerical tolerances for affected attention tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->