### PR TITLE
Split trtllm-gen cubin pins per arch

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -576,6 +576,9 @@ def gen_all_modules(
             jit_specs.append(gen_cutlass_fused_moe_sm103_module())
         if has_sm107:
             jit_specs.append(gen_fp4_quantization_sm107_module())
+            jit_specs.append(gen_trtllm_gen_gemm_module(enable_rubin=True))
+            jit_specs.append(gen_trtllm_low_latency_gemm_module(enable_rubin=True))
+            jit_specs.append(gen_trtllm_gen_fused_moe_sm100_module(enable_rubin=True))
         if has_sm110:
             jit_specs.append(gen_fp4_quantization_sm110_module())
         if has_sm120:

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -137,9 +137,15 @@ class ArtifactPath:
 
     TRTLLM_GEN_FMHA: str = "158f6fa11ef139a098cfddcdddce73ca99d164ad/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
-        "46d3f3561e3336c131a141191ee6aaa0690723bb/batched_gemm-17629de-61f1bc7/"
+        "b368d003e8fdfe4b271bff7c788ac52ef789a81b/batched_gemm-da58956-b4ac80e/"
     )
     TRTLLM_GEN_GEMM: str = (
+        "10f64528a1172dae8e29601a3b99ab9dc78d37be/gemm-91e0ba0-2710384/"
+    )
+    TRTLLM_GEN_BMM_RUBIN: str = (
+        "46d3f3561e3336c131a141191ee6aaa0690723bb/batched_gemm-17629de-61f1bc7/"
+    )
+    TRTLLM_GEN_GEMM_RUBIN: str = (
         "46d3f3561e3336c131a141191ee6aaa0690723bb/gemm-17629de-25754e6/"
     )
     CUDNN_SDPA: str = "a72d85b019dc125b9f711300cb989430f762f5a6/fmha/cudnn/"
@@ -160,10 +166,16 @@ class CheckSumHash:
         "c2d9399b2537be785882354a4f9902ed6c03136c0ea341e201eac40c3923e1dc"
     )
     TRTLLM_GEN_BMM: str = (
-        "31c9f4cdd59299fc6a9a6f3a31b403b817a1fea63238eec2cbcd3009d2feb3f7"
+        "d0178cd486be54e622386e88daba9c2aca654be7e6f3dcd1af7ecca3354492d2"
     )
     DEEPGEMM: str = "1a2a166839042dbd2a57f48051c82cd1ad032815927c753db269a4ed10d0ffbf"
     TRTLLM_GEN_GEMM: str = (
+        "f97f90f9ce1dab73eb3d7c90fca4bbd52687642dd87a79dd10b77d7802b25c33"
+    )
+    TRTLLM_GEN_BMM_RUBIN: str = (
+        "31c9f4cdd59299fc6a9a6f3a31b403b817a1fea63238eec2cbcd3009d2feb3f7"
+    )
+    TRTLLM_GEN_GEMM_RUBIN: str = (
         "2174e60bc8248a8af41a3d0afdc4cac8f2b04893ac983f654065dd14c77ec139"
     )
     # SHA256 of the checksums.txt manifest file per cpu-arch/sm-arch,
@@ -185,6 +197,12 @@ class CheckSumHash:
         safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM, "checksums.txt"): TRTLLM_GEN_BMM,
         safe_urljoin(ArtifactPath.DEEPGEMM, "checksums.txt"): DEEPGEMM,
         safe_urljoin(ArtifactPath.TRTLLM_GEN_GEMM, "checksums.txt"): TRTLLM_GEN_GEMM,
