### PR TITLE
feat(examples): FP8 / NVFP4 quantized linear for the e2e LLM example

### DIFF
--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -1,0 +1,124 @@
+# End-to-End PyTorch LLM Examples
+
+Tracking doc for the `examples/pytorch/llm/` effort.
+
+## Motivation
+
+FlashInfer's test suite is kernel-centric: each op is validated in isolation
+against a reference. What we lack is a *self-contained* end-to-end exercise of
+the library — a real model forward pass that strings together attention
+(paged KV cache, prefill + decode), RoPE, RMSNorm, activation, GEMM, and
+sampling the way a serving stack would. Integration-level regressions are
+invisible to unit tests but very visible to users, e.g.:
+
+- JIT/cubin cache not being hit → kernels silently recompiling on every
+  process start (or worse, every call);
+- backend dispatch quietly falling back to a slow/generic path on some
+  SM version;
+- plan/run wrapper API drift that only shows up when prefill, append, and
+  decode are used together across steps;
+- dtype/layout mismatches between ops that each pass their own unit tests.
+
+Serving frameworks that embed FlashInfer do catch some of this, but through
+their own abstraction layers and on their own release cadence. These examples
+let us close the loop *within this repo*: a plain-PyTorch reference usage of
+the public API that we can run on any machine with weights from Hugging Face
+and no external inference framework in the dependency chain. They are
+**reference/verification code, not a serving engine** — for production
+inference, use a real serving stack. The point is that when something breaks
+end to end, we can reproduce and bisect it here with nothing but
+`flashinfer + torch + transformers(tokenizer/config only) + safetensors`.
+
+This extends the existing `examples/pytorch/` direction (the WAN diffusion
+example) to the LLM serving path, which is FlashInfer's core use case.
+
+## Non-goals
+
+- Production-grade throughput (no continuous batching scheduler, no
+  overlapping, no speculative decoding). Batching exists only to exercise the
+  batched kernel paths.
+- Competing with or benchmarking against inference frameworks.
+- Covering every model architecture. We pick a small set that maximizes
+  kernel-path coverage per line of example code.
+
+## What fits on a B200 node
+
+Working numbers: one B200 has 192 GB HBM3e (~180 GB usable). A node gives us
+up to 4 GPUs ≈ 768 GB nominal. Weights-only footprint below; add ~10–20 % for
+KV cache + activations at modest batch/context.
+
+### Single GPU (1× B200, 192 GB)
+
+| Model | Params | Weights (BF16) | Notes |
+|---|---|---|---|
+| Qwen3-0.6B / 1.7B / 4B | 0.6–4 B | 1.2–8 GB | fast smoke-test tier; ungated |
+| Llama-3.2-1B / 3B, Llama-3.1-8B | 1–8 B | 2–16 GB | gated on HF (license click-through) |
+| Qwen3-8B / 14B / 32B (dense) | 8–32 B | 16–64 GB | ungated; good single-GPU "real model" tier |
+| Qwen3-30B-A3B (MoE) | 30 B total / 3 B active | ~60 GB | exercises fused MoE path on one GPU |
+| Mixtral-8x7B | 47 B | ~94 GB | classic MoE |
+| GPT-OSS-20B / 120B | 20 B / 117 B | ~12 / ~60 GB (native MXFP4) | exercises MXFP4 weight path |
+| Llama-3.3-70B | 70 B | ~140 GB BF16 (tight) / ~70 GB FP8 | FP8 comfortable on one GPU |
+
+### 2–4 GPUs (TP)
+
+| Model | Weights | Fits? |
+|---|---|---|
+| Qwen3-235B-A22B (MoE) | ~235 GB FP8 / ~470 GB BF16 | FP8 on 2 GPUs, BF16 on 4 |
+| Llama-3.1-405B | ~405 GB FP8 | 4 GPUs, tight but viable at small batch |
+| DeepSeek-V3 / R1 (671B) | ~671 GB native FP8 | **no** at 4 GPUs once KV + activations are counted; needs a full 8-GPU node |
+| Kimi-K2 (1T) | > 1 TB | no |
+
+Conclusion: everything we need for phase 1 (dense GQA + MoE + FP8/FP4 weight
+paths) runs on **one** B200; 4 GPUs only become interesting when we add
+tensor-parallel examples (phase 3).
+
+## Example design
+
+Directory: `examples/pytorch/llm/`
+
+| File | Purpose |
+|---|---|
+| `modeling.py` | Llama/Qwen-family decoder built from FlashInfer ops: `BatchPrefillWithPagedKVCacheWrapper`, `BatchDecodeWithPagedKVCacheWrapper`, `append_paged_kv_cache`, `apply_rope_pos_ids`, `rmsnorm`/`fused_add_rmsnorm`, `silu_and_mul`. Weights loaded straight from HF safetensors (no `AutoModel`). |
+| `generate.py` | CLI: prompt(s) → prefill → decode loop → text, with FlashInfer sampling ops; `--max-tokens`, `--batch`, greedy or top-k/top-p. |
+| `smoke_test.py` | The verification harness (see below). |
+| `README.md` | Usage + backend/env-var knobs, mirroring the style of `examples/pytorch/README.md`. |
+
+Model support keyed off HF `config.json` `model_type` ∈ {`llama`, `qwen2`,
+`qwen3`} — same skeleton (RMSNorm → GQA attn with RoPE → SwiGLU FFN), small
+per-family deltas (Qwen3 q/k per-head norm, Qwen2 QKV bias, Llama-3.1 RoPE
+scaling).
+
+### The verification harness (`smoke_test.py`)
+
+This is the actual point of the exercise. Checks, each cheap and scriptable:
+
+1. **Correctness sanity** — greedy decode of a fixed prompt must be
+   deterministic across runs and produce a plausible continuation. Optionally
+   compare prefill logits against a `transformers` eager forward (tolerance
+   check) when `--reference` is passed.
+2. **JIT/cache hygiene** — run generation in a fresh subprocess twice; the
+   second run must not invoke `nvcc`/`cicc` (asserted via
+   `FLASHINFER_LOGGING_LEVEL=DEBUG` JIT logs) and its module-load phase must
+   be dramatically faster. This is the "kernel cache silently broken" canary.
+3. **No recompiles across steps** — within one process, decode steps after
+   warmup must not trigger new JIT builds (plan/run reuse working).
+4. **Backend dispatch** — the selected attention/GEMM backends actually run
+   (no silent fallback), asserted via `FLASHINFER_LOGLEVEL` API logs.
+
+## Status log
+
+- **2026-07-21** — doc created; upstream main synced (`b7cd951d`). Phase 1
+  in progress: dense Qwen3/Llama single-GPU example + smoke harness, to be
+  validated on a computelab B200.
+
+## Roadmap
+
+- **Phase 1 (this change):** dense single-GPU example (Qwen3 0.6B–32B,
+  Llama-family), paged-KV prefill/decode, sampling, smoke harness; validate
+  on B200.
+- **Phase 2:** MoE variant (Qwen3-30B-A3B) exercising `fused_moe`; FP8/FP4
+  weight-quantized linear via the shared `flashinfer_modules.py` backends.
+- **Phase 3:** tensor-parallel (2–4 GPU) variant exercising
+  `flashinfer.comm` all-reduce; unlocks the 70B–235B tier.
+- **Phase 4:** wire the smoke harness into CI (it's designed to be a
+  single-command pass/fail).

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -135,6 +135,11 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
     as 0.6B (head_dim 128, BF16).
   - Note: decode with `use_tensor_cores=True` shares the prefill module, so
     the dense BF16 path needs only 4 JIT modules end to end.
+- **2026-07-21** — `--chat` mode validated on B200 (Qwen3-8B, greedy,
+  96 tokens): correct answers to factual questions, EOS stop confirmed,
+  ~404 tok/s batch-3 decode. One portability fix: transformers v5 changed
+  `apply_chat_template`'s tokenized return type, so the example now renders
+  the template to text and tokenizes explicitly.
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -167,7 +167,27 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
   the identical kernel path as Qwen3-30B-A3B, so no large download is needed
   for functional verification. Remaining: FP8/FP4 weight-quantized linear
   backends.
-- **Phase 3:** tensor-parallel (2–4 GPU) variant exercising
-  `flashinfer.comm` all-reduce; unlocks the 70B–235B tier.
-- **Phase 4:** wire the smoke harness into CI (it's designed to be a
-  single-command pass/fail).
+- **Phase 3 (in progress):** TEP (TP=EP) multi-GPU — attention
+  tensor-parallel, MoE expert-parallel over the same ranks, two NCCL
+  allreduces per layer, launched with `torchrun`; `reference_check.py`
+  validates the sharded result against the single-GPU transformers
+  reference. Follow-ups: swap NCCL allreduce for `flashinfer.comm`
+  (trtllm/vllm allreduce) as a selectable backend; 4-GPU runs for the
+  70B–235B tier.
+- **Phase 4 (started):** health instrumentation + performance gates.
+  `health_check.py` measures the serving lifecycle (import, load, cold
+  prefill incl. JIT builds, warm prefill/decode throughput, steady-state
+  recompiles, optional autotune delta) and emits JSON — the gate inputs.
+  Planned next: CUDA-graph capture of the decode step
+  (`use_cuda_graph=True` wrapper mode with preallocated page tables),
+  threshold files + trend comparison, then CI wiring of
+  smoke/reference/health checks. Multi-node is explicitly out of scope for
+  now.
+
+### Ops note: persistent JIT cache for GPU-node runs
+
+Node containers are ephemeral; a container-local `~/.cache/flashinfer`
+loses the ~1 h `fused_moe_100` compile on every teardown. Runs now mount an
+NFS-backed cache (`flashinfer2/var/jit_cache` →
+`/home/aleyang/.cache/flashinfer`), so any node/container reuses compiled
+artifacts.

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -110,6 +110,21 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
 - **2026-07-21** — doc created; upstream main synced (`b7cd951d`). Phase 1
   in progress: dense Qwen3/Llama single-GPU example + smoke harness, to be
   validated on a computelab B200.
