### PR TITLE
fix(trtllm-gen moe): persistent, CUDA-graph-capture-safe routing scratch

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <tuple>
 #include <type_traits>
@@ -232,6 +233,49 @@ inline void check_gemm1_bias_mn(Optional<TensorView> const& gemm1_bias,
       << "gemm1_bias must have shape [num_tokens, top_k, 2 * intermediate_size].";
 }
 
+// Persistent, CUDA-graph-capture-safe routing scratch (flashinfer#3427, #3168).
+//
+// The trtllm-gen MoE routing scratch (expanded_idx_to_permuted_idx and its
+// siblings) used to be allocated per call via alloc_tensor(), i.e. from the
+// framework caching allocator. Under CUDA-graph *piecewise* capture (e.g. SGLang
+// PCG, one graph piece per decoder layer) those allocations come from the graph's
+// private memory pool, whose offsets are recycled across the separately captured
+// layer pieces. The routing cooperative kernel bakes the address of its in-bounds
+// store `mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx`; at replay that
+// address aliases a *different* piece's allocation -> corruption -> a downstream
+// trtllm-gen GEMM raises an illegal memory access.
+//
+// The scratch is pure per-call working memory (written by routing, consumed by
+// the GEMMs within the same call), so a single persistent buffer per device,
+// allocated once and reused across all layers and graph replays, is correct and
+// keeps the baked address stable. It is pre-sized to a generous maximum so the
+// arena is allocated before capture and never re-allocated during capture (a
+// re-allocation mid-capture would re-introduce the pool-relative address). The
+// arena is a few MB per device.
+namespace {
+constexpr int64_t kMaxRoutingScratchTokens = 65536;  // upper bound on tokens processed per capture
+struct RoutingScratchSlot {
+  Tensor tensor;
+  int64_t capacity = 0;
+};
+struct RoutingScratchArena {
+  RoutingScratchSlot num_tokens_per_expert, total_num_padded_tokens, expanded_idx_to_permuted_idx,
+      permuted_idx_to_token_idx, permuted_idx_to_expanded_idx, expert_indexes,
+      expert_count_histogram, cta_idx_xy_to_batch_idx, cta_idx_xy_to_mn_limit, num_non_exiting_ctas;
+};
+std::mutex g_routing_scratch_mu;
+std::unordered_map<int, RoutingScratchArena> g_routing_scratch;  // key = device_id
+// Grow-only int32 slot; once seeded at kMaxRoutingScratchTokens it is not
+// re-allocated for any smaller/equal request, so its address is capture-stable.
+inline Tensor& ensure_routing_slot(RoutingScratchSlot& slot, int64_t numel, DLDevice dev) {
+  if (slot.capacity < numel) {
+    slot.tensor = alloc_tensor({numel}, dl_int32, dev);
+    slot.capacity = numel;
+  }
+  return slot.tensor;
+}
+}  // namespace
+
 class FusedMoeLauncher {
  protected:
   Optional<TensorView> routing_logits;
@@ -430,6 +474,11 @@ class FusedMoeLauncher {
   Tensor cta_idx_xy_to_mn_limit;
   Tensor num_non_exiting_ctas;
 
+  // Set by run() before prepare_routing(): true when expanded_idx_to_permuted_idx
+  // is returned to the caller (must stay per-call then; otherwise it may share the
+  // persistent arena). See run()'s return-array layout.
+  bool mExpandedIdxReturned = false;
+
   void* permuted_idx_to_expanded_idx_ptr() const {
     return permuted_idx_to_expanded_idx.defined() ? permuted_idx_to_expanded_idx.data_ptr()
                                                   : nullptr;
@@ -439,44 +488,48 @@ class FusedMoeLauncher {
     int32_t const totalExpertsPerToken = args->top_k + args->num_fused_shared_experts;
     int32_t const totalNumExperts = args->num_experts + args->num_fused_shared_experts;
 
-    // Allocate routing phase workspace tensors
-    num_tokens_per_expert = alloc_tensor({totalNumExperts}, dl_int32, hidden_states.device());
+    // Allocate routing phase workspace from the persistent per-device arena
+    // (see RoutingScratchArena; flashinfer#3427, #3168).
+    auto dev = hidden_states.device();
     int32_t max_num_padded_tokens =
         tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxPermutedPaddedCount(
             args->num_tokens, totalExpertsPerToken, totalNumExperts, tile_tokens_dim);
-
-    total_num_padded_tokens = alloc_tensor({1}, dl_int32, hidden_states.device());
-
-    expanded_idx_to_permuted_idx =
-        alloc_tensor({args->num_tokens * totalExpertsPerToken}, dl_int32, hidden_states.device());
-
-    permuted_idx_to_token_idx =
-        alloc_tensor({max_num_padded_tokens}, dl_int32, hidden_states.device());
-
-    if (gemm1_bias_type == batchedGemm::gemm::BiasType::Mn) {
-      permuted_idx_to_expanded_idx =
-          alloc_tensor({max_num_padded_tokens}, dl_int32, hidden_states.device());
-    }
-
-    expert_indexes =
-        alloc_tensor({args->num_tokens, totalExpertsPerToken}, dl_int32, hidden_states.device());
-
-    // expert_weights allocation should be done by derived class since data type could vary
-
     int64_t const size_of_expert_count_histogram = std::max(totalNumExperts * 2, 256 * 2);
-    expert_count_histogram = alloc_tensor({size_of_expert_count_histogram},
-                                          dl_int32,  // 256 is the max number of threads per block
-                                                     // and max number of experts
-                                          hidden_states.device());
-
-    int32_t max_num_ctas = tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxNumCtasInBatchDim(
-        args->num_tokens, totalExpertsPerToken, totalNumExperts, tile_tokens_dim);
-
-    cta_idx_xy_to_batch_idx = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
-
-    cta_idx_xy_to_mn_limit = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
-
-    num_non_exiting_ctas = alloc_tensor({1}, dl_int32, hidden_states.device());
+    int64_t const scratch_tokens = std::max<int64_t>(args->num_tokens, kMaxRoutingScratchTokens);
+    int32_t const scratch_padded =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxPermutedPaddedCount(
+            scratch_tokens, totalExpertsPerToken, totalNumExperts, tile_tokens_dim);
+    int32_t const scratch_ctas =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxNumCtasInBatchDim(
+            scratch_tokens, totalExpertsPerToken, totalNumExperts, tile_tokens_dim);
+    {
+      std::lock_guard<std::mutex> lk(g_routing_scratch_mu);
+      auto& sc = g_routing_scratch[dev.device_id];
+      num_tokens_per_expert = ensure_routing_slot(sc.num_tokens_per_expert, totalNumExperts, dev);
+      total_num_padded_tokens = ensure_routing_slot(sc.total_num_padded_tokens, 1, dev);
+      permuted_idx_to_token_idx =
+          ensure_routing_slot(sc.permuted_idx_to_token_idx, scratch_padded, dev);
+      if (gemm1_bias_type == batchedGemm::gemm::BiasType::Mn) {
+        permuted_idx_to_expanded_idx =
+            ensure_routing_slot(sc.permuted_idx_to_expanded_idx, scratch_padded, dev);
+      }
+      expert_indexes =
+          ensure_routing_slot(sc.expert_indexes, scratch_tokens * totalExpertsPerToken, dev);
+      expert_count_histogram =
+          ensure_routing_slot(sc.expert_count_histogram, size_of_expert_count_histogram, dev);
+      cta_idx_xy_to_batch_idx = ensure_routing_slot(sc.cta_idx_xy_to_batch_idx, scratch_ctas, dev);
+      cta_idx_xy_to_mn_limit = ensure_routing_slot(sc.cta_idx_xy_to_mn_limit, scratch_ctas, dev);
+      num_non_exiting_ctas = ensure_routing_slot(sc.num_non_exiting_ctas, 1, dev);
+      // expanded_idx_to_permuted_idx is returned to the caller when mExpandedIdxReturned;
+      // only share it (persistent) when it is not returned.
+      if (mExpandedIdxReturned) {
+        expanded_idx_to_permuted_idx =
+            alloc_tensor({args->num_tokens * totalExpertsPerToken}, dl_int32, dev);
+      } else {
+        expanded_idx_to_permuted_idx = ensure_routing_slot(
+            sc.expanded_idx_to_permuted_idx, scratch_tokens * totalExpertsPerToken, dev);
+      }
+    }
 
     workspace.total_num_padded_tokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
     workspace.total_max_padded_tokens = max_num_padded_tokens;
@@ -627,6 +680,7 @@ class FusedMoeLauncher {
                             bool use_deep_seek_fp8 = false, bool return_activation_output = false) {
     ffi::CUDADeviceGuard device_guard(hidden_states.device().device_id);
     check_routing();
+    mExpandedIdxReturned = !args->do_finalize || return_activation_output;
     prepare_routing();
 
     // Execute routing
@@ -1118,6 +1172,7 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
                     bool use_routing_scales_on_input = false, bool use_deep_seek_fp8 = false,
                     bool return_activation_output = false) override {
     check_routing();
+    mExpandedIdxReturned = !args->do_finalize || return_activation_output;
     prepare_routing();
 
     tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
@@ -1556,6 +1611,7 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
                     bool return_activation_output = false) override {
     ffi::CUDADeviceGuard device_guard(hidden_states.device().device_id);
     check_routing();
+    mExpandedIdxReturned = !args->do_finalize || return_activation_output;
     prepare_routing();
 
     cudaStream_t routing_stream = get_stream(hidden_states.device());
@@ -1932,26 +1988,41 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
   }
 
   void prepare_routing() override {
-    num_tokens_per_expert = alloc_tensor({args->num_experts}, dl_int32, hidden_states.device());
+    // Persistent per-device routing scratch (flashinfer#3427, #3168) -- same
+    // capture-safety fix as prepare_routing_common(). FP4 takes topk ids/weights
+    // as inputs, so expert_indexes is not part of the arena here.
+    auto dev = hidden_states.device();
     int32_t max_num_padded_tokens =
         tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxPermutedPaddedCount(
             args->num_tokens, args->top_k, args->num_experts, tile_tokens_dim);
-
-    total_num_padded_tokens = alloc_tensor({1}, dl_int32, hidden_states.device());
-    expanded_idx_to_permuted_idx =
-        alloc_tensor({args->num_tokens * args->top_k}, dl_int32, hidden_states.device());
-    permuted_idx_to_token_idx =
-        alloc_tensor({max_num_padded_tokens}, dl_int32, hidden_states.device());
-
     int64_t const size_of_expert_count_histogram = std::max(args->num_experts * 2, 256 * 2);
-    expert_count_histogram =
-        alloc_tensor({size_of_expert_count_histogram}, dl_int32, hidden_states.device());
-
-    int32_t max_num_ctas = tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxNumCtasInBatchDim(
-        args->num_tokens, args->top_k, args->num_experts, tile_tokens_dim);
-    cta_idx_xy_to_batch_idx = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
-    cta_idx_xy_to_mn_limit = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
-    num_non_exiting_ctas = alloc_tensor({1}, dl_int32, hidden_states.device());
+    int64_t const scratch_tokens = std::max<int64_t>(args->num_tokens, kMaxRoutingScratchTokens);
+    int32_t const scratch_padded =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxPermutedPaddedCount(
+            scratch_tokens, args->top_k, args->num_experts, tile_tokens_dim);
+    int32_t const scratch_ctas =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxNumCtasInBatchDim(
+            scratch_tokens, args->top_k, args->num_experts, tile_tokens_dim);
+    {
+      std::lock_guard<std::mutex> lk(g_routing_scratch_mu);
+      auto& sc = g_routing_scratch[dev.device_id];
+      num_tokens_per_expert = ensure_routing_slot(sc.num_tokens_per_expert, args->num_experts, dev);
+      total_num_padded_tokens = ensure_routing_slot(sc.total_num_padded_tokens, 1, dev);
+      permuted_idx_to_token_idx =
+          ensure_routing_slot(sc.permuted_idx_to_token_idx, scratch_padded, dev);
+      expert_count_histogram =
+          ensure_routing_slot(sc.expert_count_histogram, size_of_expert_count_histogram, dev);
+      cta_idx_xy_to_batch_idx = ensure_routing_slot(sc.cta_idx_xy_to_batch_idx, scratch_ctas, dev);
+      cta_idx_xy_to_mn_limit = ensure_routing_slot(sc.cta_idx_xy_to_mn_limit, scratch_ctas, dev);
+      num_non_exiting_ctas = ensure_routing_slot(sc.num_non_exiting_ctas, 1, dev);
+      if (mExpandedIdxReturned) {
+        expanded_idx_to_permuted_idx =
+            alloc_tensor({args->num_tokens * args->top_k}, dl_int32, dev);
+      } else {
+        expanded_idx_to_permuted_idx =
+            ensure_routing_slot(sc.expanded_idx_to_permuted_idx, scratch_tokens * args->top_k, dev);
+      }
+    }
 
     workspace.total_num_padded_tokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
     workspace.total_max_padded_tokens = max_num_padded_tokens;
@@ -2133,6 +2204,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
     TVM_FFI_ICHECK(!return_activation_output)
         << "return_activation_output is not supported for FP4 block-scale MoE";
     check_routing();
+    mExpandedIdxReturned = !args->do_finalize;
     prepare_routing();
 
     // Execute routing

--- a/tests/moe/test_trtllm_gen_moe_cudagraph_capture_safety.py
+++ b/tests/moe/test_trtllm_gen_moe_cudagraph_capture_safety.py
@@ -1,0 +1,132 @@
+"""CUDA-graph capture-safety regression test for trtllm-gen MoE routing scratch.
+
+Guards flashinfer#3427 / #3168: the routing scratch (expanded_idx_to_permuted_idx
+and siblings) must stay valid across CUDA-graph capture + replay. This test
+captures N *separate* single-MoE graphs that share ONE graph mempool -- the
+sglang piecewise-CUDA-graph structure, where each piece's routing scratch is
+freed before the next piece captures, so the shared pool recycles that offset
+across pieces. It runs at a token count that selects the cooperative routing
+kernel (> 8192; the existing suite only covers <= 64 tokens, i.e. the
+single-cluster kernel), then replays every piece and checks each replayed output
+against its eager reference.
+
+Note: the full illegal-memory-access reproduction of #3427/#3168 requires
+sglang's torch.compile piecewise-cudagraph backend; a raw torch.cuda.graph
+capture recycles the routing scratch but does not itself trigger the fault. This
+test therefore guards capture+replay correctness of the cooperative-routing path
+(new coverage) rather than reproducing the sglang-specific crash. It passes with
+the persistent-arena fix and exercises exactly the code path the fix changes.
+"""
+
+import pytest
+import torch
+
+from flashinfer import RoutingMethodType, shuffle_matrix_a
+from flashinfer.fused_moe import WeightLayout, convert_to_block_layout, trtllm_bf16_moe
+from flashinfer.utils import device_support_pdl, get_compute_capability
+
+
+def _build_shuffled_bf16_weights(num_experts, intermediate_size, hidden_size, device):
+    gemm1 = torch.randn(
+        num_experts,
+        2 * intermediate_size,
+        hidden_size,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    gemm2 = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device, dtype=torch.bfloat16
+    )
+    g1, g2 = [], []
+    for i in range(num_experts):
+        g1.append(
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm1[i].view(torch.uint8), 64), 128
+            )
+        )
+        g2.append(
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm2[i].view(torch.uint8), 64), 128
+            )
+        )
+    return torch.stack(g1).view(torch.bfloat16), torch.stack(g2).view(torch.bfloat16)
+
+
+@pytest.mark.parametrize("num_tokens", [12288])  # > 8192 -> cooperative routing kernel
+@pytest.mark.parametrize("pieces", [4])
+@pytest.mark.parametrize("num_experts", [32])
+@pytest.mark.parametrize("top_k", [8])
+def test_trtllm_bf16_moe_cudagraph_capture_safety(
+    num_tokens, pieces, num_experts, top_k
+):
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] not in [10]:
+        pytest.skip("trtllm-gen MoE is only supported on SM100/SM103 GPUs.")
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    hidden_size, intermediate_size = 1024, 1024
+    enable_pdl = device_support_pdl(device)
+
+    gemm1_weights, gemm2_weights = _build_shuffled_bf16_weights(
+        num_experts, intermediate_size, hidden_size, device
+    )
+
+    def moe(routing_logits, hidden_states):
+        return trtllm_bf16_moe(
+            routing_logits=routing_logits,
+            routing_bias=None,
+            hidden_states=hidden_states,
+            gemm1_weights=gemm1_weights,
+            gemm2_weights=gemm2_weights,
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=RoutingMethodType.Renormalize.value,
+            use_shuffled_weight=True,
+            weight_layout=WeightLayout.BlockMajorK,
+            do_finalize=True,
+            enable_pdl=enable_pdl,
+        )
+
+    # Distinct, persistent inputs per piece (persistent so each captured graph has
+    # valid inputs at replay).
+    inputs = []
+    for _ in range(pieces):
+        routing_logits = torch.rand(
+            num_tokens, num_experts, device=device, dtype=torch.bfloat16
+        )
+        hidden_states = (torch.randn(num_tokens, hidden_size, device=device) * 0.1).to(
+            torch.bfloat16
+        )
+        inputs.append((routing_logits, hidden_states))
+
+    # Eager references (also warms the autotuner cache before capture).
+    references = [moe(rl, h).to(torch.float32) for rl, h in inputs]
+    torch.cuda.synchronize()
+
+    # Capture each piece as a SEPARATE graph sharing ONE mempool. Each piece's
+    # routing scratch is freed when the op returns, so the shared pool recycles
+    # that offset across pieces -- the aliasing condition the fix guards against.
+    pool = torch.cuda.graph_pool_handle()
+    graphs = []
+    for routing_logits, hidden_states in inputs:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, pool=pool):
+            out = moe(routing_logits, hidden_states)
+        graphs.append((graph, out))
+    torch.cuda.synchronize()
+
+    for graph, _ in graphs:
+        graph.replay()
+    torch.cuda.synchronize()
+
+    # Every replayed captured output must match its eager reference.
+    for i, (_, out) in enumerate(graphs):
+        torch.testing.assert_close(
+            out.to(torch.float32), references[i], rtol=1e-2, atol=1e-2
+        )


