### PR TITLE
fix: align module-status table headers

### DIFF
--- a/flashinfer/__main__.py
+++ b/flashinfer/__main__.py
@@ -291,7 +291,7 @@ def module_status_cmd(detailed, filter):
                 ]
             )
 
-        headers = ["Module Name", "Type", "Status", "Sources", "Device Linking"]
+        headers = ["Module Name", "Status", "Sources", "Device Linking"]
         click.echo(tabulate(table_data, headers=headers, tablefmt="github"))
 
     # Show summary statistics

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -13,6 +13,8 @@ Note: The `replay` command is tested in tests/utils/test_logging_replay.py along
 the other logging/replay functionality tests, since it's tightly coupled with that feature.
 """
 
+from types import SimpleNamespace
+
 from .cli_cmd_helpers import (
     _test_cmd_helper,
     _assert_output_contains_all,
@@ -206,6 +208,30 @@ def test_clear_cubin_cmd_real(monkeypatch, tmp_path):
 
     # Verify the cubin directory has been removed
     assert not temp_cubin_dir.exists()
+
+
+def test_module_status_cmd_mocked(monkeypatch):
+    status = SimpleNamespace(
+        name="module_a",
+        status="Compiled",
+        is_compiled=True,
+        sources=["kernel_a.cu", "kernel_b.cu"],
+        needs_device_linking=False,
+    )
+    monkeypatch.setattr(
+        "flashinfer.__main__._ensure_modules_registered", lambda: [status]
+    )
+    monkeypatch.setattr(
+        "flashinfer.__main__.jit_spec_registry.get_stats",
+        lambda: {"total": 1, "compiled": 1, "not_compiled": 0},
+    )
+
+    out = _test_cmd_helper(["module-status"])
+
+    header = next(line for line in out.splitlines() if "Module Name" in line)
+    _assert_output_contains_all(header, "Status", "Sources", "Device Linking")
+    assert "Type" not in header
+    _assert_output_contains_all(out, "module_a", "Compiled", "2", "No")
 
 
 class MockJitSpec:


### PR DESCRIPTION
## 📌 Description

Fix the non-detailed `flashinfer module-status` table so its headers match the four values in each row. The previous five-column header included a `Type` field that the command never populated, causing `tabulate` to shift the remaining labels and omit `Device Linking`.

Add a mocked CLI regression test that checks the header and row alignment without compiling a JIT module or requiring a GPU.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Verification performed locally:

- Compiled the changed Python files with `python -m compileall`.
- Reproduced the table rendering with `tabulate==0.10.0` and asserted the four headers and values align.
- Ran `git diff --check` and verified the patch applies cleanly.

The repository test suite and pre-commit hooks were not run because this minimal environment intentionally did not install PyTorch, CUDA, or the full development dependency set.

## Reviewer Notes

The change and test were prepared with AI assistance and manually inspected. The mocked test follows the existing CLI test style and avoids touching JIT caches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the `module-status` table so its column headers accurately match the displayed module information.
  * Removed the misleading `Type` column from the standard status view.

* **Tests**
  * Added coverage to verify module status headers, statuses, sources, and device-linking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->