### PR TITLE
docs: improve Ulysses communicator and MoE EP docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ FlashInfer is a GPU kernel library for LLM serving that uses **JIT (Just-In-Time
 | Enable GDN strided QKV path | `export FLASHINFER_GDN_WY_STRIDED_QKV=1` |
 | Enable GDN native A/B tensors | `export FLASHINFER_GDN_WY_NATIVE_AB=1` |
 | Override CuTe-DSL prefill scheduling | `export FLASHINFER_CUTE_PREFILL_PERSISTENT=0` (non-persistent) or `1` (persistent) |
+| Skip MoE EP CuTe-DSL import/version guard | `export FLASHINFER_MOE_EP_SKIP_DSL_CHECK=1` |
+| Override MoE EP knob-cache path | `export FLASHINFER_MOE_EP_KNOB_CACHE=/path/to/knobs.json` |
+| Disable MoE EP fused staging kernel | `export FLASHINFER_MEGA_FUSED_STAGE=0` |
 
 ## Quick Start for Development
 

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -252,9 +252,6 @@ Topology Probing and Backend Selection
 .. autosummary::
     :toctree: ../generated
 
-    resolve_ulysses_backend
-    decide_ulysses_backend
-    probe_ulysses_rank_topology
     UlyssesBackendDecision
     UlyssesRankTopology
     UlyssesBackendError
@@ -271,6 +268,12 @@ verified all-pairs NVLink P2P and owns the IPC workspace lifecycle.
     init_ulysses_a2a
     dispose_ulysses_a2a
     ulysses_a2a
+
+.. autofunction:: resolve_ulysses_backend
+
+.. autofunction:: decide_ulysses_backend
+
+.. autofunction:: probe_ulysses_rank_topology
 
 MNNVL (Multi-Node NVLink)
 -------------------------

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -256,12 +256,6 @@ Topology Probing and Backend Selection
     UlyssesRankTopology
     UlyssesBackendError
 
-.. autofunction:: resolve_ulysses_backend
-
-.. autofunction:: decide_ulysses_backend
-
-.. autofunction:: probe_ulysses_rank_topology
-
 Raw Kernel Entry Points (advanced)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -256,6 +256,12 @@ Topology Probing and Backend Selection
     UlyssesRankTopology
     UlyssesBackendError
 
+.. autofunction:: resolve_ulysses_backend
+
+.. autofunction:: decide_ulysses_backend
+
+.. autofunction:: probe_ulysses_rank_topology
+
 Raw Kernel Entry Points (advanced)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -268,12 +274,6 @@ verified all-pairs NVLink P2P and owns the IPC workspace lifecycle.
     init_ulysses_a2a
     dispose_ulysses_a2a
     ulysses_a2a
-
-.. autofunction:: resolve_ulysses_backend
-
-.. autofunction:: decide_ulysses_backend
-
-.. autofunction:: probe_ulysses_rank_topology
 
 MNNVL (Multi-Node NVLink)
 -------------------------

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -256,6 +256,12 @@ Topology Probing and Backend Selection
     UlyssesRankTopology
     UlyssesBackendError
 
+.. autofunction:: resolve_ulysses_backend
+
+.. autofunction:: decide_ulysses_backend
+
+.. autofunction:: probe_ulysses_rank_topology
+
 Raw Kernel Entry Points (advanced)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/flashinfer/comm/mixed_comm.py
+++ b/flashinfer/comm/mixed_comm.py
@@ -940,8 +940,11 @@ class MixedCommHandler:
         Parameters
         ----------
         comm_backend : CommBackend
-            Intra-node communication backend used to exchange and synchronize
-            the restored VMM mappings.
+            Intra-node communication backend whose ``Get_rank()`` and
+            ``Get_size()`` match this handler's ``local_rank`` and
+            ``local_size``. Its ``bcast`` and ``barrier`` operations
+            coordinate the Unix-socket handle exchange and synchronize VMM
+            mapping restoration.
         """
         if self.para_info.use_inter:
             raise NotImplementedError(

--- a/flashinfer/comm/mixed_comm.py
+++ b/flashinfer/comm/mixed_comm.py
@@ -935,7 +935,14 @@ class MixedCommHandler:
 
     @flashinfer_api
     def checkpoint_restore(self, comm_backend: CommBackend):
-        """Restore physical VMM backing at retained graph-visible addresses."""
+        """Restore physical VMM backing at retained graph-visible addresses.
+
+        Parameters
+        ----------
+        comm_backend : CommBackend
+            Intra-node communication backend used to exchange and synchronize
+            the restored VMM mappings.
+        """
         if self.para_info.use_inter:
             raise NotImplementedError(
                 "MixedComm checkpointing does not yet support multi-node handlers"

--- a/flashinfer/comm/ulysses.py
+++ b/flashinfer/comm/ulysses.py
@@ -149,6 +149,29 @@ class UlyssesCommunicator:
         backend: str = "auto",
         device: Optional[Union[torch.device, str, int]] = None,
     ):
+        r"""Construct a Ulysses communicator.
+
+        Parameters
+        ----------
+        group : Optional[ProcessGroup], optional
+            Process group spanning the participating ranks. ``None`` uses
+            ``torch.distributed.group.WORLD``.
+        max_elems : int
+            Per-rank upper bound on the number of elements communicated by a
+            single collective call. Used to size the backend workspace.
+        dtype : torch.dtype
+            Element dtype for collective operands. Must be one of
+            ``torch.float16``, ``torch.bfloat16``, or ``torch.float32``.
+        backend : str, default = "auto"
+            Backend selection policy. ``"auto"`` probes topology and prefers
+            NVLink when supported, otherwise falls back to NCCL. ``"nvlink"``
+            forces the NVLink backend and raises if unavailable. ``"nccl"``
+            forces the NCCL path.
+        device : Optional[Union[torch.device, str, int]], optional
+            CUDA device bound to this rank. ``None`` uses the current CUDA
+            device. Strings and integers are normalized to an explicit CUDA
+            ordinal.
+        """
         self._state = _CLOSED  # flipped to OPEN only when construction succeeds
         self._nvlink_armed = False  # joint property: set on all ranks or none
         # opaque NVLink-backend handle (a C++ UlyssesA2A* as an int) from
@@ -650,6 +673,17 @@ class UlyssesCommunicator:
         ``[rank * H_local, (rank+1) * H_local)`` of every token. Runs on the
         current CUDA stream. Returns the input unchanged when
         ``world_size == 1``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Contiguous 4-D CUDA tensor with shape ``[B, S_local, H, D]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor with shape ``[B, S_global, H_local, D]`` on the same device
+            and dtype as ``x``.
         """
         self._validate(x, "scatter_heads")
         B, S_local, H, D = x.shape
@@ -681,6 +715,17 @@ class UlyssesCommunicator:
         Inverse of :meth:`scatter_heads`: gather all head slices for this
         rank's local sequence shard. Runs on the current CUDA stream. Returns
         the input unchanged when ``world_size == 1``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Contiguous 4-D CUDA tensor with shape ``[B, S_global, H_local, D]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor with shape ``[B, S_local, H, D]`` on the same device and
+            dtype as ``x``.
         """
         self._validate(x, "gather_heads")
         B, S_global, H_local, D = x.shape

--- a/flashinfer/comm/ulysses.py
+++ b/flashinfer/comm/ulysses.py
@@ -1003,6 +1003,26 @@ def ulysses_a2a(
     tensors of the same dtype (float32/float16/bfloat16). All ranks must call
     with consistent geometry in the same order; a mismatch is a collective
     failure (hang or corruption), as with any collective.
+
+    Parameters
+    ----------
+    fa : int
+        Opaque backend handle returned by :func:`init_ulysses_a2a`.
+    inp : torch.Tensor
+        Contiguous 4-D CUDA input tensor.
+    out : torch.Tensor
+        Contiguous 4-D CUDA output tensor written in place.
+    B : int
+        Batch size.
+    S_local : int
+        Local sequence length per rank.
+    H : int
+        Global head count.
+    D : int
+        Head dimension.
+    mode : int
+        ``0`` for scatter-heads input all-to-all, ``1`` for gather-heads
+        output all-to-all.
     """
     if type(fa) is not int or fa == 0:
         raise ValueError(

--- a/flashinfer/comm/ulysses_topology.py
+++ b/flashinfer/comm/ulysses_topology.py
@@ -21,6 +21,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import torch
 import torch.distributed as dist
 
+from ..api_logging import flashinfer_api
+
 # world sizes for which the fused-transpose NVLink kernel is instantiated;
 # lives here (the policy layer) so the dependency direction stays
 # ulysses.py -> ulysses_topology.py with no cycle
@@ -70,6 +72,7 @@ class UlyssesBackendDecision:
     reason: str
 
 
+@flashinfer_api
 def probe_ulysses_rank_topology(
     device: Optional[Union[torch.device, str, int]], rank: int
 ) -> UlyssesRankTopology:
@@ -79,6 +82,19 @@ def probe_ulysses_rank_topology(
     Never raises: the whole probe (including hostname and device resolution)
     runs inside an exception envelope, so any failure lands in ``probe_error``
     and the (conservative) decision layer falls back to NCCL.
+
+    Parameters
+    ----------
+    device : torch.device or str or int, optional
+        CUDA device for this rank. ``None`` uses the current CUDA device.
+    rank : int
+        Rank id to record in the returned topology object.
+
+    Returns
+    -------
+    UlyssesRankTopology
+        Per-rank topology information, including any probe error instead of
+        raising locally.
     """
     topo = UlyssesRankTopology(rank=rank)
     try:
@@ -148,6 +164,7 @@ def probe_ulysses_rank_topology(
     return topo
 
 
+@flashinfer_api
 def decide_ulysses_backend(
     requested: str,
     topologies: List[UlyssesRankTopology],
@@ -160,6 +177,20 @@ def decide_ulysses_backend(
     inconsistent, or unverifiable selects NCCL. Raises
     :class:`UlyssesBackendError` only when ``requested == "nvlink"`` and the
     NVLink path cannot be used.
+
+    Parameters
+    ----------
+    requested : str
+        Requested backend policy: ``"auto"``, ``"nvlink"``, or ``"nccl"``.
+    topologies : list[UlyssesRankTopology]
+        Per-rank topology probe results gathered from the process group.
+    supported_world_sizes : Sequence[int], optional
+        World sizes for which the fused NVLink kernel is instantiated.
+
+    Returns
+    -------
+    UlyssesBackendDecision
+        Backend choice and selection or fallback reason.
     """
     if requested not in ULYSSES_BACKENDS:
         raise ValueError(
@@ -236,6 +267,7 @@ def decide_ulysses_backend(
     )
 
 
+@flashinfer_api
 def resolve_ulysses_backend(
     backend: str = "auto",
     group: Optional[dist.ProcessGroup] = None,
@@ -267,6 +299,21 @@ def resolve_ulysses_backend(
        catches the result into an outcome, gathers, and cross-checks. Any
        disagreement conservatively selects NCCL — or raises for
        ``backend="nvlink"``.
+
+    Parameters
+    ----------
+    backend : str, default = "auto"
+        Requested backend policy: ``"auto"``, ``"nvlink"``, or ``"nccl"``.
+    group : torch.distributed.ProcessGroup, optional
+        Process group whose ranks must make a consistent backend decision.
+        Defaults to ``torch.distributed.group.WORLD``.
+    device : torch.device or str or int, optional
+        CUDA device to use for probe and metadata collective guards.
+
+    Returns
+    -------
+    UlyssesBackendDecision
+        Group-consistent backend choice and selection or fallback reason.
     """
     if group is None:
         group = dist.group.WORLD

--- a/flashinfer/comm/ulysses_topology.py
+++ b/flashinfer/comm/ulysses_topology.py
@@ -21,8 +21,6 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import torch
 import torch.distributed as dist
 
-from ..api_logging import flashinfer_api
-
 # world sizes for which the fused-transpose NVLink kernel is instantiated;
 # lives here (the policy layer) so the dependency direction stays
 # ulysses.py -> ulysses_topology.py with no cycle
@@ -72,7 +70,6 @@ class UlyssesBackendDecision:
     reason: str
 
 
-@flashinfer_api
 def probe_ulysses_rank_topology(
     device: Optional[Union[torch.device, str, int]], rank: int
 ) -> UlyssesRankTopology:
@@ -164,7 +161,6 @@ def probe_ulysses_rank_topology(
     return topo
 
 
-@flashinfer_api
 def decide_ulysses_backend(
     requested: str,
     topologies: List[UlyssesRankTopology],
@@ -267,7 +263,6 @@ def decide_ulysses_backend(
     )
 
 
-@flashinfer_api
 def resolve_ulysses_backend(
     backend: str = "auto",
     group: Optional[dist.ProcessGroup] = None,


### PR DESCRIPTION
## 📌 Description

Fixes the NEW documentation issues reported by the comm doc check.

Changes:
- document MoE EP environment variables in `CLAUDE.md`
- keep Ulysses topology helper functions documented under the topology API section without marking them as `@flashinfer_api`
- add missing parameter documentation for Ulysses communicator/raw A2A APIs
- add missing parameter documentation for `MixedCommHandler.checkpoint_restore`

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation:
- `git diff --check`
- `python3 -m compileall flashinfer/comm/ulysses.py flashinfer/comm/ulysses_topology.py flashinfer/comm/mixed_comm.py`
- AST check for the reported decorator/docstring/env-var items

## Reviewer Notes

The Ulysses topology helper functions are intentionally documented but remain internal and are not marked with `@flashinfer_api`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added quick-reference documentation for three MoE EP environment variables.
  * Expanded Ulysses communication API documentation with parameters, tensor shapes, backend modes, device and dtype requirements, and return semantics.
  * Clarified topology probing, backend selection, and checkpoint restoration behavior.
  * Improved API reference generation for Ulysses backend utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->