+- **2026-07-21** — first B200 deployment (Qwen3-0.6B) surfaced two findings
+  on day one, validating the approach:
+  1. *Environment class:* a source checkout without the (new) `3rdparty/cccl`
+     submodule fails every attention JIT compile — the JIT include path puts
+     the vendored CCCL first and `fastdiv.cuh` now needs
+     `cuda::fast_mod_div`, so an empty `3rdparty/cccl` silently falls back to
+     the CUDA toolkit's older libcudacxx and nvcc errors out. Anyone
+     updating an existing checkout across that upstream change hits this.
+  2. *Harness calibration:* `JitSpecNvcc.try_load()` returns `None` for
+     JIT-path modules *by design* (artifact freshness is delegated to
+     ninja's dependency scan), so `build()` runs in every fresh process and
+     ninja no-ops on a warm cache. "Recompile" must therefore be measured as
+     "built artifact changed across `build()`", which is what the harness
+     now does; raw `build()` invocations are reported separately as the
+     warm-start overhead metric (`jit_build_calls`).
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -152,6 +152,17 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
   checkpoints (all real HF models tested) were unaffected. Also measured:
   the `fused_moe_100` module is by far the heaviest JIT unit (267 objects,
   ~1 h cold compile at 30-way parallelism on the shared node).
+- **2026-07-22** — Phase 3 TEP validated on 2× B200 (umbriel-b200-040):
+  `torchrun --nproc_per_node=2 reference_check.py` matches the single-GPU
+  transformers reference at identical quality (dense rel-L2 0.0077–0.0089,
+  MoE 0.0080–0.0383, top-1 agreement everywhere) — TP attention sharding,
+  EP expert dispatch (`ep_size/ep_rank` + global routing), and both
+  allreduce points are numerically correct. `health_check.py` passes in
+  both modes with `jit_builds_cold=0` — the NFS-mounted JIT cache
+  (ops note below) served a fresh container on a different node with zero
+  recompiles. Tiny-model TEP throughput is (expectedly) below single-GPU
+  (decode 1601 vs 1847 tok/s) since allreduce latency dominates at toy
+  sizes; real-model TEP numbers are a phase-4 measurement.
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -125,6 +125,16 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
      "built artifact changed across `build()`", which is what the harness
      now does; raw `build()` invocations are reported separately as the
      warm-start overhead metric (`jit_build_calls`).
+- **2026-07-21** — Phase 1 validated on B200 (computelab, CI cu130 image):
+  - Cold cache: Qwen3-0.6B smoke run 1 compiled 4 modules (batch_prefill,
+    rope, page, silu_and_mul; 57.8 s), run 2 compiled **0** (6.4 s) —
+    cross-process cache reuse confirmed; greedy outputs identical; zero
+    steady-state builds. `smoke_test.py` exit 0.
+  - Qwen3-8B (36 layers): coherent batch-3 completions, ~316 tok/s decode
+    (uninstrumented loop, not a benchmark), zero compiles — same kernel URIs
+    as 0.6B (head_dim 128, BF16).
+  - Note: decode with `use_tensor_cores=True` shares the prefill module, so
+    the dense BF16 path needs only 4 JIT modules end to end.
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -143,11 +143,18 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
 
 ## Roadmap
 
-- **Phase 1 (this change):** dense single-GPU example (Qwen3 0.6B–32B,
+- **Phase 1 (done):** dense single-GPU example (Qwen3 0.6B–32B,
   Llama-family), paged-KV prefill/decode, sampling, smoke harness; validate
   on B200.
-- **Phase 2:** MoE variant (Qwen3-30B-A3B) exercising `fused_moe`; FP8/FP4
-  weight-quantized linear via the shared `flashinfer_modules.py` backends.
+- **Phase 2 (in progress):** `qwen3_moe` support through
+  `fused_moe.cutlass_fused_moe` (BF16 SwiGLU experts, external
+  softmax→top-k→renorm routing mirroring the HF reference), plus
+  `reference_check.py`: tiny random-weight dense/MoE checkpoints built with
+  `transformers`, our last-token prefill logits asserted against
+  transformers eager within a relative-L2 tolerance. The tiny MoE exercises
+  the identical kernel path as Qwen3-30B-A3B, so no large download is needed
+  for functional verification. Remaining: FP8/FP4 weight-quantized linear
+  backends.
 - **Phase 3:** tensor-parallel (2–4 GPU) variant exercising
   `flashinfer.comm` all-reduce; unlocks the 70B–235B tier.
 - **Phase 4:** wire the smoke harness into CI (it's designed to be a

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -140,6 +140,18 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
   ~404 tok/s batch-3 decode. One portability fix: transformers v5 changed
   `apply_chat_template`'s tokenized return type, so the example now renders
   the template to text and tokenizes explicitly.
+- **2026-07-22** — Phase 2 (MoE) validated on B200. `reference_check.py`
+  results vs transformers eager (bf16, tolerance 0.05 rel-L2):
+  dense 0.008–0.010, MoE 0.007–0.039, top-1 agreement at every length;
+  tiny-MoE decode loop deterministic. The check caught a real bug on its
+  first run: transformers v5 moved rope config into nested
+  `rope_parameters` (and renamed the expert count to `num_local_experts`),
+  so the old flat-schema read silently used rope_theta=1e4 for v5-saved
+  checkpoints — a with-length-growing logits divergence (0.16→0.64) that
+  the HF-bf16-vs-fp32 baseline (~0.007, flat) proved was ours. Older
+  checkpoints (all real HF models tested) were unaffected. Also measured:
+  the `fused_moe_100` module is by far the heaviest JIT unit (267 objects,
+  ~1 h cold compile at 30-way parallelism on the shared node).
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -176,8 +176,16 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
   `transformers`, our last-token prefill logits asserted against
   transformers eager within a relative-L2 tolerance. The tiny MoE exercises
   the identical kernel path as Qwen3-30B-A3B, so no large download is needed
-  for functional verification. Remaining: FP8/FP4 weight-quantized linear
-  backends.
+  for functional verification. Quantized linear landed 2026-07-28:
+  `--quant {bf16,fp8,nvfp4}` (`quant.py`) quantizes the dense projections on
+  the fly from a BF16 checkpoint — FP8 W8A8 per-tensor via `bmm_fp8`, NVFP4
+  W4A4 block-16 via `nvfp4_quantize` + `mm_fp4`. B200-measured: FP8 GEMM cos
+  0.9993 / logits rel-L2 0.074–0.081; NVFP4 cos 0.9910 / rel-L2 0.281–0.346;
+  autotuner exercises `fp8_gemm` and `fp4_gemm` tactics. Router, `lm_head`
+  and the MoE expert GEMMs stay BF16 by design (see the example README).
+  Remaining: quantized MoE experts (`quant_scales` is a mode-specific
+  positional list whose fc1 scales must follow the up-above-gate pack order
+  of `moe_w31`).
 - **Phase 3 (in progress):** TEP (TP=EP) multi-GPU — attention
   tensor-parallel, MoE expert-parallel over the same ranks, two NCCL
   allreduces per layer, launched with `torchrun`; `reference_check.py`

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -3,6 +3,11 @@
 This directory contains reusable FlashInfer PyTorch building blocks and model
 examples that use them.
 
+| Example | Description |
+|---------|-------------|
+| [`llm/`](llm/) | Self-contained Llama/Qwen decoder over FlashInfer's paged-KV prefill/decode path, with an end-to-end smoke test (JIT-cache reuse, determinism) |
+| [`wan/`](wan/) | WAN text-to-video diffusion transformer using the shared modules below |
+
 ## Shared Modules
 
 `flashinfer_modules.py` contains model-independent components that can be reused

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -1,13 +1,20 @@
 # FlashInfer LLM Example (Llama / Qwen dense)
 
 A self-contained, plain-PyTorch LLM decoder built from FlashInfer's
-serving-path ops. This is **reference and verification code, not a serving
-engine**: it exists so FlashInfer's public APIs can be exercised end to end —
-paged KV cache, batched prefill/decode attention, RoPE, RMSNorm, SwiGLU
-activation, and sampling — with nothing but `flashinfer`, `torch`, and a
-Hugging Face checkpoint. Integration-level regressions (a broken JIT cache,
-per-step recompiles, silent backend fallbacks) show up here even when every
-kernel unit test passes. Background and roadmap:
+serving-path ops.
+
+**Scope.** Serving models independently is explicitly *not* a goal of this
+example — production inference belongs to the serving frameworks that build
+on FlashInfer. What *is* the goal, and what we consider paramount for the
+library's robustness, is being able to **close the loop independently**: a
+functional end-to-end verification path that exercises FlashInfer's public
+APIs the way a serving stack composes them — paged KV cache, batched
+prefill/decode attention, RoPE, RMSNorm, SwiGLU activation, and sampling —
+with nothing but `flashinfer`, `torch`, and a Hugging Face checkpoint.
+Integration-level regressions (a broken JIT cache, per-step recompiles,
+silent backend fallbacks) show up here even when every kernel unit test
+passes, and can be reproduced and bisected inside this repo without any
+external framework in the dependency chain. Background and roadmap:
 [`docs/design_docs/e2e_pytorch_llm_examples.md`](../../../docs/design_docs/e2e_pytorch_llm_examples.md).
 
 ## FlashInfer APIs exercised

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -1,0 +1,87 @@
+# FlashInfer LLM Example (Llama / Qwen dense)
+
+A self-contained, plain-PyTorch LLM decoder built from FlashInfer's
+serving-path ops. This is **reference and verification code, not a serving
+engine**: it exists so FlashInfer's public APIs can be exercised end to end —
+paged KV cache, batched prefill/decode attention, RoPE, RMSNorm, SwiGLU
+activation, and sampling — with nothing but `flashinfer`, `torch`, and a
+Hugging Face checkpoint. Integration-level regressions (a broken JIT cache,
+per-step recompiles, silent backend fallbacks) show up here even when every
+kernel unit test passes. Background and roadmap:
+[`docs/design_docs/e2e_pytorch_llm_examples.md`](../../../docs/design_docs/e2e_pytorch_llm_examples.md).
+
+## FlashInfer APIs exercised
+
+| API | Where |
+|-----|-------|
+| `BatchPrefillWithPagedKVCacheWrapper` (plan/run, causal, ragged batch) | prompt prefill |
+| `BatchDecodeWithPagedKVCacheWrapper` (plan/run, tensor cores) | token-by-token decode |
+| `append_paged_kv_cache`, `get_batch_indices_positions` | paged KV maintenance every step |
+| `apply_rope_pos_ids_inplace` / `apply_llama31_rope_pos_ids_inplace` | rotary embedding (incl. Llama-3.1 scaling) |
+| `rmsnorm`, `fused_add_rmsnorm` | pre/post-attention norms, Qwen3 per-head q/k norm |
+| `silu_and_mul` | SwiGLU FFN |
+| `sampling.top_k_top_p_sampling_from_logits` | non-greedy sampling |
+
+## Supported models
+
+Any dense Hugging Face checkpoint with `model_type` ∈ {`llama`, `qwen2`,
+`qwen3`}. Weights are read straight from safetensors (BF16 compute). Sizing
+guide (single GPU): Qwen3-0.6B…32B and Llama 1B…8B fit comfortably on one
+modern data-center GPU; see the design doc for a full B200 fit table.
+
+| Tier | Model | Notes |
+|------|-------|-------|
+| Smoke test (fast) | `Qwen/Qwen3-0.6B` | default; ungated download |
+| Real model | `Qwen/Qwen3-8B`, `Qwen/Qwen3-32B` | ungated |
+| Llama family | `meta-llama/Llama-3.1-8B-Instruct` | gated (HF license); exercises llama3 RoPE scaling |
+
+## Usage
+
+```bash
+# Batch greedy completion with the built-in prompts
+python generate.py --model-id Qwen/Qwen3-0.6B --max-tokens 32
+
+# Chat template + sampling
+python generate.py --model-id Qwen/Qwen3-8B --chat \
+  --prompt "Explain KV cache paging in two sentences." \
+  --temperature 0.7 --top-k 50 --top-p 0.9 --max-tokens 128
+
+# Steer the attention backends (forwarded to the wrapper constructors)
+python generate.py --prefill-backend fa2 --decode-backend fa2
+```
+
+`generate.py` prints the completions, coarse prefill/decode timing (this is a
+correctness harness — the timing includes JIT warmup and per-step host work;
+do not read it as a benchmark), and machine-readable `[smoke] key=value`
+lines used by the smoke test.
+
+## Smoke test
+
+```bash
+python smoke_test.py --model-id Qwen/Qwen3-0.6B --max-tokens 16
+```
+
+Runs generation in two fresh processes and asserts:
+
+1. the second process compiles **zero** JIT modules (on-disk kernel cache is
+   actually reused — catches "cache silently broken, everyone recompiles");
+2. no JIT build ever happens during steady-state decode steps;
+3. greedy outputs are identical across the two runs;
+4. every request produced tokens.
+
+Exit code 0/1, suitable for CI. To force a fully cold first run:
+`rm -rf ~/.cache/flashinfer` first.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `modeling.py` | config/weight loading, paged KV cache, decoder forward pass |
+| `generate.py` | CLI generation loop (prefill → decode → sample) + JIT-build counter |
+| `smoke_test.py` | two-process verification harness (see above) |
+
+## Requirements
+
+`flashinfer`, `torch`, and — for checkpoint/tokenizer handling only —
+`transformers`, `huggingface_hub`, `safetensors`. No inference framework is
+imported; model weights download to the standard HF cache (`HF_HOME`).

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -88,7 +88,40 @@ Exit code 0/1, suitable for CI. To force a fully cold first run:
 | `modeling.py` | config/weight loading, paged KV cache, decoder forward pass (dense + MoE) |
 | `generate.py` | CLI generation loop (prefill → decode → sample) + JIT-build counter |
 | `smoke_test.py` | two-process verification harness (see above) |
-| `reference_check.py` | numerical check: tiny random dense/MoE models, last-token prefill logits vs `transformers` eager within a relative-L2 tolerance |
+| `reference_check.py` | numerical check: tiny random dense/MoE models, last-token prefill logits vs `transformers` eager within a relative-L2 tolerance; also runs under `torchrun` for TEP |
+| `health_check.py` | lifecycle metrics (import / load / cold prefill+JIT / warm prefill / decode throughput / steady recompiles) with JSON output — groundwork for performance gates |
+
+## Multi-GPU: TEP (TP = EP)
+
+Launch any of the scripts with `torchrun` to run tensor-parallel attention
+with expert-parallel MoE over the same ranks — the standard single-node
+deployment shape for MoE models, minimally mimicked:
+
+```bash
+torchrun --nproc_per_node=2 reference_check.py           # numerics vs 1-GPU reference
+torchrun --nproc_per_node=2 generate.py --model-id Qwen/Qwen3-0.6B
+torchrun --nproc_per_node=2 health_check.py --tiny moe
+```
+
+Sharding: QKV column-parallel / `o_proj` row-parallel, dense-FFN gate/up
+column- / down row-parallel, MoE experts sliced per rank
+(`cutlass_fused_moe(ep_size=, ep_rank=)` with global routing computed on
+every rank). Exactly two allreduces per layer (post-attention and
+post-FFN/MoE), over NCCL. Requires head counts / intermediate size / expert
+count divisible by the world size.
+
+## Health instrumentation
+
+```bash
+python health_check.py --tiny moe --json health.json
+python health_check.py --model-id Qwen/Qwen3-8B --batch 4 --prompt-len 512 --autotune
+```
+
+Reports import / load / cold-prefill (JIT warmup) / warm prefill / decode
+throughput / steady-state recompile count (must be 0), optionally re-measured
+after an `autotune(True)` warmup pass. The JSON output is the intended input
+for future performance gates. Host-side timings — for trend and gating, not
+kernel benchmarking.
 
 ## Requirements
 

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -26,13 +26,14 @@ external framework in the dependency chain. Background and roadmap:
 | `append_paged_kv_cache`, `get_batch_indices_positions` | paged KV maintenance every step |
 | `apply_rope_pos_ids_inplace` / `apply_llama31_rope_pos_ids_inplace` | rotary embedding (incl. Llama-3.1 scaling) |
 | `rmsnorm`, `fused_add_rmsnorm` | pre/post-attention norms, Qwen3 per-head q/k norm |
-| `silu_and_mul` | SwiGLU FFN |
+| `silu_and_mul` | SwiGLU FFN (dense layers) |
+| `fused_moe.cutlass_fused_moe` | MoE expert dispatch (`qwen3_moe`): SwiGLU experts with external top-k routing |
 | `sampling.top_k_top_p_sampling_from_logits` | non-greedy sampling |
 
 ## Supported models
 
-Any dense Hugging Face checkpoint with `model_type` ∈ {`llama`, `qwen2`,
-`qwen3`}. Weights are read straight from safetensors (BF16 compute). Sizing
+Any Hugging Face checkpoint with `model_type` ∈ {`llama`, `qwen2`, `qwen3`,
+`qwen3_moe`}. Weights are read straight from safetensors (BF16 compute). Sizing
 guide (single GPU): Qwen3-0.6B…32B and Llama 1B…8B fit comfortably on one
 modern data-center GPU; see the design doc for a full B200 fit table.
 
@@ -41,6 +42,7 @@ modern data-center GPU; see the design doc for a full B200 fit table.
 | Smoke test (fast) | `Qwen/Qwen3-0.6B` | default; ungated download |
 | Real model | `Qwen/Qwen3-8B`, `Qwen/Qwen3-32B` | ungated |
 | Llama family | `meta-llama/Llama-3.1-8B-Instruct` | gated (HF license); exercises llama3 RoPE scaling |
+| MoE | `Qwen/Qwen3-30B-A3B` | ungated; ~60 GB BF16, one B200-class GPU; `reference_check.py` covers the same kernel path with a tiny model |
 
 ## Usage
 
@@ -83,9 +85,10 @@ Exit code 0/1, suitable for CI. To force a fully cold first run:
 
 | File | Purpose |
 |------|---------|
-| `modeling.py` | config/weight loading, paged KV cache, decoder forward pass |
+| `modeling.py` | config/weight loading, paged KV cache, decoder forward pass (dense + MoE) |
 | `generate.py` | CLI generation loop (prefill → decode → sample) + JIT-build counter |
 | `smoke_test.py` | two-process verification harness (see above) |
+| `reference_check.py` | numerical check: tiny random dense/MoE models, last-token prefill logits vs `transformers` eager within a relative-L2 tolerance |
 
 ## Requirements
 

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -123,6 +123,43 @@ after an `autotune(True)` warmup pass. The JSON output is the intended input
 for future performance gates. Host-side timings — for trend and gating, not
 kernel benchmarking.
 
+## Quantized linear (FP8 / NVFP4)
+
+```bash
+python generate.py --model-id Qwen/Qwen3-0.6B --quant fp8
+python reference_check.py --arch dense --quant all     # numerics gate
+python health_check.py --model-id Qwen/Qwen3-0.6B --quant nvfp4 --autotune
+```
+
+| mode | what | FlashInfer API |
+|------|------|----------------|
+| `bf16` | default, and the numerical reference | `torch.nn.functional.linear` |
+| `fp8` | W8A8 per-tensor e4m3 | `bmm_fp8` |
+| `nvfp4` | W4A4 block-16 e2m1 + e4m3 block scales | `nvfp4_quantize` + `mm_fp4` |
+
+Weights are quantized **on the fly** at load time from a plain BF16
+checkpoint — no pre-quantized weights needed — and activations are quantized
+per forward. Only the dense projections (q/k/v/o, gate/up/down) are
+quantized: the MoE router stays in model dtype (top-k is discrete, so a
+perturbation flips experts), `lm_head` is the same tensor as the embedding
+table under `tie_word_embeddings`, and the MoE expert GEMMs still pass
+`quant_scales=None`.
+
+**Expect quality loss, especially with `nvfp4`.** This is dynamic per-tensor
+scaling with no calibration, SmoothQuant, or rotation — the point is to
+exercise the kernels end to end, not to ship a good quantized model. On
+Qwen3-0.6B, FP8 output is close to BF16 while NVFP4 stays fluent but drifts
+factually. Nothing gates on generated text.
+
+**Expect lower tok/s too.** Each linear adds an amax reduction and a
+quantize kernel, which at verification-scale shapes dominates the GEMM
+saving. That is launch overhead, not a kernel regression.
+
+`--quant-backend` pins the GEMM backend; by default `auto` resolves
+version-dependently (on B200/CUDA 13 we measured `cutlass_sm10x` for FP8 and
+`cudnn` for NVFP4), and the resolved choice is printed as
+`[smoke] quant_resolved_backends` so it is never silent.
+
 ## Requirements
 
 `flashinfer`, `torch`, and — for checkpoint/tokenizer handling only —

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -1,0 +1,357 @@
+"""Batch text generation with the FlashInfer LLM example model.
+
+Usage:
+    python generate.py --model-id Qwen/Qwen3-0.6B --max-tokens 32
+    python generate.py --model-id Qwen/Qwen3-8B --prompt "The capital of France is" \
+        --temperature 0.7 --top-k 50 --top-p 0.9
+
+Besides generating text, this script emits machine-readable ``[smoke] key=value``
+lines consumed by ``smoke_test.py``:
+
+- ``jit_builds_total`` — number of FlashInfer JIT modules actually *compiled*
+  in this process (``JitSpec.build()`` calls, which happen only on a JIT cache
+  miss). On a warm cache this must be 0.
+- ``jit_builds_steady`` — compilations triggered after the first decode step
+  (must always be 0: steady-state decoding must not recompile anything).
+- ``tokens_<i>`` — generated token ids per request, for determinism checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import math
+import time
+from typing import Dict, List, Optional
+
+import torch
+
+import flashinfer
+
+from modeling import FlashInferLLM, PagedKVCache, resolve_checkpoint_dir
+
+DEFAULT_PROMPTS = [
+    "The capital of France is",
+    "The three primary colors are",
+    "To bake bread you need flour, water,",
+]
+
+
+def install_jit_build_counter() -> Dict:
+    """Count actual JIT compilations (cache misses) in this process.
+
+    ``JitSpec.build_and_load()`` calls ``build()`` only after ``try_load()``
+    misses (see flashinfer/jit/core.py), so wrapping the concrete subclasses'
+    ``build`` gives an exact "module was recompiled" counter.
+    """
+    import flashinfer.jit.core as jit_core
+
+    # Registers the CuTe-DSL JitSpec subclass if the DSL is installed.
+    with contextlib.suppress(Exception):
+        import flashinfer.jit.cute_dsl_core  # noqa: F401
+
+    counter: Dict = {"count": 0, "names": []}
+
+    def _wrap(cls):
+        orig = cls.__dict__.get("build")
+        if orig is None:
+            return
+
+        def build(self, *args, _orig=orig, **kwargs):
+            counter["count"] += 1
+            counter["names"].append(self.name)
+            return _orig(self, *args, **kwargs)
+
+        cls.build = build
+
+    seen = set()
+    stack = [jit_core.JitSpec]
+    while stack:
+        c = stack.pop()
+        for sub in c.__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                _wrap(sub)
+                stack.append(sub)
+    return counter
+
+
+def sample_tokens(
+    logits: torch.Tensor,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    generator: Optional[torch.Generator],
+) -> torch.Tensor:
+    if temperature <= 0.0:
+        return logits.argmax(dim=-1).to(torch.int32)
+    logits = logits / temperature
+    vocab = logits.shape[-1]
+    effective_top_k = top_k if top_k > 0 else vocab
+    return flashinfer.sampling.top_k_top_p_sampling_from_logits(
+        logits, effective_top_k, top_p, deterministic=True, generator=generator
+    )
+
+
+class GenerationEngine:
+    def __init__(
+        self,
+        model: FlashInferLLM,
+        page_size: int = 16,
+        prefill_backend: str = "auto",
+        decode_backend: str = "auto",
+    ):
+        self.model = model
+        self.page_size = page_size
+        device = model.device
+        # Separate 128 MB workspaces; the decode one must start zeroed.
+        self.prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device),
+            kv_layout="NHD",
+            backend=prefill_backend,
+        )
+        self.decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device),
+            kv_layout="NHD",
+            use_tensor_cores=True,
+            backend=decode_backend,
+        )
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        prompt_token_ids: List[List[int]],
+        max_new_tokens: int,
+        temperature: float = 0.0,
+        top_k: int = 0,
+        top_p: float = 1.0,
+        seed: int = 0,
+        jit_counter: Optional[Dict] = None,
+    ) -> Dict:
+        model, cfg, device = self.model, self.model.config, self.model.device
+        batch = len(prompt_token_ids)
+        page_size = self.page_size
+        num_q, num_kv, hd = (
+            cfg.num_attention_heads,
+            cfg.num_key_value_heads,
+            cfg.head_dim,
+        )
+        generator = None
+        if temperature > 0.0:
+            generator = torch.Generator(device=device)
+            generator.manual_seed(seed)
+
+        max_pages = sum(
+            math.ceil((len(p) + max_new_tokens) / page_size) for p in prompt_token_ids
+        )
+        kv = PagedKVCache(cfg, max_pages, page_size, device, model.dtype)
+        for ids in prompt_token_ids:
+            req = kv.add_request()
+            kv.extend(req, len(ids))
+
+        # ---- Prefill: all prompts in one ragged batch ----
+        t_start = time.perf_counter()
+        input_ids = torch.tensor(
+            [t for ids in prompt_token_ids for t in ids],
+            dtype=torch.int64,
+            device=device,
+        )
+        qo_indptr_list = [0]
+        for ids in prompt_token_ids:
+            qo_indptr_list.append(qo_indptr_list[-1] + len(ids))
+        qo_indptr = torch.tensor(qo_indptr_list, dtype=torch.int32, device=device)
+        nnz = input_ids.shape[0]
+        kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
+        batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
+            qo_indptr, kv.seq_lens_tensor(), nnz
+        )
+        self.prefill_wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_q,
+            num_kv,
+            hd,
+            page_size,
+            causal=True,
+            q_data_type=model.dtype,
+            kv_data_type=model.dtype,
+        )
+        logits = model.forward(
+            input_ids,
+            pos_ids,
+            self.prefill_wrapper,
+            kv,
+            batch_indices,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            last_token_rows=(qo_indptr[1:].to(torch.int64) - 1),
+        )
+        next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
+        torch.cuda.synchronize()
+        t_prefill = time.perf_counter()
+
+        eos = set(cfg.eos_token_ids)
+        outputs: List[List[int]] = [[] for _ in range(batch)]
+        finished = [False] * batch
+        for i, tok in enumerate(next_tokens.tolist()):
+            outputs[i].append(tok)
+            finished[i] = tok in eos
+
+        # ---- Decode: one token per request per step ----
+        builds_after_first_decode: Optional[int] = None
+        decode_rows = torch.arange(batch, dtype=torch.int64, device=device)
+        append_indptr = torch.arange(batch + 1, dtype=torch.int32, device=device)
+        steps = 0
+        for _ in range(max_new_tokens - 1):
+            if all(finished):
+                break
+            for req in range(batch):
+                kv.extend(req, 1)
+            kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
+            self.decode_wrapper.plan(
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_q,
+                num_kv,
+                hd,
+                page_size,
+                q_data_type=model.dtype,
+                kv_data_type=model.dtype,
+            )
+            batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
+                append_indptr, kv.seq_lens_tensor(), batch
+            )
+            logits = model.forward(
+                next_tokens.to(torch.int64),
+                pos_ids,
+                self.decode_wrapper,
+                kv,
+                batch_indices,
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                last_token_rows=decode_rows,
+            )
+            next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
+            for i, tok in enumerate(next_tokens.tolist()):
+                if not finished[i]:
+                    outputs[i].append(tok)
+                    finished[i] = tok in eos
+            steps += 1
+            if steps == 1 and jit_counter is not None:
+                torch.cuda.synchronize()
+                builds_after_first_decode = jit_counter["count"]
+        torch.cuda.synchronize()
+        t_end = time.perf_counter()
+
+        jit_builds_steady = 0
+        if jit_counter is not None and builds_after_first_decode is not None:
+            jit_builds_steady = jit_counter["count"] - builds_after_first_decode
+        return {
+            "outputs": outputs,
+            "finished": finished,
+            "prefill_seconds": t_prefill - t_start,
+            "decode_seconds": t_end - t_prefill,
+            "decode_steps": steps,
+            "decode_tokens": steps * batch,
+            "jit_builds_steady": jit_builds_steady,
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default="Qwen/Qwen3-0.6B")
+    parser.add_argument(
+        "--prompt",
+        action="append",
+        help="Prompt (repeatable). Defaults to a small built-in batch.",
+    )
+    parser.add_argument("--chat", action="store_true", help="Apply the chat template")
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument(
+        "--temperature", type=float, default=0.0, help="0 = greedy (default)"
+    )
+    parser.add_argument("--top-k", type=int, default=0, help="0 = disabled")
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--page-size", type=int, default=16)
+    parser.add_argument("--prefill-backend", default="auto")
+    parser.add_argument("--decode-backend", default="auto")
+    args = parser.parse_args()
+
+    jit_counter = install_jit_build_counter()
+    device = torch.device("cuda")
+    ckpt_dir = resolve_checkpoint_dir(args.model_id)
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(str(ckpt_dir))
+    t0 = time.perf_counter()
+    model = FlashInferLLM.from_pretrained(str(ckpt_dir), device)
+    print(
+        f"Loaded {args.model_id} ({model.config.model_type}, "
+        f"{model.config.num_hidden_layers} layers) in {time.perf_counter() - t0:.1f}s"
+    )
+
+    prompts = args.prompt or DEFAULT_PROMPTS
+    if args.chat:
+        prompt_token_ids = []
+        for p in prompts:
+            messages = [{"role": "user", "content": p}]
+            try:
+                ids = tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True, enable_thinking=False
+                )
+            except TypeError:  # template without enable_thinking support
+                ids = tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True
+                )
+            prompt_token_ids.append(list(ids))
+        eos_extra = tokenizer.eos_token_id
+        if eos_extra is not None and eos_extra not in model.config.eos_token_ids:
+            model.config.eos_token_ids.append(eos_extra)
+    else:
+        prompt_token_ids = [tokenizer(p)["input_ids"] for p in prompts]
+
+    engine = GenerationEngine(
+        model,
+        page_size=args.page_size,
+        prefill_backend=args.prefill_backend,
+        decode_backend=args.decode_backend,
+    )
+    result = engine.generate(
+        prompt_token_ids,
+        max_new_tokens=args.max_tokens,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        seed=args.seed,
+        jit_counter=jit_counter,
+    )
+
+    for i, (prompt, out_ids) in enumerate(zip(prompts, result["outputs"], strict=True)):
+        text = tokenizer.decode(out_ids, skip_special_tokens=True)
+        print(f"\n--- request {i} ({'eos' if result['finished'][i] else 'length'}) ---")
+        print(f"prompt:     {prompt!r}")
+        print(f"completion: {text!r}")
+
+    decode_tps = result["decode_tokens"] / max(result["decode_seconds"], 1e-9)
+    print(
+        f"\nprefill {result['prefill_seconds']:.3f}s | "
+        f"decode {result['decode_steps']} steps, {decode_tps:.1f} tok/s "
+        f"(batch={len(prompts)}; includes first-call JIT warmup)"
+    )
+
+    print(f"[smoke] jit_builds_total={jit_counter['count']}")
+    print(f"[smoke] jit_builds_names={','.join(jit_counter['names'])}")
+    print(f"[smoke] jit_builds_steady={result['jit_builds_steady']}")
+    for i, out_ids in enumerate(result["outputs"]):
+        print(f"[smoke] tokens_{i}={','.join(map(str, out_ids))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import argparse
 import contextlib
 import math
+import os
+import sys
 import time
 from typing import Dict, List, Optional
 
@@ -38,6 +40,20 @@ DEFAULT_PROMPTS = [
     "The three primary colors are",
     "To bake bread you need flour, water,",
 ]
+
+
+def maybe_init_distributed() -> tuple:
+    """Initialize NCCL for torchrun launches (TEP: TP=EP over all ranks).
+
+    Returns (world_size, rank). Single-process runs return (1, 0) untouched.
+    """
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if world_size == 1:
+        return 1, 0
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    torch.distributed.init_process_group(backend="nccl")
+    return world_size, torch.distributed.get_rank()
 
 
 def install_jit_build_counter() -> Dict:
@@ -146,7 +162,14 @@ class GenerationEngine:
             math.ceil((len(p) + max_new_tokens) / self.page_size)
             for p in prompt_token_ids
         )
-        kv = PagedKVCache(cfg, max_pages, self.page_size, device, self.model.dtype)
+        kv = PagedKVCache(
+            cfg,
+            max_pages,
+            self.page_size,
+            device,
+            self.model.dtype,
+            num_kv_heads=self.model.num_local_kv_heads,
+        )
         for ids in prompt_token_ids:
             req = kv.add_request()
             kv.extend(req, len(ids))
@@ -176,8 +199,8 @@ class GenerationEngine:
             kv_indptr,
             kv_indices,
             kv_last_page_len,
-            cfg.num_attention_heads,
-            cfg.num_key_value_heads,
+            model.num_local_qo_heads,
+            model.num_local_kv_heads,
             cfg.head_dim,
             self.page_size,
             causal=True,
@@ -220,8 +243,8 @@ class GenerationEngine:
         batch = len(prompt_token_ids)
         page_size = self.page_size
         num_q, num_kv, hd = (
-            cfg.num_attention_heads,
-            cfg.num_key_value_heads,
+            model.num_local_qo_heads,
+            model.num_local_kv_heads,
             cfg.head_dim,
         )
         generator = None
@@ -329,17 +352,24 @@ def main():
     args = parser.parse_args()
 
     jit_counter = install_jit_build_counter()
-    device = torch.device("cuda")
+    world_size, rank = maybe_init_distributed()
+    if rank != 0:  # keep stdout single-writer; stderr stays visible
+        sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
+    device = torch.device("cuda", torch.cuda.current_device())
     ckpt_dir = resolve_checkpoint_dir(args.model_id)
 
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(str(ckpt_dir))
     t0 = time.perf_counter()
-    model = FlashInferLLM.from_pretrained(str(ckpt_dir), device)
+    model = FlashInferLLM.from_pretrained(
+        str(ckpt_dir), device, tp_size=world_size, tp_rank=rank
+    )
+    tp_note = f", tep tp=ep={world_size}" if world_size > 1 else ""
     print(
         f"Loaded {args.model_id} ({model.config.model_type}, "
-        f"{model.config.num_hidden_layers} layers) in {time.perf_counter() - t0:.1f}s"
+        f"{model.config.num_hidden_layers} layers{tp_note}) "
+        f"in {time.perf_counter() - t0:.1f}s"
     )
 
     prompts = args.prompt or DEFAULT_PROMPTS
@@ -404,6 +434,8 @@ def main():
     print(f"[smoke] jit_builds_steady={result['jit_builds_steady']}")
     for i, out_ids in enumerate(result["outputs"]):
         print(f"[smoke] tokens_{i}={','.join(map(str, out_ids))}")
+    if world_size > 1:
+        torch.distributed.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -9,8 +9,11 @@ Besides generating text, this script emits machine-readable ``[smoke] key=value`
 lines consumed by ``smoke_test.py``:
 
 - ``jit_builds_total`` — number of FlashInfer JIT modules actually *compiled*
-  in this process (``JitSpec.build()`` calls, which happen only on a JIT cache
-  miss). On a warm cache this must be 0.
+  in this process (the built artifact changed during ``JitSpec.build()``).
+  On a warm cache this must be 0.
+- ``jit_build_calls`` — informational: ``build()`` invocations, i.e. ninja
+  dependency scans. By design this equals the number of JIT modules used
+  even on a warm cache (``try_load`` defers freshness to ninja).
 - ``jit_builds_steady`` — compilations triggered after the first decode step
   (must always be 0: steady-state decoding must not recompile anything).
 - ``tokens_<i>`` — generated token ids per request, for determinism checks.
@@ -38,11 +41,18 @@ DEFAULT_PROMPTS = [
 
 
 def install_jit_build_counter() -> Dict:
-    """Count actual JIT compilations (cache misses) in this process.
+    """Count actual JIT compilations (not mere cache probes) in this process.
 
-    ``JitSpec.build_and_load()`` calls ``build()`` only after ``try_load()``
-    misses (see flashinfer/jit/core.py), so wrapping the concrete subclasses'
-    ``build`` gives an exact "module was recompiled" counter.
+    Nuance discovered on first deployment of this harness:
+    ``JitSpecNvcc.try_load()`` intentionally returns ``None`` for JIT-path
+    modules — artifact freshness is owned by ninja's dependency scan — so
+    ``build()`` runs in *every* process and ninja no-ops when the cached
+    ``.so`` is up to date (see flashinfer/jit/core.py). Counting ``build()``
+    calls therefore counts ninja invocations, not recompiles. A module was
+    actually (re)compiled iff its built artifact changed across the
+    ``build()`` call, so that is what ``count``/``names`` track;
+    ``build_calls`` keeps the raw invocation count as an informational
+    warm-start metric.
     """
     import flashinfer.jit.core as jit_core
 
@@ -50,7 +60,14 @@ def install_jit_build_counter() -> Dict:
     with contextlib.suppress(Exception):
         import flashinfer.jit.cute_dsl_core  # noqa: F401
 
-    counter: Dict = {"count": 0, "names": []}
+    counter: Dict = {"count": 0, "names": [], "build_calls": 0}
+
+    def _artifact_stamp(spec):
+        try:
+            lib = spec.get_library_path()
+            return lib.stat().st_mtime_ns if lib.exists() else None
+        except Exception:
+            return None
 
     def _wrap(cls):
         orig = cls.__dict__.get("build")
@@ -58,9 +75,13 @@ def install_jit_build_counter() -> Dict:
             return
 
         def build(self, *args, _orig=orig, **kwargs):
-            counter["count"] += 1
-            counter["names"].append(self.name)
-            return _orig(self, *args, **kwargs)
+            counter["build_calls"] += 1
+            before = _artifact_stamp(self)
+            result = _orig(self, *args, **kwargs)
+            if _artifact_stamp(self) != before:
+                counter["count"] += 1
+                counter["names"].append(self.name)
+            return result
 
         cls.build = build
 
@@ -348,6 +369,7 @@ def main():
 
     print(f"[smoke] jit_builds_total={jit_counter['count']}")
     print(f"[smoke] jit_builds_names={','.join(jit_counter['names'])}")
+    print(f"[smoke] jit_build_calls={jit_counter['build_calls']}")
     print(f"[smoke] jit_builds_steady={result['jit_builds_steady']}")
     for i, out_ids in enumerate(result["outputs"]):
         print(f"[smoke] tokens_{i}={','.join(map(str, out_ids))}")

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -138,6 +138,73 @@ class GenerationEngine:
             backend=decode_backend,
         )
 
+    def _make_cache(
+        self, prompt_token_ids: List[List[int]], max_new_tokens: int
+    ) -> PagedKVCache:
+        cfg, device = self.model.config, self.model.device
+        max_pages = sum(
+            math.ceil((len(p) + max_new_tokens) / self.page_size)
+            for p in prompt_token_ids
+        )
+        kv = PagedKVCache(cfg, max_pages, self.page_size, device, self.model.dtype)
+        for ids in prompt_token_ids:
+            req = kv.add_request()
+            kv.extend(req, len(ids))
+        return kv
+
+    def _prefill(
+        self, prompt_token_ids: List[List[int]], kv: PagedKVCache
+    ) -> torch.Tensor:
+        """Run the batched causal prefill; returns last-token logits [batch, vocab]."""
+        model, cfg, device = self.model, self.model.config, self.model.device
+        input_ids = torch.tensor(
+            [t for ids in prompt_token_ids for t in ids],
+            dtype=torch.int64,
+            device=device,
+        )
+        qo_indptr_list = [0]
+        for ids in prompt_token_ids:
+            qo_indptr_list.append(qo_indptr_list[-1] + len(ids))
+        qo_indptr = torch.tensor(qo_indptr_list, dtype=torch.int32, device=device)
+        nnz = input_ids.shape[0]
+        kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
+        batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
+            qo_indptr, kv.seq_lens_tensor(), nnz
+        )
+        self.prefill_wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            cfg.num_attention_heads,
+            cfg.num_key_value_heads,
+            cfg.head_dim,
+            self.page_size,
+            causal=True,
+            q_data_type=model.dtype,
+            kv_data_type=model.dtype,
+        )
+        return model.forward(
+            input_ids,
+            pos_ids,
+            self.prefill_wrapper,
+            kv,
+            batch_indices,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            last_token_rows=(qo_indptr[1:].to(torch.int64) - 1),
+        )
+
+    @torch.inference_mode()
+    def prefill_logits(self, prompt_token_ids: List[List[int]]) -> torch.Tensor:
+        """Last-token prefill logits per prompt (no decode).
+
+        Used by reference checks that compare against another implementation.
+        """
+        kv = self._make_cache(prompt_token_ids, max_new_tokens=1)
+        return self._prefill(prompt_token_ids, kv)
+
     @torch.inference_mode()
     def generate(
         self,
@@ -162,54 +229,11 @@ class GenerationEngine:
             generator = torch.Generator(device=device)
             generator.manual_seed(seed)
 
-        max_pages = sum(
-            math.ceil((len(p) + max_new_tokens) / page_size) for p in prompt_token_ids
-        )
-        kv = PagedKVCache(cfg, max_pages, page_size, device, model.dtype)
-        for ids in prompt_token_ids:
-            req = kv.add_request()
-            kv.extend(req, len(ids))
+        kv = self._make_cache(prompt_token_ids, max_new_tokens)
 
         # ---- Prefill: all prompts in one ragged batch ----
         t_start = time.perf_counter()
-        input_ids = torch.tensor(
-            [t for ids in prompt_token_ids for t in ids],
-            dtype=torch.int64,
-            device=device,
-        )
-        qo_indptr_list = [0]
-        for ids in prompt_token_ids:
-            qo_indptr_list.append(qo_indptr_list[-1] + len(ids))
-        qo_indptr = torch.tensor(qo_indptr_list, dtype=torch.int32, device=device)
-        nnz = input_ids.shape[0]
-        kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
-        batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
-            qo_indptr, kv.seq_lens_tensor(), nnz
-        )
-        self.prefill_wrapper.plan(
-            qo_indptr,
-            kv_indptr,
-            kv_indices,
-            kv_last_page_len,
-            num_q,
-            num_kv,
-            hd,
-            page_size,
-            causal=True,
-            q_data_type=model.dtype,
-            kv_data_type=model.dtype,
-        )
-        logits = model.forward(
-            input_ids,
-            pos_ids,
-            self.prefill_wrapper,
-            kv,
-            batch_indices,
-            kv_indptr,
-            kv_indices,
-            kv_last_page_len,
-            last_token_rows=(qo_indptr[1:].to(torch.int64) - 1),
-        )
+        logits = self._prefill(prompt_token_ids, kv)
         next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
         torch.cuda.synchronize()
         t_prefill = time.perf_counter()

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -323,15 +323,22 @@ def main():
         prompt_token_ids = []
         for p in prompts:
             messages = [{"role": "user", "content": p}]
