### PR TITLE
test: fix #4191 regressions in autotuner_core and symlink race test

### DIFF
--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -1283,7 +1283,7 @@ def test_make_tuning_config_reuses_topk_ids_initializer():
     """_make_tuning_config must return configs whose topk_ids initializer is the
     same object across calls for the same num_experts.
     """
-    fn = core_mod.get_trtllm_moe_sm100_module
+    fn = core_mod._get_trtllm_moe_sm100_module_impl
     fn.cache_clear()
     try:
         mock_module = MagicMock()

--- a/tests/utils/test_gen_module_symlink_race_condition.py
+++ b/tests/utils/test_gen_module_symlink_race_condition.py
@@ -24,6 +24,8 @@ def _bmm_export_symlink_path(gen_src_dir):
     """Location where the BMM export headers are symlinked for C++ includes."""
     return (
         Path(gen_src_dir)
+        / "trtllm_export"
+        / "fused_moe_trtllm_sm100"
         / "flashinfer"
         / "trtllm"
         / "batched_gemm"


### PR DESCRIPTION
## Summary

Fixes two test regressions introduced by #4191 (release-only, not on `main`):

- **#4208** — `test_make_tuning_config_reuses_topk_ids_initializer` called `get_trtllm_moe_sm100_module.cache_clear()`, but #4191 moved `@functools.cache` to `_get_trtllm_moe_sm100_module_impl`.
- **#4166 (re-open)** — #4187 updated the symlink test to assert under `GEN_SRC_DIR/flashinfer/...`, but #4191 moved the export symlink to `GEN_SRC_DIR/trtllm_export/fused_moe_trtllm_sm100/flashinfer/...`.

Both failures appeared on all Blackwell jobs in Test Cycle 2 (pipeline 59912149, rc3).

## Test plan

- [x] `pytest tests/autotuner/test_autotuner_core.py::test_make_tuning_config_reuses_topk_ids_initializer` — pass
- [x] `pytest tests/utils/test_gen_module_symlink_race_condition.py` — pass
- [ ] B300/GB200 CI rerun to confirm cycle-2 green on these two files