### PR TITLE
Skip m=1 tuning profile for trtllm_bf16_moe to avoid IMA in autotune sweep

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1470,6 +1470,14 @@ def get_trtllm_moe_sm100_module():
                 tune_min_num_tokens: Lower bound for the num_tokens tuning buckets.
                 **kwargs: Extra TuningConfig kwargs (e.g. use_cold_l2_cache).
             """
+            if tune_min_num_tokens > tune_max_num_tokens:
+                # get_hybrid_num_tokens_buckets always emits max_num_tokens as
+                # a bucket, so an out-of-range floor would silently reintroduce
+                # the buckets it was meant to exclude.
+                raise ValueError(
+                    f"tune_min_num_tokens ({tune_min_num_tokens}) must not "
+                    f"exceed tune_max_num_tokens ({tune_max_num_tokens})"
+                )
 
             spec = {
                 "output": autotuner_initializer_empty,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1458,6 +1458,7 @@ def get_trtllm_moe_sm100_module():
             moe_inputs: "MoeRunnerInputs",
             tune_max_num_tokens: int = 8192,
             routing_input_mode: RoutingInputMode = RoutingInputMode.PackedPrecomputed,
+            tune_min_num_tokens: int = 1,
             **kwargs,
         ) -> TuningConfig:
             """Build a TuningConfig for this runner instance.
@@ -1466,6 +1467,7 @@ def get_trtllm_moe_sm100_module():
                 moe_inputs: Input parameters for this call.
                 tune_max_num_tokens: Upper bound for the num_tokens tuning buckets.
                 routing_input_mode: Routing representation used by the launcher.