+            # Render to text, then tokenize explicitly: apply_chat_template's
+            # tokenized return type varies across transformers versions.
             try:
-                ids = tokenizer.apply_chat_template(
-                    messages, add_generation_prompt=True, enable_thinking=False
+                text = tokenizer.apply_chat_template(
+                    messages,
+                    add_generation_prompt=True,
+                    tokenize=False,
+                    enable_thinking=False,
                 )
             except TypeError:  # template without enable_thinking support
-                ids = tokenizer.apply_chat_template(
-                    messages, add_generation_prompt=True
+                text = tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True, tokenize=False
                 )
-            prompt_token_ids.append(list(ids))
+            prompt_token_ids.append(
+                tokenizer(text, add_special_tokens=False)["input_ids"]
+            )
         eos_extra = tokenizer.eos_token_id
         if eos_extra is not None and eos_extra not in model.config.eos_token_ids:
             model.config.eos_token_ids.append(eos_extra)

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -33,6 +33,7 @@ import torch
 
 import flashinfer
 
+import quant
 from modeling import FlashInferLLM, PagedKVCache, resolve_checkpoint_dir
 
 DEFAULT_PROMPTS = [
@@ -349,6 +350,18 @@ def main():
     parser.add_argument("--page-size", type=int, default=16)
     parser.add_argument("--prefill-backend", default="auto")
     parser.add_argument("--decode-backend", default="auto")
+    parser.add_argument(
+        "--quant",
+        choices=quant.QUANT_MODES,
+        default="bf16",
+        help="Quantize the dense projections on the fly (default: bf16)",
+    )
+    parser.add_argument(
+        "--quant-backend",
+        default="auto",
+        help="FlashInfer GEMM backend for --quant "
+        "(fp8: cublas|cudnn|cutlass|auto, nvfp4: cudnn|cutlass|auto)",
+    )
     args = parser.parse_args()
 
     jit_counter = install_jit_build_counter()
@@ -356,14 +369,22 @@ def main():
     if rank != 0:  # keep stdout single-writer; stderr stays visible
         sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
     device = torch.device("cuda", torch.cuda.current_device())
+    reason = quant.unsupported_reason(args.quant, args.quant_backend, device)
+    if reason:
+        print(f"skipping: {reason}")
+        print("[smoke] quant=skip")
+        if world_size > 1:
+            torch.distributed.destroy_process_group()
+        return
     ckpt_dir = resolve_checkpoint_dir(args.model_id)
 
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(str(ckpt_dir))
+    qcfg = quant.QuantConfig(args.quant, args.quant_backend)
     t0 = time.perf_counter()
     model = FlashInferLLM.from_pretrained(
-        str(ckpt_dir), device, tp_size=world_size, tp_rank=rank
+        str(ckpt_dir), device, tp_size=world_size, tp_rank=rank, quant=qcfg
     )
     tp_note = f", tep tp=ep={world_size}" if world_size > 1 else ""
     print(
@@ -428,6 +449,14 @@ def main():
         f"(batch={len(prompts)}; includes first-call JIT warmup)"
     )
 
+    qs = qcfg.summary()
+    print(f"[smoke] quant_mode={qs['mode']}")
+    if qs["mode"] != "bf16":
+        # Which backend "auto" resolved to is version-dependent (cuDNN vs
+        # CUTLASS on SM100), so make it visible instead of silent.
+        print(f"[smoke] quant_linears={qs['quantized_linears']}")
+        print(f"[smoke] quant_fallbacks={qs['bf16_fallbacks']}")
+        print(f"[smoke] quant_resolved_backends={qs['resolved_backends']}")
     print(f"[smoke] jit_builds_total={jit_counter['count']}")
     print(f"[smoke] jit_builds_names={','.join(jit_counter['names'])}")
     print(f"[smoke] jit_build_calls={jit_counter['build_calls']}")

--- a/examples/pytorch/llm/health_check.py
+++ b/examples/pytorch/llm/health_check.py
@@ -1,0 +1,199 @@
+"""Model-health instrumentation for the FlashInfer LLM example.
+
+Measures the lifecycle stages a serving deployment cares about and emits
+them as both a human summary and machine-readable JSON — groundwork for
+performance gates (each metric is a natural threshold candidate):
+
+- ``import_seconds``   — ``import flashinfer`` in a fresh interpreter
+- ``load_seconds``     — checkpoint -> device (weights + sharding)
+- ``cold_prefill_seconds`` / ``jit_builds_cold`` — first forward, including
+  JIT compilation / cubin loading (startup-preparation cost)
+- ``warm_prefill_tokens_per_s`` — prefill throughput after warmup
+- ``decode_tokens_per_s`` — steady-state decode throughput
+- ``jit_builds_steady`` — must be 0 (no recompiles once serving)
+- with ``--autotune``: decode/prefill re-measured after a
+  ``flashinfer.autotune(True)`` warmup pass, reported as ``*_autotuned``
+
+Timing is host-side (``perf_counter`` around synchronized calls): this is
+health instrumentation for trend/gate purposes, not a kernel benchmark —
+use ``flashinfer.testing.bench_gpu_time`` / CUPTI for kernel numbers.
+CUDA-graph capture of the decode step is a planned addition (the wrappers
+support ``use_cuda_graph=True`` with preallocated page-table buffers).
+
+Usage:
+    python health_check.py --tiny moe --json health.json
+    python health_check.py --model-id Qwen/Qwen3-0.6B --batch 4 --prompt-len 512
+    torchrun --nproc_per_node=2 health_check.py --tiny moe    # TEP (TP=EP)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+import torch
+
+from generate import GenerationEngine, install_jit_build_counter, maybe_init_distributed
+from modeling import FlashInferLLM, resolve_checkpoint_dir
+
+
+def measure_import_seconds() -> float:
+    code = (
+        "import time; t = time.perf_counter(); import flashinfer; "
+        "print(time.perf_counter() - t)"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=600
+    )
+    return float(out.stdout.strip().splitlines()[-1])
+
+
+def timed(fn) -> float:
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    fn()
+    torch.cuda.synchronize()
+    return time.perf_counter() - t0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", help="HF model id or local checkpoint path")
+    parser.add_argument(
+        "--tiny",
+        choices=["dense", "moe"],
+        help="use a tiny random-weight checkpoint (no download) instead of --model-id",
+    )
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--prompt-len", type=int, default=256)
+    parser.add_argument("--decode-tokens", type=int, default=64)
+    parser.add_argument("--prefill-iters", type=int, default=5)
+    parser.add_argument("--autotune", action="store_true")
+    parser.add_argument("--json", dest="json_path", help="write metrics JSON here")
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+    if not args.model_id and not args.tiny:
+        parser.error("pass --model-id or --tiny")
+
+    jit_counter = install_jit_build_counter()
+    world_size, rank = maybe_init_distributed()
+    if rank != 0:  # keep stdout single-writer; stderr stays visible
+        sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    metrics = {
+        "gpu": torch.cuda.get_device_name(device),
+        "world_size": world_size,
+        "batch": args.batch,
+        "prompt_len": args.prompt_len,
+        "decode_tokens": args.decode_tokens,
+    }
+
+    # --- stage 0: import cost (fresh interpreter, rank 0 only) ---
+    if rank == 0:
+        metrics["import_seconds"] = round(measure_import_seconds(), 3)
+
+    # --- resolve checkpoint ---
+    tmpdir = None
+    if args.tiny:
+        from reference_check import build_tiny_checkpoint
+
+        ckpt = None
+        if rank == 0:
+            tmpdir = tempfile.mkdtemp()
+            ckpt = build_tiny_checkpoint(args.tiny, tmpdir, args.seed)
+        if world_size > 1:
+            obj = [ckpt]
+            torch.distributed.broadcast_object_list(obj, src=0)
+            ckpt = obj[0]
+        metrics["model"] = f"tiny-{args.tiny}"
+    else:
+        ckpt = str(resolve_checkpoint_dir(args.model_id))
+        metrics["model"] = args.model_id
+
+    try:
+        # --- stage 1: load ---
+        t0 = time.perf_counter()
+        model = FlashInferLLM.from_pretrained(
+            ckpt, device, tp_size=world_size, tp_rank=rank
+        )
+        engine = GenerationEngine(model)
+        metrics["load_seconds"] = round(time.perf_counter() - t0, 3)
+
+        g = torch.Generator().manual_seed(args.seed + 1)
+        vocab = model.config.vocab_size
+        prompts = [
+            torch.randint(0, vocab, (args.prompt_len,), generator=g).tolist()
+            for _ in range(args.batch)
+        ]
+        prefill_tokens = args.batch * args.prompt_len
+
+        # --- stage 2: cold prefill (JIT warmup / cubin loads) ---
+        builds_before = jit_counter["count"]
+        metrics["cold_prefill_seconds"] = round(
+            timed(lambda: engine.prefill_logits(prompts)), 3
+        )
+        metrics["jit_builds_cold"] = jit_counter["count"] - builds_before
+
+        def measure_throughput(tag: str):
+            times = [
+                timed(lambda: engine.prefill_logits(prompts))
+                for _ in range(args.prefill_iters)
+            ]
+            metrics[f"warm_prefill_seconds{tag}"] = round(statistics.median(times), 4)
+            metrics[f"warm_prefill_tokens_per_s{tag}"] = round(
+                prefill_tokens / statistics.median(times), 1
+            )
+            result = engine.generate(
+                prompts, max_new_tokens=args.decode_tokens, jit_counter=jit_counter
+            )
+            metrics[f"decode_tokens_per_s{tag}"] = round(
+                result["decode_tokens"] / max(result["decode_seconds"], 1e-9), 1
+            )
+            return result
+
+        # --- stage 3: warm throughput ---
+        result = measure_throughput("")
+        metrics["jit_builds_steady"] = result["jit_builds_steady"]
+        metrics["jit_builds_total"] = jit_counter["count"]
+
+        # --- stage 4 (optional): autotuned throughput ---
+        if args.autotune:
+            import flashinfer
+
+            with flashinfer.autotune(True):
+                engine.generate(prompts, max_new_tokens=4)
+            metrics["autotune_warmup"] = True
+            measure_throughput("_autotuned")
+
+        print(
+            f"\nhealth check: {metrics['model']} "
+            f"({'TEP tp=ep=' + str(world_size) if world_size > 1 else '1 GPU'})"
+        )
+        for key, value in metrics.items():
+            print(f"  {key:>32}: {value}")
+        for key in ("jit_builds_steady",):
+            if metrics.get(key, 0) != 0:
+                print(f"UNHEALTHY: {key}={metrics[key]} (expected 0)")
+                sys.exit(1)
+        if args.json_path and rank == 0:
+            with open(args.json_path, "w") as f:
+                json.dump(metrics, f, indent=1)
+            print(f"metrics written to {args.json_path}")
+        print("[smoke] health=pass")
+    finally:
+        if rank == 0 and tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        if world_size > 1:
+            torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/health_check.py
+++ b/examples/pytorch/llm/health_check.py
@@ -40,6 +40,7 @@ import time
 
 import torch
 
+import quant
 from generate import GenerationEngine, install_jit_build_counter, maybe_init_distributed
 from modeling import FlashInferLLM, resolve_checkpoint_dir
 
@@ -78,6 +79,8 @@ def main():
     parser.add_argument("--autotune", action="store_true")
     parser.add_argument("--json", dest="json_path", help="write metrics JSON here")
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--quant", choices=quant.QUANT_MODES, default="bf16")
+    parser.add_argument("--quant-backend", default="auto")
     args = parser.parse_args()
     if not args.model_id and not args.tiny:
         parser.error("pass --model-id or --tiny")
@@ -87,6 +90,14 @@ def main():
     if rank != 0:  # keep stdout single-writer; stderr stays visible
         sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
     device = torch.device("cuda", torch.cuda.current_device())
+
+    reason = quant.unsupported_reason(args.quant, args.quant_backend, device)
+    if reason:
+        print(f"skipping: {reason}")
+        print("[smoke] health=skip")
+        if world_size > 1:
+            torch.distributed.destroy_process_group()
+        return
 
     metrics = {
         "gpu": torch.cuda.get_device_name(device),
@@ -121,11 +132,17 @@ def main():
     try:
         # --- stage 1: load ---
         t0 = time.perf_counter()
+        qcfg = quant.QuantConfig(args.quant, args.quant_backend)
         model = FlashInferLLM.from_pretrained(
-            ckpt, device, tp_size=world_size, tp_rank=rank
+            ckpt, device, tp_size=world_size, tp_rank=rank, quant=qcfg
         )
         engine = GenerationEngine(model)
         metrics["load_seconds"] = round(time.perf_counter() - t0, 3)
+        if args.quant != "bf16":
+            # Two extra elementwise kernels per linear (amax + quantize) mean
+            # tok/s can DROP under --quant at verification-scale shapes. That
+            # is launch overhead, not a kernel regression.
+            metrics["quant"] = qcfg.summary()
 
         g = torch.Generator().manual_seed(args.seed + 1)
         vocab = model.config.vocab_size

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -159,8 +159,19 @@ def _load_state_dict(ckpt_dir: Path) -> Dict[str, torch.Tensor]:
 
 
 class DecoderLayerWeights:
+    """Per-layer weights, sharded at load time when tp_size > 1 (TEP style:
+    attention heads and dense-FFN intermediate are tensor-parallel; MoE
+    experts are expert-parallel across the same ranks)."""
+
     def __init__(
-        self, sd: Dict[str, torch.Tensor], i: int, device, dtype, config: "ModelConfig"
+        self,
+        sd: Dict[str, torch.Tensor],
+        i: int,
+        device,
+        dtype,
+        config: "ModelConfig",
+        tp_size: int = 1,
+        tp_rank: int = 0,
     ):
         p = f"model.layers.{i}."
 
@@ -172,25 +183,36 @@ class DecoderLayerWeights:
                 return None
             return sd[key].to(device=device, dtype=dtype)
 
+        def shard(t: Optional[torch.Tensor], dim: int) -> Optional[torch.Tensor]:
+            if t is None or tp_size == 1:
+                return t
+            return t.chunk(tp_size, dim=dim)[tp_rank].contiguous()
+
         self.input_layernorm = get("input_layernorm.weight")
         self.post_attention_layernorm = get("post_attention_layernorm.weight")
-        self.q_proj = get("self_attn.q_proj.weight")
-        self.k_proj = get("self_attn.k_proj.weight")
-        self.v_proj = get("self_attn.v_proj.weight")
-        self.o_proj = get("self_attn.o_proj.weight")
+        # Column-parallel QKV (head-contiguous rows), row-parallel o_proj.
+        self.q_proj = shard(get("self_attn.q_proj.weight"), 0)
+        self.k_proj = shard(get("self_attn.k_proj.weight"), 0)
+        self.v_proj = shard(get("self_attn.v_proj.weight"), 0)
+        self.o_proj = shard(get("self_attn.o_proj.weight"), 1)
         # Qwen2-family checkpoints carry QKV bias; Llama/Qwen3 do not.
-        self.q_bias = get("self_attn.q_proj.bias", required=False)
-        self.k_bias = get("self_attn.k_proj.bias", required=False)
-        self.v_bias = get("self_attn.v_proj.bias", required=False)
-        # Qwen3 per-head q/k RMSNorm over head_dim.
+        self.q_bias = shard(get("self_attn.q_proj.bias", required=False), 0)
+        self.k_bias = shard(get("self_attn.k_proj.bias", required=False), 0)
+        self.v_bias = shard(get("self_attn.v_proj.bias", required=False), 0)
+        # Qwen3 per-head q/k RMSNorm over head_dim: replicated (shape [head_dim]).
         self.q_norm = get("self_attn.q_norm.weight", required=False)
         self.k_norm = get("self_attn.k_norm.weight", required=False)
         self.is_sparse = config.is_sparse_layer(i)
         if self.is_sparse:
             self.gate_proj = self.up_proj = self.down_proj = None
-            self.moe_gate = get("mlp.gate.weight")  # router, [num_experts, hidden]
+            # Router is replicated; every rank computes the global routing.
+            self.moe_gate = get("mlp.gate.weight")  # [num_experts, hidden]
+            # Expert-parallel: this rank holds experts
+            # [tp_rank * E/tp, (tp_rank+1) * E/tp).
+            experts_per_rank = config.num_experts // tp_size
+            expert_start = tp_rank * experts_per_rank
             w31, w2 = [], []
-            for j in range(config.num_experts):
+            for j in range(expert_start, expert_start + experts_per_rank):
                 ep = f"{p}mlp.experts.{j}."
                 gate = sd[ep + "gate_proj.weight"].to(device=device, dtype=dtype)
                 up = sd[ep + "up_proj.weight"].to(device=device, dtype=dtype)
@@ -200,13 +222,14 @@ class DecoderLayerWeights:
                 # silu(x @ w1.T) * (x @ w3.T) internally.
                 w31.append(torch.cat([up, gate], dim=0))
                 w2.append(down)
-            self.moe_w31 = torch.stack(w31).contiguous()  # [E, 2*I, H]
-            self.moe_w2 = torch.stack(w2).contiguous()  # [E, H, I]
+            self.moe_w31 = torch.stack(w31).contiguous()  # [E_local, 2*I, H]
+            self.moe_w2 = torch.stack(w2).contiguous()  # [E_local, H, I]
         else:
             self.moe_gate = self.moe_w31 = self.moe_w2 = None
-            self.gate_proj = get("mlp.gate_proj.weight")
-            self.up_proj = get("mlp.up_proj.weight")
-            self.down_proj = get("mlp.down_proj.weight")
+            # Column-parallel gate/up, row-parallel down.
+            self.gate_proj = shard(get("mlp.gate_proj.weight"), 0)
+            self.up_proj = shard(get("mlp.up_proj.weight"), 0)
+            self.down_proj = shard(get("mlp.down_proj.weight"), 1)
 
 
 class FlashInferLLM:
@@ -223,10 +246,25 @@ class FlashInferLLM:
         state_dict: Dict[str, torch.Tensor],
         device: torch.device,
         dtype: torch.dtype = torch.bfloat16,
+        tp_size: int = 1,
+        tp_rank: int = 0,
     ):
         self.config = config
         self.device = device
         self.dtype = dtype
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        if tp_size > 1:
+            if config.num_attention_heads % tp_size:
+                raise ValueError("num_attention_heads must divide by tp_size")
+            if config.num_key_value_heads % tp_size:
+                raise ValueError("num_key_value_heads must divide by tp_size")
+            if config.intermediate_size % tp_size:
+                raise ValueError("intermediate_size must divide by tp_size")
+            if config.is_moe and config.num_experts % tp_size:
+                raise ValueError("num_experts must divide by tp_size (TP=EP)")
+        self.num_local_qo_heads = config.num_attention_heads // tp_size
+        self.num_local_kv_heads = config.num_key_value_heads // tp_size
         self.embed_tokens = state_dict["model.embed_tokens.weight"].to(
             device=device, dtype=dtype
         )
@@ -236,9 +274,15 @@ class FlashInferLLM:
         else:
             self.lm_head = state_dict["lm_head.weight"].to(device=device, dtype=dtype)
         self.layers = [
-            DecoderLayerWeights(state_dict, i, device, dtype, config)
+            DecoderLayerWeights(state_dict, i, device, dtype, config, tp_size, tp_rank)
             for i in range(config.num_hidden_layers)
         ]
+
+    def _maybe_all_reduce(self, t: torch.Tensor) -> torch.Tensor:
+        """Sum partial results across the TP=EP group (no-op when tp_size==1)."""
+        if self.tp_size > 1:
+            torch.distributed.all_reduce(t)
+        return t
 
     @classmethod
     def from_pretrained(
@@ -246,12 +290,16 @@ class FlashInferLLM:
         model_id_or_path: str,
         device: torch.device,
         dtype: torch.dtype = torch.bfloat16,
+        tp_size: int = 1,
+        tp_rank: int = 0,
     ) -> "FlashInferLLM":
         ckpt_dir = resolve_checkpoint_dir(model_id_or_path)
         with open(ckpt_dir / "config.json") as f:
             config = ModelConfig.from_hf_config(json.load(f))
+        # Every rank reads the full state dict and slices its shard — fine
+        # for verification-scale models; a real loader would shard reads.
         state_dict = _load_state_dict(ckpt_dir)
-        return cls(config, state_dict, device, dtype)
+        return cls(config, state_dict, device, dtype, tp_size, tp_rank)
 
     def _apply_rope(self, q: torch.Tensor, k: torch.Tensor, pos_ids: torch.Tensor):
         cfg = self.config
@@ -292,8 +340,8 @@ class FlashInferLLM:
         cfg = self.config
         nnz = input_ids.shape[0]
         num_q, num_kv, hd = (
-            cfg.num_attention_heads,
-            cfg.num_key_value_heads,
+            self.num_local_qo_heads,
+            self.num_local_kv_heads,
             cfg.head_dim,
         )
         x = torch.nn.functional.embedding(input_ids, self.embed_tokens)
@@ -326,6 +374,7 @@ class FlashInferLLM:
             )
             attn = attn_wrapper.run(q, kv_cache.layer_view(i))
             attn = torch.nn.functional.linear(attn.reshape(nnz, num_q * hd), w.o_proj)
+            self._maybe_all_reduce(attn)
             flashinfer.fused_add_rmsnorm(
                 attn, residual, w.post_attention_layernorm, cfg.rms_norm_eps
             )
@@ -341,6 +390,8 @@ class FlashInferLLM:
                     routing_weights = routing_weights / routing_weights.sum(
                         dim=-1, keepdim=True
                     )
+                # Expert-parallel: global routing on every rank, local expert
+                # slice here; partial outputs are summed across ranks.
                 x = flashinfer.fused_moe.cutlass_fused_moe(
                     attn,
                     selected_experts.to(torch.int),
@@ -349,7 +400,10 @@ class FlashInferLLM:
                     w.moe_w2,
                     self.dtype,
                     quant_scales=None,
+                    ep_size=self.tp_size,
+                    ep_rank=self.tp_rank,
                 )[0]
+                self._maybe_all_reduce(x)
             else:
                 gate_up = torch.cat(
                     [
@@ -361,6 +415,7 @@ class FlashInferLLM:
                 x = torch.nn.functional.linear(
                     flashinfer.silu_and_mul(gate_up), w.down_proj
                 )
+                self._maybe_all_reduce(x)
         # Final residual add + norm, only then project the rows we sample from.
         flashinfer.fused_add_rmsnorm(x, residual, self.final_norm, cfg.rms_norm_eps)
         hidden = x[last_token_rows]
@@ -382,6 +437,7 @@ class PagedKVCache:
         page_size: int,
         device: torch.device,
         dtype: torch.dtype = torch.bfloat16,
+        num_kv_heads: Optional[int] = None,  # local count under TP
     ):
         self.page_size = page_size
         self.device = device
@@ -390,7 +446,7 @@ class PagedKVCache:
             max_pages,
             2,
             page_size,
-            config.num_key_value_heads,
+            num_kv_heads or config.num_key_value_heads,
             config.head_dim,
             device=device,
             dtype=dtype,

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -25,8 +25,9 @@ from typing import Dict, List, Optional
 import torch
 
 import flashinfer
+import flashinfer.fused_moe  # noqa: F401  (subpackage attribute access)
 
-SUPPORTED_MODEL_TYPES = ("llama", "qwen2", "qwen3")
+SUPPORTED_MODEL_TYPES = ("llama", "qwen2", "qwen3", "qwen3_moe")
 
 
 @dataclasses.dataclass
@@ -44,6 +45,25 @@ class ModelConfig:
     tie_word_embeddings: bool
     rope_scaling: Optional[dict]
     eos_token_ids: List[int]
+    # MoE fields (qwen3_moe); None/0 for dense models.
+    num_experts: int = 0
+    num_experts_per_tok: int = 0
+    moe_intermediate_size: int = 0
+    norm_topk_prob: bool = False
+    decoder_sparse_step: int = 1
+    mlp_only_layers: tuple = ()
+
+    @property
+    def is_moe(self) -> bool:
+        return self.num_experts > 0
+
+    def is_sparse_layer(self, layer_idx: int) -> bool:
+        # Mirrors transformers' Qwen3MoeDecoderLayer selection logic.
+        return (
+            self.num_experts > 0
+            and layer_idx not in self.mlp_only_layers
+            and (layer_idx + 1) % self.decoder_sparse_step == 0
+        )
 
     @classmethod
     def from_hf_config(cls, cfg: dict) -> "ModelConfig":
@@ -86,6 +106,12 @@ class ModelConfig:
             tie_word_embeddings=cfg.get("tie_word_embeddings", False),
             rope_scaling=rope_scaling,
             eos_token_ids=eos_token_ids,
+            num_experts=cfg.get("num_experts", 0),
+            num_experts_per_tok=cfg.get("num_experts_per_tok", 0),
+            moe_intermediate_size=cfg.get("moe_intermediate_size", 0),
+            norm_topk_prob=cfg.get("norm_topk_prob", False),
+            decoder_sparse_step=cfg.get("decoder_sparse_step", 1),
+            mlp_only_layers=tuple(cfg.get("mlp_only_layers", ()) or ()),
         )
 
 
@@ -126,7 +152,9 @@ def _load_state_dict(ckpt_dir: Path) -> Dict[str, torch.Tensor]:
 
 
 class DecoderLayerWeights:
-    def __init__(self, sd: Dict[str, torch.Tensor], i: int, device, dtype):
+    def __init__(
+        self, sd: Dict[str, torch.Tensor], i: int, device, dtype, config: "ModelConfig"
+    ):
         p = f"model.layers.{i}."
 
         def get(name: str, required: bool = True) -> Optional[torch.Tensor]:
@@ -150,9 +178,28 @@ class DecoderLayerWeights:
         # Qwen3 per-head q/k RMSNorm over head_dim.
         self.q_norm = get("self_attn.q_norm.weight", required=False)
         self.k_norm = get("self_attn.k_norm.weight", required=False)
-        self.gate_proj = get("mlp.gate_proj.weight")
-        self.up_proj = get("mlp.up_proj.weight")
-        self.down_proj = get("mlp.down_proj.weight")
+        self.is_sparse = config.is_sparse_layer(i)
+        if self.is_sparse:
+            self.gate_proj = self.up_proj = self.down_proj = None
+            self.moe_gate = get("mlp.gate.weight")  # router, [num_experts, hidden]
+            w31, w2 = [], []
+            for j in range(config.num_experts):
+                ep = f"{p}mlp.experts.{j}."
+                gate = sd[ep + "gate_proj.weight"].to(device=device, dtype=dtype)
+                up = sd[ep + "up_proj.weight"].to(device=device, dtype=dtype)
+                down = sd[ep + "down_proj.weight"].to(device=device, dtype=dtype)
+                # cutlass_fused_moe fc1 ("w31") layout: up_proj (w3) stacked
+                # above gate_proj (w1); the kernel computes
+                # silu(x @ w1.T) * (x @ w3.T) internally.
+                w31.append(torch.cat([up, gate], dim=0))
+                w2.append(down)
+            self.moe_w31 = torch.stack(w31).contiguous()  # [E, 2*I, H]
+            self.moe_w2 = torch.stack(w2).contiguous()  # [E, H, I]
+        else:
+            self.moe_gate = self.moe_w31 = self.moe_w2 = None
+            self.gate_proj = get("mlp.gate_proj.weight")
+            self.up_proj = get("mlp.up_proj.weight")
+            self.down_proj = get("mlp.down_proj.weight")
 
 
 class FlashInferLLM:
@@ -182,7 +229,7 @@ class FlashInferLLM:
         else:
             self.lm_head = state_dict["lm_head.weight"].to(device=device, dtype=dtype)
         self.layers = [
-            DecoderLayerWeights(state_dict, i, device, dtype)
+            DecoderLayerWeights(state_dict, i, device, dtype, config)
             for i in range(config.num_hidden_layers)
         ]
 
@@ -275,16 +322,38 @@ class FlashInferLLM:
             flashinfer.fused_add_rmsnorm(
                 attn, residual, w.post_attention_layernorm, cfg.rms_norm_eps
             )
-            gate_up = torch.cat(
-                [
-                    torch.nn.functional.linear(attn, w.gate_proj),
-                    torch.nn.functional.linear(attn, w.up_proj),
-                ],
-                dim=-1,
-            )
-            x = torch.nn.functional.linear(
-                flashinfer.silu_and_mul(gate_up), w.down_proj
-            )
+            if w.is_sparse:
+                # Router in model dtype, softmax in fp32 — mirrors the HF
+                # Qwen3MoeSparseMoeBlock reference implementation.
+                router_logits = torch.nn.functional.linear(attn, w.moe_gate)
+                routing_weights = torch.softmax(router_logits.float(), dim=-1)
+                routing_weights, selected_experts = torch.topk(
+                    routing_weights, cfg.num_experts_per_tok, dim=-1
+                )
+                if cfg.norm_topk_prob:
+                    routing_weights = routing_weights / routing_weights.sum(
+                        dim=-1, keepdim=True
+                    )
+                x = flashinfer.fused_moe.cutlass_fused_moe(
+                    attn,
+                    selected_experts.to(torch.int),
+                    routing_weights,
+                    w.moe_w31,
+                    w.moe_w2,
+                    self.dtype,
+                    quant_scales=None,
+                )[0]
+            else:
+                gate_up = torch.cat(
+                    [
+                        torch.nn.functional.linear(attn, w.gate_proj),
+                        torch.nn.functional.linear(attn, w.up_proj),
+                    ],
+                    dim=-1,
+                )
+                x = torch.nn.functional.linear(
+                    flashinfer.silu_and_mul(gate_up), w.down_proj
+                )
         # Final residual add + norm, only then project the rows we sample from.
         flashinfer.fused_add_rmsnorm(x, residual, self.final_norm, cfg.rms_norm_eps)
         hidden = x[last_token_rows]

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -73,7 +73,13 @@ class ModelConfig:
                 f"Unsupported model_type {model_type!r}; this example supports "
                 f"{SUPPORTED_MODEL_TYPES}"
             )
+        # transformers v5 nests rope config under "rope_parameters"; older
+        # checkpoints use top-level "rope_theta" + optional "rope_scaling".
+        rope_params = cfg.get("rope_parameters") or {}
+        rope_theta = rope_params.get("rope_theta", cfg.get("rope_theta", 1e4))
         rope_scaling = cfg.get("rope_scaling")
+        if rope_params.get("rope_type", "default") != "default":
+            rope_scaling = rope_params
         if rope_scaling is not None:
             rope_type = rope_scaling.get("rope_type", rope_scaling.get("type"))
             if rope_type not in ("llama3", "default"):
@@ -102,11 +108,12 @@ class ModelConfig:
             ),
             vocab_size=cfg["vocab_size"],
             rms_norm_eps=cfg["rms_norm_eps"],
-            rope_theta=cfg.get("rope_theta", 1e4),
+            rope_theta=rope_theta,
             tie_word_embeddings=cfg.get("tie_word_embeddings", False),
             rope_scaling=rope_scaling,
             eos_token_ids=eos_token_ids,
-            num_experts=cfg.get("num_experts", 0),
+            # "num_local_experts" is the transformers-v5 serialization.
+            num_experts=cfg.get("num_experts", cfg.get("num_local_experts", 0)),
             num_experts_per_tok=cfg.get("num_experts_per_tok", 0),
             moe_intermediate_size=cfg.get("moe_intermediate_size", 0),
             norm_topk_prob=cfg.get("norm_topk_prob", False),

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -1,0 +1,372 @@
+"""FlashInfer end-to-end LLM example: Llama / Qwen dense decoder.
+
+Reference/verification code, not a serving engine: it strings FlashInfer's
+serving-path ops together the way an inference framework would — paged KV
+cache (`append_paged_kv_cache`), batched prefill/decode attention wrappers,
+RoPE (`apply_rope_pos_ids_inplace`), RMSNorm (`rmsnorm` /
+`fused_add_rmsnorm`), and SwiGLU (`silu_and_mul`) — in plain PyTorch, loading
+weights directly from a Hugging Face checkpoint's safetensors. See
+`docs/design_docs/e2e_pytorch_llm_examples.md` for the rationale.
+
+Supported HF `model_type`s: `llama`, `qwen2`, `qwen3` (dense). The three
+share one skeleton (RMSNorm -> GQA attention with RoPE -> SwiGLU FFN); the
+deltas are Qwen3's per-head q/k norm, Qwen2's QKV bias, and Llama-3.1-style
+RoPE scaling.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import torch
+
+import flashinfer
+
+SUPPORTED_MODEL_TYPES = ("llama", "qwen2", "qwen3")
+
+
+@dataclasses.dataclass
+class ModelConfig:
+    model_type: str
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    vocab_size: int
+    rms_norm_eps: float
+    rope_theta: float
+    tie_word_embeddings: bool
+    rope_scaling: Optional[dict]
+    eos_token_ids: List[int]
+
+    @classmethod
+    def from_hf_config(cls, cfg: dict) -> "ModelConfig":
+        model_type = cfg["model_type"]
+        if model_type not in SUPPORTED_MODEL_TYPES:
+            raise ValueError(
+                f"Unsupported model_type {model_type!r}; this example supports "
+                f"{SUPPORTED_MODEL_TYPES}"
+            )
+        rope_scaling = cfg.get("rope_scaling")
+        if rope_scaling is not None:
+            rope_type = rope_scaling.get("rope_type", rope_scaling.get("type"))
+            if rope_type not in ("llama3", "default"):
+                raise ValueError(
+                    f"Unsupported rope_scaling {rope_scaling!r}; this example "
+                    "supports null, 'default', and 'llama3' scaling"
+                )
+        eos = cfg.get("eos_token_id")
+        if eos is None:
+            eos_token_ids = []
+        elif isinstance(eos, int):
+            eos_token_ids = [eos]
+        else:
+            eos_token_ids = list(eos)
+        return cls(
+            model_type=model_type,
+            hidden_size=cfg["hidden_size"],
+            intermediate_size=cfg["intermediate_size"],
+            num_hidden_layers=cfg["num_hidden_layers"],
+            num_attention_heads=cfg["num_attention_heads"],
+            num_key_value_heads=cfg.get(
+                "num_key_value_heads", cfg["num_attention_heads"]
+            ),
+            head_dim=cfg.get(
+                "head_dim", cfg["hidden_size"] // cfg["num_attention_heads"]
+            ),
+            vocab_size=cfg["vocab_size"],
+            rms_norm_eps=cfg["rms_norm_eps"],
+            rope_theta=cfg.get("rope_theta", 1e4),
+            tie_word_embeddings=cfg.get("tie_word_embeddings", False),
+            rope_scaling=rope_scaling,
+            eos_token_ids=eos_token_ids,
+        )
+
+
+def resolve_checkpoint_dir(model_id_or_path: str) -> Path:
+    """Return a local directory containing config.json + safetensors.
+
+    Accepts either a local path or a Hugging Face model id (downloads
+    config/tokenizer/safetensors via huggingface_hub, honoring HF_HOME).
+    """
+    local = Path(model_id_or_path)
+    if local.is_dir():
+        return local
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            model_id_or_path,
+            allow_patterns=["*.json", "*.safetensors", "tokenizer*", "*.txt"],
+        )
+    )
+
+
+def _load_state_dict(ckpt_dir: Path) -> Dict[str, torch.Tensor]:
+    from safetensors.torch import load_file
+
+    index_file = ckpt_dir / "model.safetensors.index.json"
+    if index_file.exists():
+        with open(index_file) as f:
+            shard_names = sorted(set(json.load(f)["weight_map"].values()))
+    else:
+        shard_names = [p.name for p in sorted(ckpt_dir.glob("*.safetensors"))]
+    if not shard_names:
+        raise FileNotFoundError(f"No safetensors found under {ckpt_dir}")
+    state_dict: Dict[str, torch.Tensor] = {}
+    for shard in shard_names:
+        state_dict.update(load_file(ckpt_dir / shard))
+    return state_dict
+
+
+class DecoderLayerWeights:
+    def __init__(self, sd: Dict[str, torch.Tensor], i: int, device, dtype):
+        p = f"model.layers.{i}."
+
+        def get(name: str, required: bool = True) -> Optional[torch.Tensor]:
+            key = p + name
+            if key not in sd:
+                if required:
+                    raise KeyError(f"Missing weight {key}")
+                return None
+            return sd[key].to(device=device, dtype=dtype)
+
+        self.input_layernorm = get("input_layernorm.weight")
+        self.post_attention_layernorm = get("post_attention_layernorm.weight")
+        self.q_proj = get("self_attn.q_proj.weight")
+        self.k_proj = get("self_attn.k_proj.weight")
+        self.v_proj = get("self_attn.v_proj.weight")
+        self.o_proj = get("self_attn.o_proj.weight")
+        # Qwen2-family checkpoints carry QKV bias; Llama/Qwen3 do not.
+        self.q_bias = get("self_attn.q_proj.bias", required=False)
+        self.k_bias = get("self_attn.k_proj.bias", required=False)
+        self.v_bias = get("self_attn.v_proj.bias", required=False)
+        # Qwen3 per-head q/k RMSNorm over head_dim.
+        self.q_norm = get("self_attn.q_norm.weight", required=False)
+        self.k_norm = get("self_attn.k_norm.weight", required=False)
+        self.gate_proj = get("mlp.gate_proj.weight")
+        self.up_proj = get("mlp.up_proj.weight")
+        self.down_proj = get("mlp.down_proj.weight")
+
+
+class FlashInferLLM:
+    """Dense Llama/Qwen-family decoder over a paged KV cache.
+
+    The model itself is stateless w.r.t. sequences: all per-request state
+    (page tables, sequence lengths) lives in the caller-provided
+    :class:`PagedKVCache` and the planned attention wrapper.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        state_dict: Dict[str, torch.Tensor],
+        device: torch.device,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.config = config
+        self.device = device
+        self.dtype = dtype
+        self.embed_tokens = state_dict["model.embed_tokens.weight"].to(
+            device=device, dtype=dtype
+        )
+        self.final_norm = state_dict["model.norm.weight"].to(device=device, dtype=dtype)
+        if config.tie_word_embeddings or "lm_head.weight" not in state_dict:
+            self.lm_head = self.embed_tokens
+        else:
+            self.lm_head = state_dict["lm_head.weight"].to(device=device, dtype=dtype)
+        self.layers = [
+            DecoderLayerWeights(state_dict, i, device, dtype)
+            for i in range(config.num_hidden_layers)
+        ]
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_id_or_path: str,
+        device: torch.device,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> "FlashInferLLM":
+        ckpt_dir = resolve_checkpoint_dir(model_id_or_path)
+        with open(ckpt_dir / "config.json") as f:
+            config = ModelConfig.from_hf_config(json.load(f))
+        state_dict = _load_state_dict(ckpt_dir)
+        return cls(config, state_dict, device, dtype)
+
+    def _apply_rope(self, q: torch.Tensor, k: torch.Tensor, pos_ids: torch.Tensor):
+        cfg = self.config
+        scaling = cfg.rope_scaling
+        if (
+            scaling is not None
+            and scaling.get("rope_type", scaling.get("type")) == "llama3"
+        ):
+            flashinfer.apply_llama31_rope_pos_ids_inplace(
+                q,
+                k,
+                pos_ids,
+                interleave=False,
+                rope_scale=scaling["factor"],
+                rope_theta=cfg.rope_theta,
+                low_freq_factor=scaling["low_freq_factor"],
+                high_freq_factor=scaling["high_freq_factor"],
+                old_context_len=scaling["original_max_position_embeddings"],
+            )
+        else:
+            flashinfer.apply_rope_pos_ids_inplace(
+                q, k, pos_ids, interleave=False, rope_theta=cfg.rope_theta
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,  # (nnz,) int64, tokens packed over the batch
+        pos_ids: torch.Tensor,  # (nnz,) int32, absolute position per token
+        attn_wrapper,  # planned prefill or decode wrapper
+        kv_cache: "PagedKVCache",
+        batch_indices: torch.Tensor,  # (nnz,) int32, request of each token
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_last_page_len: torch.Tensor,
+        last_token_rows: torch.Tensor,  # (batch,) int64 rows to compute logits for
+    ) -> torch.Tensor:
+        """One forward step (prefill or decode). Returns (batch, vocab) fp32 logits."""
+        cfg = self.config
+        nnz = input_ids.shape[0]
+        num_q, num_kv, hd = (
+            cfg.num_attention_heads,
+            cfg.num_key_value_heads,
+            cfg.head_dim,
+        )
+        x = torch.nn.functional.embedding(input_ids, self.embed_tokens)
+        residual: Optional[torch.Tensor] = None
+        for i, w in enumerate(self.layers):
+            if residual is None:
+                residual = x
+                x = flashinfer.rmsnorm(x, w.input_layernorm, cfg.rms_norm_eps)
+            else:
+                flashinfer.fused_add_rmsnorm(
+                    x, residual, w.input_layernorm, cfg.rms_norm_eps
+                )
+            q = torch.nn.functional.linear(x, w.q_proj, w.q_bias).view(nnz, num_q, hd)
+            k = torch.nn.functional.linear(x, w.k_proj, w.k_bias).view(nnz, num_kv, hd)
+            v = torch.nn.functional.linear(x, w.v_proj, w.v_bias).view(nnz, num_kv, hd)
+            if w.q_norm is not None:
+                q = flashinfer.rmsnorm(q, w.q_norm, cfg.rms_norm_eps)
+                k = flashinfer.rmsnorm(k, w.k_norm, cfg.rms_norm_eps)
+            self._apply_rope(q, k, pos_ids)
+            flashinfer.append_paged_kv_cache(
+                k,
+                v,
+                batch_indices,
+                pos_ids,
+                kv_cache.layer_view(i),
+                kv_indices,
+                kv_indptr,
+                kv_last_page_len,
+                kv_layout="NHD",
+            )
+            attn = attn_wrapper.run(q, kv_cache.layer_view(i))
+            attn = torch.nn.functional.linear(attn.reshape(nnz, num_q * hd), w.o_proj)
+            flashinfer.fused_add_rmsnorm(
+                attn, residual, w.post_attention_layernorm, cfg.rms_norm_eps
+            )
+            gate_up = torch.cat(
+                [
+                    torch.nn.functional.linear(attn, w.gate_proj),
+                    torch.nn.functional.linear(attn, w.up_proj),
+                ],
+                dim=-1,
+            )
+            x = torch.nn.functional.linear(
+                flashinfer.silu_and_mul(gate_up), w.down_proj
+            )
+        # Final residual add + norm, only then project the rows we sample from.
+        flashinfer.fused_add_rmsnorm(x, residual, self.final_norm, cfg.rms_norm_eps)
+        hidden = x[last_token_rows]
+        return torch.nn.functional.linear(hidden, self.lm_head).float()
+
+
+class PagedKVCache:
+    """Paged KV cache + page tables for a fixed batch of requests.
+
+    Layout is NHD: per layer ``[max_pages, 2, page_size, num_kv_heads,
+    head_dim]``. Pages are handed out from a bump allocator; all index
+    tensors are int32 as required by the FlashInfer kernels.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        max_pages: int,
+        page_size: int,
+        device: torch.device,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.page_size = page_size
+        self.device = device
+        self.kv_data = torch.zeros(
+            config.num_hidden_layers,
+            max_pages,
+            2,
+            page_size,
+            config.num_key_value_heads,
+            config.head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        self.max_pages = max_pages
+        self._next_free_page = 0
+        self.page_tables: List[List[int]] = []
+        self.seq_lens: List[int] = []
+
+    def layer_view(self, layer: int) -> torch.Tensor:
+        return self.kv_data[layer]
+
+    def add_request(self) -> int:
+        self.page_tables.append([])
+        self.seq_lens.append(0)
+        return len(self.page_tables) - 1
+
+    def _alloc_page(self) -> int:
+        if self._next_free_page >= self.max_pages:
+            raise RuntimeError(
+                f"Out of KV pages (max_pages={self.max_pages}); increase the "
+                "page budget for this prompt/generation length"
+            )
+        page = self._next_free_page
+        self._next_free_page += 1
+        return page
+
+    def extend(self, request: int, num_new_tokens: int) -> None:
+        """Grow request's page table to hold num_new_tokens more tokens."""
+        self.seq_lens[request] += num_new_tokens
+        needed_pages = math.ceil(self.seq_lens[request] / self.page_size)
+        table = self.page_tables[request]
+        while len(table) < needed_pages:
+            table.append(self._alloc_page())
+
+    def page_table_tensors(self):
+        """Return (kv_indptr, kv_indices, kv_last_page_len) int32 tensors."""
+        indptr = [0]
+        for t in self.page_tables:
+            indptr.append(indptr[-1] + len(t))
+        kv_indptr = torch.tensor(indptr, dtype=torch.int32, device=self.device)
+        kv_indices = torch.tensor(
+            [p for t in self.page_tables for p in t],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        kv_last_page_len = torch.tensor(
+            [(sl - 1) % self.page_size + 1 for sl in self.seq_lens],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        return kv_indptr, kv_indices, kv_last_page_len
+
+    def seq_lens_tensor(self) -> torch.Tensor:
+        return torch.tensor(self.seq_lens, dtype=torch.int32, device=self.device)

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -27,6 +27,8 @@ import torch
 import flashinfer
 import flashinfer.fused_moe  # noqa: F401  (subpackage attribute access)
 
+from quant import QuantConfig
+
 SUPPORTED_MODEL_TYPES = ("llama", "qwen2", "qwen3", "qwen3_moe")
 
 
@@ -172,8 +174,10 @@ class DecoderLayerWeights:
         config: "ModelConfig",
         tp_size: int = 1,
         tp_rank: int = 0,
+        quant: Optional["QuantConfig"] = None,
     ):
         p = f"model.layers.{i}."
+        quant = quant or QuantConfig()
 
         def get(name: str, required: bool = True) -> Optional[torch.Tensor]:
             key = p + name
@@ -190,15 +194,26 @@ class DecoderLayerWeights:
 
         self.input_layernorm = get("input_layernorm.weight")
         self.post_attention_layernorm = get("post_attention_layernorm.weight")
-        # Column-parallel QKV (head-contiguous rows), row-parallel o_proj.
-        self.q_proj = shard(get("self_attn.q_proj.weight"), 0)
-        self.k_proj = shard(get("self_attn.k_proj.weight"), 0)
-        self.v_proj = shard(get("self_attn.v_proj.weight"), 0)
-        self.o_proj = shard(get("self_attn.o_proj.weight"), 1)
         # Qwen2-family checkpoints carry QKV bias; Llama/Qwen3 do not.
-        self.q_bias = shard(get("self_attn.q_proj.bias", required=False), 0)
-        self.k_bias = shard(get("self_attn.k_proj.bias", required=False), 0)
-        self.v_bias = shard(get("self_attn.v_proj.bias", required=False), 0)
+        q_bias = shard(get("self_attn.q_proj.bias", required=False), 0)
+        k_bias = shard(get("self_attn.k_proj.bias", required=False), 0)
+        v_bias = shard(get("self_attn.v_proj.bias", required=False), 0)
+        # Column-parallel QKV (head-contiguous rows), row-parallel o_proj.
+        # quant.linear returns a callable: plain F.linear by default, or an
+        # FP8/NVFP4 GEMM whose weight was quantized here, once, at load time.
+        # Each rank quantizes its own shard, so the scales need no slicing.
+        self.q_proj = quant.linear(
+            shard(get("self_attn.q_proj.weight"), 0), q_bias, "q_proj"
+        )
+        self.k_proj = quant.linear(
+            shard(get("self_attn.k_proj.weight"), 0), k_bias, "k_proj"
+        )
+        self.v_proj = quant.linear(
+            shard(get("self_attn.v_proj.weight"), 0), v_bias, "v_proj"
+        )
+        self.o_proj = quant.linear(
+            shard(get("self_attn.o_proj.weight"), 1), None, "o_proj"
+        )
         # Qwen3 per-head q/k RMSNorm over head_dim: replicated (shape [head_dim]).
         self.q_norm = get("self_attn.q_norm.weight", required=False)
         self.k_norm = get("self_attn.k_norm.weight", required=False)
@@ -206,6 +221,9 @@ class DecoderLayerWeights:
         if self.is_sparse:
             self.gate_proj = self.up_proj = self.down_proj = None
             # Router is replicated; every rank computes the global routing.
+            # Deliberately NOT quantized: top-k selection is discrete, so a
+            # quantization perturbation flips experts and produces a step
+            # change in the logits that no tolerance can call a bug or not.
             self.moe_gate = get("mlp.gate.weight")  # [num_experts, hidden]
             # Expert-parallel: this rank holds experts
             # [tp_rank * E/tp, (tp_rank+1) * E/tp).
@@ -227,9 +245,15 @@ class DecoderLayerWeights:
         else:
             self.moe_gate = self.moe_w31 = self.moe_w2 = None
             # Column-parallel gate/up, row-parallel down.
-            self.gate_proj = shard(get("mlp.gate_proj.weight"), 0)
-            self.up_proj = shard(get("mlp.up_proj.weight"), 0)
-            self.down_proj = shard(get("mlp.down_proj.weight"), 1)
+            self.gate_proj = quant.linear(
+                shard(get("mlp.gate_proj.weight"), 0), None, "gate_proj"
+            )
+            self.up_proj = quant.linear(
+                shard(get("mlp.up_proj.weight"), 0), None, "up_proj"
+            )
+            self.down_proj = quant.linear(
+                shard(get("mlp.down_proj.weight"), 1), None, "down_proj"
+            )
 
 
 class FlashInferLLM:
@@ -248,12 +272,14 @@ class FlashInferLLM:
         dtype: torch.dtype = torch.bfloat16,
         tp_size: int = 1,
         tp_rank: int = 0,
+        quant: Optional[QuantConfig] = None,
     ):
         self.config = config
         self.device = device
         self.dtype = dtype
         self.tp_size = tp_size
         self.tp_rank = tp_rank
+        self.quant = quant or QuantConfig()
         if tp_size > 1:
             if config.num_attention_heads % tp_size:
                 raise ValueError("num_attention_heads must divide by tp_size")
@@ -269,12 +295,19 @@ class FlashInferLLM:
             device=device, dtype=dtype
         )
         self.final_norm = state_dict["model.norm.weight"].to(device=device, dtype=dtype)
