### PR TITLE
feat(topk): support separate page table row starts

### DIFF
--- a/csrc/flashinfer_topk_binding.cu
+++ b/csrc/flashinfer_topk_binding.cu
@@ -26,7 +26,8 @@ void radix_topk_page_table_transform(TensorView input, TensorView output_page_ta
                                      Optional<TensorView> maybe_row_to_batch, TensorView lengths,
                                      Optional<TensorView> maybe_row_states_buffer, int64_t top_k,
                                      bool deterministic, int64_t tie_break, bool dsa_graph_safe,
-                                     Optional<TensorView> maybe_row_starts);
+                                     Optional<TensorView> maybe_row_starts,
+                                     Optional<TensorView> maybe_page_table_row_starts);
 
 void radix_topk_ragged_transform(TensorView input, TensorView output_indices, TensorView offsets,
                                  TensorView lengths, Optional<TensorView> maybe_row_states_buffer,

--- a/csrc/topk.cu
+++ b/csrc/topk.cu
@@ -85,7 +85,8 @@ void radix_topk_page_table_transform(TensorView input, TensorView output_page_ta
                                      Optional<TensorView> maybe_row_to_batch, TensorView lengths,
                                      Optional<TensorView> maybe_row_states_buffer, int64_t top_k,
                                      bool deterministic, int64_t tie_break, bool dsa_graph_safe,
-                                     Optional<TensorView> maybe_row_starts) {
+                                     Optional<TensorView> maybe_row_starts,
+                                     Optional<TensorView> maybe_page_table_row_starts) {
   CHECK_INPUT(input);
   CHECK_INPUT(output_page_table);
   CHECK_INPUT(src_page_table);
@@ -97,6 +98,10 @@ void radix_topk_page_table_transform(TensorView input, TensorView output_page_ta
   if (maybe_row_starts.has_value()) {
     CHECK_INPUT(maybe_row_starts.value());
     CHECK_DIM(1, maybe_row_starts.value());
+  }
+  if (maybe_page_table_row_starts.has_value()) {
+    CHECK_INPUT(maybe_page_table_row_starts.value());
+    CHECK_DIM(1, maybe_page_table_row_starts.value());
   }
 
   unsigned int num_rows = input.size(0);
@@ -129,6 +134,14 @@ void radix_topk_page_table_transform(TensorView input, TensorView output_page_ta
         << "row_starts must have shape (num_rows,)";
     row_starts_ptr = static_cast<int32_t*>(maybe_row_starts.value().data_ptr());
   }
+  int32_t* page_table_row_starts_ptr = nullptr;
+  if (maybe_page_table_row_starts.has_value()) {
+    TVM_FFI_ICHECK(static_cast<unsigned int>(maybe_page_table_row_starts.value().size(0)) ==
+                   num_rows)
+        << "page_table_row_starts must have shape (num_rows,)";
+    page_table_row_starts_ptr =
+        static_cast<int32_t*>(maybe_page_table_row_starts.value().data_ptr());
+  }
 
   // Use unified dispatch with heuristics to choose between FilteredTopK and RadixTopK
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP32_FP16(dtype, c_type, [&] {
@@ -137,7 +150,7 @@ void radix_topk_page_table_transform(TensorView input, TensorView output_page_ta
         static_cast<const int32_t*>(src_page_table.data_ptr()), src_stride,
         static_cast<int32_t*>(lengths.data_ptr()), row_starts_ptr, row_to_batch_ptr, num_rows,
         static_cast<uint32_t>(top_k), max_len, row_states_ptr, deterministic, tie_break_mode,
-        stream, dsa_graph_safe);
+        stream, dsa_graph_safe, page_table_row_starts_ptr);
     return true;
   });
 

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -259,6 +259,7 @@ def get_topk_module():
         tie_break: int,
         dsa_graph_safe: bool = False,
         row_starts: Optional[torch.Tensor] = None,
+        page_table_row_starts: Optional[torch.Tensor] = None,
     ) -> None:
         assert input.dtype in [torch.float32, torch.float16, torch.bfloat16], (
             f"Unsupported dtype {input.dtype}, expected float32, float16, or bfloat16"
@@ -275,6 +276,7 @@ def get_topk_module():
             tie_break,
             dsa_graph_safe,
             row_starts,
+            page_table_row_starts,
         )
 
     @register_fake_op("flashinfer::radix_topk_page_table_transform")
@@ -290,6 +292,7 @@ def get_topk_module():
         tie_break: int,
         dsa_graph_safe: bool = False,
         row_starts: Optional[torch.Tensor] = None,
+        page_table_row_starts: Optional[torch.Tensor] = None,
     ) -> None:
         pass
 
