### PR TITLE
docs: add missing trtllm_fp8_per_tensor_scale_routed_moe API entry

### DIFF
--- a/docs/api/fused_moe.rst
+++ b/docs/api/fused_moe.rst
@@ -82,6 +82,7 @@ TensorRT-LLM Fused MoE
     trtllm_fp8_block_scale_moe
     trtllm_fp8_block_scale_routed_moe
     trtllm_fp8_per_tensor_scale_moe
+    trtllm_fp8_per_tensor_scale_routed_moe
     trtllm_mxint4_block_scale_moe
     trtllm_mxint4_block_scale_routed_moe
 


### PR DESCRIPTION
## Summary
- add the missing `trtllm_fp8_per_tensor_scale_routed_moe` entry to `docs/api/fused_moe.rst`
- fix the doc coverage regression reported by the doc checker

## Testing
- not run (docs autosummary list change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the routed FP8 per-tensor scale API to the TensorRT-LLM Fused MoE reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->