### PR TITLE
fix(moe): reject incompatible output-scale cubins

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -117,9 +117,17 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
         if (options.mFusedBiasShuffleMode != mOptions.fusedBiasShuffleMode) continue;
         if (options.mBiasDtype != mOptions.biasDtype) continue;
       }
-      if (mOptions.usePerTokenScaling) {
-        if (options.mTransposeMmaOutput && !options.mUsePerTokenSfB) continue;
-        if (!options.mTransposeMmaOutput && !options.mUsePerTokenSfA) continue;
+      bool const usesPerTokenScaling =
+          options.mTransposeMmaOutput ? options.mUsePerTokenSfB : options.mUsePerTokenSfA;
+      if (mOptions.usePerTokenScaling && !usesPerTokenScaling) continue;
+      // The MoE pipeline allocates and consumes output scaling factors in the
+      // block format's default dtype. Reject cubins that override that
+      // contract, such as bmm_E2m1xFp32_* kernels that emit linear FP32
+      // scaling factors into a buffer sized for E4M3 factors.
+      if (tg::dtypeIsBlockFmt(options.mDtypeC)) {
+        if (options.mDtypeSfC != tg::dtypeGetBlockSfType(options.mDtypeC)) continue;
+      } else if (options.mDtypeSfC != Dtype::Void) {
+        continue;
       }
       if (mOptions.usePerChannelScaling) {
         if (options.mTransposeMmaOutput && !options.mUsePerTokenSfA) continue;

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1190,8 +1190,11 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
           static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout),
           // FP8 per-tensor doesn't use Mn-bias (LoRA) cubins.
           /*gemm1BiasType*/ batchedGemm::gemm::BiasType::None,
-          true,  // usePerTokenScalingGemm1. always true for per-tensor fp8 due to llama4 routing
-          false, false, false);
+          // Keep tactic enumeration aligned with prepare_moe_common(). The
+          // one-way cubin filter still admits the exported FP8 FC1 kernels
+          // that optionally consume BF16 routing scales.
+          /*usePerTokenScalingGemm1*/ false,
+          /*usePerTokenScalingGemm2*/ false, false, false);
 
       auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
                                                     num_local_experts, num_tokens);
@@ -2220,9 +2223,11 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
           /*weight_layout*/ batchedGemm::gemm::MatrixLayout::MajorK,
           // FP4 MoE getValidConfigs doesn't exercise the Mn-bias (LoRA) cubins.
           /*gemm1BiasType*/ batchedGemm::gemm::BiasType::None,
-          // NOTE(siyuan): currently FP4 MoE always apply per-token scaling to both FC1 and FC2.
           /*usePerTokenScalingGemm1*/ use_per_token_scaling,
-          /*usePerTokenScalingGemm2*/ use_per_token_scaling, false, false);
+          // Match prepare_moe_common(): only NVFP4 uses the explicit
+          // per-token scale operand for FC2.
+          /*usePerTokenScalingGemm2*/
+          use_per_token_scaling && dtype_act == btg::Dtype::E2m1, false, false);
 
       auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
                                                     num_local_experts, num_tokens);

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -333,6 +333,99 @@ def _enumerate_valid_tactics(
     )
 
 
+def test_nvfp4_per_tensor_small_shape_all_tactics_are_correct():
+    """Every advertised small-shape tactic must honor the output-SF contract."""
+    if get_compute_capability(torch.device(device="cuda"))[0] not in [10]:
+        pytest.skip("Only work on SM100 / SM103.")
+
+    AutoTuner.get()._logged_file_hits.discard(_TEST_LOG_KEY_FP4)
+
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    num_tokens = 32
+    hidden_size = intermediate_size = 1024
+    num_experts = 16
+    top_k = 2
+    inputs = _build_fp4_routed_moe_inputs(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        num_experts=num_experts,
+        quant_mode="NvFP4xNvFP4",
+        routing_method_type=RoutingMethodType.Renormalize,
+        device=device,
+    )
+    profile_shapes = _moe_profile_shapes(inputs, num_tokens, num_tokens)
+
+    def _run(tactic: list[int] | None) -> torch.Tensor:
+        _force_tactic_in_autotuner_cache(profile_shapes, tactic, custom_op=_TEST_OP_FP4)
+        output = trtllm_fp4_block_scale_routed_moe(
+            topk_ids=inputs["packed_topk"],
+            routing_bias=None,
+            hidden_states=inputs["hidden_states"],
+            hidden_states_scale=inputs["hidden_states_scale"],
+            gemm1_weights=inputs["w13"],
+            gemm1_weights_scale=inputs["w13_scale"],
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=inputs["w2"],
+            gemm2_weights_scale=inputs["w2_scale"],
+            gemm2_bias=None,
+            output1_scale_scalar=inputs["output1_scale_scalar"],
+            output1_scale_gate_scalar=inputs["output1_scale_gate_scalar"],
+            output2_scale_scalar=inputs["output2_scale_scalar"],
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=RoutingMethodType.Renormalize.value,
+            do_finalize=True,
+            enable_pdl=device_support_pdl(device),
+            activation_type=ActivationType.Swiglu.value,
+            tune_max_num_tokens=num_tokens,
+        )[0]
+        torch.cuda.synchronize()
+        return output
+
+    moe_op = gen_trtllm_gen_fused_moe_sm100_module().build_and_load()
+    valid_tactics = _enumerate_valid_tactics(
+        moe_op,
+        "NvFP4xNvFP4",
+        top_k,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        num_tokens,
+    )
+    assert valid_tactics
+    assert any(tactic[0] == 8 for tactic in valid_tactics), (
+        "the regression shape no longer exercises tile-N 8 tactics"
+    )
+    reference = _run(None).float()
+    ref_max = reference.abs().max().item()
+    assert torch.isfinite(reference).all(), "heuristic reference output is not finite"
+
+    failures = []
+    for tactic in valid_tactics:
+        failure = _check_tactic(_run, tactic, reference, ref_max, n_iters=2)
+        if failure is not None:
+            failures.append(failure)
+    assert not failures, (
+        f"{len(failures)} per-tensor NVFP4 tactics failed correctness; "
+        f"first failures: {failures[:10]}"
+    )
+    assert _TEST_LOG_KEY_FP4 in AutoTuner.get()._logged_file_hits, (
+        "the forced regression tactic was not dispatched through the autotuner cache"
+    )
+
+
 @pytest.mark.parametrize("quant_mode", ["NvFP4xNvFP4", "MxFP4xMxFP8", "MxFP4xBf16"])
 @pytest.mark.parametrize("num_tokens", [16, 23, 128])
 @pytest.mark.parametrize("hidden_size", [4096, 7168])


