### PR TITLE
perf(sampling): gate __launch_bounds__ to SM107 only (NVBug 6517769)

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -96,6 +96,19 @@ __device__ __forceinline__ float ieee_div(float a, float b) {
 constexpr BlockScanAlgorithm SCAN_ALGO = BLOCK_SCAN_WARP_SCANS;
 constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
 
+// On SM107 (Rubin), ptxas can allocate >64 regs/thread for these 1024-thread
+// sampling kernels, which exceeds the 65536-register SM budget and fails with
+// "too many resources requested for launch" (internal MR !611 / feat_sm107).
+// Gate __launch_bounds__ to native sm_107* compiles only so other arches keep
+// unconstrained register allocation (avoids the B300/H100 spill regression in
+// NVBug 6517769). When SM107 is mapped to sm_100f at JIT time, this gate is
+// inactive; that path inherits sm_100 register counts which already fit.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1070)
+#define FLASHINFER_SAMPLING_LAUNCH_BOUNDS(block_threads) __launch_bounds__(block_threads)
+#else
+#define FLASHINFER_SAMPLING_LAUNCH_BOUNDS(block_threads)
+#endif
+
 #if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120100)
 #define FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
 #endif
@@ -290,8 +303,8 @@ __device__ __forceinline__ float GetMaxValue(float* in_data, uint32_t row_idx, u
 }
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType, bool CACHE_INPUT>
-__global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* temperature_arr,
-                                         DType temperature_val, uint32_t d) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxFusedKernel(
+    DType* logits, DType* output, DType* temperature_arr, DType temperature_val, uint32_t d) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
   const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
