### PR TITLE
feat(examples): exercise and audit top-k/top-p sampling end to end

### DIFF
--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -1,0 +1,124 @@
+# End-to-End PyTorch LLM Examples
+
+Tracking doc for the `examples/pytorch/llm/` effort.
+
+## Motivation
+
+FlashInfer's test suite is kernel-centric: each op is validated in isolation
+against a reference. What we lack is a *self-contained* end-to-end exercise of
+the library — a real model forward pass that strings together attention
+(paged KV cache, prefill + decode), RoPE, RMSNorm, activation, GEMM, and
+sampling the way a serving stack would. Integration-level regressions are
+invisible to unit tests but very visible to users, e.g.:
+
+- JIT/cubin cache not being hit → kernels silently recompiling on every
+  process start (or worse, every call);
+- backend dispatch quietly falling back to a slow/generic path on some
+  SM version;
+- plan/run wrapper API drift that only shows up when prefill, append, and
+  decode are used together across steps;
+- dtype/layout mismatches between ops that each pass their own unit tests.
+
+Serving frameworks that embed FlashInfer do catch some of this, but through
+their own abstraction layers and on their own release cadence. These examples
+let us close the loop *within this repo*: a plain-PyTorch reference usage of
+the public API that we can run on any machine with weights from Hugging Face
+and no external inference framework in the dependency chain. They are
+**reference/verification code, not a serving engine** — for production
+inference, use a real serving stack. The point is that when something breaks
+end to end, we can reproduce and bisect it here with nothing but
+`flashinfer + torch + transformers(tokenizer/config only) + safetensors`.
+
+This extends the existing `examples/pytorch/` direction (the WAN diffusion
+example) to the LLM serving path, which is FlashInfer's core use case.
+
+## Non-goals
+
+- Production-grade throughput (no continuous batching scheduler, no
+  overlapping, no speculative decoding). Batching exists only to exercise the
+  batched kernel paths.
+- Competing with or benchmarking against inference frameworks.
+- Covering every model architecture. We pick a small set that maximizes
+  kernel-path coverage per line of example code.
+
+## What fits on a B200 node
+
+Working numbers: one B200 has 192 GB HBM3e (~180 GB usable). A node gives us
+up to 4 GPUs ≈ 768 GB nominal. Weights-only footprint below; add ~10–20 % for
+KV cache + activations at modest batch/context.
+
+### Single GPU (1× B200, 192 GB)
+
+| Model | Params | Weights (BF16) | Notes |
+|---|---|---|---|
+| Qwen3-0.6B / 1.7B / 4B | 0.6–4 B | 1.2–8 GB | fast smoke-test tier; ungated |
+| Llama-3.2-1B / 3B, Llama-3.1-8B | 1–8 B | 2–16 GB | gated on HF (license click-through) |
+| Qwen3-8B / 14B / 32B (dense) | 8–32 B | 16–64 GB | ungated; good single-GPU "real model" tier |
+| Qwen3-30B-A3B (MoE) | 30 B total / 3 B active | ~60 GB | exercises fused MoE path on one GPU |
+| Mixtral-8x7B | 47 B | ~94 GB | classic MoE |
+| GPT-OSS-20B / 120B | 20 B / 117 B | ~12 / ~60 GB (native MXFP4) | exercises MXFP4 weight path |
+| Llama-3.3-70B | 70 B | ~140 GB BF16 (tight) / ~70 GB FP8 | FP8 comfortable on one GPU |
+
+### 2–4 GPUs (TP)
+
+| Model | Weights | Fits? |
+|---|---|---|
+| Qwen3-235B-A22B (MoE) | ~235 GB FP8 / ~470 GB BF16 | FP8 on 2 GPUs, BF16 on 4 |
+| Llama-3.1-405B | ~405 GB FP8 | 4 GPUs, tight but viable at small batch |
+| DeepSeek-V3 / R1 (671B) | ~671 GB native FP8 | **no** at 4 GPUs once KV + activations are counted; needs a full 8-GPU node |
+| Kimi-K2 (1T) | > 1 TB | no |
+
+Conclusion: everything we need for phase 1 (dense GQA + MoE + FP8/FP4 weight
+paths) runs on **one** B200; 4 GPUs only become interesting when we add
+tensor-parallel examples (phase 3).
+
+## Example design
+
+Directory: `examples/pytorch/llm/`
+
+| File | Purpose |
+|---|---|
+| `modeling.py` | Llama/Qwen-family decoder built from FlashInfer ops: `BatchPrefillWithPagedKVCacheWrapper`, `BatchDecodeWithPagedKVCacheWrapper`, `append_paged_kv_cache`, `apply_rope_pos_ids`, `rmsnorm`/`fused_add_rmsnorm`, `silu_and_mul`. Weights loaded straight from HF safetensors (no `AutoModel`). |
+| `generate.py` | CLI: prompt(s) → prefill → decode loop → text, with FlashInfer sampling ops; `--max-tokens`, `--batch`, greedy or top-k/top-p. |
+| `smoke_test.py` | The verification harness (see below). |
+| `README.md` | Usage + backend/env-var knobs, mirroring the style of `examples/pytorch/README.md`. |
+
+Model support keyed off HF `config.json` `model_type` ∈ {`llama`, `qwen2`,
+`qwen3`} — same skeleton (RMSNorm → GQA attn with RoPE → SwiGLU FFN), small
+per-family deltas (Qwen3 q/k per-head norm, Qwen2 QKV bias, Llama-3.1 RoPE
+scaling).
+
+### The verification harness (`smoke_test.py`)
+
+This is the actual point of the exercise. Checks, each cheap and scriptable:
+
+1. **Correctness sanity** — greedy decode of a fixed prompt must be
+   deterministic across runs and produce a plausible continuation. Optionally
+   compare prefill logits against a `transformers` eager forward (tolerance
+   check) when `--reference` is passed.
+2. **JIT/cache hygiene** — run generation in a fresh subprocess twice; the
+   second run must not invoke `nvcc`/`cicc` (asserted via
+   `FLASHINFER_LOGGING_LEVEL=DEBUG` JIT logs) and its module-load phase must
+   be dramatically faster. This is the "kernel cache silently broken" canary.
+3. **No recompiles across steps** — within one process, decode steps after
+   warmup must not trigger new JIT builds (plan/run reuse working).
+4. **Backend dispatch** — the selected attention/GEMM backends actually run
+   (no silent fallback), asserted via `FLASHINFER_LOGLEVEL` API logs.
+
+## Status log
+
+- **2026-07-21** — doc created; upstream main synced (`b7cd951d`). Phase 1
+  in progress: dense Qwen3/Llama single-GPU example + smoke harness, to be
+  validated on a computelab B200.
+
+## Roadmap
+
+- **Phase 1 (this change):** dense single-GPU example (Qwen3 0.6B–32B,
+  Llama-family), paged-KV prefill/decode, sampling, smoke harness; validate
+  on B200.
+- **Phase 2:** MoE variant (Qwen3-30B-A3B) exercising `fused_moe`; FP8/FP4
+  weight-quantized linear via the shared `flashinfer_modules.py` backends.
+- **Phase 3:** tensor-parallel (2–4 GPU) variant exercising
+  `flashinfer.comm` all-reduce; unlocks the 70B–235B tier.
+- **Phase 4:** wire the smoke harness into CI (it's designed to be a
+  single-command pass/fail).

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -135,6 +135,11 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
     as 0.6B (head_dim 128, BF16).
   - Note: decode with `use_tensor_cores=True` shares the prefill module, so
     the dense BF16 path needs only 4 JIT modules end to end.
+- **2026-07-21** — `--chat` mode validated on B200 (Qwen3-8B, greedy,
+  96 tokens): correct answers to factual questions, EOS stop confirmed,
+  ~404 tok/s batch-3 decode. One portability fix: transformers v5 changed
+  `apply_chat_template`'s tokenized return type, so the example now renders
+  the template to text and tokenizes explicitly.
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -167,7 +167,27 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
   the identical kernel path as Qwen3-30B-A3B, so no large download is needed
   for functional verification. Remaining: FP8/FP4 weight-quantized linear
   backends.
-- **Phase 3:** tensor-parallel (2–4 GPU) variant exercising
-  `flashinfer.comm` all-reduce; unlocks the 70B–235B tier.
-- **Phase 4:** wire the smoke harness into CI (it's designed to be a
-  single-command pass/fail).
+- **Phase 3 (in progress):** TEP (TP=EP) multi-GPU — attention
+  tensor-parallel, MoE expert-parallel over the same ranks, two NCCL
+  allreduces per layer, launched with `torchrun`; `reference_check.py`
+  validates the sharded result against the single-GPU transformers
+  reference. Follow-ups: swap NCCL allreduce for `flashinfer.comm`
+  (trtllm/vllm allreduce) as a selectable backend; 4-GPU runs for the
+  70B–235B tier.
+- **Phase 4 (started):** health instrumentation + performance gates.
+  `health_check.py` measures the serving lifecycle (import, load, cold
+  prefill incl. JIT builds, warm prefill/decode throughput, steady-state
+  recompiles, optional autotune delta) and emits JSON — the gate inputs.
+  Planned next: CUDA-graph capture of the decode step
+  (`use_cuda_graph=True` wrapper mode with preallocated page tables),
+  threshold files + trend comparison, then CI wiring of
+  smoke/reference/health checks. Multi-node is explicitly out of scope for
+  now.
+
+### Ops note: persistent JIT cache for GPU-node runs
+
+Node containers are ephemeral; a container-local `~/.cache/flashinfer`
+loses the ~1 h `fused_moe_100` compile on every teardown. Runs now mount an
+NFS-backed cache (`flashinfer2/var/jit_cache` →
+`/home/aleyang/.cache/flashinfer`), so any node/container reuses compiled
+artifacts.

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -110,6 +110,21 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
 - **2026-07-21** — doc created; upstream main synced (`b7cd951d`). Phase 1
   in progress: dense Qwen3/Llama single-GPU example + smoke harness, to be
   validated on a computelab B200.
