### PR TITLE
test: skip NVFP4-KV decode tests on SM107

### DIFF
--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -53,6 +53,13 @@ def skip_if_nvfp4_large_head_decode_unsupported(head_dim: int):
         )
 
 
+def skip_if_nvfp4_kv_unsupported():
+    # Mirrors the guard in flashinfer.decode/prefill: no NVFP4-KV decode
+    # kernels exist for SM107.
+    if get_compute_capability(torch.device("cuda:0")) == (10, 7):
+        pytest.skip("KV Cache NVFP4 is not supported on SM107")
+
+
 @pytest.fixture(
     autouse=not has_flashinfer_jit_cache(),
     scope="module",
@@ -734,6 +741,7 @@ def test_batch_decode_with_paged_kv_cache_nvfp4(
     Reference is computed by dequantizing the packed KV back to q_dtype and running
     single_decode_with_kv_cache per batch item.
     """
+    skip_if_nvfp4_kv_unsupported()
     kv_layout = "NHD"
     torch.manual_seed(42)
 


### PR DESCRIPTION
## What

Adds a `skip_if_nvfp4_kv_unsupported()` helper to `tests/attention/test_batch_decode_kernels.py` and calls it at the top of `test_batch_decode_with_paged_kv_cache_nvfp4`, skipping the NVFP4-KV decode tests on SM107 (compute capability `(10, 7)`).

## Why

NVFP4 KV-cache decode is deliberately unsupported on SM107: #4122 (Adds SM107 support) added guards in `flashinfer/decode.py` and `flashinfer/prefill.py` that raise `ValueError("KV Cache NVFP4 is not supported on SM107")` for any packed-FP4 (uint8) KV cache on that arch. These tests exercise the FA2 tensor-cores decode path (`use_tensor_cores=True`) with NVFP4 KV, so on Rubin hardware all 289 nvfp4 ids in this file currently **fail** with that exact ValueError instead of skipping:

```
[289 failed, 2970 passed] ValueError: KV Cache NVFP4 is not supported on SM107 (x289)
```

(full release-v0.6.16 sweep on VR200, 2026-07-28)

## Notes

- The skip keys on `== (10, 7)` to mirror the library guard exactly — it skips precisely where the library declares unsupported, nowhere else.
- All nvfp4 entry points route through `test_batch_decode_with_paged_kv_cache_nvfp4` (including the `_large_head` variant and the torch-compile smoke test), so the single call site covers all 289 ids.
- Related but distinct: the trtllm-gen backend has its own NVFP4-KV gap on SM107 (published E2m1-KV FMHA kernels exist only for Sm100a/103a). That affects the trtllm-gen decode test files, not this one.
- When NVFP4-KV support lands for SM107, lifting this skip belongs to the same change that lifts the library guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
