### PR TITLE
feat: paged KV cache support for the modular CuTe-DSL Blackwell prefill

### DIFF
--- a/flashinfer/cute_dsl/attention/collective_builder.py
+++ b/flashinfer/cute_dsl/attention/collective_builder.py
@@ -62,14 +62,9 @@ def build_fmha_launch_params(
     config = mainloop.config
 
     # Paged KV shares the K/V smem ring layouts with ragged; only the TMA
-    # atoms (per-page box) and their smem partition views differ.  Mixed
-    # K/V dtypes would need the stage-stride padding below replicated on
-    # the *_for_tma views — not wired up yet.
-    if config.page_size is not None and k_dtype.width != v_dtype.width:
-        raise ValueError(
-            "paged KV cache with mixed K/V dtypes is not supported yet; "
-            "use a uniform dtype or the ragged (contiguous) KV path"
-        )
+    # atoms (per-page box) and their smem partition views differ.  With
+    # mixed K/V dtypes the stage-stride padding below is replicated on the
+    # *_for_tma views so page copies land in the shared ring's slots.
 
     cta_group = tcgen05.CtaGroup.ONE
     p_major_mode = cute.nvgpu.OperandMajorMode.K
@@ -186,6 +181,14 @@ def build_fmha_launch_params(
             k_dtype,
             mainloop.kv_stages,
         )
+        if v_dtype.width > k_dtype.width:
+            # Mixed widths: the shared ring's slot pitch is the wider
+            # operand's tile footprint (see the staged padding above) —
+            # rebuild the stage mode with the same padded stride.
+            k_smem_layout_for_tma = cute.append(
+                cute.select(k_smem_layout_for_tma, mode=[0, 1]),
+                cute.make_layout(mainloop.kv_stages, stride=k_stage_stride),
+            )
         k_smem_layout_for_tma = cute.tiled_divide(
             k_smem_layout_for_tma, (config.page_size, config.qk_mma_tiler[2])
         )
@@ -204,6 +207,13 @@ def build_fmha_launch_params(
             v_dtype,
             mainloop.kv_stages,
         )
+        if k_dtype.width > v_dtype.width:
+            # Mixed widths: pad V's stage stride to K's tile footprint,
+            # mirroring the staged-layout padding above.
+            v_smem_layout_for_tma = cute.append(
+                cute.select(v_smem_layout_for_tma, mode=[0, 1]),
+                cute.make_layout(mainloop.kv_stages, stride=v_stage_stride),
+            )
         v_smem_layout_for_tma = cute.tiled_divide(
             v_smem_layout_for_tma, (config.pv_mma_tiler[1], config.page_size)
         )

--- a/flashinfer/cute_dsl/attention/collective_builder.py
+++ b/flashinfer/cute_dsl/attention/collective_builder.py
@@ -61,6 +61,16 @@ def build_fmha_launch_params(
     """
     config = mainloop.config
 
+    # Paged KV shares the K/V smem ring layouts with ragged; only the TMA
+    # atoms (per-page box) and their smem partition views differ.  Mixed
+    # K/V dtypes would need the stage-stride padding below replicated on
+    # the *_for_tma views — not wired up yet.
+    if config.page_size is not None and k_dtype.width != v_dtype.width:
+        raise ValueError(
+            "paged KV cache with mixed K/V dtypes is not supported yet; "
+            "use a uniform dtype or the ragged (contiguous) KV path"
+        )
+
     cta_group = tcgen05.CtaGroup.ONE
     p_major_mode = cute.nvgpu.OperandMajorMode.K
     p_source = tcgen05.OperandSource.TMEM
@@ -160,23 +170,69 @@ def build_fmha_launch_params(
         cluster_layout_vmnk.shape,
     )
     k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
-    tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
-        tma_load_op,
-        k,
-        k_smem_layout,
-        config.qk_mma_tiler,
-        qk_tiled_mma,
-        cluster_layout_vmnk.shape,
-    )
     v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
-    tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
-        tma_load_op,
-        v,
-        v_smem_layout,
-        config.pv_mma_tiler,
-        pv_tiled_mma,
-        cluster_layout_vmnk.shape,
-    )
+    k_smem_layout_for_tma = None
+    v_smem_layout_for_tma = None
+    if config.page_size is not None:
+        # Paged: the TMA box shrinks to one page ((page_size, d) for K,
+        # (d, page_size) for V) and the loader issues pages_per_kv_tile
+        # copies per tile, indexing the page mode with a runtime page id.
+        # The *_for_tma layouts view the same physical smem ring divided
+        # into per-page sub-boxes — the MLA decode pairing
+        # (kc_smem_layout_for_tma / make_paged_tiled_tma_atom).
+        k_smem_layout_for_tma = sm100_utils.make_smem_layout(
+            OperandMajorMode.K,
+            (config.qk_mma_tiler[1], config.qk_mma_tiler[2]),
+            k_dtype,
+            mainloop.kv_stages,
+        )
+        k_smem_layout_for_tma = cute.tiled_divide(
+            k_smem_layout_for_tma, (config.page_size, config.qk_mma_tiler[2])
+        )
+        tma_atom_k, tma_tensor_k = make_paged_tiled_tma_atom(
+            tma_load_op,
+            k,
+            cute.select(k_smem_layout_for_tma, mode=[0]),
+            (config.qk_mma_tiler[1], config.qk_mma_tiler[2]),
+            qk_tiled_mma,
+            config.page_size,
+            is_k_load=True,
+        )
+        v_smem_layout_for_tma = sm100_utils.make_smem_layout(
+            OperandMajorMode.MN,
+            (config.pv_mma_tiler[1], config.pv_mma_tiler[2]),
+            v_dtype,
+            mainloop.kv_stages,
+        )
+        v_smem_layout_for_tma = cute.tiled_divide(
+            v_smem_layout_for_tma, (config.pv_mma_tiler[1], config.page_size)
+        )
+        tma_atom_v, tma_tensor_v = make_paged_tiled_tma_atom(
+            tma_load_op,
+            v,
+            cute.select(v_smem_layout_for_tma, mode=[0]),
+            (config.pv_mma_tiler[1], config.pv_mma_tiler[2]),
+            pv_tiled_mma,
+            config.page_size,
+            is_k_load=False,
+        )
+    else:
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k,
+            k_smem_layout,
+            config.qk_mma_tiler,
+            qk_tiled_mma,
+            cluster_layout_vmnk.shape,
+        )
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_smem_layout,
+            config.pv_mma_tiler,
+            pv_tiled_mma,
+            cluster_layout_vmnk.shape,
+        )
     o_smem_layout = cute.select(o_smem_layout_staged, mode=[0, 1])
     tma_atom_o, tma_tensor_o = cute.nvgpu.cpasync.make_tiled_tma_atom(
         tma_store_op,
@@ -251,6 +307,8 @@ def build_fmha_launch_params(
         p_tmem_layout_staged=p_tmem_layout_staged,
         v_smem_layout_staged=v_smem_layout_staged,
         o_smem_layout_staged=o_smem_layout_staged,
+        k_smem_layout_for_tma=k_smem_layout_for_tma,
+        v_smem_layout_for_tma=v_smem_layout_for_tma,
         SharedStorage=SharedStorage,
         tma_copy_q_bytes=tma_copy_q_bytes,
         tma_copy_kv_bytes=tma_copy_kv_bytes,

--- a/flashinfer/cute_dsl/attention/collective_builder.py
+++ b/flashinfer/cute_dsl/attention/collective_builder.py
@@ -268,6 +268,15 @@ def build_fmha_launch_params(
     )
     s0_epi_stages = mainloop.epi_stage if mainloop.has_logits_transform else 1
 
+    # Page-table ring (empty-warp pt producer).  Zero-length fields at the
+    # end of the struct keep every other offset and the total size
+    # bit-identical for builds without the ring.
+    pt_stages = mainloop.config.load_pt_stages
+    pt_barrier_slots = 2 * pt_stages if pt_stages is not None else 0
+    pt_ring_slots = (
+        pt_stages * mainloop.config.pages_per_kv_tile if pt_stages is not None else 0
+    )
+
     @cute.struct
     class SharedStorage:
         load_q_mbar_ptr: cute.struct.MemRange[Int64, mainloop.q_stages * 2]
@@ -297,6 +306,8 @@ def build_fmha_launch_params(
             cute.struct.MemRange[k_dtype, sK_cosize],
             align,
         ]
+        load_pt_mbar_ptr: cute.struct.MemRange[Int64, pt_barrier_slots]
+        smem_page_table: cute.struct.MemRange[cutlass.Int32, pt_ring_slots]
 
         @classmethod
         def size_in_bytes(cls) -> int: ...  # noqa: F811

--- a/flashinfer/cute_dsl/attention/config.py
+++ b/flashinfer/cute_dsl/attention/config.py
@@ -167,6 +167,25 @@ class AttentionConfig:
         return self.mma_tiler[1] // self.page_size
 
     @property
+    def load_pt_stages(self) -> int | None:
+        """Depth of the page-table SMEM ring, or None to read ids in-loop.
+
+        At 16+ pages per KV tile the loader's in-loop id loads dominate
+        its issue cadence (one global-latency load feeding each TMA copy,
+        twice per tile across the K and V loops).  A dedicated producer
+        warp then pays for itself: it stages each tile's ids into an SMEM
+        ring ahead of the loader, which reads them back at LDS latency
+        (the MLA-decode pt-loader design).  Below that copy count the
+        ring's handshake costs more than the id loads it removes (the
+        handshake is a fixed per-tile cost; the savings scale with the
+        copy count — measured on both sides of the crossover), so the
+        loader keeps the direct path.
+        """
+        if self.page_size is not None and self.pages_per_kv_tile >= 16:
+            return 4
+        return None
+
+    @property
     def tile_bounds(self) -> TileBounds:
         """Derive tile bounds from head mapping."""
         if self.head_mapping == HeadMapping.MMA_M and self.num_heads > 0:

--- a/flashinfer/cute_dsl/attention/config.py
+++ b/flashinfer/cute_dsl/attention/config.py
@@ -71,6 +71,12 @@ class AttentionConfig:
     mask_spec: MaskSpec
     num_repeat_kv_heads: int = 1
 
+    # Paged KV cache: tokens per page, or None for contiguous (ragged) KV.
+    # Compile-time on purpose — the per-page TMA loop in the loader fully
+    # unrolls (pages_per_kv_tile copies per KV tile) and the TMA box shape
+    # depends on it.
+    page_size: int | None = None
+
     # Reserved for decode — unused by prefill. Decode kernels pack heads into
     # MMA M/N dimensions; prefill maps heads via the grid (HeadMapping.GRID).
     head_mapping: HeadMapping = HeadMapping.GRID
@@ -109,6 +115,16 @@ class AttentionConfig:
             raise ValueError(
                 f"num_repeat_kv_heads={self.num_repeat_kv_heads} must be >= 1"
             )
+        if self.page_size is not None:
+            kv_tile = self.mma_tiler[1]
+            # >= 8 keeps the page box aligned to the 8-row smem swizzle atom;
+            # dividing the KV tile keeps the per-page copy loop a constexpr
+            # unroll with no partial-page boxes inside a tile.
+            if self.page_size < 8 or kv_tile % self.page_size != 0:
+                raise ValueError(
+                    f"page_size={self.page_size} must be >= 8 and divide the "
+                    f"KV tile size ({kv_tile})"
+                )
 
     @property
     def cta_tiler(self) -> Tuple[int, int, int]:
@@ -137,6 +153,18 @@ class AttentionConfig:
     def cluster_shape_mn(self) -> Tuple[int, int]:
         """Cluster shape (always (1,1) for prefill)."""
         return (1, 1)
+
+    @property
+    def paged(self) -> bool:
+        """Whether KV comes from a paged cache (page-table indirection)."""
+        return self.page_size is not None
+
+    @property
+    def pages_per_kv_tile(self) -> int:
+        """TMA copies per 128-token KV tile in paged mode (1 for ragged)."""
+        if self.page_size is None:
+            return 1
+        return self.mma_tiler[1] // self.page_size
 
     @property
     def tile_bounds(self) -> TileBounds:

--- a/flashinfer/cute_dsl/attention/mainloop_spec.py
+++ b/flashinfer/cute_dsl/attention/mainloop_spec.py
@@ -80,6 +80,7 @@ class MainloopSpec:
                 kv_stages=kv_stages,
                 mma_softmax_stages=self.mma_softmax_stage,
                 epi_stages=self.epi_stage,
+                load_pt_stages=self.config.load_pt_stages,
             )
         else:
             topology = make_prefill_topology(
@@ -90,6 +91,7 @@ class MainloopSpec:
                 softmax_corr_stages=self.softmax_corr_stage,
                 mma_corr_stages=self.mma_corr_stage,
                 epi_stages=self.epi_stage,
+                load_pt_stages=self.config.load_pt_stages,
             )
         return replace(self, kv_stages=kv_stages, pipeline_topology=topology)
 

--- a/flashinfer/cute_dsl/attention/pipeline_topology.py
+++ b/flashinfer/cute_dsl/attention/pipeline_topology.py
@@ -185,6 +185,7 @@ def make_prefill_topology(
     softmax_corr_stages: int = 1,
     mma_corr_stages: int = 2,
     epi_stages: int = 2,
+    load_pt_stages: int | None = None,
 ) -> PipelineTopology:
     """Build the pipeline topology for FMHA prefill.
 
@@ -195,8 +196,15 @@ def make_prefill_topology(
                                 --[mma_corr]------------------------------>
                                               Softmax0 --[s0_s1_seq]--> Softmax1
 
+    With ``load_pt_stages`` set (paged KV at high pages-per-tile), a tenth
+    pipeline feeds the loader pre-clamped page ids from the otherwise-idle
+    empty warp::
+
+        PT_Load --[load_pt]--> Load
+
     :param schedule: Warp schedule defining warp role assignments.
     :param kv_stages: Stage count for KV pipeline (3 for fp16/bf16, 4 for fp8).
+    :param load_pt_stages: Page-table ring depth, or None for no pt pipeline.
     """
     s = schedule
     load = (s.load_warp_id,)
@@ -206,8 +214,10 @@ def make_prefill_topology(
     corr = s.correction_warp_ids
     epi = (s.epilogue_warp_id,)
 
+    pt_edges = _load_pt_edges(schedule, load_pt_stages)
     return PipelineTopology(
-        edges=[
+        edges=pt_edges
+        + [
             PipelineEdge(
                 "load_q",
                 PipelineType.TMA_UMMA,
@@ -280,12 +290,30 @@ def make_prefill_topology(
     )
 
 
+def _load_pt_edges(
+    schedule: WarpSchedule, load_pt_stages: int | None
+) -> List[PipelineEdge]:
+    """The empty-warp -> loader page-table edge ([] when disabled)."""
+    if load_pt_stages is None:
+        return []
+    return [
+        PipelineEdge(
+            "load_pt",
+            PipelineType.CP_ASYNC,
+            stages=load_pt_stages,
+            producer_warp_ids=(schedule.empty_warp_id,),
+            consumer_warp_ids=(schedule.load_warp_id,),
+        )
+    ]
+
+
 def make_prefill_topology_transform(
     schedule: WarpSchedule,
     q_stages: int = 2,
     kv_stages: int = 3,
     mma_softmax_stages: int = 1,
     epi_stages: int = 2,
+    load_pt_stages: int | None = None,
 ) -> PipelineTopology:
     """Build the pipeline topology for FMHA prefill with logits_transform variants.
 
@@ -298,8 +326,12 @@ def make_prefill_topology_transform(
               --[load_kv]->     --[mma_s1]--> Softmax1 --[s1_epi]-->
                                 Softmax0 --[s0_s1_seq]--> Softmax1
 
+    With ``load_pt_stages`` set, the same PT_Load --[load_pt]--> Load edge
+    as :func:`make_prefill_topology`.
+
     :param schedule: Warp schedule defining warp role assignments.
     :param kv_stages: Stage count for KV pipeline (3 for fp16/bf16, 4 for fp8).
+    :param load_pt_stages: Page-table ring depth, or None for no pt pipeline.
     """
     s = schedule
     load = (s.load_warp_id,)
@@ -308,8 +340,10 @@ def make_prefill_topology_transform(
     s1 = s.softmax1_warp_ids
     epi = (s.epilogue_warp_id,)
 
+    pt_edges = _load_pt_edges(schedule, load_pt_stages)
     return PipelineTopology(
-        edges=[
+        edges=pt_edges
+        + [
             PipelineEdge(
                 "load_q",
                 PipelineType.TMA_UMMA,

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -25,6 +25,7 @@ from .roles.mma import MmaRole
 from .compat import get_current_arch as _get_current_arch
 
 import warnings
+from dataclasses import replace
 
 warnings.filterwarnings(
     "ignore",
@@ -64,6 +65,20 @@ class BlackwellFusedMultiHeadAttentionForward:
         else:
             self.schedule = PREFILL_SCHEDULE
 
+        if config.page_size is not None:
+            # Paged-only rebalance: one setmaxnreg quantum (8 registers)
+            # from correction to the mma/load/epi group.  The paged
+            # loader adds the per-page id-load/copy loop to the ragged
+            # loader's work; at the default budgets the build is still
+            # spill-free but measures ~1-2% slower at ps16/32 than with
+            # this headroom.  The schedule is a shared frozen dataclass
+            # (PREFILL_SCHEDULE), so modify a copy.
+            self.schedule = replace(
+                self.schedule,
+                num_regs_correction=self.schedule.num_regs_correction - 8,
+                num_regs_other=self.schedule.num_regs_other + 8,
+            )
+
         self.mainloop = make_prefill_mainloop_spec(
             config,
             self.schedule,
@@ -89,17 +104,24 @@ class BlackwellFusedMultiHeadAttentionForward:
         window_right: Int32,
         params_in: cute.Tensor | None,
         lse_in: cute.Tensor | None,
+        kv_page_table: cute.Tensor | None,
+        kv_page_indptr: cute.Tensor | None,
         stream,
     ):
         """Execute the Fused Multi-Head Attention operation on the provided tensors.
 
         :param q_in: The query tensor (NHD layout)
-        :param k_in: The key tensor (NHD layout)
-        :param v_in: The value tensor (NHD layout)
+        :param k_in: The key tensor (NHD layout), or the paged K cache
+            ``(num_pages, page_size, h_k, d)`` when ``config.page_size`` is set
+        :param v_in: The value tensor (NHD layout), or the paged V cache
+            ``(num_pages, page_size, h_k, d)`` when ``config.page_size`` is set
         :param o_in: The output tensor (NHD layout, with padding before data pointer)
         :param problem_size: ``(b, s_q, s_k, h_q, h_k, d)``
         :param cum_seqlen_q: Cumulative query sequence lengths, or None
-        :param cum_seqlen_k: Cumulative KV sequence lengths, or None
+        :param cum_seqlen_k: Cumulative KV sequence lengths, or None.  For
+            paged KV these are cumulative *logical token* counts (not page
+            counts) — the consumer roles derive per-item seqlen_k from them
+            exactly as on the ragged path.
         :param scale_softmax_log2: ``log2(e) * sm_scale``
         :param scale_output: Output scaling factor
         :param window_left: runtime lookback bound (read only when the
@@ -107,6 +129,10 @@ class BlackwellFusedMultiHeadAttentionForward:
         :param window_right: runtime lookahead bound (read only when the
             compile-time ``MaskSpec.has_window_right`` is set)
         :param params_in: Variant runtime data tensor, or None
+        :param kv_page_table: Flat int32 physical page ids
+            (``paged_kv_indices``), or None for ragged KV
+        :param kv_page_indptr: int32 ``[B+1]`` page-count cumsums locating each
+            batch item's slice of ``kv_page_table``, or None for ragged KV
         :param stream: CUDA stream
         """
         b, s_q, s_k, h_q, h_k, d = problem_size
@@ -126,18 +152,48 @@ class BlackwellFusedMultiHeadAttentionForward:
             stride=(d * h_r * h_k, 1, ((d, d * h_r), stride_b_q)),
         )
         q = cute.make_tensor(q_in.iterator, q_layout)
-        # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
-        k_layout = cute.make_layout(
-            (s_k_all, d, ((h_r, h_k), b_kv)),
-            stride=(d * h_k, 1, ((0, d), stride_b_kv)),
-        )
-        k = cute.make_tensor(k_in.iterator, k_layout)
-        # (d, s, ((h_r, h_k), b)), 0-stride for h_r to broadcast
-        v_layout = cute.make_layout(
-            (d, s_k_all, ((h_r, h_k), b_kv)),
-            stride=(1, d * h_k, ((0, d), stride_b_kv)),
-        )
-        v = cute.make_tensor(v_in.iterator, v_layout)
+        if cutlass.const_expr(self.config.page_size is not None):
+            # Paged KV: the loader indexes the trailing page mode with a
+            # runtime page id per TMA copy, so item boundaries need no
+            # domain shift.  Consumer roles still derive seqlen_k from
+            # cum_seqlen_k, which is therefore required.
+            if cutlass.const_expr(cum_seqlen_k is None):
+                raise ValueError("paged KV requires cum_seqlen_k (varlen mode)")
+            if cutlass.const_expr(kv_page_table is None or kv_page_indptr is None):
+                raise ValueError("paged KV requires kv_page_table and kv_page_indptr")
+            page_size = self.config.page_size
+            num_pages = k_in.shape[0]
+            # Strides come from the incoming (num_pages, page_size, h_k, d)
+            # views, not from compact math: the wrapper compiles with
+            # symbolic outer strides (batch_decode.py precedent) so one
+            # kernel serves NHD-compact caches, combined-cache slices
+            # (2x page stride), and HND-transposed views alike.  Only the
+            # head_dim stride is pinned to 1 (TMA contiguity).
+            # (page, d, ((h_r, h_k), num_pages)), 0-stride h_r broadcast
+            k_layout = cute.make_layout(
+                (page_size, d, ((h_r, h_k), num_pages)),
+                stride=(k_in.stride[1], 1, ((0, k_in.stride[2]), k_in.stride[0])),
+            )
+            k = cute.make_tensor(k_in.iterator, k_layout)
+            # (d, page, ((h_r, h_k), num_pages)), 0-stride h_r broadcast
+            v_layout = cute.make_layout(
+                (d, page_size, ((h_r, h_k), num_pages)),
+                stride=(1, v_in.stride[1], ((0, v_in.stride[2]), v_in.stride[0])),
+            )
+            v = cute.make_tensor(v_in.iterator, v_layout)
+        else:
+            # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+            k_layout = cute.make_layout(
+                (s_k_all, d, ((h_r, h_k), b_kv)),
+                stride=(d * h_k, 1, ((0, d), stride_b_kv)),
+            )
+            k = cute.make_tensor(k_in.iterator, k_layout)
+            # (d, s, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+            v_layout = cute.make_layout(
+                (d, s_k_all, ((h_r, h_k), b_kv)),
+                stride=(1, d * h_k, ((0, d), stride_b_kv)),
+            )
+            v = cute.make_tensor(v_in.iterator, v_layout)
         # (s, d, ((h_r, h_k), b))
         o_layout = cute.make_layout(
             (s_q, d, ((h_r, h_k), b_o)),
@@ -306,6 +362,10 @@ class BlackwellFusedMultiHeadAttentionForward:
             lp.v_smem_layout_staged,
             lp.o_smem_layout_staged,
             self.tile_sched_params,
+            lp.k_smem_layout_for_tma,
+            lp.v_smem_layout_for_tma,
+            kv_page_table,
+            kv_page_indptr,
         ).launch(
             grid=grid,
             block=[self.schedule.threads_per_cta, 1, 1],
@@ -415,6 +475,10 @@ class BlackwellFusedMultiHeadAttentionForward:
         v_smem_layout_staged: cute.ComposedLayout,
         o_smem_layout_staged: cute.ComposedLayout,
         tile_sched_params: FmhaStaticTileSchedulerParams,
+        k_smem_layout_for_tma: cute.ComposedLayout | None,
+        v_smem_layout_for_tma: cute.ComposedLayout | None,
+        kv_page_table: cute.Tensor | None,
+        kv_page_indptr: cute.Tensor | None,
     ):
         """FMHA device kernel: warp-specialized attention with pipelined TMA loads."""
 
@@ -481,7 +545,21 @@ class BlackwellFusedMultiHeadAttentionForward:
         sO = storage.sO.get_tensor(
             o_smem_layout_staged.outer, swizzle=o_smem_layout_staged.inner
         )
-
+        # Paged-only views of the same K/V smem ring, divided into per-page
+        # TMA boxes (the MLA decode kc/vc_smem_layout_for_tma pairing).
+        sK_tma = None
+        sV_tma = None
+        if cutlass.const_expr(k_smem_layout_for_tma is not None):
+            sK_tma = storage.sK.get_tensor(
+                k_smem_layout_for_tma.outer, swizzle=k_smem_layout_for_tma.inner
+            )
+            sV_tma = cute.make_tensor(
+                cute.recast_ptr(
+                    cute.recast_ptr(sK.iterator, dtype=self.v_dtype),
+                    v_smem_layout_for_tma.inner,
+                ),
+                v_smem_layout_for_tma.outer,
+            )
         (
             qk_thr_mma,
             pv_thr_mma,
@@ -539,6 +617,10 @@ class BlackwellFusedMultiHeadAttentionForward:
                 load_kv_producer,
                 tile_sched_params,
                 storage.load_kv_mbar_ptr.data_ptr(),
+                sK_tma,
+                sV_tma,
+                kv_page_table,
+                kv_page_indptr,
             )
 
         # ///////////////////////////////////////////////////////////////////////////////

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -21,6 +21,7 @@ from .roles.softmax import SoftmaxRole
 from .roles.correction import CorrectionRole
 from .roles.epilogue import EpilogueRole
 from .roles.loader_tma import LoaderRole
+from .roles.pt_loader import PageTableLoaderRole
 from .roles.mma import MmaRole
 from .compat import get_current_arch as _get_current_arch
 
@@ -277,6 +278,11 @@ class BlackwellFusedMultiHeadAttentionForward:
             )
         self.epilogue_role = EpilogueRole(self.config)
         self.loader_role = LoaderRole(self.config)
+        self.pt_loader_role = (
+            PageTableLoaderRole(self.config)
+            if self.config.load_pt_stages is not None
+            else None
+        )
         self.mma_role = MmaRole(
             self.config,
             tmem_alloc_cols=self.tmem.alloc_cols,
@@ -501,6 +507,11 @@ class BlackwellFusedMultiHeadAttentionForward:
         s0_s1_sequence_producer, s0_s1_sequence_consumer = pipes["s0_s1_sequence"]
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.data_ptr()
 
+        # Page-table ring (empty-warp pt producer -> loader)
+        load_pt_producer = load_pt_consumer = None
+        if cutlass.const_expr(self.config.load_pt_stages is not None):
+            load_pt_producer, load_pt_consumer = pipes["load_pt"]
+
         # Standard path pipelines (correction warp)
         s0_corr_producer = s0_corr_consumer = None
         s1_corr_producer = s1_corr_consumer = None
@@ -559,6 +570,13 @@ class BlackwellFusedMultiHeadAttentionForward:
                 ),
                 v_smem_layout_for_tma.outer,
             )
+        sPT = None
+        if cutlass.const_expr(self.config.load_pt_stages is not None):
+            sPT = storage.smem_page_table.get_tensor(
+                cute.make_layout(
+                    (self.config.pages_per_kv_tile, self.config.load_pt_stages)
+                )
+            )
         (
             qk_thr_mma,
             pv_thr_mma,
@@ -586,10 +604,24 @@ class BlackwellFusedMultiHeadAttentionForward:
             number_of_threads=self.schedule.threads_per_cta,
         )
         # ///////////////////////////////////////////////////////////////////////////////
-        #  EMPTY
+        #  EMPTY (page-table producer when the pt ring is enabled)
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.schedule.empty_warp_id:
             cute.arch.warpgroup_reg_dealloc(self.schedule.num_regs_empty)
+            if cutlass.const_expr(self.config.load_pt_stages is not None):
+                self.pt_loader_role.run(
+                    mQ_qdl.shape[0],
+                    mK_kdl.shape[0],
+                    cum_seqlen_q,
+                    cum_seqlen_k,
+                    window_left,
+                    window_right,
+                    load_pt_producer,
+                    kv_page_table,
+                    kv_page_indptr,
+                    sPT,
+                    tile_sched_params,
+                )
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  LOAD
@@ -619,6 +651,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                 sV_tma,
                 kv_page_table,
                 kv_page_indptr,
+                load_pt_consumer,
+                sPT,
             )
 
         # ///////////////////////////////////////////////////////////////////////////////

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -329,7 +329,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         # V's byte count (None means uniform: plain acquires).
         self.loader_role.set_v_tx_bytes(
             lp.tma_copy_v_bytes if self.k_dtype.width != self.v_dtype.width else None,
-            self.mainloop.kv_stages,
         )
 
         if cutlass.const_expr(not self.has_logits_transform):
@@ -616,7 +615,6 @@ class BlackwellFusedMultiHeadAttentionForward:
                 load_q_producer,
                 load_kv_producer,
                 tile_sched_params,
-                storage.load_kv_mbar_ptr.data_ptr(),
                 sK_tma,
                 sV_tma,
                 kv_page_table,

--- a/flashinfer/cute_dsl/attention/roles/epilogue.py
+++ b/flashinfer/cute_dsl/attention/roles/epilogue.py
@@ -7,7 +7,7 @@ Reusable primitives (pipeline-unaware, for composing new kernel variants):
 - partition_output(): partition output global tensor for TMA stores
 - store_tile(): issue a single TMA store + commit group
 
-Orchestration (prefill-specific, uses raw CuTe ops for JIT compatibility):
+Orchestration (prefill-specific):
 - run(): O0/O1 double-buffered TMA stores with pipeline sync
 """
 
@@ -37,12 +37,6 @@ class EpilogueRole:
 
     # =========================================================================
     #  Reusable primitives — for composing new kernel variants
-    #
-    #  NOTE on CuTe DSL JIT limitations:
-    #  - partition_output(): Returns tensor tuples — CuTe DSL JIT does not
-    #    reliably handle returning tensors from @cute.jit methods.
-    #  - store_tile(): SAFE — takes pre-sliced tensors as arguments, no
-    #    runtime indexing or return values. Used in run() successfully.
     # =========================================================================
 
     @cute.jit
@@ -139,16 +133,8 @@ class EpilogueRole:
 
                 o0_coord = 2 * curr_block_coord_o[0]
                 o1_coord = o0_coord + 1
-                gO_qdl = cute.flat_divide(
-                    mO_qdl_, cute.select(self.pv_mma_tiler, mode=[0, 1])
-                )
-                gO = gO_qdl[None, None, None, 0, curr_block_coord_o[2]]
-                tOsO, tOgO = cute.nvgpu.cpasync.tma_partition(
-                    tma_atom_o,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sO, 0, 2),
-                    cute.group_modes(gO, 0, 2),
+                tOsO, tOgO = self.partition_output(
+                    tma_atom_o, mO_qdl_, sO, curr_block_coord_o
                 )
 
                 if cutlass.const_expr(corr_epi_consumer is not None):

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -76,12 +76,15 @@ class LoaderRole:
     ):
         """Issue one K or V tile's per-page TMA copies.
 
-        ``unroll=1`` is required: left to heuristics, LLVM/ptxas
-        fully unroll this constant-trip loop (static UTMALDGs 12 -> 68)
-        and the enlarged loader text regresses ps16 to ~1.2x ragged via
-        instruction-fetch stalls (four warp-group code regions share
-        fetch).  K and V run separate loops and re-read the ids —
-        fusing the loops or staging ids across them measured worse.
+        The loop is kept (nearly) rolled rather than unrolled: the four
+        warp-group code regions share instruction fetch, and a fully
+        unrolled body is large enough to stall them all on fetch.  The
+        one exception is 16+ pages per tile (page_size 8), where the
+        per-iteration id-load latency dominates instead; unrolling by 2
+        keeps two id loads in flight without giving back the fetch win.
+        Deeper unrolling measured slower on both counts.  K and V run
+        separate loops and re-read the ids — fusing the loops or
+        staging ids across them measured worse.
 
         A page id of -1 puts the TMA coordinate out of bounds: the copy
         writes zeros to smem and still credits the barrier with the full
@@ -100,7 +103,8 @@ class LoaderRole:
         which plan() enforces by rejecting zero-length KV items.
         """
         logical0 = kv_tile * self.pages_per_kv_tile
-        for p in cutlass.range(self.pages_per_kv_tile, unroll=1):
+        unroll = 2 if self.pages_per_kv_tile >= 16 else 1
+        for p in cutlass.range(self.pages_per_kv_tile, unroll=unroll):
             logical_page = logical0 + p
             safe_page = cutlass.min(logical_page, num_pages_kv - 1)
             page_idx = kv_page_table[table_base + safe_page]

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -39,6 +39,10 @@ class LoaderRole:
         self.qk_mma_tiler = config.qk_mma_tiler
         self.pv_mma_tiler = config.pv_mma_tiler
         self.mask_spec = config.mask_spec
+        # Paged KV: tokens per page (None = ragged) and the per-tile
+        # TMA copy count, both compile-time.
+        self.page_size = config.page_size
+        self.pages_per_kv_tile = config.pages_per_kv_tile
         # Populated by set_v_tx_bytes() once dtypes are known at __call__
         # time.  None means K and V have the same width (plain acquires).
         self.v_tx_bytes = None
@@ -77,6 +81,70 @@ class LoaderRole:
             )
         load_kv_producer.advance()
         return state.index, load_kv_mbar_base_ptr + state.index
+
+    @cute.jit
+    def _load_paged_tile(
+        self,
+        tma_atom,
+        tGg,
+        tGs,
+        stage_index,
+        barrier,
+        kv_tile,
+        table_base,
+        page_idx_lb,
+        num_pages_kv,
+        kv_page_table,
+        first_tile: cutlass.Constexpr,
+        is_k: cutlass.Constexpr,
+    ):
+        """Issue one K or V tile's per-page TMA copies.
+
+        ``unroll=1`` is required: left to heuristics, LLVM/ptxas
+        fully unroll this constant-trip loop (static UTMALDGs 12 -> 68)
+        and the enlarged loader text regresses ps16 to ~1.2x ragged via
+        instruction-fetch stalls (four warp-group code regions share
+        fetch).  K and V run separate loops and re-read the ids —
+        fusing the loops or staging ids across them measured worse.
+
+        A page id of -1 puts the TMA coordinate out of bounds: the copy
+        writes zeros to smem and still credits the barrier with the full
+        box bytes.  Two kinds of pages are mapped to -1: pages past the
+        end of the sequence, and — on windowed kernels — pages below
+        ``page_idx_lb``, whose table slots serving frameworks repoint at
+        a shared scratch block that may hold NaN (trtllm-gen's pageIdxLb
+        contract).  Loading zeros there, rather than relying on the
+        softmax mask, is required for correctness: masked-out positions
+        still pass through the PV MMA with P=0, and 0 * NaN = NaN.
+        Only an item's first tile can contain the window lower bound,
+        so only ``first_tile`` applies the window clamp.  The table
+        index is min-clamped separately so the table read itself never
+        goes past the item's slice.
+        """
+        logical0 = kv_tile * self.pages_per_kv_tile
+        for p in cutlass.range(self.pages_per_kv_tile, unroll=1):
+            logical_page = logical0 + p
+            safe_page = cutlass.min(logical_page, num_pages_kv - 1)
+            page_idx = kv_page_table[table_base + safe_page]
+            if cutlass.const_expr(first_tile and self.mask_spec.has_window_left):
+                in_range = (logical_page >= page_idx_lb) & (logical_page < num_pages_kv)
+            else:
+                in_range = logical_page < num_pages_kv
+            page_idx = cutlass.select_(in_range, page_idx, Int32(-1))
+            if cutlass.const_expr(is_k):
+                cute.copy(
+                    tma_atom,
+                    tGg[None, page_idx],
+                    tGs[None, p, 0, stage_index],
+                    tma_bar_ptr=barrier,
+                )
+            else:
+                cute.copy(
+                    tma_atom,
+                    tGg[None, page_idx],
+                    tGs[None, 0, p, stage_index],
+                    tma_bar_ptr=barrier,
+                )
 
     # =========================================================================
     #  Reusable primitives — for composing new kernel variants
@@ -200,10 +268,18 @@ class LoaderRole:
         load_kv_producer: PipelineProducer,
         tile_sched_params: FmhaStaticTileSchedulerParams,
         load_kv_mbar_base_ptr,
+        sK_tma: cute.Tensor | None,
+        sV_tma: cute.Tensor | None,
+        kv_page_table: cute.Tensor | None,
+        kv_page_indptr: cute.Tensor | None,
     ):
         """Loader warp orchestration loop (prefill-specific).
 
-        Q0/Q1 double-buffered loads with KV tile streaming.
+        Q0/Q1 double-buffered loads with KV tile streaming.  With paged KV
+        (``config.page_size`` set), K/V TMA boxes shrink to one page, each
+        tile issues ``pages_per_kv_tile`` copies indexed by runtime page
+        ids from ``kv_page_table``, and ``sK_tma``/``sV_tma`` are the
+        per-page-divided views of the same K/V smem ring.
         """
         tile_sched = create_fmha_static_tile_scheduler(
             tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
@@ -246,15 +322,16 @@ class LoaderRole:
                 if cutlass.const_expr(cum_seqlen_k is not None):
                     cuseqlen_k = cum_seqlen_k[batch_coord]
                     seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                    logical_offset_mK = (cuseqlen_k, 0, (0, 0))
-                    logical_offset_mV = (0, cuseqlen_k, (0, 0))
-                    mK_kdl_ = cute.domain_offset(logical_offset_mK, mK_kdl)
-                    mV_dkl_ = cute.domain_offset(logical_offset_mV, mV_dkl)
-                    curr_block_coord_kv = (
-                        curr_block_coord[0],
-                        curr_block_coord[1],
-                        (curr_block_coord[2][0], Int32(0)),
-                    )
+                    if cutlass.const_expr(self.page_size is None):
+                        logical_offset_mK = (cuseqlen_k, 0, (0, 0))
+                        logical_offset_mV = (0, cuseqlen_k, (0, 0))
+                        mK_kdl_ = cute.domain_offset(logical_offset_mK, mK_kdl)
+                        mV_dkl_ = cute.domain_offset(logical_offset_mV, mV_dkl)
+                        curr_block_coord_kv = (
+                            curr_block_coord[0],
+                            curr_block_coord[1],
+                            (curr_block_coord[2][0], Int32(0)),
+                        )
 
                 # Local tile partition global tensors
                 gQ_qdl = cute.flat_divide(
@@ -270,31 +347,77 @@ class LoaderRole:
                 )
                 tQgQ = tQgQ_qdl[None, None, 0, curr_block_coord_q[2]]
 
-                gK_kdl = cute.flat_divide(
-                    mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2])
-                )
-                tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
-                tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
-                    tma_atom_k,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sK, 0, 3),
-                    cute.group_modes(tSgK_kdl, 0, 3),
-                )
-                tKgK = tKgK_kdl[None, None, 0, curr_block_coord_kv[2]]
+                table_base = Int32(0)
+                num_pages_kv = Int32(0)
+                page_idx_lb = Int32(0)
+                if cutlass.const_expr(self.page_size is not None):
+                    # Paged: per-page TMA boxes over the page pool.  No
+                    # thr_mma partition_B — the box is one page, not the
+                    # MMA tile — and no domain shift: the trailing page
+                    # mode is indexed with a runtime page id per copy
+                    # (the MLA decode loader pattern).
+                    gK_kdl = cute.tiled_divide(
+                        mK_kdl_, (self.page_size, self.qk_mma_tiler[2])
+                    )
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        0,
+                        cute.make_layout(1),
+                        sK_tma,
+                        gK_kdl[None, 0, 0, None],
+                    )
+                    tKgK = tKgK_kdl[None, (curr_block_coord[2][0], None)]
 