### PR DESCRIPTION
<!-- PR body formatted to flashinfer .github/pull_request_template.md.
     Title: fix(trtllm-gen moe): persistent, CUDA-graph-capture-safe routing scratch
     DRAFT for jbernloehr review; Tests section finalized after the capture-repro probe. -->

## 📌 Description

Under CUDA-graph **piecewise** capture (one captured graph piece per decoder layer, e.g. SGLang's Piecewise CUDA Graph), the trtllm-gen fused-MoE launcher allocates its routing scratch (`expanded_idx_to_permuted_idx` and siblings) **per call** via `alloc_tensor`. Those allocations come from the graph's private memory pool, whose offsets are recycled across the separately-captured layer pieces. The routing cooperative kernel bakes the address of its in-bounds store `mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx`; at replay that address aliases a **different** piece's allocation → memory corruption → a downstream trtllm-gen GEMM raises an illegal memory access. This is the `UTMALDG` fault in #3427 and the capture-time fault in #3168.

**Fix:** allocate the routing scratch from a **persistent, per-device arena** (`RoutingScratchArena`), created once and reused across all layers and graph replays, so the baked address stays valid. The scratch is pure per-call working memory (written by routing, consumed by the GEMMs in the same call), so sharing it is safe — verified bitwise-identical to per-call allocation (below). The arena is pre-sized to a generous max so it is allocated before capture and never re-allocated during capture; it costs a few MB per device.

`expanded_idx_to_permuted_idx` is returned to the caller when it is not finalized (`!do_finalize || return_activation_output`); it is kept per-call in exactly those cases (via a `mExpandedIdxReturned` flag set in `run()` before `prepare_routing()`) and shared only when it is not returned. Covers the bf16 / fp8-per-tensor / fp8-block-scale / mxint4 launchers (shared `prepare_routing_common`) and the FP4 launcher (which inlines the same allocation pattern).

**Root cause was localized on-device** by a marker-validated kernel-skip bisect on the reproducing workload (Qwen3-235B-A22B BF16, TP4, GB200/SM100, SGLang piecewise capture, `num_tokens=16384`):

| Experiment | Result |
|---|---|
| skip GEMM1 / GEMM2 / finalize individually | still IMA |
| skip routing + GEMM1 + GEMM2 + finalize | healthy |
| routing runs, all consumers skipped | **IMA** → routing itself issues the fault |
| skip `routingIndicesCoopKernel` only | healthy |
| skip only the store `mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx` | healthy |
| over-allocate the buffer 4× per call | healthy |
| over-allocate 2× per call | **still IMA** (→ not a size/overrun bug) |
| allocate the same-size buffer **once, persistently** | **healthy** (→ the per-call graph-pool allocation is the problem) |

The empirical WAR boundary (`--piecewise-cuda-graph-max-tokens 8192`) equals `MaxNumTokensSingleCluster = 8192` — ≤8192 uses the single-cluster kernel (different write phase, healthy), >8192 selects the cooperative kernel (faults). Retaining the tensor's refcount does **not** help (address recycling, not object lifetime).

## 🔍 Related Issues

- Fixes #3427 (bf16, B200)
- Fixes #3168 (fp4 block-scale, clean at 8192 / corrupt at 16384)

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] `pre-commit run --all-files` clean

