### PR TITLE
test(msa): fix split-K heuristic test's stale closed-form expectation

### DIFF
--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -439,6 +439,14 @@ def test_proxy_fp4_paged_packed():
     assert rel < 5e-2, f"paged-packed max rel err {rel}"
 
 
+def _makespan_cost(base_ctas, max_k_tiles, resident_ctas, ns):
+    """Same cost model `_split_k_makespan_argmin` picks its argmin from (see its
+    docstring): full resident-CTA waves times per-split work, plus ~one KV block
+    of fixed per-CTA overhead."""
+    waves = -(-(base_ctas * ns) // resident_ctas)
+    return waves * (-(-max_k_tiles // ns) + 1)
+
+
 def test_proxy_split_k_heuristic():
     """The kv-block split factor is 1 once the base grid fills the SMs and grows
     as the base grid shrinks (low-batch decode), capped by max_k_tiles."""
@@ -453,7 +461,20 @@ def test_proxy_split_k_heuristic():
     assert _proxy_split_k_fp4(8, 1, dev) == 1
     assert _proxy_split_k_fp4(0, 512, dev) == 1
     # Small base grid -> split enough to reach ~2 CTAs/SM, capped by max_k_tiles.
-    assert _proxy_split_k_fp4(8, 512, dev) == -(-2 * sm // 8)
+    # The split factor minimizing makespan cost isn't a fixed ceiling formula:
+    # ties break to the smaller split (fewer Q reloads), so the argmin can land
+    # below a naive ceil(2*sm/base_ctas) on many SM counts (e.g. 170, RTX 5090).
+    base_ctas, max_k_tiles, resident = 8, 512, 2 * sm
+    ns = _proxy_split_k_fp4(base_ctas, max_k_tiles, dev)
+    best_cost = min(
+        _makespan_cost(base_ctas, max_k_tiles, resident, n)
+        for n in range(1, max_k_tiles + 1)
+    )
+    assert _makespan_cost(base_ctas, max_k_tiles, resident, ns) == best_cost
+    assert all(
+        _makespan_cost(base_ctas, max_k_tiles, resident, n) > best_cost
+        for n in range(1, ns)
+    )
     assert _proxy_split_k_fp4(4, 8, dev) == 8  # clamped to max_k_tiles
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`test_proxy_split_k_heuristic` (`tests/msa_ops/test_proxy_fp4.py:456`) asserted `_proxy_split_k_fp4(8, 512, dev) == -(-2 * sm // 8)`, a closed-form ceiling formula that is independent of the actual cost model the function's answer comes from. `_proxy_split_k_fp4` delegates to `_split_k_makespan_argmin` (`flashinfer/msa_ops/proxy_score.py:91-106`), which searches every candidate split factor for the one minimizing `waves * (ceil(max_k_tiles / ns) + 1)` and, per its own docstring, ties break to the smaller split. Both functions were introduced together in #3655 (86800591); the test's closed form was never actually derived from the model it is meant to check.

That gap is invisible on SM counts where the tie-break happens to land on the ceiling value, but not on others. At sm=170 (RTX 5090, this issue): `base_ctas=8, max_k_tiles=512, resident_ctas=340` costs 14 at ns=40, 41 and 42 alike, and the model picks the smallest tied value, 40. The old closed form asserts `ceil(340/8) = 43`, which sits at ns=43, already one split factor into the `waves=2` region (cost 26). The mismatch isn't 5090-specific: the same closed-form/model divergence also happens on several other SM counts I checked (78, 114, 132, 144), so the test was fragile on more hardware than just this one report.

**Fix:** replace the closed-form assertion with a check against the same cost formula the docstring documents (reimplemented independently in the test, not calling back into `_split_k_makespan_argmin`): the returned split factor must achieve the minimum cost over the full candidate range, and no smaller split factor may match or beat that cost. This is true of the model's actual behavior for every SM count I checked, not just the ones where the old formula coincidentally agreed.

## 🔍 Related Issues

Fixes #4184

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Verification, run in a clean `python:3.12-slim` container against the two integer functions extracted from `flashinfer/msa_ops/proxy_score.py` at HEAD (`6812ddb4`), no GPU or torch install needed since both are pure integer math:

- Reproduced the reported mismatch directly: at sm=170, `_proxy_split_k_fp4(8, 512, ...)` returns 40; the old test assertion expected 43.
- The new assertion (minimum-cost + no-smaller-tie check) passes at sm=170 and at every other SM count I checked (56, 68, 78, 80, 84, 96, 108, 114, 132, 144, 148).
- `pre-commit run --files tests/msa_ops/test_proxy_fp4.py` (ruff-check, ruff-format, and the standard hooks) is clean, controlled against pristine HEAD first.
- Not verified: an actual GPU run of this test through pytest, since `tests/conftest.py` imports the full compiled `flashinfer` package (`tvm_ffi` and friends), which needs a CUDA build toolchain this sandbox does not have. The change is to the test's assertion logic only, not to any kernel or runtime code.

## Reviewer Notes

Test-only change, no kernel/runtime code touched. The new `_makespan_cost` helper in the test intentionally reimplements the cost formula from `_split_k_makespan_argmin`'s docstring rather than importing the production function, so the test still catches a real divergence between the two.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for the proxy split-K heuristic.
  * Added validation that the selected split factor minimizes estimated makespan cost across all allowed candidates.
  * Added checks confirming smaller split factors have higher costs, including tie-break scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->