### PR TITLE
fix: key CUDA property caches by device index

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -277,26 +277,55 @@ def canonicalize_torch_dtype(dtype: Union[torch.dtype, str]) -> torch.dtype:
         )
 
 
-@functools.cache
-def get_device_properties(device: torch.device):
-    return torch.cuda.get_device_properties(device)
+def get_device_index(device: torch.device) -> int:
+    """Concrete CUDA device index for *device* (bare "cuda" -> current device)."""
+    return device.index if device.index is not None else torch.cuda.current_device()
 
 
-@functools.cache
-def get_compute_capability(device: torch.device) -> Tuple[int, int]:
+def _require_cuda_device_index(device: torch.device) -> int:
     if device.type != "cuda":
         raise ValueError("device must be a cuda device")
+    return get_device_index(device)
+
+
+@functools.cache
+def _get_device_properties(device_index: int):
+    return torch.cuda.get_device_properties(device_index)
+
+
+def get_device_properties(device: torch.device):
+    return _get_device_properties(_require_cuda_device_index(device))
+
+
+def get_compute_capability(device: torch.device) -> Tuple[int, int]:
     properties = get_device_properties(device)
     return properties.major, properties.minor
 
 
 @functools.cache
-def get_gpu_memory_bandwidth(device: torch.device) -> float:
+def _get_gpu_memory_bandwidth(device_index: int) -> float:
+    """Get GPU memory bandwidth in GB/s for a concrete CUDA device index."""
+    pynvml.nvmlInit()
+    try:
+        device_uuid = str(_get_device_properties(device_index).uuid)
+        if not device_uuid.startswith(("GPU-", "MIG-")):
+            device_uuid = f"GPU-{device_uuid}"
+        handle = pynvml.nvmlDeviceGetHandleByUUID(device_uuid)
+        bus_width = pynvml.nvmlDeviceGetMemoryBusWidth(handle)
+        mem_clock = pynvml.nvmlDeviceGetMaxClockInfo(handle, pynvml.NVML_CLOCK_MEM)
+
+        # Calculate theoretical peak bandwidth (GB/s)
+        return (mem_clock * bus_width * 2) / 8 / 1000
+    finally:
+        pynvml.nvmlShutdown()
+
+
+def get_gpu_memory_bandwidth(device: Union[torch.device, str]) -> float:
     """
     Get GPU memory bandwidth in GB/s for the specified CUDA device.
 
     Args:
-        device: torch.device object, e.g., torch.device('cuda:0')
+        device: torch.device object or string, e.g., torch.device("cuda:0")
 
     Returns:
         float: GPU memory bandwidth (GB/s)
@@ -308,32 +337,11 @@ def get_gpu_memory_bandwidth(device: torch.device) -> float:
     if isinstance(device, str):
         device = torch.device(device)
 
-    # Check if it's a CUDA device
-    if device.type != "cuda":
-        raise ValueError(f"Device must be a CUDA device, got {device}")
-
-    # Get device index
-    device_index = device.index if device.index is not None else 0
-
-    # Use pynvml to get bandwidth
-    pynvml.nvmlInit()
-    try:
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
-        bus_width = pynvml.nvmlDeviceGetMemoryBusWidth(handle)
-        mem_clock = pynvml.nvmlDeviceGetClockInfo(handle, pynvml.NVML_CLOCK_MEM)
-
-        # Calculate theoretical peak bandwidth (GB/s)
-        bandwidth = (mem_clock * bus_width * 2) / 8 / 1000
-
-        return bandwidth
-    finally:
-        pynvml.nvmlShutdown()
+    return _get_gpu_memory_bandwidth(_require_cuda_device_index(device))
 
 
-@functools.cache
 def get_shared_bytes_per_block_optin(device: torch.device) -> int:
-    cap = get_device_properties(device)
-    return cap.shared_memory_per_block_optin
+    return get_device_properties(device).shared_memory_per_block_optin
 
 
 def _check_cached_qkv_data_type(
@@ -807,7 +815,6 @@ def set_log_level(lvl_str: str) -> None:
     get_logging_module().set_log_level(log_level_map[lvl_str].value)
 
 
-@functools.cache
 def device_support_pdl(device: torch.device) -> bool:
     if device.type != "cuda":
         return False
@@ -834,19 +841,12 @@ def round_up(x: int, y: int) -> int:
     return ceil_div(x, y) * y
 
 
-@functools.cache
 def get_device_sm_count(device: torch.device) -> int:
     return get_device_properties(device).multi_processor_count
 
 
-@functools.cache
 def get_device_name(device: torch.device) -> str:
     return get_device_properties(device).name
-
-
-def get_device_index(device: torch.device) -> int:
-    """Concrete CUDA device index for *device* (bare "cuda" -> current device)."""
-    return device.index if device.index is not None else torch.cuda.current_device()
 
 
 def get_trtllm_gen_multi_ctas_kv_counter_bytes(
@@ -1447,9 +1447,13 @@ def backend_requirement(
 
 
 @functools.cache
-def get_default_generators(device: torch.device):
+def _get_default_generator(device_index: int):
     torch.cuda.init()
-    return torch.cuda.default_generators[device.index]
+    return torch.cuda.default_generators[device_index]
+
+
+def get_default_generators(device: torch.device):
+    return _get_default_generator(_require_cuda_device_index(device))
 
 
 def prepare_jit_additional_args(

--- a/tests/utils/test_device_utils.py
+++ b/tests/utils/test_device_utils.py
@@ -1,0 +1,165 @@
+"""Regression tests for helpers that accept an unindexed CUDA device."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import flashinfer.utils as utils
+
+
+_CACHED_DEVICE_HELPERS = (
+    utils._get_device_properties,
+    utils._get_gpu_memory_bandwidth,
+    utils._get_default_generator,
+)
+
+
+def _clear_device_caches() -> None:
+    for helper in _CACHED_DEVICE_HELPERS:
+        helper.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_device_caches():
+    _clear_device_caches()
+    yield
+    _clear_device_caches()
+
+
+def test_get_compute_capability_tracks_current_device(monkeypatch):
+    current_device = 0
+    capabilities = {0: (8, 0), 1: (10, 3)}
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: current_device)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda index: SimpleNamespace(
+            major=capabilities[index][0], minor=capabilities[index][1]
+        ),
+    )
+
+    device = torch.device("cuda")
+    assert utils.get_compute_capability(device) == (8, 0)
+
+    current_device = 1
+    assert utils.get_compute_capability(device) == (10, 3)
+    assert utils.get_compute_capability(torch.device("cuda:0")) == (8, 0)
+    assert utils._get_device_properties.cache_info().currsize == 2
+
+
+def test_cached_device_properties_track_current_device(monkeypatch):
+    current_device = 0
+    properties = {
+        0: SimpleNamespace(
+            major=8,
+            minor=0,
+            name="GPU 0",
+            multi_processor_count=80,
+            shared_memory_per_block_optin=64 * 1024,
+        ),
+        1: SimpleNamespace(
+            major=10,
+            minor=3,
+            name="GPU 1",
+            multi_processor_count=160,
+            shared_memory_per_block_optin=128 * 1024,
+        ),
+    }
+
+    def resolve_index(device=None):
+        if isinstance(device, torch.device):
+            return current_device if device.index is None else device.index
+        return current_device if device is None else device
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: current_device)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda device=None: properties[resolve_index(device)],
+    )
+    device = torch.device("cuda")
+    assert utils.get_device_sm_count(device) == 80
+    assert utils.get_shared_bytes_per_block_optin(device) == 64 * 1024
+    assert utils.get_device_name(device) == "GPU 0"
+    assert not utils.device_support_pdl(device)
+
+    current_device = 1
+    assert utils.get_device_sm_count(device) == 160
+    assert utils.get_shared_bytes_per_block_optin(device) == 128 * 1024
+    assert utils.get_device_name(device) == "GPU 1"
+    assert utils.device_support_pdl(device)
+    assert utils._get_device_properties.cache_info().currsize == 2
+
+
+def test_gpu_memory_bandwidth_tracks_current_device(monkeypatch):
+    current_device = 0
+    device_uuids = {0: "uuid-0", 1: "MIG-uuid-1"}
+    bus_widths = {"GPU-uuid-0": 256, "MIG-uuid-1": 512}
+    memory_clocks = {"GPU-uuid-0": 1000, "MIG-uuid-1": 2000}
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: current_device)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda index: SimpleNamespace(uuid=device_uuids[index]),
+    )
+    monkeypatch.setattr(utils.pynvml, "nvmlInit", lambda: None)
+    monkeypatch.setattr(utils.pynvml, "nvmlShutdown", lambda: None)
+    monkeypatch.setattr(utils.pynvml, "nvmlDeviceGetHandleByUUID", lambda uuid: uuid)
+    monkeypatch.setattr(
+        utils.pynvml,
+        "nvmlDeviceGetMemoryBusWidth",
+        lambda handle: bus_widths[handle],
+    )
+    monkeypatch.setattr(
+        utils.pynvml,
+        "nvmlDeviceGetMaxClockInfo",
+        lambda handle, _: memory_clocks[handle],
+    )
+
+    device = torch.device("cuda")
+    assert utils.get_gpu_memory_bandwidth(device) == 64.0
+
+    current_device = 1
+    assert utils.get_gpu_memory_bandwidth(device) == 256.0
+    assert utils.get_gpu_memory_bandwidth("cuda:0") == 64.0
+    assert utils._get_gpu_memory_bandwidth.cache_info().currsize == 2
+
+
+def test_default_generator_uses_current_device(monkeypatch):
+    current_device = 0
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: current_device)
+    monkeypatch.setattr(
+        torch.cuda, "default_generators", ("generator-0", "generator-1")
+    )
+    monkeypatch.setattr(torch.cuda, "init", lambda: None)
+
+    device = torch.device("cuda")
+    assert utils.get_default_generators(device) == "generator-0"
+
+    current_device = 1
+    assert utils.get_default_generators(device) == "generator-1"
+    assert utils.get_default_generators(torch.device("cuda:0")) == "generator-0"
+    assert utils._get_default_generator.cache_info().currsize == 2
+
+
+@pytest.mark.parametrize(
+    "helper",
+    (
+        utils.get_compute_capability,
+        utils.get_gpu_memory_bandwidth,
+        utils.get_shared_bytes_per_block_optin,
+        utils.get_device_sm_count,
+        utils.get_default_generators,
+    ),
+)
+def test_cuda_only_device_helpers_reject_cpu(helper):
+    with pytest.raises(ValueError, match="device must be a cuda device"):
+        helper(torch.device("cpu"))
+
+
+def test_device_support_pdl_returns_false_for_cpu():
+    assert not utils.device_support_pdl(torch.device("cpu"))


