### PR TITLE
fix: disable PDL for FP4 MoE kernel to prevent TP deadlock (#4172)

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import functools
 import math
+import os
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -2761,8 +2762,16 @@ def get_trtllm_moe_sm100_module():
                 topk_weights = torch.empty(
                     num_tokens, top_k, dtype=routing_dtype, device=hidden_states.device
                 )
+        # Allow disabling PDL via env var for debugging/workaround
+        _pdl_override = os.environ.get("FLASHINFER_DISABLE_PDL_MOE", "0")
+        if _pdl_override == "1":
+            enable_pdl = False
         if enable_pdl is None:
-            enable_pdl = device_support_pdl(hidden_states.device)
+            # PDL (CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION) can
+            # cause kernel hangs when interprocess CUDA events are recorded on
+            # the same stream. Disable by default for FP4 MoE to avoid
+            # trtllm_fp4_block_scale_moe deadlock under LMCache/vLLM MP mode.
+            enable_pdl = False
         if output is None:
             output = _alloc_trtllm_moe_output(
                 num_tokens, hidden_size, do_finalize, hidden_states.device


### PR DESCRIPTION
Fix for #4172: disable PDL for `trtllm_fp4_block_scale_moe_op` by default.

PDL (`CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION`) on SM100+
can cause the trtllm_fp4_block_scale_moe kernel to hang when interprocess
CUDA events are recorded on the same stream. This is a performance
optimization, not a correctness requirement — disabling it eliminates the
sensitivity at minimal perf cost.

Changes: `flashinfer/fused_moe/core.py` — `trtllm_fp4_block_scale_moe_op`
defaults `enable_pdl` to `False` instead of auto-detecting device support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FP4 block-scale MoE behavior to disable PDL by default when it isn’t explicitly enabled, ensuring consistent results across supported devices.
  * Added an environment-variable override (`FLASHINFER_DISABLE_PDL_MOE=1`) to force-disable PDL regardless of the current configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->