### PR TITLE
Mark pre-release versions as pre-releases in create-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,10 +286,25 @@ jobs:
           # Read release notes from file
           NOTES=$(cat ${{ steps.release-notes.outputs.notes_file }})
 
+          # Mark pre-release versions as such, otherwise GitHub reports them as
+          # the repository's "Latest release" and /releases/latest serves them
+          # to users and tooling as if they were stable. PEP 440 pre-release
+          # suffixes only: .postN is a post-release of a stable version and
+          # must stay a full release.
+          VERSION="${{ needs.setup.outputs.version }}"
+          PRERELEASE_FLAG=""
+          if [[ "$VERSION" =~ \.?(rc|a|b|alpha|beta|dev)[0-9]*$ ]]; then
+            PRERELEASE_FLAG="--prerelease"
+            echo "✓ $VERSION is a pre-release; marking it accordingly"
+          else
+            echo "✓ $VERSION is a full release"
+          fi
+
           # Create new release without assets first
           gh release create "$TAG" \
-            --title "Release v${{ needs.setup.outputs.version }}" \
-            --notes "$NOTES"
+            --title "Release v${VERSION}" \
+            --notes "$NOTES" \
+            $PRERELEASE_FLAG
 
       - name: Download flashinfer-python artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`create-release` invokes:

```bash
gh release create "$TAG"   --title "Release v${{ needs.setup.outputs.version }}"   --notes "$NOTES"
```

with no `--prerelease`, so **every** tag becomes a full GitHub release. GitHub then treats the newest such release as the repository's **"Latest release"** and serves it from `/releases/latest` — so a release candidate supersedes the last stable release both on the repo page and for anything reading that endpoint programmatically.

This surfaced with `v0.6.16rc3`, the first rc ever to reach `create-release` (earlier rcs never got past the build jobs). It became "Latest release" and had to be re-flagged by hand.

**Fix:** derive the flag from the version string. Only PEP 440 pre-release suffixes (`rc`/`a`/`b`/`alpha`/`beta`/`dev`) qualify — `.postN` is a post-release of a *stable* version and must remain a full release.

Nightly releases are created elsewhere and already set `prerelease` correctly, so they are unaffected.

## 🔍 Related Issues

- Surfaced during the 0.6.16rc3 release ([run 30336403860](https://github.com/flashinfer-ai/flashinfer/actions/runs/30336403860)); build fixes for that release were #4200 / #4203.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (\`unittest\`, etc.).

This is a workflow-only change with no unit-testable surface, so no tests were added. Verified two ways instead:

1. The classifier was exercised directly against every relevant version form:

| version | result |
|---|---|
| `0.6.16rc3` | PRERELEASE |
| `0.6.16a1` | PRERELEASE |
| `0.6.16b2` | PRERELEASE |
| `0.6.16.dev1` | PRERELEASE |
| `0.7.0rc1` | PRERELEASE |
| `0.6.16` | full release |
| `0.6.15` | full release |
| `0.6.16.post1` | full release |
| `1.2.3.post2` | full release |

2. `release.yml` re-parsed as YAML after the edit; all 7 jobs still present.

## Reviewer Notes

- Accepted suffixes are a superset of what the workflow's own tag-format check allows (`^v[0-9]+\.[0-9]+\.[0-9]+(\.?[a-z][a-z0-9]*)?$`), so nothing that currently passes validation changes classification except actual pre-releases.
- The `--title` now uses the `\$VERSION` shell variable rather than re-expanding the workflow output twice; behaviour is identical.
- No effect on stable releases: they take the same path as before with an empty flag.
- `v0.6.16rc3` has already been corrected manually, so this only prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Releases with pre-release version suffixes are now automatically marked as pre-releases.
  * Release titles consistently display the computed version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->