### PR TITLE
test(kda): enable recurrent_kda decode tests on SM12x

### DIFF
--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Recurrent KDA (Kimi Delta Attention) decode kernels using CuTe DSL for SM100.
+Recurrent KDA (Kimi Delta Attention) decode kernels using CuTe DSL for SM100+
+and SM12x.
 
 Supports single-token decode and fused speculative-token updates with
 per-key-dimension gating.
@@ -1251,7 +1252,7 @@ def run_recurrent_kda(
               state pool used by the shim.
 
     Note:
-        - Requires SM100 (Blackwell) architecture
+        - Requires SM100+ or SM12x (Blackwell)
         - State is bfloat16 ``[N, HV, V, K]`` and updated in-place
         - HEAD_DIM (K=V) must be 64 or 128
         - When using ``cu_seqlens``, batch size ``B`` must be 1

--- a/tests/kda/test_recurrent_kda.py
+++ b/tests/kda/test_recurrent_kda.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from flashinfer.utils import is_sm100a_supported
+from flashinfer.utils import is_sm100a_supported, is_sm12x_supported
 
 try:
     from flashinfer.kda_decode import _RECURRENT_KDA_AVAILABLE, recurrent_kda
@@ -33,8 +33,11 @@ except ImportError:
 def _require_recurrent_kda():
     if not torch.cuda.is_available():
         pytest.skip("Recurrent KDA requires CUDA")
-    if not is_sm100a_supported(torch.device("cuda")):
-        pytest.skip("Recurrent KDA requires SM100a (Blackwell)")
+    if not (
+        is_sm100a_supported(torch.device("cuda"))
+        or is_sm12x_supported(torch.device("cuda"))
+    ):
+        pytest.skip("Recurrent KDA requires SM100a or SM12x (Blackwell)")
     if not _has_recurrent_kda:
         pytest.skip("recurrent_kda kernel not available (missing cutlass DSL deps)")
 


### PR DESCRIPTION
## 📌 Description

`recurrent_kda` decode works on SM12x today, but the test suite skips it.

The kernel (`flashinfer/kda_kernels/recurrent_kda.py`, including the #4001 one-warp/grouped hybrid dispatch) contains only shuffle/elementwise arithmetic — no tcgen05, no tmem, no arch-specific instructions. The runtime import path already gates on the generic `is_cute_dsl_arch_supported`, so the op loads and runs on SM120/SM121 without any changes. Only the pytest fixture was SM100a-specific.

Changes (9 lines):

- `tests/kda/test_recurrent_kda.py`: gate relaxed from `is_sm100a_supported` to `is_sm100a_supported or is_sm12x_supported` (reuses the existing util, which handles the SM120/SM121 CUDA-version floors)
- `flashinfer/kda_kernels/recurrent_kda.py`: module/API docstrings updated from "SM100" to "SM100+ or SM12x"

No kernel or API changes.

## 🧪 Tests

RTX 5060 Ti (SM120, CUDA 13.3, torch 2.12+cu130, nvidia-cutlass-dsl 4.6.1):

```
tests/kda/test_recurrent_kda.py: 77 passed in 33.76s
```

(previously 77 skipped). Covers standard T=1 decode, fused speculative decode, GQA, varlen packing, paged state pools, and both reduction strategies.

Decode latency sanity check, B=64, H=16, K=V=128, bf16 state, single token:

| | latency |
|---|---:|
| flashinfer `recurrent_kda` | 160.6 µs |
| FLA `fused_recurrent_kda` | 178.0 µs |

## Reviewer Notes

Prefill is a separate story: #3885 (KDA prefill) uses tcgen05/tmem and is genuinely SM100-only — this PR deliberately touches decode only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that recurrent KDA decode kernels require SM100+ or SM12x (Blackwell) GPUs.

* **Tests**
  * Updated GPU compatibility checks so recurrent KDA tests run on supported SM100a and SM12x devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->