+- **2026-07-21** — first B200 deployment (Qwen3-0.6B) surfaced two findings
+  on day one, validating the approach:
+  1. *Environment class:* a source checkout without the (new) `3rdparty/cccl`
+     submodule fails every attention JIT compile — the JIT include path puts
+     the vendored CCCL first and `fastdiv.cuh` now needs
+     `cuda::fast_mod_div`, so an empty `3rdparty/cccl` silently falls back to
+     the CUDA toolkit's older libcudacxx and nvcc errors out. Anyone
+     updating an existing checkout across that upstream change hits this.
+  2. *Harness calibration:* `JitSpecNvcc.try_load()` returns `None` for
+     JIT-path modules *by design* (artifact freshness is delegated to
+     ninja's dependency scan), so `build()` runs in every fresh process and
+     ninja no-ops on a warm cache. "Recompile" must therefore be measured as
+     "built artifact changed across `build()`", which is what the harness
+     now does; raw `build()` invocations are reported separately as the
+     warm-start overhead metric (`jit_build_calls`).
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -152,6 +152,17 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
   checkpoints (all real HF models tested) were unaffected. Also measured:
   the `fused_moe_100` module is by far the heaviest JIT unit (267 objects,
   ~1 h cold compile at 30-way parallelism on the shared node).
+- **2026-07-22** — Phase 3 TEP validated on 2× B200 (umbriel-b200-040):
+  `torchrun --nproc_per_node=2 reference_check.py` matches the single-GPU
+  transformers reference at identical quality (dense rel-L2 0.0077–0.0089,
+  MoE 0.0080–0.0383, top-1 agreement everywhere) — TP attention sharding,
+  EP expert dispatch (`ep_size/ep_rank` + global routing), and both
+  allreduce points are numerically correct. `health_check.py` passes in
+  both modes with `jit_builds_cold=0` — the NFS-mounted JIT cache
+  (ops note below) served a fresh container on a different node with zero
+  recompiles. Tiny-model TEP throughput is (expectedly) below single-GPU
+  (decode 1601 vs 1847 tok/s) since allreduce latency dominates at toy
+  sizes; real-model TEP numbers are a phase-4 measurement.
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -125,6 +125,16 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
      "built artifact changed across `build()`", which is what the harness
      now does; raw `build()` invocations are reported separately as the
      warm-start overhead metric (`jit_build_calls`).
+- **2026-07-21** — Phase 1 validated on B200 (computelab, CI cu130 image):
+  - Cold cache: Qwen3-0.6B smoke run 1 compiled 4 modules (batch_prefill,
+    rope, page, silu_and_mul; 57.8 s), run 2 compiled **0** (6.4 s) —
+    cross-process cache reuse confirmed; greedy outputs identical; zero
+    steady-state builds. `smoke_test.py` exit 0.
+  - Qwen3-8B (36 layers): coherent batch-3 completions, ~316 tok/s decode
+    (uninstrumented loop, not a benchmark), zero compiles — same kernel URIs
+    as 0.6B (head_dim 128, BF16).
+  - Note: decode with `use_tensor_cores=True` shares the prefill module, so
+    the dense BF16 path needs only 4 JIT modules end to end.
 
 ## Roadmap
 

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -143,11 +143,18 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
 
 ## Roadmap
 
-- **Phase 1 (this change):** dense single-GPU example (Qwen3 0.6B–32B,
+- **Phase 1 (done):** dense single-GPU example (Qwen3 0.6B–32B,
   Llama-family), paged-KV prefill/decode, sampling, smoke harness; validate
   on B200.
-- **Phase 2:** MoE variant (Qwen3-30B-A3B) exercising `fused_moe`; FP8/FP4
-  weight-quantized linear via the shared `flashinfer_modules.py` backends.
+- **Phase 2 (in progress):** `qwen3_moe` support through
+  `fused_moe.cutlass_fused_moe` (BF16 SwiGLU experts, external
+  softmax→top-k→renorm routing mirroring the HF reference), plus
+  `reference_check.py`: tiny random-weight dense/MoE checkpoints built with
+  `transformers`, our last-token prefill logits asserted against
+  transformers eager within a relative-L2 tolerance. The tiny MoE exercises
+  the identical kernel path as Qwen3-30B-A3B, so no large download is needed
+  for functional verification. Remaining: FP8/FP4 weight-quantized linear
+  backends.
 - **Phase 3:** tensor-parallel (2–4 GPU) variant exercising
   `flashinfer.comm` all-reduce; unlocks the 70B–235B tier.
 - **Phase 4:** wire the smoke harness into CI (it's designed to be a

--- a/docs/design_docs/e2e_pytorch_llm_examples.md
+++ b/docs/design_docs/e2e_pytorch_llm_examples.md
@@ -140,6 +140,18 @@ This is the actual point of the exercise. Checks, each cheap and scriptable:
   ~404 tok/s batch-3 decode. One portability fix: transformers v5 changed
   `apply_chat_template`'s tokenized return type, so the example now renders
   the template to text and tokenizes explicitly.
+- **2026-07-22** — Phase 2 (MoE) validated on B200. `reference_check.py`
+  results vs transformers eager (bf16, tolerance 0.05 rel-L2):
+  dense 0.008–0.010, MoE 0.007–0.039, top-1 agreement at every length;
+  tiny-MoE decode loop deterministic. The check caught a real bug on its
+  first run: transformers v5 moved rope config into nested
+  `rope_parameters` (and renamed the expert count to `num_local_experts`),
+  so the old flat-schema read silently used rope_theta=1e4 for v5-saved
+  checkpoints — a with-length-growing logits divergence (0.16→0.64) that
+  the HF-bf16-vs-fp32 baseline (~0.007, flat) proved was ours. Older
+  checkpoints (all real HF models tested) were unaffected. Also measured:
+  the `fused_moe_100` module is by far the heaviest JIT unit (267 objects,
+  ~1 h cold compile at 30-way parallelism on the shared node).
 
 ## Roadmap
 

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -3,6 +3,11 @@
 This directory contains reusable FlashInfer PyTorch building blocks and model
 examples that use them.
 
+| Example | Description |
+|---------|-------------|
+| [`llm/`](llm/) | Self-contained Llama/Qwen decoder over FlashInfer's paged-KV prefill/decode path, with an end-to-end smoke test (JIT-cache reuse, determinism) |
+| [`wan/`](wan/) | WAN text-to-video diffusion transformer using the shared modules below |
+
 ## Shared Modules
 
 `flashinfer_modules.py` contains model-independent components that can be reused

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -1,13 +1,20 @@
 # FlashInfer LLM Example (Llama / Qwen dense)
 
 A self-contained, plain-PyTorch LLM decoder built from FlashInfer's
-serving-path ops. This is **reference and verification code, not a serving
-engine**: it exists so FlashInfer's public APIs can be exercised end to end —
-paged KV cache, batched prefill/decode attention, RoPE, RMSNorm, SwiGLU
-activation, and sampling — with nothing but `flashinfer`, `torch`, and a
-Hugging Face checkpoint. Integration-level regressions (a broken JIT cache,
-per-step recompiles, silent backend fallbacks) show up here even when every
-kernel unit test passes. Background and roadmap:
+serving-path ops.
+
+**Scope.** Serving models independently is explicitly *not* a goal of this
+example — production inference belongs to the serving frameworks that build
+on FlashInfer. What *is* the goal, and what we consider paramount for the
+library's robustness, is being able to **close the loop independently**: a
+functional end-to-end verification path that exercises FlashInfer's public
+APIs the way a serving stack composes them — paged KV cache, batched
+prefill/decode attention, RoPE, RMSNorm, SwiGLU activation, and sampling —
+with nothing but `flashinfer`, `torch`, and a Hugging Face checkpoint.
+Integration-level regressions (a broken JIT cache, per-step recompiles,
+silent backend fallbacks) show up here even when every kernel unit test
+passes, and can be reproduced and bisected inside this repo without any
+external framework in the dependency chain. Background and roadmap:
 [`docs/design_docs/e2e_pytorch_llm_examples.md`](../../../docs/design_docs/e2e_pytorch_llm_examples.md).
 
 ## FlashInfer APIs exercised

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -1,0 +1,87 @@
+# FlashInfer LLM Example (Llama / Qwen dense)
+
+A self-contained, plain-PyTorch LLM decoder built from FlashInfer's
+serving-path ops. This is **reference and verification code, not a serving
+engine**: it exists so FlashInfer's public APIs can be exercised end to end —
+paged KV cache, batched prefill/decode attention, RoPE, RMSNorm, SwiGLU
+activation, and sampling — with nothing but `flashinfer`, `torch`, and a
+Hugging Face checkpoint. Integration-level regressions (a broken JIT cache,
+per-step recompiles, silent backend fallbacks) show up here even when every
+kernel unit test passes. Background and roadmap:
+[`docs/design_docs/e2e_pytorch_llm_examples.md`](../../../docs/design_docs/e2e_pytorch_llm_examples.md).
+
+## FlashInfer APIs exercised
+
+| API | Where |
+|-----|-------|
+| `BatchPrefillWithPagedKVCacheWrapper` (plan/run, causal, ragged batch) | prompt prefill |
+| `BatchDecodeWithPagedKVCacheWrapper` (plan/run, tensor cores) | token-by-token decode |
+| `append_paged_kv_cache`, `get_batch_indices_positions` | paged KV maintenance every step |
+| `apply_rope_pos_ids_inplace` / `apply_llama31_rope_pos_ids_inplace` | rotary embedding (incl. Llama-3.1 scaling) |
+| `rmsnorm`, `fused_add_rmsnorm` | pre/post-attention norms, Qwen3 per-head q/k norm |
+| `silu_and_mul` | SwiGLU FFN |
+| `sampling.top_k_top_p_sampling_from_logits` | non-greedy sampling |
+
+## Supported models
+
+Any dense Hugging Face checkpoint with `model_type` ∈ {`llama`, `qwen2`,
+`qwen3`}. Weights are read straight from safetensors (BF16 compute). Sizing
+guide (single GPU): Qwen3-0.6B…32B and Llama 1B…8B fit comfortably on one
+modern data-center GPU; see the design doc for a full B200 fit table.
+
+| Tier | Model | Notes |
+|------|-------|-------|
+| Smoke test (fast) | `Qwen/Qwen3-0.6B` | default; ungated download |
+| Real model | `Qwen/Qwen3-8B`, `Qwen/Qwen3-32B` | ungated |
+| Llama family | `meta-llama/Llama-3.1-8B-Instruct` | gated (HF license); exercises llama3 RoPE scaling |
+
+## Usage
+
+```bash
+# Batch greedy completion with the built-in prompts
+python generate.py --model-id Qwen/Qwen3-0.6B --max-tokens 32
+
+# Chat template + sampling
+python generate.py --model-id Qwen/Qwen3-8B --chat \
+  --prompt "Explain KV cache paging in two sentences." \
+  --temperature 0.7 --top-k 50 --top-p 0.9 --max-tokens 128
+
+# Steer the attention backends (forwarded to the wrapper constructors)
+python generate.py --prefill-backend fa2 --decode-backend fa2
+```
+
+`generate.py` prints the completions, coarse prefill/decode timing (this is a
+correctness harness — the timing includes JIT warmup and per-step host work;
+do not read it as a benchmark), and machine-readable `[smoke] key=value`
+lines used by the smoke test.
+
+## Smoke test
+
+```bash
+python smoke_test.py --model-id Qwen/Qwen3-0.6B --max-tokens 16
+```
+
+Runs generation in two fresh processes and asserts:
+
+1. the second process compiles **zero** JIT modules (on-disk kernel cache is
+   actually reused — catches "cache silently broken, everyone recompiles");
+2. no JIT build ever happens during steady-state decode steps;
+3. greedy outputs are identical across the two runs;
+4. every request produced tokens.
+
+Exit code 0/1, suitable for CI. To force a fully cold first run:
+`rm -rf ~/.cache/flashinfer` first.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `modeling.py` | config/weight loading, paged KV cache, decoder forward pass |
+| `generate.py` | CLI generation loop (prefill → decode → sample) + JIT-build counter |
+| `smoke_test.py` | two-process verification harness (see above) |
+
+## Requirements
+
+`flashinfer`, `torch`, and — for checkpoint/tokenizer handling only —
+`transformers`, `huggingface_hub`, `safetensors`. No inference framework is
+imported; model weights download to the standard HF cache (`HF_HOME`).

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -88,7 +88,40 @@ Exit code 0/1, suitable for CI. To force a fully cold first run:
 | `modeling.py` | config/weight loading, paged KV cache, decoder forward pass (dense + MoE) |
 | `generate.py` | CLI generation loop (prefill → decode → sample) + JIT-build counter |
 | `smoke_test.py` | two-process verification harness (see above) |
-| `reference_check.py` | numerical check: tiny random dense/MoE models, last-token prefill logits vs `transformers` eager within a relative-L2 tolerance |
+| `reference_check.py` | numerical check: tiny random dense/MoE models, last-token prefill logits vs `transformers` eager within a relative-L2 tolerance; also runs under `torchrun` for TEP |
+| `health_check.py` | lifecycle metrics (import / load / cold prefill+JIT / warm prefill / decode throughput / steady recompiles) with JSON output — groundwork for performance gates |
+
+## Multi-GPU: TEP (TP = EP)
+
+Launch any of the scripts with `torchrun` to run tensor-parallel attention
+with expert-parallel MoE over the same ranks — the standard single-node
+deployment shape for MoE models, minimally mimicked:
+
+```bash
+torchrun --nproc_per_node=2 reference_check.py           # numerics vs 1-GPU reference
+torchrun --nproc_per_node=2 generate.py --model-id Qwen/Qwen3-0.6B
+torchrun --nproc_per_node=2 health_check.py --tiny moe
+```
+
+Sharding: QKV column-parallel / `o_proj` row-parallel, dense-FFN gate/up
+column- / down row-parallel, MoE experts sliced per rank
+(`cutlass_fused_moe(ep_size=, ep_rank=)` with global routing computed on
+every rank). Exactly two allreduces per layer (post-attention and
+post-FFN/MoE), over NCCL. Requires head counts / intermediate size / expert
+count divisible by the world size.
+
+## Health instrumentation
+
+```bash
+python health_check.py --tiny moe --json health.json
+python health_check.py --model-id Qwen/Qwen3-8B --batch 4 --prompt-len 512 --autotune
+```
+
+Reports import / load / cold-prefill (JIT warmup) / warm prefill / decode
+throughput / steady-state recompile count (must be 0), optionally re-measured
+after an `autotune(True)` warmup pass. The JSON output is the intended input
+for future performance gates. Host-side timings — for trend and gating, not
+kernel benchmarking.
 
 ## Requirements
 

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -26,13 +26,14 @@ external framework in the dependency chain. Background and roadmap:
 | `append_paged_kv_cache`, `get_batch_indices_positions` | paged KV maintenance every step |
 | `apply_rope_pos_ids_inplace` / `apply_llama31_rope_pos_ids_inplace` | rotary embedding (incl. Llama-3.1 scaling) |
 | `rmsnorm`, `fused_add_rmsnorm` | pre/post-attention norms, Qwen3 per-head q/k norm |
-| `silu_and_mul` | SwiGLU FFN |
+| `silu_and_mul` | SwiGLU FFN (dense layers) |
+| `fused_moe.cutlass_fused_moe` | MoE expert dispatch (`qwen3_moe`): SwiGLU experts with external top-k routing |
 | `sampling.top_k_top_p_sampling_from_logits` | non-greedy sampling |
 
 ## Supported models
 
-Any dense Hugging Face checkpoint with `model_type` ∈ {`llama`, `qwen2`,
-`qwen3`}. Weights are read straight from safetensors (BF16 compute). Sizing
+Any Hugging Face checkpoint with `model_type` ∈ {`llama`, `qwen2`, `qwen3`,
+`qwen3_moe`}. Weights are read straight from safetensors (BF16 compute). Sizing
 guide (single GPU): Qwen3-0.6B…32B and Llama 1B…8B fit comfortably on one
 modern data-center GPU; see the design doc for a full B200 fit table.
 
@@ -41,6 +42,7 @@ modern data-center GPU; see the design doc for a full B200 fit table.
 | Smoke test (fast) | `Qwen/Qwen3-0.6B` | default; ungated download |
 | Real model | `Qwen/Qwen3-8B`, `Qwen/Qwen3-32B` | ungated |
 | Llama family | `meta-llama/Llama-3.1-8B-Instruct` | gated (HF license); exercises llama3 RoPE scaling |
+| MoE | `Qwen/Qwen3-30B-A3B` | ungated; ~60 GB BF16, one B200-class GPU; `reference_check.py` covers the same kernel path with a tiny model |
 
 ## Usage
 
@@ -83,9 +85,10 @@ Exit code 0/1, suitable for CI. To force a fully cold first run:
 
 | File | Purpose |
 |------|---------|
-| `modeling.py` | config/weight loading, paged KV cache, decoder forward pass |
+| `modeling.py` | config/weight loading, paged KV cache, decoder forward pass (dense + MoE) |
 | `generate.py` | CLI generation loop (prefill → decode → sample) + JIT-build counter |
 | `smoke_test.py` | two-process verification harness (see above) |
+| `reference_check.py` | numerical check: tiny random dense/MoE models, last-token prefill logits vs `transformers` eager within a relative-L2 tolerance |
 
 ## Requirements
 

--- a/examples/pytorch/llm/README.md
+++ b/examples/pytorch/llm/README.md
@@ -123,6 +123,38 @@ after an `autotune(True)` warmup pass. The JSON output is the intended input
 for future performance gates. Host-side timings — for trend and gating, not
 kernel benchmarking.
 
+## Sampling
+
+Greedy decode (`--temperature 0.0`, the default) short-circuits to
+`argmax` and never touches `flashinfer.sampling` at all. To exercise the
+sampling kernels:
+
+```bash
+python generate.py --model-id Qwen/Qwen3-0.6B \
+    --temperature 0.8 --top-k 50 --top-p 0.9 --check-sampling
+```
+
+`--check-sampling` audits **every** sampled token against a plain-torch
+reference support (top-k ∩ nucleus, computed from the same
+temperature-scaled logits, with both boundaries closed over ties). It reports:
+
+| `[smoke]` key | meaning | bar |
+|---|---|---|
+| `sample_violations` | tokens outside the reference support | 0 |
+| `sample_out_of_range` | ids outside `[0, vocab)` | 0 |
+| `sample_allowed_mean` | mean admissible set size — guards against a *vacuous* check | ≤ 2·top_k |
+| `sample_divergences` / `sample_expected_divergences` | observed vs expected departures from greedy | catches a sampler degenerated to argmax |
+| `sample_replay_match` | same logits + freshly seeded generator ⇒ same tokens | 1 |
+| `sample_perreq_violations` | same audit with per-request **tensor** top_k/top_p (a different kernel path) | 0 |
+
+`smoke_test.py` runs a greedy pair *and* a sampling pair, asserting all of the
+above plus seeded cross-process determinism and that the `sampling`/`topk`
+modules are reused from the JIT cache. Pass `--skip-sampling` for greedy only.
+
+Measured on B200 (Qwen3-0.6B, temperature 0.8 / top-k 50 / top-p 0.9): 0
+violations in 72 draws, mean admissible set **4.3** of 151936, and 15 observed
+divergences against 16.58 expected.
+
 ## Requirements
 
 `flashinfer`, `torch`, and — for checkpoint/tokenizer handling only —

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -1,0 +1,357 @@
+"""Batch text generation with the FlashInfer LLM example model.
+
+Usage:
+    python generate.py --model-id Qwen/Qwen3-0.6B --max-tokens 32
+    python generate.py --model-id Qwen/Qwen3-8B --prompt "The capital of France is" \
+        --temperature 0.7 --top-k 50 --top-p 0.9
+
+Besides generating text, this script emits machine-readable ``[smoke] key=value``
+lines consumed by ``smoke_test.py``:
+
+- ``jit_builds_total`` — number of FlashInfer JIT modules actually *compiled*
+  in this process (``JitSpec.build()`` calls, which happen only on a JIT cache
+  miss). On a warm cache this must be 0.
+- ``jit_builds_steady`` — compilations triggered after the first decode step
+  (must always be 0: steady-state decoding must not recompile anything).
+- ``tokens_<i>`` — generated token ids per request, for determinism checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import math
+import time
+from typing import Dict, List, Optional
+
+import torch
+
+import flashinfer
+
+from modeling import FlashInferLLM, PagedKVCache, resolve_checkpoint_dir
+
+DEFAULT_PROMPTS = [
+    "The capital of France is",
+    "The three primary colors are",
+    "To bake bread you need flour, water,",
+]
+
+
+def install_jit_build_counter() -> Dict:
+    """Count actual JIT compilations (cache misses) in this process.
+
+    ``JitSpec.build_and_load()`` calls ``build()`` only after ``try_load()``
+    misses (see flashinfer/jit/core.py), so wrapping the concrete subclasses'
+    ``build`` gives an exact "module was recompiled" counter.
+    """
+    import flashinfer.jit.core as jit_core
+
+    # Registers the CuTe-DSL JitSpec subclass if the DSL is installed.
+    with contextlib.suppress(Exception):
+        import flashinfer.jit.cute_dsl_core  # noqa: F401
+
+    counter: Dict = {"count": 0, "names": []}
+
+    def _wrap(cls):
+        orig = cls.__dict__.get("build")
+        if orig is None:
+            return
+
+        def build(self, *args, _orig=orig, **kwargs):
+            counter["count"] += 1
+            counter["names"].append(self.name)
+            return _orig(self, *args, **kwargs)
+
+        cls.build = build
+
+    seen = set()
+    stack = [jit_core.JitSpec]
+    while stack:
+        c = stack.pop()
+        for sub in c.__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                _wrap(sub)
+                stack.append(sub)
+    return counter
+
+
+def sample_tokens(
+    logits: torch.Tensor,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    generator: Optional[torch.Generator],
+) -> torch.Tensor:
+    if temperature <= 0.0:
+        return logits.argmax(dim=-1).to(torch.int32)
+    logits = logits / temperature
+    vocab = logits.shape[-1]
+    effective_top_k = top_k if top_k > 0 else vocab
+    return flashinfer.sampling.top_k_top_p_sampling_from_logits(
+        logits, effective_top_k, top_p, deterministic=True, generator=generator
+    )
+
+
+class GenerationEngine:
+    def __init__(
+        self,
+        model: FlashInferLLM,
+        page_size: int = 16,
+        prefill_backend: str = "auto",
+        decode_backend: str = "auto",
+    ):
+        self.model = model
+        self.page_size = page_size
+        device = model.device
+        # Separate 128 MB workspaces; the decode one must start zeroed.
+        self.prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device),
+            kv_layout="NHD",
+            backend=prefill_backend,
+        )
+        self.decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device),
+            kv_layout="NHD",
+            use_tensor_cores=True,
+            backend=decode_backend,
+        )
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        prompt_token_ids: List[List[int]],
+        max_new_tokens: int,
+        temperature: float = 0.0,
+        top_k: int = 0,
+        top_p: float = 1.0,
+        seed: int = 0,
+        jit_counter: Optional[Dict] = None,
+    ) -> Dict:
+        model, cfg, device = self.model, self.model.config, self.model.device
+        batch = len(prompt_token_ids)
+        page_size = self.page_size
+        num_q, num_kv, hd = (
+            cfg.num_attention_heads,
+            cfg.num_key_value_heads,
+            cfg.head_dim,
+        )
+        generator = None
+        if temperature > 0.0:
+            generator = torch.Generator(device=device)
+            generator.manual_seed(seed)
+
+        max_pages = sum(
+            math.ceil((len(p) + max_new_tokens) / page_size) for p in prompt_token_ids
+        )
+        kv = PagedKVCache(cfg, max_pages, page_size, device, model.dtype)
+        for ids in prompt_token_ids:
+            req = kv.add_request()
+            kv.extend(req, len(ids))
+
+        # ---- Prefill: all prompts in one ragged batch ----
+        t_start = time.perf_counter()
+        input_ids = torch.tensor(
+            [t for ids in prompt_token_ids for t in ids],
+            dtype=torch.int64,
+            device=device,
+        )
+        qo_indptr_list = [0]
+        for ids in prompt_token_ids:
+            qo_indptr_list.append(qo_indptr_list[-1] + len(ids))
+        qo_indptr = torch.tensor(qo_indptr_list, dtype=torch.int32, device=device)
+        nnz = input_ids.shape[0]
+        kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
+        batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
+            qo_indptr, kv.seq_lens_tensor(), nnz
+        )
+        self.prefill_wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_q,
+            num_kv,
+            hd,
+            page_size,
+            causal=True,
+            q_data_type=model.dtype,
+            kv_data_type=model.dtype,
+        )
+        logits = model.forward(
+            input_ids,
+            pos_ids,
+            self.prefill_wrapper,
+            kv,
+            batch_indices,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            last_token_rows=(qo_indptr[1:].to(torch.int64) - 1),
+        )
+        next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
+        torch.cuda.synchronize()
+        t_prefill = time.perf_counter()
+
+        eos = set(cfg.eos_token_ids)
+        outputs: List[List[int]] = [[] for _ in range(batch)]
+        finished = [False] * batch
+        for i, tok in enumerate(next_tokens.tolist()):
+            outputs[i].append(tok)
+            finished[i] = tok in eos
+
+        # ---- Decode: one token per request per step ----
+        builds_after_first_decode: Optional[int] = None
+        decode_rows = torch.arange(batch, dtype=torch.int64, device=device)
+        append_indptr = torch.arange(batch + 1, dtype=torch.int32, device=device)
+        steps = 0
+        for _ in range(max_new_tokens - 1):
+            if all(finished):
+                break
+            for req in range(batch):
+                kv.extend(req, 1)
+            kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
+            self.decode_wrapper.plan(
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_q,
+                num_kv,
+                hd,
+                page_size,
+                q_data_type=model.dtype,
+                kv_data_type=model.dtype,
+            )
+            batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
+                append_indptr, kv.seq_lens_tensor(), batch
+            )
+            logits = model.forward(
+                next_tokens.to(torch.int64),
+                pos_ids,
+                self.decode_wrapper,
+                kv,
+                batch_indices,
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                last_token_rows=decode_rows,
+            )
+            next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
+            for i, tok in enumerate(next_tokens.tolist()):
+                if not finished[i]:
+                    outputs[i].append(tok)
+                    finished[i] = tok in eos
+            steps += 1
+            if steps == 1 and jit_counter is not None:
+                torch.cuda.synchronize()
+                builds_after_first_decode = jit_counter["count"]
+        torch.cuda.synchronize()
+        t_end = time.perf_counter()
+
+        jit_builds_steady = 0
+        if jit_counter is not None and builds_after_first_decode is not None:
+            jit_builds_steady = jit_counter["count"] - builds_after_first_decode
+        return {
+            "outputs": outputs,
+            "finished": finished,
+            "prefill_seconds": t_prefill - t_start,
+            "decode_seconds": t_end - t_prefill,
+            "decode_steps": steps,
+            "decode_tokens": steps * batch,
+            "jit_builds_steady": jit_builds_steady,
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default="Qwen/Qwen3-0.6B")
+    parser.add_argument(
+        "--prompt",
+        action="append",
+        help="Prompt (repeatable). Defaults to a small built-in batch.",
+    )
+    parser.add_argument("--chat", action="store_true", help="Apply the chat template")
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument(
+        "--temperature", type=float, default=0.0, help="0 = greedy (default)"
+    )
+    parser.add_argument("--top-k", type=int, default=0, help="0 = disabled")
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--page-size", type=int, default=16)
+    parser.add_argument("--prefill-backend", default="auto")
+    parser.add_argument("--decode-backend", default="auto")
+    args = parser.parse_args()
+
+    jit_counter = install_jit_build_counter()
+    device = torch.device("cuda")
+    ckpt_dir = resolve_checkpoint_dir(args.model_id)
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(str(ckpt_dir))
+    t0 = time.perf_counter()
+    model = FlashInferLLM.from_pretrained(str(ckpt_dir), device)
+    print(
+        f"Loaded {args.model_id} ({model.config.model_type}, "
+        f"{model.config.num_hidden_layers} layers) in {time.perf_counter() - t0:.1f}s"
+    )
+
+    prompts = args.prompt or DEFAULT_PROMPTS
+    if args.chat:
+        prompt_token_ids = []
+        for p in prompts:
+            messages = [{"role": "user", "content": p}]
+            try:
+                ids = tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True, enable_thinking=False
+                )
+            except TypeError:  # template without enable_thinking support
+                ids = tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True
+                )
+            prompt_token_ids.append(list(ids))
+        eos_extra = tokenizer.eos_token_id
+        if eos_extra is not None and eos_extra not in model.config.eos_token_ids:
+            model.config.eos_token_ids.append(eos_extra)
+    else:
+        prompt_token_ids = [tokenizer(p)["input_ids"] for p in prompts]
+
+    engine = GenerationEngine(
+        model,
+        page_size=args.page_size,
+        prefill_backend=args.prefill_backend,
+        decode_backend=args.decode_backend,
+    )
+    result = engine.generate(
+        prompt_token_ids,
+        max_new_tokens=args.max_tokens,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        seed=args.seed,
+        jit_counter=jit_counter,
+    )
+
+    for i, (prompt, out_ids) in enumerate(zip(prompts, result["outputs"], strict=True)):
+        text = tokenizer.decode(out_ids, skip_special_tokens=True)
+        print(f"\n--- request {i} ({'eos' if result['finished'][i] else 'length'}) ---")
+        print(f"prompt:     {prompt!r}")
+        print(f"completion: {text!r}")
+
+    decode_tps = result["decode_tokens"] / max(result["decode_seconds"], 1e-9)
+    print(
+        f"\nprefill {result['prefill_seconds']:.3f}s | "
+        f"decode {result['decode_steps']} steps, {decode_tps:.1f} tok/s "
+        f"(batch={len(prompts)}; includes first-call JIT warmup)"
+    )
+
+    print(f"[smoke] jit_builds_total={jit_counter['count']}")
+    print(f"[smoke] jit_builds_names={','.join(jit_counter['names'])}")
+    print(f"[smoke] jit_builds_steady={result['jit_builds_steady']}")
+    for i, out_ids in enumerate(result["outputs"]):
+        print(f"[smoke] tokens_{i}={','.join(map(str, out_ids))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import argparse
 import contextlib
 import math
+import os
+import sys
 import time
 from typing import Dict, List, Optional
 
@@ -38,6 +40,20 @@ DEFAULT_PROMPTS = [
     "The three primary colors are",
     "To bake bread you need flour, water,",
 ]
+
+
+def maybe_init_distributed() -> tuple:
+    """Initialize NCCL for torchrun launches (TEP: TP=EP over all ranks).
+
+    Returns (world_size, rank). Single-process runs return (1, 0) untouched.
+    """
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if world_size == 1:
+        return 1, 0
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    torch.distributed.init_process_group(backend="nccl")
+    return world_size, torch.distributed.get_rank()
 
 
 def install_jit_build_counter() -> Dict:
@@ -146,7 +162,14 @@ class GenerationEngine:
             math.ceil((len(p) + max_new_tokens) / self.page_size)
             for p in prompt_token_ids
         )
-        kv = PagedKVCache(cfg, max_pages, self.page_size, device, self.model.dtype)
+        kv = PagedKVCache(
+            cfg,
+            max_pages,
+            self.page_size,
+            device,
+            self.model.dtype,
+            num_kv_heads=self.model.num_local_kv_heads,
+        )
         for ids in prompt_token_ids:
             req = kv.add_request()
             kv.extend(req, len(ids))
@@ -176,8 +199,8 @@ class GenerationEngine:
             kv_indptr,
             kv_indices,
             kv_last_page_len,
-            cfg.num_attention_heads,
-            cfg.num_key_value_heads,
+            model.num_local_qo_heads,
+            model.num_local_kv_heads,
             cfg.head_dim,
             self.page_size,
             causal=True,
@@ -220,8 +243,8 @@ class GenerationEngine:
         batch = len(prompt_token_ids)
         page_size = self.page_size
         num_q, num_kv, hd = (
-            cfg.num_attention_heads,
-            cfg.num_key_value_heads,
+            model.num_local_qo_heads,
+            model.num_local_kv_heads,
             cfg.head_dim,
         )
         generator = None
@@ -329,17 +352,24 @@ def main():
     args = parser.parse_args()
 
     jit_counter = install_jit_build_counter()
-    device = torch.device("cuda")
+    world_size, rank = maybe_init_distributed()
+    if rank != 0:  # keep stdout single-writer; stderr stays visible
+        sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
+    device = torch.device("cuda", torch.cuda.current_device())
     ckpt_dir = resolve_checkpoint_dir(args.model_id)
 
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(str(ckpt_dir))
     t0 = time.perf_counter()
-    model = FlashInferLLM.from_pretrained(str(ckpt_dir), device)
+    model = FlashInferLLM.from_pretrained(
+        str(ckpt_dir), device, tp_size=world_size, tp_rank=rank
+    )
+    tp_note = f", tep tp=ep={world_size}" if world_size > 1 else ""
     print(
         f"Loaded {args.model_id} ({model.config.model_type}, "
-        f"{model.config.num_hidden_layers} layers) in {time.perf_counter() - t0:.1f}s"
+        f"{model.config.num_hidden_layers} layers{tp_note}) "
+        f"in {time.perf_counter() - t0:.1f}s"
     )
 
     prompts = args.prompt or DEFAULT_PROMPTS
@@ -404,6 +434,8 @@ def main():
     print(f"[smoke] jit_builds_steady={result['jit_builds_steady']}")
     for i, out_ids in enumerate(result["outputs"]):
         print(f"[smoke] tokens_{i}={','.join(map(str, out_ids))}")
+    if world_size > 1:
+        torch.distributed.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -9,8 +9,11 @@ Besides generating text, this script emits machine-readable ``[smoke] key=value`
 lines consumed by ``smoke_test.py``:
 
 - ``jit_builds_total`` — number of FlashInfer JIT modules actually *compiled*
-  in this process (``JitSpec.build()`` calls, which happen only on a JIT cache
-  miss). On a warm cache this must be 0.
+  in this process (the built artifact changed during ``JitSpec.build()``).
+  On a warm cache this must be 0.
+- ``jit_build_calls`` — informational: ``build()`` invocations, i.e. ninja
+  dependency scans. By design this equals the number of JIT modules used
+  even on a warm cache (``try_load`` defers freshness to ninja).
 - ``jit_builds_steady`` — compilations triggered after the first decode step
   (must always be 0: steady-state decoding must not recompile anything).
 - ``tokens_<i>`` — generated token ids per request, for determinism checks.
@@ -38,11 +41,18 @@ DEFAULT_PROMPTS = [
 
 
 def install_jit_build_counter() -> Dict:
-    """Count actual JIT compilations (cache misses) in this process.
+    """Count actual JIT compilations (not mere cache probes) in this process.
 
-    ``JitSpec.build_and_load()`` calls ``build()`` only after ``try_load()``
-    misses (see flashinfer/jit/core.py), so wrapping the concrete subclasses'
-    ``build`` gives an exact "module was recompiled" counter.
+    Nuance discovered on first deployment of this harness:
+    ``JitSpecNvcc.try_load()`` intentionally returns ``None`` for JIT-path
+    modules — artifact freshness is owned by ninja's dependency scan — so
+    ``build()`` runs in *every* process and ninja no-ops when the cached
+    ``.so`` is up to date (see flashinfer/jit/core.py). Counting ``build()``
+    calls therefore counts ninja invocations, not recompiles. A module was
+    actually (re)compiled iff its built artifact changed across the
+    ``build()`` call, so that is what ``count``/``names`` track;
+    ``build_calls`` keeps the raw invocation count as an informational
+    warm-start metric.
     """
     import flashinfer.jit.core as jit_core
 
@@ -50,7 +60,14 @@ def install_jit_build_counter() -> Dict:
     with contextlib.suppress(Exception):
         import flashinfer.jit.cute_dsl_core  # noqa: F401
 
-    counter: Dict = {"count": 0, "names": []}
+    counter: Dict = {"count": 0, "names": [], "build_calls": 0}
+
+    def _artifact_stamp(spec):
+        try:
+            lib = spec.get_library_path()
+            return lib.stat().st_mtime_ns if lib.exists() else None
+        except Exception:
+            return None
 
     def _wrap(cls):
         orig = cls.__dict__.get("build")
@@ -58,9 +75,13 @@ def install_jit_build_counter() -> Dict:
             return
 
         def build(self, *args, _orig=orig, **kwargs):
-            counter["count"] += 1
-            counter["names"].append(self.name)
-            return _orig(self, *args, **kwargs)
+            counter["build_calls"] += 1
+            before = _artifact_stamp(self)
+            result = _orig(self, *args, **kwargs)
+            if _artifact_stamp(self) != before:
+                counter["count"] += 1
+                counter["names"].append(self.name)
+            return result
 
         cls.build = build
 
@@ -348,6 +369,7 @@ def main():
 
     print(f"[smoke] jit_builds_total={jit_counter['count']}")
     print(f"[smoke] jit_builds_names={','.join(jit_counter['names'])}")
+    print(f"[smoke] jit_build_calls={jit_counter['build_calls']}")
     print(f"[smoke] jit_builds_steady={result['jit_builds_steady']}")
     for i, out_ids in enumerate(result["outputs"]):
         print(f"[smoke] tokens_{i}={','.join(map(str, out_ids))}")

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -138,6 +138,73 @@ class GenerationEngine:
             backend=decode_backend,
         )
 
+    def _make_cache(
+        self, prompt_token_ids: List[List[int]], max_new_tokens: int
+    ) -> PagedKVCache:
+        cfg, device = self.model.config, self.model.device
+        max_pages = sum(
+            math.ceil((len(p) + max_new_tokens) / self.page_size)
+            for p in prompt_token_ids
+        )
+        kv = PagedKVCache(cfg, max_pages, self.page_size, device, self.model.dtype)
+        for ids in prompt_token_ids:
+            req = kv.add_request()
+            kv.extend(req, len(ids))
+        return kv
+
+    def _prefill(
+        self, prompt_token_ids: List[List[int]], kv: PagedKVCache
+    ) -> torch.Tensor:
+        """Run the batched causal prefill; returns last-token logits [batch, vocab]."""
+        model, cfg, device = self.model, self.model.config, self.model.device
+        input_ids = torch.tensor(
+            [t for ids in prompt_token_ids for t in ids],
+            dtype=torch.int64,
+            device=device,
+        )
+        qo_indptr_list = [0]
+        for ids in prompt_token_ids:
+            qo_indptr_list.append(qo_indptr_list[-1] + len(ids))
+        qo_indptr = torch.tensor(qo_indptr_list, dtype=torch.int32, device=device)
+        nnz = input_ids.shape[0]
+        kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
+        batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
+            qo_indptr, kv.seq_lens_tensor(), nnz
+        )
+        self.prefill_wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            cfg.num_attention_heads,
+            cfg.num_key_value_heads,
+            cfg.head_dim,
+            self.page_size,
+            causal=True,
+            q_data_type=model.dtype,
+            kv_data_type=model.dtype,
+        )
+        return model.forward(
+            input_ids,
+            pos_ids,
+            self.prefill_wrapper,
+            kv,
+            batch_indices,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            last_token_rows=(qo_indptr[1:].to(torch.int64) - 1),
+        )
+
+    @torch.inference_mode()
+    def prefill_logits(self, prompt_token_ids: List[List[int]]) -> torch.Tensor:
+        """Last-token prefill logits per prompt (no decode).
+
+        Used by reference checks that compare against another implementation.
+        """
+        kv = self._make_cache(prompt_token_ids, max_new_tokens=1)
+        return self._prefill(prompt_token_ids, kv)
+
     @torch.inference_mode()
     def generate(
         self,
@@ -162,54 +229,11 @@ class GenerationEngine:
             generator = torch.Generator(device=device)
             generator.manual_seed(seed)
 
-        max_pages = sum(
-            math.ceil((len(p) + max_new_tokens) / page_size) for p in prompt_token_ids
-        )
-        kv = PagedKVCache(cfg, max_pages, page_size, device, model.dtype)
-        for ids in prompt_token_ids:
-            req = kv.add_request()
-            kv.extend(req, len(ids))
+        kv = self._make_cache(prompt_token_ids, max_new_tokens)
 
         # ---- Prefill: all prompts in one ragged batch ----
         t_start = time.perf_counter()
-        input_ids = torch.tensor(
-            [t for ids in prompt_token_ids for t in ids],
-            dtype=torch.int64,
-            device=device,
-        )
-        qo_indptr_list = [0]
-        for ids in prompt_token_ids:
-            qo_indptr_list.append(qo_indptr_list[-1] + len(ids))
-        qo_indptr = torch.tensor(qo_indptr_list, dtype=torch.int32, device=device)
-        nnz = input_ids.shape[0]
-        kv_indptr, kv_indices, kv_last_page_len = kv.page_table_tensors()
-        batch_indices, pos_ids = flashinfer.get_batch_indices_positions(
-            qo_indptr, kv.seq_lens_tensor(), nnz
-        )
-        self.prefill_wrapper.plan(
-            qo_indptr,
-            kv_indptr,
-            kv_indices,
-            kv_last_page_len,
-            num_q,
-            num_kv,
-            hd,
-            page_size,
-            causal=True,
-            q_data_type=model.dtype,
-            kv_data_type=model.dtype,
-        )
-        logits = model.forward(
-            input_ids,
-            pos_ids,
-            self.prefill_wrapper,
-            kv,
-            batch_indices,
-            kv_indptr,
-            kv_indices,
-            kv_last_page_len,
-            last_token_rows=(qo_indptr[1:].to(torch.int64) - 1),
-        )
+        logits = self._prefill(prompt_token_ids, kv)
         next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
         torch.cuda.synchronize()
         t_prefill = time.perf_counter()

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -323,15 +323,22 @@ def main():
         prompt_token_ids = []
         for p in prompts:
             messages = [{"role": "user", "content": p}]
+            # Render to text, then tokenize explicitly: apply_chat_template's
+            # tokenized return type varies across transformers versions.
             try:
-                ids = tokenizer.apply_chat_template(
-                    messages, add_generation_prompt=True, enable_thinking=False
+                text = tokenizer.apply_chat_template(
+                    messages,
+                    add_generation_prompt=True,
+                    tokenize=False,
+                    enable_thinking=False,
                 )
             except TypeError:  # template without enable_thinking support
-                ids = tokenizer.apply_chat_template(
-                    messages, add_generation_prompt=True
+                text = tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True, tokenize=False
                 )
-            prompt_token_ids.append(list(ids))
+            prompt_token_ids.append(
+                tokenizer(text, add_special_tokens=False)["input_ids"]
+            )
         eos_extra = tokenizer.eos_token_id
         if eos_extra is not None and eos_extra not in model.config.eos_token_ids:
             model.config.eos_token_ids.append(eos_extra)

--- a/examples/pytorch/llm/generate.py
+++ b/examples/pytorch/llm/generate.py
@@ -113,21 +113,77 @@ def install_jit_build_counter() -> Dict:
     return counter
 
 
+def sampling_support(x: torch.Tensor, top_k: int, top_p: float):
+    """Reference top-k ∩ nucleus support for temperature-scaled logits ``x``.
+
+    Returns ``(allowed, p_top1)``: a bool mask over the vocabulary of tokens the
+    sampler is permitted to return, and the greedy token's probability under the
+    filtered+renormalized distribution the kernel actually draws from.
+
+    Both boundaries close over ties (``>=`` against a *value*, not a rank), and
+    the ``eps`` slack is applied on the permissive side only — the mask is a
+    superset of what any correct implementation may keep, so a violation is
+    unambiguous. This mirrors ``tests/utils/test_sampling.py``, which builds the
+    same masks with sort/cumsum and asserts membership over many draws.
+
+    The renormalization denominator is the *tie closure* of the top-k, not the
+    k largest entries: if two logits collide exactly at the k-th position the
+    kernel may legitimately keep both, and a narrower denominator would produce
+    rare false failures.
+    """
+    eps = 1e-4
+    vocab = x.shape[-1]
+    k = min(top_k if top_k > 0 else vocab, vocab)
+    values, ids = torch.topk(x, k, dim=-1)  # descending
+    # Tie closure of the top-k, renormalized — the largest set the kernel may keep.
+    probs = torch.softmax(x.masked_fill(x < values[:, -1:], float("-inf")), dim=-1)
+    kept = probs.gather(1, ids)
+    mass_above = torch.cumsum(kept, dim=-1) - kept
+    n_keep = (mass_above < top_p + eps).sum(dim=-1, keepdim=True).clamp(min=1)
+    cutoff = values.gather(1, n_keep - 1)
+    allowed = x >= cutoff
+    kept_mass = torch.cumsum(kept, dim=-1).gather(1, n_keep - 1).clamp(min=1e-20)
+    return allowed, (kept[:, :1] / kept_mass).squeeze(-1)
+
+
 def sample_tokens(
     logits: torch.Tensor,
     temperature: float,
     top_k: int,
     top_p: float,
     generator: Optional[torch.Generator],
+    audit: Optional[Dict] = None,
 ) -> torch.Tensor:
     if temperature <= 0.0:
         return logits.argmax(dim=-1).to(torch.int32)
     logits = logits / temperature
     vocab = logits.shape[-1]
     effective_top_k = top_k if top_k > 0 else vocab
-    return flashinfer.sampling.top_k_top_p_sampling_from_logits(
+    tokens = flashinfer.sampling.top_k_top_p_sampling_from_logits(
         logits, effective_top_k, top_p, deterministic=True, generator=generator
     )
+    if audit is not None:
+        _audit_sample(audit, logits, tokens, top_k, top_p)
+    return tokens
+
+
+def _audit_sample(audit: Dict, x: torch.Tensor, tokens: torch.Tensor, top_k, top_p):
+    """Accumulate support-membership evidence for one sampled step."""
+    rows, vocab = x.shape
+    tok = tokens.long()
+    in_range = (tok >= 0) & (tok < vocab)
+    audit["out_of_range"] += int((~in_range).sum())
+    if not bool(in_range.all()):  # keep the gather below safe
+        tok = tok.clamp(0, vocab - 1)
+    allowed, p_top1 = sampling_support(x, top_k, top_p)
+    audit["violations"] += int((~allowed.gather(1, tok[:, None]).squeeze(-1)).sum())
+    audit["draws"] += rows
+    audit["allowed_total"] += int(allowed.sum())
+    # A sampler that has silently degenerated to argmax is still always inside
+    # the support, so membership cannot see it; count divergences from greedy
+    # against how many we should expect from the filtered distribution.
+    audit["divergences"] += int((tok != x.argmax(dim=-1)).sum())
+    audit["expected_divergences"] += float((1.0 - p_top1).sum())
 
 
 class GenerationEngine:
@@ -238,6 +294,7 @@ class GenerationEngine:
         top_p: float = 1.0,
         seed: int = 0,
         jit_counter: Optional[Dict] = None,
+        audit: Optional[Dict] = None,
     ) -> Dict:
         model, cfg, device = self.model, self.model.config, self.model.device
         batch = len(prompt_token_ids)
@@ -257,7 +314,33 @@ class GenerationEngine:
         # ---- Prefill: all prompts in one ragged batch ----
         t_start = time.perf_counter()
         logits = self._prefill(prompt_token_ids, kv)
-        next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
+        next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator, audit)
+        if audit is not None and temperature > 0.0:
+            # Hermetic replay: same logits, a freshly seeded generator. Model
+            # independent, so a mismatch is unambiguously the sampler (a
+            # generator state that is not honored, or a deterministic=True that
+            # does not actually pin the reduction order).
+            replay_gen = torch.Generator(device=device)
+            replay_gen.manual_seed(seed)
+            replay = sample_tokens(logits, temperature, top_k, top_p, replay_gen)
+            audit["replay_match"] = int(bool(torch.equal(replay, next_tokens)))
+            # Per-request tensor params take the non-fast-path kernels
+            # (top_k_mask_logits + full-vocab top_p_sampling_from_probs); a
+            # scalar top_k on a large vocab only ever exercises the fast path.
+            x = logits / temperature
+            vocab = x.shape[-1]
+            k_t = torch.full(
+                (x.shape[0],), top_k if top_k > 0 else vocab, device=device
+            )
+            p_t = torch.full((x.shape[0],), top_p, device=device)
+            per_req = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+                x, k_t, p_t, deterministic=True, generator=replay_gen
+            )
+            allowed, _ = sampling_support(x, top_k, top_p)
+            tok = per_req.long().clamp(0, vocab - 1)
+            audit["perreq_violations"] = int(
+                (~allowed.gather(1, tok[:, None]).squeeze(-1)).sum()
+            )
         torch.cuda.synchronize()
         t_prefill = time.perf_counter()
 
