### PR TITLE
fix: support fp8 e5m2 output in rmsnorm_quant and fused_add_rmsnorm_quant

### DIFF
--- a/flashinfer/norm/__init__.py
+++ b/flashinfer/norm/__init__.py
@@ -199,7 +199,8 @@ def rmsnorm_quant(
     Parameters
     ----------
     out: torch.Tensor
-        The output tensor, will quantize the output to the dtype of this tensor.
+        The output tensor, will quantize the output to the dtype of this tensor,
+        which must be float8_e4m3fn or float8_e5m2.
     input: torch.Tensor
         Input tensor, 2D shape (batch_size, hidden_size).
     weight: torch.Tensor
@@ -312,7 +313,8 @@ def fused_add_rmsnorm_quant(
     Parameters
     ----------
     out: torch.Tensor
-        The output tensor, will quantize the output to the dtype of this tensor.
+        The output tensor, will quantize the output to the dtype of this tensor,
+        which must be float8_e4m3fn or float8_e5m2.
     input: torch.Tensor
         Input tensor, shape (batch_size, hidden_size).
     residual: torch.Tensor

--- a/flashinfer/norm/kernels/fused_add_rmsnorm.py
+++ b/flashinfer/norm/kernels/fused_add_rmsnorm.py
@@ -30,14 +30,14 @@ import torch
 from cutlass import Float32, Int32, Int64
 
 from ..utils import (
-    FLOAT8_E4M3_MAX,
     COPY_BITS,
+    get_fp8_max,
     rcp_approx_ftz,
-    cvt_and_store_f32_to_e4m3_hw,
-    cvt_and_store_f32_to_e4m3_sw,
-    cvt_and_store_8xf32_to_e4m3_hw,
-    cvt_and_store_4xf32_to_e4m3_hw,
-    cvt_and_store_2xf32_to_e4m3_hw,
+    cvt_and_store_f32_to_fp8_hw,
+    cvt_and_store_f32_to_fp8_sw,
+    cvt_and_store_8xf32_to_fp8_hw,
+    cvt_and_store_4xf32_to_fp8_hw,
+    cvt_and_store_2xf32_to_fp8_hw,
     has_hw_fp8_cvt,
     get_ptr_as_int64,
     get_sm_version,
@@ -426,7 +426,8 @@ class FusedAddRMSNormQuantKernel:
 
     Computes:
     1. residual = input + residual (in-place update)
-    2. output = clamp(residual / sqrt(mean(residual^2) + eps) * weight / scale, -448, 448)
+    2. output = residual / sqrt(mean(residual^2) + eps) * weight / scale,
+       clamped to the finite range of the FP8 output dtype (E4M3 or E5M2)
 
     """
 
@@ -737,6 +738,7 @@ class FusedAddRMSNormQuantKernel:
         # against M or used in the address arithmetic below.
         actual_row = Int64(bidx) * rows_per_block + row_in_block
         col_offset = lane_in_row * vec_size
+        fp8_max = get_fp8_max(mY.element_type)
 
         if cutlass.const_expr(self.use_hw_fp8 and vec_size == 8):
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -744,7 +746,7 @@ class FusedAddRMSNormQuantKernel:
                 abs_col = cluster_y * cols_per_tile + local_col
                 if abs_col + 8 <= H and actual_row < M:
                     base = v * 8
-                    cvt_and_store_8xf32_to_e4m3_hw(
+                    cvt_and_store_8xf32_to_fp8_hw(
                         tYrY_f32[base],
                         tYrY_f32[base + 1],
                         tYrY_f32[base + 2],
@@ -759,15 +761,16 @@ class FusedAddRMSNormQuantKernel:
                                 (Int64(actual_row), Int32(abs_col)), mY.layout
                             ),
                         ),
+                        mY.element_type,
                     )
                 else:
                     for e in cutlass.range_constexpr(vec_size):
                         abs_col_e = cluster_y * cols_per_tile + local_col + e
                         if abs_col_e < H and actual_row < M:
                             flat_idx = v * vec_size + e
-                            clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                            clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
-                            cvt_and_store_f32_to_e4m3_hw(
+                            clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                            clamped = min(clamped, Float32(fp8_max))
+                            cvt_and_store_f32_to_fp8_hw(
                                 clamped,
                                 get_ptr_as_int64(
                                     mY,
@@ -776,6 +779,7 @@ class FusedAddRMSNormQuantKernel:
                                         mY.layout,
                                     ),
                                 ),
+                                mY.element_type,
                             )
         elif cutlass.const_expr(self.use_hw_fp8 and vec_size == 4):
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -783,7 +787,7 @@ class FusedAddRMSNormQuantKernel:
                 abs_col = cluster_y * cols_per_tile + local_col
                 if abs_col + 4 <= H and actual_row < M:
                     base = v * 4
-                    cvt_and_store_4xf32_to_e4m3_hw(
+                    cvt_and_store_4xf32_to_fp8_hw(
                         tYrY_f32[base],
                         tYrY_f32[base + 1],
                         tYrY_f32[base + 2],
@@ -794,15 +798,16 @@ class FusedAddRMSNormQuantKernel:
                                 (Int64(actual_row), Int32(abs_col)), mY.layout
                             ),
                         ),
+                        mY.element_type,
                     )
                 else:
                     for e in cutlass.range_constexpr(vec_size):
                         abs_col_e = cluster_y * cols_per_tile + local_col + e
                         if abs_col_e < H and actual_row < M:
                             flat_idx = v * vec_size + e
-                            clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                            clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
-                            cvt_and_store_f32_to_e4m3_hw(
+                            clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                            clamped = min(clamped, Float32(fp8_max))
+                            cvt_and_store_f32_to_fp8_hw(
                                 clamped,
                                 get_ptr_as_int64(
                                     mY,
@@ -811,6 +816,7 @@ class FusedAddRMSNormQuantKernel:
                                         mY.layout,
                                     ),
                                 ),
+                                mY.element_type,
                             )
         elif cutlass.const_expr(self.use_hw_fp8 and vec_size == 2):
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -818,7 +824,7 @@ class FusedAddRMSNormQuantKernel:
                 abs_col = cluster_y * cols_per_tile + local_col
                 if abs_col + 2 <= H and actual_row < M:
                     base = v * 2
-                    cvt_and_store_2xf32_to_e4m3_hw(
+                    cvt_and_store_2xf32_to_fp8_hw(
                         tYrY_f32[base],
                         tYrY_f32[base + 1],
                         get_ptr_as_int64(
@@ -827,15 +833,16 @@ class FusedAddRMSNormQuantKernel:
                                 (Int64(actual_row), Int32(abs_col)), mY.layout
                             ),
                         ),
+                        mY.element_type,
                     )
                 else:
                     for e in cutlass.range_constexpr(vec_size):
                         abs_col_e = cluster_y * cols_per_tile + local_col + e
                         if abs_col_e < H and actual_row < M:
                             flat_idx = v * vec_size + e
-                            clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                            clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
-                            cvt_and_store_f32_to_e4m3_hw(
+                            clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                            clamped = min(clamped, Float32(fp8_max))
+                            cvt_and_store_f32_to_fp8_hw(
                                 clamped,
                                 get_ptr_as_int64(
                                     mY,
@@ -844,6 +851,7 @@ class FusedAddRMSNormQuantKernel:
                                         mY.layout,
                                     ),
                                 ),
+                                mY.element_type,
                             )
         else:
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -852,8 +860,8 @@ class FusedAddRMSNormQuantKernel:
                     abs_col = cluster_y * cols_per_tile + local_col
                     if abs_col < H and actual_row < M:
                         flat_idx = v * vec_size + e
-                        clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                        clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
+                        clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                        clamped = min(clamped, Float32(fp8_max))
                         out_ptr = get_ptr_as_int64(
                             mY,
                             cute.crd2idx(
@@ -861,9 +869,13 @@ class FusedAddRMSNormQuantKernel:
                             ),
                         )
                         if self.use_hw_fp8:
-                            cvt_and_store_f32_to_e4m3_hw(clamped, out_ptr)
+                            cvt_and_store_f32_to_fp8_hw(
+                                clamped, out_ptr, mY.element_type
+                            )
                         else:
-                            cvt_and_store_f32_to_e4m3_sw(clamped, out_ptr)
+                            cvt_and_store_f32_to_fp8_sw(
+                                clamped, out_ptr, mY.element_type
+                            )
 
         # PDL: Signal dependent kernels (SM90+ only)
         if enable_pdl:

--- a/flashinfer/norm/kernels/rmsnorm.py
+++ b/flashinfer/norm/kernels/rmsnorm.py
@@ -31,14 +31,14 @@ import torch
 from cutlass import Float32, Int32, Int64
 
 from ..utils import (
-    FLOAT8_E4M3_MAX,
     COPY_BITS,
+    get_fp8_max,
     rcp_approx_ftz,
-    cvt_and_store_f32_to_e4m3_hw,
-    cvt_and_store_f32_to_e4m3_sw,
-    cvt_and_store_8xf32_to_e4m3_hw,
-    cvt_and_store_4xf32_to_e4m3_hw,
-    cvt_and_store_2xf32_to_e4m3_hw,
+    cvt_and_store_f32_to_fp8_hw,
+    cvt_and_store_f32_to_fp8_sw,
+    cvt_and_store_8xf32_to_fp8_hw,
+    cvt_and_store_4xf32_to_fp8_hw,
+    cvt_and_store_2xf32_to_fp8_hw,
     has_hw_fp8_cvt,
     get_ptr_as_int64,
     get_sm_version,
@@ -685,8 +685,8 @@ class RMSNormQuantKernel:
     """
     RMSNorm + FP8 Quantization Kernel using CuTe-DSL.
 
-    Computes: output = clamp(input / sqrt(mean(input^2) + eps) * weight / scale, -448, 448)
-    Then quantizes to FP8 E4M3.
+    Computes: output = input / sqrt(mean(input^2) + eps) * weight / scale,
+    clamped to the finite range of the FP8 output dtype (E4M3 or E5M2).
     """
 
     def __init__(
@@ -962,6 +962,7 @@ class RMSNormQuantKernel:
         # against M or used in the address arithmetic below.
         actual_row = Int64(bidx) * rows_per_block + row_in_block
         col_offset = lane_in_row * vec_size
+        fp8_max = get_fp8_max(mY.element_type)
 
         if cutlass.const_expr(self.use_hw_fp8 and vec_size == 8):
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -969,7 +970,7 @@ class RMSNormQuantKernel:
                 abs_col = cluster_y * cols_per_tile + local_col
                 if abs_col + 8 <= H and actual_row < M:
                     base = v * 8
-                    cvt_and_store_8xf32_to_e4m3_hw(
+                    cvt_and_store_8xf32_to_fp8_hw(
                         tYrY_f32[base],
                         tYrY_f32[base + 1],
                         tYrY_f32[base + 2],
@@ -984,15 +985,16 @@ class RMSNormQuantKernel:
                                 (Int64(actual_row), Int32(abs_col)), mY.layout
                             ),
                         ),
+                        mY.element_type,
                     )
                 else:
                     for e in cutlass.range_constexpr(vec_size):
                         abs_col_e = cluster_y * cols_per_tile + local_col + e
                         if abs_col_e < H and actual_row < M:
                             flat_idx = v * vec_size + e
-                            clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                            clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
-                            cvt_and_store_f32_to_e4m3_hw(
+                            clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                            clamped = min(clamped, Float32(fp8_max))
+                            cvt_and_store_f32_to_fp8_hw(
                                 clamped,
                                 get_ptr_as_int64(
                                     mY,
@@ -1001,6 +1003,7 @@ class RMSNormQuantKernel:
                                         mY.layout,
                                     ),
                                 ),
+                                mY.element_type,
                             )
         elif cutlass.const_expr(self.use_hw_fp8 and vec_size == 4):
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -1008,7 +1011,7 @@ class RMSNormQuantKernel:
                 abs_col = cluster_y * cols_per_tile + local_col
                 if abs_col + 4 <= H and actual_row < M:
                     base = v * 4
-                    cvt_and_store_4xf32_to_e4m3_hw(
+                    cvt_and_store_4xf32_to_fp8_hw(
                         tYrY_f32[base],
                         tYrY_f32[base + 1],
                         tYrY_f32[base + 2],
@@ -1019,15 +1022,16 @@ class RMSNormQuantKernel:
                                 (Int64(actual_row), Int32(abs_col)), mY.layout
                             ),
                         ),
+                        mY.element_type,
                     )
                 else:
                     for e in cutlass.range_constexpr(vec_size):
                         abs_col_e = cluster_y * cols_per_tile + local_col + e
                         if abs_col_e < H and actual_row < M:
                             flat_idx = v * vec_size + e
-                            clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                            clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
-                            cvt_and_store_f32_to_e4m3_hw(
+                            clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                            clamped = min(clamped, Float32(fp8_max))
+                            cvt_and_store_f32_to_fp8_hw(
                                 clamped,
                                 get_ptr_as_int64(
                                     mY,
@@ -1036,6 +1040,7 @@ class RMSNormQuantKernel:
                                         mY.layout,
                                     ),
                                 ),
+                                mY.element_type,
                             )
         elif cutlass.const_expr(self.use_hw_fp8 and vec_size == 2):
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -1043,7 +1048,7 @@ class RMSNormQuantKernel:
                 abs_col = cluster_y * cols_per_tile + local_col
                 if abs_col + 2 <= H and actual_row < M:
                     base = v * 2
-                    cvt_and_store_2xf32_to_e4m3_hw(
+                    cvt_and_store_2xf32_to_fp8_hw(
                         tYrY_f32[base],
                         tYrY_f32[base + 1],
                         get_ptr_as_int64(
@@ -1052,15 +1057,16 @@ class RMSNormQuantKernel:
                                 (Int64(actual_row), Int32(abs_col)), mY.layout
                             ),
                         ),
+                        mY.element_type,
                     )
                 else:
                     for e in cutlass.range_constexpr(vec_size):
                         abs_col_e = cluster_y * cols_per_tile + local_col + e
                         if abs_col_e < H and actual_row < M:
                             flat_idx = v * vec_size + e
-                            clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                            clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
-                            cvt_and_store_f32_to_e4m3_hw(
+                            clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                            clamped = min(clamped, Float32(fp8_max))
+                            cvt_and_store_f32_to_fp8_hw(
                                 clamped,
                                 get_ptr_as_int64(
                                     mY,
@@ -1069,6 +1075,7 @@ class RMSNormQuantKernel:
                                         mY.layout,
                                     ),
                                 ),
+                                mY.element_type,
                             )
         else:
             for v in cutlass.range_constexpr(num_vec_blocks):
@@ -1077,8 +1084,8 @@ class RMSNormQuantKernel:
                     abs_col = cluster_y * cols_per_tile + local_col
                     if abs_col < H and actual_row < M:
                         flat_idx = v * vec_size + e
-                        clamped = max(tYrY_f32[flat_idx], Float32(-FLOAT8_E4M3_MAX))
-                        clamped = min(clamped, Float32(FLOAT8_E4M3_MAX))
+                        clamped = max(tYrY_f32[flat_idx], Float32(-fp8_max))
+                        clamped = min(clamped, Float32(fp8_max))
                         out_ptr = get_ptr_as_int64(
                             mY,
                             cute.crd2idx(
@@ -1086,9 +1093,13 @@ class RMSNormQuantKernel:
                             ),
                         )
                         if self.use_hw_fp8:
-                            cvt_and_store_f32_to_e4m3_hw(clamped, out_ptr)
+                            cvt_and_store_f32_to_fp8_hw(
+                                clamped, out_ptr, mY.element_type
+                            )
                         else:
-                            cvt_and_store_f32_to_e4m3_sw(clamped, out_ptr)
+                            cvt_and_store_f32_to_fp8_sw(
+                                clamped, out_ptr, mY.element_type
+                            )
 
         # PDL: Signal dependent kernels (SM90+ only)
         if enable_pdl:

--- a/flashinfer/norm/utils.py
+++ b/flashinfer/norm/utils.py
@@ -45,7 +45,17 @@ from ..cute_dsl.utils import get_cutlass_dtype, get_num_sm
 # =============================================================================
 
 FLOAT8_E4M3_MAX = 448.0  # Maximum value representable in FP8 E4M3
+FLOAT8_E5M2_MAX = 57344.0  # Maximum value representable in FP8 E5M2
 COPY_BITS = 128  # 128-bit vectorized loads
+
+
+def get_fp8_max(dtype) -> float:
+    """Maximum finite value of a supported FP8 output dtype."""
+    if dtype is cutlass.Float8E4M3FN:
+        return FLOAT8_E4M3_MAX
+    if dtype is cutlass.Float8E5M2:
+        return FLOAT8_E5M2_MAX
+    raise ValueError(f"Unsupported FP8 output dtype: {dtype}")
 
 
 # =============================================================================
@@ -300,6 +310,295 @@ def cvt_and_store_2xf32_to_e4m3_hw(
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
     )
+
+
+@dsl_user_op
+def cvt_and_store_f32_to_e5m2_hw(val: Float32, addr: Int64, *, loc=None, ip=None):
+    """Convert float32 to E5M2 and store single byte — hardware path (sm_89+)."""
+    llvm.inline_asm(
+        None,
+        [Float32(val).ir_value(loc=loc, ip=ip), Int64(addr).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 fp8_pair;
+            .reg .f32 zero;
+            mov.f32 zero, 0f00000000;
+            cvt.rn.satfinite.e5m2x2.f32 fp8_pair, zero, $0;
+            st.global.b8 [$1], fp8_pair;
+        }
+        """,
+        "f,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cvt_and_store_f32_to_e5m2_sw(val: Float32, addr: Int64, *, loc=None, ip=None):
+    """Convert float32 to E5M2 and store single byte — software path (all architectures).
+
+    Same bit-manipulation scheme as cvt_and_store_f32_to_e4m3_sw with the
+    constants rederived for E5M2 (1 sign bit, 5 exponent bits with bias=15,
+    2 mantissa bits). The caller must clamp the value to [-57344, 57344]:
+      - Normal range (f32 biased exp >= 113): direct extraction with RNE
+      - Denormal range (f32 biased exp in [110..112]): shift mantissa with
+        implicit bit, RNE
+      - Underflow (abs <= 2^-17): flush to zero (RNE midpoint to min denorm)
+    """
+    llvm.inline_asm(
+        None,
+        [Float32(val).ir_value(loc=loc, ip=ip), Int64(addr).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 fbits, sign8, abs_bits, f32_exp, f32_mant;
+            .reg .b32 e5m2_exp, e5m2_mant, norm_raw;
+            .reg .b32 rbit, sticky, odd_bit, radj;
+            .reg .b32 shift, dmant3, denorm_raw;
+            .reg .b32 dr_bit, dsticky, dadj;
+            .reg .b32 e5m2_raw, tmp, tmp2;
+            .reg .pred p_zero, p_denorm;
+
+            // Bitcast float to int and extract sign/exponent/mantissa
+            mov.b32 fbits, $0;
+            shr.u32 sign8, fbits, 24;
+            and.b32 sign8, sign8, 128;
+            and.b32 abs_bits, fbits, 0x7FFFFFFF;
+            shr.u32 f32_exp, abs_bits, 23;
+            and.b32 f32_mant, abs_bits, 0x007FFFFF;
+
+            // === Normal path (f32 biased exp >= 113, i.e. e5m2 exp >= 1) ===
+            sub.u32 e5m2_exp, f32_exp, 112;
+            shr.u32 e5m2_mant, f32_mant, 21;
+            shl.b32 norm_raw, e5m2_exp, 2;
+            or.b32  norm_raw, norm_raw, e5m2_mant;
+
+            // Round-to-nearest-even: round up if round_bit AND (sticky OR odd)
+            shr.u32 rbit, f32_mant, 20;
+            and.b32 rbit, rbit, 1;
+            and.b32 sticky, f32_mant, 0x000FFFFF;
+            and.b32 odd_bit, e5m2_mant, 1;
+            or.b32  tmp, sticky, odd_bit;
+            min.u32 tmp, tmp, 1;
+            and.b32 radj, tmp, rbit;
+            add.u32 norm_raw, norm_raw, radj;
+            min.u32 norm_raw, norm_raw, 123;
+
+            // === Denormal path (f32 biased exp in {110,111,112}) ===
+            sub.u32 shift, 113, f32_exp;
+            shr.u32 tmp, f32_mant, 21;
+            or.b32  dmant3, tmp, 4;
+            shr.u32 denorm_raw, dmant3, shift;
+
+            // RNE rounding for denormals
+            sub.u32 tmp, shift, 1;
+            shr.u32 dr_bit, dmant3, tmp;
+            and.b32 dr_bit, dr_bit, 1;
+            shl.b32 tmp2, 1, tmp;
+            sub.u32 tmp2, tmp2, 1;
+            and.b32 dsticky, dmant3, tmp2;
+            and.b32 tmp, f32_mant, 0x001FFFFF;
+            or.b32  dsticky, dsticky, tmp;
+            and.b32 odd_bit, denorm_raw, 1;
+            or.b32  tmp, dsticky, odd_bit;
+            min.u32 tmp, tmp, 1;
+            and.b32 dadj, tmp, dr_bit;
+            add.u32 denorm_raw, denorm_raw, dadj;
+
+            // Select between normal/denormal, then apply zero flush
+            setp.le.u32 p_denorm, f32_exp, 112;
+            selp.u32 e5m2_raw, denorm_raw, norm_raw, p_denorm;
+            setp.le.u32 p_zero, abs_bits, 0x37000000;
+            selp.u32 e5m2_raw, 0, e5m2_raw, p_zero;
+
+            // Apply sign and store single byte
+            or.b32  e5m2_raw, e5m2_raw, sign8;
+            st.global.b8 [$1], e5m2_raw;
+        }
+        """,
+        "f,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cvt_and_store_8xf32_to_e5m2_hw(
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    v4: Float32,
+    v5: Float32,
+    v6: Float32,
+    v7: Float32,
+    addr: Int64,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Convert 8 float32 values to E5M2 and store as one 64-bit global store (sm_89+)."""
+    llvm.inline_asm(
+        None,
+        [
+            Float32(v0).ir_value(loc=loc, ip=ip),
+            Float32(v1).ir_value(loc=loc, ip=ip),
+            Float32(v2).ir_value(loc=loc, ip=ip),
+            Float32(v3).ir_value(loc=loc, ip=ip),
+            Float32(v4).ir_value(loc=loc, ip=ip),
+            Float32(v5).ir_value(loc=loc, ip=ip),
+            Float32(v6).ir_value(loc=loc, ip=ip),
+            Float32(v7).ir_value(loc=loc, ip=ip),
+            Int64(addr).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b16 p01, p23, p45, p67;
+            .reg .b32 lo, hi;
+            cvt.rn.satfinite.e5m2x2.f32 p01, $1, $0;
+            cvt.rn.satfinite.e5m2x2.f32 p23, $3, $2;
+            cvt.rn.satfinite.e5m2x2.f32 p45, $5, $4;
+            cvt.rn.satfinite.e5m2x2.f32 p67, $7, $6;
+            mov.b32 lo, {p01, p23};
+            mov.b32 hi, {p45, p67};
+            st.global.v2.b32 [$8], {lo, hi};
+        }
+        """,
+        "f,f,f,f,f,f,f,f,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cvt_and_store_4xf32_to_e5m2_hw(
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    addr: Int64,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Convert 4 float32 values to E5M2 and store as one 32-bit global store (sm_89+)."""
+    llvm.inline_asm(
+        None,
+        [
+            Float32(v0).ir_value(loc=loc, ip=ip),
+            Float32(v1).ir_value(loc=loc, ip=ip),
+            Float32(v2).ir_value(loc=loc, ip=ip),
+            Float32(v3).ir_value(loc=loc, ip=ip),
+            Int64(addr).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b16 p01, p23;
+            .reg .b32 packed;
+            cvt.rn.satfinite.e5m2x2.f32 p01, $1, $0;
+            cvt.rn.satfinite.e5m2x2.f32 p23, $3, $2;
+            mov.b32 packed, {p01, p23};
+            st.global.b32 [$4], packed;
+        }
+        """,
+        "f,f,f,f,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cvt_and_store_2xf32_to_e5m2_hw(
+    v0: Float32, v1: Float32, addr: Int64, *, loc=None, ip=None
+):
+    """Convert 2 float32 values to E5M2 and store as one 16-bit global store (sm_89+)."""
+    llvm.inline_asm(
+        None,
+        [
+            Float32(v0).ir_value(loc=loc, ip=ip),
+            Float32(v1).ir_value(loc=loc, ip=ip),
+            Int64(addr).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b16 packed;
+            cvt.rn.satfinite.e5m2x2.f32 packed, $1, $0;
+            st.global.b16 [$2], packed;
+        }
+        """,
+        "f,f,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+# =============================================================================
+# FP8 dtype dispatch wrappers
+# =============================================================================
+
+
+@cute.jit
+def cvt_and_store_f32_to_fp8_hw(val: Float32, addr: Int64, dtype: cutlass.Constexpr):
+    if cutlass.const_expr(dtype is cutlass.Float8E5M2):
+        cvt_and_store_f32_to_e5m2_hw(val, addr)
+    else:
+        cvt_and_store_f32_to_e4m3_hw(val, addr)
+
+
+@cute.jit
+def cvt_and_store_f32_to_fp8_sw(val: Float32, addr: Int64, dtype: cutlass.Constexpr):
+    if cutlass.const_expr(dtype is cutlass.Float8E5M2):
+        cvt_and_store_f32_to_e5m2_sw(val, addr)
+    else:
+        cvt_and_store_f32_to_e4m3_sw(val, addr)
+
+
+@cute.jit
+def cvt_and_store_8xf32_to_fp8_hw(
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    v4: Float32,
+    v5: Float32,
+    v6: Float32,
+    v7: Float32,
+    addr: Int64,
+    dtype: cutlass.Constexpr,
+):
+    if cutlass.const_expr(dtype is cutlass.Float8E5M2):
+        cvt_and_store_8xf32_to_e5m2_hw(v0, v1, v2, v3, v4, v5, v6, v7, addr)
+    else:
+        cvt_and_store_8xf32_to_e4m3_hw(v0, v1, v2, v3, v4, v5, v6, v7, addr)
+
+
+@cute.jit
+def cvt_and_store_4xf32_to_fp8_hw(
+    v0: Float32,
+    v1: Float32,
+    v2: Float32,
+    v3: Float32,
+    addr: Int64,
+    dtype: cutlass.Constexpr,
+):
+    if cutlass.const_expr(dtype is cutlass.Float8E5M2):
+        cvt_and_store_4xf32_to_e5m2_hw(v0, v1, v2, v3, addr)
+    else:
+        cvt_and_store_4xf32_to_e4m3_hw(v0, v1, v2, v3, addr)
+
+
+@cute.jit
+def cvt_and_store_2xf32_to_fp8_hw(
+    v0: Float32, v1: Float32, addr: Int64, dtype: cutlass.Constexpr
+):
+    if cutlass.const_expr(dtype is cutlass.Float8E5M2):
+        cvt_and_store_2xf32_to_e5m2_hw(v0, v1, addr)
+    else:
+        cvt_and_store_2xf32_to_e4m3_hw(v0, v1, addr)
 
 
 def has_hw_fp8_cvt(device: torch.device = None) -> bool:
@@ -713,6 +1012,7 @@ _TORCH_DTYPE_TO_STR_MAP = {
     torch.bfloat16: "bfloat16",
     torch.float32: "float32",
     torch.float8_e4m3fn: "float8_e4m3fn",
+    torch.float8_e5m2: "float8_e5m2",
 }
 
 
@@ -724,7 +1024,9 @@ def _torch_dtype_to_str(dtype: torch.dtype) -> str:
 __all__ = [
     # Constants
     "FLOAT8_E4M3_MAX",
+    "FLOAT8_E5M2_MAX",
     "COPY_BITS",
+    "get_fp8_max",
     # PTX intrinsics
     "rcp_approx_ftz",
     "cvt_and_store_f32_to_e4m3_hw",
@@ -732,6 +1034,16 @@ __all__ = [
     "cvt_and_store_8xf32_to_e4m3_hw",
     "cvt_and_store_4xf32_to_e4m3_hw",
     "cvt_and_store_2xf32_to_e4m3_hw",
+    "cvt_and_store_f32_to_e5m2_hw",
+    "cvt_and_store_f32_to_e5m2_sw",
+    "cvt_and_store_8xf32_to_e5m2_hw",
+    "cvt_and_store_4xf32_to_e5m2_hw",
+    "cvt_and_store_2xf32_to_e5m2_hw",
+    "cvt_and_store_f32_to_fp8_hw",
+    "cvt_and_store_f32_to_fp8_sw",
+    "cvt_and_store_8xf32_to_fp8_hw",
+    "cvt_and_store_4xf32_to_fp8_hw",
+    "cvt_and_store_2xf32_to_fp8_hw",
     "has_hw_fp8_cvt",
     "get_ptr_as_int64",
     # PTX intrinsics - Cluster operations

--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -33,6 +33,32 @@ namespace norm {
 
 using namespace tensorrt_llm::common;
 
+template <typename T>
+struct QuantTypeStaticVals;
+
+template <>
+struct QuantTypeStaticVals<int8_t> {
+  static constexpr float MAX_VAL = 127.f;
+  static constexpr float MIN_SCALING_FACTOR = 0.f;
+  static constexpr float MIN_SCALING_FACTOR_RCP = FLT_MAX;
+};
+
+// Same values as TRT-LLM quantTypeUtils.cuh; MIN_SCALING_FACTOR bound follows
+// https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
+template <>
+struct QuantTypeStaticVals<__nv_fp8_e4m3> {
+  static constexpr float MAX_VAL = 448.f;
+  static constexpr float MIN_SCALING_FACTOR = 1.0f / (448.f * 512.f);
+  static constexpr float MIN_SCALING_FACTOR_RCP = 448.f * 512.f;
+};
+
+template <>
+struct QuantTypeStaticVals<__nv_fp8_e5m2> {
+  static constexpr float MAX_VAL = 57344.f;
+  static constexpr float MIN_SCALING_FACTOR = 1.0f / (57344.f * 512.f);
+  static constexpr float MIN_SCALING_FACTOR_RCP = 57344.f * 512.f;
+};
+
 template <uint32_t VEC_SIZE, typename T>
 __global__ void RMSNormKernel(T* __restrict__ input, T* __restrict__ weight, T* __restrict__ output,
                               const uint32_t d, const uint32_t stride_input,
@@ -199,6 +225,7 @@ __global__ void RMSNormQuantKernel(T* __restrict__ input, T* __restrict__ weight
   __syncthreads();
 
   float rms_rcp = math::rsqrt(smem[0] / float(d) + eps);
+  constexpr float max_val = QuantTypeStaticVals<O>::MAX_VAL;
 
   for (uint32_t i = 0; i < rounds; i++) {
     vec_t<T, VEC_SIZE> input_vec;
@@ -214,7 +241,7 @@ __global__ void RMSNormQuantKernel(T* __restrict__ input, T* __restrict__ weight
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
       output_vec[j] =
           float(input_vec[j]) * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
-      output_vec[j] = fmaxf(-448.0f, fminf(output_vec[j], 448.0f));
+      output_vec[j] = fmaxf(-max_val, fminf(output_vec[j], max_val));
     }
     if ((i * num_threads + thread_id) * VEC_SIZE < d) {
       output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +
@@ -583,6 +610,7 @@ __global__ void FusedAddRMSNormQuantKernel(T* __restrict__ input, T* __restrict_
   __syncthreads();
 
   float rms_rcp = math::rsqrt(smem[0] / float(d) + eps);
+  constexpr float max_val = QuantTypeStaticVals<O>::MAX_VAL;
 
   for (uint32_t i = 0; i < rounds; i++) {
     vec_t<float, VEC_SIZE> output_vec;
@@ -598,7 +626,7 @@ __global__ void FusedAddRMSNormQuantKernel(T* __restrict__ input, T* __restrict_
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
       output_vec[j] = x_vec[j] * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
-      output_vec[j] = fmaxf(-448.0f, fminf(output_vec[j], 448.0f));
+      output_vec[j] = fmaxf(-max_val, fminf(output_vec[j], max_val));
     }
     if ((i * num_threads + thread_id) * VEC_SIZE < d) {
       output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +
@@ -719,34 +747,6 @@ cudaError_t GemmaFusedAddRMSNorm(T* input, T* residual, T* weight, uint32_t batc
 
   return cudaSuccess;
 }
-
-template <typename T>
-struct QuantTypeStaticVals;
-
-template <>
-struct QuantTypeStaticVals<int8_t> {
-  static constexpr float MAX_VAL = 127.f;
-  static constexpr float MIN_SCALING_FACTOR = 0.f;
-  static constexpr float MIN_SCALING_FACTOR_RCP = FLT_MAX;
-};
-
-#ifdef ENABLE_FP8
-// Same values as TRT-LLM quantTypeUtils.cuh; MIN_SCALING_FACTOR bound follows
-// https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
-template <>
-struct QuantTypeStaticVals<__nv_fp8_e4m3> {
-  static constexpr float MAX_VAL = 448.f;
-  static constexpr float MIN_SCALING_FACTOR = 1.0f / (448.f * 512.f);
-  static constexpr float MIN_SCALING_FACTOR_RCP = 448.f * 512.f;
-};
-
-template <>
-struct QuantTypeStaticVals<__nv_fp8_e5m2> {
-  static constexpr float MAX_VAL = 57344.f;
-  static constexpr float MIN_SCALING_FACTOR = 1.0f / (57344.f * 512.f);
-  static constexpr float MIN_SCALING_FACTOR_RCP = 57344.f * 512.f;
-};
-#endif  // ENABLE_FP8
 
 template <typename Tf, typename T>
 __inline__ __device__ Tf compute_layernorm(Tf val, float s_mean, float s_variance, T const* gemma,

--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -34,17 +34,16 @@ def llama_rms_norm(x, w, eps=1e-6):
     return x
 
 
-def llama_rms_norm_quant(x, w, scale, eps=1e-6):
+def llama_rms_norm_quant(x, w, scale, quant_dtype, eps=1e-6):
     inv_scale = torch.reciprocal(torch.tensor(scale)).float()
     x = x.float()
     variance = x.pow(2).mean(dim=-1, keepdim=True)
     x = x * torch.rsqrt(variance + eps)
     x = x * w.float()
     x = x * inv_scale
-    x = torch.clamp(
-        x, torch.finfo(torch.float8_e4m3fn).min, torch.finfo(torch.float8_e4m3fn).max
-    )
-    x = x.to(torch.float8_e4m3fn)
+    finfo = torch.finfo(quant_dtype)
+    x = torch.clamp(x, finfo.min, finfo.max)
+    x = x.to(quant_dtype)
     return x
 
 
@@ -93,7 +92,7 @@ def fused_add_rms_norm(x, residual, weight, eps):
     return x, residual
 
 
-def fused_add_rms_norm_quant(x, residual, weight, scale, eps):
+def fused_add_rms_norm_quant(x, residual, weight, scale, quant_dtype, eps):
     inv_scale = torch.reciprocal(torch.tensor(scale)).float()
     orig_dtype = x.dtype
     x = x.to(torch.float32)
@@ -103,10 +102,9 @@ def fused_add_rms_norm_quant(x, residual, weight, scale, eps):
     x = x * torch.rsqrt(variance + eps)
     x = x * weight.float()
     x = x * inv_scale
-    x = torch.clamp(
-        x, torch.finfo(torch.float8_e4m3fn).min, torch.finfo(torch.float8_e4m3fn).max
-    )
-    x = x.to(torch.float8_e4m3fn)
+    finfo = torch.finfo(quant_dtype)
+    x = torch.clamp(x, finfo.min, finfo.max)
+    x = x.to(quant_dtype)
     return x, residual
 
 
@@ -141,11 +139,12 @@ def test_norm(batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguou
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192, 16384])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("quant_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 @pytest.mark.parametrize("quant_scale", [0.01, 1.0, 10.0])
 @pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
 def test_norm_quant(
-    batch_size, hidden_size, dtype, quant_scale, enable_pdl, contiguous
+    batch_size, hidden_size, dtype, quant_dtype, quant_scale, enable_pdl, contiguous
 ):
     if contiguous:
         x = torch.randn(batch_size, hidden_size).to(0).to(dtype)
@@ -158,8 +157,8 @@ def test_norm_quant(
 
     w = torch.randn(hidden_size).to(0).to(dtype)
 
-    y_ref = llama_rms_norm_quant(x, w, quant_scale)
-    y = torch.empty_like(x, dtype=torch.float8_e4m3fn, device="cuda")
+    y_ref = llama_rms_norm_quant(x, w, quant_scale, quant_dtype)
+    y = torch.empty_like(x, dtype=quant_dtype, device="cuda")
     flashinfer.norm.rmsnorm_quant(
         y, x, w, torch.tensor(quant_scale, device="cuda"), enable_pdl=enable_pdl
     )
@@ -235,11 +234,12 @@ def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, enable_pdl, contiguou
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192, 16384])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("quant_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 @pytest.mark.parametrize("quant_scale", [0.01, 1.0, 10.0])
 @pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
 def test_fused_add_rmsnorm_quant(
-    batch_size, hidden_size, dtype, quant_scale, enable_pdl, contiguous
+    batch_size, hidden_size, dtype, quant_dtype, quant_scale, enable_pdl, contiguous
 ):
     eps = 1e-6
 
@@ -256,12 +256,12 @@ def test_fused_add_rmsnorm_quant(
     weight = torch.randn(hidden_size, dtype=dtype, device="cuda")
 
     x_native, residual_native = fused_add_rms_norm_quant(
-        x.clone(), residual.clone(), weight, quant_scale, eps
+        x.clone(), residual.clone(), weight, quant_scale, quant_dtype, eps
     )
 
     x_fused = x.clone()
     residual_fused = residual.clone()
-    y = torch.empty_like(x, dtype=torch.float8_e4m3fn, device="cuda")
+    y = torch.empty_like(x, dtype=quant_dtype, device="cuda")
     flashinfer.norm.fused_add_rmsnorm_quant(
         y,
         x_fused,
@@ -476,7 +476,7 @@ def test_rmsnorm_quant_int64_stride():
     y = torch.empty(2, H, dtype=torch.float8_e4m3fn, device="cuda")
     flashinfer.norm.rmsnorm_quant(y, x, w, torch.tensor(quant_scale, device="cuda"))
 
-    y_ref = llama_rms_norm_quant(x.contiguous(), w, quant_scale)
+    y_ref = llama_rms_norm_quant(x.contiguous(), w, quant_scale, torch.float8_e4m3fn)
     torch.testing.assert_close(y.float(), y_ref.float(), rtol=1, atol=1)
 
 
@@ -516,7 +516,7 @@ def test_fused_add_rmsnorm_quant_int64_stride():
     x = torch.as_strided(buf_x, (2, H), (_INT64_STRIDE, 1))
     assert not x.is_contiguous()
     x_ref, r_ref = fused_add_rms_norm_quant(
-        x.contiguous().clone(), r.clone(), w, quant_scale, eps
+        x.contiguous().clone(), r.clone(), w, quant_scale, torch.float8_e4m3fn, eps
     )
 
     y = torch.empty(2, H, dtype=torch.float8_e4m3fn, device="cuda")
@@ -619,7 +619,9 @@ def test_rmsnorm_quant_contiguous_overflow():
     _spot_check_rows(
         y,
         x,
-        lambda r: llama_rms_norm_quant(x[r : r + 1], w, quant_scale),
+        lambda r: llama_rms_norm_quant(
+            x[r : r + 1], w, quant_scale, torch.float8_e4m3fn
+        ),
         rtol=1,
         atol=1,
     )
@@ -703,7 +705,7 @@ def test_fused_add_rmsnorm_quant_contiguous_overflow():
 
     for i in check_rows:
         y_ref, r_ref = fused_add_rms_norm_quant(
-            x_snap[i], r_snap[i], w, quant_scale, eps
+            x_snap[i], r_snap[i], w, quant_scale, torch.float8_e4m3fn, eps
         )
         torch.testing.assert_close(y[i : i + 1].float(), y_ref.float(), rtol=1, atol=1)
         torch.testing.assert_close(r[i : i + 1], r_ref, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

E5M2 output is rarely used in inference, but the current code fails silently instead of rejecting it. This PR is a small fix to close that gap.

`rmsnorm_quant` and `fused_add_rmsnorm_quant` quantize to the dtype of the `out` tensor and the CUDA dispatch accepts e5m2, but:

- CuTe-DSL backend (default): the norm dtype map has no `float8_e5m2`  entry, so an e5m2 out tensor raises `KeyError`; the store epilogue and the clamp were e4m3 only anyway.
- CUDA fallback (`FLASHINFER_USE_CUDA_NORM=1`): the kernels clamp to `[-448, 448]` for any output dtype, silently collapsing the e5m2 range (max 57344).

Changes:

- `norm/utils.py`: `FLOAT8_E5M2_MAX`, e5m2 conversion intrinsics (hw via`cvt.rn.satfinite.e5m2x2.f32`, sw via bit manipulation), thin fp8 wrappers that select the variant from a constexpr dtype, and a
  `float8_e5m2` dtype map entry.
- `norm/kernels/{rmsnorm,fused_add_rmsnorm}.py`: quant epilogues dispatch on the output element type; the clamp bound follows the output dtype. Kernel signatures and compile cache keys are unchanged.
- `include/flashinfer/norm.cuh`: both quant kernels clamp with `QuantTypeStaticVals<O>::MAX_VAL`, as `layernorm_quant` already does. The trait moves above the kernels and drops its `ENABLE_FP8` guard:
  the fp8 types are always visible (`vec_dtypes.cuh` includes `cuda_fp8.h` unconditionally), and these kernels are instantiated for fp8 through `DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8` even in builds without `ENABLE_FP8`, so keeping the guard would break the no-fp8 build once they reference the trait (exercised by `test_norm_compilation_without_fp8`).
- Tests: `test_norm_quant` and `test_fused_add_rmsnorm_quant` parametrized over `quant_dtype` (e4m3fn, e5m2), same style as `test_layernorm_quant`.

Verified on RTX 5090: the full quant grids pass on both backends (3072 CuTe-DSL, 3085 CUDA cases). Both hw and sw conversion paths were checked bit-exact against torch fp8 casts over all finite fp16 values plus random and boundary floats, for both formats; since sm_120 always dispatches the hw path, the sw path was force-compiled with `use_hw_fp8=False` for this.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes


<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FP8 E5M2 support for RMSNorm quantization and fused add + RMSNorm quantization.
  * Quantized outputs now support both FP8 E4M3 and E5M2 formats.
  * Clamping automatically uses the selected output format’s valid numeric range.

* **Documentation**
  * Clarified supported FP8 output formats and quantization behavior.

* **Tests**
  * Expanded coverage across both FP8 formats, including stride and large-tensor cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->