### PR TITLE
fix(comm): make TorchDistBackend.Split() synchronizing, and report every rank's fate on comm-test failure

### DIFF
--- a/flashinfer/comm/comm_backend.py
+++ b/flashinfer/comm/comm_backend.py
@@ -179,4 +179,14 @@ class TorchDistBackend:
         cur_group, _ = self._dist.new_subgroups_by_enumeration(
             _split_partition(all_info)
         )  # pyright: ignore
+        # new_group() does not synchronize the ranks by default (torch only runs
+        # its post-init store barrier when TORCH_DIST_INIT_BARRIER=1), so a rank
+        # can return from a sub-group rendezvous while a peer is still inside it.
+        # With gloo the rendezvous is eager: the peer that is still connecting
+        # then sees "connectFullMesh failed ... Connection closed by peer" as soon
+        # as the rank that raced ahead tears its process group down or exits.
+        # Barrier on the parent group so Split() is collective *and* synchronizing,
+        # matching MPI_Comm_split (and MPIBackend.Split) semantics. Split happens
+        # once at setup, so the cost is irrelevant.
+        self.barrier()
         return TorchDistBackend(group=cur_group)  # pyright: ignore

--- a/tests/comm/test_comm_backend.py
+++ b/tests/comm/test_comm_backend.py
@@ -22,8 +22,10 @@ logic is unit-tested against an injected fake mpi4py communicator.
 import importlib.util
 import multiprocessing as mp
 import os
+import queue
 import shutil
 import tempfile
+import time
 from typing import Any
 
 import pytest
@@ -63,6 +65,9 @@ def _backend_checks(rank: int) -> dict[str, Any]:
     res["sub_type"] = type(sub).__name__
     res["sub_rank"] = sub.Get_rank()
     res["sub_size"] = sub.Get_size()
+    # Collectives must work on the sub-group, not just report the right shape.
+    sub.barrier()
+    res["sub_allgather"] = sub.allgather(rank)
     return res
 
 
@@ -96,14 +101,28 @@ def _run_dist(world_size: int) -> dict[int, dict[str, Any]]:
     try:
         for p in procs:
             p.start()
+        # Drain the queue *before* join: a worker blocks on exit until its queue
+        # feeder thread has flushed, so join-then-read can deadlock. q.empty() is
+        # also unreliable, hence counting results instead of polling it.
+        results: dict[int, dict[str, Any]] = {}
+        deadline = time.monotonic() + _TIMEOUT_S
+        while len(results) < world_size:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                rank, res = q.get(timeout=min(remaining, 1.0))
+            except queue.Empty:
+                # Nothing more is coming once every worker is gone; fall through
+                # to the exitcode assert below, which gives the better message.
+                if all(p.exitcode is not None for p in procs):
+                    break
+                continue
+            results[rank] = res
         for p in procs:
-            p.join(timeout=_TIMEOUT_S)
+            p.join(timeout=max(0.0, deadline - time.monotonic()))
         for p in procs:
             assert p.exitcode == 0, f"worker pid={p.pid} exited with {p.exitcode}"
-        results: dict[int, dict[str, Any]] = {}
-        while not q.empty():
-            rank, res = q.get()
-            results[rank] = res
         assert len(results) == world_size, (
             f"expected {world_size} results, got {sorted(results)}"
         )
@@ -137,6 +156,8 @@ def test_torch_dist_backend_collectives(world_size: int) -> None:
         assert res["sub_type"] == "TorchDistBackend"
         assert res["sub_size"] == len(peers)
         assert res["sub_rank"] == peers.index(rank)
+        # Collectives on the sub-group see only the same-parity ranks.
+        assert res["sub_allgather"] == tuple(peers)
 
 
 class _FakeGroup:
@@ -154,6 +175,7 @@ class _FakeDist:
         self._world = world_size
         self._all_info = all_info
         self.created: list[tuple[int, ...]] = []  # sub-groups created, in order
+        self.barriers: list[Any] = []  # groups barriered on, in order
 
     def get_rank(self, group: Any = None) -> int:
         return self._rank if group is None else group.ranks.index(self._rank)
@@ -177,6 +199,9 @@ class _FakeDist:
         self.created.extend(g.ranks for g in subs)
         cur = next((g for g in subs if self._rank in g.ranks), None)
         return cur, subs
+
+    def barrier(self, group: Any = None) -> None:
+        self.barriers.append(group)
 
     def new_group(self, ranks: list[int]) -> Any:
         # Unused by the fixed Split, but recorded so a regression to the buggy