@@ -407,9 +420,9 @@ __global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* te
 }
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* partial_results,
-                                       DType* temperature_arr, float temperature_val, uint32_t d,
-                                       uint32_t num_slices) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxMapKernel(
+    DType* logits, PartialSoftmaxResult* partial_results, DType* temperature_arr,
+    float temperature_val, uint32_t d, uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t by = blockIdx.y;  // slice index
   const uint32_t tx = threadIdx.x;
@@ -492,10 +505,9 @@ __global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* part
 }
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ void OnlineSoftmaxReduceKernel(DType* logits, DType* output,
-                                          PartialSoftmaxResult* partial_results,
-                                          DType* temperature_arr, float temperature_val, uint32_t d,
-                                          uint32_t num_slices) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxReduceKernel(
+    DType* logits, DType* output, PartialSoftmaxResult* partial_results, DType* temperature_arr,
+    float temperature_val, uint32_t d, uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t tx = threadIdx.x;
   float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
@@ -721,9 +733,9 @@ __device__ __forceinline__ vec_t<DType, VEC_SIZE> GenerateGumbelNoise(uint64_t p
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void SamplingFromLogitsKernel(DType* logits, IdType* output, IdType* indices, uint32_t d,
-                                         uint64_t* seed_arr, uint64_t seed_val,
-                                         uint64_t* offset_arr, uint64_t offset_val) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void SamplingFromLogitsKernel(
+    DType* logits, IdType* output, IdType* indices, uint32_t d, uint64_t* seed_arr,
+    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
@@ -770,9 +782,9 @@ __global__ void SamplingFromLogitsKernel(DType* logits, IdType* output, IdType* 
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void SamplingFromProbKernel(DType* probs, IdType* output, bool* valid, IdType* indices,
-                                       uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                       uint64_t* offset_arr, uint64_t offset_val) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void SamplingFromProbKernel(
+    DType* probs, IdType* output, bool* valid, IdType* indices, uint32_t d, uint64_t* seed_arr,
+    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
   curandStatePhilox4_32_10_t state;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -834,10 +846,10 @@ __global__ void SamplingFromProbKernel(DType* probs, IdType* output, bool* valid
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void TopKSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
-                                           IdType* indices, IdType* top_k_arr, uint32_t top_k_val,
-                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                           uint64_t* offset_arr, uint64_t offset_val) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKSamplingFromProbKernel(
+    DType* probs, IdType* output, bool* valid, IdType* indices, IdType* top_k_arr,
+    uint32_t top_k_val, uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
+    uint64_t offset_val) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -967,10 +979,9 @@ __global__ void TopKSamplingFromProbKernel(DType* probs, IdType* output, bool* v
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void TopPSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
-                                           IdType* indices, float* top_p_arr, float top_p_val,
-                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                           uint64_t* offset_arr, uint64_t offset_val) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopPSamplingFromProbKernel(
+    DType* probs, IdType* output, bool* valid, IdType* indices, float* top_p_arr, float top_p_val,
+    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -1094,10 +1105,9 @@ __global__ void TopPSamplingFromProbKernel(DType* probs, IdType* output, bool* v
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void MinPSamplingFromProbKernel(DType* probs, float* min_p_arr, IdType* output,
-                                           bool* valid, IdType* indices, float min_p_val,
-                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                           uint64_t* offset_arr, uint64_t offset_val) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void MinPSamplingFromProbKernel(
+    DType* probs, float* min_p_arr, IdType* output, bool* valid, IdType* indices, float min_p_val,
+    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
@@ -1189,11 +1199,10 @@ __global__ void MinPSamplingFromProbKernel(DType* probs, float* min_p_arr, IdTyp
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, float* top_p_arr,
-                                               IdType* output, bool* valid, IdType* indices,
-                                               IdType top_k_val, float top_p_val, uint32_t d,
-                                               uint64_t* seed_arr, uint64_t seed_val,
-                                               uint64_t* offset_arr, uint64_t offset_val) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKTopPSamplingFromProbKernel(
+    DType* probs, IdType* top_k_arr, float* top_p_arr, IdType* output, bool* valid, IdType* indices,
+    IdType top_k_val, float top_p_val, uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+    uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -1660,8 +1669,8 @@ struct RenormTempStorage {
 
 template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE,
           typename DType>
-__global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* top_p_arr,
-                                     float top_p_val, uint32_t d) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopPRenormProbKernel(
+    DType* probs, DType* renormed_prob, float* top_p_arr, float top_p_val, uint32_t d) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   const uint32_t row_idx = bx;
   float p = top_p_arr == nullptr ? top_p_val : top_p_arr[bx];
@@ -1857,13 +1866,11 @@ cudaError_t TopPRenormProb(DType* probs, DType* renormed_prob, float* top_p_arr,
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
-                                         DType* target_probs, IdType* output_token_ids,
-                                         IdType* output_accepted_token_num,
-                                         IdType* output_emitted_draft_token_num,
-                                         uint32_t num_speculative_tokens, uint32_t d,
-                                         uint64_t* seed_arr, uint64_t seed_val,
-                                         uint64_t* offset_arr, uint64_t offset_val) {
+__global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void ChainSpeculativeSampling(
+    DType* draft_probs, IdType* draft_token_ids, DType* target_probs, IdType* output_token_ids,
+    IdType* output_accepted_token_num, IdType* output_emitted_draft_token_num,
+    uint32_t num_speculative_tokens, uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+    uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   const uint32_t row_idx = bx;
 

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -290,8 +290,8 @@ __device__ __forceinline__ float GetMaxValue(float* in_data, uint32_t row_idx, u
 }
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType, bool CACHE_INPUT>
-__global__ __launch_bounds__(BLOCK_THREADS) void OnlineSoftmaxFusedKernel(
-    DType* logits, DType* output, DType* temperature_arr, DType temperature_val, uint32_t d) {
+__global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* temperature_arr,
+                                         DType temperature_val, uint32_t d) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
   const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
@@ -407,9 +407,9 @@ __global__ __launch_bounds__(BLOCK_THREADS) void OnlineSoftmaxFusedKernel(
 }
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ __launch_bounds__(BLOCK_THREADS) void OnlineSoftmaxMapKernel(
-    DType* logits, PartialSoftmaxResult* partial_results, DType* temperature_arr,
-    float temperature_val, uint32_t d, uint32_t num_slices) {
+__global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* partial_results,
+                                       DType* temperature_arr, float temperature_val, uint32_t d,
+                                       uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t by = blockIdx.y;  // slice index
   const uint32_t tx = threadIdx.x;
@@ -492,9 +492,10 @@ __global__ __launch_bounds__(BLOCK_THREADS) void OnlineSoftmaxMapKernel(
 }
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ __launch_bounds__(BLOCK_THREADS) void OnlineSoftmaxReduceKernel(
-    DType* logits, DType* output, PartialSoftmaxResult* partial_results, DType* temperature_arr,
-    float temperature_val, uint32_t d, uint32_t num_slices) {
+__global__ void OnlineSoftmaxReduceKernel(DType* logits, DType* output,
+                                          PartialSoftmaxResult* partial_results,
+                                          DType* temperature_arr, float temperature_val, uint32_t d,
+                                          uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t tx = threadIdx.x;
   float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
@@ -720,9 +721,9 @@ __device__ __forceinline__ vec_t<DType, VEC_SIZE> GenerateGumbelNoise(uint64_t p
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ __launch_bounds__(BLOCK_THREADS) void SamplingFromLogitsKernel(
-    DType* logits, IdType* output, IdType* indices, uint32_t d, uint64_t* seed_arr,
-    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+__global__ void SamplingFromLogitsKernel(DType* logits, IdType* output, IdType* indices, uint32_t d,
+                                         uint64_t* seed_arr, uint64_t seed_val,
+                                         uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
@@ -769,9 +770,9 @@ __global__ __launch_bounds__(BLOCK_THREADS) void SamplingFromLogitsKernel(
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ __launch_bounds__(BLOCK_THREADS) void SamplingFromProbKernel(
-    DType* probs, IdType* output, bool* valid, IdType* indices, uint32_t d, uint64_t* seed_arr,
-    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+__global__ void SamplingFromProbKernel(DType* probs, IdType* output, bool* valid, IdType* indices,
+                                       uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                       uint64_t* offset_arr, uint64_t offset_val) {
   curandStatePhilox4_32_10_t state;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -833,10 +834,10 @@ __global__ __launch_bounds__(BLOCK_THREADS) void SamplingFromProbKernel(
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ __launch_bounds__(BLOCK_THREADS) void TopKSamplingFromProbKernel(
-    DType* probs, IdType* output, bool* valid, IdType* indices, IdType* top_k_arr,
-    uint32_t top_k_val, uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
-    uint64_t offset_val) {
+__global__ void TopKSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
+                                           IdType* indices, IdType* top_k_arr, uint32_t top_k_val,
+                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                           uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -966,9 +967,10 @@ __global__ __launch_bounds__(BLOCK_THREADS) void TopKSamplingFromProbKernel(
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ __launch_bounds__(BLOCK_THREADS) void TopPSamplingFromProbKernel(
-    DType* probs, IdType* output, bool* valid, IdType* indices, float* top_p_arr, float top_p_val,
-    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+__global__ void TopPSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
+                                           IdType* indices, float* top_p_arr, float top_p_val,
+                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                           uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -1092,9 +1094,10 @@ __global__ __launch_bounds__(BLOCK_THREADS) void TopPSamplingFromProbKernel(
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ __launch_bounds__(BLOCK_THREADS) void MinPSamplingFromProbKernel(
-    DType* probs, float* min_p_arr, IdType* output, bool* valid, IdType* indices, float min_p_val,
-    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+__global__ void MinPSamplingFromProbKernel(DType* probs, float* min_p_arr, IdType* output,
+                                           bool* valid, IdType* indices, float min_p_val,
+                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                           uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
@@ -1186,10 +1189,11 @@ __global__ __launch_bounds__(BLOCK_THREADS) void MinPSamplingFromProbKernel(
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ __launch_bounds__(BLOCK_THREADS) void TopKTopPSamplingFromProbKernel(
-    DType* probs, IdType* top_k_arr, float* top_p_arr, IdType* output, bool* valid, IdType* indices,
-    IdType top_k_val, float top_p_val, uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-    uint64_t* offset_arr, uint64_t offset_val) {
+__global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, float* top_p_arr,
+                                               IdType* output, bool* valid, IdType* indices,
+                                               IdType top_k_val, float top_p_val, uint32_t d,
+                                               uint64_t* seed_arr, uint64_t seed_val,
+                                               uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
@@ -1656,10 +1660,8 @@ struct RenormTempStorage {
 
 template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE,
           typename DType>
-__global__ __launch_bounds__(BLOCK_THREADS) void TopPRenormProbKernel(DType* probs,
-                                                                      DType* renormed_prob,
-                                                                      float* top_p_arr,
-                                                                      float top_p_val, uint32_t d) {
+__global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* top_p_arr,
+                                     float top_p_val, uint32_t d) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   const uint32_t row_idx = bx;
   float p = top_p_arr == nullptr ? top_p_val : top_p_arr[bx];
@@ -1855,11 +1857,13 @@ cudaError_t TopPRenormProb(DType* probs, DType* renormed_prob, float* top_p_arr,
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ __launch_bounds__(BLOCK_THREADS) void ChainSpeculativeSampling(
-    DType* draft_probs, IdType* draft_token_ids, DType* target_probs, IdType* output_token_ids,
-    IdType* output_accepted_token_num, IdType* output_emitted_draft_token_num,
-    uint32_t num_speculative_tokens, uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-    uint64_t* offset_arr, uint64_t offset_val) {
+__global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
+                                         DType* target_probs, IdType* output_token_ids,
+                                         IdType* output_accepted_token_num,
+                                         IdType* output_emitted_draft_token_num,
+                                         uint32_t num_speculative_tokens, uint32_t d,
+                                         uint64_t* seed_arr, uint64_t seed_val,
+                                         uint64_t* offset_arr, uint64_t offset_val) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   const uint32_t row_idx = bx;
 


### PR DESCRIPTION
## 📌 Description

Fixes the B300 sampling performance regression tracked in **NVBug 6517769**, targeting `release-v0.6.16` directly.

[#4122](https://github.com/flashinfer-ai/flashinfer/pull/4122) annotated 11 sampling kernels with `__launch_bounds__(BLOCK_THREADS)`. That annotation is effectively `__launch_bounds__(1024)` on every cc ≥ 8, which forces ptxas under a 64-reg/thread ceiling and causes measurable spills / slowdowns on B300 and H100.

### Why not a blanket removal?

The annotations were not unexplained noise. Internal GitLab [MR !611](https://gitlab-master.nvidia.com/dl/flashinfer/flashinfer/-/merge_requests/611) (`Fix Rubin (SM 10.7) launch failures in sampling kernels via __launch_bounds__`, merged into `feat_sm107` 2026-04-28) documented the Rubin failure mode:

> The Top-K sampling kernel was using >64 regs per thread with 1024 threads per block, exceeding the 65,536 register budget.

The [Rubin Kernel Requirements Tracker](https://docs.google.com/spreadsheets/d/1Cn0_F6n_HMrzXPYreYbVIWbKQmfp-zzKne3Lz7akysU) recorded the pre-fix failures as `too many resources requested for launch` on `tests/utils/test_sampling.py` / logits sampling. That rationale never made the public #4122 description, but the release branch still carries SM107 support, so a full drop would re-break Rubin native launches.

### Fix

Gate the annotation to native SM107 compiles only:

```cuda
#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1070)
#define FLASHINFER_SAMPLING_LAUNCH_BOUNDS(block_threads) __launch_bounds__(block_threads)
#else
#define FLASHINFER_SAMPLING_LAUNCH_BOUNDS(block_threads)
#endif
```

All 11 kernels use `FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS)` instead of unconditional `__launch_bounds__(BLOCK_THREADS)`.

When today's JIT maps SM107 → `sm_100f` (`map_sm107_to_100f=True` while CUTLASS lacks `Sm107`), `__CUDA_ARCH__` is 1000 and the gate is inactive; that path inherits sm_100 register counts, which already fit a 1024-thread launch on the arches we measured. The gate is the safety net for **native `sm_107a`** compiles — the path MR !611 actually fixed.

## 🔍 Related Issues

- NVBug 6517769 — B300 sampling perf drop after 290c091
- Internal MR !611 / commit `a8c10c24` on `feat_sm107` (Rubin launch-failure root cause)
- Caused by #4122; #4171 reverted #4122 wholesale on `main` (no cherry-pick possible)

## 🧪 Tests

### ptxas (CUDA 13.0) with the gated macro

| Target | Kernel | Result |
|---|---|---|
| sm_90a | MinP / TopK / TopP / TopKTopP | ≤48 regs, **no spills** (matches unconstrained) |
| sm_103a | same | ≤48 regs, **no spills** |
| sm_107a | — | **cannot compile** on this toolkit (`Unsupported gpu architecture`) |

### Wall-clock (NVBug repro on H100 NVL)

```
python3 flashinfer_benchmark.py --routine min_p_sampling_from_probs \
    --batch_size 32 --vocab_size 129280 --min_p 0.1 -vv
```

| Config | median |
|---|---|
| release (unconditional `__launch_bounds__`) | 0.051 ms |
| this PR (SM107-gated) | **0.045 ms** (same as full removal) |

Correctness: earlier full-removal run of `tests/utils/test_sampling.py` on this header family was 1320 passed / 0 failed; the gated form is a no-op on H100 device code, so that result still applies.

## Reviewer Notes

- Please confirm on **B300** that the NVBug case is restored, and on **Rubin** that `tests/utils/test_sampling.py` still launches when compiled for native `sm_107a` (and/or under the current `sm_100f` JIT mapping).
- `#4171` already removed these annotations from `main` along with all SM107 enablement; this PR is release-only and preserves SM107 launchability.
