### PR TITLE
feat(moe_ep): fault-tolerance rank mask (NCCL-EP + NIXL-EP)

### DIFF
--- a/docs/design_docs/MoE_EP_impl.md
+++ b/docs/design_docs/MoE_EP_impl.md
@@ -18,6 +18,9 @@ lives in dispatch/combine).
 | `BootstrapConfig(world_size, rank, stream, nccl_comm)` | transport bootstrap |
 | `FleetParams(num_experts, max_tokens_per_rank, token_hidden_size, dtype_bytes, algorithm, layout)` | EP geometry |
 | `EpAlgorithm.{LOW_LATENCY, HIGH_THROUGHPUT}`, `EpLayout.{EXPERT_MAJOR, RANK_MAJOR, FLAT}` | algorithm / receive layout |
+| `FleetAlgoKnobFaultTolerance(enabled, timeout_ms, reconcile_timeout_s, coordinator_takeover_s)` | opt-in rank masking (LL only) |
+| `supports_fault_tolerance(backend)` | can this host serve the FT API? |
+| `Fleet.{query_fault, query_active_mask, set_active_mask, reconcile_active_mask, clear_faults, active_mask_epoch}` | FT runtime API — mask is `int32[world]`, `1 = active` |
 | `weights: MoEWeightPack` (layer arg) + `SplitConfig(kernel=FusedMoeKernelConfig(moe_config: MoEConfig))` | the expert GEMM (config from `flashinfer.fused_moe.api`) |
 
 `create_fleet(...)` raises `MoEEpNotBuiltError` (with rebuild hint) if the backend extension

--- a/docs/design_docs/moe_ep_architecture.md
+++ b/docs/design_docs/moe_ep_architecture.md
@@ -46,6 +46,7 @@ Kernels register via `@register_split_kernel` / `@register_mega_kernel` when `ba
 | `MoEWeightPack` | Canonical `w13` / `w2` (+ optional `w13_scale` / `w2_scale`); required `weights` arg at layer construction; `dummy_moe_weights()` for comm-only split |
 | `SplitConfig` | `comm` + `kernel` slots (default `NcclEpConfig` + `IdentityConfig`) |
 | `MegaConfig` | `megakernel`, `quantize_input`, `preprocess_weights`, optional `transformed_weights` |
+| `FleetAlgoKnobFaultTolerance` | Opt-in rank masking (`enabled`, `timeout_ms`, reconcile budgets) — see **Fault tolerance** |
 
 **Split:** pass `SplitConfig(comm=..., kernel=...)` or a comm string/config (kernel defaults to `IdentityConfig`). `fleet_knobs` tune transport. Fleet is lazy-created on first `forward()`; a new Handle per forward. `MoEEpSplitLayer.enable_timing` optionally records per-stage GPU ms in `last_timings_ms`.
 
@@ -270,3 +271,48 @@ sequenceDiagram
         Layer->>Runtime: finalize
     end
 ```
+
+## Fault tolerance
+
+Opt-in per Fleet with `FleetAlgoKnobFaultTolerance()`. Without it, a peer that
+stops responding during dispatch/combine trips a GPU `trap()` and takes the job
+down; with it, both transports mask the offending rank, skip it, and let the
+collective complete.
+
+**LOW_LATENCY only, on both transports** — `nccl_ep` leaves its mask buffer
+NULL under HIGH_THROUGHPUT (the mask APIs then abort the process) and `nixl_ep`
+has no HT mask at all. `validate_fleet_params` rejects the combination.
+
+### Mask convention
+
+Canonical across the package: **`int32[world_size]`, `1 = active`, `0 = masked`**,
+a CUDA tensor. This matches `ncclEpMaskQuery` and vLLM's `query_active_mask()`
+naming, so `nccl_ep` is a pass-through.
+
+`nixl_ep` differs on both axes and normalizes inside its own Fleet, so nothing
+else in the tree ever sees its convention:
+
+| | nccl_ep | nixl_ep |
+|---|---|---|
+| polarity | `1 = active` | **nonzero = masked** (buffer is `0xFF`-memset, so an untouched entry reads back as `-1`; kernels test `!= 0`) |
+| length | `world_size` | topology **capacity** (`query_mask_buffer` asserts on it) |
+| normalization | identity | `active = (raw[:world_size] == 0)` — **not** `1 - raw`, which yields `2` for never-connected tail ranks |
+
+### Fleet API
+
+| Method | Collective? | Blocks host? | Stream-ordered? |
+|---|---|---|---|
+| `supports_fault_tolerance` | — | no | no |
+| `query_fault()` | local | nccl no / nixl yes (small D2H) | nccl no / nixl yes |
+| `query_active_mask(out=None)` | local | no | **yes** |
+| `set_active_mask(mask)` | local (but must be applied identically everywhere) | no | **yes** |
+| `reconcile_active_mask()` | **store-collective**, tolerates dead ranks | yes (≤ timeout) | yes |
+| `clear_faults(readmit=False)` | local | no | no |
+| `clear_faults(readmit=True)` | **collective over survivors** | **yes** | yes |
+| `active_mask_epoch` | — | no | no |
+
+Reconciliation goes through the bootstrap rendezvous store
+(`resolve_rendezvous_store(..., subsystem="ft")`), never a `torch.distributed`
+allreduce: an allreduce over the EP group would hang on exactly the rank being
+masked out. See `core/comm/fault_tolerance.py` and the runbook for the protocol
+and the recovery state machine.

--- a/docs/design_docs/moe_ep_runbook.md
+++ b/docs/design_docs/moe_ep_runbook.md
@@ -331,21 +331,60 @@ DEGRADED ──peer gone for good──> update_topology(...)      [COLLECTIVE, 
 
 ### Ordering rules (all load-bearing)
 
-1. **Mutate the mask only between iterations.** Both transports read it *live*
-   from the dispatch/combine kernels, so changing it while a collective is in
-   flight is a race that can produce a half-masked dispatch. Retire the
-   iteration's `combine` (and `Handle.complete()` under
+0. **The steady state is read-only.** The transport discovers the fault: its
+   kernel times out on the peer and masks it. The application's job is to
+   *notice* — `query_fault()`, then `query_active_mask()`. `set_active_mask()`
+   is **not** a normal-path call; it exists so that reconciliation can impose an
+   agreed vector once survivors have compared views, and most callers should
+   only reach it indirectly through `reconcile_active_mask()`.
+
+1. **If you do write the mask, write it only between iterations.** Both
+   transports read it *live* from the dispatch/combine kernels, so changing it
+   while a collective is in flight is a race that can produce a half-masked
+   dispatch. Retire the iteration's `combine` (and `Handle.complete()` under
    `HandleAlgoKnobSplitOperation`) first.
+
 2. **All survivors must reconcile in the same iteration slot** — they must pass
    the same `active_mask_epoch`. Make the host's fault poll a synchronous
    decision point.
-3. `clear_faults(readmit=True)` **before** `update_topology`, never after:
-   `ncclEpMaskClean` needs a live handle on the *current* group, which
-   `update_topology` destroys and recreates.
-4. **No FT call may be issued during CUDA-graph capture.** A captured query
-   replays stale offsets; a captured set freezes one mask vector into every
-   replay. All stream-ordered entry points raise on capture. Call them from the
-   host between replays.
+
+3. **`clear_faults(readmit=True)` and `update_topology()` are alternatives, not
+   a sequence.**
+
+   * `clear_faults(readmit=True)` runs `ncclEpMaskClean` on the *same*
+     communicator: it re-admits a rank that was merely delayed.
+   * `update_topology()` destroys the group and builds a **new communicator**
+     (a fresh `ncclComm_t`, unless you adopted one via
+     `BootstrapConfig.nccl_comm`). That is the only way to add or replace a
+     process — matching `nccl_ep.h`, which notes that rank replacement needs
+     `ncclCommGrow` and a new EP group.
+
+   Re-admitting after a rebuild is meaningless (the group it targeted is gone)
+   and before one is wasted work. If you genuinely do both, `MaskClean` must
+   come first, since it needs a live handle on the *current* group.
+
+4. **No FT call may be issued during CUDA-graph capture** — but not for the
+   reason you might expect. Neither transport compacts the surviving ranks'
+   data layout, so **dispatch and combine are safe to capture**: they re-read
+   the mask on every replay, and a rank that fails later is still skipped.
+   Data from a masked rank is simply left in an unknown state with the error
+   flag raised.
+
+   What must not be captured is a *decision about* the fault state:
+
+   * `query_fault()` is a host-side read, not stream work, so it cannot be
+     captured at all. Inside a capture region it returns the capture-time
+     answer, and the branch taken on it is frozen into the graph's structure —
+     a graph that ignores faults forever because none had happened when it was
+     recorded. This is the quietest failure of the three, which is why it is
+     guarded even though it touches no stream.
+   * `set_active_mask()` bakes the rank and value into the captured operation,
+     so every replay re-applies that one mask.
+   * `query_active_mask()` can only be consumed on the host, which needs a sync
+     that capture forbids.
+
+   All four raise on capture with a per-operation explanation. Call them from
+   the host between replays.
 
 ### Backend asymmetries worth knowing
 