+        # lm_head stays BF16: under tie_word_embeddings it is the *same tensor*
+        # as embed_tokens, so quantizing it would corrupt the embedding lookup.
+        # It is also never TP-sharded, and keeping it exact makes the logits
+        # comparison a measurement of the decoder stack rather than the vocab
+        # projection.
         if config.tie_word_embeddings or "lm_head.weight" not in state_dict:
             self.lm_head = self.embed_tokens
         else:
             self.lm_head = state_dict["lm_head.weight"].to(device=device, dtype=dtype)
         self.layers = [
-            DecoderLayerWeights(state_dict, i, device, dtype, config, tp_size, tp_rank)
+            DecoderLayerWeights(
+                state_dict, i, device, dtype, config, tp_size, tp_rank, self.quant
+            )
             for i in range(config.num_hidden_layers)
         ]
 
@@ -292,6 +325,7 @@ class FlashInferLLM:
         dtype: torch.dtype = torch.bfloat16,
         tp_size: int = 1,
         tp_rank: int = 0,
+        quant: Optional[QuantConfig] = None,
     ) -> "FlashInferLLM":
         ckpt_dir = resolve_checkpoint_dir(model_id_or_path)
         with open(ckpt_dir / "config.json") as f:
@@ -299,7 +333,7 @@ class FlashInferLLM:
         # Every rank reads the full state dict and slices its shard — fine
         # for verification-scale models; a real loader would shard reads.
         state_dict = _load_state_dict(ckpt_dir)
