### PR TITLE
fix(trtllm): restrict routed-MoE backends to supported architectures (release port for #4107)

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <cstring>
 #include <vector>
 
@@ -35,6 +36,49 @@ using namespace batchedGemm::gemm;
 using namespace batchedGemm::trtllm::gen;
 
 static BatchedGemmInterface::ModuleCache globalTrtllmGenBatchedGemmModuleCache;
+
+namespace {
+
+// The trtllm-gen cubin manifest is a downloaded artifact, so which architectures
+// it actually covers is not knowable at compile time. Encode only the
+// cubin-arch -> SM-version compatibility rules here and let `config.mSm` decide
+// what is available. Unknown cubin families are rejected so that a newly shipped
+// one fails loudly instead of being mis-dispatched onto hardware that cannot run
+// it (see #4107).
+bool isArchCompatible(int smVersion, tg::CudaArch cubinArch) {
+  switch (cubinArch) {
+    case tg::CudaArch::Sm100a:
+      return smVersion == 100;
+    case tg::CudaArch::Sm100f:
+      return smVersion == 100 || smVersion == 103;
+    case tg::CudaArch::Sm103a:
+      return smVersion == 103;
+#ifdef TLLM_RUBIN_FEATURES
+    // CudaArch::Sm107a only exists in the Rubin cubin pin's generated headers,
+    // which is also the only build that defines TLLM_RUBIN_FEATURES. sm107 is
+    // unreachable in the non-Rubin module: get_trtllm_moe_sm100_module() picks
+    // the Rubin variant by device compute capability before this runs.
+    case tg::CudaArch::Sm107a:
+      return smVersion == 107;
+#endif
+    default:
+      return false;
+  }
+}
+
+void checkPassingConfigIndex(std::vector<int64_t> const& passingConfigIndices,
+                             int32_t configIndex) {
+  auto const it = std::find(passingConfigIndices.begin(), passingConfigIndices.end(), configIndex);
+  if (it == passingConfigIndices.end()) {
+    std::ostringstream msg;
+    msg << "Config index " << configIndex
+        << " is not in this runner's compatible config set (device architecture or GEMM options "
+           "mismatch)";
+    FLASHINFER_ERROR(msg.str());
+  }
+}
+
+}  // namespace
 
 std::vector<int64_t> prioritizePredefinedConfigs(
     int m, int n, int k, std::vector<int64_t> const& sortedIndices,
@@ -141,23 +185,9 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
       if ((int64_t)options.mEltwiseActType != (int64_t)mOptions.eltwiseActType) {
         continue;
       }
-#ifdef TLLM_RUBIN_FEATURES
-      // CudaArch::Sm107a only exists in the Rubin cubin pin's generated
-      // headers (TRTLLM_GEN_BMM_RUBIN). The default pin has no such enumerator,
-      // so this comparison must not be compiled into the non-Rubin module.
-      // sm_version == 107 is unreachable there anyway: the Rubin module is
-      // selected by device compute capability before this runs.
-      if (sm_version == 107) {
-        if (config.mSm != tg::CudaArch::Sm107a) continue;
-      }
-#endif
-      if (sm_version == 103) {
-        if (config.mSm != tg::CudaArch::Sm103a && config.mSm != tg::CudaArch::Sm100f) continue;
-        if (options.mPatchF2fp && config.mSm != tg::CudaArch::Sm103a) continue;
-      }
-      if (sm_version == 100) {
-        if (config.mSm != tg::CudaArch::Sm100a && config.mSm != tg::CudaArch::Sm100f) continue;
-      }
+      if (!isArchCompatible(sm_version, config.mSm)) continue;
+      // Sm100f cubins miss the f2fp patch, so sm103 must fall back to Sm103a for it.
+      if (sm_version == 103 && options.mPatchF2fp && config.mSm != tg::CudaArch::Sm103a) continue;
       if (mOptions.transposeMmaOutput && options.mEpilogueTileM == mOptions.epilogueTileM) {
         // Skip cubins with clusterZ > 1 due to correctness issues described in
         // https://github.com/flashinfer-ai/flashinfer/issues/3197
@@ -165,6 +195,23 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
         mPassingConfigIndices.push_back(i);
       }
     }
+  }
+
+  if (mPassingConfigIndices.empty()) {
+    // Distinguish "this GPU has no cubins at all" from "no cubin matches these GEMM
+    // options". The former is the common failure on unsupported hardware, and the
+    // option dump below would send users looking in entirely the wrong place.
+    bool anyArchCompatible = false;
+    for (size_t i = 0; i < bmm.getNumBatchedGemmConfigs(); ++i) {
+      if (isArchCompatible(sm_version, configs[i].mSm)) {
+        anyArchCompatible = true;
+        break;
+      }
+    }
+    std::ostringstream arch_msg;
+    arch_msg << "The trtllm-gen batched GEMM cubin manifest contains no kernels runnable on sm"
+             << sm_version << "; this backend currently ships cubins for sm100, sm103 and sm107.";
+    FLASHINFER_CHECK(anyArchCompatible, arch_msg.str());
   }
 
   std::ostringstream error_msg;
