### PR TITLE
fix(quantization): use 64-bit row addressing in per-token NVFP4 quantizer

### DIFF
--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -39,7 +39,7 @@ import cutlass.cute.nvgpu.cpasync as cpasync
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import torch
-from cutlass import Float32, Int32, Uint8
+from cutlass import Float32, Int32, Int64, Uint8
 
 from ...api_logging import flashinfer_api
 from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
@@ -786,7 +786,35 @@ class NVFP4QuantizePerTokenKernel:
         row_idx = bidx
         num_sf_blocks_per_row = self.num_sf_blocks_per_row
         padded_sf_cols = self.padded_sf_cols
-        row_input = mInput[row_idx, None]
+        # Build the row views from 64-bit byte addresses. Slicing with
+        # mInput[row_idx, None] computes the row offset row_idx * K in
+        # Int32, which wraps once row_idx * K exceeds 2**31 - 1 (reached by
+        # the MoE per-token intermediate, e.g. M=851456 x K=2688) and makes
+        # the loads fault.
+        input_row_addr = get_ptr_as_int64(mInput, Int32(0)) + Int64(row_idx) * Int64(
+            self.K * (mInput.element_type.width // 8)
+        )
+        row_input = cute.make_tensor(
+            cute.make_ptr(
+                mInput.element_type,
+                input_row_addr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            cute.make_layout((self.K,)),
+        )
+        output_row_addr = get_ptr_as_int64(mOutput, Int32(0)) + Int64(row_idx) * Int64(
+            self.K // 2
+        )
+        row_output = cute.make_tensor(
+            cute.make_ptr(
+                mOutput.element_type,
+                output_row_addr,
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            ),
+            cute.make_layout((self.K // 2,)),
+        )
 
         local_amax = Float32(0.0)
         sf_col_idx = tidx
@@ -840,7 +868,6 @@ class NVFP4QuantizePerTokenKernel:
             sf_offset = self._compute_sf_offset(row_idx, sf_col_idx, padded_sf_cols)
             mScales[sf_offset] = scale_fp8
 
-            row_output = mOutput[row_idx, None]
             out_base = sf_col_idx * Int32(NVFP4_SF_VEC_SIZE // 2)
             out_ptr = get_ptr_as_int64(row_output, out_base)
             st_global_u64(out_ptr, packed64)

--- a/tests/utils/test_nvfp4_per_token_quantize_large_m.py
+++ b/tests/utils/test_nvfp4_per_token_quantize_large_m.py
@@ -1,0 +1,84 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Regression test for row addressing in the per-token NVFP4 CuTe-DSL
+quantizer at M large enough that a row's element offset (row * K)
+exceeds 2**31 - 1.
+
+The fused-MoE per-token path quantizes the GEMM1 intermediate of shape
+(max_num_permuted_tokens, intermediate_size). For
+NVIDIA-Nemotron-3-Super-120B (intermediate 2688, 32768 tokens, top_k 22,
+512 experts) the 256-row tactics produce M=851456, whose upper rows have
+element offsets past 2**31. Row slicing that folds row * K in Int32
+wraps negative there and faults with cudaErrorIllegalAddress.
+"""
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl import is_cute_dsl_available
+
+K = 2688
+# First row whose element offset row * K exceeds 2**31 - 1 is
+# ceil(2**31 / 2688) = 798916. The two sizes bracket it: every row of the
+# first fits in Int32 even including the in-row offset; the second has 124
+# rows past the boundary.
+M_BELOW_INT32_BOUNDARY = 798848
+M_ABOVE_INT32_BOUNDARY = 799040
+
+REQUIRED_FREE_BYTES = 8 * 1024**3
+
+
+def _enough_gpu_memory() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    free, _total = torch.cuda.mem_get_info()
+    return free >= REQUIRED_FREE_BYTES
+
+
+@pytest.mark.skipif(not is_cute_dsl_available(), reason="CuteDSL not available")
+@pytest.mark.skipif(
+    not _enough_gpu_memory(),
+    reason=f"requires >= {REQUIRED_FREE_BYTES / 2**30:.0f} GiB free GPU memory",
+)
+@pytest.mark.parametrize("rows", [M_BELOW_INT32_BOUNDARY, M_ABOVE_INT32_BOUNDARY])
+@pytest.mark.parametrize("enable_pdl", [False, None])
+def test_nvfp4_per_token_quantize_row_offset_past_int32(rows, enable_pdl):
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        SF_LAYOUT_128x4,
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    device = torch.device("cuda")
+    # Fill each row with a per-row constant so the returned per-token scale
+    # (row amax with a global scale of 1.0) identifies the row that was
+    # actually read. A wrapped row address either faults or fails the
+    # exact-scale comparison below.
+    row_values = (1.0 + (torch.arange(rows, device=device) % 7)).float()
+    x = row_values.to(torch.bfloat16).unsqueeze(1).expand(rows, K).contiguous()
+    global_scale_inv = torch.ones(1, dtype=torch.float32, device=device)
+
+    fp4, sf, per_token_scale = nvfp4_quantize_per_token_cute_dsl(
+        x, global_scale_inv, sf_layout=SF_LAYOUT_128x4, enable_pdl=enable_pdl
+    )
+    torch.cuda.synchronize()
+
+    assert fp4.shape == (rows, K // 2)
+    torch.testing.assert_close(per_token_scale, row_values, rtol=0.0, atol=0.0)
+    # Every element of a constant row equals the row amax, so each packed
+    # byte must decode to a pair of E2M1 6.0 values (0x77), including in the
+    # rows whose element offsets exceed 2**31 - 1.
+    tail = fp4[-64:]
+    assert bool((tail == 0x77).all().item())


### PR DESCRIPTION
## 📌 Description

The per-token NVFP4 quantizer formed row views with `mInput[row_idx, None]` and `mOutput[row_idx, None]`. For sufficiently large 2D tensors, CuTe folds the row element offset into an Int32 value. With `K=2688`, rows at and above `ceil(2**31 / 2688) = 798916` cross that range.

This is reached by the padded GEMM1 intermediate for NVIDIA Nemotron 3 Super:

| Row tile | Intermediate shape | Elements | Result before this change |
|---:|---:|---:|---|
| 128 | `785920 x 2688` | 2,112,552,960 | Passes |
| 256 | `851456 x 2688` | 2,288,713,728 | CUDA address error |

The change constructs input and output row views from explicit 64-bit byte addresses. Quantization math, layouts, alignment, output format, and the public API are unchanged.

It also adds a focused GPU regression test on both sides of the boundary and with both default and explicitly disabled PDL.

## 🧪 Validation

The equivalent wheel-compatible patch was validated on GB200 with:

- all eight relevant fused-MoE configurations, with PDL enabled and disabled;
- quantizer-only probes at `M=785920`, `798848`, `799040`, and `851456`, with exact per-token scale checks;
- one-token, partial-routing, and full-routing cases;
- a complete autotuning pass over token buckets from 1 through 32768;
- randomized-data numerical comparisons.

The 128-row configurations remained within benchmark noise. At 32768 tokens, enabling the valid 256-row configurations improved the best measured time from 10.61 ms to 9.93 ms.

Targeted pre-commit hooks pass for both changed files.

## Reviewer Notes

The linear and swizzled NVFP4 quantizers contain similar row-slice expressions, but their currently supported shapes do not approach this address range. They are intentionally left out of this focused change and can be handled separately if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVFP4 per-token quantization for very large tensors, preventing incorrect memory access when row offsets exceed 32-bit limits.
  * Ensured quantization results remain accurate for large workloads.

* **Tests**
  * Added regression coverage for row addressing beyond the 32-bit boundary, including validation of scales and packed FP4 output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->