### PR TITLE
docs: document CuTe prefill scheduling override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ FlashInfer is a GPU kernel library for LLM serving that uses **JIT (Just-In-Time
 | Enable GDN native short-T path | `export FLASHINFER_GDN_WY_NATIVE_T=1` |
 | Enable GDN strided QKV path | `export FLASHINFER_GDN_WY_STRIDED_QKV=1` |
 | Enable GDN native A/B tensors | `export FLASHINFER_GDN_WY_NATIVE_AB=1` |
+| Override CuTe-DSL prefill scheduling | `export FLASHINFER_CUTE_PREFILL_PERSISTENT=0` (non-persistent) or `1` (persistent) |
 
 ## Quick Start for Development
 


### PR DESCRIPTION
## Summary

- document FLASHINFER_CUTE_PREFILL_PERSISTENT in the CLAUDE.md environment-variable quick reference
- clarify that 0 selects non-persistent scheduling and 1 selects persistent scheduling

## Testing

- pre-commit run --files CLAUDE.md
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the `FLASHINFER_CUTE_PREFILL_PERSISTENT` environment variable for controlling CuTe-DSL prefill scheduling.
  * Added explanations for the supported values: `0` for non-persistent scheduling and `1` for persistent scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->