+                tune_min_num_tokens: Lower bound for the num_tokens tuning buckets.
                 **kwargs: Extra TuningConfig kwargs (e.g. use_cold_l2_cache).
             """
 
@@ -1523,7 +1525,9 @@ def get_trtllm_moe_sm100_module():
                     DynamicTensorSpec(
                         input_idx,
                         dim_idx,
-                        get_hybrid_num_tokens_buckets(tune_max_num_tokens, 1),
+                        get_hybrid_num_tokens_buckets(
+                            tune_max_num_tokens, tune_min_num_tokens
+                        ),
                         make_hybrid_bucket_mapper(tune_max_num_tokens),
                         initializers,
                     ),
@@ -1965,6 +1969,15 @@ def get_trtllm_moe_sm100_module():
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            # Skip the m=1 tuning profile: BF16 dynB GEMM2 candidates hit an
+            # illegal memory access when executed under the sweep's 1-token
+            # profile on sm100f, and the IMA is context-fatal so the sweep
+            # cannot skip past a faulting candidate (issue #4157). Runtime
+            # m=1 maps to the (now untuned) 1 bucket and falls back to the
+            # default tactic, which is stable at 1 token; it is intentionally
+            # NOT remapped to the m=2 bucket, since that would execute a
+            # swept candidate at m=1, the exact faulting scenario.
+            tune_min_num_tokens=2,
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -1577,5 +1577,13 @@ def test_moe_tuning_config_min_num_tokens_two_generates_no_m1_profile():
             "MoE sweep would execute the faulting 1-token candidates."
         )
         assert 2 in opt_tokens
+
+        # Boundary: a floor above the ceiling must be rejected, because
+        # get_hybrid_num_tokens_buckets always emits max_num_tokens as a
+        # bucket -- (1, 2) would silently produce the (1,) bucket again.
+        with pytest.raises(ValueError, match="tune_min_num_tokens"):
+            runner._make_tuning_config(
+                moe_inputs, tune_max_num_tokens=1, tune_min_num_tokens=2
+            )
     finally:
         fn.cache_clear()

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -1508,3 +1508,74 @@ def test_cute_dsl_runner_cache_tracks_split_workspace_geometry():
 
     key_small_workspace = _cute_dsl_runner_cache_extras(257, 800_000)
     assert key_257 != key_small_workspace
+
+
+def test_hybrid_num_tokens_buckets_min_two_drops_only_the_one_bucket():
+    """min_num_tokens=2 must remove exactly the 1-token bucket."""
+    full = get_hybrid_num_tokens_buckets(8192, 1)
+    trimmed = get_hybrid_num_tokens_buckets(8192, 2)
+    assert 1 in full
+    assert 1 not in trimmed
+    assert trimmed == tuple(b for b in full if b != 1)
+
+
+def test_moe_tuning_config_min_num_tokens_two_generates_no_m1_profile():
+    """A MoE tuning config built with tune_min_num_tokens=2 must not produce
+    an m=1 optimization profile.
+
+    trtllm_bf16_moe tunes with tune_min_num_tokens=2 because BF16 dynB GEMM2
+    candidates hit a context-fatal illegal memory access when executed under
+    the sweep's 1-token profile on sm100f (issue #4157).
+    """
+    fn = core_mod.get_trtllm_moe_sm100_module
+    fn.cache_clear()
+    try:
+        mock_module = MagicMock()
+        mock_module.get_library_path.return_value = "/tmp/fake.so"
+        with (
+            patch.object(
+                core_mod,
+                "gen_trtllm_gen_fused_moe_sm100_module",
+                return_value=mock_module,
+            ),
+            patch.object(core_mod, "setup_cubin_loader"),
+        ):
+            MoERunner = core_mod.get_trtllm_moe_sm100_module().MoERunner
+
+        runner = MoERunner(
+            top_k=8,
+            num_local_experts=256,
+            dtype_act=DtypeTrtllmGen.Bfloat16,
+            dtype_weights=DtypeTrtllmGen.Bfloat16,
+            fp8_quantization_type=Fp8QuantizationType.NoneFp8,
+            hidden_size=6144,
+            intermediate_size=256,
+            num_experts=256,
+        )
+        moe_inputs = MoeRunnerInputs(
+            output=torch.empty((1, 6144)),
+            routing_logits=torch.empty((1, 256)),
+            topk_ids=None,
+            expert_weights=None,
+            hidden_states=torch.empty((1, 6144)),
+            hidden_states_scale=None,
+            gemm1_lora_delta=None,
+            per_token_scale=None,
+        )
+
+        config = runner._make_tuning_config(moe_inputs, tune_min_num_tokens=2)
+        profiles = AutoTuner.get()._generate_optimization_profiles(
+            config, moe_inputs.to_list()
+        )
+
+        spec = config.dynamic_tensor_specs[0]
+        token_input, token_dim = spec.input_idx[0], spec.dim_idx[0]
+        opt_tokens = {p.get_opt_shapes()[token_input][token_dim] for p in profiles}
+
+        assert 1 not in opt_tokens, (
+            "tune_min_num_tokens=2 still generated an m=1 profile; the BF16 "
+            "MoE sweep would execute the faulting 1-token candidates."
+        )
+        assert 2 in opt_tokens
+    finally:
+        fn.cache_clear()


### PR DESCRIPTION
## 📌 Description

Fixes the engine-fatal `cudaErrorIllegalAddress` reported in #4157: BF16 dynB
GEMM2 candidates fault when executed under the AutoTuner sweep's 1-token
profile on sm100f, and the IMA is context-fatal, so the sweep cannot
skip-and-continue past a faulting candidate.

The change threads a `tune_min_num_tokens` parameter through
`MoERunner._make_tuning_config` (default 1, no behavior change for other ops)
and sets it to 2 for `flashinfer::trtllm_bf16_moe`, so the sweep starts at the
m=2 bucket. This is the same principle as the existing correctness skip of
clusterZ>1 cubins in `trtllm_batched_gemm_runner.cu`, applied at the
tuning-profile level: a selection-layer mitigation while the cubin defect is
addressed.

Two deliberate scope choices:

- Only `trtllm_bf16_moe` opts in; the fp8/fp4 MoE ops keep the m=1 profile
  (no evidence of faults there).
- The runtime bucket mapper is intentionally NOT changed. Runtime m=1 maps to
  the now-untuned 1 bucket and falls back to the default tactic, which is
  stable at 1 token (drafter decode runs 1-token batches in production
  without issue). Remapping m=1 to the m=2 bucket would execute a swept
  candidate at m=1, which is the exact faulting scenario.

Validation on 8xB200 (the serving config from #4157): the bf16 sweep
completes 20/20 remaining profiles, the engine serves, and single-stream
decode recovers full trtllm autotune value (+35% over the cutlass fallback we
were pinned to by the crash). Numbers in #4157.

## 🔍 Related Issues

Fixes #4157. Possibly related: #3427 (kernel-family overlap, discussed in
#4157).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed: bucket generation with
      `min_num_tokens=2` drops exactly the 1 bucket, and a MoE-style tuning
      config built with `tune_min_num_tokens=2` generates no m=1 optimization
      profile (CPU-only, mirrors the existing mocked `_make_tuning_config`
      tests in `tests/autotuner/test_autotuner_core.py`).
- [x] All tests are passing: full `tests/autotuner/` suite (core + CUDA
      integration) is 240 passed, 0 failed on B200 (sm100f). The fp8/fp4 MoE
      autotune smokes confirm the default `tune_min_num_tokens=1` path is
      unchanged for other ops.

## Reviewer Notes

Disclosure: debugging and patch were AI-assisted (Claude); findings and fix
validated by a human on hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable lower bound for MoE autotuning token-bucket sizing (with validation against the upper bound).
* **Bug Fixes**
  * Updated BF16 routed MoE tuning to skip unsupported one-token tuning profiles on affected configurations, ensuring only valid candidates are produced.
* **Tests**
  * Added regression coverage for hybrid token-bucket trimming when the minimum bucket size increases.
  * Added validation checks for invalid tuning bounds and verified absence of one-token candidates while confirming expected candidates remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->