### PR DESCRIPTION
## 📌 Description

This PR fixes CUDA device property helpers whose cached results could be incorrectly reused across different GPUs when called with an unindexed `torch.device("cuda")`.

The changes:

- Resolve an unindexed CUDA device to `torch.cuda.current_device()` before cache lookup.
- Key compute capability, shared-memory capacity, SM count, PDL support, default generator, and memory-bandwidth caches by concrete CUDA device index.
- Resolve NVML devices by GPU/MIG UUID so that `CUDA_VISIBLE_DEVICES` remapping is handled correctly.
- Use the maximum NVML memory clock when calculating theoretical peak memory bandwidth instead of caching the current clock.
- Add regression tests covering current-device switching, explicit CUDA devices, CPU rejection, UUID normalization, and per-device cache isolation.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Validation completed on a Linux CUDA environment with two NVIDIA GeForce RTX 5090 GPUs:

- `pre-commit run --all-files`: all 14 hooks passed.
- `pytest -q tests/utils/test_device_utils.py`: 10 passed.
- Dual-GPU validation with `CUDA_VISIBLE_DEVICES=1,0`: passed, including correct logical-to-physical UUID mapping and separate cache entries for both devices.
- Isolated `tests/utils` run: 19,099 passed and 973 skipped.

The remaining 57 failures and one collection error reproduce identically on `origin/main`:

- FP4 quantization: 56 failures on both this branch and `origin/main`.
- cuDNN logging replay: 1 failure on both this branch and `origin/main`.
- IPC test collection: the same Python 3.11 `array.array[int]` annotation error occurs on both branches.

A repository-wide collection check discovered 524,276 tests with no branch-specific collection regressions.

Reviewer focus areas:

- Resolution of unindexed CUDA devices before caching.
- NVML UUID-based lookup under `CUDA_VISIBLE_DEVICES` remapping.
- Cache isolation across multiple CUDA devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA device selection for unindexed devices and explicit device indices.
  * Ensured GPU properties, bandwidth, shared-memory, and generator queries target the correct active device.
  * Improved handling of GPU identifiers, including string inputs and MIG-style UUIDs.
  * Added clearer validation for CUDA-only operations and CPU device inputs.
  * Corrected device capability and PDL checks to reflect the selected device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->