@@ -670,6 +673,7 @@ def top_k_page_table_transform(
     tie_break: int = TopKTieBreak.NONE,
     dsa_graph_safe: bool = False,
     row_starts: Optional[torch.Tensor] = None,
+    page_table_row_starts: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     r"""Fused Top-K selection + Page Table Transform for sparse attention.
 
@@ -679,9 +683,12 @@ def top_k_page_table_transform(
     need to be mapped through page tables.
 
     For each row i:
-        output_page_table[i, j] = src_page_table[batch_idx, topk_indices[j]]
+        output_page_table[i, j] = src_page_table[
+            batch_idx, page_table_row_start[i] + topk_indices[j]
+        ]
 
-    where batch_idx is determined by row_to_batch[i] if provided, otherwise i.
+    where ``batch_idx`` is determined by ``row_to_batch[i]`` if provided,
+    otherwise ``i``. ``topk_indices`` are relative to ``row_starts[i]``.
 
     Parameters
     ----------
@@ -717,7 +724,10 @@ def top_k_page_table_transform(
         Per-row start indices of shape ``(num_rows,)`` with dtype ``int32``.
         Top-k is computed over ``[row_starts[i], row_starts[i] + lengths[i])`` for row ``i``.
         Default is None (equivalent to all zeros).
-
+    page_table_row_starts : Optional[torch.Tensor], optional
+        Per-row page-table start indices of shape ``(num_rows,)`` with dtype
+        ``int32``. If None, defaults to ``row_starts`` to preserve the legacy
+        behavior where score and page-table windows share the same start.
 
     Returns
     -------
@@ -730,8 +740,7 @@ def top_k_page_table_transform(
     ----
     - This is specifically designed for sparse attention's second stage.
     - If lengths[i] <= k, the output simply contains
-      ``src_page_table[batch_idx, row_starts[i]:row_starts[i] + lengths[i]]`` (or start 0 when
-      ``row_starts`` is None)
+      ``src_page_table[batch_idx, page_table_row_start[i]:page_table_row_start[i] + lengths[i]]``
       with remaining positions set to -1.
 
     Examples
@@ -759,6 +768,7 @@ def top_k_page_table_transform(
         can_use_clusters_topk(input.device, deterministic, dsa_graph_safe)
         and row_to_batch is None
         and row_starts is None
+        and page_table_row_starts is None
     ):
         return topk_clusters_page_table_transform(input, lengths, src_page_table, k)
 
@@ -785,6 +795,7 @@ def top_k_page_table_transform(
         tie_break,
         dsa_graph_safe,
         row_starts=row_starts,
+        page_table_row_starts=page_table_row_starts,
     )
 
     return output_page_table

--- a/flashinfer/trace/templates/sampling.py
+++ b/flashinfer/trace/templates/sampling.py
@@ -1023,12 +1023,13 @@ def _top_k_page_table_transform_reference(
     **_unused,
 ) -> torch.Tensor:
     """Reference for top_k_page_table_transform: per-row top-k selection on
-    the leading ``lengths[i]`` valid entries, then translate the selected
-    indices through ``src_page_table[row_to_batch[i]]``. Used in sparse
-    attention's second stage to produce per-row page-id sequences.
+    the score window starting at ``row_starts[i]``, then translate the selected
+    local indices from the page-table window starting at
+    ``page_table_row_starts[i]``. Used in sparse attention's second stage to
+    produce per-row page-id sequences.
     """
     num_rows = input.shape[0]
-    out = torch.zeros(num_rows, int(k), dtype=torch.int32, device=input.device)
+    out = torch.full((num_rows, int(k)), -1, dtype=torch.int32, device=input.device)
     for i in range(num_rows):
         L = int(lengths[i].item())
         if L <= 0:

--- a/flashinfer/trace/templates/sampling.py
+++ b/flashinfer/trace/templates/sampling.py
@@ -1019,6 +1019,7 @@ def _top_k_page_table_transform_reference(
     tie_break: int = 0,
     dsa_graph_safe: bool = False,
     row_starts=None,
+    page_table_row_starts=None,
     **_unused,
 ) -> torch.Tensor:
     """Reference for top_k_page_table_transform: per-row top-k selection on
@@ -1033,10 +1034,18 @@ def _top_k_page_table_transform_reference(
         if L <= 0:
             continue
         b = int(row_to_batch[i].item()) if row_to_batch is not None else i
-        row = input[i, :L].to(torch.float32)
+        row_start = int(row_starts[i].item()) if row_starts is not None else 0
+        page_table_row_start = (
+            int(page_table_row_starts[i].item())
+            if page_table_row_starts is not None
+            else row_start
+        )
+        row = input[i, row_start : row_start + L].to(torch.float32)
         kk = min(int(k), L)
         _, idx = torch.topk(row, kk, sorted=True)
-        out[i, :kk] = src_page_table[b, idx.to(torch.long)].to(torch.int32)
+        out[i, :kk] = src_page_table[b, page_table_row_start + idx.to(torch.long)].to(
+            torch.int32
+        )
     return out
 
 
@@ -1070,9 +1079,9 @@ top_k_page_table_transform_trace = TraceTemplate(
     name_prefix="top_k_page_table_transform",
     description=(
         "Fused per-row top-k selection plus page-table translation. For "
-        "each row i: pick top-k indices over input[i, :lengths[i]] and "
-        "translate them via src_page_table[row_to_batch[i]] to produce "
-        "per-row page-id sequences for sparse attention."
+        "each row i: pick top-k indices from the score window starting at "
+        "row_starts[i] and translate them from the page-table window starting "
+        "at page_table_row_starts[i] to produce per-row page-id sequences."
     ),
     axes={
         "num_rows": Var(),
@@ -1090,6 +1099,8 @@ top_k_page_table_transform_trace = TraceTemplate(
         "lengths": Tensor(["num_rows"], dtype="int32"),
         "k": Scalar("int32"),
         "row_to_batch": Tensor(["num_rows"], dtype="int32", optional=True),
+        "row_starts": Tensor(["num_rows"], dtype="int32", optional=True),
+        "page_table_row_starts": Tensor(["num_rows"], dtype="int32", optional=True),
     },
     outputs={
         "indices": Tensor(["num_rows", "k"], dtype="int32"),

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -1173,10 +1173,11 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKKernel_Unified(
     DType* output_values,    // [num_rows, top_k] - only used in Basic mode, nullptr otherwise
     const IdType*
         aux_data,  // Mode-specific: top_k_arr (Basic), src_page_table (PageTable), offsets (Ragged)
-    IdType* lengths,             // [num_rows] per-row lengths, nullptr for Basic (uses stride)
-    const IdType* row_starts,    // [num_rows] per-row start indices, nullptr => 0
-    const IdType* row_to_batch,  // [num_rows] batch mapping for PageTable, nullptr otherwise
-    int64_t aux_stride,          // src_page_table stride for PageTable mode, 0 otherwise
+    IdType* lengths,                      // [num_rows] lengths, nullptr for Basic
+    const IdType* row_starts,             // [num_rows] score starts, nullptr => 0
+    const IdType* page_table_row_starts,  // [num_rows] page-table starts
+    const IdType* row_to_batch,           // [num_rows] batch mapping for PageTable
+    int64_t aux_stride,                   // src_page_table stride for PageTable
     uint32_t top_k_val, uint32_t stride, uint32_t num_rows, RadixRowState* row_states,
     RadixDeterministicCollectScratch* det_scratches, uint32_t chunk_size, uint32_t ctas_per_group) {
   using Traits = RadixTopKTraits<DType>;
@@ -1219,6 +1220,10 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKKernel_Unified(
     if (row_idx >= num_rows) break;
     const uint32_t row_start =
         (row_starts != nullptr && MODE != RadixTopKMode::Basic) ? row_starts[row_idx] : 0;
+    const uint32_t page_table_row_start =
+        (page_table_row_starts != nullptr && MODE == RadixTopKMode::PageTableTransform)
+            ? page_table_row_starts[row_idx]
+            : row_start;
     DType* row_input = input + static_cast<size_t>(row_idx) * stride + row_start;
 
     // Mode-specific: get row length and k value
@@ -1266,7 +1271,8 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKKernel_Unified(
       const IdType* src_page_entry = aux_data + batch_idx * aux_stride;
       if (length <= top_k_val) {
         for (uint32_t i = tx; i < top_k_val; i += BLOCK_THREADS) {
-          row_output[i] = (i < length) ? src_page_entry[row_start + i] : static_cast<IdType>(-1);
+          row_output[i] =
+              (i < length) ? src_page_entry[page_table_row_start + i] : static_cast<IdType>(-1);
         }
         // Clear histogram for next iteration
         if constexpr (!SINGLE_CTA) {
@@ -1348,7 +1354,7 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKKernel_Unified(
         // Transform through page table with coalesced access
         for (uint32_t i = tx; i < k; i += BLOCK_THREADS) {
           IdType idx = row_output[i];
-          row_output[i] = src_page_entry[row_start + idx];
+          row_output[i] = src_page_entry[page_table_row_start + idx];
         }
       } else {
         // Barrier to ensure all CTAs finished writing indices
@@ -1360,7 +1366,7 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKKernel_Unified(
         uint32_t my_end = min(my_start + elems_per_cta, k);
         for (uint32_t i = my_start + tx; i < my_end; i += BLOCK_THREADS) {
           IdType idx = row_output[i];
-          row_output[i] = src_page_entry[row_start + idx];
+          row_output[i] = src_page_entry[page_table_row_start + idx];
         }
       }
     } else {  // RaggedTransform
@@ -1920,7 +1926,9 @@ cudaError_t RadixTopKRenormProbMultiCTA(DType* probs, DType* renormed_prob, IdTy
  * \param src_stride Stride of source page table (typically max_len)
  * \param row_to_batch Mapping from row index to batch index [num_rows], or nullptr if 1:1
  * \param lengths Sequence lengths per row [num_rows]
- * \param row_starts Start indices per row [num_rows], or nullptr to use 0
+ * \param row_starts Score start indices per row [num_rows], or nullptr to use 0
+ * \param page_table_row_starts Page-table start indices per row [num_rows], or nullptr to use
+ * row_starts
  * \param num_rows Number of rows to process
  * \param top_k_val Number of top elements to select
  * \param max_len Maximum sequence length (input stride)
@@ -1928,13 +1936,11 @@ cudaError_t RadixTopKRenormProbMultiCTA(DType* probs, DType* renormed_prob, IdTy
  * \param stream CUDA stream
  */
 template <typename DType, typename IdType>
-cudaError_t RadixTopKPageTableTransformMultiCTA(DType* input, IdType* output_page_table,
-                                                const IdType* src_page_table, int64_t src_stride,
-                                                const IdType* row_to_batch, IdType* lengths,
-                                                const IdType* row_starts, uint32_t num_rows,
-                                                uint32_t top_k_val, uint32_t max_len,
-                                                RadixRowState* row_states_buffer,
-                                                bool deterministic, cudaStream_t stream = 0) {
+cudaError_t RadixTopKPageTableTransformMultiCTA(
+    DType* input, IdType* output_page_table, const IdType* src_page_table, int64_t src_stride,
+    const IdType* row_to_batch, IdType* lengths, const IdType* row_starts, uint32_t num_rows,
+    uint32_t top_k_val, uint32_t max_len, RadixRowState* row_states_buffer, bool deterministic,
+    cudaStream_t stream = 0, const IdType* page_table_row_starts = nullptr) {
   using OrderedType = typename RadixTopKTraits<DType>::OrderedType;
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = (row_starts != nullptr) ? 1 : std::gcd(16 / sizeof(DType), max_len);
@@ -1980,12 +1986,14 @@ cudaError_t RadixTopKPageTableTransformMultiCTA(DType* input, IdType* output_pag
 
   // Unified kernel parameters
   DType* output_values = nullptr;  // Not used in PageTableTransform mode
+  const IdType* page_starts = page_table_row_starts;
   dim3 nblks(total_ctas);
   dim3 nthrs(BLOCK_THREADS);
   void* args[] = {
-      &input,      &output_page_table, &output_values,      &src_page_table, &lengths,
-      &row_starts, &row_to_batch,      &src_stride,         &top_k_val,      &max_len,
-      &num_rows,   &row_states_buffer, &det_scratch_buffer, &chunk_size,     &ctas_per_group};
+      &input,         &output_page_table, &output_values,     &src_page_table,     &lengths,
+      &row_starts,    &page_starts,       &row_to_batch,      &src_stride,         &top_k_val,
+      &max_len,       &num_rows,          &row_states_buffer, &det_scratch_buffer, &chunk_size,
+      &ctas_per_group};
 
 #define LAUNCH_PAGE_TABLE_KERNEL(THREADS, SINGLE_CTA_FLAG, DET_FLAG)                              \
   do {                                                                                            \
@@ -2085,14 +2093,27 @@ cudaError_t RadixTopKRaggedTransformMultiCTA(DType* input, IdType* output_indice
 
   // Unified kernel parameters
   DType* output_values = nullptr;        // Not used in RaggedTransform mode
+  const IdType* page_starts = nullptr;   // Not used in RaggedTransform mode
   const IdType* row_to_batch = nullptr;  // Not used in RaggedTransform mode
   int64_t aux_stride = 0;                // Not used in RaggedTransform mode
   dim3 nblks(total_ctas);
   dim3 nthrs(BLOCK_THREADS);
-  void* args[] = {
-      &input,      &output_indices,    &output_values,      &offsets,    &lengths,
-      &row_starts, &row_to_batch,      &aux_stride,         &top_k_val,  &max_len,
-      &num_rows,   &row_states_buffer, &det_scratch_buffer, &chunk_size, &ctas_per_group};
+  void* args[] = {&input,
+                  &output_indices,
+                  &output_values,
+                  &offsets,
+                  &lengths,
+                  &row_starts,
+                  &page_starts,
+                  &row_to_batch,
+                  &aux_stride,
+                  &top_k_val,
+                  &max_len,
+                  &num_rows,
+                  &row_states_buffer,
+                  &det_scratch_buffer,
+                  &chunk_size,
+                  &ctas_per_group};
 
 #define LAUNCH_RAGGED_KERNEL(THREADS, SINGLE_CTA_FLAG, DET_FLAG)                                  \
   do {                                                                                            \
@@ -2194,14 +2215,16 @@ cudaError_t RadixTopKMultiCTA(DType* input, IdType* output_indices, DType* outpu
   // Unified kernel parameters
   IdType* lengths = nullptr;             // Not used in Basic mode
   const IdType* row_starts = nullptr;    // Not used in Basic mode
+  const IdType* page_starts = nullptr;   // Not used in Basic mode
   const IdType* row_to_batch = nullptr;  // Not used in Basic mode
   int64_t aux_stride = 0;                // Not used in Basic mode
   dim3 nblks(total_ctas);
   dim3 nthrs(BLOCK_THREADS);
   void* args[] = {
-      &input,      &output_indices,    &output_values,      &top_k_arr,  &lengths,
-      &row_starts, &row_to_batch,      &aux_stride,         &top_k_val,  &vocab_size,
-      &batch_size, &row_states_buffer, &det_scratch_buffer, &chunk_size, &ctas_per_group};
+      &input,         &output_indices, &output_values,     &top_k_arr,          &lengths,
+      &row_starts,    &page_starts,    &row_to_batch,      &aux_stride,         &top_k_val,
+      &vocab_size,    &batch_size,     &row_states_buffer, &det_scratch_buffer, &chunk_size,
+      &ctas_per_group};
 
 #define LAUNCH_BASIC_KERNEL(THREADS, SINGLE_CTA_FLAG, DET_FLAG)                                   \
   do {                                                                                            \
@@ -2335,8 +2358,9 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
                               int64_t aux_stride,                       // src_stride for PageTable
                               const IdType* __restrict__ row_to_batch,  // for PageTable
                               const IdType* __restrict__ lengths,
-                              const IdType* __restrict__ row_starts,  // per-row score start
-                              uint32_t num_rows, uint32_t top_k, uint32_t max_len) {
+                              const IdType* __restrict__ row_starts,
+                              const IdType* __restrict__ page_table_row_starts, uint32_t num_rows,
+                              uint32_t top_k, uint32_t max_len) {
   constexpr uint32_t BLOCK_SIZE = FILTERED_TOPK_BLOCK_THREADS;
   constexpr int RADIX = 256;
   constexpr int SMEM_INPUT_SIZE = FILTERED_TOPK_SMEM_INPUT_SIZE;
@@ -2350,6 +2374,10 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
   const int length = (lengths != nullptr) ? lengths[bid] : static_cast<int>(max_len);
   const IdType row_start =
       (row_starts != nullptr && MODE != FilteredTopKMode::Plain) ? row_starts[bid] : 0;
+  const IdType page_table_row_start =
+      (page_table_row_starts != nullptr && MODE == FilteredTopKMode::PageTable)
+          ? page_table_row_starts[bid]
+          : row_start;
   const DType* score = input + static_cast<size_t>(bid) * max_len + row_start;
   IdType* dst = output + bid * top_k;
 
@@ -2382,7 +2410,7 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
         // In deterministic mode the page-table/ragged transform happens in SortTopKByIndexKernel
         dst[i] = (i < length) ? static_cast<IdType>(i) : static_cast<IdType>(-1);
       } else if constexpr (MODE == FilteredTopKMode::PageTable) {
-        dst[i] = (i < length) ? src_page_entry[row_start + i] : static_cast<IdType>(-1);
+        dst[i] = (i < length) ? src_page_entry[page_table_row_start + i] : static_cast<IdType>(-1);
       } else {  // Ragged
         dst[i] = (i < length) ? static_cast<IdType>(i) + offset_val : static_cast<IdType>(-1);
       }
@@ -2874,7 +2902,7 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
     } else if constexpr (DETERMINISTIC) {  // transform in SortTopKByIndexKernel
       dst[base] = static_cast<IdType>(idx);
     } else if constexpr (MODE == FilteredTopKMode::PageTable) {
-      dst[base] = src_page_entry[row_start + idx];
+      dst[base] = src_page_entry[page_table_row_start + idx];
     } else {  // Ragged
       dst[base] = static_cast<IdType>(idx) + offset_val;
     }
@@ -2921,8 +2949,8 @@ template <FilteredTopKMode MODE, uint32_t BLOCK_THREADS, uint32_t ITEMS_PER_THRE
           typename IdType>
 __global__ void __launch_bounds__(BLOCK_THREADS)
     SortTopKByIndexKernel(IdType* output_indices, DType* output_values, const IdType* aux_input,
-                          int64_t aux_stride, const IdType* row_starts, const IdType* row_to_batch,
-                          uint32_t top_k, uint32_t max_len) {
+                          int64_t aux_stride, const IdType* page_table_row_starts,
+                          const IdType* row_to_batch, uint32_t top_k, uint32_t max_len) {
   constexpr bool WITH_VALUES = (MODE == FilteredTopKMode::Plain);
   using BlockRadixSortT = typename SortTopKByIndexBlockRadixSort<WITH_VALUES, BLOCK_THREADS,
                                                                  ITEMS_PER_THREAD, DType>::Type;
@@ -2961,11 +2989,11 @@ __global__ void __launch_bounds__(BLOCK_THREADS)
 
   const IdType* src_page_entry = nullptr;
   IdType offset = 0;
-  IdType row_start = 0;
+  IdType page_table_row_start = 0;
   if constexpr (MODE == FilteredTopKMode::PageTable) {
     const uint32_t batch_idx = (row_to_batch != nullptr) ? row_to_batch[row] : row;
     src_page_entry = aux_input + static_cast<int64_t>(batch_idx) * aux_stride;
-    row_start = (row_starts != nullptr) ? row_starts[row] : 0;
+    page_table_row_start = (page_table_row_starts != nullptr) ? page_table_row_starts[row] : 0;
   } else if constexpr (MODE == FilteredTopKMode::Ragged) {
     offset = aux_input[row];
   }
@@ -2979,7 +3007,8 @@ __global__ void __launch_bounds__(BLOCK_THREADS)
         row_output[pos] = static_cast<IdType>(idx);
         output_values[static_cast<size_t>(row) * top_k + pos] = values[i];
       } else if constexpr (MODE == FilteredTopKMode::PageTable) {
-        row_output[pos] = (idx != ~0u) ? src_page_entry[row_start + idx] : static_cast<IdType>(-1);
+        row_output[pos] =
+            (idx != ~0u) ? src_page_entry[page_table_row_start + idx] : static_cast<IdType>(-1);
       } else {  // Ragged
         row_output[pos] =
             (idx != ~0u) ? static_cast<IdType>(idx) + offset : static_cast<IdType>(-1);
@@ -2991,7 +3020,7 @@ __global__ void __launch_bounds__(BLOCK_THREADS)
 template <FilteredTopKMode MODE, typename DType, typename IdType>
 cudaError_t LaunchSortTopKByIndex(IdType* output_indices, DType* output_values,
                                   const IdType* aux_input, int64_t aux_stride,
-                                  const IdType* row_starts, const IdType* row_to_batch,
+                                  const IdType* page_table_row_starts, const IdType* row_to_batch,
                                   uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
                                   cudaStream_t stream = 0) {
   // Block-local sort variants cover at most 256 * 8 = 2048 elements.
@@ -3008,8 +3037,8 @@ cudaError_t LaunchSortTopKByIndex(IdType* output_indices, DType* output_values,
   }
 
   dim3 grid(num_rows);
-  void* args[] = {&output_indices, &output_values, &aux_input, &aux_stride,
-                  &row_starts,     &row_to_batch,  &top_k_val, &max_len};
+  void* args[] = {&output_indices,        &output_values, &aux_input, &aux_stride,
+                  &page_table_row_starts, &row_to_batch,  &top_k_val, &max_len};
   auto launch_sort = [&](auto kernel, uint32_t threads) -> cudaError_t {
     dim3 block(threads);
     return cudaLaunchKernel((void*)kernel, grid, block, args, 0, stream);
@@ -3123,8 +3152,8 @@ template <FilteredTopKMode MODE, typename DType, typename IdType>
 cudaError_t LaunchFilteredTopKUnified(DType* input, IdType* output, DType* aux_output,
                                       const IdType* aux_input, int64_t aux_stride,
                                       const IdType* row_to_batch, const IdType* lengths,
-                                      const IdType* row_starts, uint32_t num_rows,
-                                      uint32_t top_k_val, uint32_t max_len,
+                                      const IdType* row_starts, const IdType* page_table_row_starts,
+                                      uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
                                       bool deterministic = false,
                                       TopKTieBreak tie_break = TopKTieBreak::None,
                                       cudaStream_t stream = 0, bool dsa_graph_safe = false) {
@@ -3133,8 +3162,10 @@ cudaError_t LaunchFilteredTopKUnified(DType* input, IdType* output, DType* aux_o
 
   dim3 grid(num_rows);
   dim3 block(FILTERED_TOPK_BLOCK_THREADS);
-  void* args[] = {&input,   &output,     &aux_output, &aux_input, &aux_stride, &row_to_batch,
-                  &lengths, &row_starts, &num_rows,   &top_k_val, &max_len};
+  void* args[] = {&input,     &output,     &aux_output,
+                  &aux_input, &aux_stride, &row_to_batch,
+                  &lengths,   &row_starts, &page_table_row_starts,
+                  &num_rows,  &top_k_val,  &max_len};
 
   const int vec_size = (row_starts != nullptr && MODE != FilteredTopKMode::Plain)
                            ? 1
@@ -3178,18 +3209,17 @@ cudaError_t LaunchFilteredTopKUnified(DType* input, IdType* output, DType* aux_o
 
 // Launch functions with VEC_SIZE and BLOCK_THREADS dispatch - using unified kernel
 template <typename DType, typename IdType>
-cudaError_t FilteredTopKPageTableTransform(DType* input, IdType* output_page_table,
-                                           const IdType* src_page_table, int64_t src_stride,
-                                           const IdType* row_to_batch, IdType* lengths,
-                                           const IdType* row_starts, uint32_t num_rows,
-                                           uint32_t top_k_val, uint32_t max_len,
-                                           bool deterministic = false,
-                                           TopKTieBreak tie_break = TopKTieBreak::None,
-                                           cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+cudaError_t FilteredTopKPageTableTransform(
+    DType* input, IdType* output_page_table, const IdType* src_page_table, int64_t src_stride,
+    const IdType* row_to_batch, IdType* lengths, const IdType* row_starts, uint32_t num_rows,
+    uint32_t top_k_val, uint32_t max_len, bool deterministic = false,
+    TopKTieBreak tie_break = TopKTieBreak::None, cudaStream_t stream = 0,
+    bool dsa_graph_safe = false, const IdType* page_table_row_starts = nullptr) {
   DType* aux_output = nullptr;  // Not used for PageTable mode
   return LaunchFilteredTopKUnified<FilteredTopKMode::PageTable, DType, IdType>(
       input, output_page_table, aux_output, src_page_table, src_stride, row_to_batch, lengths,
-      row_starts, num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe);
+      row_starts, page_table_row_starts, num_rows, top_k_val, max_len, deterministic, tie_break,
+      stream, dsa_graph_safe);
 }
 
 template <typename DType, typename IdType>
@@ -3199,12 +3229,14 @@ cudaError_t FilteredTopKRaggedTransform(DType* input, IdType* output_indices, co
                                         bool deterministic = false,
                                         TopKTieBreak tie_break = TopKTieBreak::None,
                                         cudaStream_t stream = 0, bool dsa_graph_safe = false) {
-  DType* aux_output = nullptr;           // Not used for Ragged mode
-  int64_t aux_stride = 0;                // Not used for Ragged mode
-  const IdType* row_to_batch = nullptr;  // Not used for Ragged mode
+  DType* aux_output = nullptr;                    // Not used for Ragged mode
+  int64_t aux_stride = 0;                         // Not used for Ragged mode
+  const IdType* page_table_row_starts = nullptr;  // Not used for Ragged mode
+  const IdType* row_to_batch = nullptr;           // Not used for Ragged mode
   return LaunchFilteredTopKUnified<FilteredTopKMode::Ragged, DType, IdType>(
       input, output_indices, aux_output, offsets, aux_stride, row_to_batch, lengths, row_starts,
-      num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe);
+      page_table_row_starts, num_rows, top_k_val, max_len, deterministic, tie_break, stream,
+      dsa_graph_safe);
 }
 
 template <typename DType, typename IdType>
@@ -3213,13 +3245,15 @@ cudaError_t FilteredTopK(DType* input, IdType* output_indices, DType* output_val
                          uint32_t max_len, bool deterministic = false,
                          TopKTieBreak tie_break = TopKTieBreak::None, cudaStream_t stream = 0,
                          bool dsa_graph_safe = false) {
-  const IdType* aux_input = nullptr;     // Not used for Plain mode
-  int64_t aux_stride = 0;                // Not used for Plain mode
-  const IdType* row_starts = nullptr;    // Not used for Plain mode
-  const IdType* row_to_batch = nullptr;  // Not used for Plain mode
+  const IdType* aux_input = nullptr;              // Not used for Plain mode
+  int64_t aux_stride = 0;                         // Not used for Plain mode
+  const IdType* row_starts = nullptr;             // Not used for Plain mode
+  const IdType* page_table_row_starts = nullptr;  // Not used for Plain mode
+  const IdType* row_to_batch = nullptr;           // Not used for Plain mode
   return LaunchFilteredTopKUnified<FilteredTopKMode::Plain, DType, IdType>(
       input, output_indices, output_values, aux_input, aux_stride, row_to_batch, lengths,
-      row_starts, num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe);
+      row_starts, page_table_row_starts, num_rows, top_k_val, max_len, deterministic, tie_break,
+      stream, dsa_graph_safe);
 }
 
 /*!
@@ -3318,14 +3352,15 @@ inline bool ShouldUseFilteredTopK(uint32_t num_rows, uint32_t top_k_val, uint32_
 
 // Dispatch functions with heuristics
 template <typename DType, typename IdType>
-cudaError_t TopKPageTableTransformDispatch(DType* input, IdType* output_page_table,
-                                           const IdType* src_page_table, int64_t src_stride,
-                                           IdType* lengths, const IdType* row_starts,
-                                           const IdType* row_to_batch, uint32_t num_rows,
-                                           uint32_t top_k_val, uint32_t max_len,
-                                           RadixRowState* row_states_buffer, bool deterministic,
-                                           TopKTieBreak tie_break = TopKTieBreak::None,
-                                           cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+cudaError_t TopKPageTableTransformDispatch(
+    DType* input, IdType* output_page_table, const IdType* src_page_table, int64_t src_stride,
+    IdType* lengths, const IdType* row_starts, const IdType* row_to_batch, uint32_t num_rows,
+    uint32_t top_k_val, uint32_t max_len, RadixRowState* row_states_buffer, bool deterministic,
+    TopKTieBreak tie_break = TopKTieBreak::None, cudaStream_t stream = 0,
+    bool dsa_graph_safe = false, const IdType* page_table_row_starts = nullptr) {
+  if (page_table_row_starts == nullptr) {
+    page_table_row_starts = row_starts;
+  }
   const bool require_filtered = dsa_graph_safe || tie_break != TopKTieBreak::None;
   if (tie_break != TopKTieBreak::None) {
     deterministic = true;
@@ -3337,17 +3372,19 @@ cudaError_t TopKPageTableTransformDispatch(DType* input, IdType* output_page_tab
                                    dsa_graph_safe)) {
     FLASHINFER_CUDA_CALL((FilteredTopKPageTableTransform<DType, IdType>(
         input, output_page_table, src_page_table, src_stride, row_to_batch, lengths, row_starts,
-        num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe)));
+        num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe,
+        page_table_row_starts)));
     if (deterministic) {
       FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::PageTable, uint8_t, IdType>(
-          output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride, row_starts,
-          row_to_batch, num_rows, top_k_val, max_len, stream)));
+          output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride,
+          page_table_row_starts, row_to_batch, num_rows, top_k_val, max_len, stream)));
     }
     return cudaSuccess;
   }
   return RadixTopKPageTableTransformMultiCTA<DType, IdType>(
       input, output_page_table, src_page_table, src_stride, row_to_batch, lengths, row_starts,
-      num_rows, top_k_val, max_len, row_states_buffer, deterministic, stream);
+      num_rows, top_k_val, max_len, row_states_buffer, deterministic, stream,
+      page_table_row_starts);
 }
 
 template <typename DType, typename IdType>
@@ -3371,7 +3408,7 @@ cudaError_t TopKRaggedTransformDispatch(DType* input, IdType* output_indices, co
         deterministic, tie_break, stream, dsa_graph_safe)));
     if (deterministic) {
       FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::Ragged, uint8_t, IdType>(
-          output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, row_starts, nullptr, num_rows,
+          output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, nullptr, nullptr, num_rows,
           top_k_val, max_len, stream)));
     }
     return cudaSuccess;

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -1938,9 +1938,9 @@ cudaError_t RadixTopKRenormProbMultiCTA(DType* probs, DType* renormed_prob, IdTy
 template <typename DType, typename IdType>
 cudaError_t RadixTopKPageTableTransformMultiCTA(
     DType* input, IdType* output_page_table, const IdType* src_page_table, int64_t src_stride,
-    const IdType* row_to_batch, IdType* lengths, const IdType* row_starts, uint32_t num_rows,
-    uint32_t top_k_val, uint32_t max_len, RadixRowState* row_states_buffer, bool deterministic,
-    cudaStream_t stream = 0, const IdType* page_table_row_starts = nullptr) {
+    const IdType* row_to_batch, IdType* lengths, const IdType* row_starts,
+    const IdType* page_table_row_starts, uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
+    RadixRowState* row_states_buffer, bool deterministic, cudaStream_t stream = 0) {
   using OrderedType = typename RadixTopKTraits<DType>::OrderedType;
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = (row_starts != nullptr) ? 1 : std::gcd(16 / sizeof(DType), max_len);
@@ -1986,14 +1986,24 @@ cudaError_t RadixTopKPageTableTransformMultiCTA(
 
   // Unified kernel parameters
   DType* output_values = nullptr;  // Not used in PageTableTransform mode
-  const IdType* page_starts = page_table_row_starts;
   dim3 nblks(total_ctas);
   dim3 nthrs(BLOCK_THREADS);
-  void* args[] = {
-      &input,         &output_page_table, &output_values,     &src_page_table,     &lengths,
-      &row_starts,    &page_starts,       &row_to_batch,      &src_stride,         &top_k_val,
-      &max_len,       &num_rows,          &row_states_buffer, &det_scratch_buffer, &chunk_size,
-      &ctas_per_group};
+  void* args[] = {&input,
+                  &output_page_table,
+                  &output_values,
+                  &src_page_table,
+                  &lengths,
+                  &row_starts,
+                  &page_table_row_starts,
+                  &row_to_batch,
+                  &src_stride,
+                  &top_k_val,
+                  &max_len,
+                  &num_rows,
+                  &row_states_buffer,
+                  &det_scratch_buffer,
+                  &chunk_size,
+                  &ctas_per_group};
 
 #define LAUNCH_PAGE_TABLE_KERNEL(THREADS, SINGLE_CTA_FLAG, DET_FLAG)                              \
   do {                                                                                            \
@@ -3211,10 +3221,10 @@ cudaError_t LaunchFilteredTopKUnified(DType* input, IdType* output, DType* aux_o
 template <typename DType, typename IdType>
 cudaError_t FilteredTopKPageTableTransform(
     DType* input, IdType* output_page_table, const IdType* src_page_table, int64_t src_stride,
-    const IdType* row_to_batch, IdType* lengths, const IdType* row_starts, uint32_t num_rows,
-    uint32_t top_k_val, uint32_t max_len, bool deterministic = false,
-    TopKTieBreak tie_break = TopKTieBreak::None, cudaStream_t stream = 0,
-    bool dsa_graph_safe = false, const IdType* page_table_row_starts = nullptr) {
+    const IdType* row_to_batch, IdType* lengths, const IdType* row_starts,
+    const IdType* page_table_row_starts, uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
+    bool deterministic = false, TopKTieBreak tie_break = TopKTieBreak::None,
+    cudaStream_t stream = 0, bool dsa_graph_safe = false) {
   DType* aux_output = nullptr;  // Not used for PageTable mode
   return LaunchFilteredTopKUnified<FilteredTopKMode::PageTable, DType, IdType>(
       input, output_page_table, aux_output, src_page_table, src_stride, row_to_batch, lengths,
@@ -3372,8 +3382,8 @@ cudaError_t TopKPageTableTransformDispatch(
                                    dsa_graph_safe)) {
     FLASHINFER_CUDA_CALL((FilteredTopKPageTableTransform<DType, IdType>(
         input, output_page_table, src_page_table, src_stride, row_to_batch, lengths, row_starts,
-        num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe,
-        page_table_row_starts)));
+        page_table_row_starts, num_rows, top_k_val, max_len, deterministic, tie_break, stream,
+        dsa_graph_safe)));
     if (deterministic) {
       FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::PageTable, uint8_t, IdType>(
           output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride,
@@ -3383,8 +3393,8 @@ cudaError_t TopKPageTableTransformDispatch(
   }
   return RadixTopKPageTableTransformMultiCTA<DType, IdType>(
       input, output_page_table, src_page_table, src_stride, row_to_batch, lengths, row_starts,
-      num_rows, top_k_val, max_len, row_states_buffer, deterministic, stream,
-      page_table_row_starts);
+      page_table_row_starts, num_rows, top_k_val, max_len, row_states_buffer, deterministic,
+      stream);
 }
 
 template <typename DType, typename IdType>

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -415,6 +415,7 @@ def reference_page_table_transform(
     k: int,
     row_to_batch: torch.Tensor = None,
     row_starts: torch.Tensor = None,
+    page_table_row_starts: torch.Tensor = None,
 ) -> torch.Tensor:
     """Reference implementation for page table transform using torch.topk."""
     num_rows = scores.size(0)
@@ -426,19 +427,26 @@ def reference_page_table_transform(
     for i in range(num_rows):
         length = lengths[i].item()
         row_start = row_starts[i].item() if row_starts is not None else 0
+        page_table_row_start = (
+            page_table_row_starts[i].item()
+            if page_table_row_starts is not None
+            else row_start
+        )
         batch_idx = row_to_batch[i].item() if row_to_batch is not None else i
 
         if length <= k:
             # Trivial case: just copy first `length` entries
             output[i, :length] = src_page_table[
-                batch_idx, row_start : row_start + length
+                batch_idx, page_table_row_start : page_table_row_start + length
             ]
         else:
             # Get top-k indices
             row_scores = scores[i, row_start : row_start + length]
             _, topk_indices = torch.topk(row_scores.float(), k)
             # Gather from page table
-            output[i] = src_page_table[batch_idx, row_start + topk_indices.long()]
+            output[i] = src_page_table[
+                batch_idx, page_table_row_start + topk_indices.long()
+            ]
 
     return output
 
@@ -581,6 +589,8 @@ def test_top_k_ragged_transform(num_rows, max_len, k, dtype):
 
 @pytest.mark.parametrize("algo", ["multi_cta", "filtered"])
 @pytest.mark.parametrize("dsa_graph_safe", [False, True])
+@pytest.mark.parametrize("deterministic", [False, True])
+@pytest.mark.parametrize("separate_page_table_row_starts", [False, True])
 @pytest.mark.parametrize(
     "num_rows,max_len,k",
     [
@@ -590,9 +600,16 @@ def test_top_k_ragged_transform(num_rows, max_len, k, dtype):
     ],
 )
 def test_top_k_transform_with_row_starts(
-    algo, dsa_graph_safe, num_rows, max_len, k, set_topk_algo
+    algo,
+    dsa_graph_safe,
+    deterministic,
+    separate_page_table_row_starts,
+    num_rows,
+    max_len,
+    k,
+    set_topk_algo,
 ):
-    """Transform APIs should honor row_starts windowing with local-index semantics."""
+    """Transform APIs should honor independent score and page-table row starts."""
     if (algo == "filtered" or dsa_graph_safe) and not can_implement_filtered_topk():
         pytest.skip("Filtered top-k not supported on this device")
 
@@ -602,17 +619,25 @@ def test_top_k_transform_with_row_starts(
     base = -torch.arange(max_len, device=device, dtype=torch.float32)
     scores = base.unsqueeze(0).repeat(num_rows, 1).contiguous()
 
+    row_ids = torch.arange(num_rows, device=device, dtype=torch.int32)
     max_start = max_len - (k + 1)
     start_stride = max(1, max_start // max(1, num_rows - 1))
-    row_starts = (
-        torch.arange(num_rows, device=device, dtype=torch.int32) * start_stride
-    ).clamp(max=max_start)
+    row_starts = (row_ids * start_stride).clamp(max=max_start)
     max_windows = max_len - row_starts
     lengths = torch.minimum(
         max_windows,
-        k + 1 + (torch.arange(num_rows, device=device, dtype=torch.int32) % 4),
+        k + 1 + (row_ids % 4),
     )
-    offsets = torch.arange(num_rows, device=device, dtype=torch.int32) * 100
+    page_table_row_starts = None
+    if separate_page_table_row_starts:
+        lengths = torch.where(
+            row_ids % 2 == 0,
+            torch.full_like(lengths, k - 1),
+            lengths,
+        )
+        candidate_starts = 7 + 17 * row_ids
+        page_table_row_starts = torch.minimum(candidate_starts, max_len - lengths)
+    offsets = row_ids * 100
     row_to_batch = torch.arange(num_rows - 1, -1, -1, device=device, dtype=torch.int32)
 
     src_page_table = (
@@ -632,7 +657,8 @@ def test_top_k_transform_with_row_starts(
         k,
         row_to_batch=row_to_batch,
         row_starts=row_starts,
-        deterministic=True,
+        page_table_row_starts=page_table_row_starts,
+        deterministic=deterministic,
         dsa_graph_safe=dsa_graph_safe,
     )
     output_ragged = flashinfer.top_k_ragged_transform(
@@ -641,7 +667,7 @@ def test_top_k_transform_with_row_starts(
         lengths,
         k,
         row_starts=row_starts,
-        deterministic=True,
+        deterministic=deterministic,
         dsa_graph_safe=dsa_graph_safe,
     )
     ref_page = reference_page_table_transform(
@@ -651,6 +677,7 @@ def test_top_k_transform_with_row_starts(
         k,
         row_to_batch=row_to_batch,
         row_starts=row_starts,
+        page_table_row_starts=page_table_row_starts,
     )
 
     ref_ragged = reference_ragged_transform(

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -679,13 +679,28 @@ def test_top_k_transform_with_row_starts(
         row_starts=row_starts,
         page_table_row_starts=page_table_row_starts,
     )
+    from flashinfer.trace.templates.sampling import (
+        top_k_page_table_transform_trace,
+    )
+
+    trace_ref_page = top_k_page_table_transform_trace.reference(
+        scores,
+        src_page_table,
+        lengths,
+        k,
+        row_to_batch=row_to_batch,
+        row_starts=row_starts,
+        page_table_row_starts=page_table_row_starts,
+    )
 
     ref_ragged = reference_ragged_transform(
         scores, offsets, lengths, k, row_starts=row_starts
     )
     output_page_sorted, _ = torch.sort(output_page, dim=-1)
     ref_page_sorted, _ = torch.sort(ref_page, dim=-1)
+    trace_ref_page_sorted, _ = torch.sort(trace_ref_page, dim=-1)
     assert torch.equal(output_page_sorted, ref_page_sorted)
+    assert torch.equal(trace_ref_page_sorted, ref_page_sorted)
 
     output_ragged_sorted, _ = torch.sort(output_ragged, dim=-1)
     ref_ragged_sorted, _ = torch.sort(ref_ragged, dim=-1)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

@humansand

SGLang needs `top_k_page_table_transform` to support independent score-window and page-table starts in its fused packed PAGED DSA path:

- `row_starts` identifies the score window used for top-k selection.
- `page_table_row_starts` identifies the page-table window used to translate the selected local indices.

The current FlashInfer API applies `row_starts` to both operations, so it cannot represent this case. SGLang must therefore fall back to the SGL kernel even when `--dsa-topk-backend flashinfer` is selected. That produces correct indices, but it bypasses FlashInfer's deterministic, tie-break, and graph-safe fused top-k behavior for this path.

This PR adds optional `page_table_row_starts` support. When it is omitted, FlashInfer continues to use `row_starts` for both operations, preserving the existing API behavior. The separate start is propagated through the Python and trace APIs, TVM FFI binding, radix and filtered implementations, deterministic post-sort, graph-safe dispatch, and the trivial `length <= k` path.

Once SGLang adopts a FlashInfer release containing this API, it can remove the packed PAGED fallback and use FlashInfer fused top-k with the intended backend semantics. This PR does not change the SGLang call site.

### API Design

For each output row `i`, define:

```text
batch_i       = row_to_batch[i]             if row_to_batch is provided, else i
score_start_i = row_starts[i]               if row_starts is provided, else 0
page_start_i  = page_table_row_starts[i]    if page_table_row_starts is provided,
                else score_start_i
length_i      = lengths[i]
```

Top-k selection produces local offsets `local_idx[i, j]` in `[0, length_i)` by ranking:

```text
input[i, score_start_i + local_idx[i, j]]
```

The page-table transform uses the same local offsets but an independent page-table origin:

```text
output[i, j] = src_page_table[batch_i, page_start_i + local_idx[i, j]]
```

**`page_table_row_starts` affects only the page-table lookup used to produce output values.** It does not change the input score window, the selected local offsets, or the output tensor shape; it only changes which columns of `src_page_table` are gathered into the output.

The argument responsibilities are therefore orthogonal:

- `row_to_batch` selects only the row of `src_page_table`; multiple score rows may map to the same page-table row.
- `row_starts` selects only the score-window origin.
- `page_table_row_starts` selects only the page-table-window origin. It may be provided independently of `row_starts`; when omitted, it reuses `row_starts` for backward compatibility.

If `length_i <= k`, all local offsets `0..length_i-1` are transformed and the remaining output positions are `-1`. Otherwise, exactly `k` local offsets are selected according to the existing deterministic and tie-break semantics.

Each optional mapping/start tensor has shape `(num_rows,)`, dtype `int32`, and resides on the same CUDA device as `input`. Callers must satisfy `0 <= length_i`, `0 <= batch_i < src_page_table.shape[0]`, `0 <= score_start_i`, `score_start_i + length_i <= input.shape[1]`, `0 <= page_start_i`, and `page_start_i + length_i <= src_page_table.shape[1]`.

This selection-plus-gather contract is not specific to SGLang: it represents any packed layout where score storage and lookup-table storage use different origins. Absolute starts are used instead of deltas so the API does not assume a relationship between the two windows or expose framework-specific metadata such as `cu_seqlens`.

## 🔍 Related Issues

- SGLang DSA top-k backend integration: https://github.com/sgl-project/sglang/pull/22851
- SGLang packed PAGED correctness fallback and backend-selection cleanup: https://github.com/sgl-project/sglang/pull/32490

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation on an NVIDIA B200 using the editable source build and source JIT:

```text
pre-commit run --all-files
Passed

python3 -m pytest -vv -s tests/utils/test_topk.py -k 'test_top_k_transform_with_row_starts'
48 passed, 1334 deselected, 2 warnings in 0.61s
```

The test extends the existing `test_top_k_transform_with_row_starts` Cartesian product across radix/filtered dispatch, graph-safe mode, deterministic mode, shared/separate starts, and both trivial and selected rows.

## Reviewer Notes

Review focus is welcome on propagation through the deterministic post-sort and graph-safe filtered paths, where page-table translation occurs separately from score selection.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `page_table_row_starts` support to the fused Top‑K page-table transform for independent per-row destination window offsets.
  * Updated tracing and reference implementations to model separate score-window (`row_starts`) and destination page-table-window (`page_table_row_starts`) offsets.
* **Bug Fixes**
  * Corrected page-table addressing when the score and destination windows start at different offsets.
* **Tests**
  * Expanded Top‑K transform coverage to include deterministic mode and separate `page_table_row_starts`, with additional trace-based reference checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


