### PR TITLE
perf: remove NVFP4 TMA input padding copy

### DIFF
--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -1038,13 +1038,12 @@ class NVFP4QuantizeTMAKernel:
         global_scale: Union[Float32, cute.Tensor],
         stream,
     ):
-        # 3D global tensor: [padded_M, K/64, 64] so each warp's 64-col
-        # stripe is the contiguous innermost dimension, matching the CUDA
-        # TMA kernel's 3D tensor map.
+        # TMA zero-fills rows beyond the physical input extent while the kernel
+        # visits padded_M rows required by the scale layout.
         gInput = cute.make_tensor(
             mInput.iterator,
             cute.make_layout(
-                (padded_M, self.K // _TMA_COL_TILE, _TMA_COL_TILE),
+                (M, self.K // _TMA_COL_TILE, _TMA_COL_TILE),
                 stride=(self.K, _TMA_COL_TILE, 1),
             ),
         )
@@ -1694,10 +1693,9 @@ def _get_compiled_kernel_nvfp4_tma(
     )
 
     sym_m = cute.sym_int()
-    sym_padded_m = cute.sym_int()
 
     input_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass_dtype, (sym_padded_m, K), stride_order=(1, 0), assumed_align=16
+        cutlass_dtype, (sym_m, K), stride_order=(1, 0), assumed_align=16
     )
     output_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Uint8, (sym_m, K // 2), stride_order=(1, 0), assumed_align=16
@@ -1874,20 +1872,13 @@ def nvfp4_quantize_cute_dsl(
             (padded_m + rows_per_block - 1) // rows_per_block, tma_target_grid
         )
 
-        input_padded = input
-        if padded_m > m:
-            input_padded = torch.zeros(
-                padded_m, k, dtype=input.dtype, device=input.device
-            )
-            input_padded[:m, :] = input
-
         fp4_output = torch.empty(m, k // 2, dtype=torch.uint8, device=input.device)
         scale_output = torch.empty(
             scale_output_size, dtype=torch.uint8, device=input.device
         )
 
         kernel_fn(
-            input_padded,
+            input,
             fp4_output,
             scale_output,
             m,

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -1393,6 +1393,80 @@ def test_nvfp4_quantize_tma_backend_parity(
     )
 
 
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_nvfp4_quantize_tma_oob_rows(device: str) -> None:
+    """Verify partial and fully-OOB rows for M padded from 8193 to 8320."""
+    if not _is_fp4_supported(torch.device(device)):
+        pytest.skip("Nvfp4 Requires compute capability >= 10 and CUDA >= 12.8")
+    if not _is_cute_dsl_available():
+        pytest.skip("CuTe-DSL not available")
+
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        SF_LAYOUT_128x4,
+        _get_compiled_kernel_nvfp4_tma,
+    )
+
+    torch.set_default_device(device)
+    torch.manual_seed(42)
+
+    m, n = 8193, 4096
+    padded_m = ((m + 127) // 128) * 128
+    padded_sf_cols = n // 16
+    x = torch.randn((m, n), dtype=torch.bfloat16)
+    tensor_amax = torch.abs(x).max().to(torch.float32)
+    global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax).reshape(1)
+    quant_ref, scale_ref = nvfp4_quantize(
+        x,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        backend="cuda",
+    )
+
+    kernel_fn, rows_per_block = _get_compiled_kernel_nvfp4_tma(
+        "bfloat16", n, SF_LAYOUT_128x4
+    )
+    num_sm = torch.cuda.get_device_properties(
+        torch.device(device)
+    ).multi_processor_count
+    num_blocks = min(
+        (padded_m + rows_per_block - 1) // rows_per_block,
+        num_sm * 2,
+    )
+
+    quant_output = torch.empty(m, n // 2, dtype=torch.uint8)
+    scale_output = torch.full(
+        (padded_m * padded_sf_cols,),
+        0xA5,
+        dtype=torch.uint8,
+    )
+    kernel_fn(
+        x,
+        quant_output,
+        scale_output,
+        m,
+        padded_m,
+        num_blocks,
+        global_scale,
+    )
+    torch.cuda.synchronize()
+
+    scale_unswizzled = unswizzle_sf(
+        scale_output.reshape(padded_m, padded_sf_cols),
+        padded_m,
+        n,
+    )
+    scale_ref_unswizzled = unswizzle_sf(scale_ref, padded_m, n)
+
+    quant_match_pct = (quant_output[-1] == quant_ref[-1]).float().mean().item() * 100
+    assert quant_match_pct > 95.0
+    scale_match_pct = (
+        scale_unswizzled[m - 1] == scale_ref_unswizzled[m - 1]
+    ).float().mean().item() * 100
+    assert scale_match_pct > 95.0
+    assert torch.count_nonzero(scale_unswizzled[m:]).item() == 0
+
+
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("batch_shape", BATCH_SHAPES)
 @pytest.mark.parametrize("seed", SEEDS)


### PR DESCRIPTION
## 📌 Description

Remove the temporary padded input allocation and full-tensor copy from the CuTe DSL NVFP4 TMA path. The TMA tensor map now describes the physical `M` rows and relies on G2S TMA out-of-bounds zero fill for row tiles that extend into the padded scale layout. The FP4 output remains bounded by `M`, while padded scale rows are still explicitly zeroed.

This keeps the existing TMA pipeline and 128x4 scale layout while eliminating the non-128-aligned `M` copy cliff.

### B200 performance

Configuration: NVIDIA B200, BF16 input, `K=4096`, 128x4 scale layout, PDL enabled, eager/no CUDA Graph, cold L2, CUPTI timing. Each value is the median of three runs with 20 warmups and 100 measured iterations per run.

| M | Aligned to 128 | TMA + input copy (µs) | Vectorized (µs) | This PR (µs) |
|---:|:---:|---:|---:|---:|
| 32283 | No | 212.446 | 62.399 | **59.248** |
| 32384 | Yes | 59.072 | 62.399 | **59.312** |
| 32386 | No | 213.054 | 62.367 | **59.151** |
| 32512 | Yes | 59.375 | 62.431 | **59.184** |
| 32621 | No | 213.581 | 62.031 | **59.423** |
| 32640 | Yes | 59.455 | 62.031 | **59.392** |
| 32733 | No | 213.902 | 62.080 | **59.407** |
| 32768 | Yes | 59.439 | 61.967 | **59.552** |

For non-aligned 32K shapes, this reduces API GPU time by 72.1%–72.2% versus TMA with the padded input copy and is 4.2%–5.2% faster than the vectorized path. For aligned shapes, it stays within ±0.41% of the previous TMA path and is 3.9%–5.2% faster than vectorized. `M=6326/6400` remains on the existing vectorized heuristic and is unaffected by this TMA change.

Reproduction template:

```bash
FLASHINFER_NVFP4_QUANTIZE_USE_TMA=1 python3 benchmarks/flashinfer_benchmark.py   --routine nvfp4_quantize   --backends cute-dsl   --m 32283   --k 4096   --input_dtype bfloat16   --global_scale 1.0   --sf_layout 128x4   --sf_vec_size 16   --enable_pdl   --no_cuda_graph   --dry_run_iters 20   --num_iters 100   --refcheck   -vv
```

## 🔍 Related Issues

Related to #3905.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see the [pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] Relevant B200 validation is passing: FP16/BF16 partial- and fully-OOB cross-path checks, nonzero-sentinel padding-scale checks, and `compute-sanitizer --tool memcheck` (`ERROR SUMMARY: 0 errors`).

## Reviewer Notes

The TMA descriptor uses the physical `M`, but the kernel intentionally continues through `padded_M` to initialize the scale layout. The focused regression case uses `M=8193`, which produces one partial TMA tile followed by seven fully-OOB tiles before the 128-row scale boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVFP4 quantization for inputs whose row count requires padding.
  * Ensured out-of-bounds padded rows are automatically zero-filled during TMA processing.
  * Preserved correct quantization results and scale factors for valid rows.

* **Tests**
  * Added coverage for non-aligned row counts and verified zero values in padded rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->