### PR TITLE
fix(trtllm): restrict TRT-LLM routed-MoE and GEMM backends to supported architectures

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstring>
 #include <vector>
 
@@ -35,6 +38,65 @@ using namespace batchedGemm::gemm;
 using namespace batchedGemm::trtllm::gen;
 
 static BatchedGemmInterface::ModuleCache globalTrtllmGenBatchedGemmModuleCache;
+
+namespace {
+
+// The trtllm-gen cubin manifest is a downloaded artifact, so which architectures
+// it covers is not knowable at compile time. Encode only the explicit
+// cubin-arch -> SM-version compatibility rules here and let `config.mSm` decide
+// what is available: adding an architecture means adding one enum case, not
+// updating a hardcoded SM allowlist. Unknown cubin families are rejected so a
+// newly shipped one fails loudly instead of being silently dispatched onto
+// hardware that cannot run it (see #4107).
+bool isArchCompatible(int smVersion, tg::CudaArch cubinArch) {
+  switch (cubinArch) {
+    case tg::CudaArch::Sm100a:
+      return smVersion == 100;
+    case tg::CudaArch::Sm100f:
+      return smVersion == 100 || smVersion == 103;
+    case tg::CudaArch::Sm103a:
+      return smVersion == 103;
+    default:
+      return false;
+  }
+}
+
+// SM version of an explicit device, for entry points that take a target
+// device argument. `getSMVersion()` reads the *current* CUDA device, which is
+// not necessarily the device the caller wants to run on. The result is
+// cached per device so the dispatch-path guard does not issue a
+// cudaDeviceGetAttribute call on every run.
+int getSmVersionForDevice(int device) {
+  constexpr int kMaxCachedDevices = 64;
+  // 0 = not queried yet; a real SM version is never 0.
+  static std::array<std::atomic<int>, kMaxCachedDevices> cache{};
+  bool const cacheable = device >= 0 && device < kMaxCachedDevices;
+  if (cacheable) {
+    int const cached = cache[device].load(std::memory_order_relaxed);
+    if (cached != 0) return cached;
+  }
+  int smMajor = 0;
+  int smMinor = 0;
+  CUDACHECK(cudaDeviceGetAttribute(&smMajor, cudaDevAttrComputeCapabilityMajor, device));
+  CUDACHECK(cudaDeviceGetAttribute(&smMinor, cudaDevAttrComputeCapabilityMinor, device));
+  int const sm = smMajor * 10 + smMinor;
+  if (cacheable) cache[device].store(sm, std::memory_order_relaxed);
+  return sm;
+}
+
+void checkPassingConfigIndex(std::vector<int64_t> const& passingConfigIndices,
+                             int32_t configIndex) {
+  auto const it = std::find(passingConfigIndices.begin(), passingConfigIndices.end(), configIndex);
+  if (it == passingConfigIndices.end()) {
+    std::ostringstream msg;
+    msg << "Config index " << configIndex
+        << " is not in this runner's compatible config set (device architecture or GEMM options "
+           "mismatch)";
+    FLASHINFER_ERROR(msg.str());
+  }
+}
+
+}  // namespace
 
 std::vector<int64_t> prioritizePredefinedConfigs(
     int m, int n, int k, std::vector<int64_t> const& sortedIndices,
@@ -144,13 +206,9 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
       if ((int64_t)options.mEltwiseActType != (int64_t)mOptions.eltwiseActType) {
         continue;
       }
+      if (!isArchCompatible(sm_version, config.mSm)) continue;
       // if patchF2fp is enabled, sm100f cubins cannot be used for sm103
-      if (options.mPatchF2fp && sm_version == 103) {
-        if (config.mSm != tg::CudaArch::Sm103a) continue;
-      }
-      if (options.mPatchF2fp && sm_version == 100) {
-        if (config.mSm != tg::CudaArch::Sm100a && config.mSm != tg::CudaArch::Sm100f) continue;
-      }
+      if (options.mPatchF2fp && sm_version == 103 && config.mSm != tg::CudaArch::Sm103a) continue;
       if (mOptions.transposeMmaOutput && options.mEpilogueTileM == mOptions.epilogueTileM) {
         // Skip cubins with clusterZ > 1 due to correctness issues described in
         // https://github.com/flashinfer-ai/flashinfer/issues/3197
@@ -158,6 +216,24 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
         mPassingConfigIndices.push_back(i);
       }
     }