@@ -189,6 +236,7 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
 size_t TrtllmGenBatchedGemmRunner::getWorkspaceSizeInBytes(
     int32_t m, int32_t n, int32_t k, std::vector<int32_t> const& batchedTokens, int32_t numTokens,
     int32_t numBatches, int32_t maxNumCtasInBatchDim, int32_t configIndex) const {
+  checkPassingConfigIndex(mPassingConfigIndices, configIndex);
   BatchedGemmData gemmData{};
   gemmData.mProblemDimensions.mNumBatches = numBatches;
   gemmData.mProblemDimensions.mNumTokens = numTokens;
@@ -232,7 +280,12 @@ void TrtllmGenBatchedGemmRunner::run(
   BatchedGemmData gemmData{};
 
   auto const configs = bmm.getBatchedGemmConfigs();
+  auto const numConfigs = bmm.getNumBatchedGemmConfigs();
 
+  FLASHINFER_CHECK(
+      configIndex >= 0 && static_cast<size_t>(configIndex) < static_cast<size_t>(numConfigs),
+      "Config index", configIndex, "is out of range; the manifest has", numConfigs, "configs");
+  checkPassingConfigIndex(mPassingConfigIndices, configIndex);
   auto const& config = configs[configIndex];
   // printf("running config %d: %s\n", configIndex, config.mFunctionName);
 

--- a/csrc/trtllm_gemm_runner.cu
+++ b/csrc/trtllm_gemm_runner.cu
@@ -16,6 +16,8 @@
 
 #include <cuda.h>
 
+#include <algorithm>
+#include <sstream>
 #include <string>
 
 #include "flashinfer/exception.h"
@@ -32,6 +34,38 @@ static thread_local gemm::gemm::GemmInterface::ModuleCache globalTrtllmGenGemmMo
 }  // namespace
 
 namespace flashinfer {
+
+namespace {
+
+// The trtllm-gen cubin manifest is a downloaded artifact, so which architectures
+// it actually covers is not knowable at compile time. Encode only the
+// cubin-arch -> SM-version compatibility rules here and let `config.mSm` decide
+// what is available. Unknown cubin families are rejected so that a newly shipped
+// one fails loudly instead of being mis-dispatched onto hardware that cannot run
+// it (see #4107).
+bool isArchCompatible(int smVersion, gemm::trtllm::gen::CudaArch cubinArch) {
+  using CudaArch = gemm::trtllm::gen::CudaArch;
+  switch (cubinArch) {
+    case CudaArch::Sm100a:
+      return smVersion == 100;
+    case CudaArch::Sm100f:
+      return smVersion == 100 || smVersion == 103;
+    case CudaArch::Sm103a:
+      return smVersion == 103;
+#ifdef TLLM_RUBIN_FEATURES
+    // CudaArch::Sm107a only exists in the Rubin cubin pin's generated headers,
+    // which is also the only build that defines TLLM_RUBIN_FEATURES. sm107 is
+    // unreachable in the non-Rubin module: get_trtllm_gemm_module() picks the
+    // Rubin variant by device compute capability before this runs.
+    case CudaArch::Sm107a:
+      return smVersion == 107;
+#endif
+    default:
+      return false;
+  }
+}
+
+}  // namespace
 
 struct TrtllmGenGemmRunnerOptions {
   gemm::trtllm::gen::Dtype eltType;
@@ -110,6 +144,7 @@ class TrtllmGenGemmRunner {
     auto const configs = gemm.getGemmConfigs();
 
     mPassingConfigIndices.clear();
+    int const sv = getSMVersion();
 
     for (size_t i = 0; i < gemm.getNumGemmConfigs(); ++i) {
       auto const options = configs[i].mOptions;
@@ -118,7 +153,27 @@ class TrtllmGenGemmRunner {
           options.mTransposeMmaOutput == mOptions.transposeMmaOutput &&
           options.mSfLayoutB == mOptions.sfLayoutB &&
           options.mLayoutA == mOptions.layoutA) {  // FIXME(siyuanf): expose matrix layout to user
+        if (!isArchCompatible(sv, configs[i].mSm)) continue;
         mPassingConfigIndices.push_back(i);
+      }
+    }
+
+    if (mPassingConfigIndices.empty()) {
+      // Distinguish "this GPU has no cubins at all" from "no cubin matches these GEMM
+      // options". The former is the common failure on unsupported hardware, and the
+      // option dump below would send users looking in entirely the wrong place.
+      bool anyArchCompatible = false;
+      for (size_t i = 0; i < gemm.getNumGemmConfigs(); ++i) {
+        if (isArchCompatible(sv, configs[i].mSm)) {
+          anyArchCompatible = true;
+          break;
+        }
+      }
+      if (!anyArchCompatible) {
+        std::ostringstream arch_msg;
+        arch_msg << "The trtllm-gen GEMM cubin manifest contains no kernels runnable on sm" << sv
+                 << "; this backend currently ships cubins for sm100, sm103 and sm107.";
+        FLASHINFER_ERROR(arch_msg.str());
       }
     }
 
@@ -130,11 +185,20 @@ class TrtllmGenGemmRunner {
                      "mSfLayoutB: ", gemm::trtllm::gen::sfLayoutToString(mOptions.sfLayoutB));
   }
 
+  void checkPassingConfigIndex(int64_t tactic) const {
+    auto it = std::find(mPassingConfigIndices.begin(), mPassingConfigIndices.end(), tactic);
+    TVM_FFI_ICHECK(it != mPassingConfigIndices.end())
+        << "Tactic " << tactic
+        << " is not in this runner's compatible config set (device architecture or GEMM options "
+           "mismatch)";
+  }
+
   int64_t getWorkspaceSizeInBytes(int64_t m, int64_t n, int64_t k, int64_t tactic) {
     auto gemm = gemm::gemm::GemmInterface();
     auto const configs = gemm.getGemmConfigs();
     FLASHINFER_CHECK(tactic >= 0 && tactic < gemm.getNumGemmConfigs(),
                      "Invalid tactic in getWorkspaceSizeInBytes");
+    checkPassingConfigIndex(tactic);
     auto const config = configs[tactic];
 
     gemm::gemm::GemmData gemmData;
@@ -156,6 +220,7 @@ class TrtllmGenGemmRunner {
     auto gemm = gemm::gemm::GemmInterface();
     auto const configs = gemm.getGemmConfigs();
     TVM_FFI_ICHECK(tactic >= 0 && tactic < gemm.getNumGemmConfigs()) << "Invalid tactic id in run";
+    checkPassingConfigIndex(tactic);
     auto const& config = configs[tactic];
     TVM_FFI_ICHECK(config.mOptions.mSfLayoutB == mOptions.sfLayoutB) << "Invalid sf layout in run";
 

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -223,6 +223,17 @@ class ExecutionConfig:
 # Backend configs — each declares hardware preconditions
 # ---------------------------------------------------------------------------
 
+# Architectures the TRT-LLM routed-MoE cubin manifest ships kernels for.  The
+# manifest is a downloaded artifact, so this cannot be derived at import time and
+# has to be kept in sync with the cubin-arch compatibility rules in
+# csrc/trtllm_batched_gemm_runner.cu.  SM110/120/121 need upstream cubins first;
+# claiming them here makes the batched-GEMM runner abort at dispatch (#4107).
+_TRTLLM_ROUTED_ARCHS = (100, 103, 107)
+
+# The FP8 kernels are validated on the SM100 family only — the outer JIT module
+# compiles for major 12 as well, but those cubins fail at runtime on SM120/121.
+_TRTLLM_ROUTED_FP8_ARCHS = (100, 103)
+
 
 @dataclass(frozen=True)
 class TrtllmFp4Config:
@@ -230,11 +241,7 @@ class TrtllmFp4Config:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        # SM100+ only: the routed runner delegates to the trtllm-gen sm100
-        # module, which core.is_trtllm_moe_supported() gates on major >= 10.
-        # Returning True on SM90 would mark the backend available on H100 and
-        # then fail at dispatch.
-        return arch >= 100
+        return arch in _TRTLLM_ROUTED_ARCHS
 
     @staticmethod
     def prepare_weights(
@@ -274,10 +281,7 @@ class TrtllmFp8BlockConfig:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        # The available TRTLLM block-FP8 BMM cubins are validated only on the
-        # SM100 family. The outer JIT can compile for major 12, but its FP8
-        # kernels currently fail at runtime on SM120/121.
-        return arch in (100, 103)
+        return arch in _TRTLLM_ROUTED_FP8_ARCHS
 
     @staticmethod
     def prepare_weights(
@@ -327,7 +331,7 @@ class TrtllmFp8PerTensorConfig:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        return arch in (100, 103)
+        return arch in _TRTLLM_ROUTED_FP8_ARCHS
 
     @staticmethod
     def prepare_weights(
@@ -375,7 +379,7 @@ class TrtllmBf16Config:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        return arch >= 100
+        return arch in _TRTLLM_ROUTED_ARCHS
 
     @staticmethod
     def prepare_weights(
@@ -415,7 +419,11 @@ class TrtllmMxInt4Config:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        return arch >= 100
+        # Same trtllm-gen routed batched-GEMM path as the FP4/BF16 backends, so it
+        # inherits the same manifest coverage.  Whether sm107a MxE2m1 cubins exist
+        # is not verifiable from this repo; this only narrows the previous
+        # ``arch >= 100``, leaving SM100/103/107 behaviour unchanged.
+        return arch in _TRTLLM_ROUTED_ARCHS
 
     def __repr__(self) -> str:
         return "TrtllmMxInt4Config()"

--- a/tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py
+++ b/tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py
@@ -26,6 +26,14 @@ from __future__ import annotations
 
 import pytest
 
+from flashinfer.fused_moe.api import (
+    TrtllmBf16Config,
+    TrtllmFp4Config,
+    TrtllmFp8BlockConfig,
+    TrtllmFp8PerTensorConfig,
+    TrtllmMxInt4Config,
+)
+
 NUM_EXPERTS = 16
 TOP_K = 4
 NUM_TOKENS = 64
@@ -33,13 +41,16 @@ HIDDEN = 2048
 INTERMEDIATE = 1024
 
 
-def _require_blackwell():
+def _require_backend(config_cls):
     import torch
 
     if not torch.cuda.is_available():
         pytest.skip("needs CUDA")
-    if torch.cuda.get_device_capability()[0] < 10:
-        pytest.skip("trtllm-gen fused_moe requires SM100+")
+
+    major, minor = torch.cuda.get_device_capability()
+    arch = major * 10 + minor
+    if not config_cls.supported(arch):
+        pytest.skip(f"{config_cls.__name__} is not supported on sm{arch}")
 
 
 def _make_problem():
@@ -155,7 +166,7 @@ def _fp4_quant_dequant(t_2d_bf16):
 @pytest.mark.arch_blackwell
 def test_split_bf16_kernel_matches_torch_reference():
     """``trtllm_bf16_routed`` (all experts local) matches the fp32 torch oracle."""
-    _require_blackwell()
+    _require_backend(TrtllmBf16Config)
 
     import torch
 
@@ -202,7 +213,7 @@ def test_split_bf16_kernel_matches_torch_reference():
 @pytest.mark.arch_blackwell
 def test_split_nvfp4_kernel_matches_torch_reference():
     """``trtllm_fp4_routed`` (all experts local) matches the dequant torch oracle."""
-    _require_blackwell()
+    _require_backend(TrtllmFp4Config)
 
     import torch
 
@@ -265,3 +276,62 @@ def test_split_nvfp4_kernel_matches_torch_reference():
     # at the gemm1→gemm2 round-trip dominate; 51/131072 cells past 5e-2).
     torch.testing.assert_close(yk, yr, rtol=5e-2, atol=0.15)
     assert rel_l2.item() < 0.05
+
+
+@pytest.mark.parametrize(
+    ("arch", "expected"),
+    [
+        (90, False),
+        (100, True),
+        (103, True),
+        (107, True),
+        (110, False),
+        (120, False),
+        (121, False),
+    ],
+)
+@pytest.mark.parametrize(
+    "config_cls",
+    [TrtllmBf16Config, TrtllmFp4Config, TrtllmMxInt4Config],
+)
+def test_trtllm_routed_moe_supported_architectures(config_cls, arch, expected):
+    """CPU-only: lock down the backend support contract."""
+    assert config_cls.supported(arch) is expected
+
+
+@pytest.mark.parametrize(
+    ("arch", "expected"),
+    [
+        (90, False),
+        (100, True),
+        (103, True),
+        (107, False),
+        (110, False),
+        (120, False),
+        (121, False),
+    ],
+)
+@pytest.mark.parametrize(
+    "config_cls",
+    [TrtllmFp8BlockConfig, TrtllmFp8PerTensorConfig],
+)
+def test_trtllm_routed_moe_fp8_supported_architectures(config_cls, arch, expected):
+    """CPU-only: the FP8 backends are SM100-family only, unlike FP4/BF16/MxInt4."""
+    assert config_cls.supported(arch) is expected
+
+
+def test_no_trtllm_routed_backend_claims_sm120():
+    """Regression guard for #4107: no trtllm-gen routed backend may claim SM120/121.
+
+    The batched-GEMM runner has no cubins there and aborts during construction, so a
+    backend that reports itself supported turns a fallback into a hard failure.
+    """
+    from flashinfer.fused_moe.api import _DEFAULT_BACKEND
+
+    for arch in (110, 120, 121):
+        claimed = [
+            type(c).__name__
+            for c in _DEFAULT_BACKEND
+            if type(c).__name__.startswith("Trtllm") and type(c).supported(arch)
+        ]
+        assert claimed == [], f"trtllm backends wrongly claim sm{arch}: {claimed}"


### PR DESCRIPTION
## Description

Release-specific port of #4177 onto `release-v0.6.16` for #4107.

On SM12x (Spark, RTX Pro 6000), TRTLLM routed-MoE backends were incorrectly
claiming support (`arch >= 100`) and then dispatching sm100f/sm103a cubins,
causing `RuntimeError: Error occurred when running GEMM!` or segfaults in
`test_split_fused_moe_kernel_vs_reference`.

## Changes

- **`csrc/trtllm_batched_gemm_runner.cu`**: Replace per-SM if-chains with
  `isArchCompatible()`; reject unknown cubin families; guard `Sm107a` behind
  `#ifdef TLLM_RUBIN_FEATURES` (only exists in the Rubin cubin pin's headers).
- **`csrc/trtllm_gemm_runner.cu`**: Same arch filter for the plain GEMM runner
  (previously had no arch filtering at all).
- **`flashinfer/fused_moe/api.py`**: Tighten `Trtllm*Config.supported()` from
  `arch >= 100` to explicit allowlists `_TRTLLM_ROUTED_ARCHS = (100, 103, 107)`
  and `_TRTLLM_ROUTED_FP8_ARCHS = (100, 103)`.
- **`tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py`**: Gate GPU tests
  on `config_cls.supported(arch)`; add CPU contract tests + SM120 regression guard.

## Release-specific notes

- Includes **sm107** in the allowlist (unlike the rebased #4177 for `main`, which
  will drop 107 after the #4122 revert).
- `Sm107a` enum case is gated behind `TLLM_RUBIN_FEATURES`, matching the existing
  release pattern from #4122/#4191. Verified against the actual pinned headers:
  the default BMM/GEMM pins do not define `Sm107a`; only the Rubin pins do.

## Verification

- CPU tests: 36 passed, 2 skipped (`test_split_fused_moe_kernel_vs_reference.py`)
- Backend claims: sm120/sm121 now fall back to Cutlass only (no Trtllm* backends)
- Compile: `isArchCompatible()` builds cleanly against both default and Rubin BMM
  export headers; ported batched runner compiles against default pin

## Related

- Fixes #4107
- Upstream PR: #4177 (targets `main`, has merge conflicts)
- Cherry-pick source commit on `main`: not yet merged

## Pre-existing issue (not in scope)

`#4213` on release references `options.mDtypeSfC`, which does not exist in the
default BMM cubin pin's headers (only in the Rubin pin). This is a separate
release-only compile issue on the non-Rubin module, predating this port.