### PR TITLE
fix(moe): serialize CuTe DSL autotune replay

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -611,6 +611,7 @@ class CuteDslMoEWrapper:
         moe_output: Optional[torch.Tensor] = None,
         per_token_scale: Optional[torch.Tensor] = None,
         enable_pdl: bool = True,
+        use_async_memset: bool = True,
         **kwargs,
     ) -> torch.Tensor:
         """Forward implementation called by auto-tuner."""
@@ -644,7 +645,7 @@ class CuteDslMoEWrapper:
             main_event=self._main_event,
             memset_event=self._memset_event,
             output_dtype=output_dtype,
-            use_async_memset=True,
+            use_async_memset=use_async_memset,
             use_fused_finalize=use_fused_finalize,
             enable_pdl=enable_pdl,
             activation_type=self.activation_type.value,
@@ -755,7 +756,13 @@ class CuteDslMoEWrapper:
             inputs,
         )
 
-        return runner(inputs, tactic=best_tactic)
+        # Timed tactic runs retain the default async path; only this
+        # selected-tactic execution is single-stream while tuning.
+        return runner(
+            inputs,
+            tactic=best_tactic,
+            use_async_memset=not tuner.is_tuning_mode,
+        )
 
     def get_valid_tactics(self) -> list:
         """Return list of valid tactics for this MoE configuration."""
