### PR TITLE
fix(xqa): fix PDL load ordering and SM90 fp8 draft-mask dispatch

### DIFF
--- a/csrc/xqa/mha.cu
+++ b/csrc/xqa/mha.cu
@@ -1579,8 +1579,6 @@ CUBIN_EXPORT __global__
 #endif
         uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
 
-  float const qScaleValue = qScalePtr != nullptr ? qScalePtr[0] : qScale;
-  float const kvCacheScaleValue = kvScalePtr != nullptr ? kvScalePtr[0] : kvCacheScale;
   assert(allowMultiBlockMode || gridDim.x == 1);
   bool const isMultiBlock = allowMultiBlockMode && (gridDim.x != 1);
   uint32_t const nbSubSeqPerSeq = allowMultiBlockMode ? gridDim.x : 1;
@@ -1594,37 +1592,7 @@ CUBIN_EXPORT __global__
   SharedMem& smem = *reinterpret_cast<SharedMem*>(&smemByteBuf[0]);
 
   uint32_t const idxReq = blockIdx.z;
-#if SPEC_DEC
-  // Variable query sequence length support.
-  bool const variableQSeqLen = qCuSeqLens != nullptr;
-  uint32_t const actualQSeqLen =
-      variableQSeqLen ? uint32_t(qCuSeqLens[idxReq + 1] - qCuSeqLens[idxReq]) : qSeqLen;
-  // Same as idxReq * qSeqLen if all sequences all the same.
-  // Take different beams as different requests/sequences currently.
-  uint32_t const reqSeqOffset = variableQSeqLen ? uint32_t(qCuSeqLens[idxReq]) : (qSeqLen * idxReq);
-  // A ragged request may have 0 draft tokens (all rejected). It owns no rows
-  // and min(row, actualQSeqLen - 1) would underflow, so exit before any
-  // barrier/semaphore interaction (uniform across the request's CTAs).
-  if (variableQSeqLen && actualQSeqLen == 0) {
-    return;
-  }
-
-  uint32_t const nbVHeads = nbKHeads;
-  uint32_t const nbQHeads = nbKHeads * headGrpSize;
-  uint32_t const nbQHeadTokens = nbQHeads * actualQSeqLen;
-  uint32_t const nbQKVHeads = nbQHeads + nbKHeads + nbVHeads;
-
-  uint32_t const nbTokenBlocksPerGrp = gridDim.y / nbKHeads;
-  uint32_t const idxHeadGrp = blockIdx.y / nbTokenBlocksPerGrp;  // inside one request
-  uint32_t const idxHeadTokenInGrp = (blockIdx.y % nbTokenBlocksPerGrp) * warpTile.y;
-  uint32_t const totalNbHeadTokensInGrp = actualQSeqLen * headGrpSize;
-  uint32_t const nbValidHeadTokens =
-      idxHeadTokenInGrp > totalNbHeadTokensInGrp
-          ? 0u
-          : mha::min(totalNbHeadTokensInGrp - idxHeadTokenInGrp, rowsPerBlock);
-  // Shift the mask ptr by batch_idx.
-  mask += reqSeqOffset * divUp(qSeqLen, 32u);
-#else
+#if !SPEC_DEC
   uint32_t const nbQHeads = nbKHeads * headGrpSize;
 
   uint32_t const idxHeadGrp = blockIdx.y;  // inside one request
@@ -1685,6 +1653,41 @@ CUBIN_EXPORT __global__
 #if ENABLE_PDL
   preExit();
   acqBulk();
