### PR TITLE
cherry-pick: #4152 ([perf] Optimize TRT-LLM routing for high-expert, high-top-k workloads) 

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -23,7 +23,7 @@ namespace routingCustom {
 // and the kernel was actually launched; the definitions live in
 // trtllm_fused_moe_routing_custom.cu. Keep these signatures in sync (the return
 // type is not part of the mangled name, so a mismatch would silently be UB).
-bool launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
+bool launchBlockKernel(Data const& data, void* stream);
 bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
 bool launchClusterKernel(Data const& data, void* stream);
 void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHist, void* stream);
@@ -94,7 +94,7 @@ void runPostTopKPipeline(DataType const& data, void* stream) {
         " for the post-topK permutation (dyn-block path). Add a matching Tier<E, K> to "
         "PolicyTraits<NoOpPreprocess, SoftmaxPostprocess> in RoutingCustomPolicy.cuh.");
   } else if (useStaticBlock) {
-    bool const launched = routingCustom::launchBlockKernel(customData, numThreadsHist, stream);
+    bool const launched = routingCustom::launchBlockKernel(customData, stream);
     FLASHINFER_CHECK(
         launched, "runPostTopKPipeline: no compiled tier covers numExperts=", data.mNumExperts,
         " topK=", data.mTopK,

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -300,8 +300,10 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
 // Returns whether a compiled tier covered the runtime (numExperts, topK) and the
 // kernel was actually launched. A false return means no routing output was written;
 // the caller (run) must not proceed to the downstream pipeline in that case.
-bool launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
-  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesBlockKernel, 1, numThreadsHist,
+bool launchBlockKernel(Data const& data, void* stream) {
+  uint32_t const numThreadsBlock =
+      std::min(1024u, static_cast<uint32_t>(queryDispatchedMaxExperts(data)));
+  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesBlockKernel, 1, numThreadsBlock,
                         /*smemSize=*/0,  // No dynamic smem
                         stream);
   return queryPolicyHasCompiledTier(data);
@@ -677,8 +679,13 @@ struct FilterClusterTiers<ClusterBlockDim, TierList<>> {
 template <int ClusterBlockDim, typename First, typename... Rest>
 struct FilterClusterTiers<ClusterBlockDim, TierList<First, Rest...>> {
   using Tail = typename FilterClusterTiers<ClusterBlockDim, TierList<Rest...>>::type;
+  // The ceil-divided scan supports a bounded zero-padded tail. Limit the extra scan work to
+  // four warps and only enable it for the optimized high-expert/high-TopK tier family.
   static constexpr bool IsValid =
-      First::kExperts <= ClusterBlockDim || First::kExperts % ClusterBlockDim == 0;
+      First::kExperts <= ClusterBlockDim || First::kExperts % ClusterBlockDim == 0 ||
+      (topk::isInHighExpertLaneOwnedTopKRange(First::kExperts, First::kTopK) &&
+       ((First::kExperts + ClusterBlockDim - 1) / ClusterBlockDim * ClusterBlockDim -
+        First::kExperts) <= 4 * WarpSize);
   using type = std::conditional_t<IsValid, typename PrependTier<First, Tail>::type, Tail>;
 };
 
@@ -839,6 +846,16 @@ bool launchClusterKernelForBlockDim(Data const& data, void* stream) {
 // Returns whether a compiled tier covered the runtime (numExperts, topK) and the
 // kernel was actually launched (see launchBlockKernel).
 bool launchClusterKernel(Data const& data, void* stream) {
+  // Use the wider cluster only for permutation-only launches in the bounded high-expert/high-TopK
+  // range. Score-to-TopK fused clusters retain the general capacity-based dispatch.
+  bool const useWidePermutationCluster =
+      data.mPtrScores == nullptr &&
+      topk::isInHighExpertLaneOwnedTopKRange(data.mNumExperts, data.mTopK) &&
+      data.mNumTokens >= 32 && data.mNumTokens <= 64;
+  if (useWidePermutationCluster) {
+    return launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
+  }
+
   // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
   // Use them only where the requested token count fits; otherwise keep the original 1024-thread
   // launch.
@@ -927,7 +944,9 @@ __global__ void __launch_bounds__(
     routingIndicesHistogramScoresKernel(KernelParams params) {
   using OutputT = typename KernelParams::OutputT;
   using InputT = typename KernelParams::InputT;
-  using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
+  using ExpertSelect = typename KernelParams::ExpertSelectPolicy;
+  using PostProc = typename ExpertSelect::PostprocessPolicy;
+  using BaseType = typename ExpertSelect::template BaseType<InputT>;
   static constexpr int NumThreadsBlock =
       HistogramScoresKernelConfig<typename KernelParams::ExpertSelectPolicy,
                                   KernelParams::MaxNumExperts,
@@ -935,6 +954,10 @@ __global__ void __launch_bounds__(
 
   // VecSize stays based on MaxNumExperts — each warp still processes all experts for one token.
   static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
+  static constexpr bool UseLaneOwnedTopK =
+      topk::isInHighExpertLaneOwnedTopKRange(KernelParams::MaxNumExperts,
+                                             KernelParams::MaxNumTopExperts) &&
+      PostprocessSupportsLaneOwnedTopK<PostProc>::value;
 
   int32_t const laneIdx = cutlass::arch::LaneId();
   int32_t const warpIdx = threadIdx.x / WarpSize;
@@ -959,25 +982,35 @@ __global__ void __launch_bounds__(
 
   // in this case, each warp represents a token, and we use a grid-stride loop
   // over all warps/tokens
-  BaseType warpTopKScore[KernelParams::MaxNumTopExperts];
-  int32_t warpTopKExpertIdx[KernelParams::MaxNumTopExperts];
   for (int tokenIdx = globalWarpIdx; tokenIdx < params.mNumTokens; tokenIdx += globalWarpStride) {
     auto scoreOffset = tokenIdx * params.mNumExperts;
 
-    KernelParams::ExpertSelectPolicy::template apply<BaseType, InputT, VecSize,
-                                                     KernelParams::MaxNumTopExperts>(
-        warp, warpTopKScore, warpTopKExpertIdx, laneIdx, params.mNumExperts, params.mTopK,
-        params.mPtrScores + scoreOffset, params);
+    BaseType laneTopKScore;
+    int32_t laneTopKExpertIdx;
+    if constexpr (UseLaneOwnedTopK) {
+      ExpertSelect::template applyForLane<BaseType, InputT, VecSize,
+                                          KernelParams::MaxNumTopExperts>(
+          warp, laneTopKScore, laneTopKExpertIdx, laneIdx, params.mNumExperts, params.mTopK,
+          params.mPtrScores + scoreOffset, params);
+    } else {
+      BaseType warpTopKScore[KernelParams::MaxNumTopExperts];
+      int32_t warpTopKExpertIdx[KernelParams::MaxNumTopExperts];
+      ExpertSelect::template apply<BaseType, InputT, VecSize, KernelParams::MaxNumTopExperts>(
+          warp, warpTopKScore, warpTopKExpertIdx, laneIdx, params.mNumExperts, params.mTopK,
+          params.mPtrScores + scoreOffset, params);
+      laneTopKScore = laneIdx < params.mTopK ? warpTopKScore[laneIdx] : BaseType{-INFINITY};
+      laneTopKExpertIdx = laneIdx < params.mTopK ? warpTopKExpertIdx[laneIdx] : -1;
+    }
 
     if (laneIdx < params.mTopK) {
-      PackedScoreIdx<OutputT> packedScore{static_cast<OutputT>(warpTopKScore[laneIdx]),
-                                          static_cast<int16_t>(warpTopKExpertIdx[laneIdx])};
+      PackedScoreIdx<OutputT> packedScore{static_cast<OutputT>(laneTopKScore),
+                                          static_cast<int16_t>(laneTopKExpertIdx)};
       params.mPtrTopKPacked[tokenIdx * params.mTopK + laneIdx] = packedScore;
       // Routing replay: record selected expert IDs. Layout: [num_tokens, topK]
       // -- same indexing as mPtrTopKPacked.
       if (params.mPtrRoutingReplayOut != nullptr) {
         params.mPtrRoutingReplayOut[tokenIdx * params.mTopK + laneIdx] =
-            static_cast<int16_t>(warpTopKExpertIdx[laneIdx]);
+            static_cast<int16_t>(laneTopKExpertIdx);
       }
     }
   }
@@ -1027,7 +1060,7 @@ bool launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// 3b. BlockScores kernel — one block per token, block-parallel preprocess + warp-0 sort-based topK.
+// 3b. BlockScores kernel — one block per token with block-parallel preprocess and topK.
 //
 // Motivation: for small numTokens with high topK (e.g. Nemotron Super V3:
 // BS<=256, E=512, K=22), the per-warp-per-token `routingIndicesHistogramScoresKernel`
@@ -1041,12 +1074,13 @@ bool launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32
 //   Phase 1: parallelise the preprocess across all threads via a grid-stride
 //            loop (PreprocessPolicy::applyToSmem), writing per-expert topK
 //            key (and optional aux data) into smem.
-//   Phase 2: warp 0 alone does the topK via a sort-based reduceTopK with
-//            N = ceil(MaxNumExperts / WarpSize) elements per lane.
+//   Phase 2: the generic path uses warp 0 for sort-based topK. Bounded
+//            high-expert/high-topK tiers use worker warps over 128-expert
+//            partitions, then warp 0 merges their candidates.
 //   Phase 3: warp 0 applies the postprocess (PostprocessPolicy::applyWithAux),
 //            in-place modifying topScores.
-// Only warp 0 carries the K-sized register arrays, so per-block register
-// pressure stays low (~64 regs/thread) and occupancy rises to 2 blocks/SM.
+// Only the generic fallback carries final K-sized register arrays. The
+// bounded path keeps one result per lane and uses all required expert warps.
 //
 // The kernel is generic in (PreprocessPolicy, PostprocessPolicy).  The
 // auxiliary smem array is only allocated when the policy pair requires it
@@ -1084,6 +1118,15 @@ __global__ void __launch_bounds__(kBlockScoresKernelBlockDim)
   // Sort<N>'s 64-element cap (the static_assert inside topk::reduceTopK).
   static constexpr int NumChunks = (MaxNumExperts + WarpSize - 1) / WarpSize;
 
+  // Enable the hierarchical specialization for the shared high-expert/high-TopK range.
+  // dispatchTierPairs still determines which concrete tiers are instantiated.
+  static constexpr int LaneTopKValuesPerWorkerLane = 4;
+  static constexpr int LaneTopKExpertsPerWorkerWarp = LaneTopKValuesPerWorkerLane * WarpSize;
+  static constexpr int LaneTopKNumWorkerWarps =
+      (MaxNumExperts + LaneTopKExpertsPerWorkerWarp - 1) / LaneTopKExpertsPerWorkerWarp;
+  static constexpr int LaneTopKNumIntermediate = LaneTopKNumWorkerWarps * MaxNumTopExperts;
+  static constexpr int LaneTopKMergeValuesPerLane =
+      (LaneTopKNumIntermediate + WarpSize - 1) / WarpSize;
   // Compile-time opt-out: the macro dispatch instantiates this kernel across
   // every (PreProc, PostProc, tier) combination, but we only emit a real
   // kernel body for policy pairs that implement the block-per-token interface
@@ -1165,9 +1208,85 @@ __global__ void __launch_bounds__(kBlockScoresKernelBlockDim)
 
     __syncthreads();
 
-    // Phase 2: warp-0 sort-based topK over NumChunks elements per lane.
-    // Warps 1..N-1 are done and can exit; only warp 0 carries the K-sized
-    // register arrays from here on.
+    // Phase 2a: bounded hierarchical lane-owned TopK. Worker warps each
+    // reduce a 128-expert partition; warp 0 merges their scalar lane-owned
+    // outputs. No K-element output array is dynamically indexed per thread.
+    if constexpr (topk::isInHighExpertLaneOwnedTopKRange(MaxNumExperts, MaxNumTopExperts) &&
+                  LaneTopKNumWorkerWarps <= kBlockScoresKernelBlockDim / WarpSize &&
+                  LaneTopKMergeValuesPerLane <= 64 &&
+                  PostprocessSupportsLaneOwnedTopK<PostProc>::value) {
+      __shared__ BaseType
+          __attribute((aligned(128))) smemIntermediateScores[LaneTopKNumIntermediate];
+      __shared__ int32_t
+          __attribute((aligned(128))) smemIntermediateExperts[LaneTopKNumIntermediate];
+
+      if (warpIdx < LaneTopKNumWorkerWarps) {
+        BaseType localScores[LaneTopKValuesPerWorkerLane];
+        int32_t localIdx[LaneTopKValuesPerWorkerLane];
+#pragma unroll
+        for (int ii = 0; ii < LaneTopKValuesPerWorkerLane; ++ii) {
+          int const expertIdx = warpIdx * LaneTopKExpertsPerWorkerWarp + ii * WarpSize + laneIdx;
+          localIdx[ii] = expertIdx;
+          localScores[ii] =
+              expertIdx < params.mNumExperts ? smemBiased[expertIdx] : BaseType{invalidScoreFloat};
+        }
+
+        BaseType laneScore;
+        int32_t laneExpert;
+        topk::reduceTopKForLane<MaxNumTopExperts>(
+            warp, laneScore, laneExpert, localScores, localIdx,
+            /*minValue=*/BaseType{invalidScoreFloat}, laneIdx);
+        if (laneIdx < MaxNumTopExperts) {
+          int const intermediateIdx = warpIdx * MaxNumTopExperts + laneIdx;
+          bool const valid = laneIdx < params.mTopK;
+          smemIntermediateScores[intermediateIdx] = valid ? laneScore : BaseType{invalidScoreFloat};
+          smemIntermediateExperts[intermediateIdx] = valid ? laneExpert : MaxNumExperts;
+        }
+      }
+      __syncthreads();
+
+      if (warpIdx != 0) {
+        return;
+      }
+
+      BaseType intermediateScores[LaneTopKMergeValuesPerLane];
+      int32_t intermediateExperts[LaneTopKMergeValuesPerLane];
+#pragma unroll
+      for (int ii = 0; ii < LaneTopKMergeValuesPerLane; ++ii) {
+        int const intermediateIdx = ii * WarpSize + laneIdx;
+        bool const valid = intermediateIdx < LaneTopKNumIntermediate;
+        intermediateScores[ii] =
+            valid ? smemIntermediateScores[intermediateIdx] : BaseType{invalidScoreFloat};
+        intermediateExperts[ii] = valid ? smemIntermediateExperts[intermediateIdx] : MaxNumExperts;
+      }
+
+      BaseType laneTopKScore;
+      int32_t laneTopKExpertIdx;
+      topk::reduceTopKForLane<MaxNumTopExperts>(warp, laneTopKScore, laneTopKExpertIdx,
+                                                intermediateScores, intermediateExperts,
+                                                /*minValue=*/BaseType{invalidScoreFloat}, laneIdx);
+      PostProc::applyForLaneWithAux(warp, laneTopKScore, laneTopKExpertIdx, laneIdx, params.mTopK,
+                                    auxPtr, params.mExpertSelectParams.mPostprocessParams);
+
+      if (laneIdx < params.mTopK) {
+        PackedScoreIdx<OutputT> packedScore{static_cast<OutputT>(laneTopKScore),
+                                            static_cast<int16_t>(laneTopKExpertIdx)};
+        int64_t const outputIdx = int64_t{tokenIdx} * int64_t{params.mTopK} + laneIdx;
+        params.mPtrTopKPacked[outputIdx] = packedScore;
+        if (params.mPtrRoutingReplayOut != nullptr) {
+          params.mPtrRoutingReplayOut[outputIdx] = static_cast<int16_t>(laneTopKExpertIdx);
+        }
+      }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+      if (params.mUsePdl) {
+        cudaTriggerProgrammaticLaunchCompletion();
+      }
+#endif
+      return;
+    }
+
+    // Phase 2b: generic fallback. Warp 0 sorts NumChunks candidates per lane.
     if (warpIdx != 0) {
       return;
     }
@@ -1252,14 +1371,35 @@ bool launchBlockScoresKernel(Data const& data, void* stream) {
 // 4. Coop kernel — cooperative histogram + offsets via grid-sync.
 //
 // The coop kernel only performs the post-topK permutation pipeline (histogram, prefix-scan,
-// index writes). It does NOT compute topK — it reads pre-computed results from mPtrTopKPacked
-// or mPtrTopKIds. Therefore, only the NumExperts template tier matters (it sizes shared memory
-// arrays and determines the thread count). The NumTopExperts tier is fixed at NumTop8Experts
-// because the kernel uses a hardcoded MaxExpandedIdxPerThread=64 and processes all expanded
-// indices (mNumTokens * mTopK) via a grid-stride loop with runtime bounds checking, regardless
-// of the compile-time MaxNumTopExperts value.
+// index writes). It does not compute TopK; it reads pre-computed results from mPtrTopKPacked
+// or mPtrTopKIds. The expert tier sizes shared memory and determines the thread count. Most
+// tiers use NumTop8Experts and generic 64-entry per-thread state. Bounded high-expert/high-TopK
+// tiers can use NumTop16Experts with four entries per thread when that state covers
+// mNumTokens * mTopK.
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int NumExpertsTier>
+void launchCoopKernelTier(Data const& data, int numBlocksCoop, uint32_t numThreadsHist,
+                          void* stream) {
+  bool useBoundedState = false;
+  if constexpr (topk::isInHighExpertLaneOwnedTopKRange(NumExpertsTier, NumTop16Experts)) {
+    int64_t const expandedIdxSize = int64_t{data.mNumTokens} * int64_t{data.mTopK};
+    int64_t const boundedCapacity = int64_t{4} * int64_t{numBlocksCoop} * int64_t{numThreadsHist};
+    useBoundedState = data.mTopK > NumTop8Experts && data.mTopK <= NumTop16Experts &&
+                      expandedIdxSize <= boundedCapacity;
+  }
+
+  if (useBoundedState) {
+    LAUNCH_ROUTING_WITH_POLICIES(
+        data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, numThreadsHist,
+        /*smemSize=*/0, stream, NoOpPreprocess, NoOpPostprocess, NumExpertsTier, NumTop16Experts);
+  } else {
+    LAUNCH_ROUTING_WITH_POLICIES(
+        data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, numThreadsHist,
+        /*smemSize=*/0, stream, NoOpPreprocess, NoOpPostprocess, NumExpertsTier, NumTop8Experts);
+  }
+}
 
 void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHist, void* stream) {
   if (data.mNumExperts <= NumExperts128Experts) {
@@ -1286,10 +1426,10 @@ void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHi
     LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
                                  numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
                                  NoOpPostprocess, NumExperts576Experts, NumTop8Experts);
+  } else if (data.mNumExperts <= NumExperts896Experts) {
+    launchCoopKernelTier<NumExperts896Experts>(data, numBlocksCoop, numThreadsHist, stream);
   } else if (data.mNumExperts <= NumExperts1024Experts) {
-    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
-                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
-                                 NoOpPostprocess, NumExperts1024Experts, NumTop8Experts);
+    launchCoopKernelTier<NumExperts1024Experts>(data, numBlocksCoop, numThreadsHist, stream);
   } else {
     TVM_FFI_LOG_AND_THROW(NotImplementedError)
         << "Coop kernel does not support numExperts > " << NumExperts1024Experts << ", got "
@@ -1369,7 +1509,6 @@ void run(Data const& data, void* stream) {
       << MaxSupportedExperts << ".";
 
   static int const smMajor = tensorrt_llm::common::getSMVersion() / 10;
-  bool const useStaticBlock = data.mNumTokens <= BlockKernelMaxNumTokens;
   // Gate on the dispatched tier size, not the raw expert count.
   // Example: a model with 512 experts and topK=22 skips Tier<512,8> (topK too
   // large) and falls through to Tier<1024,32>.  queryDispatchedMaxExperts()
@@ -1378,15 +1517,30 @@ void run(Data const& data, void* stream) {
   // 512, passes) would let it enter a 1024-expert specialization that exceeds
   // the smem budget.
   int32_t const dispatchedMaxExperts = queryDispatchedMaxExperts(data);
+
+  // Does the currently-active policy pair implement the block-per-token interface?
+  bool const policySupportsBlockPerToken = queryPolicySupportsBlockPerToken(data);
+
+  // At the static-block boundary, high-E/high-K TopK has enough parallel work to benefit from
+  // one score block per token. The downstream post-TopK pipeline still uses its single-block
+  // kernel, so this only splits the score selection from permutation. Keep the generic static
+  // kernel for smaller batches, expert counts at or below the dyn-block limit, other K ranges,
+  // no-op preprocessing, and policy pairs without block-per-token support.
+  bool const useSplitStaticBoundary =
+      smMajor >= 9 && data.mNumTokens == BlockKernelMaxNumTokens &&
+      data.mNumExperts > DynBlockKernelMaxNumExperts &&
+      topk::isInHighExpertLaneOwnedTopKRange(data.mNumExperts, data.mTopK) &&
+      policySupportsBlockPerToken && data.mPreprocessType != RoutingPreprocessType::None;
+  bool const useStaticBlock = data.mNumTokens <= BlockKernelMaxNumTokens && !useSplitStaticBoundary;
   bool const useDynBlock = !useStaticBlock && data.mNumTokens <= DynBlockKernelMaxNumTokens &&
                            dispatchedMaxExperts <= DynBlockKernelMaxNumExperts;
   bool const useSingleBlock = useStaticBlock || useDynBlock;
   bool const useSingleCluster =
       (smMajor >= 9) && (data.mNumTokens <= MaxNumTokensSingleClusterScores);
 
-  // Split-topK path: block-per-token scores kernel + permutation-only cluster
-  // kernel, the two overlapping via PDL.  This replaces the fused single-
-  // cluster kernel for configs where it underperforms:
+  // Split-topK path: block-per-token scores kernel + the shared post-TopK pipeline, with PDL
+  // between them. For cluster-sized batches this replaces the fused score-and-permutation
+  // cluster kernel where it underperforms:
   //
   //   - Register pressure / spills: the fused kernel has every cluster warp
   //     carry K-sized per-thread arrays across the cluster barrier.  For
@@ -1399,10 +1553,10 @@ void run(Data const& data, void* stream) {
   //   - No PDL overlap: everything happens in one kernel.
   //
   // Split-path structure:
-  //   * routingIndicesBlockScoresKernel writes mPtrTopKPacked
-  //     (1 block / token, 256 threads, only warp 0 carries K-sized regs).
-  //   * runPostTopKPipeline selects the cluster kernel with
-  //     LoadExpertIdxFromGlobal=true → permutation only.
+  //   * routingIndicesBlockScoresKernel writes mPtrTopKPacked with block-parallel preprocessing
+  //     and either generic warp-0 TopK or the bounded worker-warp specialization.
+  //   * runPostTopKPipeline consumes mPtrTopKPacked and selects the existing block, cluster,
+  //     cooperative, or multi-kernel permutation path for the batch size.
   // The two kernels overlap via cudaTriggerProgrammaticLaunchCompletion()
   // and cudaGridDependencySynchronize().
   //
@@ -1410,6 +1564,7 @@ void run(Data const& data, void* stream) {
   // `bench_routing_sweep.py` + `bench_routing_analyze.py`):
   //
   //   useSplit = useSingleCluster && !useSingleBlock && numExperts >= 160
+  //   plus the bounded high-E/high-K static-block boundary selected above.
   //
   // Why this rule (measured on B200 across {Default, Renormalize,
   // DeepSeekV3_nGrp1, MiniMax2} policies, BS ∈ [17, 256]):
@@ -1419,8 +1574,8 @@ void run(Data const& data, void* stream) {
   //     handoff) approximately cancels the single-cluster savings.  Default
   //     128/8 is ~1.0×; DeepSeekV3 / MiniMax2 128/8 show ~1.11× but
   //     Renormalize 128/8 is ~1.06× — not worth the complexity.
-  //   - At numTokens < 17 the block/dynblock kernels already handle small
-  //     BS optimally; this branch only fires when the cluster path would.
+  //   - Below the cluster range, block/dynblock remains the default; the bounded high-E/high-K
+  //     static-block boundary above is the measured exception.
   //
   // Env-var override for benchmarking, applies to *both* the single-cluster
   // split path and the large-BS topK kernel choice:
@@ -1445,11 +1600,6 @@ void run(Data const& data, void* stream) {
     return ForceMode::kAuto;
   }();
 
-  // Does the currently-active policy pair implement the block-per-token
-  // interface?  Queried via PolicyPairSupportsBlockPerToken — policies that
-  // don't opt in (no applyToSmem / applyWithAux specialisation) will force
-  // this branch to false and fall back to the fused single-cluster kernel.
-  bool const policySupportsBlockPerToken = queryPolicySupportsBlockPerToken(data);
   if (forceMode == ForceMode::kOn && !policySupportsBlockPerToken) {
     FLASHINFER_WARN(
         "FLASHINFER_ROUTING_FORCE_BLOCK_PER_TOKEN is set but the active routing policy does not "
@@ -1492,20 +1642,14 @@ void run(Data const& data, void* stream) {
     // mirrors TRT-LLM's deepseek_v3_topk_kernel (no-groups path) layout:
     //   - One block per token, kBlockScoresKernelBlockDim threads per block.
     //   - Block-parallel preprocess (via PreprocessPolicy::applyToSmem).
-    //   - Warp 0 alone does the sort-based reduceTopK<K, N=ceil(E/32)> plus
-    //     the postprocess (via PostprocessPolicy::applyWithAux).
-    //   - Only warp 0 holds the K-sized register arrays, so per-block
-    //     register pressure stays low and occupancy high.
+    //   - Generic tiers use warp 0 for sort-based TopK and postprocessing.
+    //   - Bounded high-expert/high-TopK tiers partition candidates across worker warps,
+    //     then merge to one final result per lane.
     //
-    // Why 256 threads (kBlockScoresKernelBlockDim): larger blocks (e.g. 512)
-    // would reserve the ~99-register budget across more threads and limit
-    // occupancy to 1 block/SM.  256 threads gives 2 blocks/SM with the same
-    // per-warp workload, doubling arithmetic throughput during the preprocess
-    // phase.  For E=512 the grid-stride loop iterates 2× per thread; for
-    // E<=256 it iterates once.
+    // The fixed 256-thread block provides eight worker warps while preserving occupancy for
+    // the generic path; each preprocess pass covers experts with a grid-stride loop.
     //
-    // The kernel is generic in (PreprocessPolicy, PostprocessPolicy) — any
-    // registered policy pair in RoutingCustomPolicy.cuh works here.
+    // The kernel remains generic across policy pairs that opt into the block-per-token interface.
     bool const launched = launchBlockScoresKernel(mutableData, stream);
     FLASHINFER_CHECK(
         launched, "routingCustom::run: no compiled tier covers numExperts=", data.mNumExperts,
@@ -1513,11 +1657,9 @@ void run(Data const& data, void* stream) {
         " for the active routing policy (block-per-token split path; see preceding "
         "warning). Add a matching Tier<E, K> to PolicyTraits in RoutingCustomPolicy.cuh.");
 
-    // Step 2: delegate the permutation pipeline to runPostTopKPipeline, which
-    //   will pick the cluster kernel (LoadExpertIdxFromGlobal=true branch) for
-    //   small numTokens.  The cluster kernel in that branch reads topK from
-    //   mPtrTopKPacked instead of doing topK itself, so it does not carry the
-    //   K-sized register arrays or suffer from idle-warp barrier waits.
+    // Step 2: delegate permutation to runPostTopKPipeline. It consumes mPtrTopKPacked without
+    // recomputing TopK, then selects the single-block path at the static boundary or the cluster
+    // path for larger small batches. This keeps K-sized score state out of the permutation kernel.
     //
     //   Clear mPtrScores so runPostTopKPipeline takes the pre-computed-topK
     //   path (we've already written mPtrTopKPacked above).
@@ -1534,7 +1676,7 @@ void run(Data const& data, void* stream) {
                      " for the active routing policy (dyn-block path; see preceding warning). "
                      "Add a matching Tier<E, K> to PolicyTraits in RoutingCustomPolicy.cuh.");
   } else if (useStaticBlock) {
-    bool const launched = launchBlockKernel(mutableData, numThreadsHist, stream);
+    bool const launched = launchBlockKernel(mutableData, stream);
     FLASHINFER_CHECK(launched,
                      "routingCustom::run: no compiled tier covers numExperts=", data.mNumExperts,
                      " topK=", data.mTopK,
@@ -1557,13 +1699,9 @@ void run(Data const& data, void* stream) {
     // there's naturally one warp's worth of work per token.
     //
     // For policies that support the block-per-token interface and have E >= 256,
-    // `routingIndicesBlockScoresKernel` (1 block/token, warp-0 sort-based topK)
-    // can be faster because:
-    //   - Only warp 0 carries the K-sized topK register arrays (saves ~40
-    //     regs/thread for K=22, avoids spills even at large E).
-    //   - The bitonic-sort reduceTopK over N=ceil(E/32) elements per lane
-    //     beats the K sequential warp reductions a warp-per-token layout
-    //     does for high-K configs like Nemotron.
+    // routingIndicesBlockScoresKernel (1 block/token) can be faster because it parallelizes
+    // preprocessing across a block. The generic path confines K-sized output arrays to warp 0;
+    // bounded high-expert/high-TopK tiers use worker warps and lane-owned final results.
     //
     // The trade-off is one block per token — at BS = 4096 that's 4096 blocks
     // vs ~128 blocks for warp-per-token.  Above BS ≈ 1024 block-per-token
@@ -1617,7 +1755,10 @@ void run(Data const& data, void* stream) {
 
     if (useCoop) {
       logCoopLaunchSMCounts(coopLaunchSMCounts);
-      launchInitExpertCounts(mutableData, numThreadsHist, stream);
+      // Both score-to-TopK kernels above zero the full 2*numExperts histogram.
+      // Stream ordering (or the PDL dependency) makes that state visible to
+      // the cooperative permutation kernel, so a separate init launch would
+      // only repeat the same writes.
       launchCoopKernel(mutableData, numBlocksCoop, numThreadsHist, stream);
     } else {
       uint32_t const expandedIdxSize = data.mNumTokens * data.mTopK;

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -393,6 +393,7 @@ struct SumNormalizePostprocess {
 struct ScaledSumNormalizePostprocess {
   /// Opts into the block-per-token kernel (provides applyWithAux below).
   static constexpr bool kSupportsBlockPerToken = true;
+  static constexpr bool kSupportsLaneOwnedTopK = true;
 
   /// Needs per-expert aux data (un-biased sigmoid) in the block-per-token
   /// kernel — paired with SigmoidBiasPreprocess, which writes the un-biased
@@ -431,6 +432,41 @@ struct ScaledSumNormalizePostprocess {
     float sum = cg::reduce(warp, sigmoidScore, cg::plus<float>());
     if (laneIdx < topK) {
       warpTopKScore[laneIdx] =
+          static_cast<DataType>(sigmoidScore * params.routeScale / (sum + params.sumEpsilon));
+    }
+  }
+
+  /// Lane-owned TopK postprocess for warp-per-token kernels. The selected
+  /// score/expert are scalar values owned by laneIdx, so no K-element output
+  /// arrays need to be materialized in local memory.
+  template <typename DataType, typename ParamsT>
+  __forceinline__ __device__ static void applyForLane(cg::thread_block_tile<WarpSize> const& warp,
+                                                      DataType& laneTopKScore,
+                                                      int32_t laneTopKExpertIdx, int32_t laneIdx,
+                                                      int32_t topK, ParamsT const& params) {
+    float const biasVal =
+        laneIdx < topK ? loadScalar(params.ptrRoutingBias, laneTopKExpertIdx, params.dtypeBias)
+                       : 0.f;
+    float const sigmoidScore = laneIdx < topK ? static_cast<float>(laneTopKScore) - biasVal : 0.f;
+    float const sum = cg::reduce(warp, sigmoidScore, cg::plus<float>());
+    if (laneIdx < topK) {
+      laneTopKScore =
+          static_cast<DataType>(sigmoidScore * params.routeScale / (sum + params.sumEpsilon));
+    }
+  }
+
+  /// Lane-owned block-per-token variant. Reads the un-biased sigmoid from
+  /// smemAux just like applyWithAux, but consumes scalar TopK state.
+  template <typename DataType, typename SmemT, typename ParamsT>
+  __forceinline__ __device__ static void applyForLaneWithAux(
+      cg::thread_block_tile<WarpSize> const& warp, DataType& laneTopKScore,
+      int32_t laneTopKExpertIdx, int32_t laneIdx, int32_t topK, SmemT const* smemAux,
+      ParamsT const& params) {
+    float const sigmoidScore =
+        laneIdx < topK ? static_cast<float>(smemAux[laneTopKExpertIdx]) : 0.f;
+    float const sum = cg::reduce(warp, sigmoidScore, cg::plus<float>());
+    if (laneIdx < topK) {
+      laneTopKScore =
           static_cast<DataType>(sigmoidScore * params.routeScale / (sum + params.sumEpsilon));
     }
   }
@@ -490,6 +526,17 @@ struct PostprocessNeedsAux<PostprocessPolicy_, std::void_t<decltype(PostprocessP
 
 template <typename PreprocessPolicy_, typename PostprocessPolicy_>
 struct PolicyPairNeedsAux : PostprocessNeedsAux<PostprocessPolicy_> {};
+
+/// Does a postprocess policy implement the scalar lane-owned TopK interface?
+/// This is intentionally opt-in: adding a new policy cannot silently select a
+/// specialization whose numerical semantics it has not implemented.
+template <typename PostprocessPolicy_, typename = void>
+struct PostprocessSupportsLaneOwnedTopK : std::false_type {};
+
+template <typename PostprocessPolicy_>
+struct PostprocessSupportsLaneOwnedTopK<
+    PostprocessPolicy_, std::void_t<decltype(PostprocessPolicy_::kSupportsLaneOwnedTopK)>>
+    : std::bool_constant<PostprocessPolicy_::kSupportsLaneOwnedTopK> {};
 
 /// Trait: does a (pre, post) policy pair implement the block-per-token
 /// interface (`PreProc::applyToSmem` + `PostProc::applyWithAux`) and
@@ -569,6 +616,35 @@ struct TopKExpertSelect {
     PostprocessPolicy_::apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK,
                               params.mExpertSelectParams.mPostprocessParams);
   }
+
+  /// Lane-owned TopK variant. It shares the generic preprocess and exact
+  /// comparison/tie-breaking logic, but returns only the result consumed by
+  /// laneIdx. Callers gate this method with PostprocessSupportsLaneOwnedTopK.
+  template <typename DataType, typename InputType, int VecSize, int K, typename KP>
+  __forceinline__ __device__ static void applyForLane(cg::thread_block_tile<WarpSize> const& warp,
+                                                      DataType& laneTopKScore,
+                                                      int32_t& laneTopKExpertIdx, int32_t laneIdx,
+                                                      int32_t numExperts, int32_t topK,
+                                                      InputType const* ptrScores,
+                                                      KP const& params) {
+    DataType const minScore = DataType{-INFINITY};
+    DataType score[VecSize];
+    int32_t idx[VecSize];
+
+#pragma unroll
+    for (int i = 0; i < VecSize; ++i) {
+      int32_t const expertIdx = i * WarpSize + laneIdx;
+      score[i] = expertIdx < numExperts ? static_cast<DataType>(ptrScores[expertIdx]) : minScore;
+      idx[i] = expertIdx;
+    }
+
+    PreprocessPolicy_::apply(warp, score, idx, numExperts,
+                             params.mExpertSelectParams.mPreprocessParams);
+    topk::reduceTopKForLane<K>(warp, laneTopKScore, laneTopKExpertIdx, score, idx, minScore,
+                               laneIdx);
+    PostprocessPolicy_::applyForLane(warp, laneTopKScore, laneTopKExpertIdx, laneIdx, topK,
+                                     params.mExpertSelectParams.mPostprocessParams);
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -584,6 +660,7 @@ static constexpr int NumExperts256Experts = 256;
 static constexpr int NumExperts384Experts = 384;
 static constexpr int NumExperts512Experts = 512;
 static constexpr int NumExperts576Experts = 576;
+static constexpr int NumExperts896Experts = 896;
 static constexpr int NumExperts1024Experts = 1024;
 static constexpr int MaxSupportedExperts = 2048;
 
@@ -619,6 +696,8 @@ inline int32_t getMaxNumExperts(int32_t numExperts) {
     return NumExperts512Experts;
   } else if (numExperts <= NumExperts576Experts) {
     return NumExperts576Experts;
+  } else if (numExperts <= NumExperts896Experts) {
+    return NumExperts896Experts;
   } else if (numExperts <= NumExperts1024Experts) {
     return NumExperts1024Experts;
   } else if (numExperts <= MaxSupportedExperts) {
@@ -709,7 +788,8 @@ struct PolicyTraits<NoOpPreprocess, SoftmaxPostprocess> {
                          Tier<512, 32>,   // 512-expert models with topK 23..32
                          Tier<576, 8>,    // Customized model with 576 experts
                          Tier<768, 32>,   // 576..768 experts with high topK
-                         Tier<1024, 32>,  // 768..1024 experts with high topK
+                         Tier<896, 16>,   // 769..896 experts with topK <=16
+                         Tier<1024, 32>,  // 896..1024 experts with high topK
                          Tier<2048, 32>   // Large-expert fallback
                          >;
 };
@@ -732,7 +812,8 @@ struct PolicyTraits<SigmoidBiasPreprocess, ScaledSumNormalizePostprocess> {
                          Tier<384, 8>,  // Kimi K2 (384 experts)
                          Tier<512, 8>,  // DeepSeek nGroup≤1 (256 experts → E512 fallback)
                          Tier<512, 22>,  // Nemotron Super V3 (512 experts, topK=22, nGroup≤1)
-                         Tier<1024, 32>  // Default fallback (expert count may grow beyond 512)
+                         Tier<896, 16>,  // 513..896 experts with topK <=16
+                         Tier<1024, 32>  // Default fallback (expert count may grow beyond 896)
                          >;
 };
 
@@ -863,6 +944,10 @@ struct DefaultRoutingLaunchConfig {
   } else if (data.mNumExperts <= NumExperts576Experts) {                                           \
     LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,        \
                                  stream, NoOpPreprocess, NoOpPostprocess, NumExperts576Experts,    \
+                                 NumTop8Experts);                                                  \
+  } else if (data.mNumExperts <= NumExperts896Experts) {                                           \
+    LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,        \
+                                 stream, NoOpPreprocess, NoOpPostprocess, NumExperts896Experts,    \
                                  NumTop8Experts);                                                  \
   } else if (data.mNumExperts <= NumExperts1024Experts) {                                          \
     LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,        \

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
@@ -267,12 +267,16 @@ __device__ void routingPermutation(KernelParams params,
   using OutputT = typename KernelParams::OutputT;
   using TypePacked = PackedScoreIdx<BaseType>;
 
-  // When MaxNumExperts > NumThreads, each thread handles multiple experts.
+  // When MaxNumExperts > NumThreads, each thread handles multiple experts. Use ceiling division
+  // so non-divisible expert tiers (notably E=896 with 256- or 512-thread cluster blocks) are
+  // represented by a zero-padded tail in the block scan. Every shared-memory/global-memory access
+  // below is guarded by expert < params.mNumExperts, so the padded items exist only in registers
+  // and contribute zero to the scan.
   static constexpr int MaxNumExperts = KernelParams::MaxNumExperts;
   static constexpr int ExpertsPerThread =
-      MaxNumExperts <= NumThreads ? 1 : MaxNumExperts / NumThreads;
-  static_assert(MaxNumExperts <= NumThreads || MaxNumExperts % NumThreads == 0,
-                "MaxNumExperts must be <= NumThreads or a multiple of NumThreads");
+      MaxNumExperts <= NumThreads ? 1 : (MaxNumExperts + NumThreads - 1) / NumThreads;
+  static_assert(ExpertsPerThread * NumThreads >= MaxNumExperts,
+                "Thread-local expert slots must cover MaxNumExperts");
 
   static constexpr int MaxNumTokensSingleCluster = NumBlocksPerCluster * NumThreads;
   // Number of threads in the cluster.
@@ -968,8 +972,13 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
   // needed for the exclusive sum of token offsets
   using Scan = cub::BlockScan<int32_t, NumThreads, cub::BLOCK_SCAN_WARP_SCANS>;
   __shared__ typename Scan::TempStorage tempStorage;
-  // 64 elements -> 128+ registers. Above that we may start to see spilling to local memory.
-  static constexpr int MaxExpandedIdxPerThread = 64;
+  // Lane-owned high-expert/high-topK tiers use this kernel only while four
+  // expanded indices per thread cover the runtime batch. Keeping the bounded
+  // range explicit lets the compiler scalarize the expert/offset state instead
+  // of spilling the generic 64-entry arrays to local memory.
+  static constexpr int MaxExpandedIdxPerThread =
+      topk::isInHighExpertLaneOwnedTopKRange(MaxNumExperts, KernelParams::MaxNumTopExperts) ? 4
+                                                                                            : 64;
 
   // Initialize grid.
   cg::grid_group grid = cg::this_grid();

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
@@ -320,6 +320,70 @@ __forceinline__ __device__ void reduceTopK(cg::thread_block_tile<WarpSize> const
   }
 };
 
+/// Capability envelope for the high-expert lane-owned routing specialization.
+/// This predicate is shared by compile-time tier selection and runtime dispatch;
+/// dispatch tables still decide which concrete tiers are instantiated.
+static constexpr int HighExpertLaneOwnedTopKMinExperts = 512;
+static constexpr int HighExpertLaneOwnedTopKMaxExperts = 1024;
+static constexpr int HighExpertLaneOwnedTopKMinTopExperts = 9;
+static constexpr int HighExpertLaneOwnedTopKMaxTopExperts = 16;
+
+__host__ __device__ constexpr bool isInHighExpertLaneOwnedTopKRange(int numExperts,
+                                                                    int numTopExperts) {
+  return numExperts >= HighExpertLaneOwnedTopKMinExperts &&
+         numExperts <= HighExpertLaneOwnedTopKMaxExperts &&
+         numTopExperts >= HighExpertLaneOwnedTopKMinTopExperts &&
+         numTopExperts <= HighExpertLaneOwnedTopKMaxTopExperts;
+}
+
+// Exact-K variant that returns only the result owned by this lane. The generic
+// reduceTopK interface materializes K scores and K indices per thread even though
+// routing kernels ultimately consume only element laneIdx. For high-K tiers that
+// dynamic lane-indexed array is placed in local memory and can spill the sorted
+// candidates as well. Keeping a single packed result per lane lets nvcc scalarize
+// the output while preserving the same comparison and tie-breaking order.
+template <int K, typename Type, int N>
+__forceinline__ __device__ void reduceTopKForLane(cg::thread_block_tile<WarpSize> const& warp,
+                                                  Type& out, int32_t& outIdx, Type (&value)[N],
+                                                  int32_t (&idx)[N], Type const minValue,
+                                                  int32_t laneIdx) {
+  static_assert(K > 0, "Top K must have K > 0");
+  static_assert(K <= WarpSize, "Top K must have K <= WarpSize");
+  static_assert(N > 0, "Top K must have N > 0");
+  static_assert(N <= 64, "Only support candidates number less than or equal to 64*32=2048");
+  using RedType = TopKRedType<Type>;
+  RedType topK[N];
+#pragma unroll
+  for (int nn = 0; nn < N; ++nn) {
+    topK[nn] = RedType{value[nn], idx[nn]};
+  }
+
+  Sort<N, RedType>::run(topK);
+
+  typename RedType::TypeCmp packedMax{};
+  typename RedType::TypeCmp lanePacked{};
+#pragma unroll
+  for (int kk = 0; kk < K; ++kk) {
+    bool update = kk > 0 && packedMax == topK[0].compVal;
+#pragma unroll
+    for (int nn = 0; nn < N; ++nn) {
+      topK[nn] = update && nn == N - 1 ? RedType{minValue, idx[nn]}
+                 : update              ? topK[nn + 1]
+                                       : topK[nn];
+    }
+    packedMax = topK[0].reduce(warp);
+    if (laneIdx == kk) {
+      lanePacked = packedMax;
+    }
+  }
+
+  if (laneIdx < K) {
+    RedType::unpack(out, outIdx, lanePacked);
+  } else {
+    out = minValue;
+    outIdx = -1;
+  }
+}
 #undef TOPK_SWAP
 }  // namespace topk
 }  // namespace moe::dev::routing


### PR DESCRIPTION
…s (#4152)

<!-- .github/pull_request_template.md -->

## 📌 Description

- Add Tier<896, 16> to the routing and post-TopK policy tables, avoiding fallback to Tier<1024, 32>. Static-block dimensions now follow the selected policy tier.

- Add `reduceTopKForLane`, where each lane retains only its assigned TopK rank instead of materializing K outputs per thread. This preserves comparison semantics while reducing register and local-memory pressure.

- Parallelize block-per-token TopK For E=512..1024 and tier TopK 9..16, worker warps process 128-expert partitions and warp 0 merges their lane-owned candidates. Other shapes retain the generic fallback.

- Use four expanded indices per thread when the high-expert/high-top-K workload fits the bounded cooperative capacity. Larger inputs retain the existing 64-entry fallback.

- Derive launch dimensions from the selected tier, use wider clusters for bounded permutation-only launches, and split TopK from permutation at the measured boundary. Reuse histogram initialization already performed by the score kernel.

## Performance on affected shapes
### NoOp + Softmax

| E | K | Tokens | Baseline (us) | Best opt (us) | Speedup | Gain | |---:|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 1,024 | 9.219 | 8.192 | 1.1253x | +12.53% | | 256 | 8 | 2,048 | 10.247 | 10.238 | 1.0008x | +0.08% | | 256 | 8 | 4,096 | 12.193 | 10.238 | 1.1909x | +19.09% | | 256 | 8 | 8,192 | 14.332 | 12.331 | 1.1623x | +16.23% | | 512 | 8 | 512 | 10.239 | 8.869 | 1.1545x | +15.45% | | 512 | 8 | 1,024 | 12.296 | 12.281 | 1.0012x | +0.12% | | 512 | 8 | 2,048 | 12.287 | 10.492 | 1.1711x | +17.11% | | 512 | 8 | 4,096 | 14.529 | 13.613 | 1.0673x | +6.73% | | 512 | 8 | 8,192 | 18.443 | 16.394 | 1.1250x | +12.50% | | 512 | 10 | 1,024 | 12.308 | 12.104 | 1.0169x | +1.69% | | 512 | 10 | 2,048 | 12.296 | 11.052 | 1.1125x | +11.25% | | 512 | 10 | 4,096 | 14.389 | 14.289 | 1.0070x | +0.70% | | 512 | 10 | 8,192 | 20.490 | 18.442 | 1.1111x | +11.11% | | 896 | 16 | 8 | 10.247 | 10.238 | 1.0009x | +0.09% | | 896 | 16 | 16 | 11.267 | 10.247 | 1.0995x | +9.95% | | 896 | 16 | 32 | 12.181 | 10.238 | 1.1897x | +18.97% | | 896 | 16 | 64 | 12.296 | 10.243 | 1.2004x | +20.04% | | 896 | 16 | 128 | 10.247 | 10.243 | 1.0004x | +0.04% | | 896 | 16 | 256 | 12.290 | 10.248 | 1.1993x | +19.93% | | 896 | 16 | 512 | 13.341 | 10.248 | 1.3018x | +30.18% | | 896 | 16 | 1,024 | 16.574 | 14.332 | 1.1564x | +15.64% | | 896 | 16 | 2,048 | 18.385 | 14.345 | 1.2816x | +28.16% | | 896 | 16 | 4,096 | 24.582 | 20.957 | 1.1729x | +17.29% | | 896 | 16 | 8,192 | 34.805 | 34.025 | 1.0229x | +2.29% | | 1024 | 32 | 8 | 12.285 | 10.719 | 1.1461x | +14.61% | | 1024 | 32 | 16 | 12.286 | 12.285 | 1.0001x | +0.01% | | 1024 | 32 | 32 | 12.297 | 12.296 | 1.0001x | +0.01% | | 1024 | 32 | 64 | 14.332 | 14.332 | 1.0000x | +0.00% | | 1024 | 32 | 128 | 12.286 | 12.285 | 1.0001x | +0.01% | | 1024 | 32 | 256 | 14.312 | 13.640 | 1.0493x | +4.93% | | 1024 | 32 | 512 | 14.334 | 12.297 | 1.1657x | +16.57% | | 1024 | 32 | 1,024 | 20.292 | 17.813 | 1.1392x | +13.92% | | 1024 | 32 | 2,048 | 24.570 | 24.433 | 1.0056x | +0.56% | | 1024 | 32 | 4,096 | 33.614 | 32.765 | 1.0259x | +2.59% | | 1024 | 32 | 8,192 | 53.229 | 52.324 | 1.0173x | +1.73% | | 2048 | 32 | 8 | 24.590 | 24.567 | 1.0009x | +0.09% | | 2048 | 32 | 16 | 26.545 | 24.586 | 1.0797x | +7.97% | | 2048 | 32 | 32 | 28.037 | 26.624 | 1.0531x | +5.31% | | 2048 | 32 | 64 | 30.549 | 28.688 | 1.0649x | +6.49% | | 2048 | 32 | 128 | 22.520 | 20.834 | 1.0810x | +8.10% | | 2048 | 32 | 256 | 20.476 | 20.473 | 1.0001x | +0.01% | | 2048 | 32 | 512 | 35.067 | 33.208 | 1.0560x | +5.60% | | 2048 | 32 | 1,024 | 49.486 | 47.084 | 1.0510x | +5.10% | | 2048 | 32 | 2,048 | 75.816 | 70.466 | 1.0759x | +7.59% | | 2048 | 32 | 4,096 | 126.997 | 116.489 | 1.0902x | +9.02% | | 2048 | 32 | 8,192 | 227.442 | 208.942 | 1.0885x | +8.85% |

### Softmax + SumNormalize

| E | K | Tokens | Baseline (us) | Best opt (us) | Speedup | Gain | |---:|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 256 | 10.238 | 8.480 | 1.2073x | +20.73% | | 256 | 8 | 512 | 10.238 | 8.197 | 1.2490x | +24.90% | | 256 | 8 | 1,024 | 10.286 | 10.238 | 1.0046x | +0.46% | | 256 | 8 | 2,048 | 12.286 | 10.247 | 1.1989x | +19.89% | | 256 | 8 | 4,096 | 14.332 | 12.285 | 1.1666x | +16.66% | | 256 | 8 | 8,192 | 16.416 | 16.319 | 1.0059x | +0.59% | | 512 | 8 | 512 | 12.290 | 10.247 | 1.1994x | +19.94% | | 512 | 8 | 1,024 | 17.698 | 14.346 | 1.2337x | +23.37% | | 512 | 8 | 2,048 | 14.378 | 14.332 | 1.0032x | +0.32% | | 512 | 8 | 4,096 | 20.473 | 18.426 | 1.1111x | +11.11% | | 512 | 8 | 8,192 | 28.660 | 26.614 | 1.0769x | +7.69% | | 512 | 10 | 512 | 12.287 | 10.239 | 1.2000x | +20.00% | | 512 | 10 | 1,024 | 18.393 | 14.346 | 1.2821x | +28.21% | | 512 | 10 | 2,048 | 15.371 | 14.332 | 1.0725x | +7.25% | | 512 | 10 | 4,096 | 20.587 | 19.934 | 1.0328x | +3.28% | | 512 | 10 | 8,192 | 30.211 | 27.942 | 1.0812x | +8.12% | | 896 | 16 | 8 | 22.541 | 22.520 | 1.0010x | +0.10% | | 896 | 16 | 16 | 24.590 | 23.437 | 1.0492x | +4.92% | | 896 | 16 | 32 | 24.765 | 22.541 | 1.0987x | +9.87% | | 896 | 16 | 64 | 26.056 | 22.541 | 1.1559x | +15.59% | | 896 | 16 | 128 | 24.565 | 22.541 | 1.0898x | +8.98% | | 896 | 16 | 256 | 38.915 | 36.857 | 1.0558x | +5.58% | | 896 | 16 | 512 | 61.465 | 53.276 | 1.1537x | +15.37% | | 896 | 16 | 1,024 | 102.407 | 92.649 | 1.1053x | +10.53% | | 896 | 16 | 2,048 | 53.234 | 47.081 | 1.1307x | +13.07% | | 896 | 16 | 4,096 | 92.188 | 83.926 | 1.0984x | +9.84% | | 896 | 16 | 8,192 | 153.474 | 140.932 | 1.0890x | +8.90% | | 1024 | 32 | 8 | 26.590 | 24.567 | 1.0823x | +8.23% | | 1024 | 32 | 16 | 28.661 | 26.634 | 1.0761x | +7.61% | | 1024 | 32 | 32 | 28.662 | 26.639 | 1.0759x | +7.59% | | 1024 | 32 | 64 | 28.675 | 26.640 | 1.0764x | +7.64% | | 1024 | 32 | 128 | 26.614 | 24.592 | 1.0822x | +8.22% | | 1024 | 32 | 256 | 43.438 | 42.989 | 1.0105x | +1.05% | | 1024 | 32 | 512 | 71.633 | 67.604 | 1.0596x | +5.96% | | 1024 | 32 | 1,024 | 120.501 | 114.753 | 1.0501x | +5.01% | | 1024 | 32 | 2,048 | 219.059 | 211.049 | 1.0380x | +3.80% | | 1024 | 32 | 4,096 | 412.856 | 399.442 | 1.0336x | +3.36% | | 1024 | 32 | 8,192 | 807.110 | 781.711 | 1.0325x | +3.25% | | 2048 | 32 | 8 | 34.807 | 34.519 | 1.0083x | +0.83% | | 2048 | 32 | 16 | 37.639 | 36.849 | 1.0214x | +2.14% | | 2048 | 32 | 32 | 38.897 | 36.902 | 1.0541x | +5.41% | | 2048 | 32 | 64 | 40.958 | 39.007 | 1.0500x | +5.00% | | 2048 | 32 | 128 | 32.787 | 32.755 | 1.0010x | +0.10% | | 2048 | 32 | 256 | 49.131 | 47.129 | 1.0425x | +4.25% | | 2048 | 32 | 512 | 84.027 | 81.859 | 1.0265x | +2.65% | | 2048 | 32 | 1,024 | 135.455 | 131.144 | 1.0329x | +3.29% | | 2048 | 32 | 2,048 | 241.258 | 233.501 | 1.0332x | +3.32% | | 2048 | 32 | 4,096 | 448.555 | 434.204 | 1.0330x | +3.30% | | 2048 | 32 | 8,192 | 863.408 | 837.840 | 1.0305x | +3.05% |

### SigmoidBias + ScaledSumNormalize

| E | K | Tokens | Baseline (us) | Best opt (us) | Speedup | Gain | |---:|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 1,024 | 10.238 | 8.220 | 1.2456x | +24.56% | | 256 | 8 | 2,048 | 12.282 | 10.238 | 1.1996x | +19.96% | | 256 | 8 | 4,096 | 14.332 | 11.788 | 1.2159x | +21.59% | | 256 | 8 | 8,192 | 16.427 | 14.347 | 1.1450x | +14.50% | | 512 | 8 | 1,024 | 14.333 | 12.297 | 1.1656x | +16.56% | | 512 | 8 | 2,048 | 16.379 | 14.346 | 1.1418x | +14.18% | | 512 | 8 | 4,096 | 20.491 | 20.473 | 1.0009x | +0.09% | | 512 | 8 | 8,192 | 28.688 | 28.662 | 1.0009x | +0.09% | | 896 | 16 | 8 | 14.333 | 10.245 | 1.3990x | +39.90% | | 896 | 16 | 16 | 14.369 | 10.247 | 1.4023x | +40.23% | | 896 | 16 | 32 | 14.530 | 10.238 | 1.4192x | +41.92% | | 896 | 16 | 64 | 15.812 | 10.238 | 1.5444x | +54.44% | | 896 | 16 | 128 | 14.333 | 10.247 | 1.3987x | +39.87% | | 896 | 16 | 256 | 16.317 | 12.285 | 1.3282x | +32.82% | | 896 | 16 | 512 | 20.473 | 12.296 | 1.6651x | +66.51% | | 896 | 16 | 1,024 | 24.633 | 14.345 | 1.7172x | +71.72% | | 896 | 16 | 2,048 | 28.688 | 18.439 | 1.5558x | +55.58% | | 896 | 16 | 4,096 | 45.069 | 28.104 | 1.6036x | +60.36% | | 896 | 16 | 8,192 | 70.405 | 42.111 | 1.6719x | +67.19% | | 1024 | 32 | 8 | 15.235 | 14.345 | 1.0620x | +6.20% | | 1024 | 32 | 16 | 16.379 | 16.107 | 1.0169x | +1.69% | | 1024 | 32 | 32 | 16.394 | 16.379 | 1.0009x | +0.09% | | 1024 | 32 | 64 | 17.410 | 16.394 | 1.0620x | +6.20% | | 1024 | 32 | 128 | 16.380 | 14.346 | 1.1418x | +14.18% | | 1024 | 32 | 256 | 16.402 | 16.394 | 1.0005x | +0.05% | | 1024 | 32 | 512 | 22.536 | 20.492 | 1.0997x | +9.97% | | 1024 | 32 | 1,024 | 28.810 | 28.376 | 1.0153x | +1.53% | | 1024 | 32 | 2,048 | 43.058 | 40.987 | 1.0505x | +5.05% | | 1024 | 32 | 4,096 | 73.783 | 71.667 | 1.0295x | +2.95% | | 1024 | 32 | 8,192 | 134.244 | 130.549 | 1.0283x | +2.83% |

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the
pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
* Enhanced Mixture-of-Experts routing with opt-in lane-owned TopK support for eligible postprocess policies.
* Extended expert-tier coverage up to **896 experts**, including additional routing dispatch branches for specific configurations.
* **Performance**
* Improved TopK selection and permutation/coop launch behavior for bounded high-expert/high-TopK ranges, including SM90+ heuristics and tighter cooperative state limits.
* Enhanced robustness for non-divisible expert tiers via padded per-thread expert coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------


(cherry picked from commit cd1342af6f633afaf8f1c6e1286c1e5027cae4e6)

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
