### PR TITLE
fix/test(moe_ep): self-bootstrap 1-rank process group in dg mega oracle test

### DIFF
--- a/tests/moe_ep/run_tests.sh
+++ b/tests/moe_ep/run_tests.sh
@@ -187,7 +187,8 @@ run_oracle() {
     -m arch_blackwell || rc=1
 
   # deep_gemm's symm buffer needs an initialized process group (no
-  # MEGA_NO_DIST equivalent), hence the 1-proc torchrun.
+  # MEGA_NO_DIST equivalent). The test self-bootstraps a 1-rank group under
+  # plain pytest; the 1-proc torchrun here also exercises its env:// path.
   "${TORCHRUN}" --standalone --nproc_per_node=1 -m pytest \
     "${MOE_EP_PYTEST_FLAGS[@]}" \
     tests/moe_ep/test_deep_gemm_mega_kernel_vs_reference.py -v \

--- a/tests/moe_ep/test_deep_gemm_mega_kernel_vs_reference.py
+++ b/tests/moe_ep/test_deep_gemm_mega_kernel_vs_reference.py
@@ -17,17 +17,19 @@ Oracle conventions (pinned against ``deep_gemm`` sources):
   * ``silu(gate) * up * topk_weight`` folded BEFORE the fc1-out fp8 round-trip
   * combine: plain sum over topk (weight already folded)
 
-The deep_gemm symmetric buffer requires an initialized process group, so run
-under a single-process torchrun::
+The deep_gemm symmetric buffer requires an initialized process group. Under
+torchrun the usual ``env://`` rendezvous is used; under plain ``pytest`` (CI
+unit-test jobs) the test self-bootstraps a 1-rank group via an explicit
+``tcp://`` init so no torchrun launch is needed::
 
-    torchrun --standalone --nproc_per_node=1 -m pytest \\
-        tests/moe_ep/test_deep_gemm_mega_kernel_vs_reference.py -v \\
+    pytest tests/moe_ep/test_deep_gemm_mega_kernel_vs_reference.py -v \\
         -m arch_blackwell
 """
 
 from __future__ import annotations
 
 import os
+import socket
 from datetime import timedelta
 
 import pytest
@@ -239,7 +241,25 @@ def test_deep_gemm_mega_kernel_matches_torch_reference():
     )
 
     if not dist.is_initialized():
-        dist.init_process_group(backend="nccl", timeout=_PG_TIMEOUT)
+        if "RANK" in os.environ:
+            # torchrun launch: use its env:// rendezvous.
+            dist.init_process_group(backend="nccl", timeout=_PG_TIMEOUT)
+        else:
+            # Plain-pytest launch (CI unit-test jobs): self-bootstrap a 1-rank
+            # group with an explicit tcp:// store instead of mutating the
+            # RANK/MASTER_* env vars, which would leak to later tests in the
+            # same pytest process. The freed port can theoretically be
+            # snatched before torch rebinds it; acceptable for a test.
+            with socket.socket() as s:
+                s.bind(("127.0.0.1", 0))
+                port = s.getsockname()[1]
+            dist.init_process_group(
+                backend="nccl",
+                init_method=f"tcp://127.0.0.1:{port}",
+                rank=0,
+                world_size=1,
+                timeout=_PG_TIMEOUT,
+            )
     torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
     problem = _make_problem()


### PR DESCRIPTION
test_deep_gemm_mega_kernel_matches_torch_reference (added in #3980) fails under plain pytest with "ValueError: ... environment variable RANK expected, but not set": its WORLD_SIZE guard only skips when the variable is set and != 1, so without torchrun it falls through to dist.init_process_group(backend="nccl"), whose default env:// rendezvous requires torchrun's RANK/MASTER_* variables.

This is only reachable on CI jobs that combine plain-pytest discovery of tests/moe_ep, a cu13 image with the EP stack (deep_gemm) installed, and a capability-10 GPU — i.e. the B300 cu130 unit-test job, where it currently errors on every run.

Fix: when RANK is absent, self-bootstrap a 1-rank NCCL group via an explicit tcp://127.0.0.1:<free-port> init (rank=0, world_size=1) instead of env://. Deliberately avoids os.environ mutation so RANK/MASTER_* don't leak to later tests in the same pytest process; teardown is unchanged (conftest.pytest_sessionfinish destroys the group). The torchrun path is preserved and run_tests.sh still exercises it.

Verified on GB200 (single GPU): both launch modes pass with rel_l2=0.0027 vs the torch oracle; the plain-pytest mode was confirmed with RANK/WORLD_SIZE/MASTER_ADDR/MASTER_PORT/LOCAL_RANK explicitly unset.

AI-assisted (Claude Code).

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test compatibility by allowing the deep-gemm oracle test to run directly with standard pytest.
  * Added automatic single-process distributed setup when launched outside torchrun.
  * Preserved support for torchrun-based execution and clarified the available test modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->