@@ -222,6 +247,10 @@ def test_torch_dist_backend_split_creates_every_subgroup_on_every_rank(
         assert fake.created == expected, f"rank {rank}: {fake.created}"
         # ...and gets back a backend scoped to its own color's sub-group.
         assert sub._group.ranks == expected[rank % 2]  # pyright: ignore[reportPrivateUsage, reportOptionalMemberAccess]
+        # Split must synchronize on the *parent* group before returning, or a
+        # rank can race ahead and tear down while a peer is still inside the
+        # sub-group rendezvous (gloo then fails connectFullMesh -- see #4193).
+        assert fake.barriers == [None], f"rank {rank}: {fake.barriers}"
 
 
 def test_split_partition_covers_all_colors_ordered_by_key() -> None:

--- a/tests/comm/test_comm_backend.py
+++ b/tests/comm/test_comm_backend.py
@@ -24,6 +24,7 @@ import multiprocessing as mp
 import os
 import queue
 import shutil
+import signal
 import tempfile
 import time
 from typing import Any
@@ -38,6 +39,9 @@ from flashinfer.comm.comm_backend import (
 )
 
 _TIMEOUT_S = 120.0
+# Per-rank output kept in a failure message; enough for a gloo/c10d error plus
+# the traceback that follows it, without burying the report.
+_LOG_TAIL_LINES = 40
 
 
 def _backend_checks(rank: int) -> dict[str, Any]:
@@ -71,7 +75,20 @@ def _backend_checks(rank: int) -> dict[str, Any]:
     return res
 
 
-def _dist_entry(rank: int, world_size: int, store_path: str, q: Any) -> None:
+def _dist_entry(
+    rank: int, world_size: int, store_path: str, q: Any, log_dir: str
+) -> None:
+    # Give this worker its own stdout/stderr file, redirected at the *fd* level:
+    # gloo and c10d log from C++ straight to fd 2, so a Python-level redirect
+    # would miss exactly the messages worth having, and N workers sharing the
+    # parent's stderr interleave into something unattributable. Per-rank files
+    # are what let the parent report which rank died first, and why (#4193).
+    fd = os.open(
+        os.path.join(log_dir, f"rank{rank}.log"), os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    )
+    os.dup2(fd, 1)
+    os.dup2(fd, 2)
+    os.close(fd)
     # Pin gloo to loopback; otherwise it may pick a real NIC and fail to connect
     # the full mesh between local processes.
     os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
@@ -87,6 +104,49 @@ def _dist_entry(rank: int, world_size: int, store_path: str, q: Any) -> None:
         dist.destroy_process_group()
 
 
+def _describe_exit(code: int | None) -> str:
+    """Human-readable worker status, naming the signal when one killed it."""
+    if code is None:
+        return "STILL RUNNING (timed out)"
+    if code == 0:
+        return "exited 0"
+    if code < 0:
+        try:
+            return f"KILLED by {signal.Signals(-code).name}"
+        except ValueError:
+            return f"KILLED by signal {-code}"
+    return f"exited {code}"
+
+
+def _worker_report(
+    procs: list[Any],
+    codes: list[int | None],
+    log_dir: str,
+    results: dict[int, dict[str, Any]],
+) -> str:
+    """Per-rank status and captured output, for the assertion messages.
+
+    A worker that dies takes the interesting evidence with it: a signal kill
+    prints no traceback at all, and the old "assert on the first bad exitcode"
+    stopped before it ever looked at the later ranks. So report *every* rank --
+    status, whether it produced a result, and its captured output -- rather than
+    only the first one that tripped the assert.
+    """
+    lines: list[str] = []
+    for rank, (p, code) in enumerate(zip(procs, codes, strict=True)):
+        got = "result received" if rank in results else "NO RESULT"
+        lines.append(f"  rank {rank} (pid {p.pid}): {_describe_exit(code)}, {got}")
+        if code == 0 and rank in results:
+            continue  # healthy rank, its output is noise
+        try:
+            with open(os.path.join(log_dir, f"rank{rank}.log")) as f:
+                tail = f.read().strip().splitlines()[-_LOG_TAIL_LINES:]
+        except OSError as err:  # pragma: no cover - only on a broken worker
+            tail = [f"<could not read rank {rank} log: {err}>"]
+        lines.extend(f"    | {line}" for line in tail or ["<no output>"])
+    return "\n".join(lines)
+
+
 def _run_dist(world_size: int) -> dict[int, dict[str, Any]]:
     # spawn (not fork/forkserver): starts fresh interpreters, so it stays safe
     # even if an MPI test in the same session has already called MPI_Init.
@@ -95,7 +155,7 @@ def _run_dist(world_size: int) -> dict[int, dict[str, Any]]:
     store_path = os.path.join(tmpdir, "store")
     q = ctx.Queue()
     procs = [
-        ctx.Process(target=_dist_entry, args=(r, world_size, store_path, q))
+        ctx.Process(target=_dist_entry, args=(r, world_size, store_path, q, tmpdir))
         for r in range(world_size)
     ]
     try:
@@ -121,11 +181,26 @@ def _run_dist(world_size: int) -> dict[int, dict[str, Any]]:
             results[rank] = res
         for p in procs:
             p.join(timeout=max(0.0, deadline - time.monotonic()))
+        # Snapshot the exit codes *before* cleaning up, so the report describes
+        # how each worker actually ended rather than how we ended it.
+        codes = [p.exitcode for p in procs]
+        # A worker that lost a peer sits in a collective until gloo's own
+        # timeout (30 min by default), which would turn a failure into a CI
+        # hang. Bound it: past the deadline, the survivors get killed and are
+        # reported as timed out.
         for p in procs:
-            assert p.exitcode == 0, f"worker pid={p.pid} exited with {p.exitcode}"
-        assert len(results) == world_size, (
-            f"expected {world_size} results, got {sorted(results)}"
-        )
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=5)
+        # Build the report before asserting: the finally below deletes the
+        # directory holding the per-rank logs.
+        bad = [r for r, c in enumerate(codes) if c != 0]
+        if bad or len(results) != world_size:
+            report = _worker_report(procs, codes, tmpdir, results)
+            assert not bad, f"workers {bad} did not exit cleanly:\n{report}"
+            raise AssertionError(
+                f"expected {world_size} results, got {sorted(results)}:\n{report}"
+            )
         return results
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`tests/comm/test_comm_backend.py::test_torch_dist_backend_collectives[4]` failed once on the public H100 CI, and while investigating #4193 I found a genuine synchronization gap in `TorchDistBackend.Split()`. This PR closes that gap. It is **hardening prompted by** #4193, not a demonstrated fix for it — see Reviewer Notes before reading it as a resolution.