+        safe_urljoin(
+            ArtifactPath.TRTLLM_GEN_BMM_RUBIN, "checksums.txt"
+        ): TRTLLM_GEN_BMM_RUBIN,
+        safe_urljoin(
+            ArtifactPath.TRTLLM_GEN_GEMM_RUBIN, "checksums.txt"
+        ): TRTLLM_GEN_GEMM_RUBIN,
         **{
             safe_urljoin(
                 ArtifactPath.DSL_FMHA, f"{cpu_arch}/{sm_arch}/checksums.txt"
@@ -232,6 +250,8 @@ def get_subdir_file_list() -> Generator[tuple[str, str], None, None]:
         ArtifactPath.TRTLLM_GEN_FMHA,
         ArtifactPath.TRTLLM_GEN_BMM,
         ArtifactPath.TRTLLM_GEN_GEMM,
+        ArtifactPath.TRTLLM_GEN_BMM_RUBIN,
+        ArtifactPath.TRTLLM_GEN_GEMM_RUBIN,
         ArtifactPath.DEEPGEMM,
         # DSL FMHA: per cpu-arch and sm-arch subdirectories
         *(
@@ -260,6 +280,24 @@ def get_subdir_file_list() -> Generator[tuple[str, str], None, None]:
         safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM, "include/flashinferMetaInfo.h"),
         checksums[
             safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM, "include/flashinferMetaInfo.h")
+        ],
+    )
+    yield (
+        safe_urljoin(
+            ArtifactPath.TRTLLM_GEN_GEMM_RUBIN, "include/flashinferMetaInfo.h"
+        ),
+        checksums[
+            safe_urljoin(
+                ArtifactPath.TRTLLM_GEN_GEMM_RUBIN, "include/flashinferMetaInfo.h"
+            )
+        ],
+    )
+    yield (
+        safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM_RUBIN, "include/flashinferMetaInfo.h"),
+        checksums[
+            safe_urljoin(
+                ArtifactPath.TRTLLM_GEN_BMM_RUBIN, "include/flashinferMetaInfo.h"
+            )
         ],
     )
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1398,16 +1398,22 @@ def _unpack_trtllm_moe_output(
         ]
 
 
-@functools.cache
 def get_trtllm_moe_sm100_module():
-    module = gen_trtllm_gen_fused_moe_sm100_module()
+    device = torch.device("cuda", torch.cuda.current_device())
+    enable_rubin = get_compute_capability(device) == (10, 7)
+    return _get_trtllm_moe_sm100_module_impl(enable_rubin)
+
+
+@functools.cache
+def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
+    module = gen_trtllm_gen_fused_moe_sm100_module(enable_rubin=enable_rubin)
     moe_op = module.build_and_load()
     setup_cubin_loader(str(module.get_library_path()))
 
     class MoERunner(TunableRunner):
         # Cache valid tactics to reduce the overhead of re-querying the kernel.
         # TODO(siyuan): directly cache the runners
