### PR TITLE
fix(moe): pad trtllm-gen route map by one element to avoid OOB read

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -450,8 +450,10 @@ class FusedMoeLauncher {
     expanded_idx_to_permuted_idx =
         alloc_tensor({args->num_tokens * totalExpertsPerToken}, dl_int32, hidden_states.device());
 
+    // WAR: the routed batched-GEMM kernels read one int32 past the end of the route map.
+    // TODO: drop the +1 once the fixed kernel cubins land.
     permuted_idx_to_token_idx =
-        alloc_tensor({max_num_padded_tokens}, dl_int32, hidden_states.device());
+        alloc_tensor({max_num_padded_tokens + 1}, dl_int32, hidden_states.device());
 
     if (gemm1_bias_type == batchedGemm::gemm::BiasType::Mn) {
       permuted_idx_to_expanded_idx =
@@ -1940,8 +1942,10 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
     total_num_padded_tokens = alloc_tensor({1}, dl_int32, hidden_states.device());
     expanded_idx_to_permuted_idx =
         alloc_tensor({args->num_tokens * args->top_k}, dl_int32, hidden_states.device());
+    // WAR: the routed batched-GEMM kernels read one int32 past the end of the route map.
+    // TODO: drop the +1 once the fixed kernel cubins land.
     permuted_idx_to_token_idx =
-        alloc_tensor({max_num_padded_tokens}, dl_int32, hidden_states.device());
+        alloc_tensor({max_num_padded_tokens + 1}, dl_int32, hidden_states.device());
 
     int64_t const size_of_expert_count_histogram = std::max(args->num_experts * 2, 256 * 2);
     expert_count_histogram =


### PR DESCRIPTION
## 📌 Description

The routed dynamic-batch batched-GEMM kernels (`Bmm_*_dynB` with `-routeAct`)
read one `int32` past the end of `ptrRouteMap`, from the last batch-dim CTA, on
every launch. The read is speculative — its value is never consumed, so outputs
are always bitwise correct — but it faults with `CUDA_ERROR_ILLEGAL_ADDRESS`
whenever the allocation happens to end at a mapped-region boundary. That
allocator-placement dependence is what makes it surface as *flaky* MoE autotune
and inference crashes.

Root cause is kernel-side: an off-by-one clamp in the hoisted load-task
initializer (`WarpGrpThreadIdx` is clamped to the load-group size instead of
size − 1), so off-group threads compute row `tileN` of a `tileN`-row tile, i.e.
index `(ctaIdxY + 1) * tileN`. For the last CTA that is exactly one element past
the shape documented in `KernelParamsDecl.h`
(`[sum(divUpMul(N[bi], tileN) for bi in B)]`) — which is what we allocate. It has
been reported to the kernel owners and is being fixed there.

This PR is the integration-side workaround: allocate the route map with one
extra element, so the already-shipped prebuilt cubins stay in bounds. The
overrun is provably always exactly one `int32` from one CTA, so `+1` is
sufficient by construction, not a heuristic. The pad slot's contents are
irrelevant since the value is never used.

Two allocation sites, both `permuted_idx_to_token_idx` (→ `routeMap`). Marked
`WAR` + `TODO` so the `+1` can be dropped once regenerated cubins land.

## 🔍 Related Issues

Likely explains #3530 and #3168 (and possibly #4012, #2776) — all report
intermittent NVFP4 MoE autotune crashes, and #3168 additionally reports silent
garbage output, which is the expected signature of an OOB read that usually
lands on mapped memory.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

No test added — the failure is allocator-placement dependent and does not
reproduce deterministically through the public API. Validation was done on
`v0.6.15.post1` (B200, SM100, Kimi-K2.5 NVFP4 TP4):

| Check | stock | route map +1 |
|---|---|---|
| `compute-sanitizer` memcheck, M=2 bucket × 4 ranks | 40 × `Invalid __global__ read of size 4` | **0 violations** (816 profiles/rank) |
| Guard-page probe (route map placed at the tail of a VMM mapping) | faults on every launch | **clean** |
| Full-model TP4 autotune crash loop | crashed by attempt 2 in 3/3 loops | **6/6 clean** |

The guard-page probe is the load-bearing one: it removes all dependence on
allocator placement, so it is deterministic in both directions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for fused mixture-of-experts routing operations by preventing out-of-bounds memory access in supported execution paths.
  * Applied the safeguard to both standard and FP4 block-scale routing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->