-                gV_dkl = cute.flat_divide(
-                    mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2])
-                )
-                tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
-                tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
-                    tma_atom_v,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sV, 0, 3),
-                    cute.group_modes(tSgV_dkl, 0, 3),
-                )
-                tVgV = tVgV_dkl[None, 0, None, curr_block_coord_kv[2]]
+                    gV_dkl = cute.tiled_divide(
+                        mV_dkl_, (self.pv_mma_tiler[1], self.page_size)
+                    )
+                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        0,
+                        cute.make_layout(1),
+                        sV_tma,
+                        gV_dkl[None, 0, 0, None],
+                    )
+                    tVgV = tVgV_dkl[None, (curr_block_coord[2][0], None)]
+
+                    table_base = kv_page_indptr[batch_coord]
+                    num_pages_kv = cute.ceil_div(seqlen_k, self.page_size)
+                    # Window clamp lower bound: pages wholly below every Q
+                    # row's band start are never attended, and their table
+                    # slots may point at a reclaimed null block (see
+                    # _paged_page_idx).  Row 0 of the Q tile has the
+                    # smallest band start: lo = q0 + (seqlen_k - seqlen_q)
+                    # - window_left.
+                    if cutlass.const_expr(self.mask_spec.has_window_left):
+                        q0 = curr_block_coord[0] * self.cta_tiler[0]
+                        lo_min = q0 + (seqlen_k - seqlen_q) - window_left
+                        page_idx_lb = cutlass.max(lo_min, Int32(0)) // self.page_size
+                else:
+                    gK_kdl = cute.flat_divide(
+                        mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2])
+                    )
+                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        0,
+                        cute.make_layout(1),
+                        cute.group_modes(sK, 0, 3),
+                        cute.group_modes(tSgK_kdl, 0, 3),
+                    )
+                    tKgK = tKgK_kdl[None, None, 0, curr_block_coord_kv[2]]
+
+                    gV_dkl = cute.flat_divide(
+                        mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2])
+                    )
+                    tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
+                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        0,
+                        cute.make_layout(1),
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tSgV_dkl, 0, 3),
+                    )
+                    tVgV = tVgV_dkl[None, 0, None, curr_block_coord_kv[2]]
 
                 # Q0
                 q0_coord = 2 * curr_block_coord_q[0]
