### PR TITLE
fix(xqa): read the runtime draft mask on the SWAP_AB spec-dec path

### DIFF
--- a/csrc/xqa/mha_sm90.cu
+++ b/csrc/xqa/mha_sm90.cu
@@ -1758,41 +1758,119 @@ __device__ inline void warpGrpApplyMask(Gemm0Acc& acc, SpecDec const& specDec,
 #endif
                                         uint32_t cacheSeqLen, uint32_t idxTile, uint32_t warpRank) {
   constexpr uint32_t tileSize = gemm0CtaTileNbTokens;
-  static_assert(SPEC_Q_SEQ_LEN <= sizeof(MaskType) * 8, "not implemented");
-
-  assert(cacheSeqLen >= SPEC_Q_SEQ_LEN);
-  uint32_t const maskStartRow = cacheSeqLen - SPEC_Q_SEQ_LEN;
-  uint32_t const tileStartRow = tileSize * idxTile;
-  if (tileStartRow + tileSize < maskStartRow) {
-    return;
-  }
+  constexpr uint64_t fullMask = ~uint64_t{0};
+  static_assert(tileSize == sizeof(fullMask) * 8, "not implemented");
 
   uint32_t const idxInQuad = laneId() % 4;
   uint32_t const idxQuad = laneId() / 4;
+  uint32_t const tileStartRow = tileSize * idxTile;
 
+  if (specDec.params.mask == nullptr) {
+    // Fallback: no device-side mask available; synthesize a causal draft mask
+    // (legacy behavior).
+    static_assert(SPEC_Q_SEQ_LEN <= sizeof(MaskType) * 8, "not implemented");
+    // cacheSeqLen < SPEC_Q_SEQ_LEN is reachable via direct C++ callers; clamp
+    // instead of letting the uint32 subtraction underflow, which would make
+    // the early-exit below skip masking entirely in release builds.
+    uint32_t const maskStartRow = cacheSeqLen >= SPEC_Q_SEQ_LEN ? cacheSeqLen - SPEC_Q_SEQ_LEN : 0;
+    if (tileStartRow + tileSize < maskStartRow) {
+      return;
+    }
+#pragma unroll
+    for (uint32_t n = 0; n < acc.cols; n++) {
+#pragma unroll
+      for (uint32_t j = 0; j < GmmaAccCoreMat::cols; j++) {
+        uint32_t const col = GmmaAccCoreMat::cols * (4 * n + idxInQuad) + j;
+        uint32_t const maskCol = col / headGrpSize;
+        MaskType const bit_mask = (1ULL << (maskCol + 1)) - 1;
+
+#pragma unroll
+        for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+          for (uint32_t i = 0; i < GmmaAccCoreMat::rows; i++) {
+            uint32_t const row = gmma::instM * m + gmma::instM / 4 * warpRank + 8 * i + idxQuad;
+            uint32_t const globalRow = tileStartRow + row;
+            if (globalRow >= cacheSeqLen) {
+              acc(m, n)(i, j) = safeInitRowMax;
+              continue;
+            }
+            if (globalRow >= maskStartRow) {
+              uint32_t const maskRow = globalRow - maskStartRow;
+              if ((bit_mask >> maskRow) == 0) {
+                acc(m, n)(i, j) = safeInitRowMax;
+              }
+            }
+          }
+        }
+      }
+    }
+    return;
+  }
+
+  // Runtime draft mask. SWAP_AB transposes gemm0: acc rows are KV positions
+  // inside the tile and acc columns are q heads, so the mask lookup direction
+  // is the opposite of the non-SWAP_AB version: each q token (column group)
+  // selects one TileMaskRow and the bit index is the KV row.
+  uint32_t const nbValidRows =
+      mha::min(tileStartRow < cacheSeqLen ? cacheSeqLen - tileStartRow : 0U, tileSize);
+  bool const ctaNeedEndMask = (nbValidRows < tileSize);
+  bool const ctaNeedSpecDecMask = specDec.needMask(idxTile, 0);
+#if SLIDING_WINDOW && !IS_SPEC_DEC_TREE
+  // The last q token in the CTA has the largest window begin: tok0WinBeg +
+  // (inputTokensPerCta - 1). tok0WinBeg is int32 and may be deeply negative.
+  bool const ctaNeedBegMask =
+      int64_t(tileStartRow) < int64_t(mha::max(0, tok0WinBeg)) + int64_t(inputTokensPerCta - 1);
+#else
+  constexpr bool ctaNeedBegMask = false;
+#endif
+  if (!(ctaNeedBegMask || ctaNeedEndMask || ctaNeedSpecDecMask)) {
+    return;
+  }
+  uint64_t const endMask =
+      ctaNeedEndMask ? (nbValidRows == 0 ? uint64_t{0} : fullMask >> (tileSize - nbValidRows))
+                     : fullMask;
+
+  uint32_t prevMaskCol = ~0U;
+  uint64_t colMask = fullMask;
 #pragma unroll
   for (uint32_t n = 0; n < acc.cols; n++) {
 #pragma unroll
     for (uint32_t j = 0; j < GmmaAccCoreMat::cols; j++) {
       uint32_t const col = GmmaAccCoreMat::cols * (4 * n + idxInQuad) + j;
-      uint32_t const maskCol = col / headGrpSize;
-      MaskType const bit_mask = (1ULL << (maskCol + 1)) - 1;
-
+      uint32_t const maskCol = col / headGrpSize;  // q token index inside the CTA
+      if (maskCol != prevMaskCol) {
+        prevMaskCol = maskCol;
+        bool const isQTokValid =
+            (headGrpSize * inputTokensPerCta == ctaNbQHeads) || (maskCol < inputTokensPerCta);
+        uint64_t specDecMask = fullMask;
+        if (isQTokValid && specDec.needMask(idxTile, maskCol)) {
+          auto const tileMaskRow = specDec.loadTileMaskRow(idxTile, maskCol);
+          specDecMask = reinterpret_cast<uint64_t const&>(tileMaskRow);
+        }
+#if SLIDING_WINDOW && !IS_SPEC_DEC_TREE
+        // KV rows before this q token's window begin (tok0WinBeg + maskCol)
+        // are masked out. Guard the 64-bit shift explicitly: the shift count
+        // may reach or exceed 64 and tok0WinBeg may be deeply negative.
+        int32_t const begNbMaskOut = int32_t(tok0WinBeg) - int32_t(tileStartRow) + int32_t(maskCol);
+        uint64_t const begMask =
+            begNbMaskOut <= 0
+                ? fullMask
+                : (begNbMaskOut >= int32_t(tileSize) ? uint64_t{0} : fullMask << begNbMaskOut);
+#else
+        uint64_t const begMask = fullMask;
+#endif
+        colMask = specDecMask & begMask & endMask;
+      }
+      if (colMask == fullMask) {
+        continue;
+      }
 #pragma unroll
       for (uint32_t m = 0; m < acc.rows; m++) {
 #pragma unroll
         for (uint32_t i = 0; i < GmmaAccCoreMat::rows; i++) {
           uint32_t const row = gmma::instM * m + gmma::instM / 4 * warpRank + 8 * i + idxQuad;
-          uint32_t const globalRow = tileStartRow + row;
-          if (globalRow >= cacheSeqLen) {
+          if ((colMask & (uint64_t{1} << row)) == 0) {
             acc(m, n)(i, j) = safeInitRowMax;
-            continue;
-          }
-          if (globalRow >= maskStartRow) {
-            uint32_t const maskRow = globalRow - maskStartRow;
-            if ((bit_mask >> maskRow) == 0) {
-              acc(m, n)(i, j) = safeInitRowMax;
-            }
           }
         }
       }

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3575,9 +3575,6 @@ def xqa_batch_decode_with_kv_cache(
     window_left : int = -1
         The left (inclusive) window size for the attention window, when set to ``-1``, the window
         size will be set to the full length of the sequence. Defaults to ``-1``.
-        On SM90 with fp8 KV cache, speculative decode with a non-negative window
-        runs on the generic kernel instead of the Hopper fp8 kernel (see
-        :func:`flashinfer.xqa.xqa`).
 
     out :  Optional[torch.Tensor] = None
         output tensor, if not provided, will be allocated with ``query.dtype``.

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -25,7 +25,6 @@ from .jit.xqa import (
     gen_xqa_module,
     gen_xqa_module_mla,
     ragged_q_changes_build,
-    swap_ab_eligible,
 )
 from .jit.utils import filename_safe_dtype_map
 from .utils import (
@@ -302,9 +301,8 @@ def xqa(
     Note
     ----
     On SM90 with fp8 KV cache, speculative decode runs on the generic kernel
-    instead of the Hopper fp8 kernel when any of these holds: ragged Q,
-    attention sinks, a positive ``sliding_win_size`` (even one larger than
-    every sequence), or ``q_seq_len * (num_q_heads // num_kv_heads) <= 32``.
+    instead of the Hopper fp8 kernel when ragged Q is used, or when ``sinks``
+    are provided together with speculative decoding.
 
     The function automatically infers several parameters from tensor shapes:
     - batch_size from q.shape[0] (or seq_lens.shape[0] with ragged Q)
@@ -417,14 +415,8 @@ def xqa(
         assert mask is not None, "Mask is required for speculative decoding"
         if sinks is not None:
             run_sm90_fp8_mha = False  # TODO: mha_sm90.cu has precision issue if sinks and speculative decoding are used simultaneously
-        if (
-            use_ragged_q
-            or use_sliding_window
-            or swap_ab_eligible(q_seq_len, head_group_ratio)
-        ):
-            # mha_sm90.cu rejects ragged Q and gets full draft masks wrong,
-            # both under sliding windows and in SWAP_AB. Causal masks can't
-            # be exempted without inspecting the device-side mask.
+        if use_ragged_q:
+            # mha_sm90.cu rejects ragged Q.
             run_sm90_fp8_mha = False
 
     xqa_module.xqa(

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -1079,9 +1079,11 @@ def test_xqa_batch_decode_nvfp4_kv(
 @pytest.mark.parametrize(
     "num_kv_heads,head_grp_size",
     [
-        # q_len * head_grp_size <= 32: falls back to the generic kernel on SM90 fp8
+        # q_len(4) * head_grp_size = 16 <= 32: SM90 fp8 takes the SWAP_AB
+        # specialization of mha_sm90.cu
         (2, 4),
-        # q_len * head_grp_size > 32: stays on the SM90 fp8 kernel (mha_sm90.cu)
+        # q_len(4) * head_grp_size = 64 > 32: SM90 fp8 takes the non-SWAP_AB
+        # path of mha_sm90.cu
         (2, 16),
     ],
 )


### PR DESCRIPTION
## 📌 Description

Partially addresses #4198: fixes the SWAP_AB runtime-mask and sliding-window gaps on the SM90 fp8 XQA spec-decode path. Ragged Q and the PDL scale-load hazard remain open (follow-ups).

On the SWAP_AB layout (`q_seq_len * head_group_ratio <= 32`), `warpGrpApplyMask` synthesized a causal mask from the column index and never read `specDec.params.mask`; the `tok0WinBeg` argument was accepted but unused, so sliding-window begin-masking was also lost on this path.

Changes:

- `csrc/xqa/mha_sm90.cu` — rewrite the `SWAP_AB && SPEC_DEC` variant of `warpGrpApplyMask`:
  - read the runtime draft mask through the same `SpecDec::needMask` / `loadTileMaskRow` helpers as the non-SWAP_AB variant, with the lookup transposed for this layout (mask row selected by the q-token column, bit index = the thread's KV row); `TileMaskRow` loads are deduplicated across adjacent columns sharing a q token;
  - apply the per-column sliding-window begin mask (`globalRow < tok0WinBeg + maskCol`), with signed comparisons (`tok0WinBeg` can be deeply negative) and explicit shift clamping instead of relying on PTX `shl.b64` clamp behavior;
  - fix the early-exit condition so window-edge tiles far from the draft region are still masked (previously the function returned early based on the draft region alone, which is one structural reason `tok0WinBeg` was dead);
  - keep the hard-coded causal behavior as a fallback when `params.mask == nullptr`.
- `flashinfer/xqa.py` — remove the `use_sliding_window` and `swap_ab_eligible` conditions from the SM90 fp8 MHA fallback guard (the kernel now handles both); keep the `use_ragged_q` and `sinks` fallbacks; update the note.
- `flashinfer/decode.py` — drop the now-stale docstring sentence saying sliding-window falls back to the generic kernel.
- `tests/attention/test_xqa_batch_decode.py` — comment-only: label the deterministic-test parametrizations (`(2,4)` → SM90 fp8 SWAP_AB path, `(2,16)` → non-SWAP_AB path).

The kernel change also clamps `maskStartRow` in the null-mask fallback (`cacheSeqLen >= SPEC_Q_SEQ_LEN ? cacheSeqLen - SPEC_Q_SEQ_LEN : 0`) so a `cacheSeqLen < SPEC_Q_SEQ_LEN` call from direct C++ users cannot underflow and skip masking in release builds.

## 🔍 Related Issues

Partially addresses #4198 (gaps (a) and (b); ragged Q and the `qScalePtr`/`kvScalePtr` PDL load-ordering item are intentionally left for follow-ups). Builds on the deterministic tests introduced in #4199.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

Validation on a matching reported CUDA/PyTorch stack — H100 (SXM) / SM90, CUDA 13.0 (nvcc 13.0.88), torch 2.12.0+cu130, source build (JIT), on current main + this patch. Notes: the original report is from an H100 PCIe; the node's kernel driver here is 550.127.08 with the CUDA 13.0 forward-compatibility package, not a native 580-series driver.

| test (H100) | before (unpatched, SM90 fp8 MHA forced on) | after (patched, default dispatch) |
|---|---|---|
| `spec_dec_sliding_window[300-full-False-…-63-…-2-32-2-4]` | FAILED | PASSED |
| `spec_dec_sliding_window[300-full-False-…-63-…-4-64-4-2]` | FAILED | PASSED |
| `spec_dec_sliding_window[300-full-False-…-127-…-2-32-2-4]` | FAILED | PASSED |
| `spec_dec_sliding_window[300-full-False-…-127-…-4-64-4-2]` | FAILED | PASSED |
| `mask_mode_deterministic[2-4-full-fp8]` | FAILED | PASSED |
| causal controls (deterministic causal + all causal window cases) | PASSED | PASSED |
| full `pytest tests/attention/test_xqa_batch_decode.py -k fp8` | — | 1380 passed / 480 skipped / 0 failed |

The 16 remaining before-failures in the forced-on targeted subset are the known sinks + spec-dec accuracy TODO (unchanged by this PR; sinks still fall back in normal dispatch).

Primary development validation — H200 / SM90, CUDA 13.0, torch 2.13.0, source build (JIT): same 5 cases fail before / pass after; post-rebase targeted regression 68 passed / 0 failed; full `-k fp8` (pre-rebase tree) 1378 passed / 0 failed.

- [x] Tests have been added or updated as needed (this PR relies on the deterministic + sliding-window tests introduced in #4199; the only test-file change here is comment labeling of the parametrizations).
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- I could not reproduce out-of-tolerance full-mask + sliding-window results for **non-SWAP_AB** shapes (q_len×grp products 40/64 pass at tol 0.1 on both H100 and H200), so this PR only changes the SWAP_AB variant; the non-SWAP_AB `warpGrpApplyMask` is untouched.
- The known sinks + spec-dec accuracy issue on the forced SM90 path is unchanged (pre-existing TODO, still gated by the sinks fallback in normal dispatch).
- The `qScalePtr`/`kvScalePtr` PDL load-ordering hazard added to #4198 is not addressed here; happy to take it as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speculative decoding mask handling for custom masks, causal masking, sequence boundaries, and sliding-window limits.
  * Prevented incorrect accumulator values when tokens fall outside valid masking or sequence ranges.
  * Improved SM90 FP8 speculative-decoding kernel selection, including clearer handling for ragged queries and sink values.

* **Documentation**
  * Updated XQA documentation to reflect current FP8 fallback behavior.
  * Clarified test coverage comments for SM90 head-group configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->