@@ -304,7 +387,9 @@ class GenerationEngine:
                 kv_last_page_len,
                 last_token_rows=decode_rows,
             )
-            next_tokens = sample_tokens(logits, temperature, top_k, top_p, generator)
+            next_tokens = sample_tokens(
+                logits, temperature, top_k, top_p, generator, audit
+            )
             for i, tok in enumerate(next_tokens.tolist()):
                 if not finished[i]:
                     outputs[i].append(tok)
@@ -347,9 +432,28 @@ def main():
     parser.add_argument("--top-p", type=float, default=1.0)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--page-size", type=int, default=16)
+    parser.add_argument(
+        "--check-sampling",
+        action="store_true",
+        help="Audit every sampled token against a torch reference support "
+        "(top-k ∩ nucleus). Adds a topk+softmax per step; off by default.",
+    )
     parser.add_argument("--prefill-backend", default="auto")
     parser.add_argument("--decode-backend", default="auto")
     args = parser.parse_args()
+
+    audit = None
+    if args.check_sampling and args.temperature > 0.0:
+        audit = {
+            "violations": 0,
+            "out_of_range": 0,
+            "draws": 0,
+            "allowed_total": 0,
+            "divergences": 0,
+            "expected_divergences": 0.0,
+            "replay_match": -1,
+            "perreq_violations": -1,
+        }
 
     jit_counter = install_jit_build_counter()
     world_size, rank = maybe_init_distributed()