-        return cls(config, state_dict, device, dtype, tp_size, tp_rank)
+        return cls(config, state_dict, device, dtype, tp_size, tp_rank, quant)
 
     def _apply_rope(self, q: torch.Tensor, k: torch.Tensor, pos_ids: torch.Tensor):
         cfg = self.config
@@ -354,9 +388,9 @@ class FlashInferLLM:
                 flashinfer.fused_add_rmsnorm(
                     x, residual, w.input_layernorm, cfg.rms_norm_eps
                 )
-            q = torch.nn.functional.linear(x, w.q_proj, w.q_bias).view(nnz, num_q, hd)
-            k = torch.nn.functional.linear(x, w.k_proj, w.k_bias).view(nnz, num_kv, hd)
-            v = torch.nn.functional.linear(x, w.v_proj, w.v_bias).view(nnz, num_kv, hd)
+            q = w.q_proj(x).view(nnz, num_q, hd)
+            k = w.k_proj(x).view(nnz, num_kv, hd)
+            v = w.v_proj(x).view(nnz, num_kv, hd)
             if w.q_norm is not None:
                 q = flashinfer.rmsnorm(q, w.q_norm, cfg.rms_norm_eps)
                 k = flashinfer.rmsnorm(k, w.k_norm, cfg.rms_norm_eps)