+#endif
+
+  // The scale tensors and qCuSeqLens may be written by the previous grid;
+  // do not read them before acqBulk().
+  float const qScaleValue = qScalePtr != nullptr ? qScalePtr[0] : qScale;
+  float const kvCacheScaleValue = kvScalePtr != nullptr ? kvScalePtr[0] : kvCacheScale;
+
+#if SPEC_DEC
+  bool const variableQSeqLen = qCuSeqLens != nullptr;
+  uint32_t const actualQSeqLen =
+      variableQSeqLen ? uint32_t(qCuSeqLens[idxReq + 1] - qCuSeqLens[idxReq]) : qSeqLen;
+  // Same as idxReq * qSeqLen if all sequences all the same.
+  // Take different beams as different requests/sequences currently.
+  uint32_t const reqSeqOffset = variableQSeqLen ? uint32_t(qCuSeqLens[idxReq]) : (qSeqLen * idxReq);
+  // A request whose drafts were all rejected has 0 tokens and owns no rows.
+  // The exit is uniform across the request's CTAs.
+  if (variableQSeqLen && actualQSeqLen == 0) {
+    return;
+  }
+
+  uint32_t const nbVHeads = nbKHeads;
+  uint32_t const nbQHeads = nbKHeads * headGrpSize;
+  uint32_t const nbQHeadTokens = nbQHeads * actualQSeqLen;
+  uint32_t const nbQKVHeads = nbQHeads + nbKHeads + nbVHeads;
+
+  uint32_t const nbTokenBlocksPerGrp = gridDim.y / nbKHeads;
+  uint32_t const idxHeadGrp = blockIdx.y / nbTokenBlocksPerGrp;  // inside one request
+  uint32_t const idxHeadTokenInGrp = (blockIdx.y % nbTokenBlocksPerGrp) * warpTile.y;
+  uint32_t const totalNbHeadTokensInGrp = actualQSeqLen * headGrpSize;
+  uint32_t const nbValidHeadTokens =
+      idxHeadTokenInGrp > totalNbHeadTokensInGrp
+          ? 0u
+          : mha::min(totalNbHeadTokensInGrp - idxHeadTokenInGrp, rowsPerBlock);
+  // Shift the mask ptr by batch_idx.
+  mask += reqSeqOffset * divUp(qSeqLen, 32u);
 #endif
 
   constexpr bool qkSwizzle = true;

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3575,6 +3575,9 @@ def xqa_batch_decode_with_kv_cache(
     window_left : int = -1
         The left (inclusive) window size for the attention window, when set to ``-1``, the window
         size will be set to the full length of the sequence. Defaults to ``-1``.
+        On SM90 with fp8 KV cache, speculative decode with a non-negative window
+        runs on the generic kernel instead of the Hopper fp8 kernel (see
+        :func:`flashinfer.xqa.xqa`).
 
     out :  Optional[torch.Tensor] = None
         output tensor, if not provided, will be allocated with ``query.dtype``.

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3608,7 +3608,9 @@ def xqa_batch_decode_with_kv_cache(
         ragged Q: requests may have different draft lengths. When given,
         query/out stay packed as [total_q_tokens, num_heads, head_dim],
         q_len_per_req must be the maximum draft length, and mask rows are
-        packed by the same cumulative offsets.
+        packed by the same cumulative offsets. On SM90 with fp8 KV cache,
+        speculative decode runs on the generic kernel instead of the Hopper
+        fp8 kernel (see :func:`flashinfer.xqa.xqa`).
 
     Returns
     -------

--- a/flashinfer/jit/xqa.py
+++ b/flashinfer/jit/xqa.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
+
 from . import env as jit_env
 import torch
 from .utils import filename_safe_dtype_map
@@ -29,6 +31,23 @@ xqa_nvcc_flags = [
     "-DUSE_INPUT_KV=0",
     "-DUSE_CUSTOM_BARRIER=1",
 ]
+
+
+def swap_ab_eligible(q_seq_len: int, head_group_ratio: int) -> bool:
+    """True when the shape fits the SM90 kernel's SPEC_Q_SEQ_LEN (SWAP_AB)
+    specialization."""
+    return q_seq_len * head_group_ratio <= 32
+
+
+@functools.cache
+def _has_sm90_target() -> bool:
+    return any(major == 9 for major, _ in CompilationContext().TARGET_CUDA_ARCHS)
+
+
+def ragged_q_changes_build(q_seq_len: int, head_group_ratio: int) -> bool:
+    """True when ragged Q changes the build: it suppresses SPEC_Q_SEQ_LEN
+    (SWAP_AB), which only the SM90 kernel uses."""
+    return swap_ab_eligible(q_seq_len, head_group_ratio) and _has_sm90_target()
 
 
 def gen_xqa_module(
@@ -88,7 +107,10 @@ def gen_xqa_module(
         use_spec_dec = True
         # The SPEC_Q_SEQ_LEN (SWAP_AB) specialization requires a uniform q
         # length across the batch, so it must be skipped for ragged Q.
-        if q_seq_len * head_group_ratio <= 32 and not use_ragged_q:
+        ragged_changes_flags = use_ragged_q and ragged_q_changes_build(
+            q_seq_len, head_group_ratio
+        )
+        if swap_ab_eligible(q_seq_len, head_group_ratio) and not ragged_changes_flags:
             flag_spec_dec = ["-DSPEC_DEC=1", f"-DSPEC_Q_SEQ_LEN={q_seq_len}"]
         else:
             flag_spec_dec = ["-DSPEC_DEC=1"]
@@ -100,6 +122,7 @@ def gen_xqa_module(
             raise ValueError("use_ragged_q requires q_seq_len > 1 (speculative decode)")
         flag_spec_dec = ["-DSPEC_DEC=0"]
         use_spec_dec = False
+        ragged_changes_flags = False
 
     compilation_context = CompilationContext()
     nvcc_flags = compilation_context.get_nvcc_flags_list(
@@ -115,10 +138,7 @@ def gen_xqa_module(
         jit_env.FLASHINFER_CSRC_DIR / "flashinfer_xqa_binding.cu",
     ]
 
-    target_archs = compilation_context.TARGET_CUDA_ARCHS
-
-    has_sm90 = any(major == 9 for major, minor in target_archs)
-    if has_sm90:
+    if _has_sm90_target():
         sources.append(jit_env.FLASHINFER_CSRC_DIR / "xqa/mha_sm90.cu")
         sources.append(jit_env.FLASHINFER_CSRC_DIR / "xqa/tensorMap.cpp")
         flag_sm90_mha = ["-DUSE_SM90_MHA=1"]
@@ -127,7 +147,6 @@ def gen_xqa_module(
 
     # Suffix the URI only when ragged Q actually changes the compile flags
     # (i.e. it suppressed the SPEC_Q_SEQ_LEN specialization above).
-    ragged_changes_flags = use_ragged_q and q_seq_len * head_group_ratio <= 32
     ragged_suffix = "_ragged_q" if ragged_changes_flags else ""
     return gen_jit_spec(
         f"xqa_input_{filename_safe_dtype_map[input_dtype]}_kv_cache_{filename_safe_dtype_map[kv_cache_dtype]}_output_{filename_safe_dtype_map[output_dtype]}_page_size_{page_size}_head_dim_{head_dim}_head_group_ratio_{head_group_ratio}_use_sliding_window_{use_sliding_window}_use_spec_dec_{use_spec_dec}_spec_q_seq_len_{q_seq_len}{ragged_suffix}",

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -2770,16 +2770,6 @@ xqa_batch_decode_trace = TraceTemplate(
         "bmm2_scale": Scalar(
             "float32", optional=True, description="Scale applied after softmax @ V."
         ),
-        "q_cu_seq_lens": Tensor(
-            ["len_indptr"],
-            dtype="int32",
-            optional=True,
-            description=(
-                "Cumulative per-request draft lengths [batch_size + 1] for "
-                "ragged speculative decode; query stays packed as "
-                "[num_tokens, num_heads, head_dim]."
-            ),
-        ),
     },
     outputs={
         "output": Tensor(["num_tokens", "num_heads", "head_dim"], dtype_from="query"),

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -21,7 +21,12 @@ import torch
 
 from .api_logging import flashinfer_api
 from .trace.templates.page import xqa_mla_trace, xqa_trace
-from .jit.xqa import gen_xqa_module, gen_xqa_module_mla
+from .jit.xqa import (
+    gen_xqa_module,
+    gen_xqa_module_mla,
+    ragged_q_changes_build,
+    swap_ab_eligible,
+)
 from .jit.utils import filename_safe_dtype_map
 from .utils import (
     get_device_sm_count,
@@ -32,7 +37,6 @@ from .utils import (
 )
 
 
-@functools.cache
 def get_xqa_module(
     input_dtype: torch.dtype,
     kv_cache_dtype: torch.dtype,
@@ -43,6 +47,34 @@ def get_xqa_module(
     output_dtype: torch.dtype,
     q_seq_len: int,
     use_ragged_q: bool = False,
+):
+    # Ragged Q must reuse the uniform module unless it changes the compile
+    # flags; a second cache entry would re-register the same torch op.
+    use_ragged_q = use_ragged_q and ragged_q_changes_build(q_seq_len, head_group_ratio)
+    return _get_xqa_module_cached(
+        input_dtype,
+        kv_cache_dtype,
+        page_size,
+        head_dim,
+        head_group_ratio,
+        use_sliding_window,
+        output_dtype,
+        q_seq_len,
+        use_ragged_q,
+    )
+
+
+@functools.cache
+def _get_xqa_module_cached(
+    input_dtype: torch.dtype,
+    kv_cache_dtype: torch.dtype,
+    page_size: int,
+    head_dim: int,
+    head_group_ratio: int,
+    use_sliding_window: bool,
+    output_dtype: torch.dtype,
+    q_seq_len: int,
+    use_ragged_q: bool,
 ):
     spec = gen_xqa_module(
         input_dtype,
@@ -237,8 +269,6 @@ def xqa(
         per draft row, assuming draft tokens occupy consecutive positions at
         the end of the sequence (linear chains, causal or full masks);
         tree-structured drafts are not supported with sliding window.
-        On SM90 with fp8 KV cache, speculative decode with a sliding window
-        runs on the generic kernel rather than the Hopper fp8 kernel.
     kv_layout : str, default="NHD"
         The layout of the KV cache. Can be either ``NHD`` or ``HND``.
     sm_count : Optional[int], default=None
@@ -267,11 +297,15 @@ def xqa(
         tokens this step. When set, ``q`` and ``output`` are packed as
         ``[total_q_tokens, num_q_heads, head_dim]``, ``q_seq_len`` must be
         the maximum draft length, and ``mask`` rows are packed by the same
-        cumulative offsets. On SM90 with fp8 KV cache, ragged Q runs on the
-        generic kernel rather than the Hopper fp8 kernel.
+        cumulative offsets.
 
     Note
     ----
+    On SM90 with fp8 KV cache, speculative decode runs on the generic kernel
+    instead of the Hopper fp8 kernel when any of these holds: ragged Q,
+    a positive ``sliding_win_size`` (even one larger than every sequence),
+    or ``q_seq_len * (num_q_heads // num_kv_heads) <= 32``.
+
     The function automatically infers several parameters from tensor shapes:
     - batch_size from q.shape[0] (or seq_lens.shape[0] with ragged Q)
     - num_q_heads from q.shape[-2]
@@ -367,10 +401,6 @@ def xqa(
     if get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12]:
         raise RuntimeError("XQA is only supported on SM90, SM100, SM120/SM121 GPUs")
 
-    # Ragged Q only changes the build when it suppresses the SPEC_Q_SEQ_LEN
-    # specialization; otherwise reuse the uniform module (a separate cache
-    # entry would re-register the same torch op name and fail).
-    ragged_build = use_ragged_q and q_seq_len * head_group_ratio <= 32
     xqa_module = get_xqa_module(
         q.dtype,
         k_cache.dtype,
@@ -380,16 +410,21 @@ def xqa(
         use_sliding_window,
         output.dtype,
         q_seq_len,
-        ragged_build,
+        use_ragged_q,
     )
 
     if q_seq_len > 1:
         assert mask is not None, "Mask is required for speculative decoding"
         if sinks is not None:
             run_sm90_fp8_mha = False  # TODO: mha_sm90.cu has precision issue if sinks and speculative decoding are used simultaneously
-        if use_ragged_q or use_sliding_window:
-            # mha_sm90.cu rejects ragged Q, and its spec-dec sliding-window
-            # path mis-masks full draft masks; use the generic kernel.
+        if (
+            use_ragged_q
+            or use_sliding_window
+            or swap_ab_eligible(q_seq_len, head_group_ratio)
+        ):
+            # mha_sm90.cu rejects ragged Q and gets full draft masks wrong,
+            # both under sliding windows and in SWAP_AB. Causal masks can't
+            # be exempted without inspecting the device-side mask.
             run_sm90_fp8_mha = False
 
     xqa_module.xqa(

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -303,8 +303,8 @@ def xqa(
     ----
     On SM90 with fp8 KV cache, speculative decode runs on the generic kernel
     instead of the Hopper fp8 kernel when any of these holds: ragged Q,
-    a positive ``sliding_win_size`` (even one larger than every sequence),
-    or ``q_seq_len * (num_q_heads // num_kv_heads) <= 32``.
+    attention sinks, a positive ``sliding_win_size`` (even one larger than
+    every sequence), or ``q_seq_len * (num_q_heads // num_kv_heads) <= 32``.
 
     The function automatically infers several parameters from tensor shapes:
     - batch_size from q.shape[0] (or seq_lens.shape[0] with ragged Q)

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -1070,6 +1070,90 @@ def test_xqa_batch_decode_nvfp4_kv(
     )
 
 
+@pytest.mark.skipif(
+    get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12],
+    reason="XQA is only supported on SM90, SM100, SM120/SM121 GPUs",
+)
+@pytest.mark.parametrize("kv_dtype", ["bf16", "fp8"])
+@pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
+def test_xqa_batch_decode_mask_mode_deterministic(kv_dtype, spec_dec_mask_mode):
+    """Zero Q and K make the softmax uniform, so each output row is exactly
+    the mean of V over the row's visible positions. Draft V values are
+    distinct powers of two, so any deviation from the requested draft mask
+    shifts the output far beyond fp8 noise."""
+    torch.manual_seed(0)
+    batch_size, q_len, page_size, num_kv_heads, head_grp_size = 2, 4, 16, 2, 4
+    head_dim = 128
+    num_qo_heads = num_kv_heads * head_grp_size
+    prefix_lens = [21, 3]
+    seq_lens = torch.tensor([p + q_len for p in prefix_lens], dtype=torch.int32)
+
+    pages_per_seq = (int(seq_lens.max()) + page_size - 1) // page_size
+    num_pages = pages_per_seq * batch_size
+    # kv_cache: [num_pages, 2 (K/V), page_size, num_kv_heads, head_dim] (NHD)
+    kv_cache = torch.zeros(
+        num_pages,
+        2,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=GPU_DEVICE,
+    )
+    for i in range(batch_size):
+        for t in range(int(seq_lens[i])):
+            val = 1.0 if t < prefix_lens[i] else 2.0 ** (t - prefix_lens[i] + 1)
+            kv_cache[i * pages_per_seq + t // page_size, 1, t % page_size] = val
+    if kv_dtype == "fp8":
+        kv_cache = kv_cache.to(torch.float8_e4m3fn)  # all values exact in e4m3
+    page_table = (
+        torch.arange(num_pages, dtype=torch.int32, device=GPU_DEVICE)
+        .reshape(batch_size, pages_per_seq)
+        .contiguous()
+    )
+
+    q = torch.zeros(
+        batch_size * q_len,
+        num_qo_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=GPU_DEVICE,
+    )
+    out, o_scale = create_output(q, "bf16")
+    workspace_buffer, _ = create_workspace_buffers(GPU_DEVICE)
+    mask = generate_spec_dec_mask(batch_size, q_len, GPU_DEVICE, spec_dec_mask_mode)
+
+    output = flashinfer.decode.xqa_batch_decode_with_kv_cache(
+        q,
+        kv_cache,
+        workspace_buffer,
+        page_table,
+        seq_lens.to(GPU_DEVICE),
+        int(seq_lens.max()),
+        float(1.0 / (head_dim**0.5)),  # bmm1_scale
+        1.0,  # bmm2_scale
+        -1,  # window_left
+        out=out,
+        kv_layout="NHD",
+        q_len_per_req=q_len,
+        o_scale=o_scale,
+        mask=mask,
+    )
+
+    expected = torch.empty(batch_size, q_len, device=GPU_DEVICE)
+    for i in range(batch_size):
+        for r in range(q_len):
+            n_vis_draft = r + 1 if spec_dec_mask_mode == "causal" else q_len
+            v_sum = prefix_lens[i] + sum(2.0 ** (j + 1) for j in range(n_vis_draft))
+            expected[i, r] = v_sum / (prefix_lens[i] + n_vis_draft)
+    torch.testing.assert_close(
+        output.reshape(batch_size, q_len, num_qo_heads, head_dim).float(),
+        expected[:, :, None, None].expand(-1, -1, num_qo_heads, head_dim),
+        rtol=2e-2,
+        atol=5e-2,
+    )
+
+
 if __name__ == "__main__":
     # Run a simple test case
     test_xqa_batch_decode(

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -1076,13 +1076,24 @@ def test_xqa_batch_decode_nvfp4_kv(
 )
 @pytest.mark.parametrize("kv_dtype", ["bf16", "fp8"])
 @pytest.mark.parametrize("spec_dec_mask_mode", ["causal", "full"])
-def test_xqa_batch_decode_mask_mode_deterministic(kv_dtype, spec_dec_mask_mode):
+@pytest.mark.parametrize(
+    "num_kv_heads,head_grp_size",
+    [
+        # q_len * head_grp_size <= 32: falls back to the generic kernel on SM90 fp8
+        (2, 4),
+        # q_len * head_grp_size > 32: stays on the SM90 fp8 kernel (mha_sm90.cu)
+        (2, 16),
+    ],
+)
+def test_xqa_batch_decode_mask_mode_deterministic(
+    kv_dtype, spec_dec_mask_mode, num_kv_heads, head_grp_size
+):
     """Zero Q and K make the softmax uniform, so each output row is exactly
     the mean of V over the row's visible positions. Draft V values are
     distinct powers of two, so any deviation from the requested draft mask
     shifts the output far beyond fp8 noise."""
     torch.manual_seed(0)
-    batch_size, q_len, page_size, num_kv_heads, head_grp_size = 2, 4, 16, 2, 4
+    batch_size, q_len, page_size = 2, 4, 16
     head_dim = 128
     num_qo_heads = num_kv_heads * head_grp_size
     prefix_lens = [21, 3]


### PR DESCRIPTION
## 📌 Description

Follow-up to #4137, addressing [the review feedback](https://github.com/flashinfer-ai/flashinfer/pull/4137#issuecomment-5099541418) that arrived after auto-merge. Thanks @qsang-nv for the detailed analysis.

Issues:

- Under programmatic dependent launch (PDL), the generic XQA kernel (`csrc/xqa/mha.cu`) read `q_cu_seq_lens` and the scale tensors before the acquire that makes a producer kernel's writes visible. `q_cu_seq_lens` drives the output row offset, so a stale read could write into the wrong request's rows.
- On SM90 with fp8 KV cache, the small-batch layout of the Hopper XQA kernel (`csrc/xqa/mha_sm90.cu`, used when `q_seq_len * head_group_ratio <= 32`) hardcodes a causal draft mask, so a full draft mask silently returned causal results. Existing refchecks use random data and cannot tell the two modes apart within fp8 tolerance.
- The XQA trace template declared a `q_cu_seq_lens` input that the trace reference silently dropped.

Fixes:

- Move the `q_cu_seq_lens` and scale-tensor loads below the PDL acquire in `mha.cu`.
- Extend the SM90 fp8 fallback so small-batch speculative decode also runs on the generic kernel, matching the sliding-window and ragged-Q cases. Restoring the Hopper fast path is tracked in #4198.
- Add a deterministic mask test: zero Q and K make each output row an exact mean of the visible V values, so any deviation from the requested mask fails loudly on every architecture. It runs two shapes, one that falls back to the generic kernel and one that stays on the Hopper kernel on SM90 fp8.
- Remove `q_cu_seq_lens` from the trace template until the trace reference supports ragged Q.
- Normalize the ragged-Q module key inside the module getter, and build a separate ragged variant only when an SM90 target is compiled; on other targets it is identical to the uniform module.
- Document the SM90 fp8 fallback in the `xqa()`, `xqa_batch_decode_with_kv_cache`, and `trtllm_batch_decode_with_kv_cache` docstrings.

## 🔍 Related Issues

#4198 (restore the Hopper fp8 fast path for speculative decode). Review thread: #4137.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- Added `test_xqa_batch_decode_mask_mode_deterministic` (causal/full mask, bf16/fp8 KV, two head-group shapes) with exact expected outputs.
- On SM120 (RTX 5080): the new test, the ragged-Q and sliding-window suites (256 cases), and the trace suite (970 cases) pass.
- SM90/SM100 are covered by CI. On SM90 fp8 the new test's `head_grp_size=16` shape exercises the Hopper kernel and the `head_grp_size=4` shape exercises the widened fallback.

## Reviewer Notes

- Behavior change on SM90 with fp8 KV cache: small-batch speculative decode now runs on the generic kernel, including causal masks. The mask lives on the device, so dispatch cannot check its content without a sync. The Hopper kernel previously returned causal results regardless of the requested mask; #4198 restores that fast path.
- The `SPEC_Q_SEQ_LEN` build specialization is no longer reachable at run time but is kept: the fast-path restoration in #4198 re-enables it.
- Ragged workloads cannot be represented in trace dumps until the trace reference supports ragged Q; removing the inert input beats shipping a wrong reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speculative decoding handling for variable-length queries, including safer execution ordering for mask/sequence offsets.
  * Refined SM90 FP8 KV-cache kernel selection, extending the conditions that fall back to the generic kernel (ragged queries, attention sinks, sliding-window, and small head-group bound).
  * Improved compilation/caching behavior to better match supported speculative-decoding configurations.

* **Documentation**
  * Updated the XQA documentation to clarify when the generic kernel is used for SM90 FP8 speculative decoding.

* **Tests**
  * Added a deterministic test covering causal/full speculative-decoding masks for both BF16 and FP8 KV caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->