+  }
+
+  if (mPassingConfigIndices.empty()) {
+    // Distinguish "this GPU has no compatible cubins at all" from "no cubin
+    // matches these GEMM options". The former is the common failure on
+    // unsupported hardware, and the option dump below would send users looking
+    // in entirely the wrong place.
+    bool anyArchCompatible = false;
+    for (size_t i = 0; i < bmm.getNumBatchedGemmConfigs(); ++i) {
+      if (isArchCompatible(sm_version, configs[i].mSm)) {
+        anyArchCompatible = true;
+        break;
+      }
+    }
+    std::ostringstream arch_msg;
+    arch_msg << "The trtllm-gen batched GEMM cubin manifest contains no kernels runnable on sm"
+             << sm_version << "; this backend currently supports sm100 and sm103 only.";
+    FLASHINFER_CHECK(anyArchCompatible, arch_msg.str());
   }
 
   std::ostringstream error_msg;
@@ -183,6 +259,7 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
 size_t TrtllmGenBatchedGemmRunner::getWorkspaceSizeInBytes(
     int32_t m, int32_t n, int32_t k, std::vector<int32_t> const& batchedTokens, int32_t numTokens,
     int32_t numBatches, int32_t maxNumCtasInBatchDim, int32_t configIndex) const {
+  checkPassingConfigIndex(mPassingConfigIndices, configIndex);
   BatchedGemmData gemmData{};
   gemmData.mProblemDimensions.mNumBatches = numBatches;
   gemmData.mProblemDimensions.mNumTokens = numTokens;
@@ -226,9 +303,25 @@ void TrtllmGenBatchedGemmRunner::run(
   BatchedGemmData gemmData{};
 
   auto const configs = bmm.getBatchedGemmConfigs();
+  auto const numConfigs = bmm.getNumBatchedGemmConfigs();
 
+  FLASHINFER_CHECK(
+      configIndex >= 0 && static_cast<size_t>(configIndex) < static_cast<size_t>(numConfigs),
+      "Config index ", configIndex, " is out of range; the manifest has ", numConfigs, " configs");
+  checkPassingConfigIndex(mPassingConfigIndices, configIndex);
   auto const& config = configs[configIndex];
   // printf("running config %d: %s\n", configIndex, config.mFunctionName);
+
+  // mPassingConfigIndices was filtered against the device that was current
+  // when this runner was constructed, but run() takes an explicit target
+  // device. Re-check the selected cubin against that device so a
+  // construction-time/dispatch-time device mismatch fails loudly here instead
+  // of aborting inside the kernel launch.
+  int const deviceSm = getSmVersionForDevice(device);
+  FLASHINFER_CHECK(isArchCompatible(deviceSm, config.mSm),
+                   "The selected trtllm-gen batched GEMM cubin cannot run on target device ",
+                   device, " (sm", deviceSm,
+                   "); this runner's config set was filtered for a different device architecture.");
 
   FLASHINFER_CHECK(numBatches > 0, "Batched GEMM requires numBatches > 0");
   if (!mOptions.staticBatch) {

--- a/csrc/trtllm_gemm_runner.cu
+++ b/csrc/trtllm_gemm_runner.cu
@@ -16,6 +16,9 @@
 
 #include <cuda.h>
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <string>
 
 #include "flashinfer/exception.h"
@@ -32,6 +35,54 @@ static thread_local gemm::gemm::GemmInterface::ModuleCache globalTrtllmGenGemmMo
 }  // namespace
 
 namespace flashinfer {
+
+namespace {
+
+// The trtllm-gen cubin manifest is a downloaded artifact, so which architectures
+// it covers is not knowable at compile time. Encode only the explicit
+// cubin-arch -> SM-version compatibility rules here and let `config.mSm` decide
+// what is available: adding an architecture means adding one enum case, not
+// updating a hardcoded SM allowlist. Unknown cubin families are rejected so a
+// newly shipped one fails loudly instead of being silently dispatched onto
+// hardware that cannot run it (see #4107).
+bool isArchCompatible(int smVersion, gemm::trtllm::gen::CudaArch cubinArch) {
+  using CudaArch = gemm::trtllm::gen::CudaArch;
+  switch (cubinArch) {
+    case CudaArch::Sm100a:
+      return smVersion == 100;
+    case CudaArch::Sm100f:
+      return smVersion == 100 || smVersion == 103;
+    case CudaArch::Sm103a:
+      return smVersion == 103;
+    default:
+      return false;
+  }
+}
+
+// SM version of an explicit device, for entry points that take a target
+// device argument. `getSMVersion()` reads the *current* CUDA device, which is
+// not necessarily the device the caller wants to run on. The result is
+// cached per device so the dispatch-path guard does not issue a
+// cudaDeviceGetAttribute call on every run.
+int getSmVersionForDevice(int device) {
+  constexpr int kMaxCachedDevices = 64;
+  // 0 = not queried yet; a real SM version is never 0.
+  static std::array<std::atomic<int>, kMaxCachedDevices> cache{};
+  bool const cacheable = device >= 0 && device < kMaxCachedDevices;
+  if (cacheable) {
+    int const cached = cache[device].load(std::memory_order_relaxed);
+    if (cached != 0) return cached;
+  }
+  int smMajor = 0;
+  int smMinor = 0;
+  CUDACHECK(cudaDeviceGetAttribute(&smMajor, cudaDevAttrComputeCapabilityMajor, device));
+  CUDACHECK(cudaDeviceGetAttribute(&smMinor, cudaDevAttrComputeCapabilityMinor, device));
+  int const sm = smMajor * 10 + smMinor;
+  if (cacheable) cache[device].store(sm, std::memory_order_relaxed);
+  return sm;
+}
+
+}  // namespace
 
 struct TrtllmGenGemmRunnerOptions {
   gemm::trtllm::gen::Dtype eltType;
@@ -93,6 +144,7 @@ class TrtllmGenGemmRunner {
     auto const configs = gemm.getGemmConfigs();
 
     mPassingConfigIndices.clear();
+    int const sm_version = getSMVersion();
 
     for (size_t i = 0; i < gemm.getNumGemmConfigs(); ++i) {
       auto const options = configs[i].mOptions;
@@ -101,8 +153,27 @@ class TrtllmGenGemmRunner {
           options.mTransposeMmaOutput == mOptions.transposeMmaOutput &&
           options.mSfLayoutB == mOptions.sfLayoutB &&
           options.mLayoutA == mOptions.layoutA) {  // FIXME(siyuanf): expose matrix layout to user
+        if (!isArchCompatible(sm_version, configs[i].mSm)) continue;
         mPassingConfigIndices.push_back(i);
       }
+    }
+
+    if (mPassingConfigIndices.empty()) {
+      // Distinguish "this GPU has no compatible cubins at all" from "no cubin
+      // matches these GEMM options". The former is the common failure on
+      // unsupported hardware, and the option dump below would send users
+      // looking in entirely the wrong place.
+      bool anyArchCompatible = false;
+      for (size_t i = 0; i < gemm.getNumGemmConfigs(); ++i) {
+        if (isArchCompatible(sm_version, configs[i].mSm)) {
+          anyArchCompatible = true;
+          break;
+        }
+      }
+      std::ostringstream arch_msg;
+      arch_msg << "The trtllm-gen GEMM cubin manifest contains no kernels runnable on sm"
+               << sm_version << "; this backend currently supports sm100 and sm103 only.";
+      FLASHINFER_CHECK(anyArchCompatible, arch_msg.str());
     }
 
     FLASHINFER_CHECK(mPassingConfigIndices.size() > 0,
@@ -113,11 +184,23 @@ class TrtllmGenGemmRunner {
                      "mSfLayoutB: ", gemm::trtllm::gen::sfLayoutToString(mOptions.sfLayoutB));
   }
 
+  // Reject tactics outside the filtered config set (e.g. cached or
+  // user-supplied indices for a different device architecture) instead of
+  // silently dispatching a cubin the current GPU cannot run.
+  void checkPassingConfigIndex(int64_t tactic) const {
+    auto const it = std::find(mPassingConfigIndices.begin(), mPassingConfigIndices.end(), tactic);
+    TVM_FFI_ICHECK(it != mPassingConfigIndices.end())
+        << "Tactic " << tactic
+        << " is not in this runner's compatible config set (device architecture or GEMM options "
+           "mismatch)";
+  }
+
   int64_t getWorkspaceSizeInBytes(int64_t m, int64_t n, int64_t k, int64_t tactic) {
     auto gemm = gemm::gemm::GemmInterface();
     auto const configs = gemm.getGemmConfigs();
     FLASHINFER_CHECK(tactic >= 0 && tactic < gemm.getNumGemmConfigs(),
                      "Invalid tactic in getWorkspaceSizeInBytes");
+    checkPassingConfigIndex(tactic);
     auto const config = configs[tactic];
 
     gemm::gemm::GemmData gemmData;
@@ -139,8 +222,20 @@ class TrtllmGenGemmRunner {
     auto gemm = gemm::gemm::GemmInterface();
     auto const configs = gemm.getGemmConfigs();
     TVM_FFI_ICHECK(tactic >= 0 && tactic < gemm.getNumGemmConfigs()) << "Invalid tactic id in run";
+    checkPassingConfigIndex(tactic);
     auto const& config = configs[tactic];
     TVM_FFI_ICHECK(config.mOptions.mSfLayoutB == mOptions.sfLayoutB) << "Invalid sf layout in run";
+
+    // mPassingConfigIndices was filtered against the device that was current
+    // when this runner was constructed, but run() takes an explicit target
+    // device. Re-check the selected cubin against that device so a
+    // construction-time/dispatch-time device mismatch fails loudly here
+    // instead of aborting inside the kernel launch.
+    int const deviceSm = getSmVersionForDevice(device_index);
+    TVM_FFI_ICHECK(isArchCompatible(deviceSm, config.mSm))
+        << "The selected trtllm-gen GEMM cubin cannot run on target device " << device_index
+        << " (sm" << deviceSm
+        << "); this runner's config set was filtered for a different device architecture.";
 
     gemm::gemm::GemmData gemmData;
     // Dims

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -434,7 +434,10 @@ class TrtllmMxInt4Config:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        return arch >= 100
+        # Rides the same trtllm-gen routed batched-GEMM path as the FP4/BF16
+        # backends, so it inherits the same cubin coverage: claiming an arch
+        # without cubins makes the runner abort at dispatch (#4107).
+        return arch in (100, 103)
 
     def __repr__(self) -> str:
         return "TrtllmMxInt4Config()"

--- a/tests/gemm/test_trtllm_gemm_arch_guard.py
+++ b/tests/gemm/test_trtllm_gemm_arch_guard.py
@@ -1,0 +1,97 @@
+"""Arch/tactic guards of the trtllm-gen GEMM runner (#4107).
+
+Two layers of defense are exercised:
+
+1. On a GPU without compatible cubins the runner constructor raises an
+   explicit architecture error instead of dumping the GEMM option list.
+2. On a supported GPU, a tactic that is a valid manifest index ("in range")
+   but not in the runner's passing config set is rejected before any kernel
+   work. ``trtllm_gemm`` reaches ``getWorkspaceSizeInBytes()`` first, so that
+   is the guard observed here; ``run()`` performs the same membership check
+   at entry for callers that reach it directly.
+"""
+
+import pytest
+import torch
+
+from flashinfer.tllm_enums import DtypeTrtllmGen
+
+M, N, K = 128, 256, 512
+
+
+def _arch():
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor
+
+
+def _load_op():
+    from flashinfer.jit.gemm.core import gen_trtllm_gen_gemm_module
+
+    return gen_trtllm_gen_gemm_module().build_and_load()
+
+
+def test_trtllm_gemm_arch_error_on_unsupported_sm():
+    """Constructing any trtllm-gen GEMM runner on an unsupported GPU must
+    raise the explicit arch error, not the GEMM option dump."""
+    arch = _arch()
+    if arch in (100, 103):
+        pytest.skip("needs a GPU without trtllm-gen cubins (e.g. sm90/sm120)")
+
+    op = _load_op()
+    with pytest.raises(Exception, match="contains no kernels runnable on sm"):
+        op.trtllm_gemm_tactics(
+            M, N, K, int(DtypeTrtllmGen.E4m3), int(DtypeTrtllmGen.Bfloat16), True
+        )
+
+
+def test_trtllm_gemm_rejects_in_range_tactic_outside_config_set():
+    """A manifest index that belongs to a different runner configuration must
+    be rejected by the tactic-membership guard, not silently dispatched."""
+    arch = _arch()
+    # Explicit device-arch gate: skip only on hardware that is not sm100/103.
+    # On sm100/103 this test must run and must not skip.
+    if arch not in (100, 103):
+        pytest.skip(f"requires an sm100/sm103 GPU, detected sm{arch}")
+
+    op = _load_op()
+    fp8_tactics = set(
+        op.trtllm_gemm_tactics(
+            M, N, K, int(DtypeTrtllmGen.E4m3), int(DtypeTrtllmGen.Bfloat16), False
+        )
+    )
+    fp4_tactics = list(
+        op.trtllm_gemm_tactics(
+            M, N, K, int(DtypeTrtllmGen.E2m1), int(DtypeTrtllmGen.Bfloat16), True
+        )
+    )
+    foreign = [t for t in fp4_tactics if t not in fp8_tactics]
+    # On supported hardware this test must not skip: the E2m1 and E4m3 cubin
+    # families are disjoint in the manifest, so a foreign tactic must exist.
+    assert foreign, (
+        "expected at least one E2m1 tactic outside the E4m3 set; "
+        f"E4m3={sorted(fp8_tactics)} E2m1={sorted(fp4_tactics)}"
+    )
+
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+    b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+    a_scale = torch.ones(1, device="cuda", dtype=torch.float32)
+    b_scale = torch.ones(1, device="cuda", dtype=torch.float32)
+    out = torch.zeros(M, N, device="cuda", dtype=torch.bfloat16)
+    workspace = torch.empty(4 * 1024 * 1024, device="cuda", dtype=torch.int8)
+
+    with pytest.raises(Exception, match="not in this runner's compatible config set"):
+        op.trtllm_gemm(
+            int(DtypeTrtllmGen.E4m3),
+            int(DtypeTrtllmGen.Bfloat16),
+            workspace,
+            a,
+            b,
+            a_scale,
+            b_scale,
+            None,
+            out,
+            False,
+            int(foreign[0]),
+        )

--- a/tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py
+++ b/tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py
@@ -26,6 +26,14 @@ from __future__ import annotations
 
 import pytest
 
+from flashinfer.fused_moe.api import (
+    TrtllmBf16Config,
+    TrtllmFp4Config,
+    TrtllmFp8BlockConfig,
+    TrtllmFp8PerTensorConfig,
+    TrtllmMxInt4Config,
+)
+
 NUM_EXPERTS = 16
 TOP_K = 4
 NUM_TOKENS = 64
@@ -33,13 +41,16 @@ HIDDEN = 2048
 INTERMEDIATE = 1024
 
 
-def _require_blackwell():
+def _require_backend(config_cls):
     import torch
 
     if not torch.cuda.is_available():
         pytest.skip("needs CUDA")
-    if torch.cuda.get_device_capability()[0] < 10:
-        pytest.skip("trtllm-gen fused_moe requires SM100+")
+
+    major, minor = torch.cuda.get_device_capability()
+    arch = major * 10 + minor
+    if not config_cls.supported(arch):
+        pytest.skip(f"{config_cls.__name__} is not supported on sm{arch}")
 
 
 def _make_problem():
@@ -155,7 +166,7 @@ def _fp4_quant_dequant(t_2d_bf16):
 @pytest.mark.arch_blackwell
 def test_split_bf16_kernel_matches_torch_reference():
     """``trtllm_bf16_routed`` (all experts local) matches the fp32 torch oracle."""
-    _require_blackwell()
+    _require_backend(TrtllmBf16Config)
 
     import torch
 
@@ -202,7 +213,7 @@ def test_split_bf16_kernel_matches_torch_reference():
 @pytest.mark.arch_blackwell
 def test_split_nvfp4_kernel_matches_torch_reference():
     """``trtllm_fp4_routed`` (all experts local) matches the dequant torch oracle."""
-    _require_blackwell()
+    _require_backend(TrtllmFp4Config)
 
     import torch
 
@@ -265,3 +276,54 @@ def test_split_nvfp4_kernel_matches_torch_reference():
     # at the gemm1→gemm2 round-trip dominate; 51/131072 cells past 5e-2).
     torch.testing.assert_close(yk, yr, rtol=5e-2, atol=0.15)
     assert rel_l2.item() < 0.05
+
+
+@pytest.mark.parametrize(
+    ("arch", "expected"),
+    [
+        (90, False),
+        (100, True),
+        (103, True),
+        (107, False),
+        (110, False),
+        (120, False),
+        (121, False),
+    ],
+)
+@pytest.mark.parametrize(
+    "config_cls",
+    [
+        TrtllmBf16Config,
+        TrtllmFp4Config,
+        TrtllmFp8BlockConfig,
+        TrtllmFp8PerTensorConfig,
+        TrtllmMxInt4Config,
+    ],
+)
+def test_trtllm_routed_moe_supported_architectures(config_cls, arch, expected):
+    """CPU-only: lock down the backend support contract.
+
+    The trtllm-gen cubin manifest currently ships kernels for sm100/sm103 only
+    (sm107 support from #4122 was reverted by #4171); a backend claiming any
+    other arch makes the batched-GEMM runner abort at dispatch (#4107).
+    """
+    assert config_cls.supported(arch) is expected
+
+
+def test_no_trtllm_routed_backend_claims_unsupported_arch():
+    """Regression guard for #4107: no trtllm-gen routed backend may claim
+    sm107/sm110/sm120/sm121.
+
+    The batched-GEMM runner has no cubins there and aborts during construction,
+    so a backend that reports itself supported turns a fallback into a hard
+    failure.
+    """
+    from flashinfer.fused_moe.api import _DEFAULT_BACKEND
+
+    for arch in (107, 110, 120, 121):
+        claimed = [
+            type(c).__name__
+            for c in _DEFAULT_BACKEND
+            if type(c).__name__.startswith("Trtllm") and type(c).supported(arch)
+        ]
+        assert claimed == [], f"trtllm backends wrongly claim sm{arch}: {claimed}"


### PR DESCRIPTION
### What this PR does

The trtllm-gen GEMM runners selected cubins without checking that the cubin
architecture can actually run on the current device:

- `TrtllmGenBatchedGemmRunner` only applied an arch filter when `mPatchF2fp`
  was set, so on unsupported GPUs (e.g. SM120/SM121) sm100f cubins were
  selected and aborted at dispatch (#4107).
- `TrtllmGenGemmRunner` had no `config.mSm` filter at all.

Changes:

1. Both runners filter configs through an explicit
   `isArchCompatible(smVersion, config.mSm)` rule set
   (`Sm100a -> sm100`, `Sm100f -> sm100/sm103`, `Sm103a -> sm103`,
   anything unknown -> rejected). Adding a future arch is one enum case, not a
   hardcoded SM allowlist edit.
2. When a GPU has no compatible cubins at all, the constructor raises an
   explicit architecture error instead of the GEMM-options dump.
3. The tactic/configIndex passed to `getWorkspaceSizeInBytes()` and `run()` is
   validated against the filtered config set, so cached or user-supplied
   indices for a different configuration fail with a clear error.
4. `run()` additionally re-checks the selected cubin against the SM of the
   explicit target `device` argument, so a construction-time/dispatch-time
   device mismatch fails loudly at dispatch rather than inside the kernel
   launch. The per-device SM version is cached (static atomic array), so this
   guard performs no driver query on the dispatch path after first use.
   (The construction-time filter still uses the device current at
   construction; deriving the passing set per target device would require
   runner-cache/API changes and is left to a follow-up.)
5. `TrtllmMxInt4Config.supported()` is tightened from `arch >= 100` to
   `(100, 103)`, matching the other trtllm routed-MoE backends. The pinned
   BMM manifest ships MxInt4 kernels exclusively as `sm100f` (runs on
   sm100/sm103), so the narrowed claim matches actual cubin coverage.
6. Tests: backend `supported()` contract tests (CPU), a negative-path test for
   the explicit arch error on GPUs without compatible cubins, and a direct
   rejection test for a manifest-valid tactic outside the runner's config set
   (requires SM100/SM103 to construct the runner; on other GPUs it skips via
   an explicit device-arch check).

Rebased onto current `main` (includes #4180, which touches the same
batched-runner filter loop and updates the BMM artifact pin, and #4237/#4130;
no conflicts).

Fixes #4107

### Validation

- JIT builds of `gen_trtllm_gen_fused_moe_sm100_module` and
  `gen_trtllm_gen_gemm_module` from source at the new BMM pin.
- On an SM90 GPU, both runners now raise the explicit architecture error
  (previously: option dump / abort at dispatch).
- `tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py` and
  `tests/gemm/test_trtllm_gemm_arch_guard.py` pass on SM90 (SM100-only cases
  skip); the SM100/SM103 positive paths require Blackwell hardware I don't
  have access to — they are intended to run in this repo's CI when it is
  triggered on this PR.

### Notes for reviewers

- The CodeRabbit finding that config filtering derives the SM from the device
  current at construction rather than the tensor's target device is only
  partially addressed here (item 4 makes the mismatch fail loudly at
  dispatch). A full fix needs the passing set keyed per target device
  (public struct + runner-cache changes) and is proposed as a follow-up issue.