@@ -373,7 +407,7 @@ class FlashInferLLM:
                 kv_layout="NHD",
             )
             attn = attn_wrapper.run(q, kv_cache.layer_view(i))
-            attn = torch.nn.functional.linear(attn.reshape(nnz, num_q * hd), w.o_proj)
+            attn = w.o_proj(attn.reshape(nnz, num_q * hd))
             self._maybe_all_reduce(attn)
             flashinfer.fused_add_rmsnorm(
                 attn, residual, w.post_attention_layernorm, cfg.rms_norm_eps
@@ -405,16 +439,11 @@ class FlashInferLLM:
                 )[0]
                 self._maybe_all_reduce(x)
             else:
-                gate_up = torch.cat(
-                    [
-                        torch.nn.functional.linear(attn, w.gate_proj),
-                        torch.nn.functional.linear(attn, w.up_proj),
-                    ],
-                    dim=-1,
-                )
-                x = torch.nn.functional.linear(
-                    flashinfer.silu_and_mul(gate_up), w.down_proj
-                )
+                # gate and up quantize `attn` twice; a production impl would
+                # fuse them into one (2*I, H) weight and a single GEMM. Kept
+                # separate so the BF16 path stays byte-identical to before.
+                gate_up = torch.cat([w.gate_proj(attn), w.up_proj(attn)], dim=-1)
+                x = w.down_proj(flashinfer.silu_and_mul(gate_up))
                 self._maybe_all_reduce(x)
         # Final residual add + norm, only then project the rows we sample from.
         flashinfer.fused_add_rmsnorm(x, residual, self.final_norm, cfg.rms_norm_eps)

