### PR TITLE
perf: optimize cuDNN GEMM autotuning for versions <= 9.23.1

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2415,6 +2415,12 @@ def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
 def _finalize_cudnn_graph_for_tactic(
     graph, tactic, heur_modes, deselect_eng0: bool = False
 ) -> None:
+    # An integer tactic >= 0 is only ever passed by a runner's get_valid_tactics,
+    # which builds a graph solely to read back the available (engine_id, knobs)
+    # pairs via _cudnn_graph_engine_knob_tactics.  Every other caller passes
+    # either an engine/knob tuple (execute this plan) or -1 (heuristic default).
+    enumeration_only = not _is_cudnn_engine_knob_tactic(tactic) and tactic >= 0
+
     graph.validate()
     graph.build_operation_graph()
 
@@ -2435,6 +2441,17 @@ def _finalize_cudnn_graph_for_tactic(
             graph.deselect_engines(["eng0"])
 
     graph.check_support()
+
+    # check_support() already populates the plan metadata that tactic
+    # enumeration reads, so compiling every plan is wasted work -- unless this
+    # graph is later reused to *execute* those tactics.  That reuse happens only
+    # on the override-shape path (cuDNN >= 9.23.1), where _tactic_for_graph_cache
+    # maps engine/knob tactics back to key 0 and the runtime call lands on this
+    # same lru_cache entry.  Without override-shape, execution rebuilds a
+    # per-tactic graph under its own cache key and these plans are never run.
+    if enumeration_only and not _is_cudnn_override_shape_available():
+        return
+
     if policy is None:
         graph.build_plans()
     else:

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2415,10 +2415,8 @@ def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
 def _finalize_cudnn_graph_for_tactic(
     graph, tactic, heur_modes, deselect_eng0: bool = False
 ) -> None:
-    # An integer tactic >= 0 is only ever passed by a runner's get_valid_tactics,
-    # which builds a graph solely to read back the available (engine_id, knobs)
-    # pairs via _cudnn_graph_engine_knob_tactics.  Every other caller passes
-    # either an engine/knob tuple (execute this plan) or -1 (heuristic default).
+    # Only get_valid_tactics passes an integer tactic >= 0, to read back the
+    # available (engine_id, knobs) via _cudnn_graph_engine_knob_tactics.
     enumeration_only = not _is_cudnn_engine_knob_tactic(tactic) and tactic >= 0
 
     graph.validate()
@@ -2442,13 +2440,8 @@ def _finalize_cudnn_graph_for_tactic(
 
     graph.check_support()
 
-    # check_support() already populates the plan metadata that tactic
-    # enumeration reads, so compiling every plan is wasted work -- unless this
-    # graph is later reused to *execute* those tactics.  That reuse happens only
-    # on the override-shape path (cuDNN >= 9.23.1), where _tactic_for_graph_cache
-    # maps engine/knob tactics back to key 0 and the runtime call lands on this
-    # same lru_cache entry.  Without override-shape, execution rebuilds a
-    # per-tactic graph under its own cache key and these plans are never run.
+    # check_support() already populates the metadata enumeration reads.  Only the
+    # override-shape path reuses this graph to execute (see _tactic_for_graph_cache).
     if enumeration_only and not _is_cudnn_override_shape_available():
         return
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Skip redundant cuDNN execution-plan compilation during tactic enumeration on cuDNN backends older than 9.23.1.

`_finalize_cudnn_graph_for_tactic` compiles cuDNN execution plans. Every cuDNN GEMM runner calls it indirectly from `get_valid_tactics` with an integer `tactic=0`, in order to read back the available `(engine_id, knobs)` pairs via `_cudnn_graph_engine_knob_tactics`. An integer tactic `>= 0` selects `build_plan_policy.ALL`, which compiles every candidate plan.

The plan metadata that enumeration reads is already populated by `graph.check_support()`. Compiling the plans is only necessary if the same graph object is later reused to execute those tactics. That reuse happens only on the override-shape path (cuDNN >= 9.23.1): `_tactic_for_graph_cache()` maps engine/knob tactics back to cache key `0`, so the runtime call resolves to the same `functools.lru_cache` entry the enumeration populated. Without override-shape, `forward` rebuilds a per-tactic graph under a different cache key, and the plans compiled during enumeration are never executed.

This PR returns after `check_support()` for the enumeration-only call when `_is_cudnn_override_shape_available()` is False. Behaviour on cuDNN >= 9.23.1 is unchanged.

Enumeration returns an identical tactic list with and without the compile step (16/16 `(engine_id, knobs)` pairs matched on the shape tested), at 11.4 ms instead of 314.8 ms.

Breakdown of one autotune event on cuDNN 9.20.0 before the change (`bmm_bf16`, `b=1, m=48, n=80, k=64`, bf16 out):

| phase | calls | wall | share |
|---|---|---|---|
| plan compile, enumeration (`build_plans(ALL)`) | 7 | 1.88 s | 49% |
| plan compile, per tactic (`build_plans()`) | 104 | 1.73 s | 45% |
| warmup, CUDA-graph capture, timed iterations | 104 | 0.20 s | 5% |

The first row is what this PR removes on that path.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

All measurements on GB300 (SM103), `nvidia-cudnn-frontend` 1.26.0, torch 2.12.1+cu132.

1. **Correctness and tuning cost across cuDNN versions.** Run `tests/gemm/test_bmm_bf16.py` before and after the change on cuDNN 9.20.0, 9.23.0 and 9.23.1, checking pass counts, wall time, and the absence of `cuDNN ... tactic failed; falling back to default tactic=-1` warnings. 9.23.0 and 9.23.1 are adjacent releases that differ in the override-shape gate, which isolates the gated behaviour from unrelated cuDNN changes.
2. **Cross-routine correctness.** Run a 108-test cuDNN slice of `tests/gemm/test_bmm_fp8.py` before and after, on cuDNN 9.20.0.
3. **Runtime performance of the affected operations.** Run `benchmarks/flashinfer_benchmark.py` with `--autotune --refcheck --use_cupti` over the cuDNN-backed GEMM routines, before and after, on cuDNN 9.20.0 (the configuration where the change is active).
4. **Tactic-selection equivalence.** Dump the autotuner's selected `(engine_id, knobs)` per profile before and after, with same-configuration repeats as a control for autotuner non-determinism.

**1. Tuning cost and correctness.** All runs: `193 passed, 48 skipped`, zero fallback warnings.

| cuDNN backend | override-shape | before | after | change |
|---|---|---|---|---|
| 9.20.0 | off | 153.05 s | 101.26 s | -34% |
| 9.23.0 | off | 264.94 s | 201.44 s | -24% |
| 9.23.1 | on | 109.44 s | 107.75 s | no-op (within noise) |

**2. Cross-routine.** `tests/gemm/test_bmm_fp8.py` cuDNN slice: 91.34 s to 56.39 s, `108 passed` both.

**3. Runtime performance.** No regression. CUPTI timing, 2 repetitions per configuration; `--refcheck` passed in all cases. "noise" is the run-to-run spread within a configuration.

| routine | b | m | n | k | before (ms) | after (ms) | delta | noise |
|---|---|---|---|---|---|---|---|---|
| bmm_bf16 | 4 | 8 | 4096 | 4096 | 0.0287 | 0.0287 | -0.11% | 0.45% |
| bmm_bf16 | 4 | 128 | 4096 | 4096 | 0.0311 | 0.0306 | -1.57% | 2.67% |
| bmm_bf16 | 4 | 4096 | 4096 | 4096 | 0.2808 | 0.2808 | -0.00% | 0.30% |
| mm_bf16 | - | 128 | 4096 | 4096 | 0.0107 | 0.0107 | -0.15% | 0.15% |
| mm_bf16 | - | 4096 | 4096 | 4096 | 0.0756 | 0.0790 | +4.51%* | 0.51% |
| bmm_fp8 | 4 | 128 | 4096 | 4096 | 0.0172 | 0.0172 | -0.28% | 0.84% |
| bmm_fp8 | 256 | 1 | 1024 | 7168 | 0.2759 | 0.2761 | +0.06% | 0.15% |
| bmm_mxfp8 | 4 | 128 | 4096 | 4096 | 0.0179 | 0.0179 | -0.22% | 0.18% |
| mm_mxfp8 | - | 128 | 4096 | 4096 | 0.0097 | 0.0097 | +0.17% | 0.33% |
| mm_fp4 | - | 128 | 4096 | 4096 | 0.0078 | 0.0077 | -0.72% | 0.62% |
| mm_fp4 | - | 4096 | 4096 | 4096 | 0.0269 | 0.0271 | +0.86% | 2.26% |

**4. Tactic selection.** Selected tactics do differ between a before-run and an after-run, but same-configuration repeats differ at least as much, so the difference is not attributable to this change:

| comparison | profiles differing (of 21) |
|---|---|
| after run 1 vs after run 2 | 13 |
| before run 1 vs before run 2 | 10 |
| before run 1 vs after run 1 | 8 |
| before run 2 vs after run 2 | 4 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cuDNN tactic enumeration by avoiding unnecessary execution-plan construction when override-shape execution is unavailable.
  * Preserved engine and knob combination metadata for supported enumeration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->