### PR TITLE
[fix]fix xqa flaky test on spark

### DIFF
--- a/csrc/xqa/barriers.cuh
+++ b/csrc/xqa/barriers.cuh
@@ -68,6 +68,11 @@ class MBarrier  // rename this to MBarrier
   __device__ inline mha::conditional_t<scope == Scope::CTA, ArrivalToken, void> arrive(
       uint32_t update = 1) {
     ArrivalToken token{};
+#if __CUDA_ARCH__ == 1210
+    // GB10 (sm121) does not reliably honor the mbarrier release ordering under
+    // tight scheduling: make prior writes visible before the arrival is observed.
+    __threadfence_block();
+#endif
 #if __CUDA_ARCH__ >= 900
     if constexpr (scope == Scope::CTA) {
       switch (order) {

--- a/csrc/xqa/mha.cu
+++ b/csrc/xqa/mha.cu
@@ -2477,6 +2477,11 @@ CUBIN_EXPORT __global__
             idxCurrSMemVBuf++;
           }
         }  // idxBeam
+#if __CUDA_ARCH__ == 1210
+        // GB10 (sm121): release prior reads of smem.x before signaling the buffer
+        // is consumed, so the gemm0 producer does not overwrite it too early.
+        __threadfence_block();
+#endif
         xBar.consumed.arrive();
       }  // xIter
       flip(xBarProducedParityNext);
@@ -2565,6 +2570,9 @@ CUBIN_EXPORT __global__
     bool reorderOutRows = inputElemSize == 2 && cacheElemSize == 1;
 #endif
     SharedMem::XSmemBuffer* smemOutTile = mergeAndSaveOutTile(outTile, reorderOutRows);
+    // In multi-block mode only the last CTA writes the merged output; the other
+    // sub-sequences only contribute their partials via global scratch below.
+    bool ctaShouldWriteOut = !isMultiBlock;
     if (isMultiBlock) {
       static_assert(ctaShapeInWarps.y == 1, "not implemented");
 #if SPEC_DEC
@@ -2599,6 +2607,12 @@ CUBIN_EXPORT __global__
       copyGrains<false, nbValidRows * ScratchBuf::cols, gemm1NbWarpGrps>(
           warpGrpIdx, &scratchBuffers[idxBuf][warpIdxInGrp](0, 0), &(*smemOutTile)(0, 0));
       __syncthreads();
+#if __CUDA_ARCH__ == 1210
+      // GB10 (sm121): device-scope release so the partials just written to global
+      // scratch are visible to the last CTA (a different block) before the
+      // semaphore increment below signals that this sub-sequence is done.
+      __threadfence();
+#endif
       constexpr uint32_t nbTileBuffers = 2;
 
       struct MultiBlockSMem {
@@ -2632,6 +2646,7 @@ CUBIN_EXPORT __global__
 
       // merge if we are the last CTA.
       bool const isLastCta = mbsmem.isLastCta;
+      ctaShouldWriteOut = isLastCta;
       if (isLastCta) {
         MultiBlockSMem::MBBuf& mbbuf = mbsmem.storage[warpIdx.y];
         SMemWarpRowMax& smemRowMax = reinterpret_cast<SMemWarpRowMax&>(smem);
@@ -2720,7 +2735,7 @@ CUBIN_EXPORT __global__
         smemOutTile = mergeAndSaveOutTile(mergedOutTile, false);
       }
     }
-    if (warpGrpIdx == 0) {
+    if (ctaShouldWriteOut && warpGrpIdx == 0) {
 #if SPEC_DEC
       copyOutputToGlobalMem(
           warp, &output[reqSeqOffset * nbQHeads], nbQHeads, headGrpSize, (idxHeadGrp * headGrpSize),


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`test_xqa` intermittently fails its tolerance check on **DGX Spark (GB10, sm121)**.
**Reproduced on DGX Spark and fixed by this PR.** Two races in the JIT `mha.cu`
decode kernel, only exposed under GB10's tight few-SM scheduling (does not
reproduce on sm120).

## Fixes

1. **mbarrier / multi-block-semaphore release ordering** not honored on GB10 →
   producer overwrites `smem.x` early / scratch not visible to the last CTA.
   Add three release fences, compile-gated to sm121 (`#if __CUDA_ARCH__ == 1210`),
   so other archs are unchanged.
2. **Multi-block output write missing the last-CTA gate**: every sub-sequence CTA
   wrote the output; with sliding-window an empty sub-sequence writes zeros and
   races the correct write. Gate on last-CTA (`ctaShouldWriteOut`), mirroring
   `mha_sm90.cu`. Arch-independent.

## Validation (DGX Spark, sm121)

- Before: full `test_xqa` under `-P8` parallel stress reliably fails (down to ~8%
  elements passing).
- After: 40× `-P8` full-suite runs → **zero failures**.

Fixes #3658.
## 🔍 Related Issues

#3658

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization during multi-block processing to prevent premature data overwrites.
  * Ensured partial results are fully visible before they are combined.
  * Prevented duplicate output writes when multiple processing blocks contribute to the same result.
  * Improved reliability and correctness for supported GPU workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->