The observed CI failure was:

```
[rank2] Gloo connectFullMesh failed with [.../transport/tcp/pair.cc:547] Connection closed by peer [127.0.0.1]:18085
  ... TorchDistBackend.Split -> new_subgroups_by_enumeration -> ProcessGroupGloo(...)
```

**The gap.** Two facts combine into a real race window in `TorchDistBackend.Split`:

1. **`new_group()` does not synchronize ranks.** Its post-init store barrier only runs when `TORCH_DIST_INIT_BARRIER=1`, and that env var defaults to `0` (`_is_barrier_after_init` in torch's `distributed_c10d.py`). A rank therefore returns from `new_subgroups_by_enumeration()` as soon as *its own* side of the rendezvous is done.
2. **The gloo pair handshake is asymmetric.** Per `gloo/transport/tcp/pair.cc`: "one side takes a passive role and the other side takes an active role". The active side connects, writes a sequence number and returns; the passive side must still accept and *read* that sequence number.

Applied to the observed failure, that *would* look like this — presented as a hypothesis, since I could not reproduce it. With `world_size=4` and `color = rank % 2` the partition is `[[0, 2], [1, 3]]`. Rank 0 finished its half of sub-group `[0, 2]`, returned from `Split()`, published its result, called `destroy_process_group()` and exited — while rank 2 was still completing the mesh. Rank 2 then read EOF on the socket, which gloo reports as `Connection closed by peer`. Rank 0 exited `0` and only rank 2 died, which matches the CI log exactly (only `SpawnProcess-5` / `[rank2]` failed).

This is not confined to the test: `MnnvlMemory.set_comm_from_config()` in `flashinfer/comm/mnnvl.py` calls `Split()` the same way, so any caller doing rank-dependent work or tearing down right after a split is exposed.

**Fix.** Barrier on the **parent** group at the end of `TorchDistBackend.Split()`, making `Split()` collective *and* synchronizing — matching `MPI_Comm_split` (and `MPIBackend.Split`) semantics. No rank can leave `Split()` until every peer has finished its sub-group rendezvous. `Split()` runs once at setup, so the cost is irrelevant.

### Second change: make the next failure diagnosable

Independent of the barrier, and arguably the more useful half. When this test fails, the evidence that matters is the **first** death — and the harness was discarding it:

- `for p in procs: assert p.exitcode == 0` stopped at the first bad rank, so later ranks were never inspected. In the #4193 log we learned rank 2 raised and never found out what rank 3 did.
- A worker killed by a signal prints **no traceback at all**, so an OOM-kill or a runner shutdown was indistinguishable from a clean failure — it just surfaced as a peer that could not be reached.
- All workers shared the parent's stderr, so gloo/c10d output from N ranks interleaved into something unattributable.

Now each worker gets its own stdout/stderr file, redirected at the **fd** level so C++-side gloo and c10d logging is captured too, and every rank is reported on failure: status, whether it produced a result, and its output. Signal deaths are named, which separates an infra kill from a test failure at a glance:

```
AssertionError: workers [0, 1, 2, 3] did not exit cleanly:
  rank 0 (pid 68390): STILL RUNNING (timed out), NO RESULT
  rank 1 (pid 68391): KILLED by SIGKILL, NO RESULT
  rank 2 (pid 68392): STILL RUNNING (timed out), NO RESULT
  rank 3 (pid 68393): STILL RUNNING (timed out), NO RESULT
```

The failure is also bounded now: a worker that loses a peer blocks in a collective until gloo's own 30-minute timeout, turning a failure into a CI hang. Past the deadline survivors are killed and reported as timed out, with exit codes snapshotted first so the report says how each worker actually ended rather than how we ended it.

Verified by fault injection — one rank raising, and one rank `SIGKILL`ing itself — the report names the culprit with its traceback and marks the rest as victims, in 16s instead of hanging.

**Happy to split this into its own PR** if you'd rather it land independently of the barrier, which is the contested part. It touches the same function, so I kept them together to avoid a merge conflict rather than out of any conviction that they belong in one review.

## 🔍 Related Issues

Related to #4193 — but this PR **does not claim to fix it**, and deliberately does not use a closing keyword. See Reviewer Notes: the failure was never reproduced, and #4193 should stay open (and keep its `infra` label) independently of whether this merges.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/comm/test_comm_backend.py`: 9 passed, 1 skipped (mpi4py not installed).

I then tried hard to reproduce the failure on Linux/x86_64 with CPU-only gloo — the **tcp** transport, same as CI — on torch 2.11. Every pre-fix configuration below is green:

| build | scenario | runs | failures |
|---|---|---|---|
| pre-fix | pytest, idle host | 60 | 0 |
| pre-fix | pytest, 6-way concurrent, pinned to 2 CPUs | 72 | 0 |
| pre-fix | hard-exit stress, sub-groups of 2 / 4 / 8 ranks | 90 | 0 |
| pre-fix | hard-exit stress, 16 ranks timesharing 1 CPU | 20 | 0 |
| **pre-fix total** | | **242** | **0** |
| post-fix | pytest, idle host | 60 | 0 |

The "hard-exit stress" harness was written specifically to trigger the hypothesized mechanism: every rank calls `os._exit(0)` the instant `Split()` returns — no `destroy_process_group()`, sockets closed abruptly — and the sub-group is scaled up so the rendezvous has many more pairs and a wider spread between the first and last rank to finish. It did not reproduce.

## Reviewer Notes

**I could not reproduce the failure in 242 pre-fix runs, and I want that stated up front rather than buried.** Worse for my own hypothesis: the harness built specifically to trigger it (immediate `os._exit` after `Split()`, enlarged mesh, single-CPU starvation) is also green. That is evidence *against* the specific causal story, not for it. The chain is *inferred from the pytorch and gloo sources*, not demonstrated. Treat this PR as closing a synchronization gap that is provably there, rather than as a confirmed fix for #4193.

By the rule of three, 0 failures in 242 runs puts the 95% upper bound on the per-run failure rate at ~1.2%, and 1% is already in mild tension with the data — so the true rate is likely well under 1%. That has a direct consequence for review: **a green CI run on this PR is not evidence the fix works.** At p ≈ 1% a single run passes with ~99% probability even with the bug fully present; catching it with 95% confidence would take roughly 300 runs. Please don't read a green pipeline as validation here.

What **is** certain, independent of the repro: `new_group()` performs no cross-rank synchronization by default, so `Split()` today can return on one rank while a peer is still inside the sub-group rendezvous. That gap is real whether or not it is what bit CI on build 8864.

Note also that this is **not a regression** — `git log --follow` shows the current `Split()` implementation and its multi-process gloo test both landed together in 6104afe3 / #3701 on 2026-07-22, five days before the failure. There was no prior CI coverage that created gloo sub-groups, so nothing "started failing"; a new intermittent test started running. That is also why the gated per-PR check did not block it: a required check blocks deterministic failures, and #3701's own run was green.

Worth a reviewer's eye: the added barrier is on the parent group (`self._group`), which every rank reaches because `Split()` is already collective on that group (it starts with an `allgather`) — so it cannot deadlock, including when splitting an existing sub-group. It also adds no new device requirement beyond what the existing `all_gather_object` in `Split()` already imposes.

AI-assisted (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed subgroup splitting so all processes synchronize before the operation completes, preventing race conditions during setup and teardown.

* **Tests**
  * Expanded coverage for subgroup synchronization and collective operations.
  * Improved distributed test diagnostics, including per-process logs and clearer failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->