### PR DESCRIPTION
## 📌 Description

Reject TRTLLM Gen batched-GEMM cubins whose output scaling-factor dtype does
not match the format allocated and consumed by the MoE pipeline.

For block-format FC1 output, MoE allocates the default block-SF representation:
E4M3 for NVFP4 and UE8M0 for MX formats. The affected
`bmm_E2m1xFp32_*` cubins instead write linear FP32 factors. On the small
routed-NVFP4 `32 x 1024`, 16-expert fixture, that writes roughly 44 KiB into a
roughly 16 KiB E4M3 buffer and then feeds the wrong representation to FC2.
The result is non-finite output and can surface later as
`cudaErrorInvalidAddressSpace`.

Qualification retains the existing one-way input per-token requirement and
checks the causal output-SF contract:

- block-format output must use that format's default SF dtype;
- non-block output must not produce an output SF tensor.

This removes exactly 132 `E2m1 -> FP32/Linear` FC1 cubins from the current
5,194-entry bundle. It removes no candidates from MXFP4+MXFP8, MXFP4+BF16,
DeepSeek FP8, MXFP8, or NVFP4 per-token execution.

The FP8 per-tensor and FP4 tactic-query constructors are also aligned with the
runtime constructor so enumeration and execution use the same per-token flags.
There is no replay-time predicate or kernel overhead.

## 🔍 Related Issues

No linked issue.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

The changed-file hooks pass:

```text
pre-commit run --files \
  csrc/trtllm_batched_gemm_runner.cu \
  csrc/trtllm_fused_moe_kernel_launcher.cu \
  tests/moe/test_trtllm_gen_moe_autotune_tactics.py
```

The all-files check was not run.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

The regression is index-free and sweeps every tactic advertised for the
small-shape public routed NVFP4 wrapper:

```text
tests/moe/test_trtllm_gen_moe_autotune_tactics.py::
  test_nvfp4_per_tensor_small_shape_all_tactics_are_correct
```

Against exact PR parent `4b969c936`, the 1,056-tactic process fails the
numerical/determinism check. The first bad FC1 output poisons that process's
CUDA state, so the report lists all later tactics as failures too; the first
entries include `(8,96)`, `(8,97)`, and `(8,98)`:

```text
AssertionError: 1056 per-tensor NVFP4 tactics failed correctness
1 failed, 2 warnings in 897.53s
```

The fixed branch passes the same test and explicitly requires tile-N 8
coverage:

```text
1 passed, 2 warnings in 4.14s
```

The full routed FP8 per-tensor matrix and focused NVFP4 controls pass:

```text
67 passed, 2 warnings in 659.46s
```

A representative all-tactics sweep executed every surviving tactic for
NVFP4, MXFP4+MXFP8, MXFP4+BF16, DeepSeek FP8, and MXFP8:

```text
6 passed, 2 warnings in 199.02s
5,824 tactics executed; 0 failed
```

## Reviewer Notes

The initial global symmetric `mUsePerTokenSfA/B` check was rejected: those
metadata bits are overloaded by dtype family, and equality removes every
eligible routed FP8 per-tensor FC1 cubin. The output-SF predicate instead
matches the allocation/consumer contract and affects only NVFP4 per-tensor in
the current bundle.

Independent source reconstruction and bundle analysis found:

- `mDtypeSfC=Fp32`, `mSfLayoutC=Linear`, and the
  `bmm_E2m1xFp32_*` family identify the same 132 configs;
- all 616 ordinary E2M1-output cubins use E4M3 factors;
- all 1,616 MX block-output cubins use UE8M0 factors;
- non-block output cubins advertise no output-SF tensor.

No Compute Sanitizer run was used. The exact-parent red test and fixed
cross-precision all-tactics execution provide the lightweight behavioral
evidence for this small fix.