--- a/examples/pytorch/llm/quant.py
+++ b/examples/pytorch/llm/quant.py
@@ -1,0 +1,235 @@
+"""On-the-fly weight/activation quantization for the FlashInfer LLM example.
+
+Weights are quantized once at load time from a plain BF16 Hugging Face
+checkpoint; activations are quantized per forward. No pre-quantized checkpoint
+is needed, and BF16 remains the default *and* the numerical reference.
+
+    bf16   torch.nn.functional.linear (default, the reference path)
+    fp8    W8A8 per-tensor e4m3, via ``flashinfer.bmm_fp8``
+    nvfp4  W4A4 block-16 e2m1 + e4m3 block scales, via ``flashinfer.mm_fp4``
+
+Scope. Only the dense projections (q/k/v/o, gate/up/down) are quantized. The
+MoE router stays in model dtype (top-k is discrete — a quantization
+perturbation flips experts and produces a step change no tolerance can
+distinguish from a real bug), the MoE expert GEMMs keep ``quant_scales=None``,
+and ``lm_head`` is left alone because it is literally the same tensor as the
+embedding table under ``tie_word_embeddings``.
+
+This is a verification harness, not a serving stack: the point is to exercise
+FlashInfer's quantized GEMM kernels end to end, not to produce a well-behaved
+quantized model. Expect FP4 output quality on a small model to be poor.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import List, Optional, Tuple
+
+import torch
+
+import flashinfer
+from flashinfer.utils import get_compute_capability
+
+QUANT_MODES = ("bf16", "fp8", "nvfp4")
+
+FP8_DTYPE = torch.float8_e4m3fn
+FP8_MAX = torch.finfo(FP8_DTYPE).max  # 448.0
+# e4m3 max * e2m1 max — the global scale-factor convention mm_fp4 expects.
+NVFP4_SF_NUM = 448.0 * 6.0
+
+
+class Linear:
+    """BF16 reference path — numerically identical to the pre-quantization code."""
+
+    kind = "bf16"
+
+    def __init__(self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None):
+        self.weight = weight
+        self.bias = bias
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.linear(x, self.weight, self.bias)
+
+
+class Fp8Linear:
+    """W8A8 per-tensor e4m3 via ``bmm_fp8``.
+
+    Both scales are *dequant multipliers* (``out = (A*a_s) @ (B*b_s)``), which
+    is what ``tests/utils_fp8.py:to_float8`` returns as its second value — do
+    not invert them again.
+    """
+
+    kind = "fp8"
+
+    def __init__(self, weight, bias=None, backend: str = "auto"):
+        self.bias = bias
+        self.backend = backend
+        w_fp8, self.b_scale = _to_fp8_per_tensor(weight)
+        # bmm_fp8 wants B as (b, k, n) column-major. An (n, k) row-major fp8
+        # tensor *is* that memory, so the transpose is a free view — quantize
+        # first, then transpose, never .contiguous() the result.
+        self.b = w_fp8.unsqueeze(0).transpose(-2, -1)
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        x_fp8, a_scale = _to_fp8_per_tensor(x)
+        out = flashinfer.bmm_fp8(
+            x_fp8.unsqueeze(0),
+            self.b,
+            a_scale,
+            self.b_scale,
+            torch.bfloat16,
+            backend=self.backend,
+        ).squeeze(0)
+        return out if self.bias is None else out + self.bias
+
+
+class Nvfp4Linear:
+    """W4A4 block-16 e2m1 with e4m3 block scales via ``mm_fp4``.
+
+    Layout follows ``tests/gemm/test_mm_fp4.py``: quantize the (n, k) weight as
+    given, then pass ``b`` and ``b_descale`` as plain ``.T`` views. The block
+    scales are a swizzled 128x4 blob whose 2-D shape is a fiction — never
+    ``.contiguous()`` them, and never re-swizzle.
+    """
+
+    kind = "nvfp4"
+
+    def __init__(self, weight, bias=None, backend: str = "auto"):
+        self.bias = bias
+        self.backend = backend
+        self.w_sf_global = _global_sf(weight)
+        w_fp4, w_sf = flashinfer.nvfp4_quantize(
+            weight,
+            self.w_sf_global,
+            sfLayout=flashinfer.SfLayout.layout_128x4,
+            # Only the TRT-LLM backend wants shuffled B scales, and it is not
+            # reachable from this example's --quant-backend choices.
+            do_shuffle=False,
+        )
+        self.b = w_fp4.T
+        self.b_sf = w_sf.T
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        if not x.is_contiguous():
+            x = x.contiguous()
+        x_sf_global = _global_sf(x)
+        x_fp4, x_sf = flashinfer.nvfp4_quantize(
+            x,
+            x_sf_global,
+            sfLayout=flashinfer.SfLayout.layout_128x4,
+            do_shuffle=False,
+        )
+        out = flashinfer.mm_fp4(
+            x_fp4,
+            self.b,
+            x_sf,
+            self.b_sf,
+            1.0 / (x_sf_global * self.w_sf_global),
+            torch.bfloat16,
+            block_size=16,
+            use_8x4_sf_layout=False,
+            backend=self.backend,
+            use_nvfp4=True,
+        )
+        return out if self.bias is None else out + self.bias
+
+
+def _to_fp8_per_tensor(t: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize to e4m3 with one scale for the whole tensor.
+
+    Stays device-side throughout (no ``.item()``), so the decode loop does not
+    pick up a host sync per projection.
+    """
+    amax = t.float().abs().amax().clamp(min=1e-12)
+    scale = FP8_MAX / amax
+    q = (t * scale).clamp(min=-FP8_MAX, max=FP8_MAX).to(FP8_DTYPE)
+    return q, scale.reciprocal()
+
+
+def _global_sf(t: torch.Tensor) -> torch.Tensor:
+    return NVFP4_SF_NUM / t.float().abs().nan_to_num().amax().clamp(min=1e-12)
+
+
+def _shape_ok(mode: str, weight: torch.Tensor) -> bool:
+    n, k = weight.shape
+    if mode == "fp8":
+        return n % 16 == 0 and k % 16 == 0
+    # nvfp4_quantize itself only needs k % 16, but the CUTLASS SM100/103 kernel
+    # hard-checks k % 32 and n % 32. Use the strict bound so which weights fall
+    # back is a property of the checkpoint, not of the installed cuDNN version.
+    return n % 32 == 0 and k % 32 == 0
+
+
+def unsupported_reason(mode: str, backend: str, device) -> Optional[str]:
+    """``None`` if this mode can run here, else a message for a clean skip."""
+    if mode == "bf16":
+        return None
+    if mode not in QUANT_MODES:
+        return f"unknown --quant mode {mode!r}"
+    api = flashinfer.bmm_fp8 if mode == "fp8" else flashinfer.mm_fp4
+    major, minor = get_compute_capability(device)
+    cc = major * 10 + minor
+    if not api.is_compute_capability_supported(cc):
+        return f"--quant {mode} is not supported on sm{cc}"
+    if backend != "auto" and not api.is_backend_supported(backend, cc):
+        return f"--quant-backend {backend!r} is not supported for {mode} on sm{cc}"
+    return None
+
+
+@dataclasses.dataclass
+class QuantConfig:
+    """Factory for the per-projection linear, plus the accounting we report."""
+
+    mode: str = "bf16"
+    backend: str = "auto"
+    quantized: int = 0
+    fallbacks: List[Tuple[str, Tuple[int, ...]]] = dataclasses.field(
+        default_factory=list
+    )
+
+    def linear(self, weight, bias=None, name: str = ""):
+        if weight is None:
+            return None
+        if self.mode == "bf16":
+            return Linear(weight, bias)
+        if not _shape_ok(self.mode, weight):
+            self.fallbacks.append((name, tuple(weight.shape)))
+            return Linear(weight, bias)
+        self.quantized += 1
+        cls = Fp8Linear if self.mode == "fp8" else Nvfp4Linear
+        return cls(weight, bias, self.backend)
+
+    def resolved_backends(self) -> str:
+        """Which backend ``auto`` actually picked, set after the first call."""
+        if self.mode == "bf16":
+            return ""
+        api = flashinfer.bmm_fp8 if self.mode == "fp8" else flashinfer.mm_fp4
+        return ",".join(getattr(api, "suitable_auto_backends", []) or [])
+
+    def summary(self) -> dict:
+        return {
+            "mode": self.mode,
+            "backend": self.backend,
+            "quantized_linears": self.quantized,
+            "bf16_fallbacks": len(self.fallbacks),
+            "resolved_backends": self.resolved_backends(),
+        }
+
+
+def self_check(
+    mode: str, backend: str, device, m: int = 64, k: int = 512, n: int = 256
+) -> Tuple[float, float]:
+    """One random GEMM through the quantized path vs BF16 ``F.linear``.
+
+    Returns ``(cosine_similarity, bar)``. The bars mirror the kernel tests
+    (``tests/gemm/test_bmm_fp8.py`` > 0.99, ``tests/gemm/test_mm_fp4.py`` >
+    0.97). This exists to separate "the wrapper is wired wrong" from "this
+    model is small and FP4 is lossy": a transposed descale or a re-swizzled
+    scale blob lands near cos=0, while honest quantization error does not.
+    """
+    x = torch.randn(m, k, device=device, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=device, dtype=torch.bfloat16)
+    ref = torch.nn.functional.linear(x, w).float().reshape(-1)
+    got = QuantConfig(mode, backend).linear(w)(x).float().reshape(-1)
+    cos = torch.nn.functional.cosine_similarity(got, ref, dim=0).item()
+    return cos, (0.99 if mode == "fp8" else 0.97)

--- a/examples/pytorch/llm/reference_check.py
+++ b/examples/pytorch/llm/reference_check.py
@@ -1,0 +1,153 @@
+"""Numerical reference check for the FlashInfer LLM example.
+
+Builds tiny random-weight models (dense Qwen3 and Qwen3-MoE) with
+``transformers``, saves them as normal HF checkpoints, loads them with this
+example's FlashInfer-based implementation, and compares last-token prefill
+logits between the two — position by position, in BF16 — for a batch of
+random prompts of varying lengths.
+
+This validates the full numerical wiring (attention over the paged KV cache,
+RoPE, norms, SwiGLU, MoE routing + ``cutlass_fused_moe`` expert dispatch)
+without downloading real checkpoints: a tiny random MoE exercises exactly
+the same kernel paths as Qwen3-30B-A3B. Kernel-vs-eager BF16 accumulation
+differences are expected; the assertion is a relative-L2 bound per prompt.
+
+Usage:
+    python reference_check.py                    # dense + moe tiny models
+    python reference_check.py --arch moe         # just the MoE model
+    python reference_check.py --rel-tol 0.05
+
+Emits ``[smoke] refcheck_<arch>=pass|fail`` lines; exit code 0/1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+
+import torch
+
+from generate import GenerationEngine
+from modeling import FlashInferLLM
+
+# Tiny but kernel-legal shapes: head_dim 64/128 for attention; hidden and
+# (moe_)intermediate must be multiples of 8 for the BF16 cutlass MoE path.
+COMMON = dict(
+    hidden_size=256,
+    intermediate_size=512,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=64,
+    vocab_size=2048,
+    max_position_embeddings=4096,
+    rms_norm_eps=1e-6,
+    rope_theta=1e6,
+    tie_word_embeddings=False,
+    attention_bias=False,
+    use_cache=False,
+)
+
+
+def build_tiny_checkpoint(arch: str, tmpdir: str, seed: int) -> str:
+    torch.manual_seed(seed)
+    if arch == "dense":
+        from transformers import Qwen3Config, Qwen3ForCausalLM
+
+        cfg = Qwen3Config(**COMMON)
+        model = Qwen3ForCausalLM(cfg)
+    elif arch == "moe":
+        from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+        cfg = Qwen3MoeConfig(
+            **COMMON,
+            num_experts=8,
+            num_experts_per_tok=2,
+            moe_intermediate_size=128,
+            norm_topk_prob=True,
+            decoder_sparse_step=1,
+            mlp_only_layers=[],
+            router_aux_loss_coef=0.0,
+        )
+        model = Qwen3MoeForCausalLM(cfg)
+    else:
+        raise ValueError(arch)
+    model = model.to(torch.bfloat16).eval()
+    path = f"{tmpdir}/tiny_{arch}"
+    model.save_pretrained(path, safe_serialization=True)
+    return path
+
+
+def check_arch(arch: str, rel_tol: float, seed: int) -> bool:
+    device = torch.device("cuda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ckpt = build_tiny_checkpoint(arch, tmpdir, seed)
+
+        from transformers import AutoModelForCausalLM
+
+        ref_model = (
+            AutoModelForCausalLM.from_pretrained(
+                ckpt, dtype=torch.bfloat16, attn_implementation="eager"
+            )
+            .to(device)
+            .eval()
+        )
+        our_model = FlashInferLLM.from_pretrained(ckpt, device)
+        engine = GenerationEngine(our_model)
+
+        g = torch.Generator().manual_seed(seed + 1)
+        vocab = our_model.config.vocab_size
+        prompts = [
+            torch.randint(0, vocab, (n,), generator=g).tolist()
+            for n in (7, 33, 61, 128)
+        ]
+
+        ours = engine.prefill_logits(prompts).float()  # [batch, vocab]
+        ok = True
+        for i, ids in enumerate(prompts):
+            with torch.inference_mode():
+                ref = (
+                    ref_model(torch.tensor([ids], device=device)).logits[0, -1].float()
+                )
+            rel = (ours[i] - ref).norm() / ref.norm()
+            top1_match = ours[i].argmax().item() == ref.argmax().item()
+            status = "ok" if rel <= rel_tol else "MISMATCH"
+            print(
+                f"  {arch} len={len(ids):>3}: rel_l2={rel:.4f} "
+                f"top1_match={top1_match} [{status}]"
+            )
+            ok &= rel <= rel_tol
+        del ref_model, our_model, engine
+        torch.cuda.empty_cache()
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arch", choices=["dense", "moe", "all"], default="all")
+    parser.add_argument(
+        "--rel-tol",
+        type=float,
+        default=0.05,
+        help="max relative L2 error of last-token logits vs transformers eager",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    archs = ["dense", "moe"] if args.arch == "all" else [args.arch]
+    failed = []
+    for arch in archs:
+        print(f"reference check: tiny {arch} model vs transformers eager (bf16)")
+        ok = check_arch(arch, args.rel_tol, args.seed)
+        print(f"[smoke] refcheck_{arch}={'pass' if ok else 'fail'}")
+        if not ok:
+            failed.append(arch)
+    if failed:
+        print(f"FAIL: logits mismatch for: {', '.join(failed)}")
+        sys.exit(1)
+    print("PASS: FlashInfer path matches transformers reference within tolerance")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/reference_check.py
+++ b/examples/pytorch/llm/reference_check.py
@@ -3,19 +3,24 @@
 Builds tiny random-weight models (dense Qwen3 and Qwen3-MoE) with
 ``transformers``, saves them as normal HF checkpoints, loads them with this
 example's FlashInfer-based implementation, and compares last-token prefill
-logits between the two — position by position, in BF16 — for a batch of
-random prompts of varying lengths.
+logits between the two — in BF16 — for a batch of random prompts of varying
+lengths.
 
 This validates the full numerical wiring (attention over the paged KV cache,
 RoPE, norms, SwiGLU, MoE routing + ``cutlass_fused_moe`` expert dispatch)
 without downloading real checkpoints: a tiny random MoE exercises exactly
 the same kernel paths as Qwen3-30B-A3B. Kernel-vs-eager BF16 accumulation
-differences are expected; the assertion is a relative-L2 bound per prompt.
+differences are expected; the assertion is a relative-L2 bound per prompt
+(the HF bf16-vs-fp32 noise floor for these models is ~0.007).
 
-Usage:
+Single GPU:
     python reference_check.py                    # dense + moe tiny models
-    python reference_check.py --arch moe         # just the MoE model
-    python reference_check.py --rel-tol 0.05
+    python reference_check.py --arch moe --rel-tol 0.05
+
+TEP (TP=EP) across N GPUs — attention tensor-parallel, MoE expert-parallel,
+one allreduce after attention and one after the FFN/MoE; rank 0 compares
+against the single-GPU transformers reference:
+    torchrun --nproc_per_node=2 reference_check.py
 
 Emits ``[smoke] refcheck_<arch>=pass|fail`` lines; exit code 0/1.
 """
@@ -23,16 +28,19 @@ Emits ``[smoke] refcheck_<arch>=pass|fail`` lines; exit code 0/1.
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
 import sys
 import tempfile
 
 import torch
 
-from generate import GenerationEngine
+from generate import GenerationEngine, maybe_init_distributed
 from modeling import FlashInferLLM
 
 # Tiny but kernel-legal shapes: head_dim 64/128 for attention; hidden and
 # (moe_)intermediate must be multiples of 8 for the BF16 cutlass MoE path.
