### PR TITLE
Yanqinz/fix-gemm-and-grouped-mm-test-issue

### DIFF
--- a/tests/gemm/test_unified_gemm_fuzz.py
+++ b/tests/gemm/test_unified_gemm_fuzz.py
@@ -628,7 +628,7 @@ def _snap_nvfp4(t, dtype=None):
     gsf = (448 * 6) / flat.float().abs().nan_to_num().max().clamp_min(1e-30)
     q, sf = nvfp4_quantize(flat, gsf, sfLayout=SfLayout.layout_128x4, do_shuffle=False)
     deq = e2m1_and_ufp8sf_scale_to_float(
-        q.cpu(), sf.cpu().view(torch.uint8).reshape(-1), (1.0 / gsf).cpu(), 16, 1, False
+        q.cpu(), sf.cpu().view(torch.uint8).reshape(-1), (1.0 / gsf).cpu(), 16, 1, True
     )
     return deq.reshape(t.shape).to(t.device, torch.bfloat16)
 

--- a/tests/grouped_mm/conftest.py
+++ b/tests/grouped_mm/conftest.py
@@ -9,6 +9,7 @@ from flashinfer.grouped_mm.core import (
     _check_grouped_mm_fp8,
     _check_grouped_mm_mxfp8,
 )
+from flashinfer.grouped_mm.cudnn import _CUDNN_MOE_MIN_VERSION
 from flashinfer.utils import get_compute_capability
 
 try:
@@ -25,15 +26,22 @@ except (ImportError, OSError):
     CUDNN_BACKEND_VERSION = 0
     CUDNN_HAS_MOE_API = False
 
-requires_cudnn_moe = pytest.mark.skipif(
-    not CUDNN_AVAILABLE or CUDNN_BACKEND_VERSION < 91800 or not CUDNN_HAS_MOE_API,
-    reason="cuDNN MOE requires backend >= 9.18.0 and a frontend exposing moe_grouped_matmul_mode",
-)
 
-requires_cudnn_moe_block_scale = pytest.mark.skipif(
-    not CUDNN_AVAILABLE or CUDNN_BACKEND_VERSION < 92100 or not CUDNN_HAS_MOE_API,
-    reason="cuDNN MOE block-scale requires backend >= 9.21.0 and a frontend exposing moe_grouped_matmul_mode",
-)
+def _requires_cudnn_moe(feature: str):
+    min_ver = _CUDNN_MOE_MIN_VERSION
+    ver = CUDNN_BACKEND_VERSION
+    return pytest.mark.skipif(
+        not CUDNN_AVAILABLE or ver < min_ver or not CUDNN_HAS_MOE_API,
+        reason=(
+            f"cuDNN MOE {feature} requires backend >= {min_ver // 10000}."
+            f"{min_ver // 100 % 100}.{min_ver % 100} and a frontend exposing "
+            "moe_grouped_matmul_mode"
+        ),
+    )
+
+
+requires_cudnn_moe = _requires_cudnn_moe("grouped matmul")
+requires_cudnn_moe_block_scale = _requires_cudnn_moe("block-scale")
 
 
 def _requires_supported_cc(check_fn):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

Fix ci failure issue introduced by incorrect testing tensor layout:
tests/gemm/test_unified_gemm_fuzz.py

Fix ci failure issue introduced by testing on unsupported cudnn version:
tests/grouped_mm/test_grouped_mm_bf16.py 
tests/grouped_mm/test_grouped_mm_fp8.py

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved NVFP4 quantization validation by aligning test inputs with the exact reference dequantization grid.
  - Updated grouped matrix multiplication tests to consistently detect supported cuDNN versions and capabilities.
  - Improved test skipping behavior for environments that lack required mixture-of-experts functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->