### PR TITLE
test(moe): add tests for trtllm-gen fused MoE with GeGLU activation

### DIFF
--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -302,10 +302,10 @@ def test_trtllm_gen_routed_fused_moe(
 
 
 @pytest.mark.parametrize("num_tokens", [1, 8, 1024])
-@pytest.mark.parametrize("hidden_size", [1024, 4096])
+@pytest.mark.parametrize("hidden_size", [1024])
 @pytest.mark.parametrize("intermediate_size", [1024])
 @pytest.mark.parametrize("num_experts", [128, 256])
-@pytest.mark.parametrize("top_k", [4, 8])
+@pytest.mark.parametrize("top_k", [4])
 @pytest.mark.parametrize(
     "routing_method_type",
     [

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -301,6 +301,44 @@ def test_trtllm_gen_routed_fused_moe(
     )
 
 
+@pytest.mark.parametrize("num_tokens", [1, 8, 1024])
+@pytest.mark.parametrize("hidden_size", [1024, 4096])
+@pytest.mark.parametrize("intermediate_size", [1024])
+@pytest.mark.parametrize("num_experts", [128, 256])
+@pytest.mark.parametrize("top_k", [4, 8])
+@pytest.mark.parametrize(
+    "routing_method_type",
+    [
+        RoutingMethodType.Renormalize,
+        RoutingMethodType.RenormalizeNaive,
+        RoutingMethodType.TopK,
+    ],
+)
+@pytest.mark.parametrize("quant_mode", ["NvFP4xNvFP4", "MxFP4xMxFP8"])
+@pytest.mark.parametrize("routing_format", ["packed", "unpacked"])
+def test_trtllm_gen_routed_fused_moe_geglu(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    num_experts: int,
+    routing_method_type: RoutingMethodType,
+    quant_mode: Literal["NvFP4xNvFP4", "MxFP4xMxFP8"],
+    routing_format: Literal["packed", "unpacked"],
+):
+    _run_trtllm_gen_routed_fused_moe_case(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        top_k,
+        num_experts,
+        routing_method_type,
+        quant_mode,
+        routing_format,
+        ActivationType.Geglu,
+    )
+
+
 def test_trtllm_gen_routed_fused_moe_unpacked_fp32():
     # All quantization modes share this finalize path.
     _run_trtllm_gen_routed_fused_moe_case(
@@ -915,6 +953,7 @@ def test_trtllm_gen_mxint4_routed_fused_moe(
     "activation_type",
     [
         pytest.param(ActivationType.Swiglu.value, id="Swiglu"),
+        pytest.param(ActivationType.Geglu.value, id="Geglu"),
         pytest.param(ActivationType.Relu2.value, id="Relu2"),
     ],
 )

--- a/tests/moe/utils.py
+++ b/tests/moe/utils.py
@@ -22,7 +22,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from flashinfer import RoutingMethodType, is_gated_activation
+from flashinfer import is_gated_activation
 from flashinfer.fused_moe import WeightLayout
 from flashinfer.fused_moe.cute_dsl.moe_utils import (
     normalize_cute_dsl_moe_activation_type,
@@ -104,6 +104,12 @@ NON_GATED_ACTIVATION_SUPPORTED_QUANT_MODES = [
     QuantMode.BF16,
 ]
 
+GEGLU_SUPPORTED_QUANT_MODES = [
+    QuantMode.FP4_NVFP4_NVFP4,
+    QuantMode.FP8_BLOCK_SCALE_MXFP8,
+    QuantMode.FP4_MXFP4_MXFP8,
+]
+
 
 def skip_checks(
     moe_impl,
@@ -131,13 +137,10 @@ def skip_checks(
 
     # Skip incompatible combinations
     if activation_type == ActivationType.Geglu and (
-        not is_fp4_moe
-        or moe_impl.quant_mode != QuantMode.FP4_NVFP4_NVFP4
-        or routing_config["routing_method_type"] != RoutingMethodType.TopK
-        or num_tokens > 128
+        moe_impl.quant_mode not in GEGLU_SUPPORTED_QUANT_MODES or num_tokens > 128
     ):
         pytest.skip(
-            f"Incompatible: {moe_impl.name} + {activation_type} + {routing_config['routing_method_type']} + {num_tokens}"
+            f"Incompatible: {moe_impl.name} + {activation_type} + quant_mode={moe_impl.quant_mode} + {num_tokens}"
         )
     elif activation_type == ActivationType.Swiglu and (
         hidden_size > 1024 or intermediate_size > 1024


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The trtllm-gen BMM cubins for GeGLU have been included in the latest cubin path. This PR enables GeGLU test coverage for trtllm-gen fused MoE on **MXFP8 × MXFP8 (block scale 1×32)** and **MXFP4(w) × MXFP8(a)**, and adds routed-path GeGLU coverage that did not previously exist.

## 🔍 Related Issues

<!-- Link any related issues here -->

For #3454

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation:
```
python -m pytest \
      tests/moe/test_trtllm_gen_routed_fused_moe.py::test_trtllm_gen_routed_fused_moe_geglu \
      tests/moe/test_trtllm_gen_routed_fused_moe.py::test_trtllm_gen_fp8_mxfp8_routed_activation_parity \
      -q --no-header -p no:randomly

75 passed, 2 warnings in 7.35s
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added a new parameterized validation for routed mixture-of-experts with the Geglu activation.
  * Expanded FP8 and MXFP8 activation parity coverage to include Geglu.
  * Updated Geglu compatibility/skipping logic to consistently exclude unsupported configurations and large token counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->