### PR TITLE
deep_gemm: arch-based split for DEEPGEMM_RUBIN cubins

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -150,6 +150,7 @@ class ArtifactPath:
     )
     CUDNN_SDPA: str = "a72d85b019dc125b9f711300cb989430f762f5a6/fmha/cudnn/"
     # For DEEPGEMM, we also need to update KernelMap.KERNEL_MAP_HASH in flashinfer/deep_gemm.py
+    # (and KernelMap.KERNEL_MAP_HASH_RUBIN for the Rubin variant below).
     DEEPGEMM: str = "a72d85b019dc125b9f711300cb989430f762f5a6/deep-gemm/"
     DEEPGEMM_RUBIN: str = "7ec7ac40b9fd48172651b77ff2ebe20d79decc39/deep-gemm/"
     DSL_FMHA: str = "801e770219613fbf088bc074c414732b26cc550d/fmha/cute-dsl/"
@@ -261,6 +262,7 @@ def get_subdir_file_list() -> Generator[tuple[str, str], None, None]:
         ArtifactPath.TRTLLM_GEN_BMM_RUBIN,
         ArtifactPath.TRTLLM_GEN_GEMM_RUBIN,
         ArtifactPath.DEEPGEMM,
+        ArtifactPath.DEEPGEMM_RUBIN,
         # DSL FMHA: per cpu-arch and sm-arch subdirectories
         *(
             safe_urljoin(ArtifactPath.DSL_FMHA, f"{cpu_arch}/{arch}/")

--- a/flashinfer/deep_gemm.py
+++ b/flashinfer/deep_gemm.py
@@ -281,6 +281,16 @@ def get_device_arch():
     return f"{major * 10 + minor}{suffix}"
 
 
+def is_rubin_arch() -> bool:
+    # Rubin (sm_107, cc 10.7) ships its own deep-gemm cubins in a separate
+    # artifact directory; every other arch uses the default DEEPGEMM path.
+    return get_device_arch() == "107a"
+
+
+def get_deepgemm_artifact_path() -> str:
+    return ArtifactPath.DEEPGEMM_RUBIN if is_rubin_arch() else ArtifactPath.DEEPGEMM
+
+
 def hash_to_hex(s: str) -> str:
     md5 = hashlib.md5()
     md5.update(s.encode("utf-8"))
@@ -948,8 +958,9 @@ def load_all():
             continue
         symbol, sha256 = KERNEL_MAP[cubin_name]
         cubin_name = cubin_name + ".cubin"
-        get_artifact(ArtifactPath.DEEPGEMM + "/" + cubin_name, sha256)
-        path = FLASHINFER_CUBIN_DIR / ArtifactPath.DEEPGEMM / cubin_name
+        artifact_path = get_deepgemm_artifact_path()
+        get_artifact(artifact_path + "/" + cubin_name, sha256)
+        path = FLASHINFER_CUBIN_DIR / artifact_path / cubin_name
         assert path.exists()
         RUNTIME_CACHE[cubin_name] = SM100FP8GemmRuntime(str(path), symbol)
 
@@ -963,8 +974,9 @@ def load(name: str, code: str) -> SM100FP8GemmRuntime:
         return RUNTIME_CACHE[cubin_name]
     symbol, sha256 = KERNEL_MAP[cubin_name]
     cubin_name = cubin_name + ".cubin"
-    get_artifact(ArtifactPath.DEEPGEMM + "/" + cubin_name, sha256)
-    path = FLASHINFER_CUBIN_DIR / ArtifactPath.DEEPGEMM / cubin_name
+    artifact_path = get_deepgemm_artifact_path()
+    get_artifact(artifact_path + "/" + cubin_name, sha256)
+    path = FLASHINFER_CUBIN_DIR / artifact_path / cubin_name
     assert path.exists()
     RUNTIME_CACHE[cubin_name] = SM100FP8GemmRuntime(str(path), symbol)
     return RUNTIME_CACHE[cubin_name]
@@ -1600,15 +1612,24 @@ def m_grouped_fp8_gemm_nt_masked(
 
 
 class KernelMap:
-    # Hash for kernel_map.json, updated when deepgemm cubins are republished
+    # Hash for kernel_map.json, updated when deepgemm cubins are republished.
+    # The Rubin (sm_107) cubins ship a separate kernel_map.json, so it has its
+    # own hash selected by arch in init_indices().
     KERNEL_MAP_HASH = "f161e031826adb8c4f0d31ddbd2ed77e4909e4e43cdfc9728918162a62fcccfb"
+    KERNEL_MAP_HASH_RUBIN = (
+        "f8bf2b1bc943170559a9f18cfdcec2c30d84ba872d13f66dd52b9be3f3a36e27"
+    )
 
     def __init__(self):
         self.indice = None
 
     def init_indices(self):
-        indice_path = ArtifactPath.DEEPGEMM + "/" + "kernel_map.json"
-        assert get_artifact(indice_path, self.KERNEL_MAP_HASH), (
+        artifact_path = get_deepgemm_artifact_path()
+        map_hash = (
+            self.KERNEL_MAP_HASH_RUBIN if is_rubin_arch() else self.KERNEL_MAP_HASH
+        )
+        indice_path = artifact_path + "/" + "kernel_map.json"
+        assert get_artifact(indice_path, map_hash), (
             "cubin kernel map file not found, nor downloaded with matched sha256"
         )
         path = FLASHINFER_CUBIN_DIR / indice_path


### PR DESCRIPTION
## Summary

Follow-up to #4258 (which added `ArtifactPath.DEEPGEMM_RUBIN` and its checksum). That PR merged the path + checksum only; this PR adds the arch-based split that actually routes deep-gemm cubin loading to the Rubin directory on sm_107, mirroring the `enable_rubin` pattern from #4191.

### `flashinfer/deep_gemm.py`
- New `is_rubin_arch()` / `get_deepgemm_artifact_path()` helpers selecting `DEEPGEMM_RUBIN` on arch `107a` and `DEEPGEMM` otherwise.
- Used in `load_all()`, `load()`, and `KernelMap.init_indices()` so both the kernel cubins and `kernel_map.json` are fetched from the correct per-arch directory.
- Added `KernelMap.KERNEL_MAP_HASH_RUBIN = f8bf2b1b…a36e27` for the Rubin `kernel_map.json` (a separate manifest from the default one), selected by arch.

### `flashinfer/artifacts.py`
- Added `DEEPGEMM_RUBIN` to `get_subdir_file_list()`'s download list so `flashinfer artifacts download` fetches it, and updated the DEEPGEMM comment to reference the Rubin map hash.

Both Rubin hashes were verified by downloading the artifacts directly from the cubin repository.

Targets the `release-v0.6.16` release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)