@@ -317,12 +440,28 @@ class LoaderRole:
                 )
                 kv_coord = kv_block_start
                 k_handle_producer = load_kv_producer.acquire_and_advance()
-                cute.copy(
-                    tma_atom_k,
-                    tKgK[None, kv_coord],
-                    tKsK[None, k_handle_producer.index],
-                    tma_bar_ptr=k_handle_producer.barrier,
-                )
+                if cutlass.const_expr(self.page_size is not None):
+                    self._load_paged_tile(
+                        tma_atom_k,
+                        tKgK,
+                        tKsK,
+                        k_handle_producer.index,
+                        k_handle_producer.barrier,
+                        kv_coord,
+                        table_base,
+                        page_idx_lb,
+                        num_pages_kv,
+                        kv_page_table,
+                        True,
+                        True,
+                    )
+                else:
+                    cute.copy(
+                        tma_atom_k,
+                        tKgK[None, kv_coord],
+                        tKsK[None, k_handle_producer.index],
+                        tma_bar_ptr=k_handle_producer.barrier,
+                    )
                 # Q1
                 q1_coord = q0_coord + 1
                 q1_handle_producer = load_q_producer.acquire_and_advance()
@@ -336,34 +475,82 @@ class LoaderRole:
                 v_index, v_bar_ptr = self._acquire_v(
                     load_kv_producer, load_kv_mbar_base_ptr
                 )
-                cute.copy(
-                    tma_atom_v,
-                    tVgV[None, kv_coord],
-                    tVsV[None, v_index],
-                    tma_bar_ptr=v_bar_ptr,
-                )
-                kv_coord += 1
-
-                seqlen_kv_loop_steps = kv_block_end - kv_block_start - 1
-                for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
-                    # Ki
-                    k_handle_producer = load_kv_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_k,
-                        tKgK[None, kv_coord],
-                        tKsK[None, k_handle_producer.index],
-                        tma_bar_ptr=k_handle_producer.barrier,
+                if cutlass.const_expr(self.page_size is not None):
+                    self._load_paged_tile(
+                        tma_atom_v,
+                        tVgV,
+                        tVsV,
+                        v_index,
+                        v_bar_ptr,
+                        kv_coord,
+                        table_base,
+                        page_idx_lb,
+                        num_pages_kv,
+                        kv_page_table,
+                        True,
+                        False,
                     )
-                    # Vi
-                    v_index, v_bar_ptr = self._acquire_v(
-                        load_kv_producer, load_kv_mbar_base_ptr
-                    )
+                else:
                     cute.copy(
                         tma_atom_v,
                         tVgV[None, kv_coord],
                         tVsV[None, v_index],
                         tma_bar_ptr=v_bar_ptr,
                     )
+                kv_coord += 1
+
+                seqlen_kv_loop_steps = kv_block_end - kv_block_start - 1
+                for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
+                    # Ki
+                    k_handle_producer = load_kv_producer.acquire_and_advance()
+                    if cutlass.const_expr(self.page_size is not None):
+                        self._load_paged_tile(
+                            tma_atom_k,
+                            tKgK,
+                            tKsK,
+                            k_handle_producer.index,
+                            k_handle_producer.barrier,
+                            kv_coord,
+                            table_base,
+                            page_idx_lb,
+                            num_pages_kv,
+                            kv_page_table,
+                            False,
+                            True,
+                        )
+                    else:
+                        cute.copy(
+                            tma_atom_k,
+                            tKgK[None, kv_coord],
+                            tKsK[None, k_handle_producer.index],
+                            tma_bar_ptr=k_handle_producer.barrier,
+                        )
+                    # Vi
+                    v_index, v_bar_ptr = self._acquire_v(
+                        load_kv_producer, load_kv_mbar_base_ptr
+                    )
+                    if cutlass.const_expr(self.page_size is not None):
+                        self._load_paged_tile(
+                            tma_atom_v,
+                            tVgV,
+                            tVsV,
+                            v_index,
+                            v_bar_ptr,
+                            kv_coord,
+                            table_base,
+                            page_idx_lb,
+                            num_pages_kv,
+                            kv_page_table,
+                            False,
+                            False,
+                        )
+                    else:
+                        cute.copy(
+                            tma_atom_v,
+                            tVgV[None, kv_coord],
+                            tVsV[None, v_index],
+                            tma_bar_ptr=v_bar_ptr,
+                        )
                     kv_coord += 1
 
             tile_sched.advance_to_next_work()

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -428,10 +428,16 @@ class LoaderRole:
                 )
                 # V0.  With mixed K/V widths, expected_tx re-arms the slot
                 # with V's byte count (the ring's barriers are init-armed
-                # with K's); expected_tx=None is the plain acquire.
-                v_handle = load_kv_producer.acquire_and_advance(
-                    expected_tx=self.v_tx_bytes
-                )
+                # with K's).  The kwarg is passed only on the mixed path:
+                # it requires nvidia-cutlass-dsl >= 4.6 (the wrapper gates
+                # mixed plans), while the plain acquire keeps uniform
+                # builds working on the 4.5 floor.
+                if cutlass.const_expr(self.v_tx_bytes is None):
+                    v_handle = load_kv_producer.acquire_and_advance()
+                else:
+                    v_handle = load_kv_producer.acquire_and_advance(
+                        expected_tx=self.v_tx_bytes
+                    )
                 if cutlass.const_expr(self.page_size is not None):
                     self._load_paged_tile(
                         tma_atom_v,
@@ -483,9 +489,12 @@ class LoaderRole:
                             tma_bar_ptr=k_handle_producer.barrier,
                         )
                     # Vi (see V0 for the expected_tx contract)
-                    v_handle = load_kv_producer.acquire_and_advance(
-                        expected_tx=self.v_tx_bytes
-                    )
+                    if cutlass.const_expr(self.v_tx_bytes is None):
+                        v_handle = load_kv_producer.acquire_and_advance()
+                    else:
+                        v_handle = load_kv_producer.acquire_and_advance(
+                            expected_tx=self.v_tx_bytes
+                        )
                     if cutlass.const_expr(self.page_size is not None):
                         self._load_paged_tile(
                             tma_atom_v,

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -95,7 +95,9 @@ class LoaderRole:
         Only an item's first tile can contain the window lower bound,
         so only ``first_tile`` applies the window clamp.  The table
         index is min-clamped separately so the table read itself never
-        goes past the item's slice.
+        goes past the item's slice; this relies on every item having at
+        least one page (``num_pages_kv >= 1``, i.e. ``safe_page >= 0``),
+        which plan() enforces by rejecting zero-length KV items.
         """
         logical0 = kv_tile * self.pages_per_kv_tile
         for p in cutlass.range(self.pages_per_kv_tile, unroll=1):

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -9,7 +9,7 @@ Reusable primitives (pipeline-unaware, for composing new kernel variants):
 - partition_v(): partition V global tensor for TMA loads
 - load_tile(): issue a single TMA load with barrier
 
-Orchestration (prefill-specific, uses raw CuTe ops for JIT compatibility):
+Orchestration (prefill-specific):
 - run(): Q0/Q1 double-buffered loads with KV streaming
 """
 
@@ -46,41 +46,17 @@ class LoaderRole:
         # Populated by set_v_tx_bytes() once dtypes are known at __call__
         # time.  None means K and V have the same width (plain acquires).
         self.v_tx_bytes = None
-        self.kv_stages = None
 
-    def set_v_tx_bytes(self, v_tx_bytes, kv_stages) -> None:
+    def set_v_tx_bytes(self, v_tx_bytes) -> None:
         """Set V's TMA byte count for mixed K/V dtype builds.
 
         The shared K/V ring's barriers are initialized with K's byte
-        count; when the widths differ, each V acquire must re-arm its
-        slot with V's byte count instead (pass None for uniform builds).
+        count; when the widths differ, each V acquire re-arms its slot
+        with V's byte count via ``acquire_and_advance(expected_tx=...)``
+        (pass None for uniform builds: expected_tx=None keeps the
+        barrier-init count).
         """
         self.v_tx_bytes = v_tx_bytes
-        self.kv_stages = kv_stages
-
-    def _acquire_v(self, load_kv_producer: PipelineProducer, load_kv_mbar_base_ptr):
-        """Acquire a V slot on the shared K/V ring.
-
-        Returns (slot index, barrier pointer for the TMA copy).  With
-        mixed K/V dtypes this bypasses acquire_and_advance() to arm the
-        full barrier with V's byte count — the same scheme as the
-        vendored FMHA kernel's kv_producer_update_tx_acquire_and_advance.
-        Undecorated on purpose: it is inlined at trace time (like the
-        vendored helper) because it handles pipeline participant objects.
-        """
-        if self.v_tx_bytes is None:
-            handle = load_kv_producer.acquire_and_advance()
-            return handle.index, handle.barrier
-        state = load_kv_producer._PipelineProducer__state.clone()
-        cute.arch.mbarrier_wait(
-            load_kv_mbar_base_ptr + self.kv_stages + state.index, state.phase
-        )
-        with cute.arch.elect_one():
-            cute.arch.mbarrier_arrive_and_expect_tx(
-                load_kv_mbar_base_ptr + state.index, self.v_tx_bytes
-            )
-        load_kv_producer.advance()
-        return state.index, load_kv_mbar_base_ptr + state.index
 
     @cute.jit
     def _load_paged_tile(
@@ -149,14 +125,14 @@ class LoaderRole:
     # =========================================================================
     #  Reusable primitives — for composing new kernel variants
     #
-    #  NOTE on CuTe DSL JIT limitations:
-    #  - partition_q/k/v(): Return tensor tuples — CuTe DSL JIT does not
-    #    reliably handle returning tensors from @cute.jit methods.
-    #  - load_tile(): Uses runtime indexing (handle.index) to create tensor
-    #    views internally — causes correctness issues in CuTe DSL JIT.
-    #  These primitives document the intended decomposition but cannot be
-    #  used inside run() until CuTe DSL JIT support improves. Use the
-    #  inline patterns in run() as the working reference.
+    #  Hazard (nvidia-cutlass-dsl 4.6.0): the DSL picks a dynamic loop's
+    #  carried values from the CALLER's own syntax (assignments and
+    #  x.method() receivers), so pipeline/scheduler state advanced inside
+    #  a helper is not yielded across while/for iterations and silently
+    #  resets each iteration.  Keep acquire/advance calls in run()'s loop
+    #  body and pass handle.index / handle.barrier into helpers (the
+    #  _load_paged_tile pattern), or return the mutated object and rebind
+    #  it at the call site (the softmax.py step() pattern).
     # =========================================================================
 
     @cute.jit
@@ -231,15 +207,21 @@ class LoaderRole:
         tma_atom: cute.CopyAtom,
         src_global: cute.Tensor,
         dst_smem: cute.Tensor,
-        producer: PipelineProducer,
+        index: Int32,
+        barrier,
     ):
-        """Issue a single TMA load into SMEM with pipeline barrier."""
-        handle = producer.acquire_and_advance()
+        """Issue a single TMA load into a runtime-indexed SMEM stage slot.
+
+        The pipeline acquire stays in the caller's loop body (see the
+        helper-method rules above): do ``handle =
+        producer.acquire_and_advance()`` inline and pass ``handle.index``
+        / ``handle.barrier`` here.
+        """
         cute.copy(
             tma_atom,
             src_global,
-            dst_smem[None, handle.index],
-            tma_bar_ptr=handle.barrier,
+            dst_smem[None, index],
+            tma_bar_ptr=barrier,
         )
 
     # =========================================================================
@@ -267,7 +249,6 @@ class LoaderRole:
         load_q_producer: PipelineProducer,
         load_kv_producer: PipelineProducer,
         tile_sched_params: FmhaStaticTileSchedulerParams,
-        load_kv_mbar_base_ptr,
         sK_tma: cute.Tensor | None,
         sV_tma: cute.Tensor | None,
         kv_page_table: cute.Tensor | None,
@@ -334,18 +315,9 @@ class LoaderRole:
                         )
 
                 # Local tile partition global tensors
-                gQ_qdl = cute.flat_divide(
-                    mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2])
+                tQsQ, tQgQ = self.partition_q(
+                    qk_thr_mma, tma_atom_q, mQ_qdl_, sQ, curr_block_coord_q
                 )
-                tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
-                tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
-                    tma_atom_q,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sQ, 0, 3),
-                    cute.group_modes(tSgQ_qdl, 0, 3),
-                )
-                tQgQ = tQgQ_qdl[None, None, 0, curr_block_coord_q[2]]
 
                 table_base = Int32(0)
                 num_pages_kv = Int32(0)
@@ -393,31 +365,12 @@ class LoaderRole:
                         lo_min = q0 + (seqlen_k - seqlen_q) - window_left
                         page_idx_lb = cutlass.max(lo_min, Int32(0)) // self.page_size
                 else:
-                    gK_kdl = cute.flat_divide(
-                        mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2])
+                    tKsK, tKgK = self.partition_k(
+                        qk_thr_mma, tma_atom_k, mK_kdl_, sK, curr_block_coord_kv
                     )
-                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
-                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_k,
-                        0,
-                        cute.make_layout(1),
-                        cute.group_modes(sK, 0, 3),
-                        cute.group_modes(tSgK_kdl, 0, 3),
+                    tVsV, tVgV = self.partition_v(
+                        pv_thr_mma, tma_atom_v, mV_dkl_, sV, curr_block_coord_kv
                     )
-                    tKgK = tKgK_kdl[None, None, 0, curr_block_coord_kv[2]]
-
-                    gV_dkl = cute.flat_divide(
-                        mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2])
-                    )
-                    tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
-                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_v,
-                        0,
-                        cute.make_layout(1),
-                        cute.group_modes(sV, 0, 3),
-                        cute.group_modes(tSgV_dkl, 0, 3),
-                    )
-                    tVgV = tVgV_dkl[None, 0, None, curr_block_coord_kv[2]]
 
                 # Q0
                 q0_coord = 2 * curr_block_coord_q[0]
@@ -471,17 +424,19 @@ class LoaderRole:
                     tQsQ[None, q1_handle_producer.index],
                     tma_bar_ptr=q1_handle_producer.barrier,
                 )