+# Head counts / expert count divide by 2 so the same configs run under TP=2.
 COMMON = dict(
     hidden_size=256,
     intermediate_size=512,
@@ -79,21 +87,23 @@ def build_tiny_checkpoint(arch: str, tmpdir: str, seed: int) -> str:
     return path
 
 
-def check_arch(arch: str, rel_tol: float, seed: int) -> bool:
-    device = torch.device("cuda")
-    with tempfile.TemporaryDirectory() as tmpdir:
+def check_arch(
+    arch: str, rel_tol: float, seed: int, world_size: int, rank: int
+) -> bool:
+    device = torch.device("cuda", torch.cuda.current_device())
+    tmpdir = ckpt = None
+    if rank == 0:
+        tmpdir = tempfile.mkdtemp()
         ckpt = build_tiny_checkpoint(arch, tmpdir, seed)
+    if world_size > 1:
+        obj = [ckpt]
+        torch.distributed.broadcast_object_list(obj, src=0)
+        ckpt = obj[0]
 
-        from transformers import AutoModelForCausalLM
-
-        ref_model = (
-            AutoModelForCausalLM.from_pretrained(
-                ckpt, dtype=torch.bfloat16, attn_implementation="eager"
-            )
-            .to(device)
-            .eval()
+    try:
+        our_model = FlashInferLLM.from_pretrained(
+            ckpt, device, tp_size=world_size, tp_rank=rank
         )
-        our_model = FlashInferLLM.from_pretrained(ckpt, device)
         engine = GenerationEngine(our_model)
 
         g = torch.Generator().manual_seed(seed + 1)
@@ -103,24 +113,47 @@ def check_arch(arch: str, rel_tol: float, seed: int) -> bool:
             for n in (7, 33, 61, 128)
         ]
 
-        ours = engine.prefill_logits(prompts).float()  # [batch, vocab]
+        # Collective under TP: every rank participates; logits identical on
+        # all ranks after the final allreduce.
+        ours = engine.prefill_logits(prompts).float()
+
         ok = True
-        for i, ids in enumerate(prompts):
-            with torch.inference_mode():
-                ref = (
-                    ref_model(torch.tensor([ids], device=device)).logits[0, -1].float()
+        if rank == 0:
+            from transformers import AutoModelForCausalLM
+
+            ref_model = (
+                AutoModelForCausalLM.from_pretrained(
+                    ckpt, dtype=torch.bfloat16, attn_implementation="eager"
                 )
-            rel = (ours[i] - ref).norm() / ref.norm()
-            top1_match = ours[i].argmax().item() == ref.argmax().item()
-            status = "ok" if rel <= rel_tol else "MISMATCH"
-            print(
-                f"  {arch} len={len(ids):>3}: rel_l2={rel:.4f} "
-                f"top1_match={top1_match} [{status}]"
+                .to(device)
+                .eval()
             )
-            ok &= rel <= rel_tol
-        del ref_model, our_model, engine
+            for i, ids in enumerate(prompts):
+                with torch.inference_mode():
+                    ref = (
+                        ref_model(torch.tensor([ids], device=device))
+                        .logits[0, -1]
+                        .float()
+                    )
+                rel = (ours[i] - ref).norm() / ref.norm()
+                top1_match = ours[i].argmax().item() == ref.argmax().item()
+                status = "ok" if rel <= rel_tol else "MISMATCH"
+                print(
+                    f"  {arch} len={len(ids):>3}: rel_l2={rel:.4f} "
+                    f"top1_match={top1_match} [{status}]"
+                )
+                ok &= rel <= rel_tol
+            del ref_model
+        del our_model, engine
         torch.cuda.empty_cache()
-    return ok
+        if world_size > 1:  # share the verdict so every rank exits alike
+            flag = torch.tensor([int(ok)], device=device)
+            torch.distributed.broadcast(flag, src=0)
+            ok = bool(flag.item())
+        return ok
+    finally:
+        if rank == 0 and tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def main():
@@ -135,14 +168,21 @@ def main():
     parser.add_argument("--seed", type=int, default=0)
     args = parser.parse_args()
 
+    world_size, rank = maybe_init_distributed()
+    if rank != 0:  # keep stdout single-writer; stderr stays visible
+        sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
+
+    mode = f"TEP tp=ep={world_size}" if world_size > 1 else "single GPU"
     archs = ["dense", "moe"] if args.arch == "all" else [args.arch]
     failed = []
     for arch in archs:
-        print(f"reference check: tiny {arch} model vs transformers eager (bf16)")
-        ok = check_arch(arch, args.rel_tol, args.seed)
+        print(f"reference check ({mode}): tiny {arch} vs transformers eager (bf16)")
+        ok = check_arch(arch, args.rel_tol, args.seed, world_size, rank)
         print(f"[smoke] refcheck_{arch}={'pass' if ok else 'fail'}")
         if not ok:
             failed.append(arch)
+    if world_size > 1:
+        torch.distributed.destroy_process_group()
     if failed:
         print(f"FAIL: logits mismatch for: {', '.join(failed)}")
         sys.exit(1)

--- a/examples/pytorch/llm/reference_check.py
+++ b/examples/pytorch/llm/reference_check.py
@@ -44,8 +44,13 @@ from modeling import FlashInferLLM
 # example's own BF16 logits, not against transformers, so the bf16-vs-eager
 # noise floor does not enter. A plumbing bug (transposed descale, re-swizzled
 # scale blob) lands at cos~0 / rel_l2~1.4, which is what these must separate
-# from honest low-precision error. Re-baseline from hardware before trusting.
-QUANT_GATES = {"fp8": (0.10, 0.99), "nvfp4": (0.45, 0.90)}
+# from honest low-precision error.
+#
+# Baselined on B200 (sm100a, flashinfer 0.6.16rc3) against the tiny dense
+# fixture: fp8 rel_l2 0.074-0.081 / cos 0.9967-0.9972; nvfp4 rel_l2
+# 0.281-0.346 / cos 0.940-0.960. The bounds below carry ~2x headroom over
+# those, since a deeper or worse-conditioned model accumulates more error.
+QUANT_GATES = {"fp8": (0.20, 0.99), "nvfp4": (0.60, 0.90)}
 
 # Tiny but kernel-legal shapes: head_dim 64/128 for attention; hidden and
 # (moe_)intermediate must be multiples of 8 for the BF16 cutlass MoE path.

--- a/examples/pytorch/llm/reference_check.py
+++ b/examples/pytorch/llm/reference_check.py
@@ -35,8 +35,17 @@ import tempfile
 
 import torch
 
+import quant
 from generate import GenerationEngine, maybe_init_distributed
 from modeling import FlashInferLLM
+
+# Quantized-vs-BF16 gates, per mode: (max rel-L2, min cosine similarity).
+# These bound *quantization* error only — the comparison is against this
+# example's own BF16 logits, not against transformers, so the bf16-vs-eager
+# noise floor does not enter. A plumbing bug (transposed descale, re-swizzled
+# scale blob) lands at cos~0 / rel_l2~1.4, which is what these must separate
+# from honest low-precision error. Re-baseline from hardware before trusting.
+QUANT_GATES = {"fp8": (0.10, 0.99), "nvfp4": (0.45, 0.90)}
 
 # Tiny but kernel-legal shapes: head_dim 64/128 for attention; hidden and
 # (moe_)intermediate must be multiples of 8 for the BF16 cutlass MoE path.
@@ -156,6 +165,98 @@ def check_arch(
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def _prefill_logits(ckpt, device, world_size, rank, qcfg, prompts):
+    model = FlashInferLLM.from_pretrained(
+        ckpt, device, tp_size=world_size, tp_rank=rank, quant=qcfg
+    )
+    engine = GenerationEngine(model)
+    out = engine.prefill_logits(prompts).float()
+    del model, engine
+    torch.cuda.empty_cache()
+    return out
+
+
+def check_quant(
+    arch: str, mode: str, backend: str, seed: int, world_size: int, rank: int
+) -> bool:
+    """Compare the quantized path against this example's own BF16 logits.
+
+    Deliberately *not* folded into :func:`check_arch`: that gate measures
+    FlashInfer-vs-transformers, and adding quantization error on top would
+    conflate three error sources. Comparing against our own BF16 output
+    isolates quantization exactly and leaves the existing gate as the anchor.
+    """
+    device = torch.device("cuda", torch.cuda.current_device())
+    rel_tol, cos_bar = QUANT_GATES[mode]
+
+    # A single random GEMM first: this separates "the wrapper is wired wrong"
+    # from "this model is tiny and FP4 is lossy".
+    if rank == 0:
+        cos, bar = quant.self_check(mode, backend, device)
+        status = "ok" if cos >= bar else "WIRED WRONG"
+        print(f"  {mode} gemm self-check: cos={cos:.4f} (bar {bar}) [{status}]")
+        if cos < bar:
+            return False
+
+    tmpdir = ckpt = None
+    if rank == 0:
+        tmpdir = tempfile.mkdtemp()
+        ckpt = build_tiny_checkpoint(arch, tmpdir, seed)
+    if world_size > 1:
+        obj = [ckpt]
+        torch.distributed.broadcast_object_list(obj, src=0)
+        ckpt = obj[0]
+
+    try:
+        g = torch.Generator().manual_seed(seed + 1)
+        # vocab_size is fixed by the tiny fixture; read it off a throwaway load
+        # rather than duplicating the constant here.
+        probe = FlashInferLLM.from_pretrained(ckpt, device, tp_size=1, tp_rank=0)
+        vocab = probe.config.vocab_size
+        del probe
+        torch.cuda.empty_cache()
+        prompts = [
+            torch.randint(0, vocab, (n,), generator=g).tolist() for n in (7, 33, 61)
+        ]
+
+        ref = _prefill_logits(
+            ckpt, device, world_size, rank, quant.QuantConfig(), prompts
+        )
+        qcfg = quant.QuantConfig(mode, backend)
+        got = _prefill_logits(ckpt, device, world_size, rank, qcfg, prompts)
+
+        ok = True
+        if rank == 0:
+            qs = qcfg.summary()
+            print(
+                f"  {mode} on {arch}: {qs['quantized_linears']} quantized linears, "
+                f"{qs['bf16_fallbacks']} bf16 fallbacks, "
+                f"backend={qs['resolved_backends'] or backend}"
+            )
+            if qs["quantized_linears"] == 0:
+                print("  nothing was quantized — shapes all fell back")
+                return False
+            for i, ids in enumerate(prompts):
+                rel = ((got[i] - ref[i]).norm() / ref[i].norm()).item()
+                cos = torch.nn.functional.cosine_similarity(
+                    got[i], ref[i], dim=0
+                ).item()
+                good = rel <= rel_tol and cos >= cos_bar
+                print(
+                    f"  {mode} len={len(ids):>3}: rel_l2={rel:.4f} cos={cos:.4f} "
+                    f"[{'ok' if good else 'MISMATCH'}]"
+                )
+                ok &= good
+        if world_size > 1:
+            flag = torch.tensor([int(ok)], device=device)
+            torch.distributed.broadcast(flag, src=0)
+            ok = bool(flag.item())
+        return ok
+    finally:
+        if rank == 0 and tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--arch", choices=["dense", "moe", "all"], default="all")
@@ -166,6 +267,13 @@ def main():
         help="max relative L2 error of last-token logits vs transformers eager",
     )
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--quant",
+        choices=("bf16", "fp8", "nvfp4", "all"),
+        default="bf16",
+        help="Also check quantized paths against this example's BF16 logits",
+    )
+    parser.add_argument("--quant-backend", default="auto")
     args = parser.parse_args()
 
     world_size, rank = maybe_init_distributed()
@@ -181,6 +289,23 @@ def main():
         print(f"[smoke] refcheck_{arch}={'pass' if ok else 'fail'}")
         if not ok:
             failed.append(arch)
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    qmodes = ["fp8", "nvfp4"] if args.quant == "all" else [args.quant]
+    for qmode in [m for m in qmodes if m != "bf16"]:
+        reason = quant.unsupported_reason(qmode, args.quant_backend, device)
+        if reason:
+            print(f"skipping {qmode}: {reason}")
+            print(f"[smoke] refcheck_quant_{qmode}=skip")
+            continue
+        for arch in archs:
+            print(f"quant check ({mode}): tiny {arch}, {qmode} vs our own bf16")
+            ok = check_quant(
+                arch, qmode, args.quant_backend, args.seed, world_size, rank
+            )
+            print(f"[smoke] refcheck_quant_{qmode}_{arch}={'pass' if ok else 'fail'}")
+            if not ok:
+                failed.append(f"{qmode}/{arch}")
     if world_size > 1:
         torch.distributed.destroy_process_group()
     if failed:

--- a/examples/pytorch/llm/smoke_test.py
+++ b/examples/pytorch/llm/smoke_test.py
@@ -1,0 +1,121 @@
+"""End-to-end smoke test for the FlashInfer LLM example.
+
+Runs ``generate.py`` in two fresh subprocesses and verifies integration-level
+invariants that kernel unit tests cannot see:
+
+1. **JIT cache works across processes** — the second run must compile zero
+   modules (``jit_builds_total == 0``). If this fails, the on-disk kernel
+   cache is broken and every user process pays full recompilation.
+2. **No steady-state recompiles** — decode steps after the first must never
+   trigger a JIT build (``jit_builds_steady == 0``), in both runs.
+3. **Greedy determinism** — both runs must produce identical token ids.
+4. **Liveness** — every request produced at least one token.
+
+Usage:
+    python smoke_test.py --model-id Qwen/Qwen3-0.6B --max-tokens 16
+
+Exit code 0 on pass, 1 on failure (with both runs' output dumped).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List
+
+
+def run_generate(args: argparse.Namespace, label: str) -> Dict:
+    cmd = [
+        sys.executable,
+        str(Path(__file__).parent / "generate.py"),
+        "--model-id",
+        args.model_id,
+        "--max-tokens",
+        str(args.max_tokens),
+        "--temperature",
+        "0.0",
+    ]
+    t0 = time.perf_counter()
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout)
+    elapsed = time.perf_counter() - t0
+    if proc.returncode != 0:
+        print(f"=== {label}: generate.py failed (rc={proc.returncode}) ===")
+        print(proc.stdout)
+        print(proc.stderr, file=sys.stderr)
+        sys.exit(1)
+    smoke: Dict = {"elapsed": elapsed, "stdout": proc.stdout}
+    tokens: List[str] = []
+    for line in proc.stdout.splitlines():
+        if not line.startswith("[smoke] "):
+            continue
+        key, _, value = line[len("[smoke] ") :].partition("=")
+        if key.startswith("tokens_"):
+            tokens.append(value)
+        else:
+            smoke[key] = value
+    smoke["tokens"] = tokens
+    print(
+        f"{label}: {elapsed:.1f}s, jit_builds_total={smoke.get('jit_builds_total')}, "
+        f"jit_builds_steady={smoke.get('jit_builds_steady')}, "
+        f"{len(tokens)} completions"
+    )
+    return smoke
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=3600,
+        help="Per-run timeout in seconds (cold JIT compile can be slow)",
+    )
+    args = parser.parse_args()
+
+    print(f"smoke test: {args.model_id}, greedy, {args.max_tokens} new tokens")
+    first = run_generate(args, "run 1 (warmup, compiles allowed)")
+    second = run_generate(args, "run 2 (must be fully cached)")
+
+    failures: List[str] = []
+
+    if second.get("jit_builds_total") != "0":
+        failures.append(
+            "JIT cache miss on warm run: second process compiled "
+            f"{second.get('jit_builds_total')} modules "
+            f"({second.get('jit_builds_names')}) — the on-disk kernel cache "
+            "is not being reused"
+        )
+    for label, run in (("run 1", first), ("run 2", second)):
+        if run.get("jit_builds_steady") != "0":
+            failures.append(
+                f"{label}: {run.get('jit_builds_steady')} JIT builds during "
+                "steady-state decode — kernels are recompiling across steps"
+            )
+    if first["tokens"] != second["tokens"]:
+        failures.append(
+            "greedy decode is not deterministic across runs:\n"
+            f"  run 1: {first['tokens']}\n  run 2: {second['tokens']}"
+        )
+    if not first["tokens"] or any(not t for t in first["tokens"]):
+        failures.append("empty completion(s) in run 1")
+
+    if failures:
+        print("\nFAIL:")
+        for f in failures:
+            print(f"  - {f}")
+        print("\n=== run 1 output ===\n" + first["stdout"])
+        print("\n=== run 2 output ===\n" + second["stdout"])
+        sys.exit(1)
+    print(
+        f"\nPASS ({first['elapsed']:.1f}s cold -> {second['elapsed']:.1f}s warm; "
+        "cache reuse, steady-state stability, and determinism verified)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/smoke_test.py
+++ b/examples/pytorch/llm/smoke_test.py
@@ -4,8 +4,9 @@ Runs ``generate.py`` in two fresh subprocesses and verifies integration-level
 invariants that kernel unit tests cannot see:
 
 1. **JIT cache works across processes** — the second run must compile zero
-   modules (``jit_builds_total == 0``). If this fails, the on-disk kernel
-   cache is broken and every user process pays full recompilation.
+   modules (``jit_builds_total == 0``, measured as "built artifact changed";
+   ninja dependency scans still run by design). If this fails, the on-disk
+   kernel cache is broken and every user process pays full recompilation.
 2. **No steady-state recompiles** — decode steps after the first must never
    trigger a JIT build (``jit_builds_steady == 0``), in both runs.
 3. **Greedy determinism** — both runs must produce identical token ids.
@@ -59,6 +60,7 @@ def run_generate(args: argparse.Namespace, label: str) -> Dict:
     smoke["tokens"] = tokens
     print(
         f"{label}: {elapsed:.1f}s, jit_builds_total={smoke.get('jit_builds_total')}, "
+        f"jit_build_calls={smoke.get('jit_build_calls')}, "
         f"jit_builds_steady={smoke.get('jit_builds_steady')}, "
         f"{len(tokens)} completions"
     )

--- a/examples/pytorch/llm/smoke_test.py
+++ b/examples/pytorch/llm/smoke_test.py
@@ -38,6 +38,10 @@ def run_generate(args: argparse.Namespace, label: str) -> Dict:
         str(args.max_tokens),
         "--temperature",
         "0.0",
+        "--quant",
+        args.quant,
+        "--quant-backend",
+        args.quant_backend,
     ]
     t0 = time.perf_counter()
     proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout)
@@ -70,6 +74,8 @@ def run_generate(args: argparse.Namespace, label: str) -> Dict:
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-id", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--quant", default="bf16")
+    parser.add_argument("--quant-backend", default="auto")
     parser.add_argument("--max-tokens", type=int, default=16)
     parser.add_argument(
         "--timeout",
@@ -82,6 +88,10 @@ def main():
     print(f"smoke test: {args.model_id}, greedy, {args.max_tokens} new tokens")
     first = run_generate(args, "run 1 (warmup, compiles allowed)")
     second = run_generate(args, "run 2 (must be fully cached)")
+
+    if first.get("quant") == "skip":
+        print("PASS (quant mode unsupported here; skipped)")
+        return
 
     failures: List[str] = []
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Closes the phase-2 **FP8/FP4 quantized linear** item on the end-to-end LLM
example (#4083, which this stacks on — the diff below includes #4083's
commits until that one lands). The harness can now exercise FlashInfer's
quantized GEMM kernels end to end from a plain BF16 Hugging Face checkpoint —
no pre-quantized weights required.

```
--quant fp8    W8A8 per-tensor e4m3   -> flashinfer.bmm_fp8
--quant nvfp4  W4A4 block-16 e2m1     -> flashinfer.nvfp4_quantize + mm_fp4
```

All quantization lives in a new `examples/pytorch/llm/quant.py`. Weights are
quantized once at load from the already-TP-sharded tensor (so scales need no
slicing); activations are quantized per forward, device-side throughout so the
decode loop picks up no host sync. `modeling.py` gains one seam — weight
attributes become callables — which is what lets scales be cached per weight
instead of recomputed every step.

**Deliberately left in BF16**, each for a reason that would otherwise produce a
confusing failure: the MoE router (top-k is discrete, so a perturbation flips
experts and yields a step change no tolerance can classify), `lm_head` (it is
the same tensor as `embed_tokens` under `tie_word_embeddings`, so quantizing it
would corrupt the embedding lookup), and the MoE expert GEMMs (`quant_scales`
is a mode-specific positional list whose fc1 scales must follow the
up-above-gate pack order — separate change).

**Verification is layered** so a wiring bug is distinguishable from honest
low-precision error: `quant.self_check` runs one random GEMM against
`F.linear` at the kernel tests' own bars, and `reference_check --quant`
compares quantized logits against *this example's own* BF16 logits rather than
folding quantization into the existing FlashInfer-vs-transformers gate.

**Graceful degradation at two levels**: whole-mode skip via
`is_compute_capability_supported` / `is_backend_supported`, and per-weight
fallback to BF16 on alignment — both surfaced as `[smoke]` counters so a
silently-unquantized run cannot masquerade as a quantized one.

## 🔍 Related Issues

Stacks on #4083 (end-to-end PyTorch LLM example).

## 🧪 Tests

Validated on **B200 (sm100a)**, flashinfer 0.6.16rc3 — 9 stages, all green:

| Stage | Result |
|---|---|
| GEMM wiring self-check, 3 shapes/mode | fp8 cos **0.9993**, nvfp4 cos **0.9910** (bars 0.99 / 0.97) |
| fp8 logits vs our own BF16 (tiny dense) | rel-L2 0.074–0.081, cos 0.9967+ |
| nvfp4 logits vs our own BF16 | rel-L2 0.281–0.346, cos 0.9398+ |
| Qwen3-0.6B `--quant fp8` / `--quant nvfp4` | 196/196 dense linears quantized, 0 fallbacks |
| autotune + fp8 / nvfp4 | `fp8_gemm` and `fp4_gemm` tactics tuned, no crash |
| `smoke_test --quant fp8` | 0 warm JIT builds, deterministic |
| BF16 regression | unchanged |

Resolved `auto` backends on that host: `cutlass_sm10x` (fp8), `cudnn` (nvfp4).
Both are printed as `[smoke] quant_resolved_backends`, since the choice is
CUDA/cuDNN-version dependent.

Gate thresholds are **baselined from that hardware run** (with ~2x headroom),
not estimated — the initial FP8 estimate was ~3x optimistic.

Two things reviewers should know rather than discover:
- **Output quality degrades, especially NVFP4.** This is dynamic per-tensor
  scaling with no calibration/SmoothQuant/rotation. On Qwen3-0.6B, FP8 tracks
  BF16 closely; NVFP4 stays fluent but drifts factually. Nothing gates on
  generated text.
- **tok/s drops under `--quant`** at verification-scale shapes (BF16 683 →
  fp8 94 → nvfp4 48). Each linear adds an amax reduction plus a quantize
  kernel, which dominates the GEMM saving at these sizes. That is launch
  overhead, not a kernel regression — these are not quantization perf numbers.

## ✅ Checklist

- [x] Passes `pre-commit run -a`
- [x] Validated on real hardware (B200)
- [x] BF16 default path unchanged
- [ ] MoE expert GEMMs quantized (deliberately out of scope; see above)

AI-assisted (Claude Code).