-        valid_tactics_dict = dict()
+        valid_tactics_dict: dict = dict()
 
         def __init__(
             self,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -7112,7 +7112,7 @@ def get_trtllm_gemm_module():
 def _get_trtllm_gemm_module_impl(enable_rubin: bool):
     mod = gen_trtllm_gen_gemm_module(enable_rubin=enable_rubin)
     op = mod.build_and_load()
-    setup_cubin_loader(mod.get_library_path())
+    setup_cubin_loader(str(mod.get_library_path()))
 
     class TrtllmGemmRunner(TunableRunner):
         def __init__(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -7102,9 +7102,15 @@ def gemm_fp8_nt_groupwise(
     return out
 
 
-@functools.cache
 def get_trtllm_gemm_module():
-    mod = gen_trtllm_gen_gemm_module()
+    device = torch.device("cuda", torch.cuda.current_device())
+    enable_rubin = get_compute_capability(device) == (10, 7)
+    return _get_trtllm_gemm_module_impl(enable_rubin)
+
+
+@functools.cache
+def _get_trtllm_gemm_module_impl(enable_rubin: bool):
+    mod = gen_trtllm_gen_gemm_module(enable_rubin=enable_rubin)
     op = mod.build_and_load()
     setup_cubin_loader(mod.get_library_path())
 

--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -281,12 +281,12 @@ def gen_trtllm_gen_fused_moe_sm100_module(enable_rubin: bool = False) -> JitSpec
     for header in BMM_EXPORT_HEADERS:
         h = get_artifact(f"{bmm_export_path}/{header}", get_meta_hash(checksum, header))
         assert h, f"{header} not found"
+    # Per-module export-header root: the Blackwell and Rubin variants must not
+    # share this symlink, or an AOT build (all modules generated, then compiled)
+    # lets the last gen_* call's target win and skews the other module's ABI.
+    gen_root = jit_env.FLASHINFER_GEN_SRC_DIR / "trtllm_export" / module_name
     symlink_path = (
-        jit_env.FLASHINFER_GEN_SRC_DIR
-        / "flashinfer"
-        / "trtllm"
-        / "batched_gemm"
-        / "trtllmGen_bmm_export"
+        gen_root / "flashinfer" / "trtllm" / "batched_gemm" / "trtllmGen_bmm_export"
     )
     ensure_symlink(symlink_path, jit_env.FLASHINFER_CUBIN_DIR / bmm_export_path)
     verify_symlinked_headers(symlink_path, BMM_EXPORT_HEADERS, checksum)
@@ -333,6 +333,7 @@ def gen_trtllm_gen_fused_moe_sm100_module(enable_rubin: bool = False) -> JitSpec
         ]
         + nvcc_flags,
         extra_include_paths=[
+            gen_root,
             jit_env.FLASHINFER_GEN_SRC_DIR,
             jit_env.FLASHINFER_CUBIN_DIR,
             jit_env.FLASHINFER_CUBIN_DIR / include_path,

--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -243,16 +243,28 @@ def gen_cutlass_fused_moe_module(
     )
 
 
-def gen_trtllm_gen_fused_moe_sm100_module() -> JitSpec:
+def gen_trtllm_gen_fused_moe_sm100_module(enable_rubin: bool = False) -> JitSpec:
     # Fetch "flashinferMetaInfo.h" from the online kernel cache. This file
     # contains the `tllmGenBatchedGemmList` as the list of available kernels
     # online. It is included when compiling `trtllm_fused_moe_runner.cu`, etc.
-    include_path = f"{ArtifactPath.TRTLLM_GEN_BMM}/include"
+    bmm_path = (
+        ArtifactPath.TRTLLM_GEN_BMM_RUBIN
+        if enable_rubin
+        else ArtifactPath.TRTLLM_GEN_BMM
+    )
+    bmm_checksum = (
+        CheckSumHash.TRTLLM_GEN_BMM_RUBIN
+        if enable_rubin
+        else CheckSumHash.TRTLLM_GEN_BMM
+    )
+    module_name = "fused_moe_trtllm_sm107" if enable_rubin else "fused_moe_trtllm_sm100"
+    rubin_flags = ["-DTLLM_RUBIN_FEATURES"] if enable_rubin else []
+    include_path = f"{bmm_path}/include"
     header_name = "flashinferMetaInfo"
 
     # Check if checksums.txt exists in the cubin directory
-    checksum_path = f"{ArtifactPath.TRTLLM_GEN_BMM}/checksums.txt"
-    checksum = get_artifact(checksum_path, CheckSumHash.TRTLLM_GEN_BMM)
+    checksum_path = f"{bmm_path}/checksums.txt"
+    checksum = get_artifact(checksum_path, bmm_checksum)
     assert checksum, f"Failed to get checksums.txt from {checksum_path}"
     meta_hash = get_meta_hash(checksum)
 
@@ -286,7 +298,7 @@ def gen_trtllm_gen_fused_moe_sm100_module() -> JitSpec:
     )
 
     return gen_jit_spec(
-        "fused_moe_trtllm_sm100",
+        module_name,
         [
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/kernels/quantization.cu",
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/envUtils.cpp",
@@ -311,13 +323,13 @@ def gen_trtllm_gen_fused_moe_sm100_module() -> JitSpec:
         extra_cuda_cflags=[
             "-DTLLM_GEN_EXPORT_INTERFACE",
             "-DTLLM_GEN_EXPORT_FLASHINFER",
-            "-DTLLM_RUBIN_FEATURES",
+            *rubin_flags,
             "-DTLLM_ENABLE_CUDA",
             "-DENABLE_BF16",
             "-DENABLE_FP8",
             "-DENABLE_FP4",
             "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
-            f'-DTLLM_GEN_GEMM_CUBIN_PATH=\\"{ArtifactPath.TRTLLM_GEN_BMM}\\"',
+            f'-DTLLM_GEN_GEMM_CUBIN_PATH=\\"{bmm_path}\\"',
         ]
         + nvcc_flags,
         extra_include_paths=[

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -717,16 +717,28 @@ def gen_gemm_sm120_module() -> JitSpec:
     )
 
 
-def gen_trtllm_gen_gemm_module() -> JitSpec:
+def gen_trtllm_gen_gemm_module(enable_rubin: bool = False) -> JitSpec:
     # Fetch "flashinferMetaInfo.h" from the online kernel cache. This file
     # contains the `tllmGenGemmList` as the list of available kernels online.
     # It is included when compiling `trtllm_gemm_runner.cu`.
-    include_path = f"{ArtifactPath.TRTLLM_GEN_GEMM}/include"
+    gemm_path = (
+        ArtifactPath.TRTLLM_GEN_GEMM_RUBIN
+        if enable_rubin
+        else ArtifactPath.TRTLLM_GEN_GEMM
+    )
+    gemm_checksum = (
+        CheckSumHash.TRTLLM_GEN_GEMM_RUBIN
+        if enable_rubin
+        else CheckSumHash.TRTLLM_GEN_GEMM
+    )
+    module_name = "trtllm_gemm_sm107" if enable_rubin else "trtllm_gemm"
+    rubin_flags = ["-DTLLM_RUBIN_FEATURES"] if enable_rubin else []
+    include_path = f"{gemm_path}/include"
     header_name = "flashinferMetaInfo"
 
     # Check if checksums.txt exists in the cubin directory
-    checksum_path = f"{ArtifactPath.TRTLLM_GEN_GEMM}/checksums.txt"
-    checksum = get_artifact(checksum_path, CheckSumHash.TRTLLM_GEN_GEMM)
+    checksum_path = f"{gemm_path}/checksums.txt"
+    checksum = get_artifact(checksum_path, gemm_checksum)
     assert checksum, f"Failed to get checksums.txt from {checksum_path}"
     meta_hash = get_meta_hash(checksum)
 
@@ -756,16 +768,16 @@ def gen_trtllm_gen_gemm_module() -> JitSpec:
     verify_symlinked_headers(symlink_path, GEMM_EXPORT_HEADERS, checksum)
 
     return gen_jit_spec(
-        "trtllm_gemm",
+        module_name,
         [
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_gemm_runner.cu",
         ],
         extra_cuda_cflags=[
             "-DTLLM_GEN_EXPORT_INTERFACE",
             "-DTLLM_GEN_EXPORT_FLASHINFER",
-            "-DTLLM_RUBIN_FEATURES",
+            *rubin_flags,
             "-DTLLM_ENABLE_CUDA",
-            f'-DTLLM_GEN_GEMM_CUBIN_PATH=\\"{ArtifactPath.TRTLLM_GEN_GEMM}\\"',
+            f'-DTLLM_GEN_GEMM_CUBIN_PATH=\\"{gemm_path}\\"',
         ]
         + sm100a_nvcc_flags,
         extra_include_paths=[
@@ -896,13 +908,27 @@ def gen_gemm_sm90_module() -> JitSpec:
     )
 
 
-def gen_trtllm_low_latency_gemm_module() -> JitSpec:
-    include_path = f"{ArtifactPath.TRTLLM_GEN_GEMM}/include"
+def gen_trtllm_low_latency_gemm_module(enable_rubin: bool = False) -> JitSpec:
+    gemm_path = (
+        ArtifactPath.TRTLLM_GEN_GEMM_RUBIN
+        if enable_rubin
+        else ArtifactPath.TRTLLM_GEN_GEMM
+    )
+    gemm_checksum = (
+        CheckSumHash.TRTLLM_GEN_GEMM_RUBIN
+        if enable_rubin
+        else CheckSumHash.TRTLLM_GEN_GEMM
+    )
+    module_name = (
+        "trtllm_low_latency_gemm_sm107" if enable_rubin else "trtllm_low_latency_gemm"
+    )
+    rubin_flags = ["-DTLLM_RUBIN_FEATURES"] if enable_rubin else []
+    include_path = f"{gemm_path}/include"
     header_name = "flashinferMetaInfo"
 
     # Check if checksums.txt exists in the cubin directory
-    checksum_path = f"{ArtifactPath.TRTLLM_GEN_GEMM}/checksums.txt"
-    checksum = get_artifact(checksum_path, CheckSumHash.TRTLLM_GEN_GEMM)
+    checksum_path = f"{gemm_path}/checksums.txt"
+    checksum = get_artifact(checksum_path, gemm_checksum)
     assert checksum, f"Failed to get checksums.txt from {checksum_path}"
     meta_hash = get_meta_hash(checksum)
 
@@ -932,16 +958,16 @@ def gen_trtllm_low_latency_gemm_module() -> JitSpec:
     verify_symlinked_headers(symlink_path, GEMM_EXPORT_HEADERS, checksum)
 
     return gen_jit_spec(
-        "trtllm_low_latency_gemm",
+        module_name,
         [
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_low_latency_gemm_runner.cu",
         ],
         extra_cuda_cflags=[
             "-DTLLM_GEN_EXPORT_INTERFACE",
             "-DTLLM_GEN_EXPORT_FLASHINFER",
-            "-DTLLM_RUBIN_FEATURES",
+            *rubin_flags,
             "-DTLLM_ENABLE_CUDA",
-            f'-DTLLM_GEN_GEMM_CUBIN_PATH=\\"{ArtifactPath.TRTLLM_GEN_GEMM}\\"',
+            f'-DTLLM_GEN_GEMM_CUBIN_PATH=\\"{gemm_path}\\"',
         ]
         + sm100a_nvcc_flags,
         extra_include_paths=[

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -757,13 +757,11 @@ def gen_trtllm_gen_gemm_module(enable_rubin: bool = False) -> JitSpec:
             f"{gemm_export_path}/{header}", get_meta_hash(checksum, header)
         )
         assert h, f"{header} not found"
-    symlink_path = (
-        jit_env.FLASHINFER_GEN_SRC_DIR
-        / "flashinfer"
-        / "trtllm"
-        / "gemm"
-        / "trtllmGen_gemm_export"
-    )
+    # Per-module export-header root: the Blackwell and Rubin variants must not
+    # share this symlink, or an AOT build (all modules generated, then compiled)
+    # lets the last gen_* call's target win and skews the other module's ABI.
+    gen_root = jit_env.FLASHINFER_GEN_SRC_DIR / "trtllm_export" / module_name
+    symlink_path = gen_root / "flashinfer" / "trtllm" / "gemm" / "trtllmGen_gemm_export"
     ensure_symlink(symlink_path, jit_env.FLASHINFER_CUBIN_DIR / gemm_export_path)
     verify_symlinked_headers(symlink_path, GEMM_EXPORT_HEADERS, checksum)
 
@@ -781,6 +779,7 @@ def gen_trtllm_gen_gemm_module(enable_rubin: bool = False) -> JitSpec:
         ]
         + sm100a_nvcc_flags,
         extra_include_paths=[
+            gen_root,
             jit_env.FLASHINFER_GEN_SRC_DIR,
             jit_env.FLASHINFER_CUBIN_DIR,
             jit_env.FLASHINFER_CUBIN_DIR / include_path,
@@ -947,13 +946,11 @@ def gen_trtllm_low_latency_gemm_module(enable_rubin: bool = False) -> JitSpec:
             f"{gemm_export_path}/{header}", get_meta_hash(checksum, header)
         )
         assert h, f"{header} not found"
-    symlink_path = (
-        jit_env.FLASHINFER_GEN_SRC_DIR
-        / "flashinfer"
-        / "trtllm"
-        / "gemm"
-        / "trtllmGen_gemm_export"
-    )
+    # Per-module export-header root: the Blackwell and Rubin variants must not
+    # share this symlink, or an AOT build (all modules generated, then compiled)
+    # lets the last gen_* call's target win and skews the other module's ABI.
+    gen_root = jit_env.FLASHINFER_GEN_SRC_DIR / "trtllm_export" / module_name
+    symlink_path = gen_root / "flashinfer" / "trtllm" / "gemm" / "trtllmGen_gemm_export"
     ensure_symlink(symlink_path, jit_env.FLASHINFER_CUBIN_DIR / gemm_export_path)
     verify_symlinked_headers(symlink_path, GEMM_EXPORT_HEADERS, checksum)
 
@@ -971,6 +968,7 @@ def gen_trtllm_low_latency_gemm_module(enable_rubin: bool = False) -> JitSpec:
         ]
         + sm100a_nvcc_flags,
         extra_include_paths=[
+            gen_root,
             jit_env.FLASHINFER_GEN_SRC_DIR,
             jit_env.FLASHINFER_CUBIN_DIR,
             jit_env.FLASHINFER_CUBIN_DIR / include_path,

--- a/flashinfer/trtllm_low_latency_gemm.py
+++ b/flashinfer/trtllm_low_latency_gemm.py
@@ -40,7 +40,7 @@ from flashinfer.fused_moe.utils import (
     map_to_hybrid_bucket_uncapped,
 )
 from flashinfer.jit import setup_cubin_loader
-from flashinfer.utils import _get_cache_buf
+from flashinfer.utils import _get_cache_buf, get_compute_capability
 
 # Tensor index constants for trtllm_low_latency_gemm inputs: [A, B, global_scale, out]
 _LLGEMM_A_IDX = 0
@@ -63,9 +63,15 @@ _LLGEMM_TUNING_CONFIG = TuningConfig(
 )
 
 
-@functools.cache
 def get_trtllm_low_latency_gemm_module():
-    mod = gen_trtllm_low_latency_gemm_module()
+    device = torch.device("cuda", torch.cuda.current_device())
+    enable_rubin = get_compute_capability(device) == (10, 7)
+    return _get_trtllm_low_latency_gemm_module_impl(enable_rubin)
+
+
+@functools.cache
+def _get_trtllm_low_latency_gemm_module_impl(enable_rubin: bool):
+    mod = gen_trtllm_low_latency_gemm_module(enable_rubin=enable_rubin)
     op = mod.build_and_load()
     setup_cubin_loader(str(mod.get_library_path()))
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The BMM & GEMM trtllm-gen cubins in ToT fail on SM 100. This MR introduces a WAR, loading an older set of published cubins when targeting SM 100.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