@@ -794,6 +801,7 @@ def _cute_dsl_fused_moe_nvfp4_impl(
     per_token_scale: Optional[torch.Tensor] = None,
     aux_stream: Optional[torch.cuda.Stream] = None,
     enable_pdl: bool = True,
+    use_async_memset: bool = True,
     activation_type: int = ActivationType.Swiglu.value,
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
@@ -825,7 +833,7 @@ def _cute_dsl_fused_moe_nvfp4_impl(
         per_token_scale=per_token_scale,
         aux_stream=aux_stream,
         output_dtype=output_dtype,
-        use_async_memset=True,
+        use_async_memset=use_async_memset,
         use_fused_finalize=use_fused_finalize,
         enable_pdl=enable_pdl,
         activation_type=activation_type,
@@ -994,10 +1002,13 @@ def cute_dsl_fused_moe_nvfp4(
         aux_stream=aux_stream,
     )
 
+    # Tactic profiling retains the default async path; only this selected
+    # execution is single-stream while tuning.
     return runner(
         inputs,
         tactic=best_tactic,
         aux_stream=aux_stream,
+        use_async_memset=not tuner.is_tuning_mode,
     )
 
 

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -418,6 +418,81 @@ class TestInputsHelperContract:
 
 
 # =============================================================================
+# Test Class: autotune replay stream contract (no GPU required)
+# =============================================================================
+
+
+@cute_dsl_available
+class TestAutotuneReplayMemsetContract:
+    @pytest.mark.parametrize("api", ["functional", "wrapper"])
+    @pytest.mark.parametrize("is_tuning_mode", [False, True])
+    def test_selected_tactic_disables_async_memset_while_tuning(
+        self, monkeypatch, api, is_tuning_mode
+    ):
+        from flashinfer.fused_moe.cute_dsl import fused_moe
+
+        calls = []
+
+        class RecordingRunner:
+            def __init__(self, *args, **kwargs):
+                self.tuning_config = object()
+
+            def __call__(self, inputs, **kwargs):
+                calls.append(kwargs)
+                return inputs[-1]
+
+        class StubTuner:
+            def __init__(self):
+                self.is_tuning_mode = is_tuning_mode
+
+            def choose_one(self, custom_op, runners, tuning_config, inputs, **kwargs):
+                assert "use_async_memset" not in kwargs
+                return runners[0], ("selected",)
+
+        monkeypatch.setattr(
+            fused_moe.AutoTuner, "get", staticmethod(lambda: StubTuner())
+        )
+
+        tensors = {
+            "x": torch.empty((2, 8), dtype=torch.uint8),
+            "x_sf": torch.empty((2, 1), dtype=torch.uint8),
+            "token_selected_experts": torch.zeros((2, 1), dtype=torch.int32),
+            "token_final_scales": torch.ones((2, 1), dtype=torch.float32),
+            "w1_weight": torch.empty((1, 32, 8), dtype=torch.uint8),
+            "w1_weight_sf": torch.empty((1, 32, 1), dtype=torch.uint8),
+            "w1_alpha": torch.ones(1, dtype=torch.float32),
+            "fc2_input_scale": torch.ones(1, dtype=torch.float32),
+            "w2_weight": torch.empty((1, 16, 8), dtype=torch.uint8),
+            "w2_weight_sf": torch.empty((1, 16, 1), dtype=torch.uint8),
+            "w2_alpha": torch.ones(1, dtype=torch.float32),
+        }
+
+        if api == "functional":
+            monkeypatch.setattr(
+                fused_moe, "CuteDslFusedMoENvfp4Runner", RecordingRunner
+            )
+            result = fused_moe.cute_dsl_fused_moe_nvfp4(
+                **tensors,
+                num_experts=1,
+                top_k=1,
+            )
+        else:
+            wrapper = fused_moe.CuteDslMoEWrapper(
+                num_experts=1,
+                top_k=1,
+                hidden_size=16,
+                intermediate_size=16,
+                use_cuda_graph=False,
+            )
+            wrapper._runner = RecordingRunner()
+            wrapper._per_token_runner = RecordingRunner()
+            result = wrapper.run(**tensors)
+
+        assert result.shape == (2, 16)
+        assert calls[-1]["use_async_memset"] is not is_tuning_mode
+
+
+# =============================================================================
 # Test Class: get_max_num_tiles / get_max_num_permuted_tokens (no GPU required)
 # =============================================================================
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

CuTe DSL MoE fused finalize overlaps its output memset on an auxiliary CUDA stream. During `autotune(True)`, the selected tactic is executed once more after `choose_one` returns but before the tuning context exits. Keeping the auxiliary memset enabled for that replay can leave cross-stream work outstanding and deadlock a subsequent first-time CUDA module load during multi-rank serving startup.

This PR:

- threads the existing internal `use_async_memset` control through the CuTe DSL MoE functional and wrapper dispatch layers;
- disables the auxiliary-stream memset only for the selected-tactic replay while `AutoTuner.is_tuning_mode` is true;
- preserves async memset for each timed tactic profile, normal inference, and explicit-tactic execution; and
- adds a contract test covering functional/wrapper dispatch both inside and outside tuning mode.

This follows the existing tuning-aware dispatch pattern in `flashinfer/mla/_sparse_mla_sm120.py`, which branches on `AutoTuner.is_tuning_mode`. It also relies on the distinction documented in `flashinfer/autotuner/autotuner.py`: `is_tuning_mode` covers the final invocation after `choose_one`, while `is_in_profile_measurement` covers only an individual tactic's measurement window.

## 🔍 Related Issues

Downstream integration: https://github.com/sgl-project/sglang/pull/28354

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Focused CuTe DSL MoE contract and GPU autotune coverage on B200:

```bash
FLASHINFER_DISABLE_VERSION_CHECK=1 \
FLASHINFER_CUDA_ARCH_LIST=10.0a \
CUDA_VISIBLE_DEVICES=0 \
FLASHINFER_NVFP4_4OVER6=1 \
FLASHINFER_NVFP4_4OVER6_E4M3_USE_256=1 \
FLASHINFER_NVFP4_4OVER6_ERR_MODE=MSE \
FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH=1 \
python3 -m pytest -v -s \
  tests/moe/test_cute_dsl_fused_moe.py::TestAutotuneReplayMemsetContract \
  tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslFusedMoeFunctional::test_with_autotune \
  tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoEWrapper::test_wrapper_with_autotune
```

Result: `7 passed`.

The downstream 4-GPU Nemotron NVFP4-online + EAGLE startup was also validated with cold target and draft MoE autotune caches, fused finalize left at its default, and CUDA graphs enabled. All ranks completed FlashInfer autotuning, target verification graph capture, draft decode/extend graph capture, and a health generation request.

## Reviewer Notes

- This changes no public API or kernel implementation. It reuses `_moe_core_impl`'s existing `use_async_memset` control.
- Only the post-selection replay within `autotune(True)` becomes single-stream. Timed tactic measurements still profile the production async path.
- Explicit-tactic dispatch remains unchanged.
- No collective or all-reduce behavior is changed by this PR; that path was not required for the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved MoE auto-tuning behavior by disabling asynchronous memory clearing during timing runs.
  * Asynchronous memory clearing remains enabled during normal execution of the selected tactic.

* **Tests**
  * Added coverage for both functional and wrapper APIs across tuning and normal execution modes.
  * Verified output shape and memory-clearing behavior during tactic replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->