### PR TITLE
fix(jit): pass map_sm107_to_100f in gen_moe_utils_module

### DIFF
--- a/flashinfer/jit/moe_utils.py
+++ b/flashinfer/jit/moe_utils.py
@@ -74,8 +74,14 @@ def gen_moe_utils_module() -> JitSpec:
         "-DENABLE_FP4",
     ]
 
+    # SM107 (Rubin) must be built for the sm100f family target: no public CUDA
+    # toolkit (13.0 or 13.2) accepts ``compute_107a``, so without this mapping
+    # nvcc aborts with "Unsupported gpu architecture 'compute_107a'". Every other
+    # MoE JitSpec already opts in; this one was missed. Because these flags are
+    # passed as ``extra_cuda_cflags`` they override the correctly-mapped global
+    # flags, so omitting it here is not merely redundant -- it breaks the build.
     nvcc_flags += current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10]
+        supported_major_versions=[10], map_sm107_to_100f=True
     )
 
     return gen_jit_spec(


### PR DESCRIPTION
## 📌 Description

`gen_moe_utils_module()` is the only MoE JitSpec that does not pass `map_sm107_to_100f=True`. On Rubin (SM107) this breaks the build outright:

```
nvcc fatal   : Unsupported gpu architecture 'compute_107a'
```

No public CUDA toolkit (13.0 or 13.2) accepts `compute_107a`, so the SM107 → `sm100f` family mapping is required.

### Why the omission is not merely redundant

These flags are passed as `extra_cuda_cflags`. In `build_cuda_cflags` (`flashinfer/jit/cpp_ext.py`), the `module_has_gencode` branch lets module-level flags **override** the globally computed, correctly-mapped flags. So leaving the argument off does not fall back to the global mapping — it *removes* it.

### Blast radius

Strictly a no-op off Rubin. `CompilationContext.get_nvcc_flags_list` only rewrites the gencode when `(major, minor) == (10, "7a")`:

```python
if apply_sm107_mapping and major == 10 and minor == "7a":
    flags.append("-gencode=arch=compute_100f,code=sm_100f")
```

`apply_sm107_mapping` is additionally gated on `not cutlass_supports_sm107()`, so once the bundled CUTLASS gains native `compute_107a` support this stops applying automatically, with no further code change.

Affects the CuteDSL MoE path — `gen_moe_utils_module()` is reached from `aot.py` and `flashinfer/fused_moe/cute_dsl/moe_utils.py`.

## 🔍 Related Issues

Found while investigating the Rubin NVFP4 MoE failure. This is **independent of** and complementary to #4168 / #4213 (incompatible output-scale cubins) — that one fixes a runtime correctness bug, this one fixes a build break. Both are needed on Rubin.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] All tests are passing (`unittest`, etc.).

Verified on Hecate GR100 (cc 10.7, aarch64): without this change the `moe_utils` JIT module fails to compile on SM107; with it the module builds and the MoE suites run.

No test added — this is a build-configuration fix on a JitSpec, exercised by any SM107 build of the CuteDSL MoE path.

## Reviewer Notes

Single-line change plus comment. Every other MoE JitSpec already opts into this mapping; this one appears to have simply been missed when SM107 support was added in #4122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)