### PR TITLE
feat(gemm): sync mm_fp4 SM120 NVFP4 dense GEMM kernel to b12x HEAD

### DIFF
--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -42,6 +42,7 @@ import cutlass.utils.blockscaled_layout as blockscaled_utils
 import cutlass.utils.hopper_helpers as sm90_utils
 import logging
 from cutlass import Int32, Int64
+from cutlass.cute.arch import griddepcontrol_launch_dependents, griddepcontrol_wait
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp.mma import Field as WarpField
 from cutlass.cutlass_dsl import T, dsl_user_op
@@ -531,6 +532,7 @@ class DenseGemmKernel:
             block=[self.threads_per_cta, 1, 1],
             cluster=[1, 1, 1],
             stream=stream,
+            use_pdl=self.enable_pdl,
         )
         return
 
@@ -1131,6 +1133,9 @@ class DenseGemmKernel:
         else:
             cute.arch.sync_threads()
 
+        if cutlass.const_expr(self.enable_pdl):
+            griddepcontrol_wait()
+
         k_tile_cnt = cute.size(gA_mkl, mode=[3])
         block_idx = cute.arch.block_idx()
         k_tile_start = Int32(0)
@@ -1355,15 +1360,17 @@ class DenseGemmKernel:
                 tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
                 tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
 
+                # The fragments hold a full stage of scale factors, so copy
+                # them once per stage.
                 cute.copy(
                     smem_tiled_copy_SFA,
-                    tCsSFA_p_filtered[None, None, 0],
-                    tCrSFA_copy_view_filtered[None, None, 0],
+                    tCsSFA_p_filtered,
+                    tCrSFA_copy_view_filtered,
                 )
                 cute.copy(
                     smem_tiled_copy_SFB,
-                    tCsSFB_p_filtered[None, None, 0],
-                    tCrSFB_copy_view_filtered[None, None, 0],
+                    tCsSFB_p_filtered,
+                    tCrSFB_copy_view_filtered,
                 )
 
                 for _k_tile in range(0, k_tile_iter_cnt - 1, 1, unroll=2):  # type: ignore[call-overload]
@@ -1426,24 +1433,27 @@ class DenseGemmKernel:
                             tCrB_copy_view[None, None, k_block_next],
                         )
 
-                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
-                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(
-                            tCrSFA_tile_copy_view
-                        )
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(
-                            tCrSFB_tile_copy_view
-                        )
-                        cute.copy(
-                            smem_tiled_copy_SFA,
-                            tCsSFA_p_filtered[None, None, k_block_next],
-                            tCrSFA_copy_view_filtered[None, None, k_block_next],
-                        )
-                        cute.copy(
-                            smem_tiled_copy_SFB,
-                            tCsSFB_p_filtered[None, None, k_block_next],
-                            tCrSFB_copy_view_filtered[None, None, k_block_next],
-                        )
+                        if k_block_idx == num_k_blocks - 1:
+                            # The MMAs have already read the old scale
+                            # factors, so the new stage can overwrite them.
+                            tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                            tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                            tCrSFA_copy_view_filtered = cute.filter_zeros(
+                                tCrSFA_tile_copy_view
+                            )
+                            tCrSFB_copy_view_filtered = cute.filter_zeros(
+                                tCrSFB_tile_copy_view
+                            )
+                            cute.copy(
+                                smem_tiled_copy_SFA,
+                                tCsSFA_p_filtered,
+                                tCrSFA_copy_view_filtered,
+                            )
+                            cute.copy(
+                                smem_tiled_copy_SFB,
+                                tCsSFB_p_filtered,
+                                tCrSFB_copy_view_filtered,
+                            )
 
                 # Hoist out last k_tile
                 for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -1465,24 +1475,6 @@ class DenseGemmKernel:
                             smem_tiled_copy_B,
                             tCsB_p[None, None, k_block_next],
                             tCrB_copy_view[None, None, k_block_next],
-                        )
-                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
-                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(
-                            tCrSFA_tile_copy_view
-                        )
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(
-                            tCrSFB_tile_copy_view
-                        )
-                        cute.copy(
-                            smem_tiled_copy_SFA,
-                            tCsSFA_p_filtered[None, None, k_block_next],
-                            tCrSFA_copy_view_filtered[None, None, k_block_next],
-                        )
-                        cute.copy(
-                            smem_tiled_copy_SFB,
-                            tCsSFB_p_filtered[None, None, k_block_next],
-                            tCrSFB_copy_view_filtered[None, None, k_block_next],
                         )
                     # Manual atom unroll: avoids hasAuxTensor address space bug
                     for _mt in range(self.num_m_tiles):
@@ -2163,6 +2155,9 @@ class DenseGemmKernel:
                     work_tile = tile_sched.get_current_work()
 
             mainloop_pipeline.producer_tail(mainloop_producer_state)
+
+        if cutlass.const_expr(self.enable_pdl):
+            griddepcontrol_launch_dependents()
         return
 
     @staticmethod


### PR DESCRIPTION
## 📌 Description

Syncs the vendored dense FP4 GEMM kernel behind `mm_fp4(backend="b12x")` with upstream [b12x](https://github.com/local-inference-lab/sparkinfer) at `f9be272`. The SM12x MoE kernels reuse its layout helpers, so the W4A4 MoE update (#4223 item 2) builds on this sync.

Changes:

- Load a pipeline stage's scale-factor tiles into registers once, when the stage is acquired, instead of once per k block.
- Make `mm_fp4`'s `enable_pdl` parameter take effect. The kernel previously accepted the flag but ignored it.

## 📊 Performance

Perf-neutral. Geomean speedup over main across 104 NVFP4 DeepSeek-R1 and Llama-3 layer shapes (m = 1..4096, CUPTI timing, baseline and branch interleaved): 0.999x on RTX 5080, 0.997x on RTX PRO 6000 Server Edition, 1.009x on DGX Spark.

## 🔍 Related Issues

#4223 (item 1).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- On SM121 (DGX Spark GB10): `tests/gemm/test_mm_fp4.py -k b12x` (797 cases) and `tests/moe/test_b12x_fused_moe.py` (142 cases) pass.
- No new tests: the change adds no code paths, and the FP4 suites already check results against references.

## Reviewer Notes

- The vendored file keeps only what `mm_fp4` uses, so it never matches b12x line-for-line. The reviewable delta is against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved execution scheduling for dense block-scaled GEMM on supported CUDA hardware.
  * Streamlined scale-factor fragment updates to reduce redundant SMEM copy work and better target the final K-stage behavior.
  * Tightened synchronization and launch sequencing to avoid unnecessary waiting while ensuring correct dependent work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->