### PR TITLE
feat(attention): cuDNN paged prefill via direct mixed-form cu_seq_lens

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -18,7 +18,7 @@ except Exception:
 
 
 @functools.cache
-def _cudnn_supports_direct_seqlens(dtype: torch.dtype) -> bool:
+def _cudnn_supports_direct_seqlens(dtype: torch.dtype, *, mixed: bool = False) -> bool:
     """True if cuDNN can consume token-unit indptr buffers directly for `dtype`.
 
     Requires cu_seq_len_q/kv SDPA inputs and per-tensor ragged-offset
@@ -26,13 +26,24 @@ def _cudnn_supports_direct_seqlens(dtype: torch.dtype) -> bool:
     - fp16/bf16: cuDNN backend 9.24+ with cudnn-frontend 1.25+
     - fp8 (e4m3/e5m2): cuDNN backend 9.25+ with cudnn-frontend 1.27+ (the first
       release whose sdpa_fp8 python binding exposes cu_seq_len_q/kv)
+
+    `mixed=True` additionally requires *mixed-form* sequence lengths (cu_seq_len
+    on one side, per-batch on the other). This is the paged path, which pairs a
+    token-unit cu_seq_len_q with an actual-length seq_len_kv (KV addressed via
+    the page table). It needs cuDNN backend 9.25+ and a cudnn-frontend carrying
+    the per-side relaxation (frontend PR #430; released in 1.27+).
+
+    Note: this is a pure version compare against the runtime backend and the FE
+    package version (the practical proxy for the FE's compiled-against cuDNN).
+    The FE exposes no compiled/effective-version query, so a feature-probe with
+    NOT_SUPPORTED fallback is left as a follow-up.
     """
     if not CUDNN_AVAILABLE:
         return False
-    if dtype in (torch.float16, torch.bfloat16):
-        min_backend, min_frontend = 92400, (1, 25)
-    elif dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+    if mixed or (dtype in (torch.float8_e4m3fn, torch.float8_e5m2)):
         min_backend, min_frontend = 92500, (1, 27)
+    elif dtype in (torch.float16, torch.bfloat16):
+        min_backend, min_frontend = 92400, (1, 25)
     else:
         return False
     try:
@@ -207,24 +218,32 @@ if CUDNN_AVAILABLE:
         # multipliers. Mutually exclusive with actual_seq_lens_q/kv for the
         # mask role; dtype/version support is the caller's responsibility
         # (_cudnn_supports_direct_seqlens).
-        assert (cu_seq_lens_q is None) == (cu_seq_lens_kv is None), (
-            "cu_seq_lens_q and cu_seq_lens_kv must both be set or both unset"
-        )
+        # cu_seq_lens_q selects the direct (token-unit) path for Q: the buffer
+        # feeds the padding mask and, via batch_offsets_q, the Q/O ragged
+        # offsets. The KV side chooses its form independently -- cumulative
+        # (cu_seq_lens_kv, non-paged) or per-batch (actual_seq_lens_kv, paged).
+        # The paged case is the *mixed* form (cu_seq_len_q + seq_len_kv); KV is
+        # addressed through block_tables and carries no ragged offset. Mixed
+        # forms need cuDNN 9.25+ (_cudnn_supports_direct_seqlens(mixed=True)).
         use_cu_seq_lens = cu_seq_lens_q is not None
         if use_cu_seq_lens:
-            # Non-paged only for now: this is a FlashInfer plumbing limitation,
-            # not a cuDNN one (the unified engine supports paged attention with
-            # cu_seq_lens). The direct path reuses the token-unit indptrs as
-            # both cu_seq_lens and ragged offsets, and no paged caller passes a
-            # token-unit KV prefix sum today.
-            assert (
-                batch_offsets_q is not None
-                and batch_offsets_k is not None
-                and block_tables is None
-            ), (
-                "the cu_seq_lens path currently requires non-paged KV with "
-                "token-unit q/k batch offsets"
+            assert batch_offsets_q is not None, (
+                "cu_seq_lens_q requires token-unit batch_offsets_q"
             )
+            if block_tables is None:
+                assert cu_seq_lens_kv is not None and batch_offsets_k is not None, (
+                    "non-paged cu_seq_lens requires cu_seq_lens_kv and token-unit "
+                    "batch_offsets_k"
+                )
+            else:
+                assert (
+                    actual_seq_lens_kv is not None
+                    and cu_seq_lens_kv is None
+                    and batch_offsets_k is None
+                ), (
+                    "paged cu_seq_lens requires actual_seq_lens_kv and no "
+                    "cu_seq_lens_kv / batch_offsets_k (KV is paged)"
+                )
 
         if actual_seq_lens_q is not None:
             graph_b = actual_seq_lens_q.shape[0]
@@ -414,17 +433,12 @@ if CUDNN_AVAILABLE:
                 cudnn_v_block_tables.set_uid(UIDs.BLOCK_TABLES_V_UID.value)
 
             if use_cu_seq_lens:
-                # The cumulative seq lens occupy the ACTUAL_SEQ_LENS UID slots
-                # -- mutually exclusive with per-batch seq lens, same role. On
-                # the ragged path the caller passes the token-unit indptrs
-                # here, i.e. the same buffers as the ragged offsets.
+                # cu_seq_len_q occupies the Q seq-len UID slot (mutually
+                # exclusive with a per-batch seq_len_q, same role). On the
+                # ragged path it is the same buffer as the Q ragged offset.
                 cudnn_cu_seq_lens_q = g.tensor_like(cu_seq_lens_q)
                 cudnn_cu_seq_lens_q.set_name("cu_seq_lens_q")
                 cudnn_cu_seq_lens_q.set_uid(UIDs.ACTUAL_SEQ_LENS_Q_UID.value)
-
-                cudnn_cu_seq_lens_kv = g.tensor_like(cu_seq_lens_kv)
-                cudnn_cu_seq_lens_kv.set_name("cu_seq_lens_kv")
-                cudnn_cu_seq_lens_kv.set_uid(UIDs.ACTUAL_SEQ_LENS_KV_UID.value)
 
                 padding_mask = True
                 # These kwargs need a newer cudnn-frontend than the declared
@@ -433,13 +447,28 @@ if CUDNN_AVAILABLE:
                 # on this path, which _cudnn_supports_direct_seqlens guards.
                 seq_len_kwargs = {
                     "cu_seq_len_q": cudnn_cu_seq_lens_q,
-                    "cu_seq_len_kv": cudnn_cu_seq_lens_kv,
                     # cu_seq_lens are unified-engine-only; pin the
                     # implementation so an unsupported config fails with the
                     # unified engine's specific error instead of
                     # auto-selection's generic failure.
                     "implementation": cudnn.attention_implementation.UNIFIED,
                 }
+                # KV side, independent form. Both tensors take the shared
+                # ACTUAL_SEQ_LENS_KV UID; the execute var_map binds cu_seq_lens_kv
+                # or actual_seq_lens_kv to it accordingly.
+                if cu_seq_lens_kv is not None:
+                    # Non-paged: both-cumulative (KV also token-unit ragged).
+                    cudnn_cu_seq_lens_kv = g.tensor_like(cu_seq_lens_kv)
+                    cudnn_cu_seq_lens_kv.set_name("cu_seq_lens_kv")
+                    cudnn_cu_seq_lens_kv.set_uid(UIDs.ACTUAL_SEQ_LENS_KV_UID.value)
+                    seq_len_kwargs["cu_seq_len_kv"] = cudnn_cu_seq_lens_kv
+                else:
+                    # Mixed (paged): per-batch KV lengths mask; KV addressed via
+                    # block_tables. This form requires cuDNN 9.25+.
+                    cudnn_seq_len_kv = g.tensor_like(actual_seq_lens_kv)
+                    cudnn_seq_len_kv.set_name("seq_len_kv")
+                    cudnn_seq_len_kv.set_uid(UIDs.ACTUAL_SEQ_LENS_KV_UID.value)
+                    seq_len_kwargs["seq_len_kv"] = cudnn_seq_len_kv
             else:
                 if actual_seq_lens_q is not None:
                     cudnn_actual_seq_lens_q = g.tensor_like(actual_seq_lens_q)
@@ -565,7 +594,13 @@ if CUDNN_AVAILABLE:
 
             if use_cu_seq_lens:
                 tensors_to_return.append(cudnn_cu_seq_lens_q)
-                tensors_to_return.append(cudnn_cu_seq_lens_kv)
+                # KV tensor is cu_seq_len_kv (both-cumulative) or seq_len_kv
+                # (mixed/paged), whichever the KV branch above created.
+                tensors_to_return.append(
+                    cudnn_cu_seq_lens_kv
+                    if cu_seq_lens_kv is not None
+                    else cudnn_seq_len_kv
+                )
             else:
                 if actual_seq_lens_q is not None:
                     tensors_to_return.append(cudnn_actual_seq_lens_q)
@@ -939,19 +974,32 @@ def cudnn_batch_prefill_with_kv_cache(
 
         if batch_offsets_units == "tokens":
             h_kv = k_cache.shape[1]
-            use_direct = (
-                _cudnn_supports_direct_seqlens(q.dtype)
-                and block_tables is None
-                # The direct path consumes the q/k indptrs as cu_seq_lens.
-                and batch_offsets_q is not None
-                and batch_offsets_k is not None
-            )
+            if block_tables is None:
+                # Non-paged: both-cumulative direct path (KV is ragged). The
+                # token-unit q/k indptrs double as cu_seq_lens.
+                use_direct = (
+                    _cudnn_supports_direct_seqlens(q.dtype)
+                    and batch_offsets_q is not None
+                    and batch_offsets_k is not None
+                )
+            else:
+                # Paged: mixed direct path -- cu_seq_len_q (token-unit q indptr)
+                # + per-batch actual_seq_lens_kv for the mask; KV addressed via
+                # block_tables (no k/v ragged offsets). Requires mixed-form
+                # support (cuDNN 9.25+).
+                use_direct = (
+                    _cudnn_supports_direct_seqlens(q.dtype, mixed=True)
+                    and batch_offsets_q is not None
+                    and actual_seq_lens_kv is not None
+                )
             if use_direct:
-                # On the ragged path the token-unit indptrs are also the
-                # cumulative seq lens; cuDNN consumes them and the offsets
-                # directly (scaling offsets by per-tensor multipliers).
+                # The token-unit q indptr is both cu_seq_len_q and the Q/O
+                # ragged offset (per-tensor multipliers applied in the builder).
                 run_kwargs["cu_seq_lens_q"] = batch_offsets_q
-                run_kwargs["cu_seq_lens_kv"] = batch_offsets_k
+                if block_tables is None:
+                    run_kwargs["cu_seq_lens_kv"] = batch_offsets_k
+                # Paged: KV masked by actual_seq_lens_kv (already in run_kwargs);
+                # batch_offsets_k/v stay None.
             else:
                 # Old cuDNN/frontend or paged: convert the token-unit indptrs
                 # to the element units the legacy graph expects. Names are

--- a/tests/attention/test_cudnn_prefill_paged_cu_seqlens.py
+++ b/tests/attention/test_cudnn_prefill_paged_cu_seqlens.py
@@ -1,0 +1,153 @@
+"""cuDNN paged prefill via the direct mixed-form sequence-length path.
+
+The paged direct path binds the token-unit ``qo_indptr`` as ``cu_seq_len_q``
+(doubling as the Q/O ragged offset) and the per-request KV lengths as
+``seq_len_kv`` -- a *mixed* form (cumulative on Q, per-batch on KV) that cuDNN
+supports from backend 9.25+. KV is addressed through the page tables, so no
+KV-side cumulative prefix sum (and no element-unit offset conversion) is needed.
+
+Each case compares the direct path against the legacy element-conversion paged
+path (already covered against the fa2 reference by ``test_cudnn_prefill``), so a
+match here validates the new plumbing.
+"""
+
+import functools
+
+import pytest
+import torch
+
+from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
+from flashinfer.cudnn import prefill as cudnn_prefill
+
+
+@functools.lru_cache(maxsize=1)
+def _mixed_paged_supported() -> bool:
+    """Whether this cuDNN backend + frontend supports the mixed-form paged path.
+
+    Defers to the same production gate the dispatch uses, so the test only runs
+    where the direct path would actually be taken (rather than a separate ad-hoc
+    version/attribute probe that could diverge from production).
+    """
+    if not torch.cuda.is_available():
+        return False
+    return cudnn_prefill._cudnn_supports_direct_seqlens(torch.bfloat16, mixed=True)
+
+
+def _make_paged_inputs(
+    batch_size, s_qo, s_kv, page_size, num_qo_heads, num_kv_heads, head_dim, device
+):
+    torch.manual_seed(1)
+    seq_q = torch.randint(1, s_qo + 1, (batch_size,), dtype=torch.int32, device=device)
+    seq_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    zero = torch.zeros(1, dtype=torch.int32, device=device)
+    qo_indptr = torch.cat([zero, torch.cumsum(seq_q, 0)]).int()  # token-unit
+
+    q = torch.randn(
+        int(seq_q.sum()), num_qo_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+
+    num_pages_per_seq = (s_kv + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_cache = torch.randn(
+        total_num_pages,
+        2,
+        num_kv_heads,
+        page_size,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    strides = (
+        2 * page_size * num_kv_heads * head_dim,
+        head_dim,
+        num_kv_heads * head_dim,
+        1,
+    )
+    k_cache = kv_cache[:, 0].as_strided(kv_cache[:, 0].shape, strides)
+    v_cache = kv_cache[:, 1].as_strided(kv_cache[:, 1].shape, strides)
+    block_tables = torch.tensor(
+        [
+            [k + i * num_pages_per_seq for k in range(num_pages_per_seq)]
+            for i in range(batch_size)
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    return dict(
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        block_tables=block_tables,
+        qo_indptr=qo_indptr,
+        actual_seq_lens_q=seq_q.view(batch_size, 1, 1, 1),
+        actual_seq_lens_kv=seq_kv.view(batch_size, 1, 1, 1),
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("s_qo,s_kv", [(64, 512), (17, 200)])
+@pytest.mark.parametrize("page_size", [16, 64])
+@pytest.mark.parametrize("num_kv_heads", [1, 2])
+@pytest.mark.parametrize("causal", [True, False])
+def test_cudnn_paged_prefill_cu_seqlens_direct_matches_legacy(
+    monkeypatch, batch_size, s_qo, s_kv, page_size, num_kv_heads, causal
+):
+    if not cudnn_prefill.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package not available")
+    if not _mixed_paged_supported():
+        pytest.skip("cuDNN backend/frontend too old for mixed-form paged seqlens")
+
+    device = "cuda:0"
+    num_qo_heads, head_dim = 8, 128
+    inp = _make_paged_inputs(
+        batch_size, s_qo, s_kv, page_size, num_qo_heads, num_kv_heads, head_dim, device
+    )
+    scale = float(head_dim**-0.5)
+    ws = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    common = dict(
+        max_token_per_sequence=s_qo,
+        max_sequence_kv=s_kv,
+        actual_seq_lens_q=inp["actual_seq_lens_q"],
+        actual_seq_lens_kv=inp["actual_seq_lens_kv"],
+        block_tables=inp["block_tables"],
+        causal=causal,
+        return_lse=False,
+        batch_offsets_q=inp["qo_indptr"],
+        batch_offsets_units="tokens",
+    )
+
+    def run():
+        return cudnn_batch_prefill_with_kv_cache(
+            inp["q"], inp["k_cache"], inp["v_cache"], scale, ws, **common
+        )[0]
+
+    # Legacy paged path: force the gate off -> element-offset conversion.
+    monkeypatch.setattr(
+        cudnn_prefill,
+        "_cudnn_supports_direct_seqlens",
+        lambda dtype, *, mixed=False: False,
+    )
+    out_legacy = run()
+
+    # Direct paged path: force the gate on, but only for the mixed-form request
+    # the paged dispatch must make. `return mixed` yields True iff the caller asks
+    # for mixed=True, so if the paged path ever stops requesting the mixed form it
+    # falls back to legacy and the assertion below fails instead of silently
+    # passing.
+    mixed_calls = []
+
+    def _gate_direct(dtype, *, mixed=False):
+        mixed_calls.append(mixed)
+        return mixed
+
+    monkeypatch.setattr(cudnn_prefill, "_cudnn_supports_direct_seqlens", _gate_direct)
+    out_direct = run()
+
+    assert True in mixed_calls, (
+        "paged dispatch did not consult _cudnn_supports_direct_seqlens with "
+        "mixed=True, so the direct mixed-form path was not exercised"
+    )
+    torch.testing.assert_close(out_direct, out_legacy, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
## 📌 Description

Extends the cuDNN prefill **direct (token-unit) sequence-length path** (#3921) to **paged KV**, using the cuDNN **mixed sequence-length form** (cumulative on Q, per-batch on KV) that landed in cuDNN backend 9.25 + cudnn-frontend (per-side relaxation).

**How it works.** The paged case binds:
- the token-unit `qo_indptr` as `cu_seq_len_q` — which *also* serves as the Q/O ragged offset (per-tensor multipliers applied in the graph builder), and
- the per-request KV lengths as `seq_len_kv`.

KV is addressed through the page tables, so — unlike the non-paged both-cumulative path — **no KV-side cumulative prefix sum is materialized, and no element-unit offset conversion is performed**. This is the FlashInfer paged shape the mixed-form work was built to enable.

Gated separately from the non-paged path via `_cudnn_supports_direct_seqlens(dtype, mixed=True)` (backend `>= 92500`, frontend `>= 1.27`). Below the gate, the existing legacy element-conversion paged graph is used unchanged — no behavior change for current cuDNN versions.

Aside: the direct path also sidesteps the int32 overflow latent in the legacy path's element-unit offsets (`token_offset * num_heads * head_dim`) for large models, since token-unit indptrs stay at token scale.

## Scope / status

Core low-level path only, kept localized to `flashinfer/cudnn/prefill.py`. **The following are deferred to a separate follow-up PR:**
- Wiring `BatchPrefillWithPagedKVCacheWrapper` (`backend="cudnn"`) to pass token-unit `qo_indptr` + `actual_seq_lens_kv` so the wrapper takes the direct path.
- LSE base-2 fold / de-pad for the unified-attention output contract.
- A NOT_SUPPORTED feature-probe fallback (the FE exposes no compiled/effective-version query, so the gate is a version compare today).

## 🔍 Related

- #3921 (token-unit indptr / cu_seq_len direct path — non-paged)
- cuDNN mixed-form sequence-length support (backend + cudnn-frontend, merged separately)
- Aligns with P2 of the paged-prefill unification proposal (cuDNN adapter: paged + cu_seq_len direct plumbing)

## 🧪 Tests

New `tests/attention/test_cudnn_prefill_paged_cu_seqlens.py`: compares the paged **direct** path against the paged **legacy** path (itself validated against the fa2 reference by `test_cudnn_prefill`) across batch × seqlen × page_size × GQA × causal — **32/32 passed on H100 (sm90)**. The test probes real mixed-paged capability and skips cleanly on older cuDNN.

Regression: `test_cudnn_prefill` (paged) 288 passed, `test_cudnn_prefill_token_indptr` (non-paged direct) 130 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mixed sequence-length handling for paged attention.
  - Added support for independently supplied query and key/value sequence lengths.
  - Improved compatibility with direct sequence-length processing for standard and paged inputs.

- **Bug Fixes**
  - Updated processing to use direct handling when supported, with safe fallback behavior otherwise.

- **Tests**
  - Added coverage across batch sizes, sequence lengths, page sizes, head counts, and causal attention modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->