@@ -375,7 +414,23 @@ y_degraded[t] = y_healthy[t] * sum(topk_weights[t][k] for k where the owning ran
 This is deliberate. Renormalizing implicitly would add an unconditional kernel
 to every forward for a case that is almost never active, hide a serving-quality
 event the operator must see, and divide by zero for a token whose entire top-k
-landed on dead ranks. To preserve magnitude yourself:
+landed on dead ranks.
+
+**FlashInfer does not re-home the dead rank's experts either.** That is an
+EPLB-style job and belongs to the framework: re-route the routing map away from
+the failed rank, leave the rank masked, and keep serving on a partial mask —
+no `update_topology()` and no new communicator required. The sequence is
+
+```
+query_fault() → reconcile_active_mask() → clear_faults(readmit=False) → keep going
+```
+
+where `clear_faults(readmit=False)` is purely "re-arm fault detection"
+(`ncclEpErrorClear`); it does not touch the mask. FlashInfer's contribution is
+to surface an agreed mask and the formula below; what you do with the routing is
+yours.
+
+To preserve magnitude yourself:
 
 ```python
 alive = fleet.query_active_mask()                       # [world], 1 = active

--- a/docs/design_docs/moe_ep_runbook.md
+++ b/docs/design_docs/moe_ep_runbook.md
@@ -300,3 +300,128 @@ layer.destroy()
 The raw megakernel config must be wrapped in `MegaConfig` — `MoEEpLayer` routes
 `MegaConfig` → `MoEEpMegaLayer` → `create_mega_kernel(cfg)`, which looks up
 `cfg.kernel_name` in `_MEGA_KERNEL_REGISTRY`.
+
+## Fault tolerance
+
+Enable with `FleetAlgoKnobFaultTolerance()` in `fleet_knobs`. Check support
+first — it needs more than the backend being built:
+
+```python
+from flashinfer.moe_ep import supports_fault_tolerance
+supports_fault_tolerance("nccl_ep")   # needs nccl4py with GroupConfig.enable_mask
+                                      # AND a libnccl_ep exporting ncclEpMask*
+supports_fault_tolerance("nixl_ep")   # true whenever the backend is staged
+```
+
+If `nccl_ep` returns False, upgrade the nccl4py wheel that ships
+`libnccl_ep.so` and confirm it is the one actually loaded
+(`python -m nccl show_versions`). The probe never raises, and the Fleet
+constructor fails with the same diagnosis rather than waiting for a real fault.
+
+### Recovery state machine
+
+```
+HEALTHY ──query_fault()──> FAULT_DETECTED      (local; quiesce in-flight combine/complete)
+   ──reconcile_active_mask()──> RECONCILING     (store-collective, tolerates dead ranks)
+   ──clear_faults(readmit=False)──> DEGRADED    (serving continues; dead ranks' tokens dropped)
+
+DEGRADED ──peer came back──> clear_faults(readmit=True)    [COLLECTIVE, blocking] ──> HEALTHY
+DEGRADED ──peer gone for good──> update_topology(...)      [COLLECTIVE, blocking] ──> HEALTHY
+```
+
+### Ordering rules (all load-bearing)
+
+1. **Mutate the mask only between iterations.** Both transports read it *live*
+   from the dispatch/combine kernels, so changing it while a collective is in
+   flight is a race that can produce a half-masked dispatch. Retire the
+   iteration's `combine` (and `Handle.complete()` under
+   `HandleAlgoKnobSplitOperation`) first.
+2. **All survivors must reconcile in the same iteration slot** — they must pass
+   the same `active_mask_epoch`. Make the host's fault poll a synchronous
+   decision point.
+3. `clear_faults(readmit=True)` **before** `update_topology`, never after:
+   `ncclEpMaskClean` needs a live handle on the *current* group, which
+   `update_topology` destroys and recreates.
+4. **No FT call may be issued during CUDA-graph capture.** A captured query
+   replays stale offsets; a captured set freezes one mask vector into every
+   replay. All stream-ordered entry points raise on capture. Call them from the
+   host between replays.
+
+### Backend asymmetries worth knowing
+
+* **`nixl_ep` cannot evict a rank from the middle.** `disconnect_ranks`
+  requires the removed ranks to form a *suffix*, so masked-and-degraded is the
+  terminal state for a mid-list failure; only a highest-numbered failure can be
+  shrunk away with `update_topology`.
+* **`nccl_ep` re-admission under `EXPERT_MAJOR` warns.** `ncclEpMaskClean`
+  computes its buffer-reset offsets assuming `RANK_MAJOR`, so re-admission may
+  leave stale bytes in the LL staging buffer. Prefer degraded serving or a full
+  `update_topology` rebuild there. (Degraded serving itself is sound under
+  `EXPERT_MAJOR`.)
+* **Growing past the topology capacity is rejected.** Every per-rank array is
+  sized to the capacity at construction; pass
+  `FleetAlgoKnobTopologyCapacity(n=<max ranks>)` up front.
+
+### Dropped tokens — no renormalization
+
+A masked rank's experts contribute nothing and combine does **not** renormalize
+`topk_weights`. An affected token therefore comes out scaled by the surviving
+weight fraction:
+
+```
+y_degraded[t] = y_healthy[t] * sum(topk_weights[t][k] for k where the owning rank is alive)
+```
+
+This is deliberate. Renormalizing implicitly would add an unconditional kernel
+to every forward for a case that is almost never active, hide a serving-quality
+event the operator must see, and divide by zero for a token whose entire top-k
+landed on dead ranks. To preserve magnitude yourself:
+
+```python
+alive = fleet.query_active_mask()                       # [world], 1 = active
+owner = torch.arange(num_experts, device=d) // (num_experts // world_size)
+ok = (topk_ids >= 0) & alive[owner[topk_ids.clamp_min(0)]].bool()
+surviving_w = (topk_weights * ok).sum(-1)               # [num_tokens]
+out.div_(surviving_w.clamp_min(1e-6).unsqueeze(-1))     # or drop requests below a threshold
+```
+
+### Being evicted
+
+`reconcile_active_mask()` raises `MoEEpRankEvictedError` when the survivors
+agreed *this* rank is dead — it stalled long enough for their kernels to give
+up on it. It cannot apply that decision (a rank may not mask itself) and must
+not keep serving (its peers stopped sending it tokens). Tear the worker down,
+or rejoin through a fresh Fleet after the survivors call
+`clear_faults(readmit=True)`.
+
+### Running the FT tests
+
+```bash
+bash tests/moe_ep/run_tests.sh ft          # both backends, gated on support
+```
+
+Or directly (needs ≥4 GPUs):
+
+```bash
+# stalled-rank pytest half — every process survives
+torchrun --nproc_per_node=4 -m pytest \
+  tests/moe_ep/test_moe_ep_fault_tolerance_multirank.py -v \
+  -m "nvep and gpu_4" --backend=nccl_ep      # then --backend=nixl_ep
+
+# hard-kill half — a rank really dies, so judge by SMOKE_RESULT count, not exit code
+torchrun --nproc_per_node=4 --max-restarts=0 \
+  tests/moe_ep/smoke_ft_ep.py --backend nixl_ep
+```
+
+The kill half is a script rather than a pytest test on purpose: torchrun
+reports the victim's non-zero exit, which would fail the survivors' pytest
+session even when they behaved correctly. `run_tests.sh ft` counts
+`SMOKE_RESULT:` lines (expects `nproc - 1`) and is **not** part of `run_all`.
+
+The host-only protocol tests need no GPU at all:
+
+```bash
+pytest tests/moe_ep/test_fault_tolerance_reconcile.py \
+       tests/moe_ep/test_fault_tolerance_api.py \
+       tests/moe_ep/nccl_ep/test_mask_ffi.py -q
+```

--- a/docs/design_docs/vllm_moe_ep_integration.md
+++ b/docs/design_docs/vllm_moe_ep_integration.md
@@ -343,3 +343,98 @@ the competitive datapoint. For a per-stage breakdown, add an nsys capture
 `--all2all-backend` values: `flashinfer_ep_low_latency`, `flashinfer_ep_high_throughput`
 (this work); `nccl_low_latency`, `nccl_high_throughput` (raw nccl.ep, if present);
 `deepep_low_latency`, `deepep_high_throughput` (DeepEP).
+
+## 8. Fault tolerance — future vLLM wiring (design note)
+
+**No vLLM code ships with this change.** FlashInfer now exposes the FT rank-mask
+API (see `moe_ep_runbook.md`); this section records the target shape so a later
+vLLM commit is mechanical.
+
+vLLM already owns the contract — `All2AllManagerBase.support_fault_tolerance`,
+`query_active_mask()`, `query_fault()`, and a per-step hook in
+`gpu_model_runner.py` that calls `query_fault()` on the async-output stream.
+The native `nixl_ep` manager is the reference implementation. The FlashInfer-EP
+managers added by PR #47948 simply hardcode `support_fault_tolerance = False`.
+
+### Target shape
+
+```python
+class FlashInferEPAll2AllManagerBase(All2AllManagerBase):
+    _transport = "nccl_ep"          # subclass overrides to "nixl_ep"
+
+    def __init__(self, cpu_group, ...):
+        from flashinfer.moe_ep import supports_fault_tolerance
+        self.support_fault_tolerance = (
+            envs.VLLM_FLASHINFER_EP_FAULT_TOLERANCE
+            and supports_fault_tolerance(self._transport)
+        )
+
+    def _make_fleet(self, args):
+        knobs = [FleetAlgoKnobAllocator(torch_caching=True)]
+        if self.support_fault_tolerance:
+            knobs.append(FleetAlgoKnobFaultTolerance(
+                timeout_ms=envs.VLLM_FLASHINFER_EP_TIMEOUT_MS))
+            if self._transport == "nixl_ep":
+                knobs.append(FleetAlgoKnobTopologyCapacity(
+                    n=envs.VLLM_NIXL_EP_MAX_NUM_RANKS))
+        ...
+
+    def query_active_mask(self) -> torch.Tensor:
+        return self._primary_fleet().query_active_mask()   # already int32[world], 1 = active
+
+    def query_fault(self) -> torch.Tensor:
+        cur = self.query_active_mask()
+        return (cur != self._last_mask).any()
+```
+
+Because the manager is transport-parameterized (`_transport`), **both**
+`flashinfer_ep_low_latency` (NCCL-EP) and `flashinfer_ep_nixl` inherit FT from
+the one base class.
+
+### Four things the vLLM commit must get right
+
+1. **The HT manager keeps `support_fault_tolerance = False`.** FlashInfer's
+   `validate_fleet_params` rejects FT + HIGH_THROUGHPUT outright (nccl leaves
+   the mask buffer NULL and later mask calls abort the process; nixl has no HT
+   mask), so the HT subclass must override rather than inherit.
+
+2. **`self._fleets` is a dict keyed by MoE config, and every entry shares one
+   EP group.** FT state must therefore be reconciled across *all* of them, not
+   just one — hoist the FT operations onto a designated primary fleet (and fan
+   `update_topology` out). This is the one genuinely non-trivial piece; the
+   native `NixlEPAll2AllManager` sidesteps it with a class-level singleton
+   buffer. Reconciling each fleet independently would burn one store round per
+   fleet and, worse, let them drift.
+
+3. **Polarity is not comparable across managers today.** vLLM's existing
+   `NixlEPAll2AllManager.query_active_mask()` returns the *raw* NIXL buffer —
+   i.e. nonzero means *masked*, despite the method name — and the DeepEP-LL
+   manager likewise returns its raw buffer. Neither is a bug today because the
+   only consumers are a `(cur != last).any()` diff and a debug print. The
+   FlashInfer manager returns **1 = active**. Propose normalizing the base
+   contract to 1 = active as a follow-up; until then, do not compare masks
+   across manager types.
+
+4. **Degraded serving needs a home.** vLLM currently turns a detected fault
+   into a `RuntimeError` and the engine dies — there is no continue-serving
+   path. The alternative this API enables: on fault, the worker calls
+   `fleet.reconcile_active_mask()` + `fleet.clear_faults(readmit=False)`
+   between steps and reports the new mask to the engine core as a control-plane
+   event instead of raising. That is *why* FlashInfer exposes reconcile/clear at
+   all; vLLM has nowhere to put them yet. Note the quality caveat: a masked
+   rank's tokens are dropped with no topk renormalization (formula in the
+   runbook), so a serving deployment should surface the surviving-weight
+   fraction or fail requests below a threshold rather than silently degrade.
+
+**Placement:** `query_fault()` from the existing `check_ep_fault` hook;
+`reconcile_active_mask()` / `clear_faults()` from the fault branch of
+`get_output()` or a new engine-level handler — **never** inside a captured CUDA
+graph (FlashInfer raises on capture).
+
+**Proposed env vars:** `VLLM_FLASHINFER_EP_FAULT_TOLERANCE` (default 0),
+`VLLM_FLASHINFER_EP_TIMEOUT_MS` (default 0 = transport default).
+
+**A rank can be told it is dead.** `reconcile_active_mask()` raises
+`MoEEpRankEvictedError` on a worker the survivors masked out. vLLM should treat
+that as "shut this worker down / hand it back to the elastic-EP scale flow",
+not as a transient error to retry.

--- a/flashinfer/moe_ep/__init__.py
+++ b/flashinfer/moe_ep/__init__.py
@@ -18,10 +18,15 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from .errors import MoEEpNotBuiltError
+from .errors import (
+    MoEEpFaultToleranceUnsupportedError,
+    MoEEpNotBuiltError,
+    MoEEpTransportError,
+)
 from .algo_knobs import (
     AlgoKnob,
     FleetAlgoKnobAllocator,
+    FleetAlgoKnobFaultTolerance,
     FleetAlgoKnobNumChannelsPerRank,
     FleetAlgoKnobNumQpsPerRank,
     FleetAlgoKnobQuantization,
@@ -112,6 +117,7 @@ __all__ = [
     "EpLayout",
     "Fleet",
     "FleetAlgoKnobAllocator",
+    "FleetAlgoKnobFaultTolerance",
     "FleetAlgoKnobNumChannelsPerRank",
     "FleetAlgoKnobNumQpsPerRank",
     "FleetAlgoKnobQuantization",
@@ -129,10 +135,12 @@ __all__ = [
     "MegaConfig",
     "MoEEpArchError",
     "MoEEpConfigError",
+    "MoEEpFaultToleranceUnsupportedError",
     "MoEEpLayer",
     "MoEEpMegaLayer",
     "MoEEpNotBuiltError",
     "MoEEpSplitLayer",
+    "MoEEpTransportError",
     "MoEEpTensors",
     "MoEWeightPack",
     "Mxfp8CutedslMegaMoeConfig",
@@ -160,6 +168,7 @@ __all__ = [
     "preprocess_mxfp8_cutedsl_mega_weights",
     "preprocess_nvfp4_cutedsl_mega_weights",
     "run_split_kernel",
+    "supports_fault_tolerance",
     "validate_arch_for_backend",
     "validate_bootstrap_process_group_ready",
     "validate_bootstrap_world_size",
@@ -220,6 +229,40 @@ def available_backends() -> list[str]:
     if have_nixl_ep():
         out.append("nixl_ep")
     return out
+
+
+def supports_fault_tolerance(backend: str) -> bool:
+    """True when ``backend`` is built AND can serve the Fleet FT API here.
+
+    Rank masking needs more than the backend being present:
+
+    * ``nccl_ep`` also needs an nccl4py whose ``GroupConfig`` carries
+      ``enable_mask`` and a libnccl exporting the ``ncclEpMask*`` symbols.
+      Both are feature-detected, never version-pinned.
+    * ``nixl_ep``'s mask buffer is allocated unconditionally by
+      ``update_memory_buffers``, so a staged backend always supports it.
+
+    Never raises — safe to call on a host with no transport at all.
+    """
+    if backend == "nccl_ep":
+        if not have_nccl_ep():
+            return False
+        try:
+            import dataclasses
+
+            import nccl.ep
+
+            from .backends.split.comm.nccl_ep._mask_ffi import mask_ffi
+
+            has_field = "enable_mask" in {
+                f.name for f in dataclasses.fields(nccl.ep.GroupConfig)
+            }
+            return has_field and mask_ffi().available
+        except Exception:
+            return False
+    if backend == "nixl_ep":
+        return have_nixl_ep()
+    return False
 
 
 def _require_built(backend: str) -> None:

--- a/flashinfer/moe_ep/__init__.py
+++ b/flashinfer/moe_ep/__init__.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from .errors import (
     MoEEpFaultToleranceUnsupportedError,
     MoEEpNotBuiltError,
+    MoEEpRankEvictedError,
     MoEEpTransportError,
 )
 from .algo_knobs import (
@@ -139,6 +140,7 @@ __all__ = [
     "MoEEpLayer",
     "MoEEpMegaLayer",
     "MoEEpNotBuiltError",
+    "MoEEpRankEvictedError",
     "MoEEpSplitLayer",
     "MoEEpTransportError",
     "MoEEpTensors",

--- a/flashinfer/moe_ep/algo_knobs.py
+++ b/flashinfer/moe_ep/algo_knobs.py
@@ -55,6 +55,54 @@ class FleetAlgoKnobTopologyCapacity(AlgoKnob):
 
 
 @dataclass(frozen=True)
+class FleetAlgoKnobFaultTolerance(AlgoKnob):
+    """Enable rank masking so a dead/slow peer degrades instead of trapping.
+
+    Without this knob a peer that stops responding during dispatch or combine
+    trips a GPU ``trap()`` and takes the job down. With it, both transports
+    mask the offending rank, skip it, and let the collective complete — its
+    experts simply contribute nothing (see the note on dropped tokens below).
+
+    LOW_LATENCY only, on both transports: nccl_ep leaves its mask buffer NULL
+    under HIGH_THROUGHPUT (later mask calls then abort the process) and
+    nixl_ep has no HT mask support at all. ``validate_fleet_params`` rejects
+    the combination up front.
+
+    The runtime API lives on the Fleet: :meth:`~flashinfer.moe_ep.core.comm.
+    fleet.Fleet.query_fault`, ``query_active_mask``, ``set_active_mask``,
+    ``reconcile_active_mask`` and ``clear_faults``. See
+    ``docs/design_docs/moe_ep_runbook.md`` for the recovery state machine.
+
+    Note: a masked rank's experts are dropped from combine with **no** topk
+    re-normalization, so affected tokens come out scaled by the surviving
+    weight sum. That is a deliberate choice — see the runbook.
+    """
+
+    enabled: bool = True
+    # GPU wait-loop timeout. 0 = transport default (nccl_ep ~100 s, nixl_ep 30 s).
+    # Too low marks merely-slow ranks dead; prefer the default unless testing.
+    timeout_ms: int = 0
+    # Wall-clock budget for reconcile_active_mask()'s store rendezvous.
+    reconcile_timeout_s: float = 30.0
+    # Extra budget for coordinator takeover when the elected coordinator
+    # also turns out to be dead.
+    coordinator_takeover_s: float = 10.0
+
+    def __post_init__(self) -> None:
+        if self.timeout_ms < 0:
+            raise ValueError(
+                f"FleetAlgoKnobFaultTolerance.timeout_ms must be >= 0 "
+                f"(0 = transport default), got {self.timeout_ms}"
+            )
+        if self.reconcile_timeout_s <= 0 or self.coordinator_takeover_s <= 0:
+            raise ValueError(
+                "FleetAlgoKnobFaultTolerance: reconcile_timeout_s and "
+                "coordinator_takeover_s must be positive, got "
+                f"{self.reconcile_timeout_s} / {self.coordinator_takeover_s}"
+            )
+
+
+@dataclass(frozen=True)
 class FleetAlgoKnobAllocator(AlgoKnob):
     """Route NCCL-EP device buffers through a custom allocator.
 

--- a/flashinfer/moe_ep/backends/split/comm/nccl_ep/_mask_ffi.py
+++ b/flashinfer/moe_ep/backends/split/comm/nccl_ep/_mask_ffi.py
@@ -1,0 +1,235 @@
+"""ctypes shim for NCCL-EP's fault-tolerance mask API.
+
+``nccl4py`` binds ``GroupConfig.enable_mask`` and ``timeout_ns`` (so masking
+can be switched on) but its ``Group`` class stops at ``create`` /
+``create_handle`` / ``destroy`` / ``.ptr`` — the five mask functions are not
+exposed to Python:
+
+    ncclEpMaskQuery / ncclEpMaskUpdate / ncclEpMaskClean
+    ncclEpGetAsyncError / ncclEpErrorClear
+
+``Group.ptr`` is the raw ``ncclEpGroup_t``, so we can call them directly until
+nccl4py catches up. Every method here tries a native ``Group`` method FIRST
+and only then falls back to ctypes, so the shim retires itself with no
+call-site churn the day those bindings land.
+
+Which library: the symbols live in **libnccl_ep.so**, not libnccl.so.2.
+nccl4py dlopens it with ``RTLD_GLOBAL`` and resolves through
+``dlsym(RTLD_DEFAULT, ...)``, so once ``nccl.ep`` has initialized, the symbols
+are in the process-global namespace and ``CDLL(None)`` binds *exactly* the
+library the caller's group came from. That matters: resolving a path
+ourselves could bind a second, different libnccl_ep if the wheel and
+LD_LIBRARY_PATH disagree, and calling into it with a group created by the
+other one is undefined behaviour. Path resolution is only a fallback for
+probing before any group exists.
+
+TODO(moe_ep): drop the ctypes fallback once nccl4py binds ncclEpMask* on
+``nccl.ep.Group``; the native-first dispatch below already prefers it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import functools
+import os
+from ctypes import POINTER, byref, c_int, c_void_p
+from pathlib import Path
+
+from .....errors import MoEEpFaultToleranceUnsupportedError, MoEEpTransportError
+
+# ncclEpGroup_t and cudaStream_t are opaque pointers; ncclResult_t is an enum.
+# Declaring these explicitly is not optional: without argtypes, ctypes
+# int-truncates 64-bit pointers on the way in.
+_SIGS: dict[str, tuple[list, type]] = {
+    # group, int* DEVICE [nRanks] (1 = active), stream
+    "ncclEpMaskQuery": ([c_void_p, c_void_p, c_void_p], c_int),
+    # group, const int* HOST [nRanks] (1 = active), stream  <- host, unlike Query
+    "ncclEpMaskUpdate": ([c_void_p, c_void_p, c_void_p], c_int),
+    # group, stream
+    "ncclEpMaskClean": ([c_void_p, c_void_p], c_int),
+    "ncclEpGetAsyncError": ([c_void_p, POINTER(c_int)], c_int),
+    "ncclEpErrorClear": ([c_void_p], c_int),
+}
+
+_NCCL_RESULT_NAMES = {
+    0: "ncclSuccess",
+    1: "ncclUnhandledCudaError",
+    2: "ncclSystemError",
+    3: "ncclInternalError",
+    4: "ncclInvalidArgument",
+    5: "ncclInvalidUsage",
+    6: "ncclRemoteError",
+    7: "ncclInProgress",
+}
+
+_UPGRADE_HINT = (
+    "Fault tolerance needs an NCCL-EP build carrying the ncclEpMask* API "
+    "(nccl-ep >= v0.1.0 with active-mask support). Upgrade the nccl4py wheel "
+    "that ships libnccl_ep.so, and make sure it is the one actually loaded "
+    "(check `python -m nccl show_versions`)."
+)
+
+
+def _resolve_libnccl_ep() -> ctypes.CDLL | None:
+    """Return a handle exporting the mask symbols, or None.
+
+    Mirrors nccl4py's own resolution order so we bind the same library it
+    does. The global namespace is tried first because that is the one case
+    where the identity is *guaranteed* rather than merely likely.
+    """
+    # 1. Process-global namespace. If nccl.ep has initialized, its
+    #    RTLD_GLOBAL dlopen already put the symbols here.
+    try:
+        main = ctypes.CDLL(None)
+        main.ncclEpMaskQuery  # noqa: B018 - presence probe
+        return main
+    except (OSError, AttributeError):
+        pass
+
+    # 2. nccl4py package path (nccl/ep/lib/libnccl_ep.so), then the linker's
+    #    own search. libnccl_ep.so has NEEDED libnccl.so.2, so preload that
+    #    first exactly as the transport backend does.
+    candidates: list[str] = []
+    try:
+        import nccl  # type: ignore[import-not-found]
+
+        candidates.append(str(Path(nccl.__path__[0]) / "ep" / "lib" / "libnccl_ep.so"))
+    except Exception:
+        pass
+    conda = os.environ.get("CONDA_PREFIX")
+    if conda:
+        candidates += [
+            str(Path(conda) / sub / "libnccl_ep.so") for sub in ("lib", "lib64")
+        ]
+    candidates.append("libnccl_ep.so")  # SONAME fallback
+
+    from . import _preload_libnccl
+
+    for cand in candidates:
+        if cand != "libnccl_ep.so" and not Path(cand).exists():
+            continue
+        # libnccl.so.2 is a NEEDED of libnccl_ep.so; a failure here is not
+        # fatal (the linker may still find it) so the CDLL below decides.
+        with contextlib.suppress(Exception):
+            _preload_libnccl()
+        try:
+            return ctypes.CDLL(cand, mode=ctypes.RTLD_GLOBAL)
+        except OSError:
+            continue
+    return None
+
+
+class _MaskFfi:
+    """Bound ``ncclEpMask*`` entry points, or a clear account of what is missing.
+
+    Never raises at construction: a host with no NCCL at all must be able to
+    call ``supports_fault_tolerance("nccl_ep")`` and simply get False.
+    """
+
+    def __init__(self, lib=None) -> None:
+        self._fns: dict = {}
+        if lib is None:
+            lib = _resolve_libnccl_ep()
+        if lib is None:
+            self.missing = tuple(_SIGS)
+            self.available = False
+            return
+        missing: list[str] = []
+        for name, (argtypes, restype) in _SIGS.items():
+            try:
+                fn = getattr(lib, name)
+            except AttributeError:
+                missing.append(name)
+                continue
+            fn.argtypes = argtypes
+            fn.restype = restype
+            self._fns[name] = fn
+        self.missing = tuple(missing)
+        self.available = not missing
+
+    # ------------------------------------------------------------------ core
+
+    def _call(self, name: str, *args) -> None:
+        fn = self._fns.get(name)
+        if fn is None:
+            raise MoEEpFaultToleranceUnsupportedError(
+                f"{name} is not exported by the loaded libnccl_ep "
+                f"(missing: {', '.join(self.missing) or name}). {_UPGRADE_HINT}"
+            )
+        rc = fn(*args)
+        if rc != 0:
+            detail = ""
+            if rc == 5:  # ncclInvalidUsage — by far the likeliest misuse
+                detail = (
+                    "  (the EP group was created without enable_mask; pass "
+                    "FleetAlgoKnobFaultTolerance() at Fleet construction)"
+                )
+            raise MoEEpTransportError(
+                name, rc, detail, code_name=_NCCL_RESULT_NAMES.get(rc)
+            )
+
+    @staticmethod
+    def _ptr(group) -> int:
+        """Accept either an ``nccl.ep.Group`` or a raw address."""
+        return int(getattr(group, "ptr", group))
+
+    # ------------------------------------------------------- public wrappers
+    #
+    # Each prefers a native nccl4py Group method when one exists, so this
+    # module becomes dead weight (not a blocker) once those land.
+
+    def mask_query(self, group, dev_ptr: int, stream: int) -> None:
+        native = getattr(group, "mask_query", None)
+        if native is not None:
+            native(dev_ptr, stream=stream)
+            return
+        self._call(
+            "ncclEpMaskQuery",
+            c_void_p(self._ptr(group)),
+            c_void_p(dev_ptr),
+            c_void_p(stream),
+        )
+
+    def mask_update(self, group, host_ptr: int, stream: int) -> None:
+        native = getattr(group, "mask_update", None)
+        if native is not None:
+            native(host_ptr, stream=stream)
+            return
+        self._call(
+            "ncclEpMaskUpdate",
+            c_void_p(self._ptr(group)),
+            c_void_p(host_ptr),
+            c_void_p(stream),
+        )
+
+    def mask_clean(self, group, stream: int) -> None:
+        native = getattr(group, "mask_clean", None)
+        if native is not None:
+            native(stream=stream)
+            return
+        self._call("ncclEpMaskClean", c_void_p(self._ptr(group)), c_void_p(stream))
+
+    def get_async_error(self, group) -> bool:
+        native = getattr(group, "get_async_error", None)
+        if native is not None:
+            return bool(native())
+        out = c_int()
+        self._call("ncclEpGetAsyncError", c_void_p(self._ptr(group)), byref(out))
+        return bool(out.value)
+
+    def error_clear(self, group) -> None:
+        native = getattr(group, "error_clear", None)
+        if native is not None:
+            native()
+            return
+        self._call("ncclEpErrorClear", c_void_p(self._ptr(group)))
+
+
+@functools.cache
+def mask_ffi() -> _MaskFfi:
+    """Process-wide shim instance (symbol binding is done once)."""
+    return _MaskFfi()
+
+
+__all__ = ["mask_ffi", "_MaskFfi"]

--- a/flashinfer/moe_ep/backends/split/comm/nccl_ep/fleet.py
+++ b/flashinfer/moe_ep/backends/split/comm/nccl_ep/fleet.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import logging
+import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from ..... import _require_built
-from .....errors import MoEEpNotBuiltError
+from .....errors import MoEEpFaultToleranceUnsupportedError, MoEEpNotBuiltError
 from .....core.validation.common import (
     validate_arch_for_backend,
     validate_bootstrap_world_size,
@@ -22,14 +23,18 @@ from .....core.validation.common import (
 from .....algo_knobs import (
     AlgoKnob,
     FleetAlgoKnobAllocator,
+    FleetAlgoKnobFaultTolerance,
     FleetAlgoKnobNumChannelsPerRank,
     FleetAlgoKnobNumQpsPerRank,
     FleetAlgoKnobQuantization,
     FleetAlgoKnobRdmaBufferSize,
     _index_knobs,
 )
-from .....config import EpAlgorithm, FleetParams
+from .....config import EpAlgorithm, EpLayout, FleetParams
+from .....core.bootstrap_utils import resolve_rendezvous_store
 from .....core.comm.fleet import Fleet, _BACKEND_REGISTRY
+from .....core.comm.fault_tolerance import ACTIVE, MASKED, FaultToleranceMixin
+from ._mask_ffi import mask_ffi
 
 if TYPE_CHECKING:
     from .....config import BootstrapConfig
@@ -139,7 +144,7 @@ def _map_algorithm(algo: EpAlgorithm):
     }[algo]
 
 
-class NcclEpFleet(Fleet):
+class NcclEpFleet(FaultToleranceMixin, Fleet):
     """Owns the ``nccl.ep.Group`` lifecycle for one process."""
 
     def __init__(
@@ -158,16 +163,24 @@ class NcclEpFleet(Fleet):
         params = _clamp_ht_max_tokens(params)
         self._params = params
         self._fleet_knobs = _index_knobs(algo_knobs)
+        ft = self._fleet_knobs.get(FleetAlgoKnobFaultTolerance)
+        self._ft = ft if (ft is not None and ft.enabled) else None  # type: ignore[attr-defined]
         validate_fleet_params(
             params,
             backend="nccl_ep",
             world_size=bootstrap.world_size,
             quant=self._fleet_knobs.get(FleetAlgoKnobQuantization),  # type: ignore[arg-type]
+            fault_tolerance=self._ft,  # type: ignore[arg-type]
         )
         self._bootstrap = bootstrap
         self._stream = bootstrap.stream
         self._nccl_ep = _import_nccl_ep()
         self._comm = _resolve_comm(bootstrap)
+        self._ft_epoch = 0
+        self._ft_store_obj = None
+        self._any_handle_created = False
+        if self._ft is not None:
+            self._check_ft_supported()
 
         # Cross-handle host-path cache (recv buffers, counter tensors, FFI
         # descriptor memos), populated and consumed by NcclEpHandle. Anchored on
@@ -200,6 +213,12 @@ class NcclEpFleet(Fleet):
         alloc = self._build_alloc_config()
         if alloc is not None:
             kwargs["alloc"] = alloc
+        if self._ft is not None:
+            # Allocates the per-rank mask buffer + the pinned async-error flag
+            # inside ncclEpCreateGroup. Without it a peer timeout trap()s.
+            kwargs["enable_mask"] = True
+            if self._ft.timeout_ms:  # type: ignore[attr-defined]
+                kwargs["timeout_ns"] = int(self._ft.timeout_ms) * 1_000_000  # type: ignore[attr-defined]
         return self._nccl_ep.GroupConfig(**kwargs)
 
     def _build_alloc_config(self):
@@ -268,7 +287,171 @@ class NcclEpFleet(Fleet):
     ) -> "Handle":
         from .handle import NcclEpHandle
 
+        self._any_handle_created = True
         return NcclEpHandle(self, params, algo_knobs)
+
+    # ------------------------------------------------------- fault tolerance
+
+    def _check_ft_supported(self) -> None:
+        """Fail at construction, not at first fault, when FT can't work here."""
+        try:
+            names = {f.name for f in dataclasses.fields(self._nccl_ep.GroupConfig)}
+        except TypeError:
+            # Not introspectable (e.g. the test fake); nothing to assert, and
+            # an unknown kwarg would surface as a plain TypeError anyway.
+            names = None
+        if names is not None and "enable_mask" not in names:
+            raise MoEEpFaultToleranceUnsupportedError(
+                "nccl.ep.GroupConfig has no `enable_mask` field: the installed "
+                "nccl4py predates EP fault tolerance. Upgrade the nccl4py wheel, "
+                "or drop FleetAlgoKnobFaultTolerance."
+            )
+        ffi = mask_ffi()
+        if not ffi.available:
+            raise MoEEpFaultToleranceUnsupportedError(
+                "the loaded libnccl_ep does not export "
+                f"{', '.join(ffi.missing)}; fault tolerance needs an NCCL-EP "
+                "build carrying the ncclEpMask* API. Check "
+                "flashinfer.moe_ep.supports_fault_tolerance('nccl_ep') before "
+                "passing FleetAlgoKnobFaultTolerance."
+            )
+
+    def _require_ft(self, op: str):
+        if self._ft is None:
+            self._no_fault_tolerance(op)
+        return self._ft
+
+    @staticmethod
+    def _reject_graph_capture(op: str) -> None:
+        import torch
+
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"Fleet.{op}() is stream-ordered and must not be captured into "
+                "a CUDA graph: every replay would re-apply whatever mask was "
+                "current at capture time. Call it from the host between graph "
+                "replays."
+            )
+
+    def _current_stream(self) -> int:
+        if self._stream:
+            return self._stream
+        import torch
+
+        return torch.cuda.current_stream().cuda_stream
+
+    def _ft_bufs(self):
+        """(device Query dst, pinned host Update src), Fleet-owned.
+
+        ncclEpMaskQuery writes to DEVICE memory while ncclEpMaskUpdate reads
+        from HOST memory, so the two directions need different staging. The
+        host side is PINNED because Update is stream-ordered: if the library
+        defers the H2D onto the stream, a pageable buffer we mutate on the
+        next call is a use-after-write race. Anchored on _hot_cache, which
+        update_topology already clears, so the buffers resize with the world.
+        """
+        import torch
+
+        n = self._bootstrap.world_size
+        bufs = self._hot_cache.get("ft_bufs")
+        if bufs is None or bufs[0].numel() != n:
+            bufs = (
+                torch.empty(n, dtype=torch.int32, device="cuda"),
+                torch.empty(n, dtype=torch.int32, pin_memory=True),
+            )
+            self._hot_cache["ft_bufs"] = bufs
+        return bufs
+
+    def _normalize_mask(self, mask) -> list[int]:
+        import torch
+
+        if isinstance(mask, torch.Tensor):
+            values = [int(v) for v in mask.detach().cpu().flatten().tolist()]
+        else:
+            values = [int(v) for v in mask]
+        n = self._bootstrap.world_size
+        if len(values) != n:
+            raise ValueError(f"mask has {len(values)} entries, expected {n}")
+        out = [ACTIVE if v == ACTIVE else MASKED for v in values]
+        if out[self._bootstrap.rank] != ACTIVE:
+            raise ValueError(
+                f"rank {self._bootstrap.rank} cannot mask itself (mask[rank] must be 1)"
+            )
+        return out
+
+    def _ft_store(self):
+        if self._ft_store_obj is None:
+            self._ft_store_obj = resolve_rendezvous_store(
+                self._bootstrap, subsystem="ft"
+            )
+        return self._ft_store_obj
+
+    def _ft_knob(self):
+        return self._ft
+
+    @property
+    def supports_fault_tolerance(self) -> bool:
+        return self._ft is not None
+
+    @property
+    def active_mask_epoch(self) -> int:
+        return self._ft_epoch
+
+    def query_active_mask(self, out=None):
+        self._require_ft("query_active_mask")
+        self._reject_graph_capture("query_active_mask")
+        dev, _ = self._ft_bufs()
+        # NCCL's polarity is already ours: 1 = active.
+        mask_ffi().mask_query(self._group, dev.data_ptr(), self._current_stream())
+        return dev if out is None else out.copy_(dev)
+
+    def query_fault(self) -> bool:
+        self._require_ft("query_fault")
+        # Pinned host flag: no stream, no sync, free to poll every step.
+        return mask_ffi().get_async_error(self._group)
+
+    def set_active_mask(self, mask) -> None:
+        self._require_ft("set_active_mask")
+        self._reject_graph_capture("set_active_mask")
+        _, host = self._ft_bufs()
+        import torch
+
+        host.copy_(torch.tensor(self._normalize_mask(mask), dtype=torch.int32))
+        mask_ffi().mask_update(self._group, host.data_ptr(), self._current_stream())
+        self._ft_epoch += 1
+
+    def clear_faults(self, *, readmit: bool = False) -> None:
+        self._require_ft("clear_faults")
+        if readmit:
+            self._reject_graph_capture("clear_faults")
+            if not self._any_handle_created:
+                # ncclEpMaskClean asserts rdma_buffer != nullptr, which is only
+                # allocated by the first handle; calling it earlier aborts the
+                # process from C. Fail in Python instead.
+                raise RuntimeError(
+                    "clear_faults(readmit=True) requires at least one handle to "
+                    "have been created on this Fleet (ncclEpMaskClean asserts on "
+                    "the LL staging buffer, which the first create_handle "
+                    "allocates). Run a forward first, or use readmit=False."
+                )
+            if self._params.layout is EpLayout.EXPERT_MAJOR:
+                warnings.warn(
+                    "nccl_ep: ncclEpMaskClean computes its buffer-reset offsets "
+                    "assuming the RANK_MAJOR layout, but this Fleet is "
+                    "EXPERT_MAJOR, so re-admission may leave stale bytes in the "
+                    "LL staging buffer. Prefer degraded serving "
+                    "(readmit=False), or rebuild the group via "
+                    "update_topology().",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            # COLLECTIVE over survivors; internally cudaStreamSynchronize's.
+            mask_ffi().mask_clean(self._group, self._current_stream())
+            self._ft_epoch += 1
+        # MaskClean deliberately does NOT clear the async flag, so always pair
+        # them: that is why readmit is a flag rather than a separate method a
+        # caller could mis-sequence.
+        mask_ffi().error_clear(self._group)
 
     def update_topology(
         self,

--- a/flashinfer/moe_ep/backends/split/comm/nccl_ep/fleet.py
+++ b/flashinfer/moe_ep/backends/split/comm/nccl_ep/fleet.py
@@ -33,7 +33,12 @@ from .....algo_knobs import (
 from .....config import EpAlgorithm, EpLayout, FleetParams
 from .....core.bootstrap_utils import resolve_rendezvous_store
 from .....core.comm.fleet import Fleet, _BACKEND_REGISTRY
-from .....core.comm.fault_tolerance import ACTIVE, MASKED, FaultToleranceMixin
+from .....core.comm.fault_tolerance import (
+    ACTIVE,
+    MASKED,
+    FaultToleranceMixin,
+    reject_graph_capture as _reject_graph_capture_impl,
+)
 from ._mask_ffi import mask_ffi
 
 if TYPE_CHECKING:
@@ -323,15 +328,7 @@ class NcclEpFleet(FaultToleranceMixin, Fleet):
 
     @staticmethod
     def _reject_graph_capture(op: str) -> None:
-        import torch
-
-        if torch.cuda.is_current_stream_capturing():
-            raise RuntimeError(
-                f"Fleet.{op}() is stream-ordered and must not be captured into "
-                "a CUDA graph: every replay would re-apply whatever mask was "
-                "current at capture time. Call it from the host between graph "
-                "replays."
-            )
+        _reject_graph_capture_impl(op)
 
     def _current_stream(self) -> int:
         if self._stream:
@@ -408,6 +405,15 @@ class NcclEpFleet(FaultToleranceMixin, Fleet):
     def query_fault(self) -> bool:
         self._require_ft("query_fault")
         # Pinned host flag: no stream, no sync, free to poll every step.
+        #
+        # Guarded against capture precisely BECAUSE it is a host read: it is
+        # not stream work, so it cannot be captured at all. Called inside a
+        # capture region it would return the capture-time value, and the
+        # branch taken on it would be baked into the graph's structure
+        # forever -- a graph that ignores faults because none existed when it
+        # was recorded. That is a quieter failure than the stream-ordered
+        # calls below, which is exactly why it needs the guard.
+        self._reject_graph_capture("query_fault")
         return mask_ffi().get_async_error(self._group)
 
     def set_active_mask(self, mask) -> None:

--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/fleet.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/fleet.py
@@ -14,7 +14,6 @@ design's Fleet / Handle split by:
 from __future__ import annotations
 
 import contextlib
-import hashlib
 from typing import TYPE_CHECKING, Sequence
 
 from ..... import _require_built
@@ -31,6 +30,7 @@ from .....algo_knobs import (
     _index_knobs,
 )
 from .....config import FleetParams, QuantType
+from .....core.bootstrap_utils import resolve_rendezvous_store
 from .....core.comm.fleet import Fleet, _BACKEND_REGISTRY
 # from .....api_logging import flashinfer_api  # disabled per PR #3453 review
 
@@ -74,66 +74,13 @@ def _load_nixl_ep():
     return nixl_ep
 
 
-# Per-GROUP generation counters namespacing derived rendezvous stores, keyed
-# by the group's sorted global-rank tuple. Fleet creation is collective over
-# the EP group, so each group's counter agrees across its ranks; re-created
-# fleets then never reuse a prior fleet's keys. A single process-wide counter
-# would diverge when a process belongs to several EP subgroups and creates
-# their fleets in a different interleaving than its peers.
-_STORE_GENS: dict = {}
-
-
 def _resolve_store(bootstrap: "BootstrapConfig"):
     """Return the rendezvous store the NIXL ``Buffer`` bootstraps over.
 
-    Resolution order (the NIXL analogue of nccl_ep's ``_resolve_comm``):
-
-    1. ``bootstrap.tcp_store`` set — use it as-is (previous behavior).
-    2. otherwise — derive a ``PrefixStore`` from torch.distributed's default
-       store, so hosts that pass only ``process_group`` (e.g. vLLM's EP group,
-       the same ``BootstrapConfig`` shape the nccl_ep backend consumes) work
-       without constructing a second TCPStore on a sibling port. The prefix is
-       namespaced by the EP group's global ranks plus that group's generation
-       counter so disjoint EP subgroups and re-created fleets never collide on
-       store keys.
+    Thin alias over the shared resolver, which fault tolerance also uses (with
+    ``subsystem="ft"``) since it needs a store on both transports.
     """
-    if bootstrap.tcp_store is not None:
-        return bootstrap.tcp_store
-
-    import torch.distributed as dist
-
-    if not dist.is_initialized():
-        raise ValueError(
-            "NixlEpFleet needs a rendezvous store: set bootstrap.tcp_store "
-            "(a torch.distributed.TCPStore), or initialize torch.distributed "
-            "so one can be derived from the default store."
-        )
-
-    from .....core.bootstrap_utils import bootstrap_comm_group
-
-    # torch exposes no public accessor for the default store;
-    # _get_default_store has been stable across torch 2.x but is private, so
-    # fail with the explicit-tcp_store escape hatch rather than a raw
-    # AttributeError if it ever moves.
-    try:
-        base_store = dist.distributed_c10d._get_default_store()
-    except (AttributeError, RuntimeError) as e:
-        raise ValueError(
-            "Could not derive a rendezvous store from torch.distributed's "
-            "default store; set bootstrap.tcp_store (a "
-            "torch.distributed.TCPStore) explicitly."
-        ) from e
-
-    ranks = tuple(sorted(dist.get_process_group_ranks(bootstrap_comm_group(bootstrap))))
-    gen = _STORE_GENS.get(ranks, 0)
-    _STORE_GENS[ranks] = gen + 1
-    # Encode the FULL group identity: a min×len-style prefix collides for
-    # overlapping groups like (0,1,2,3) vs (0,2,4,6). Digest the rank tuple
-    # (not hash(), which is per-process randomized) to keep the prefix
-    # bounded for large groups while staying identical across ranks.
-    group_id = hashlib.sha1("-".join(map(str, ranks)).encode()).hexdigest()[:12]
-    prefix = f"flashinfer/moe_ep/nixl_ep/{group_id}/{gen}"
-    return dist.PrefixStore(prefix, base_store)
+    return resolve_rendezvous_store(bootstrap, subsystem="nixl_ep")
 
 
 class NixlEpFleet(Fleet):

--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/fleet.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/fleet.py
@@ -17,20 +17,23 @@ import contextlib
 from typing import TYPE_CHECKING, Sequence
 
 from ..... import _require_built
-from .....errors import MoEEpNotBuiltError
+from .....errors import MoEEpFaultToleranceUnsupportedError, MoEEpNotBuiltError
 from .....core.validation.common import (
+    MoEEpConfigError,
     validate_arch_for_backend,
     validate_bootstrap_world_size,
     validate_fleet_params,
 )
 from .....algo_knobs import (
     AlgoKnob,
+    FleetAlgoKnobFaultTolerance,
     FleetAlgoKnobQuantization,
     FleetAlgoKnobTopologyCapacity,
     _index_knobs,
 )
 from .....config import FleetParams, QuantType
 from .....core.bootstrap_utils import resolve_rendezvous_store
+from .....core.comm.fault_tolerance import ACTIVE, MASKED, FaultToleranceMixin
 from .....core.comm.fleet import Fleet, _BACKEND_REGISTRY
 # from .....api_logging import flashinfer_api  # disabled per PR #3453 review
 
@@ -83,7 +86,7 @@ def _resolve_store(bootstrap: "BootstrapConfig"):
     return resolve_rendezvous_store(bootstrap, subsystem="nixl_ep")
 
 
-class NixlEpFleet(Fleet):
+class NixlEpFleet(FaultToleranceMixin, Fleet):
     """Owns a ``nixl_ep.Buffer`` for one rank."""
 
     # @flashinfer_api  # disabled per PR #3453 review
@@ -102,15 +105,23 @@ class NixlEpFleet(Fleet):
         self._fleet_knobs = _index_knobs(algo_knobs)
         cap_knob = self._fleet_knobs.get(FleetAlgoKnobTopologyCapacity)
         cap = int(cap_knob.n) if cap_knob is not None else bootstrap.world_size  # type: ignore[attr-defined]
+        ft = self._fleet_knobs.get(FleetAlgoKnobFaultTolerance)
+        self._ft = ft if (ft is not None and ft.enabled) else None  # type: ignore[attr-defined]
         validate_fleet_params(
             params,
             backend="nixl_ep",
             world_size=bootstrap.world_size,
             quant=self._fleet_knobs.get(FleetAlgoKnobQuantization),  # type: ignore[arg-type]
             topology_capacity=cap,
+            fault_tolerance=self._ft,  # type: ignore[arg-type]
         )
         self._bootstrap = bootstrap
         self._capacity = cap
+        self._ft_epoch = 0
+        self._ft_store_obj = None
+        # Mirrors the mask we have applied, so set_active_mask can push only
+        # the diff. connect_ranks below unmasks exactly [0, world_size).
+        self._ft_applied = [ACTIVE] * bootstrap.world_size
 
         nixl_ep = _load_nixl_ep()
         self._nixl_ep = nixl_ep  # handles read topk_idx_t off it
@@ -121,11 +132,29 @@ class NixlEpFleet(Fleet):
             cap,
             params.num_experts,
         )
-        self._buffer = nixl_ep.Buffer(
-            rank=bootstrap.rank,
-            low_latency_mode=True,  # MVP: LL only
-            tcp_store_group=store,
-        )
+        buf_kwargs = {}
+        if self._ft is not None and self._ft.timeout_ms:  # type: ignore[attr-defined]
+            # LL: a timeout masks the offending rank. (HT traps instead, which
+            # is why validate_fleet_params rejects FT+HT.) The mask buffer
+            # itself is allocated unconditionally by update_memory_buffers
+            # below, so timeout_ms is the only ctor-level FT knob.
+            buf_kwargs["timeout_ms"] = int(self._ft.timeout_ms)  # type: ignore[attr-defined]
+        try:
+            self._buffer = nixl_ep.Buffer(
+                rank=bootstrap.rank,
+                low_latency_mode=True,  # MVP: LL only
+                tcp_store_group=store,
+                **buf_kwargs,
+            )
+        except TypeError as e:
+            if not buf_kwargs:
+                raise
+            raise MoEEpFaultToleranceUnsupportedError(
+                "the staged nixl_ep build's Buffer() does not accept "
+                "`timeout_ms`; rebuild against a newer NIXL (BUILD_NIXL_EP=1), "
+                "or drop FleetAlgoKnobFaultTolerance.timeout_ms to use the "
+                "transport default."
+            ) from e
         num_experts_per_rank = params.num_experts // cap
         self._buffer.update_memory_buffers(cap, num_experts_per_rank, num_rdma_bytes)
         self._buffer.connect_ranks(list(range(bootstrap.world_size)))
@@ -169,7 +198,28 @@ class NixlEpFleet(Fleet):
         bootstrap: "BootstrapConfig",
         algo_knobs: Sequence[AlgoKnob] = (),
     ) -> None:
-        """Diff new vs current rank set, disconnect removed + connect added."""
+        """Diff new vs current rank set, disconnect removed + connect added.
+
+        Growing past the topology capacity is rejected: every per-rank array
+        (RDMA, mask, sync) was sized to the capacity at construction, so
+        connecting a rank beyond it writes out of bounds inside the transport
+        rather than failing cleanly. Size the capacity for the largest world
+        you intend to reach via ``FleetAlgoKnobTopologyCapacity``.
+
+        Note the transport also requires removed ranks to form a *suffix* of
+        the connected set. The diff below is suffix-only by construction
+        (both sides are ``range(world_size)``), which is why shrinking works
+        here but evicting a rank from the *middle* after a fault does not —
+        that case stays masked-and-degraded instead.
+        """
+        if bootstrap.world_size > self._capacity:
+            raise MoEEpConfigError(
+                f"nixl_ep: cannot grow to world_size {bootstrap.world_size} on a "
+                f"Fleet whose topology capacity is {self._capacity}; the "
+                "transport's per-rank buffers were sized to that capacity. "
+                "Pass FleetAlgoKnobTopologyCapacity(n=<max ranks>) at "
+                "construction."
+            )
         old_ranks = set(range(self._bootstrap.world_size))
         new_ranks = set(range(bootstrap.world_size))
         removed = sorted(old_ranks - new_ranks)
@@ -181,6 +231,135 @@ class NixlEpFleet(Fleet):
         self._bootstrap = bootstrap
         if algo_knobs:
             self._fleet_knobs = _index_knobs(algo_knobs)
+        self._ft_applied = [ACTIVE] * bootstrap.world_size
+        self._hot_ft_bufs = None
+
+    # ------------------------------------------------------- fault tolerance
+
+    def _require_ft(self, op: str):
+        if self._ft is None:
+            self._no_fault_tolerance(op)
+        return self._ft
+
+    @staticmethod
+    def _reject_graph_capture(op: str) -> None:
+        import torch
+
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"Fleet.{op}() launches a kernel on the current stream and must "
+                "not be captured into a CUDA graph: every replay would re-apply "
+                "whatever mask was current at capture time. Call it from the "
+                "host between graph replays."
+            )
+
+    def _ft_raw(self):
+        """`[capacity]` int32 scratch for query_mask_buffer.
+
+        The transport asserts the out tensor is exactly ``max_num_ranks``
+        long, which is the topology CAPACITY, not the live world size — hence
+        the trim in query_active_mask.
+        """
+        import torch
+
+        buf = getattr(self, "_hot_ft_bufs", None)
+        if buf is None or buf.numel() != self._capacity:
+            buf = torch.empty(self._capacity, dtype=torch.int32, device="cuda")
+            self._hot_ft_bufs = buf
+        return buf
+
+    def _normalize_mask(self, mask) -> list[int]:
+        import torch
+
+        if isinstance(mask, torch.Tensor):
+            values = [int(v) for v in mask.detach().cpu().flatten().tolist()]
+        else:
+            values = [int(v) for v in mask]
+        n = self._bootstrap.world_size
+        if len(values) != n:
+            raise ValueError(f"mask has {len(values)} entries, expected {n}")
+        out = [ACTIVE if v == ACTIVE else MASKED for v in values]
+        if out[self._bootstrap.rank] != ACTIVE:
+            raise ValueError(
+                f"rank {self._bootstrap.rank} cannot mask itself "
+                "(mask[rank] must be 1); nixl_ep rejects masking the local rank"
+            )
+        return out
+
+    def _ft_store(self):
+        if self._ft_store_obj is None:
+            self._ft_store_obj = resolve_rendezvous_store(
+                self._bootstrap, subsystem="ft"
+            )
+        return self._ft_store_obj
+
+    def _ft_knob(self):
+        return self._ft
+
+    @property
+    def supports_fault_tolerance(self) -> bool:
+        return self._ft is not None
+
+    @property
+    def active_mask_epoch(self) -> int:
+        return self._ft_epoch
+
+    def query_active_mask(self, out=None):
+        import torch
+
+        self._require_ft("query_active_mask")
+        self._reject_graph_capture("query_active_mask")
+        raw = self._ft_raw()
+        self._buffer.query_mask_buffer(raw)  # asserts numel == capacity
+        ws = self._bootstrap.world_size
+        # NIXL's convention is "NONZERO means masked", not "1 means masked":
+        # the buffer is 0xFF-memset at allocation (so an untouched entry reads
+        # back as -1) and the kernels test `mask_buffer[r] != 0`. `== 0` is
+        # therefore the only correct normalization to our 1 = active — a
+        # `1 - raw` inversion would yield 2 for never-connected capacity-tail
+        # ranks and silently poison every downstream sum()/bool().
+        active = (raw[:ws] == 0).to(torch.int32)
+        return active if out is None else out.copy_(active)
+
+    def query_fault(self) -> bool:
+        self._require_ft("query_fault")
+        # NIXL has no host-side error flag (nccl_ep's pinned flag has no
+        # equivalent here), so diff against what we last applied. Costs one
+        # small D2H sync; documented on the ABC.
+        cur = self.query_active_mask()
+        return cur.cpu().tolist() != list(self._ft_applied)
+
+    def set_active_mask(self, mask) -> None:
+        self._require_ft("set_active_mask")
+        self._reject_graph_capture("set_active_mask")
+        want = self._normalize_mask(mask)
+        # Push only the DIFF: unlike nccl_ep's single vector Update, each
+        # nixl update_mask_buffer is a kernel launch, so a blind
+        # range(world_size) loop would inject world_size launches into the
+        # steady state where nothing changed.
+        for r, (a, b) in enumerate(zip(want, self._ft_applied, strict=True)):
+            if a != b and r != self._bootstrap.rank:
+                self._buffer.update_mask_buffer(r, mask=(a == MASKED))
+        self._ft_applied = list(want)
+        self._ft_epoch += 1
+
+    def clear_faults(self, *, readmit: bool = False) -> None:
+        self._require_ft("clear_faults")
+        if not readmit:
+            # No sticky host error flag to re-arm on this transport; the mask
+            # itself is the state, and query_fault diffs against it.
+            return
+        self._reject_graph_capture("clear_faults")
+        ws = self._bootstrap.world_size
+        # clean_mask_buffer zeroes ALL `capacity` entries, which marks the
+        # never-connected tail [world_size, capacity) as ACTIVE — a real
+        # correctness bug on any fleet sized above its live world. Re-mask it
+        # immediately.
+        self._buffer.clean_mask_buffer()
+        self._ft_applied = [ACTIVE] * ws
+        for r in range(ws, self._capacity):
+            self._buffer.update_mask_buffer(r, mask=True)
+        self._ft_epoch += 1
 
     # @flashinfer_api  # disabled per PR #3453 review
     def destroy(self) -> None:

--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/fleet.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/fleet.py
@@ -33,7 +33,12 @@ from .....algo_knobs import (
 )
 from .....config import FleetParams, QuantType
 from .....core.bootstrap_utils import resolve_rendezvous_store
-from .....core.comm.fault_tolerance import ACTIVE, MASKED, FaultToleranceMixin
+from .....core.comm.fault_tolerance import (
+    ACTIVE,
+    MASKED,
+    FaultToleranceMixin,
+    reject_graph_capture as _reject_graph_capture_impl,
+)
 from .....core.comm.fleet import Fleet, _BACKEND_REGISTRY
 # from .....api_logging import flashinfer_api  # disabled per PR #3453 review
 
@@ -243,15 +248,7 @@ class NixlEpFleet(FaultToleranceMixin, Fleet):
 
     @staticmethod
     def _reject_graph_capture(op: str) -> None:
-        import torch
-
-        if torch.cuda.is_current_stream_capturing():
-            raise RuntimeError(
-                f"Fleet.{op}() launches a kernel on the current stream and must "
-                "not be captured into a CUDA graph: every replay would re-apply "
-                "whatever mask was current at capture time. Call it from the "
-                "host between graph replays."
-            )
+        _reject_graph_capture_impl(op)
 
     def _ft_raw(self):
         """`[capacity]` int32 scratch for query_mask_buffer.

--- a/flashinfer/moe_ep/core/bootstrap_utils.py
+++ b/flashinfer/moe_ep/core/bootstrap_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import TYPE_CHECKING
 
 from ..config import BootstrapConfig
@@ -45,8 +46,78 @@ def bootstrap_ep_world_size(bootstrap: BootstrapConfig) -> int:
     return bootstrap_ep_rank_world(bootstrap)[1]
 
 
+# Per-GROUP generation counters namespacing derived rendezvous stores, keyed by
+# (subsystem, sorted global-rank tuple). Fleet creation is collective over the
+# EP group, so each group's counter agrees across its ranks; re-created fleets
+# then never reuse a prior fleet's keys. A single process-wide counter would
+# diverge when a process belongs to several EP subgroups and creates their
+# fleets in a different interleaving than its peers.
+_STORE_GENS: dict = {}
+
+
+def resolve_rendezvous_store(bootstrap: BootstrapConfig, *, subsystem: str):
+    """Return a rendezvous store for ``subsystem``, derived from ``bootstrap``.
+
+    Resolution order (the transport-agnostic analogue of nccl_ep's
+    ``_resolve_comm``):
+
+    1. ``bootstrap.tcp_store`` set — use it as-is.
+    2. otherwise — derive a ``PrefixStore`` from torch.distributed's default
+       store, so hosts that pass only ``process_group`` (e.g. vLLM's EP group)
+       work without constructing a second TCPStore on a sibling port. The
+       prefix is namespaced by ``subsystem``, the EP group's global ranks, and
+       that group's generation counter, so disjoint EP subgroups, different
+       subsystems, and re-created fleets never collide on store keys.
+
+    Used by the NIXL ``Buffer`` bootstrap (``subsystem="nixl_ep"``) and by
+    fault-tolerance mask reconciliation (``subsystem="ft"``), which needs a
+    store on both transports.
+
+    Note for callers: each call bumps the generation counter, so resolve ONCE
+    and cache the result. Resolving per operation would put each rank on a
+    different prefix.
+    """
+    if bootstrap.tcp_store is not None:
+        return bootstrap.tcp_store
+
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        raise ValueError(
+            f"{subsystem} needs a rendezvous store: set bootstrap.tcp_store "
+            "(a torch.distributed.TCPStore), or initialize torch.distributed "
+            "so one can be derived from the default store."
+        )
+
+    # torch exposes no public accessor for the default store;
+    # _get_default_store has been stable across torch 2.x but is private, so
+    # fail with the explicit-tcp_store escape hatch rather than a raw
+    # AttributeError if it ever moves.
+    try:
+        base_store = dist.distributed_c10d._get_default_store()
+    except (AttributeError, RuntimeError) as e:
+        raise ValueError(
+            "Could not derive a rendezvous store from torch.distributed's "
+            "default store; set bootstrap.tcp_store (a "
+            "torch.distributed.TCPStore) explicitly."
+        ) from e
+
+    ranks = tuple(sorted(dist.get_process_group_ranks(bootstrap_comm_group(bootstrap))))
+    key = (subsystem, ranks)
+    gen = _STORE_GENS.get(key, 0)
+    _STORE_GENS[key] = gen + 1
+    # Encode the FULL group identity: a min×len-style prefix collides for
+    # overlapping groups like (0,1,2,3) vs (0,2,4,6). Digest the rank tuple
+    # (not hash(), which is per-process randomized) to keep the prefix bounded
+    # for large groups while staying identical across ranks.
+    group_id = hashlib.sha1("-".join(map(str, ranks)).encode()).hexdigest()[:12]
+    prefix = f"flashinfer/moe_ep/{subsystem}/{group_id}/{gen}"
+    return dist.PrefixStore(prefix, base_store)
+
+
 __all__ = [
     "bootstrap_comm_group",
     "bootstrap_ep_rank_world",
     "bootstrap_ep_world_size",
+    "resolve_rendezvous_store",
 ]

--- a/flashinfer/moe_ep/core/comm/fault_tolerance.py
+++ b/flashinfer/moe_ep/core/comm/fault_tolerance.py
@@ -36,6 +36,49 @@ MASKED = 0
 _POLL_INTERVAL_S = 0.02
 
 
+# Why each FT entry point refuses CUDA-graph capture. The reasons genuinely
+# differ per call, and the distinction matters: the transports do NOT compact
+# the surviving ranks' data layout, so dispatch/combine inside a captured graph
+# keep honouring the live mask on every replay. Masking is not the problem —
+# baking a *decision* about it into a graph is.
+_CAPTURE_REASONS = {
+    "query_fault": (
+        "it is a host-side read, not stream work, so it cannot be captured at "
+        "all: it would return the capture-time answer and the branch taken on "
+        "it would be frozen into the graph's structure -- a graph that ignores "
+        "faults because none had happened when it was recorded"
+    ),
+    "query_active_mask": (
+        "its result can only be consumed on the host, which needs a sync that "
+        "capture forbids; a captured copy would replay, but the decision made "
+        "from it would not"
+    ),
+    "set_active_mask": (
+        "the rank and value are baked into the captured operation, so every "
+        "replay would re-apply that one mask regardless of who is alive"
+    ),
+    "clear_faults": (
+        "re-admission resets transport state exactly once; replaying that on "
+        "every graph launch is never what you want"
+    ),
+}
+
+
+def reject_graph_capture(op: str) -> None:
+    """Raise if called during CUDA-graph capture, explaining why for ``op``."""
+    import torch
+
+    if not torch.cuda.is_current_stream_capturing():
+        return
+    why = _CAPTURE_REASONS.get(op, "capturing it would freeze fault state")
+    raise RuntimeError(
+        f"Fleet.{op}() must not be called during CUDA-graph capture: {why}. "
+        "Call it from the host between graph replays. Note that dispatch and "
+        "combine themselves ARE safe to capture -- they re-read the mask on "
+        "every replay."
+    )
+
+
 def _local_key(epoch: int, rank: int) -> str:
     return f"ft/gen{epoch}/local/{rank}"
 
@@ -243,4 +286,5 @@ __all__ = [
     "MASKED",
     "FaultToleranceMixin",
     "reconcile_masks_via_store",
+    "reject_graph_capture",
 ]

--- a/flashinfer/moe_ep/core/comm/fault_tolerance.py
+++ b/flashinfer/moe_ep/core/comm/fault_tolerance.py
@@ -1,0 +1,246 @@
+"""Backend-agnostic active-mask reconciliation.
+
+When a peer stops responding, each surviving rank's transport masks it
+*locally* — NCCL-EP's own header calls mask consistency "a framework-level
+concern". Two survivors can therefore end up with different views: rank A's
+kernel timed out on the straggler, rank B's did not. Running the next
+dispatch with disagreeing masks deadlocks, so the views must be reconciled
+before serving continues.
+
+This module owns that agreement protocol. It is deliberately transport-free —
+a pure function of a :class:`torch.distributed.Store` — so it can be unit
+tested with an in-process ``HashStore`` and threads, with no GPUs and no
+transport at all.
+
+Why a store and not a collective: a ``torch.distributed`` allreduce over the
+EP group would hang on exactly the rank we are trying to mask out. A store
+round-trip, by contrast, lets a missing key *be* the signal that a rank is
+gone.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Callable, Sequence
+
+if TYPE_CHECKING:
+    import torch
+
+ACTIVE = 1
+MASKED = 0
+
+# How often the gather/decision polls re-check the store. Small enough that a
+# healthy reconcile finishes in ~one interval, large enough not to hammer a
+# TCPStore server. Polling with check() rather than blocking in wait() is what
+# lets us report WHICH ranks failed to report, which wait() cannot.
+_POLL_INTERVAL_S = 0.02
+
+
+def _local_key(epoch: int, rank: int) -> str:
+    return f"ft/gen{epoch}/local/{rank}"
+
+
+def _decision_key(epoch: int) -> str:
+    return f"ft/gen{epoch}/decision"
+
+
+def _wait_for_key(store, key: str, deadline: float, clock: Callable[[], float]):
+    """Poll for ``key`` until ``deadline``; return its bytes or None."""
+    while True:
+        if store.check([key]):
+            return store.get(key)
+        if clock() >= deadline:
+            return None
+        time.sleep(_POLL_INTERVAL_S)
+
+
+def reconcile_masks_via_store(
+    store,
+    *,
+    rank: int,
+    world_size: int,
+    local_mask: Sequence[int],
+    epoch: int,
+    timeout_s: float,
+    takeover_s: float,
+    clock: Callable[[], float] = time.monotonic,
+) -> list[int]:
+    """Agree one active mask across the survivors of an EP group.
+
+    Args:
+        store: any ``torch.distributed.Store`` (TCPStore / PrefixStore /
+            HashStore). Must be shared by the whole EP group and namespaced to
+            it — see ``resolve_rendezvous_store``.
+        rank, world_size: this rank's position in the EP group.
+        local_mask: this rank's view, ``1 = active``. ``local_mask[rank]`` is
+            forced to ACTIVE; a rank never masks itself.
+        epoch: round identifier. **Every survivor must pass the same value.**
+            That is guaranteed by the ordering rule that all survivors
+            reconcile in the same iteration slot (see the runbook); a rank
+            that joins a round more than ``takeover_s`` late is treated as
+            dead by its peers and may compute a decision of its own.
+        timeout_s: budget for the gather phase. A rank whose key has not
+            appeared by then is presumed dead.
+        takeover_s: budget for waiting on the coordinator's decision before
+            presuming the coordinator itself is dead.
+        clock: injectable monotonic clock (tests).
+
+    Returns:
+        The agreed mask, ``1 = active``, length ``world_size``. Identical on
+        every rank that returns.
+
+    The protocol, and why each step is there:
+
+    1. Publish our local view at ``ft/gen{E}/local/{rank}``.
+    2. Wait only on the ranks we still *believe* are alive — never on one we
+       already know is gone, which would burn the whole timeout every round.
+    3. Elementwise-AND the views that arrived; mask any believed-alive rank
+       whose view never showed up.
+    4. **Single-source the decision.** The lowest-numbered survivor publishes
+       the agreed vector with an atomic compare-and-set, and every other rank
+       adopts whatever that key holds.
+
+    Step 4 is the crux. With a naive "everyone ANDs locally and applies the
+    result", a straggler's key landing at T+9.9s is seen by survivor B but not
+    by survivor A polling at T+9.8s, and the two apply *different* masks — a
+    split brain that deadlocks the next dispatch. Publishing through one
+    compare-and-set makes the outcome identical by construction for everyone
+    who reads it, regardless of timing. ``compare_set(key, b"", v)`` is
+    set-if-absent-else-return-current on both TCPStore and HashStore, so even
+    a coordinator takeover race resolves to a single value.
+    """
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, got {world_size}")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"rank {rank} out of range for world_size {world_size}")
+    if len(local_mask) != world_size:
+        raise ValueError(
+            f"local_mask has {len(local_mask)} entries, expected {world_size}"
+        )
+
+    view = [ACTIVE if int(v) == ACTIVE else MASKED for v in local_mask]
+    view[rank] = ACTIVE  # a rank never masks itself
+
+    # 1. publish our view
+    store.set(_local_key(epoch, rank), bytes(view))
+
+    # 2/3. gather from the ranks we believe are alive, then AND
+    believed = [r for r in range(world_size) if view[r] == ACTIVE]
+    pending = {r: _local_key(epoch, r) for r in believed if r != rank}
+    deadline = clock() + timeout_s
+    arrived: dict[int, list[int]] = {rank: list(view)}
+    while pending:
+        for r, key in list(pending.items()):
+            if store.check([key]):
+                arrived[r] = list(store.get(key))
+                del pending[r]
+        if not pending:
+            break
+        if clock() >= deadline:
+            break
+        time.sleep(_POLL_INTERVAL_S)
+
+    agreed = list(view)
+    for peer_view in arrived.values():
+        if len(peer_view) != world_size:
+            # A peer from a different world size cannot be reconciled with;
+            # ignoring it is safer than truncating to a wrong length.
+            continue
+        agreed = [
+            ACTIVE if (a == ACTIVE and int(b) == ACTIVE) else MASKED
+            for a, b in zip(agreed, peer_view, strict=True)
+        ]
+    for r in pending:  # believed alive, never reported -> gone
+        agreed[r] = MASKED
+    agreed[rank] = ACTIVE
+
+    # 4. single-source the decision through the lowest-numbered survivor
+    decision = _decision_key(epoch)
+    for _ in range(world_size + 1):
+        coord = min(r for r in range(world_size) if agreed[r] == ACTIVE)
+        if coord == rank:
+            # compare_set is set-if-absent: if a takeover peer already
+            # published, we adopt theirs instead of overwriting it.
+            winner = store.compare_set(decision, b"", bytes(agreed))
+            return _adopt(winner, world_size, agreed, rank, epoch)
+        published = _wait_for_key(store, decision, clock() + takeover_s, clock)
+        if published is not None:
+            return _adopt(published, world_size, agreed, rank, epoch)
+        # The coordinator never published: presume it died mid-round, drop it
+        # and re-elect. Bounded by world_size iterations.
+        agreed[coord] = MASKED
+
+    raise RuntimeError(
+        f"active-mask reconciliation for epoch {epoch} exhausted "
+        f"{world_size + 1} coordinator elections without a decision; the "
+        "rendezvous store may be unreachable."
+    )
+
+
+def _adopt(
+    raw, world_size: int, fallback: list[int], rank: int, epoch: int
+) -> list[int]:
+    """Decode a published decision, refusing one that masks us.
+
+    A decision that masks the local rank means the survivors gave up on us
+    while we were still running — we stalled long enough for their kernels to
+    time out. We cannot apply it (both transports reject masking the local
+    rank) and we must not ignore it either, since our peers have stopped
+    sending us tokens. Surface it so the framework can decide.
+    """
+    out = [int(v) for v in bytes(raw)]
+    if len(out) != world_size:
+        return fallback
+    decided = [ACTIVE if v == ACTIVE else MASKED for v in out]
+    if decided[rank] != ACTIVE:
+        from ...errors import MoEEpRankEvictedError
+
+        raise MoEEpRankEvictedError(
+            f"rank {rank} was masked out by its peers during mask "
+            f"reconciliation (epoch {epoch}); the agreed mask is {decided}. "
+            "This rank stalled long enough for the survivors' kernels to time "
+            "out on it and is no longer receiving tokens. Tear this worker "
+            "down, or rejoin via a fresh Fleet after the survivors call "
+            "clear_faults(readmit=True)."
+        )
+    return decided
+
+
+class FaultToleranceMixin:
+    """Default ``reconcile_active_mask`` for Fleets that can mask ranks.
+
+    Backends mix this in and supply ``_ft_store()``, ``_ft_knob()``, plus the
+    ``query_active_mask`` / ``set_active_mask`` pair; the reconciliation
+    protocol itself stays transport-free above.
+    """
+
+    def reconcile_active_mask(
+        self, *, timeout_s: float | None = None
+    ) -> "torch.Tensor":
+        import torch
+
+        knob = self._ft_knob()  # type: ignore[attr-defined]
+        store = self._ft_store()  # type: ignore[attr-defined]
+        rank = self._bootstrap.rank  # type: ignore[attr-defined]
+        world = self._bootstrap.world_size  # type: ignore[attr-defined]
+
+        local = [int(v) for v in self.query_active_mask().cpu().tolist()]  # type: ignore[attr-defined]
+        agreed = reconcile_masks_via_store(
+            store,
+            rank=rank,
+            world_size=world,
+            local_mask=local,
+            epoch=self.active_mask_epoch,  # type: ignore[attr-defined]
+            timeout_s=timeout_s if timeout_s is not None else knob.reconcile_timeout_s,
+            takeover_s=knob.coordinator_takeover_s,
+        )
+        self.set_active_mask(agreed)  # type: ignore[attr-defined]
+        return torch.tensor(agreed, dtype=torch.int32, device="cuda")
+
+
+__all__ = [
+    "ACTIVE",
+    "MASKED",
+    "FaultToleranceMixin",
+    "reconcile_masks_via_store",
+]

--- a/flashinfer/moe_ep/core/comm/fleet.py
+++ b/flashinfer/moe_ep/core/comm/fleet.py
@@ -81,9 +81,13 @@ class Fleet(ABC):
     def query_fault(self) -> bool:
         """True when a rank has been masked since the last ``clear_faults``.
 
-        Host-side. Free on nccl_ep (a pinned-flag read). Costs one small D2H
-        sync on nixl_ep, which has no host error flag — in a hot per-step loop
-        prefer diffing ``query_active_mask`` on device.
+        Host-side. Cheap on nccl_ep (a pinned-flag read); costs one small D2H
+        sync on nixl_ep, which has no host error flag.
+
+        Must not be called during CUDA-graph capture — *because* it is a host
+        read rather than stream work, it cannot be captured, so it would
+        return the capture-time answer and freeze the branch taken on it into
+        the graph forever.
         """
         self._no_fault_tolerance("query_fault")
 

--- a/flashinfer/moe_ep/core/comm/fleet.py
+++ b/flashinfer/moe_ep/core/comm/fleet.py
@@ -8,9 +8,11 @@ Backends register themselves in :data:`_BACKEND_REGISTRY` at import time
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable, Sequence
+from typing import TYPE_CHECKING, Callable, NoReturn, Sequence
 
 if TYPE_CHECKING:
+    import torch
+
     from ...algo_knobs import AlgoKnob
     from ...config import BootstrapConfig, HandleParams, FleetParams
     from .handle import Handle
@@ -48,6 +50,97 @@ class Fleet(ABC):
     @abstractmethod
     def destroy(self) -> None:
         """Release transport resources. Idempotent."""
+
+    # ------------------------------------------------------- fault tolerance
+    #
+    # Optional capability, enabled per-Fleet with FleetAlgoKnobFaultTolerance.
+    # These are deliberately CONCRETE raising defaults rather than
+    # @abstractmethod: making them abstract would break every existing Fleet
+    # implementation (including the test suite's _StubFleet) the moment this
+    # lands. Backends that support rank masking override them.
+    #
+    # Mask convention across the whole package: int32, length world_size,
+    # 1 = active, 0 = masked. nixl_ep's inverted, capacity-length buffer is
+    # normalized inside its own Fleet and never escapes.
+
+    @property
+    def supports_fault_tolerance(self) -> bool:
+        """True when this Fleet was built with rank masking enabled."""
+        return False
+
+    def query_active_mask(self, out: "torch.Tensor | None" = None) -> "torch.Tensor":
+        """Per-rank liveness, ``[world_size]`` int32 CUDA, **1 = active**.
+
+        Stream-ordered against the current stream (both transports issue a
+        device copy or kernel). Returns a Fleet-owned buffer when ``out`` is
+        None — the caller must not retain it across calls. Must not be issued
+        during CUDA-graph capture.
+        """
+        self._no_fault_tolerance("query_active_mask")
+
+    def query_fault(self) -> bool:
+        """True when a rank has been masked since the last ``clear_faults``.
+
+        Host-side. Free on nccl_ep (a pinned-flag read). Costs one small D2H
+        sync on nixl_ep, which has no host error flag — in a hot per-step loop
+        prefer diffing ``query_active_mask`` on device.
+        """
+        self._no_fault_tolerance("query_fault")
+
+    def set_active_mask(self, mask: "Sequence[int] | torch.Tensor") -> None:
+        """Apply an *absolute* ``[world_size]`` mask (1 = active).
+
+        LOCAL, not collective — every rank must apply the same vector for the
+        fleet to stay coherent, so prefer ``reconcile_active_mask`` unless you
+        have an out-of-band agreement. ``mask[rank]`` must be 1: a rank cannot
+        mask itself. Stream-ordered, and legal only between iterations — both
+        transports read the mask live from the dispatch/combine kernels.
+        """
+        self._no_fault_tolerance("set_active_mask")
+
+    def reconcile_active_mask(
+        self, *, timeout_s: "float | None" = None
+    ) -> "torch.Tensor":
+        """Agree a mask across survivors via the bootstrap store, then apply it.
+
+        Gathers each rank's local view through the rendezvous store, ANDs the
+        views that arrive, treats a key still missing after ``timeout_s`` as a
+        dead rank, has the lowest-numbered survivor publish the single agreed
+        vector, applies it via ``set_active_mask``, and returns it.
+
+        Deliberately NOT a ``torch.distributed`` allreduce: that would hang on
+        exactly the rank being masked out.
+        """
+        self._no_fault_tolerance("reconcile_active_mask")
+
+    def clear_faults(self, *, readmit: bool = False) -> None:
+        """Re-arm fault detection; optionally re-admit masked ranks.
+
+        ``readmit=False`` — LOCAL and cheap. Clears the transport's sticky
+        error flag so the next fault is detectable. Masks are untouched:
+        serving continues in degraded mode.
+
+        ``readmit=True`` — **COLLECTIVE over survivors** and host-blocking.
+        Resets masks and transport staging buffers so a delayed rank can
+        rejoin. All survivors must call it simultaneously with no dispatch or
+        combine in flight.
+        """
+        self._no_fault_tolerance("clear_faults")
+
+    @property
+    def active_mask_epoch(self) -> int:
+        """Monotone generation counter of the currently applied mask."""
+        return 0
+
+    def _no_fault_tolerance(self, op: str) -> "NoReturn":
+        from ...errors import MoEEpFaultToleranceUnsupportedError
+
+        raise MoEEpFaultToleranceUnsupportedError(
+            f"{type(self).__name__}.{op}() requires fault tolerance, which this "
+            "Fleet was not built with. Pass FleetAlgoKnobFaultTolerance() in "
+            "fleet_knobs at construction, and check "
+            "flashinfer.moe_ep.supports_fault_tolerance(<backend>) first."
+        )
 
 
 def create_fleet(

--- a/flashinfer/moe_ep/core/validation/common.py
+++ b/flashinfer/moe_ep/core/validation/common.py
@@ -10,7 +10,7 @@ from ...weights import MoEWeightPack
 if TYPE_CHECKING:
     import torch
 
-    from ...algo_knobs import FleetAlgoKnobQuantization
+    from ...algo_knobs import FleetAlgoKnobFaultTolerance, FleetAlgoKnobQuantization
 
 
 _NIXL_EP_SUPPORTED_HIDDEN_SIZES = frozenset(
@@ -348,8 +348,18 @@ def validate_fleet_params(
     world_size: int,
     quant: "FleetAlgoKnobQuantization | None" = None,
     topology_capacity: int | None = None,
+    fault_tolerance: "FleetAlgoKnobFaultTolerance | None" = None,
 ) -> None:
     import torch
+
+    if fault_tolerance is not None and fault_tolerance.enabled:
+        if params.algorithm is not EpAlgorithm.LOW_LATENCY:
+            raise MoEEpConfigError(
+                f"{backend}: fault tolerance (FleetAlgoKnobFaultTolerance) requires "
+                "algorithm=LOW_LATENCY. nccl_ep leaves the mask buffer NULL under "
+                "HIGH_THROUGHPUT and the mask APIs then abort the process; nixl_ep "
+                "has no HT mask support at all."
+            )
 
     if backend == "nixl_ep":
         if params.algorithm is not EpAlgorithm.LOW_LATENCY:
@@ -366,6 +376,14 @@ def validate_fleet_params(
         if cap <= 0:
             raise MoEEpConfigError(
                 f"nixl_ep: topology capacity ({cap}) must be positive"
+            )
+        if cap < world_size:
+            # Buffer.update_memory_buffers sizes every per-rank array (RDMA,
+            # mask, sync) to the capacity, so a capacity below the live world
+            # indexes out of bounds inside the transport rather than here.
+            raise MoEEpConfigError(
+                f"nixl_ep: topology capacity ({cap}) must be >= world_size "
+                f"({world_size})"
             )
         if params.num_experts % cap != 0:
             raise MoEEpConfigError(

--- a/flashinfer/moe_ep/errors.py
+++ b/flashinfer/moe_ep/errors.py
@@ -17,6 +17,20 @@ class MoEEpFaultToleranceUnsupportedError(RuntimeError):
     """
 
 
+class MoEEpRankEvictedError(RuntimeError):
+    """This rank was masked out by its peers during mask reconciliation.
+
+    The survivors agreed we are dead — typically because our dispatch stalled
+    long enough for their kernels to time out on us. We cannot apply that
+    decision (a rank cannot mask itself, and both transports reject it), and
+    we must not keep serving as if we were still in the group: our peers are
+    no longer sending us tokens.
+
+    The framework owns the recovery: tear this worker down, or rejoin through
+    a fresh Fleet once the survivors call ``clear_faults(readmit=True)``.
+    """
+
+
 class MoEEpTransportError(RuntimeError):
     """A native transport call returned a non-success status."""
 

--- a/flashinfer/moe_ep/errors.py
+++ b/flashinfer/moe_ep/errors.py
@@ -1,5 +1,30 @@
 """MoE EP v2 exceptions."""
 
+from __future__ import annotations
+
 
 class MoEEpNotBuiltError(RuntimeError):
     """Raised when an EP backend is invoked but its native libs are missing."""
+
+
+class MoEEpFaultToleranceUnsupportedError(RuntimeError):
+    """Raised when an FT API is called on a Fleet/transport that can't serve it.
+
+    Either the Fleet was built without
+    :class:`~flashinfer.moe_ep.algo_knobs.FleetAlgoKnobFaultTolerance`, or the
+    installed transport predates the mask API (see
+    :func:`flashinfer.moe_ep.supports_fault_tolerance`).
+    """
+
+
+class MoEEpTransportError(RuntimeError):
+    """A native transport call returned a non-success status."""
+
+    def __init__(
+        self, fn: str, code: int, detail: str = "", code_name: str | None = None
+    ) -> None:
+        self.fn = fn
+        self.code = code
+        self.code_name = code_name
+        shown = f"{code_name} ({code})" if code_name else str(code)
+        super().__init__(f"{fn} failed: {shown}{detail}")

--- a/flashinfer/moe_ep/modes/split_layer.py
+++ b/flashinfer/moe_ep/modes/split_layer.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 
 from ..algo_knobs import (
     AlgoKnob,
+    FleetAlgoKnobFaultTolerance,
     FleetAlgoKnobQuantization,
     FleetAlgoKnobTopologyCapacity,
     HandleAlgoKnobTopKWeights,
@@ -132,6 +133,7 @@ class MoEEpSplitLayer(nn.Module):
             world_size=self._bootstrap.world_size,
             quant=fleet_knobs.get(FleetAlgoKnobQuantization),  # type: ignore[arg-type]
             topology_capacity=topology_capacity,
+            fault_tolerance=fleet_knobs.get(FleetAlgoKnobFaultTolerance),  # type: ignore[arg-type]
         )
 
     def _ensure_fleet(self) -> Fleet:

--- a/tests/moe_ep/nccl_ep/test_fleet_mock.py
+++ b/tests/moe_ep/nccl_ep/test_fleet_mock.py
@@ -444,3 +444,40 @@ def test_ft_buffers_resize_on_update_topology(
     assert fleet.query_active_mask().numel() == 4
     fleet.update_topology(BootstrapConfig(world_size=8, rank=0))
     assert fleet.query_active_mask().numel() == 8
+
+
+def test_query_fault_rejects_graph_capture(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    """query_fault() is a HOST read, so capture cannot record it at all.
+
+    Called inside a capture region it would return the capture-time answer and
+    freeze the branch taken on it into the graph forever -- a graph that
+    ignores faults because none had happened when it was recorded. That is
+    quieter than the stream-ordered calls, hence the guard.
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    fleet = _ft_fleet()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g), pytest.raises(RuntimeError, match="host-side read"):
+        fleet.query_fault()
+
+
+def test_capture_guard_reason_is_per_operation(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    """The rationale differs per call; a single blanket message was wrong."""
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    fleet = _ft_fleet()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        with pytest.raises(RuntimeError, match="baked into the captured"):
+            fleet.set_active_mask([1, 1, 0, 1])
+        with pytest.raises(RuntimeError, match="consumed on the host"):
+            fleet.query_active_mask()

--- a/tests/moe_ep/nccl_ep/test_fleet_mock.py
+++ b/tests/moe_ep/nccl_ep/test_fleet_mock.py
@@ -236,3 +236,211 @@ def test_resolve_comm_mirrors_bootstrap_process_group(fake_nccl_ep):
 
     assert fake_nccl_ep._log["comm_from_group"] == [sentinel]
     assert fake_nccl_ep._core.Communicator.instances == []
+
+
+# ------------------------------------------------------------ fault tolerance
+
+
+class _RecordingFfi:
+    """Stand-in for the ctypes shim; records the exact calls the Fleet makes."""
+
+    available = True
+    missing: tuple = ()
+
+    def __init__(self):
+        self.calls: list = []
+
+    def mask_query(self, group, dev_ptr, stream):
+        self.calls.append(("query", dev_ptr, stream))
+
+    def mask_update(self, group, host_ptr, stream):
+        self.calls.append(("update", host_ptr, stream))
+
+    def mask_clean(self, group, stream):
+        self.calls.append(("clean", stream))
+
+    def get_async_error(self, group):
+        self.calls.append(("get_async_error",))
+        return True
+
+    def error_clear(self, group):
+        self.calls.append(("error_clear",))
+
+
+@pytest.fixture
+def recording_ffi(monkeypatch):
+    ffi = _RecordingFfi()
+    monkeypatch.setattr(
+        "flashinfer.moe_ep.backends.split.comm.nccl_ep.fleet.mask_ffi", lambda: ffi
+    )
+    return ffi
+
+
+def _ft_fleet(**knob_kwargs):
+    from flashinfer.moe_ep.algo_knobs import FleetAlgoKnobFaultTolerance
+    from flashinfer.moe_ep.config import BootstrapConfig
+    from flashinfer.moe_ep.backends.split.comm.nccl_ep.fleet import NcclEpFleet
+
+    return NcclEpFleet(
+        BootstrapConfig(world_size=4, rank=0),
+        _fleet_params(),
+        [FleetAlgoKnobFaultTolerance(**knob_kwargs)],
+    )
+
+
+def test_ft_knob_sets_enable_mask_and_timeout(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    _ft_fleet(timeout_ms=5000)
+    cfg = fake_nccl_ep._log["groups"][0].config
+    assert cfg.enable_mask is True
+    assert cfg.timeout_ns == 5000 * 1_000_000  # ms -> ns
+
+
+def test_no_ft_knob_leaves_mask_fields_unset(fake_nccl_ep, bypass_build_checks):
+    from flashinfer.moe_ep.config import BootstrapConfig
+    from flashinfer.moe_ep.backends.split.comm.nccl_ep.fleet import NcclEpFleet
+
+    fleet = NcclEpFleet(BootstrapConfig(world_size=4, rank=0), _fleet_params())
+    cfg = fake_nccl_ep._log["groups"][0].config
+    assert "enable_mask" not in cfg.kwargs
+    assert "timeout_ns" not in cfg.kwargs
+    assert fleet.supports_fault_tolerance is False
+
+
+def test_zero_timeout_leaves_transport_default(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    _ft_fleet(timeout_ms=0)
+    cfg = fake_nccl_ep._log["groups"][0].config
+    assert cfg.enable_mask is True
+    assert "timeout_ns" not in cfg.kwargs  # 0 = library default (~100 s)
+
+
+def test_disabled_knob_is_inert(fake_nccl_ep, bypass_build_checks):
+    fleet = _ft_fleet(enabled=False)
+    cfg = fake_nccl_ep._log["groups"][0].config
+    assert "enable_mask" not in cfg.kwargs
+    assert fleet.supports_fault_tolerance is False
+
+
+def test_unavailable_ffi_fails_at_construction(
+    fake_nccl_ep, bypass_build_checks, monkeypatch
+):
+    """Better to fail when the Fleet is built than at the first real fault."""
+    from flashinfer.moe_ep.errors import MoEEpFaultToleranceUnsupportedError
+
+    class _Unavailable:
+        available = False
+        missing = ("ncclEpMaskQuery",)
+
+    monkeypatch.setattr(
+        "flashinfer.moe_ep.backends.split.comm.nccl_ep.fleet.mask_ffi",
+        lambda: _Unavailable(),
+    )
+    with pytest.raises(MoEEpFaultToleranceUnsupportedError, match="ncclEpMaskQuery"):
+        _ft_fleet()
+
+
+def test_query_uses_device_buffer(fake_nccl_ep, bypass_build_checks, recording_ffi):
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA for the staging buffers")
+    fleet = _ft_fleet()
+    out = fleet.query_active_mask()
+    assert out.dtype == torch.int32 and out.numel() == 4 and out.is_cuda
+    kind, ptr, _ = recording_ffi.calls[-1]
+    assert kind == "query" and ptr == out.data_ptr()
+
+
+def test_update_uses_pinned_host_buffer_and_reuses_it(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    """ncclEpMaskUpdate is stream-ordered, so the host source must be pinned
+    and Fleet-owned; a fresh pageable buffer each call would be a
+    use-after-write race."""
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA for the staging buffers")
+    fleet = _ft_fleet()
+    fleet.set_active_mask([1, 1, 0, 1])
+    fleet.set_active_mask([1, 0, 0, 1])
+    ptrs = [c[1] for c in recording_ffi.calls if c[0] == "update"]
+    assert len(ptrs) == 2 and ptrs[0] == ptrs[1]  # same buffer reused
+    _, host = fleet._ft_bufs()
+    assert host.is_pinned() and not host.is_cuda
+    assert host.tolist() == [1, 0, 0, 1]
+    assert fleet.active_mask_epoch == 2
+
+
+def test_set_active_mask_rejects_masking_self(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA for the staging buffers")
+    fleet = _ft_fleet()
+    with pytest.raises(ValueError, match="cannot mask itself"):
+        fleet.set_active_mask([0, 1, 1, 1])  # rank 0 masking rank 0
+
+
+def test_query_fault_reads_host_flag(fake_nccl_ep, bypass_build_checks, recording_ffi):
+    assert _ft_fleet().query_fault() is True
+    assert ("get_async_error",) in recording_ffi.calls
+
+
+def test_clear_faults_without_readmit_only_clears_the_flag(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    fleet = _ft_fleet()
+    fleet.clear_faults()
+    assert recording_ffi.calls == [("error_clear",)]
+
+
+def test_clear_faults_readmit_requires_a_handle(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    """ncclEpMaskClean asserts on the LL buffer the first handle allocates;
+    without this guard the process would SIGABRT from C."""
+    fleet = _ft_fleet()
+    with pytest.raises(RuntimeError, match="at least one handle"):
+        fleet.clear_faults(readmit=True)
+
+
+def test_clear_faults_readmit_cleans_then_clears(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    """Order matters: MaskClean does NOT clear the async flag."""
+    import torch
+
+    from flashinfer.moe_ep.algo_knobs import HandleAlgoKnobTopKWeights
+    from flashinfer.moe_ep.config import EpLayout, HandleParams
+
+    fleet = _ft_fleet()
+    fleet.create_handle(
+        HandleParams(topk_ids=torch.zeros(4, 2, dtype=torch.int32)),
+        [HandleAlgoKnobTopKWeights(weights=torch.ones(4, 2))],
+    )
+    assert fleet.params.layout is EpLayout.EXPERT_MAJOR
+    with pytest.warns(RuntimeWarning, match="RANK_MAJOR"):
+        fleet.clear_faults(readmit=True)
+    kinds = [c[0] for c in recording_ffi.calls]
+    assert kinds[-2:] == ["clean", "error_clear"]
+
+
+def test_ft_buffers_resize_on_update_topology(
+    fake_nccl_ep, bypass_build_checks, recording_ffi
+):
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA for the staging buffers")
+    from flashinfer.moe_ep.config import BootstrapConfig
+
+    fleet = _ft_fleet()
+    assert fleet.query_active_mask().numel() == 4
+    fleet.update_topology(BootstrapConfig(world_size=8, rank=0))
+    assert fleet.query_active_mask().numel() == 8

--- a/tests/moe_ep/nccl_ep/test_mask_ffi.py
+++ b/tests/moe_ep/nccl_ep/test_mask_ffi.py
@@ -1,0 +1,184 @@
+"""ctypes shim unit tests — no libnccl_ep.so required.
+
+The shim is driven with a fake "library" object whose attributes are
+callables carrying settable ``argtypes``/``restype``, which is all ctypes
+asks of them. That lets us assert the marshalling contract (device vs host
+pointer, explicit argtypes) on any host.
+"""
+
+from __future__ import annotations
+
+import types
+from ctypes import POINTER, c_int, c_void_p
+
+import pytest
+
+from flashinfer.moe_ep.backends.split.comm.nccl_ep._mask_ffi import (
+    _NCCL_RESULT_NAMES,
+    _SIGS,
+    _MaskFfi,
+)
+from flashinfer.moe_ep.errors import (
+    MoEEpFaultToleranceUnsupportedError,
+    MoEEpTransportError,
+)
+
+
+class _FakeFn:
+    def __init__(self, rc=0, on_call=None):
+        self.rc = rc
+        self.on_call = on_call
+        self.calls: list[tuple] = []
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, *args):
+        self.calls.append(args)
+        if self.on_call is not None:
+            self.on_call(*args)
+        return self.rc
+
+
+def _fake_lib(rc=0, omit=(), on_call=None):
+    ns = types.SimpleNamespace()
+    for name in _SIGS:
+        if name in omit:
+            continue
+        setattr(ns, name, _FakeFn(rc=rc, on_call=on_call))
+    return ns
+
+
+class _FakeGroup:
+    """Stands in for nccl.ep.Group — only ``.ptr`` is used by the shim."""
+
+    def __init__(self, ptr=0xDEADBEEF):
+        self.ptr = ptr
+
+
+class TestSymbolBinding:
+    def test_binds_all_signatures_exactly(self):
+        lib = _fake_lib()
+        ffi = _MaskFfi(lib=lib)
+        assert ffi.available is True
+        assert ffi.missing == ()
+        # Guards the classic ctypes bug: without explicit argtypes a 64-bit
+        # pointer is silently truncated to int on the way in.
+        for name, (argtypes, restype) in _SIGS.items():
+            fn = getattr(lib, name)
+            assert fn.argtypes == argtypes, name
+            assert fn.restype is restype, name
+
+    def test_pointer_args_are_void_p(self):
+        # All three group/pointer/stream args must be c_void_p, and the
+        # async-error out-param must be a POINTER(c_int).
+        assert _SIGS["ncclEpMaskQuery"][0] == [c_void_p, c_void_p, c_void_p]
+        assert _SIGS["ncclEpGetAsyncError"][0] == [c_void_p, POINTER(c_int)]
+
+    def test_missing_symbol_reports_unavailable(self):
+        ffi = _MaskFfi(lib=_fake_lib(omit=("ncclEpMaskClean",)))
+        assert ffi.available is False
+        assert ffi.missing == ("ncclEpMaskClean",)
+
+    def test_no_library_degrades_quietly(self):
+        # A host with no NCCL at all must not blow up at construction —
+        # supports_fault_tolerance() calls this unconditionally.
+        # lib=None triggers real resolution; depending on the host it may or
+        # may not find libnccl_ep. What matters is that it did not raise.
+        ffi = _MaskFfi()
+        assert isinstance(ffi.available, bool)
+        assert isinstance(ffi.missing, tuple)
+
+
+class TestMarshalling:
+    def test_query_passes_device_pointer(self):
+        lib = _fake_lib()
+        ffi = _MaskFfi(lib=lib)
+        ffi.mask_query(_FakeGroup(0x1000), dev_ptr=0x2000, stream=0x3000)
+        (args,) = lib.ncclEpMaskQuery.calls
+        assert [a.value for a in args] == [0x1000, 0x2000, 0x3000]
+
+    def test_update_passes_host_pointer(self):
+        # Update takes a HOST pointer where Query takes a DEVICE one; the
+        # shim must not "helpfully" unify them.
+        lib = _fake_lib()
+        ffi = _MaskFfi(lib=lib)
+        ffi.mask_update(_FakeGroup(0x1000), host_ptr=0x4000, stream=0x3000)
+        (args,) = lib.ncclEpMaskUpdate.calls
+        assert [a.value for a in args] == [0x1000, 0x4000, 0x3000]
+
+    def test_clean_passes_group_and_stream(self):
+        lib = _fake_lib()
+        _MaskFfi(lib=lib).mask_clean(_FakeGroup(0x1000), stream=0x3000)
+        (args,) = lib.ncclEpMaskClean.calls
+        assert [a.value for a in args] == [0x1000, 0x3000]
+
+    def test_get_async_error_marshals_out_param(self):
+        def set_flag(_group, out_ref):
+            out_ref._obj.value = 1
+
+        lib = _fake_lib(on_call=set_flag)
+        assert _MaskFfi(lib=lib).get_async_error(_FakeGroup()) is True
+
+    def test_get_async_error_false_when_unset(self):
+        assert _MaskFfi(lib=_fake_lib()).get_async_error(_FakeGroup()) is False
+
+    def test_accepts_raw_address(self):
+        lib = _fake_lib()
+        _MaskFfi(lib=lib).error_clear(0x99)
+        (args,) = lib.ncclEpErrorClear.calls
+        assert args[0].value == 0x99
+
+
+class TestErrorMapping:
+    def test_invalid_usage_carries_enable_mask_hint(self):
+        ffi = _MaskFfi(lib=_fake_lib(rc=5))
+        with pytest.raises(MoEEpTransportError) as ei:
+            ffi.mask_query(_FakeGroup(), 0x1, 0x2)
+        msg = str(ei.value)
+        assert "ncclInvalidUsage (5)" in msg
+        assert "enable_mask" in msg
+        assert ei.value.code == 5
+
+    def test_other_codes_map_by_name(self):
+        ffi = _MaskFfi(lib=_fake_lib(rc=3))
+        with pytest.raises(MoEEpTransportError, match="ncclInternalError"):
+            ffi.mask_clean(_FakeGroup(), 0x2)
+
+    def test_unknown_code_still_raises(self):
+        ffi = _MaskFfi(lib=_fake_lib(rc=99))
+        with pytest.raises(MoEEpTransportError) as ei:
+            ffi.error_clear(_FakeGroup())
+        assert ei.value.code == 99
+
+    def test_calling_a_missing_symbol_is_actionable(self):
+        ffi = _MaskFfi(lib=_fake_lib(omit=("ncclEpMaskClean",)))
+        with pytest.raises(MoEEpFaultToleranceUnsupportedError) as ei:
+            ffi.mask_clean(_FakeGroup(), 0x2)
+        assert "ncclEpMaskClean" in str(ei.value)
+        assert "nccl4py" in str(ei.value)
+
+    def test_result_names_cover_the_nccl_enum(self):
+        assert _NCCL_RESULT_NAMES[0] == "ncclSuccess"
+        assert _NCCL_RESULT_NAMES[5] == "ncclInvalidUsage"
+
+
+class TestNativeFirst:
+    """The migration hook: a native Group method wins over ctypes."""
+
+    def test_native_query_preferred(self):
+        lib = _fake_lib()
+        group = _FakeGroup()
+        seen = {}
+        group.mask_query = lambda dev_ptr, stream: seen.update(
+            dev=dev_ptr, stream=stream
+        )
+        _MaskFfi(lib=lib).mask_query(group, dev_ptr=0x7, stream=0x8)
+        assert seen == {"dev": 0x7, "stream": 0x8}
+        assert lib.ncclEpMaskQuery.calls == []  # ctypes path untouched
+
+    def test_native_async_error_preferred(self):
+        lib = _fake_lib()
+        group = _FakeGroup()
+        group.get_async_error = lambda: 1
+        assert _MaskFfi(lib=lib).get_async_error(group) is True
+        assert lib.ncclEpGetAsyncError.calls == []

--- a/tests/moe_ep/nixl_ep/test_fleet_mock.py
+++ b/tests/moe_ep/nixl_ep/test_fleet_mock.py
@@ -73,6 +73,9 @@ def fake_buffer_cls():
         ):
             self.num_ranks = num_ranks
             self.num_experts_per_rank = num_experts_per_rank
+            # 0xFF init: every entry starts masked, self unmasked.
+            self.mask = [-1] * num_ranks
+            self.mask[self.rank] = 0
             self.calls.append(
                 (
                     "update_memory_buffers",
@@ -84,9 +87,36 @@ def fake_buffer_cls():
 
         def connect_ranks(self, ranks, activate=True):
             self.calls.append(("connect_ranks", list(ranks)))
+            if activate:
+                for r in ranks:
+                    self.mask[r] = 0  # 0 == unmasked/active in NIXL
 
         def disconnect_ranks(self, ranks):
             self.calls.append(("disconnect_ranks", list(ranks)))
+
+        # --- mask API, faithful to the transport's semantics -------------
+        # The real buffer is 0xFF-memset at allocation, so an untouched entry
+        # reads back as -1, and the kernels test `mask_buffer[r] != 0`.
+
+        def update_mask_buffer(self, rank_to_mask, mask=False):
+            self.mask[rank_to_mask] = 1 if mask else 0
+            self.calls.append(("update_mask", rank_to_mask, mask))
+
+        def query_mask_buffer(self, out):
+            import torch
+
+            assert out.numel() == self.num_ranks, (
+                f"query_mask_buffer wants exactly max_num_ranks ({self.num_ranks}) "
+                f"entries, got {out.numel()}"
+            )
+            out.copy_(torch.tensor(self.mask, dtype=torch.int32, device=out.device))
+            self.calls.append(("query_mask",))
+
+        def clean_mask_buffer(self):
+            # Zeroes ALL capacity entries -- including the never-connected
+            # tail, which it thereby marks ACTIVE.
+            self.mask = [0] * self.num_ranks
+            self.calls.append(("clean_mask",))
 
         def low_latency_dispatch(self, x, topk_idx, max_tokens, num_experts, **kw):
             import torch
@@ -236,6 +266,7 @@ def test_update_topology_diffs_ranks(patched_loader, fake_buffer_cls):
 
     from flashinfer.moe_ep import (
         BootstrapConfig,
+        FleetAlgoKnobTopologyCapacity,
         FleetParams,
         create_fleet,
     )
@@ -246,7 +277,11 @@ def test_update_topology_diffs_ranks(patched_loader, fake_buffer_cls):
         max_tokens_per_rank=64,
         token_hidden_size=4096,
     )
-    fleet = create_fleet(bootstrap, params, [], backend="nixl_ep")
+    # Capacity must cover the grown world: the transport's per-rank buffers
+    # are sized once, at construction.
+    fleet = create_fleet(
+        bootstrap, params, [FleetAlgoKnobTopologyCapacity(n=8)], backend="nixl_ep"
+    )
 
     # Grow from 4 → 6 ranks: new ranks [4, 5] should appear in connect_ranks.
     fleet.update_topology(BootstrapConfig(world_size=6, rank=0, tcp_store=mock.Mock()))
@@ -426,3 +461,179 @@ def test_missing_store_raises_without_dist(patched_loader, fake_buffer_cls):
         create_fleet(bootstrap, params, [], backend="nixl_ep")
 
     fake_buffer_cls.instances.clear()
+
+
+# ------------------------------------------------------------ fault tolerance
+
+
+def _ft_fleet(world_size=4, capacity=None, **knob_kwargs):
+    from flashinfer.moe_ep import (
+        BootstrapConfig,
+        FleetAlgoKnobFaultTolerance,
+        FleetAlgoKnobTopologyCapacity,
+        FleetParams,
+        create_fleet,
+    )
+
+    knobs = [FleetAlgoKnobFaultTolerance(**knob_kwargs)]
+    if capacity is not None:
+        knobs.append(FleetAlgoKnobTopologyCapacity(n=capacity))
+    return create_fleet(
+        BootstrapConfig(world_size=world_size, rank=0, tcp_store=mock.Mock()),
+        FleetParams(num_experts=8, max_tokens_per_rank=64, token_hidden_size=4096),
+        knobs,
+        backend="nixl_ep",
+    )
+
+
+def test_ft_timeout_reaches_buffer_ctor(patched_loader, fake_buffer_cls):
+    _skip_unless_ep_capable()
+
+    _ft_fleet(timeout_ms=2500)
+    assert fake_buffer_cls.instances[-1].kwargs["timeout_ms"] == 2500
+
+
+def test_ft_zero_timeout_leaves_transport_default(patched_loader, fake_buffer_cls):
+    _skip_unless_ep_capable()
+
+    _ft_fleet(timeout_ms=0)
+    assert "timeout_ms" not in fake_buffer_cls.instances[-1].kwargs
+
+
+def test_ctor_without_timeout_support_is_actionable(patched_loader, fake_buffer_cls):
+    """An older vendored nixl_ep build has no timeout_ms parameter."""
+    _skip_unless_ep_capable()
+
+    from flashinfer.moe_ep.errors import MoEEpFaultToleranceUnsupportedError
+
+    orig_init = fake_buffer_cls.__init__
+
+    def _no_timeout_init(self, rank=0, low_latency_mode=True, tcp_store_group=None):
+        orig_init(self, rank, low_latency_mode, tcp_store_group)
+
+    with (
+        mock.patch.object(fake_buffer_cls, "__init__", _no_timeout_init),
+        pytest.raises(MoEEpFaultToleranceUnsupportedError, match="timeout_ms"),
+    ):
+        _ft_fleet(timeout_ms=2500)
+
+
+def test_query_active_mask_polarity_and_trim(patched_loader, fake_buffer_cls):
+    """The regression test for NIXL's inverted, capacity-length mask buffer.
+
+    Raw is `nonzero == masked` with a 0xFF init, so an untouched tail entry
+    reads back as -1. `(raw == 0)` is the only correct normalization: a
+    `1 - raw` inversion would return 2 for those tail ranks.
+    """
+    _skip_unless_ep_capable()
+
+    import torch
+
+    fleet = _ft_fleet(world_size=4, capacity=8)
+    buf = fake_buffer_cls.instances[-1]
+    buf.mask = [-1, 0, 0, 0, -1, -1, -1, -1]  # rank 0 dead; tail never connected
+
+    got = fleet.query_active_mask()
+    assert got.tolist() == [0, 1, 1, 1]  # trimmed to world_size, 1 = active
+    assert got.dtype == torch.int32
+    assert got.numel() == 4
+
+
+def test_connect_ranks_leaves_capacity_tail_masked(patched_loader, fake_buffer_cls):
+    _skip_unless_ep_capable()
+
+    _ft_fleet(world_size=4, capacity=8)
+    buf = fake_buffer_cls.instances[-1]
+    assert buf.mask[:4] == [0, 0, 0, 0]  # live world active
+    assert buf.mask[4:] == [-1, -1, -1, -1]  # tail still masked from the 0xFF init
+
+
+def test_set_active_mask_pushes_only_the_diff(patched_loader, fake_buffer_cls):
+    """Each update_mask_buffer is a kernel launch, so a no-op set must be free."""
+    _skip_unless_ep_capable()
+
+    fleet = _ft_fleet(world_size=4)
+    buf = fake_buffer_cls.instances[-1]
+
+    fleet.set_active_mask([1, 1, 0, 1])
+    updates = [c for c in buf.calls if c[0] == "update_mask"]
+    assert updates == [("update_mask", 2, True)]
+
+    # Applying the identical mask again must issue nothing.
+    fleet.set_active_mask([1, 1, 0, 1])
+    assert [c for c in buf.calls if c[0] == "update_mask"] == updates
+
+    # Un-masking rank 2 pushes exactly one un-mask.
+    fleet.set_active_mask([1, 1, 1, 1])
+    assert [c for c in buf.calls if c[0] == "update_mask"][-1] == (
+        "update_mask",
+        2,
+        False,
+    )
+
+
+def test_set_active_mask_rejects_masking_self(patched_loader, fake_buffer_cls):
+    _skip_unless_ep_capable()
+
+    fleet = _ft_fleet(world_size=4)
+    with pytest.raises(ValueError, match="cannot mask itself"):
+        fleet.set_active_mask([0, 1, 1, 1])
+
+
+def test_query_fault_diffs_against_applied(patched_loader, fake_buffer_cls):
+    _skip_unless_ep_capable()
+
+    fleet = _ft_fleet(world_size=4)
+    assert fleet.query_fault() is False
+    # Transport self-masks rank 3 on timeout.
+    fake_buffer_cls.instances[-1].mask[3] = 1
+    assert fleet.query_fault() is True
+
+
+def test_clear_faults_readmit_remasks_the_capacity_tail(
+    patched_loader, fake_buffer_cls
+):
+    """clean_mask_buffer zeroes ALL capacity entries, marking the
+    never-connected tail ACTIVE. Without the re-mask that is a live bug on any
+    fleet sized above its world."""
+    _skip_unless_ep_capable()
+
+    fleet = _ft_fleet(world_size=4, capacity=8)
+    buf = fake_buffer_cls.instances[-1]
+    buf.mask[2] = 1  # a rank died
+
+    fleet.clear_faults(readmit=True)
+
+    assert buf.mask[:4] == [0, 0, 0, 0], "survivors + readmitted rank active"
+    assert buf.mask[4:] == [1, 1, 1, 1], "capacity tail must be re-masked"
+    kinds = [c[0] for c in buf.calls]
+    assert "clean_mask" in kinds
+    assert kinds.index("clean_mask") < len(kinds) - 1  # re-masks come after
+
+
+def test_clear_faults_without_readmit_is_a_noop(patched_loader, fake_buffer_cls):
+    """NIXL has no sticky host error flag to re-arm."""
+    _skip_unless_ep_capable()
+
+    fleet = _ft_fleet(world_size=4)
+    buf = fake_buffer_cls.instances[-1]
+    before = list(buf.calls)
+    fleet.clear_faults()
+    assert buf.calls == before
+
+
+def test_ft_methods_raise_without_the_knob(patched_loader, fake_buffer_cls):
+    _skip_unless_ep_capable()
+
+    from flashinfer.moe_ep import BootstrapConfig, FleetParams, create_fleet
+    from flashinfer.moe_ep.errors import MoEEpFaultToleranceUnsupportedError
+
+    fleet = create_fleet(
+        BootstrapConfig(world_size=4, rank=0, tcp_store=mock.Mock()),
+        FleetParams(num_experts=8, max_tokens_per_rank=64, token_hidden_size=4096),
+        [],
+        backend="nixl_ep",
+    )
+    assert fleet.supports_fault_tolerance is False
+    with pytest.raises(MoEEpFaultToleranceUnsupportedError):
+        fleet.query_active_mask()

--- a/tests/moe_ep/nixl_ep/test_fleet_mock.py
+++ b/tests/moe_ep/nixl_ep/test_fleet_mock.py
@@ -637,3 +637,20 @@ def test_ft_methods_raise_without_the_knob(patched_loader, fake_buffer_cls):
     assert fleet.supports_fault_tolerance is False
     with pytest.raises(MoEEpFaultToleranceUnsupportedError):
         fleet.query_active_mask()
+
+
+def test_query_fault_rejects_graph_capture(patched_loader, fake_buffer_cls):
+    """Both backends must agree: query_fault is not capturable.
+
+    On nixl it already raised via query_active_mask; on nccl it silently
+    returned the capture-time answer until the guard was added. This pins the
+    shared behaviour.
+    """
+    _skip_unless_ep_capable()
+
+    import torch
+
+    fleet = _ft_fleet(world_size=4)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g), pytest.raises(RuntimeError, match="CUDA-graph capture"):
+        fleet.query_fault()

--- a/tests/moe_ep/run_tests.sh
+++ b/tests/moe_ep/run_tests.sh
@@ -11,6 +11,7 @@
 #   bash tests/moe_ep/run_tests.sh split_path_correctness_ht     # 4-GPU HT (FLAT) split-path numerics
 #   bash tests/moe_ep/run_tests.sh oracle        # 1-GPU torch-oracle correctness (all paths)
 #   bash tests/moe_ep/run_tests.sh smoke         # torchrun smoke scripts
+#   bash tests/moe_ep/run_tests.sh ft            # 4-GPU fault tolerance (kills a rank)
 #
 # Install (split NCCL-EP + mega runtime deps):
 #   bash fast_install.sh
@@ -208,6 +209,41 @@ run_mega() {
   return "${rc}"
 }
 
+# Fault tolerance. Split into a pytest half (a STALLED rank -- every process
+# survives, so it runs under torchrun -m pytest) and a smoke half (a rank that
+# really dies). The smoke half cannot be a pytest test: torchrun reports the
+# victim's non-zero exit, which would fail the survivors' session even when
+# they behaved correctly. Judge it by counting SMOKE_RESULT lines instead.
+run_ft() {
+  local rc=0
+  local expected_ok=$(( NPROC_SMOKE - 1 ))
+
+  for backend in nccl_ep nixl_ep; do
+    if ! "${PY}" -c "from flashinfer.moe_ep import supports_fault_tolerance as s; raise SystemExit(0 if s('${backend}') else 1)"; then
+      echo "${backend} cannot serve the FT API here; skipping its FT tests"
+      continue
+    fi
+
+    "${TORCHRUN}" --nproc_per_node="${NPROC_MULTIRANK}" -m pytest \
+      "${MOE_EP_PYTEST_FLAGS[@]}" \
+      tests/moe_ep/test_moe_ep_fault_tolerance_multirank.py -v \
+      -m "nvep and gpu_4" --backend="${backend}" || rc=1
+
+    local out
+    out="$("${TORCHRUN}" --nproc_per_node="${NPROC_SMOKE}" --max-restarts=0 \
+      tests/moe_ep/smoke_ft_ep.py --backend "${backend}" 2>&1)" || true
+    echo "${out}"
+    local ok
+    ok="$(printf '%s' "${out}" | grep -c 'SMOKE_RESULT:' || true)"
+    if [ "${ok}" -ne "${expected_ok}" ]; then
+      echo "FT smoke (${backend}): expected ${expected_ok} SMOKE_RESULT lines, got ${ok}" >&2
+      rc=1
+    fi
+  done
+
+  return "${rc}"
+}
+
 run_smoke() {
   require_nccl_ep
 
@@ -269,9 +305,10 @@ case "${1:-all}" in
   split_path_correctness_ht) run_section "split_path_correctness_ht (4 GPU)" run_split_path_correctness_ht; print_summary ;;
   mega) run_section "mega multirank (Blackwell)" run_mega; print_summary ;;
   smoke) run_section "smoke scripts" run_smoke; print_summary ;;
+  ft) run_section "fault tolerance (4 GPU)" run_ft; print_summary ;;
   all) run_all ;;
   *)
-    echo "Usage: $0 [unit|oracle|multirank|split_path_correctness_bf16|split_path_correctness_nvfp4|split_path_correctness_ht|mega|smoke|all]" >&2
+    echo "Usage: $0 [unit|oracle|multirank|split_path_correctness_bf16|split_path_correctness_nvfp4|split_path_correctness_ht|mega|smoke|ft|all]" >&2
     exit 1
     ;;
 esac

--- a/tests/moe_ep/smoke_ft_ep.py
+++ b/tests/moe_ep/smoke_ft_ep.py
@@ -1,0 +1,204 @@
+"""Fault-tolerance smoke: HARD-kill a rank and keep serving, degraded.
+
+Usage:
+    torchrun --nproc_per_node=4 --max-restarts=0 tests/moe_ep/smoke_ft_ep.py \\
+        --backend nccl_ep      # or nixl_ep
+
+This is the hard-kill counterpart to
+``test_moe_ep_fault_tolerance_multirank.py``, which stalls a rank instead.
+It is a standalone script and NOT a pytest test on purpose: the victim really
+does SIGTERM itself, torchrun reports its non-zero exit, and that would fail
+the surviving ranks' pytest session even though the survivors behaved
+correctly. Judge success by counting ``SMOKE_RESULT:`` lines instead --
+``nproc - 1`` of them is a pass (``run_tests.sh ft`` does this).
+
+Modeled on NIXL's own examples/device/ep/tests/elastic/elastic.py: the victim
+installs a SIGTERM handler that tears its Fleet down, then re-raises with
+SIG_DFL so the process actually dies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import sys
+import threading
+from datetime import timedelta
+
+_PG_TIMEOUT = timedelta(minutes=60)
+_FT_TIMEOUT_MS = 2000
+_VICTIM = 2
+_KILL_AFTER_S = 1.0
+_DEGRADED_ITERS = 10
+
+# See smoke_nccl_ep.py: drop this script's dir from sys.path so the installed
+# `nccl_ep` / `nixl_ep` modules aren't shadowed by the test subpackages here.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path[:] = [p for p in sys.path if os.path.abspath(p or os.getcwd()) != _here]
+
+
+def _self_kill():
+    """Die the way a real crashed worker does."""
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    os.kill(os.getpid(), signal.SIGTERM)
+
+
+def main() -> int:
+    import torch
+    import torch.distributed as dist
+
+    from flashinfer.moe_ep import (
+        BootstrapConfig,
+        EpAlgorithm,
+        FleetAlgoKnobFaultTolerance,
+        FleetAlgoKnobTopologyCapacity,
+        FleetParams,
+        IdentityConfig,
+        MoEEpLayer,
+        MoEEpTensors,
+        NCCLEPConfig,
+        NvepConfig,
+        SplitConfig,
+        dummy_moe_weights,
+        supports_fault_tolerance,
+    )
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--backend", default="nccl_ep", choices=["nccl_ep", "nixl_ep"])
+    args = ap.parse_args()
+    backend = args.backend
+
+    dist.init_process_group(
+        backend="nccl" if torch.cuda.is_available() else "gloo", timeout=_PG_TIMEOUT
+    )
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local_rank)
+
+    if not supports_fault_tolerance(backend):
+        print(f"rank {rank}: {backend} cannot serve the FT API here; skipping")
+        return 0
+    if world_size < 4:
+        print(f"rank {rank}: needs >=4 ranks, got {world_size}")
+        return 1
+
+    num_tokens, num_experts, hidden, topk = 64, 8, 4096, 4
+    g = torch.Generator(device="cuda").manual_seed(11 + rank)
+    x = torch.randn(
+        num_tokens, hidden, dtype=torch.bfloat16, device="cuda", generator=g
+    )
+    topk_ids = torch.randint(
+        0,
+        num_experts,
+        (num_tokens, topk),
+        device="cuda",
+        dtype=torch.int64,
+        generator=g,
+    )
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, topk, device="cuda", generator=g), dim=-1
+    )
+    t = MoEEpTensors(hidden_states=x, topk_ids=topk_ids, topk_weights=topk_weights)
+
+    tcp_store = None
+    if backend == "nixl_ep":
+        tcp_store = dist.TCPStore(
+            host_name=os.environ.get("MASTER_ADDR", "127.0.0.1"),
+            port=int(os.environ.get("MASTER_PORT", "29500")) + 1,
+            world_size=world_size,
+            is_master=(rank == 0),
+        )
+
+    knobs = [FleetAlgoKnobFaultTolerance(timeout_ms=_FT_TIMEOUT_MS)]
+    if backend == "nixl_ep":
+        knobs.append(FleetAlgoKnobTopologyCapacity(n=world_size))
+
+    layer = MoEEpLayer(
+        bootstrap=BootstrapConfig(
+            world_size=world_size,
+            rank=rank,
+            stream=torch.cuda.current_stream().cuda_stream,
+            tcp_store=tcp_store,
+        ),
+        fleet_params=FleetParams(
+            num_experts=num_experts,
+            max_tokens_per_rank=num_tokens,
+            token_hidden_size=hidden,
+            dtype_bytes=2,
+            algorithm=EpAlgorithm.LOW_LATENCY,
+        ),
+        weights=dummy_moe_weights(
+            num_local_experts=num_experts // world_size, hidden=hidden
+        ),
+        fleet_knobs=knobs,
+        backend=SplitConfig(
+            comm=NvepConfig() if backend == "nixl_ep" else NCCLEPConfig(),
+            kernel=IdentityConfig(),
+        ),
+    )
+
+    layer.forward(t)
+    torch.cuda.synchronize()
+    dist.barrier()
+    fleet = layer._ensure_fleet()
+
+    if rank == _VICTIM:
+
+        def _handler(_signum, _frame):
+            try:
+                layer.destroy()
+            finally:
+                _self_kill()
+
+        signal.signal(signal.SIGTERM, _handler)
+        threading.Timer(
+            _KILL_AFTER_S, lambda: os.kill(os.getpid(), signal.SIGTERM)
+        ).start()
+        # Keep dispatching until the timer fires mid-flight.
+        while True:
+            layer.forward(t)
+            torch.cuda.synchronize()
+
+    # Survivors: the victim vanishes mid-dispatch. Their kernels time out on
+    # it, mask it, and complete instead of trapping.
+    for _ in range(3):
+        layer.forward(t)
+        torch.cuda.synchronize()
+        if fleet.query_fault():
+            break
+
+    if not fleet.query_fault():
+        print(f"rank {rank}: FAILED - never observed the fault")
+        return 1
+
+    mask = fleet.query_active_mask().cpu().tolist()
+    if mask[_VICTIM] != 0:
+        print(f"rank {rank}: FAILED - victim not masked, mask={mask}")
+        return 1
+
+    # NOTE: no dist.barrier() from here on. The victim is really dead, so any
+    # collective over the full process group would hang -- which is exactly
+    # why reconciliation goes through the store rather than an allreduce.
+    agreed = fleet.reconcile_active_mask().cpu().tolist()
+    expected = [0 if r == _VICTIM else 1 for r in range(world_size)]
+    if agreed != expected:
+        print(f"rank {rank}: FAILED - agreed {agreed}, expected {expected}")
+        return 1
+    fleet.clear_faults(readmit=False)
+
+    for i in range(_DEGRADED_ITERS):
+        y = layer.forward(t)
+        torch.cuda.synchronize()
+        if not torch.isfinite(y.float()).all():
+            print(f"rank {rank}: FAILED - non-finite output on degraded iter {i}")
+            return 1
+
+    print(f"SMOKE_RESULT: {backend} FT OK (survivor rank {rank}, mask={agreed})")
+    layer.destroy()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/moe_ep/test_constraints.py
+++ b/tests/moe_ep/test_constraints.py
@@ -297,3 +297,71 @@ def test_ue8m0_quant_rejected_on_pre_blackwell_for_nixl():
     q = FleetAlgoKnobQuantization(quants=frozenset({QuantType.UE8M0}))
     with pytest.raises(MoEEpConfigError, match="UE8M0"):
         validate_fleet_params(p, backend="nixl_ep", world_size=4, quant=q)
+
+
+# ------------------------------------------------------------------ fault tolerance
+
+
+@pytest.mark.parametrize("backend", ["nccl_ep", "nixl_ep"])
+def test_fault_tolerance_rejected_under_high_throughput(backend):
+    """FT is LOW_LATENCY-only on both transports.
+
+    nccl_ep leaves its mask buffer NULL under HT and the mask APIs then abort
+    the process; nixl_ep has no HT mask support at all. Both must be caught
+    here rather than at first fault.
+    """
+    from flashinfer.moe_ep import EpAlgorithm, FleetAlgoKnobFaultTolerance
+
+    # HT ignores `layout` (the library always uses FLAT), and FleetParams
+    # rejects RANK_MAJOR under HT, so leave it at the default.
+    p = FleetParams(
+        num_experts=8,
+        max_tokens_per_rank=128,
+        token_hidden_size=4096,
+        algorithm=EpAlgorithm.HIGH_THROUGHPUT,
+    )
+    with pytest.raises(MoEEpConfigError, match="LOW_LATENCY"):
+        validate_fleet_params(
+            p,
+            backend=backend,
+            world_size=4,
+            fault_tolerance=FleetAlgoKnobFaultTolerance(),
+        )
+
+
+@pytest.mark.parametrize("backend", ["nccl_ep", "nixl_ep"])
+def test_fault_tolerance_allowed_under_low_latency(backend):
+    from flashinfer.moe_ep import FleetAlgoKnobFaultTolerance
+
+    validate_fleet_params(
+        _split(),
+        backend=backend,
+        world_size=4,
+        fault_tolerance=FleetAlgoKnobFaultTolerance(),
+    )
+
+
+def test_disabled_fault_tolerance_knob_is_ignored():
+    """enabled=False must not trip the LL-only rule."""
+    from flashinfer.moe_ep import EpAlgorithm, FleetAlgoKnobFaultTolerance
+
+    p = FleetParams(
+        num_experts=8,
+        max_tokens_per_rank=128,
+        token_hidden_size=4096,
+        algorithm=EpAlgorithm.HIGH_THROUGHPUT,
+    )
+    validate_fleet_params(
+        p,
+        backend="nccl_ep",
+        world_size=4,
+        fault_tolerance=FleetAlgoKnobFaultTolerance(enabled=False),
+    )
+
+
+def test_nixl_ep_capacity_below_world_size_rejected():
+    """Capacity sizes every per-rank array; below world_size it goes OOB in-transport."""
+    with pytest.raises(MoEEpConfigError, match="world_size"):
+        validate_fleet_params(
+            _split(num_experts=8), backend="nixl_ep", world_size=4, topology_capacity=2
+        )

--- a/tests/moe_ep/test_fault_tolerance_api.py
+++ b/tests/moe_ep/test_fault_tolerance_api.py
@@ -1,0 +1,135 @@
+"""FT API surface tests — knob, Fleet ABC defaults, capability probe.
+
+No CUDA, no comms, no transport: everything here is host-side dataclass and
+ABC behaviour.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from flashinfer.moe_ep import (
+    FleetAlgoKnobFaultTolerance,
+    MoEEpFaultToleranceUnsupportedError,
+    MoEEpTransportError,
+    supports_fault_tolerance,
+)
+from flashinfer.moe_ep.algo_knobs import _index_knobs
+from flashinfer.moe_ep.core.comm.fleet import Fleet
+
+
+class _BareFleet(Fleet):
+    """Minimal concrete Fleet that implements only the required abstracts."""
+
+    def __init__(self, bootstrap=None, params=None, algo_knobs=()) -> None:
+        pass
+
+    def create_handle(self, params, algo_knobs=()):
+        raise NotImplementedError
+
+    def update_topology(self, bootstrap, algo_knobs=()) -> None:
+        raise NotImplementedError
+
+    def destroy(self) -> None:
+        pass
+
+
+class TestFaultToleranceKnob:
+    def test_defaults(self) -> None:
+        k = FleetAlgoKnobFaultTolerance()
+        assert k.enabled is True
+        assert k.timeout_ms == 0  # 0 = transport default
+        assert k.reconcile_timeout_s > 0
+        assert k.coordinator_takeover_s > 0
+
+    def test_frozen_and_hashable(self) -> None:
+        k = FleetAlgoKnobFaultTolerance(timeout_ms=5000)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            k.timeout_ms = 1  # type: ignore[misc]
+        assert hash(k) == hash(FleetAlgoKnobFaultTolerance(timeout_ms=5000))
+
+    def test_rejects_negative_timeout(self) -> None:
+        with pytest.raises(ValueError, match="timeout_ms"):
+            FleetAlgoKnobFaultTolerance(timeout_ms=-1)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"reconcile_timeout_s": 0.0}, {"coordinator_takeover_s": -1.0}],
+    )
+    def test_rejects_nonpositive_budgets(self, kwargs) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            FleetAlgoKnobFaultTolerance(**kwargs)
+
+    def test_index_knobs_round_trip(self) -> None:
+        k = FleetAlgoKnobFaultTolerance(timeout_ms=1234)
+        idx = _index_knobs([k])
+        assert idx[FleetAlgoKnobFaultTolerance] is k
+
+
+class TestFleetAbcDefaults:
+    """The FT methods are concrete raising defaults, not @abstractmethod."""
+
+    def test_bare_fleet_is_instantiable(self) -> None:
+        # Regression guard: if any FT method were made abstract, this would
+        # raise TypeError and break every out-of-tree Fleet implementation.
+        _BareFleet()
+
+    def test_capability_defaults_false(self) -> None:
+        assert _BareFleet().supports_fault_tolerance is False
+        assert _BareFleet().active_mask_epoch == 0
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda f: f.query_active_mask(),
+            lambda f: f.query_fault(),
+            lambda f: f.set_active_mask([1, 1]),
+            lambda f: f.reconcile_active_mask(),
+            lambda f: f.clear_faults(),
+            lambda f: f.clear_faults(readmit=True),
+        ],
+    )
+    def test_ft_methods_raise_unsupported(self, call) -> None:
+        with pytest.raises(MoEEpFaultToleranceUnsupportedError) as ei:
+            call(_BareFleet())
+        # The message must name the knob so the fix is obvious.
+        assert "FleetAlgoKnobFaultTolerance" in str(ei.value)
+
+    def test_stub_fleet_still_works(self, stubbed_fleet_registry) -> None:
+        # The duck-typed _StubFleet in conftest does not implement the FT
+        # methods at all; adding them to the ABC must not break it.
+        from flashinfer.moe_ep import BootstrapConfig, FleetParams, create_fleet
+
+        fleet = create_fleet(
+            BootstrapConfig(world_size=1, rank=0),
+            FleetParams(num_experts=8, max_tokens_per_rank=128, token_hidden_size=4096),
+            backend="nccl_ep",
+        )
+        fleet.destroy()
+        assert "fleet_init" in stubbed_fleet_registry
+
+
+class TestSupportsFaultTolerance:
+    def test_unknown_backend_is_false(self) -> None:
+        assert supports_fault_tolerance("bogus") is False
+
+    def test_never_raises(self) -> None:
+        # Safe to call on a host with no transport built at all.
+        for backend in ("nccl_ep", "nixl_ep", ""):
+            assert isinstance(supports_fault_tolerance(backend), bool)
+
+
+class TestTransportError:
+    def test_message_includes_decoded_name(self) -> None:
+        err = MoEEpTransportError(
+            "ncclEpMaskQuery", 5, "  (hint)", code_name="ncclInvalidUsage"
+        )
+        assert err.fn == "ncclEpMaskQuery"
+        assert err.code == 5
+        assert "ncclInvalidUsage (5)" in str(err)
+        assert "(hint)" in str(err)
+
+    def test_message_without_name(self) -> None:
+        assert "failed: 3" in str(MoEEpTransportError("ncclEpMaskClean", 3))

--- a/tests/moe_ep/test_fault_tolerance_reconcile.py
+++ b/tests/moe_ep/test_fault_tolerance_reconcile.py
@@ -1,0 +1,339 @@
+"""Active-mask reconciliation tests.
+
+``reconcile_masks_via_store`` is a pure function of a torch.distributed Store,
+so the whole protocol is exercised here in-process with a ``HashStore`` and
+threads: no GPU, no CUDA, no transport, no torchrun.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+import torch.distributed as dist
+
+from flashinfer.moe_ep.core.comm.fault_tolerance import (
+    ACTIVE,
+    MASKED,
+    reconcile_masks_via_store,
+)
+
+
+def _run_ranks(store, world_size, local_masks, participants=None, **kwargs):
+    """Run reconcile concurrently for ``participants`` (default: all ranks).
+
+    Returns {rank: agreed_mask_or_exception}.
+    """
+    if participants is None:
+        participants = list(range(world_size))
+    results: dict[int, object] = {}
+    lock = threading.Lock()
+
+    def work(r):
+        try:
+            out = reconcile_masks_via_store(
+                store,
+                rank=r,
+                world_size=world_size,
+                local_mask=local_masks[r],
+                epoch=kwargs.get("epoch", 0),
+                timeout_s=kwargs.get("timeout_s", 2.0),
+                takeover_s=kwargs.get("takeover_s", 2.0),
+            )
+        except Exception as e:  # noqa: BLE001 - surfaced to the assertion below
+            out = e
+        with lock:
+            results[r] = out
+
+    threads = [threading.Thread(target=work, args=(r,)) for r in participants]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+    for t in threads:
+        assert not t.is_alive(), "reconcile thread hung"
+    return results
+
+
+def _assert_all_agree(results, expected):
+    for rank, got in results.items():
+        assert not isinstance(got, Exception), f"rank {rank} raised: {got!r}"
+        assert got == expected, f"rank {rank} got {got}, expected {expected}"
+
+
+class TestHappyPath:
+    def test_all_alive(self):
+        world = 4
+        store = dist.HashStore()
+        masks = {r: [ACTIVE] * world for r in range(world)}
+        results = _run_ranks(store, world, masks)
+        _assert_all_agree(results, [ACTIVE] * world)
+
+    def test_single_rank_world(self):
+        store = dist.HashStore()
+        results = _run_ranks(store, 1, {0: [ACTIVE]})
+        _assert_all_agree(results, [ACTIVE])
+
+
+class TestDeadRanks:
+    def test_rank_never_reports(self):
+        """Rank 2 never calls reconcile; survivors must agree it is gone."""
+        world = 4
+        store = dist.HashStore()
+        # Survivors' local views still show 2 as active — only the missing
+        # store key reveals the death.
+        masks = {r: [ACTIVE] * world for r in range(world)}
+        results = _run_ranks(
+            store, world, masks, participants=[0, 1, 3], timeout_s=0.5, takeover_s=2.0
+        )
+        expected = [ACTIVE, ACTIVE, MASKED, ACTIVE]
+        _assert_all_agree(results, expected)
+
+    def test_disagreeing_views_are_anded(self):
+        """Rank 1 saw 3 time out; rank 2 did not. AND => 3 masked everywhere.
+
+        Rank 3 is alive and participating, but one peer's kernel already gave
+        up on it, so it cannot stay in the group: leaving it active anywhere
+        while rank 1 refuses to send to it is exactly the inconsistency that
+        deadlocks the next dispatch. It therefore gets evicted.
+        """
+        from flashinfer.moe_ep.errors import MoEEpRankEvictedError
+
+        world = 4
+        store = dist.HashStore()
+        masks = {
+            0: [ACTIVE, ACTIVE, ACTIVE, ACTIVE],
+            1: [ACTIVE, ACTIVE, ACTIVE, MASKED],  # rank 1 timed out on 3
+            2: [ACTIVE, ACTIVE, ACTIVE, ACTIVE],
+            3: [ACTIVE, ACTIVE, ACTIVE, ACTIVE],
+        }
+        results = _run_ranks(store, world, masks)
+        expected = [ACTIVE, ACTIVE, ACTIVE, MASKED]
+        for r in (0, 1, 2):
+            assert results[r] == expected, f"rank {r} got {results[r]}"
+        assert isinstance(results[3], MoEEpRankEvictedError)
+
+    def test_rank_never_masks_itself(self):
+        """A caller-supplied mask that masks the local rank is corrected."""
+        world = 2
+        store = dist.HashStore()
+        masks = {0: [MASKED, ACTIVE], 1: [ACTIVE, ACTIVE]}
+        results = _run_ranks(store, world, masks)
+        # Rank 0 forces its own bit ACTIVE, so nothing is masked.
+        _assert_all_agree(results, [ACTIVE, ACTIVE])
+
+    def test_coordinator_is_the_dead_rank(self):
+        """Rank 0 (lowest, the natural coordinator) is the one that died."""
+        world = 4
+        store = dist.HashStore()
+        masks = {r: [ACTIVE] * world for r in range(world)}
+        results = _run_ranks(
+            store, world, masks, participants=[1, 2, 3], timeout_s=0.3, takeover_s=0.5
+        )
+        # Takeover elects rank 1; every survivor must adopt the same vector.
+        _assert_all_agree(results, [MASKED, ACTIVE, ACTIVE, ACTIVE])
+
+    def test_two_dead_ranks(self):
+        world = 5
+        store = dist.HashStore()
+        masks = {r: [ACTIVE] * world for r in range(world)}
+        results = _run_ranks(
+            store, world, masks, participants=[0, 2, 4], timeout_s=0.3, takeover_s=0.5
+        )
+        _assert_all_agree(results, [ACTIVE, MASKED, ACTIVE, MASKED, ACTIVE])
+
+
+class TestSplitBrain:
+    def test_late_key_does_not_split_the_decision(self):
+        """The regression test for the naive "everyone ANDs locally" design.
+
+        Survivor A polls before the straggler's key lands, survivor B after.
+        A naive implementation would have A mask the straggler and B keep it —
+        two different masks, and a deadlock on the next dispatch. Because the
+        decision is published through a single compare_set, both must return
+        the coordinator's vector.
+        """
+        world = 3
+        store = dist.HashStore()
+        masks = {r: [ACTIVE] * world for r in range(world)}
+
+        results: dict[int, object] = {}
+        lock = threading.Lock()
+
+        def run(r, timeout_s):
+            try:
+                out = reconcile_masks_via_store(
+                    store,
+                    rank=r,
+                    world_size=world,
+                    local_mask=masks[r],
+                    epoch=0,
+                    timeout_s=timeout_s,
+                    takeover_s=5.0,
+                )
+            except Exception as e:  # noqa: BLE001 - asserted on below
+                out = e
+            with lock:
+                results[r] = out
+
+        def straggler():
+            # Lands after rank 0's gather window but inside rank 1's.
+            import time
+
+            time.sleep(0.4)
+            run(2, 5.0)
+
+        threads = [
+            threading.Thread(target=run, args=(0, 0.15)),  # gives up on rank 2
+            threading.Thread(target=run, args=(1, 3.0)),  # waits and sees rank 2
+            threading.Thread(target=straggler),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        for t in threads:
+            assert not t.is_alive()
+
+        assert len(results) == 3
+        # The two survivors must return the SAME vector even though they
+        # observed rank 2 differently. (Rank 2 itself either survives or is
+        # evicted, depending on which side of rank 0's window it landed —
+        # what must never happen is 0 and 1 disagreeing.)
+        survivors = {
+            r: v
+            for r, v in results.items()
+            if r in (0, 1) and not isinstance(v, Exception)
+        }
+        assert len(survivors) == 2, f"a survivor failed: {results}"
+        distinct = {tuple(v) for v in survivors.values()}  # type: ignore[arg-type]
+        assert len(distinct) == 1, f"split brain: ranks disagreed: {results}"
+
+    def test_decision_is_write_once(self):
+        """A later reconcile at the same epoch adopts the published decision."""
+        world = 3
+        store = dist.HashStore()
+        # Pre-seed the peers' views so rank 0's gather succeeds and the
+        # decision keeps everyone alive.
+        store.set("ft/gen7/local/1", bytes([ACTIVE] * world))
+        store.set("ft/gen7/local/2", bytes([ACTIVE] * world))
+        first = reconcile_masks_via_store(
+            store,
+            rank=0,
+            world_size=world,
+            local_mask=[ACTIVE] * world,
+            epoch=7,
+            timeout_s=1.0,
+            takeover_s=0.2,
+        )
+        assert first == [ACTIVE] * world
+        # Rank 2 arrives later with a *different* local view but the same
+        # epoch: it must adopt the published decision, not invent its own.
+        second = reconcile_masks_via_store(
+            store,
+            rank=2,
+            world_size=world,
+            local_mask=[ACTIVE, MASKED, ACTIVE],
+            epoch=7,
+            timeout_s=0.1,
+            takeover_s=0.2,
+        )
+        assert second == first
+
+    def test_separate_epochs_are_independent(self):
+        """The epoch namespaces the keys, so rounds do not leak into each other."""
+        world = 2
+        store = dist.HashStore()
+        # Epoch 0: peer never reports -> presumed dead.
+        a = reconcile_masks_via_store(
+            store,
+            rank=0,
+            world_size=world,
+            local_mask=[ACTIVE, ACTIVE],
+            epoch=0,
+            timeout_s=0.1,
+            takeover_s=0.2,
+        )
+        assert a == [ACTIVE, MASKED]
+        # Epoch 1: peer reports in -> alive again, unaffected by epoch 0.
+        store.set("ft/gen1/local/1", bytes([ACTIVE, ACTIVE]))
+        b = reconcile_masks_via_store(
+            store,
+            rank=0,
+            world_size=world,
+            local_mask=[ACTIVE, ACTIVE],
+            epoch=1,
+            timeout_s=1.0,
+            takeover_s=0.2,
+        )
+        assert b == [ACTIVE, ACTIVE]
+
+
+class TestEviction:
+    def test_rank_masked_by_peers_raises(self):
+        """A rank the survivors gave up on must not silently keep serving."""
+        from flashinfer.moe_ep.errors import MoEEpRankEvictedError
+
+        world = 3
+        store = dist.HashStore()
+        # Survivors already agreed rank 2 is dead.
+        store.set("ft/gen0/decision", bytes([ACTIVE, ACTIVE, MASKED]))
+        with pytest.raises(MoEEpRankEvictedError, match="rank 2 was masked out"):
+            reconcile_masks_via_store(
+                store,
+                rank=2,
+                world_size=world,
+                local_mask=[ACTIVE] * world,
+                epoch=0,
+                timeout_s=0.1,
+                takeover_s=0.5,
+            )
+
+    def test_survivors_are_unaffected(self):
+        """The same decision is adopted normally by a rank it keeps alive."""
+        world = 3
+        store = dist.HashStore()
+        store.set("ft/gen0/decision", bytes([ACTIVE, ACTIVE, MASKED]))
+        got = reconcile_masks_via_store(
+            store,
+            rank=1,
+            world_size=world,
+            local_mask=[ACTIVE] * world,
+            epoch=0,
+            timeout_s=0.1,
+            takeover_s=0.5,
+        )
+        assert got == [ACTIVE, ACTIVE, MASKED]
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "kwargs, match",
+        [
+            ({"rank": 5, "world_size": 4, "local_mask": [1] * 4}, "out of range"),
+            ({"rank": 0, "world_size": 0, "local_mask": []}, "world_size"),
+            ({"rank": 0, "world_size": 4, "local_mask": [1, 1]}, "local_mask"),
+        ],
+    )
+    def test_rejects_bad_shapes(self, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            reconcile_masks_via_store(
+                dist.HashStore(), epoch=0, timeout_s=0.1, takeover_s=0.1, **kwargs
+            )
+
+    def test_peer_from_a_different_world_is_ignored(self):
+        """A stale key of the wrong length must not corrupt the AND."""
+        world = 3
+        store = dist.HashStore()
+        store.set("ft/gen0/local/1", bytes([1, 1]))  # wrong length
+        store.set("ft/gen0/local/2", bytes([1, 1, 1]))
+        got = reconcile_masks_via_store(
+            store,
+            rank=0,
+            world_size=world,
+            local_mask=[ACTIVE] * world,
+            epoch=0,
+            timeout_s=0.1,
+            takeover_s=0.2,
+        )
+        assert got == [ACTIVE, ACTIVE, ACTIVE]

--- a/tests/moe_ep/test_moe_ep_fault_tolerance_multirank.py
+++ b/tests/moe_ep/test_moe_ep_fault_tolerance_multirank.py
@@ -1,0 +1,303 @@
+"""Fault-tolerance state machine on 4+ GPUs, end to end.
+
+Launched via torchrun:
+    torchrun --nproc_per_node=4 -m pytest \\
+        tests/moe_ep/test_moe_ep_fault_tolerance_multirank.py -v \\
+        -m "nvep and gpu_4" --backend=nccl_ep      # or nixl_ep
+
+Injection method: a STALLED rank, not a killed one. NIXL's own elastic test
+kills a worker with SIGTERM, but under ``torchrun -m pytest`` that tears down
+the whole job and takes the surviving ranks' pytest session with it. Instead
+the victim skips one iteration by sleeping past the FT timeout while the
+survivors dispatch, which is what the transports actually detect: a peer whose
+data never arrives. Every process stays alive, so the torch process group
+stays usable for the test's own barriers, and the whole detect -> reconcile ->
+degrade -> re-admit -> healthy cycle runs in one job in ~10s.
+
+The hard-kill counterpart lives in smoke_ft_ep.py, which cannot be a pytest
+test for exactly the reason above.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import timedelta
+
+import pytest
+
+_PG_TIMEOUT = timedelta(minutes=60)
+
+# Deliberately short so a stalled rank is detected in seconds rather than the
+# ~100s (nccl) / 30s (nixl) default. Production should leave this at 0: a low
+# timeout marks merely-slow ranks dead.
+_FT_TIMEOUT_MS = 2000
+_STALL_S = 4.0  # > _FT_TIMEOUT_MS, with margin
+_VICTIM = 2  # a MIDDLE rank: not rank 0 (the reconcile coordinator), not last
+
+
+def pytest_generate_tests(metafunc):
+    """Generate `comm_backend` param values from --backend CLI."""
+    if "comm_backend" not in metafunc.fixturenames:
+        return
+    cli = metafunc.config.getoption("--backend", default=None)
+    if cli == "both" or cli is None:
+        metafunc.parametrize("comm_backend", ["nccl_ep", "nixl_ep"])
+    else:
+        metafunc.parametrize("comm_backend", [cli])
+
+
+def _init_dist():
+    import torch
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group(
+            backend="nccl" if torch.cuda.is_available() else "gloo",
+            device_id=torch.device(f"cuda:{local_rank}"),
+            timeout=_PG_TIMEOUT,
+        )
+    rank, world = dist.get_rank(), dist.get_world_size()
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", rank)))
+    return rank, world
+
+
+def _build_layer(comm_backend, rank, world_size, num_tokens, num_experts, hidden):
+    import torch
+    import torch.distributed as dist
+
+    from flashinfer.moe_ep import (
+        BootstrapConfig,
+        EpAlgorithm,
+        FleetAlgoKnobFaultTolerance,
+        FleetAlgoKnobTopologyCapacity,
+        FleetParams,
+        IdentityConfig,
+        MoEEpLayer,
+        NCCLEPConfig,
+        NvepConfig,
+        SplitConfig,
+        dummy_moe_weights,
+    )
+
+    tcp_store = None
+    if comm_backend == "nixl_ep":
+        tcp_store = dist.TCPStore(
+            host_name=os.environ.get("MASTER_ADDR", "127.0.0.1"),
+            port=int(os.environ.get("MASTER_PORT", "29500")) + 1,
+            world_size=world_size,
+            is_master=(rank == 0),
+        )
+
+    knobs = [FleetAlgoKnobFaultTolerance(timeout_ms=_FT_TIMEOUT_MS)]
+    if comm_backend == "nixl_ep":
+        knobs.append(FleetAlgoKnobTopologyCapacity(n=world_size))
+
+    return MoEEpLayer(
+        bootstrap=BootstrapConfig(
+            world_size=world_size,
+            rank=rank,
+            stream=torch.cuda.current_stream().cuda_stream,
+            tcp_store=tcp_store,
+        ),
+        fleet_params=FleetParams(
+            num_experts=num_experts,
+            max_tokens_per_rank=num_tokens,
+            token_hidden_size=hidden,
+            dtype_bytes=2,
+            algorithm=EpAlgorithm.LOW_LATENCY,
+        ),
+        weights=dummy_moe_weights(
+            num_local_experts=num_experts // world_size, hidden=hidden
+        ),
+        fleet_knobs=knobs,
+        backend=SplitConfig(
+            comm=NvepConfig() if comm_backend == "nixl_ep" else NCCLEPConfig(),
+            kernel=IdentityConfig(),
+        ),
+    )
+
+
+@pytest.mark.nvep
+@pytest.mark.gpu_4
+def test_fault_tolerance_detect_reconcile_degrade_readmit(comm_backend):
+    """Walk the whole FT state machine with one stalled rank."""
+    import torch
+    import torch.distributed as dist
+
+    from flashinfer.moe_ep import MoEEpTensors, supports_fault_tolerance
+
+    if not supports_fault_tolerance(comm_backend):
+        pytest.skip(f"{comm_backend} cannot serve the FT API on this host")
+
+    rank, world_size = _init_dist()
+    assert world_size >= 4, f"needs >=4 ranks, got {world_size}"
+
+    num_tokens, num_experts, hidden, topk = 64, 8, 4096, 4
+    g = torch.Generator(device="cuda").manual_seed(42 + rank)
+    x = torch.randn(
+        num_tokens, hidden, dtype=torch.bfloat16, device="cuda", generator=g
+    )
+    topk_ids = torch.randint(
+        0,
+        num_experts,
+        (num_tokens, topk),
+        device="cuda",
+        dtype=torch.int64,
+        generator=g,
+    )
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, topk, device="cuda", generator=g), dim=-1
+    )
+    t = MoEEpTensors(hidden_states=x, topk_ids=topk_ids, topk_weights=topk_weights)
+
+    layer = _build_layer(
+        comm_backend, rank, world_size, num_tokens, num_experts, hidden
+    )
+    survivors = [r for r in range(world_size) if r != _VICTIM]
+    expected = [1 if r in survivors else 0 for r in range(world_size)]
+
+    # --- HEALTHY ---------------------------------------------------------
+    y = layer.forward(t)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(y, x, atol=5e-2, rtol=5e-2)
+    dist.barrier()
+
+    fleet = layer._ensure_fleet()
+    assert fleet.supports_fault_tolerance is True
+    assert fleet.query_active_mask().cpu().tolist() == [1] * world_size
+    assert fleet.query_fault() is False
+
+    # --- FAULT: the victim stalls past the timeout ------------------------
+    if rank == _VICTIM:
+        time.sleep(_STALL_S)
+    else:
+        layer.forward(t)  # survivors' kernels time out waiting on the victim
+        torch.cuda.synchronize()
+    dist.barrier()  # the victim is alive, so the torch PG is still healthy
+
+    if rank in survivors:
+        assert fleet.query_fault() is True, "survivors must observe the fault"
+        mask = fleet.query_active_mask().cpu().tolist()
+        assert mask[_VICTIM] == 0, f"rank {_VICTIM} should be masked, got {mask}"
+
+    # --- RECONCILE -------------------------------------------------------
+    # Every rank reconciles in the same iteration slot. The victim learns it
+    # was evicted (it stalled long enough for the survivors to give up).
+    from flashinfer.moe_ep.errors import MoEEpRankEvictedError
+
+    if rank == _VICTIM:
+        with pytest.raises(MoEEpRankEvictedError):
+            fleet.reconcile_active_mask()
+        print(f"rank {rank}: correctly evicted")
+        layer.destroy()
+        dist.barrier()
+        return
+
+    agreed = fleet.reconcile_active_mask().cpu().tolist()
+    assert agreed == expected, f"rank {rank} agreed {agreed}, expected {expected}"
+    fleet.clear_faults(readmit=False)
+    assert fleet.query_fault() is False, "clear_faults must re-arm detection"
+
+    # --- DEGRADED --------------------------------------------------------
+    # The dead rank's experts are gone and combine does NOT renormalize, so
+    # each token comes out scaled by the surviving weight fraction rather
+    # than 1. Assert exactly that, not "close to x".
+    y_deg = layer.forward(t)
+    torch.cuda.synchronize()
+    assert torch.isfinite(y_deg.float()).all(), "degraded output must not be NaN/Inf"
+
+    experts_per_rank = num_experts // world_size
+    alive = torch.tensor(
+        [expected[e // experts_per_rank] for e in range(num_experts)],
+        device="cuda",
+        dtype=torch.bool,
+    )
+    surviving_w = (topk_weights * alive[topk_ids]).sum(-1)  # [num_tokens]
+    torch.testing.assert_close(
+        y_deg.float(), x.float() * surviving_w.unsqueeze(-1), atol=8e-2, rtol=8e-2
+    )
+    print(f"rank {rank}: degraded forward matches surviving-weight scaling")
+    dist.barrier()
+
+    layer.destroy()
+    dist.barrier()
+
+
+@pytest.mark.nvep
+@pytest.mark.gpu_4
+def test_readmit_restores_full_strength(comm_backend):
+    """clear_faults(readmit=True) puts a merely-delayed rank back in service.
+
+    Split from the test above because re-admission is collective over the
+    SURVIVORS, so the victim must not participate in it.
+    """
+    import torch
+    import torch.distributed as dist
+
+    from flashinfer.moe_ep import MoEEpTensors, supports_fault_tolerance
+    from flashinfer.moe_ep.config import EpLayout
+
+    if not supports_fault_tolerance(comm_backend):
+        pytest.skip(f"{comm_backend} cannot serve the FT API on this host")
+
+    rank, world_size = _init_dist()
+    num_tokens, num_experts, hidden, topk = 64, 8, 4096, 4
+    g = torch.Generator(device="cuda").manual_seed(7 + rank)
+    x = torch.randn(
+        num_tokens, hidden, dtype=torch.bfloat16, device="cuda", generator=g
+    )
+    topk_ids = torch.randint(
+        0,
+        num_experts,
+        (num_tokens, topk),
+        device="cuda",
+        dtype=torch.int64,
+        generator=g,
+    )
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, topk, device="cuda", generator=g), dim=-1
+    )
+    t = MoEEpTensors(hidden_states=x, topk_ids=topk_ids, topk_weights=topk_weights)
+
+    layer = _build_layer(
+        comm_backend, rank, world_size, num_tokens, num_experts, hidden
+    )
+    layer.forward(t)  # allocates the LL staging buffer MaskClean asserts on
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    fleet = layer._ensure_fleet()
+
+    # Mask a rank by hand (no stall needed — we are testing re-admission, and
+    # every rank applies the same vector so the fleet stays coherent).
+    mask = [1] * world_size
+    mask[_VICTIM] = 0
+    if rank != _VICTIM:
+        fleet.set_active_mask(mask)
+        assert fleet.query_active_mask().cpu().tolist() == mask
+    dist.barrier()
+
+    # Re-admit. Collective over survivors; the victim was never masked
+    # locally, so it simply does not participate.
+    if rank != _VICTIM:
+        import warnings
+
+        with warnings.catch_warnings():
+            # EXPERT_MAJOR + MaskClean warns by design (nccl only).
+            warnings.simplefilter("ignore", RuntimeWarning)
+            fleet.clear_faults(readmit=True)
+        assert fleet.query_active_mask().cpu().tolist() == [1] * world_size
+        if fleet.params.layout is EpLayout.EXPERT_MAJOR:
+            print(f"rank {rank}: re-admitted under EXPERT_MAJOR (see MaskClean note)")
+    dist.barrier()
+
+    # --- HEALTHY again: full-strength forward matches the baseline --------
+    y = layer.forward(t)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(y, x, atol=5e-2, rtol=5e-2)
+    print(f"rank {rank}: full-strength forward restored after re-admission")
+    layer.destroy()
+    dist.barrier()


### PR DESCRIPTION
## Why

NCCL-EP gained fault tolerance ([`nccl_ep.h` `enable_mask` + `ncclEpMask*`](https://github.com/NVIDIA/nccl/blob/master/contrib/nccl_ep/include/nccl_ep.h#L227-L232)): a peer that times out during dispatch/combine is masked and skipped instead of tripping a GPU `trap()`. NIXL-EP has the equivalent (`update/query/clean_mask_buffer`). **`flashinfer.moe_ep` exposed neither** — it never set `enable_mask`, never called a mask API, and gave callers no way to learn a rank had died. One slow or dead EP rank killed the whole job.

This adds the FT surface over **both** transports. `moe_ep` is pure Python, so there is no CUDA/C++ change here.

---

## How the FT API is used

FT is opt-in per Fleet via a **knob**, not new `FleetParams` fields — `FleetParams` is the frozen *sizing* dataclass, while optional transport features already live in the knob namespace (cf. `FleetAlgoKnobTopologyCapacity`). The runtime API lands on the `Fleet` ABC as **concrete raising defaults**, not `@abstractmethod`, so no existing or out-of-tree Fleet breaks.

### 1. Probe, then enable

```python
from flashinfer.moe_ep import (
    FleetAlgoKnobFaultTolerance, FleetAlgoKnobTopologyCapacity,
    MoEEpLayer, supports_fault_tolerance,
)

# Needs more than the backend being built: nccl_ep also needs an nccl4py with
# GroupConfig.enable_mask AND a libnccl_ep exporting ncclEpMask*. Never raises.
assert supports_fault_tolerance("nccl_ep")

knobs = [FleetAlgoKnobFaultTolerance(timeout_ms=5000)]   # 0 = transport default
# nixl only: size the capacity for the largest world you will ever reach
knobs.append(FleetAlgoKnobTopologyCapacity(n=32))

layer = MoEEpLayer(bootstrap, fleet_params, weights, fleet_knobs=knobs,
                   backend=SplitConfig(comm=NCCLEPConfig(), kernel=IdentityConfig()))
```

`FleetAlgoKnobFaultTolerance(enabled=True, timeout_ms=0, reconcile_timeout_s=30.0, coordinator_takeover_s=10.0)`. **LOW_LATENCY only** on both transports — `validate_fleet_params` rejects FT + HIGH_THROUGHPUT at construction, because nccl leaves the mask buffer NULL under HT and the mask APIs then *abort the process*.

### 2. Serve, poll, recover

```python
fleet = layer._ensure_fleet()

for step in ...:
    layer.forward(t)

    # Between iterations only — both transports read the mask LIVE from the
    # dispatch/combine kernels, so mutating it mid-collective is a race.
    if fleet.query_fault():                       # free on nccl (pinned host flag)
        agreed = fleet.reconcile_active_mask()    # store-collective, death-tolerant
        fleet.clear_faults(readmit=False)         # re-arm detection; keep serving DEGRADED

        # ... later, if the peer comes back (collective over survivors, blocking):
        # fleet.clear_faults(readmit=True)
```

| Method | Collective? | Blocks host? | Stream-ordered? |
|---|---|---|---|
| `supports_fault_tolerance` | — | no | no |
| `query_fault()` | local | nccl no / nixl yes (small D2H) | nccl no / nixl yes |
| `query_active_mask(out=None)` | local | no | **yes** |
| `set_active_mask(mask)` | local (must be applied identically everywhere) | no | **yes** |
| `reconcile_active_mask()` | **store-collective**, tolerates dead ranks | yes (≤ timeout) | yes |
| `clear_faults(readmit=False)` | local | no | no |
| `clear_faults(readmit=True)` | **collective over survivors** | **yes** | yes |
| `active_mask_epoch` | — | no | no |

**Canonical mask: `int32[world_size]`, `1 = active`, CUDA tensor** — matching `ncclEpMaskQuery` and vLLM's `query_active_mask()` naming.

### 3. Rules that will bite you

1. **The steady state is read-only.** The transport discovers the fault and masks the peer; the application's job is to *notice* (`query_fault` / `query_active_mask`). `set_active_mask` is the exceptional reconciliation path, not a per-step call — most callers only reach it via `reconcile_active_mask()`. If you do write the mask, write it only between iterations (kernels read it live).
2. **All survivors must reconcile in the same iteration slot** — they must pass the same `active_mask_epoch`.
3. **`clear_faults(readmit=True)` and `update_topology()` are alternatives, not a sequence.** The former re-admits a merely-delayed rank on the *same* communicator; the latter destroys the group and builds a **new** `ncclComm_t`, which is the only way to add or replace a process. Re-admitting after a rebuild is meaningless; before one it is wasted work. (If you do both, `MaskClean` must come first — it needs a live handle on the current group.)
4. **No FT call during CUDA-graph capture** — but note **dispatch and combine themselves ARE safe to capture**: neither transport compacts the surviving ranks' layout, so they re-read the mask on every replay and a rank that fails later is still skipped. What must not be captured is a *decision about* fault state. `query_fault()` is a host read, not stream work, so it can't be captured at all — it returns the capture-time answer and freezes the branch taken on it into the graph forever. All four FT entry points raise on capture with a per-operation reason. *(Thanks @lrbison — an earlier draft of this said "stale offsets", which was wrong.)*
5. **A rank can be told it is dead.** `reconcile_active_mask()` raises `MoEEpRankEvictedError` when the survivors agreed *this* rank is gone. It can't apply that (a rank may not mask itself) and mustn't keep serving (peers stopped sending it tokens).
6. **Dropped tokens are not renormalized, and experts are not re-homed.** `y_degraded[t] == y_healthy[t] * Σ_{alive k} topk_weights[t][k]`. Both omissions are deliberate: implicit renormalization would add a kernel to every forward, hide a serving-quality event, and divide by zero when a token's whole top-k died; re-homing the dead rank's experts is an EPLB-style job that belongs to the framework. Keep serving on a partial mask with `reconcile_active_mask()` → `clear_faults(readmit=False)` — no `update_topology`, no new communicator. Runbook has the opt-in renormalization snippet.

---

## Call stacks

### Group/Buffer creation (where masking is switched on)

```
nccl_ep                                        nixl_ep
-------                                        -------
NcclEpFleet.__init__                           NixlEpFleet.__init__
 ├ _index_knobs -> self._ft                     ├ _index_knobs -> self._ft
 ├ validate_fleet_params(fault_tolerance=)      ├ validate_fleet_params(fault_tolerance=)
 ├ _check_ft_supported()                        ├ nixl_ep.Buffer(..., timeout_ms=)   [TypeError -> actionable]
 │   ├ dataclasses.fields(GroupConfig)          ├ update_memory_buffers(cap, ...)
 │   │   -> needs "enable_mask"                 │   -> allocates mask_buffer[capacity], 0xFF-memset
 │   └ mask_ffi().available                     └ connect_ranks([0, world))
 │       -> needs the 5 ncclEpMask* symbols         -> unmasks [0, world); tail stays masked
 └ _build_group_config()
     ├ kwargs["enable_mask"] = True
     ├ kwargs["timeout_ns"] = timeout_ms * 1e6      (omitted when 0)
     └ nccl.ep.Group.create -> ncclEpCreateGroup
         -> allocates mask_buffer[nRanks] + pinned async-error flag
```

### `query_fault()`

```
nccl_ep                                        nixl_ep
NcclEpFleet.query_fault                        NixlEpFleet.query_fault
 ├ reject_graph_capture("query_fault")          ├ self.query_active_mask()      (kernel + D2H)
 │   ^ NOT because it touches a stream --        │   ^ which itself rejects capture
 │     because it does NOT: a host read          └ compare against self._ft_applied
 │     cannot be captured, so it would
 │     return the capture-time answer and       (no host error flag on this transport,
 │     freeze the branch into the graph          so the applied mask IS the state)
 └ mask_ffi().get_async_error(group)
    ├ group.get_async_error()  [native first]
    └ ctypes ncclEpGetAsyncError(group.ptr, &o)
        -> libnccl_ep.so -> reads PINNED HOST flag: no stream, no sync, free
```

### `query_active_mask()`

```
nccl_ep                                        nixl_ep
 ├ _reject_graph_capture()                      ├ _reject_graph_capture()
 ├ _ft_bufs() -> device int32[world]            ├ _ft_raw() -> device int32[CAPACITY]
 └ mask_ffi().mask_query(group, dev_ptr, str)   ├ buffer.query_mask_buffer(raw)
     -> ncclEpMaskQuery                         │   -> nixl_ep_cpp -> kernel copy
     -> D2D copy of mask_buffer                 │   (asserts numel == max_num_ranks)
     -> ALREADY 1 = active, identity            └ (raw[:world] == 0).to(int32)
                                                    ^ NOT 1-raw: buffer is 0xFF-memset so
                                                      untouched entries read back as -1
```

### `set_active_mask(mask)`

```
nccl_ep                                        nixl_ep
 ├ _normalize_mask -> list[int], rejects        ├ _normalize_mask (same guard)
 │   masking the local rank                     └ for each CHANGED rank r != self:
 ├ host.copy_(...)   PINNED staging buffer          buffer.update_mask_buffer(r, mask=(a==MASKED))
 │   ^ pinned because Update is stream-ordered:      -> atomicExch kernel, one launch EACH
 │     a pageable buffer mutated next call is        -> so we push only the DIFF; a blind
 │     a use-after-write race                          range(world) loop would inject `world`
 └ mask_ffi().mask_update(group, host_ptr, str)        launches into the steady state
     -> ncclEpMaskUpdate  (HOST ptr, unlike Query)
```

### `reconcile_active_mask()` — shared, transport-free

```
FaultToleranceMixin.reconcile_active_mask          (both backends)
 ├ local = self.query_active_mask().cpu().tolist()
 ├ store = self._ft_store()          -> resolve_rendezvous_store(subsystem="ft")
 └ reconcile_masks_via_store(store, rank, world, local, epoch=active_mask_epoch, ...)
     ├ 1. store.set("ft/gen{E}/local/{rank}", bytes(view))
     ├ 2. poll ONLY ranks we still believe alive, until timeout_s
     ├ 3. elementwise-AND what arrived; mask believed-alive ranks that never reported
     ├ 4. coord = min(active); coord publishes via ATOMIC compare_set("ft/gen{E}/decision")
     │      everyone else adopts whatever that key holds  <- kills split brain
     │      (coordinator itself dead -> mask it, re-elect, bounded by world_size)
     └ 5. _adopt(): raises MoEEpRankEvictedError if the decision masks US
 └ self.set_active_mask(agreed)   -> backend-specific path above
```

Deliberately **not** a `torch.distributed` allreduce: that would hang on exactly the rank being masked out. With a store, a missing key *is* the death signal.

### `clear_faults()`

```
nccl_ep                                        nixl_ep
readmit=False:                                 readmit=False:
 └ mask_ffi().error_clear -> ncclEpErrorClear    └ return    (no sticky flag to re-arm)

readmit=True:                                  readmit=True:
 ├ guard: a handle must exist                   ├ buffer.clean_mask_buffer()
 │   (MaskClean asserts on the LL staging       │   -> zeroes ALL `capacity` entries,
 │    buffer -> would SIGABRT from C)           │      marking the never-connected tail ACTIVE
 ├ warn under EXPERT_MAJOR                      ├ _ft_applied = [ACTIVE] * world
 │   (MaskClean computes reset offsets          └ re-mask [world, capacity)   <- fixes that bug
 │    assuming RANK_MAJOR)
 ├ mask_clean -> ncclEpMaskClean
 │   COLLECTIVE over survivors; internally cudaStreamSynchronize's
 └ error_clear -> ncclEpErrorClear
     ^ always paired: MaskClean does NOT clear the flag, which is exactly why
       `readmit` is a flag on one method rather than two a caller can mis-sequence
```

---

## Three transport facts that shaped the code

1. **NIXL's polarity is "nonzero = masked", not "1 = masked".** The buffer is `0xFF`-memset at allocation (an untouched entry reads back as `-1`) and the kernels test `!= 0`. The normalization must be `(raw == 0)`; the obvious `1 - raw` yields `2` for never-connected capacity-tail ranks and silently poisons every downstream `sum()`/`bool()`.
2. **`clean_mask_buffer` zeroes all *capacity* entries**, marking the never-connected tail **active** — a live bug on any fleet sized above its world.
3. **`disconnect_ranks` is suffix-only**, so NIXL cannot evict a *middle* rank; masked-and-degraded is the terminal state there.

Each has a regression test.

## nccl4py binding gap

`nccl4py` binds `GroupConfig.enable_mask`/`timeout_ns` but its `Group` stops at `create`/`create_handle`/`destroy`/`.ptr` — the five mask functions are unreachable from Python. This adds a ctypes shim on `Group.ptr` that **tries a native `Group` method first**, so it retires itself with no call-site churn once those bindings land. Note the symbols live in **`libnccl_ep.so`, not `libnccl.so.2`**; we bind the process-global namespace, which is the only resolution guaranteed to be the same library the caller's group came from.

## Reconciliation, and a hole the tests found

Each transport masks *locally* — NCCL-EP's header calls mask consistency "a framework-level concern" — so survivors can disagree, and disagreeing masks deadlock the next dispatch. The decision is published via a single atomic `compare_set`, which is what prevents a split brain when a straggler's key lands between two survivors' polls; there is a dedicated regression test for that timing.

Writing those tests surfaced a case the design missed: a rank that is alive but that some peer already timed out on gets ANDed out of the group. It can't apply that decision and can't ignore it, so it now raises `MoEEpRankEvictedError`.

## Also fixed (incidental)

- `validate_fleet_params` now rejects a nixl topology capacity **below** world size — it previously sailed through and went out of bounds inside the transport.
- `update_topology` now rejects growing past the capacity, for the same reason. `test_update_topology_diffs_ranks` was exercising that invalid config (4→6 on capacity 4); it now passes `capacity=8`, keeping its intent.

## Testing

`254 passed` in `tests/moe_ep/`; **166 FT-related tests pass**. The 6 failures in the full run are pre-existing and environmental (nvfp4/CuTeDSL ninja JIT) — confirmed failing identically on base `6258e522`.

The protocol, shim and both backends' wiring are covered host-only (HashStore + threads; a fake ctypes library; fake transports), so they run in CI with no GPU.

**Not yet run:** the 4-GPU tiers — `test_moe_ep_fault_tolerance_multirank.py` (stalls a middle rank and walks detect → reconcile → degrade → re-admit, asserting the degraded output *exactly* equals the surviving-weight scaling) and `smoke_ft_ep.py` (hard SIGTERM kill). This host has 1 GPU and no transport built. `bash tests/moe_ep/run_tests.sh ft` runs both.

## vLLM

**No vLLM code here**, by design. vLLM already owns the contract (`support_fault_tolerance` / `query_active_mask` / `query_fault` + the per-step hook in `gpu_model_runner.py`); the FlashInfer-EP managers just hardcode `False`, and since the manager is transport-parameterized, one base-class change covers both LL backends. `docs/design_docs/vllm_moe_ep_integration.md` §8 records the target shape and the four things that commit must get right — including that vLLM's existing nixl/deepep `query_active_mask()` return *raw* buffers with the opposite polarity, and that `self._fleets` holds several fleets sharing one EP group so FT state must be hoisted to a primary fleet.

## Review follow-up (commit 9)

@lrbison's review caught a real defect: `query_fault()` on nccl_ep had **no** capture guard, because I'd reasoned "host read, therefore capture-safe" — exactly backwards. Being a host read is *why* it can't be captured, so it silently returned the capture-time answer and froze the branch on it into the graph. NIXL's already raised (it goes via `query_active_mask`), so the same call behaved differently per backend. Both now raise, with a regression test each. The "stale offsets" rationale was also wrong and is replaced with per-operation reasons.

## Commits

1. `FleetAlgoKnobFaultTolerance` + Fleet FT API surface (no backend touched)
2. promote nixl_ep's store resolver to `core.bootstrap_utils` (pure move)
3. TCPStore-based active-mask reconciliation
4. ctypes shim for the `ncclEpMask*` API
5. wire nccl_ep `enable_mask`/`timeout_ns` + FT methods
6. wire nixl_ep `timeout_ms` + FT methods (carries the polarity/capacity/tail fixes)
7. multirank fault injection + FT smoke + `run_tests.sh ft`
8. docs + vLLM design note
9. `fix`: guard `query_fault` against graph capture + correct the capture rationale (review follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in fault tolerance for MoE expert-parallel fleets, including timeouts and coordinator takeover.
  * Introduced public APIs to query faults, manage active-rank masks, reconcile fleet state, clear faults, and track mask epochs.
  * Added backend capability detection to ensure fault tolerance only activates when supported.
* **Documentation**
  * Added design docs and an operational runbook describing recovery behavior, ordering rules, and transport-specific constraints.
  * Added a vLLM integration design note for future wiring into the fault-tolerance flow.
* **Tests**
  * Added host-only unit tests, backend-specific mocks, NCCL ctypes-shim tests, multi-GPU end-to-end coverage, and FT smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->