### PR TITLE
fix(comm): make TorchDistBackend.Split() synchronizing, like MPI_Comm_split

### DIFF
--- a/flashinfer/comm/comm_backend.py
+++ b/flashinfer/comm/comm_backend.py
@@ -179,4 +179,14 @@ class TorchDistBackend:
         cur_group, _ = self._dist.new_subgroups_by_enumeration(
             _split_partition(all_info)
         )  # pyright: ignore
+        # new_group() does not synchronize the ranks by default (torch only runs
+        # its post-init store barrier when TORCH_DIST_INIT_BARRIER=1), so a rank
+        # can return from a sub-group rendezvous while a peer is still inside it.
+        # With gloo the rendezvous is eager: the peer that is still connecting
+        # then sees "connectFullMesh failed ... Connection closed by peer" as soon
+        # as the rank that raced ahead tears its process group down or exits.
+        # Barrier on the parent group so Split() is collective *and* synchronizing,
+        # matching MPI_Comm_split (and MPIBackend.Split) semantics. Split happens
+        # once at setup, so the cost is irrelevant.
+        self.barrier()
         return TorchDistBackend(group=cur_group)  # pyright: ignore

--- a/tests/comm/test_comm_backend.py
+++ b/tests/comm/test_comm_backend.py
@@ -154,6 +154,7 @@ class _FakeDist:
         self._world = world_size
         self._all_info = all_info
         self.created: list[tuple[int, ...]] = []  # sub-groups created, in order
+        self.barriers: list[Any] = []  # groups barriered on, in order
 
     def get_rank(self, group: Any = None) -> int:
         return self._rank if group is None else group.ranks.index(self._rank)
@@ -177,6 +178,9 @@ class _FakeDist:
         self.created.extend(g.ranks for g in subs)
         cur = next((g for g in subs if self._rank in g.ranks), None)
         return cur, subs
+
+    def barrier(self, group: Any = None) -> None:
+        self.barriers.append(group)
 
     def new_group(self, ranks: list[int]) -> Any:
         # Unused by the fixed Split, but recorded so a regression to the buggy
@@ -222,6 +226,10 @@ def test_torch_dist_backend_split_creates_every_subgroup_on_every_rank(
         assert fake.created == expected, f"rank {rank}: {fake.created}"
         # ...and gets back a backend scoped to its own color's sub-group.
         assert sub._group.ranks == expected[rank % 2]  # pyright: ignore[reportPrivateUsage, reportOptionalMemberAccess]
+        # Split must synchronize on the *parent* group before returning, or a
+        # rank can race ahead and tear down while a peer is still inside the
+        # sub-group rendezvous (gloo then fails connectFullMesh -- see #4193).
+        assert fake.barriers == [None], f"rank {rank}: {fake.barriers}"
 
 
 def test_split_partition_covers_all_colors_ordered_by_key() -> None:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`TorchDistBackend.Split()` returns without synchronizing the ranks, which leaves a window where one rank can walk away while a peer is still building the sub-group. Two facts combine:

1. **`new_group()` does not synchronize ranks.** Its post-init store barrier only runs when `TORCH_DIST_INIT_BARRIER=1`, and that env var defaults to `0` (`_is_barrier_after_init` in torch's `distributed_c10d.py`). A rank returns from `new_subgroups_by_enumeration()` as soon as *its own* side of the rendezvous is done.
2. **The gloo pair handshake is asymmetric.** Per `gloo/transport/tcp/pair.cc`: "one side takes a passive role and the other side takes an active role" — the active side connects, writes a sequence number and returns; the passive side must still accept and *read* it.

So `Split()` can return on one rank while a peer is still inside the mesh. If that rank then tears its process groups down or exits, the peer is left holding a socket that just closed.

**Fix:** barrier on the **parent** group before returning. `Split()` becomes collective *and* synchronizing, matching `MPI_Comm_split` — and `MPIBackend.Split` — semantics: no rank leaves until every peer has finished its sub-group rendezvous. `Split()` runs once at setup, so the cost is irrelevant.

## 🔍 Related Issues

Related to #4193 — but this PR **does not claim to fix it**, and deliberately uses no closing keyword. See Reviewer Notes. The instrumentation half of the original #4195 was split out into #4205 so it can land independently of this one.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/comm/test_comm_backend.py`: 9 passed, 1 skipped (mpi4py not installed). The fake-`dist` unit test now asserts that `Split()` barriers on the parent group, so a regression is caught without needing real processes.

## Reviewer Notes

**I could not reproduce the CI failure in 242 runs against the unfixed code, and I want that stated up front rather than buried.** On Linux/x86_64 with CPU-only gloo (the **tcp** transport, same as CI):

| scenario | runs | failures |
|---|---|---|
| pytest, idle host | 60 | 0 |
| pytest, 6-way concurrent, pinned to 2 CPUs | 72 | 0 |
| hard-exit stress, sub-groups of 2 / 4 / 8 ranks | 90 | 0 |
| hard-exit stress, 16 ranks timesharing 1 CPU | 20 | 0 |

The "hard-exit stress" harness was written specifically to trigger the window described above — every rank calls `os._exit(0)` the instant `Split()` returns, no `destroy_process_group()`, with the sub-group enlarged so the rendezvous has more pairs and a wider spread between first and last rank to finish. It is green. That is evidence *against* the specific causal story, not for it.

By the rule of three, 0 failures in 242 runs puts the 95% upper bound on the per-run failure rate at ~1.2%, and 1% is already in mild tension with the data. **A green CI run on this PR is therefore not evidence that anything was fixed** — at p ≈ 1% a single run passes with ~99% probability even with the bug fully present, and catching it with 95% confidence would take roughly 300 runs. Please don't read a green pipeline as validation.

So: treat this as closing a synchronization gap that is **provable from the torch and gloo sources**, not as a fix for #4193. That issue should stay open with its `infra` label; infrastructure is not exonerated, and the runners on this repo demonstrably kill jobs mid-run.

On the change itself: the barrier is on the parent group, which every rank reaches because `Split()` is already collective on it (it opens with an `allgather`). So it cannot deadlock — including when splitting an existing sub-group — and it adds no device requirement beyond what that `allgather` already imposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved communicator splitting to synchronize all processes before returning the new subgroup.
  * Ensures split operations behave consistently with MPI-style communication semantics.

* **Tests**
  * Added coverage verifying synchronization occurs on the parent communicator during subgroup creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->