### 🧪 Tests

- Added `tests/moe/test_trtllm_gen_moe_cudagraph_capture_safety.py`: captures N *separate* single-MoE graphs sharing one mempool (the sglang piecewise-CUDA-graph structure) at a token count that selects the **cooperative** routing kernel (>8192 — the existing suite only covers ≤64 tokens, i.e. the single-cluster kernel), replays them, and asserts each replayed output matches its eager reference. This is new coverage for the coop-routing path the fix changes.
- **Scope of this test (honest):** the *full* illegal-memory-access reproduction of #3427/#3168 requires sglang's `torch.compile` piecewise-cudagraph backend; a raw `torch.cuda.graph` capture recycles the routing scratch but does not itself trigger the fault (verified on GB200 — a standalone 40-piece shared-pool capture stays clean with and without the fix). The end-to-end crash→heal was therefore validated at the **integration level** on the sglang server workload (see Reviewer Notes), and this unit test guards capture+replay correctness of the affected path rather than reproducing the sglang-specific crash. Happy to add a fuller integration repro if the maintainers have a preferred harness.

## Reviewer Notes

- **On-device validation:** on the *actual* failing workload (full 94-layer Qwen3-235B-A22B, TP4, `num_tokens=16384` piecewise capture), per-call reproduces the fault (`trtllm_fused_moe_dev_kernel.cu:991 ... illegal memory access`, all 4 TP) and the persistent arena is **healthy**. A per-call vs. persistent-arena numeric check on 16 sequential calls at 16384 tokens is **bitwise-identical** (`torch.equal`, `max_abs_diff=0`).
- **Sizing — two options, reviewer's choice.** This PR uses an internal arena pre-sized to `kMaxRoutingScratchTokens = 65536` (a few MB/device); smallest diff, no API change, matches the validated build. The fully-general alternative is a caller-provided workspace/max — the same pattern already used for `routing_replay_out`; happy to switch if preferred.
- **Concurrency.** The arena is keyed by `device_id` and mutex-guarded; it assumes routing scratch has no cross-call/cross-stream aliveness requirement (true today: written by routing, consumed by the GEMMs in the same call, on the same stream). If two-stream micro-batch overlap runs two MoE calls concurrently on one device, key by `(device_id, stream)` — a one-line change; flagged for input.
- **Scope of on-device validation:** bf16 is validated end-to-end; fp8-per-tensor / fp8-block-scale / mxint4 share `prepare_routing_common` verbatim, and FP4 receives the same edit **by code symmetry** — those precisions were not independently reproduced here.

Co-Authored with Claude Code (Fable 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mixture-of-Experts routing during CUDA Graph capture and replay.
  * Prevented routing workspace reuse from causing incorrect or corrupted outputs across graph replays.
  * Preserved correct output handling when activation results are returned.

* **Tests**
  * Added regression coverage validating consistent MoE results across multiple captured and replayed CUDA graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->