### PR TITLE
feat(mla): support packed low-head and variable-Q decode

### DIFF
--- a/flashinfer/cute_dsl/attention/mla_dispatch.py
+++ b/flashinfer/cute_dsl/attention/mla_dispatch.py
@@ -10,7 +10,9 @@ controlled by the ``cute_dsl_impl`` kwarg, with three valid values:
 * ``"auto"`` (default) — library picks the right implementation.
   Monolithic by default, automatically promoted to modular when the call
   uses a feature monolithic doesn't support (currently: ``sinks``).
-* ``"modular"`` — strict.  Always run the modular implementation.
+  Compact variable Q is selected through the monolithic implementation.
+* ``"modular"`` — strict.  Always run the modular implementation; reject
+  monolithic-only features such as compact variable Q.
 * ``"monolithic"`` — strict.  Always run the monolithic implementation;
   raise :class:`ValueError` if the call uses any modular-only feature.
   No silent fallback — the contract is "you asked for monolithic, you
@@ -45,12 +47,21 @@ _logged_impls: set[str] = set()
 # Add new entries here as more variants are exposed through the standalone
 # signature.
 MODULAR_ONLY_KWARGS = ("sinks",)
+MONOLITHIC_ONLY_KWARGS = ("cum_seq_lens_q", "max_q_len")
 
 
 def _has_modular_only_feature(kwargs: dict) -> Optional[str]:
     """Return the name of the first modular-only kwarg present (and non-None),
     or None if no modular-only feature was requested."""
     for name in MODULAR_ONLY_KWARGS:
+        if kwargs.get(name) is not None:
+            return name
+    return None
+
+
+def _has_monolithic_only_feature(kwargs: dict) -> Optional[str]:
+    """Return the first requested feature implemented only by monolithic."""
+    for name in MONOLITHIC_ONLY_KWARGS:
         if kwargs.get(name) is not None:
             return name
     return None
@@ -68,9 +79,21 @@ def _resolve_impl(*, requested: str, kwargs: dict) -> str:
         )
 
     needs_modular = _has_modular_only_feature(kwargs)
+    needs_monolithic = _has_monolithic_only_feature(kwargs)
+
+    if needs_modular is not None and needs_monolithic is not None:
+        raise ValueError(
+            "No CuTeDSL MLA implementation supports both "
+            f"{needs_modular!r} (modular-only) and "
+            f"{needs_monolithic!r} (monolithic-only)."
+        )
 
     if requested == "auto":
-        return "modular" if needs_modular is not None else _DEFAULT_IMPL
+        if needs_modular is not None:
+            return "modular"
+        if needs_monolithic is not None:
+            return "monolithic"
+        return _DEFAULT_IMPL
 
     if requested == "monolithic" and needs_modular is not None:
         raise ValueError(
@@ -80,29 +103,36 @@ def _resolve_impl(*, requested: str, kwargs: dict) -> str:
             f"right impl based on the call) or cute_dsl_impl='modular'."
         )
 
+    if requested == "modular" and needs_monolithic is not None:
+        raise ValueError(
+            f"cute_dsl_impl='modular' was requested but the call uses "
+            f"{needs_monolithic!r}, which is only supported by the "
+            "monolithic implementation."
+        )
+
     return requested  # "modular" or "monolithic"
 
 
 def cute_dsl_mla_decode(*args, cute_dsl_impl: str = "auto", **kwargs):
     """Run CuTe DSL MLA decode using the resolved implementation.
 
-    Forwards all positional and keyword arguments verbatim to the underlying
-    implementation. See
+    Forwards positional arguments and supported keyword arguments to the
+    resolved implementation. See
     :func:`flashinfer.cute_dsl.attention.wrappers.batch_mla.cute_dsl_mla_decode`
     (modular, supports ``sinks=``) and
     :func:`flashinfer.cute_dsl.attention.monolithic.mla_decode.cute_dsl_mla_decode`
-    (monolithic, no variant support) — their signatures are otherwise
-    identical.
+    (monolithic, supports compact variable Q) — their common fixed-Q
+    signatures are otherwise identical.
 
     Parameters
     ----------
     cute_dsl_impl : str, default ``"auto"``
         ``"auto"`` (default) lets the dispatcher pick: monolithic by
         default, modular when the call uses a modular-only feature
-        (currently ``sinks``).  ``"modular"`` and ``"monolithic"`` are
-        strict — the dispatcher will not silently switch implementations,
-        and ``"monolithic"`` raises :class:`ValueError` if the call uses
-        a modular-only feature.
+        (currently ``sinks``), and monolithic for compact variable Q.
+        ``"modular"`` and ``"monolithic"`` are strict — the dispatcher
+        will not silently switch implementations, and each raises
+        :class:`ValueError` for features exclusive to the other.
     """
     impl = _resolve_impl(requested=cute_dsl_impl, kwargs=kwargs)
 
@@ -122,5 +152,8 @@ def cute_dsl_mla_decode(*args, cute_dsl_impl: str = "auto", **kwargs):
         kwargs = {k: v for k, v in kwargs.items() if k not in MODULAR_ONLY_KWARGS}
         from .monolithic.mla_decode import cute_dsl_mla_decode as _impl
     else:
+        # Symmetrically strip inactive monolithic-only kwargs after the strict
+        # resolver has established that none requests a feature.
+        kwargs = {k: v for k, v in kwargs.items() if k not in MONOLITHIC_ONLY_KWARGS}
         from .wrappers.batch_mla import cute_dsl_mla_decode as _impl
     return _impl(*args, **kwargs)

--- a/flashinfer/cute_dsl/attention/mla_dispatch.py
+++ b/flashinfer/cute_dsl/attention/mla_dispatch.py
@@ -10,9 +10,9 @@ controlled by the ``cute_dsl_impl`` kwarg, with three valid values:
 * ``"auto"`` (default) — library picks the right implementation.
   Monolithic by default, automatically promoted to modular when the call
   uses a feature monolithic doesn't support (currently: ``sinks``).
-  Compact variable Q is selected through the monolithic implementation.
+  Compact variable Q and DCP select the monolithic implementation.
 * ``"modular"`` — strict.  Always run the modular implementation; reject
-  monolithic-only features such as compact variable Q.
+  monolithic-only features such as compact variable Q and DCP.
 * ``"monolithic"`` — strict.  Always run the monolithic implementation;
   raise :class:`ValueError` if the call uses any modular-only feature.
   No silent fallback — the contract is "you asked for monolithic, you
@@ -48,6 +48,12 @@ _logged_impls: set[str] = set()
 # signature.
 MODULAR_ONLY_KWARGS = ("sinks",)
 MONOLITHIC_ONLY_KWARGS = ("cum_seq_lens_q", "max_q_len")
+DCP_KWARGS = (
+    "enable_dcp",
+    "cp_world",
+    "cp_rank",
+    "causal_seqlens_kv_global",
+)
 
 
 def _has_modular_only_feature(kwargs: dict) -> Optional[str]:
@@ -67,6 +73,45 @@ def _has_monolithic_only_feature(kwargs: dict) -> Optional[str]:
     return None
 
 
+def _validate_dcp_kwargs(kwargs: dict) -> bool:
+    """Validate dispatcher-level DCP selection and return whether it is enabled.
+
+    Tensor shape, dtype, and device validation belongs to the monolithic
+    wrapper, which has access to the normalized query batch. The dispatcher
+    only enforces the static feature contract and prevents non-default DCP
+    arguments from being silently ignored.
+    """
+    enable_dcp = kwargs.get("enable_dcp", False)
+    if not isinstance(enable_dcp, bool):
+        raise TypeError(f"enable_dcp must be a bool, got {type(enable_dcp).__name__}")
+
+    cp_world = kwargs.get("cp_world", 1)
+    cp_rank = kwargs.get("cp_rank", 0)
+    causal_seqlens_kv_global = kwargs.get("causal_seqlens_kv_global")
+    if not isinstance(cp_world, int) or isinstance(cp_world, bool) or cp_world <= 0:
+        raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
+    if not isinstance(cp_rank, int) or isinstance(cp_rank, bool):
+        raise TypeError(f"cp_rank must be an integer, got {type(cp_rank).__name__}")
+    if enable_dcp and not 0 <= cp_rank < cp_world:
+        raise ValueError(
+            f"cp_rank must satisfy 0 <= cp_rank < cp_world, got "
+            f"cp_rank={cp_rank}, cp_world={cp_world}"
+        )
+    if not enable_dcp:
+        nondefault = []
+        if cp_world != 1:
+            nondefault.append(f"cp_world={cp_world!r}")
+        if cp_rank != 0:
+            nondefault.append(f"cp_rank={cp_rank!r}")
+        if causal_seqlens_kv_global is not None:
+            nondefault.append("causal_seqlens_kv_global")
+        if nondefault:
+            raise ValueError(
+                "DCP arguments require enable_dcp=True; got " + ", ".join(nondefault)
+            )
+    return enable_dcp
+
+
 def _resolve_impl(*, requested: str, kwargs: dict) -> str:
     """Map a user request and call kwargs to a concrete impl name.
 
@@ -78,6 +123,7 @@ def _resolve_impl(*, requested: str, kwargs: dict) -> str:
             f"Invalid cute_dsl_impl={requested!r}; expected one of {VALID_IMPLS}"
         )
 
+    enable_dcp = _validate_dcp_kwargs(kwargs)
     needs_modular = _has_modular_only_feature(kwargs)
     needs_monolithic = _has_monolithic_only_feature(kwargs)
 
@@ -88,10 +134,19 @@ def _resolve_impl(*, requested: str, kwargs: dict) -> str:
             f"{needs_monolithic!r} (monolithic-only)."
         )
 
+    if enable_dcp and needs_modular is not None:
+        raise ValueError(
+            f"DCP cannot be combined with {needs_modular!r}: DCP requires the "
+            "monolithic CuTeDSL MLA implementation, while the requested feature "
+            "requires the modular implementation."
+        )
+    if enable_dcp and needs_monolithic is not None:
+        raise ValueError("DCP does not support cum_seq_lens_q / max_q_len")
+
     if requested == "auto":
         if needs_modular is not None:
             return "modular"
-        if needs_monolithic is not None:
+        if enable_dcp or needs_monolithic is not None:
             return "monolithic"
         return _DEFAULT_IMPL
 
@@ -101,6 +156,13 @@ def _resolve_impl(*, requested: str, kwargs: dict) -> str:
             f"{needs_modular!r}, which is only supported by the modular "
             f"implementation. Use cute_dsl_impl='auto' (default, picks the "
             f"right impl based on the call) or cute_dsl_impl='modular'."
+        )
+
+    if requested == "modular" and enable_dcp:
+        raise ValueError(
+            "cute_dsl_impl='modular' was requested with enable_dcp=True, but "
+            "DCP is only supported by the monolithic CuTeDSL MLA implementation. "
+            "Use cute_dsl_impl='auto' or cute_dsl_impl='monolithic'."
         )
 
     if requested == "modular" and needs_monolithic is not None:
@@ -121,18 +183,21 @@ def cute_dsl_mla_decode(*args, cute_dsl_impl: str = "auto", **kwargs):
     :func:`flashinfer.cute_dsl.attention.wrappers.batch_mla.cute_dsl_mla_decode`
     (modular, supports ``sinks=``) and
     :func:`flashinfer.cute_dsl.attention.monolithic.mla_decode.cute_dsl_mla_decode`
-    (monolithic, supports compact variable Q) — their common fixed-Q
-    signatures are otherwise identical.
+    (monolithic, supports compact variable Q and static DCP).
+    Implementation-specific keyword
+    arguments are validated before dispatch and stripped only when their
+    default values make them irrelevant to the selected implementation.
 
     Parameters
     ----------
     cute_dsl_impl : str, default ``"auto"``
         ``"auto"`` (default) lets the dispatcher pick: monolithic by
         default, modular when the call uses a modular-only feature
-        (currently ``sinks``), and monolithic for compact variable Q.
-        ``"modular"`` and ``"monolithic"`` are strict — the dispatcher
-        will not silently switch implementations, and each raises
-        :class:`ValueError` for features exclusive to the other.
+        (currently ``sinks``); compact variable Q and DCP require monolithic.
+        ``"modular"`` and
+        ``"monolithic"`` are strict — the dispatcher will not silently switch
+        implementations, and raises :class:`ValueError` for an incompatible
+        feature request.
     """
     impl = _resolve_impl(requested=cute_dsl_impl, kwargs=kwargs)
 
@@ -156,9 +221,14 @@ def cute_dsl_mla_decode(*args, cute_dsl_impl: str = "auto", **kwargs):
 
         return _monolithic_impl(*args, **kwargs)
     else:
-        # Symmetrically strip inactive monolithic-only kwargs after the strict
-        # resolver has established that none requests a feature.
-        kwargs = {k: v for k, v in kwargs.items() if k not in MONOLITHIC_ONLY_KWARGS}
+        # Symmetrically strip inactive monolithic-only and default-valued DCP
+        # kwargs after the strict resolver has established that none requests
+        # a feature.
+        kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in MONOLITHIC_ONLY_KWARGS and k not in DCP_KWARGS
+        }
         from .wrappers.batch_mla import cute_dsl_mla_decode as _modular_impl
 
         return _modular_impl(*args, **kwargs)

--- a/flashinfer/cute_dsl/attention/mla_dispatch.py
+++ b/flashinfer/cute_dsl/attention/mla_dispatch.py
@@ -150,10 +150,15 @@ def cute_dsl_mla_decode(*args, cute_dsl_impl: str = "auto", **kwargs):
         # they're all None when we land here, but the monolithic standalone
         # signature predates these kwargs and would TypeError on them.
         kwargs = {k: v for k, v in kwargs.items() if k not in MODULAR_ONLY_KWARGS}
-        from .monolithic.mla_decode import cute_dsl_mla_decode as _impl
+        from .monolithic.mla_decode import (
+            cute_dsl_mla_decode as _monolithic_impl,
+        )
+
+        return _monolithic_impl(*args, **kwargs)
     else:
         # Symmetrically strip inactive monolithic-only kwargs after the strict
         # resolver has established that none requests a feature.
         kwargs = {k: v for k, v in kwargs.items() if k not in MONOLITHIC_ONLY_KWARGS}
-        from .wrappers.batch_mla import cute_dsl_mla_decode as _impl
-    return _impl(*args, **kwargs)
+        from .wrappers.batch_mla import cute_dsl_mla_decode as _modular_impl
+
+        return _modular_impl(*args, **kwargs)

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
@@ -158,8 +158,19 @@ def _check_can_implement(
     is_persistent: bool,
     is_var_seq: bool,
     is_var_split_kv: bool,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
 ) -> None:
     """Check if the kernel supports the given configuration (cached)."""
+    if not isinstance(enable_dcp, bool):
+        raise TypeError(f"enable_dcp must be a bool, got {type(enable_dcp).__name__}")
+    if not isinstance(cp_world, int) or isinstance(cp_world, bool) or cp_world <= 0:
+        raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
+    if not enable_dcp and cp_world != 1:
+        raise ValueError(
+            f"cp_world={cp_world} requires enable_dcp=True; disabled DCP uses cp_world=1"
+        )
+
     mma_qk_tiler_mn = (128, 128)
     mma_pv_tiler_mn = (128, 256)
 
@@ -214,13 +225,15 @@ def _get_compiled_mla_kernel(
     skip_correction_threshold: float = 0.0,
     is_workspace_size_zero: bool = False,
     enable_pdl: bool = False,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
 ) -> Callable:
     """Compile and cache an MLA decode kernel.
 
     Returns a callable that accepts (q_latent, q_rope, c_latent, c_rope,
     page_table, o, lse, workspace, split_kv_scalar, cache_seqs,
-    cum_seq_lens_q, block_split_kvs, softmax_scale_scalar,
-    output_scale_scalar).
+    cum_seq_lens_q, causal_seqlens_kv_global, cp_rank_scalar,
+    block_split_kvs, softmax_scale_scalar, output_scale_scalar).
 
     All scalar arguments must be pre-wrapped as Int32/Float32.
     """
@@ -259,6 +272,8 @@ def _get_compiled_mla_kernel(
         seq_len_q=seq_len_q,
         reducer_d_tiles=reducer_d_tiles,
         reducer_max_splits=reducer_max_splits,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
     )
 
     # All dimensions as sym_int — this matches the original kernel's use of
@@ -383,6 +398,19 @@ def _get_compiled_mla_kernel(
         )
     else:
         cum_seq_lens_q_fake = None
+
+    # DCP's causal boundary is global while cache_seqs remains the physical
+    # rank-local length used for paging and split-K traversal. Keep the tensor
+    # absent from the disabled specialization so no load or pointer argument
+    # reaches its generated device code.
+    if enable_dcp:
+        causal_seqlens_kv_global_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (sym_batch,),
+            assumed_align=4,
+        )
+    else:
+        causal_seqlens_kv_global_fake = None
     # block_split_kvs: [batch_size] — int32 (only needed for is_var_split_kv=True)
     if is_var_split_kv:
         block_split_kvs_fake = cute.runtime.make_fake_compact_tensor(
@@ -408,6 +436,8 @@ def _get_compiled_mla_kernel(
         Int32(1),  # split_kv placeholder
         cache_seqs_fake,
         cum_seq_lens_q_fake,
+        causal_seqlens_kv_global_fake,
+        Int32(0),  # cp_rank placeholder (runtime-uniform, not a JIT key)
         block_split_kvs_fake,
         Float32(1.0),  # softmax_scale placeholder
         Float32(1.0),  # output_scale placeholder
@@ -438,6 +468,10 @@ def cute_dsl_mla_decode(
     return_lse: bool = False,
     cum_seq_lens_q: Optional[torch.Tensor] = None,
     max_q_len: Optional[int] = None,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
+    cp_rank: int = 0,
+    causal_seqlens_kv_global: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """CuTe DSL MLA decode kernel for Blackwell SM100.
 
@@ -514,6 +548,17 @@ def cute_dsl_mla_decode(
         synchronization and makes the call CUDA-graph-capturable. It must be
         at least the largest request query length; the compiled kernel is
         specialized to this capacity.
+    enable_dcp : bool
+        Enable static cyclic decode context-parallel masking. DCP returns a
+        rank-local attention state and therefore requires ``return_lse=True``.
+    cp_world : int
+        Compile-time context-parallel world size. The local cache owns global
+        token positions ``cp_world * local_k + cp_rank``.
+    cp_rank : int
+        Runtime-uniform context-parallel rank.
+    causal_seqlens_kv_global : Optional[torch.Tensor]
+        Contiguous CUDA int32 tensor ``[B]`` containing the global exclusive
+        causal bound for the newest query token. Required when DCP is enabled.
     Returns
     -------
     torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
@@ -530,6 +575,8 @@ def cute_dsl_mla_decode(
     )
     is_var_q = cum_seq_lens_q is not None
     if is_var_q:
+        if query.ndim != 3:
+            raise ValueError("query must have shape [total_q, num_heads, head_dim_qk]")
         total_q, H, D_qk = query.shape
         B = cum_seq_lens_q.numel() - 1
         if max_q_len is None:
@@ -540,9 +587,75 @@ def cute_dsl_mla_decode(
         q_len = max_q_len
         cum_seq_lens_q = cum_seq_lens_q.contiguous()
     else:
+        if query.ndim != 4:
+            raise ValueError(
+                "query must have shape "
+                "[batch_size, q_len_per_request, num_heads, head_dim_qk]"
+            )
         B, q_len, H, D_qk = query.shape
         total_q = B * q_len
     assert D_qk == kv_lora_rank + qk_rope_head_dim
+
+    if not isinstance(enable_dcp, bool):
+        raise TypeError(f"enable_dcp must be a bool, got {type(enable_dcp).__name__}")
+    if not isinstance(cp_world, int) or isinstance(cp_world, bool) or cp_world <= 0:
+        raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
+    if not isinstance(cp_rank, int) or isinstance(cp_rank, bool):
+        raise TypeError(f"cp_rank must be an integer, got {type(cp_rank).__name__}")
+
+    if enable_dcp:
+        if is_var_q:
+            raise ValueError("DCP does not support cum_seq_lens_q / max_q_len")
+        if not 0 <= cp_rank < cp_world:
+            raise ValueError(
+                f"cp_rank must satisfy 0 <= cp_rank < cp_world, got "
+                f"cp_rank={cp_rank}, cp_world={cp_world}"
+            )
+        if not return_lse:
+            raise ValueError(
+                "enable_dcp=True requires return_lse=True so rank-local states "
+                "can be merged with their LSE values"
+            )
+        if causal_seqlens_kv_global is None:
+            raise ValueError(
+                "causal_seqlens_kv_global is required when enable_dcp=True"
+            )
+        if not isinstance(causal_seqlens_kv_global, torch.Tensor):
+            raise TypeError(
+                "causal_seqlens_kv_global must be a torch.Tensor, got "
+                f"{type(causal_seqlens_kv_global).__name__}"
+            )
+        if causal_seqlens_kv_global.dtype != torch.int32:
+            raise ValueError(
+                "causal_seqlens_kv_global must have dtype torch.int32, got "
+                f"{causal_seqlens_kv_global.dtype}"
+            )
+        if not causal_seqlens_kv_global.is_cuda:
+            raise ValueError("causal_seqlens_kv_global must be a CUDA tensor")
+        if causal_seqlens_kv_global.device != query.device:
+            raise ValueError(
+                "causal_seqlens_kv_global must be on the query device "
+                f"{query.device}, got {causal_seqlens_kv_global.device}"
+            )
+        if tuple(causal_seqlens_kv_global.shape) != (B,):
+            raise ValueError(
+                f"causal_seqlens_kv_global must have shape ({B},), got "
+                f"{tuple(causal_seqlens_kv_global.shape)}"
+            )
+        if not causal_seqlens_kv_global.is_contiguous():
+            raise ValueError("causal_seqlens_kv_global must be contiguous")
+    else:
+        nondefault = []
+        if cp_world != 1:
+            nondefault.append(f"cp_world={cp_world}")
+        if cp_rank != 0:
+            nondefault.append(f"cp_rank={cp_rank}")
+        if causal_seqlens_kv_global is not None:
+            nondefault.append("causal_seqlens_kv_global")
+        if nondefault:
+            raise ValueError(
+                "DCP arguments require enable_dcp=True; got " + ", ".join(nondefault)
+            )
 
     # Each request's Q descriptor flattens (query_token, head) into one affine
     # row mode. Adjacent tokens must therefore follow all H head rows.
@@ -700,6 +813,8 @@ def cute_dsl_mla_decode(
         is_persistent=is_persistent,
         is_var_seq=is_var_seq,
         is_var_split_kv=is_var_split_kv,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
     )
 
     enable_pdl = device_support_pdl(query.device) if enable_pdl is None else enable_pdl
@@ -724,6 +839,8 @@ def cute_dsl_mla_decode(
         skip_correction_threshold=skip_correction_threshold,
         is_workspace_size_zero=is_workspace_size_zero,
         enable_pdl=enable_pdl,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
     )
 
     # Call the kernel
@@ -739,6 +856,8 @@ def cute_dsl_mla_decode(
         Int32(split_kv),
         cache_seqs,
         cum_seq_lens_q,
+        causal_seqlens_kv_global,
+        Int32(cp_rank),
         block_split_kvs,
         Float32(softmax_scale),
         Float32(output_scale),

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
@@ -32,12 +32,67 @@ from flashinfer.utils import device_support_pdl
 
 from .mla_decode_fp16 import BlackwellMultiHeadLatentAttentionForwardFP16
 from .mla_decode_fp8 import BlackwellMultiHeadLatentAttentionForwardFP8
+from .mla_helpers import MAX_SPLITS, ceil_div, compute_q_tile_layout
 from flashinfer.cute_dsl.utils import (
     _as_cute_dsl_workspace_i8,
     get_max_active_clusters,
     get_num_sm,
     torch_to_cutlass_dtype,
 )
+
+
+_CUDA_GRID_Y_MAX = 65_535
+_REDUCER_D_TILE_CANDIDATES = (1, 2, 4)
+_STATIC_REDUCER_MAX_SPLITS = 32
+
+
+def _validate_nonpersistent_grid_y(
+    batch_size: int, num_q_tiles: int, is_persistent: bool
+) -> None:
+    """Reject nonpersistent launch grids whose Y dimension CUDA cannot encode."""
+    grid_y = batch_size * num_q_tiles
+    if not is_persistent and grid_y > _CUDA_GRID_Y_MAX:
+        raise ValueError(
+            "nonpersistent CuTeDSL MLA grid.y would be "
+            f"{grid_y}, exceeding the CUDA limit {_CUDA_GRID_Y_MAX} "
+            f"(batch_size={batch_size}, num_q_tiles={num_q_tiles})"
+        )
+
+
+def _get_reducer_d_tiles(
+    batch_size: int,
+    seq_len_q: int,
+    num_heads: int,
+    num_sms: int,
+    effective_split_kv: int,
+) -> int:
+    """Choose output-side reducer parallelism for an underfilled row grid.
+
+    A reducer CTA normally owns one D512 row.  When the real row grid does not
+    cover one resident wave, compare the conservative wave count for one, two,
+    or four equal D bands and keep the smallest topology with the shortest
+    per-band critical path.  Once rows already cover every SM, retain one CTA
+    per row and avoid duplicated LSE work.
+    """
+    reducer_rows = batch_size * seq_len_q * num_heads
+    if (
+        reducer_rows <= 0
+        or num_sms <= 0
+        or reducer_rows >= num_sms
+        or effective_split_kv <= 1
+    ):
+        return 1
+
+    best_tiles = 1
+    best_waves = ceil_div(reducer_rows, num_sms)
+    for d_tiles in _REDUCER_D_TILE_CANDIDATES[1:]:
+        if d_tiles > effective_split_kv:
+            continue
+        waves = ceil_div(reducer_rows * d_tiles, num_sms)
+        if waves * best_tiles < best_waves * d_tiles:
+            best_tiles = d_tiles
+            best_waves = waves
+    return best_tiles
 
 
 @functools.cache
@@ -47,22 +102,46 @@ def _get_split_kv_and_workspace_size(
     H: int,
     kv_lora_rank: int,
     max_active_blocks: int,
+    max_seq_len: Optional[int] = None,
+    occupancy_q_tiles: Optional[int] = None,
 ) -> Tuple[int, int]:
-    """Cache split_kv and workspace_size since they are deterministic for the same params."""
-    # When folding S_q into heads, the workspace dims are the effective dims
-    # (num_heads * F, q_len // F). get_workspace_size already pads H<128 to
-    # 128, so passing num_heads_eff and seq_len_q_eff yields the right size.
+    """Return the nonempty split count and its workspace requirement.
+
+    The occupancy heuristic can request more splits than the kernel's uniform
+    contiguous partitioning actually uses.  When ``max_seq_len`` is known,
+    normalize the candidate to the number of nonempty fixed-size K chunks so
+    the grid and reducer do not carry an empty final split.
+
+    ``occupancy_q_tiles`` may tighten the occupancy estimate for a compact
+    variable-Q launch. Workspace sizing always retains the full rectangular
+    ``B * ceil(max_q_len * H / 128)`` capacity.
+    """
+    # Flatten (query_token, head) into one contiguous row space.  A cooperative
+    # 2-CTA MMA tile owns 128 consecutive rows and may cross token boundaries;
+    # only the final query tile of each request can be padded.
     mma_qk_tile_m = 128
-    fold_sq_ratio = BlackwellMultiHeadLatentAttentionForwardFP16.compute_fold_sq_ratio(
-        H, q_len, mma_qk_tile_m
+    mma_qk_tile_n = 128
+    _, num_q_tiles, _ = compute_q_tile_layout(H, q_len, mma_qk_tile_m)
+    rectangular_q_tiles = B * num_q_tiles
+    occupancy_q_tiles = (
+        rectangular_q_tiles if occupancy_q_tiles is None else occupancy_q_tiles
     )
-    num_heads_eff = H * fold_sq_ratio
-    seq_len_q_eff = q_len // fold_sq_ratio
+    if occupancy_q_tiles <= 0 or occupancy_q_tiles > rectangular_q_tiles:
+        raise ValueError(
+            "occupancy_q_tiles must be in "
+            f"[1, {rectangular_q_tiles}], got {occupancy_q_tiles}"
+        )
     split_kv = BlackwellMultiHeadLatentAttentionForwardFP16.get_split_kv_simplified(
-        B, seq_len_q_eff, max_active_blocks
+        1, occupancy_q_tiles, max_active_blocks
     )
+    if max_seq_len is not None:
+        if max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be > 0, got {max_seq_len}")
+        k_tile_total = ceil_div(max_seq_len, mma_qk_tile_n)
+        k_tiles_per_split = ceil_div(k_tile_total, split_kv)
+        split_kv = ceil_div(k_tile_total, k_tiles_per_split)
     workspace_size = BlackwellMultiHeadLatentAttentionForwardFP16.get_workspace_size(
-        num_heads_eff, seq_len_q_eff, kv_lora_rank, B, split_kv, cutlass.Float32
+        mma_qk_tile_m, num_q_tiles, kv_lora_rank, B, split_kv, cutlass.Float32
     )
     return split_kv, workspace_size
 
@@ -128,7 +207,10 @@ def _get_compiled_mla_kernel(
     seq_len_q: int,
     is_persistent: bool,
     is_var_seq: bool,
+    is_var_q: bool,
     is_var_split_kv: bool,
+    reducer_d_tiles: int = 1,
+    reducer_max_splits: int = MAX_SPLITS,
     skip_correction_threshold: float = 0.0,
     is_workspace_size_zero: bool = False,
     enable_pdl: bool = False,
@@ -137,7 +219,8 @@ def _get_compiled_mla_kernel(
 
     Returns a callable that accepts (q_latent, q_rope, c_latent, c_rope,
     page_table, o, lse, workspace, split_kv_scalar, cache_seqs,
-    block_split_kvs, softmax_scale_scalar, output_scale_scalar).
+    cum_seq_lens_q, block_split_kvs, softmax_scale_scalar,
+    output_scale_scalar).
 
     All scalar arguments must be pre-wrapped as Int32/Float32.
     """
@@ -157,14 +240,6 @@ def _get_compiled_mla_kernel(
     cutlass_dtype = torch_to_cutlass_dtype(torch_dtype)
     cutlass_out_dtype = torch_to_cutlass_dtype(torch_out_dtype)
 
-    # Derive the seq_len_q-into-heads fold factor.  F > 1 means the kernel
-    # repacks the [H, S_q] tile to [H*F, S_q/F] internally so MTP / spec-decoding
-    # with H < 128 fully populates the 128-wide MMA-M tile.
-    fold_sq_ratio = KernelClass.compute_fold_sq_ratio(
-        num_heads, seq_len_q, mma_qk_tiler_mn[0]
-    )
-    fold_sq = fold_sq_ratio > 1
-
     kernel_obj = KernelClass(
         acc_dtype=cutlass.Float32,
         lse_dtype=cutlass.Float32,
@@ -179,9 +254,11 @@ def _get_compiled_mla_kernel(
         is_var_seq=is_var_seq,
         is_var_split_kv=is_var_split_kv,
         enable_pdl=enable_pdl,
+        is_var_q=is_var_q,
         num_heads=num_heads,
         seq_len_q=seq_len_q,
-        fold_sq=fold_sq,
+        reducer_d_tiles=reducer_d_tiles,
+        reducer_max_splits=reducer_max_splits,
     )
 
     # All dimensions as sym_int — this matches the original kernel's use of
@@ -190,7 +267,6 @@ def _get_compiled_mla_kernel(
     # inside initialize_workspace() since it expects DSL Integer types.
     sym_heads = cute.sym_int()
     sym_latent = cute.sym_int(divisibility=16)
-    sym_seq_q = cute.sym_int()
     sym_rope = cute.sym_int(divisibility=16)
     sym_batch = cute.sym_int()  # query/output batch dimension
     sym_kv_batch = cute.sym_int()  # KV cache batch dim (flat pool, =1 in paged mode)
@@ -204,20 +280,36 @@ def _get_compiled_mla_kernel(
     # Use make_fake_tensor with fully dynamic strides so the compiled kernel
     # reads actual strides from the runtime tensor.  Last-dim stride is always 1.
 
-    # q_latent: [batch_size, seq_len_q, num_heads, latent_dim] — non-contiguous slice
-    q_latent_fake = cute.runtime.make_fake_tensor(
-        cutlass_dtype,
-        (sym_batch, sym_seq_q, sym_heads, sym_latent),
-        stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
-        assumed_align=16,
-    )
-    # q_rope: [batch_size, seq_len_q, num_heads, rope_dim] — non-contiguous slice
-    q_rope_fake = cute.runtime.make_fake_tensor(
-        cutlass_dtype,
-        (sym_batch, sym_seq_q, sym_heads, sym_rope),
-        stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
-        assumed_align=16,
-    )
+    if is_var_q:
+        # Compact variable-Q tensors: [total_q, num_heads, dim].
+        sym_total_q = cute.sym_int()
+        q_latent_fake = cute.runtime.make_fake_tensor(
+            cutlass_dtype,
+            (sym_total_q, sym_heads, sym_latent),
+            stride=(cute.sym_int(), cute.sym_int(), 1),
+            assumed_align=16,
+        )
+        q_rope_fake = cute.runtime.make_fake_tensor(
+            cutlass_dtype,
+            (sym_total_q, sym_heads, sym_rope),
+            stride=(cute.sym_int(), cute.sym_int(), 1),
+            assumed_align=16,
+        )
+    else:
+        # Fixed Q: [batch_size, seq_len_q, num_heads, dim].
+        sym_seq_q = cute.sym_int()
+        q_latent_fake = cute.runtime.make_fake_tensor(
+            cutlass_dtype,
+            (sym_batch, sym_seq_q, sym_heads, sym_latent),
+            stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
+            assumed_align=16,
+        )
+        q_rope_fake = cute.runtime.make_fake_tensor(
+            cutlass_dtype,
+            (sym_batch, sym_seq_q, sym_heads, sym_rope),
+            stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
+            assumed_align=16,
+        )
     # c_latent: [kv_batch, seq_len_k, latent_dim] — non-contiguous slice
     # kv_batch is a separate sym_int from query batch: paged KV cache uses a flat
     # pool so kv_batch=num_pages at runtime, while query batch can be any value.
@@ -241,20 +333,32 @@ def _get_compiled_mla_kernel(
         stride_order=(1, 0),
         assumed_align=16,
     )
-    # o: [batch_size, seq_len_q, num_heads, latent_dim] — contiguous
-    o_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass_out_dtype,
-        (sym_batch, sym_seq_q, sym_heads, sym_latent),
-        stride_order=(3, 2, 1, 0),
-        assumed_align=16,
-    )
-    # lse: [batch_size, seq_len_q, num_heads] — contiguous
-    lse_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass.Float32,
-        (sym_batch, sym_seq_q, sym_heads),
-        stride_order=(2, 1, 0),
-        assumed_align=16,
-    )
+    if is_var_q:
+        o_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass_out_dtype,
+            (sym_total_q, sym_heads, sym_latent),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        lse_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (sym_total_q, sym_heads),
+            stride_order=(1, 0),
+            assumed_align=16,
+        )
+    else:
+        o_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass_out_dtype,
+            (sym_batch, sym_seq_q, sym_heads, sym_latent),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=16,
+        )
+        lse_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (sym_batch, sym_seq_q, sym_heads),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
     if is_workspace_size_zero:
         workspace_fake = None
     else:
@@ -271,6 +375,14 @@ def _get_compiled_mla_kernel(
         (sym_batch,),
         assumed_align=16,
     )
+    if is_var_q:
+        cum_seq_lens_q_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (cute.sym_int(),),
+            assumed_align=16,
+        )
+    else:
+        cum_seq_lens_q_fake = None
     # block_split_kvs: [batch_size] — int32 (only needed for is_var_split_kv=True)
     if is_var_split_kv:
         block_split_kvs_fake = cute.runtime.make_fake_compact_tensor(
@@ -295,6 +407,7 @@ def _get_compiled_mla_kernel(
         workspace_fake,
         Int32(1),  # split_kv placeholder
         cache_seqs_fake,
+        cum_seq_lens_q_fake,
         block_split_kvs_fake,
         Float32(1.0),  # softmax_scale placeholder
         Float32(1.0),  # output_scale placeholder
@@ -323,21 +436,27 @@ def cute_dsl_mla_decode(
     enable_pdl: Optional[bool] = None,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
+    cum_seq_lens_q: Optional[torch.Tensor] = None,
+    max_q_len: Optional[int] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """CuTe DSL MLA decode kernel for Blackwell SM100.
 
     Parameters
     ----------
     query : torch.Tensor
-        [B, q_len, H, D_qk] where D_qk = kv_lora_rank + qk_rope_head_dim
+        Query tensor where ``D_qk = kv_lora_rank + qk_rope_head_dim``.
+        Without ``cum_seq_lens_q``, its shape is ``[B, q_len, H, D_qk]``.
+        With ``cum_seq_lens_q``, query tokens are compacted across requests
+        and its shape is ``[total_q, H, D_qk]``.
     kv_cache : torch.Tensor
         [num_pages, page_size, D_ckv + D_kpe] (3D) or [num_pages, 1, page_size, D_ckv + D_kpe] (4D)
     workspace_buffer : torch.Tensor
         Pre-allocated workspace buffer (int8 or uint8). Required size depends on batch size
         and split_kv (auto-computed from B, q_len, and number of SMs):
 
-        - Formula: ``B * H * q_len * split_kv * (kv_lora_rank + 1) * 4`` bytes
-          (0 when split_kv == 1, which happens when B >= num_SMs / 2)
+        - Formula: ``B * 128 * q_tiles * split_kv * (kv_lora_rank + 1) * 4``
+          bytes, where ``q_tiles = ceil(q_len * H / 128)``
+          (0 when ``split_kv == 1``, typically once ``B * q_tiles >= num_SMs / 2``)
         - Typical max: ~18 MB on a 148-SM GPU (e.g. B=4..8, H=128, D=512)
         - Safe default: 128 MB covers all realistic configurations
     kv_lora_rank : int
@@ -355,7 +474,9 @@ def cute_dsl_mla_decode(
     output_scale : float
         Scale factor applied to the output.
     out : Optional[torch.Tensor]
-        Pre-allocated output tensor [B, q_len, H, kv_lora_rank].
+        Contiguous pre-allocated output tensor. Its shape is
+        ``[B, q_len, H, kv_lora_rank]`` for fixed Q or
+        ``[total_q, H, kv_lora_rank]`` for compact variable Q.
     out_dtype : Optional[torch.dtype]
         Output data type. If None, defaults to torch.bfloat16 (matching trtllm-gen backend).
         Supported values: torch.bfloat16, torch.float8_e4m3fn (FP8 input only),
@@ -373,20 +494,32 @@ def cute_dsl_mla_decode(
 
         * ``[B, q_len, H]`` (native kernel layout, no reshape), or
         * ``[B * q_len, H]`` (matches ``trtllm-gen`` shape; the wrapper
-          reshapes via ``.view`` to the native layout).
+          reshapes via ``.view`` to the native layout), or
+        * ``[total_q, H]`` for compact variable Q.
+
+        Caller-provided buffers must be contiguous.
 
         If ``return_lse`` is True and this is None, a buffer of the native
-        ``[B, q_len, H]`` shape is allocated internally.
+        fixed or compact shape is allocated internally.
     return_lse : bool
         Whether to return LSE values.  When True, the function returns
         ``(out, lse)`` (the ``lse`` tensor returned is in whatever shape
-        the caller supplied; if no ``lse`` was supplied, ``[B, q_len, H]``).
-
+        the caller supplied).
+    cum_seq_lens_q : Optional[torch.Tensor]
+        Device-resident int32 cumulative query lengths with shape
+        ``[B + 1]``. When provided, selects compact variable-Q input and
+        output layouts. Empty requests are allowed.
+    max_q_len : Optional[int]
+        Static launch capacity for variable Q. Supplying it avoids a host
+        synchronization and makes the call CUDA-graph-capturable. It must be
+        at least the largest request query length; the compiled kernel is
+        specialized to this capacity.
     Returns
     -------
     torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
-        Output tensor [B, q_len, H, kv_lora_rank] when ``return_lse=False``;
-        otherwise ``(output, lse)``.
+        Fixed-Q output has shape ``[B, q_len, H, kv_lora_rank]``. Compact
+        variable-Q output has shape ``[total_q, H, kv_lora_rank]``. When
+        ``return_lse=True``, returns ``(output, lse)``.
     """
     supported_dtypes = {torch.float16, torch.bfloat16, torch.float8_e4m3fn}
     assert query.dtype in supported_dtypes, (
@@ -395,8 +528,37 @@ def cute_dsl_mla_decode(
     assert kv_cache.dtype == query.dtype, (
         f"kv_cache dtype {kv_cache.dtype} must match query dtype {query.dtype}"
     )
-    B, q_len, H, D_qk = query.shape
+    is_var_q = cum_seq_lens_q is not None
+    if is_var_q:
+        total_q, H, D_qk = query.shape
+        B = cum_seq_lens_q.numel() - 1
+        if max_q_len is None:
+            q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
+            max_q_len = int(q_lens.max().item())
+        if max_q_len <= 0:
+            raise ValueError("max_q_len must be greater than 0")
+        q_len = max_q_len
+        cum_seq_lens_q = cum_seq_lens_q.contiguous()
+    else:
+        B, q_len, H, D_qk = query.shape
+        total_q = B * q_len
     assert D_qk == kv_lora_rank + qk_rope_head_dim
+
+    # Each request's Q descriptor flattens (query_token, head) into one affine
+    # row mode. Adjacent tokens must therefore follow all H head rows.
+    # Fixed-Q keeps batch as a separate descriptor mode, while compact
+    # variable-Q uses one global token mode.
+    token_stride_ok = query.stride(-3) == H * query.stride(-2)
+    if query.stride(-1) != 1 or not token_stride_ok:
+        query = query.contiguous()
+
+    # O/LSE are compiled with compact layouts. In particular, a token-gapped
+    # view cannot be flattened across an M128 tile boundary and would be
+    # silently written through the gap, so reject noncompact buffers early.
+    if out is not None and not out.is_contiguous():
+        raise ValueError(f"out must be contiguous, got strides {out.stride()}")
+    if lse is not None and not lse.is_contiguous():
+        raise ValueError(f"lse must be contiguous, got strides {lse.stride()}")
 
     q_dtype = query.dtype
     # Resolve output dtype: for FP8 input, default to bfloat16 (matching trtllm-gen backend);
@@ -415,8 +577,9 @@ def cute_dsl_mla_decode(
         kv_cache = kv_cache.squeeze(1)
     page_size = kv_cache.shape[1]
 
-    # Split query into latent and rope components — keep contiguous [B, q_len, H, D].
-    # The kernel's __call__ reinterprets to [H, D, q_len, B] via zero-cost make_tensor.
+    # Split query into latent and rope components. The kernel reinterprets
+    # fixed Q with an explicit batch mode and compact Q with one global
+    # token/head-row mode.
     q_latent_k = query[..., :kv_lora_rank]
     q_rope_k = query[..., kv_lora_rank:]
 
@@ -431,11 +594,30 @@ def cute_dsl_mla_decode(
     if max_seq_len <= 0:
         raise ValueError(f"max_seq_len must be > 0, got {max_seq_len}")
 
-    # Cached split_kv and workspace_size computation
+    _, num_q_tiles, _ = compute_q_tile_layout(H, q_len)
+
+    # Compact storage exposes total_q without reading the device indptr. Since
+    # H <= 128, adding one token can add at most one M128 tile; therefore
+    # min(total_q, rectangular_tiles) is a safe upper bound on active tiles.
+    # Use that tighter bound only for occupancy. The helper still sizes the
+    # workspace for every rectangular scheduler slot.
+    occupancy_q_tiles = (
+        max(1, min(total_q, B * num_q_tiles)) if is_var_q else B * num_q_tiles
+    )
+
     max_active_blocks = get_num_sm(query.device)
     split_kv, workspace_size = _get_split_kv_and_workspace_size(
-        B, q_len, H, kv_lora_rank, max_active_blocks
+        B,
+        q_len,
+        H,
+        kv_lora_rank,
+        max_active_blocks,
+        max_seq_len,
+        occupancy_q_tiles=occupancy_q_tiles,
     )
+
+    is_persistent = not is_var_seq
+    _validate_nonpersistent_grid_y(B, num_q_tiles, is_persistent)
 
     # Prepare workspace: the CUTE signature uses int8, while public FlashInfer
     # workspace buffers are byte storage and may be uint8.
@@ -446,38 +628,58 @@ def cute_dsl_mla_decode(
             f"need {workspace_size} bytes"
         )
     is_workspace_size_zero = workspace_size == 0
+    reducer_d_tiles = (
+        1
+        if is_workspace_size_zero
+        else _get_reducer_d_tiles(
+            # The reducer grid remains rectangular for variable Q, including
+            # inactive request/token slots. Base output slicing on that
+            # physical grid so sparse batches do not multiply empty CTAs.
+            B,
+            q_len,
+            H,
+            max_active_blocks,
+            split_kv,
+        )
+    )
     if is_workspace_size_zero:
         workspace_bytes = None
     else:
         workspace_bytes = workspace_buffer[:workspace_size]
-    # Output buffer: contiguous [B, q_len, H, D].
-    # Kernel reinterprets to [H, D, q_len, B] internally via zero-cost make_tensor.
+    output_shape = (
+        (total_q, H, kv_lora_rank) if is_var_q else (B, q_len, H, kv_lora_rank)
+    )
     if out is not None:
         o_k = out
     else:
-        o_k = torch.empty(
-            (B, q_len, H, kv_lora_rank), dtype=o_dtype, device=query.device
-        )
+        o_k = torch.empty(output_shape, dtype=o_dtype, device=query.device)
 
-    # LSE: contiguous [B, q_len, H]. Kernel reinterprets to [H, q_len, B].
-    # If caller supplied an `lse` buffer in either the native 3D shape or the
-    # 2D trtllm-gen shape [B*q_len, H], reshape to the 3D native layout for
-    # the kernel call.
+    # Fixed Q accepts both public LSE shapes. Compact variable Q has one
+    # natural layout, [total_q, H].
     if lse is not None:
         if lse.dtype != torch.float32:
             raise ValueError(f"lse must be torch.float32, got {lse.dtype}")
-        if lse.shape == (B, q_len, H):
+        if is_var_q:
+            if lse.shape != (total_q, H):
+                raise ValueError(
+                    f"lse must have shape ({total_q}, {H}) for variable Q; "
+                    f"got {tuple(lse.shape)}"
+                )
             lse_k = lse
-        elif lse.shape == (B * q_len, H):
-            # Native kernel layout is 3D; .view is zero-cost when contiguous.
-            lse_k = lse.view(B, q_len, H)
         else:
-            raise ValueError(
-                f"lse must have shape (B, q_len, H)=({B}, {q_len}, {H}) "
-                f"or (B*q_len, H)=({B * q_len}, {H}); got {tuple(lse.shape)}"
-            )
+            if lse.shape == (B, q_len, H):
+                lse_k = lse
+            elif lse.shape == (B * q_len, H):
+                lse_k = lse.view(B, q_len, H)
+            else:
+                raise ValueError(
+                    f"lse must have shape (B, q_len, H)=({B}, {q_len}, {H}) "
+                    f"or (B*q_len, H)=({B * q_len}, {H}); "
+                    f"got {tuple(lse.shape)}"
+                )
     else:
-        lse_k = torch.empty((B, q_len, H), dtype=torch.float32, device=query.device)
+        lse_shape = (total_q, H) if is_var_q else (B, q_len, H)
+        lse_k = torch.empty(lse_shape, dtype=torch.float32, device=query.device)
 
     # cache_seqs: per-batch sequence lengths (skip .to() if already int32)
     cache_seqs = seq_lens if seq_lens.dtype == torch.int32 else seq_lens.to(torch.int32)
@@ -485,9 +687,6 @@ def cute_dsl_mla_decode(
     is_var_split_kv = False
     block_split_kvs = None
     skip_correction_threshold = 0.0
-
-    # for fix-length, set is_persistent to True; otherwise, set to False.
-    is_persistent = not is_var_seq
 
     # Validate configuration (cached, negligible overhead after first call)
     _check_can_implement(
@@ -518,7 +717,10 @@ def cute_dsl_mla_decode(
         seq_len_q=q_len,
         is_persistent=is_persistent,
         is_var_seq=is_var_seq,
+        is_var_q=is_var_q,
         is_var_split_kv=is_var_split_kv,
+        reducer_d_tiles=reducer_d_tiles,
+        reducer_max_splits=_STATIC_REDUCER_MAX_SPLITS,
         skip_correction_threshold=skip_correction_threshold,
         is_workspace_size_zero=is_workspace_size_zero,
         enable_pdl=enable_pdl,
@@ -536,21 +738,15 @@ def cute_dsl_mla_decode(
         workspace_bytes,
         Int32(split_kv),
         cache_seqs,
+        cum_seq_lens_q,
         block_split_kvs,
         Float32(softmax_scale),
         Float32(output_scale),
     )
 
-    # Pick the output to return: caller-provided buffer (already written
-    # in-place) or the freshly allocated o_k.  o_k is [B, q_len, H, D],
-    # matching trtllm-gen output shape.
-    out_tensor = out if out is not None else o_k
-
     if return_lse:
-        # Return the lse tensor in the shape the caller supplied (or 3D when
-        # we allocated it).  When caller passed 2D, lse_k is a .view into
-        # that same memory, so returning the original `lse` keeps the
-        # caller's expected shape.
-        return out_tensor, (lse if lse is not None else lse_k)
+        # Return the lse tensor in the shape the caller supplied. For fixed Q,
+        # a caller's 2D buffer is viewed as 3D internally but shares storage.
+        return o_k, (lse if lse is not None else lse_k)
 
-    return out_tensor
+    return o_k

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -146,6 +146,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         seq_len_q: int = 1,
         reducer_d_tiles: int = 1,
         reducer_max_splits: int = MAX_SPLITS,
+        enable_dcp: bool = False,
+        cp_world: int = 1,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -187,6 +189,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             retain the generic 256-split capacity by default; callers choosing
             a smaller specialization must cap runtime split-KV accordingly.
         :type reducer_max_splits: int
+        :param enable_dcp: Whether to compile the decode-context-parallel
+            global-coordinate causal mask.
+        :type enable_dcp: bool
+        :param cp_world: Number of cyclic context-parallel shards. This is a
+            compile-time parameter when DCP is enabled.
+        :type cp_world: int
         """
 
         self.latent_dim = 512
@@ -218,6 +226,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         # specializations use it as the request length; variable-query
         # specializations obtain each request's actual length from its indptr.
         # Both flatten (query token, head) into the same physical M128 mode.
+        if cp_world < 1:
+            raise ValueError(f"cp_world must be positive, got {cp_world}")
+        if not enable_dcp and cp_world != 1:
+            raise ValueError(
+                f"cp_world must be 1 when DCP is disabled, got cp_world={cp_world}"
+            )
+        self.enable_dcp = enable_dcp
+        self.cp_world = cp_world
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
         (
@@ -333,6 +349,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         split_kv: cutlass.Int32,
         cache_seqs: Optional[cute.Tensor],
         cum_seq_lens_q: Optional[cute.Tensor],
+        causal_seqlens_kv_global: Optional[cute.Tensor],
+        cp_rank: cutlass.Int32,
         block_split_kvs: Optional[cute.Tensor],
         softmax_scale: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -379,6 +397,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :param cum_seq_lens_q: Query indptr with shape [batch_size + 1] for
             compact variable-Q tensors; unused for fixed Q.
         :type cum_seq_lens_q: cute.Tensor
+        :param causal_seqlens_kv_global: Global exclusive causal KV bound for
+            the newest query on each batch item. Present only for DCP kernels.
+        :type causal_seqlens_kv_global: cute.Tensor
+        :param cp_rank: Runtime context-parallel rank.
+        :type cp_rank: cutlass.Int32
         :param block_split_kvs: The block split KV tensor with shape [batch_size]
         :type block_split_kvs: cute.Tensor
         :param softmax_scale: The scale factor for softmax
@@ -849,6 +872,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             split_kv,
             cache_seqs,
             cum_seq_lens_q,
+            causal_seqlens_kv_global,
+            cp_rank,
             block_split_kvs,
             softmax_scale_log2,
             output_scale,
@@ -955,6 +980,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
         cum_seq_lens_q: Optional[cute.Tensor],
+        causal_seqlens_kv_global: Optional[cute.Tensor],
+        cp_rank: cutlass.Int32,
         block_split_kvs: cute.Tensor,
         softmax_scale_log2: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -1019,6 +1046,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :type split_kv: cutlass.Int32
         :param cache_seqs: The variable sequence length tensor
         :type cache_seqs: cute.Tensor
+        :param causal_seqlens_kv_global: Per-batch global exclusive causal KV
+            bound for the newest query, present only when DCP is enabled.
+        :type causal_seqlens_kv_global: cute.Tensor
+        :param cp_rank: Runtime context-parallel rank.
+        :type cp_rank: cutlass.Int32
         :param block_split_kvs: The per-block split_kv values tensor
         :type block_split_kvs: cute.Tensor
         :param softmax_scale_log2: The log2 scale factor for softmax
@@ -1435,6 +1467,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     blk_coord,
                 )
                 if k_tile_count > 0:
+                    causal_global = cutlass.Int32(0)
+                    if cutlass.const_expr(self.enable_dcp):
+                        causal_global = causal_seqlens_kv_global[blk_coord[2]]
                     compute_common_params = SimpleNamespace(
                         blk_coord=blk_coord,
                         split_kv=split_kv,
@@ -1444,6 +1479,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
                         q_len=q_len,
+                        causal_global=causal_global,
+                        cp_rank=cp_rank,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -1501,7 +1538,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     k_tile_count,
                     local_split_kv,
                     q_begin,
-                    _,
+                    q_len,
                     valid_q_rows,
                 ) = self.get_k_tile_count(
                     split_kv,
@@ -1511,6 +1548,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     blk_coord,
                 )
                 if k_tile_count > 0:
+                    causal_global = cutlass.Int32(0)
+                    if cutlass.const_expr(self.enable_dcp):
+                        causal_global = causal_seqlens_kv_global[blk_coord[2]]
                     compute_common_params = SimpleNamespace(
                         blk_coord=blk_coord,
                         split_kv=split_kv,
@@ -1520,6 +1560,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
                         q_begin=q_begin,
+                        q_len=q_len,
+                        causal_global=causal_global,
+                        cp_rank=cp_rank,
+                        split_start_key=k_index * self.mma_qk_tiler[1],
                         L=mCL.shape[1],
                         H=valid_q_rows,
                         tmem_ptr=tmem_ptr,
@@ -1541,10 +1585,65 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         p_cor_consumer_state=p_cor_consumer_state,
                         mma_o_consumer_state=mma_o_consumer_state,
                     )
+                elif cutlass.const_expr(self.enable_dcp):
+                    self.store_empty_dcp_work(
+                        mO,
+                        mLSE,
+                        mAccO,
+                        mAccLSE,
+                        blk_coord,
+                        self.get_valid_q_rows(blk_coord[1]),
+                        tidx,
+                    )
                 tile_sched.advance_to_next_work()
                 work_tile = tile_sched.get_current_work()
 
         return
+
+    @cute.jit
+    def store_empty_dcp_work(
+        self,
+        mO: Optional[cute.Tensor],
+        mLSE: Optional[cute.Tensor],
+        mAccO: Optional[cute.Tensor],
+        mAccLSE: Optional[cute.Tensor],
+        blk_coord: cute.Coord,
+        valid_q_rows: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        """Materialize the neutral attention state for a split with no K tile."""
+        cta_m_rows = self.mma_qk_tiler[0] // self.cluster_shape_mnk[0]
+        compute_threads = self.num_compute_warps * self.threads_per_warp
+        local_tidx = tidx % compute_threads
+        cta_row_base = blk_coord[0] * cta_m_rows
+
+        for linear_idx in cutlass.range(
+            local_tidx, cta_m_rows * self.latent_dim, compute_threads
+        ):
+            cta_row = linear_idx // self.latent_dim
+            d_idx = linear_idx % self.latent_dim
+            q_row = cta_row_base + cta_row
+            if cute.elem_less(q_row, valid_q_rows):
+                if cutlass.const_expr(mAccO is None):
+                    mO[q_row, d_idx, blk_coord[1], blk_coord[2]] = self.o_dtype(0.0)
+                else:
+                    mAccO[
+                        q_row,
+                        blk_coord[3],
+                        d_idx,
+                        blk_coord[1],
+                        blk_coord[2],
+                    ] = self.acc_dtype(0.0)
+
+        if cute.elem_less(local_tidx, cta_m_rows):
+            q_row = cta_row_base + local_tidx
+            if cute.elem_less(q_row, valid_q_rows):
+                if cutlass.const_expr(mAccLSE is None):
+                    mLSE[q_row, blk_coord[1], blk_coord[2]] = -self.lse_dtype.inf
+                else:
+                    mAccLSE[
+                        q_row, blk_coord[3], blk_coord[1], blk_coord[2]
+                    ] = -self.lse_dtype.inf
 
     @cute.jit
     def get_valid_q_rows(self, q_tile_idx: cutlass.Int32) -> cutlass.Int32:
@@ -1622,8 +1721,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             if cutlass.const_expr(self.is_var_split_kv):
                 local_split_kv = block_split_kvs[bidz]
             k_tile_total = cute.ceil_div(cache_seqs[bidz], self.mma_qk_tiler[1])
-            k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
-            local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
+            if cutlass.const_expr(self.enable_dcp):
+                k_tile_per_cta = cutlass.max(
+                    cute.ceil_div(k_tile_total, local_split_kv), cutlass.Int32(1)
+                )
+                local_split_kv = cutlass.max(
+                    cute.ceil_div(k_tile_total, k_tile_per_cta), cutlass.Int32(1)
+                )
+            else:
+                k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
+                local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
             gLSE = mAccLSE[q_tile_row, None, q_tile, bidz]
             warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -1646,16 +1753,27 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     )
                     lse_max = cute.arch.fmax(lse_max, local_lse[i])
                 lse_max = cute.arch.warp_reduction_max(lse_max)
-                lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
+                if cutlass.const_expr(self.enable_dcp):
+                    has_valid_lse = lse_max != -self.lse_dtype.inf
+                    lse_max = lse_max if has_valid_lse else 0.0
+                else:
+                    lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
                 sum_lse = 0.0
                 for i in cutlass.range_constexpr(lse_per_thread):
                     sum_lse += cute.math.exp2(local_lse[i] - lse_max, fastmath=True)
                 sum_lse = cute.arch.warp_reduction_sum(sum_lse)
-                global_lse = (
-                    lse_max + cute.math.log2(sum_lse, fastmath=True)
-                    if sum_lse != self.lse_dtype(0.0) or sum_lse != sum_lse
-                    else self.lse_dtype.inf
-                )
+                if cutlass.const_expr(self.enable_dcp):
+                    global_lse = (
+                        lse_max + cute.math.log2(sum_lse, fastmath=True)
+                        if has_valid_lse
+                        else -self.lse_dtype.inf
+                    )
+                else:
+                    global_lse = (
+                        lse_max + cute.math.log2(sum_lse, fastmath=True)
+                        if sum_lse != self.lse_dtype(0.0) or sum_lse != sum_lse
+                        else self.lse_dtype.inf
+                    )
                 if d_tile_idx == 0:
                     if tidx == 0:
                         # Convert the internal log2 value to natural log.
@@ -1666,9 +1784,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 for i in cutlass.range_constexpr(lse_per_thread):
                     split_kv_idx = tidx + i * self.threads_per_warp
                     if cute.elem_less(split_kv_idx, local_split_kv):
-                        smem_lse_scale[split_kv_idx] = cute.math.exp2(
-                            local_lse[i] - global_lse, fastmath=True
-                        )
+                        if cutlass.const_expr(self.enable_dcp):
+                            smem_lse_scale[split_kv_idx] = (
+                                cute.math.exp2(local_lse[i] - global_lse, fastmath=True)
+                                if has_valid_lse
+                                else self.acc_dtype(0.0)
+                            )
+                        else:
+                            smem_lse_scale[split_kv_idx] = cute.math.exp2(
+                                local_lse[i] - global_lse, fastmath=True
+                            )
 
             pipeline.sync(barrier_id=4)
 
@@ -2673,10 +2798,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             first_q_token = (
                 common_params.blk_coord[1] * self.mma_qk_tiler[0]
             ) // self.num_heads
-        first_mask_tile_idx = cutlass.max(
-            (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
-            cutlass.Int32(0),
-        )
+        if cutlass.const_expr(self.enable_dcp):
+            # The earliest token in this full M128 query tile determines the
+            # dense-prefix boundary shared by both CTAs.  Keep the physical
+            # local K bound separate so a partial final local tile is never
+            # misclassified as dense.
+            earliest_bound_numer = (
+                common_params.causal_global
+                - common_params.cp_rank
+                - (common_params.q_len - 1)
+                + first_q_token
+            )
+            earliest_local_bound = cute.ceil_div(
+                cutlass.max(earliest_bound_numer, cutlass.Int32(0)),
+                self.cp_world,
+            )
+            effective_local_bound = cutlass.min(common_params.K, earliest_local_bound)
+            first_mask_tile_idx = effective_local_bound // tile_n
+        else:
+            first_mask_tile_idx = cutlass.max(
+                (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
+                cutlass.Int32(0),
+            )
 
         # Phase 1: pure unmasked bulk tiles (all columns strictly < min k_bound).
         while k_tile_count > 1 and k_index < first_mask_tile_idx:
@@ -2975,14 +3118,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         + tTR_tS[i][0]
                     )
                     key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    mask_threshold = self.num_heads * (
-                        key_pos - common_params.K + common_params.q_len
-                    )
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if not cute.elem_less(flat_q_row, mask_threshold)
-                        else self.acc_dtype(-1.0e6)
-                    )
+                    if cutlass.const_expr(self.enable_dcp):
+                        mask_threshold = self.num_heads * (
+                            self.cp_world * key_pos
+                            + common_params.cp_rank
+                            - common_params.causal_global
+                            + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(key_pos, common_params.K)
+                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
+                    else:
+                        mask_threshold = self.num_heads * (
+                            key_pos - common_params.K + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
             # reduction for row_max
             row_max_new = tTR_rAcc.load().reduce(cute.ReductionOp.MAX, row_max_new, 0)
 
@@ -3016,14 +3173,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         + tTR_tS[i][0]
                     )
                     key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    mask_threshold = self.num_heads * (
-                        key_pos - common_params.K + common_params.q_len
-                    )
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if not cute.elem_less(flat_q_row, mask_threshold)
-                        else self.acc_dtype(-1.0e6)
-                    )
+                    if cutlass.const_expr(self.enable_dcp):
+                        mask_threshold = self.num_heads * (
+                            self.cp_world * key_pos
+                            + common_params.cp_rank
+                            - common_params.causal_global
+                            + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(key_pos, common_params.K)
+                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
+                    else:
+                        mask_threshold = self.num_heads * (
+                            key_pos - common_params.K + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
                 # reduction for row_max after manual masking
                 row_max_new = tTR_rAcc.load().reduce(
                     cute.ReductionOp.MAX, row_max_new, 0
@@ -3471,15 +3642,44 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             # load o
             cute.copy(tmem_load_tiled_copy, tTR_tAcc, tTR_rAcc)
 
-            # apply output scale and normalize by row_sum
-            for i in cutlass.range(
-                cute.size(tTR_rAcc), vectorize=True, unroll_full=True
-            ):
-                tTR_rAcc[i] = (
-                    tTR_rAcc[i]
-                    * epilogue_params.output_scale
-                    * cute.arch.rcp_approx(row_sum)
+            row_has_key = True
+            if cutlass.const_expr(self.enable_dcp):
+                # The coordinate tensor returned by local_tile already carries
+                # the CTA's offset within the full M128 query tile.
+                flat_q_row = (
+                    common_params.blk_coord[1] * self.mma_qk_tiler[0] + tTR_cO[0][0]
                 )
+                first_key_threshold = self.num_heads * (
+                    self.cp_world * common_params.split_start_key
+                    + common_params.cp_rank
+                    - common_params.causal_global
+                    + common_params.q_len
+                )
+                row_has_key = cute.elem_less(
+                    common_params.split_start_key, common_params.K
+                ) and not cute.elem_less(flat_q_row, first_key_threshold)
+
+            # apply output scale and normalize by row_sum
+            if cutlass.const_expr(self.enable_dcp):
+                normalization_scale = (
+                    epilogue_params.output_scale * cute.arch.rcp_approx(row_sum)
+                )
+                normalization_scale = (
+                    normalization_scale if row_has_key else self.acc_dtype(0.0)
+                )
+                for i in cutlass.range(
+                    cute.size(tTR_rAcc), vectorize=True, unroll_full=True
+                ):
+                    tTR_rAcc[i] = tTR_rAcc[i] * normalization_scale
+            else:
+                for i in cutlass.range(
+                    cute.size(tTR_rAcc), vectorize=True, unroll_full=True
+                ):
+                    tTR_rAcc[i] = (
+                        tTR_rAcc[i]
+                        * epilogue_params.output_scale
+                        * cute.arch.rcp_approx(row_sum)
+                    )
 
             # store o to global memory
             tR2G_rO_src = None
@@ -3590,6 +3790,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 cute.math.log2(row_sum, fastmath=True)
                 + epilogue_params.softmax_scale_log2 * row_max
             )
+            if cutlass.const_expr(self.enable_dcp):
+                lse = lse if row_has_key else -self.lse_dtype.inf
             # When writing directly to the user-facing mLSE (single-tile,
             # no split-KV merge), convert from log2 base to natural log.
             # When writing the per-split intermediate (mAccLSE branch), keep

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -77,12 +77,14 @@ from cutlass.cutlass_dsl import BaseDSL
 
 from .mla_helpers import (
     ceil_div,
+    compute_q_tile_layout,
     MAX_SPLITS,
     LOG2_E,
     MLAStaticTileScheduler,
     MLAStaticTileSchedulerParams,
     create_mla_static_tile_scheduler,
     create_mla_static_tile_scheduler_params,
+    get_variable_query_tile_info,
 )
 
 """
@@ -108,15 +110,18 @@ launcher and ``flashinfer/cute_dsl/attention/mla_dispatch.py`` for impl selectio
 
 Constraints:
 * Data type requirements:
-  - Input/output: Float16
+  - Input: Float16 or BFloat16
+  - Output: Float16 or BFloat16
   - Accumulation and LSE: Float32
 * Fixed architecture parameters:
-  - Number of attention heads: 128
+  - Number of attention heads: 1-128
   - Latent dimension: 512
   - RoPE dimension: 64
-* Input query modes should be (NumHeads, LatentDim/RopeDim, SeqLenQ, BatchSize)
+* Query storage is fixed [BatchSize, SeqLenQ, NumHeads, Dim] or compact
+  [TotalQueryTokens, NumHeads, Dim]; both map token/head rows into M128 tiles
 * Input kv latent/rope modes should be (SeqLenK, LatentDim/RopeDim, BatchSize)
-* Query sequence length must be 1-4
+* Query sequence length must be positive; query (token, head) rows are packed
+  continuously into 128-row M tiles with a safely padded final tile
 * Only supports 2-CTA instructions
 * Variable sequence length requires page table storage enabled
 """
@@ -136,9 +141,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         is_var_seq: bool,
         is_var_split_kv: bool,
         enable_pdl: bool,
+        is_var_q: bool = False,
         num_heads: int = 128,
         seq_len_q: int = 1,
-        fold_sq: bool = False,
+        reducer_d_tiles: int = 1,
+        reducer_max_splits: int = MAX_SPLITS,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -164,17 +171,22 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :type is_var_split_kv: bool
         :param enable_pdl: Whether to use PDL
         :type enable_pdl: bool
-        :param num_heads: Number of attention heads (pre-fold). Used for the
-            per-row spec-decoding (MTP) causal mask q_token_index computation.
+        :param is_var_q: Whether query tensors use compact variable-length
+            storage described by ``cum_seq_lens_q``.
+        :type is_var_q: bool
+        :param num_heads: Number of attention heads. Defines the flattened
+            ``(query_token, head)`` row geometry and division-free causal mask.
         :type num_heads: int
-        :param seq_len_q: Query sequence length (pre-fold). Combined with
-            ``num_heads`` to derive the per-row q_token used by the causal mask.
+        :param seq_len_q: Fixed query length, or the per-request query-length
+            capacity when ``is_var_q`` is enabled. Combined with ``num_heads``
+            to define the scheduler's flattened query-row extent.
         :type seq_len_q: int
-        :param fold_sq: Whether to fold tokens of ``seq_len_q`` into the head
-            dimension so the M tile becomes [F sub_q_tok][num_heads heads].
-            Required when ``num_heads < mma_qk_tiler_mn[0]`` and ``seq_len_q > 1``
-            so the M tile is fully populated.
-        :type fold_sq: bool
+        :param reducer_d_tiles: Number of independent D bands reduced per row.
+        :type reducer_d_tiles: int
+        :param reducer_max_splits: Compile-time reducer capacity. Direct users
+            retain the generic 256-split capacity by default; callers choosing
+            a smaller specialization must cap runtime split-KV accordingly.
+        :type reducer_max_splits: int
         """
 
         self.latent_dim = 512
@@ -189,25 +201,30 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         self.page_size = page_size
         self.is_var_seq = is_var_seq
         self.is_var_split_kv = is_var_split_kv
+        self.is_var_q = is_var_q
+        if not 1 <= reducer_max_splits <= MAX_SPLITS:
+            raise ValueError(
+                f"reducer_max_splits must be in [1, {MAX_SPLITS}], "
+                f"got {reducer_max_splits}"
+            )
+        if is_var_split_kv and reducer_max_splits != MAX_SPLITS:
+            raise ValueError(
+                "variable split-KV requires the generic reducer capacity "
+                f"of {MAX_SPLITS}, got {reducer_max_splits}"
+            )
+        self.reducer_max_splits = reducer_max_splits
         self.enable_pdl = enable_pdl
-        # Original (pre-fold) num_heads and seq_len_q used for per-row
-        # spec-decoding (MTP) causal q_token_index computation. When fold_sq is
-        # True the M tile is laid out as [F sub_q_tok][num_heads heads]; the
-        # full q_tok for row r is blk_coord[1] * F + (r // num_heads).
+        # ``seq_len_q`` is the compile-time query capacity.  Fixed-query
+        # specializations use it as the request length; variable-query
+        # specializations obtain each request's actual length from its indptr.
+        # Both flatten (query token, head) into the same physical M128 mode.
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
-        # fold_sq (caller-controlled): whether the folding code path is enabled.
-        # fold_sq_ratio (derived): fold factor F ≥ 1; the largest divisor of
-        # seq_len_q with num_heads * F ≤ M_tile and F ≤ seq_len_q. When the
-        # caller passes fold_sq=False, the kernel ignores the ratio.
-        # When fold_sq=True but the derived ratio is 1, the folding branch
-        # is taken with F=1 (a no-op transform).
-        self.fold_sq = fold_sq
-        self.fold_sq_ratio = (
-            BlackwellMultiHeadLatentAttentionForwardFP16.compute_fold_sq_ratio(
-                num_heads, seq_len_q, mma_qk_tiler_mn[0]
-            )
-        )
+        (
+            self.total_q_rows,
+            self.num_q_tiles,
+            self.tail_q_rows,
+        ) = compute_q_tile_layout(num_heads, seq_len_q, mma_qk_tiler_mn[0])
         self.cluster_shape_mnk = (2, 1, 1)
         self.use_2cta_instrs = True
         # When using 2 CTAs with m=128: warps 0-1 handle accumulation for first half [0, n/2),
@@ -215,6 +232,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         self.warps_in_n = 2
         self.num_compute_warps = 4
         self.threads_per_warp = 32
+        if reducer_d_tiles not in (1, 2, 4):
+            raise ValueError(f"unsupported reducer_d_tiles={reducer_d_tiles}")
+        self.reducer_d_tiles = reducer_d_tiles
+        self.reducer_d_tile = self.latent_dim // reducer_d_tiles
         mma_qk_tiler_k = self.rope_dim if self.seq_len_q == 1 else self.rope_dim * 2
         self.mma_qk_tiler = (
             self.mma_qk_tiler_mn[0],
@@ -311,6 +332,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         workspace: cute.Tensor,
         split_kv: cutlass.Int32,
         cache_seqs: Optional[cute.Tensor],
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: Optional[cute.Tensor],
         softmax_scale: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -326,9 +348,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         5. Grid and work scheduling computation
         6. Kernel launch(split KV kernel and reduction kernel) with appropriate parameters
 
-        :param q_latent: The query tensor with shape [batch_size, seq_len_q, num_head, latent_dim] (contiguous)
+        :param q_latent: Fixed-Q query with shape
+            [batch_size, seq_len_q, num_head, latent_dim], or compact variable-Q
+            query with shape [total_q, num_head, latent_dim] (contiguous).
         :type q_latent: cute.Tensor
-        :param q_rope: The query RoPE tensor with shape [batch_size, seq_len_q, num_head, rope_dim] (contiguous)
+        :param q_rope: Fixed-Q query RoPE with shape
+            [batch_size, seq_len_q, num_head, rope_dim], or compact variable-Q
+            query RoPE with shape [total_q, num_head, rope_dim] (contiguous).
         :type q_rope: cute.Tensor
         :param c_latent: The key tensor with shape [num_pages, page_size, latent_dim] (contiguous)
         :type c_latent: cute.Tensor
@@ -336,9 +362,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :type c_rope: cute.Tensor
         :param page_table: The page table tensor with shape [batch_size, page_count] (contiguous)
         :type page_table: cute.Tensor
-        :param o: The output tensor with shape [batch_size, seq_len_q, num_head, latent_dim] (contiguous)
+        :param o: Fixed-Q output with shape
+            [batch_size, seq_len_q, num_head, latent_dim], or compact variable-Q
+            output with shape [total_q, num_head, latent_dim] (contiguous).
         :type o: cute.Tensor
-        :param lse: The LSE tensor with shape [batch_size, seq_len_q, num_head] (contiguous)
+        :param lse: Fixed-Q LSE with shape
+            [batch_size, seq_len_q, num_head], or compact variable-Q LSE with
+            shape [total_q, num_head] (contiguous).
         :type lse: cute.Tensor
         :param workspace: The workspace tensor with 1-d shape prepared for acc_o and acc_lse
         :type workspace: cute.Tensor
@@ -346,6 +376,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :type split_kv: cutlass.Int32
         :param cache_seqs: The cache sequences tensor with shape [batch_size]
         :type cache_seqs: cute.Tensor
+        :param cum_seq_lens_q: Query indptr with shape [batch_size + 1] for
+            compact variable-Q tensors; unused for fixed Q.
+        :type cum_seq_lens_q: cute.Tensor
         :param block_split_kvs: The block split KV tensor with shape [batch_size]
         :type block_split_kvs: cute.Tensor
         :param softmax_scale: The scale factor for softmax
@@ -372,20 +405,76 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 f"Type mismatch: {self.q_dtype} != {self.k_dtype} or {self.q_dtype} != {self.v_dtype}"
             )
 
-        # Reinterpret contiguous [B, S_q, H, D] as [H, D, S_q, B]
-        # Input stride: (S_q*H*D, H*D, D, 1) → Target: (D, 1, H*D, S_q*H*D)
+        def _flatten_compact_q_rows(t):
+            total_tokens = t.shape[0]
+            num_heads = t.shape[1]
+            head_dim = t.shape[2]
+            token_stride = t.stride[0]
+            head_stride = t.stride[1]
+            dim_stride = t.stride[2]
+            return cute.make_tensor(
+                t.iterator,
+                cute.make_layout(
+                    (total_tokens * num_heads, head_dim, 1),
+                    stride=(
+                        head_stride,
+                        dim_stride,
+                        token_stride * total_tokens,
+                    ),
+                ),
+            )
+
+        def _make_compact_unpacked_o(t):
+            total_tokens = t.shape[0]
+            num_heads = t.shape[1]
+            head_dim = t.shape[2]
+            token_stride = t.stride[0]
+            head_stride = t.stride[1]
+            dim_stride = t.stride[2]
+            return cute.make_tensor(
+                t.iterator,
+                cute.make_layout(
+                    (num_heads, head_dim, total_tokens),
+                    stride=(head_stride, dim_stride, token_stride),
+                ),
+            )
+
         def _reinterpret_4d(t):
             return cute.make_tensor(
                 t.iterator,
                 cute.make_layout(
                     (t.shape[2], t.shape[3], t.shape[1], t.shape[0]),
-                    stride=(t.stride[2], t.stride[3], t.stride[1], t.stride[0]),
+                    stride=(
+                        t.stride[2],
+                        t.stride[3],
+                        t.stride[1],
+                        t.stride[0],
+                    ),
                 ),
             )
 
-        q_latent = _reinterpret_4d(q_latent)
-        q_rope = _reinterpret_4d(q_rope)
-        o = _reinterpret_4d(o)
+        def _flatten_fixed_q_rows(t):
+            return cute.make_tensor(
+                t.iterator,
+                cute.make_layout(
+                    (self.total_q_rows, t.shape[1], t.shape[3]),
+                    stride=(t.stride[0], t.stride[1], t.stride[3]),
+                ),
+            )
+
+        if cutlass.const_expr(self.is_var_q):
+            # Compact variable-Q tensors use one global affine row space:
+            # [total_q, H, D] -> [global_token * H + head, D, 1].
+            q_latent = _flatten_compact_q_rows(q_latent)
+            q_rope = _flatten_compact_q_rows(q_rope)
+            o_unpacked = _make_compact_unpacked_o(o)
+            o = _flatten_compact_q_rows(o)
+        else:
+            # Fixed Q retains an explicit batch mode in its descriptors.
+            q_latent = _reinterpret_4d(q_latent)
+            q_rope = _reinterpret_4d(q_rope)
+            o = _reinterpret_4d(o)
+            o_unpacked = o
 
         # Reinterpret contiguous [num_pages, page_size, D] as [page_size, D, num_pages]
         # Input stride: (PS*D, D, 1) → Target: (D, 1, PS*D)
@@ -410,67 +499,93 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             ),
         )
 
-        # Reinterpret contiguous [B, S_q, H] as [H, S_q, B]
-        # Input stride: (S_q*H, H, 1) → Target: (1, H, S_q*H)
-        lse = cute.make_tensor(
-            lse.iterator,
-            cute.make_layout(
-                (lse.shape[2], lse.shape[1], lse.shape[0]),
-                stride=(lse.stride[2], lse.stride[1], lse.stride[0]),
-            ),
-        )
-
-        # When num_heads < M tile, fold up to F = fold_sq_ratio tokens of
-        # seq_len_q into the head dimension so M_eff = num_heads * F (≤ M_tile).
-        # E.g., H=32, S_q=4 → F=4, M_eff=128, S_q_eff=1
-        # E.g., H=32, S_q=8 → F=4, M_eff=128, S_q_eff=2
-        # This works because MLA shares KV across all heads/queries independently.
-        # Tensor layout: [H, D, S_q, B] → [H*F, D, S_q/F, B]; relies on
-        # stride_S == stride_H * H (always true for contiguous [B, S_q, H, D]
-        # tensors after _reinterpret_4d).
-        if cutlass.const_expr(self.fold_sq):
-            F = self.fold_sq_ratio
-
-            def _fold_sq_4d(t):
-                return cute.make_tensor(
-                    t.iterator,
-                    cute.make_layout(
-                        (
-                            t.shape[0] * F,
-                            t.shape[1],
-                            t.shape[2] // F,
-                            t.shape[3],
-                        ),
-                        stride=(
-                            t.stride[0],
-                            t.stride[1],
-                            t.stride[2] * F,
-                            t.stride[3],
-                        ),
-                    ),
-                )
-
-            q_latent = _fold_sq_4d(q_latent)
-            q_rope = _fold_sq_4d(q_rope)
-            o = _fold_sq_4d(o)
-            # LSE: [H, S_q, B] → [H*F, S_q/F, B]
+        m_tile = self.mma_qk_tiler_mn[0]
+        runtime_batch_size = page_table.shape[1]
+        if cutlass.const_expr(self.is_var_q):
+            lse_total_tokens = lse.shape[0]
+            lse_num_heads = lse.shape[1]
+            lse_token_stride = lse.stride[0]
+            lse_head_stride = lse.stride[1]
+            lse_unpacked = cute.make_tensor(
+                lse.iterator,
+                cute.make_layout(
+                    (lse_num_heads, lse_total_tokens),
+                    stride=(lse_head_stride, lse_token_stride),
+                ),
+            )
             lse = cute.make_tensor(
                 lse.iterator,
                 cute.make_layout(
-                    (lse.shape[0] * F, lse.shape[1] // F, lse.shape[2]),
-                    stride=(lse.stride[0], lse.stride[1] * F, lse.stride[2]),
+                    (lse_total_tokens * lse_num_heads, 1, 1),
+                    stride=(
+                        lse_head_stride,
+                        lse_token_stride * lse_total_tokens,
+                        lse_token_stride * lse_total_tokens,
+                    ),
                 ),
             )
 
-        acc_o, acc_lse = self.initialize_workspace(
-            q_latent.shape[0],
-            q_latent.shape[1],
-            q_latent.shape[2],
-            q_latent.shape[3],
-            split_kv,
-            self.acc_dtype,
-            workspace,
-        )
+            runtime_num_q_tiles = cute.ceil_div(
+                o_unpacked.shape[0] * self.seq_len_q, m_tile
+            )
+            acc_o, acc_lse = self.initialize_workspace(
+                cutlass.Int32(m_tile),
+                o.shape[1],
+                runtime_num_q_tiles,
+                runtime_batch_size,
+                split_kv,
+                self.acc_dtype,
+                workspace,
+            )
+        else:
+            # Reinterpret contiguous [B, S_q, H] as [H, S_q, B].
+            lse = cute.make_tensor(
+                lse.iterator,
+                cute.make_layout(
+                    (lse.shape[2], lse.shape[1], lse.shape[0]),
+                    stride=(lse.stride[2], lse.stride[1], lse.stride[0]),
+                ),
+            )
+            lse_unpacked = lse
+
+            # Flatten token-major [H, D, S_q, B] query storage while retaining
+            # the fixed-Q batch mode.
+            q_latent = _flatten_fixed_q_rows(q_latent)
+            q_rope = _flatten_fixed_q_rows(q_rope)
+
+            runtime_num_q_tiles = cute.ceil_div(o.shape[0] * o.shape[2], m_tile)
+            o = cute.make_tensor(
+                o.iterator,
+                cute.make_layout(
+                    (m_tile, o.shape[1], runtime_num_q_tiles, o.shape[3]),
+                    stride=(
+                        o.stride[0],
+                        o.stride[1],
+                        o.stride[0] * m_tile,
+                        o.stride[3],
+                    ),
+                ),
+            )
+            lse = cute.make_tensor(
+                lse.iterator,
+                cute.make_layout(
+                    (m_tile, runtime_num_q_tiles, lse.shape[2]),
+                    stride=(
+                        lse.stride[0],
+                        lse.stride[0] * m_tile,
+                        lse.stride[2],
+                    ),
+                ),
+            )
+            acc_o, acc_lse = self.initialize_workspace(
+                o.shape[0],
+                o.shape[1],
+                o.shape[2],
+                o.shape[3],
+                split_kv,
+                self.acc_dtype,
+                workspace,
+            )
 
         c_latent_tranpose_layout = cute.select(c_latent.layout, mode=[1, 0, 2])
         c_latent_transpose = cute.make_tensor(
@@ -654,7 +769,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         self.tma_copy_kc_bytes = kc_copy_size
 
         tile_sched_params, grid = self._compute_grid(
-            o,
+            runtime_batch_size,
+            runtime_num_q_tiles,
             split_kv,
             self.cluster_shape_mnk,
             self.max_active_clusters,
@@ -732,6 +848,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             acc_lse,
             split_kv,
             cache_seqs,
+            cum_seq_lens_q,
             block_split_kvs,
             softmax_scale_log2,
             output_scale,
@@ -756,17 +873,22 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         )
         if cutlass.const_expr(acc_o is not None):
             self.reduction_kernel(
-                o,
-                lse,
+                o_unpacked,
+                lse_unpacked,
                 acc_o,
                 acc_lse,
                 split_kv,
                 cache_seqs,
+                cum_seq_lens_q,
                 block_split_kvs,
             ).launch(
-                grid=(q_latent.shape[0], q_latent.shape[2], q_latent.shape[3]),
+                grid=(
+                    o_unpacked.shape[0] * self.reducer_d_tiles,
+                    self.seq_len_q,
+                    runtime_batch_size,
+                ),
                 block=[self.threads_per_warp * self.num_compute_warps, 1, 1],
-                smem=MAX_SPLITS * self.acc_dtype.width // 8,
+                smem=self.reducer_max_splits * self.acc_dtype.width // 8,
                 stream=stream,
                 min_blocks_per_mp=1,
                 use_pdl=self.enable_pdl,
@@ -832,6 +954,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         mAccLSE: Optional[cute.Tensor],
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: cute.Tensor,
         softmax_scale_log2: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -872,8 +995,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :type mQL: cute.Tensor
         :param tma_atom_q_rope: TMA copy atom for query rope tensor
         :type tma_atom_q_rope: cute.CopyAtom
-        :param mKR: Compressed rope tensor
-        :type mKR: cute.Tensor
+        :param mQR: query rope tensor
+        :type mQR: cute.Tensor
         :param tma_atom_c_latent: TMA copy atom for c latent tensor
         :type tma_atom_c_latent: cute.CopyAtom
         :param mCL: Compressed latent tensor
@@ -1044,9 +1167,17 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    _,
+                    _,
+                ) = self.get_k_tile_count(
                     split_kv,
                     cache_seqs,
+                    cum_seq_lens_q,
                     block_split_kvs,
                     blk_coord,
                 )
@@ -1088,9 +1219,17 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    q_begin,
+                    _,
+                    _,
+                ) = self.get_k_tile_count(
                     split_kv,
                     cache_seqs,
+                    cum_seq_lens_q,
                     block_split_kvs,
                     blk_coord,
                 )
@@ -1099,6 +1238,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     tma_common_params = SimpleNamespace(
                         blk_coord=blk_coord,
                         local_split_kv=local_split_kv,
+                        q_begin=q_begin,
                         load_q_pipeline=load_q_pipeline,
                         load_kv_pipeline=load_kv_pipeline,
                         mPT=mPT,
@@ -1181,8 +1321,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    _,
+                    _,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     mma_common_params = SimpleNamespace(
@@ -1269,8 +1420,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    q_len,
+                    _,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     compute_common_params = SimpleNamespace(
@@ -1281,6 +1443,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         mAccO=mAccO,
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
+                        q_len=q_len,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -1333,8 +1496,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    q_begin,
+                    _,
+                    valid_q_rows,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     compute_common_params = SimpleNamespace(
@@ -1345,8 +1519,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         mAccO=mAccO,
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
+                        q_begin=q_begin,
                         L=mCL.shape[1],
-                        H=mQL.shape[0],
+                        H=valid_q_rows,
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
                         tiled_mma_pv=tiled_mma_pv,
@@ -1371,6 +1546,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
 
         return
 
+    @cute.jit
+    def get_valid_q_rows(self, q_tile_idx: cutlass.Int32) -> cutlass.Int32:
+        """Number of valid flattened query rows in one fixed-Q M tile."""
+        valid_rows = self.mma_qk_tiler_mn[0]
+        if q_tile_idx == self.num_q_tiles - 1:
+            valid_rows = self.tail_q_rows
+        return valid_rows
+
     @cute.kernel
     def reduction_kernel(
         self,
@@ -1380,6 +1563,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         mAccLSE: cute.Tensor,
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: cute.Tensor,
     ):
         """The reduction kernel for Multi-Head Latent Attention (MLA) that combines intermediate results
@@ -1402,89 +1586,123 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         """
         bidx, bidy, bidz = cute.arch.block_idx()
         tidx, _, _ = cute.arch.thread_idx()
-        blk_coord = (bidx, bidy, bidz)
-        local_split_kv = (
-            block_split_kvs[blk_coord[2]] if self.is_var_split_kv else split_kv
-        )
-        k_tile_total = cute.ceil_div(cache_seqs[blk_coord[2]], self.mma_qk_tiler[1])
-        k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
-        local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
+        # Reducer blocks cover one D band of one logical output row.
+        d_tile_idx = bidx % self.reducer_d_tiles
+        head_idx = bidx // self.reducer_d_tiles
+        q_begin = cutlass.Int32(0)
+        q_len = cutlass.Int32(self.seq_len_q)
+        is_active = True
+        if cutlass.const_expr(self.is_var_q):
+            q_begin, q_len, _ = get_variable_query_tile_info(
+                self.num_heads,
+                cutlass.Int32(0),
+                bidz,
+                cum_seq_lens_q,
+                self.mma_qk_tiler[0],
+            )
+            is_active = bidy < q_len
 
-        # Alloc shared memory
+        # In the variable-Q specialization, inactive CTAs still execute the
+        # balanced PDL protocol but do not touch workspace or outputs.
         smem = utils.SmemAllocator()
-        storage = smem.allocate(MAX_SPLITS * self.acc_dtype.width // 8, 16)
+        storage = smem.allocate(self.reducer_max_splits * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
-        smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))
+        smem_lse_scale = cute.make_tensor(
+            lse_scale_ptr, cute.make_layout(self.reducer_max_splits)
+        )
 
         if cutlass.const_expr(self.enable_pdl):
             cute.arch.griddepcontrol_wait()
-        gLSE = mAccLSE[blk_coord[0], None, blk_coord[1], blk_coord[2]]
-        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        if warp_idx == 0:
-            # calculate the global lse and exp ^ (local_lse - global_lse)
-            lse_per_thread = cute.ceil_div(MAX_SPLITS, self.threads_per_warp)
+        if is_active:
+            flat_q_row = bidy * self.num_heads + head_idx
+            # The physical M tile is fixed at 128 rows, so map with shift/mask.
+            q_tile = flat_q_row >> 7
+            q_tile_row = flat_q_row & 127
+            local_split_kv = split_kv
+            if cutlass.const_expr(self.is_var_split_kv):
+                local_split_kv = block_split_kvs[bidz]
+            k_tile_total = cute.ceil_div(cache_seqs[bidz], self.mma_qk_tiler[1])
+            k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
+            local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
-            local_lse = cute.make_rmem_tensor(
-                cute.make_layout(lse_per_thread), self.lse_dtype
-            )
-            lse_max = -self.lse_dtype.inf
-            # find the max lse
-            for i in cutlass.range_constexpr(lse_per_thread):
-                split_kv_idx = tidx + i * self.threads_per_warp
-                local_lse[i] = (
-                    gLSE[split_kv_idx]
-                    if cute.elem_less(split_kv_idx, local_split_kv)
-                    else -self.lse_dtype.inf
+            gLSE = mAccLSE[q_tile_row, None, q_tile, bidz]
+            warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+            if warp_idx == 0:
+                # Calculate the global LSE and exp2(local_lse - global_lse).
+                lse_per_thread = cute.ceil_div(
+                    self.reducer_max_splits, self.threads_per_warp
                 )
-                # reduce the local lse
-                lse_max = cute.arch.fmax(lse_max, local_lse[i])
-            lse_max = cute.arch.warp_reduction_max(lse_max)
-            lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
-            # calculate sum_lse
-            sum_lse = 0.0
-            for i in cutlass.range_constexpr(lse_per_thread):
-                sum_lse += cute.math.exp2(local_lse[i] - lse_max, fastmath=True)
-            sum_lse = cute.arch.warp_reduction_sum(sum_lse)
-            # calculate the global_lse
-            global_lse = (
-                lse_max + cute.math.log2(sum_lse, fastmath=True)
-                if not sum_lse == self.lse_dtype(0.0) or sum_lse != sum_lse  # noqa: SIM201
-                else self.lse_dtype.inf
-            )
-            if tidx == 0:
-                # Convert from kernel-internal log2 base to the natural-log
-                # convention exposed to callers (matches trtllm-gen / flash-attn).
-                # `1.0 / LOG2_E == ln(2)`.
-                mLSE[blk_coord[0], blk_coord[1], blk_coord[2]] = global_lse * (
-                    1.0 / LOG2_E
+
+                local_lse = cute.make_rmem_tensor(
+                    cute.make_layout(lse_per_thread), self.lse_dtype
                 )
-            # store the scale to shared memory
-            for i in cutlass.range_constexpr(lse_per_thread):
-                split_kv_idx = tidx + i * self.threads_per_warp
-                if cute.elem_less(split_kv_idx, local_split_kv):
-                    smem_lse_scale[split_kv_idx] = cute.math.exp2(
-                        local_lse[i] - global_lse, fastmath=True
+                lse_max = -self.lse_dtype.inf
+                for i in cutlass.range_constexpr(lse_per_thread):
+                    split_kv_idx = tidx + i * self.threads_per_warp
+                    local_lse[i] = (
+                        gLSE[split_kv_idx]
+                        if cute.elem_less(split_kv_idx, local_split_kv)
+                        else -self.lse_dtype.inf
                     )
+                    lse_max = cute.arch.fmax(lse_max, local_lse[i])
+                lse_max = cute.arch.warp_reduction_max(lse_max)
+                lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
+                sum_lse = 0.0
+                for i in cutlass.range_constexpr(lse_per_thread):
+                    sum_lse += cute.math.exp2(local_lse[i] - lse_max, fastmath=True)
+                sum_lse = cute.arch.warp_reduction_sum(sum_lse)
+                global_lse = (
+                    lse_max + cute.math.log2(sum_lse, fastmath=True)
+                    if sum_lse != self.lse_dtype(0.0) or sum_lse != sum_lse
+                    else self.lse_dtype.inf
+                )
+                if d_tile_idx == 0:
+                    if tidx == 0:
+                        # Convert the internal log2 value to natural log.
+                        if cutlass.const_expr(self.is_var_q):
+                            mLSE[head_idx, q_begin + bidy] = global_lse * (1.0 / LOG2_E)
+                        else:
+                            mLSE[head_idx, bidy, bidz] = global_lse * (1.0 / LOG2_E)
+                for i in cutlass.range_constexpr(lse_per_thread):
+                    split_kv_idx = tidx + i * self.threads_per_warp
+                    if cute.elem_less(split_kv_idx, local_split_kv):
+                        smem_lse_scale[split_kv_idx] = cute.math.exp2(
+                            local_lse[i] - global_lse, fastmath=True
+                        )
 
-        pipeline.sync(barrier_id=4)
+            pipeline.sync(barrier_id=4)
 
-        elements_per_thread = cute.ceil_div(
-            self.latent_dim, self.threads_per_warp * self.num_compute_warps
-        )
-        gAccO = mAccO[blk_coord[0], None, None, blk_coord[1], blk_coord[2]]
-        rAccO = cute.make_rmem_tensor(
-            cute.make_layout(elements_per_thread), self.acc_dtype
-        )
-        rO = cute.make_rmem_tensor(cute.make_layout(elements_per_thread), self.o_dtype)
-        rAccO.fill(0.0)
-        for i in range(local_split_kv):
+            elements_per_thread = cute.ceil_div(
+                self.reducer_d_tile,
+                self.threads_per_warp * self.num_compute_warps,
+            )
+            gAccO = mAccO[q_tile_row, None, None, q_tile, bidz]
+            rAccO = cute.make_rmem_tensor(
+                cute.make_layout(elements_per_thread), self.acc_dtype
+            )
+            rO = cute.make_rmem_tensor(
+                cute.make_layout(elements_per_thread), self.o_dtype
+            )
+            rAccO.fill(0.0)
+            for i in range(local_split_kv):
+                for j in cutlass.range_constexpr(elements_per_thread):
+                    element_idx = (
+                        d_tile_idx * self.reducer_d_tile
+                        + tidx
+                        + j * self.threads_per_warp * self.num_compute_warps
+                    )
+                    rAccO[j] += gAccO[i, element_idx] * smem_lse_scale[i]
+            rO.store(rAccO.load().to(self.o_dtype))
             for j in cutlass.range_constexpr(elements_per_thread):
-                element_idx = tidx + j * self.threads_per_warp * self.num_compute_warps
-                rAccO[j] += gAccO[i, element_idx] * smem_lse_scale[i]
-        rO.store(rAccO.load().to(self.o_dtype))
-        for j in cutlass.range_constexpr(elements_per_thread):
-            element_idx = tidx + j * self.threads_per_warp * self.num_compute_warps
-            mO[blk_coord[0], element_idx, blk_coord[1], blk_coord[2]] = rO[j]
+                element_idx = (
+                    d_tile_idx * self.reducer_d_tile
+                    + tidx
+                    + j * self.threads_per_warp * self.num_compute_warps
+                )
+                if cutlass.const_expr(self.is_var_q):
+                    mO[head_idx, element_idx, q_begin + bidy] = rO[j]
+                else:
+                    mO[head_idx, element_idx, bidy, bidz] = rO[j]
         if cutlass.const_expr(self.enable_pdl):
             cute.arch.griddepcontrol_launch_dependents()
         return
@@ -1530,21 +1748,30 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         self,
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: cute.Tensor,
         blk_coord: cute.Coord,
-    ) -> tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]:
-        """Get the current k_index, k_tile_count, and local split_kv value for the MLA kernel.
+    ) -> tuple[
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+    ]:
+        """Get K split and request-local query metadata for one work item.
 
         :param split_kv: Split_kv value
         :type split_kv: cutlass.Int32
         :param cache_seqs: Cache sequence lengths tensor
         :type cache_seqs: cute.Tensor
+        :param cum_seq_lens_q: Compact-query indptr, or None for fixed Q
+        :type cum_seq_lens_q: cute.Tensor
         :param block_split_kvs: Per-block split_kv values tensor
         :type block_split_kvs: cute.Tensor
         :param blk_coord: Block coordinate
         :type blk_coord: cute.Coord
-        :return: k_index, k_tile_count, split_kv
-        :rtype: tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]
+        :return: K range, effective split count, and request-local Q metadata
         """
         K = cache_seqs[blk_coord[2]]
         if cutlass.const_expr(self.is_var_split_kv):
@@ -1557,7 +1784,31 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         k_tile_per_cta = cute.ceil_div(k_tile_total, split_kv)
         k_index = blk_coord[3] * k_tile_per_cta
         k_tile_count = max(0, min(k_tile_total, k_index + k_tile_per_cta) - k_index)
-        return k_index, k_tile_count, split_kv
+        q_begin = cutlass.Int32(0)
+        q_len = cutlass.Int32(self.seq_len_q)
+        if cutlass.const_expr(self.is_var_q):
+            q_begin, q_len, valid_q_rows = get_variable_query_tile_info(
+                self.num_heads,
+                blk_coord[1],
+                blk_coord[2],
+                cum_seq_lens_q,
+                self.mma_qk_tiler[0],
+            )
+            if valid_q_rows == 0:
+                # Keep the rectangular scheduler slot valid.  A persistent
+                # cluster may encounter a later active request after this
+                # no-op slot.
+                k_tile_count = cutlass.Int32(0)
+        else:
+            valid_q_rows = self.get_valid_q_rows(blk_coord[1])
+        return (
+            k_index,
+            k_tile_count,
+            split_kv,
+            q_begin,
+            q_len,
+            valid_q_rows,
+        )
 
     @cute.jit
     def load_page_table(
@@ -1665,19 +1916,32 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         # page table
         mPT = common_params.mPT[None, common_params.blk_coord[2]]
 
-        # Flatten divide and partition global tensors for QK TMA load
+        if cutlass.const_expr(self.is_var_q):
+            # Offset the compact global descriptor to this request.  A middle
+            # request's tail can read the next request's rows; output stores
+            # remain predicated by this request's valid-row count.
+            mQL = cute.domain_offset(
+                (common_params.q_begin * self.num_heads, 0, 0),
+                qk_params.mQL,
+            )
+            mQR = cute.domain_offset(
+                (common_params.q_begin * self.num_heads, 0, 0),
+                qk_params.mQR,
+            )
+        else:
+            mQL = qk_params.mQL
+            mQR = qk_params.mQR
         # (bM, bK, rM, rK, rL)
         mma_qk_tiler_mk = cute.select(self.mma_qk_tiler, mode=[0, 2])
-        gQL = cute.flat_divide(qk_params.mQL, mma_qk_tiler_mk)
+        gQL = cute.flat_divide(mQL, mma_qk_tiler_mk)
         mma_qk_tiler_mk_rope = cute.select(self.mma_qk_rope_tiler, mode=[0, 2])
-        gQR = cute.flat_divide(qk_params.mQR, mma_qk_tiler_mk_rope)
+        gQR = cute.flat_divide(mQR, mma_qk_tiler_mk_rope)
 
         thr_mma_qk = qk_params.tiled_mma_qk.get_slice(
             common_params.blk_coord[0] % cute.size(qk_params.tiled_mma_qk.thr_id)
         )
         tSgQL = thr_mma_qk.partition_A(gQL)
         tSgQR = thr_mma_qk.partition_A(gQR)
-
         cta_m = min(
             qk_params.tiled_mma_qk.op.shape_mnk[0]
             // qk_params.tiled_mma_qk.thr_id.shape,
@@ -1725,7 +1989,6 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             cute.group_modes(qk_params.sQ_rope, 0, 3),
             cute.group_modes(tSgQR, 0, 3),
         )
-
         tKCsKC, tCLgCL = cpasync.tma_partition(
             qk_params.tma_atom_c_latent,
             0,
@@ -1742,12 +2005,23 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             tSgKR,
         )
 
-        tQLgQL = tQLgQL_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
-        tQRgQR = tQRgQR_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
+        if cutlass.const_expr(self.is_var_q):
+            tQLgQL = tQLgQL_mkl[None, common_params.blk_coord[1], None, 0]
+            tQRgQR = tQRgQR_mkl[None, common_params.blk_coord[1], None, 0]
+        else:
+            # Fixed Q retains its descriptor batch mode.
+            tQLgQL = tQLgQL_mkl[
+                None,
+                common_params.blk_coord[1],
+                None,
+                common_params.blk_coord[2],
+            ]
+            tQRgQR = tQRgQR_mkl[
+                None,
+                common_params.blk_coord[1],
+                None,
+                common_params.blk_coord[2],
+            ]
 
         # Flatten divide and partition global tensors for V TMA load
         page_tile_size = min(self.page_size, self.mma_pv_tiler[2])
@@ -1838,6 +2112,33 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         )
 
     @cute.jit
+    def issue_q_tma_load(
+        self,
+        tma_atom_q_latent: cute.CopyAtom,
+        tQLgQL: cute.Tensor,
+        tQsQ: cute.Tensor,
+        tma_atom_q_rope: cute.CopyAtom,
+        tQRgQR: cute.Tensor,
+        tQsQ_rope: cute.Tensor,
+        tma_bar_ptr,
+    ):
+        """Issue one bounded flattened query-tile load into shared Q stages."""
+        for i in cutlass.range(self.iterations_qk_latent):
+            cute.copy(
+                tma_atom_q_latent,
+                tQLgQL[None, i],
+                tQsQ[None, (i, 0)],
+                tma_bar_ptr=tma_bar_ptr,
+            )
+        for i in cutlass.range(self.iterations_qk_rope):
+            cute.copy(
+                tma_atom_q_rope,
+                tQRgQR[None, i],
+                tQsQ_rope[None, i],
+                tma_bar_ptr=tma_bar_ptr,
+            )
+
+    @cute.jit
     def load_tma_qk_one_k_tile(
         self,
         common_params: SimpleNamespace,
@@ -1893,22 +2194,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             tma_bar_ptr = common_params.load_q_pipeline.producer_get_barrier(
                 load_q_producer_state
             )
-            for i in cutlass.range(self.iterations_qk_latent):
-                # load q latent
-                cute.copy(
-                    qk_params.tma_atom_q_latent,
-                    qk_params.tQLgQL[None, 0, i],
-                    qk_params.tQsQ[None, (i, 0)],
-                    tma_bar_ptr=tma_bar_ptr,
-                )
-            for i in cutlass.range(self.iterations_qk_rope):
-                # load q rope
-                cute.copy(
-                    qk_params.tma_atom_q_rope,
-                    qk_params.tQRgQR[None, 0, i],
-                    qk_params.tQsQ_rope[None, i],
-                    tma_bar_ptr=tma_bar_ptr,
-                )
+            self.issue_q_tma_load(
+                qk_params.tma_atom_q_latent,
+                qk_params.tQLgQL,
+                qk_params.tQsQ,
+                qk_params.tma_atom_q_rope,
+                qk_params.tQRgQR,
+                qk_params.tQsQ_rope,
+                tma_bar_ptr,
+            )
             load_q_producer_state.advance()
         load_kv_pipeline = common_params.load_kv_pipeline
         tma_bar_ptr = load_kv_pipeline.producer_get_barrier(load_kv_producer_state)
@@ -2361,24 +2655,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :rtype: tuple[pipeline.PipelineState, pipeline.PipelineState, pipeline.PipelineState]
         """
 
-        k_tile_total = cute.ceil_div(common_params.K, self.mma_qk_tiler[1])
-
         row_max = -self.acc_dtype.inf
         row_sum = self.acc_dtype(0)
         correction_factor = self.acc_dtype(1)
         common_params.p_cor_pipeline.producer_acquire(p_cor_producer_state)
 
-        # Number of tiles from the global-K end that may contain causal-masked
-        # positions. Min k_bound = K - (S_q-1), which can span up to
-        # ceil((seq_len_q-2)/tile_N)+1 tiles (tile-boundary-crossing case). For
-        # S_q=1 this reduces to 1 tile — identical to a plain K-bound check.
+        # The first tile that can contain a key at or beyond this query tile's
+        # earliest causal bound.  A flat M tile starts at row q_tile * M, so
+        # floor(row / H) is its earliest query token.  Later query tiles can
+        # therefore keep more fully dense K tiles on the compile-time unmasked
+        # path.  The token division is outside the per-score loop (and is
+        # replicated by each participating CTA/compute group); tile_n is a
+        # static power of two, so the remaining division is a shift.
         tile_n = self.mma_qk_tiler[1]
-        mask_tile_count = (self.seq_len_q - 2 + tile_n - 1) // tile_n + 1
-
-        # first_mask_tile_idx is the global index of the first tile that may
-        # need masking. Runtime because it depends on K (per-batch in
-        # var-seq / split-KV).
-        first_mask_tile_idx = k_tile_total - mask_tile_count
+        first_q_token = cutlass.Int32(0)
+        if cutlass.const_expr(self.num_q_tiles > 1):
+            first_q_token = (
+                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+            ) // self.num_heads
+        first_mask_tile_idx = cutlass.max(
+            (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
+            cutlass.Int32(0),
+        )
 
         # Phase 1: pure unmasked bulk tiles (all columns strictly < min k_bound).
         while k_tile_count > 1 and k_index < first_mask_tile_idx:
@@ -2431,52 +2729,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             k_index = k_index + 1
             k_tile_count = k_tile_count - 1
 
-        # Phase 3: this work-split's final tile.
-        if cutlass.const_expr(common_params.mAccO is not None):
-            # Split-KV: only apply mask when this final tile is globally in
-            # the mask region (covers both last-split last-tile and straddling
-            # splits). Runtime comparison.
-            (
-                mma_s_consumer_state,
-                p_mma_producer_state,
-                p_cor_producer_state,
-                row_max,
-                row_sum,
-                correction_factor,
-            ) = self.softmax(
-                common_params,
-                softmax_params,
-                k_index,
-                mma_s_consumer_state,
-                p_mma_producer_state,
-                p_cor_producer_state,
-                row_max,
-                row_sum,
-                correction_factor,
-                k_index >= first_mask_tile_idx,
-                True,
-            )
-        else:
-            (
-                mma_s_consumer_state,
-                p_mma_producer_state,
-                p_cor_producer_state,
-                row_max,
-                row_sum,
-                correction_factor,
-            ) = self.softmax(
-                common_params,
-                softmax_params,
-                k_index,
-                mma_s_consumer_state,
-                p_mma_producer_state,
-                p_cor_producer_state,
-                row_max,
-                row_sum,
-                correction_factor,
-                True,
-                True,
-            )
+        # Phase 3: this work-split's final tile.  Mask it only when its global
+        # index reaches the causal/K-bound region.
+        (
+            mma_s_consumer_state,
+            p_mma_producer_state,
+            p_cor_producer_state,
+            row_max,
+            row_sum,
+            correction_factor,
+        ) = self.softmax(
+            common_params,
+            softmax_params,
+            k_index,
+            mma_s_consumer_state,
+            p_mma_producer_state,
+            p_cor_producer_state,
+            row_max,
+            row_sum,
+            correction_factor,
+            k_index >= first_mask_tile_idx,
+            True,
+        )
 
         return mma_s_consumer_state, p_mma_producer_state, p_cor_producer_state
 
@@ -2635,8 +2909,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :param correction_factor: The correction factor
         :type correction_factor: cutlass.Float32
         :param apply_mask: Whether the tile needs K-bound / causal masking (Python bool
-            for the unmasked/masked bulk loops; runtime cutlass.Boolean for the
-            split-KV final iter where mask only applies on the global last tile).
+            for the unmasked/masked bulk loops; runtime cutlass.Boolean for a
+            work-split final tile at the exact per-query-tile mask boundary).
         :type apply_mask: bool | cutlass.Boolean
         :param is_local_last_tile: Whether the last tile is local
         :type is_local_last_tile: cutlass.Boolean
@@ -2680,38 +2954,33 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         tTR_rAcc = cute.make_fragment_like(tTR_tS, self.acc_dtype)
 
         row_max_new = row_max
-        # Spec-decoding (MTP) causal mask: each row represents one (q_token, head)
-        # pair; row r's effective K bound is K - (S_q - 1 - q_tok(r)).
-        # With fold factor F = self.fold_sq_ratio (fold_sq=True), the M tile is
-        # laid out as [F sub_q_tok][num_heads heads] and there are S_q/F outer
-        # chunks indexed by blk_coord[1]:
-        #   q_tok(r) = blk_coord[1] * F + (r_global // num_heads)
-        # r_global = row_in_cta + cluster_idx * (M_tile / cluster_m)
-        # When fold_sq=False this reduces to q_tok = blk_coord[1]. For S_q=1
-        # this further reduces to k_bound = K (plain K-bound check).
-        # Masked positions are filled with a large negative sentinel (not -inf)
-        # to avoid NaN propagation when an entire row becomes masked.
+        # Spec-decoding (MTP) causal mask.  A flattened row r corresponds to
+        # q_token=floor(r/H), whose last valid key is K-S_q+q_token.  Avoid the
+        # per-element integer division using the equivalent integer predicate:
+        #
+        #   H * (key_pos - K + S_q) <= r
+        #
+        # This arithmetic remains inside `if apply_mask`, so the compile-time
+        # dense path emits no row-mask work.  Masked positions use a large
+        # negative sentinel (not -inf) to avoid all-masked-row NaNs.
         cta_m_rows = self.mma_qk_tiler[0] // self.cluster_shape_mnk[0]
         arch = BaseDSL._get_dsl().get_arch_enum()
         if cutlass.const_expr(arch >= Arch.sm_100 and arch <= Arch.sm_100f):
             cute.copy(tmem_tiled_copy, tTR_tAcc, tTR_rAcc)
             for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                 if apply_mask:
-                    if cutlass.const_expr(self.fold_sq):
-                        q_tok = (
-                            common_params.blk_coord[1] * self.fold_sq_ratio
-                            + (tTR_tS[i][0] + common_params.blk_coord[0] * cta_m_rows)
-                            // self.num_heads
-                        )
-                    else:
-                        q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    flat_q_row = (
+                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                        + common_params.blk_coord[0] * cta_m_rows
+                        + tTR_tS[i][0]
+                    )
+                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
+                    mask_threshold = self.num_heads * (
+                        key_pos - common_params.K + common_params.q_len
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
-                        if cute.elem_less(
-                            tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
-                        )
+                        if not cute.elem_less(flat_q_row, mask_threshold)
                         else self.acc_dtype(-1.0e6)
                     )
             # reduction for row_max
@@ -2741,21 +3010,18 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             tTR_rAcc = cute.make_tensor(tTR_rAcc_red.iterator, tTR_rAcc.layout)
             if apply_mask:
                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                    if cutlass.const_expr(self.fold_sq):
-                        q_tok = (
-                            common_params.blk_coord[1] * self.fold_sq_ratio
-                            + (tTR_tS[i][0] + common_params.blk_coord[0] * cta_m_rows)
-                            // self.num_heads
-                        )
-                    else:
-                        q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    flat_q_row = (
+                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                        + common_params.blk_coord[0] * cta_m_rows
+                        + tTR_tS[i][0]
+                    )
+                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
+                    mask_threshold = self.num_heads * (
+                        key_pos - common_params.K + common_params.q_len
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
-                        if cute.elem_less(
-                            tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
-                        )
+                        if not cute.elem_less(flat_q_row, mask_threshold)
                         else self.acc_dtype(-1.0e6)
                     )
                 # reduction for row_max after manual masking
@@ -2977,26 +3243,58 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 ),
             )
         else:
-            gO = cute.local_tile(
-                common_params.mO,
-                cta_pv_tiler_mn,
-                (
-                    common_params.blk_coord[0],
-                    iter_n,
-                    common_params.blk_coord[1],
-                    common_params.blk_coord[2],
-                ),
-            )
-            cO = cute.local_tile(
-                cute.make_identity_tensor(common_params.mO.shape),
-                cta_pv_tiler_mn,
-                (
-                    common_params.blk_coord[0],
-                    iter_n,
-                    common_params.blk_coord[1],
-                    common_params.blk_coord[2],
-                ),
-            )
+            if cutlass.const_expr(self.is_var_q):
+                request_o = cute.domain_offset(
+                    (common_params.q_begin * self.num_heads, 0, 0),
+                    common_params.mO,
+                )
+                request_cta_m = (
+                    common_params.blk_coord[1] * self.cluster_shape_mnk[0]
+                    + common_params.blk_coord[0]
+                )
+                gO = cute.local_tile(
+                    request_o,
+                    cta_pv_tiler_mn,
+                    (
+                        request_cta_m,
+                        iter_n,
+                        0,
+                    ),
+                )
+                cO = cute.local_tile(
+                    # Keep coordinates request-local so ``coord < valid_rows``
+                    # remains correct for every q_tile and q_begin.
+                    cute.make_identity_tensor(
+                        (self.mma_qk_tiler[0], request_o.shape[1], 1)
+                    ),
+                    cta_pv_tiler_mn,
+                    (
+                        common_params.blk_coord[0],
+                        iter_n,
+                        0,
+                    ),
+                )
+            else:
+                gO = cute.local_tile(
+                    common_params.mO,
+                    cta_pv_tiler_mn,
+                    (
+                        common_params.blk_coord[0],
+                        iter_n,
+                        common_params.blk_coord[1],
+                        common_params.blk_coord[2],
+                    ),
+                )
+                cO = cute.local_tile(
+                    cute.make_identity_tensor(common_params.mO.shape),
+                    cta_pv_tiler_mn,
+                    (
+                        common_params.blk_coord[0],
+                        iter_n,
+                        common_params.blk_coord[1],
+                        common_params.blk_coord[2],
+                    ),
+                )
         tTR_tAcc = tmem_load_thr_copy.partition_S(tAcc)
         tTR_gO = tmem_load_thr_copy.partition_D(gO)
         tTR_cO = tmem_load_thr_copy.partition_D(cO)
@@ -3210,26 +3508,56 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             gLSE = None
             cLSE = None
             if cutlass.const_expr(epilogue_params.mAccLSE is None):
-                gLSE = cute.local_tile(
-                    epilogue_params.mLSE,
-                    (cta_pv_tiler[0], 1, 1),
-                    (
-                        common_params.blk_coord[0],
-                        common_params.blk_coord[1],
-                        common_params.blk_coord[2],
-                    ),
-                    (1, 1, 1),
-                )
-                cLSE = cute.local_tile(
-                    cute.make_identity_tensor(epilogue_params.mLSE.shape),
-                    (cta_pv_tiler[0], 1, 1),
-                    (
-                        common_params.blk_coord[0],
-                        common_params.blk_coord[1],
-                        common_params.blk_coord[2],
-                    ),
-                    (1, 1, 1),
-                )
+                if cutlass.const_expr(self.is_var_q):
+                    request_lse = cute.domain_offset(
+                        (common_params.q_begin * self.num_heads, 0, 0),
+                        epilogue_params.mLSE,
+                    )
+                    request_cta_m = (
+                        common_params.blk_coord[1] * self.cluster_shape_mnk[0]
+                        + common_params.blk_coord[0]
+                    )
+                    gLSE = cute.local_tile(
+                        request_lse,
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            request_cta_m,
+                            0,
+                            0,
+                        ),
+                        (1, 1, 1),
+                    )
+                    cLSE = cute.local_tile(
+                        cute.make_identity_tensor((self.mma_qk_tiler[0], 1, 1)),
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            common_params.blk_coord[0],
+                            0,
+                            0,
+                        ),
+                        (1, 1, 1),
+                    )
+                else:
+                    gLSE = cute.local_tile(
+                        epilogue_params.mLSE,
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            common_params.blk_coord[0],
+                            common_params.blk_coord[1],
+                            common_params.blk_coord[2],
+                        ),
+                        (1, 1, 1),
+                    )
+                    cLSE = cute.local_tile(
+                        cute.make_identity_tensor(epilogue_params.mLSE.shape),
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            common_params.blk_coord[0],
+                            common_params.blk_coord[1],
+                            common_params.blk_coord[2],
+                        ),
+                        (1, 1, 1),
+                    )
 
             else:
                 gLSE = cute.local_tile(
@@ -3472,7 +3800,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
 
     @staticmethod
     def _compute_grid(
-        o: cute.Tensor,
+        batch_size: cutlass.Int32,
+        num_q_tiles: cutlass.Int32,
         split_kv: cutlass.Int32,
         cluster_shape_mnk: Tuple[int, int, int],
         max_active_clusters: int,
@@ -3490,11 +3819,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :return: Tile scheduler parameters and grid shape.
         :rtype: tuple[MLAStaticTileSchedulerParams, tuple[int, int, int]]
         """
-        o_shape = o.shape
         tile_sched_params = create_mla_static_tile_scheduler_params(
             is_persistent,
-            cute.size(o_shape[3]),
-            cute.size(o_shape[2]),
+            batch_size,
+            num_q_tiles,
             cluster_shape_mnk,
             split_kv,
         )
@@ -3503,25 +3831,6 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         )
 
         return tile_sched_params, grid
-
-    @staticmethod
-    def compute_fold_sq_ratio(num_heads: int, seq_len_q: int, m_tile: int) -> int:
-        """Derive the seq_len_q-into-heads fold factor F.
-
-        Returns the largest integer F such that:
-          - F divides seq_len_q evenly
-          - num_heads * F ≤ m_tile
-          - 1 ≤ F ≤ seq_len_q
-
-        F=1 means no folding (i.e. ``fold_sq`` should be False at the caller).
-        """
-        if num_heads >= m_tile:
-            return 1
-        max_fold = min(seq_len_q, m_tile // num_heads)
-        for f in range(max_fold, 0, -1):
-            if seq_len_q % f == 0:
-                return f
-        return 1
 
     @staticmethod
     def get_workspace_size(
@@ -3552,12 +3861,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         """
         if split_kv == 1:
             return 0
-        # Decode packs heads into a physical 128-wide MMA-M tile. For H < 128,
-        # split-KV partials can still touch the padded head lanes before
-        # reduction, so size the workspace for max(H, 128).  Mirrors the same
-        # padding applied in initialize_workspace().  See #3235.
-        workspace_heads = max(H, 128)
-        return B * workspace_heads * S * split_kv * (D + 1) * acc_dtype.width // 8
+        # The first workspace mode is the physical MMA-M row extent. Direct
+        # callers may still pass a logical H < 128, so preserve the M128 floor
+        # used by initialize_workspace(). The flat internal path passes 128.
+        workspace_rows = max(H, 128)
+        return B * workspace_rows * S * split_kv * (D + 1) * acc_dtype.width // 8
 
     @cute.jit
     def initialize_workspace(
@@ -3593,29 +3901,29 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         """
         acc_o, acc_lse = None, None
         if cutlass.const_expr(workspace is not None):
-            # Pad head dim to the physical 128-wide MMA-M tile.  Without this,
-            # H<128 split-KV partials write past the workspace.  See #3235.
-            workspace_H = cutlass.max(H, cutlass.Int32(128))
+            # The first workspace mode is the physical MMA-M row extent.
+            # Preserve the M128 floor for direct callers that pass H < 128.
+            workspace_rows = cutlass.max(H, cutlass.Int32(128))
             align = 256 // self.q_dtype.width
             acc_o_layout = cute.make_layout(
-                (workspace_H, split_kv, D, S, B),
+                (workspace_rows, split_kv, D, S, B),
                 stride=(
                     cute.assume(split_kv * D, align),
                     cute.assume(D, align),
                     1,
-                    cute.assume(split_kv * workspace_H * D, align),
-                    cute.assume(workspace_H * split_kv * S * D, align),
+                    cute.assume(split_kv * workspace_rows * D, align),
+                    cute.assume(workspace_rows * split_kv * S * D, align),
                 ),
             )
             acc_o_iter = cute.recast_ptr(workspace.iterator, dtype=acc_dtype)
             acc_o = cute.make_tensor(acc_o_iter, acc_o_layout)
             acc_lse_layout = cute.make_layout(
-                (workspace_H, split_kv, S, B),
+                (workspace_rows, split_kv, S, B),
                 stride=(
                     split_kv,
                     1,
-                    workspace_H * split_kv,
-                    workspace_H * split_kv * S,
+                    workspace_rows * split_kv,
+                    workspace_rows * split_kv * S,
                 ),
             )
             acc_lse_iter = cute.recast_ptr(
@@ -3697,11 +4005,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             return False
         if is_var_split_kv and not is_var_seq:
             return False
-        if mma_qk_tiler_mn[0] < H:
+        if H <= 0 or mma_qk_tiler_mn[0] < H:
             return False
-        # When H < M tile, fold up to F tokens of S into H (M_eff = H*F ≤ M_tile).
-        # F is auto-picked as the largest divisor of S with H*F ≤ M_tile.
-        # F=1 always works, so any (H ≤ M_tile, S ≥ 1) is implementable.
+        # Query (token, head) rows are packed continuously into 128-row M
+        # tiles.  A partial final tile is supported, so any H <= M_tile and
+        # S >= 1 is valid.
         if S < 1:
             return False
         if K <= 0:

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -75,12 +75,14 @@ from cutlass.cutlass_dsl import BaseDSL
 
 from .mla_helpers import (
     ceil_div,
+    compute_q_tile_layout,
     MAX_SPLITS,
     LOG2_E,
     MLAStaticTileScheduler,
     MLAStaticTileSchedulerParams,
     create_mla_static_tile_scheduler,
     create_mla_static_tile_scheduler_params,
+    get_variable_query_tile_info,
 )
 
 """
@@ -106,15 +108,18 @@ launcher and ``flashinfer/cute_dsl/attention/mla_dispatch.py`` for impl selectio
 
 Constraints:
 * Data type requirements:
-  - Input/output: Float8E4M3FN
+  - Input: Float8E4M3FN
+  - Output: BFloat16 or Float8E4M3FN
   - Accumulation and LSE: Float32
 * Fixed architecture parameters:
-  - Number of attention heads: 128
+  - Number of attention heads: 1-128
   - Latent dimension: 512
   - RoPE dimension: 64
-* Input query modes should be (NumHeads, LatentDim/RopeDim, SeqLenQ, BatchSize)
+* Query storage is fixed [BatchSize, SeqLenQ, NumHeads, Dim] or compact
+  [TotalQueryTokens, NumHeads, Dim]; both map token/head rows into M128 tiles
 * Input kv latent/rope modes should be (SeqLenK, LatentDim/RopeDim, BatchSize)
-* Query sequence length must be 1-4
+* Query sequence length must be positive; token/head rows are flattened across
+  128-row M tiles with a safely padded final tile
 * Only supports 2-CTA instructions
 * Variable sequence length requires page table storage enabled
 """
@@ -134,9 +139,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         is_var_seq: bool,
         is_var_split_kv: bool,
         enable_pdl: bool,
+        is_var_q: bool = False,
         num_heads: int = 128,
         seq_len_q: int = 1,
-        fold_sq: bool = False,
+        reducer_d_tiles: int = 1,
+        reducer_max_splits: int = MAX_SPLITS,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -162,17 +169,21 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type is_var_split_kv: bool
         :param enable_pdl: Whether to use PDL
         :type enable_pdl: bool
-        :param num_heads: Number of attention heads (pre-fold). Used for the
-            per-row spec-decoding (MTP) causal mask q_token_index computation.
+        :param is_var_q: Whether query tokens use compact variable-length
+            storage with request boundaries supplied by ``cum_seq_lens_q``.
+        :type is_var_q: bool
+        :param num_heads: Number of attention heads. Defines the flattened
+            ``(query_token, head)`` row geometry and division-free causal mask.
         :type num_heads: int
-        :param seq_len_q: Query sequence length (pre-fold). Combined with
-            ``num_heads`` to derive the per-row q_token used by the causal mask.
+        :param seq_len_q: Fixed query length, or the static maximum query
+            length used as launch capacity when ``is_var_q`` is true.
         :type seq_len_q: int
-        :param fold_sq: Whether to fold tokens of ``seq_len_q`` into the head
-            dimension so the M tile becomes [F sub_q_tok][num_heads heads].
-            Required when ``num_heads < mma_qk_tiler_mn[0]`` and ``seq_len_q > 1``
-            so the M tile is fully populated.
-        :type fold_sq: bool
+        :param reducer_d_tiles: Number of independent D bands reduced per row.
+        :type reducer_d_tiles: int
+        :param reducer_max_splits: Compile-time reducer capacity. Direct users
+            retain the generic 256-split capacity by default; callers choosing
+            a smaller specialization must cap runtime split-KV accordingly.
+        :type reducer_max_splits: int
         """
 
         self.latent_dim = 512
@@ -187,25 +198,29 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         self.page_size = page_size
         self.is_var_seq = is_var_seq
         self.is_var_split_kv = is_var_split_kv
+        self.is_var_q = is_var_q
+        if not 1 <= reducer_max_splits <= MAX_SPLITS:
+            raise ValueError(
+                f"reducer_max_splits must be in [1, {MAX_SPLITS}], "
+                f"got {reducer_max_splits}"
+            )
+        if is_var_split_kv and reducer_max_splits != MAX_SPLITS:
+            raise ValueError(
+                "variable split-KV requires the generic reducer capacity "
+                f"of {MAX_SPLITS}, got {reducer_max_splits}"
+            )
+        self.reducer_max_splits = reducer_max_splits
         self.enable_pdl = enable_pdl
-        # Original (pre-fold) num_heads and seq_len_q used for per-row
-        # spec-decoding (MTP) causal q_token_index computation. When fold_sq is
-        # True the M tile is laid out as [F sub_q_tok][num_heads heads]; the
-        # full q_tok for row r is blk_coord[1] * F + (r // num_heads).
+        # ``seq_len_q`` is the compile-time query capacity.  Fixed-query
+        # specializations use it as the request length; variable-query
+        # specializations load each request's actual length from its indptr.
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
-        # fold_sq (caller-controlled): whether the folding code path is enabled.
-        # fold_sq_ratio (derived): fold factor F ≥ 1; the largest divisor of
-        # seq_len_q with num_heads * F ≤ M_tile and F ≤ seq_len_q. When the
-        # caller passes fold_sq=False, the kernel ignores the ratio.
-        # When fold_sq=True but the derived ratio is 1, the folding branch
-        # is taken with F=1 (a no-op transform).
-        self.fold_sq = fold_sq
-        self.fold_sq_ratio = (
-            BlackwellMultiHeadLatentAttentionForwardFP8.compute_fold_sq_ratio(
-                num_heads, seq_len_q, mma_qk_tiler_mn[0]
-            )
-        )
+        (
+            self.total_q_rows,
+            self.num_q_tiles,
+            self.tail_q_rows,
+        ) = compute_q_tile_layout(num_heads, seq_len_q, mma_qk_tiler_mn[0])
         self.cluster_shape_mnk = (2, 1, 1)
         self.use_2cta_instrs = True
         # When using 2 CTAs with m=128: warps 0-1 handle accumulation for first half [0, n/2),
@@ -213,6 +228,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         self.warps_in_n = 2
         self.num_compute_warps = 4
         self.threads_per_warp = 32
+        if reducer_d_tiles not in (1, 2, 4):
+            raise ValueError(f"unsupported reducer_d_tiles={reducer_d_tiles}")
+        self.reducer_d_tiles = reducer_d_tiles
+        self.reducer_d_tile = self.latent_dim // reducer_d_tiles
         mma_qk_tiler_k = self.rope_dim * 2
         self.mma_qk_tiler = (
             self.mma_qk_tiler_mn[0],
@@ -294,13 +313,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             num_threads=(self.threads_per_warp * self.num_compute_warps),
         )
         # Pingpong order barriers (OrderedSequenceBarrier<1,2> pattern). Each
-        # group waits on its own bar via arrive_and_wait (= bar.sync); the OTHER
-        # group signals via split-phase .arrive() (non-blocking). num_threads
+        # group waits on its own bar via arrive_and_wait (= bar.sync), while the
+        # other group normally signals via split-phase .arrive(). num_threads
         # MUST cover both groups (256 = wait-side 128 + signal-side 128) so the
         # bar releases only after BOTH have arrived — that's the cross-group
-        # serialization that gives the TMEM peer-read its happens-before.
-        # Init-phase trick: g1 pre-arrives bar_0 once at warp setup so g0's
-        # first arrive_and_wait completes without waiting for g1's loop arrive.
+        # serialization that gives the TMEM peer-read its happens-before. The
+        # final owner also waits, closing the named-barrier generation before a
+        # persistent group can start its next logical work item.
         self.softmax_order_bar_0 = pipeline.NamedBarrier(
             barrier_id=5,
             num_threads=(self.threads_per_warp * self.num_total_compute_warps),
@@ -353,6 +372,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         workspace: cute.Tensor,
         split_kv: cutlass.Int32,
         cache_seqs: Optional[cute.Tensor],
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: Optional[cute.Tensor],
         softmax_scale: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -368,9 +388,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         5. Grid and work scheduling computation
         6. Kernel launch(split KV kernel and reduction kernel) with appropriate parameters
 
-        :param q_latent: The query tensor with shape [batch_size, seq_len_q, num_head, latent_dim] (contiguous)
+        :param q_latent: Fixed query tensor
+            ``[batch_size, seq_len_q, num_head, latent_dim]``, or compact
+            variable-Q tensor ``[total_q, num_head, latent_dim]``.
         :type q_latent: cute.Tensor
-        :param q_rope: The query RoPE tensor with shape [batch_size, seq_len_q, num_head, rope_dim] (contiguous)
+        :param q_rope: Fixed query RoPE tensor
+            ``[batch_size, seq_len_q, num_head, rope_dim]``, or compact
+            variable-Q tensor ``[total_q, num_head, rope_dim]``.
         :type q_rope: cute.Tensor
         :param c_latent: The key tensor with shape [num_pages, page_size, latent_dim] (contiguous)
         :type c_latent: cute.Tensor
@@ -378,9 +402,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type c_rope: cute.Tensor
         :param page_table: The page table tensor with shape [batch_size, page_count] (contiguous)
         :type page_table: cute.Tensor
-        :param o: The output tensor with shape [batch_size, seq_len_q, num_head, latent_dim] (contiguous)
+        :param o: Fixed output ``[batch_size, seq_len_q, num_head, latent_dim]``
+            or compact output ``[total_q, num_head, latent_dim]``.
         :type o: cute.Tensor
-        :param lse: The LSE tensor with shape [batch_size, seq_len_q, num_head] (contiguous)
+        :param lse: Fixed LSE ``[batch_size, seq_len_q, num_head]`` or compact
+            LSE ``[total_q, num_head]``.
         :type lse: cute.Tensor
         :param workspace: The workspace tensor with 1-d shape prepared for acc_o and acc_lse
         :type workspace: cute.Tensor
@@ -388,6 +414,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type split_kv: cutlass.Int32
         :param cache_seqs: The cache sequences tensor with shape [batch_size]
         :type cache_seqs: cute.Tensor
+        :param cum_seq_lens_q: Compact-query request indptr with shape
+            ``[batch_size + 1]``. Must be ``None`` for fixed Q.
+        :type cum_seq_lens_q: cute.Tensor
         :param block_split_kvs: The block split KV tensor with shape [batch_size]
         :type block_split_kvs: cute.Tensor
         :param softmax_scale: The scale factor for softmax
@@ -414,20 +443,68 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 f"Type mismatch: {self.q_dtype} != {self.k_dtype} or {self.q_dtype} != {self.v_dtype}"
             )
 
-        # Reinterpret contiguous [B, S_q, H, D] as [H, D, S_q, B]
-        # Input stride: (S_q*H*D, H*D, D, 1) → Target: (D, 1, H*D, S_q*H*D)
-        def _reinterpret_4d(t):
-            return cute.make_tensor(
-                t.iterator,
-                cute.make_layout(
-                    (t.shape[2], t.shape[3], t.shape[1], t.shape[0]),
-                    stride=(t.stride[2], t.stride[3], t.stride[1], t.stride[0]),
-                ),
-            )
+        if cutlass.const_expr(self.is_var_q):
+            # Compact Q uses one globally bounded token/head row mode.  Each
+            # request selects its local M128 tiles with a domain offset below.
+            def _flatten_compact_q_rows(t):
+                total_tokens = t.shape[0]
+                num_heads = t.shape[1]
+                head_dim = t.shape[2]
+                token_stride = t.stride[0]
+                head_stride = t.stride[1]
+                dim_stride = t.stride[2]
+                return cute.make_tensor(
+                    t.iterator,
+                    cute.make_layout(
+                        (total_tokens * num_heads, head_dim, 1),
+                        stride=(
+                            head_stride,
+                            dim_stride,
+                            token_stride * total_tokens,
+                        ),
+                    ),
+                )
 
-        q_latent = _reinterpret_4d(q_latent)
-        q_rope = _reinterpret_4d(q_rope)
-        o = _reinterpret_4d(o)
+            def _make_compact_unpacked_o(t):
+                total_tokens = t.shape[0]
+                num_heads = t.shape[1]
+                head_dim = t.shape[2]
+                token_stride = t.stride[0]
+                head_stride = t.stride[1]
+                dim_stride = t.stride[2]
+                return cute.make_tensor(
+                    t.iterator,
+                    cute.make_layout(
+                        (num_heads, head_dim, total_tokens),
+                        stride=(head_stride, dim_stride, token_stride),
+                    ),
+                )
+
+            q_latent = _flatten_compact_q_rows(q_latent)
+            q_rope = _flatten_compact_q_rows(q_rope)
+            o_unpacked = _make_compact_unpacked_o(o)
+            o = _flatten_compact_q_rows(o)
+        else:
+            # Fixed Q retains a physical batch mode; O/LSE expose separate
+            # query-tile and batch modes.
+            def _reinterpret_4d(t):
+                return cute.make_tensor(
+                    t.iterator,
+                    cute.make_layout(
+                        (t.shape[2], t.shape[3], t.shape[1], t.shape[0]),
+                        stride=(
+                            t.stride[2],
+                            t.stride[3],
+                            t.stride[1],
+                            t.stride[0],
+                        ),
+                    ),
+                )
+
+            q_latent = _reinterpret_4d(q_latent)
+            q_rope = _reinterpret_4d(q_rope)
+            o = _reinterpret_4d(o)
+            o_unpacked = o
 
         # Reinterpret contiguous [num_pages, page_size, D] as [page_size, D, num_pages]
         # Input stride: (PS*D, D, 1) → Target: (D, 1, PS*D)
@@ -452,67 +529,99 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             ),
         )
 
-        # Reinterpret contiguous [B, S_q, H] as [H, S_q, B]
-        # Input stride: (S_q*H, H, 1) → Target: (1, H, S_q*H)
-        lse = cute.make_tensor(
-            lse.iterator,
-            cute.make_layout(
-                (lse.shape[2], lse.shape[1], lse.shape[0]),
-                stride=(lse.stride[2], lse.stride[1], lse.stride[0]),
-            ),
-        )
-
-        # When num_heads < M tile, fold up to F = fold_sq_ratio tokens of
-        # seq_len_q into the head dimension so M_eff = num_heads * F (≤ M_tile).
-        # E.g., H=32, S_q=4 → F=4, M_eff=128, S_q_eff=1
-        # E.g., H=32, S_q=8 → F=4, M_eff=128, S_q_eff=2
-        # This works because MLA shares KV across all heads/queries independently.
-        # Tensor layout: [H, D, S_q, B] → [H*F, D, S_q/F, B]; relies on
-        # stride_S == stride_H * H (always true for contiguous [B, S_q, H, D]
-        # tensors after _reinterpret_4d).
-        if cutlass.const_expr(self.fold_sq):
-            F = self.fold_sq_ratio
-
-            def _fold_sq_4d(t):
-                return cute.make_tensor(
-                    t.iterator,
-                    cute.make_layout(
-                        (
-                            t.shape[0] * F,
-                            t.shape[1],
-                            t.shape[2] // F,
-                            t.shape[3],
-                        ),
-                        stride=(
-                            t.stride[0],
-                            t.stride[1],
-                            t.stride[2] * F,
-                            t.stride[3],
-                        ),
-                    ),
-                )
-
-            q_latent = _fold_sq_4d(q_latent)
-            q_rope = _fold_sq_4d(q_rope)
-            o = _fold_sq_4d(o)
-            # LSE: [H, S_q, B] → [H*F, S_q/F, B]
+        m_tile = self.mma_qk_tiler_mn[0]
+        runtime_batch_size = page_table.shape[1]
+        if cutlass.const_expr(self.is_var_q):
+            lse_total_tokens = lse.shape[0]
+            lse_num_heads = lse.shape[1]
+            lse_token_stride = lse.stride[0]
+            lse_head_stride = lse.stride[1]
+            lse_unpacked = cute.make_tensor(
+                lse.iterator,
+                cute.make_layout(
+                    (lse_num_heads, lse_total_tokens),
+                    stride=(lse_head_stride, lse_token_stride),
+                ),
+            )
             lse = cute.make_tensor(
                 lse.iterator,
                 cute.make_layout(
-                    (lse.shape[0] * F, lse.shape[1] // F, lse.shape[2]),
-                    stride=(lse.stride[0], lse.stride[1] * F, lse.stride[2]),
+                    (lse_total_tokens * lse_num_heads, 1, 1),
+                    stride=(
+                        lse_head_stride,
+                        lse_token_stride * lse_total_tokens,
+                        lse_token_stride * lse_total_tokens,
+                    ),
                 ),
             )
+            runtime_num_q_tiles = cute.ceil_div(
+                o_unpacked.shape[0] * self.seq_len_q, m_tile
+            )
+            acc_o, acc_lse = self.initialize_workspace(
+                cutlass.Int32(m_tile),
+                o.shape[1],
+                runtime_num_q_tiles,
+                runtime_batch_size,
+                split_kv,
+                self.acc_dtype,
+                workspace,
+            )
+        else:
+            lse = cute.make_tensor(
+                lse.iterator,
+                cute.make_layout(
+                    (lse.shape[2], lse.shape[1], lse.shape[0]),
+                    stride=(lse.stride[2], lse.stride[1], lse.stride[0]),
+                ),
+            )
+            lse_unpacked = lse
 
-        acc_o, acc_lse = self.initialize_workspace(
-            q_latent.shape[0],
-            q_latent.shape[1],
-            q_latent.shape[2],
-            q_latent.shape[3],
-            split_kv,
-            self.acc_dtype,
-            workspace,
-        )
+            def _flatten_fixed_q_rows(t):
+                return cute.make_tensor(
+                    t.iterator,
+                    cute.make_layout(
+                        (self.total_q_rows, t.shape[1], t.shape[3]),
+                        stride=(t.stride[0], t.stride[1], t.stride[3]),
+                    ),
+                )
+
+            q_latent = _flatten_fixed_q_rows(q_latent)
+            q_rope = _flatten_fixed_q_rows(q_rope)
+
+            runtime_num_q_tiles = cute.ceil_div(o.shape[0] * o.shape[2], m_tile)
+            o = cute.make_tensor(
+                o.iterator,
+                cute.make_layout(
+                    (m_tile, o.shape[1], runtime_num_q_tiles, o.shape[3]),
+                    stride=(
+                        o.stride[0],
+                        o.stride[1],
+                        o.stride[0] * m_tile,
+                        o.stride[3],
+                    ),
+                ),
+            )
+            lse = cute.make_tensor(
+                lse.iterator,
+                cute.make_layout(
+                    (m_tile, runtime_num_q_tiles, lse.shape[2]),
+                    stride=(
+                        lse.stride[0],
+                        lse.stride[0] * m_tile,
+                        lse.stride[2],
+                    ),
+                ),
+            )
+            runtime_batch_size = o.shape[3]
+            acc_o, acc_lse = self.initialize_workspace(
+                o.shape[0],
+                o.shape[1],
+                o.shape[2],
+                o.shape[3],
+                split_kv,
+                self.acc_dtype,
+                workspace,
+            )
 
         c_latent_tranpose_layout = cute.select(c_latent.layout, mode=[1, 0, 2])
         c_latent_transpose = cute.make_tensor(
@@ -752,7 +861,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         self.tma_copy_vc_bytes = vc_copy_size
 
         tile_sched_params, grid = self._compute_grid(
-            o,
+            runtime_batch_size,
+            runtime_num_q_tiles,
             split_kv,
             self.cluster_shape_mnk,
             self.max_active_clusters,
@@ -841,6 +951,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             acc_lse,
             split_kv,
             cache_seqs,
+            cum_seq_lens_q,
             block_split_kvs,
             softmax_scale_log2,
             output_scale,
@@ -867,17 +978,22 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         )
         if cutlass.const_expr(acc_o is not None):
             self.reduction_kernel(
-                o,
-                lse,
+                o_unpacked,
+                lse_unpacked,
                 acc_o,
                 acc_lse,
                 split_kv,
                 cache_seqs,
+                cum_seq_lens_q,
                 block_split_kvs,
             ).launch(
-                grid=(q_latent.shape[0], q_latent.shape[2], q_latent.shape[3]),
+                grid=(
+                    o_unpacked.shape[0] * self.reducer_d_tiles,
+                    self.seq_len_q,
+                    runtime_batch_size,
+                ),
                 block=[self.threads_per_warp * self.num_compute_warps, 1, 1],
-                smem=MAX_SPLITS * self.acc_dtype.width // 8,
+                smem=self.reducer_max_splits * self.acc_dtype.width // 8,
                 stream=stream,
                 min_blocks_per_mp=1,
                 use_pdl=self.enable_pdl,
@@ -943,6 +1059,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         mAccLSE: Optional[cute.Tensor],
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: cute.Tensor,
         softmax_scale_log2: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -985,8 +1102,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type mQL: cute.Tensor
         :param tma_atom_q_rope: TMA copy atom for query rope tensor
         :type tma_atom_q_rope: cute.CopyAtom
-        :param mKR: Compressed rope tensor
-        :type mKR: cute.Tensor
+        :param mQR: query rope tensor
+        :type mQR: cute.Tensor
         :param tma_atom_c_latent: TMA copy atom for c latent tensor
         :type tma_atom_c_latent: cute.CopyAtom
         :param mCL: Compressed latent tensor
@@ -1171,9 +1288,17 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    q_begin,
+                    _,
+                    _,
+                ) = self.get_k_tile_count(
                     split_kv,
                     cache_seqs,
+                    cum_seq_lens_q,
                     block_split_kvs,
                     blk_coord,
                 )
@@ -1182,6 +1307,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     tma_common_params = SimpleNamespace(
                         blk_coord=blk_coord,
                         local_split_kv=local_split_kv,
+                        q_begin=q_begin,
                         load_q_pipeline=load_q_pipeline,
                         load_k_pipeline=load_k_pipeline,
                         load_v_pipeline=load_v_pipeline,
@@ -1228,9 +1354,17 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    _,
+                    _,
+                ) = self.get_k_tile_count(
                     split_kv,
                     cache_seqs,
+                    cum_seq_lens_q,
                     block_split_kvs,
                     blk_coord,
                 )
@@ -1285,8 +1419,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    _,
+                    _,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     mma_common_params = SimpleNamespace(
@@ -1350,8 +1495,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    _,
+                    _,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     mma_pv_common_params = SimpleNamespace(
@@ -1421,8 +1577,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    q_len,
+                    _,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     compute_common_params = SimpleNamespace(
@@ -1433,6 +1600,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mAccO=mAccO,
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
+                        q_len=q_len,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -1492,15 +1660,24 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             mma_s_consumer_state.advance()
             p_mma_producer_state.advance()
             p_cor_producer_state.advance()
-            # Pingpong init-phase trick: g1 pre-arrives softmax_order_bar_0 once
-            # so g0's FIRST softmax_order_bar_0.arrive_and_wait() completes
-            # without waiting for g1's first loop arrive. Replaces a per-iter
-            # is_first_tile guard. Bar is num_total_compute_warps (256 threads)
-            # so wait-side 128 + signal-side 128 = 256 → release.
+            # Each nonempty compute() call initializes g1's peer metadata and
+            # pre-arrives softmax_order_bar_0 for that logical work item. This
+            # lets g0's first wait complete without a first-tile special case.
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    _,
+                    q_len,
+                    _,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     compute_common_params = SimpleNamespace(
@@ -1511,6 +1688,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mAccO=mAccO,
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
+                        q_len=q_len,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -1564,8 +1742,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             work_tile = tile_sched.initial_work_tile_info()
             while work_tile.is_valid_tile:
                 blk_coord = work_tile.tile_idx
-                k_index, k_tile_count, local_split_kv = self.get_k_tile_count(
-                    split_kv, cache_seqs, block_split_kvs, blk_coord
+                (
+                    k_index,
+                    k_tile_count,
+                    local_split_kv,
+                    q_begin,
+                    _,
+                    valid_q_rows,
+                ) = self.get_k_tile_count(
+                    split_kv,
+                    cache_seqs,
+                    cum_seq_lens_q,
+                    block_split_kvs,
+                    blk_coord,
                 )
                 if k_tile_count > 0:
                     compute_common_params = SimpleNamespace(
@@ -1576,8 +1765,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mAccO=mAccO,
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
+                        q_begin=q_begin,
                         L=mCL.shape[1],
-                        H=mQL.shape[0],
+                        H=valid_q_rows,
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
                         tiled_mma_pv=tiled_mma_pv,
@@ -1601,6 +1791,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 work_tile = tile_sched.get_current_work()
         return
 
+    @cute.jit
+    def get_valid_q_rows(self, q_tile_idx: cutlass.Int32) -> cutlass.Int32:
+        """Number of valid flattened query rows in one fixed-query M tile."""
+        valid_rows = self.mma_qk_tiler_mn[0]
+        if q_tile_idx == self.num_q_tiles - 1:
+            valid_rows = self.tail_q_rows
+        return valid_rows
+
     @cute.kernel
     def reduction_kernel(
         self,
@@ -1610,6 +1808,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         mAccLSE: cute.Tensor,
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: cute.Tensor,
     ):
         """The reduction kernel for Multi-Head Latent Attention (MLA) that combines intermediate results
@@ -1632,89 +1831,118 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         """
         bidx, bidy, bidz = cute.arch.block_idx()
         tidx, _, _ = cute.arch.thread_idx()
-        blk_coord = (bidx, bidy, bidz)
-        local_split_kv = (
-            block_split_kvs[blk_coord[2]] if self.is_var_split_kv else split_kv
-        )
-        k_tile_total = cute.ceil_div(cache_seqs[blk_coord[2]], self.mma_qk_tiler[1])
-        k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
-        local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
+        d_tile_idx = bidx % self.reducer_d_tiles
+        head_idx = bidx // self.reducer_d_tiles
+        q_begin = cutlass.Int32(0)
+        q_len = cutlass.Int32(self.seq_len_q)
+        is_active = True
+        if cutlass.const_expr(self.is_var_q):
+            q_begin, q_len, _ = get_variable_query_tile_info(
+                self.num_heads,
+                cutlass.Int32(0),
+                bidz,
+                cum_seq_lens_q,
+                self.mma_qk_tiler[0],
+            )
+            is_active = bidy < q_len
 
-        # Alloc shared memory
+        # Inactive compact rows still complete the PDL protocol, but do not
+        # touch workspace or enter the active-row shared-memory barrier.
         smem = utils.SmemAllocator()
-        storage = smem.allocate(MAX_SPLITS * self.acc_dtype.width // 8, 16)
+        storage = smem.allocate(self.reducer_max_splits * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
-        smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))
+        smem_lse_scale = cute.make_tensor(
+            lse_scale_ptr, cute.make_layout(self.reducer_max_splits)
+        )
 
         if cutlass.const_expr(self.enable_pdl):
             cute.arch.griddepcontrol_wait()
-        gLSE = mAccLSE[blk_coord[0], None, blk_coord[1], blk_coord[2]]
-        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        if warp_idx == 0:
-            # calculate the global lse and exp ^ (local_lse - global_lse)
-            lse_per_thread = cute.ceil_div(MAX_SPLITS, self.threads_per_warp)
+        if is_active:
+            flat_q_row = bidy * self.num_heads + head_idx
+            q_tile = flat_q_row >> 7
+            q_tile_row = flat_q_row & 127
+            local_split_kv = split_kv
+            if cutlass.const_expr(self.is_var_split_kv):
+                local_split_kv = block_split_kvs[bidz]
+            k_tile_total = cute.ceil_div(cache_seqs[bidz], self.mma_qk_tiler[1])
+            k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
+            local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
-            local_lse = cute.make_rmem_tensor(
-                cute.make_layout(lse_per_thread), self.lse_dtype
-            )
-            lse_max = -self.lse_dtype.inf
-            # find the max lse
-            for i in cutlass.range_constexpr(lse_per_thread):
-                split_kv_idx = tidx + i * self.threads_per_warp
-                local_lse[i] = (
-                    gLSE[split_kv_idx]
-                    if cute.elem_less(split_kv_idx, local_split_kv)
-                    else -self.lse_dtype.inf
+            gLSE = mAccLSE[q_tile_row, None, q_tile, bidz]
+            warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+            if warp_idx == 0:
+                lse_per_thread = cute.ceil_div(
+                    self.reducer_max_splits, self.threads_per_warp
                 )
-                # reduce the local lse
-                lse_max = cute.arch.fmax(lse_max, local_lse[i])
-            lse_max = cute.arch.warp_reduction_max(lse_max)
-            lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
-            # calculate sum_lse
-            sum_lse = 0.0
-            for i in cutlass.range_constexpr(lse_per_thread):
-                sum_lse += cute.math.exp2(local_lse[i] - lse_max, fastmath=True)
-            sum_lse = cute.arch.warp_reduction_sum(sum_lse)
-            # calculate the global_lse
-            global_lse = (
-                lse_max + cute.math.log2(sum_lse, fastmath=True)
-                if not sum_lse == self.lse_dtype(0.0) or sum_lse != sum_lse  # noqa: SIM201
-                else self.lse_dtype.inf
-            )
-            if tidx == 0:
-                # Convert from kernel-internal log2 base to the natural-log
-                # convention exposed to callers (matches trtllm-gen / flash-attn).
-                # `1.0 / LOG2_E == ln(2)`.
-                mLSE[blk_coord[0], blk_coord[1], blk_coord[2]] = global_lse * (
-                    1.0 / LOG2_E
+                local_lse = cute.make_rmem_tensor(
+                    cute.make_layout(lse_per_thread), self.lse_dtype
                 )
-            # store the scale to shared memory
-            for i in cutlass.range_constexpr(lse_per_thread):
-                split_kv_idx = tidx + i * self.threads_per_warp
-                if cute.elem_less(split_kv_idx, local_split_kv):
-                    smem_lse_scale[split_kv_idx] = cute.math.exp2(
-                        local_lse[i] - global_lse, fastmath=True
+                lse_max = -self.lse_dtype.inf
+                for i in cutlass.range_constexpr(lse_per_thread):
+                    split_kv_idx = tidx + i * self.threads_per_warp
+                    local_lse[i] = (
+                        gLSE[split_kv_idx]
+                        if cute.elem_less(split_kv_idx, local_split_kv)
+                        else -self.lse_dtype.inf
                     )
+                    lse_max = cute.arch.fmax(lse_max, local_lse[i])
+                lse_max = cute.arch.warp_reduction_max(lse_max)
+                lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
+                sum_lse = 0.0
+                for i in cutlass.range_constexpr(lse_per_thread):
+                    sum_lse += cute.math.exp2(local_lse[i] - lse_max, fastmath=True)
+                sum_lse = cute.arch.warp_reduction_sum(sum_lse)
+                global_lse = (
+                    lse_max + cute.math.log2(sum_lse, fastmath=True)
+                    if sum_lse != self.lse_dtype(0.0) or sum_lse != sum_lse
+                    else self.lse_dtype.inf
+                )
+                if d_tile_idx == 0:
+                    if tidx == 0:
+                        if cutlass.const_expr(self.is_var_q):
+                            mLSE[head_idx, q_begin + bidy] = global_lse * (1.0 / LOG2_E)
+                        else:
+                            mLSE[head_idx, bidy, bidz] = global_lse * (1.0 / LOG2_E)
+                for i in cutlass.range_constexpr(lse_per_thread):
+                    split_kv_idx = tidx + i * self.threads_per_warp
+                    if cute.elem_less(split_kv_idx, local_split_kv):
+                        smem_lse_scale[split_kv_idx] = cute.math.exp2(
+                            local_lse[i] - global_lse, fastmath=True
+                        )
 
-        pipeline.sync(barrier_id=4)
+            pipeline.sync(barrier_id=4)
 
-        elements_per_thread = cute.ceil_div(
-            self.latent_dim, self.threads_per_warp * self.num_compute_warps
-        )
-        gAccO = mAccO[blk_coord[0], None, None, blk_coord[1], blk_coord[2]]
-        rAccO = cute.make_rmem_tensor(
-            cute.make_layout(elements_per_thread), self.acc_dtype
-        )
-        rO = cute.make_rmem_tensor(cute.make_layout(elements_per_thread), self.o_dtype)
-        rAccO.fill(0.0)
-        for i in range(local_split_kv):
+            elements_per_thread = cute.ceil_div(
+                self.reducer_d_tile,
+                self.threads_per_warp * self.num_compute_warps,
+            )
+            gAccO = mAccO[q_tile_row, None, None, q_tile, bidz]
+            rAccO = cute.make_rmem_tensor(
+                cute.make_layout(elements_per_thread), self.acc_dtype
+            )
+            rO = cute.make_rmem_tensor(
+                cute.make_layout(elements_per_thread), self.o_dtype
+            )
+            rAccO.fill(0.0)
+            for i in range(local_split_kv):
+                for j in cutlass.range_constexpr(elements_per_thread):
+                    element_idx = (
+                        d_tile_idx * self.reducer_d_tile
+                        + tidx
+                        + j * self.threads_per_warp * self.num_compute_warps
+                    )
+                    rAccO[j] += gAccO[i, element_idx] * smem_lse_scale[i]
+            rO.store(rAccO.load().to(self.o_dtype))
             for j in cutlass.range_constexpr(elements_per_thread):
-                element_idx = tidx + j * self.threads_per_warp * self.num_compute_warps
-                rAccO[j] += gAccO[i, element_idx] * smem_lse_scale[i]
-        rO.store(rAccO.load().to(self.o_dtype))
-        for j in cutlass.range_constexpr(elements_per_thread):
-            element_idx = tidx + j * self.threads_per_warp * self.num_compute_warps
-            mO[blk_coord[0], element_idx, blk_coord[1], blk_coord[2]] = rO[j]
+                element_idx = (
+                    d_tile_idx * self.reducer_d_tile
+                    + tidx
+                    + j * self.threads_per_warp * self.num_compute_warps
+                )
+                if cutlass.const_expr(self.is_var_q):
+                    mO[head_idx, element_idx, q_begin + bidy] = rO[j]
+                else:
+                    mO[head_idx, element_idx, bidy, bidz] = rO[j]
         if cutlass.const_expr(self.enable_pdl):
             cute.arch.griddepcontrol_launch_dependents()
         return
@@ -1760,21 +1988,30 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         self,
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
+        cum_seq_lens_q: Optional[cute.Tensor],
         block_split_kvs: cute.Tensor,
         blk_coord: cute.Coord,
-    ) -> tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]:
-        """Get the current k_index, k_tile_count, and local split_kv value for the MLA kernel.
+    ) -> tuple[
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+        cutlass.Int32,
+    ]:
+        """Get K split and request-local query metadata for one work item.
 
         :param split_kv: Split_kv value
         :type split_kv: cutlass.Int32
         :param cache_seqs: Cache sequence lengths tensor
         :type cache_seqs: cute.Tensor
+        :param cum_seq_lens_q: Compact-query indptr, or None for fixed Q
+        :type cum_seq_lens_q: cute.Tensor
         :param block_split_kvs: Per-block split_kv values tensor
         :type block_split_kvs: cute.Tensor
         :param blk_coord: Block coordinate
         :type blk_coord: cute.Coord
-        :return: k_index, k_tile_count, split_kv
-        :rtype: tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]
+        :return: K range, effective split count, and request-local Q metadata
         """
         K = cache_seqs[blk_coord[2]]
         if cutlass.const_expr(self.is_var_split_kv):
@@ -1787,7 +2024,30 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         k_tile_per_cta = cute.ceil_div(k_tile_total, split_kv)
         k_index = blk_coord[3] * k_tile_per_cta
         k_tile_count = max(0, min(k_tile_total, k_index + k_tile_per_cta) - k_index)
-        return k_index, k_tile_count, split_kv
+        q_begin = cutlass.Int32(0)
+        q_len = cutlass.Int32(self.seq_len_q)
+        if cutlass.const_expr(self.is_var_q):
+            q_begin, q_len, valid_q_rows = get_variable_query_tile_info(
+                self.num_heads,
+                blk_coord[1],
+                blk_coord[2],
+                cum_seq_lens_q,
+                self.mma_qk_tiler[0],
+            )
+            if valid_q_rows == 0:
+                # Keep the rectangular slot scheduler-valid; later requests
+                # owned by the same persistent cluster may still be active.
+                k_tile_count = cutlass.Int32(0)
+        else:
+            valid_q_rows = self.get_valid_q_rows(blk_coord[1])
+        return (
+            k_index,
+            k_tile_count,
+            split_kv,
+            q_begin,
+            q_len,
+            valid_q_rows,
+        )
 
     @cute.jit
     def load_tma_qk(
@@ -1820,12 +2080,25 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # page table
         mPT = common_params.mPT[None, common_params.blk_coord[2]]
 
-        # Flatten divide and partition global tensors for QK TMA load
+        if cutlass.const_expr(self.is_var_q):
+            # Compact Q has no physical batch mode, so select this request by
+            # offsetting its global token/head row.
+            mQL = cute.domain_offset(
+                (common_params.q_begin * self.num_heads, 0, 0),
+                qk_params.mQL,
+            )
+            mQR = cute.domain_offset(
+                (common_params.q_begin * self.num_heads, 0, 0),
+                qk_params.mQR,
+            )
+        else:
+            mQL = qk_params.mQL
+            mQR = qk_params.mQR
         # (bM, bK, rM, rK, rL)
         mma_qk_tiler_mk = cute.select(self.mma_qk_tiler, mode=[0, 2])
-        gQL = cute.flat_divide(qk_params.mQL, mma_qk_tiler_mk)
+        gQL = cute.flat_divide(mQL, mma_qk_tiler_mk)
         mma_qk_tiler_mk_rope = cute.select(self.mma_qk_rope_tiler, mode=[0, 2])
-        gQR = cute.flat_divide(qk_params.mQR, mma_qk_tiler_mk_rope)
+        gQR = cute.flat_divide(mQR, mma_qk_tiler_mk_rope)
 
         thr_mma_qk = qk_params.tiled_mma_qk.get_slice(
             common_params.blk_coord[0] % cute.size(qk_params.tiled_mma_qk.thr_id)
@@ -1898,12 +2171,23 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             tSgKR,
         )
 
-        tQLgQL = tQLgQL_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
-        tQRgQR = tQRgQR_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
+        if cutlass.const_expr(self.is_var_q):
+            tQLgQL = tQLgQL_mkl[None, common_params.blk_coord[1], None, 0]
+            tQRgQR = tQRgQR_mkl[None, common_params.blk_coord[1], None, 0]
+        else:
+            # Fixed-Q TMA selects the descriptor's explicit batch mode.
+            tQLgQL = tQLgQL_mkl[
+                None,
+                common_params.blk_coord[1],
+                None,
+                common_params.blk_coord[2],
+            ]
+            tQRgQR = tQRgQR_mkl[
+                None,
+                common_params.blk_coord[1],
+                None,
+                common_params.blk_coord[2],
+            ]
 
         # set extra params
         common_params.mPT = mPT
@@ -2003,6 +2287,33 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         return load_v_producer_state
 
     @cute.jit
+    def issue_q_tma_load(
+        self,
+        tma_atom_q_latent: cute.CopyAtom,
+        tQLgQL: cute.Tensor,
+        tQsQ: cute.Tensor,
+        tma_atom_q_rope: cute.CopyAtom,
+        tQRgQR: cute.Tensor,
+        tQsQ_rope: cute.Tensor,
+        tma_bar_ptr,
+    ):
+        """Issue one bounded flattened query-tile load into shared Q stages."""
+        for i in cutlass.range_constexpr(self.iterations_qk_latent):
+            cute.copy(
+                tma_atom_q_latent,
+                tQLgQL[None, i],
+                tQsQ[None, (i, 0)],
+                tma_bar_ptr=tma_bar_ptr,
+            )
+        for i in cutlass.range_constexpr(self.iterations_qk_rope):
+            cute.copy(
+                tma_atom_q_rope,
+                tQRgQR[None, i],
+                tQsQ_rope[None, i],
+                tma_bar_ptr=tma_bar_ptr,
+            )
+
+    @cute.jit
     def load_tma_qk_one_k_tile(
         self,
         common_params: SimpleNamespace,
@@ -2057,22 +2368,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             tma_bar_ptr = load_q_pipeline.producer_get_barrier(load_q_producer_state)
             # expect the extra bytes for q.
             load_q_pipeline.producer_acquire(load_q_producer_state)
-            for i in cutlass.range_constexpr(self.iterations_qk_latent):
-                # load q latent
-                cute.copy(
-                    qk_params.tma_atom_q_latent,
-                    qk_params.tQLgQL[None, 0, i],
-                    qk_params.tQsQ[None, (i, 0)],
-                    tma_bar_ptr=tma_bar_ptr,
-                )
-            for i in cutlass.range_constexpr(self.iterations_qk_rope):
-                # load q rope
-                cute.copy(
-                    qk_params.tma_atom_q_rope,
-                    qk_params.tQRgQR[None, 0, i],
-                    qk_params.tQsQ_rope[None, i],
-                    tma_bar_ptr=tma_bar_ptr,
-                )
+            self.issue_q_tma_load(
+                qk_params.tma_atom_q_latent,
+                qk_params.tQLgQL,
+                qk_params.tQsQ,
+                qk_params.tma_atom_q_rope,
+                qk_params.tQRgQR,
+                qk_params.tQsQ_rope,
+                tma_bar_ptr,
+            )
             load_q_producer_state.advance()
         # get the mbar ptr from pipeline.
         tma_bar_ptr = common_params.load_k_pipeline.producer_get_barrier(
@@ -2525,7 +2829,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         row_max = self.acc_dtype(self.init_row_max)
         row_sum = self.acc_dtype(0)
         correction_factor = self.acc_dtype(1)
-        odd_k_tile = k_tile_count % 2 == 1
+        k_tile_count_init = k_tile_count
+        odd_k_tile = k_tile_count_init % 2 == 1
         # 2softmax: g0 takes even k-tiles, g1 takes odd k-tiles. g1 advances all
         # pipeline states once at entry to start on stage 1 (one stage per group).
         if cutlass.const_expr(is_second_compute_warp):
@@ -2544,26 +2849,41 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 common_params, softmax_params, p_cor_producer_state
             )
             self.softmax_order_bar_0.arrive()
-        # Number of tiles from the global-K end that may contain causal-masked
-        # positions. Min k_bound = K - (S_q-1), which can span up to
-        # ceil((seq_len_q-2)/tile_N)+1 tiles (tile-boundary-crossing case). For
-        # S_q=1 this reduces to 1 tile — identical to a plain K-bound check.
+        # The first tile that can contain a key at or beyond this query tile's
+        # earliest causal bound.  A flat M tile starts at row q_tile * M, so
+        # floor(row / H) is its earliest query token.  Later query tiles can
+        # therefore keep more fully dense K tiles on the compile-time unmasked
+        # path.  The token division is outside the per-score loop (and is
+        # replicated by each participating CTA/compute group); tile_n is a
+        # static power of two, so the remaining division is a shift.
         tile_n = self.mma_qk_tiler[1]
-        mask_tile_count = (self.seq_len_q - 2 + tile_n - 1) // tile_n + 1
+        first_q_token = cutlass.Int32(0)
+        if cutlass.const_expr(self.num_q_tiles > 1):
+            first_q_token = (
+                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+            ) // self.num_heads
+        first_mask_tile_idx = cutlass.max(
+            (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
+            cutlass.Int32(0),
+        )
 
-        # first_mask_tile_idx is the global index of the first tile that may
-        # need masking. Runtime because it depends on K (per-batch in
-        # var-seq / split-KV).
-        first_mask_tile_idx = k_tile_total - mask_tile_count
+        # The non-split two-softmax path still needs its global final tile in
+        # phase 2 for final metadata exchange, even when that tile is dense.
+        # Masking itself remains controlled by first_mask_tile_idx below.
+        first_phase_2_tile_idx = cutlass.min(first_mask_tile_idx, k_tile_total - 1)
 
         # Phase 1: pure unmasked bulk tiles (all columns strictly < min k_bound).
         # 2softmax: each group steps by 2 k-tiles; phase boundaries respect this.
-        while k_tile_count > 0 and k_index < first_mask_tile_idx:
+        while k_tile_count > 0 and k_index < first_phase_2_tile_idx:
             is_local_last_tile = (
                 False
                 if cutlass.const_expr(common_params.mAccO is None)
                 else k_tile_count == 1
             )
+            if cutlass.const_expr(is_second_compute_warp):
+                is_order_chain_last_tile = k_tile_count == 1 and not odd_k_tile
+            else:
+                is_order_chain_last_tile = k_tile_count == 1 and odd_k_tile
             (
                 mma_s_consumer_state,
                 p_mma_producer_state,
@@ -2584,6 +2904,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 is_second_compute_warp,
                 False,
                 is_local_last_tile,
+                is_order_chain_last_tile,
             )
             k_index = k_index + 2
             k_tile_count = k_tile_count - 1
@@ -2600,6 +2921,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # Phase 2: remaining tiles that overlap the causal / K-bound region,
         # including this work-split's final tile.
         while k_tile_count > 0:
+            if cutlass.const_expr(is_second_compute_warp):
+                is_order_chain_last_tile = k_tile_count == 1 and not odd_k_tile
+            else:
+                is_order_chain_last_tile = k_tile_count == 1 and odd_k_tile
             (
                 mma_s_consumer_state,
                 p_mma_producer_state,
@@ -2618,8 +2943,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 row_sum,
                 correction_factor,
                 is_second_compute_warp,
+                k_index >= first_mask_tile_idx,
                 True,
-                True,
+                is_order_chain_last_tile,
             )
             k_index = k_index + 2
             k_tile_count = k_tile_count - 1
@@ -2635,14 +2961,17 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
 
         if odd_k_tile:
             if cutlass.const_expr(is_second_compute_warp):
-                # next first compute warp in this wave
+                # Keep g1 exactly one pipeline entry ahead of g0 at the next
+                # logical work item.  When this split has one tile, g1 owns no
+                # tile and needs only this single advance.  For larger odd
+                # splits it also skips the final g0-owned stage below.
                 p_mma_producer_state.advance()
                 mma_s_consumer_state.advance()
                 p_cor_producer_state.advance()
-                # first compute warp in next wave
-                p_mma_producer_state.advance()
-                mma_s_consumer_state.advance()
-                p_cor_producer_state.advance()
+                if k_tile_count_init > 1:
+                    p_mma_producer_state.advance()
+                    mma_s_consumer_state.advance()
+                    p_cor_producer_state.advance()
         else:
             p_mma_producer_state.advance()
             mma_s_consumer_state.advance()
@@ -2949,6 +3278,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         is_second_compute_warp: bool,
         apply_mask: bool,
         is_local_last_tile: cutlass.Boolean,
+        is_order_chain_last_tile: cutlass.Boolean,
     ) -> tuple[
         pipeline.PipelineState,
         pipeline.PipelineState,
@@ -2978,11 +3308,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :param correction_factor: The correction factor
         :type correction_factor: cutlass.Float32
         :param apply_mask: Whether the tile needs K-bound / causal masking (Python bool
-            for the unmasked/masked bulk loops; runtime cutlass.Boolean for the
-            split-KV final iter where mask only applies on the global last tile).
+            for the unmasked/masked bulk loops; runtime cutlass.Boolean for a
+            work-split final tile at the exact per-query-tile mask boundary).
         :type apply_mask: bool | cutlass.Boolean
         :param is_local_last_tile: Whether the last tile is local
         :type is_local_last_tile: cutlass.Boolean
+        :param is_order_chain_last_tile: Whether this group owns the final tile
+            in the logical work item's cross-group order chain
+        :type is_order_chain_last_tile: cutlass.Boolean
 
         :return: The MMA s consumer state, the P MMA producer state, the P correction producer state, the row max, the row sum, and the correction factor
         :rtype: tuple[pipeline.PipelineState, pipeline.PipelineState, pipeline.PipelineState, cutlass.Float32, cutlass.Float32, cutlass.Float32]
@@ -3028,15 +3361,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         tTR_rAcc = cute.make_fragment_like(tTR_tS, self.acc_dtype)
 
         row_max_new = row_max
-        # Spec-decoding (MTP) causal mask: each row represents one (q_token, head)
-        # pair; row r's effective K bound is K - (S_q - 1 - q_tok(r)).
-        # With fold factor F = self.fold_sq_ratio (fold_sq=True), the M tile is
-        # laid out as [F sub_q_tok][num_heads heads] and there are S_q/F outer
-        # chunks indexed by blk_coord[1]:
-        #   q_tok(r) = blk_coord[1] * F + (r_global // num_heads)
-        # r_global = row_in_cta + cluster_idx * (M_tile / cluster_m)
-        # When fold_sq=False this reduces to q_tok = blk_coord[1]. For S_q=1
-        # this further reduces to k_bound = K (plain K-bound check).
+        # Spec-decoding (MTP) causal mask.  For flattened row
+        #   r = q_token * H + q_head,
+        # the usual key < K - S_q + 1 + q_token predicate is equivalent to
+        #   H * (key - K + S_q) <= r.
+        # This avoids integer division/modulo.  The enclosing apply_mask
+        # branch remains compile-time false for dense bulk K tiles, so they do
+        # not execute any of this row-dependent arithmetic.
         # Masked positions are filled with a large negative sentinel (not -inf)
         # to avoid NaN propagation when an entire row becomes masked.
         cta_m_rows = self.mma_qk_tiler[0] // self.cluster_shape_mnk[0]
@@ -3045,21 +3376,18 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             cute.copy(tmem_tiled_copy, tTR_tAcc, tTR_rAcc)
             for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                 if apply_mask:
-                    if cutlass.const_expr(self.fold_sq):
-                        q_tok = (
-                            common_params.blk_coord[1] * self.fold_sq_ratio
-                            + (tTR_tS[i][0] + common_params.blk_coord[0] * cta_m_rows)
-                            // self.num_heads
-                        )
-                    else:
-                        q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    flat_q_row = (
+                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                        + common_params.blk_coord[0] * cta_m_rows
+                        + tTR_tS[i][0]
+                    )
+                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
+                    mask_threshold = self.num_heads * (
+                        key_pos - common_params.K + common_params.q_len
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
-                        if cute.elem_less(
-                            tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
-                        )
+                        if not cute.elem_less(flat_q_row, mask_threshold)
                         else self.acc_dtype(-1.0e6)
                     )
             # reduction for row_max
@@ -3092,21 +3420,18 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             tTR_rAcc = cute.make_tensor(tTR_rAcc_red.iterator, tTR_rAcc.layout)
             if apply_mask:
                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                    if cutlass.const_expr(self.fold_sq):
-                        q_tok = (
-                            common_params.blk_coord[1] * self.fold_sq_ratio
-                            + (tTR_tS[i][0] + common_params.blk_coord[0] * cta_m_rows)
-                            // self.num_heads
-                        )
-                    else:
-                        q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    flat_q_row = (
+                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                        + common_params.blk_coord[0] * cta_m_rows
+                        + tTR_tS[i][0]
+                    )
+                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
+                    mask_threshold = self.num_heads * (
+                        key_pos - common_params.K + common_params.q_len
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
-                        if cute.elem_less(
-                            tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
-                        )
+                        if not cute.elem_less(flat_q_row, mask_threshold)
                         else self.acc_dtype(-1.0e6)
                     )
                 # reduction for row_max after manual masking
@@ -3152,7 +3477,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # the .arrive() it issues at the bottom of its prev iter, so this
         # arrive_and_wait gives us the acquire memory ordering needed for the
         # load_other_group_metadata read below. g0's first wait is satisfied
-        # by g1's pre-arrive of bar_0 at warp setup (init-phase trick).
+        # by g1's per-work pre-arrive of bar_0 (init-phase trick).
         if cutlass.const_expr(is_second_compute_warp):
             self.softmax_order_bar_1.arrive_and_wait()
         else:
@@ -3285,9 +3610,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             )
 
         # Pingpong B — signal the OTHER group to start its critical section.
-        # Split-phase .arrive() contributes this group's threads to the other
-        # group's bar and falls through immediately. cfence: control-flow fence
-        # to prevent ptxas from hoisting subsequent work above bar.arrive.
+        # Intermediate tiles use split-phase arrive so the groups overlap.  The
+        # final owner waits for the peer's parity-tail rendezvous, preventing a
+        # persistent group from arriving on the same named-barrier generation
+        # again in the next logical work item before this one has reset.
 
         # split kv case
         if is_local_last_tile:
@@ -3304,9 +3630,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             )
         # cute.nvgpu.cfence()
         if cutlass.const_expr(is_second_compute_warp):
-            self.softmax_order_bar_0.arrive()  # g1 → g0
+            if is_order_chain_last_tile:
+                self.softmax_order_bar_0.arrive_and_wait()  # g1 → g0, final even tile
+            else:
+                self.softmax_order_bar_0.arrive()  # g1 → g0
         else:
-            self.softmax_order_bar_1.arrive()  # g0 → g1
+            if is_order_chain_last_tile:
+                self.softmax_order_bar_1.arrive_and_wait()  # g0 → g1, final odd tile
+            else:
+                self.softmax_order_bar_1.arrive()  # g0 → g1
         # cute.nvgpu.cfence()
 
         mma_s_consumer_state.advance()
@@ -3403,26 +3735,56 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 ),
             )
         else:
-            gO = cute.local_tile(
-                common_params.mO,
-                cta_pv_tiler_mn,
-                (
-                    common_params.blk_coord[0],
-                    iter_n,
-                    common_params.blk_coord[1],
-                    common_params.blk_coord[2],
-                ),
-            )
-            cO = cute.local_tile(
-                cute.make_identity_tensor(common_params.mO.shape),
-                cta_pv_tiler_mn,
-                (
-                    common_params.blk_coord[0],
-                    iter_n,
-                    common_params.blk_coord[1],
-                    common_params.blk_coord[2],
-                ),
-            )
+            if cutlass.const_expr(self.is_var_q):
+                request_o = cute.domain_offset(
+                    (common_params.q_begin * self.num_heads, 0, 0),
+                    common_params.mO,
+                )
+                request_cta_m = (
+                    common_params.blk_coord[1] * self.cluster_shape_mnk[0]
+                    + common_params.blk_coord[0]
+                )
+                gO = cute.local_tile(
+                    request_o,
+                    cta_pv_tiler_mn,
+                    (
+                        request_cta_m,
+                        iter_n,
+                        0,
+                    ),
+                )
+                cO = cute.local_tile(
+                    cute.make_identity_tensor(
+                        (self.mma_qk_tiler[0], request_o.shape[1], 1)
+                    ),
+                    cta_pv_tiler_mn,
+                    (
+                        common_params.blk_coord[0],
+                        iter_n,
+                        0,
+                    ),
+                )
+            else:
+                gO = cute.local_tile(
+                    common_params.mO,
+                    cta_pv_tiler_mn,
+                    (
+                        common_params.blk_coord[0],
+                        iter_n,
+                        common_params.blk_coord[1],
+                        common_params.blk_coord[2],
+                    ),
+                )
+                cO = cute.local_tile(
+                    cute.make_identity_tensor(common_params.mO.shape),
+                    cta_pv_tiler_mn,
+                    (
+                        common_params.blk_coord[0],
+                        iter_n,
+                        common_params.blk_coord[1],
+                        common_params.blk_coord[2],
+                    ),
+                )
         tTR_tAcc = tmem_load_thr_copy.partition_S(tAcc)
         tTR_gO = tmem_load_thr_copy.partition_D(gO)
         tTR_cO = tmem_load_thr_copy.partition_D(cO)
@@ -3636,26 +3998,56 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             gLSE = None
             cLSE = None
             if cutlass.const_expr(epilogue_params.mAccLSE is None):
-                gLSE = cute.local_tile(
-                    epilogue_params.mLSE,
-                    (cta_pv_tiler[0], 1, 1),
-                    (
-                        common_params.blk_coord[0],
-                        common_params.blk_coord[1],
-                        common_params.blk_coord[2],
-                    ),
-                    (1, 1, 1),
-                )
-                cLSE = cute.local_tile(
-                    cute.make_identity_tensor(epilogue_params.mLSE.shape),
-                    (cta_pv_tiler[0], 1, 1),
-                    (
-                        common_params.blk_coord[0],
-                        common_params.blk_coord[1],
-                        common_params.blk_coord[2],
-                    ),
-                    (1, 1, 1),
-                )
+                if cutlass.const_expr(self.is_var_q):
+                    request_lse = cute.domain_offset(
+                        (common_params.q_begin * self.num_heads, 0, 0),
+                        epilogue_params.mLSE,
+                    )
+                    request_cta_m = (
+                        common_params.blk_coord[1] * self.cluster_shape_mnk[0]
+                        + common_params.blk_coord[0]
+                    )
+                    gLSE = cute.local_tile(
+                        request_lse,
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            request_cta_m,
+                            0,
+                            0,
+                        ),
+                        (1, 1, 1),
+                    )
+                    cLSE = cute.local_tile(
+                        cute.make_identity_tensor((self.mma_qk_tiler[0], 1, 1)),
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            common_params.blk_coord[0],
+                            0,
+                            0,
+                        ),
+                        (1, 1, 1),
+                    )
+                else:
+                    gLSE = cute.local_tile(
+                        epilogue_params.mLSE,
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            common_params.blk_coord[0],
+                            common_params.blk_coord[1],
+                            common_params.blk_coord[2],
+                        ),
+                        (1, 1, 1),
+                    )
+                    cLSE = cute.local_tile(
+                        cute.make_identity_tensor(epilogue_params.mLSE.shape),
+                        (cta_pv_tiler[0], 1, 1),
+                        (
+                            common_params.blk_coord[0],
+                            common_params.blk_coord[1],
+                            common_params.blk_coord[2],
+                        ),
+                        (1, 1, 1),
+                    )
 
             else:
                 gLSE = cute.local_tile(
@@ -3873,7 +4265,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
 
     @staticmethod
     def _compute_grid(
-        o: cute.Tensor,
+        batch_size: cutlass.Int32,
+        num_q_tiles: cutlass.Int32,
         split_kv: cutlass.Int32,
         cluster_shape_mnk: Tuple[int, int, int],
         max_active_clusters: int,
@@ -3891,11 +4284,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :return: Tile scheduler parameters and grid shape.
         :rtype: tuple[MLAStaticTileSchedulerParams, tuple[int, int, int]]
         """
-        o_shape = o.shape
         tile_sched_params = create_mla_static_tile_scheduler_params(
             is_persistent,
-            cute.size(o_shape[3]),
-            cute.size(o_shape[2]),
+            batch_size,
+            num_q_tiles,
             cluster_shape_mnk,
             split_kv,
         )
@@ -3904,25 +4296,6 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         )
 
         return tile_sched_params, grid
-
-    @staticmethod
-    def compute_fold_sq_ratio(num_heads: int, seq_len_q: int, m_tile: int) -> int:
-        """Derive the seq_len_q-into-heads fold factor F.
-
-        Returns the largest integer F such that:
-          - F divides seq_len_q evenly
-          - num_heads * F ≤ m_tile
-          - 1 ≤ F ≤ seq_len_q
-
-        F=1 means no folding (i.e. ``fold_sq`` should be False at the caller).
-        """
-        if num_heads >= m_tile:
-            return 1
-        max_fold = min(seq_len_q, m_tile // num_heads)
-        for f in range(max_fold, 0, -1):
-            if seq_len_q % f == 0:
-                return f
-        return 1
 
     @staticmethod
     def get_workspace_size(
@@ -3953,12 +4326,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         """
         if split_kv == 1:
             return 0
-        # Decode packs heads into a physical 128-wide MMA-M tile. For H < 128,
-        # split-KV partials can still touch the padded head lanes before
-        # reduction, so size the workspace for max(H, 128).  Mirrors the same
-        # padding applied in initialize_workspace().  See #3235.
-        workspace_heads = max(H, 128)
-        return B * workspace_heads * S * split_kv * (D + 1) * acc_dtype.width // 8
+        # The first workspace mode is the physical MMA-M row extent. Direct
+        # callers may still pass a logical H < 128, so preserve the M128 floor
+        # used by initialize_workspace(). The flat internal path passes 128.
+        workspace_rows = max(H, 128)
+        return B * workspace_rows * S * split_kv * (D + 1) * acc_dtype.width // 8
 
     @cute.jit
     def initialize_workspace(
@@ -3994,29 +4366,29 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         """
         acc_o, acc_lse = None, None
         if cutlass.const_expr(workspace is not None):
-            # Pad head dim to the physical 128-wide MMA-M tile.  Without this,
-            # H<128 split-KV partials write past the workspace.  See #3235.
-            workspace_H = cutlass.max(H, cutlass.Int32(128))
+            # The first workspace mode is the physical MMA-M row extent.
+            # Preserve the M128 floor for direct callers that pass H < 128.
+            workspace_rows = cutlass.max(H, cutlass.Int32(128))
             align = 256 // self.q_dtype.width
             acc_o_layout = cute.make_layout(
-                (workspace_H, split_kv, D, S, B),
+                (workspace_rows, split_kv, D, S, B),
                 stride=(
                     cute.assume(split_kv * D, align),
                     cute.assume(D, align),
                     1,
-                    cute.assume(split_kv * workspace_H * D, align),
-                    cute.assume(workspace_H * split_kv * S * D, align),
+                    cute.assume(split_kv * workspace_rows * D, align),
+                    cute.assume(workspace_rows * split_kv * S * D, align),
                 ),
             )
             acc_o_iter = cute.recast_ptr(workspace.iterator, dtype=acc_dtype)
             acc_o = cute.make_tensor(acc_o_iter, acc_o_layout)
             acc_lse_layout = cute.make_layout(
-                (workspace_H, split_kv, S, B),
+                (workspace_rows, split_kv, S, B),
                 stride=(
                     split_kv,
                     1,
-                    workspace_H * split_kv,
-                    workspace_H * split_kv * S,
+                    workspace_rows * split_kv,
+                    workspace_rows * split_kv * S,
                 ),
             )
             acc_lse_iter = cute.recast_ptr(
@@ -4098,11 +4470,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             return False
         if is_var_split_kv and not is_var_seq:
             return False
-        if mma_qk_tiler_mn[0] < H:
+        if H <= 0 or mma_qk_tiler_mn[0] < H:
             return False
-        # When H < M tile, fold up to F tokens of S into H (M_eff = H*F ≤ M_tile).
-        # F is auto-picked as the largest divisor of S with H*F ≤ M_tile.
-        # F=1 always works, so any (H ≤ M_tile, S ≥ 1) is implementable.
+        # Query-token/head rows are flattened across 128-row M tiles.  A
+        # partial final tile is supported, so any H <= M_tile and S >= 1 is
+        # valid.
         if S < 1:
             return False
         if K <= 0:

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -144,6 +144,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         seq_len_q: int = 1,
         reducer_d_tiles: int = 1,
         reducer_max_splits: int = MAX_SPLITS,
+        enable_dcp: bool = False,
+        cp_world: int = 1,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -184,6 +186,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             retain the generic 256-split capacity by default; callers choosing
             a smaller specialization must cap runtime split-KV accordingly.
         :type reducer_max_splits: int
+        :param enable_dcp: Statically enable decode context-parallel causal
+            masking over a cyclic rank-local KV shard.
+        :type enable_dcp: bool
+        :param cp_world: Compile-time DCP world size. Rank-local key ``k`` maps
+            to global key ``k * cp_world + cp_rank``.
+        :type cp_world: int
         """
 
         self.latent_dim = 512
@@ -214,6 +222,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # ``seq_len_q`` is the compile-time query capacity.  Fixed-query
         # specializations use it as the request length; variable-query
         # specializations load each request's actual length from its indptr.
+        if cp_world < 1:
+            raise ValueError(f"cp_world must be positive, got {cp_world}")
+        if not enable_dcp and cp_world != 1:
+            raise ValueError(
+                "cp_world must be 1 when decode context parallelism is disabled"
+            )
+        self.enable_dcp = enable_dcp
+        self.cp_world = cp_world
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
         (
@@ -373,6 +389,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         split_kv: cutlass.Int32,
         cache_seqs: Optional[cute.Tensor],
         cum_seq_lens_q: Optional[cute.Tensor],
+        causal_seqlens_kv_global: Optional[cute.Tensor],
+        cp_rank: cutlass.Int32,
         block_split_kvs: Optional[cute.Tensor],
         softmax_scale: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -417,6 +435,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :param cum_seq_lens_q: Compact-query request indptr with shape
             ``[batch_size + 1]``. Must be ``None`` for fixed Q.
         :type cum_seq_lens_q: cute.Tensor
+        :param causal_seqlens_kv_global: Global exclusive causal bounds for the
+            newest query, with shape [batch_size]. Used only when DCP is
+            statically enabled.
+        :type causal_seqlens_kv_global: cute.Tensor
+        :param cp_rank: Runtime DCP rank in ``[0, cp_world)``.
+        :type cp_rank: cutlass.Int32
         :param block_split_kvs: The block split KV tensor with shape [batch_size]
         :type block_split_kvs: cute.Tensor
         :param softmax_scale: The scale factor for softmax
@@ -952,6 +976,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             split_kv,
             cache_seqs,
             cum_seq_lens_q,
+            causal_seqlens_kv_global,
+            cp_rank,
             block_split_kvs,
             softmax_scale_log2,
             output_scale,
@@ -1060,6 +1086,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         split_kv: cutlass.Int32,
         cache_seqs: cute.Tensor,
         cum_seq_lens_q: Optional[cute.Tensor],
+        causal_seqlens_kv_global: Optional[cute.Tensor],
+        cp_rank: cutlass.Int32,
         block_split_kvs: cute.Tensor,
         softmax_scale_log2: cutlass.Float32,
         output_scale: cutlass.Float32,
@@ -1126,6 +1154,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type split_kv: cutlass.Int32
         :param cache_seqs: The variable sequence length tensor
         :type cache_seqs: cute.Tensor
+        :param causal_seqlens_kv_global: Global exclusive causal bounds for the
+            newest query. Present only in the statically enabled DCP
+            specialization.
+        :type causal_seqlens_kv_global: cute.Tensor
+        :param cp_rank: Runtime rank of this cyclic KV shard
+        :type cp_rank: cutlass.Int32
         :param block_split_kvs: The per-block split_kv values tensor
         :type block_split_kvs: cute.Tensor
         :param softmax_scale_log2: The log2 scale factor for softmax
@@ -1592,6 +1626,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     blk_coord,
                 )
                 if k_tile_count > 0:
+                    causal_seq_len = cutlass.Int32(0)
+                    if cutlass.const_expr(self.enable_dcp):
+                        causal_seq_len = causal_seqlens_kv_global[blk_coord[2]]
                     compute_common_params = SimpleNamespace(
                         blk_coord=blk_coord,
                         split_kv=split_kv,
@@ -1601,6 +1638,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
                         q_len=q_len,
+                        causal_seq_len=causal_seq_len,
+                        cp_rank=cp_rank,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -1680,6 +1719,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     blk_coord,
                 )
                 if k_tile_count > 0:
+                    causal_seq_len = cutlass.Int32(0)
+                    if cutlass.const_expr(self.enable_dcp):
+                        causal_seq_len = causal_seqlens_kv_global[blk_coord[2]]
                     compute_common_params = SimpleNamespace(
                         blk_coord=blk_coord,
                         split_kv=split_kv,
@@ -1689,6 +1731,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
                         q_len=q_len,
+                        causal_seq_len=causal_seq_len,
+                        cp_rank=cp_rank,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -1747,7 +1791,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     k_tile_count,
                     local_split_kv,
                     q_begin,
-                    _,
+                    q_len,
                     valid_q_rows,
                 ) = self.get_k_tile_count(
                     split_kv,
@@ -1757,15 +1801,22 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     blk_coord,
                 )
                 if k_tile_count > 0:
+                    causal_seq_len = cutlass.Int32(0)
+                    if cutlass.const_expr(self.enable_dcp):
+                        causal_seq_len = causal_seqlens_kv_global[blk_coord[2]]
                     compute_common_params = SimpleNamespace(
                         blk_coord=blk_coord,
                         split_kv=split_kv,
                         local_split_kv=local_split_kv,
+                        k_index=k_index,
                         smem_exchange=epilogue_smem_exchange,
                         mAccO=mAccO,
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
                         q_begin=q_begin,
+                        q_len=q_len,
+                        causal_seq_len=causal_seq_len,
+                        cp_rank=cp_rank,
                         L=mCL.shape[1],
                         H=valid_q_rows,
                         tmem_ptr=tmem_ptr,
@@ -1787,9 +1838,64 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         p_cor_consumer_state=p_cor_consumer_state,
                         mma_o_consumer_state=mma_o_consumer_state,
                     )
+                elif cutlass.const_expr(self.enable_dcp):
+                    self.store_empty_dcp_work(
+                        mO,
+                        mLSE,
+                        mAccO,
+                        mAccLSE,
+                        blk_coord,
+                        self.get_valid_q_rows(blk_coord[1]),
+                        tidx,
+                    )
                 tile_sched.advance_to_next_work()
                 work_tile = tile_sched.get_current_work()
         return
+
+    @cute.jit
+    def store_empty_dcp_work(
+        self,
+        mO: Optional[cute.Tensor],
+        mLSE: Optional[cute.Tensor],
+        mAccO: Optional[cute.Tensor],
+        mAccLSE: Optional[cute.Tensor],
+        blk_coord: cute.Coord,
+        valid_q_rows: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        """Materialize O=0 and LSE=-inf for a DCP split with no physical K tile."""
+        cta_m_rows = self.mma_qk_tiler[0] // self.cluster_shape_mnk[0]
+        compute_threads = self.num_compute_warps * self.threads_per_warp
+        local_tidx = tidx % compute_threads
+        cta_row_base = blk_coord[0] * cta_m_rows
+
+        for linear_idx in cutlass.range(
+            local_tidx, cta_m_rows * self.latent_dim, compute_threads
+        ):
+            cta_row = linear_idx // self.latent_dim
+            d_idx = linear_idx % self.latent_dim
+            q_row = cta_row_base + cta_row
+            if cute.elem_less(q_row, valid_q_rows):
+                if cutlass.const_expr(mAccO is None):
+                    mO[q_row, d_idx, blk_coord[1], blk_coord[2]] = self.o_dtype(0.0)
+                else:
+                    mAccO[
+                        q_row,
+                        blk_coord[3],
+                        d_idx,
+                        blk_coord[1],
+                        blk_coord[2],
+                    ] = self.acc_dtype(0.0)
+
+        if cute.elem_less(local_tidx, cta_m_rows):
+            q_row = cta_row_base + local_tidx
+            if cute.elem_less(q_row, valid_q_rows):
+                if cutlass.const_expr(mAccLSE is None):
+                    mLSE[q_row, blk_coord[1], blk_coord[2]] = -self.lse_dtype.inf
+                else:
+                    mAccLSE[
+                        q_row, blk_coord[3], blk_coord[1], blk_coord[2]
+                    ] = -self.lse_dtype.inf
 
     @cute.jit
     def get_valid_q_rows(self, q_tile_idx: cutlass.Int32) -> cutlass.Int32:
@@ -1865,8 +1971,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             if cutlass.const_expr(self.is_var_split_kv):
                 local_split_kv = block_split_kvs[bidz]
             k_tile_total = cute.ceil_div(cache_seqs[bidz], self.mma_qk_tiler[1])
-            k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
-            local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
+            if cutlass.const_expr(self.enable_dcp):
+                k_tile_per_cta = cutlass.max(
+                    cute.ceil_div(k_tile_total, local_split_kv), cutlass.Int32(1)
+                )
+                local_split_kv = cutlass.max(
+                    cute.ceil_div(k_tile_total, k_tile_per_cta), cutlass.Int32(1)
+                )
+            else:
+                k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
+                local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
             gLSE = mAccLSE[q_tile_row, None, q_tile, bidz]
             warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -1887,16 +2001,27 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     )
                     lse_max = cute.arch.fmax(lse_max, local_lse[i])
                 lse_max = cute.arch.warp_reduction_max(lse_max)
-                lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
+                if cutlass.const_expr(self.enable_dcp):
+                    has_valid_lse = lse_max != -self.lse_dtype.inf
+                    lse_max = lse_max if has_valid_lse else 0.0
+                else:
+                    lse_max = lse_max if lse_max != -self.lse_dtype.inf else 0.0
                 sum_lse = 0.0
                 for i in cutlass.range_constexpr(lse_per_thread):
                     sum_lse += cute.math.exp2(local_lse[i] - lse_max, fastmath=True)
                 sum_lse = cute.arch.warp_reduction_sum(sum_lse)
-                global_lse = (
-                    lse_max + cute.math.log2(sum_lse, fastmath=True)
-                    if sum_lse != self.lse_dtype(0.0) or sum_lse != sum_lse
-                    else self.lse_dtype.inf
-                )
+                if cutlass.const_expr(self.enable_dcp):
+                    global_lse = (
+                        lse_max + cute.math.log2(sum_lse, fastmath=True)
+                        if has_valid_lse
+                        else -self.lse_dtype.inf
+                    )
+                else:
+                    global_lse = (
+                        lse_max + cute.math.log2(sum_lse, fastmath=True)
+                        if sum_lse != self.lse_dtype(0.0) or sum_lse != sum_lse
+                        else self.lse_dtype.inf
+                    )
                 if d_tile_idx == 0:
                     if tidx == 0:
                         if cutlass.const_expr(self.is_var_q):
@@ -1906,9 +2031,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 for i in cutlass.range_constexpr(lse_per_thread):
                     split_kv_idx = tidx + i * self.threads_per_warp
                     if cute.elem_less(split_kv_idx, local_split_kv):
-                        smem_lse_scale[split_kv_idx] = cute.math.exp2(
-                            local_lse[i] - global_lse, fastmath=True
-                        )
+                        if cutlass.const_expr(self.enable_dcp):
+                            smem_lse_scale[split_kv_idx] = (
+                                cute.math.exp2(local_lse[i] - global_lse, fastmath=True)
+                                if has_valid_lse
+                                else self.acc_dtype(0.0)
+                            )
+                        else:
+                            smem_lse_scale[split_kv_idx] = cute.math.exp2(
+                                local_lse[i] - global_lse, fastmath=True
+                            )
 
             pipeline.sync(barrier_id=4)
 
@@ -2862,10 +2994,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             first_q_token = (
                 common_params.blk_coord[1] * self.mma_qk_tiler[0]
             ) // self.num_heads
-        first_mask_tile_idx = cutlass.max(
-            (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
-            cutlass.Int32(0),
-        )
+        if cutlass.const_expr(self.enable_dcp):
+            # The earliest chronological query represented by this physical
+            # M128 tile has the smallest visible rank-local K bound.  Compute
+            # that bound once per query tile, then cap it by the physical
+            # rank-local K extent so a partial physical tail is still masked.
+            dcp_bound_numerator = cutlass.max(
+                common_params.causal_seq_len
+                - common_params.cp_rank
+                - (common_params.q_len - 1)
+                + first_q_token,
+                cutlass.Int32(0),
+            )
+            earliest_local_bound = (
+                dcp_bound_numerator + self.cp_world - 1
+            ) // self.cp_world
+            effective_local_bound = cutlass.min(common_params.K, earliest_local_bound)
+            first_mask_tile_idx = effective_local_bound // tile_n
+        else:
+            first_mask_tile_idx = cutlass.max(
+                (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
+                cutlass.Int32(0),
+            )
 
         # The non-split two-softmax path still needs its global final tile in
         # phase 2 for final metadata exchange, even when that tile is dense.
@@ -3361,15 +3511,18 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         tTR_rAcc = cute.make_fragment_like(tTR_tS, self.acc_dtype)
 
         row_max_new = row_max
-        # Spec-decoding (MTP) causal mask.  For flattened row
+        # Spec-decoding (MTP) causal mask. For flattened row
         #   r = q_token * H + q_head,
         # the usual key < K - S_q + 1 + q_token predicate is equivalent to
         #   H * (key - K + S_q) <= r.
-        # This avoids integer division/modulo.  The enclosing apply_mask
+        # With cyclic DCP, local key k maps to W*k+rank, producing
+        #   H * (W*k + rank - G + S_q) <= r.
+        # Both forms avoid integer division/modulo. The enclosing apply_mask
         # branch remains compile-time false for dense bulk K tiles, so they do
         # not execute any of this row-dependent arithmetic.
         # Masked positions are filled with a large negative sentinel (not -inf)
-        # to avoid NaN propagation when an entire row becomes masked.
+        # to avoid NaN propagation when an entire row becomes masked. The DCP
+        # epilogue turns such an empty row into the neutral O=0, LSE=-inf pair.
         cta_m_rows = self.mma_qk_tiler[0] // self.cluster_shape_mnk[0]
         arch = BaseDSL._get_dsl().get_arch_enum()
         if cutlass.const_expr(arch >= Arch.sm_100 and arch <= Arch.sm_100f):
@@ -3382,14 +3535,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         + tTR_tS[i][0]
                     )
                     key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    mask_threshold = self.num_heads * (
-                        key_pos - common_params.K + common_params.q_len
-                    )
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if not cute.elem_less(flat_q_row, mask_threshold)
-                        else self.acc_dtype(-1.0e6)
-                    )
+                    if cutlass.const_expr(self.enable_dcp):
+                        mask_threshold = self.num_heads * (
+                            self.cp_world * key_pos
+                            + common_params.cp_rank
+                            - common_params.causal_seq_len
+                            + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(key_pos, common_params.K)
+                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
+                    else:
+                        mask_threshold = self.num_heads * (
+                            key_pos - common_params.K + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
             # reduction for row_max
             row_max_new = tTR_rAcc.load().reduce(cute.ReductionOp.MAX, row_max_new, 0)
         elif cutlass.const_expr(
@@ -3426,14 +3593,28 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         + tTR_tS[i][0]
                     )
                     key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    mask_threshold = self.num_heads * (
-                        key_pos - common_params.K + common_params.q_len
-                    )
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if not cute.elem_less(flat_q_row, mask_threshold)
-                        else self.acc_dtype(-1.0e6)
-                    )
+                    if cutlass.const_expr(self.enable_dcp):
+                        mask_threshold = self.num_heads * (
+                            self.cp_world * key_pos
+                            + common_params.cp_rank
+                            - common_params.causal_seq_len
+                            + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(key_pos, common_params.K)
+                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
+                    else:
+                        mask_threshold = self.num_heads * (
+                            key_pos - common_params.K + common_params.q_len
+                        )
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if not cute.elem_less(flat_q_row, mask_threshold)
+                            else self.acc_dtype(-1.0e6)
+                        )
                 # reduction for row_max after manual masking
                 row_max_new = tTR_rAcc.load().reduce(
                     cute.ReductionOp.MAX, row_max_new, 0
@@ -3910,6 +4091,24 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         return mma_o_consumer_state
 
     @cute.jit
+    def dcp_split_has_valid_key(
+        self,
+        common_params: SimpleNamespace,
+        flat_q_row: cutlass.Int32,
+    ) -> cutlass.Boolean:
+        """Whether this row has a visible key in the current local K split."""
+        first_local_key = common_params.k_index * self.mma_qk_tiler[1]
+        mask_threshold = self.num_heads * (
+            self.cp_world * first_local_key
+            + common_params.cp_rank
+            - common_params.causal_seq_len
+            + self.seq_len_q
+        )
+        return cute.elem_less(first_local_key, common_params.K) and not cute.elem_less(
+            flat_q_row, mask_threshold
+        )
+
+    @cute.jit
     def epilogue(
         self,
         common_params: SimpleNamespace,
@@ -3962,14 +4161,33 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             cute.copy(tmem_load_tiled_copy, tTR_tAcc, tTR_rAcc)
 
             # apply output scale and normalize by row_sum
-            for i in cutlass.range(
-                cute.size(tTR_rAcc), vectorize=True, unroll_full=True
-            ):
-                tTR_rAcc[i] = (
-                    tTR_rAcc[i]
-                    * epilogue_params.output_scale
-                    * cute.arch.rcp_approx(row_sum)
+            row_has_valid_key = True
+            if cutlass.const_expr(self.enable_dcp):
+                flat_q_row = (
+                    common_params.blk_coord[1] * self.mma_qk_tiler[0] + tTR_cO[0][0]
                 )
+                row_has_valid_key = self.dcp_split_has_valid_key(
+                    common_params, flat_q_row
+                )
+            if cutlass.const_expr(self.enable_dcp):
+                output_normalizer = (
+                    epilogue_params.output_scale * cute.arch.rcp_approx(row_sum)
+                    if row_has_valid_key
+                    else self.acc_dtype(0.0)
+                )
+                for i in cutlass.range(
+                    cute.size(tTR_rAcc), vectorize=True, unroll_full=True
+                ):
+                    tTR_rAcc[i] = tTR_rAcc[i] * output_normalizer
+            else:
+                for i in cutlass.range(
+                    cute.size(tTR_rAcc), vectorize=True, unroll_full=True
+                ):
+                    tTR_rAcc[i] = (
+                        tTR_rAcc[i]
+                        * epilogue_params.output_scale
+                        * cute.arch.rcp_approx(row_sum)
+                    )
 
             # store o to global memory
             tR2G_rO_src = None
@@ -4080,6 +4298,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 cute.math.log2(row_sum, fastmath=True)
                 + epilogue_params.softmax_scale_log2 * row_max
             )
+            if cutlass.const_expr(self.enable_dcp):
+                lse = lse if row_has_valid_key else -self.lse_dtype.inf
             # When writing directly to the user-facing mLSE (single-tile,
             # no split-KV merge), convert from log2 base to natural log.
             # When writing the per-split intermediate (mAccLSE branch), keep

--- a/flashinfer/cute_dsl/attention/monolithic/mla_helpers.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_helpers.py
@@ -300,5 +300,67 @@ LOG2_E = 1.4426950408889634074
 MAX_SPLITS = 256
 
 
+@cute.jit
+def get_variable_query_tile_info(
+    num_heads: cutlass.Constexpr,
+    q_tile_idx: cutlass.Int32,
+    batch_idx: cutlass.Int32,
+    cum_seq_lens_q: cute.Tensor,
+    m_tile: cutlass.Constexpr,
+) -> tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]:
+    """Return request-local metadata for one compact token/head tile.
+
+    Compact Q uses ``row = token * num_heads + head``. Returns
+    ``(q_begin, q_len, valid_rows)``; ``valid_rows == 0`` identifies a
+    rectangular schedule slot beyond the request. Such a slot must remain
+    scheduler-valid and become a no-op rather than terminate a persistent
+    scheduler iteration.
+    """
+    # Every caller supplies a CTA-uniform request index. Marking the two indptr
+    # loads warp-uniform avoids issuing the same scalar load in every lane,
+    # especially in the many small standalone-reducer CTAs.
+    q_begin = cute.arch.make_warp_uniform(cum_seq_lens_q[batch_idx])
+    q_end = cute.arch.make_warp_uniform(cum_seq_lens_q[batch_idx + 1])
+    q_len = q_end - q_begin
+
+    remaining_rows = q_len * num_heads - q_tile_idx * m_tile
+    valid_rows = cutlass.max(
+        cutlass.Int32(0),
+        cutlass.min(cutlass.Int32(m_tile), remaining_rows),
+    )
+    return q_begin, q_len, valid_rows
+
+
 def ceil_div(a: int, b: int) -> int:
     return (a + b - 1) // b
+
+
+def compute_q_tile_layout(
+    num_heads: int, seq_len_q: int, m_tile: int = 128
+) -> tuple[int, int, int]:
+    """Return ``(total_rows, num_tiles, tail_rows)`` for flat query packing.
+
+    Query-token and head modes are one affine row space ordered as
+    ``flat_row = q_token * num_heads + q_head``.  Consecutive M tiles may
+    therefore cross token boundaries; only the final tile can be partial.
+    ``tail_rows`` is always in ``[1, m_tile]`` and equals ``m_tile`` when the
+    flattened row count exactly fills the final tile.
+
+    This host-side helper is shared by launch/workspace selection and both
+    kernel variants so their split-KV geometry cannot drift apart.
+    """
+    if num_heads <= 0:
+        raise ValueError(f"num_heads must be positive, got {num_heads}")
+    if seq_len_q <= 0:
+        raise ValueError(f"seq_len_q must be positive, got {seq_len_q}")
+    if m_tile <= 0:
+        raise ValueError(f"m_tile must be positive, got {m_tile}")
+    if num_heads > m_tile:
+        raise ValueError(
+            f"num_heads ({num_heads}) must not exceed the MMA M tile ({m_tile})"
+        )
+
+    total_rows = num_heads * seq_len_q
+    num_tiles = ceil_div(total_rows, m_tile)
+    tail_rows = total_rows - (num_tiles - 1) * m_tile
+    return total_rows, num_tiles, tail_rows

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1983,13 +1983,60 @@ def _round_to_seq_len_bucket(x: int) -> int:
     return 1 << (x - 1).bit_length()
 
 
+def _resolve_cute_dsl_workspace_sizer(
+    cute_dsl_impl: str,
+    sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
+):
+    """Resolve the selected CuTeDSL implementation and its workspace policy."""
+    from ..cute_dsl.attention.mla_dispatch import _resolve_impl
+
+    resolved_impl = _resolve_impl(requested=cute_dsl_impl, kwargs={"sinks": sinks})
+    if resolved_impl == "monolithic":
+        from ..cute_dsl.attention.monolithic.mla_decode import (
+            _get_split_kv_and_workspace_size,
+        )
+    else:
+        from ..cute_dsl.attention.wrappers.batch_mla import (
+            _get_split_kv_and_workspace_size,
+        )
+    return _get_split_kv_and_workspace_size, resolved_impl
+
+
+def _get_cute_dsl_workspace_sizer(
+    cute_dsl_impl: str,
+    sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
+):
+    """Return the workspace policy owned by the selected CuTeDSL implementation."""
+    return _resolve_cute_dsl_workspace_sizer(cute_dsl_impl, sinks)[0]
+
+
+def _call_cute_dsl_workspace_sizer(
+    workspace_sizer,
+    resolved_impl: str,
+    batch_size: int,
+    q_len: int,
+    num_heads: int,
+    kv_lora_rank: int,
+    max_active_blocks: int,
+    max_seq_len: int,
+):
+    """Call an implementation's workspace policy with its supported arguments."""
+    args = (batch_size, q_len, num_heads, kv_lora_rank, max_active_blocks)
+    if resolved_impl == "monolithic":
+        return workspace_sizer(*args, max_seq_len)
+    return workspace_sizer(*args)
+
+
 def _cute_dsl_max_supported_batch(
     workspace_bytes: int,
     q_len: int,
     num_heads: int,
     kv_lora_rank: int,
     max_active_blocks: int,
+    max_seq_len: int,
     candidate_max: int,
+    cute_dsl_impl: str,
+    sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
 ) -> int:
     """Largest batch the caller's workspace can support for cute-dsl MLA decode.
 
@@ -1997,15 +2044,22 @@ def _cute_dsl_max_supported_batch(
     split-K state. Binary-search for the largest ``B <= candidate_max`` whose
     ``get_workspace_size(...)`` fits in ``workspace_bytes``.
     """
-    from ..cute_dsl.attention.wrappers.batch_mla import (
-        _get_split_kv_and_workspace_size,
+    workspace_sizer, resolved_impl = _resolve_cute_dsl_workspace_sizer(
+        cute_dsl_impl, sinks
     )
 
     lo, hi = 1, max(1, candidate_max)
     while lo < hi:
         mid = (lo + hi + 1) // 2
-        _, ws = _get_split_kv_and_workspace_size(
-            mid, q_len, num_heads, kv_lora_rank, max_active_blocks
+        _, ws = _call_cute_dsl_workspace_sizer(
+            workspace_sizer,
+            resolved_impl,
+            mid,
+            q_len,
+            num_heads,
+            kv_lora_rank,
+            max_active_blocks,
+            max_seq_len,
         )
         if ws <= workspace_bytes:
             lo = mid
@@ -2020,7 +2074,10 @@ def _compute_mla_decode_buckets(
     q_len: int,
     num_heads: int,
     kv_lora_rank: int,
+    max_seq_len: int,
     device: torch.device,
+    cute_dsl_impl: str,
+    sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
 ) -> Tuple[int, ...]:
     """Compute the autotune bucket list from kernel/workspace limits only.
 
@@ -2048,7 +2105,10 @@ def _compute_mla_decode_buckets(
             num_heads=num_heads,
             kv_lora_rank=kv_lora_rank,
             max_active_blocks=get_num_sm(device),
+            max_seq_len=max_seq_len,
             candidate_max=_TRTLLM_GEN_MLA_MAX_BATCH,
+            cute_dsl_impl=cute_dsl_impl,
+            sinks=sinks,
         )
         cap = max(cap, cute_dsl_cap)
 
@@ -2068,9 +2128,9 @@ def _cute_dsl_incompatibility_reason(
     kv_lora_rank: int,
     page_size: int,
     is_var_seq: bool,
-    return_lse: bool,
-    lse: Optional[torch.Tensor],
     cute_dsl_impl: str = "auto",
+    cum_seq_lens_q: Optional[torch.Tensor] = None,
+    max_q_len: Optional[int] = None,
 ) -> Optional[str]:
     """Return None if cute-dsl can handle this call, else a human-readable reason.
 
@@ -2126,11 +2186,32 @@ def _cute_dsl_incompatibility_reason(
     # We don't pre-reject here so that the common case
     # (cute_dsl_impl="auto" + LSE + no sinks → monolithic) goes through.
 
-    _, q_len, num_heads, _ = query.shape
+    is_var_q = cum_seq_lens_q is not None
+    if is_var_q:
+        if query.ndim != 3 or max_q_len is None:
+            return (
+                "cute-dsl backend (MLA decode kernel) requires compact "
+                "query [total_q, H, D] and max_q_len for variable Q"
+            )
+        q_len = max_q_len
+        num_heads = query.shape[1]
+    else:
+        if query.ndim != 4:
+            return (
+                "cute-dsl backend (MLA decode kernel) requires query rank 4 for fixed Q"
+            )
+        _, q_len, num_heads, _ = query.shape
     try:
         from ..cute_dsl.attention.mla_dispatch import _resolve_impl
 
-        resolved_impl = _resolve_impl(requested=cute_dsl_impl, kwargs={"sinks": sinks})
+        resolved_impl = _resolve_impl(
+            requested=cute_dsl_impl,
+            kwargs={
+                "sinks": sinks,
+                "cum_seq_lens_q": cum_seq_lens_q,
+                "max_q_len": max_q_len,
+            },
+        )
     except (ValueError, ImportError) as e:
         return f"cute-dsl backend (MLA decode kernel): {e}"
 
@@ -2214,6 +2295,10 @@ def _build_mla_decode_tuning_config(
     kv_lora_rank: int,
     max_seq_len: int,
     device: torch.device,
+    cute_dsl_impl: str = "auto",
+    sinks: Optional[
+        Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]
+    ] = None,
 ) -> TuningConfig:
     """Reduce call args to the memoization key of ``_mla_decode_tuning_config``.
 
@@ -2236,7 +2321,10 @@ def _build_mla_decode_tuning_config(
         q_len,
         num_heads,
         kv_lora_rank,
+        max_seq_len,
         device,
+        cute_dsl_impl,
+        sinks,
     )
 
     return _mla_decode_tuning_config(buckets, num_pages, profile_seq_len)
@@ -2489,6 +2577,9 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         self.return_lse = return_lse
         self.sinks = sinks
         self.cute_dsl_impl = cute_dsl_impl
+        self._workspace_sizer, self._resolved_cute_dsl_impl = (
+            _resolve_cute_dsl_workspace_sizer(cute_dsl_impl, sinks)
+        )
 
     def __hash__(self):
         # See TrtllmGenMlaDecodeRunner.__hash__ — tactic-determining state is
@@ -2502,15 +2593,19 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         # If the caller's workspace can't fit batch=B for this profile, opt
         # out so the autotuner skips us (no JIT cost) and trtllm-gen wins by
         # default for that bucket.
-        from ..cute_dsl.attention.wrappers.batch_mla import (
-            _get_split_kv_and_workspace_size,
-        )
         from ..cute_dsl.utils import get_num_sm
 
         q = inputs[0]
         B, q_len, num_heads, _ = q.shape
-        _, ws = _get_split_kv_and_workspace_size(
-            B, q_len, num_heads, self.kv_lora_rank, get_num_sm(q.device)
+        _, ws = _call_cute_dsl_workspace_sizer(
+            self._workspace_sizer,
+            self._resolved_cute_dsl_impl,
+            B,
+            q_len,
+            num_heads,
+            self.kv_lora_rank,
+            get_num_sm(q.device),
+            self.max_seq_len,
         )
         workspace_bytes = (
             self.workspace_buffer.numel() * self.workspace_buffer.element_size()
@@ -2524,9 +2619,19 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         # Cute-dsl rejects sparse/skip-softmax/tensor-scales upstream, so
         # those are omitted from extras as constants for this runner.
         # ``sinks`` and ``cute_dsl_impl`` are included because they flip the
-        # impl (modular vs monolithic) inside ``cute_dsl_mla_decode``.
+        # impl (modular vs monolithic) inside ``cute_dsl_mla_decode``.  The
+        # monolithic K-tile count and workspace capacity keep cache hits from
+        # bypassing a different split-workspace validity decision.
         sinks_key = (
             None if self.sinks is None else (tuple(self.sinks.shape), self.sinks.dtype)
+        )
+        workspace_bytes = (
+            self.workspace_buffer.numel() * self.workspace_buffer.element_size()
+        )
+        seq_len_workspace_key = (
+            (self.max_seq_len + 127) // 128
+            if self._resolved_cute_dsl_impl == "monolithic"
+            else _round_to_seq_len_bucket(self.max_seq_len)
         )
         return (
             q.dtype,
@@ -2536,7 +2641,8 @@ class CuteDslMlaDecodeRunner(TunableRunner):
             self.kv_lora_rank,
             self.qk_rope_head_dim,
             self.page_size,
-            _round_to_seq_len_bucket(self.max_seq_len),
+            seq_len_workspace_key,
+            workspace_bytes,
             self.is_var_seq,
             self.uses_shared_paged_kv_idx,
             self.enable_pdl,
@@ -2614,8 +2720,11 @@ def trtllm_batch_decode_with_kv_cache_mla(
     query : torch.Tensor
         Query tensor with shape
         ``[batch_size, q_len_per_request, num_heads, head_dim_qk]`` where
-        ``head_dim_qk = kv_lora_rank + qk_rope_head_dim``. For the SM120/SM121
-        v32/GLM sparse backend, this must be BF16 with ``head_dim_qk == 576``.
+        ``head_dim_qk = kv_lora_rank + qk_rope_head_dim``. When
+        ``cum_seq_lens_q`` is provided, TRTLLM-GEN and monolithic CuTeDSL
+        instead accept compact ``[total_q, num_heads, head_dim_qk]`` input.
+        For the SM120/SM121 v32/GLM sparse backend, this must be BF16 with
+        ``head_dim_qk == 576``.
     kv_cache : torch.Tensor
         For TRTLLM-GEN, CuteDSL, and XQA, the paged KV cache is
         ``[num_pages, page_size, kv_lora_rank + qk_rope_head_dim]`` or
@@ -2690,9 +2799,13 @@ def trtllm_batch_decode_with_kv_cache_mla(
         chooses ``"trtllm-gen"`` for SM100/SM103 sparse MLA and chooses
         ``"sparse"`` for SM120/SM121 when ``sparse_mla_top_k > 0``; otherwise
         SM120/SM121 dense decode uses ``"xqa"``.
-        The ``cute-dsl`` backend has two interchangeable implementations
-        (``monolithic`` and ``modular``) on the same shape/dtype envelope;
-        which one runs is controlled by the ``cute_dsl_impl`` kwarg below.
+        For compact variable Q on SM100/SM103, ``"auto"`` keeps TRTLLM-GEN
+        when it supports the call and uses monolithic CuTeDSL for TRT gaps or
+        LSE output.
+        The ``cute-dsl`` backend has monolithic and modular implementations
+        with a common fixed-Q shape/dtype envelope. Compact variable Q is
+        monolithic-only, while features such as ``sinks`` are modular-only;
+        selection is controlled by the ``cute_dsl_impl`` kwarg below.
     is_var_seq : bool
         Whether the sequence length is variable.
         If True, the sequence length is variable.
@@ -2710,14 +2823,17 @@ def trtllm_batch_decode_with_kv_cache_mla(
         * ``[batch_size * q_len_per_request, num_qo_heads]`` (TRTLLM-GEN
           native; accepted by sparse), or
         * ``[batch_size, q_len_per_request, num_qo_heads]`` (cute-dsl native;
-          also accepted by cute-dsl).
+          also accepted by cute-dsl), or
+        * ``[total_q, num_qo_heads]`` for compact variable Q with monolithic
+          CuTeDSL.
 
         If ``return_lse`` is True and this is None, a buffer will be
         allocated by the backend.
     return_lse : bool = False
         Whether to return LSE values. Supported by ``trtllm-gen``,
         ``cute-dsl``, and ``sparse`` backends. When True, the function
-        returns ``(out, lse)``.
+        returns ``(out, lse)``. With compact variable Q, LSE is currently
+        supported only by monolithic CuTeDSL.
     cute_dsl_impl : str = "auto"
         Which cute-dsl implementation to use. Honored when
         ``backend="cute-dsl"`` and when ``backend="auto"`` considers the
@@ -2725,7 +2841,8 @@ def trtllm_batch_decode_with_kv_cache_mla(
 
         * ``"auto"`` (default) — picks monolithic by default, automatically
           promoted to modular when the call uses a feature monolithic
-          doesn't support (currently ``sinks``).
+          doesn't support (currently ``sinks``), and keeps compact variable Q
+          on monolithic.
         * ``"modular"`` — strict.  Always run the modular kernels.
         * ``"monolithic"`` — strict.  Always run the monolithic kernels;
           raise :class:`ValueError` if the call uses any modular-only
@@ -2740,9 +2857,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
         shape ``[batch_size + 1]``, dtype ``torch.int32``. Must be a 1D tensor
         with at least two entries. When ``max_q_len`` is not provided, this
         function validates that it starts with 0, ends at ``query.size(0)``,
-        and is monotonically non-decreasing. Only supported by the
-        ``trtllm-gen`` backend. When provided, ``query`` must have shape
-        ``[total_q, num_heads, head_dim_qk]``.
+        and is monotonically non-decreasing. Supported by TRTLLM-GEN and the
+        monolithic CuTeDSL implementation. When provided, ``query`` must have
+        shape ``[total_q, num_heads, head_dim_qk]``.
         For best performance, provide ``max_q_len`` together with
         ``cum_seq_lens_q`` to avoid host-side metadata validation.
     max_q_len : Optional[int] = None
@@ -2920,8 +3037,16 @@ def trtllm_batch_decode_with_kv_cache_mla(
     sm_count = get_device_sm_count(query.device)
 
     block_size = kv_cache.size(-2)
+    num_heads_q = query.size(-2)
     trtllm_gen_not_supported_reason: Optional[str] = None
-    if block_size != 32 and block_size != 64:
+    if 64 < num_heads_q < 128:
+        trtllm_gen_not_supported_reason = (
+            "trtllm-gen MLA decode does not support "
+            f"64 < num_heads_q < 128; got num_heads_q={num_heads_q}. "
+            "Use backend='cute-dsl' instead when the remaining configuration "
+            "is CuTeDSL-compatible."
+        )
+    elif block_size != 32 and block_size != 64:
         trtllm_gen_not_supported_reason = (
             f"trtllm-gen requires block_size in (32, 64), got {block_size}"
         )
@@ -2931,12 +3056,6 @@ def trtllm_batch_decode_with_kv_cache_mla(
 
     has_var_q = cum_seq_lens_q is not None
     if has_var_q:
-        if backend == "cute-dsl":
-            raise ValueError("cute-dsl MLA does not support cum_seq_lens_q")
-        if return_lse or lse is not None:
-            raise NotImplementedError(
-                "trtllm-gen MLA does not support return_lse/lse with cum_seq_lens_q"
-            )
         if query.ndim != 3:
             raise ValueError(
                 "query must have shape [total_q, num_heads, head_dim_qk] "
@@ -2979,8 +3098,60 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 )
         elif max_q_len <= 0:
             raise ValueError("max_q_len must be greater than 0")
-        elif max_q_len > query.size(0):
-            raise ValueError("max_q_len cannot exceed the flattened query length")
+
+        trt_var_q_reason = trtllm_gen_not_supported_reason
+        if return_lse or lse is not None:
+            trt_var_q_reason = (
+                "trtllm-gen MLA does not support return_lse/lse with cum_seq_lens_q"
+            )
+
+        # Explicit TRT and auto calls that TRT supports do not need to import
+        # or validate CuTeDSL. Evaluate the fallback only when it can run.
+        cute_dsl_reason: Optional[str] = None
+        if backend == "cute-dsl" or (
+            backend == "auto" and trt_var_q_reason is not None
+        ):
+            cute_dsl_reason = _cute_dsl_incompatibility_reason(
+                query,
+                torch.bfloat16,
+                bmm1_scale,
+                bmm2_scale,
+                sinks,
+                sparse_mla_top_k,
+                skip_softmax_threshold_scale_factor,
+                uses_shared_paged_kv_idx,
+                qk_rope_head_dim,
+                kv_lora_rank,
+                kv_cache.shape[-2],
+                is_var_seq,
+                cute_dsl_impl,
+                cum_seq_lens_q,
+                max_q_len,
+            )
+
+        selected_var_q_backend: str
+        if backend == "cute-dsl":
+            if cute_dsl_reason is not None:
+                raise ValueError(cute_dsl_reason)
+            selected_var_q_backend = "cute-dsl"
+        elif backend == "trtllm-gen":
+            if trt_var_q_reason is not None:
+                if return_lse or lse is not None:
+                    raise NotImplementedError(trt_var_q_reason)
+                raise ValueError(trt_var_q_reason)
+            selected_var_q_backend = "trtllm-gen"
+        else:
+            # CuTeDSL fills TRT capability gaps and is the ragged-Q LSE path.
+            if trt_var_q_reason is None:
+                selected_var_q_backend = "trtllm-gen"
+            elif cute_dsl_reason is None:
+                selected_var_q_backend = "cute-dsl"
+            else:
+                raise ValueError(
+                    "auto: no backend supports this variable-Q configuration "
+                    f"(trtllm-gen: {trt_var_q_reason}; "
+                    f"cute-dsl: {cute_dsl_reason})"
+                )
 
         kv_cache = _check_trtllm_gen_mla_shape(
             query,
@@ -2993,7 +3164,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
             uses_shared_paged_kv_idx,
             batch_size=batch_size,
             max_q_len=max_q_len,
-            require_aligned_block_table=False,
+            require_aligned_block_table=selected_var_q_backend == "cute-dsl",
         )
 
         expected_out_shape = query.shape[:-1] + (kv_lora_rank,)
@@ -3008,6 +3179,52 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 torch.bfloat16,
                 query.device,
                 "out",
+            )
+
+        if return_lse:
+            expected_lse_shape = (query.size(0), query.size(1))
+            if lse is None:
+                lse = torch.empty(
+                    expected_lse_shape,
+                    dtype=torch.float32,
+                    device=query.device,
+                )
+            else:
+                check_shape_dtype_device(
+                    lse,
+                    expected_lse_shape,
+                    torch.float32,
+                    query.device,
+                    "lse",
+                )
+
+        if selected_var_q_backend == "cute-dsl":
+            if multi_ctas_kv_counter_buffer is not None:
+                raise ValueError(
+                    "multi_ctas_kv_counter_buffer is only supported by the "
+                    "trtllm-gen backend"
+                )
+            from ..cute_dsl.attention import cute_dsl_mla_decode
+
+            return cute_dsl_mla_decode(
+                query=query,
+                kv_cache=kv_cache,
+                workspace_buffer=workspace_buffer,
+                kv_lora_rank=kv_lora_rank,
+                qk_rope_head_dim=qk_rope_head_dim,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                max_seq_len=max_seq_len,
+                softmax_scale=bmm1_scale,
+                output_scale=bmm2_scale,
+                out=out,
+                is_var_seq=is_var_seq,
+                enable_pdl=enable_pdl,
+                lse=lse,
+                return_lse=return_lse,
+                cute_dsl_impl=cute_dsl_impl,
+                cum_seq_lens_q=cum_seq_lens_q,
+                max_q_len=max_q_len,
             )
 
         multi_ctas_kv_counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
@@ -3123,8 +3340,6 @@ def trtllm_batch_decode_with_kv_cache_mla(
         kv_lora_rank,
         page_size,
         is_var_seq,
-        return_lse,
-        lse,
         cute_dsl_impl,
     )
     if backend == "cute-dsl":
@@ -3224,6 +3439,8 @@ def trtllm_batch_decode_with_kv_cache_mla(
         kv_lora_rank=kv_lora_rank,
         max_seq_len=max_seq_len,
         device=query.device,
+        cute_dsl_impl=cute_dsl_impl,
+        sinks=sinks,
     )
     inputs = [query, block_tables, seq_lens, out]
     runner, tactic = AutoTuner.get().choose_one(

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1986,28 +1986,36 @@ def _round_to_seq_len_bucket(x: int) -> int:
 def _resolve_cute_dsl_workspace_sizer(
     cute_dsl_impl: str,
     sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
+    enable_dcp: bool = False,
 ):
     """Resolve the selected CuTeDSL implementation and its workspace policy."""
     from ..cute_dsl.attention.mla_dispatch import _resolve_impl
 
-    resolved_impl = _resolve_impl(requested=cute_dsl_impl, kwargs={"sinks": sinks})
+    resolved_impl = _resolve_impl(
+        requested=cute_dsl_impl,
+        kwargs={"sinks": sinks, "enable_dcp": enable_dcp},
+    )
     if resolved_impl == "monolithic":
         from ..cute_dsl.attention.monolithic.mla_decode import (
-            _get_split_kv_and_workspace_size,
+            _get_split_kv_and_workspace_size as monolithic_workspace_sizer,
         )
-    else:
-        from ..cute_dsl.attention.wrappers.batch_mla import (
-            _get_split_kv_and_workspace_size,
-        )
-    return _get_split_kv_and_workspace_size, resolved_impl
+
+        return monolithic_workspace_sizer, resolved_impl
+
+    from ..cute_dsl.attention.wrappers.batch_mla import (
+        _get_split_kv_and_workspace_size as modular_workspace_sizer,
+    )
+
+    return modular_workspace_sizer, resolved_impl
 
 
 def _get_cute_dsl_workspace_sizer(
     cute_dsl_impl: str,
     sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
+    enable_dcp: bool = False,
 ):
     """Return the workspace policy owned by the selected CuTeDSL implementation."""
-    return _resolve_cute_dsl_workspace_sizer(cute_dsl_impl, sinks)[0]
+    return _resolve_cute_dsl_workspace_sizer(cute_dsl_impl, sinks, enable_dcp)[0]
 
 
 def _call_cute_dsl_workspace_sizer(
@@ -2037,6 +2045,7 @@ def _cute_dsl_max_supported_batch(
     candidate_max: int,
     cute_dsl_impl: str,
     sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
+    enable_dcp: bool = False,
 ) -> int:
     """Largest batch the caller's workspace can support for cute-dsl MLA decode.
 
@@ -2045,7 +2054,7 @@ def _cute_dsl_max_supported_batch(
     ``get_workspace_size(...)`` fits in ``workspace_bytes``.
     """
     workspace_sizer, resolved_impl = _resolve_cute_dsl_workspace_sizer(
-        cute_dsl_impl, sinks
+        cute_dsl_impl, sinks, enable_dcp
     )
 
     lo, hi = 1, max(1, candidate_max)
@@ -2078,6 +2087,7 @@ def _compute_mla_decode_buckets(
     device: torch.device,
     cute_dsl_impl: str,
     sinks: Optional[Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]],
+    enable_dcp: bool = False,
 ) -> Tuple[int, ...]:
     """Compute the autotune bucket list from kernel/workspace limits only.
 
@@ -2109,10 +2119,104 @@ def _compute_mla_decode_buckets(
             candidate_max=_TRTLLM_GEN_MLA_MAX_BATCH,
             cute_dsl_impl=cute_dsl_impl,
             sinks=sinks,
+            enable_dcp=enable_dcp,
         )
         cap = max(cap, cute_dsl_cap)
 
     return get_hybrid_num_tokens_buckets(max(1, cap))
+
+
+def _validate_mla_dcp_args(
+    *,
+    query: torch.Tensor,
+    backend: str,
+    sinks: Optional[List[torch.Tensor]],
+    cum_seq_lens_q: Optional[torch.Tensor],
+    max_q_len: Optional[int],
+    return_lse: bool,
+    enable_dcp: bool,
+    cp_world: int,
+    cp_rank: int,
+    causal_seqlens_kv_global: Optional[torch.Tensor],
+) -> str:
+    """Validate the public DCP contract and return the effective backend."""
+    if not isinstance(enable_dcp, bool):
+        raise TypeError(f"enable_dcp must be a bool, got {type(enable_dcp).__name__}")
+    if not isinstance(cp_world, int) or isinstance(cp_world, bool) or cp_world <= 0:
+        raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
+    if not isinstance(cp_rank, int) or isinstance(cp_rank, bool):
+        raise TypeError(f"cp_rank must be an integer, got {type(cp_rank).__name__}")
+
+    if not enable_dcp:
+        nondefault = []
+        if cp_world != 1:
+            nondefault.append(f"cp_world={cp_world}")
+        if cp_rank != 0:
+            nondefault.append(f"cp_rank={cp_rank}")
+        if causal_seqlens_kv_global is not None:
+            nondefault.append("causal_seqlens_kv_global")
+        if nondefault:
+            raise ValueError(
+                "DCP arguments require enable_dcp=True; got " + ", ".join(nondefault)
+            )
+        return backend
+
+    if query.ndim != 4:
+        raise ValueError(
+            "DCP requires a dense query with shape "
+            "[batch_size, q_len_per_request, num_heads, head_dim_qk]"
+        )
+    if not 0 <= cp_rank < cp_world:
+        raise ValueError(
+            f"cp_rank must satisfy 0 <= cp_rank < cp_world, got "
+            f"cp_rank={cp_rank}, cp_world={cp_world}"
+        )
+    if backend not in ("auto", "cute-dsl"):
+        raise ValueError(
+            f"enable_dcp=True is only supported by backend='cute-dsl', got "
+            f"backend={backend!r}"
+        )
+    if not return_lse:
+        raise ValueError(
+            "enable_dcp=True requires return_lse=True so rank-local "
+            "attention states can be merged"
+        )
+    if sinks is not None:
+        raise ValueError(
+            "DCP cannot be combined with sinks: DCP requires monolithic "
+            "CuTeDSL MLA, while sinks require the modular implementation"
+        )
+    if cum_seq_lens_q is not None or max_q_len is not None:
+        raise ValueError("DCP does not support cum_seq_lens_q / max_q_len")
+    if causal_seqlens_kv_global is None:
+        raise ValueError("causal_seqlens_kv_global is required when enable_dcp=True")
+    if not isinstance(causal_seqlens_kv_global, torch.Tensor):
+        raise TypeError(
+            "causal_seqlens_kv_global must be a torch.Tensor, got "
+            f"{type(causal_seqlens_kv_global).__name__}"
+        )
+    if causal_seqlens_kv_global.dtype != torch.int32:
+        raise ValueError(
+            "causal_seqlens_kv_global must have dtype torch.int32, got "
+            f"{causal_seqlens_kv_global.dtype}"
+        )
+    if not causal_seqlens_kv_global.is_cuda:
+        raise ValueError("causal_seqlens_kv_global must be a CUDA tensor")
+    if causal_seqlens_kv_global.device != query.device:
+        raise ValueError(
+            "causal_seqlens_kv_global must be on the query device "
+            f"{query.device}, got {causal_seqlens_kv_global.device}"
+        )
+    if tuple(causal_seqlens_kv_global.shape) != (query.shape[0],):
+        raise ValueError(
+            "causal_seqlens_kv_global must have shape "
+            f"({query.shape[0]},), got {tuple(causal_seqlens_kv_global.shape)}"
+        )
+    if not causal_seqlens_kv_global.is_contiguous():
+        raise ValueError("causal_seqlens_kv_global must be contiguous")
+
+    # DCP masking exists only in the monolithic CuTeDSL implementation.
+    return "cute-dsl"
 
 
 def _cute_dsl_incompatibility_reason(
@@ -2131,6 +2235,8 @@ def _cute_dsl_incompatibility_reason(
     cute_dsl_impl: str = "auto",
     cum_seq_lens_q: Optional[torch.Tensor] = None,
     max_q_len: Optional[int] = None,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
 ) -> Optional[str]:
     """Return None if cute-dsl can handle this call, else a human-readable reason.
 
@@ -2210,18 +2316,23 @@ def _cute_dsl_incompatibility_reason(
                 "sinks": sinks,
                 "cum_seq_lens_q": cum_seq_lens_q,
                 "max_q_len": max_q_len,
+                "enable_dcp": enable_dcp,
             },
         )
-    except (ValueError, ImportError) as e:
+    except (TypeError, ValueError, ImportError) as e:
         return f"cute-dsl backend (MLA decode kernel): {e}"
 
     try:
         if resolved_impl == "monolithic":
-            from ..cute_dsl.attention.monolithic.mla_decode import _check_can_implement
+            from ..cute_dsl.attention.monolithic.mla_decode import (
+                _check_can_implement as check_monolithic_can_implement,
+            )
         else:
-            from ..cute_dsl.attention.wrappers.batch_mla import _check_can_implement
+            from ..cute_dsl.attention.wrappers.batch_mla import (
+                _check_can_implement as check_modular_can_implement,
+            )
 
-        _check_can_implement(
+        check_kwargs = dict(
             torch_dtype=query.dtype,
             torch_out_dtype=out_dtype,
             page_size=page_size,
@@ -2233,7 +2344,12 @@ def _cute_dsl_incompatibility_reason(
             is_var_seq=is_var_seq,
             is_var_split_kv=False,
         )
-    except (ValueError, ImportError) as e:
+        if resolved_impl == "monolithic":
+            check_kwargs.update(enable_dcp=enable_dcp, cp_world=cp_world)
+            check_monolithic_can_implement(**check_kwargs)
+        else:
+            check_modular_can_implement(**check_kwargs)
+    except (TypeError, ValueError, ImportError) as e:
         return f"cute-dsl backend (MLA decode kernel) cannot implement this configuration: {e}"
     return None
 
@@ -2243,8 +2359,11 @@ def _mla_decode_tuning_config(
     buckets: tuple[int, ...],
     num_pages: int,
     profile_seq_len: int,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
+    cp_rank: int = 0,
 ) -> TuningConfig:
-    """One TuningConfig (and one pair of initializer closures) per key.
+    """One TuningConfig and stable initializer set per key.
 
     Memoized because ``AutoTuner._find_nearest_profile`` lru-caches on
     ``(shapes, tuning_config)``: a fresh config per dispatcher call shares
@@ -2252,12 +2371,13 @@ def _mla_decode_tuning_config(
     ``tensor_initializers``) but never compares equal (closures compare by
     identity), so would result in a leak.
 
-    The DynamicTensorSpec sweeps batch dim across all four ``inputs`` tensors
-    (query, block_tables, seq_lens, out). ``block_tables`` is initialized via
-    ``random_(0, num_pages)`` which wraps mod kv_cache size — safe for autotune
-    profiling because MLA decode reads kv_cache and never writes it, so aliased
-    page reads give correct timing measurements. ``seq_lens`` is filled
-    homogeneously with ``profile_seq_len``.
+    The DynamicTensorSpec sweeps batch dim across ``query``, ``block_tables``,
+    ``seq_lens``, ``out``, and, for DCP, ``causal_seqlens_kv_global``.
+    ``block_tables`` is initialized via ``random_(0, num_pages)`` which wraps
+    mod kv_cache size — safe for autotune profiling because MLA decode reads
+    kv_cache and never writes it, so aliased page reads give correct timing
+    measurements. ``seq_lens`` is filled with ``profile_seq_len``; the
+    synthetic DCP global bound preserves that exact rank-local length.
     """
 
     def init_block_tables(shapes, dtype, device):
@@ -2270,14 +2390,32 @@ def _mla_decode_tuning_config(
         tensor.fill_(profile_seq_len)
         return tensor
 
+    def init_causal_seqlens_kv_global(shapes, dtype, device):
+        tensor = torch.empty(shapes, dtype=dtype, device=device)
+        tensor.fill_(profile_seq_len * cp_world + cp_rank)
+        return tensor
+
+    input_idx = (0, 1, 2, 3, 4) if enable_dcp else (0, 1, 2, 3)
+    tensor_initializers = (
+        (
+            None,
+            init_block_tables,
+            init_seq_lens,
+            None,
+            init_causal_seqlens_kv_global,
+        )
+        if enable_dcp
+        else (None, init_block_tables, init_seq_lens, None)
+    )
+
     return TuningConfig(
         dynamic_tensor_specs=(
             DynamicTensorSpec(
-                input_idx=(0, 1, 2, 3),
-                dim_idx=(0, 0, 0, 0),
+                input_idx=input_idx,
+                dim_idx=(0,) * len(input_idx),
                 gen_tuning_buckets=buckets,
                 map_to_tuning_buckets=make_bucket_mapper(buckets, round_map=False),
-                tensor_initializers=(None, init_block_tables, init_seq_lens, None),
+                tensor_initializers=tensor_initializers,
             ),
         ),
         use_cuda_graph=True,
@@ -2299,6 +2437,9 @@ def _build_mla_decode_tuning_config(
     sinks: Optional[
         Union[List[torch.Tensor], Tuple[torch.Tensor, ...], torch.Tensor]
     ] = None,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
+    cp_rank: int = 0,
 ) -> TuningConfig:
     """Reduce call args to the memoization key of ``_mla_decode_tuning_config``.
 
@@ -2325,9 +2466,17 @@ def _build_mla_decode_tuning_config(
         device,
         cute_dsl_impl,
         sinks,
+        enable_dcp,
     )
 
-    return _mla_decode_tuning_config(buckets, num_pages, profile_seq_len)
+    return _mla_decode_tuning_config(
+        buckets,
+        num_pages,
+        profile_seq_len,
+        enable_dcp,
+        cp_world,
+        cp_rank,
+    )
 
 
 class TrtllmGenMlaDecodeRunner(TunableRunner):
@@ -2553,6 +2702,9 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         return_lse: bool,
         sinks: Optional[torch.Tensor],
         cute_dsl_impl: str,
+        enable_dcp: bool = False,
+        cp_world: int = 1,
+        cp_rank: int = 0,
     ):
         from ..cute_dsl.attention import cute_dsl_mla_decode
 
@@ -2577,8 +2729,12 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         self.return_lse = return_lse
         self.sinks = sinks
         self.cute_dsl_impl = cute_dsl_impl
+        self.enable_dcp = enable_dcp
+        self.cp_world = cp_world
+        self.cp_rank = cp_rank
+        self._profile_lse: Optional[torch.Tensor] = None
         self._workspace_sizer, self._resolved_cute_dsl_impl = (
-            _resolve_cute_dsl_workspace_sizer(cute_dsl_impl, sinks)
+            _resolve_cute_dsl_workspace_sizer(cute_dsl_impl, sinks, enable_dcp)
         )
 
     def __hash__(self):
@@ -2615,7 +2771,7 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         return [-1]
 
     def get_cache_key_extras(self, inputs):
-        q, _, _, out = inputs
+        q, _, _, out = inputs[:4]
         # Cute-dsl rejects sparse/skip-softmax/tensor-scales upstream, so
         # those are omitted from extras as constants for this runner.
         # ``sinks`` and ``cute_dsl_impl`` are included because they flip the
@@ -2648,6 +2804,8 @@ class CuteDslMlaDecodeRunner(TunableRunner):
             self.enable_pdl,
             sinks_key,
             self.cute_dsl_impl,
+            getattr(self, "enable_dcp", False),
+            getattr(self, "cp_world", 1),
         )
 
     def forward(
@@ -2657,7 +2815,31 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         do_preparation: bool = False,
         **kwargs,
     ):
-        query, block_tables, seq_lens, out = inputs
+        query, block_tables, seq_lens, out = inputs[:4]
+        causal_seqlens_kv_global = inputs[4] if self.enable_dcp else None
+
+        # LSE is not a tuning input because it does not influence tactic
+        # selection. When a synthetic batch differs from the caller batch,
+        # provide matching temporary storage while retaining the caller's LSE
+        # for the final invocation.
+        lse = self.lse
+        if self.return_lse:
+            expected_numel = query.shape[0] * query.shape[1] * query.shape[2]
+            if lse is None or lse.numel() != expected_numel:
+                expected_shape = (
+                    query.shape[0] * query.shape[1],
+                    query.shape[2],
+                )
+                if (
+                    self._profile_lse is None
+                    or tuple(self._profile_lse.shape) != expected_shape
+                ):
+                    self._profile_lse = torch.empty(
+                        expected_shape,
+                        dtype=torch.float32,
+                        device=query.device,
+                    )
+                lse = self._profile_lse
         return self._run(
             query=query,
             kv_cache=self.kv_cache,
@@ -2673,10 +2855,14 @@ class CuteDslMlaDecodeRunner(TunableRunner):
             out_dtype=self.out_dtype,
             is_var_seq=self.is_var_seq,
             enable_pdl=self.enable_pdl,
-            lse=self.lse,
+            lse=lse,
             return_lse=self.return_lse,
             sinks=self.sinks,
             cute_dsl_impl=self.cute_dsl_impl,
+            enable_dcp=self.enable_dcp,
+            cp_world=self.cp_world,
+            cp_rank=self.cp_rank,
+            causal_seqlens_kv_global=causal_seqlens_kv_global,
         )
 
 
@@ -2708,6 +2894,10 @@ def trtllm_batch_decode_with_kv_cache_mla(
     cum_seq_lens_q: Optional[torch.Tensor] = None,
     max_q_len: Optional[int] = None,
     multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
+    cp_rank: int = 0,
+    causal_seqlens_kv_global: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode MLA with TRTLLM-GEN, CuteDSL, XQA, or SM120/SM121 sparse kernels.
 
@@ -2755,12 +2945,15 @@ def trtllm_batch_decode_with_kv_cache_mla(
         With ``backend="trtllm-gen"``, the final dimension may use its native
         width and does not need padding to a multiple of ``128 / page_size``.
     seq_lens : Optional[torch.Tensor]
-        Per-request KV sequence lengths for dense and TRTLLM-GEN paths. For
+        Per-request physical KV sequence lengths for dense and TRTLLM-GEN
+        paths. With DCP these are rank-local lengths and continue to control
+        paging, memory bounds, and split-KV. For
         SM120/SM121 sparse v32/GLM, pass ``[batch_size, q_len_per_request]`` or
         flattened ``[batch_size * q_len_per_request]`` active top-k lengths; if
         ``None``, every column in ``block_tables`` is active.
     max_seq_len : int
-        Maximum KV sequence length used for dense/TRTLLM-GEN scheduling.
+        Maximum physical KV sequence length used for dense/TRTLLM-GEN
+        scheduling. With DCP this is the maximum rank-local length.
         Ignored by the SM120/SM121 sparse v32/GLM backend.
     sparse_mla_top_k : int
         Enables sparse MLA when greater than zero. On SM100/SM103 this selects
@@ -2880,6 +3073,18 @@ def trtllm_batch_decode_with_kv_cache_mla(
         for each concurrently executing CUDA stream or graph. Autotune profiling
         uses runner-owned internal storage; the caller buffer is used only for the
         final request.
+    enable_dcp : bool = False
+        Statically enable cyclic decode context parallelism in the monolithic
+        CuTeDSL MLA kernel. DCP returns a rank-local output/LSE state, so
+        ``return_lse=True`` is required and the caller must merge rank states.
+    cp_world : int = 1
+        Compile-time context-parallel world size. Rank ``r`` stores global KV
+        positions whose token index modulo ``cp_world`` equals ``r``.
+    cp_rank : int = 0
+        Runtime-uniform context-parallel rank.
+    causal_seqlens_kv_global : Optional[torch.Tensor] = None
+        Contiguous CUDA int32 tensor ``[batch_size]`` containing the global
+        exclusive causal bound for the newest query token. Required with DCP.
 
     Note
     ----
@@ -2903,11 +3108,12 @@ def trtllm_batch_decode_with_kv_cache_mla(
     Autotune
     --------
     On SM100/SM103 dense MLA, calling under ``flashinfer.autotune(True)`` with
-    ``backend="auto"`` profiles both ``trtllm-gen`` and ``cute-dsl`` across a
-    bucketed batch sweep up to each runner's kernel/workspace cap and caches the
-    winning runner per shape signature. Subsequent calls under
-    ``autotune(False)`` dispatch to the cached choice; any batch outside the
-    tuned range falls back to a default runner with a one-time warning.
+    ``backend="auto"`` profiles both ``trtllm-gen`` and ``cute-dsl`` when DCP
+    is disabled. DCP profiles only its required monolithic CuTeDSL runner.
+    Both modes use a bucketed batch sweep up to each runner's kernel/workspace
+    cap and cache the winning tactic per shape signature. Subsequent calls under
+    ``autotune(False)`` use the cached choice; any batch outside the tuned range
+    falls back to the runner's default tactic with a one-time warning.
 
     The autotune bucket range and cache key do **not** depend on
     ``kv_cache.shape[0]`` (the number of pages in the pool), so reallocating the
@@ -2928,6 +3134,19 @@ def trtllm_batch_decode_with_kv_cache_mla(
             raise TypeError("bmm2_scale tensor must have dtype torch.float32")
     if max_q_len is not None and cum_seq_lens_q is None:
         raise ValueError("max_q_len is only supported when cum_seq_lens_q is provided")
+
+    backend = _validate_mla_dcp_args(
+        query=query,
+        backend=backend,
+        sinks=sinks,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=max_q_len,
+        return_lse=return_lse,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
+        cp_rank=cp_rank,
+        causal_seqlens_kv_global=causal_seqlens_kv_global,
+    )
 
     if backend == "auto":
         cc = get_compute_capability(query.device)
@@ -3124,9 +3343,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 kv_lora_rank,
                 kv_cache.shape[-2],
                 is_var_seq,
-                cute_dsl_impl,
-                cum_seq_lens_q,
-                max_q_len,
+                cute_dsl_impl=cute_dsl_impl,
+                cum_seq_lens_q=cum_seq_lens_q,
+                max_q_len=max_q_len,
             )
 
         selected_var_q_backend: str
@@ -3340,7 +3559,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
         kv_lora_rank,
         page_size,
         is_var_seq,
-        cute_dsl_impl,
+        cute_dsl_impl=cute_dsl_impl,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
     )
     if backend == "cute-dsl":
         if cute_dsl_reason is not None:
@@ -3425,6 +3646,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 return_lse=return_lse,
                 sinks=cute_dsl_sinks,
                 cute_dsl_impl=cute_dsl_impl,
+                enable_dcp=enable_dcp,
+                cp_world=cp_world,
+                cp_rank=cp_rank,
             )
         )
 
@@ -3441,8 +3665,15 @@ def trtllm_batch_decode_with_kv_cache_mla(
         device=query.device,
         cute_dsl_impl=cute_dsl_impl,
         sinks=sinks,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
+        cp_rank=cp_rank,
     )
     inputs = [query, block_tables, seq_lens, out]
+    if enable_dcp:
+        # The global causal bound varies with batch and must be synthesized
+        # alongside the other batch-shaped tensors during autotuning.
+        inputs.append(causal_seqlens_kv_global)
     runner, tactic = AutoTuner.get().choose_one(
         "trtllm_batch_decode_mla",
         runners,

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -2692,6 +2692,11 @@ trtllm_batch_decode_mla_sparse_trace = TraceTemplate(
 
 
 def trtllm_batch_decode_mla_trace_dispatch(**kwargs):
+    if kwargs.get("enable_dcp", False):
+        raise NotImplementedError(
+            "fi_trace does not yet represent cyclic DCP KV ownership or "
+            "cross-rank LSE merging for MLA decode"
+        )
     sparse_mla_top_k = int(kwargs.get("sparse_mla_top_k", 0) or 0)
     if sparse_mla_top_k > 0:
         return trtllm_batch_decode_mla_sparse_trace

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -666,17 +666,31 @@ class TllmGenFmhaKernel {
     return seqLenPerCtaKv <= 1024 && numCtas <= params.mMultiProcessorCount;
   }
 
+  // Return the smallest shipped MLA head tile that contains a non-power-of-two head group below
+  // 64 heads. Power-of-two groups and groups with at least 128 heads return zero so callers
+  // preserve their existing heuristics; the unsupported 65-127 gap has no Q128 MLA cubin.
+  static int getPaddedMlaTileSizeQ(int numHeadsQPerKv) {
+    FLASHINFER_CHECK(numHeadsQPerKv > 0, "The numHeadsQPerKv must be positive, got %d.",
+                     numHeadsQPerKv);
+    if (numHeadsQPerKv >= 128 || (numHeadsQPerKv & (numHeadsQPerKv - 1)) == 0) {
+      return 0;
+    }
+    FLASHINFER_CHECK(numHeadsQPerKv <= 64,
+                     "Non-power-of-two MLA numHeadsQPerKv must be <= 64, got %d.", numHeadsQPerKv);
+    return std::max(8, flashinfer::UpPowerOfTwo(numHeadsQPerKv));
+  }
+
   // Select the sparse MLA generation kernel.
   // Heuristics benchmarked on B200 (SM=148, sparseMlaTopK=2048).
   void selectSparseMlaGenerationKernel(RunnerParams const& params,
                                        SelectKernelParams& selectKernelParams) const {
     // numHeadsQ <= 32 : SwapsMmaAbForGeneration
-    //   tileSizeQ = numHeadsQPerKv/2 at batch=1 (GPU under-utilized with full tile; halving creates
-    //               2x more head-splitting CTAs), or numHeadsQPerKv at batch>=2.
+    //   Non-power-of-two head counts use one padded Q8/Q16/Q32 tile. Power-of-two head counts use
+    //   tileSizeQ = numHeadsQPerKv/2 at batch=1 or numHeadsQPerKv at batch>=2.
     //   Threshold: batchSize * maxNumCtasPerSeqKv <= MP/8  (crossover at batch=1->2 on B200).
     //   Benchmarks (seqLen=8192, topK=2048): half tileSizeQ wins by 2-6% at batch=1;
     //     full tileSizeQ wins by 2-11% at batch>=2.
-    // numHeadsQ >= 64 : KeepsMmaAbForGeneration, tileSizeQ = 64
+    // numHeadsQ > 32 : KeepsMmaAbForGeneration, tileSizeQ = 64
     //   numHeadsQ=128 at large batch : 2CTA (clusterDimX=2, headDimPerCtaV=256)
     //   otherwise                    : 1CTA, headDimPerCtaV fine-tuned later
     //   Note: at small batch e4m3 prefers SwapsMmaAb tileSizeQ=32 (+10%), but fp16 prefers
@@ -706,7 +720,7 @@ class TllmGenFmhaKernel {
                                                               params.mMultiProcessorCount / 8;
       tileSizeQ = useHalfTileSizeQ ? halfTileSizeQ : fullTileSizeQ;
     } else {
-      // numHeadsQ >= 64: use KeepsMmaAbForGeneration.
+      // numHeadsQ > 32: use KeepsMmaAbForGeneration.
       kernelType = FmhaKernelType::KeepsMmaAbForGeneration;
       tileSizeQ = 64;
       selectKernelParams.mTileSizeKv = 128;
@@ -735,6 +749,12 @@ class TllmGenFmhaKernel {
         selectKernelParams.mHeadDimPerCtaV = 256;
       }
     }
+    // Preserve the legacy heuristic above for power-of-two groups. A non-power-of-two group must
+    // fit in one padded tile because the final head CTA cannot process a partial tile.
+    if (int const paddedTileSizeQ = getPaddedMlaTileSizeQ(params.mNumHeadsQPerKv);
+        paddedTileSizeQ != 0) {
+      tileSizeQ = paddedTileSizeQ;
+    }
   }
 
   // Select the MLA generation kernel.
@@ -748,13 +768,16 @@ class TllmGenFmhaKernel {
     if (isSparseMla(params.mSparseMlaType)) {
       selectSparseMlaGenerationKernel(params, selectKernelParams);
     } else {
+      int const paddedTileSizeQ = getPaddedMlaTileSizeQ(params.mNumHeadsQPerKv);
       // Non-sparse MLA: use SwapsMmaAb when numHeadsQPerKv <= 32 or seqLenPerCtaKv is small.
-      bool const useSwapsMmaAb = params.mNumHeadsQPerKv <= 32 || useSwapsMmaAbMlaGenKernel(params);
+      // Padded Q64 must use KeepsMmaAb so split-KV also follows its standalone-reducer path.
+      bool const useSwapsMmaAb =
+          paddedTileSizeQ != 0 ? paddedTileSizeQ <= 32
+                               : params.mNumHeadsQPerKv <= 32 || useSwapsMmaAbMlaGenKernel(params);
 
       if (useSwapsMmaAb) {
         kernelType = FmhaKernelType::SwapsMmaAbForGeneration;
-        // Non-sparse MLA (legacy): tileSizeQ capped at 16.
-        tileSizeQ = params.mNumHeadsQPerKv <= 8 ? 8 : 16;
+        tileSizeQ = paddedTileSizeQ != 0 ? paddedTileSizeQ : (params.mNumHeadsQPerKv <= 8 ? 8 : 16);
       } else {
         kernelType = FmhaKernelType::KeepsMmaAbForGeneration;
         tileSizeQ = 64;

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -59,11 +59,9 @@ ATTENTION_MASK_TYPE_FUNCTION(Custom)
 enum class FmhaKernelType {
   // The context-phase kernels.
   Context = 0,
-  // Choose the best generation kernel based on the heuristic:
-  // use SwapsMmaAbForGeneration kernels when numHeadsQPerKv <= 16, otherwise
-  // KeepsMmaAbForGeneration.
+  // Choose the best generation kernel based on the heuristic.
   Generation = 1,
-  // Swap tensor A and tensor B of Mma, which only supports numHeadsQPerKv <= 16.
+  // Swap tensor A and tensor B of Mma. MLA cubins provide Q8, Q16, and Q32 head tiles.
   SwapsMmaAbForGeneration,
   // Keep tensor A and tensor B of Mma.
   KeepsMmaAbForGeneration,

--- a/tests/attention/test_cute_dsl_mla_dcp.py
+++ b/tests/attention/test_cute_dsl_mla_dcp.py
@@ -1,0 +1,1069 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Correctness tests for static DCP support in monolithic CuTe DSL MLA."""
+
+import math
+from bisect import bisect_left
+from unittest import mock
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.utils import is_sm100a_supported, is_sm110a_supported
+
+
+_LATENT_DIM = 512
+_ROPE_DIM = 64
+_QK_DIM = _LATENT_DIM + _ROPE_DIM
+_PAGE_SIZE = 64
+
+
+def _skip_if_unsupported() -> None:
+    device = torch.device("cuda")
+    if not (is_sm100a_supported(device) or is_sm110a_supported(device)):
+        pytest.skip("Requires SM100-SM110 (tcgen05)")
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    return -(-numerator // denominator)
+
+
+def _local_causal_bound(
+    global_bound_newest: int,
+    q_len: int,
+    q_idx: int,
+    cp_world: int,
+    cp_rank: int,
+) -> int:
+    return _ceil_div(
+        global_bound_newest - cp_rank - (q_len - 1) + q_idx,
+        cp_world,
+    )
+
+
+def _flat_dcp_score_is_valid(
+    flat_q_row: int,
+    num_heads: int,
+    local_key: int,
+    q_len: int,
+    global_bound_newest: int,
+    cp_world: int,
+    cp_rank: int,
+) -> bool:
+    return flat_q_row >= num_heads * (
+        cp_world * local_key + cp_rank - global_bound_newest + q_len
+    )
+
+
+def _local_length(global_length: int, cp_world: int, cp_rank: int) -> int:
+    return max(_ceil_div(global_length - cp_rank, cp_world), 0)
+
+
+def _make_inputs(
+    *,
+    global_length: int,
+    q_len: int,
+    num_heads: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create one batch of quantized-once Q and global-coordinate KV."""
+    return _make_batched_inputs(
+        global_lengths=(global_length,),
+        q_len=q_len,
+        num_heads=num_heads,
+        dtype=dtype,
+    )
+
+
+def _make_batched_inputs(
+    *,
+    global_lengths: tuple[int, ...],
+    q_len: int,
+    num_heads: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create a heterogeneous batch with one padded global-coordinate KV pool."""
+    device = torch.device("cuda")
+    storage_dtype = torch.float16 if dtype == torch.float8_e4m3fn else dtype
+    batch_size = len(global_lengths)
+    query = (
+        torch.randn(
+            batch_size,
+            q_len,
+            num_heads,
+            _QK_DIM,
+            device=device,
+            dtype=storage_dtype,
+        )
+        * 0.1
+    ).to(dtype)
+    global_kv = (
+        torch.randn(
+            batch_size,
+            max(global_lengths),
+            _QK_DIM,
+            device=device,
+            dtype=storage_dtype,
+        )
+        * 0.1
+    ).to(dtype)
+    global_lens = torch.tensor(global_lengths, dtype=torch.int32, device=device)
+    return query, global_kv, global_lens
+
+
+def _pack_cyclic_rank_pages(
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    cp_world: int,
+    cp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Pack ``g % cp_world == cp_rank`` tokens into a contiguous paged cache."""
+    batch_size, _, d_qk = global_kv.shape
+    global_lens_host = global_lens.tolist()
+    local_lens_host = [
+        _local_length(global_len, cp_world, cp_rank) for global_len in global_lens_host
+    ]
+    pages_per_batch = [
+        max(1, _ceil_div(local_len, _PAGE_SIZE)) for local_len in local_lens_host
+    ]
+    max_pages = max(pages_per_batch)
+    total_pages = sum(pages_per_batch)
+
+    local_cache = torch.zeros(
+        total_pages,
+        _PAGE_SIZE,
+        d_qk,
+        dtype=global_kv.dtype,
+        device=global_kv.device,
+    )
+    block_tables = torch.zeros(
+        batch_size,
+        max_pages,
+        dtype=torch.int32,
+        device=global_kv.device,
+    )
+
+    next_page = 0
+    for batch_idx, (global_len, local_len, num_pages) in enumerate(
+        zip(
+            global_lens_host,
+            local_lens_host,
+            pages_per_batch,
+            strict=True,
+        )
+    ):
+        page_ids = torch.arange(
+            next_page,
+            next_page + num_pages,
+            dtype=torch.int32,
+            device=global_kv.device,
+        )
+        block_tables[batch_idx, :num_pages] = page_ids
+        if local_len:
+            local_tokens = global_kv[batch_idx, cp_rank:global_len:cp_world]
+            local_cache[next_page : next_page + num_pages].view(-1, d_qk)[
+                :local_len
+            ].copy_(local_tokens)
+        next_page += num_pages
+
+    local_lens = torch.tensor(
+        local_lens_host, dtype=torch.int32, device=global_kv.device
+    )
+    return (
+        local_cache,
+        block_tables,
+        local_lens,
+        max(1, max(local_lens_host)),
+    )
+
+
+def _reference_attention(
+    query: torch.Tensor,
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    *,
+    cp_world: int = 1,
+    cp_rank: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference one cyclic rank; world=1 is the full-context reference."""
+    batch_size, q_len, num_heads, _ = query.shape
+    out = torch.zeros(
+        batch_size,
+        q_len,
+        num_heads,
+        _LATENT_DIM,
+        dtype=torch.float32,
+        device=query.device,
+    )
+    lse = torch.full(
+        (batch_size, q_len, num_heads),
+        -torch.inf,
+        dtype=torch.float32,
+        device=query.device,
+    )
+    softmax_scale = 1.0 / math.sqrt(_LATENT_DIM)
+
+    for batch_idx, global_len in enumerate(global_lens.tolist()):
+        keys = global_kv[batch_idx, cp_rank:global_len:cp_world].float()
+        global_positions = range(cp_rank, global_len, cp_world)
+        for q_idx in range(q_len):
+            global_bound = global_len - (q_len - 1) + q_idx
+            # Count directly in global coordinates so this reference remains
+            # independent of the ceiling-divided kernel formula without
+            # synchronizing on a CUDA predicate.
+            visible_count = bisect_left(global_positions, global_bound)
+            if visible_count == 0:
+                continue
+            visible_keys = keys[:visible_count]
+            scores = torch.einsum(
+                "hd,kd->hk",
+                query[batch_idx, q_idx].float(),
+                visible_keys,
+            )
+            scores *= softmax_scale
+            lse[batch_idx, q_idx] = torch.logsumexp(scores, dim=-1)
+            probabilities = torch.softmax(scores, dim=-1)
+            out[batch_idx, q_idx] = torch.einsum(
+                "hk,kd->hd",
+                probabilities,
+                visible_keys[:, :_LATENT_DIM],
+            )
+    return out, lse
+
+
+def _merge_rank_outputs_natural_log(
+    rank_outputs: list[torch.Tensor],
+    rank_lses: list[torch.Tensor],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Stable LSE-weighted merge for the kernel's natural-log public LSE."""
+    outputs = torch.stack([out.float() for out in rank_outputs], dim=0)
+    lses = torch.stack([lse.float() for lse in rank_lses], dim=0)
+    max_lse = lses.max(dim=0).values
+    has_keys = torch.isfinite(max_lse)
+    safe_max = torch.where(has_keys, max_lse, torch.zeros_like(max_lse))
+    weights = torch.where(
+        torch.isfinite(lses),
+        torch.exp(lses - safe_max.unsqueeze(0)),
+        torch.zeros_like(lses),
+    )
+    weight_sum = weights.sum(dim=0)
+    safe_sum = torch.where(has_keys, weight_sum, torch.ones_like(weight_sum))
+    merged_out = (outputs * weights.unsqueeze(-1)).sum(dim=0) / safe_sum.unsqueeze(-1)
+    merged_out = torch.where(
+        has_keys.unsqueeze(-1), merged_out, torch.zeros_like(merged_out)
+    )
+    merged_lse = torch.where(
+        has_keys,
+        safe_max + torch.log(safe_sum),
+        torch.full_like(max_lse, -torch.inf),
+    )
+    return merged_out, merged_lse
+
+
+def _prepare_rank_call(
+    query: torch.Tensor,
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    *,
+    cp_world: int,
+    cp_rank: int,
+    is_var_seq: bool = False,
+    enable_pdl: bool = False,
+) -> tuple[dict, int]:
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size,
+    )
+    from flashinfer.cute_dsl.utils import get_num_sm
+
+    kv_cache, block_tables, local_lens, max_local_len = _pack_cyclic_rank_pages(
+        global_kv, global_lens, cp_world, cp_rank
+    )
+    batch_size, q_len, num_heads, _ = query.shape
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        batch_size,
+        q_len,
+        num_heads,
+        _LATENT_DIM,
+        get_num_sm(query.device),
+        max_local_len,
+    )
+    workspace = torch.empty(
+        max(workspace_size, 1), dtype=torch.int8, device=query.device
+    )
+    return (
+        {
+            "query": query,
+            "kv_cache": kv_cache,
+            "workspace_buffer": workspace,
+            "kv_lora_rank": _LATENT_DIM,
+            "qk_rope_head_dim": _ROPE_DIM,
+            "block_tables": block_tables,
+            "seq_lens": local_lens,
+            "max_seq_len": max_local_len,
+            "softmax_scale": 1.0 / math.sqrt(_LATENT_DIM),
+            "is_var_seq": is_var_seq,
+            "enable_pdl": enable_pdl,
+        },
+        split_kv,
+    )
+
+
+def _launch_rank(
+    query: torch.Tensor,
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    *,
+    cp_world: int,
+    cp_rank: int,
+    enable_dcp: bool,
+    causal_lens: torch.Tensor | None = None,
+    is_var_seq: bool = False,
+    enable_pdl: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        cute_dsl_mla_decode,
+    )
+
+    call_args, split_kv = _prepare_rank_call(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=cp_world,
+        cp_rank=cp_rank,
+        is_var_seq=is_var_seq,
+        enable_pdl=enable_pdl,
+    )
+    kwargs = {}
+    if enable_dcp:
+        kwargs = {
+            "enable_dcp": True,
+            "cp_world": cp_world,
+            "cp_rank": cp_rank,
+            "causal_seqlens_kv_global": (
+                global_lens if causal_lens is None else causal_lens
+            ),
+        }
+    out, lse = cute_dsl_mla_decode(
+        return_lse=True,
+        **call_args,
+        **kwargs,
+    )
+    return out, lse, split_kv
+
+
+def _assert_close_to_reference(
+    out: torch.Tensor,
+    lse: torch.Tensor,
+    ref_out: torch.Tensor,
+    ref_lse: torch.Tensor,
+    dtype: torch.dtype,
+) -> None:
+    if dtype == torch.float8_e4m3fn:
+        out_atol, out_rtol = 0.1, 0.1
+        lse_atol, lse_rtol = 0.2, 0.1
+    else:
+        out_atol = out_rtol = lse_atol = lse_rtol = 1e-2
+    torch.testing.assert_close(out.float(), ref_out, atol=out_atol, rtol=out_rtol)
+    torch.testing.assert_close(lse.float(), ref_lse, atol=lse_atol, rtol=lse_rtol)
+
+
+def _assert_dcp_rank_merge_matches_reference(
+    query: torch.Tensor,
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    *,
+    cp_world: int,
+    dtype: torch.dtype,
+    is_var_seq: bool = False,
+) -> list[int]:
+    """Check every rank-local state and their final natural-log merge."""
+    rank_outputs = []
+    rank_lses = []
+    split_kvs = []
+    for cp_rank in range(cp_world):
+        out, lse, split_kv = _launch_rank(
+            query,
+            global_kv,
+            global_lens,
+            cp_world=cp_world,
+            cp_rank=cp_rank,
+            enable_dcp=True,
+            is_var_seq=is_var_seq,
+        )
+        ref_rank_out, ref_rank_lse = _reference_attention(
+            query,
+            global_kv,
+            global_lens,
+            cp_world=cp_world,
+            cp_rank=cp_rank,
+        )
+        _assert_close_to_reference(out, lse, ref_rank_out, ref_rank_lse, dtype)
+        rank_outputs.append(out)
+        rank_lses.append(lse)
+        split_kvs.append(split_kv)
+
+    merged_out, merged_lse = _merge_rank_outputs_natural_log(rank_outputs, rank_lses)
+    ref_out, ref_lse = _reference_attention(query, global_kv, global_lens)
+    _assert_close_to_reference(merged_out, merged_lse, ref_out, ref_lse, dtype)
+    return split_kvs
+
+
+def test_dcp_flat_mask_matches_ceiling_divided_bound():
+    """The division-free flattened predicate must match global coordinates."""
+    for num_heads in (6, 12, 24, 48, 64, 96, 128):
+        for q_len in (1, 2, 4, 8):
+            for cp_world in (1, 2, 4):
+                for cp_rank in range(cp_world):
+                    for global_len in (q_len, q_len + 1, 127, 128, 129):
+                        local_len = _local_length(global_len, cp_world, cp_rank)
+                        for q_idx in range(q_len):
+                            for local_key in range(local_len):
+                                expected = (
+                                    local_key * cp_world + cp_rank
+                                    < global_len - (q_len - 1) + q_idx
+                                )
+                                for head in (0, num_heads - 1):
+                                    flat_q_row = q_idx * num_heads + head
+                                    assert (
+                                        _flat_dcp_score_is_valid(
+                                            flat_q_row,
+                                            num_heads,
+                                            local_key,
+                                            q_len,
+                                            global_len,
+                                            cp_world,
+                                            cp_rank,
+                                        )
+                                        == expected
+                                    )
+
+
+def test_dcp_per_query_tile_dense_boundary_is_conservative():
+    """A tile marked dense must be valid for every real row and local key."""
+    k_tile = 128
+    for num_heads in (6, 12, 24, 48, 64, 96, 128):
+        for q_len in (2, 4, 8, 32):
+            num_q_tiles = _ceil_div(q_len * num_heads, 128)
+            for cp_world in (1, 2, 4):
+                for cp_rank in range(cp_world):
+                    global_len = max(q_len, 277)
+                    local_len = _local_length(global_len, cp_world, cp_rank)
+                    global_positions = range(cp_rank, global_len, cp_world)
+                    for q_tile_idx in range(num_q_tiles):
+                        first_flat_row = q_tile_idx * 128
+                        first_q = first_flat_row // num_heads
+                        earliest_bound = bisect_left(
+                            global_positions,
+                            global_len - (q_len - 1) + first_q,
+                        )
+                        effective_bound = min(max(earliest_bound, 0), local_len)
+                        first_mask_k_tile = effective_bound // k_tile
+                        for k_tile_idx in range(first_mask_k_tile):
+                            local_begin = k_tile_idx * k_tile
+                            local_end = min(local_begin + k_tile, local_len)
+                            for flat_q_row in range(
+                                first_flat_row,
+                                min(
+                                    first_flat_row + 128,
+                                    q_len * num_heads,
+                                ),
+                            ):
+                                for local_key in range(local_begin, local_end):
+                                    assert _flat_dcp_score_is_valid(
+                                        flat_q_row,
+                                        num_heads,
+                                        local_key,
+                                        q_len,
+                                        global_len,
+                                        cp_world,
+                                        cp_rank,
+                                    )
+
+
+def test_cute_dsl_mla_dcp_rejects_incomplete_static_contract():
+    """Reject DCP calls that cannot produce mergeable rank-local states."""
+    _skip_if_unsupported()
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        cute_dsl_mla_decode,
+    )
+
+    torch.manual_seed(40)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=128,
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    call_args, _ = _prepare_rank_call(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=0,
+    )
+
+    ragged_call_args = {**call_args, "query": query[:, 0]}
+    with pytest.raises(ValueError, match="query must have shape"):
+        cute_dsl_mla_decode(**ragged_call_args)
+    with pytest.raises(ValueError, match="requires return_lse=True"):
+        cute_dsl_mla_decode(
+            **call_args,
+            enable_dcp=True,
+            cp_world=2,
+            cp_rank=0,
+            causal_seqlens_kv_global=global_lens,
+        )
+    with pytest.raises(ValueError, match="causal_seqlens_kv_global is required"):
+        cute_dsl_mla_decode(
+            **call_args,
+            enable_dcp=True,
+            cp_world=2,
+            cp_rank=0,
+            return_lse=True,
+        )
+    with pytest.raises(TypeError, match="must be a torch.Tensor"):
+        cute_dsl_mla_decode(
+            **call_args,
+            enable_dcp=True,
+            cp_world=2,
+            cp_rank=0,
+            causal_seqlens_kv_global=[128],
+            return_lse=True,
+        )
+    with pytest.raises(ValueError, match="0 <= cp_rank < cp_world"):
+        cute_dsl_mla_decode(
+            **call_args,
+            enable_dcp=True,
+            cp_world=2,
+            cp_rank=2,
+            causal_seqlens_kv_global=global_lens,
+            return_lse=True,
+        )
+    with pytest.raises(ValueError, match="require enable_dcp=True"):
+        cute_dsl_mla_decode(**call_args, cp_world=2)
+
+
+def test_cute_dsl_mla_dcp_dispatch_is_strictly_monolithic():
+    """DCP must never silently select a backend with non-DCP mask semantics."""
+    from flashinfer.cute_dsl.attention.mla_dispatch import _resolve_impl
+    from flashinfer.trace.templates.attention import (
+        trtllm_batch_decode_mla_trace_dispatch,
+    )
+
+    assert (
+        _resolve_impl(
+            requested="auto",
+            kwargs={"enable_dcp": True, "cp_world": 2, "cp_rank": 0},
+        )
+        == "monolithic"
+    )
+    with pytest.raises(ValueError, match="only supported by the monolithic"):
+        _resolve_impl(
+            requested="modular",
+            kwargs={"enable_dcp": True, "cp_world": 2, "cp_rank": 0},
+        )
+    with pytest.raises(ValueError, match="cannot be combined with 'sinks'"):
+        _resolve_impl(
+            requested="auto",
+            kwargs={
+                "enable_dcp": True,
+                "cp_world": 2,
+                "cp_rank": 0,
+                "sinks": torch.empty(1),
+            },
+        )
+    with pytest.raises(NotImplementedError, match="does not yet represent"):
+        trtllm_batch_decode_mla_trace_dispatch(enable_dcp=True)
+
+
+def test_cute_dsl_mla_dcp_world1_matches_disabled():
+    """World-one DCP must preserve the existing monolithic MLA result."""
+    _skip_if_unsupported()
+    torch.manual_seed(41)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=128,
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    baseline_out, baseline_lse, baseline_split = _launch_rank(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=1,
+        cp_rank=0,
+        enable_dcp=False,
+    )
+    dcp_out, dcp_lse, dcp_split = _launch_rank(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=1,
+        cp_rank=0,
+        enable_dcp=True,
+    )
+    assert baseline_split == dcp_split == 1
+    torch.testing.assert_close(dcp_out, baseline_out, atol=0, rtol=0)
+    torch.testing.assert_close(dcp_lse, baseline_lse, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_q1_h128_rank_merge(dtype):
+    """Cover the distinct Q1/H128 schedule for both kernel families."""
+    _skip_if_unsupported()
+    torch.manual_seed(49)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=129,
+        q_len=1,
+        num_heads=128,
+        dtype=dtype,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=dtype,
+    )
+    assert split_kvs == [1, 1]
+
+
+@pytest.mark.parametrize("num_heads", [12, 24, 48])
+def test_cute_dsl_mla_dcp_packed_head_counts(num_heads):
+    """Exercise DCP across the supported packed query-tile geometries."""
+    _skip_if_unsupported()
+    torch.manual_seed(50 + num_heads)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=130,
+        q_len=8,
+        num_heads=num_heads,
+        dtype=torch.bfloat16,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=torch.bfloat16,
+    )
+    assert split_kvs == [1, 1]
+
+
+def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor():
+    """The public runner must batch-sweep DCP metadata and return caller B1."""
+    _skip_if_unsupported()
+    from flashinfer import autotune
+    from flashinfer.autotuner import AutoTuner
+    from flashinfer.mla._core import (
+        trtllm_batch_decode_with_kv_cache_mla,
+    )
+
+    torch.manual_seed(47)
+    query, global_kv, global_lens = _make_inputs(
+        # Two local pages satisfy the common public dispatcher's aligned
+        # block-table contract for page_size=64.
+        global_length=256,
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    call_args, split_kv = _prepare_rank_call(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=0,
+    )
+    assert split_kv == 1
+
+    public_args = {
+        "query": query,
+        "kv_cache": call_args["kv_cache"],
+        "workspace_buffer": call_args["workspace_buffer"],
+        "qk_nope_head_dim": 128,
+        "kv_lora_rank": _LATENT_DIM,
+        "qk_rope_head_dim": _ROPE_DIM,
+        "block_tables": call_args["block_tables"],
+        "seq_lens": call_args["seq_lens"],
+        "max_seq_len": call_args["max_seq_len"],
+        "bmm1_scale": call_args["softmax_scale"],
+        "bmm2_scale": 1.0,
+        "backend": "auto",
+        "cute_dsl_impl": "monolithic",
+        "is_var_seq": False,
+        "enable_pdl": False,
+        "return_lse": True,
+        "enable_dcp": True,
+        "cp_world": 2,
+        "cp_rank": 0,
+    }
+    with pytest.raises(TypeError, match="must be a torch.Tensor"):
+        trtllm_batch_decode_with_kv_cache_mla(
+            **public_args,
+            causal_seqlens_kv_global=[256],
+        )
+
+    AutoTuner.get().clear_cache()
+    try:
+        with (
+            mock.patch(
+                "flashinfer.mla._core._compute_mla_decode_buckets",
+                return_value=(2,),
+            ),
+            autotune(tune_mode=True),
+        ):
+            out, lse = trtllm_batch_decode_with_kv_cache_mla(
+                **public_args,
+                causal_seqlens_kv_global=global_lens,
+            )
+    finally:
+        AutoTuner.get().clear_cache()
+
+    ref_out, ref_lse = _reference_attention(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=0,
+    )
+    _assert_close_to_reference(
+        out,
+        lse.view_as(ref_lse),
+        ref_out,
+        ref_lse,
+        torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_rank_mask_and_merge(dtype):
+    """Cover the rank-sensitive G128/Q4/H96 boundary and rank merge."""
+    _skip_if_unsupported()
+    torch.manual_seed(42)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=128,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=dtype,
+    )
+    assert split_kvs == [1, 1]
+
+    # In particular, query zero on rank one has local bound 62, not 63.
+    assert _local_causal_bound(128, 4, 0, cp_world=2, cp_rank=1) == 62
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float16, torch.float8_e4m3fn],
+    ids=["fp16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_world4_variable_batch_h6(dtype):
+    """Cover W4, heterogeneous local tails, FP16, and packed H6 query rows."""
+    _skip_if_unsupported()
+    torch.manual_seed(46)
+    query, global_kv, global_lens = _make_batched_inputs(
+        global_lengths=(65, 130, 259),
+        q_len=8,
+        num_heads=6,
+        dtype=dtype,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=4,
+        dtype=dtype,
+        is_var_seq=True,
+    )
+    assert split_kvs == [1] * 4
+
+
+@pytest.mark.parametrize(
+    "cp_world,global_length,dtype",
+    [
+        pytest.param(4, 4 * 1024 + 3, torch.bfloat16, id="w4-k4k-bf16"),
+        pytest.param(
+            4,
+            4 * 1024 + 3,
+            torch.float8_e4m3fn,
+            id="w4-k4k-fp8",
+        ),
+        pytest.param(8, 8 * 1024 + 5, torch.bfloat16, id="w8-k8k-bf16"),
+        pytest.param(
+            8,
+            8 * 1024 + 5,
+            torch.float8_e4m3fn,
+            id="w8-k8k-fp8",
+        ),
+        pytest.param(16, 16 * 1024 + 9, torch.bfloat16, id="w16-k16k-bf16"),
+        pytest.param(
+            16,
+            16 * 1024 + 9,
+            torch.float8_e4m3fn,
+            id="w16-k16k-fp8",
+        ),
+    ],
+)
+def test_cute_dsl_mla_dcp_rank_scale_merge(cp_world, global_length, dtype):
+    """Cover W4/W8/W16 four-query speculative decode and uneven split-KV."""
+    _skip_if_unsupported()
+    torch.manual_seed(51 + cp_world)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=global_length,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+
+    base_local_length, tail_ranks = divmod(global_length, cp_world)
+    for cp_rank in range(cp_world):
+        expected_local_length = base_local_length + (1 if cp_rank < tail_ranks else 0)
+        assert _local_length(global_length, cp_world, cp_rank) == expected_local_length
+
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=cp_world,
+        dtype=dtype,
+    )
+    assert all(split_kv > 1 for split_kv in split_kvs)
+
+
+def test_cute_dsl_mla_dcp_cuda_graph_reads_updated_causal_bound():
+    """A captured launch must read causal bounds mutated in place on replay."""
+    _skip_if_unsupported()
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        cute_dsl_mla_decode,
+    )
+
+    torch.manual_seed(45)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=128,
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    call_args, split_kv = _prepare_rank_call(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=1,
+    )
+    assert split_kv == 1
+    out = torch.empty(
+        1,
+        4,
+        96,
+        _LATENT_DIM,
+        dtype=torch.bfloat16,
+        device=query.device,
+    )
+    lse = torch.empty(1, 4, 96, dtype=torch.float32, device=query.device)
+    dcp_args = {
+        "enable_dcp": True,
+        "cp_world": 2,
+        "cp_rank": 1,
+        "causal_seqlens_kv_global": global_lens,
+        "return_lse": True,
+        "out": out,
+        "lse": lse,
+    }
+
+    # Compile and initialize all persistent buffers before capture.
+    returned_out, returned_lse = cute_dsl_mla_decode(**call_args, **dcp_args)
+    assert returned_out is out
+    assert returned_lse is lse
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        cute_dsl_mla_decode(**call_args, **dcp_args)
+    lse_at_128 = lse.clone()
+
+    # Keep the physical local cache and seq_lens fixed at the G=128 shard.
+    # The G=126 replay must mask its now-extra global keys 126 and 127.
+    global_lens.fill_(126)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert not torch.equal(lse, lse_at_128)
+    ref_out, ref_lse = _reference_attention(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=1,
+    )
+    _assert_close_to_reference(out, lse, ref_out, ref_lse, torch.bfloat16)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_empty_rank_row(dtype):
+    """A rank with no visible key must contribute O=0 and LSE=-inf."""
+    _skip_if_unsupported()
+    torch.manual_seed(43)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=4,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+    out, lse, split_kv = _launch_rank(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=1,
+        enable_dcp=True,
+    )
+    assert split_kv == 1
+    assert torch.equal(out[:, 0], torch.zeros_like(out[:, 0]))
+    assert torch.isneginf(lse[:, 0]).all()
+    ref_out, ref_lse = _reference_attention(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=1,
+    )
+    _assert_close_to_reference(out, lse, ref_out, ref_lse, dtype)
+
+    # Also cover a physically empty cyclic shard and the cross-rank merge for
+    # early rows that have no visible key on any rank. The empty shard still
+    # owns one padding page, but seq_lens=0, so it may not load or reduce K.
+    query, global_kv, global_lens = _make_inputs(
+        global_length=1,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=dtype,
+    )
+    assert split_kvs == [1, 1]
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_split_kv_rank_merge(dtype):
+    """DCP must preserve natural-log LSE through standalone split reduction."""
+    _skip_if_unsupported()
+    torch.manual_seed(44)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=4096,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=dtype,
+    )
+    assert all(split_kv > 1 for split_kv in split_kvs)
+
+    # Preserve the 2048-token physical shard and its split geometry, but make
+    # every rank-1 key causally invisible. This exercises the all-empty split
+    # reducer rather than the direct zero-tile output path above.
+    empty_causal_lens = torch.tensor([1], dtype=torch.int32, device=query.device)
+    empty_out, empty_lse, empty_split_kv = _launch_rank(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=1,
+        enable_dcp=True,
+        causal_lens=empty_causal_lens,
+    )
+    assert empty_split_kv == split_kvs[1] > 1
+    assert torch.equal(empty_out, torch.zeros_like(empty_out))
+    assert torch.isneginf(empty_lse).all()
+    ref_empty_out, ref_empty_lse = _reference_attention(
+        query,
+        global_kv,
+        empty_causal_lens,
+        cp_world=2,
+        cp_rank=1,
+    )
+    _assert_close_to_reference(
+        empty_out,
+        empty_lse,
+        ref_empty_out,
+        ref_empty_lse,
+        dtype,
+    )
+
+
+def test_cute_dsl_mla_dcp_pdl_all_empty_split_reduction():
+    """PDL must order the all-empty producer path before split reduction."""
+    _skip_if_unsupported()
+    from flashinfer.utils import device_support_pdl
+
+    if not device_support_pdl(torch.device("cuda")):
+        pytest.skip("Programmatic dependent launch is not supported")
+
+    torch.manual_seed(48)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=4096,
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    empty_causal_lens = torch.tensor([1], dtype=torch.int32, device=query.device)
+    out, lse, split_kv = _launch_rank(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=1,
+        enable_dcp=True,
+        causal_lens=empty_causal_lens,
+        enable_pdl=True,
+    )
+    assert split_kv > 1
+    assert torch.equal(out, torch.zeros_like(out))
+    assert torch.isneginf(lse).all()

--- a/tests/attention/test_cute_dsl_mla_decode.py
+++ b/tests/attention/test_cute_dsl_mla_decode.py
@@ -38,6 +38,15 @@ def skip_if_unsupported():
         pytest.skip("CuTe DSL not available")
 
 
+def skip_if_sm100a_unsupported():
+    """Guard public auto-routing assertions that are specific to SM100/SM103."""
+    device = torch.device("cuda")
+    if not is_sm100a_supported(device):
+        pytest.skip("Requires SM100/SM103")
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+
+
 # Tests that exercise the standalone cute_dsl_mla_decode function or the
 # public trtllm_batch_decode_with_kv_cache_mla(backend="cute-dsl") path
 # pass this fixture's value as the cute_dsl_impl= kwarg, exercising both
@@ -91,15 +100,19 @@ def torch_reference_mla(
 
     outputs = []
     lses = []
+    # Copy the small metadata arrays once.  Calling CUDA ``.item()`` for every
+    # request and page serializes hundreds of device synchronizations at B128.
+    cache_seqs_host = cache_seqs.tolist()
+    page_table_host = page_table.tolist()
     for b in range(B):
-        seq_len = cache_seqs[b].item()
+        seq_len = cache_seqs_host[b]
         num_pages_needed = (seq_len + page_size - 1) // page_size
 
         # Gather KV for this batch via page table
-        page_indices = page_table[b, :num_pages_needed]
+        page_indices = page_table_host[b][:num_pages_needed]
         kv_indices = []
         for p in page_indices:
-            start = p.item() * page_size
+            start = p * page_size
             kv_indices.extend(range(start, start + page_size))
         kv_indices = kv_indices[:seq_len]
         kv_indices_t = torch.tensor(kv_indices, device=q_nope.device)
@@ -143,6 +156,55 @@ def torch_reference_mla(
     if return_lse:
         return out_stack, torch.stack(lses, dim=0)  # ([B,q_len,H,D], [B,q_len,H])
     return out_stack
+
+
+def torch_reference_variable_q_mla(
+    q_nope,
+    q_rope,
+    c_latent,
+    c_rope,
+    page_table,
+    cache_seqs,
+    q_lens,
+    softmax_scale,
+    output_scale,
+    page_size,
+):
+    """Reference compact variable-Q by evaluating each request independently."""
+    outputs = []
+    lses = []
+    q_begin = 0
+    for batch_idx, request_q_len in enumerate(q_lens):
+        if request_q_len == 0:
+            continue
+        q_end = q_begin + request_q_len
+        request_out, request_lse = torch_reference_mla(
+            q_nope[q_begin:q_end].unsqueeze(0),
+            q_rope[q_begin:q_end].unsqueeze(0),
+            c_latent,
+            c_rope,
+            page_table[batch_idx : batch_idx + 1],
+            cache_seqs[batch_idx : batch_idx + 1],
+            softmax_scale,
+            output_scale,
+            page_size,
+            apply_mtp_mask=True,
+            return_lse=True,
+        )
+        outputs.append(request_out.squeeze(0))
+        lses.append(request_lse.squeeze(0))
+        q_begin = q_end
+    if not outputs:
+        return (
+            q_nope.new_empty((0, q_nope.shape[1], q_nope.shape[2])),
+            torch.empty(
+                0,
+                q_nope.shape[1],
+                dtype=torch.float32,
+                device=q_nope.device,
+            ),
+        )
+    return torch.cat(outputs), torch.cat(lses)
 
 
 @pytest.mark.parametrize("batch_size", [1, 4, 32])
@@ -262,51 +324,79 @@ def test_cute_dsl_mla_decode_fp16(
         torch.testing.assert_close(lse, ref_lse, atol=1e-2, rtol=1e-2)
 
 
-# Exercises the spec-decoding (MTP) causal mask + fold_sq path: num_heads < 128
-# forces the kernel to pack F = compute_fold_sq_ratio(H, q_len, 128) tokens of
-# q_len into the head dim so the 128-wide MMA-M tile is fully populated.
-# (H=128, q_len=any) → F=1 (no fold), (H=64, q_len=2) → F=2, (H=64, q_len=4) → F=2,
-# (H=32, q_len=4) → F=4, (H=32, q_len=2) → F=2.  All paths share the same
-# kernel; the MTP causal mask is applied uniformly for q_len > 1.
-# Monolithic-only: the modular path doesn't implement fold_sq or the MTP mask.
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("seq_len_k", [128, 1024])
-@pytest.mark.parametrize("num_heads", [16, 32, 64])
-@pytest.mark.parametrize("q_len", [2, 4])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
-def test_cute_dsl_mla_decode_fold_sq(
-    batch_size, seq_len_k, num_heads, q_len, dtype, cute_dsl_impl
+def _run_padded_q_tile_case(
+    batch_size,
+    seq_len_k,
+    num_heads,
+    q_len,
+    dtype,
+    is_var_seq=False,
+    enable_pdl=None,
+    out_dtype=None,
+    query_token_stride=1,
+    via_public_api=False,
+    q_lens=None,
+    max_q_len=None,
+    public_backend="cute-dsl",
+    page_size=64,
 ):
-    """Verify the MTP causal mask + fold_sq packing for H ≤ 128 and q_len > 1."""
-    if cute_dsl_impl != "monolithic":
-        pytest.skip("fold_sq / MTP causal mask are monolithic-only features")
-    skip_if_unsupported()
+    """Run and reference-check one monolithic packed-query configuration.
 
-    from flashinfer.cute_dsl.attention import cute_dsl_mla_decode
+    ``q_lens=None`` uses the fixed rectangular query layout. Otherwise,
+    ``q_lens`` describes compact per-request query segments and ``q_len`` is
+    the static launch capacity.
+    """
+    skip_if_unsupported()
 
     torch.manual_seed(42)
     device = torch.device("cuda")
 
-    page_size = 64
     latent_dim = 512
     rope_dim = 64
     softmax_scale = 1.0 / (latent_dim**0.5)
     output_scale = 1.0
     D_qk = latent_dim + rope_dim
+    is_var_q = q_lens is not None
+    if is_var_q:
+        q_lens = list(q_lens)
+        batch_size = len(q_lens)
+        total_q = sum(q_lens)
+        cum_seq_lens_q = torch.tensor(
+            [0, *torch.tensor(q_lens).cumsum(0).tolist()],
+            dtype=torch.int32,
+            device=device,
+        )
+        query_storage_shape = (
+            total_q * query_token_stride,
+            num_heads,
+            D_qk,
+        )
+    else:
+        total_q = batch_size * q_len
+        cum_seq_lens_q = None
+        query_storage_shape = (
+            batch_size,
+            q_len * query_token_stride,
+            num_heads,
+            D_qk,
+        )
 
     # torch.randn doesn't support fp8; for FP8 inputs create as fp16 then convert.
     is_fp8 = dtype == torch.float8_e4m3fn
+    query_storage = torch.randn(
+        *query_storage_shape,
+        dtype=torch.float16 if is_fp8 else dtype,
+        device=device,
+    )
     if is_fp8:
-        query = (
-            torch.randn(
-                batch_size, q_len, num_heads, D_qk, dtype=torch.float16, device=device
-            )
-            * 0.1
-        ).to(torch.float8_e4m3fn)
-    else:
-        query = torch.randn(
-            batch_size, q_len, num_heads, D_qk, dtype=dtype, device=device
-        )
+        query_storage = (query_storage * 0.1).to(torch.float8_e4m3fn)
+    query = (
+        query_storage[::query_token_stride]
+        if is_var_q
+        else query_storage[:, ::query_token_stride]
+    )
+    if query_token_stride != 1:
+        assert query.stride(-3) != num_heads * query.stride(-2)
 
     num_pages_per_batch = (seq_len_k + page_size - 1) // page_size
     total_pages = num_pages_per_batch * batch_size + 10
@@ -327,24 +417,81 @@ def test_cute_dsl_mla_decode_fold_sq(
         for p in range(num_pages_per_batch):
             block_tables[b, p] = b * num_pages_per_batch + p
 
-    seq_lens = torch.full((batch_size,), seq_len_k, dtype=torch.int32, device=device)
+    if is_var_seq:
+        seq_lens = torch.tensor(
+            [max(page_size, seq_len_k - b * 37) for b in range(batch_size)],
+            dtype=torch.int32,
+            device=device,
+        )
+    else:
+        seq_lens = torch.full(
+            (batch_size,), seq_len_k, dtype=torch.int32, device=device
+        )
 
-    workspace_buffer = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
-
-    out = cute_dsl_mla_decode(
-        query=query,
-        kv_cache=kv_cache,
-        workspace_buffer=workspace_buffer,
-        kv_lora_rank=latent_dim,
-        qk_rope_head_dim=rope_dim,
-        block_tables=block_tables,
-        seq_lens=seq_lens,
-        max_seq_len=seq_len_k,
-        softmax_scale=softmax_scale,
-        output_scale=output_scale,
-        is_var_seq=False,
-        cute_dsl_impl=cute_dsl_impl,
+    workspace_factory = torch.zeros if via_public_api else torch.empty
+    workspace_buffer = workspace_factory(
+        256 * 1024 * 1024, dtype=torch.int8, device=device
     )
+
+    if via_public_api:
+        assert out_dtype is None
+        from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
+
+        lse_shape = (total_q, num_heads) if is_var_q else (batch_size, q_len, num_heads)
+        lse_out = torch.empty(lse_shape, dtype=torch.float32, device=device)
+        out, lse = trtllm_batch_decode_with_kv_cache_mla(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace_buffer,
+            qk_nope_head_dim=latent_dim,
+            kv_lora_rank=latent_dim,
+            qk_rope_head_dim=rope_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=seq_len_k,
+            bmm1_scale=softmax_scale,
+            bmm2_scale=output_scale,
+            backend=public_backend,
+            is_var_seq=is_var_seq,
+            enable_pdl=enable_pdl,
+            lse=lse_out,
+            return_lse=True,
+            cute_dsl_impl="monolithic",
+            cum_seq_lens_q=cum_seq_lens_q,
+            max_q_len=max_q_len,
+        )
+    else:
+        from flashinfer.cute_dsl.attention import cute_dsl_mla_decode
+
+        out, lse = cute_dsl_mla_decode(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace_buffer,
+            kv_lora_rank=latent_dim,
+            qk_rope_head_dim=rope_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=seq_len_k,
+            softmax_scale=softmax_scale,
+            output_scale=output_scale,
+            is_var_seq=is_var_seq,
+            enable_pdl=enable_pdl,
+            cute_dsl_impl="auto" if is_var_q else "monolithic",
+            return_lse=True,
+            out_dtype=out_dtype,
+            cum_seq_lens_q=cum_seq_lens_q,
+            max_q_len=max_q_len,
+        )
+
+    if via_public_api:
+        expected_out_dtype = torch.bfloat16
+    elif out_dtype is not None:
+        expected_out_dtype = out_dtype
+    elif is_fp8:
+        expected_out_dtype = torch.bfloat16
+    else:
+        expected_out_dtype = dtype
+    assert out.dtype == expected_out_dtype
 
     # FP8 input → BF16 output (default), so do the reference in FP32 with wider tolerance.
     if is_fp8:
@@ -358,64 +505,774 @@ def test_cute_dsl_mla_decode_fold_sq(
     c_latent_ref = kv_flat[:, :latent_dim]
     c_rope_ref = kv_flat[:, latent_dim:]
 
-    # Monolithic-only test — kernel always applies the MTP causal mask here.
-    ref_out = torch_reference_mla(
-        q_nope,
-        q_rope,
-        c_latent_ref,
-        c_rope_ref,
-        block_tables,
-        seq_lens,
-        softmax_scale,
-        output_scale,
-        page_size,
-        apply_mtp_mask=True,
-    )
+    # Monolithic always applies the request-local MTP causal mask.  Compact
+    # variable-Q reference segments independently so each request uses its
+    # actual q_len rather than the launch capacity.
+    if is_var_q:
+        ref_out, ref_lse = torch_reference_variable_q_mla(
+            q_nope,
+            q_rope,
+            c_latent_ref,
+            c_rope_ref,
+            block_tables,
+            seq_lens,
+            q_lens,
+            softmax_scale,
+            output_scale,
+            page_size,
+        )
+    else:
+        ref_out, ref_lse = torch_reference_mla(
+            q_nope,
+            q_rope,
+            c_latent_ref,
+            c_rope_ref,
+            block_tables,
+            seq_lens,
+            softmax_scale,
+            output_scale,
+            page_size,
+            apply_mtp_mask=True,
+            return_lse=True,
+        )
 
     if is_fp8:
         # FP8 has limited precision; compare in FP32 with wider tolerance.
         torch.testing.assert_close(
             out.to(torch.float32), ref_out.to(torch.float32), atol=0.1, rtol=0.1
         )
+        torch.testing.assert_close(lse, ref_lse, atol=0.2, rtol=0.1)
     else:
-        ref_out_cast = ref_out.to(dtype)
+        ref_out_cast = ref_out.to(out.dtype)
         torch.testing.assert_close(out, ref_out_cast, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(lse, ref_lse, atol=1e-2, rtol=1e-2)
 
 
-def test_compute_fold_sq_ratio():
-    """Unit test the static helper used by both run() and the wrapper."""
+# Exercises the spec-decoding (MTP) causal mask + flat query-row packing.
+# A cooperative 2-CTA tile owns 128 consecutive (token, head) rows and may
+# cross token boundaries; only the final flattened tile is safely padded.
+# All paths share the same kernel, and the MTP mask applies for q_len > 1.
+# Monolithic-only: the modular path doesn't implement packed query tiles or MTP.
+@pytest.mark.parametrize(
+    "num_heads,q_len,dtype",
+    [
+        pytest.param(64, 3, torch.bfloat16, id="h64-sq3-bf16"),
+        pytest.param(24, 13, torch.float8_e4m3fn, id="h24-sq13-fp8"),
+        pytest.param(12, 11, torch.bfloat16, id="h12-sq11-bf16-tail4"),
+    ],
+)
+def test_cute_dsl_mla_decode_padded_q_tiles(num_heads, q_len, dtype):
+    """Cover cross-token rows and final tails in both kernel families."""
+    _run_padded_q_tile_case(1, 1024, num_heads, q_len, dtype)
+
+
+@pytest.mark.parametrize(
+    "num_heads,dtype",
+    [
+        pytest.param(12, torch.bfloat16, id="h12-bf16"),
+        pytest.param(24, torch.bfloat16, id="h24-bf16"),
+        pytest.param(48, torch.bfloat16, id="h48-bf16"),
+        pytest.param(96, torch.bfloat16, id="h96-bf16"),
+        pytest.param(12, torch.float8_e4m3fn, id="h12-fp8"),
+        pytest.param(24, torch.float8_e4m3fn, id="h24-fp8"),
+        pytest.param(48, torch.float8_e4m3fn, id="h48-fp8"),
+        pytest.param(96, torch.float8_e4m3fn, id="h96-fp8"),
+    ],
+)
+def test_cute_dsl_mla_decode_variable_q_packing(num_heads, dtype):
+    """Compact ragged Q preserves per-request token/head capacity packing."""
+    _run_padded_q_tile_case(
+        4,
+        16 * 1024,
+        num_heads,
+        8,
+        dtype,
+        q_lens=[8, 1, 0, 3],
+        max_q_len=8,
+    )
+
+
+def test_cute_dsl_mla_decode_variable_q_infers_max_q_len():
+    """Inference supports a strided compact query and a wider page size."""
+    _run_padded_q_tile_case(
+        2,
+        128,
+        24,
+        8,
+        torch.bfloat16,
+        q_lens=[3, 1],
+        query_token_stride=2,
+        page_size=128,
+    )
+
+
+def test_cute_dsl_mla_decode_variable_q_fp8_persistent_inactive_gap():
+    """Persistent FP8 clusters can skip ragged slots and resume later work."""
+    _run_padded_q_tile_case(
+        148,
+        128,
+        96,
+        8,
+        torch.float8_e4m3fn,
+        q_lens=[8, *([0] * 146), 1],
+        max_q_len=8,
+    )
+
+
+def test_cute_dsl_mla_decode_variable_q_all_empty():
+    """A positive launch capacity permits an all-empty compact FP8 batch."""
+    _run_padded_q_tile_case(
+        2,
+        128,
+        24,
+        8,
+        torch.float8_e4m3fn,
+        q_lens=[0, 0],
+        max_q_len=8,
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
+)
+def test_cute_dsl_mla_decode_variable_q_and_k_lengths(dtype):
+    """Ragged Q composes with per-request KV lengths and split reduction."""
+    _run_padded_q_tile_case(
+        4,
+        8 * 1024,
+        24,
+        8,
+        dtype,
+        is_var_seq=True,
+        q_lens=[8, 1, 0, 3],
+        max_q_len=8,
+    )
+
+
+def test_cute_dsl_mla_decode_variable_q_cuda_graph_replay():
+    """A captured rectangular launch can replay with new ragged metadata."""
+    skip_if_unsupported()
+    from flashinfer.cute_dsl.attention import cute_dsl_mla_decode
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    batch_size, num_heads, total_q, max_q_len = 4, 96, 12, 8
+    seq_len_k, page_size = 128, 64
+    latent_dim, rope_dim = 512, 64
+    d_qk = latent_dim + rope_dim
+    scale = 1.0 / (latent_dim**0.5)
+
+    query = torch.randn(total_q, num_heads, d_qk, dtype=torch.bfloat16, device=device)
+    pages_per_request = seq_len_k // page_size
+    kv_cache = torch.randn(
+        batch_size * pages_per_request,
+        page_size,
+        d_qk,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    block_tables = torch.arange(
+        batch_size * pages_per_request,
+        dtype=torch.int32,
+        device=device,
+    ).view(batch_size, pages_per_request)
+    seq_lens = torch.full((batch_size,), seq_len_k, dtype=torch.int32, device=device)
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+    out = torch.empty(
+        total_q, num_heads, latent_dim, dtype=torch.bfloat16, device=device
+    )
+    lse = torch.empty(total_q, num_heads, dtype=torch.float32, device=device)
+    cum_q = torch.tensor([0, 4, 8, 12, 12], dtype=torch.int32, device=device)
+
+    def launch():
+        return cute_dsl_mla_decode(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace,
+            kv_lora_rank=latent_dim,
+            qk_rope_head_dim=rope_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=seq_len_k,
+            softmax_scale=scale,
+            out=out,
+            lse=lse,
+            return_lse=True,
+            is_var_seq=False,
+            cute_dsl_impl="monolithic",
+            cum_seq_lens_q=cum_q,
+            max_q_len=max_q_len,
+        )
+
+    def reference(q_lens):
+        kv_flat = kv_cache.reshape(-1, d_qk)
+        return torch_reference_variable_q_mla(
+            query[..., :latent_dim],
+            query[..., latent_dim:],
+            kv_flat[:, :latent_dim],
+            kv_flat[:, latent_dim:],
+            block_tables,
+            seq_lens,
+            q_lens,
+            scale,
+            1.0,
+            page_size,
+        )
+
+    # Compile and allocate all internal state before capture.
+    launch()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+    graph.replay()
+    torch.cuda.synchronize()
+    ref_out, ref_lse = reference([4, 4, 4, 0])
+    torch.testing.assert_close(out, ref_out.to(out.dtype), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(lse, ref_lse, atol=1e-2, rtol=1e-2)
+
+    cum_q.copy_(torch.tensor([0, 0, 1, 4, 12], dtype=torch.int32, device=device))
+    graph.replay()
+    torch.cuda.synchronize()
+    ref_out, ref_lse = reference([0, 1, 3, 8])
+    torch.testing.assert_close(out, ref_out.to(out.dtype), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(lse, ref_lse, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
+)
+@pytest.mark.parametrize(
+    "q_lens",
+    [None, [32, 1]],
+    ids=["fixed-q", "variable-q"],
+)
+def test_cute_dsl_mla_decode_per_q_tile_mask_boundary(dtype, q_lens):
+    """Use each request-local M128 tile's first token for dense-mask selection."""
+    skip_if_unsupported()
+
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size,
+        cute_dsl_mla_decode,
+    )
+    from flashinfer.cute_dsl.utils import get_num_sm
+
+    q_len, num_heads = 32, 6
+    is_var_q = q_lens is not None
+    request_q_lens = [q_len] if q_lens is None else q_lens
+    batch_size = len(request_q_lens)
+    total_q = sum(request_q_lens)
+    seq_len_k, page_size = 144, 64
+    latent_dim, rope_dim = 512, 64
+    d_qk = latent_dim + rope_dim
+    device = torch.device("cuda")
+
+    # H6/Sq32 has two M128 tiles. Token 21 straddles their boundary: heads
+    # 0-1 are in tile 0 and heads 2-5 are in tile 1. Tile 1 can treat keys
+    # 0:128 as dense from its first token (21), while tile 0 must still mask
+    # keys 113:128 for its earlier tokens. Using tile 0's last token for the
+    # coarse decision would expose those marked values incorrectly.
+    query_shape = (
+        (total_q, num_heads, d_qk) if is_var_q else (batch_size, q_len, num_heads, d_qk)
+    )
+    query = torch.zeros(query_shape, dtype=dtype, device=device)
+    num_pages = (seq_len_k + page_size - 1) // page_size
+    kv_cache = torch.zeros(
+        batch_size * num_pages,
+        page_size,
+        d_qk,
+        dtype=dtype,
+        device=device,
+    )
+    kv_flat = kv_cache.view(-1, d_qk)
+    for batch_idx in range(batch_size):
+        request_begin = batch_idx * num_pages * page_size
+        kv_flat[request_begin + 113 : request_begin + 128, 0] = 4.0
+    block_tables = torch.arange(
+        batch_size * num_pages, dtype=torch.int32, device=device
+    ).view(batch_size, num_pages)
+    seq_lens = torch.full((batch_size,), seq_len_k, dtype=torch.int32, device=device)
+    cum_seq_lens_q = (
+        torch.tensor(
+            [0, *torch.tensor(request_q_lens).cumsum(0).tolist()],
+            dtype=torch.int32,
+            device=device,
+        )
+        if is_var_q
+        else None
+    )
+
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        batch_size,
+        q_len,
+        num_heads,
+        latent_dim,
+        get_num_sm(device),
+        seq_len_k,
+    )
+    assert split_kv > 1
+    workspace = torch.empty(workspace_size, dtype=torch.int8, device=device)
+
+    out, lse = cute_dsl_mla_decode(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace,
+        kv_lora_rank=latent_dim,
+        qk_rope_head_dim=rope_dim,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=seq_len_k,
+        softmax_scale=1.0 / (latent_dim**0.5),
+        return_lse=True,
+        enable_pdl=False,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=q_len if is_var_q else None,
+    )
+
+    bounds = torch.cat(
+        [
+            torch.arange(request_q_len, dtype=torch.float32, device=device)
+            + (seq_len_k - request_q_len + 1)
+            for request_q_len in request_q_lens
+        ]
+    )
+    marked_visible = (bounds - 113).clamp(min=0, max=15)
+    expected_out_flat = torch.zeros(
+        total_q,
+        num_heads,
+        latent_dim,
+        dtype=torch.float32,
+        device=device,
+    )
+    expected_out_flat[..., 0] = (4.0 * marked_visible / bounds).view(total_q, 1)
+    expected_lse_flat = torch.log(bounds).view(total_q, 1).expand(total_q, num_heads)
+    expected_out = expected_out_flat if is_var_q else expected_out_flat.unsqueeze(0)
+    expected_lse = expected_lse_flat if is_var_q else expected_lse_flat.unsqueeze(0)
+
+    torch.testing.assert_close(out.float(), expected_out, atol=5e-3, rtol=5e-3)
+    torch.testing.assert_close(lse, expected_lse, atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.parametrize("num_heads", [12, 24, 48, 96])
+@pytest.mark.parametrize("q_len", [1, 2, 4, 8])
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
+)
+def test_cute_dsl_mla_decode_packed_q_accuracy_matrix(num_heads, q_len, dtype):
+    """Qualify the supported packed-query, causal-mask, and auto-split matrix."""
+    # Keep the batch sweep within one pytest item while all 128 requested
+    # Cartesian cells are reference checked. Split-KV and query packing are
+    # selected automatically by the public launcher.
+    for batch_size in (1, 4, 16, 128):
+        _run_padded_q_tile_case(
+            batch_size=batch_size,
+            seq_len_k=1024,
+            num_heads=num_heads,
+            q_len=q_len,
+            dtype=dtype,
+        )
+
+
+def test_cute_dsl_mla_decode_fp8_persistent_multi_work_boundaries():
+    """Reuse the FP8 two-softmax pipelines across persistent work items."""
+    # B128 exceeds one resident wave of 2CTA clusters on supported Blackwell
+    # devices.  These cases exercise one-, even-, and odd-K-tile work items;
+    # the packed-Q matrix above additionally covers the eight-tile boundary.
+    for seq_len_k, enable_pdl in ((128, True), (256, False), (384, True)):
+        _run_padded_q_tile_case(
+            batch_size=128,
+            seq_len_k=seq_len_k,
+            num_heads=96,
+            q_len=1,
+            dtype=torch.float8_e4m3fn,
+            enable_pdl=enable_pdl,
+        )
+
+
+def test_cute_dsl_mla_decode_fp8_variable_seq_order_boundaries():
+    """Balance both FP8 softmax groups for mixed nonpersistent K parity."""
+    _run_padded_q_tile_case(
+        batch_size=10,
+        seq_len_k=385,
+        num_heads=96,
+        q_len=8,
+        dtype=torch.float8_e4m3fn,
+        is_var_seq=True,
+        enable_pdl=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
+)
+def test_cute_dsl_mla_decode_h96_max_split_reducer_capacity(dtype):
+    """Reference-check output and LSE at the static reducer's 32-split cap."""
+    _run_padded_q_tile_case(
+        batch_size=1,
+        seq_len_k=8192,
+        num_heads=96,
+        q_len=1,
+        dtype=dtype,
+    )
+
+
+def test_cute_dsl_mla_decode_h96_sq8_nonempty_split_reducer():
+    """Reference-check the normalized H96/Sq8 long-K split-reducer path."""
+    _run_padded_q_tile_case(
+        batch_size=1,
+        seq_len_k=8192,
+        num_heads=96,
+        q_len=8,
+        dtype=torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
+)
+def test_cute_dsl_mla_decode_h96_odd_split_reducer_pdl_off(dtype):
+    """Cover adaptive D4 with an odd 17-split prefix and PDL disabled."""
+    _run_padded_q_tile_case(
+        batch_size=1,
+        seq_len_k=4097,
+        num_heads=96,
+        q_len=1,
+        dtype=dtype,
+        enable_pdl=False,
+    )
+
+
+def test_cute_dsl_mla_decode_variable_seq_d2_reducer():
+    """Cover adaptive D2 when batches have distinct non-power split prefixes."""
+    _run_padded_q_tile_case(
+        batch_size=2,
+        seq_len_k=4097,
+        num_heads=24,
+        q_len=1,
+        dtype=torch.bfloat16,
+        is_var_seq=True,
+        enable_pdl=False,
+    )
+
+
+def test_cute_dsl_mla_decode_padded_q_tile_direct_output():
+    """Exercise H48/Sq3 full/tail padding with split_kv=1 (no reducer)."""
+    skip_if_unsupported()
+
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size,
+    )
+    from flashinfer.cute_dsl.utils import get_num_sm
+
+    num_q_tiles = 2
+    num_sm = get_num_sm(torch.device("cuda"))
+    batch_size = (num_sm + 2 * num_q_tiles - 1) // (2 * num_q_tiles)
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        batch_size, 3, 48, 512, num_sm
+    )
+    assert split_kv == 1
+    assert workspace_size == 0
+
+    _run_padded_q_tile_case(
+        batch_size=batch_size,
+        seq_len_k=128,
+        num_heads=48,
+        q_len=3,
+        dtype=torch.float16,
+    )
+
+
+def test_cute_dsl_mla_decode_padded_q_tile_variable_seq():
+    """Cover nonpersistent variable-K scheduling with a padded H24/Sq6 tail."""
+    _run_padded_q_tile_case(
+        batch_size=3,
+        seq_len_k=385,
+        num_heads=24,
+        q_len=6,
+        dtype=torch.float16,
+        is_var_seq=True,
+        enable_pdl=False,
+    )
+
+
+def test_cute_dsl_mla_decode_padded_q_tile_fp8_output():
+    """Qualify packed-query FP8 input and FP8 output together."""
+    _run_padded_q_tile_case(
+        batch_size=1,
+        seq_len_k=128,
+        num_heads=64,
+        q_len=3,
+        dtype=torch.float8_e4m3fn,
+        out_dtype=torch.float8_e4m3fn,
+    )
+
+
+def test_cute_dsl_mla_decode_padded_q_tile_strided_query():
+    """Cover the contiguous fallback for a token-strided query view."""
+    _run_padded_q_tile_case(
+        batch_size=1,
+        seq_len_k=128,
+        num_heads=48,
+        q_len=3,
+        dtype=torch.float16,
+        query_token_stride=2,
+    )
+
+
+@pytest.mark.parametrize("buffer_name", ["out", "lse"])
+def test_cute_dsl_mla_decode_rejects_token_gapped_output(buffer_name):
+    """Reject output views that cannot represent flat rows across tokens."""
     if not is_cute_dsl_available():
         pytest.skip("CuTe DSL not available")
-    from flashinfer.cute_dsl.attention.monolithic.mla_decode_fp16 import (
-        BlackwellMultiHeadLatentAttentionForwardFP16 as FP16,
+
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        cute_dsl_mla_decode,
     )
-    from flashinfer.cute_dsl.attention.monolithic.mla_decode_fp8 import (
-        BlackwellMultiHeadLatentAttentionForwardFP8 as FP8,
+
+    batch_size, q_len, num_heads = 1, 2, 96
+    latent_dim, rope_dim = 512, 64
+    query = torch.empty(
+        batch_size,
+        q_len,
+        num_heads,
+        latent_dim + rope_dim,
+        dtype=torch.bfloat16,
+    )
+    out = torch.empty(batch_size, q_len * 2, num_heads, latent_dim)[:, ::2]
+    lse = torch.empty(batch_size, q_len * 2, num_heads, dtype=torch.float32)[:, ::2]
+    kwargs = {buffer_name: out if buffer_name == "out" else lse}
+
+    with pytest.raises(ValueError, match=rf"{buffer_name} must be contiguous"):
+        cute_dsl_mla_decode(
+            query=query,
+            kv_cache=torch.empty(1, 64, latent_dim + rope_dim, dtype=torch.bfloat16),
+            workspace_buffer=torch.empty(0, dtype=torch.int8),
+            kv_lora_rank=latent_dim,
+            qk_rope_head_dim=rope_dim,
+            block_tables=torch.zeros(1, 1, dtype=torch.int32),
+            seq_lens=torch.tensor([64], dtype=torch.int32),
+            max_seq_len=64,
+            softmax_scale=1.0,
+            **kwargs,
+        )
+
+
+def test_cute_dsl_mla_decode_padded_q_tile_via_public_api():
+    """Exercise the reported H96/Sq8 shape through the public dispatcher."""
+    _run_padded_q_tile_case(
+        batch_size=1,
+        seq_len_k=128,
+        num_heads=96,
+        q_len=8,
+        dtype=torch.bfloat16,
+        enable_pdl=False,
+        via_public_api=True,
+    )
+
+
+def test_compute_q_tile_layout():
+    """Unit test the shared host/kernel query-tile geometry."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+    from flashinfer.cute_dsl.attention.monolithic.mla_helpers import (
+        compute_q_tile_layout,
     )
 
     cases = [
-        # (num_heads, seq_len_q, m_tile, expected)
-        (128, 1, 128, 1),  # H == M_tile → no fold
-        (128, 4, 128, 1),  # H == M_tile → no fold
-        (64, 1, 128, 1),  # seq_len_q=1 → F=1
-        (64, 2, 128, 2),  # exact divisor, H*F=128 ≤ M_tile
-        (64, 4, 128, 2),  # H*F ≤ 128 caps F at 2; 4 % 2 == 0
-        (64, 3, 128, 1),  # 3's only divisors are 1 and 3; H*3=192 > M_tile → F=1
-        (32, 4, 128, 4),  # tighter pack: F=4, H*F=128
-        (32, 8, 128, 4),  # capped by M_tile/H = 4
-        (32, 3, 128, 3),  # max_fold=min(3, 4)=3; 3 % 3 == 0 → F=3
-        (16, 8, 128, 8),  # max_fold=min(8, 8)=8; 8 % 8 == 0 → F=8
-        (16, 6, 128, 6),  # max_fold=min(6, 8)=6; 6 % 6 == 0 → F=6
+        # (H, Sq, M, (total_rows, num_tiles, tail_rows))
+        (128, 3, 128, (384, 3, 128)),
+        (96, 1, 128, (96, 1, 96)),
+        (96, 3, 128, (288, 3, 32)),
+        (48, 8, 128, (384, 3, 128)),
+        (12, 11, 128, (132, 2, 4)),
     ]
     for H, S_q, m_tile, expected in cases:
-        assert FP16.compute_fold_sq_ratio(H, S_q, m_tile) == expected, (
-            f"FP16.compute_fold_sq_ratio({H}, {S_q}, {m_tile}) "
-            f"= {FP16.compute_fold_sq_ratio(H, S_q, m_tile)}, expected {expected}"
+        assert compute_q_tile_layout(H, S_q, m_tile) == expected, (
+            f"compute_q_tile_layout({H}, {S_q}, {m_tile}) "
+            f"= {compute_q_tile_layout(H, S_q, m_tile)}, expected {expected}"
         )
-        assert FP8.compute_fold_sq_ratio(H, S_q, m_tile) == expected, (
-            f"FP8.compute_fold_sq_ratio({H}, {S_q}, {m_tile}) "
-            f"= {FP8.compute_fold_sq_ratio(H, S_q, m_tile)}, expected {expected}"
+
+    for invalid in [(0, 1, 128), (129, 1, 128), (64, 0, 128), (64, 1, 0)]:
+        with pytest.raises(ValueError):
+            compute_q_tile_layout(*invalid)
+
+
+def test_nonpersistent_grid_y_limit():
+    """Reject only nonpersistent grids beyond CUDA's Y-dimension limit."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _validate_nonpersistent_grid_y,
+    )
+
+    _validate_nonpersistent_grid_y(8_191, 8, is_persistent=False)
+    _validate_nonpersistent_grid_y(65_535, 1, is_persistent=False)
+    _validate_nonpersistent_grid_y(8_192, 8, is_persistent=True)
+
+    with pytest.raises(ValueError, match=r"grid\.y would be 65536"):
+        _validate_nonpersistent_grid_y(8_192, 8, is_persistent=False)
+
+
+def test_mla_reducer_d_tile_selection():
+    """Use output bands only when they shorten an underfilled reducer wave."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_reducer_d_tiles,
+    )
+
+    # B1/H32 and B1/H96 use D4; B1/H64 uses D2. H128 already fills a wave.
+    assert _get_reducer_d_tiles(1, 1, 32, 148, 32) == 4
+    assert _get_reducer_d_tiles(1, 1, 64, 148, 32) == 2
+    assert _get_reducer_d_tiles(1, 1, 96, 148, 32) == 4
+    # Prefer the smaller tied topology and avoid duplication once rows fill a wave.
+    assert _get_reducer_d_tiles(1, 1, 48, 148, 32) == 2
+    assert _get_reducer_d_tiles(1, 1, 128, 148, 32) == 1
+    assert _get_reducer_d_tiles(4, 1, 96, 148, 32) == 1
+    assert _get_reducer_d_tiles(1, 1, 96, 0, 32) == 1
+    # Do not duplicate LSE work when a short sequence exposes too few splits.
+    assert _get_reducer_d_tiles(1, 1, 96, 148, 1) == 1
+    assert _get_reducer_d_tiles(1, 1, 24, 148, 2) == 2
+    # Variable-Q reducers still launch their rectangular B x max_q_len grid.
+    assert _get_reducer_d_tiles(148, 8, 96, 148, 32) == 1
+
+
+def test_mla_reducer_direct_class_capacity_defaults():
+    """Direct class users keep the generic capacity unless opting into a cap."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+
+    import cutlass
+
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode_fp16 import (
+        BlackwellMultiHeadLatentAttentionForwardFP16,
+    )
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode_fp8 import (
+        BlackwellMultiHeadLatentAttentionForwardFP8,
+    )
+    from flashinfer.cute_dsl.attention.monolithic.mla_helpers import MAX_SPLITS
+
+    kwargs = dict(
+        acc_dtype=cutlass.Float32,
+        lse_dtype=cutlass.Float32,
+        mma_qk_tiler_mn=(128, 128),
+        mma_pv_tiler_mn=(128, 256),
+        max_active_clusters=1,
+        page_size=64,
+        skip_correction_threshold=0.0,
+        is_persistent=True,
+        is_var_seq=False,
+        is_var_split_kv=False,
+        enable_pdl=False,
+    )
+    for kernel_cls in (
+        BlackwellMultiHeadLatentAttentionForwardFP16,
+        BlackwellMultiHeadLatentAttentionForwardFP8,
+    ):
+        assert kernel_cls(**kwargs).reducer_max_splits == MAX_SPLITS
+        assert kernel_cls(**kwargs, reducer_max_splits=32).reducer_max_splits == 32
+        with pytest.raises(ValueError, match="variable split-KV"):
+            kernel_cls(**{**kwargs, "is_var_split_kv": True}, reducer_max_splits=32)
+
+
+def test_flat_q_tile_split_workspace_geometry():
+    """Workspace sizing uses the flattened M128 query-tile count."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size,
+    )
+
+    batch_size, num_heads, q_len, num_q_tiles = 1, 48, 8, 3
+    latent_dim = 512
+    max_active_blocks = 148
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        batch_size,
+        q_len,
+        num_heads,
+        latent_dim,
+        max_active_blocks,
+    )
+    expected_split = min(max_active_blocks // (batch_size * num_q_tiles * 2), 32)
+    expected_workspace = (
+        batch_size * 128 * num_q_tiles * expected_split * (latent_dim + 1) * 4
+    )
+    assert split_kv == expected_split
+    assert workspace_size == expected_workspace
+
+    # Once one cluster per (batch, query tile) fills the machine, split-KV is
+    # disabled and no workspace is required.
+    direct_batch = max_active_blocks // (num_q_tiles * 2)
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        direct_batch,
+        q_len,
+        num_heads,
+        latent_dim,
+        max_active_blocks,
+    )
+    assert split_kv == 1
+    assert workspace_size == 0
+
+
+def test_h96_sq8_split_workspace_drops_empty_partition():
+    """Size only the eight nonempty K partitions at B1/H96/Sq8."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size,
+    )
+
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        1, 8, 96, 512, 148, 1024
+    )
+    assert split_kv == 8
+    assert workspace_size == 1 * 128 * 6 * 8 * (512 + 1) * 4
+
+
+def test_cute_dsl_workspace_sizer_follows_selected_impl():
+    """Autotuning must size workspace with the implementation it will launch."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size as monolithic_sizer,
+    )
+    from flashinfer.cute_dsl.attention.wrappers.batch_mla import (
+        _get_split_kv_and_workspace_size as modular_sizer,
+    )
+    from flashinfer.mla._core import _get_cute_dsl_workspace_sizer
+
+    assert _get_cute_dsl_workspace_sizer("monolithic", None) is monolithic_sizer
+    assert _get_cute_dsl_workspace_sizer("modular", None) is modular_sizer
+    assert _get_cute_dsl_workspace_sizer("auto", None) is monolithic_sizer
+    assert _get_cute_dsl_workspace_sizer("auto", torch.empty(0)) is modular_sizer
+
+
+def test_monolithic_workspace_cap_drops_empty_partitions():
+    """Autotuning must use the launcher's max-sequence split normalization."""
+    if not is_cute_dsl_available():
+        pytest.skip("CuTe DSL not available")
+
+    from flashinfer.mla._core import _cute_dsl_max_supported_batch
+
+    # One K tile needs no split workspace for any candidate batch. Without
+    # max_seq_len propagation this is conservatively sized as 32 splits and
+    # the zero-byte workspace incorrectly caps the autotune sweep at B=1.
+    assert (
+        _cute_dsl_max_supported_batch(
+            workspace_bytes=0,
+            q_len=1,
+            num_heads=128,
+            kv_lora_rank=512,
+            max_active_blocks=148,
+            max_seq_len=128,
+            candidate_max=8,
+            cute_dsl_impl="monolithic",
+            sinks=None,
         )
+        == 8
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 4, 16])
@@ -1718,11 +2575,10 @@ def test_cute_dsl_mla_decode_soft_capping_small_cap(batch_size, seq_len_k, page_
     torch.testing.assert_close(out, ref_out_cast, atol=1e-2, rtol=1e-2)
 
 
-def _mla_decode_block_size_128_inputs(batch_size=4, seq_len_k=512, num_heads=128):
+def _mla_decode_inputs(batch_size=4, seq_len_k=512, num_heads=128, page_size=128):
     device = torch.device("cuda")
     latent_dim = 512
     rope_dim = 64
-    page_size = 128
     D_qk = latent_dim + rope_dim
     query = torch.randn(
         batch_size, 1, num_heads, D_qk, dtype=torch.float16, device=device
@@ -1758,7 +2614,7 @@ def test_mla_decode_auto_dispatches_to_cute_dsl_for_block_size_128():
     from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
 
     torch.manual_seed(42)
-    args = _mla_decode_block_size_128_inputs()
+    args = _mla_decode_inputs()
     out = trtllm_batch_decode_with_kv_cache_mla(**args, backend="auto")
     assert out.shape == (args["query"].size(0), 1, args["query"].size(2), 512)
     assert torch.isfinite(out).all()
@@ -1768,6 +2624,45 @@ def test_mla_decode_trtllm_gen_rejects_block_size_128():
     skip_if_unsupported()
     from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
 
-    args = _mla_decode_block_size_128_inputs()
+    args = _mla_decode_inputs()
     with pytest.raises(ValueError, match=r"trtllm-gen requires block_size"):
         trtllm_batch_decode_with_kv_cache_mla(**args, backend="trtllm-gen")
+
+
+def test_mla_decode_auto_dispatches_to_cute_dsl_for_trtllm_head_gap():
+    skip_if_unsupported()
+    from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
+
+    torch.manual_seed(42)
+    args = _mla_decode_inputs(num_heads=96, page_size=64)
+    out = trtllm_batch_decode_with_kv_cache_mla(**args, backend="auto")
+    assert out.shape == (args["query"].size(0), 1, 96, 512)
+    assert torch.isfinite(out).all()
+
+
+def test_mla_decode_trtllm_gen_rejects_head_gap():
+    skip_if_unsupported()
+    from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
+
+    args = _mla_decode_inputs(num_heads=96, page_size=64)
+    with pytest.raises(
+        ValueError,
+        match=r"64 < num_heads_q < 128.*backend='cute-dsl'",
+    ):
+        trtllm_batch_decode_with_kv_cache_mla(**args, backend="trtllm-gen")
+
+
+def test_mla_decode_variable_q_auto_uses_cute_dsl_for_head_gap():
+    """Auto-routing returns accurate compact H96 output and LSE."""
+    skip_if_sm100a_unsupported()
+    _run_padded_q_tile_case(
+        1,
+        16 * 1024,
+        96,
+        8,
+        torch.bfloat16,
+        via_public_api=True,
+        q_lens=[1],
+        max_q_len=8,
+        public_backend="auto",
+    )

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -6,6 +6,7 @@ import random
 import flashinfer
 from flashinfer.mla import (
     MLALayerDimensions,
+    deepseek_mla_dimensions,
     supported_mla_layer_dimensions,
     smaller_mla_dimensions,
 )
@@ -295,6 +296,7 @@ def trtllm_batch_decode_mla(
     skips_softmax: bool,
     uses_shared_paged_kv_idx: bool = True,
     use_cum_seq_lens_q: bool = False,
+    max_q_len_exceeds_total_q: bool = False,
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if backend == "xqa":
@@ -329,8 +331,8 @@ def trtllm_batch_decode_mla(
 
     if skips_softmax and backend != "trtllm-gen":
         pytest.skip("skips_softmax is only supported for trtllm-gen backend")
-    if use_cum_seq_lens_q and backend != "trtllm-gen":
-        pytest.skip("cum_seq_lens_q is only supported for trtllm-gen backend")
+    if use_cum_seq_lens_q and backend == "xqa":
+        pytest.skip("XQA does not support cum_seq_lens_q")
 
     torch.manual_seed(42)
     device = "cuda:0"
@@ -351,6 +353,8 @@ def trtllm_batch_decode_mla(
             torch.arange(batch_size, device=device, dtype=torch.int32)
             % q_len_per_request
         ) + 1
+        if max_q_len_exceeds_total_q:
+            q_lens[0] = 0
         q_lens[-1] = q_len_per_request
         cum_seq_lens_q = torch.empty(batch_size + 1, device=device, dtype=torch.int32)
         cum_seq_lens_q[0] = 0
@@ -359,9 +363,13 @@ def trtllm_batch_decode_mla(
             [query[i, : int(q_lens[i].item())] for i in range(batch_size)],
             dim=0,
         )
-        # Overestimate to verify CUDA-graph-friendly max_q_len contracts.
-        # Exact max is q_lens.max().
-        max_q_len = min(q_len_per_request + 1, query_input.size(0))
+        # Overestimate the longest segment for CUDA-graph-friendly capacity.
+        # Focused tests can also make this exceed the current compact length.
+        max_q_len = (
+            q_len_per_request + 1
+            if max_q_len_exceeds_total_q
+            else min(q_len_per_request + 1, query_input.size(0))
+        )
     else:
         query_input = query
         cum_seq_lens_q = None
@@ -588,7 +596,7 @@ def trtllm_batch_decode_mla(
     if backend == "cute-dsl" and output.dtype == torch.float8_e4m3fn:
         output = output.to(torch.bfloat16)
 
-    if backend in ("trtllm-gen", "cute-dsl"):
+    if backend in ("trtllm-gen", "cute-dsl", "auto"):
         # check is nan
         assert not torch.isnan(o_ref).any(), "o_ref is nan"
         assert not torch.isnan(output).any(), "output is nan"
@@ -948,6 +956,174 @@ def trtllm_batch_decode_mla_sparse(
     )
 
 
+def _run_trtllm_batch_decode_mla_head_case(
+    num_heads: int,
+    batch_size: int,
+    dtype: torch.dtype,
+    max_seq_len: int,
+) -> None:
+    trtllm_batch_decode_mla(
+        MLALayerDimensions(
+            head_dimensions=deepseek_mla_dimensions,
+            num_heads=num_heads,
+        ),
+        batch_size=batch_size,
+        scale=1.0,
+        dtype=dtype,
+        page_size=64,
+        q_len_per_request=1,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=max_seq_len,
+        skips_softmax=False,
+    )
+
+
+@pytest.mark.parametrize("num_heads", [6, 12, 24, 48])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("max_seq_len", [128, 1024])
+def test_trtllm_batch_decode_mla_non_power_of_two_heads(
+    num_heads: int,
+    dtype: torch.dtype,
+    max_seq_len: int,
+) -> None:
+    _run_trtllm_batch_decode_mla_head_case(
+        num_heads,
+        1,
+        dtype,
+        max_seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_heads,dtype,max_seq_len",
+    [
+        (3, torch.bfloat16, 128),
+        (9, torch.float8_e4m3fn, 1024),
+        (17, torch.bfloat16, 1024),
+        (33, torch.float8_e4m3fn, 128),
+        (63, torch.bfloat16, 1024),
+        (192, torch.bfloat16, 128),
+    ],
+)
+def test_trtllm_batch_decode_mla_generic_non_power_of_two_heads(
+    num_heads: int,
+    dtype: torch.dtype,
+    max_seq_len: int,
+) -> None:
+    _run_trtllm_batch_decode_mla_head_case(
+        num_heads,
+        1,
+        dtype,
+        max_seq_len,
+    )
+
+
+def test_trtllm_batch_decode_mla_non_power_of_two_heads_cum_seq_lens_q() -> None:
+    trtllm_batch_decode_mla(
+        MLALayerDimensions(
+            head_dimensions=deepseek_mla_dimensions,
+            num_heads=24,
+        ),
+        batch_size=2,
+        scale=1.0,
+        dtype=torch.bfloat16,
+        page_size=64,
+        q_len_per_request=2,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=1024,
+        skips_softmax=False,
+        use_cum_seq_lens_q=True,
+    )
+
+
+def _run_trtllm_batch_decode_sparse_mla_head_case(
+    num_heads: int,
+    batch_size: int,
+    dtype: torch.dtype,
+    topk: int,
+) -> None:
+    trtllm_batch_decode_mla_sparse(
+        batch_size=batch_size,
+        scale=1.0,
+        dtype=dtype,
+        q_len_per_request=1,
+        topk=topk,
+        is_varlen=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        qk_nope_head_dim=128,
+        num_attn_heads=num_heads,
+        use_cum_seq_lens_q=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_heads,dtype",
+    [
+        (6, torch.bfloat16),
+        (12, torch.bfloat16),
+        (24, torch.bfloat16),
+        (48, torch.bfloat16),
+        (24, torch.float8_e4m3fn),
+    ],
+)
+@pytest.mark.parametrize("topk", [128, 2048])
+def test_trtllm_batch_decode_sparse_mla_non_power_of_two_heads(
+    num_heads: int,
+    dtype: torch.dtype,
+    topk: int,
+) -> None:
+    _run_trtllm_batch_decode_sparse_mla_head_case(
+        num_heads,
+        1,
+        dtype,
+        topk,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_heads,dtype,topk",
+    [
+        (3, torch.bfloat16, 128),
+        (9, torch.float8_e4m3fn, 128),
+        (17, torch.bfloat16, 2048),
+        (33, torch.float8_e4m3fn, 128),
+        (63, torch.bfloat16, 2048),
+    ],
+)
+def test_trtllm_batch_decode_sparse_mla_generic_non_power_of_two_heads(
+    num_heads: int,
+    dtype: torch.dtype,
+    topk: int,
+) -> None:
+    _run_trtllm_batch_decode_sparse_mla_head_case(
+        num_heads,
+        1,
+        dtype,
+        topk,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch_size,dtype",
+    [(1, torch.bfloat16), (2, torch.float8_e4m3fn)],
+)
+def test_trtllm_batch_decode_sparse_mla_power_of_two_heads(
+    batch_size: int,
+    dtype: torch.dtype,
+) -> None:
+    _run_trtllm_batch_decode_sparse_mla_head_case(
+        16,
+        batch_size,
+        dtype,
+        2048,
+    )
+
+
 @pytest.mark.parametrize(
     "layer_dimensions",
     supported_mla_layer_dimensions,
@@ -1033,6 +1209,29 @@ def test_trtllm_batch_decode_mla_cum_seq_lens_q(
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
         use_cum_seq_lens_q=True,
+    )
+
+
+@pytest.mark.parametrize("backend", ["trtllm-gen", "auto"])
+def test_trtllm_batch_decode_mla_variable_q_capacity_overestimate(backend: str):
+    """TRT accepts graph capacity above the current compact token count."""
+    if get_compute_capability(torch.device("cuda"))[0] != 10:
+        pytest.skip("TRTLLM-GEN MLA requires SM100 or SM103")
+    trtllm_batch_decode_mla(
+        supported_mla_layer_dimensions[0],
+        batch_size=2,
+        scale=1.0,
+        dtype=torch.bfloat16,
+        page_size=64,
+        q_len_per_request=2,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend=backend,
+        MAX_SEQ_LEN=1024,
+        skips_softmax=False,
+        uses_shared_paged_kv_idx=False,
+        use_cum_seq_lens_q=True,
+        max_q_len_exceeds_total_q=True,
     )
 
 

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -14,6 +14,7 @@ from flashinfer.fused_moe.utils import (
     make_hybrid_bucket_mapper,
 )
 from flashinfer.mla._core import (
+    CuteDslMlaDecodeRunner,
     _build_mla_decode_tuning_config,
     _mla_decode_tuning_config,
 )
@@ -1446,3 +1447,34 @@ def test_find_nearest_profile_cache_dedups_mla_decode_config():
     finally:
         AutoTuner._find_nearest_profile.cache_clear()
         _mla_decode_tuning_config.cache_clear()
+
+
+def _cute_dsl_runner_cache_extras(max_seq_len: int, workspace_bytes: int):
+    runner = object.__new__(CuteDslMlaDecodeRunner)
+    runner.kv_cache = torch.empty((1, 32, 576), dtype=torch.bfloat16)
+    runner.workspace_buffer = torch.empty(workspace_bytes, dtype=torch.uint8)
+    runner.qk_nope_head_dim = 512
+    runner.kv_lora_rank = 512
+    runner.qk_rope_head_dim = 64
+    runner.page_size = 32
+    runner.max_seq_len = max_seq_len
+    runner.is_var_seq = True
+    runner.uses_shared_paged_kv_idx = True
+    runner.enable_pdl = False
+    runner.sinks = None
+    runner.cute_dsl_impl = "auto"
+    runner._resolved_cute_dsl_impl = "monolithic"
+
+    query = torch.empty((1, 1, 128, 576), dtype=torch.bfloat16)
+    out = torch.empty((1, 1, 128, 512), dtype=torch.bfloat16)
+    return runner.get_cache_key_extras([query, None, None, out])
+
+
+def test_cute_dsl_runner_cache_tracks_split_workspace_geometry():
+    """Cache hits must not bypass sequence- or capacity-dependent validity."""
+    key_257 = _cute_dsl_runner_cache_extras(257, 1_000_000)
+    key_385 = _cute_dsl_runner_cache_extras(385, 1_000_000)
+    assert key_257 != key_385
+
+    key_small_workspace = _cute_dsl_runner_cache_extras(257, 800_000)
+    assert key_257 != key_small_workspace


### PR DESCRIPTION
## Why

Kimi K3 MLA uses 96 global query heads with one KV head, TP-local head counts of 48/24/12/6, speculative query lengths up to 8, variable request-local query lengths, and context parallelism for long contexts. The existing Blackwell decode paths do not cover that combination efficiently or completely.

## Changes

- Pack `(query_token, query_head)` rows continuously into CuTeDSL M128 tiles, so partial head groups can share a tile across tokens and only the final tile is padded.
- Add compact variable-Q support to monolithic CuTeDSL with `[total_q, Hq, D]`, `cum_seq_lens_q`, and `max_q_len`.
- Extend TRTLLM-GEN dense and sparse MLA to non-power-of-two `Hq <= 64` with padded Q8/Q16/Q32/Q64 tiles; `65 <= Hq <= 127` is routed to CuTeDSL.
- Normalize split-KV to nonempty K partitions and parallelize underfilled D512 reduction across 1/2/4 output bands.
- Classify dense versus causal work per M128 query tile so fully visible K tiles skip masking.
- Add static cyclic decode context parallelism to monolithic BF16/FP16/FP8 CuTeDSL MLA. `cp_world` is compile-time, `cp_rank` is runtime, physical KV lengths remain rank-local, and `causal_seqlens_kv_global` supplies the global causal bound. The kernel returns rank-local output/LSE states for caller-side cross-rank merging.

## Correctness fixes

- Close FP8 two-softmax named-barrier generations before a persistent 2-CTA cluster advances, fixing the upstream multi-work-item hang.
- Bound partial-query TMA descriptors and predicate output/LSE tails.
- Keep split count, workspace sizing, scheduler geometry, and autotuner keys consistent.
- Handle DCP ranks or splits with no visible local keys as the neutral state: `O=0`, `LSE=-inf`.
- Reject incompatible DCP combinations explicitly: DCP is monolithic fixed-Q only, requires `return_lse=True`, and cannot be combined with sinks or compact variable Q.

## Performance

B200 CUDA-graph measurements for the packed-query and reducer changes showed:

- up to 1.27x for flat query packing at B148/K8K;
- 1.06x at B1 and 1.08x at B16 for H96/Sq8;
- 9.7-13.0% end-to-end improvement from adaptive D2/D4 reduction;
- no repeatable regression in a cold-L2 CUDA-graph sweep over `B={1,4,16,32,128}`, `K={1K,16K,128K}`, `Hq={12,24,48,96}`, `Sq={2,4,8}`, and BF16/FP8.

DCP is statically specialized, so its disabled path does not add runtime DCP work.

## Validation

Validated on B200 with CuTeDSL 4.5.0:

- DCP matrix: 27 passed, covering BF16/FP16/FP8, `Hq={6,12,24,48,96,128}`, `Sq={1,4,8}`, `cp_world={1,2,4,8,16}`, heterogeneous/empty local KV, split-KV, PDL, and CUDA graphs.
- Existing CuTeDSL MLA decode module: 678 passed.
- Remaining MLA attention modules, including TRTLLM-GEN, DeepSeek MLA, paging, sparse MLA, XQA, and backend selection: 14,404 passed; 24,506 architecture-specific skips.
- Full `pre-commit run --all-files`: passed, including clang-format, mypy, Ruff check, and Ruff format.

## Current limitations

- CuTeDSL MLA requires SM100+, `Hq <= 128`, latent dimension 512, and RoPE dimension 64.
- DCP requires monolithic fixed-Q and external cross-rank output/LSE reduction.
- Runtime per-request variable split-KV is not qualified; automatic fixed split-KV is.
- Partial final M128 rows remain compute lanes, although their memory accesses and stores are bounded or predicated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact variable-length query support for MLA decode, including ragged query batches and inferred maximum query lengths.
  * Added static distributed context parallelism (DCP) support for monolithic MLA decoding.
  * Improved automatic backend selection for variable-query, DCP, and incompatible feature combinations.
  * Added support for non-power-of-two head configurations across MLA kernels.
* **Bug Fixes**
  * Improved query masking, workspace sizing, output layouts, and handling of empty or inactive query rows.
  * Added clearer validation for unsupported or conflicting decoder options.
* **Tests**
  * Expanded coverage for variable queries, DCP, CUDA graphs, FP8, backend routing, and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->