@@ -412,6 +516,7 @@ def main():
         top_k=args.top_k,
         top_p=args.top_p,
         seed=args.seed,
+        audit=audit,
         jit_counter=jit_counter,
     )
 
@@ -428,6 +533,20 @@ def main():
         f"(batch={len(prompts)}; includes first-call JIT warmup)"
     )
 
+    if audit is not None:
+        print(f"[smoke] sample_draws={audit['draws']}")
+        print(f"[smoke] sample_violations={audit['violations']}")
+        print(f"[smoke] sample_out_of_range={audit['out_of_range']}")
+        # Mean admissible set size: guards against a vacuous membership check
+        # (with --top-k 0 --top-p 1.0 the mask is the whole vocab).
+        mean_allowed = audit["allowed_total"] / max(audit["draws"], 1)
+        print(f"[smoke] sample_allowed_mean={mean_allowed:.1f}")
+        print(f"[smoke] sample_divergences={audit['divergences']}")
+        print(
+            f"[smoke] sample_expected_divergences={audit['expected_divergences']:.2f}"
+        )
+        print(f"[smoke] sample_replay_match={audit['replay_match']}")
+        print(f"[smoke] sample_perreq_violations={audit['perreq_violations']}")
     print(f"[smoke] jit_builds_total={jit_counter['count']}")
     print(f"[smoke] jit_builds_names={','.join(jit_counter['names'])}")
     print(f"[smoke] jit_build_calls={jit_counter['build_calls']}")

