### PR TITLE
test(jit): assert BMM export symlink under GEN_SRC_DIR

### DIFF
--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -243,7 +243,7 @@ def ensure_symlink(
     """Create or update a symlink, removing any stale file/directory at *link*.
 
     This is used to map C++ include paths (e.g.
-    ``CUBIN_DIR/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export``) to the
+    ``GEN_SRC_DIR/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export``) to the
     canonical artifact directory where ``get_artifact()`` stores downloaded files.
     """
     link = pathlib.Path(link)

--- a/tests/utils/test_gen_module_symlink_race_condition.py
+++ b/tests/utils/test_gen_module_symlink_race_condition.py
@@ -20,33 +20,45 @@ from pathlib import Path
 from multiprocessing import Pool
 
 
-def gen_fused_moe_worker_process(temp_dir):
+def _bmm_export_symlink_path(gen_src_dir):
+    """Location where the BMM export headers are symlinked for C++ includes."""
+    return (
+        Path(gen_src_dir)
+        / "flashinfer"
+        / "trtllm"
+        / "batched_gemm"
+        / "trtllmGen_bmm_export"
+    )
+
+
+def gen_fused_moe_worker_process(dirs):
     """
     Worker function that calls gen_trtllm_gen_fused_moe_sm100_module end-to-end.
 
     Each process will:
-    1. Patch FLASHINFER_CUBIN_DIR in all modules to use the shared temp directory
+    1. Patch FLASHINFER_CUBIN_DIR (artifact download cache) and
+       FLASHINFER_GEN_SRC_DIR (where the symlink is created) to use the shared
+       temp directories
     2. Call gen_trtllm_gen_fused_moe_sm100_module (downloads artifacts, creates symlinks)
     3. Verify the symlink is correct
     """
+    cubin_dir, gen_src_dir = dirs
+
     from flashinfer.jit import env as jit_env
     from flashinfer.jit import cubin_loader
 
-    jit_env.FLASHINFER_CUBIN_DIR = Path(temp_dir)
-    cubin_loader.FLASHINFER_CUBIN_DIR = Path(temp_dir)
+    jit_env.FLASHINFER_CUBIN_DIR = Path(cubin_dir)
+    cubin_loader.FLASHINFER_CUBIN_DIR = Path(cubin_dir)
+    # The symlink is created under FLASHINFER_GEN_SRC_DIR, so it must be
+    # redirected too or the test would race on the real workspace directory.
+    jit_env.FLASHINFER_GEN_SRC_DIR = Path(gen_src_dir)
 
     from flashinfer.jit.fused_moe import gen_trtllm_gen_fused_moe_sm100_module
 
     gen_trtllm_gen_fused_moe_sm100_module()
 
     # Verify the symlink was created correctly.
-    symlink_path = (
-        Path(temp_dir)
-        / "flashinfer"
-        / "trtllm"
-        / "batched_gemm"
-        / "trtllmGen_bmm_export"
-    )
+    symlink_path = _bmm_export_symlink_path(gen_src_dir)
     assert symlink_path.is_symlink(), f"Expected {symlink_path} to be a symlink"
 
     # Verify we can read a header through the symlink
@@ -74,6 +86,10 @@ def test_gen_fused_moe_symlink_race_condition(num_iterations=100, num_processes=
     after the first download. Between iterations, the symlink is deleted to
     re-trigger the race condition without re-downloading.
 
+    The artifact cache and the generated-source directory are kept as separate
+    subdirectories so the assertion pins the symlink to FLASHINFER_GEN_SRC_DIR
+    and would catch it moving back under FLASHINFER_CUBIN_DIR.
+
     Args:
         num_iterations: Number of times to repeat the test
         num_processes: Number of concurrent processes per iteration
@@ -88,25 +104,23 @@ def test_gen_fused_moe_symlink_race_condition(num_iterations=100, num_processes=
         return
 
     temp_dir = tempfile.mkdtemp(prefix="flashinfer_test_fused_moe_symlink_")
-    symlink_path = (
-        Path(temp_dir)
-        / "flashinfer"
-        / "trtllm"
-        / "batched_gemm"
-        / "trtllmGen_bmm_export"
-    )
+    cubin_dir = Path(temp_dir) / "cubins"
+    gen_src_dir = Path(temp_dir) / "generated"
+    cubin_dir.mkdir(parents=True, exist_ok=True)
+    gen_src_dir.mkdir(parents=True, exist_ok=True)
+    symlink_path = _bmm_export_symlink_path(gen_src_dir)
 
     try:
         with Pool(processes=num_processes) as pool:
             for iteration in range(num_iterations):
                 # Delete the symlink to re-trigger the race, but keep
-                # downloaded artifacts cached in temp_dir.
+                # downloaded artifacts cached in cubin_dir.
                 if symlink_path.is_symlink():
                     symlink_path.unlink()
 
                 results = pool.map(
                     gen_fused_moe_worker_process,
-                    [temp_dir] * num_processes,
+                    [(cubin_dir, gen_src_dir)] * num_processes,
                 )
 
                 assert all(results), (


### PR DESCRIPTION
## 📌 Description

Fixes #4166.

`tests/utils/test_gen_module_symlink_race_condition.py` fails on `release-v0.6.16` rc1 (`unit_test_b300`, cu129/cu130):

```text
AssertionError: Expected /tmp/flashinfer_test_fused_moe_symlink_ng4ln5vs/flashinfer/trtllm/
batched_gemm/trtllmGen_bmm_export to be a symlink
```

### Root cause

#3468 ("move JIT symlinks to writable gen dir", `b9890c85`) moved the `trtllmGen_bmm_export` symlink from `FLASHINFER_CUBIN_DIR` to `FLASHINFER_GEN_SRC_DIR` in `flashinfer/jit/fused_moe.py`, `flashinfer/jit/moe_utils.py`, and `flashinfer/jit/gemm/core.py`. That PR touched three production files and no tests.

The test redirects only `FLASHINFER_CUBIN_DIR`, then asserts the symlink under it, so it now checks a location the code no longer writes to.

There is a second, quieter consequence. Since `FLASHINFER_GEN_SRC_DIR` is never redirected, the symlink is created in the *real* workspace directory and points into the test's temp directory, which `shutil.rmtree` deletes on teardown. The between-iteration `symlink_path.unlink()` also targeted the temp path, so it never removed the symlink actually in use — meaning the race stopped being re-triggered after the first iteration, and the test would have silently under-tested even with the assertion path corrected.

### Fix

- Redirect `FLASHINFER_GEN_SRC_DIR` alongside `FLASHINFER_CUBIN_DIR` in the worker, and assert the symlink there. `tests/jit/test_jit_cpp_ext.py` already redirects `FLASHINFER_GEN_SRC_DIR` this way, and `flashinfer/aot.py` reassigns the same attribute, so this is the established pattern.
- Keep the artifact cache and generated-source dir as **separate** temp subdirectories, so the assertion still fails if the symlink ever moves back under `FLASHINFER_CUBIN_DIR`. Pointing both at one directory would make the assertion pass either way.
- Restore the race semantics and confine all symlinks to the temp tree.
- Correct the `ensure_symlink()` docstring, which still cited the pre-#3468 `CUBIN_DIR` location.

No production behavior changes; the only non-test edit is a docstring.

## 🔍 Related Issues

- Fixes #4166
- Root cause: #3468

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

All hooks pass on the changed files (`ruff check`, `ruff format`, `mypy`, whitespace/EOL).

## 🧪 Tests

- [x] Tests have been updated as needed.

The test requires SM100/SM12x and returns early elsewhere, so it cannot be executed end-to-end on the SM89/90 host available to me. **It still needs a B300/GB200 run to confirm the CI failure is cleared.**

To verify the path logic without that hardware, I exercised the real `gen_trtllm_gen_fused_moe_sm100_module()` with only artifact download/checksum verification stubbed (the symlink is created before the nvcc-arch check raises), and recorded the `ensure_symlink()` link path. A stand-in directory represents the shared workspace dir so nothing touches the real cache.

Redirecting `FLASHINFER_CUBIN_DIR` only, as the test did before:

```text
[ensure_symlink] link=/tmp/verify_before_.../shared_workspace_generated/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export
  symlink present in cubin_dir (old assertion target) : False   <-- assertion fails, matches #4166
  symlink present in shared gen dir (real workspace)  : True    <-- leaks outside the temp tree
  symlink present in test gen dir (temp, isolated)    : False
```

Redirecting both, as this PR does:

```text
[ensure_symlink] link=/tmp/verify_after_.../generated/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export
  symlink present in cubin_dir (old assertion target) : False
  symlink present in shared gen dir (real workspace)  : False   <-- no leak
  symlink present in test gen dir (temp, isolated)    : True    <-- assertion passes
```

Collection and the non-SM100 early-return path were also confirmed green: `pytest -q tests/utils/test_gen_module_symlink_race_condition.py` → `1 passed`.

## Reviewer Notes

`gen_fused_moe_worker_process` now takes a `(cubin_dir, gen_src_dir)` tuple, since `Pool.map` passes a single argument.

`flashinfer/jit/moe_utils.py` and `flashinfer/jit/gemm/core.py` have the same symlink layout but no test asserts their paths, so nothing else needed updating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an example path in the symlink helper documentation.

* **Tests**
  * Improved race-condition coverage for generated module symlinks.
  * Reduced test flakiness by separating generated files from cached build artifacts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->