### PR TITLE
fix(moe): name-filter output-scale-incompatible cubins until pinned packages carry mDtypeSfC

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -168,9 +168,14 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
       // block format's default dtype. Reject cubins that override that
       // contract, such as bmm_E2m1xFp32_* kernels that emit linear FP32
       // scaling factors into a buffer sized for E4M3 factors.
-      if (tg::dtypeIsBlockFmt(options.mDtypeC)) {
-        if (options.mDtypeSfC != tg::dtypeGetBlockSfType(options.mDtypeC)) continue;
-      } else if (options.mDtypeSfC != Dtype::Void) {
+      //
+      // The published cubin packages predate BatchedGemmOptions::mDtypeSfC, so
+      // filter by kernel name instead: the offending kernels encode the linear
+      // FP32 output scale-factor dtype as the "E2m1xFp32" name token (present
+      // only in the sm_107a package). TODO: restore the typed mDtypeSfC check
+      // once packages carrying the field are published and pinned.
+      if (config.mFunctionName != nullptr &&
+          std::strstr(config.mFunctionName, "E2m1xFp32") != nullptr) {
         continue;
       }
       if (mOptions.usePerChannelScaling) {


### PR DESCRIPTION
## 📌 Description

Fixes two coupled problems on `release-v0.6.16`:

**1. The branch tip cannot compile the trtllm-gen fused-MoE module — on any architecture.**
#4213 checks `BatchedGemmOptions::mDtypeSfC`, but that field does not exist in either pinned cubin package's exported headers (Blackwell `b368d003`, Rubin `46d3f356` — verified 0 occurrences in both published `BatchedGemmOptions.h`, and in the internal `81a53cff` package as well). Any JIT or AOT rebuild of `fused_moe_trtllm_*` fails with:
```
trtllm_batched_gemm_runner.cu(128): error: class "BatchedGemmOptions" has no member "mDtypeSfC"
```
(The original PR #4168 shows the same failure in its CI on main.)

**2. The FP4-MoE illegal-memory-access #4213 targets (#4164 / NVBug 6517914) is still live on Rubin.**
The offending `bmm_E2m1xFp32_*` kernels emit linear FP32 output scale-factors into the E4M3-sized (1 B/block) buffer the MoE pipeline allocates → device-side overflow → async IMA, near-deterministic under autotune. Verified against the published catalogs: **132 such kernels, all in the sm_107a package (`46d3f356`); zero in the Blackwell package** — which is why the per-arch pin split (#4191) healed Blackwell while Rubin still crashes.

## What changed

Replace the un-compilable typed check with a kernel-**name** filter carrying the same intent: reject configs whose `mFunctionName` contains the `E2m1xFp32` token. This compiles against the *currently published* packages and removes the bad candidates before autotune can run them. #4213's other changes (per-token-scaling restructure, launcher tactic-enumeration alignment) are inherited unchanged.

**Scope note:** the name filter is deliberately narrower than the typed check — it rejects only the known-bad family. Against the published catalogs this is behaviorally equivalent (the `E2m1xFp32` kernels are the only offenders present). The TODO in the code ties restoring the typed `mDtypeSfC` check to publishing + pinning packages that carry the field.

## Validation

- Build break reproduced (sbsa AOT wheel build, CTK 13.4) at the branch tip; gone with this patch.
- VR200 (Rubin) re-run of the affected MoE test files in progress; results will be posted here before marking ready for review.

Refs: #4164, #4213, #4168 · NVBug 6517914

🤖 Generated with [Claude Code](https://claude.com/claude-code)