### PR TITLE
cherry-pick: #4145 test(sm103): fix FP4 autotuner cache inspection

### DIFF
--- a/tests/gemm/test_mm_fp4_sm103.py
+++ b/tests/gemm/test_mm_fp4_sm103.py
@@ -77,17 +77,16 @@ def test_mm_fp4_sm103_cutlass_epilogue() -> None:
 
             if not selected_tactic_checked:
                 matching_entries = [
-                    (key, runner_id, tactic)
-                    for key, (runner_id, tactic, _) in tuner.profiling_cache.items()
+                    (key, tactic)
+                    for key, (tactic, _) in tuner.profiling_cache.items()
                     if key.custom_op == "fp4_gemm" and key.nearest_profile[0][0] == m
                 ]
                 assert len(matching_entries) == 1, (
                     "expected one fp4_gemm autotuner entry for the exact M bucket, "
                     f"got {matching_entries}"
                 )
-                key, runner_id, tactic = matching_entries[0]
+                key, tactic = matching_entries[0]
                 assert key.runner_class_name == "CutlassFp4GemmRunner"
-                assert runner_id == 0
                 assert tactic in _NATIVE_K768_TACTICS, (
                     f"autotuner selected generic tactic {tactic}; expected a native "
                     "SM103 K768 tactic"
@@ -197,15 +196,14 @@ def test_mm_fp4_sm103_generic_alignment_dispatch() -> None:
 
                 if not selected_tactic_checked:
                     matching_entries = [
-                        (key, runner_id, tactic)
-                        for key, (runner_id, tactic, _) in tuner.profiling_cache.items()
+                        (key, tactic)
+                        for key, (tactic, _) in tuner.profiling_cache.items()
                         if key.custom_op == "fp4_gemm"
                         and key.nearest_profile[0][0] == m
                     ]
                     assert len(matching_entries) == 1
-                    key, runner_id, tactic = matching_entries[0]
+                    key, tactic = matching_entries[0]
                     assert key.runner_class_name == "CutlassFp4GemmRunner"
-                    assert runner_id == 0
                     if first_alignment == "aligned":
                         assert tactic in _GENERIC_K128_K256_TACTICS
                     selected_tactic_checked = True


### PR DESCRIPTION
## Summary
- Cherry-pick of #4145 onto `release-v0.6.16`
- Fixes `ValueError: not enough values to unpack (expected 3, got 2)` in `tests/gemm/test_mm_fp4_sm103.py` after #4004 changed `profiling_cache` to 2-tuples
- Addresses #4163

## Source
- Upstream PR: https://github.com/flashinfer-ai/flashinfer/pull/4145
- Cherry-picked commit: `7715d24b`

## Test plan
- [ ] `tests/gemm/test_mm_fp4_sm103.py` on SM103