### PR TITLE
Key cubin checksums by full path to prevent cross-pin collisions

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -207,10 +207,13 @@ def get_checksums(subdirs):
             for line in f:
                 sha256, filename = line.strip().split()
 
-                # Distinguish between all meta info header files
-                if ".h" in filename:
-                    filename = safe_urljoin(subdir, filename)
-                checksums[filename] = sha256
+                # Key every entry by its full path. Bare filenames are not
+                # unique across subdirs: per-arch cubin pins publish the same
+                # kernel names built from different sources, so a flat dict
+                # lets whichever subdir is processed last silently overwrite
+                # the earlier one's hashes, failing verification for every
+                # shared name.
+                checksums[safe_urljoin(subdir, filename)] = sha256
     return checksums
 
 
@@ -268,7 +271,8 @@ def get_subdir_file_list() -> Generator[tuple[str, str], None, None]:
         checksum_path = safe_urljoin(cubin_dir, "checksums.txt")
         yield (checksum_path, CheckSumHash.map_checksums[checksum_path])
         for name in get_available_cubin_files(safe_urljoin(base, cubin_dir)):
-            yield (safe_urljoin(cubin_dir, name), checksums[name])
+            full_path = safe_urljoin(cubin_dir, name)
+            yield (full_path, checksums[full_path])
         for name in get_available_header_files(safe_urljoin(base, cubin_dir)):
             full_path = safe_urljoin(cubin_dir, name)
             yield (full_path, checksums[full_path])

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,6 +1,7 @@
 from flashinfer.artifacts import (
     ArtifactPath,
     get_available_cubin_files,
+    get_checksums,
     get_subdir_file_list,
 )
 
@@ -413,3 +414,66 @@ f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
     assert len(meta_info_headers) == 3, (
         f"Meta info headers count mismatch. Expected 3, got {len(meta_info_headers)}. Headers found: {meta_info_headers}"
     )
+
+
+@responses.activate
+def test_get_checksums_does_not_collide_across_subdirs(monkeypatch, tmp_path):
+    """Two pins publishing the same kernel filename must keep separate hashes.
+
+    Per-arch cubin pins ship identically-named sm100f/sm103a kernels built from
+    different sources. Keying the checksum map by bare filename let whichever
+    subdir was processed last overwrite the earlier one, so every shared name
+    was then verified against the wrong pin's hash.
+    """
+    from flashinfer import artifacts
+
+    temp_cubin_dir = tmp_path / "cubins"
+    temp_cubin_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(
+        artifacts, "FLASHINFER_CUBINS_REPOSITORY", test_cubin_repository
+    )
+    monkeypatch.setattr(artifacts, "FLASHINFER_CUBIN_DIR", temp_cubin_dir)
+
+    shared_kernel = "Bmm_Bfloat16_E2m1E2m1_Fp32_shared_name_sm100f.cubin"
+    subdir_a = "pin-a/batched_gemm-aaaaaaa-bbbbbbb/"
+    subdir_b = "pin-b/batched_gemm-ccccccc-ddddddd/"
+    hash_a = "1111111111111111111111111111111111111111111111111111111111111111"
+    hash_b = "2222222222222222222222222222222222222222222222222222222222222222"
+    header_a = "3333333333333333333333333333333333333333333333333333333333333333"
+    header_b = "4444444444444444444444444444444444444444444444444444444444444444"
+
+    for subdir, kernel_hash, header_hash in (
+        (subdir_a, hash_a, header_a),
+        (subdir_b, hash_b, header_b),
+    ):
+        responses.add(
+            responses.GET,
+            safe_urljoin(test_cubin_repository, safe_urljoin(subdir, "checksums.txt")),
+            body=(
+                f"{header_hash} include/flashinferMetaInfo.h\n"
+                f"{kernel_hash} {shared_kernel}\n"
+            ),
+            status=200,
+        )
+
+    checksums = get_checksums([subdir_a, subdir_b])
+
+    key_a = safe_urljoin(subdir_a, shared_kernel)
+    key_b = safe_urljoin(subdir_b, shared_kernel)
+
+    # The bare filename must not be a key at all -- that is what collided.
+    assert shared_kernel not in checksums
+
+    assert checksums[key_a] == hash_a, (
+        f"{subdir_a} kernel resolved to {checksums[key_a]}, expected {hash_a}"
+    )
+    assert checksums[key_b] == hash_b, (
+        f"{subdir_b} kernel resolved to {checksums[key_b]}, expected {hash_b}"
+    )
+    assert checksums[key_a] != checksums[key_b], (
+        "both pins resolved to the same checksum -- the per-pin hashes collided"
+    )
+
+    # Headers were already namespaced before this fix; keep them covered.
+    assert checksums[safe_urljoin(subdir_a, "include/flashinferMetaInfo.h")] == header_a
+    assert checksums[safe_urljoin(subdir_b, "include/flashinferMetaInfo.h")] == header_b


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`get_checksums()` flattens every subdir's `checksums.txt` into one dict keyed by **bare filename**, namespacing only `.h` entries:

```python
if ".h" in filename:
    filename = safe_urljoin(subdir, filename)
checksums[filename] = sha256
```

Bare filenames are **not** unique across subdirs. Per-arch cubin pins publish the same `sm100f`/`sm103a` kernel names built from different sources, so whichever subdir is processed last silently overwrites the earlier one's hashes. Every shared name is then verified against the wrong pin's hash, and `download_artifacts()` fails with `Failed to download cubins: checksum mismatch`. `get_subdir_file_list()` compounded it by looking cubins up as `checksums[name]` while headers already used the full path.

**`main` cannot trigger this today** — it defines only a single BMM/GEMM pin. This PR is therefore a latent-bug fix, not a live one.

It *did* trigger on `release-v0.6.16`, which carries a second, Rubin-specific pin. Measured against the live published manifests:

| pin pair | shared filenames | same hash | **conflicting** |
|---|---|---|---|
| `TRTLLM_GEN_BMM` vs `_RUBIN` | 2534 | 0 | **2534** |
| `TRTLLM_GEN_GEMM` vs `_RUBIN` | 108 | 3 | **105** |

2640 of 8055 files resolved to the wrong hash, taking down `build-flashinfer-cubin` for the entire release. Fixed there in #4200. Porting it here so the landmine does not re-arm the moment a second pin lands on `main` (e.g. when SM107 support returns).

**Fix:** key every entry by full path, and look cubins up the same way headers already were.

## 🔍 Related Issues

- Release-branch fix and full root-cause writeup: #4200
- Reproduced end-to-end: with the unfixed code `download_artifacts()` fails on a real non-Rubin BMM cubin whose expected hash is the Rubin pin's (`expected c31c3573… actual 41c8c4fc…`); with the fix all 21,839 files download and verify.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/test_artifacts.py`: **5 passed** (4 existing + 1 new).

The new test is deliberately **pin-independent** — it feeds `get_checksums()` two synthetic subdirs publishing the same kernel name with different hashes, so it does not depend on `main` ever defining a second `ArtifactPath`. Against the unfixed version it fails:

```
AssertionError: assert Bmm_Bfloat16_E2m1E2m1_Fp32_shared_name_sm100f.cubin not in {...}
```

## Reviewer Notes

- The #4200 test changes were **not** cherry-picked: they reference `ArtifactPath.TRTLLM_GEN_BMM_RUBIN`, which does not exist on `main` and would `AttributeError` at collection. Hence the different, synthetic-subdir test here.
- The `Sm107a` guard from #4200 is intentionally **not** included — `main` has zero `Sm107a` references since #4122 was reverted. Whoever re-lands SM107 support here must bring the `#ifdef TLLM_RUBIN_FEATURES` guard with it, or `main` will break exactly as the release branch did.
- Behaviour is unchanged for single-pin configurations; every key simply gains its subdir prefix, matching what `.h` entries already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checksum handling for artifacts with identical filenames in different subdirectories.
  * Ensured each artifact consistently uses its full path when locating and validating checksums.
  * Preserved distinct kernel and header checksums across artifact versions, preventing incorrect matches.

* **Tests**
  * Added coverage confirming checksum entries remain correctly separated across subdirectories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->