--- a/examples/pytorch/llm/health_check.py
+++ b/examples/pytorch/llm/health_check.py
@@ -1,0 +1,199 @@
+"""Model-health instrumentation for the FlashInfer LLM example.
+
+Measures the lifecycle stages a serving deployment cares about and emits
+them as both a human summary and machine-readable JSON — groundwork for
+performance gates (each metric is a natural threshold candidate):
+
+- ``import_seconds``   — ``import flashinfer`` in a fresh interpreter
+- ``load_seconds``     — checkpoint -> device (weights + sharding)
+- ``cold_prefill_seconds`` / ``jit_builds_cold`` — first forward, including
+  JIT compilation / cubin loading (startup-preparation cost)
+- ``warm_prefill_tokens_per_s`` — prefill throughput after warmup
+- ``decode_tokens_per_s`` — steady-state decode throughput
+- ``jit_builds_steady`` — must be 0 (no recompiles once serving)
+- with ``--autotune``: decode/prefill re-measured after a
+  ``flashinfer.autotune(True)`` warmup pass, reported as ``*_autotuned``
+
+Timing is host-side (``perf_counter`` around synchronized calls): this is
+health instrumentation for trend/gate purposes, not a kernel benchmark —
+use ``flashinfer.testing.bench_gpu_time`` / CUPTI for kernel numbers.
+CUDA-graph capture of the decode step is a planned addition (the wrappers
+support ``use_cuda_graph=True`` with preallocated page-table buffers).
+
+Usage:
+    python health_check.py --tiny moe --json health.json
+    python health_check.py --model-id Qwen/Qwen3-0.6B --batch 4 --prompt-len 512
+    torchrun --nproc_per_node=2 health_check.py --tiny moe    # TEP (TP=EP)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+import torch
+
+from generate import GenerationEngine, install_jit_build_counter, maybe_init_distributed
+from modeling import FlashInferLLM, resolve_checkpoint_dir
+
+
+def measure_import_seconds() -> float:
+    code = (
+        "import time; t = time.perf_counter(); import flashinfer; "
+        "print(time.perf_counter() - t)"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=600
+    )
+    return float(out.stdout.strip().splitlines()[-1])
+
+
+def timed(fn) -> float:
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    fn()
+    torch.cuda.synchronize()
+    return time.perf_counter() - t0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", help="HF model id or local checkpoint path")
+    parser.add_argument(
+        "--tiny",
+        choices=["dense", "moe"],
+        help="use a tiny random-weight checkpoint (no download) instead of --model-id",
+    )
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--prompt-len", type=int, default=256)
+    parser.add_argument("--decode-tokens", type=int, default=64)
+    parser.add_argument("--prefill-iters", type=int, default=5)
+    parser.add_argument("--autotune", action="store_true")
+    parser.add_argument("--json", dest="json_path", help="write metrics JSON here")
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+    if not args.model_id and not args.tiny:
+        parser.error("pass --model-id or --tiny")
+
+    jit_counter = install_jit_build_counter()
+    world_size, rank = maybe_init_distributed()
+    if rank != 0:  # keep stdout single-writer; stderr stays visible
+        sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    metrics = {
+        "gpu": torch.cuda.get_device_name(device),
+        "world_size": world_size,
+        "batch": args.batch,
+        "prompt_len": args.prompt_len,
+        "decode_tokens": args.decode_tokens,
+    }
+
+    # --- stage 0: import cost (fresh interpreter, rank 0 only) ---
+    if rank == 0:
+        metrics["import_seconds"] = round(measure_import_seconds(), 3)
+
+    # --- resolve checkpoint ---
+    tmpdir = None
+    if args.tiny:
+        from reference_check import build_tiny_checkpoint
+
+        ckpt = None
+        if rank == 0:
+            tmpdir = tempfile.mkdtemp()
+            ckpt = build_tiny_checkpoint(args.tiny, tmpdir, args.seed)
+        if world_size > 1:
+            obj = [ckpt]
+            torch.distributed.broadcast_object_list(obj, src=0)
+            ckpt = obj[0]
+        metrics["model"] = f"tiny-{args.tiny}"
+    else:
+        ckpt = str(resolve_checkpoint_dir(args.model_id))
+        metrics["model"] = args.model_id
+
+    try:
+        # --- stage 1: load ---
+        t0 = time.perf_counter()
+        model = FlashInferLLM.from_pretrained(
+            ckpt, device, tp_size=world_size, tp_rank=rank
+        )
+        engine = GenerationEngine(model)
+        metrics["load_seconds"] = round(time.perf_counter() - t0, 3)
+
+        g = torch.Generator().manual_seed(args.seed + 1)
+        vocab = model.config.vocab_size
+        prompts = [
+            torch.randint(0, vocab, (args.prompt_len,), generator=g).tolist()
+            for _ in range(args.batch)
+        ]
+        prefill_tokens = args.batch * args.prompt_len
+
+        # --- stage 2: cold prefill (JIT warmup / cubin loads) ---
+        builds_before = jit_counter["count"]
+        metrics["cold_prefill_seconds"] = round(
+            timed(lambda: engine.prefill_logits(prompts)), 3
+        )
+        metrics["jit_builds_cold"] = jit_counter["count"] - builds_before
+
+        def measure_throughput(tag: str):
+            times = [
+                timed(lambda: engine.prefill_logits(prompts))
+                for _ in range(args.prefill_iters)
+            ]
+            metrics[f"warm_prefill_seconds{tag}"] = round(statistics.median(times), 4)
+            metrics[f"warm_prefill_tokens_per_s{tag}"] = round(
+                prefill_tokens / statistics.median(times), 1
+            )
+            result = engine.generate(
+                prompts, max_new_tokens=args.decode_tokens, jit_counter=jit_counter
+            )
+            metrics[f"decode_tokens_per_s{tag}"] = round(
+                result["decode_tokens"] / max(result["decode_seconds"], 1e-9), 1
+            )
+            return result
+
+        # --- stage 3: warm throughput ---
+        result = measure_throughput("")
+        metrics["jit_builds_steady"] = result["jit_builds_steady"]
+        metrics["jit_builds_total"] = jit_counter["count"]
+
+        # --- stage 4 (optional): autotuned throughput ---
+        if args.autotune:
+            import flashinfer
+
+            with flashinfer.autotune(True):
+                engine.generate(prompts, max_new_tokens=4)
+            metrics["autotune_warmup"] = True
+            measure_throughput("_autotuned")
+
+        print(
+            f"\nhealth check: {metrics['model']} "
+            f"({'TEP tp=ep=' + str(world_size) if world_size > 1 else '1 GPU'})"
+        )
+        for key, value in metrics.items():
+            print(f"  {key:>32}: {value}")
+        for key in ("jit_builds_steady",):
+            if metrics.get(key, 0) != 0:
+                print(f"UNHEALTHY: {key}={metrics[key]} (expected 0)")
+                sys.exit(1)
+        if args.json_path and rank == 0:
+            with open(args.json_path, "w") as f:
+                json.dump(metrics, f, indent=1)
+            print(f"metrics written to {args.json_path}")
+        print("[smoke] health=pass")
+    finally:
+        if rank == 0 and tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        if world_size > 1:
+            torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -159,8 +159,19 @@ def _load_state_dict(ckpt_dir: Path) -> Dict[str, torch.Tensor]:
 
 
 class DecoderLayerWeights:
+    """Per-layer weights, sharded at load time when tp_size > 1 (TEP style:
+    attention heads and dense-FFN intermediate are tensor-parallel; MoE
+    experts are expert-parallel across the same ranks)."""
+
     def __init__(
-        self, sd: Dict[str, torch.Tensor], i: int, device, dtype, config: "ModelConfig"
+        self,
+        sd: Dict[str, torch.Tensor],
+        i: int,
+        device,
+        dtype,
+        config: "ModelConfig",
+        tp_size: int = 1,
+        tp_rank: int = 0,
     ):
         p = f"model.layers.{i}."
 
@@ -172,25 +183,36 @@ class DecoderLayerWeights:
                 return None
             return sd[key].to(device=device, dtype=dtype)
 
+        def shard(t: Optional[torch.Tensor], dim: int) -> Optional[torch.Tensor]:
+            if t is None or tp_size == 1:
+                return t
+            return t.chunk(tp_size, dim=dim)[tp_rank].contiguous()
+
         self.input_layernorm = get("input_layernorm.weight")
         self.post_attention_layernorm = get("post_attention_layernorm.weight")
-        self.q_proj = get("self_attn.q_proj.weight")
-        self.k_proj = get("self_attn.k_proj.weight")
-        self.v_proj = get("self_attn.v_proj.weight")
-        self.o_proj = get("self_attn.o_proj.weight")
+        # Column-parallel QKV (head-contiguous rows), row-parallel o_proj.
+        self.q_proj = shard(get("self_attn.q_proj.weight"), 0)
+        self.k_proj = shard(get("self_attn.k_proj.weight"), 0)
+        self.v_proj = shard(get("self_attn.v_proj.weight"), 0)
+        self.o_proj = shard(get("self_attn.o_proj.weight"), 1)
         # Qwen2-family checkpoints carry QKV bias; Llama/Qwen3 do not.
-        self.q_bias = get("self_attn.q_proj.bias", required=False)
-        self.k_bias = get("self_attn.k_proj.bias", required=False)
-        self.v_bias = get("self_attn.v_proj.bias", required=False)
-        # Qwen3 per-head q/k RMSNorm over head_dim.
+        self.q_bias = shard(get("self_attn.q_proj.bias", required=False), 0)
+        self.k_bias = shard(get("self_attn.k_proj.bias", required=False), 0)
+        self.v_bias = shard(get("self_attn.v_proj.bias", required=False), 0)
+        # Qwen3 per-head q/k RMSNorm over head_dim: replicated (shape [head_dim]).
         self.q_norm = get("self_attn.q_norm.weight", required=False)
         self.k_norm = get("self_attn.k_norm.weight", required=False)
         self.is_sparse = config.is_sparse_layer(i)
         if self.is_sparse:
             self.gate_proj = self.up_proj = self.down_proj = None
-            self.moe_gate = get("mlp.gate.weight")  # router, [num_experts, hidden]
+            # Router is replicated; every rank computes the global routing.
+            self.moe_gate = get("mlp.gate.weight")  # [num_experts, hidden]
+            # Expert-parallel: this rank holds experts
+            # [tp_rank * E/tp, (tp_rank+1) * E/tp).
+            experts_per_rank = config.num_experts // tp_size
+            expert_start = tp_rank * experts_per_rank
             w31, w2 = [], []
-            for j in range(config.num_experts):
+            for j in range(expert_start, expert_start + experts_per_rank):
                 ep = f"{p}mlp.experts.{j}."
                 gate = sd[ep + "gate_proj.weight"].to(device=device, dtype=dtype)
                 up = sd[ep + "up_proj.weight"].to(device=device, dtype=dtype)
@@ -200,13 +222,14 @@ class DecoderLayerWeights:
                 # silu(x @ w1.T) * (x @ w3.T) internally.
                 w31.append(torch.cat([up, gate], dim=0))
                 w2.append(down)
-            self.moe_w31 = torch.stack(w31).contiguous()  # [E, 2*I, H]
-            self.moe_w2 = torch.stack(w2).contiguous()  # [E, H, I]
+            self.moe_w31 = torch.stack(w31).contiguous()  # [E_local, 2*I, H]
+            self.moe_w2 = torch.stack(w2).contiguous()  # [E_local, H, I]
         else:
             self.moe_gate = self.moe_w31 = self.moe_w2 = None
-            self.gate_proj = get("mlp.gate_proj.weight")
-            self.up_proj = get("mlp.up_proj.weight")
-            self.down_proj = get("mlp.down_proj.weight")
+            # Column-parallel gate/up, row-parallel down.
+            self.gate_proj = shard(get("mlp.gate_proj.weight"), 0)
+            self.up_proj = shard(get("mlp.up_proj.weight"), 0)
+            self.down_proj = shard(get("mlp.down_proj.weight"), 1)
 
 
 class FlashInferLLM:
@@ -223,10 +246,25 @@ class FlashInferLLM:
         state_dict: Dict[str, torch.Tensor],
         device: torch.device,
         dtype: torch.dtype = torch.bfloat16,
+        tp_size: int = 1,
+        tp_rank: int = 0,
     ):
         self.config = config
         self.device = device
         self.dtype = dtype
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        if tp_size > 1:
+            if config.num_attention_heads % tp_size:
+                raise ValueError("num_attention_heads must divide by tp_size")
+            if config.num_key_value_heads % tp_size:
+                raise ValueError("num_key_value_heads must divide by tp_size")
+            if config.intermediate_size % tp_size:
+                raise ValueError("intermediate_size must divide by tp_size")
+            if config.is_moe and config.num_experts % tp_size:
+                raise ValueError("num_experts must divide by tp_size (TP=EP)")
+        self.num_local_qo_heads = config.num_attention_heads // tp_size
+        self.num_local_kv_heads = config.num_key_value_heads // tp_size
         self.embed_tokens = state_dict["model.embed_tokens.weight"].to(
             device=device, dtype=dtype
         )
@@ -236,9 +274,15 @@ class FlashInferLLM:
         else:
             self.lm_head = state_dict["lm_head.weight"].to(device=device, dtype=dtype)
         self.layers = [
-            DecoderLayerWeights(state_dict, i, device, dtype, config)
+            DecoderLayerWeights(state_dict, i, device, dtype, config, tp_size, tp_rank)
             for i in range(config.num_hidden_layers)
         ]
+
+    def _maybe_all_reduce(self, t: torch.Tensor) -> torch.Tensor:
+        """Sum partial results across the TP=EP group (no-op when tp_size==1)."""
+        if self.tp_size > 1:
+            torch.distributed.all_reduce(t)
+        return t
 
     @classmethod
     def from_pretrained(
@@ -246,12 +290,16 @@ class FlashInferLLM:
         model_id_or_path: str,
         device: torch.device,
         dtype: torch.dtype = torch.bfloat16,
+        tp_size: int = 1,
+        tp_rank: int = 0,
     ) -> "FlashInferLLM":
         ckpt_dir = resolve_checkpoint_dir(model_id_or_path)
         with open(ckpt_dir / "config.json") as f:
             config = ModelConfig.from_hf_config(json.load(f))
+        # Every rank reads the full state dict and slices its shard — fine
+        # for verification-scale models; a real loader would shard reads.
         state_dict = _load_state_dict(ckpt_dir)
-        return cls(config, state_dict, device, dtype)
+        return cls(config, state_dict, device, dtype, tp_size, tp_rank)
 
     def _apply_rope(self, q: torch.Tensor, k: torch.Tensor, pos_ids: torch.Tensor):
         cfg = self.config
@@ -292,8 +340,8 @@ class FlashInferLLM:
         cfg = self.config
         nnz = input_ids.shape[0]
         num_q, num_kv, hd = (
-            cfg.num_attention_heads,
-            cfg.num_key_value_heads,
+            self.num_local_qo_heads,
+            self.num_local_kv_heads,
             cfg.head_dim,
         )
         x = torch.nn.functional.embedding(input_ids, self.embed_tokens)
@@ -326,6 +374,7 @@ class FlashInferLLM:
             )
             attn = attn_wrapper.run(q, kv_cache.layer_view(i))
             attn = torch.nn.functional.linear(attn.reshape(nnz, num_q * hd), w.o_proj)
+            self._maybe_all_reduce(attn)
             flashinfer.fused_add_rmsnorm(
                 attn, residual, w.post_attention_layernorm, cfg.rms_norm_eps
             )
@@ -341,6 +390,8 @@ class FlashInferLLM:
                     routing_weights = routing_weights / routing_weights.sum(
                         dim=-1, keepdim=True
                     )
+                # Expert-parallel: global routing on every rank, local expert
+                # slice here; partial outputs are summed across ranks.
                 x = flashinfer.fused_moe.cutlass_fused_moe(
                     attn,
                     selected_experts.to(torch.int),
@@ -349,7 +400,10 @@ class FlashInferLLM:
                     w.moe_w2,
                     self.dtype,
                     quant_scales=None,
+                    ep_size=self.tp_size,
+                    ep_rank=self.tp_rank,
                 )[0]
+                self._maybe_all_reduce(x)
             else:
                 gate_up = torch.cat(
                     [
@@ -361,6 +415,7 @@ class FlashInferLLM:
                 x = torch.nn.functional.linear(
                     flashinfer.silu_and_mul(gate_up), w.down_proj
                 )
+                self._maybe_all_reduce(x)
         # Final residual add + norm, only then project the rows we sample from.
         flashinfer.fused_add_rmsnorm(x, residual, self.final_norm, cfg.rms_norm_eps)
         hidden = x[last_token_rows]
@@ -382,6 +437,7 @@ class PagedKVCache:
         page_size: int,
         device: torch.device,
         dtype: torch.dtype = torch.bfloat16,
+        num_kv_heads: Optional[int] = None,  # local count under TP
     ):
         self.page_size = page_size
         self.device = device
@@ -390,7 +446,7 @@ class PagedKVCache:
             max_pages,
             2,
             page_size,
-            config.num_key_value_heads,
+            num_kv_heads or config.num_key_value_heads,
             config.head_dim,
             device=device,
             dtype=dtype,

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -25,8 +25,9 @@ from typing import Dict, List, Optional
 import torch
 
 import flashinfer
+import flashinfer.fused_moe  # noqa: F401  (subpackage attribute access)
 
-SUPPORTED_MODEL_TYPES = ("llama", "qwen2", "qwen3")
+SUPPORTED_MODEL_TYPES = ("llama", "qwen2", "qwen3", "qwen3_moe")
 
 
 @dataclasses.dataclass
@@ -44,6 +45,25 @@ class ModelConfig:
     tie_word_embeddings: bool
     rope_scaling: Optional[dict]
     eos_token_ids: List[int]
+    # MoE fields (qwen3_moe); None/0 for dense models.
+    num_experts: int = 0
+    num_experts_per_tok: int = 0
+    moe_intermediate_size: int = 0
+    norm_topk_prob: bool = False
+    decoder_sparse_step: int = 1
+    mlp_only_layers: tuple = ()
+
+    @property
+    def is_moe(self) -> bool:
+        return self.num_experts > 0
+
+    def is_sparse_layer(self, layer_idx: int) -> bool:
+        # Mirrors transformers' Qwen3MoeDecoderLayer selection logic.
+        return (
+            self.num_experts > 0
+            and layer_idx not in self.mlp_only_layers
+            and (layer_idx + 1) % self.decoder_sparse_step == 0
+        )
 
     @classmethod
     def from_hf_config(cls, cfg: dict) -> "ModelConfig":
@@ -86,6 +106,12 @@ class ModelConfig:
             tie_word_embeddings=cfg.get("tie_word_embeddings", False),
             rope_scaling=rope_scaling,
             eos_token_ids=eos_token_ids,
+            num_experts=cfg.get("num_experts", 0),
+            num_experts_per_tok=cfg.get("num_experts_per_tok", 0),
+            moe_intermediate_size=cfg.get("moe_intermediate_size", 0),
+            norm_topk_prob=cfg.get("norm_topk_prob", False),
+            decoder_sparse_step=cfg.get("decoder_sparse_step", 1),
+            mlp_only_layers=tuple(cfg.get("mlp_only_layers", ()) or ()),
         )
 
 
@@ -126,7 +152,9 @@ def _load_state_dict(ckpt_dir: Path) -> Dict[str, torch.Tensor]:
 
 
 class DecoderLayerWeights:
-    def __init__(self, sd: Dict[str, torch.Tensor], i: int, device, dtype):
+    def __init__(
+        self, sd: Dict[str, torch.Tensor], i: int, device, dtype, config: "ModelConfig"
+    ):
         p = f"model.layers.{i}."
 
         def get(name: str, required: bool = True) -> Optional[torch.Tensor]:
@@ -150,9 +178,28 @@ class DecoderLayerWeights:
         # Qwen3 per-head q/k RMSNorm over head_dim.
         self.q_norm = get("self_attn.q_norm.weight", required=False)
         self.k_norm = get("self_attn.k_norm.weight", required=False)
-        self.gate_proj = get("mlp.gate_proj.weight")
-        self.up_proj = get("mlp.up_proj.weight")
-        self.down_proj = get("mlp.down_proj.weight")
+        self.is_sparse = config.is_sparse_layer(i)
+        if self.is_sparse:
+            self.gate_proj = self.up_proj = self.down_proj = None
+            self.moe_gate = get("mlp.gate.weight")  # router, [num_experts, hidden]
+            w31, w2 = [], []
+            for j in range(config.num_experts):
+                ep = f"{p}mlp.experts.{j}."
+                gate = sd[ep + "gate_proj.weight"].to(device=device, dtype=dtype)
+                up = sd[ep + "up_proj.weight"].to(device=device, dtype=dtype)
+                down = sd[ep + "down_proj.weight"].to(device=device, dtype=dtype)
+                # cutlass_fused_moe fc1 ("w31") layout: up_proj (w3) stacked
+                # above gate_proj (w1); the kernel computes
+                # silu(x @ w1.T) * (x @ w3.T) internally.
+                w31.append(torch.cat([up, gate], dim=0))
+                w2.append(down)
+            self.moe_w31 = torch.stack(w31).contiguous()  # [E, 2*I, H]
+            self.moe_w2 = torch.stack(w2).contiguous()  # [E, H, I]
+        else:
+            self.moe_gate = self.moe_w31 = self.moe_w2 = None
+            self.gate_proj = get("mlp.gate_proj.weight")
+            self.up_proj = get("mlp.up_proj.weight")
+            self.down_proj = get("mlp.down_proj.weight")
 
 
 class FlashInferLLM:
@@ -182,7 +229,7 @@ class FlashInferLLM:
         else:
             self.lm_head = state_dict["lm_head.weight"].to(device=device, dtype=dtype)
         self.layers = [
-            DecoderLayerWeights(state_dict, i, device, dtype)
+            DecoderLayerWeights(state_dict, i, device, dtype, config)
             for i in range(config.num_hidden_layers)
         ]
 
@@ -275,16 +322,38 @@ class FlashInferLLM:
             flashinfer.fused_add_rmsnorm(
                 attn, residual, w.post_attention_layernorm, cfg.rms_norm_eps
             )
-            gate_up = torch.cat(
-                [
-                    torch.nn.functional.linear(attn, w.gate_proj),
-                    torch.nn.functional.linear(attn, w.up_proj),
-                ],
-                dim=-1,
-            )
-            x = torch.nn.functional.linear(
-                flashinfer.silu_and_mul(gate_up), w.down_proj
-            )
+            if w.is_sparse:
+                # Router in model dtype, softmax in fp32 — mirrors the HF
+                # Qwen3MoeSparseMoeBlock reference implementation.
+                router_logits = torch.nn.functional.linear(attn, w.moe_gate)
+                routing_weights = torch.softmax(router_logits.float(), dim=-1)
+                routing_weights, selected_experts = torch.topk(
+                    routing_weights, cfg.num_experts_per_tok, dim=-1
+                )
+                if cfg.norm_topk_prob:
+                    routing_weights = routing_weights / routing_weights.sum(
+                        dim=-1, keepdim=True
+                    )
+                x = flashinfer.fused_moe.cutlass_fused_moe(
+                    attn,
+                    selected_experts.to(torch.int),
+                    routing_weights,
+                    w.moe_w31,
+                    w.moe_w2,
+                    self.dtype,
+                    quant_scales=None,
+                )[0]
+            else:
+                gate_up = torch.cat(
+                    [
+                        torch.nn.functional.linear(attn, w.gate_proj),
+                        torch.nn.functional.linear(attn, w.up_proj),
+                    ],
+                    dim=-1,
+                )
+                x = torch.nn.functional.linear(
+                    flashinfer.silu_and_mul(gate_up), w.down_proj
+                )
         # Final residual add + norm, only then project the rows we sample from.
         flashinfer.fused_add_rmsnorm(x, residual, self.final_norm, cfg.rms_norm_eps)
         hidden = x[last_token_rows]

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -73,7 +73,13 @@ class ModelConfig:
                 f"Unsupported model_type {model_type!r}; this example supports "
                 f"{SUPPORTED_MODEL_TYPES}"
             )
+        # transformers v5 nests rope config under "rope_parameters"; older
+        # checkpoints use top-level "rope_theta" + optional "rope_scaling".
+        rope_params = cfg.get("rope_parameters") or {}
+        rope_theta = rope_params.get("rope_theta", cfg.get("rope_theta", 1e4))
         rope_scaling = cfg.get("rope_scaling")
+        if rope_params.get("rope_type", "default") != "default":
+            rope_scaling = rope_params
         if rope_scaling is not None:
             rope_type = rope_scaling.get("rope_type", rope_scaling.get("type"))
             if rope_type not in ("llama3", "default"):
@@ -102,11 +108,12 @@ class ModelConfig:
             ),
             vocab_size=cfg["vocab_size"],
             rms_norm_eps=cfg["rms_norm_eps"],
-            rope_theta=cfg.get("rope_theta", 1e4),
+            rope_theta=rope_theta,
             tie_word_embeddings=cfg.get("tie_word_embeddings", False),
             rope_scaling=rope_scaling,
             eos_token_ids=eos_token_ids,
-            num_experts=cfg.get("num_experts", 0),
+            # "num_local_experts" is the transformers-v5 serialization.
+            num_experts=cfg.get("num_experts", cfg.get("num_local_experts", 0)),
             num_experts_per_tok=cfg.get("num_experts_per_tok", 0),
             moe_intermediate_size=cfg.get("moe_intermediate_size", 0),
             norm_topk_prob=cfg.get("norm_topk_prob", False),

--- a/examples/pytorch/llm/modeling.py
+++ b/examples/pytorch/llm/modeling.py
@@ -1,0 +1,372 @@
+"""FlashInfer end-to-end LLM example: Llama / Qwen dense decoder.
+
+Reference/verification code, not a serving engine: it strings FlashInfer's
+serving-path ops together the way an inference framework would — paged KV
+cache (`append_paged_kv_cache`), batched prefill/decode attention wrappers,
+RoPE (`apply_rope_pos_ids_inplace`), RMSNorm (`rmsnorm` /
+`fused_add_rmsnorm`), and SwiGLU (`silu_and_mul`) — in plain PyTorch, loading
+weights directly from a Hugging Face checkpoint's safetensors. See
+`docs/design_docs/e2e_pytorch_llm_examples.md` for the rationale.
+
+Supported HF `model_type`s: `llama`, `qwen2`, `qwen3` (dense). The three
+share one skeleton (RMSNorm -> GQA attention with RoPE -> SwiGLU FFN); the
+deltas are Qwen3's per-head q/k norm, Qwen2's QKV bias, and Llama-3.1-style
+RoPE scaling.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import torch
+
+import flashinfer
+
+SUPPORTED_MODEL_TYPES = ("llama", "qwen2", "qwen3")
+
+
+@dataclasses.dataclass
+class ModelConfig:
+    model_type: str
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    vocab_size: int
+    rms_norm_eps: float
+    rope_theta: float
+    tie_word_embeddings: bool
+    rope_scaling: Optional[dict]
+    eos_token_ids: List[int]
+
+    @classmethod
+    def from_hf_config(cls, cfg: dict) -> "ModelConfig":
+        model_type = cfg["model_type"]
+        if model_type not in SUPPORTED_MODEL_TYPES:
+            raise ValueError(
+                f"Unsupported model_type {model_type!r}; this example supports "
+                f"{SUPPORTED_MODEL_TYPES}"
+            )
+        rope_scaling = cfg.get("rope_scaling")
+        if rope_scaling is not None:
+            rope_type = rope_scaling.get("rope_type", rope_scaling.get("type"))
+            if rope_type not in ("llama3", "default"):
+                raise ValueError(
+                    f"Unsupported rope_scaling {rope_scaling!r}; this example "
+                    "supports null, 'default', and 'llama3' scaling"
+                )
+        eos = cfg.get("eos_token_id")
+        if eos is None:
+            eos_token_ids = []
+        elif isinstance(eos, int):
+            eos_token_ids = [eos]
+        else:
+            eos_token_ids = list(eos)
+        return cls(
+            model_type=model_type,
+            hidden_size=cfg["hidden_size"],
+            intermediate_size=cfg["intermediate_size"],
+            num_hidden_layers=cfg["num_hidden_layers"],
+            num_attention_heads=cfg["num_attention_heads"],
+            num_key_value_heads=cfg.get(
+                "num_key_value_heads", cfg["num_attention_heads"]
+            ),
+            head_dim=cfg.get(
+                "head_dim", cfg["hidden_size"] // cfg["num_attention_heads"]
+            ),
+            vocab_size=cfg["vocab_size"],
+            rms_norm_eps=cfg["rms_norm_eps"],
+            rope_theta=cfg.get("rope_theta", 1e4),
+            tie_word_embeddings=cfg.get("tie_word_embeddings", False),
+            rope_scaling=rope_scaling,
+            eos_token_ids=eos_token_ids,
+        )
+
+
+def resolve_checkpoint_dir(model_id_or_path: str) -> Path:
+    """Return a local directory containing config.json + safetensors.
+
+    Accepts either a local path or a Hugging Face model id (downloads
+    config/tokenizer/safetensors via huggingface_hub, honoring HF_HOME).
+    """
+    local = Path(model_id_or_path)
+    if local.is_dir():
+        return local
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            model_id_or_path,
+            allow_patterns=["*.json", "*.safetensors", "tokenizer*", "*.txt"],
+        )
+    )
+
+
+def _load_state_dict(ckpt_dir: Path) -> Dict[str, torch.Tensor]:
+    from safetensors.torch import load_file
+
+    index_file = ckpt_dir / "model.safetensors.index.json"
+    if index_file.exists():
+        with open(index_file) as f:
+            shard_names = sorted(set(json.load(f)["weight_map"].values()))
+    else:
+        shard_names = [p.name for p in sorted(ckpt_dir.glob("*.safetensors"))]
+    if not shard_names:
+        raise FileNotFoundError(f"No safetensors found under {ckpt_dir}")
+    state_dict: Dict[str, torch.Tensor] = {}
+    for shard in shard_names:
+        state_dict.update(load_file(ckpt_dir / shard))
+    return state_dict
+
+
+class DecoderLayerWeights:
+    def __init__(self, sd: Dict[str, torch.Tensor], i: int, device, dtype):
+        p = f"model.layers.{i}."
+
+        def get(name: str, required: bool = True) -> Optional[torch.Tensor]:
+            key = p + name
+            if key not in sd:
+                if required:
+                    raise KeyError(f"Missing weight {key}")
+                return None
+            return sd[key].to(device=device, dtype=dtype)
+
+        self.input_layernorm = get("input_layernorm.weight")
+        self.post_attention_layernorm = get("post_attention_layernorm.weight")
+        self.q_proj = get("self_attn.q_proj.weight")
+        self.k_proj = get("self_attn.k_proj.weight")
+        self.v_proj = get("self_attn.v_proj.weight")
+        self.o_proj = get("self_attn.o_proj.weight")
+        # Qwen2-family checkpoints carry QKV bias; Llama/Qwen3 do not.
+        self.q_bias = get("self_attn.q_proj.bias", required=False)
+        self.k_bias = get("self_attn.k_proj.bias", required=False)
+        self.v_bias = get("self_attn.v_proj.bias", required=False)
+        # Qwen3 per-head q/k RMSNorm over head_dim.
+        self.q_norm = get("self_attn.q_norm.weight", required=False)
+        self.k_norm = get("self_attn.k_norm.weight", required=False)
+        self.gate_proj = get("mlp.gate_proj.weight")
+        self.up_proj = get("mlp.up_proj.weight")
+        self.down_proj = get("mlp.down_proj.weight")
+
+
+class FlashInferLLM:
+    """Dense Llama/Qwen-family decoder over a paged KV cache.
+
+    The model itself is stateless w.r.t. sequences: all per-request state
+    (page tables, sequence lengths) lives in the caller-provided
+    :class:`PagedKVCache` and the planned attention wrapper.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        state_dict: Dict[str, torch.Tensor],
+        device: torch.device,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.config = config
+        self.device = device
+        self.dtype = dtype
+        self.embed_tokens = state_dict["model.embed_tokens.weight"].to(
+            device=device, dtype=dtype
+        )
+        self.final_norm = state_dict["model.norm.weight"].to(device=device, dtype=dtype)
+        if config.tie_word_embeddings or "lm_head.weight" not in state_dict:
+            self.lm_head = self.embed_tokens
+        else:
+            self.lm_head = state_dict["lm_head.weight"].to(device=device, dtype=dtype)
+        self.layers = [
+            DecoderLayerWeights(state_dict, i, device, dtype)
+            for i in range(config.num_hidden_layers)
+        ]
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_id_or_path: str,
+        device: torch.device,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> "FlashInferLLM":
+        ckpt_dir = resolve_checkpoint_dir(model_id_or_path)
+        with open(ckpt_dir / "config.json") as f:
+            config = ModelConfig.from_hf_config(json.load(f))
+        state_dict = _load_state_dict(ckpt_dir)
+        return cls(config, state_dict, device, dtype)
+
+    def _apply_rope(self, q: torch.Tensor, k: torch.Tensor, pos_ids: torch.Tensor):
+        cfg = self.config
+        scaling = cfg.rope_scaling
+        if (
+            scaling is not None
+            and scaling.get("rope_type", scaling.get("type")) == "llama3"
+        ):
+            flashinfer.apply_llama31_rope_pos_ids_inplace(
+                q,
+                k,
+                pos_ids,
+                interleave=False,
+                rope_scale=scaling["factor"],
+                rope_theta=cfg.rope_theta,
+                low_freq_factor=scaling["low_freq_factor"],
+                high_freq_factor=scaling["high_freq_factor"],
+                old_context_len=scaling["original_max_position_embeddings"],
+            )
+        else:
+            flashinfer.apply_rope_pos_ids_inplace(
+                q, k, pos_ids, interleave=False, rope_theta=cfg.rope_theta
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,  # (nnz,) int64, tokens packed over the batch
+        pos_ids: torch.Tensor,  # (nnz,) int32, absolute position per token
+        attn_wrapper,  # planned prefill or decode wrapper
+        kv_cache: "PagedKVCache",
+        batch_indices: torch.Tensor,  # (nnz,) int32, request of each token
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_last_page_len: torch.Tensor,
+        last_token_rows: torch.Tensor,  # (batch,) int64 rows to compute logits for
+    ) -> torch.Tensor:
+        """One forward step (prefill or decode). Returns (batch, vocab) fp32 logits."""
+        cfg = self.config
+        nnz = input_ids.shape[0]
+        num_q, num_kv, hd = (
+            cfg.num_attention_heads,
+            cfg.num_key_value_heads,
+            cfg.head_dim,
+        )
+        x = torch.nn.functional.embedding(input_ids, self.embed_tokens)
+        residual: Optional[torch.Tensor] = None
+        for i, w in enumerate(self.layers):
+            if residual is None:
+                residual = x
+                x = flashinfer.rmsnorm(x, w.input_layernorm, cfg.rms_norm_eps)
+            else:
+                flashinfer.fused_add_rmsnorm(
+                    x, residual, w.input_layernorm, cfg.rms_norm_eps
+                )
+            q = torch.nn.functional.linear(x, w.q_proj, w.q_bias).view(nnz, num_q, hd)
+            k = torch.nn.functional.linear(x, w.k_proj, w.k_bias).view(nnz, num_kv, hd)
+            v = torch.nn.functional.linear(x, w.v_proj, w.v_bias).view(nnz, num_kv, hd)
+            if w.q_norm is not None:
+                q = flashinfer.rmsnorm(q, w.q_norm, cfg.rms_norm_eps)
+                k = flashinfer.rmsnorm(k, w.k_norm, cfg.rms_norm_eps)
+            self._apply_rope(q, k, pos_ids)
+            flashinfer.append_paged_kv_cache(
+                k,
+                v,
+                batch_indices,
+                pos_ids,
+                kv_cache.layer_view(i),
+                kv_indices,
+                kv_indptr,
+                kv_last_page_len,
+                kv_layout="NHD",
+            )
+            attn = attn_wrapper.run(q, kv_cache.layer_view(i))
+            attn = torch.nn.functional.linear(attn.reshape(nnz, num_q * hd), w.o_proj)
+            flashinfer.fused_add_rmsnorm(
+                attn, residual, w.post_attention_layernorm, cfg.rms_norm_eps
+            )
+            gate_up = torch.cat(
+                [
+                    torch.nn.functional.linear(attn, w.gate_proj),
+                    torch.nn.functional.linear(attn, w.up_proj),
+                ],
+                dim=-1,
+            )
+            x = torch.nn.functional.linear(
+                flashinfer.silu_and_mul(gate_up), w.down_proj
+            )
+        # Final residual add + norm, only then project the rows we sample from.
+        flashinfer.fused_add_rmsnorm(x, residual, self.final_norm, cfg.rms_norm_eps)
+        hidden = x[last_token_rows]
+        return torch.nn.functional.linear(hidden, self.lm_head).float()
+
+
+class PagedKVCache:
+    """Paged KV cache + page tables for a fixed batch of requests.
+
+    Layout is NHD: per layer ``[max_pages, 2, page_size, num_kv_heads,
+    head_dim]``. Pages are handed out from a bump allocator; all index
+    tensors are int32 as required by the FlashInfer kernels.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        max_pages: int,
+        page_size: int,
+        device: torch.device,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.page_size = page_size
+        self.device = device
+        self.kv_data = torch.zeros(
+            config.num_hidden_layers,
+            max_pages,
+            2,
+            page_size,
+            config.num_key_value_heads,
+            config.head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        self.max_pages = max_pages
+        self._next_free_page = 0
+        self.page_tables: List[List[int]] = []
+        self.seq_lens: List[int] = []
+
+    def layer_view(self, layer: int) -> torch.Tensor:
+        return self.kv_data[layer]
+
+    def add_request(self) -> int:
+        self.page_tables.append([])
+        self.seq_lens.append(0)
+        return len(self.page_tables) - 1
+
+    def _alloc_page(self) -> int:
+        if self._next_free_page >= self.max_pages:
+            raise RuntimeError(
+                f"Out of KV pages (max_pages={self.max_pages}); increase the "
+                "page budget for this prompt/generation length"
+            )
+        page = self._next_free_page
+        self._next_free_page += 1
+        return page
+
+    def extend(self, request: int, num_new_tokens: int) -> None:
+        """Grow request's page table to hold num_new_tokens more tokens."""
+        self.seq_lens[request] += num_new_tokens
+        needed_pages = math.ceil(self.seq_lens[request] / self.page_size)
+        table = self.page_tables[request]
+        while len(table) < needed_pages:
+            table.append(self._alloc_page())
+
+    def page_table_tensors(self):
+        """Return (kv_indptr, kv_indices, kv_last_page_len) int32 tensors."""
+        indptr = [0]
+        for t in self.page_tables:
+            indptr.append(indptr[-1] + len(t))
+        kv_indptr = torch.tensor(indptr, dtype=torch.int32, device=self.device)
+        kv_indices = torch.tensor(
+            [p for t in self.page_tables for p in t],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        kv_last_page_len = torch.tensor(
+            [(sl - 1) % self.page_size + 1 for sl in self.seq_lens],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        return kv_indptr, kv_indices, kv_last_page_len
+
+    def seq_lens_tensor(self) -> torch.Tensor:
+        return torch.tensor(self.seq_lens, dtype=torch.int32, device=self.device)

--- a/examples/pytorch/llm/reference_check.py
+++ b/examples/pytorch/llm/reference_check.py
@@ -1,0 +1,153 @@
+"""Numerical reference check for the FlashInfer LLM example.
+
+Builds tiny random-weight models (dense Qwen3 and Qwen3-MoE) with
+``transformers``, saves them as normal HF checkpoints, loads them with this
+example's FlashInfer-based implementation, and compares last-token prefill
+logits between the two — position by position, in BF16 — for a batch of
+random prompts of varying lengths.
+
+This validates the full numerical wiring (attention over the paged KV cache,
+RoPE, norms, SwiGLU, MoE routing + ``cutlass_fused_moe`` expert dispatch)
+without downloading real checkpoints: a tiny random MoE exercises exactly
+the same kernel paths as Qwen3-30B-A3B. Kernel-vs-eager BF16 accumulation
+differences are expected; the assertion is a relative-L2 bound per prompt.
+
+Usage:
+    python reference_check.py                    # dense + moe tiny models
+    python reference_check.py --arch moe         # just the MoE model
+    python reference_check.py --rel-tol 0.05
+
+Emits ``[smoke] refcheck_<arch>=pass|fail`` lines; exit code 0/1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+
+import torch
+
+from generate import GenerationEngine
+from modeling import FlashInferLLM
+
+# Tiny but kernel-legal shapes: head_dim 64/128 for attention; hidden and
+# (moe_)intermediate must be multiples of 8 for the BF16 cutlass MoE path.
+COMMON = dict(
+    hidden_size=256,
+    intermediate_size=512,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=64,
+    vocab_size=2048,
+    max_position_embeddings=4096,
+    rms_norm_eps=1e-6,
+    rope_theta=1e6,
+    tie_word_embeddings=False,
+    attention_bias=False,
+    use_cache=False,
+)
+
+
+def build_tiny_checkpoint(arch: str, tmpdir: str, seed: int) -> str:
+    torch.manual_seed(seed)
+    if arch == "dense":
+        from transformers import Qwen3Config, Qwen3ForCausalLM
+
+        cfg = Qwen3Config(**COMMON)
+        model = Qwen3ForCausalLM(cfg)
+    elif arch == "moe":
+        from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+        cfg = Qwen3MoeConfig(
+            **COMMON,
+            num_experts=8,
+            num_experts_per_tok=2,
+            moe_intermediate_size=128,
+            norm_topk_prob=True,
+            decoder_sparse_step=1,
+            mlp_only_layers=[],
+            router_aux_loss_coef=0.0,
+        )
+        model = Qwen3MoeForCausalLM(cfg)
+    else:
+        raise ValueError(arch)
+    model = model.to(torch.bfloat16).eval()
+    path = f"{tmpdir}/tiny_{arch}"
+    model.save_pretrained(path, safe_serialization=True)
+    return path
+
+
+def check_arch(arch: str, rel_tol: float, seed: int) -> bool:
+    device = torch.device("cuda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ckpt = build_tiny_checkpoint(arch, tmpdir, seed)
+
+        from transformers import AutoModelForCausalLM
+
+        ref_model = (
+            AutoModelForCausalLM.from_pretrained(
+                ckpt, dtype=torch.bfloat16, attn_implementation="eager"
+            )
+            .to(device)
+            .eval()
+        )
+        our_model = FlashInferLLM.from_pretrained(ckpt, device)
+        engine = GenerationEngine(our_model)
+
+        g = torch.Generator().manual_seed(seed + 1)
+        vocab = our_model.config.vocab_size
+        prompts = [
+            torch.randint(0, vocab, (n,), generator=g).tolist()
+            for n in (7, 33, 61, 128)
+        ]
+
+        ours = engine.prefill_logits(prompts).float()  # [batch, vocab]
+        ok = True
+        for i, ids in enumerate(prompts):
+            with torch.inference_mode():
+                ref = (
+                    ref_model(torch.tensor([ids], device=device)).logits[0, -1].float()
+                )
+            rel = (ours[i] - ref).norm() / ref.norm()
+            top1_match = ours[i].argmax().item() == ref.argmax().item()
+            status = "ok" if rel <= rel_tol else "MISMATCH"
+            print(
+                f"  {arch} len={len(ids):>3}: rel_l2={rel:.4f} "
+                f"top1_match={top1_match} [{status}]"
+            )
+            ok &= rel <= rel_tol
+        del ref_model, our_model, engine
+        torch.cuda.empty_cache()
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arch", choices=["dense", "moe", "all"], default="all")
+    parser.add_argument(
+        "--rel-tol",
+        type=float,
+        default=0.05,
+        help="max relative L2 error of last-token logits vs transformers eager",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    archs = ["dense", "moe"] if args.arch == "all" else [args.arch]
+    failed = []
+    for arch in archs:
+        print(f"reference check: tiny {arch} model vs transformers eager (bf16)")
+        ok = check_arch(arch, args.rel_tol, args.seed)
+        print(f"[smoke] refcheck_{arch}={'pass' if ok else 'fail'}")
+        if not ok:
+            failed.append(arch)
+    if failed:
+        print(f"FAIL: logits mismatch for: {', '.join(failed)}")
+        sys.exit(1)
+    print("PASS: FlashInfer path matches transformers reference within tolerance")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/reference_check.py
+++ b/examples/pytorch/llm/reference_check.py
@@ -3,19 +3,24 @@
 Builds tiny random-weight models (dense Qwen3 and Qwen3-MoE) with
 ``transformers``, saves them as normal HF checkpoints, loads them with this
 example's FlashInfer-based implementation, and compares last-token prefill
-logits between the two — position by position, in BF16 — for a batch of
-random prompts of varying lengths.
+logits between the two — in BF16 — for a batch of random prompts of varying
+lengths.
 
 This validates the full numerical wiring (attention over the paged KV cache,
 RoPE, norms, SwiGLU, MoE routing + ``cutlass_fused_moe`` expert dispatch)
 without downloading real checkpoints: a tiny random MoE exercises exactly
 the same kernel paths as Qwen3-30B-A3B. Kernel-vs-eager BF16 accumulation
-differences are expected; the assertion is a relative-L2 bound per prompt.
+differences are expected; the assertion is a relative-L2 bound per prompt
+(the HF bf16-vs-fp32 noise floor for these models is ~0.007).
 
-Usage:
+Single GPU:
     python reference_check.py                    # dense + moe tiny models
-    python reference_check.py --arch moe         # just the MoE model
-    python reference_check.py --rel-tol 0.05
+    python reference_check.py --arch moe --rel-tol 0.05
+
+TEP (TP=EP) across N GPUs — attention tensor-parallel, MoE expert-parallel,
+one allreduce after attention and one after the FFN/MoE; rank 0 compares
+against the single-GPU transformers reference:
+    torchrun --nproc_per_node=2 reference_check.py
 
 Emits ``[smoke] refcheck_<arch>=pass|fail`` lines; exit code 0/1.
 """
@@ -23,16 +28,19 @@ Emits ``[smoke] refcheck_<arch>=pass|fail`` lines; exit code 0/1.
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
 import sys
 import tempfile
 
 import torch
 
-from generate import GenerationEngine
+from generate import GenerationEngine, maybe_init_distributed
 from modeling import FlashInferLLM
 
 # Tiny but kernel-legal shapes: head_dim 64/128 for attention; hidden and
 # (moe_)intermediate must be multiples of 8 for the BF16 cutlass MoE path.
+# Head counts / expert count divide by 2 so the same configs run under TP=2.
 COMMON = dict(
     hidden_size=256,
     intermediate_size=512,
@@ -79,21 +87,23 @@ def build_tiny_checkpoint(arch: str, tmpdir: str, seed: int) -> str:
     return path
 
 
-def check_arch(arch: str, rel_tol: float, seed: int) -> bool:
-    device = torch.device("cuda")
-    with tempfile.TemporaryDirectory() as tmpdir:
+def check_arch(
+    arch: str, rel_tol: float, seed: int, world_size: int, rank: int
+) -> bool:
+    device = torch.device("cuda", torch.cuda.current_device())
+    tmpdir = ckpt = None
+    if rank == 0:
+        tmpdir = tempfile.mkdtemp()
         ckpt = build_tiny_checkpoint(arch, tmpdir, seed)
+    if world_size > 1:
+        obj = [ckpt]
+        torch.distributed.broadcast_object_list(obj, src=0)
+        ckpt = obj[0]
 
-        from transformers import AutoModelForCausalLM
-
-        ref_model = (
-            AutoModelForCausalLM.from_pretrained(
-                ckpt, dtype=torch.bfloat16, attn_implementation="eager"
-            )
-            .to(device)
-            .eval()
+    try:
+        our_model = FlashInferLLM.from_pretrained(
+            ckpt, device, tp_size=world_size, tp_rank=rank
         )
-        our_model = FlashInferLLM.from_pretrained(ckpt, device)
         engine = GenerationEngine(our_model)
 
         g = torch.Generator().manual_seed(seed + 1)
@@ -103,24 +113,47 @@ def check_arch(arch: str, rel_tol: float, seed: int) -> bool:
             for n in (7, 33, 61, 128)
         ]
 
-        ours = engine.prefill_logits(prompts).float()  # [batch, vocab]
+        # Collective under TP: every rank participates; logits identical on
+        # all ranks after the final allreduce.
+        ours = engine.prefill_logits(prompts).float()
+
         ok = True
-        for i, ids in enumerate(prompts):
-            with torch.inference_mode():
-                ref = (
-                    ref_model(torch.tensor([ids], device=device)).logits[0, -1].float()
+        if rank == 0:
+            from transformers import AutoModelForCausalLM
+
+            ref_model = (
+                AutoModelForCausalLM.from_pretrained(
+                    ckpt, dtype=torch.bfloat16, attn_implementation="eager"
                 )
-            rel = (ours[i] - ref).norm() / ref.norm()
-            top1_match = ours[i].argmax().item() == ref.argmax().item()
-            status = "ok" if rel <= rel_tol else "MISMATCH"
-            print(
-                f"  {arch} len={len(ids):>3}: rel_l2={rel:.4f} "
-                f"top1_match={top1_match} [{status}]"
+                .to(device)
+                .eval()
             )
-            ok &= rel <= rel_tol
-        del ref_model, our_model, engine
+            for i, ids in enumerate(prompts):
+                with torch.inference_mode():
+                    ref = (
+                        ref_model(torch.tensor([ids], device=device))
+                        .logits[0, -1]
+                        .float()
+                    )
+                rel = (ours[i] - ref).norm() / ref.norm()
+                top1_match = ours[i].argmax().item() == ref.argmax().item()
+                status = "ok" if rel <= rel_tol else "MISMATCH"
+                print(
+                    f"  {arch} len={len(ids):>3}: rel_l2={rel:.4f} "
+                    f"top1_match={top1_match} [{status}]"
+                )
+                ok &= rel <= rel_tol
+            del ref_model
+        del our_model, engine
         torch.cuda.empty_cache()
-    return ok
+        if world_size > 1:  # share the verdict so every rank exits alike
+            flag = torch.tensor([int(ok)], device=device)
+            torch.distributed.broadcast(flag, src=0)
+            ok = bool(flag.item())
+        return ok
+    finally:
+        if rank == 0 and tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def main():
@@ -135,14 +168,21 @@ def main():
     parser.add_argument("--seed", type=int, default=0)
     args = parser.parse_args()
 
+    world_size, rank = maybe_init_distributed()
+    if rank != 0:  # keep stdout single-writer; stderr stays visible
+        sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — process-lifetime sink
+
+    mode = f"TEP tp=ep={world_size}" if world_size > 1 else "single GPU"
     archs = ["dense", "moe"] if args.arch == "all" else [args.arch]
     failed = []
     for arch in archs:
-        print(f"reference check: tiny {arch} model vs transformers eager (bf16)")
-        ok = check_arch(arch, args.rel_tol, args.seed)
+        print(f"reference check ({mode}): tiny {arch} vs transformers eager (bf16)")
+        ok = check_arch(arch, args.rel_tol, args.seed, world_size, rank)
         print(f"[smoke] refcheck_{arch}={'pass' if ok else 'fail'}")
         if not ok:
             failed.append(arch)
+    if world_size > 1:
+        torch.distributed.destroy_process_group()
     if failed:
         print(f"FAIL: logits mismatch for: {', '.join(failed)}")
         sys.exit(1)

--- a/examples/pytorch/llm/smoke_test.py
+++ b/examples/pytorch/llm/smoke_test.py
@@ -1,0 +1,121 @@
+"""End-to-end smoke test for the FlashInfer LLM example.
+
+Runs ``generate.py`` in two fresh subprocesses and verifies integration-level
+invariants that kernel unit tests cannot see:
+
+1. **JIT cache works across processes** — the second run must compile zero
+   modules (``jit_builds_total == 0``). If this fails, the on-disk kernel
+   cache is broken and every user process pays full recompilation.
+2. **No steady-state recompiles** — decode steps after the first must never
+   trigger a JIT build (``jit_builds_steady == 0``), in both runs.
+3. **Greedy determinism** — both runs must produce identical token ids.
+4. **Liveness** — every request produced at least one token.
+
+Usage:
+    python smoke_test.py --model-id Qwen/Qwen3-0.6B --max-tokens 16
+
+Exit code 0 on pass, 1 on failure (with both runs' output dumped).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List
+
+
+def run_generate(args: argparse.Namespace, label: str) -> Dict:
+    cmd = [
+        sys.executable,
+        str(Path(__file__).parent / "generate.py"),
+        "--model-id",
+        args.model_id,
+        "--max-tokens",
+        str(args.max_tokens),
+        "--temperature",
+        "0.0",
+    ]
+    t0 = time.perf_counter()
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout)
+    elapsed = time.perf_counter() - t0
+    if proc.returncode != 0:
+        print(f"=== {label}: generate.py failed (rc={proc.returncode}) ===")
+        print(proc.stdout)
+        print(proc.stderr, file=sys.stderr)
+        sys.exit(1)
+    smoke: Dict = {"elapsed": elapsed, "stdout": proc.stdout}
+    tokens: List[str] = []
+    for line in proc.stdout.splitlines():
+        if not line.startswith("[smoke] "):
+            continue
+        key, _, value = line[len("[smoke] ") :].partition("=")
+        if key.startswith("tokens_"):
+            tokens.append(value)
+        else:
+            smoke[key] = value
+    smoke["tokens"] = tokens
+    print(
+        f"{label}: {elapsed:.1f}s, jit_builds_total={smoke.get('jit_builds_total')}, "
+        f"jit_builds_steady={smoke.get('jit_builds_steady')}, "
+        f"{len(tokens)} completions"
+    )
+    return smoke
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=3600,
+        help="Per-run timeout in seconds (cold JIT compile can be slow)",
+    )
+    args = parser.parse_args()
+
+    print(f"smoke test: {args.model_id}, greedy, {args.max_tokens} new tokens")
+    first = run_generate(args, "run 1 (warmup, compiles allowed)")
+    second = run_generate(args, "run 2 (must be fully cached)")
+
+    failures: List[str] = []
+
+    if second.get("jit_builds_total") != "0":
+        failures.append(
+            "JIT cache miss on warm run: second process compiled "
+            f"{second.get('jit_builds_total')} modules "
+            f"({second.get('jit_builds_names')}) — the on-disk kernel cache "
+            "is not being reused"
+        )
+    for label, run in (("run 1", first), ("run 2", second)):
+        if run.get("jit_builds_steady") != "0":
+            failures.append(
+                f"{label}: {run.get('jit_builds_steady')} JIT builds during "
+                "steady-state decode — kernels are recompiling across steps"
+            )
+    if first["tokens"] != second["tokens"]:
+        failures.append(
+            "greedy decode is not deterministic across runs:\n"
+            f"  run 1: {first['tokens']}\n  run 2: {second['tokens']}"
+        )
+    if not first["tokens"] or any(not t for t in first["tokens"]):
+        failures.append("empty completion(s) in run 1")
+
+    if failures:
+        print("\nFAIL:")
+        for f in failures:
+            print(f"  - {f}")
+        print("\n=== run 1 output ===\n" + first["stdout"])
+        print("\n=== run 2 output ===\n" + second["stdout"])
+        sys.exit(1)
+    print(
+        f"\nPASS ({first['elapsed']:.1f}s cold -> {second['elapsed']:.1f}s warm; "
+        "cache reuse, steady-state stability, and determinism verified)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/llm/smoke_test.py
+++ b/examples/pytorch/llm/smoke_test.py
@@ -4,8 +4,9 @@ Runs ``generate.py`` in two fresh subprocesses and verifies integration-level
 invariants that kernel unit tests cannot see:
 
 1. **JIT cache works across processes** — the second run must compile zero
-   modules (``jit_builds_total == 0``). If this fails, the on-disk kernel
-   cache is broken and every user process pays full recompilation.
+   modules (``jit_builds_total == 0``, measured as "built artifact changed";
+   ninja dependency scans still run by design). If this fails, the on-disk
+   kernel cache is broken and every user process pays full recompilation.
 2. **No steady-state recompiles** — decode steps after the first must never
    trigger a JIT build (``jit_builds_steady == 0``), in both runs.
 3. **Greedy determinism** — both runs must produce identical token ids.
@@ -59,6 +60,7 @@ def run_generate(args: argparse.Namespace, label: str) -> Dict:
     smoke["tokens"] = tokens
     print(
         f"{label}: {elapsed:.1f}s, jit_builds_total={smoke.get('jit_builds_total')}, "
+        f"jit_build_calls={smoke.get('jit_build_calls')}, "
         f"jit_builds_steady={smoke.get('jit_builds_steady')}, "
         f"{len(tokens)} completions"
     )

--- a/examples/pytorch/llm/smoke_test.py
+++ b/examples/pytorch/llm/smoke_test.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Dict, List
 
 
-def run_generate(args: argparse.Namespace, label: str) -> Dict:
+def run_generate(args: argparse.Namespace, label: str, sampling: bool = False) -> Dict:
     cmd = [
         sys.executable,
         str(Path(__file__).parent / "generate.py"),
@@ -36,9 +36,21 @@ def run_generate(args: argparse.Namespace, label: str) -> Dict:
         args.model_id,
         "--max-tokens",
         str(args.max_tokens),
-        "--temperature",
-        "0.0",
     ]
+    if sampling:
+        cmd += [
+            "--temperature",
+            str(args.temperature),
+            "--top-k",
+            str(args.top_k),
+            "--top-p",
+            str(args.top_p),
+            "--seed",
+            str(args.seed),
+            "--check-sampling",
+        ]
+    else:
+        cmd += ["--temperature", "0.0"]
     t0 = time.perf_counter()
     proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout)
     elapsed = time.perf_counter() - t0
@@ -70,6 +82,15 @@ def run_generate(args: argparse.Namespace, label: str) -> Dict:
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-id", default="Qwen/Qwen3-0.6B")
+    parser.add_argument(
+        "--skip-sampling",
+        action="store_true",
+        help="Skip the top-k/top-p sampling runs (greedy checks only)",
+    )
+    parser.add_argument("--temperature", type=float, default=0.8)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--top-p", type=float, default=0.9)
+    parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--max-tokens", type=int, default=16)
     parser.add_argument(
         "--timeout",
@@ -106,16 +127,93 @@ def main():
     if not first["tokens"] or any(not t for t in first["tokens"]):
         failures.append("empty completion(s) in run 1")
 
+    # ---- top-k/top-p sampling ----
+    # Greedy never touches flashinfer.sampling at all (sample_tokens
+    # short-circuits to argmax), so without these runs the sampling and topk
+    # JIT modules are never even compiled.
+    third = fourth = None
+    if not args.skip_sampling:
+        print(
+            f"\nsampling: temperature={args.temperature} top_k={args.top_k} "
+            f"top_p={args.top_p} seed={args.seed}"
+        )
+        third = run_generate(args, "run 3 (sampling, compiles allowed)", sampling=True)
+        fourth = run_generate(args, "run 4 (sampling, must be cached)", sampling=True)
+
+        if int(third.get("sample_draws", 0)) == 0:
+            failures.append("sampling runs produced no sampled tokens to audit")
+        for label, run in (("run 3", third), ("run 4", fourth)):
+            if run.get("sample_violations") != "0":
+                failures.append(
+                    f"{label}: {run.get('sample_violations')} of "
+                    f"{run.get('sample_draws')} sampled tokens fell OUTSIDE the "
+                    "top-k ∩ nucleus support — the sampling kernel is wrong"
+                )
+            if run.get("sample_out_of_range") != "0":
+                failures.append(
+                    f"{label}: {run.get('sample_out_of_range')} sampled token ids "
+                    "were outside [0, vocab)"
+                )
+            if run.get("sample_replay_match") != "1":
+                failures.append(
+                    f"{label}: re-sampling the same logits with a freshly seeded "
+                    "generator gave different tokens — seeded sampling is not "
+                    "reproducible"
+                )
+            if run.get("sample_perreq_violations") != "0":
+                failures.append(
+                    f"{label}: {run.get('sample_perreq_violations')} violations with "
+                    "per-request tensor top_k/top_p (non-fast-path kernels)"
+                )
+            # Guard against a vacuous membership check: with top_k=0/top_p=1.0
+            # the admissible set is the whole vocabulary and it can never fail.
+            mean_allowed = float(run.get("sample_allowed_mean", 0))
+            if args.top_k > 0 and mean_allowed > 2 * args.top_k:
+                failures.append(
+                    f"{label}: mean admissible set {mean_allowed:.1f} is far wider "
+                    f"than top_k={args.top_k} — the support check is not selective"
+                )
+        # A sampler degenerated to argmax stays inside the support, so
+        # membership cannot see it; require divergence when enough is expected.
+        expected = float(third.get("sample_expected_divergences", 0))
+        got = int(third.get("sample_divergences", 0))
+        if expected >= 10.0 and got == 0:
+            failures.append(
+                f"run 3: sampling never diverged from greedy in {third.get('sample_draws')} "
+                f"draws though ~{expected:.1f} divergences were expected — the "
+                "sampler looks degenerate (dead RNG or unconditional argmax)"
+            )
+        elif expected < 10.0:
+            print(
+                f"  note: anti-argmax check INCONCLUSIVE "
+                f"(only ~{expected:.1f} divergences expected; raise --temperature)"
+            )
+        if fourth.get("jit_builds_total") != "0":
+            failures.append(
+                "JIT cache miss on warm sampling run: "
+                f"{fourth.get('jit_builds_names')} recompiled"
+            )
+        if third["tokens"] != fourth["tokens"]:
+            failures.append(
+                "seeded sampling is not deterministic across processes:\n"
+                f"  run 3: {third['tokens']}\n  run 4: {fourth['tokens']}"
+            )
+
     if failures:
         print("\nFAIL:")
         for f in failures:
             print(f"  - {f}")
         print("\n=== run 1 output ===\n" + first["stdout"])
         print("\n=== run 2 output ===\n" + second["stdout"])
+        if third is not None:
+            print("\n=== run 3 output ===\n" + third["stdout"])
+            print("\n=== run 4 output ===\n" + fourth["stdout"])
         sys.exit(1)
     print(
         f"\nPASS ({first['elapsed']:.1f}s cold -> {second['elapsed']:.1f}s warm; "
-        "cache reuse, steady-state stability, and determinism verified)"
+        "cache reuse, steady-state stability, and determinism verified"
+        + ("" if args.skip_sampling else "; sampling support audited")
+        + ")"
     )
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Closes a **structural hole** in the e2e LLM example harness (#4083, which this
stacks on — the diff includes #4083's commits until it lands).

Every stage of the harness ran greedy: `--temperature` defaults to `0.0` and
`sample_tokens()` short-circuits to `logits.argmax()`, so
`flashinfer.sampling.top_k_top_p_sampling_from_logits` was **never invoked**
and the `sampling` and `topk` JIT modules were **never even compiled**.
Measured on B200: the greedy path builds 4 modules, the sampling path builds
2 more. Nothing in the suite had ever touched them.

Running the kernel is not enough — a wrong answer has to be *caught*. So
`--check-sampling` audits every sampled token against a plain-torch reference
support (top-k ∩ nucleus, from the same temperature-scaled logits). Both
boundaries close over ties and the `eps` slack is applied on the permissive
side only, so the mask is a **superset** of what any correct implementation may
keep and a violation is unambiguous. This mirrors how
`tests/utils/test_sampling.py` asserts membership.

Membership alone has two blind spots, both covered:

- **a vacuous check** — with `top_k=0`/`top_p=1.0` the admissible set is the
  whole vocabulary and can never fail. So the mean admissible set size is
  reported and bounded. Measured: **4.3 of 151936**, i.e. genuinely selective.
- **a sampler degenerated to argmax** — always inside the support, so
  membership is blind to it. So divergences from greedy are counted against
  how many the filtered distribution predicts. Measured: **15 observed vs
  16.58 expected**.

Also audited: ids in range, seeded replay on identical logits, and the same
membership check with per-request **tensor** `top_k`/`top_p` — a different
kernel path, since a scalar `top_k` on a large vocab only ever exercises the
`top_k_first` fast path.

`smoke_test.py` gains a sampling run pair alongside the greedy pair, asserting
all of the above plus seeded cross-process determinism and `sampling`/`topk`
JIT cache reuse. **Greedy remains the default everywhere and its existing
assertions are untouched**; `--skip-sampling` restores the old behavior.

## 🔍 Related Issues

Stacks on #4083. Relevant to #4189 (`__launch_bounds__` gated to SM107): that
change makes B200 sampling codegen match what `main` already ships (main has
zero `launch_bounds` in `sampling.cuh`), so it is not a new Blackwell path —
but this is the first e2e coverage of sampling either way.

## 🧪 Tests

Validated on **B200 (sm100a)** against flashinfer **0.6.16rc3** (the tree that
carries #4189's gate — verified present in the tested checkout):

| Check | Result |
|---|---|
| `sample_violations` / 72 draws | **0** |
| `sample_out_of_range` | **0** |
| `sample_allowed_mean` | **4.3** of 151936 (bar ≤ 2·top_k) |
| divergences vs expected | **15 vs 16.58** |
| `sample_replay_match` | **1** |
| `sample_perreq_violations` | **0** |
| `smoke_test.py` (4 runs) | **PASS** — run 3 built `topk`+`sampling`, run 4 built 0 |
| `reference_check.py --arch dense` | unregressed |

Note on the cross-process sampled-determinism bar: it is a hard assertion
rather than gated on a logits fingerprint, because the harness *already*
asserts greedy determinism as a hard bar. If model numerics ever stopped being
bit-reproducible, greedy determinism would fail first and more legibly.

## ✅ Checklist

- [x] Passes `pre-commit run -a`
- [x] Validated on real hardware (B200)
- [x] Greedy default path unchanged
- [ ] Sampling under TEP/torchrun (non-zero ranks send stdout to devnull, so a
      violation there surfaces only as a nonzero exit code)

AI-assisted (Claude Code).