### PR TITLE
fix(norm): fall back to CUDA JIT kernels when CuTe DSL lacks the device arch

### DIFF
--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import ctypes
 import functools
-import os
 import importlib.util
 import warnings
 from typing import Optional, Tuple, Union
@@ -91,15 +90,19 @@ def is_cute_dsl_arch_supported(
                 return True
             except KeyError:
                 continue
-        if native_only:
-            return False
-        family = _family_fallback_arch(major, minor)
-        if family is not None:
-            # Pin the DSL's default compile target before the first kernel
-            # compile; without this the DSL derives the target from the
-            # device and raises KeyError. An explicit user setting wins.
-            os.environ.setdefault("CUTE_DSL_ARCH", family)
-            return True
+        # The device's own architecture is absent from the DSL enum.
+        #
+        # We deliberately do NOT redirect the DSL to a family-conditional
+        # target here (e.g. ``sm_100f`` for an sm_107 device). The DSL captures
+        # its compile target when ``cutlass`` is first imported -- which the
+        # ``Arch`` lookup above has already done -- so setting ``CUTE_DSL_ARCH``
+        # at this point has no effect. Doing so only reports the architecture as
+        # supported and defers the failure to a ``KeyError`` raised from inside
+        # ``cute.compile``, which is exactly what this probe exists to prevent.
+        #
+        # Report unsupported instead and let callers fall back. Users who do
+        # want the DSL on such a device can export ``CUTE_DSL_ARCH=sm_100f``
+        # *before* the process starts, which still works.
         return False
     except Exception:
         # Arch module layout changed or import failed: fall back to

--- a/flashinfer/norm/__init__.py
+++ b/flashinfer/norm/__init__.py
@@ -74,6 +74,34 @@ if not _USE_CUDA_NORM:
         _USE_CUDA_NORM = True
 
 
+@functools.lru_cache(maxsize=None)
+def _cute_dsl_supports(major: int, minor: int) -> bool:
+    """Whether the installed CuTe DSL can target this compute capability."""
+    try:
+        from ..cute_dsl.utils import is_cute_dsl_arch_supported
+
+        return is_cute_dsl_arch_supported(major, minor)
+    except Exception:
+        # Never let the capability probe itself break norm dispatch.
+        return True
+
+
+def _use_cuda_norm(device: torch.device) -> bool:
+    """Return ``True`` when the CUDA JIT norm kernels should be used instead of
+    the CuTe DSL ones.
+
+    Besides the explicit ``FLASHINFER_USE_CUDA_NORM`` opt-in, this covers
+    devices whose architecture the installed CuTe DSL cannot target (e.g.
+    ``sm_107`` / Rubin against a DSL whose ``Arch`` enum predates it). Without
+    it the DSL raises ``KeyError: 'sm_107a'`` from deep inside ``cute.compile``
+    instead of falling back; the CUDA JIT kernels are functionally equivalent
+    and build fine there.
+    """
+    if _USE_CUDA_NORM:
+        return True
+    return not _cute_dsl_supports(*torch.cuda.get_device_capability(device))
+
+
 @functools.cache
 def get_norm_module():
     """Get or compile the CUDA JIT norm module.
@@ -158,7 +186,7 @@ def _rmsnorm_impl(
 ) -> None:
     if enable_pdl is None or enable_pdl:
         enable_pdl = device_support_pdl(input.device)
-    if _USE_CUDA_NORM:
+    if _use_cuda_norm(input.device):
         get_norm_module().rmsnorm(out, input, weight, eps, enable_pdl)
     else:
         if input.dim() == 3:
@@ -216,7 +244,7 @@ def rmsnorm_quant(
     scale = _normalize_scale_tensor(scale, input)
     if enable_pdl is None or enable_pdl:
         enable_pdl = device_support_pdl(input.device)
-    if _USE_CUDA_NORM:
+    if _use_cuda_norm(input.device):
         get_norm_module().rmsnorm_quant(out, input, weight, scale, eps, enable_pdl)
     else:
         rmsnorm_quant_cute(
@@ -269,7 +297,7 @@ def fused_add_rmsnorm(
     """
     if enable_pdl is None or enable_pdl:
         enable_pdl = device_support_pdl(input.device)
-    if _USE_CUDA_NORM:
+    if _use_cuda_norm(input.device):
         get_norm_module().fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
     else:
         fused_add_rmsnorm_cute(
@@ -330,7 +358,7 @@ def fused_add_rmsnorm_quant(
     scale = _normalize_scale_tensor(scale, input)
     if enable_pdl is None or enable_pdl:
         enable_pdl = device_support_pdl(input.device)
-    if _USE_CUDA_NORM:
+    if _use_cuda_norm(input.device):
         get_norm_module().fused_add_rmsnorm_quant(
             out, input, residual, weight, scale, eps, enable_pdl
         )
@@ -407,7 +435,7 @@ def _gemma_rmsnorm_impl(
 ) -> None:
     if enable_pdl is None or enable_pdl:
         enable_pdl = device_support_pdl(input.device)
-    if _USE_CUDA_NORM:
+    if _use_cuda_norm(input.device):
         get_norm_module().gemma_rmsnorm(out, input, weight, eps, enable_pdl)
     else:
         if input.dim() == 3:
@@ -466,7 +494,7 @@ def gemma_fused_add_rmsnorm(
     """
     if enable_pdl is None or enable_pdl:
         enable_pdl = device_support_pdl(input.device)
-    if _USE_CUDA_NORM:
+    if _use_cuda_norm(input.device):
         get_norm_module().gemma_fused_add_rmsnorm(
             input, residual, weight, eps, enable_pdl
         )
@@ -513,7 +541,7 @@ def layernorm(
         Layer Normalized tensor, shape (batch_size, hidden_size). Same dtype as input.
     """
     out = torch.empty_like(input)
-    if _USE_CUDA_NORM:
+    if _use_cuda_norm(input.device):
         get_norm_module().layernorm(out, input, gemma, beta, eps)
     else:
         layernorm_cute(out, input, gemma, beta, eps)


### PR DESCRIPTION
## 📌 Description

Fixes #4218.

On Rubin (SM107), `flashinfer.rmsnorm` and the other norm entry points raise a bare `KeyError: 'sm_107a'` from deep inside `cute.compile`. The installed `nvidia-cutlass-dsl` (4.6.1) has no SM107 members in `cutlass.base_dsl.arch.Arch` — it lists only the `sm_100/103/110/120/121` families. (The MLIR enum a layer down, `cutlass._mlir.dialects.cute_nvgpu.Arch`, *does* carry `sm_107`, so the Python-facing enum looks like an oversight rather than a decision.)

FlashInfer already has a guard for precisely this, `is_cute_dsl_arch_supported`, and **most** CuTe DSL dispatchers consult it:

```
fused_moe/cute_dsl/fused_moe.py:939        _require_cute_dsl_arch_for(x.device, native_only=True)
mla/_core.py:2146                          if not is_cute_dsl_arch_supported(*cc): ...
cute_dsl/attention/compat.py:60            is_cute_dsl_arch_supported(...)
cute_dsl/rmsnorm_fp4quant.py:865           _require_cute_dsl_arch_for(input.device)
cute_dsl/add_rmsnorm_fp4quant.py:1325      _require_cute_dsl_arch_for(input.device)
cute_dsl/attention/wrappers/batch_mla.py   _require_dsl_arch(...)
```

`flashinfer/norm/` is the one CuTe DSL entry point that never did — it dispatched purely on `FLASHINFER_USE_CUDA_NORM`.

## What changed

**1. Norm dispatch consults the guard** (7 sites: `rmsnorm`, `rmsnorm_quant`, `fused_add_rmsnorm`, `fused_add_rmsnorm_quant`, `gemma_rmsnorm`, `gemma_fused_add_rmsnorm`, `layernorm`). An unsupported arch now selects the CUDA JIT kernels, which are functionally equivalent and build fine on SM107 thanks to the sm107→sm100f nvcc mapping from #4215.

**2. `is_cute_dsl_arch_supported` no longer claims support by pinning `CUTE_DSL_ARCH`.** That branch could never work, and was worse than doing nothing:

```python
from cutlass.base_dsl.arch import Arch      # <-- this import captures the DSL's compile target
...
os.environ.setdefault("CUTE_DSL_ARCH", family)   # <-- no-op; the DSL already read it
return True                                       # <-- reports "supported", then KeyErrors later
```

The DSL captures its target when `cutlass` is first imported, and the `Arch` lookup immediately above has already done that import. Measured: setting the variable right after importing *only* `cutlass.base_dsl.arch` is already too late. So the branch reported the arch as supported and deferred the failure to exactly the `KeyError` this probe exists to prevent. Removing it also stops the library from mutating process-global environment state on import.

## Validation

GR100 (cc 10.7), **no environment variables set** — the configuration that crashed before:

```
_USE_CUDA_NORM = False | CUTE_DSL_ARCH = <unset>
  rmsnorm (4, 1024)     cos=1.000000  max|err|=0
  rmsnorm (128, 2048)   cos=1.000000  max|err|=0.007812   (bf16 rounding)
  rmsnorm (37, 4096)    cos=1.000000  max|err|=0
  fused_add_rmsnorm     cos=0.999996  residual_match=True
```

versus `KeyError: 'sm_107a'` before the change. `CUTE_DSL_ARCH` stays unset, confirming the library no longer writes to the environment.

## Trade-off / scope

Rubin uses the CUDA JIT norm kernels rather than the CuTe DSL ones — but the DSL kernels do not run there at all today, so this is strictly an improvement. Once upstream adds `sm_107*` to the DSL enum, the guard returns `True` on its own and the DSL path resumes with **no further code change**.

Anyone who wants the DSL on such a device today can still `export CUTE_DSL_ARCH=sm_100f` **before** the process starts; that path is unaffected and I verified it is numerically correct (`cos=1.000000`, full e2e passes).

Targeting `release-v0.6.16` because `is_cute_dsl_arch_supported` exists only on this branch — `main` has no occurrences of it (Rubin support was reverted there).

## 🔍 Related Issues

+ #4218 (this bug)
+ #4215 (sm107→sm100f nvcc mapping, which makes the CUDA JIT fallback viable)
+ #4217 (separate, environmental: Triton needs CUDA ≥ 13.3)

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks
- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.

Validated by direct numerical comparison on GR100 (above). **Opened as a draft**: no unit test is included yet, since asserting the fallback requires either SM107 silicon or monkeypatching the guard. Happy to add a monkeypatched dispatch test if reviewers want one, and to adjust the approach — the decision on whether to adopt this at all is yours.

## Reviewer Notes

The two changes are separable. (1) alone fixes the crash; (2) removes a branch that is provably a no-op and makes the guard honest. If you would rather keep (2)'s family-pinning idea, note it can only work if `CUTE_DSL_ARCH` is set before *any* cutlass import — i.e. from the container/launcher, not from library code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)