### PR TITLE
fix(norm): convert float2 to e4m3 directly in packed cast

### DIFF
--- a/include/flashinfer/trtllm/common/cudaTypeUtils.cuh
+++ b/include/flashinfer/trtllm/common/cudaTypeUtils.cuh
@@ -592,7 +592,11 @@ __device__ inline half2 cuda_cast<half2, __nv_fp8x2_e4m3>(__nv_fp8x2_e4m3 val) {
 
 template <>
 __device__ inline __nv_fp8x2_e4m3 cuda_cast<__nv_fp8x2_e4m3, float2>(float2 val) {
-  return __nv_fp8x2_e4m3(bf1622float2(float22bf162(val)));
+  // Direct conversion: an intermediate bf16 step drops mantissa bits that a
+  // small quantization scale then amplifies past e4m3 bucket boundaries.
+  __nv_fp8x2_e4m3 out;
+  out.__x = __nv_cvt_float2_to_fp8x2(val, __NV_SATFINITE, __NV_E4M3);
+  return out;
 }
 
 template <>

--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -363,6 +363,8 @@ def test_layernorm(batch_size, hidden_size, dtype):
 @pytest.mark.parametrize("quant_scale", [0.01, 1.0, 10.0])
 @pytest.mark.parametrize("quant_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_layernorm_quant(batch_size, hidden_size, quant_scale, quant_dtype):
+    # The check bounds the fraction of drifting elements, so fix the seed.
+    torch.manual_seed(0)
     x = torch.randn(batch_size, hidden_size, dtype=torch.bfloat16, device="cuda")
     gamma = torch.randn(hidden_size, dtype=torch.float32, device="cuda")
     beta = torch.randn(hidden_size, dtype=torch.float32, device="cuda")


### PR DESCRIPTION
## 📌 Description
`layernorm_quant` can miss the FP8 e4m3 correctness bound when the quantization scale is small. Reported for A10/SM86 in the nightly pipeline.

The packed `float2` to `__nv_fp8x2_e4m3` cast in `cudaTypeUtils.cuh` rounded through bf16 before quantizing:

    return __nv_fp8x2_e4m3(bf1622float2(float22bf162(val)));

`generalLayerNorm` applies the per-tensor scale before this cast, so the mantissa bits dropped by the bf16 step are scaled up by `1/scale`. At `scale=0.01` that is a 100x amplification, enough to push values into a neighbouring e4m3 bucket. The test reference models the bf16 rounding that the kernel does before scaling, but not this second rounding after it, so the two diverge.

This PR converts directly with `__nv_cvt_float2_to_fp8x2`, matching the style already used in `vec_dtypes.cuh`. The e5m2 packed cast already converts without a bf16 round trip, so it is unchanged, which matches the failures being e4m3 only. The cast is only reachable through `generalLayerNorm`, whose sole caller is `LayerNormQuant`, so `layernorm_quant` is the only affected API.

This PR also seeds `test_layernorm_quant`. The bf16 round trip is architecture independent, so the error was always present on the packed path; the check bounds the fraction of drifting elements, and unseeded inputs left that fraction varying per run, which is why it surfaced as an intermittent SM86 failure.

## 🔍 Related Issues
#4160
## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

Verified on an RTX A6000 (SM86, same architecture as the A10 in the nightly pipeline).

Before and after, over 30 seeds per shape at `scale=0.01`, e4m3, batch 1:

| hidden | seeds over 1% bound (before) | after | worst mismatch (before) | after |
|-------:|-----------------------------:|------:|------------------------:|------:|
|    500 |                         4/30 |  0/30 |                   1.20% | 0.00% |
|   1024 |                         3/30 |  0/30 |                   1.27% | 0.00% |

The two cases named in the report, `hidden=500` and `hidden=1024` at `scale=0.01`, pass after the fix.

- Full `tests/utils/test_norm.py`: 1543 passed, 1344 skipped. Skips are PDL cases that need Hopper or newer.
- `pytest tests/trace/ -k "norm"`: 123 passed, 21 skipped.
- `pre-commit run` on the changed files: all hooks pass.

Unrelated pre-existing failures: `pytest tests/trace/ -k "rope"` reports 24 failures on this machine both with and without this change, so they are not caused by it.

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 conversion accuracy and handling by converting values directly with saturation.

* **Tests**
  * Stabilized quantized layer normalization test results by making input generation deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->