-                # V0
-                v_index, v_bar_ptr = self._acquire_v(
-                    load_kv_producer, load_kv_mbar_base_ptr
+                # V0.  With mixed K/V widths, expected_tx re-arms the slot
+                # with V's byte count (the ring's barriers are init-armed
+                # with K's); expected_tx=None is the plain acquire.
+                v_handle = load_kv_producer.acquire_and_advance(
+                    expected_tx=self.v_tx_bytes
                 )
                 if cutlass.const_expr(self.page_size is not None):
                     self._load_paged_tile(
                         tma_atom_v,
                         tVgV,
                         tVsV,
-                        v_index,
-                        v_bar_ptr,
+                        v_handle.index,
+                        v_handle.barrier,
                         kv_coord,
                         table_base,
                         page_idx_lb,
@@ -494,8 +449,8 @@ class LoaderRole:
                     cute.copy(
                         tma_atom_v,
                         tVgV[None, kv_coord],
-                        tVsV[None, v_index],
-                        tma_bar_ptr=v_bar_ptr,
+                        tVsV[None, v_handle.index],
+                        tma_bar_ptr=v_handle.barrier,
                     )
                 kv_coord += 1
 
@@ -525,17 +480,17 @@ class LoaderRole:
                             tKsK[None, k_handle_producer.index],
                             tma_bar_ptr=k_handle_producer.barrier,
                         )
-                    # Vi
-                    v_index, v_bar_ptr = self._acquire_v(
-                        load_kv_producer, load_kv_mbar_base_ptr
+                    # Vi (see V0 for the expected_tx contract)
+                    v_handle = load_kv_producer.acquire_and_advance(
+                        expected_tx=self.v_tx_bytes
                     )
                     if cutlass.const_expr(self.page_size is not None):
                         self._load_paged_tile(
                             tma_atom_v,
                             tVgV,
                             tVsV,
-                            v_index,
-                            v_bar_ptr,
+                            v_handle.index,
+                            v_handle.barrier,
                             kv_coord,
                             table_base,
                             page_idx_lb,
@@ -548,8 +503,8 @@ class LoaderRole:
                         cute.copy(
                             tma_atom_v,
                             tVgV[None, kv_coord],
-                            tVsV[None, v_index],
-                            tma_bar_ptr=v_bar_ptr,
+                            tVsV[None, v_handle.index],
+                            tma_bar_ptr=v_handle.barrier,
                         )
                     kv_coord += 1
 

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -17,7 +17,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.typing import Int32
 
-from cutlass.pipeline import PipelineProducer
+from cutlass.pipeline import PipelineConsumer, PipelineProducer
 
 from ..config import AttentionConfig
 from ..fusion.mask import get_kv_block_range
@@ -43,6 +43,10 @@ class LoaderRole:
         # TMA copy count, both compile-time.
         self.page_size = config.page_size
         self.pages_per_kv_tile = config.pages_per_kv_tile
+        # With the page-table ring, the empty warp stages pre-clamped ids
+        # into SMEM and this warp reads them back at LDS latency; without
+        # it, ids come from the global table inside the copy loop.
+        self.use_pt_ring = config.load_pt_stages is not None
         # Populated by set_v_tx_bytes() once dtypes are known at __call__
         # time.  None means K and V have the same width (plain acquires).
         self.v_tx_bytes = None
@@ -76,15 +80,15 @@ class LoaderRole:
     ):
         """Issue one K or V tile's per-page TMA copies.
 
-        The loop is kept (nearly) rolled rather than unrolled: the four
+        The loop is kept rolled rather than unrolled: the four
         warp-group code regions share instruction fetch, and a fully
-        unrolled body is large enough to stall them all on fetch.  The
-        one exception is 16+ pages per tile (page_size 8), where the
-        per-iteration id-load latency dominates instead; unrolling by 2
-        keeps two id loads in flight without giving back the fetch win.
-        Deeper unrolling measured slower on both counts.  K and V run
-        separate loops and re-read the ids — fusing the loops or
-        staging ids across them measured worse.
+        unrolled body is large enough to stall them all on fetch.  K and
+        V run separate loops and re-read the ids — fusing the loops or
+        staging ids across them measured worse.  At 16+ pages per tile
+        (page_size 8) the in-loop id loads themselves dominate the
+        loader's cadence and the build routes to the page-table ring
+        instead (``config.load_pt_stages``, ``_load_paged_tile_ring``),
+        so this loop only serves page_size >= 16.
 
         A page id of -1 puts the TMA coordinate out of bounds: the copy
         writes zeros to smem and still credits the barrier with the full
@@ -103,8 +107,7 @@ class LoaderRole:
         which plan() enforces by rejecting zero-length KV items.
         """
         logical0 = kv_tile * self.pages_per_kv_tile
-        unroll = 2 if self.pages_per_kv_tile >= 16 else 1
-        for p in cutlass.range(self.pages_per_kv_tile, unroll=unroll):
+        for p in cutlass.range(self.pages_per_kv_tile, unroll=1):
             logical_page = logical0 + p
             safe_page = cutlass.min(logical_page, num_pages_kv - 1)
             page_idx = kv_page_table[table_base + safe_page]
@@ -113,6 +116,51 @@ class LoaderRole:
             else:
                 in_range = logical_page < num_pages_kv
             page_idx = cutlass.select_(in_range, page_idx, Int32(-1))
+            if cutlass.const_expr(is_k):
+                cute.copy(
+                    tma_atom,
+                    tGg[None, page_idx],
+                    tGs[None, p, 0, stage_index],
+                    tma_bar_ptr=barrier,
+                )
+            else:
+                cute.copy(
+                    tma_atom,
+                    tGg[None, page_idx],
+                    tGs[None, 0, p, stage_index],
+                    tma_bar_ptr=barrier,
+                )
+
+    @cute.jit
+    def _load_paged_tile_ring(
+        self,
+        tma_atom,
+        tGg,
+        tGs,
+        stage_index,
+        barrier,
+        sPT,
+        pt_stage,
+        is_k: cutlass.Constexpr,
+    ):
+        """Issue one K or V tile's per-page TMA copies, ids from the ring.
+
+        The pt producer already applied the tail and window clamps (-1 =
+        TMA OOB zero-fill; see ``PageTableLoaderRole``), so each
+        iteration is just an LDS and a copy.  unroll=2 overlaps two
+        id-read chains without growing the text past what the four
+        warp-group regions' shared instruction fetch absorbs; the
+        measured-worse alternatives were a rolled loop (serializes the
+        chains on K-arrival-bound shapes), vectorized LDS.128 id reads
+        feeding 4 copies each (wide-load dependency + text growth), and
+        deeper unrolling (fetch pressure).  The pipeline wait/release
+        for ``pt_stage`` stays in run(): K and V read the same stage,
+        and the caller releases it after V's copies are issued — the ids
+        are baked into the issued copies, so the producer may overwrite
+        the stage while the TMAs are still in flight.
+        """
+        for p in cutlass.range(self.pages_per_kv_tile, unroll=2):
+            page_idx = sPT[p, pt_stage]
             if cutlass.const_expr(is_k):
                 cute.copy(
                     tma_atom,
@@ -259,6 +307,8 @@ class LoaderRole:
         sV_tma: cute.Tensor | None,
         kv_page_table: cute.Tensor | None,
         kv_page_indptr: cute.Tensor | None,
+        load_pt_consumer: PipelineConsumer | None,
+        sPT: cute.Tensor | None,
     ):
         """Loader warp orchestration loop (prefill-specific).
 
@@ -266,7 +316,10 @@ class LoaderRole:
         (``config.page_size`` set), K/V TMA boxes shrink to one page, each
         tile issues ``pages_per_kv_tile`` copies indexed by runtime page
         ids from ``kv_page_table``, and ``sK_tma``/``sV_tma`` are the
-        per-page-divided views of the same K/V smem ring.
+        per-page-divided views of the same K/V smem ring.  With the
+        page-table ring on top (``config.load_pt_stages``), ids come
+        pre-clamped from ``sPT`` — one ``load_pt_consumer`` stage per KV
+        tile, waited before K's copies and released after V's.
         """
         tile_sched = create_fmha_static_tile_scheduler(
             tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
@@ -399,7 +452,19 @@ class LoaderRole:
                 )
                 kv_coord = kv_block_start
                 k_handle_producer = load_kv_producer.acquire_and_advance()
-                if cutlass.const_expr(self.page_size is not None):
+                if cutlass.const_expr(self.use_pt_ring):
+                    pt_handle = load_pt_consumer.wait_and_advance()
+                    self._load_paged_tile_ring(
+                        tma_atom_k,
+                        tKgK,
+                        tKsK,
+                        k_handle_producer.index,
+                        k_handle_producer.barrier,
+                        sPT,
+                        pt_handle.index,
+                        True,
+                    )
+                elif cutlass.const_expr(self.page_size is not None):
                     self._load_paged_tile(
                         tma_atom_k,
                         tKgK,
@@ -442,7 +507,19 @@ class LoaderRole:
                     v_handle = load_kv_producer.acquire_and_advance(
                         expected_tx=self.v_tx_bytes
                     )
-                if cutlass.const_expr(self.page_size is not None):
+                if cutlass.const_expr(self.use_pt_ring):
+                    self._load_paged_tile_ring(
+                        tma_atom_v,
+                        tVgV,
+                        tVsV,
+                        v_handle.index,
+                        v_handle.barrier,
+                        sPT,
+                        pt_handle.index,
+                        False,
+                    )
+                    pt_handle.release()
+                elif cutlass.const_expr(self.page_size is not None):
                     self._load_paged_tile(
                         tma_atom_v,
                         tVgV,
@@ -470,7 +547,19 @@ class LoaderRole:
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
                     # Ki
                     k_handle_producer = load_kv_producer.acquire_and_advance()
-                    if cutlass.const_expr(self.page_size is not None):
+                    if cutlass.const_expr(self.use_pt_ring):
+                        pt_handle = load_pt_consumer.wait_and_advance()
+                        self._load_paged_tile_ring(
+                            tma_atom_k,
+                            tKgK,
+                            tKsK,
+                            k_handle_producer.index,
+                            k_handle_producer.barrier,
+                            sPT,
+                            pt_handle.index,
+                            True,
+                        )
+                    elif cutlass.const_expr(self.page_size is not None):
                         self._load_paged_tile(
                             tma_atom_k,
                             tKgK,
@@ -499,7 +588,19 @@ class LoaderRole:
                         v_handle = load_kv_producer.acquire_and_advance(
                             expected_tx=self.v_tx_bytes
                         )
-                    if cutlass.const_expr(self.page_size is not None):
+                    if cutlass.const_expr(self.use_pt_ring):
+                        self._load_paged_tile_ring(
+                            tma_atom_v,
+                            tVgV,
+                            tVsV,
+                            v_handle.index,
+                            v_handle.barrier,
+                            sPT,
+                            pt_handle.index,
+                            False,
+                        )
+                        pt_handle.release()
+                    elif cutlass.const_expr(self.page_size is not None):
                         self._load_paged_tile(
                             tma_atom_v,
                             tVgV,

--- a/flashinfer/cute_dsl/attention/roles/mla_mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma.py
@@ -9,10 +9,11 @@ Extracted from the monolithic mla_decode_fp16.py kernel. Owns:
 - run(): tile scheduler loop with interleaved QK/PV, pipeline lifecycle
 
 All pipeline acquire/wait/commit/release/tail calls happen directly in run(),
-not in sub-methods, because CuTe DSL compiles Python to MLIR/SSA where the
-JIT boundary acts as pass-by-value for DSL metadata (TiledMma fields,
-PipelineState). Mutations made inside @cute.jit sub-methods create new SSA
-values that are invisible to the caller.
+not in sub-methods: nested @cute.jit calls execute inline at trace time, but
+the DSL derives each dynamic loop's carried values from the caller's own
+syntax (assignments and x.method() receivers), so pipeline state advanced
+inside a sub-method is not carried across loop iterations (see the
+helper-method rules in roles/loader_tma.py).
 
 GEMM helpers take an explicit ``accumulate`` parameter following the FMHA
 prefill pattern (roles/mma.py:gemm_pv). The ACCUMULATE flag is set inside
@@ -155,8 +156,9 @@ class MLAMmaRole:
     #  whether the first k-block overwrites (False) or accumulates (True).
     #  Subsequent k-blocks always accumulate.  The caller computes the
     #  flag from its own loop position; the helper never communicates
-    #  state back via TiledMma mutations (they would be invisible to the
-    #  caller due to SSA pass-by-value at the @cute.jit boundary).
+    #  state back via TiledMma mutations (mutations of caller-owned DSL
+    #  objects inside helpers are not loop-carried across run()'s dynamic
+    #  loops — see the helper-method rules in roles/loader_tma.py).
     #
     #  Inner k-block loops use ``cutlass.range_constexpr`` (compile-time
     #  unrolled) for maximum tcgen05 MMA dispatch throughput.  To prevent

--- a/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
@@ -137,8 +137,9 @@ class MLAMmaFP8Role:
     #  whether the first k-block overwrites (False) or accumulates (True).
     #  Subsequent k-blocks always accumulate.  The caller computes the
     #  flag from its own loop position; the helper never communicates
-    #  state back via TiledMma mutations (they would be invisible to the
-    #  caller due to SSA pass-by-value at the @cute.jit boundary).
+    #  state back via TiledMma mutations (mutations of caller-owned DSL
+    #  objects inside helpers are not loop-carried across run()'s dynamic
+    #  loops — see the helper-method rules in roles/loader_tma.py).
     #
     #  Inner k-block loops use ``cutlass.range_constexpr`` (compile-time
     #  unrolled) for maximum tcgen05 MMA dispatch throughput.  To prevent

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -9,7 +9,7 @@ Reusable primitives (pipeline-unaware, for composing new kernel variants):
 - alloc_tmem(): TMEM allocation with barrier sync
 - dealloc_tmem(): TMEM deallocation after barrier wait
 
-Orchestration (prefill-specific, uses raw CuTe ops for JIT compatibility):
+Orchestration (prefill-specific):
 - run(): double-buffered interleaved QK/PV with S0/S1 and O0/O1
 
 Inner kphase loops in ``gemm_qk`` / ``gemm_pv`` use ``cutlass.range_constexpr``
@@ -126,11 +126,6 @@ class MmaRole:
 
     # =========================================================================
     #  Reusable primitives — no pipeline awareness, for composing new kernels
-    #
-    #  All primitives below are SAFE to call from run() and other @cute.jit
-    #  methods. They are void (no return values) and only use compile-time
-    #  indexing (unrolled kphase loops), avoiding the CuTe DSL JIT
-    #  limitations with runtime tensor views and return values.
     # =========================================================================
 
     @cute.jit

--- a/flashinfer/cute_dsl/attention/roles/pt_loader.py
+++ b/flashinfer/cute_dsl/attention/roles/pt_loader.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""PageTableLoaderRole — page-table producer warp for paged prefill.
+
+Runs on the schedule's otherwise-idle empty warp when
+``config.load_pt_stages`` is set (page_size 8: 16+ TMA copies per KV
+tile).  Owns its own tile-scheduler loop — it re-derives the exact
+work-item/KV-tile sequence the loader walks, with no handshake beyond
+the ``load_pt`` pipeline — and per KV tile stages that tile's page ids
+into an SMEM ring, one id per lane via ``cp.async``.  The loader then
+reads ids back at LDS latency instead of paying a global-latency load
+per page inside its TMA-issue loop (the MLA-decode pt-loader design).
+
+Clamping happens here, at produce time, because both clamps are
+positional — they depend only on the logical page index, never on the
+table value: pages past the sequence end, and (with window_left) pages
+below the work item's window lower bound, publish -1 instead of an id.
+A -1 coordinate makes the TMA copy an OOB zero-fill, which the NaN
+contract requires (see ``LoaderRole._load_paged_tile``).  The window
+bound is applied on every tile, not just the first: later tiles' pages
+all sit above it by construction (``page_idx_lb`` falls inside the
+first tile's page range), so the comparison is vacuously true there and
+the loader-side first-tile special case disappears.
+"""
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.nvgpu.cpasync as cpasync
+from cutlass.cute.typing import Int32
+from cutlass.pipeline import PipelineProducer
+
+from ..config import AttentionConfig
+from ..fusion.mask import get_kv_block_range
+from ..scheduler.persistent import (
+    FmhaStaticTileScheduler,
+    FmhaStaticTileSchedulerParams,
+    create_fmha_static_tile_scheduler,
+)
+
+
+class PageTableLoaderRole:
+    """Empty-warp producer that stages pre-clamped page ids for the loader."""
+
+    def __init__(self, config: AttentionConfig):
+        self.cta_tiler = config.cta_tiler
+        self.mask_spec = config.mask_spec
+        self.page_size = config.page_size
+        self.pages_per_kv_tile = config.pages_per_kv_tile
+        self.threads_per_warp = 32
+
+    @cute.jit
+    def run(
+        self,
+        seqlen_q_static: Int32,
+        seqlen_k_static: Int32,
+        cum_seqlen_q: cute.Tensor | None,
+        cum_seqlen_k: cute.Tensor | None,
+        window_left: Int32,
+        window_right: Int32,
+        load_pt_producer: PipelineProducer,
+        kv_page_table: cute.Tensor,
+        kv_page_indptr: cute.Tensor,
+        sPT: cute.Tensor,
+        tile_sched_params: FmhaStaticTileSchedulerParams,
+    ):
+        """Producer loop: one SMEM ring stage of clamped ids per KV tile.
+
+        The work-item walk (scheduler advance, the short-seqlen_q skip,
+        and the per-item KV block range) must match the loader's exactly
+        — every stage produced here is consumed once by the loader's
+        wait/release pair for the same tile.
+        """
+        tile_sched = create_fmha_static_tile_scheduler(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        tidx, _, _ = cute.arch.thread_idx()
+        lane = tidx % self.threads_per_warp
+        ids_per_lane = (
+            self.pages_per_kv_tile + self.threads_per_warp - 1
+        ) // self.threads_per_warp
+
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.ALWAYS),
+            cutlass.Int32,
+            num_bits_per_copy=cutlass.Int32.width,
+        )
+        mPT_for_copy = cute.flat_divide(kv_page_table, (1,))
+        sPT_for_copy = cute.flat_divide(sPT, (1,))
+
+        while work_tile.is_valid_tile:
+            curr_block_coord = work_tile.tile_idx
+            batch_coord = curr_block_coord[2][1]
+            continue_cond = False
+            seqlen_q = seqlen_q_static
+            if cutlass.const_expr(cum_seqlen_q is not None):
+                cuseqlen_q = cum_seqlen_q[batch_coord]
+                seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                continue_cond = (
+                    not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.cta_tiler[0],
+                        curr_block_coord[0],
+                        seqlen_q,
+                    )
+                )
+            if not continue_cond:
+                seqlen_k = seqlen_k_static
+                if cutlass.const_expr(cum_seqlen_k is not None):
+                    seqlen_k = cum_seqlen_k[batch_coord + 1] - cum_seqlen_k[batch_coord]
+
+                table_base = kv_page_indptr[batch_coord]
+                num_pages_kv = cute.ceil_div(seqlen_k, self.page_size)
+                page_idx_lb = Int32(0)
+                if cutlass.const_expr(self.mask_spec.has_window_left):
+                    q0 = curr_block_coord[0] * self.cta_tiler[0]
+                    lo_min = q0 + (seqlen_k - seqlen_q) - window_left
+                    page_idx_lb = cutlass.max(lo_min, Int32(0)) // self.page_size
+
+                kv_block_start, kv_block_end = get_kv_block_range(
+                    self.mask_spec,
+                    curr_block_coord,
+                    self.cta_tiler,
+                    seqlen_k,
+                    seqlen_q,
+                    window_left,
+                    window_right,
+                )
+                kv_coord = kv_block_start
+                pt_loop_steps = kv_block_end - kv_block_start
+                for _t in cutlass.range(0, pt_loop_steps, 1, unroll=1):
+                    handle = load_pt_producer.acquire_and_advance()
+                    for i in cutlass.range_constexpr(ids_per_lane):
+                        slot = i * self.threads_per_warp + lane
+                        logical_page = kv_coord * self.pages_per_kv_tile + slot
+                        in_range = logical_page < num_pages_kv
+                        if cutlass.const_expr(self.mask_spec.has_window_left):
+                            in_range = in_range & (logical_page >= page_idx_lb)
+                        if cute.elem_less(slot, self.pages_per_kv_tile):
+                            if in_range:
+                                cute.copy(
+                                    atom_async_copy,
+                                    mPT_for_copy[None, table_base + logical_page],
+                                    sPT_for_copy[None, slot, handle.index],
+                                )
+                            else:
+                                sPT_for_copy[None, slot, handle.index].fill(-1)
+                    handle.commit()
+                    kv_coord += 1
+
+            tile_sched.advance_to_next_work()
+            work_tile = tile_sched.get_current_work()
+
+        load_pt_producer.tail()

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -142,12 +142,15 @@ class SoftmaxRole:
         5. Computing row sums for normalization
         6. Coordinating pipeline synchronization between different processing stages
 
-        CONTRACT: step() advances the four pipeline participants internally
-        and returns them; every call site MUST tuple-unpack them back into
-        the same variables.  That rebinding assignment is what marks the
-        participants as loop-carried in run()'s dynamic loops — dropping it
-        silently freezes their state across iterations (see the
-        helper-method rules in loader_tma.py).
+        CONTRACT: step() advances the applicable pipeline participants
+        internally — mma_si_consumer always; s0_s1_sequence_producer
+        (stage 0) or s0_s1_sequence_consumer (stage 1) and si_corr_producer
+        only on non-logits-transform builds — and returns all four.  Every
+        call site MUST tuple-unpack them back into the same variables
+        (rebinding an unmutated participant is harmless).  That rebinding
+        assignment is what marks the participants as loop-carried in
+        run()'s dynamic loops — dropping it silently freezes their state
+        across iterations (see the helper-method rules in loader_tma.py).
         """
         assert self.q_dtype is not None
         assert self.o_dtype is not None

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -141,6 +141,13 @@ class SoftmaxRole:
         4. Transforming scores using exp2(x*scale - max*scale)
         5. Computing row sums for normalization
         6. Coordinating pipeline synchronization between different processing stages
+
+        CONTRACT: step() advances the four pipeline participants internally
+        and returns them; every call site MUST tuple-unpack them back into
+        the same variables.  That rebinding assignment is what marks the
+        participants as loop-carried in run()'s dynamic loops — dropping it
+        silently freezes their state across iterations (see the
+        helper-method rules in loader_tma.py).
         """
         assert self.q_dtype is not None
         assert self.o_dtype is not None

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -53,6 +53,7 @@ def _get_compiled_prefill_kernel(
     params_shape,
     with_lse=False,
     v_in_dtype=None,
+    page_size=None,
 ):
     """Compile and cache the prefill kernel.
 
@@ -79,6 +80,7 @@ def _get_compiled_prefill_kernel(
         is_persistent=is_persistent,
         mask_spec=mask_spec,
         num_repeat_kv_heads=h_r,
+        page_size=page_size,
     )
     _dtype_width_map = {
         cutlass.Float16: 16,
@@ -98,18 +100,52 @@ def _get_compiled_prefill_kernel(
         stride_order=(2, 1, 0),
         assumed_align=16,
     )
-    k_fake = cute.runtime.make_fake_compact_tensor(
-        in_dtype,
-        (sym_s_k, num_kv_heads, head_dim),
-        stride_order=(2, 1, 0),
-        assumed_align=16,
-    )
-    v_fake = cute.runtime.make_fake_compact_tensor(
-        v_in_dtype if v_in_dtype is not None else in_dtype,
-        (sym_s_k, num_kv_heads, head_dim),
-        stride_order=(2, 1, 0),
-        assumed_align=16,
-    )
+    page_table_fake = None
+    page_indptr_fake = None
+    if page_size is not None:
+        # Paged K/V caches: (num_pages, page_size, h_k, d) page-pool views,
+        # plus the flat page-id table and its per-item indptr.  Outer
+        # strides are fully symbolic (batch_decode.py precedent) so the
+        # same kernel handles NHD-compact caches, combined-cache slices
+        # (leading-dim stride 2x from kv_cache[:, 0/1]), and
+        # HND-transposed views; only head_dim is pinned contiguous (TMA).
+        sym_num_pages = cute.sym_int()
+        sym_num_page_ids = cute.sym_int()
+        k_fake = cute.runtime.make_fake_tensor(
+            in_dtype,
+            (sym_num_pages, page_size, num_kv_heads, head_dim),
+            stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
+            assumed_align=16,
+        )
+        v_fake = cute.runtime.make_fake_tensor(
+            v_in_dtype if v_in_dtype is not None else in_dtype,
+            (sym_num_pages, page_size, num_kv_heads, head_dim),
+            stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
+            assumed_align=16,
+        )
+        page_table_fake = cute.runtime.make_fake_compact_tensor(
+            Int32,
+            (sym_num_page_ids,),
+            assumed_align=4,
+        )
+        page_indptr_fake = cute.runtime.make_fake_compact_tensor(
+            Int32,
+            (sym_batch_p1,),
+            assumed_align=4,
+        )
+    else:
+        k_fake = cute.runtime.make_fake_compact_tensor(
+            in_dtype,
+            (sym_s_k, num_kv_heads, head_dim),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        v_fake = cute.runtime.make_fake_compact_tensor(
+            v_in_dtype if v_in_dtype is not None else in_dtype,
+            (sym_s_k, num_kv_heads, head_dim),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
     o_fake = cute.runtime.make_fake_compact_tensor(
         out_dtype,
         (sym_s_q, num_qo_heads, head_dim),
@@ -167,6 +203,8 @@ def _get_compiled_prefill_kernel(
         0,
         params_fake,
         lse_fake,
+        page_table_fake,
+        page_indptr_fake,
         stream_fake,
         options="--enable-tvm-ffi --opt-level 2",
     )
@@ -223,10 +261,10 @@ class BatchPrefillCuteDSLWrapper:
     def plan(
         self,
         qo_indptr,
-        kv_indptr,
-        num_qo_heads,
-        num_kv_heads,
-        head_dim_qk,
+        kv_indptr=None,
+        num_qo_heads=None,
+        num_kv_heads=None,
+        head_dim_qk=None,
         head_dim_vo=None,
         causal=True,
         sm_scale=None,
@@ -235,6 +273,11 @@ class BatchPrefillCuteDSLWrapper:
         window_left: int = -1,
         variant: AttentionVariant | None = None,
         window_right: int = -1,
+        page_size: Optional[int] = None,
+        paged_kv_indptr: Optional[torch.Tensor] = None,
+        paged_kv_indices: Optional[torch.Tensor] = None,
+        paged_kv_last_page_len: Optional[torch.Tensor] = None,
+        kv_layout: str = "NHD",
     ) -> None:
         """Compile the FMHA prefill kernel for the given configuration.
 
@@ -242,8 +285,11 @@ class BatchPrefillCuteDSLWrapper:
         ----------
         qo_indptr : torch.Tensor
             Cumulative query sequence lengths, shape [batch_size + 1].
-        kv_indptr : torch.Tensor
-            Cumulative KV sequence lengths, shape [batch_size + 1].
+        kv_indptr : Optional[torch.Tensor]
+            Cumulative KV sequence lengths, shape [batch_size + 1] (ragged
+            KV).  Must be None when planning for a paged KV cache — pass
+            ``page_size`` + the paged triple instead, and the logical
+            per-item KV lengths are derived from them.
         num_qo_heads : int
             Number of query/output heads.
         num_kv_heads : int
@@ -271,10 +317,81 @@ class BatchPrefillCuteDSLWrapper:
             unbounded. Mutually exclusive with ``causal=True``.
         variant : Optional[AttentionVariant]
             Attention variant (ALiBi, RPE, Sigmoid, etc.). None uses standard softmax.
+        page_size : Optional[int]
+            Tokens per KV-cache page.  None (default) plans for ragged
+            (contiguous varlen) KV; an int plans for a paged KV cache and
+            requires the ``paged_kv_*`` triple below.  Must divide the
+            128-token KV tile (16/32/64/128; 8 accepted).
+        paged_kv_indptr : Optional[torch.Tensor]
+            Page-count cumsums per batch item, shape [batch_size + 1], int32.
+        paged_kv_indices : Optional[torch.Tensor]
+            Flat physical page ids, shape [paged_kv_indptr[-1]], int32.
+            Pages referenced here must be finite everywhere (including past
+            ``last_page_len`` — the kernel over-reads full pages and relies
+            on masking, like every TMA-based paged kernel).  Reclaimed
+            out-of-window slots may point at a null block: with
+            ``window_left`` set, the kernel never reads pages wholly below
+            the attention window.
+        paged_kv_last_page_len : Optional[torch.Tensor]
+            Valid entries in each item's last page, shape [batch_size].
+        kv_layout : str
+            ``"NHD"`` (default) or ``"HND"`` page layout.  Paged-only; the
+            ragged path remains NHD.
         """
         if not torch.cuda.is_available():
             raise RuntimeError("GPU is required to run this example!")
         _require_dsl_arch(qo_indptr.device)
+
+        if num_qo_heads is None or num_kv_heads is None or head_dim_qk is None:
+            raise ValueError("num_qo_heads, num_kv_heads and head_dim_qk are required")
+
+        self._page_size = page_size
+        self._paged_kv_layout = kv_layout
+        self._paged_kv_indptr = None
+        self._paged_kv_indices = None
+        self._paged_kv_last_page_len = None
+        if kv_layout not in ("NHD", "HND"):
+            raise ValueError(f"kv_layout must be 'NHD' or 'HND', got {kv_layout!r}")
+        if page_size is not None:
+            if page_size < 8 or 128 % page_size != 0:
+                raise ValueError(
+                    f"page_size={page_size} must be >= 8 and divide the "
+                    "128-token KV tile (8/16/32/64/128)"
+                )
+            if (
+                paged_kv_indptr is None
+                or paged_kv_indices is None
+                or paged_kv_last_page_len is None
+            ):
+                raise ValueError(
+                    "paged plan requires paged_kv_indptr, paged_kv_indices "
+                    "and paged_kv_last_page_len"
+                )
+            if kv_indptr is not None:
+                raise ValueError(
+                    "pass either kv_indptr (ragged) or the paged_kv_* triple, not both"
+                )
+            from flashinfer.page import get_seq_lens
+
+            device = qo_indptr.device
+            seq_lens = get_seq_lens(
+                paged_kv_indptr.cpu(), paged_kv_last_page_len.cpu(), page_size
+            )
+            # Logical token cumsums: the kernel's consumer roles derive
+            # per-item seqlen_k from these exactly as on the ragged path.
+            kv_indptr = torch.zeros(seq_lens.numel() + 1, dtype=torch.int64)
+            kv_indptr[1:] = torch.cumsum(seq_lens, 0)
+            kv_indptr = kv_indptr.to(device)
+            self._paged_kv_indptr = paged_kv_indptr.to(torch.int32).to(device)
+            self._paged_kv_indices = paged_kv_indices.to(torch.int32).to(device)
+            self._paged_kv_last_page_len = paged_kv_last_page_len.to(torch.int32).to(
+                device
+            )
+        else:
+            if kv_indptr is None:
+                raise ValueError("kv_indptr is required for a ragged plan")
+            if kv_layout != "NHD":
+                raise NotImplementedError("HND layout is only supported with paged KV")
 
         self._batch_size = qo_indptr.shape[0] - 1
         self._num_qo_heads = num_qo_heads
@@ -400,7 +517,14 @@ class BatchPrefillCuteDSLWrapper:
             params_shape,
         )
         self._cache_variant = cache_variant
-        self._compiled_fmha = _get_compiled_prefill_kernel(*self._compile_key)
+        # page_size joins the compile key only when set, so ragged callers
+        # (kwarg-less) and the wrapper share one functools.cache entry.
+        self._page_kwargs = (
+            {"page_size": self._page_size} if self._page_size is not None else {}
+        )
+        self._compiled_fmha = _get_compiled_prefill_kernel(
+            *self._compile_key, **self._page_kwargs
+        )
         # Lazily compiled kernel variants, keyed by (with_lse, v_in_dtype):
         # return_lse and a mixed V dtype are both run()-time properties.
         self._kernel_cache = {(False, None): self._compiled_fmha}
@@ -512,9 +636,127 @@ class BatchPrefillCuteDSLWrapper:
         """
         if self._compiled_fmha is None:
             raise RuntimeError("Plan the prefill attention computation first!")
+        if self._page_size is not None:
+            raise RuntimeError(
+                "this wrapper was planned for a paged KV cache; use run_paged()"
+            )
 
         self._validate_run_inputs(q, k, v, out)
+        return self._invoke_kernel(q, k, v, out, return_lse, lse, None, None)
 
+    @flashinfer_api
+    def run_paged(
+        self,
+        q: torch.Tensor,
+        paged_kv_cache,
+        out: Optional[torch.Tensor] = None,
+        return_lse: bool = False,
+        lse: Optional[torch.Tensor] = None,
+    ):
+        r"""Run paged-KV prefill attention (requires a paged ``plan()``).
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            Query tensor, shape ``[total_q_len, num_qo_heads, head_dim]``.
+        paged_kv_cache : torch.Tensor or (torch.Tensor, torch.Tensor)
+            Either the combined cache ``[num_pages, 2, page_size,
+            num_kv_heads, head_dim]`` (NHD) / ``[num_pages, 2, num_kv_heads,
+            page_size, head_dim]`` (HND), or a ``(k_cache, v_cache)`` tuple
+            of ``[num_pages, page_size, num_kv_heads, head_dim]`` (NHD) /
+            ``[num_pages, num_kv_heads, page_size, head_dim]`` (HND).
+            Referenced pages must be finite everywhere (see ``plan``).
+        out, return_lse, lse
+            As in :meth:`run`.
+        """
+        if self._compiled_fmha is None:
+            raise RuntimeError("Plan the prefill attention computation first!")
+        if self._page_size is None:
+            raise RuntimeError(
+                "this wrapper was planned for ragged KV; use run() or re-plan "
+                "with page_size + the paged_kv_* triple"
+            )
+
+        if isinstance(paged_kv_cache, (tuple, list)):
+            k_cache, v_cache = paged_kv_cache
+        else:
+            if paged_kv_cache.dim() != 5 or paged_kv_cache.shape[1] != 2:
+                raise ValueError(
+                    "combined paged_kv_cache must be 5D [num_pages, 2, ...]; "
+                    f"got shape {tuple(paged_kv_cache.shape)}"
+                )
+            k_cache, v_cache = paged_kv_cache[:, 0], paged_kv_cache[:, 1]
+        if self._paged_kv_layout == "HND":
+            # [num_pages, h, page_size, d] -> logical NHD view; the kernel
+            # consumes the underlying strides (symbolic-stride compile).
+            k_cache = k_cache.transpose(-3, -2)
+            v_cache = v_cache.transpose(-3, -2)
+
+        for name, t in (("k_cache", k_cache), ("v_cache", v_cache)):
+            if t.dtype != self._q_data_type:
+                raise NotImplementedError(
+                    f"{name}.dtype={t.dtype} != planned {self._q_data_type}; "
+                    "mixed K/V dtypes are not supported on the paged route yet"
+                )
+            if t.shape[-3:] != (
+                self._page_size,
+                self._num_kv_heads,
+                self._head_dim,
+            ):
+                raise ValueError(
+                    f"{name} logical shape {tuple(t.shape)} mismatches plan "
+                    f"(page_size={self._page_size}, "
+                    f"num_kv_heads={self._num_kv_heads}, "
+                    f"head_dim={self._head_dim})"
+                )
+            if t.stride(-1) != 1:
+                raise ValueError(f"{name} head_dim must be contiguous")
+        if q.dtype != self._q_data_type or q.device != self._device:
+            raise ValueError(
+                f"q dtype/device ({q.dtype}, {q.device}) mismatches plan "
+                f"({self._q_data_type}, {self._device})"
+            )
+
+        if os.environ.get("FLASHINFER_VALIDATE_INPUTS", "0") not in ("", "0"):
+            self._validate_paged_cache(k_cache, v_cache)
+
+        return self._invoke_kernel(
+            q,
+            k_cache,
+            v_cache,
+            out,
+            return_lse,
+            lse,
+            self._paged_kv_indices,
+            self._paged_kv_indptr,
+        )
+
+    def _validate_paged_cache(self, k_cache, v_cache) -> None:
+        """Debug-mode (FLASHINFER_VALIDATE_INPUTS) scan: every referenced
+        page must be finite everywhere.  A NaN in a live page's tail
+        corrupts output through the PV MMA (0 x NaN = NaN) — see the paged
+        test suite's null-block contract."""
+        pages = self._paged_kv_indices.long()
+        for name, t in (("k_cache", k_cache), ("v_cache", v_cache)):
+            ref = t[pages].float()
+            if not torch.isfinite(ref).all().item():
+                raise ValueError(
+                    f"FLASHINFER_VALIDATE_INPUTS: {name} has non-finite values "
+                    "in table-referenced pages; live pages must be finite "
+                    "everywhere (including past last_page_len)"
+                )
+
+    def _invoke_kernel(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out: Optional[torch.Tensor],
+        return_lse: bool,
+        lse: Optional[torch.Tensor],
+        page_table: Optional[torch.Tensor],
+        page_indptr: Optional[torch.Tensor],
+    ):
         if return_lse:
             if self._cache_variant is not None and (
                 self._cache_variant.has_logits_transform
@@ -543,7 +785,10 @@ class BatchPrefillCuteDSLWrapper:
         kernel_fn = self._kernel_cache.get(kernel_key)
         if kernel_fn is None:
             kernel_fn = _get_compiled_prefill_kernel(
-                *self._compile_key, with_lse=return_lse, v_in_dtype=v_in_dtype
+                *self._compile_key,
+                with_lse=return_lse,
+                v_in_dtype=v_in_dtype,
+                **self._page_kwargs,
             )
             self._kernel_cache[kernel_key] = kernel_fn
 
@@ -563,6 +808,8 @@ class BatchPrefillCuteDSLWrapper:
             self._window_right,
             self._params_torch if self._has_params else None,
             lse,
+            page_table,
+            page_indptr,
         )
 
         if out is not None:

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -431,6 +431,15 @@ class BatchPrefillCuteDSLWrapper:
         s_k_all = int(kv_indptr[-1].item())
         max_s_q = int(torch.max(s_q).item())
         max_s_k = int(torch.max(s_k).item())
+        # The kernel loads the first KV tile of every valid Q tile
+        # unconditionally (all four warp roles assume >= 1 KV tile), so a
+        # zero-length KV item would read out of range (paged: page-table
+        # index -1) and produce undefined output (empty-row softmax).
+        if s_k.numel() > 0 and int(torch.min(s_k).item()) <= 0:
+            raise ValueError(
+                "cute-dsl prefill requires kv_len >= 1 for every batch item; "
+                "zero-length KV items are not supported"
+            )
 
         # Store for runtime
         self._qo_indptr = qo_indptr.to(torch.int32)
@@ -666,6 +675,9 @@ class BatchPrefillCuteDSLWrapper:
             of ``[num_pages, page_size, num_kv_heads, head_dim]`` (NHD) /
             ``[num_pages, num_kv_heads, page_size, head_dim]`` (HND).
             Referenced pages must be finite everywhere (see ``plan``).
+            The tuple form may carry a V cache whose dtype differs from
+            the planned K dtype (mixed-dtype PV path, e.g. an fp8 V cache
+            with bf16 Q/K); K must always match the plan.
         out, return_lse, lse
             As in :meth:`run`.
         """
@@ -692,12 +704,21 @@ class BatchPrefillCuteDSLWrapper:
             k_cache = k_cache.transpose(-3, -2)
             v_cache = v_cache.transpose(-3, -2)
 
+        if k_cache.dtype != self._q_data_type:
+            raise ValueError(
+                f"k_cache.dtype={k_cache.dtype} != planned {self._q_data_type}; "
+                "K must match the planned kv dtype (the QK MMA operands share it)"
+            )
+        # V may differ from Q/K (mixed-dtype PV path, e.g. fp8 V cache with
+        # bf16 Q/K); the kernel variant is selected per V dtype in
+        # _invoke_kernel, same as the ragged route.  Only the
+        # (k_cache, v_cache) tuple form can express a mixed cache.
+        if v_cache.dtype != self._q_data_type and v_cache.dtype not in _V_DTYPE_MAP:
+            raise ValueError(
+                f"v_cache.dtype={v_cache.dtype} is not supported; expected "
+                f"{self._q_data_type} or one of {sorted(map(str, _V_DTYPE_MAP))}"
+            )
         for name, t in (("k_cache", k_cache), ("v_cache", v_cache)):
-            if t.dtype != self._q_data_type:
-                raise NotImplementedError(
-                    f"{name}.dtype={t.dtype} != planned {self._q_data_type}; "
-                    "mixed K/V dtypes are not supported on the paged route yet"
-                )
             if t.shape[-3:] != (
                 self._page_size,
                 self._num_kv_heads,

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -41,6 +41,23 @@ _V_DTYPE_MAP = {
 
 
 @functools.cache
+def _dsl_supports_expected_tx() -> bool:
+    """True if the installed DSL supports per-acquire TMA byte-count
+    overrides (``PipelineTmaUmma.producer_acquire(expected_tx=...)``,
+    added in nvidia-cutlass-dsl 4.6).  Mixed K/V dtypes need it to
+    re-arm each V slot of the shared K/V ring with V's byte count.
+    """
+    import inspect
+
+    from cutlass import pipeline
+
+    return (
+        "expected_tx"
+        in inspect.signature(pipeline.PipelineTmaUmma.producer_acquire).parameters
+    )
+
+
+@functools.cache
 def _get_compiled_prefill_kernel(
     in_dtype,
     out_dtype,
@@ -802,6 +819,14 @@ class BatchPrefillCuteDSLWrapper:
             lse = None
 
         v_in_dtype = _V_DTYPE_MAP[v.dtype] if v.dtype != self._q_data_type else None
+        if v_in_dtype is not None and not _dsl_supports_expected_tx():
+            raise NotImplementedError(
+                f"mixed K/V dtypes (V={v.dtype} with planned "
+                f"{self._q_data_type}) require nvidia-cutlass-dsl>=4.6 "
+                "(producer_acquire lacks per-acquire expected_tx on the "
+                "installed version); upgrade nvidia-cutlass-dsl or use a "
+                "uniform KV dtype"
+            )
         kernel_key = (return_lse, v_in_dtype)
         kernel_fn = self._kernel_cache.get(kernel_key)
         if kernel_fn is None:

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2412,7 +2412,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
                 if cute_variant is not None:
                     raise NotImplementedError(
-                        "cute-dsl backend does not support combining ALiBi with logits_soft_cap"
+                        "the public cute-dsl route cannot combine ALiBi with "
+                        "logits_soft_cap (one plan-time variant per kernel); "
+                        "a fused custom variant can express both — use "
+                        "flashinfer.cute_dsl.attention."
+                        "BatchPrefillCuteDSLWrapper with plan(..., variant=...)"
                     )
                 cute_variant = SoftCappingAttention(cap=logits_soft_cap)
 
@@ -2761,7 +2765,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 )
             if sinks is not None:
                 raise NotImplementedError(
-                    "cute-dsl paged backend does not support attention sinks"
+                    "the public cute-dsl paged route does not accept run-time "
+                    "attention sinks yet; the backend supports sinks as a "
+                    "plan-time variant — use flashinfer.cute_dsl.attention."
+                    "BatchPrefillCuteDSLWrapper with "
+                    "plan(..., variant=AttentionWithSink(sinks))"
                 )
             if skip_softmax_threshold_scale_factor is not None:
                 raise NotImplementedError(
@@ -3590,7 +3598,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
                 if variant is not None:
                     raise NotImplementedError(
-                        "cute-dsl backend does not support combining ALiBi with logits_soft_cap"
+                        "the public cute-dsl route cannot combine ALiBi with "
+                        "logits_soft_cap (one plan-time variant per kernel); "
+                        "a fused custom variant can express both — use "
+                        "flashinfer.cute_dsl.attention."
+                        "BatchPrefillCuteDSLWrapper with plan(..., variant=...)"
                     )
                 variant = SoftCappingAttention(cap=logits_soft_cap)
 
@@ -4033,6 +4045,19 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 raise NotImplementedError(
                     "cute-dsl backend does not support NVFP4 packed KV cache "
                     "(kv_cache_sf)"
+                )
+            # vLLM's metadata builder stashes attention sinks on the wrapper
+            # for the fmha_v2 route; the cute-dsl route would silently
+            # ignore them (wrong results), so fail loudly with the
+            # supported alternative.
+            if getattr(self, "_sinks", None) is not None:
+                raise NotImplementedError(
+                    "attention sinks were set on the wrapper (_sinks) but "
+                    "the public cute-dsl ragged route does not consume "
+                    "them; the backend supports sinks as a plan-time "
+                    "variant — use flashinfer.cute_dsl.attention."
+                    "BatchPrefillCuteDSLWrapper with "
+                    "plan(..., variant=AttentionWithSink(sinks))"
                 )
             # enable_pdl is a launch-latency hint: forwarded on the FMHA
             # route below; the modular kernel has no PDL support.

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1660,10 +1660,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
             mask will be used in attention computation.
 
         backend : str
-            The implementation backend, could be ``auto``/``fa2``/``fa3``/``cudnn`` or ``trtllm-gen``.
+            The implementation backend, could be ``auto``/``fa2``/``fa3``/``cudnn``/``trtllm-gen``
+            or ``cute-dsl``.
             Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
+            The ``cute-dsl`` backend uses the CuTe DSL attention kernel for Blackwell (SM100+).
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1677,10 +1677,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
         )
         _check_kv_layout(kv_layout)
 
+        self._cute_dsl_wrapper = None
         if backend == "cute-dsl":
-            raise NotImplementedError(
-                "cute-dsl backend is not yet supported for paged KV cache. "
-                "Use BatchPrefillWithRaggedKVCacheWrapper instead."
+            from .cute_dsl.attention import BatchPrefillCuteDSLWrapper
+
+            self._cute_dsl_wrapper = BatchPrefillCuteDSLWrapper(
+                float_workspace_buffer, use_cuda_graph=use_cuda_graph
             )
 
         if jit_args is not None and backend != "cute-dsl":
@@ -2375,7 +2377,69 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._cached_kv_data_type = kv_data_type
         self._cached_o_data_type = o_data_type
 
-        if self._jit_module is not None:
+        if self._backend == "cute-dsl":
+            if custom_mask is not None or packed_custom_mask is not None:
+                raise NotImplementedError(
+                    "cute-dsl backend does not support custom_mask"
+                )
+            if head_dim_vo is not None and head_dim_vo != head_dim_qk:
+                raise NotImplementedError(
+                    "cute-dsl backend requires head_dim_vo == head_dim_qk"
+                )
+            if pos_encoding_mode not in ("NONE", "ALIBI"):
+                raise NotImplementedError(
+                    f"cute-dsl backend does not support pos_encoding_mode={pos_encoding_mode!r}. "
+                    "For RoPE, apply rotary embeddings to Q/K before calling the kernel."
+                )
+            if kv_data_type is not None and q_data_type != kv_data_type:
+                raise ValueError(
+                    "cute-dsl paged prefill requires q_data_type == "
+                    f"kv_data_type, got {q_data_type} and {kv_data_type}"
+                )
+
+            cute_variant: Optional[Any] = None
+            if pos_encoding_mode == "ALIBI":
+                from .cute_dsl.attention import ALiBiAttention
+
+                slopes = ALiBiAttention.get_slopes(num_qo_heads)
+                cute_variant = ALiBiAttention(
+                    torch.tensor(slopes, dtype=torch.float32, device=qo_indptr.device)
+                )
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                from .cute_dsl.attention import SoftCappingAttention
+
+                if cute_variant is not None:
+                    raise NotImplementedError(
+                        "cute-dsl backend does not support combining ALiBi with logits_soft_cap"
+                    )
+                cute_variant = SoftCappingAttention(cap=logits_soft_cap)
+
+            _sm_scale = (
+                sm_scale if sm_scale is not None else 1.0 / math.sqrt(head_dim_qk)
+            )
+            # All paged plans use the modular kernel — the vendored FMHA
+            # artifacts (the ragged wrapper's dense/causal route) have no
+            # paged variant.
+            self._cute_dsl_wrapper.plan(
+                qo_indptr,
+                None,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim_qk,
+                head_dim_vo=head_dim_qk,
+                causal=causal,
+                sm_scale=_sm_scale,
+                q_data_type=q_data_type,
+                kv_data_type=kv_data_type if kv_data_type is not None else q_data_type,
+                window_left=window_left,
+                variant=cute_variant,
+                page_size=page_size,
+                paged_kv_indptr=paged_kv_indptr,
+                paged_kv_indices=paged_kv_indices,
+                paged_kv_last_page_len=paged_kv_last_page_len,
+                kv_layout=self._kv_layout,
+            )
+        elif self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
@@ -2682,6 +2746,44 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     f"For paged prefill, q must have shape [total_tokens, num_heads, head_dim] "
                     f"where total_tokens = qo_indptr[-1]."
                 )
+
+        if self._backend == "cute-dsl":
+            if q_scale is not None or k_scale is not None or v_scale is not None:
+                raise NotImplementedError(
+                    "cute-dsl paged backend does not support q/k/v scale factors"
+                )
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "cute-dsl paged backend does not support NVFP4 KV cache "
+                    "scale factors (kv_cache_sf)"
+                )
+            if sinks is not None:
+                raise NotImplementedError(
+                    "cute-dsl paged backend does not support attention sinks"
+                )
+            if skip_softmax_threshold_scale_factor is not None:
+                raise NotImplementedError(
+                    "cute-dsl paged backend does not support skip-softmax"
+                )
+            if window_left is not None and window_left != self._window_left:
+                raise NotImplementedError(
+                    "cute-dsl paged backend does not support per-call "
+                    "window_left overrides; re-plan instead"
+                )
+            # enable_pdl is accepted as a hint (no-op for the modular kernel,
+            # matching the ragged cute-dsl route).
+            if out is None and q.dtype.itemsize == 1:
+                # fp8 inputs produce bf16 output, matching the ragged
+                # cute-dsl route's convention (the kernel's native scratch
+                # is fp16; the copy-out converts).
+                out = torch.empty(q.shape, dtype=torch.bfloat16, device=q.device)
+            return self._cute_dsl_wrapper.run_paged(
+                q,
+                (k_cache, v_cache),
+                out=out,
+                return_lse=return_lse,
+                lse=lse,
+            )
 
         if (
             k_cache.dtype == torch.uint8 or v_cache.dtype == torch.uint8

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2405,7 +2405,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
                 slopes = ALiBiAttention.get_slopes(num_qo_heads)
                 cute_variant = ALiBiAttention(
-                    torch.tensor(slopes, dtype=torch.float32, device=qo_indptr.device)
+                    torch.tensor(slopes, dtype=torch.float32, device=self.device)
                 )
             if logits_soft_cap is not None and logits_soft_cap > 0:
                 from .cute_dsl.attention import SoftCappingAttention
@@ -2426,8 +2426,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
             # All paged plans use the modular kernel — the vendored FMHA
             # artifacts (the ragged wrapper's dense/causal route) have no
             # paged variant.
+            # Consume the wrapper-owned buffers (populated above) rather
+            # than the raw arguments: they are the stable-address contract
+            # for CUDA-graph mode and the single normalized copy otherwise.
             self._cute_dsl_wrapper.plan(
-                qo_indptr,
+                self._qo_indptr_buf,
                 None,
                 num_qo_heads,
                 num_kv_heads,
@@ -2440,9 +2443,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 window_left=window_left,
                 variant=cute_variant,
                 page_size=page_size,
-                paged_kv_indptr=paged_kv_indptr,
-                paged_kv_indices=paged_kv_indices,
-                paged_kv_last_page_len=paged_kv_last_page_len,
+                paged_kv_indptr=self._paged_kv_indptr_buf,
+                paged_kv_indices=self._paged_kv_indices_buf,
+                paged_kv_last_page_len=self._paged_kv_last_page_len_buf,
                 kv_layout=self._kv_layout,
             )
         elif self._jit_module is not None:
@@ -3591,7 +3594,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
                 slopes = ALiBiAttention.get_slopes(num_qo_heads)
                 variant = ALiBiAttention(
-                    torch.tensor(slopes, dtype=torch.float32, device=qo_indptr.device)
+                    torch.tensor(slopes, dtype=torch.float32, device=self.device)
                 )
             if logits_soft_cap is not None and logits_soft_cap > 0:
                 from .cute_dsl.attention import SoftCappingAttention
@@ -3619,11 +3622,13 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 variant is None and head_dim_qk == 128 and window_left < 0
             )
             if self._cute_dsl_use_fmha:
-                q_lens = qo_indptr[1:] - qo_indptr[:-1]
-                k_lens = kv_indptr[1:] - kv_indptr[:-1]
+                # Wrapper-owned buffers (populated above): stable addresses
+                # for CUDA-graph mode, single normalized copy otherwise.
+                q_lens = self._qo_indptr_buf[1:] - self._qo_indptr_buf[:-1]
+                k_lens = self._kv_indptr_buf[1:] - self._kv_indptr_buf[:-1]
                 self._cute_dsl_fmha_plan = {
-                    "qo_indptr": qo_indptr,
-                    "kv_indptr": kv_indptr,
+                    "qo_indptr": self._qo_indptr_buf,
+                    "kv_indptr": self._kv_indptr_buf,
                     "seq_lens": k_lens.to(torch.int32),
                     "batch_size": qo_indptr.shape[0] - 1,
                     "max_q_len": int(q_lens.max().item()),
@@ -3644,8 +3649,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                         f"kv_data_type, got {q_data_type} and {kv_data_type}"
                     )
                 self._cute_dsl_wrapper.plan(
-                    qo_indptr,
-                    kv_indptr,
+                    self._qo_indptr_buf,
+                    self._kv_indptr_buf,
                     num_qo_heads,
                     num_kv_heads,
                     head_dim_qk,

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -881,6 +881,17 @@ def test_attention_prefill_mixed_v_dtype(
     )
     torch.testing.assert_close(o_uniform, o_ref_uniform, rtol=RTOL, atol=ATOL)
 
+    from flashinfer.cute_dsl.attention.wrappers.batch_prefill import (
+        _dsl_supports_expected_tx,
+    )
+
+    if not _dsl_supports_expected_tx():
+        # Pre-4.6 DSL: mixed V must be rejected with an actionable error
+        # (this asserts the version gate itself; uniform ran above).
+        with pytest.raises(NotImplementedError, match="nvidia-cutlass-dsl"):
+            wrapper.run(q, k, v, return_lse=True)
+        return
+
     o, lse = wrapper.run(q, k, v, return_lse=True)
     o_ref = attention_band_mask_ref(
         batch_size,

--- a/tests/attention/test_modular_fmha_prefill_paged.py
+++ b/tests/attention/test_modular_fmha_prefill_paged.py
@@ -246,9 +246,26 @@ def test_paged_identity_table():
     run_paged_vs_ragged([512, 512], [512, 512], True, 16, scramble=False)
 
 
+@pytest.mark.parametrize("page_size", [8, 16])
+def test_paged_d64_windowed_null_block(page_size):
+    """head_dim 64 (single-slice TMA box geometry) x window clamp x NaN
+    null blocks — the paged geometry the d128 cases don't reach."""
+    _skip_unless_sm100()
+    run_paged_vs_ragged(
+        [1291],
+        [1547],
+        True,
+        page_size,
+        pool_fill=float("nan"),
+        window_left=127,
+        null_below_window=True,
+        d=64,
+    )
+
+
 @pytest.mark.parametrize(
     "causal,page_size",
-    [(True, 16), (False, 64)],
+    [(True, 8), (True, 16), (False, 64)],
 )
 def test_paged_nan_pool_tail_clamp(causal, page_size):
     """Unreferenced pool pages NaN: the tail -1 clamp must keep them out."""
@@ -262,6 +279,7 @@ def test_paged_nan_pool_tail_clamp(causal, page_size):
     "sq,sk,causal,page_size,window_left",
     [
         ([1024], [1024], False, 16, 255),
+        ([1024], [1024], True, 8, 255),
         ([1291], [1547], True, 64, 511),
     ],
 )
@@ -277,6 +295,7 @@ def test_paged_windowed(sq, sk, causal, page_size, window_left):
         ([300], [1500], False, 16, 127),
         ([1291], [1547], True, 64, 511),
         ([7, 300, 1291], [23, 300, 1547], True, 16, 127),
+        ([7, 300, 1291], [23, 300, 1547], True, 8, 127),
     ],
 )
 def test_paged_null_block_window_clamp(sq, sk, causal, page_size, window_left):
@@ -454,7 +473,8 @@ def test_paged_wrapper_lse():
     assert lse.shape == (q.shape[0], 8) and torch.isfinite(lse).all().item()
 
 
-def test_paged_wrapper_fp8_bitwise_vs_ragged_wrapper():
+@pytest.mark.parametrize("page_size", [8, 16])
+def test_paged_wrapper_fp8_bitwise_vs_ragged_wrapper(page_size):
     """Uniform fp8 paged vs fp8 ragged, both on the modular kernel via a
     windowed plan — bitwise, no tolerance calibration needed."""
     _skip_unless_sm100()
@@ -462,7 +482,7 @@ def test_paged_wrapper_fp8_bitwise_vs_ragged_wrapper():
 
     dt = torch.float8_e4m3fn
     (q, k_rag, v_rag, cache, qo, kv_tok, kv_pg, ids, lpl) = _build_wrapper_problem(
-        [300, 1291], [300, 1547], 16, dt=torch.bfloat16
+        [300, 1291], [300, 1547], page_size, dt=torch.bfloat16
     )
     q8, k8, v8 = q.to(dt), k_rag.to(dt), v_rag.to(dt)
     cache8 = cache.to(dt)
@@ -475,7 +495,7 @@ def test_paged_wrapper_fp8_bitwise_vs_ragged_wrapper():
         num_qo_heads=8,
         num_kv_heads=2,
         head_dim_qk=128,
-        page_size=16,
+        page_size=page_size,
         causal=True,
         window_left=511,
         q_data_type=dt,
@@ -503,7 +523,8 @@ def test_paged_wrapper_fp8_bitwise_vs_ragged_wrapper():
     assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
 
 
-def test_paged_wrapper_mixed_v_dtype_bitwise_vs_ragged():
+@pytest.mark.parametrize("page_size", [8, 16])
+def test_paged_wrapper_mixed_v_dtype_bitwise_vs_ragged(page_size):
     """Mixed-dtype paged cache: bf16 Q/K with an fp8 V cache (tuple form).
 
     The ragged route already serves mixed V as a run()-time property; the
@@ -513,7 +534,7 @@ def test_paged_wrapper_mixed_v_dtype_bitwise_vs_ragged():
     _skip_unless_sm100()
 
     (q, k_rag, v_rag, cache, qo, kv_tok, kv_pg, ids, lpl) = _build_wrapper_problem(
-        [300, 1291], [300, 1547], 16
+        [300, 1291], [300, 1547], page_size
     )
     plan_kw = dict(
         num_qo_heads=8,
@@ -533,7 +554,7 @@ def test_paged_wrapper_mixed_v_dtype_bitwise_vs_ragged():
     )
 
     w = _paged_wrapper()
-    w.plan(qo, kv_pg, ids, lpl, page_size=16, **plan_kw)
+    w.plan(qo, kv_pg, ids, lpl, page_size=page_size, **plan_kw)
     if not _dsl_supports_expected_tx():
         # Pre-4.6 DSL: mixed V must be rejected with an actionable error
         # (this asserts the version gate itself).
@@ -564,8 +585,9 @@ def test_paged_wrapper_mixed_v_dtype_bitwise_vs_ragged():
     assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
 
 
+@pytest.mark.parametrize("page_size", [8, 16])
 @pytest.mark.parametrize("variant_name", ["sigmoid", "alibi", "sink"])
-def test_paged_wrapper_variants_bitwise_vs_ragged(variant_name):
+def test_paged_wrapper_variants_bitwise_vs_ragged(variant_name, page_size):
     """Attention variants must compose with paged KV.
 
     The loader is the only stage that differs between the paged and ragged
@@ -584,7 +606,7 @@ def test_paged_wrapper_variants_bitwise_vs_ragged(variant_name):
     )
 
     (q, k_rag, v_rag, cache, qo, kv_tok, kv_pg, ids, lpl) = _build_wrapper_problem(
-        [300, 1291], [300, 1547], 16
+        [300, 1291], [300, 1547], page_size
     )
     h_q = 8
 
@@ -612,7 +634,7 @@ def test_paged_wrapper_variants_bitwise_vs_ragged(variant_name):
     w_paged = BatchPrefillCuteDSLWrapper(ws)
     w_paged.plan(
         qo,
-        page_size=16,
+        page_size=page_size,
         paged_kv_indptr=kv_pg,
         paged_kv_indices=ids,
         paged_kv_last_page_len=lpl,

--- a/tests/attention/test_modular_fmha_prefill_paged.py
+++ b/tests/attention/test_modular_fmha_prefill_paged.py
@@ -655,13 +655,13 @@ def test_paged_wrapper_rejections():
     w = _paged_wrapper()
     w.plan(qo, kv_pg, ids, lpl, page_size=16, **plan_kw)
     k_c, v_c = cache[:, 0].to(torch.float8_e4m3fn), cache[:, 1]
-    with pytest.raises(ValueError, match="k_cache|dtype of k"):
+    with pytest.raises(ValueError, match=r"k_cache|dtype of k"):
         w.run(q, (k_c, v_c))
     # unsupported V dtype at run
     with pytest.raises(ValueError, match="v_cache"):
         w.run(q, (cache[:, 0], cache[:, 1].to(torch.float32)))
     # kv_cache_sf reject
-    with pytest.raises(NotImplementedError, match="kv_cache_sf|NVFP4"):
+    with pytest.raises(NotImplementedError, match=r"kv_cache_sf|NVFP4"):
         w.run(q, cache, kv_cache_sf=torch.zeros(1, device="cuda"))
     # zero-length KV item (would read page-table index -1 in the loader)
     w = _paged_wrapper()

--- a/tests/attention/test_modular_fmha_prefill_paged.py
+++ b/tests/attention/test_modular_fmha_prefill_paged.py
@@ -1,0 +1,567 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Paged-KV tests for the modular cute-dsl prefill kernel.
+
+The anchor property: paged output must be BITWISE identical to ragged
+output on the same logical problem — physical KV layout (page pool +
+page table) is unobservable to the compute pipeline (same smem contents,
+same schedule).  Each test scatters the ragged K/V into a page pool
+under identity or scrambled page tables and compares against the ragged
+kernel, so no separate numerical reference is needed.
+
+NaN-canary cases pin the two clamp contracts (both are -1 page ids →
+TMA out-of-bounds → zero-fill; P=+0 does NOT protect against NaN
+because 0 x NaN = NaN through the PV MMA):
+- tail clamp: logical pages past an item's last page;
+- window clamp: with prefix caching, serving frameworks reclaim pages
+  wholly below the attention window and point their table slots at a
+  shared null block that accumulates garbage/NaN (the trtllm-gen
+  pageIdxLb contract) — the kernel must not read them.
+Live pages referenced by the table are finite everywhere by framework
+contract (in-page tails past last_page_len are over-read and masked,
+like every TMA-based paged kernel).
+
+Each (mask, page_size) combination JIT-compiles one paged kernel (~30s);
+runtime configurations reuse compiled kernels via the functools cache.
+"""
+
+import math
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.utils import is_sm100a_supported
+
+if not is_cute_dsl_available():
+    pytest.skip("CuTe DSL not available", allow_module_level=True)
+
+import cutlass
+
+from flashinfer.cute_dsl.attention.fusion.mask import MaskSpec
+from flashinfer.cute_dsl.attention.wrappers.batch_prefill import (
+    _get_compiled_prefill_kernel,
+)
+
+LOG2_E = math.log2(math.exp(1.0))
+
+
+def _skip_unless_sm100():
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("Requires SM100a (Blackwell)")
+
+
+def build_paged(
+    k_ragged,
+    v_ragged,
+    kv_indptr,
+    page_size,
+    scramble,
+    pool_fill,
+    seed=0,
+    null_window_left=None,
+    qo_indptr=None,
+):
+    """Scatter ragged K/V into a page pool; return pool tensors + tables.
+
+    ``null_window_left`` simulates framework page reclamation under SWA:
+    table slots for pages wholly below every Q row's window band point at
+    a shared null page that keeps ``pool_fill`` (e.g. NaN) and never
+    receives valid data.
+    """
+    device = k_ragged.device
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    B = kv_indptr.numel() - 1
+    h_k, d = k_ragged.shape[1], k_ragged.shape[2]
+    seq_lens = (kv_indptr[1:] - kv_indptr[:-1]).tolist()
+    page_counts = [(s + page_size - 1) // page_size for s in seq_lens]
+    total_pages = sum(page_counts)
+    num_pool = total_pages + 5  # slack so physical ids differ from logical
+    null_page = num_pool - 1  # never receives valid data; stays pool_fill
+
+    k_pool = torch.full(
+        (num_pool, page_size, h_k, d), pool_fill, dtype=k_ragged.dtype, device=device
+    )
+    v_pool = torch.full(
+        (num_pool, page_size, h_k, d), pool_fill, dtype=v_ragged.dtype, device=device
+    )
+
+    if scramble:
+        ids = torch.randperm(num_pool, generator=g)[:total_pages]
+    else:
+        ids = torch.arange(total_pages)
+
+    page_table = ids.to(torch.int32).to(device)
+    page_indptr = torch.zeros(B + 1, dtype=torch.int32)
+    page_indptr[1:] = torch.cumsum(torch.tensor(page_counts), 0)
+    page_indptr = page_indptr.to(device)
+
+    flat = 0
+    for b in range(B):
+        base = int(kv_indptr[b])
+        dead_cutoff = 0
+        if null_window_left is not None:
+            q_len = int(qo_indptr[b + 1] - qo_indptr[b])
+            lo_min = max(0, (seq_lens[b] - q_len) - null_window_left)
+            dead_cutoff = lo_min // page_size
+        for p in range(page_counts[b]):
+            phys = int(ids[flat])
+            if p < dead_cutoff:
+                page_table[flat] = null_page  # reclaimed slot
+                flat += 1
+                continue
+            # Live pages are finite everywhere, including past
+            # last_page_len (framework contract; matches trtllm-gen).
+            k_pool[phys] = 0
+            v_pool[phys] = 0
+            lo = base + p * page_size
+            hi = min(base + (p + 1) * page_size, int(kv_indptr[b + 1]))
+            n = hi - lo
+            k_pool[phys, :n] = k_ragged[lo:hi]
+            v_pool[phys, :n] = v_ragged[lo:hi]
+            flat += 1
+    return k_pool, v_pool, page_table, page_indptr
+
+
+def run_paged_vs_ragged(
+    seq_lens_q,
+    seq_lens_k,
+    causal,
+    page_size,
+    scramble=True,
+    pool_fill=777.0,
+    window_left=-1,
+    null_below_window=False,
+    h_q=8,
+    h_k=2,
+    d=128,
+    dt=torch.bfloat16,
+):
+    device = "cuda"
+    B = len(seq_lens_q)
+    qo_indptr = torch.zeros(B + 1, dtype=torch.int32)
+    qo_indptr[1:] = torch.cumsum(torch.tensor(seq_lens_q), 0)
+    kv_indptr = torch.zeros(B + 1, dtype=torch.int32)
+    kv_indptr[1:] = torch.cumsum(torch.tensor(seq_lens_k), 0)
+    s_q_all, s_k_all = int(qo_indptr[-1]), int(kv_indptr[-1])
+    max_s_q, max_s_k = max(seq_lens_q), max(seq_lens_k)
+
+    torch.manual_seed(42)
+    q = torch.randn(s_q_all, h_q, d, dtype=dt, device=device)
+    k = torch.randn(s_k_all, h_k, d, dtype=dt, device=device)
+    v = torch.randn(s_k_all, h_k, d, dtype=dt, device=device)
+
+    k_pool, v_pool, page_table, page_indptr = build_paged(
+        k,
+        v,
+        kv_indptr,
+        page_size,
+        scramble,
+        pool_fill,
+        null_window_left=(window_left if null_below_window else None),
+        qo_indptr=qo_indptr,
+    )
+
+    mask_spec = MaskSpec(
+        has_window_left=window_left >= 0,
+        has_window_right=causal,
+    )
+    is_persistent = not (causal or window_left >= 0)
+    common = (
+        cutlass.BFloat16,
+        cutlass.BFloat16,
+        h_q,
+        h_k,
+        d,
+        mask_spec,
+        is_persistent,
+        None,
+        None,
+    )
+    kern_ragged = _get_compiled_prefill_kernel(*common)
+    kern_paged = _get_compiled_prefill_kernel(*common, page_size=page_size)
+
+    problem_size = (B, max_s_q, max_s_k, h_q, h_k, d)
+    scale = (1.0 / math.sqrt(d)) * LOG2_E
+    qo_i = qo_indptr.to(device)
+    kv_i = kv_indptr.to(device)
+
+    outs = []
+    for kern, kk, vv, pt, pi in (
+        (kern_ragged, k, v, None, None),
+        (kern_paged, k_pool, v_pool, page_table, page_indptr),
+    ):
+        o_scratch = torch.full(
+            (max_s_q + s_q_all, h_q, d), 7.0, dtype=dt, device=device
+        )
+        kern(
+            q,
+            kk,
+            vv,
+            o_scratch[max_s_q:],
+            problem_size,
+            qo_i,
+            s_q_all,
+            kv_i,
+            s_k_all,
+            scale,
+            1.0,
+            max(window_left, 0),
+            0,
+            None,
+            None,
+            pt,
+            pi,
+        )
+        torch.cuda.synchronize()
+        outs.append(o_scratch[max_s_q:].clone())
+
+    ref, paged = outs
+    assert not paged.float().isnan().any().item(), "NaN leaked into paged output"
+    assert torch.equal(ref.view(torch.int16), paged.view(torch.int16)), (
+        f"paged output not bitwise-equal to ragged "
+        f"(max abs diff {(ref.float() - paged.float()).abs().max().item()})"
+    )
+
+
+SHAPES = [
+    ([512, 512], [512, 512]),  # uniform, page-aligned
+    ([7, 300, 1291], [23, 300, 1547]),  # varlen, partial last pages, s_k > s_q
+]
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("page_size", [16, 64, 128])
+@pytest.mark.parametrize("shapes", SHAPES)
+def test_paged_bitwise_vs_ragged(causal, page_size, shapes):
+    _skip_unless_sm100()
+    sq, sk = shapes
+    run_paged_vs_ragged(sq, sk, causal, page_size)
+
+
+def test_paged_identity_table():
+    """Identity table (pages in pool order) — isolates pure indirection."""
+    _skip_unless_sm100()
+    run_paged_vs_ragged([512, 512], [512, 512], True, 16, scramble=False)
+
+
+@pytest.mark.parametrize(
+    "causal,page_size",
+    [(True, 16), (False, 64)],
+)
+def test_paged_nan_pool_tail_clamp(causal, page_size):
+    """Unreferenced pool pages NaN: the tail -1 clamp must keep them out."""
+    _skip_unless_sm100()
+    run_paged_vs_ragged(
+        [7, 300, 1291], [23, 300, 1547], causal, page_size, pool_fill=float("nan")
+    )
+
+
+@pytest.mark.parametrize(
+    "sq,sk,causal,page_size,window_left",
+    [
+        ([1024], [1024], False, 16, 255),
+        ([1291], [1547], True, 64, 511),
+    ],
+)
+def test_paged_windowed(sq, sk, causal, page_size, window_left):
+    """Windowed paged vs windowed ragged (all pages live)."""
+    _skip_unless_sm100()
+    run_paged_vs_ragged(sq, sk, causal, page_size, window_left=window_left)
+
+
+@pytest.mark.parametrize(
+    "sq,sk,causal,page_size,window_left",
+    [
+        ([300], [1500], False, 16, 127),
+        ([1291], [1547], True, 64, 511),
+        ([7, 300, 1291], [23, 300, 1547], True, 16, 127),
+    ],
+)
+def test_paged_null_block_window_clamp(sq, sk, causal, page_size, window_left):
+    """Null-block contract: reclaimed out-of-window table slots point at a
+    NaN null page; the window clamp (-1 page id) must never read them."""
+    _skip_unless_sm100()
+    run_paged_vs_ragged(
+        sq,
+        sk,
+        causal,
+        page_size,
+        pool_fill=float("nan"),
+        window_left=window_left,
+        null_below_window=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+#  Wrapper-level integration (BatchPrefillWithPagedKVCacheWrapper cute-dsl)
+# ---------------------------------------------------------------------------
+
+
+def _build_wrapper_problem(
+    seq_lens_q, seq_lens_k, page_size, h_q=8, h_k=2, d=128, dt=torch.bfloat16, seed=42
+):
+    """Random paged problem: returns q, ragged K/V, combined cache + tables."""
+    device = "cuda"
+    B = len(seq_lens_q)
+    qo_indptr = torch.zeros(B + 1, dtype=torch.int32)
+    qo_indptr[1:] = torch.cumsum(torch.tensor(seq_lens_q), 0)
+    torch.manual_seed(seed)
+    q = torch.randn(int(qo_indptr[-1]), h_q, d, dtype=dt, device=device)
+
+    page_counts = [(s + page_size - 1) // page_size for s in seq_lens_k]
+    num_pool = sum(page_counts) + 4
+    g = torch.Generator().manual_seed(seed)
+    ids = torch.randperm(num_pool, generator=g)[: sum(page_counts)]
+
+    kv_indptr_tok = torch.zeros(B + 1, dtype=torch.int32)
+    kv_indptr_tok[1:] = torch.cumsum(torch.tensor(seq_lens_k), 0)
+    k_ragged = torch.randn(int(kv_indptr_tok[-1]), h_k, d, dtype=dt, device=device)
+    v_ragged = torch.randn(int(kv_indptr_tok[-1]), h_k, d, dtype=dt, device=device)
+
+    cache = torch.zeros(num_pool, 2, page_size, h_k, d, dtype=dt, device=device)
+    flat = 0
+    for b in range(B):
+        base = int(kv_indptr_tok[b])
+        for p in range(page_counts[b]):
+            lo = base + p * page_size
+            hi = min(base + (p + 1) * page_size, int(kv_indptr_tok[b + 1]))
+            phys = int(ids[flat])
+            cache[phys, 0, : hi - lo] = k_ragged[lo:hi]
+            cache[phys, 1, : hi - lo] = v_ragged[lo:hi]
+            flat += 1
+
+    paged_kv_indptr = torch.zeros(B + 1, dtype=torch.int32)
+    paged_kv_indptr[1:] = torch.cumsum(torch.tensor(page_counts), 0)
+    last_page_len = torch.tensor(
+        [(s - 1) % page_size + 1 for s in seq_lens_k], dtype=torch.int32
+    )
+    return (
+        q,
+        k_ragged,
+        v_ragged,
+        cache,
+        qo_indptr.to(device),
+        kv_indptr_tok.to(device),
+        paged_kv_indptr.to(device),
+        ids.to(torch.int32).to(device),
+        last_page_len.to(device),
+    )
+
+
+def _paged_wrapper(kv_layout="NHD", backend="cute-dsl"):
+    import flashinfer
+
+    ws = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    return flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        ws, kv_layout=kv_layout, backend=backend
+    )
+
+
+def test_paged_wrapper_windowed_bitwise_vs_ragged_wrapper():
+    """Windowed plans route to the modular kernel on BOTH wrappers, so the
+    paged wrapper must be bitwise-equal to the ragged cute-dsl wrapper."""
+    _skip_unless_sm100()
+    import flashinfer
+
+    (q, k_rag, v_rag, cache, qo, kv_tok, kv_pg, ids, lpl) = _build_wrapper_problem(
+        [300, 1291], [300, 1547], 16
+    )
+    w = _paged_wrapper()
+    w.plan(
+        qo,
+        kv_pg,
+        ids,
+        lpl,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        page_size=16,
+        causal=True,
+        window_left=127,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    out_paged = w.run(q, cache)
+
+    ws = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    w_rag = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(ws, backend="cute-dsl")
+    w_rag.plan(
+        qo,
+        kv_tok,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        causal=True,
+        window_left=127,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    out_rag = w_rag.run(q, k_rag, v_rag)
+    assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
+
+
+def test_paged_wrapper_hnd_bitwise_vs_nhd():
+    _skip_unless_sm100()
+    (q, _, _, cache, qo, _, kv_pg, ids, lpl) = _build_wrapper_problem(
+        [300, 1291], [300, 1547], 16
+    )
+    plan_kw = dict(
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        page_size=16,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    w_nhd = _paged_wrapper("NHD")
+    w_nhd.plan(qo, kv_pg, ids, lpl, **plan_kw)
+    out_nhd = w_nhd.run(q, cache)
+
+    w_hnd = _paged_wrapper("HND")
+    w_hnd.plan(qo, kv_pg, ids, lpl, **plan_kw)
+    out_hnd = w_hnd.run(q, cache.transpose(2, 3).contiguous())
+    assert torch.equal(out_hnd.view(torch.int16), out_nhd.view(torch.int16))
+
+
+def test_paged_wrapper_lse():
+    _skip_unless_sm100()
+    (q, _, _, cache, qo, _, kv_pg, ids, lpl) = _build_wrapper_problem(
+        [300, 1291], [300, 1547], 16
+    )
+    w = _paged_wrapper()
+    w.plan(
+        qo,
+        kv_pg,
+        ids,
+        lpl,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        page_size=16,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    out = w.run(q, cache)
+    out_lse, lse = w.run(q, cache, return_lse=True)
+    assert torch.equal(out_lse.view(torch.int16), out.view(torch.int16))
+    assert lse.shape == (q.shape[0], 8) and torch.isfinite(lse).all().item()
+
+
+def test_paged_wrapper_fp8_bitwise_vs_ragged_wrapper():
+    """Uniform fp8 paged vs fp8 ragged, both on the modular kernel via a
+    windowed plan — bitwise, no tolerance calibration needed."""
+    _skip_unless_sm100()
+    import flashinfer
+
+    dt = torch.float8_e4m3fn
+    (q, k_rag, v_rag, cache, qo, kv_tok, kv_pg, ids, lpl) = _build_wrapper_problem(
+        [300, 1291], [300, 1547], 16, dt=torch.bfloat16
+    )
+    q8, k8, v8 = q.to(dt), k_rag.to(dt), v_rag.to(dt)
+    cache8 = cache.to(dt)
+    w = _paged_wrapper()
+    w.plan(
+        qo,
+        kv_pg,
+        ids,
+        lpl,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        page_size=16,
+        causal=True,
+        window_left=511,
+        q_data_type=dt,
+        kv_data_type=dt,
+    )
+    out_paged = w.run(q8, cache8)
+
+    ws = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    w_rag = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(ws, backend="cute-dsl")
+    w_rag.plan(
+        qo,
+        kv_tok,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        causal=True,
+        window_left=511,
+        q_data_type=dt,
+        kv_data_type=dt,
+    )
+    out_rag = w_rag.run(q8, k8, v8)
+    assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
+
+
+def test_paged_wrapper_rejections():
+    _skip_unless_sm100()
+    (q, _, _, cache, qo, _, kv_pg, ids, lpl) = _build_wrapper_problem([300], [300], 16)
+    plan_kw = dict(
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    # unsupported page size
+    w = _paged_wrapper()
+    with pytest.raises(ValueError, match="page_size"):
+        w.plan(qo, kv_pg, ids, lpl, page_size=48, **plan_kw)
+    # mixed plan dtypes
+    w = _paged_wrapper()
+    with pytest.raises(ValueError, match="kv_data_type"):
+        w.plan(
+            qo,
+            kv_pg,
+            ids,
+            lpl,
+            page_size=16,
+            num_qo_heads=8,
+            num_kv_heads=2,
+            head_dim_qk=128,
+            causal=True,
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.float8_e4m3fn,
+        )
+    # mixed-dtype cache tuple at run
+    w = _paged_wrapper()
+    w.plan(qo, kv_pg, ids, lpl, page_size=16, **plan_kw)
+    k_c, v_c = cache[:, 0], cache[:, 1].to(torch.float8_e4m3fn)
+    with pytest.raises(NotImplementedError, match="mixed"):
+        w.run(q, (k_c, v_c))
+    # kv_cache_sf reject
+    with pytest.raises(NotImplementedError, match="kv_cache_sf|NVFP4"):
+        w.run(q, cache, kv_cache_sf=torch.zeros(1, device="cuda"))
+
+
+def test_paged_wrapper_validate_inputs_nan_scan(monkeypatch):
+    """FLASHINFER_VALIDATE_INPUTS=1 must catch NaN in a referenced page."""
+    _skip_unless_sm100()
+    (q, _, _, cache, qo, _, kv_pg, ids, lpl) = _build_wrapper_problem([300], [300], 16)
+    w = _paged_wrapper()
+    w.plan(
+        qo,
+        kv_pg,
+        ids,
+        lpl,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        page_size=16,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    # poison the tail of the last referenced page (past last_page_len)
+    cache[int(ids[-1]), 1, -1] = float("nan")
+    monkeypatch.setenv("FLASHINFER_VALIDATE_INPUTS", "1")
+    with pytest.raises(ValueError, match="non-finite"):
+        w.run(q, cache)
+    monkeypatch.setenv("FLASHINFER_VALIDATE_INPUTS", "0")
+    out = w.run(q, cache)  # scan off: runs (output corrupt by contract)
+    assert out.shape == q.shape

--- a/tests/attention/test_modular_fmha_prefill_paged.py
+++ b/tests/attention/test_modular_fmha_prefill_paged.py
@@ -528,8 +528,18 @@ def test_paged_wrapper_mixed_v_dtype_bitwise_vs_ragged():
         kv_data_type=torch.bfloat16,
     )
 
+    from flashinfer.cute_dsl.attention.wrappers.batch_prefill import (
+        _dsl_supports_expected_tx,
+    )
+
     w = _paged_wrapper()
     w.plan(qo, kv_pg, ids, lpl, page_size=16, **plan_kw)
+    if not _dsl_supports_expected_tx():
+        # Pre-4.6 DSL: mixed V must be rejected with an actionable error
+        # (this asserts the version gate itself).
+        with pytest.raises(NotImplementedError, match="nvidia-cutlass-dsl"):
+            w.run(q, (cache[:, 0], cache[:, 1].to(torch.float8_e4m3fn)))
+        return
     out_paged = w.run(q, (cache[:, 0], cache[:, 1].to(torch.float8_e4m3fn)))
 
     # Reference via the INTERNAL wrapper: it always runs the modular

--- a/tests/attention/test_modular_fmha_prefill_paged.py
+++ b/tests/attention/test_modular_fmha_prefill_paged.py
@@ -232,7 +232,7 @@ SHAPES = [
 
 
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("page_size", [16, 64, 128])
+@pytest.mark.parametrize("page_size", [8, 16, 64, 128])
 @pytest.mark.parametrize("shapes", SHAPES)
 def test_paged_bitwise_vs_ragged(causal, page_size, shapes):
     _skip_unless_sm100()

--- a/tests/attention/test_modular_fmha_prefill_paged.py
+++ b/tests/attention/test_modular_fmha_prefill_paged.py
@@ -398,6 +398,9 @@ def test_paged_wrapper_windowed_bitwise_vs_ragged_wrapper():
         q_data_type=torch.bfloat16,
         kv_data_type=torch.bfloat16,
     )
+    # Routing contract: windowed ragged plans must stay on the modular
+    # kernel, or the bitwise comparison below compares different kernels.
+    assert not w_rag._cute_dsl_use_fmha
     out_rag = w_rag.run(q, k_rag, v_rag)
     assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
 
@@ -493,7 +496,125 @@ def test_paged_wrapper_fp8_bitwise_vs_ragged_wrapper():
         q_data_type=dt,
         kv_data_type=dt,
     )
+    # Routing contract: windowed ragged plans must stay on the modular
+    # kernel, or the bitwise comparison below compares different kernels.
+    assert not w_rag._cute_dsl_use_fmha
     out_rag = w_rag.run(q8, k8, v8)
+    assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
+
+
+def test_paged_wrapper_mixed_v_dtype_bitwise_vs_ragged():
+    """Mixed-dtype paged cache: bf16 Q/K with an fp8 V cache (tuple form).
+
+    The ragged route already serves mixed V as a run()-time property; the
+    paged route reuses the same lazily compiled per-V-dtype kernel variant,
+    so the outputs must be bitwise-equal to the ragged mixed run.
+    """
+    _skip_unless_sm100()
+
+    (q, k_rag, v_rag, cache, qo, kv_tok, kv_pg, ids, lpl) = _build_wrapper_problem(
+        [300, 1291], [300, 1547], 16
+    )
+    plan_kw = dict(
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        causal=True,
+        # windowed on BOTH plans: keeps the ragged wrapper off its FMHA
+        # route (a different kernel, not bitwise-comparable) and covers
+        # the window clamp x paged x mixed-V combination.
+        window_left=127,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+
+    w = _paged_wrapper()
+    w.plan(qo, kv_pg, ids, lpl, page_size=16, **plan_kw)
+    out_paged = w.run(q, (cache[:, 0], cache[:, 1].to(torch.float8_e4m3fn)))
+
+    # Reference via the INTERNAL wrapper: it always runs the modular
+    # kernel, so this comparison is pinned regardless of future changes
+    # to the public ragged wrapper's FMHA-vs-modular routing policy.
+    from flashinfer.cute_dsl.attention import BatchPrefillCuteDSLWrapper
+
+    ws = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    w_rag = BatchPrefillCuteDSLWrapper(ws)
+    w_rag.plan(
+        qo,
+        kv_tok,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        causal=True,
+        window_left=127,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    out_rag = w_rag.run(q, k_rag, v_rag.to(torch.float8_e4m3fn))
+    assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
+
+
+@pytest.mark.parametrize("variant_name", ["sigmoid", "alibi", "sink"])
+def test_paged_wrapper_variants_bitwise_vs_ragged(variant_name):
+    """Attention variants must compose with paged KV.
+
+    The loader is the only stage that differs between the paged and ragged
+    plans, so under the same variant the outputs must be bitwise-equal.
+    Covers one variant per fusion mechanism: sigmoid (logits transform —
+    the softmax->epilogue pipeline topology), ALiBi (score_mod with
+    per-head extra_params and position math), sink (statistics update +
+    output transform in the correction path).
+    """
+    _skip_unless_sm100()
+    from flashinfer.cute_dsl.attention import (
+        ALiBiAttention,
+        AttentionWithSink,
+        BatchPrefillCuteDSLWrapper,
+        SigmoidAttention,
+    )
+
+    (q, k_rag, v_rag, cache, qo, kv_tok, kv_pg, ids, lpl) = _build_wrapper_problem(
+        [300, 1291], [300, 1547], 16
+    )
+    h_q = 8
+
+    def make_variant():
+        if variant_name == "sigmoid":
+            return SigmoidAttention(scale=1.0 / math.sqrt(128), bias=-2.0)
+        if variant_name == "alibi":
+            return ALiBiAttention(
+                torch.linspace(0.1, 0.9, h_q, dtype=torch.float32, device="cuda")
+            )
+        return AttentionWithSink(
+            torch.linspace(-1.0, 1.0, h_q, dtype=torch.float32, device="cuda")
+        )
+
+    plan_kw = dict(
+        num_qo_heads=h_q,
+        num_kv_heads=2,
+        head_dim_qk=128,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+
+    ws = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    w_paged = BatchPrefillCuteDSLWrapper(ws)
+    w_paged.plan(
+        qo,
+        page_size=16,
+        paged_kv_indptr=kv_pg,
+        paged_kv_indices=ids,
+        paged_kv_last_page_len=lpl,
+        variant=make_variant(),
+        **plan_kw,
+    )
+    out_paged = w_paged.run_paged(q, cache)
+
+    ws2 = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    w_rag = BatchPrefillCuteDSLWrapper(ws2)
+    w_rag.plan(qo, kv_tok, variant=make_variant(), **plan_kw)
+    out_rag = w_rag.run(q, k_rag, v_rag)
     assert torch.equal(out_paged.view(torch.int16), out_rag.view(torch.int16))
 
 
@@ -528,15 +649,27 @@ def test_paged_wrapper_rejections():
             q_data_type=torch.bfloat16,
             kv_data_type=torch.float8_e4m3fn,
         )
-    # mixed-dtype cache tuple at run
+    # mixed K at run (only V may differ from the plan); the top-level
+    # wrapper's q/k dtype check fires first, the internal wrapper's
+    # k_cache check backstops direct callers.
     w = _paged_wrapper()
     w.plan(qo, kv_pg, ids, lpl, page_size=16, **plan_kw)
-    k_c, v_c = cache[:, 0], cache[:, 1].to(torch.float8_e4m3fn)
-    with pytest.raises(NotImplementedError, match="mixed"):
+    k_c, v_c = cache[:, 0].to(torch.float8_e4m3fn), cache[:, 1]
+    with pytest.raises(ValueError, match="k_cache|dtype of k"):
         w.run(q, (k_c, v_c))
+    # unsupported V dtype at run
+    with pytest.raises(ValueError, match="v_cache"):
+        w.run(q, (cache[:, 0], cache[:, 1].to(torch.float32)))
     # kv_cache_sf reject
     with pytest.raises(NotImplementedError, match="kv_cache_sf|NVFP4"):
         w.run(q, cache, kv_cache_sf=torch.zeros(1, device="cuda"))
+    # zero-length KV item (would read page-table index -1 in the loader)
+    w = _paged_wrapper()
+    qo_e = torch.tensor([0, 300, 316], dtype=qo.dtype, device=qo.device)
+    kv_pg_e = torch.cat([kv_pg, kv_pg[-1:]])  # second item: zero pages
+    lpl_e = torch.cat([lpl, torch.zeros_like(lpl[:1])])
+    with pytest.raises(ValueError, match="zero-length KV"):
+        w.plan(qo_e, kv_pg_e, ids, lpl_e, page_size=16, **plan_kw)
 
 
 def test_paged_wrapper_validate_inputs_nan_scan(monkeypatch):


### PR DESCRIPTION
## Summary

Adds paged KV cache support to the modular CuTe-DSL Blackwell (SM100) prefill kernel and routes `BatchPrefillWithPagedKVCacheWrapper(backend="cute-dsl")` to it. Paged execution runs at parity with the modular ragged kernel across page sizes 16–128, and within a few percent at page size 8 (dedicated page-table producer warp — see below), with bitwise-identical outputs on identical logical problems at every page size.

## Architecture

**Kernel structure** (context for where paging plugs in — unchanged by this PR): the modular prefill is a warp-specialized kernel, one CTA per (256-row Q tile, KV head group, batch item), 16 warps in fixed roles with per-role `setmaxnreg` budgets:

| warps | role | regs/thread |
|---|---|---|
| 0–3 / 4–7 | softmax warpgroups (one per 128-row Q half-tile) | 192 |
| 8–11 | correction (online-softmax rescale of O partials) | 96 (88 paged) |
| 12 | MMA (tcgen05 QK^T and PV) | 32 (40 paged) |
| 13 | load (TMA Q/K/V) | 32 (40 paged) |
| 14 | epilogue (TMA store O / LSE) | 32 (40 paged) |
| 15 | empty (page-table producer at page_size 8) | 24 |

Roles communicate through mbarrier pipelines: the load warp fills a double-buffered Q ring and a shared K/V smem ring (3 stages bf16, 4 stages fp8); the MMA warp consumes them into TMEM S tiles; softmax reads S and writes P; MMA runs PV; correction rescales output partials; the epilogue stores O. Wall time in the small-band regime is set by the per-KV-tile cadence of this pipeline, which is what paging must not disturb.

**Paged design** (per-page TMA mechanism from the in-repo MLA decode loader):

- **Layout**: the kernel reads K and V from page pools viewed as `(num_pages, page_size, H_kv, head_dim)`. Only `head_dim` must be contiguous; the other three strides are runtime arguments of a single compiled kernel (one per page size), so the same binary handles an NHD-contiguous pool, an HND pool passed as a transposed view, or the K/V slices of a combined `(num_pages, 2, ...)` cache. The TMA descriptor is built once on the host over the entire pool, and a copy selects which page to load by passing that page's physical index as one of its TMA coordinates — the page-table indirection is a coordinate, not per-page pointer arithmetic.
- **Logical/physical split**: the load warp is the only role that sees pages. It takes `kv_page_table` + `kv_page_indptr`; mask, softmax, correction and epilogue operate on logical token cumsums, untouched.
- **Zero-fill contract**: out-of-range page ids become −1 → the TMA coordinate goes out of bounds, the smem box is zero-filled, and complete-tx still credits the full byte count. This covers pages past the sequence tail *and*, on sliding-window kernels, table slots below the window start: serving frameworks repoint reclaimed slots at a shared null block that may hold garbage/NaN, and score masking cannot save the V path (P = +0.0, but 0×NaN = NaN through the PV MMA), so the load itself must be skipped. The window clamp runs only on an item's first KV tile (the window lower bound falls inside it by construction); the table read is min-clamped to the item's slice (on the page-table-ring path below, the same clamps are applied at produce time instead).
- **Page-table ring (page_size 8)**: at 16 pages per KV tile the loader's in-loop id loads — one global-latency load per TMA copy, twice per tile across the K and V loops — dominate its issue cadence. The otherwise-idle empty warp therefore stages each tile's ids into a 4-stage smem ring (`cp.async`, its own tile-scheduler instance, tail/window → −1 clamps applied at produce time), and the load warp reads them back at LDS latency — the MLA-decode pt-loader design. Compile-time gated to `pages_per_kv_tile >= 16`: at larger page sizes the ring's fixed per-tile handshake measured worse than the id loads it removes.
- **Register rebalance** (paged-only): one 8-register `setmaxnreg` quantum moves from correction to the mma/load/epilogue group. Spill-free either way; measured ~1–2% at ps16/32.

Non-paged kernels are unaffected: all paged code is `const_expr`-gated and ragged cubins compile byte-identical.

## Performance

B200, CUPTI cold-L2 interleaved, 3-pass medians (9 passes for the two >4 ms cells, which drift at 3), hq/hk = 32/8, scrambled page tables, ratio = paged / modular-ragged on identical logical problems (bitwise-identical outputs; sliding-N = sliding window of N + causal):

| dtype | d | B | S | mask | ragged (µs) | ps8 | ps16 | ps32 | ps64 | ps128 |
|---|---|---|---|---|---|---|---|---|---|---|
| bf16 | 128 | 1 | 16K | sliding-1024 | 374 | 1.071 | 1.027 | 1.017 | 1.024 | 1.013 |
| bf16 | 128 | 4 | 2K | sliding-512 | 158 | 1.069 | 1.025 | 1.019 | 1.026 | 1.009 |
| bf16 | 128 | 4 | 2K | causal | 172 | 1.072 | 1.041 | 1.007 | 1.014 | 1.000 |
| bf16 | 128 | 16 | 512 | causal | 97 | 1.058 | 1.015 | 1.011 | 1.019 | 1.000 |
| bf16 | 128 | 8 | 8K | causal | 4498 | 1.015 | 1.014 | 1.014 | 1.006 | 0.977 |
| bf16 | 128 | 2 | 16K | causal | 4221 | 1.031 | 1.018 | 1.009 | 1.019 | 1.021 |
| bf16 | 128 | 4 | 2K | full | 243 | 1.075 | 1.072 | 1.039 | 1.010 | 1.024 |
| bf16 | 128 | 16 | 512 | full | 94 | 1.091 | 1.080 | 1.028 | 1.018 | 1.013 |
| bf16 | 64 | 4 | 2K | sliding-512 | 132 | 1.066 | 1.013 | 0.995 | 0.998 | 0.992 |
| bf16 | 64 | 4 | 2K | causal | 150 | 1.080 | 1.058 | 1.037 | 1.035 | 1.009 |
| bf16 | 64 | 16 | 512 | causal | 79 | 1.083 | 1.052 | 1.034 | 1.028 | 1.013 |
| bf16 | 64 | 8 | 8K | causal | 3043 | 1.043 | 1.021 | 1.007 | 1.004 | 0.999 |
| fp8 | 128 | 4 | 2K | sliding-512 | 144 | 1.050 | 1.005 | 1.005 | 1.009 | 0.993 |
| fp8 | 128 | 4 | 2K | causal | 160 | 1.050 | 1.025 | 1.025 | 1.028 | 1.007 |
| fp8 | 128 | 8 | 8K | causal | 3160 | 1.023 | 1.015 | 1.008 | 1.010 | 0.999 |

## Tests

`tests/attention/test_modular_fmha_prefill_paged.py`: bitwise-vs-ragged anchor (identity + scrambled tables × masks × page sizes 8–128 × varlen incl. 1/7-token seqs × partial last page), pool-garbage immunity, NaN canaries (tail + null-block window slots) at head dims 64 and 128, window clamp boundary cases, LSE/fp8/mixed-dtype feature matrix, wrapper integration + rejection paths (dtype universe, combined-cache-with-mixed-dtypes, unsupported page size).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paged KV-cache support for CuTe DSL prefill attention.
  * Added page-table execution for variable-length pages and NHD/HND cache layouts.
  * Added support for causal and windowed attention, FP8 and mixed-dtype caches, LSE output, ALiBi, soft-capping, and selected ragged-cache workloads.
  * Added validation for cache shapes, layouts, dtypes, page sizes, and unsupported options.

* **Bug Fixes**
  * Improved handling of invalid, trailing, and window-excluded pages.

* **Tests**
  * Added comprehensive paged-versus-ragged output coverage across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
