### PR TITLE
feat(moe): add packed per-tensor FP8 and BF16 FromLogits routing to unified MoE API

### DIFF
--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -566,11 +566,12 @@ routine_cc_to_supported_backends = {
         "12.0": ["b12x"],
         "12.1": ["b12x"],
     },
-    # MoELayer cross-backend NVFP4: intersection of CuteDSL + TRTLLM FP4 support.
-    # SM100 only (Blackwell); unlisted archs fall through to [] (skipped).
+    # MoELayer NVFP4: CuteDSL + TRTLLM compete on SM100/SM103; SM107 uses
+    # the TRTLLM routed runner only.
     "unified_nvfp4_moe": {
         "10.0": ["unified"],
         "10.3": ["unified"],
+        "10.7": ["unified"],
     },
     # NORM
     "rmsnorm": {

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -566,12 +566,11 @@ routine_cc_to_supported_backends = {
         "12.0": ["b12x"],
         "12.1": ["b12x"],
     },
-    # MoELayer NVFP4: CuteDSL + TRTLLM compete on SM100/SM103; SM107 uses
-    # the TRTLLM routed runner only.
+    # MoELayer cross-backend NVFP4: intersection of CuteDSL + TRTLLM FP4 support.
+    # SM100 only (Blackwell); unlisted archs fall through to [] (skipped).
     "unified_nvfp4_moe": {
         "10.0": ["unified"],
         "10.3": ["unified"],
-        "10.7": ["unified"],
     },
     # NORM
     "rmsnorm": {

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -230,10 +230,8 @@ class ExecutionConfig:
 # claiming them here makes the batched-GEMM runner abort at dispatch (#4107).
 _TRTLLM_ROUTED_ARCHS = (100, 103, 107)
 
-# The pinned Rubin artifact contains SM107 FP8 cubins, but unified FP8 remains
-# gated to the validated SM100 family until SM107 runtime correctness is covered.
-# The outer JIT module compiles for major 12 as well, but those cubins fail at
-# runtime on SM120/121.
+# The FP8 kernels are validated on the SM100 family only — the outer JIT module
+# compiles for major 12 as well, but those cubins fail at runtime on SM120/121.
 _TRTLLM_ROUTED_FP8_ARCHS = (100, 103)
 
 

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -230,14 +230,22 @@ class ExecutionConfig:
 # claiming them here makes the batched-GEMM runner abort at dispatch (#4107).
 _TRTLLM_ROUTED_ARCHS = (100, 103, 107)
 
-# The FP8 kernels are validated on the SM100 family only — the outer JIT module
-# compiles for major 12 as well, but those cubins fail at runtime on SM120/121.
+# The pinned Rubin artifact contains SM107 FP8 cubins, but unified FP8 remains
+# gated to the validated SM100 family until SM107 runtime correctness is covered.
+# The outer JIT module compiles for major 12 as well, but those cubins fail at
+# runtime on SM120/121.
 _TRTLLM_ROUTED_FP8_ARCHS = (100, 103)
 
 
 @dataclass(frozen=True)
 class TrtllmFp4Config:
-    """TensorRT-LLM FP4 backend for NVFP4 and MXFP4 mixed-precision modes."""
+    """TensorRT-LLM FP4 backend for NVFP4 and MXFP4 mixed-precision modes.
+
+    ``supported(arch)`` reflects the routed-MoE cubin manifest. Variant-specific
+    restrictions are applied by ``TrtllmFp4RoutedRunner.check_support()``:
+    NVFP4/MXFP4 support SM100/SM103/SM107, while W4A16 supports SM100/SM107
+    and remains disabled on SM103.
+    """
 
     @classmethod
     def supported(cls, arch: int) -> bool:
@@ -441,9 +449,8 @@ class TrtllmMxInt4Config:
     @classmethod
     def supported(cls, arch: int) -> bool:
         # Same trtllm-gen routed batched-GEMM path as the FP4/BF16 backends, so it
-        # inherits the same manifest coverage.  Whether sm107a MxE2m1 cubins exist
-        # is not verifiable from this repo; this only narrows the previous
-        # ``arch >= 100``, leaving SM100/103/107 behaviour unchanged.
+        # inherits the same manifest coverage. The pinned Rubin manifest includes
+        # MxInt4 sm107a kernels, although unified MxInt4 still has no runner.
         return arch in _TRTLLM_ROUTED_ARCHS
 
     def __repr__(self) -> str:

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -757,8 +757,8 @@ class MoEActivationPack:
       itself per ``RoutingConfig.method``.  ``topk_ids`` / ``topk_weights`` stay ``None`` — the
       runner allocates internal kernel-filled buffers, and the routing result is not surfaced
       back through the pack (routing replay is a separate, future capability). TRTLLM FP4,
-      block-FP8, and per-tensor-FP8 runners support this mode; ``MoELayer`` dispatches a logits
-      pack only to capable backends (see each runner's ``supported_routing_modes``).
+      BF16, block-FP8, and per-tensor-FP8 runners support this mode; ``MoELayer`` dispatches
+      a logits pack only to capable backends (see each runner's ``supported_routing_modes``).
 
     ``topk_ids`` / ``topk_weights`` follow the routed-MoE naming convention (gh #2425); they
     keep the field positions of the former ``selected_experts`` / ``final_scales``, so

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -621,12 +621,26 @@ ALL_BACKEND_CONFIGS = (
 
 @dataclass(frozen=True)
 class BackendOptions:
-    """Ordered list of backend candidates for dispatch / autotuning."""
+    """Ordered list of backend candidates for dispatch and autotuning.
+
+    Each backend config implements ``supported(arch)``, where ``arch`` uses the
+    CUDA compute-capability encoding documented by :meth:`valid_for`.
+    """
 
     candidates: Tuple[BackendConfigType, ...] = ()  # type: ignore[type-arg]
 
     def valid_for(self, arch: int) -> list:
-        """Return candidates whose hardware preconditions are met."""
+        """Return candidates whose hardware preconditions are met.
+
+        Parameters
+        ----------
+        arch : int
+            CUDA compute capability encoded as ``major * 10 + minor``. For
+            example, SM90 is ``90``, SM100 is ``100``, and SM103 is ``103``.
+            :class:`MoELayer` derives it from its selected CUDA device via
+            ``get_compute_capability(self.device)``. This is not a CUDA device
+            ordinal or CUDA toolkit version.
+        """
         return [c for c in self.candidates if c.__class__.supported(arch)]
 
     def __len__(self) -> int:

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -1234,12 +1234,9 @@ class TrtllmFp8PerTensorRunner(MoERunner):
             routing_logits = None
             routing_bias = None
             topk_ids = _pack_prerouted_topk_ids(act)
-            # The routed per-tensor op allocates its own expert-weight buffer;
-            # this placeholder only satisfies the generic MoeRunnerInputs and
-            # autotuner schemas.
-            expert_weights = act.topk_weights.new_empty(
-                (num_tokens, routing.top_k), dtype=torch.bfloat16
-            )
+            # The routed per-tensor op allocates its own expert-weight buffer
+            # and consumes only the packed topk_ids from this generic schema.
+            expert_weights = None
         else:
             raise NotImplementedError(
                 f"{type(self).__name__} supports only FromLogits and "
@@ -1353,13 +1350,6 @@ class TrtllmBf16RoutedRunner(MoERunner):
         execution = config.execution
         self._num_local_experts = experts.local_num_experts or routing.num_experts
         self._local_expert_offset = experts.local_expert_offset
-        if (
-            self._local_expert_offset != 0
-            or self._num_local_experts != routing.num_experts
-        ):
-            # Keep packed routed EP available, but filter FromLogits before
-            # MoELayer enters runner packing/autotuning.
-            self.supported_routing_modes = (RoutingInputMode.PackedPrecomputed,)
         self._intermediate_size = experts.intermediate_size
         self._activation_type = int(config.activation.type)
         self._tune_max_num_tokens = execution.tune_max_num_tokens
@@ -1437,14 +1427,6 @@ class TrtllmBf16RoutedRunner(MoERunner):
 
         routing_input_mode = act.routing_input_mode
         if routing_input_mode == RoutingInputMode.FromLogits:
-            if (
-                self._local_expert_offset != 0
-                or self._num_local_experts != routing.num_experts
-            ):
-                raise NotImplementedError(
-                    "TrtllmBf16RoutedRunner FromLogits currently requires all "
-                    "experts to be local; EP routing is a separate contract."
-                )
             _validate_logits_inputs(
                 act, num_tokens, routing.num_experts, type(self).__name__
             )

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -1032,7 +1032,7 @@ class TrtllmFp8BlockRunner(MoERunner):
 
 
 # ---------------------------------------------------------------------------
-# TRTLLM per-tensor FP8 runner — E4M3 activations/weights, FromLogits only
+# TRTLLM per-tensor FP8 runner — E4M3 activations/weights
 # ---------------------------------------------------------------------------
 
 
@@ -1042,10 +1042,15 @@ class TrtllmFp8PerTensorRunner(MoERunner):
     The kernel consumes prequantized E4M3 activations and weights. Its calibrated
     activation/weight multipliers are folded into three per-expert FP32 epilogue
     scale vectors, so ``MoEActivationPack.hidden_states_scale`` remains ``None``.
+    Routing can be computed from logits or supplied as packed precomputed
+    ``(global_expert_id << 16) | bf16(weight)`` values.
     """
 
     backend_key = "trtllm_fp8_per_tensor"
-    supported_routing_modes = (RoutingInputMode.FromLogits,)
+    supported_routing_modes = (
+        RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.FromLogits,
+    )
     supported_quant_variants = (QuantVariant.FP8PerTensor,)
 
     def check_support(self) -> None:
@@ -1201,21 +1206,45 @@ class TrtllmFp8PerTensorRunner(MoERunner):
         view = weights.get_view(self.backend_key)
         routing = self.config.routing
         num_tokens, hidden_size = act.hidden_states_q.shape
-        _validate_logits_inputs(
-            act, num_tokens, routing.num_experts, type(self).__name__
-        )
         self._validate_tensors(act, view, hidden_size)
 
-        routing_logits = act.routing_logits
         output = act.hidden_states_q.new_empty(
             (num_tokens, hidden_size), dtype=torch.bfloat16
         )
-        # These buffers are autotuner inputs and routing-kernel outputs. The
-        # per-tensor FFI itself selects FromLogits from its non-optional logits.
-        topk_ids = act.hidden_states_q.new_empty(
-            (num_tokens, routing.top_k), dtype=torch.int32
-        )
-        expert_weights = routing_logits.new_empty((num_tokens, routing.top_k))
+        routing_input_mode = act.routing_input_mode
+        if routing_input_mode == RoutingInputMode.FromLogits:
+            _validate_logits_inputs(
+                act, num_tokens, routing.num_experts, type(self).__name__
+            )
+            routing_logits = act.routing_logits
+            routing_bias = act.routing_bias
+            # The routing kernel writes BF16 expert weights regardless of
+            # whether routing_logits is BF16 or FP32.
+            topk_ids = act.hidden_states_q.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.int32
+            )
+            expert_weights = act.hidden_states_q.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+        elif routing_input_mode == RoutingInputMode.PackedPrecomputed:
+            _validate_prerouted_inputs(
+                act, num_tokens, routing.top_k, type(self).__name__
+            )
+            routing_logits = None
+            routing_bias = None
+            weight_bf16_bits = (
+                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
+            )
+            topk_ids = (act.topk_ids << 16) | (weight_bf16_bits & 0xFFFF)
+            expert_weights = act.topk_weights.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+        else:
+            raise NotImplementedError(
+                f"{type(self).__name__} supports only FromLogits and "
+                "PackedPrecomputed routing."
+            )
+
         moe_inputs = MoeRunnerInputs(
             output=output,
             routing_logits=routing_logits,
@@ -1227,7 +1256,7 @@ class TrtllmFp8PerTensorRunner(MoERunner):
             per_token_scale=None,
         )
         self._static_kwargs = dict(
-            routing_bias=act.routing_bias,
+            routing_bias=routing_bias,
             gemm1_weights=view["gemm1_weights"],
             output1_scales_scalar=view["output1_scales_scalar"],
             output1_scales_gate_scalar=view["output1_scales_gate_scalar"],
@@ -1250,6 +1279,7 @@ class TrtllmFp8PerTensorRunner(MoERunner):
         self.tuning_config = self._inner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=self._tune_max_num_tokens,
+            routing_input_mode=routing_input_mode,
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )
@@ -1260,19 +1290,20 @@ class TrtllmFp8PerTensorRunner(MoERunner):
 
 
 # ---------------------------------------------------------------------------
-# TRTLLM BF16 routed runner — canonical trtllm-gen MoERunner, bf16 dtypes
+# TRTLLM BF16 runner — canonical trtllm-gen MoERunner, bf16 dtypes
 # ---------------------------------------------------------------------------
 
 
 class TrtllmBf16RoutedRunner(MoERunner):
-    """Pre-routed BF16 adapter over the canonical trtllm-gen ``MoERunner``.
+    """BF16 adapter over the canonical trtllm-gen ``MoERunner``.
 
     Mirrors :class:`TrtllmFp4RoutedRunner` but with ``Bfloat16`` activation +
     weight dtypes and no scale-factor tensors, wrapping the same inner
     ``MoERunner`` (whose ``forward`` dispatches to ``moe_op.trtllm_bf16_moe`` when
     ``dtype_weights == Bfloat16``).  Used for the EP grouped-GEMM bf16 path: the
     packed pre-routed ids carry ``(GLOBAL expert_id << 16) | bf16(weight)`` (with
-    ``local_expert_offset`` passed separately);
+    ``local_expert_offset`` passed separately), while ``FromLogits`` lets the
+    kernel compute routing from BF16 or FP32 logits;
     with the EP bridge's synthesized ``top_k=1`` + ``weight=1`` and
     ``do_finalize=True``, the output comes back in input row order.
 
@@ -1280,12 +1311,25 @@ class TrtllmBf16RoutedRunner(MoERunner):
     """
 
     backend_key = "trtllm_bf16_routed"
-    # The bf16 kernel supports FromLogits too; wiring it here is a follow-up.
-    supported_routing_modes = (RoutingInputMode.PackedPrecomputed,)
+    supported_routing_modes = (
+        RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.FromLogits,
+    )
     supported_quant_variants = (QuantVariant.BF16,)
 
     def check_support(self) -> None:
         super().check_support()
+        device = getattr(self, "device", None)
+        if device is not None:
+            from ..utils import get_compute_capability
+
+            major, minor = get_compute_capability(device)
+            arch = major * 10 + minor
+            if arch not in (100, 103):
+                raise NotImplementedError(
+                    f"{type(self).__name__} requires SM100/SM103 TRTLLM BF16 "
+                    f"cubins, got sm{arch}."
+                )
         if self.config.activation.type is not ActivationType.Swiglu:
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
@@ -1380,34 +1424,52 @@ class TrtllmBf16RoutedRunner(MoERunner):
         hidden_states = act.hidden_states_q  # raw bf16 on this path
         num_tokens, hidden_size = hidden_states.shape
 
-        if act.routing_input_mode != RoutingInputMode.PackedPrecomputed:
-            raise NotImplementedError(
-                f"TrtllmBf16RoutedRunner does not support "
-                f"routing_input_mode={act.routing_input_mode!r} "
-                "(only PackedPrecomputed is wired)."
+        routing_input_mode = act.routing_input_mode
+        if routing_input_mode == RoutingInputMode.FromLogits:
+            if (
+                self._local_expert_offset != 0
+                or self._num_local_experts != routing.num_experts
+            ):
+                raise NotImplementedError(
+                    "TrtllmBf16RoutedRunner FromLogits currently requires all "
+                    "experts to be local; EP routing is a separate contract."
+                )
+            _validate_logits_inputs(
+                act, num_tokens, routing.num_experts, type(self).__name__
             )
-        # Packed pre-routed top-k ids: (GLOBAL expert_id << 16) | bf16(weight).
-        # The kernel expects GLOBAL ids and filters/maps them via the separately
-        # passed ``local_expert_offset`` (mirrors trtllm_bf16_routed_moe in
-        # tests/moe/test_trtllm_gen_routed_fused_moe.py). Do NOT pre-subtract the
-        # offset: on ranks with local_expert_offset>0 that yields a local id below
-        # the offset, which the kernel treats as non-local and skips → zero output.
-        _validate_prerouted_inputs(
-            act, num_tokens, routing.top_k, "TrtllmBf16RoutedRunner"
-        )
-        ids = act.topk_ids
-        weight_bf16_bits = (
-            act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
-        )
-        topk_ids = (ids << 16) | (weight_bf16_bits & 0xFFFF)
+            routing_logits = act.routing_logits
+            routing_bias = act.routing_bias
+            topk_ids = hidden_states.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.int32
+            )
+            # The BF16 routing kernel writes BF16 expert weights even for FP32
+            # routing logits.
+            expert_weights = hidden_states.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+        elif routing_input_mode == RoutingInputMode.PackedPrecomputed:
+            _validate_prerouted_inputs(
+                act, num_tokens, routing.top_k, type(self).__name__
+            )
+            routing_logits = None
+            routing_bias = None
+            weight_bf16_bits = (
+                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
+            )
+            topk_ids = (act.topk_ids << 16) | (weight_bf16_bits & 0xFFFF)
+            expert_weights = act.topk_weights.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+        else:
+            raise NotImplementedError(
+                f"{type(self).__name__} supports only FromLogits and "
+                "PackedPrecomputed routing."
+            )
 
         output = hidden_states.new_empty((num_tokens, hidden_size))
-        expert_weights = act.topk_weights.new_empty(
-            (num_tokens, routing.top_k), dtype=torch.bfloat16
-        )
         moe_inputs = MoeRunnerInputs(
             output=output,
-            routing_logits=None,
+            routing_logits=routing_logits,
             topk_ids=topk_ids,
             expert_weights=expert_weights,
             hidden_states=hidden_states,
@@ -1419,8 +1481,8 @@ class TrtllmBf16RoutedRunner(MoERunner):
         from ..tllm_enums import WeightLayout
 
         self._static_kwargs = dict(
-            routing_input_mode=RoutingInputMode.PackedPrecomputed,
-            routing_bias=None,
+            routing_input_mode=routing_input_mode,
+            routing_bias=routing_bias,
             gemm1_weights=v["gemm1_weights"],
             gemm2_weights=v["gemm2_weights"],
             gemm1_alpha=v.get("gemm1_alpha"),
@@ -1436,13 +1498,14 @@ class TrtllmBf16RoutedRunner(MoERunner):
             weight_layout=int(WeightLayout.BlockMajorK),
             do_finalize=self.config.execution.do_finalize,
             enable_pdl=self._enable_pdl,
-            norm_topk_prob=False,
+            norm_topk_prob=(routing_input_mode == RoutingInputMode.FromLogits),
         )
 
         self._ensure_inner(hidden_size)
         self.tuning_config = self._inner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=self._tune_max_num_tokens,
+            routing_input_mode=routing_input_mode,
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -1324,6 +1324,10 @@ class TrtllmBf16RoutedRunner(MoERunner):
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
             )
+        if not self.config.execution.do_finalize:
+            raise NotImplementedError(
+                f"{type(self).__name__} supports only do_finalize=True."
+            )
         from ..utils import get_compute_capability
 
         major, minor = get_compute_capability(self.device)

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -115,6 +115,14 @@ def _validate_prerouted_inputs(
         )
 
 
+def _pack_prerouted_topk_ids(act: MoEActivationPack) -> torch.Tensor:
+    """Pack global expert IDs and BF16 weight bits for TRTLLM routed APIs."""
+    if act.topk_ids is None or act.topk_weights is None:
+        raise ValueError("Packed routing requires topk_ids + topk_weights.")
+    weight_bits = act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
+    return (act.topk_ids << 16) | (weight_bits & 0xFFFF)
+
+
 def _validate_logits_inputs(
     act: MoEActivationPack, num_tokens: int, num_experts: int, runner: str
 ) -> None:
@@ -639,11 +647,7 @@ class TrtllmFp4RoutedRunner(MoERunner):
             )
             routing_logits = None
             routing_bias = None
-            ids = act.topk_ids
-            weight_bf16_bits = (
-                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
-            )
-            topk_ids = (ids << 16) | (weight_bf16_bits & 0xFFFF)
+            topk_ids = _pack_prerouted_topk_ids(act)
             # PackedPrecomputed still requires a (kernel-side) topk_weights buffer:
             # the raw op declares it non-Optional.  The high-level wrapper allocates
             # an empty bf16 placeholder here; we mirror that since we bypass it.
@@ -968,10 +972,7 @@ class TrtllmFp8BlockRunner(MoERunner):
             )
             routing_logits = None
             routing_bias = None
-            weight_bits = (
-                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
-            )
-            topk_ids = (act.topk_ids << 16) | (weight_bits & 0xFFFF)
+            topk_ids = _pack_prerouted_topk_ids(act)
             expert_weights = act.topk_weights.new_empty(
                 (num_tokens, routing.top_k), dtype=torch.bfloat16
             )
@@ -1232,10 +1233,10 @@ class TrtllmFp8PerTensorRunner(MoERunner):
             )
             routing_logits = None
             routing_bias = None
-            weight_bf16_bits = (
-                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
-            )
-            topk_ids = (act.topk_ids << 16) | (weight_bf16_bits & 0xFFFF)
+            topk_ids = _pack_prerouted_topk_ids(act)
+            # The routed per-tensor op allocates its own expert-weight buffer;
+            # this placeholder only satisfies the generic MoeRunnerInputs and
+            # autotuner schemas.
             expert_weights = act.topk_weights.new_empty(
                 (num_tokens, routing.top_k), dtype=torch.bfloat16
             )
@@ -1311,7 +1312,7 @@ class TrtllmBf16RoutedRunner(MoERunner):
     """
 
     backend_key = "trtllm_bf16_routed"
-    supported_routing_modes = (
+    supported_routing_modes: tuple[RoutingInputMode, ...] = (
         RoutingInputMode.PackedPrecomputed,
         RoutingInputMode.FromLogits,
     )
@@ -1319,20 +1320,19 @@ class TrtllmBf16RoutedRunner(MoERunner):
 
     def check_support(self) -> None:
         super().check_support()
-        device = getattr(self, "device", None)
-        if device is not None:
-            from ..utils import get_compute_capability
-
-            major, minor = get_compute_capability(device)
-            arch = major * 10 + minor
-            if arch not in (100, 103):
-                raise NotImplementedError(
-                    f"{type(self).__name__} requires SM100/SM103 TRTLLM BF16 "
-                    f"cubins, got sm{arch}."
-                )
         if self.config.activation.type is not ActivationType.Swiglu:
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
+            )
+        from ..utils import get_compute_capability
+
+        major, minor = get_compute_capability(self.device)
+        arch = major * 10 + minor
+        if arch not in (100, 103):
+            raise NotImplementedError(
+                f"{type(self).__name__} is enabled only on validated "
+                f"SM100/SM103 targets, got sm{arch}. SM107 enablement was "
+                "reverted by #4171; SM120/SM121 are unsupported."
             )
 
     def __init__(self, config: MoEConfig, device: torch.device):
@@ -1349,6 +1349,13 @@ class TrtllmBf16RoutedRunner(MoERunner):
         execution = config.execution
         self._num_local_experts = experts.local_num_experts or routing.num_experts
         self._local_expert_offset = experts.local_expert_offset
+        if (
+            self._local_expert_offset != 0
+            or self._num_local_experts != routing.num_experts
+        ):
+            # Keep packed routed EP available, but filter FromLogits before
+            # MoELayer enters runner packing/autotuning.
+            self.supported_routing_modes = (RoutingInputMode.PackedPrecomputed,)
         self._intermediate_size = experts.intermediate_size
         self._activation_type = int(config.activation.type)
         self._tune_max_num_tokens = execution.tune_max_num_tokens
@@ -1453,10 +1460,10 @@ class TrtllmBf16RoutedRunner(MoERunner):
             )
             routing_logits = None
             routing_bias = None
-            weight_bf16_bits = (
-                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
-            )
-            topk_ids = (act.topk_ids << 16) | (weight_bf16_bits & 0xFFFF)
+            # Keep global IDs intact. The kernel applies local_expert_offset;
+            # pre-subtracting it here would apply the offset twice and silently
+            # drop experts on nonzero-offset ranks.
+            topk_ids = _pack_prerouted_topk_ids(act)
             expert_weights = act.topk_weights.new_empty(
                 (num_tokens, routing.top_k), dtype=torch.bfloat16
             )
@@ -1498,7 +1505,9 @@ class TrtllmBf16RoutedRunner(MoERunner):
             weight_layout=int(WeightLayout.BlockMajorK),
             do_finalize=self.config.execution.do_finalize,
             enable_pdl=self._enable_pdl,
-            norm_topk_prob=(routing_input_mode == RoutingInputMode.FromLogits),
+            # Matches the canonical BF16 FromLogits wrapper. Precomputed
+            # routing ignores this flag because weights are already final.
+            norm_topk_prob=True,
         )
 
         self._ensure_inner(hidden_size)

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -352,14 +352,14 @@ class TrtllmFp4RoutedRunner(MoERunner):
         if variant in self.supported_quant_variants:
             from ..utils import get_compute_capability
 
-            # Direct-runner guard: NVFP4/MXFP4 support SM100/SM103. W4A16
-            # remains SM100-only, matching the upstream SM103 xfail in #1754.
+            # Direct-runner guard: #4280 relanded the SM107 cubins removed by
+            # #4171. NVFP4/MXFP4 support SM100/SM103/SM107; W4A16 supports
+            # SM100/SM107 and retains the upstream SM103 xfail in #1754.
             compute_capability = get_compute_capability(self.device)
-            supported = (
-                compute_capability in ((10, 0), (10, 3))
-                if variant in (QuantVariant.NVFP4, QuantVariant.MXFP4)
-                else compute_capability == (10, 0)
-            )
+            if variant in (QuantVariant.NVFP4, QuantVariant.MXFP4):
+                supported = compute_capability in ((10, 0), (10, 3), (10, 7))
+            else:
+                supported = compute_capability in ((10, 0), (10, 7))
             if not supported:
                 raise NotImplementedError(
                     f"TRTLLM {variant.name} is unsupported on "
@@ -1329,11 +1329,10 @@ class TrtllmBf16RoutedRunner(MoERunner):
 
         major, minor = get_compute_capability(self.device)
         arch = major * 10 + minor
-        if arch not in (100, 103):
+        if arch not in (100, 103, 107):
             raise NotImplementedError(
-                f"{type(self).__name__} is enabled only on validated "
-                f"SM100/SM103 targets, got sm{arch}. SM107 enablement was "
-                "reverted by #4171; SM120/SM121 are unsupported."
+                f"{type(self).__name__} is enabled only on routed-MoE cubin "
+                f"targets SM100/SM103/SM107, got sm{arch}."
             )
 
     def __init__(self, config: MoEConfig, device: torch.device):

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -120,7 +120,7 @@ def _pack_prerouted_topk_ids(act: MoEActivationPack) -> torch.Tensor:
     if act.topk_ids is None or act.topk_weights is None:
         raise ValueError("Packed routing requires topk_ids + topk_weights.")
     weight_bits = act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
-    return (act.topk_ids << 16) | (weight_bits & 0xFFFF)
+    return ((act.topk_ids << 16) | (weight_bits & 0xFFFF)).contiguous()
 
 
 def _validate_logits_inputs(
@@ -155,6 +155,8 @@ def _validate_logits_inputs(
             f"({num_tokens}, {num_experts}) (num_tokens, num_experts) — "
             "routing scores are over the GLOBAL expert set."
         )
+    if not logits.is_contiguous():
+        raise ValueError(f"{runner}: routing_logits must be contiguous.")
     if act.routing_bias is not None:
         if act.routing_bias.dtype not in (torch.bfloat16, torch.float32):
             raise TypeError(
@@ -166,6 +168,8 @@ def _validate_logits_inputs(
                 f"{runner}: routing_bias shape {tuple(act.routing_bias.shape)} "
                 f"!= ({num_experts},) (num_experts,)."
             )
+        if not act.routing_bias.is_contiguous():
+            raise ValueError(f"{runner}: routing_bias must be contiguous.")
 
 
 class MoERunner(TunableRunner):

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -771,6 +771,16 @@ class TrtllmFp8BlockRunner(MoERunner):
             raise NotImplementedError(
                 f"{type(self).__name__} supports only do_finalize=True."
             )
+        from ..utils import get_compute_capability
+        from .api import TrtllmFp8BlockConfig
+
+        major, minor = get_compute_capability(self.device)
+        arch = major * 10 + minor
+        if not TrtllmFp8BlockConfig.supported(arch):
+            raise NotImplementedError(
+                f"{type(self).__name__} is enabled only on validated "
+                f"SM100/SM103 targets, got sm{arch}."
+            )
 
     def __init__(self, config: MoEConfig, device: torch.device):
         from ..tllm_enums import DtypeTrtllmGen, Fp8QuantizationType
@@ -1057,6 +1067,8 @@ class TrtllmFp8PerTensorRunner(MoERunner):
     def check_support(self) -> None:
         super().check_support()
         from ..tllm_enums import RoutingMethodType
+        from ..utils import get_compute_capability
+        from .api import TrtllmFp8PerTensorConfig
 
         if self.config.activation.type is not ActivationType.Swiglu:
             raise NotImplementedError(
@@ -1072,6 +1084,13 @@ class TrtllmFp8PerTensorRunner(MoERunner):
         ):
             raise ValueError(
                 f"{type(self).__name__} requires top_k=1 for Llama4 routing."
+            )
+        major, minor = get_compute_capability(self.device)
+        arch = major * 10 + minor
+        if not TrtllmFp8PerTensorConfig.supported(arch):
+            raise NotImplementedError(
+                f"{type(self).__name__} is enabled only on validated "
+                f"SM100/SM103 targets, got sm{arch}."
             )
 
     def __init__(self, config: MoEConfig, device: torch.device):

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -60,12 +60,12 @@ from .utils import (
 def is_sm100_family():
     """Check for SM100 family (Blackwell: SM100, SM103).
 
-    CuteDSL MoE NVFP4 kernels are optimized for SM10x architecture.
+    CuteDSL MoE NVFP4 does not target Rubin SM107.
     """
     if not torch.cuda.is_available():
         return False
     props = torch.cuda.get_device_properties(0)
-    return props.major == 10
+    return (props.major, props.minor) in ((10, 0), (10, 3))
 
 
 # Skip decorators
@@ -74,7 +74,7 @@ cute_dsl_available = pytest.mark.skipif(
 )
 sm100_required = pytest.mark.skipif(
     not is_sm100_family(),
-    reason="Requires SM100 family GPU (Blackwell: SM100, SM103, SM110)",
+    reason="Requires CuteDSL MoE target SM100 or SM103",
 )
 
 

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -1641,12 +1641,12 @@ def test_bf16_moe_swiglu_oa_activation_params(cache_permute_indices):
 
 def test_fp8_block_scale_routed_activation_type_relu2_smoke():
     """Smoke test routed FP8 block-scale call path with explicit non-gated activation_type."""
-    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    device = torch.device("cuda:0")
+    compute_capability = get_compute_capability(device)
     if compute_capability not in ((10, 0), (10, 3), (10, 7)):
         pytest.skip("These tests require TRTLLM FP8 MoE on SM100, SM103, or SM107.")
 
     torch.manual_seed(0)
-    device = torch.device("cuda:0")
 
     num_tokens = 32
     hidden_size = 512
@@ -1980,7 +1980,7 @@ def test_fp4_block_scale_moe_fused_shared_experts_reject_routed_only_tensors():
     """
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability not in ((10, 0), (10, 3), (10, 7)):
-        pytest.skip("These tests require TRTLLM FP8 MoE on SM100, SM103, or SM107.")
+        pytest.skip("These tests require TRTLLM FP4 MoE on SM100, SM103, or SM107.")
 
     device = torch.device("cuda")
     num_tokens = 2

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -1642,8 +1642,8 @@ def test_bf16_moe_swiglu_oa_activation_params(cache_permute_indices):
 def test_fp8_block_scale_routed_activation_type_relu2_smoke():
     """Smoke test routed FP8 block-scale call path with explicit non-gated activation_type."""
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] not in [10]:
-        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
+    if compute_capability not in ((10, 0), (10, 3), (10, 7)):
+        pytest.skip("These tests require TRTLLM FP8 MoE on SM100, SM103, or SM107.")
 
     torch.manual_seed(0)
     device = torch.device("cuda:0")
@@ -1979,8 +1979,8 @@ def test_fp4_block_scale_moe_fused_shared_experts_reject_routed_only_tensors():
     one tensor to the routed-only extent and expects the host-side reject.
     """
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] not in [10]:
-        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
+    if compute_capability not in ((10, 0), (10, 3), (10, 7)):
+        pytest.skip("These tests require TRTLLM FP8 MoE on SM100, SM103, or SM107.")
 
     device = torch.device("cuda")
     num_tokens = 2
@@ -2083,8 +2083,8 @@ def test_fp4_block_scale_moe_fused_shared_experts_reject_routed_only_tensors():
 def test_mxfp8_block_scale_moe_swiglu_oa_activation_params(cache_permute_indices):
     """TRT-LLM Gen MxFp8 MoE applies raw fused FC1 SwiGLU OA params."""
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] not in [10]:
-        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
+    if compute_capability not in ((10, 0), (10, 3), (10, 7)):
+        pytest.skip("These tests require TRTLLM FP8 MoE on SM100, SM103, or SM107.")
 
     num_experts = 64
     num_tokens = 8

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -649,13 +649,17 @@ class TestMoERunnerSupport:
         with pytest.raises(NotImplementedError, match="do_finalize=True"):
             runner.check_support()
 
-    def test_bf16_unfinalized_not_supported(self):
+    def test_bf16_unfinalized_not_supported(self, monkeypatch):
+        import flashinfer.utils as utils
+
         cfg = self._nvfp4_swiglu(
             quant=QuantConfig(variant=QuantVariant.BF16),
             execution=ExecutionConfig(do_finalize=False),
         )
         runner = TrtllmBf16RoutedRunner.__new__(TrtllmBf16RoutedRunner)
         runner.config = cfg
+        runner.device = torch.device("cuda")
+        monkeypatch.setattr(utils, "get_compute_capability", lambda _: (10, 0))
         with pytest.raises(NotImplementedError, match="do_finalize=True"):
             runner.check_support()
 
@@ -1165,6 +1169,7 @@ def _bf16_dense_reference(
     LOCAL experts; a token routed to global id ``g`` uses local weight
     ``g - expert_offset``.
     """
+    final_scales = final_scales.to(torch.bfloat16).float()
     x32 = x.float()
     out = torch.zeros_like(x32)
     for local_e in range(w1.shape[0]):
@@ -2054,8 +2059,8 @@ class TestTrtllmFromLogitsPackingContract:
 
         torch.testing.assert_close(captured, eager)
 
-    def test_bf16_from_logits_ep_rejected(self):
-        act, weights, config, _ = _make_bf16_packs_and_config(
+    def test_bf16_from_logits_with_local_expert_offset(self):
+        act, weights, config, tensors = _make_bf16_packs_and_config(
             16,
             hidden_size=256,
             intermediate_size=512,
@@ -2065,15 +2070,33 @@ class TestTrtllmFromLogitsPackingContract:
             local_expert_offset=4,
             max_tokens=16,
         )
+        logits = torch.full(
+            (16, 8), -4.0, dtype=torch.float32, device=act.hidden_states_q.device
+        )
+        logits[:8, :4] = torch.randn_like(logits[:8, :4]) + 4.0
+        logits[8:, 4:] = torch.randn_like(logits[8:, 4:]) + 4.0
+        topk_weights, topk_ids = torch.topk(torch.softmax(logits, dim=-1), 2, dim=-1)
         logits_act = MoEActivationPack(
             hidden_states_q=act.hidden_states_q,
             hidden_states_scale=None,
             routing_input_mode=RoutingInputMode.FromLogits,
-            routing_logits=torch.randn(16, 8, device=act.hidden_states_q.device),
+            routing_logits=logits,
         )
         layer = MoELayer(config, device=act.hidden_states_q.device)
-        with pytest.raises(NotImplementedError, match="none of the usable backends"):
-            layer(logits_act, weights)
+        output = layer(logits_act, weights)
+        reference = _bf16_dense_reference(
+            tensors["x"],
+            tensors["w1"],
+            tensors["w2"],
+            topk_ids.to(torch.int32),
+            topk_weights,
+            512,
+            expert_offset=4,
+        )
+        assert torch.count_nonzero(reference)
+        torch.testing.assert_close(
+            output.float(), reference, rtol=BF16_RTOL, atol=BF16_ATOL
+        )
 
 
 # 6. prepare_trtllm_bf16_weights input contract

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -50,6 +50,7 @@ from flashinfer.fused_moe.runners import (
     MoERunner,
     TrtllmBf16RoutedRunner,
     TrtllmFp8BlockRunner,
+    TrtllmFp8PerTensorRunner,
 )
 from flashinfer.fused_moe.api import (
     ActivationConfig,
@@ -648,6 +649,35 @@ class TestMoERunnerSupport:
         runner.config = cfg
         with pytest.raises(NotImplementedError, match="do_finalize=True"):
             runner.check_support()
+
+    @pytest.mark.parametrize(
+        ("runner_type", "variant"),
+        [
+            (TrtllmFp8BlockRunner, QuantVariant.DeepSeekFp8),
+            (TrtllmFp8PerTensorRunner, QuantVariant.FP8PerTensor),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("compute_capability", "supported"),
+        [((10, 0), True), ((10, 3), True), ((10, 7), False)],
+    )
+    def test_fp8_runner_arch_support(
+        self, monkeypatch, runner_type, variant, compute_capability, supported
+    ):
+        import flashinfer.utils as utils
+
+        cfg = self._nvfp4_swiglu(quant=QuantConfig(variant=variant))
+        runner = runner_type.__new__(runner_type)
+        runner.config = cfg
+        runner.device = torch.device("cuda")
+        monkeypatch.setattr(
+            utils, "get_compute_capability", lambda _: compute_capability
+        )
+        if supported:
+            runner.check_support()
+        else:
+            with pytest.raises(NotImplementedError, match="SM100/SM103"):
+                runner.check_support()
 
     def test_bf16_unfinalized_not_supported(self, monkeypatch):
         import flashinfer.utils as utils

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -1947,6 +1947,88 @@ class TestTrtllmFromLogitsPackingContract:
         )
 
     @pytest.mark.parametrize("logits_dtype", [torch.float32, torch.bfloat16])
+    @pytest.mark.parametrize(
+        "routing_method",
+        [RoutingMethodType.Default, RoutingMethodType.DeepSeekV3],
+        ids=["default", "deepseek-v3"],
+    )
+    def test_bf16_from_logits_matches_host_reference(
+        self, routing_method, logits_dtype
+    ):
+        from tests.moe.trtllm_gen_fused_moe_utils import noaux_tc_ref
+
+        num_tokens, num_experts, top_k = 16, 8, 2
+        intermediate_size = 512
+        act, weights, config, tensors = _make_bf16_packs_and_config(
+            num_tokens,
+            hidden_size=256,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            top_k=top_k,
+            max_tokens=num_tokens,
+        )
+        logits = torch.randn(
+            num_tokens,
+            num_experts,
+            dtype=logits_dtype,
+            device=act.hidden_states_q.device,
+        )
+        routing_bias = None
+        if routing_method is RoutingMethodType.DeepSeekV3:
+            routing_bias = torch.randn(
+                num_experts,
+                dtype=torch.bfloat16,
+                device=logits.device,
+            )
+            dense_scores = noaux_tc_ref(
+                logits.float(),
+                routing_bias.float(),
+                n_group=4,
+                topk_group=2,
+                top_k=top_k,
+                routed_scaling_factor=1.0,
+            )
+            topk_weights, topk_ids = torch.topk(dense_scores, top_k, dim=-1)
+            routing = RoutingConfig(
+                num_experts=num_experts,
+                top_k=top_k,
+                method=routing_method,
+                n_group=4,
+                topk_group=2,
+                routed_scaling_factor=1.0,
+            )
+        else:
+            topk_weights, topk_ids = torch.topk(
+                torch.softmax(logits.float(), dim=-1), top_k, dim=-1
+            )
+            routing = RoutingConfig(
+                num_experts=num_experts,
+                top_k=top_k,
+                method=routing_method,
+            )
+
+        logits_act = MoEActivationPack(
+            hidden_states_q=act.hidden_states_q,
+            hidden_states_scale=None,
+            routing_input_mode=RoutingInputMode.FromLogits,
+            routing_logits=logits,
+            routing_bias=routing_bias,
+        )
+        config = dataclasses.replace(config, routing=routing)
+        output = MoELayer(config)(logits_act, weights)
+        reference = _bf16_dense_reference(
+            tensors["x"],
+            tensors["w1"],
+            tensors["w2"],
+            topk_ids.to(torch.int32),
+            topk_weights,
+            intermediate_size,
+        )
+        torch.testing.assert_close(
+            output.float(), reference, rtol=BF16_RTOL, atol=BF16_ATOL
+        )
+
+    @pytest.mark.parametrize("logits_dtype", [torch.float32, torch.bfloat16])
     def test_bf16_cuda_graph_replay_matches_eager(self, logits_dtype):
         runner, inputs, _, _ = self._make_bf16_from_logits_inputs(logits_dtype)
         for _ in range(3):
@@ -1979,9 +2061,9 @@ class TestTrtllmFromLogitsPackingContract:
             routing_input_mode=RoutingInputMode.FromLogits,
             routing_logits=torch.randn(16, 8, device=act.hidden_states_q.device),
         )
-        runner = TrtllmBf16RoutedRunner(config, device=act.hidden_states_q.device)
-        with pytest.raises(NotImplementedError, match="all experts to be local"):
-            runner.pack_inputs(logits_act, weights)
+        layer = MoELayer(config, device=act.hidden_states_q.device)
+        with pytest.raises(NotImplementedError, match="none of the usable backends"):
+            layer(logits_act, weights)
 
 
 # 6. prepare_trtllm_bf16_weights input contract

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -990,6 +990,14 @@ class TestRunnerBoundaryValidation:
         with pytest.raises(ValueError, match="num_experts"):
             _validate_logits_inputs(pack, 4, 16, "T")
 
+    def test_noncontiguous_logits_rejected(self):
+        from flashinfer.fused_moe.runners import _validate_logits_inputs
+
+        logits = torch.zeros(16, 4, dtype=torch.float32).T
+        assert logits.shape == (4, 16) and not logits.is_contiguous()
+        with pytest.raises(ValueError, match="routing_logits must be contiguous"):
+            _validate_logits_inputs(self._logits_pack(logits), 4, 16, "T")
+
     @pytest.mark.parametrize("bad_dtype", [torch.float16, torch.float64])
     def test_logits_dtype_rejected(self, bad_dtype):
         from flashinfer.fused_moe.runners import _validate_logits_inputs
@@ -1019,6 +1027,15 @@ class TestRunnerBoundaryValidation:
         with pytest.raises(ValueError, match="num_experts"):
             _validate_logits_inputs(pack, 4, 16, "T")
 
+    def test_noncontiguous_bias_rejected(self):
+        from flashinfer.fused_moe.runners import _validate_logits_inputs
+
+        bias = torch.zeros(32, dtype=torch.bfloat16)[::2]
+        assert bias.shape == (16,) and not bias.is_contiguous()
+        pack = self._logits_pack(torch.zeros(4, 16), bias=bias)
+        with pytest.raises(ValueError, match="routing_bias must be contiguous"):
+            _validate_logits_inputs(pack, 4, 16, "T")
+
     def test_logits_device_mutation_caught_at_runner_boundary(self):
         from flashinfer.fused_moe.runners import _validate_logits_inputs
 
@@ -1028,6 +1045,21 @@ class TestRunnerBoundaryValidation:
         )
         with pytest.raises(ValueError, match="device"):
             _validate_logits_inputs(pack, 4, 16, "T")
+
+    def test_packed_ids_normalize_noncontiguous_inputs(self):
+        from flashinfer.fused_moe.runners import _pack_prerouted_topk_ids
+
+        x, sf, _, _, _ = _pack_tensors()
+        ids = torch.arange(8, dtype=torch.int32).reshape(2, 4).T
+        weights = torch.linspace(-1, 1, 8).reshape(2, 4).T
+        assert not ids.is_contiguous() and not weights.is_contiguous()
+        packed = _pack_prerouted_topk_ids(MoEActivationPack(x, sf, ids, weights))
+        expected_bits = (
+            weights.to(torch.bfloat16).view(torch.int16).to(torch.int32) & 0xFFFF
+        )
+        assert packed.is_contiguous()
+        assert torch.equal(packed >> 16, ids)
+        assert torch.equal(packed & 0xFFFF, expected_bits)
 
 
 def _is_unified_nvfp4_arch() -> bool:

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -649,6 +649,16 @@ class TestMoERunnerSupport:
         with pytest.raises(NotImplementedError, match="do_finalize=True"):
             runner.check_support()
 
+    def test_bf16_unfinalized_not_supported(self):
+        cfg = self._nvfp4_swiglu(
+            quant=QuantConfig(variant=QuantVariant.BF16),
+            execution=ExecutionConfig(do_finalize=False),
+        )
+        runner = TrtllmBf16RoutedRunner.__new__(TrtllmBf16RoutedRunner)
+        runner.config = cfg
+        with pytest.raises(NotImplementedError, match="do_finalize=True"):
+            runner.check_support()
+
     def test_bf16_sm120_rejected_before_launch(self, monkeypatch):
         import flashinfer.utils as utils
 

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -685,16 +685,10 @@ class TestMoERunnerSupport:
         runner.check_support()
 
     @pytest.mark.parametrize(
-        ("variant", "supported"),
-        [
-            (QuantVariant.NVFP4, True),
-            (QuantVariant.MXFP4, True),
-            (QuantVariant.W4A16, True),
-        ],
+        "variant",
+        [QuantVariant.NVFP4, QuantVariant.MXFP4, QuantVariant.W4A16],
     )
-    def test_fp4_sm107_variant_support_after_reland(
-        self, monkeypatch, variant, supported
-    ):
+    def test_fp4_sm107_variant_support_after_reland(self, monkeypatch, variant):
         import flashinfer.utils as utils
 
         cfg = self._nvfp4_swiglu(quant=QuantConfig(variant=variant))
@@ -702,11 +696,7 @@ class TestMoERunnerSupport:
         runner.config = cfg
         runner.device = torch.device("cuda")
         monkeypatch.setattr(utils, "get_compute_capability", lambda _: (10, 7))
-        if supported:
-            runner.check_support()
-        else:
-            with pytest.raises(NotImplementedError, match=rf"{variant.name}.*SM107"):
-                runner.check_support()
+        runner.check_support()
 
     def test_moe_runner_quant_support_check(self):
         class Runner(MoERunner):

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -270,10 +270,14 @@ class TestBackendOptions:
         )
         valid = opts.valid_for(100)
         assert len(valid) == 3
+        assert TrtllmBf16Config.supported(100)
+        assert TrtllmBf16Config.supported(103)
         assert TrtllmFp4Config.supported(107)
         assert not TrtllmFp8BlockConfig.supported(107)
         assert TrtllmBf16Config.supported(107)
+        assert not TrtllmBf16Config.supported(110)
         assert not TrtllmBf16Config.supported(120)
+        assert not TrtllmBf16Config.supported(121)
         assert not TrtllmFp8BlockConfig.supported(110)
         assert not TrtllmFp8BlockConfig.supported(120)
         assert TrtllmFp8PerTensorConfig.supported(100)
@@ -643,6 +647,17 @@ class TestMoERunnerSupport:
         runner = TrtllmFp8BlockRunner.__new__(TrtllmFp8BlockRunner)
         runner.config = cfg
         with pytest.raises(NotImplementedError, match="do_finalize=True"):
+            runner.check_support()
+
+    def test_bf16_sm120_rejected_before_launch(self, monkeypatch):
+        import flashinfer.utils as utils
+
+        cfg = self._nvfp4_swiglu(quant=QuantConfig(variant=QuantVariant.BF16))
+        runner = TrtllmBf16RoutedRunner.__new__(TrtllmBf16RoutedRunner)
+        runner.config = cfg
+        runner.device = torch.device("cuda")
+        monkeypatch.setattr(utils, "get_compute_capability", lambda _: (12, 0))
+        with pytest.raises(NotImplementedError, match="SM100/SM103"):
             runner.check_support()
 
     def test_moe_runner_quant_support_check(self):
@@ -1833,7 +1848,7 @@ class TestTrtllmEPOffset:
 class TestTrtllmFromLogitsPackingContract:
     """FromLogits buffer allocation must follow the kernel's output contract.
 
-    The fp4 routing kernel writes bf16 expert weights regardless of the logits
+    TRTLLM routing kernels write bf16 expert weights regardless of the logits
     dtype; allocating ``expert_weights`` with ``routing_logits.dtype`` (fp32
     DeepSeekV3 logits) mislabels the kernel-filled buffer, so an unfinalized
     read interprets bf16 bits as fp32 garbage (gh #3595 — same bug previously
@@ -1896,6 +1911,77 @@ class TestTrtllmFromLogitsPackingContract:
         assert (
             runner._static_kwargs["routing_input_mode"] == RoutingInputMode.FromLogits
         )
+
+    def _make_bf16_from_logits_inputs(self, logits_dtype):
+        from flashinfer.fused_moe.core import MoeRunnerInputs
+
+        act, weights, config, _ = _make_bf16_packs_and_config(
+            16,
+            hidden_size=256,
+            intermediate_size=512,
+            num_experts=8,
+            top_k=2,
+            max_tokens=16,
+        )
+        logits = torch.randn(
+            16, 8, dtype=logits_dtype, device=act.hidden_states_q.device
+        )
+        logits_act = MoEActivationPack(
+            hidden_states_q=act.hidden_states_q,
+            hidden_states_scale=None,
+            routing_input_mode=RoutingInputMode.FromLogits,
+            routing_logits=logits,
+        )
+        runner = TrtllmBf16RoutedRunner(config, device=logits.device)
+        inputs = runner.pack_inputs(logits_act, weights)
+        return runner, inputs, MoeRunnerInputs.from_list(inputs), logits
+
+    @pytest.mark.parametrize("logits_dtype", [torch.float32, torch.bfloat16])
+    def test_bf16_expert_weights_buffer_is_bf16(self, logits_dtype):
+        runner, _, moe_inputs, logits = self._make_bf16_from_logits_inputs(logits_dtype)
+        assert moe_inputs.routing_logits is logits
+        assert moe_inputs.topk_ids.dtype == torch.int32
+        assert moe_inputs.expert_weights.dtype == torch.bfloat16
+        assert (
+            runner._static_kwargs["routing_input_mode"] == RoutingInputMode.FromLogits
+        )
+
+    @pytest.mark.parametrize("logits_dtype", [torch.float32, torch.bfloat16])
+    def test_bf16_cuda_graph_replay_matches_eager(self, logits_dtype):
+        runner, inputs, _, _ = self._make_bf16_from_logits_inputs(logits_dtype)
+        for _ in range(3):
+            runner.forward(inputs, tactic=-1)
+        torch.cuda.synchronize()
+        eager = runner.forward(inputs, tactic=-1).clone()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = runner.forward(inputs, tactic=-1)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(captured, eager)
+
+    def test_bf16_from_logits_ep_rejected(self):
+        act, weights, config, _ = _make_bf16_packs_and_config(
+            16,
+            hidden_size=256,
+            intermediate_size=512,
+            num_experts=8,
+            top_k=2,
+            local_num_experts=4,
+            local_expert_offset=4,
+            max_tokens=16,
+        )
+        logits_act = MoEActivationPack(
+            hidden_states_q=act.hidden_states_q,
+            hidden_states_scale=None,
+            routing_input_mode=RoutingInputMode.FromLogits,
+            routing_logits=torch.randn(16, 8, device=act.hidden_states_q.device),
+        )
+        runner = TrtllmBf16RoutedRunner(config, device=act.hidden_states_q.device)
+        with pytest.raises(NotImplementedError, match="all experts to be local"):
+            runner.pack_inputs(logits_act, weights)
 
 
 # 6. prepare_trtllm_bf16_weights input contract

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -70,6 +70,7 @@ from flashinfer.fused_moe.api import (
     TrtllmFp8PerTensorConfig,
     TrtllmMxInt4Config,
 )
+from flashinfer.utils import get_compute_capability
 
 # Reuse the canonical reference implementation + accuracy helpers from the
 # existing CuteDSL test — keeps tolerance bounds consistent across tests.
@@ -77,7 +78,6 @@ from tests.moe.test_cute_dsl_fused_moe import (  # noqa: E402
     check_accuracy,
     compute_reference_moe_fp4,
     create_moe_tensors,
-    is_sm100_family,
 )
 # ---------------------------------------------------------------------------
 # Enum repr round-trip
@@ -671,8 +671,42 @@ class TestMoERunnerSupport:
         runner.config = cfg
         runner.device = torch.device("cuda")
         monkeypatch.setattr(utils, "get_compute_capability", lambda _: (12, 0))
-        with pytest.raises(NotImplementedError, match="SM100/SM103"):
+        with pytest.raises(NotImplementedError, match="SM100/SM103/SM107"):
             runner.check_support()
+
+    def test_bf16_sm107_supported_after_reland(self, monkeypatch):
+        import flashinfer.utils as utils
+
+        cfg = self._nvfp4_swiglu(quant=QuantConfig(variant=QuantVariant.BF16))
+        runner = TrtllmBf16RoutedRunner.__new__(TrtllmBf16RoutedRunner)
+        runner.config = cfg
+        runner.device = torch.device("cuda")
+        monkeypatch.setattr(utils, "get_compute_capability", lambda _: (10, 7))
+        runner.check_support()
+
+    @pytest.mark.parametrize(
+        ("variant", "supported"),
+        [
+            (QuantVariant.NVFP4, True),
+            (QuantVariant.MXFP4, True),
+            (QuantVariant.W4A16, True),
+        ],
+    )
+    def test_fp4_sm107_variant_support_after_reland(
+        self, monkeypatch, variant, supported
+    ):
+        import flashinfer.utils as utils
+
+        cfg = self._nvfp4_swiglu(quant=QuantConfig(variant=variant))
+        runner = TrtllmFp4RoutedRunner.__new__(TrtllmFp4RoutedRunner)
+        runner.config = cfg
+        runner.device = torch.device("cuda")
+        monkeypatch.setattr(utils, "get_compute_capability", lambda _: (10, 7))
+        if supported:
+            runner.check_support()
+        else:
+            with pytest.raises(NotImplementedError, match=rf"{variant.name}.*SM107"):
+                runner.check_support()
 
     def test_moe_runner_quant_support_check(self):
         class Runner(MoERunner):
@@ -976,9 +1010,15 @@ class TestRunnerBoundaryValidation:
             _validate_logits_inputs(pack, 4, 16, "T")
 
 
+def _is_unified_nvfp4_arch() -> bool:
+    return torch.cuda.is_available() and get_compute_capability(
+        torch.device("cuda")
+    ) in ((10, 0), (10, 3), (10, 7))
+
+
 sm100_required = pytest.mark.skipif(
-    not is_sm100_family(),
-    reason="Unified NVFP4 MoE requires SM100 family (Blackwell SM100/SM103)",
+    not _is_unified_nvfp4_arch(),
+    reason="Unified NVFP4 MoE requires SM100, SM103, or SM107",
 )
 
 

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -735,7 +735,9 @@ def test_fp8_per_tensor_packed_ids_keep_global_ids_and_weight_bits():
     )
 
     runner = TrtllmFp8PerTensorRunner(config, torch.device("cuda"))
-    packed = MoeRunnerInputs.from_list(runner.pack_inputs(act, weights)).topk_ids
+    moe_inputs = MoeRunnerInputs.from_list(runner.pack_inputs(act, weights))
+    packed = moe_inputs.topk_ids
+    assert moe_inputs.expert_weights is None
     assert torch.equal(packed >> 16, expected_ids)
     assert torch.equal(packed & 0xFFFF, expected_bits)
 

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -482,7 +482,7 @@ def test_block_fp8_prerouted_cuda_graph(variant):
 
 
 # ---------------------------------------------------------------------------
-# Per-tensor FP8 — calibrated E4M3 activations/weights, FromLogits only
+# Per-tensor FP8 — calibrated E4M3 activations/weights
 # ---------------------------------------------------------------------------
 
 
@@ -514,6 +514,7 @@ def _per_tensor_fp8_reference(
     routing_scales_on_input: bool = False,
 ) -> torch.Tensor:
     fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    routing_weights = routing_weights.to(torch.bfloat16).float()
     x_q = (x.float() * input_scale).clamp(-fp8_max, fp8_max)
     x_deq = x_q.to(torch.float8_e4m3fn).float() / input_scale
     w1_deq, _ = _per_tensor_quant_dequant_experts(w1)
@@ -547,6 +548,7 @@ def _per_tensor_fp8_reference(
 
 def _make_per_tensor_fp8_case(
     *,
+    routing_input_mode: RoutingInputMode = RoutingInputMode.FromLogits,
     routing_method: RoutingMethodType = RoutingMethodType.Default,
     top_k: int = TOP_K,
     num_experts: int = NUM_EXPERTS,
@@ -602,12 +604,22 @@ def _make_per_tensor_fp8_case(
         intermediate_size=INTERMEDIATE,
         device=device,
     )
-    act = MoEActivationPack(
-        hidden_states_q=x_q,
-        hidden_states_scale=x_scale,
-        routing_input_mode=RoutingInputMode.FromLogits,
-        routing_logits=logits,
-    )
+    if routing_input_mode is RoutingInputMode.FromLogits:
+        act = MoEActivationPack(
+            hidden_states_q=x_q,
+            hidden_states_scale=x_scale,
+            routing_input_mode=routing_input_mode,
+            routing_logits=logits,
+        )
+    else:
+        assert routing_input_mode is RoutingInputMode.PackedPrecomputed
+        act = MoEActivationPack(
+            hidden_states_q=x_q,
+            hidden_states_scale=x_scale,
+            routing_input_mode=routing_input_mode,
+            topk_ids=selected_experts,
+            topk_weights=routing_weights,
+        )
     weights = MoEWeightPack()
     weights.prepare_for("trtllm_fp8_per_tensor", view)
     config = MoEConfig(
@@ -644,8 +656,15 @@ def _assert_per_tensor_fp8_close(out: torch.Tensor, ref: torch.Tensor) -> None:
     check_accuracy(out.float(), ref.float(), atol=0.05, rtol=0.3, percent=0.99)
 
 
-def test_fp8_per_tensor_layer_and_direct_runner_match_reference():
-    act, weights, config, ref, _ = _make_per_tensor_fp8_case()
+@pytest.mark.parametrize(
+    "routing_input_mode",
+    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
+    ids=["from-logits", "packed"],
+)
+def test_fp8_per_tensor_layer_and_direct_runner_match_reference(routing_input_mode):
+    act, weights, config, ref, _ = _make_per_tensor_fp8_case(
+        routing_input_mode=routing_input_mode
+    )
     layer_out = MoELayer(config)(act, weights)
     _assert_per_tensor_fp8_close(layer_out, ref)
 
@@ -675,8 +694,14 @@ def test_fp8_per_tensor_llama4_routes_scale_on_input():
         invalid_runner.check_support()
 
 
-def test_fp8_per_tensor_nonzero_expert_offset():
+@pytest.mark.parametrize(
+    "routing_input_mode",
+    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
+    ids=["from-logits", "packed"],
+)
+def test_fp8_per_tensor_nonzero_expert_offset(routing_input_mode):
     act, weights, config, ref, _ = _make_per_tensor_fp8_case(
+        routing_input_mode=routing_input_mode,
         num_experts=NUM_EXPERTS,
         local_num_experts=NUM_EXPERTS // 2,
         local_expert_offset=NUM_EXPERTS // 2,
@@ -686,6 +711,27 @@ def test_fp8_per_tensor_nonzero_expert_offset():
 
     runner = TrtllmFp8PerTensorRunner(config, torch.device("cuda"))
     _assert_per_tensor_fp8_close(runner.forward(runner.pack_inputs(act, weights)), ref)
+
+
+def test_fp8_per_tensor_packed_ids_keep_global_ids_and_weight_bits():
+    from flashinfer.fused_moe.core import MoeRunnerInputs
+
+    act, weights, config, _, _ = _make_per_tensor_fp8_case(
+        routing_input_mode=RoutingInputMode.PackedPrecomputed,
+        num_experts=NUM_EXPERTS,
+        local_num_experts=NUM_EXPERTS // 2,
+        local_expert_offset=NUM_EXPERTS // 2,
+    )
+    act.topk_weights[0, 0] = -act.topk_weights[0, 0]
+    expected_ids = act.topk_ids.clone()
+    expected_bits = (
+        act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32) & 0xFFFF
+    )
+
+    runner = TrtllmFp8PerTensorRunner(config, torch.device("cuda"))
+    packed = MoeRunnerInputs.from_list(runner.pack_inputs(act, weights)).topk_ids
+    assert torch.equal(packed >> 16, expected_ids)
+    assert torch.equal(packed & 0xFFFF, expected_bits)
 
 
 def test_fp8_per_tensor_routing_replay_matches_reference():
@@ -705,8 +751,15 @@ def test_fp8_per_tensor_routing_replay_matches_reference():
     )
 
 
-def test_fp8_per_tensor_cuda_graph_replay():
-    act, weights, config, ref, _ = _make_per_tensor_fp8_case()
+@pytest.mark.parametrize(
+    "routing_input_mode",
+    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
+    ids=["from-logits", "packed"],
+)
+def test_fp8_per_tensor_cuda_graph_replay(routing_input_mode):
+    act, weights, config, ref, _ = _make_per_tensor_fp8_case(
+        routing_input_mode=routing_input_mode
+    )
     runner = TrtllmFp8PerTensorRunner(config, torch.device("cuda"))
     inputs = runner.pack_inputs(act, weights)
     runner.forward(inputs)

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -674,8 +674,14 @@ def test_fp8_per_tensor_layer_and_direct_runner_match_reference(routing_input_mo
     _assert_per_tensor_fp8_close(direct_out, ref)
 
 
-def test_fp8_per_tensor_llama4_routes_scale_on_input():
+@pytest.mark.parametrize(
+    "routing_input_mode",
+    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
+    ids=["from-logits", "packed"],
+)
+def test_fp8_per_tensor_llama4_routes_scale_on_input(routing_input_mode):
     act, weights, config, ref, _ = _make_per_tensor_fp8_case(
+        routing_input_mode=routing_input_mode,
         routing_method=RoutingMethodType.Llama4,
         top_k=1,
     )

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -742,6 +742,23 @@ def test_fp8_per_tensor_packed_ids_keep_global_ids_and_weight_bits():
     assert torch.equal(packed & 0xFFFF, expected_bits)
 
 
+def test_fp8_per_tensor_noncontiguous_packed_routing_matches_reference():
+    from flashinfer.fused_moe.core import MoeRunnerInputs
+
+    act, weights, config, ref, _ = _make_per_tensor_fp8_case(
+        routing_input_mode=RoutingInputMode.PackedPrecomputed
+    )
+    act.topk_ids = act.topk_ids.T.contiguous().T
+    act.topk_weights = act.topk_weights.T.contiguous().T
+    assert not act.topk_ids.is_contiguous()
+    assert not act.topk_weights.is_contiguous()
+
+    runner = TrtllmFp8PerTensorRunner(config, torch.device("cuda"))
+    inputs = runner.pack_inputs(act, weights)
+    assert MoeRunnerInputs.from_list(inputs).topk_ids.is_contiguous()
+    _assert_per_tensor_fp8_close(runner.forward(inputs), ref)
+
+
 def test_fp8_per_tensor_routing_replay_matches_reference():
     act, weights, config, _, selected_experts = _make_per_tensor_fp8_case()
     runner = TrtllmFp8PerTensorRunner(config, torch.device("cuda"))

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -76,9 +76,10 @@ Routing coverage (three modes, axes ``routing_method`` x ``routing_input_mode`` 
     every mode, so a kernel that routes wrong is caught by check #2. In-kernel routing is
     single-GPU (non-EP) here; EP + in-kernel routing semantics are a separate validation.
 
-Coverage today: NVFP4 (CuteDSL pre-routed + TRTLLM-FP4 packed/unpacked pre-routed/in-kernel) on
-SM100 -- CuteDSL is pre-routed-only, while FromLogits and UnpackedPrecomputed restrict to the
-TRTLLM FP4 backend.
+Coverage today: NVFP4, BF16, block-FP8, and per-tensor FP8 on SM100. TRTLLM
+FP4 supports packed/unpacked pre-routed and in-kernel routing; BF16, block-FP8,
+and per-tensor FP8 support packed pre-routed and in-kernel routing. CuteDSL is
+pre-routed-only.
 
 OPT-IN: this suite is gated behind FLASHINFER_UMOE_FUZZ (see the pytestmark below) and is
 SKIPPED unless that env var is set -- waived in CI pending root-cause of a
@@ -387,6 +388,16 @@ def _bf16_act_pack(x, selected_experts, final_scales):
     )
 
 
+def _bf16_act_pack_logits(x, routing_logits, routing_bias):
+    return MoEActivationPack(
+        hidden_states_q=x,
+        hidden_states_scale=None,
+        routing_input_mode=RoutingInputMode.FromLogits,
+        routing_logits=routing_logits,
+        routing_bias=routing_bias,
+    )
+
+
 def _bf16_reference(
     x, w1, w2, selected_experts, final_scales, intermediate_size, expert_offset=0
 ):
@@ -634,6 +645,21 @@ def _fp8_per_tensor_act_pack_logits(x, routing_logits, routing_bias):
     )
 
 
+def _fp8_per_tensor_act_pack(x, selected_experts, final_scales):
+    input_scale = _fp8_per_tensor_global_scale(x)
+    q, sf = TrtllmFp8PerTensorConfig.prepare_activations(
+        x, hidden_states_scale_global=input_scale
+    )
+    assert sf is None
+    return MoEActivationPack(
+        hidden_states_q=q,
+        hidden_states_scale=None,
+        routing_input_mode=RoutingInputMode.PackedPrecomputed,
+        topk_ids=selected_experts,
+        topk_weights=final_scales,
+    )
+
+
 def _fp8_per_tensor_dequant_experts(weights):
     fp8_max = torch.finfo(torch.float8_e4m3fn).max
     amax = weights.float().abs().amax(dim=(-1, -2))
@@ -652,6 +678,7 @@ def _fp8_per_tensor_reference(
     expert_offset=0,
 ):
     fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    final_scales = final_scales.to(torch.bfloat16).float()
     input_scale = _fp8_per_tensor_global_scale(x)
     intermediate_scale = torch.tensor(64.0, device=x.device)
     x_q = (x.float() * input_scale).clamp(-fp8_max, fp8_max)
@@ -692,7 +719,7 @@ _DTYPE = {
         candidate_configs=(TrtllmBf16Config,),
         snap=_bf16_snap,
         make_act_pack=_bf16_act_pack,
-        make_act_pack_logits=None,
+        make_act_pack_logits=_bf16_act_pack_logits,
         reference=_bf16_reference,
         poison=_poison_bf16_out,
         out_dtype=torch.bfloat16,
@@ -737,7 +764,7 @@ _DTYPE = {
         variant=QuantVariant.FP8PerTensor,
         candidate_configs=(TrtllmFp8PerTensorConfig,),
         snap=_block_fp8_snap,
-        make_act_pack=None,
+        make_act_pack=_fp8_per_tensor_act_pack,
         make_act_pack_logits=_fp8_per_tensor_act_pack_logits,
         reference=_fp8_per_tensor_reference,
         poison=_poison_bf16_out,
@@ -1113,6 +1140,34 @@ _CURATED = [
         2048, 1024, 1024, 128, 6, "bf16", "imbalanced", 900_010
     ),  # bf16 mid size + empty-expert load
     Cfg(
+        64,
+        512,
+        512,
+        32,
+        4,
+        "bf16",
+        "uniform",
+        900_032,
+        routing_method=RoutingMethodType.Default,
+        routing_input_mode="fromlogits",
+        logits_dtype="fp32",
+    ),  # BF16 FromLogits with FP32 logits; seed % 4 == 0 exercises autotuning
+    Cfg(
+        64,
+        512,
+        512,
+        32,
+        4,
+        "bf16",
+        "uniform",
+        900_033,
+        routing_method=RoutingMethodType.DeepSeekV3,
+        routing_input_mode="fromlogits",
+        n_group=4,
+        topk_group=2,
+        routed_scaling=1.0,
+    ),  # BF16 FromLogits bias/group routing
+    Cfg(
         16,
         7168,
         2048,
@@ -1161,7 +1216,18 @@ _CURATED = [
         routing_method=RoutingMethodType.Default,
         routing_input_mode="fromlogits",
         logits_dtype="fp32",
-    ),  # per-tensor FP8 is FromLogits-only; seed % 4 == 0 exercises autotuning
+    ),  # per-tensor FP8 FromLogits; seed % 4 == 0 exercises autotuning
+    Cfg(
+        256,
+        1024,
+        512,
+        32,
+        4,
+        "fp8pertensor",
+        "uniform",
+        900_036,
+        routing_input_mode="prerouted",
+    ),  # per-tensor FP8 packed routing; seed % 4 == 0 exercises autotuning
     Cfg(
         64,
         512,

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -1020,11 +1020,15 @@ def _gen(seed):
         )  # route within the local shard
 
     fromlogits_variants = _FROMLOGITS_VARIANT_IDS
+    prerouted_variants = _PREROUTED_VARIANT_IDS
     if method == RoutingMethodType.Llama4:
         # Per-tensor FP8 applies the Llama4 route scale on GEMM1 input rather
         # than in finalization, so it needs a method-aware reference.
         fromlogits_variants = tuple(
             variant for variant in fromlogits_variants if variant != "fp8pertensor"
+        )
+        prerouted_variants = tuple(
+            variant for variant in prerouted_variants if variant != "fp8pertensor"
         )
 
     variant = (
@@ -1032,7 +1036,7 @@ def _gen(seed):
         if fromlogits
         else rng.choice(_UNPACKED_VARIANT_IDS)
         if unpacked
-        else rng.choice(_PREROUTED_VARIANT_IDS)
+        else rng.choice(prerouted_variants)
     )
     # The legacy TRTLLM MXFP4 modes are validated only with BF16 router logits.
     logits_dtype = (

--- a/tests/moe/test_unified_moe_mxfp4.py
+++ b/tests/moe/test_unified_moe_mxfp4.py
@@ -50,12 +50,12 @@ from tests.moe.test_cute_dsl_fused_moe import (
 def _sm100_family() -> bool:
     return torch.cuda.is_available() and get_compute_capability(
         torch.device("cuda")
-    ) in ((10, 0), (10, 3))
+    ) in ((10, 0), (10, 3), (10, 7))
 
 
 pytestmark = pytest.mark.skipif(
     not _sm100_family(),
-    reason="TRTLLM MXFP4 unified tests require SM100 or SM103",
+    reason="TRTLLM MXFP4 unified tests require SM100, SM103, or SM107",
 )
 
 
@@ -452,15 +452,15 @@ def test_trtllm_mxfp4_rejects_unaligned_weights(
     [
         (QuantVariant.NVFP4, (10, 0), True),
         (QuantVariant.NVFP4, (10, 3), True),
-        (QuantVariant.NVFP4, (10, 7), False),
+        (QuantVariant.NVFP4, (10, 7), True),
         (QuantVariant.NVFP4, (12, 0), False),
         (QuantVariant.MXFP4, (10, 0), True),
         (QuantVariant.MXFP4, (10, 3), True),
-        (QuantVariant.MXFP4, (10, 7), False),
+        (QuantVariant.MXFP4, (10, 7), True),
         (QuantVariant.MXFP4, (12, 0), False),
         (QuantVariant.W4A16, (10, 0), True),
         (QuantVariant.W4A16, (10, 3), False),
-        (QuantVariant.W4A16, (10, 7), False),
+        (QuantVariant.W4A16, (10, 7), True),
         (QuantVariant.W4A16, (12, 0), False),
     ],
 )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Completes three unified TRTLLM MoE routing follow-ups:
- Adds `PackedPrecomputed` support to `TrtllmFp8PerTensorRunner` using #4088’s routed entry point.
- Adds `FromLogits` support to `TrtllmBf16RoutedRunner`.
- Restores SM107 support for NVFP4, MXFP4, W4A16, and BF16 unified runners. Keeps unvalidated unified FP8 paths restricted to SM100/SM103.
    - Tightens CuteDSL NVFP4 test guards to SM100/SM103 so SM107 unified coverage exercises only the supported TRTLLM runner.
- Preserves global expert IDs, BF16 routing weights, nonzero expert offsets, routing-aware autotuning, and CUDA graph compatibility.
- Addressing a remaining comment in PR #4159 as well.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests added or updated.
- [x] Targeted SM100 tests passed.
- [x] SM107 architecture tests passed: 16 tests.
- [x] SM107 MoE numerical, routing, offset, and CUDA graph tests passed: 44 passed, 1 skipped.
- [x] Targeted unified fuzzer seeds passed.

## Reviewer Notes
Please focus on:
- Packed per-tensor FP8 routing and global expert-ID encoding.
- BF16 `FromLogits` routing semantics and BF16 output weights.
- SM107 variant-specific architecture gates.
- CUDA graph and nonzero expert-offset behavior.
