### PR TITLE
[feat] Add Blackwell cutedsl BF16 splitk dense gemm

### DIFF
--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -2080,6 +2080,7 @@ def testMmBf16(args):
         "tgv",
         "cublaslt",
         "tinygemm",
+        "cute-dsl",
         "auto",
     ]
     res = []
@@ -2153,6 +2154,7 @@ def testMmBf16(args):
             "cublaslt",
             "tinygemm",
             "cutile",
+            "cute-dsl",
             "auto",
         ]:
             return flashinfer.mm_bf16(
@@ -2172,6 +2174,7 @@ def testMmBf16(args):
         reference_output_base = torch.mm(a, b).to(out_dtype)
         has_reference_output = True
 
+    cache_path = getattr(args, "autotune_cache", None)
     if getattr(args, "autotune", False):
         warmup_iters = (
             args.dry_run_iters if args.dry_run_iters and args.dry_run_iters > 0 else 10
@@ -2180,9 +2183,12 @@ def testMmBf16(args):
             if cur_backend in autotune_supported_backends:
                 if args.verbose >= 1:
                     print(f"[INFO] Autotune warmup for mm_bf16: {warmup_iters} iters")
-                with autotune(True):
+                with autotune(True, cache=cache_path):
                     for _ in range(warmup_iters):
                         run_backend(cur_backend, a, b, bias, use_pdl, out_dtype)
+    elif cache_path:
+        with autotune(False, cache=cache_path):
+            pass
 
     # Storage for timing results and outputs
     backend_times = {backend: [] for backend in backends}
@@ -2208,8 +2214,16 @@ def testMmBf16(args):
     if len(tested_backends) > 0:
         if run_refcheck and has_reference_output:
             for i in range(len(tested_backends)):
-                # Only add bias to reference when comparing against tgv backend
-                if tested_backends[i] == "tgv" and bias is not None:
+                if (
+                    tested_backends[i]
+                    in (
+                        "cudnn",
+                        "tgv",
+                        "tinygemm",
+                        "cute-dsl",
+                    )
+                    and bias is not None
+                ):
                     reference_output = reference_output_base + bias.unsqueeze(0).to(
                         out_dtype
                     )

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -18,7 +18,7 @@ import functools
 import logging
 import warnings
 from collections import defaultdict
-from dataclasses import replace
+from dataclasses import astuple, replace
 from enum import Enum
 from types import SimpleNamespace
 from typing import Callable, List, Literal, Optional, Tuple
@@ -387,6 +387,54 @@ def _tgv_gemm_requirement(
     return True
 
 
+@supported_compute_capability([100, 103])
+def _cute_dsl_splitk_mm_bf16_requirement(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    bias: Optional[torch.Tensor] = None,
+    pdl: bool = False,
+    backend: Literal[
+        "cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cute-dsl", "auto"
+    ] = "cudnn",
+):
+    if out_dtype != torch.bfloat16:
+        raise ValueError("The CuTeDSL split-K backend requires bfloat16 output.")
+    if a.ndim != 2 or b.ndim != 2:
+        raise ValueError("The CuTeDSL split-K backend requires 2D inputs.")
+    if not a.is_contiguous():
+        raise ValueError("The CuTeDSL split-K backend requires row-major A.")
+    if not b.T.is_contiguous():
+        raise ValueError("The CuTeDSL split-K backend requires column-major B.")
+    if b.shape[0] != a.shape[1]:
+        raise ValueError(
+            f"Incompatible shapes: A is {tuple(a.shape)}, B is {tuple(b.shape)}."
+        )
+    if b.device != a.device:
+        raise ValueError("A and B must be on the same CUDA device.")
+    if out is not None and not out.is_contiguous():
+        raise ValueError("The CuTeDSL split-K backend requires row-major output.")
+    if bias is not None and (
+        bias.device != a.device
+        or bias.shape != (b.shape[1],)
+        or not bias.is_contiguous()
+    ):
+        raise ValueError(
+            f"Bias must be contiguous on A's device with shape {(b.shape[1],)}."
+        )
+
+    from flashinfer.cute_dsl.utils import is_cute_dsl_available
+
+    if not is_cute_dsl_available():
+        raise LibraryError("The CuTeDSL split-K backend requires nvidia-cutlass-dsl.")
+
+    from .kernels.dense_bf16_gemm_sm100_splitk import default_tactic
+
+    default_tactic(a.shape[0], b.shape[1], a.shape[1])
+    return True
+
+
 @supported_compute_capability([90, 100, 103, 110, 120, 121])
 def _cutile_mm_bf16_requirement(
     a: torch.Tensor,
@@ -534,6 +582,7 @@ def _heuristic_func_mm_bf16(
         "cublaslt": _cublaslt_mm_bf16_requirement,
         "tinygemm": _tinygemm_mm_bf16_requirement,
         "cutile": _cutile_mm_bf16_requirement,
+        "cute-dsl": _cute_dsl_splitk_mm_bf16_requirement,
     },
     common_check=_check_mm_bf16_problem_size,
     heuristic_func=_heuristic_func_mm_bf16,
@@ -547,7 +596,14 @@ def mm_bf16(
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
     backend: Literal[
-        "cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "auto"
+        "cudnn",
+        "cutlass",
+        "tgv",
+        "cublaslt",
+        "tinygemm",
+        "cutile",
+        "cute-dsl",
+        "auto",
     ] = "cudnn",
 ) -> torch.Tensor:
     r"""MM BF16
@@ -574,7 +630,7 @@ def mm_bf16(
         Output dtype, bf16, fp16, or fp32. Enabled for CUTLASS, cuDNN, and cuBLASLt backends.
         Defaults to ``torch.bfloat16``.
 
-    backend: Literal["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "auto"]
+    backend: Literal["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "cute-dsl", "auto"]
         The backend to use for the operation. Defaults to ``"cudnn"``.
         ``"cudnn"`` uses the cuDNN backend.
         ``"cutlass"`` uses the CUTLASS backend.
@@ -584,6 +640,8 @@ def mm_bf16(
         ``"cutile"`` uses the cuTile (cuda.tile Python) backend. Pure-Python
             persistent-scheduled GEMM with per-shape exhaustive autotune; ignores
             ``bias`` / ``pdl``. Requires SM >= 90.
+        ``"cute-dsl"`` uses the standalone Blackwell low-M split-K kernel. It is
+        never auto-selected; serving frameworks must select it explicitly.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
 
     Returns
@@ -1416,6 +1474,74 @@ def _tgv_gemm_runner(dtype: torch.dtype, use_sm_100f: bool):
     return TGVRunner()
 
 
+@functools.cache
+def _cute_dsl_splitk_bf16_gemm_runner(
+    compute_capability: int,
+):
+    from .kernels.dense_bf16_gemm_sm100_splitk import (
+        SplitKTactic,
+        autotune_tactics,
+        default_tactic,
+        run_splitk_dense,
+    )
+
+    class CuteDSLSplitKBf16Runner(TunableRunner):
+        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+            return (
+                str(inputs[0].dtype),
+                str(inputs[4].dtype),
+                inputs[2] is not None,
+                bool(inputs[3]),
+                compute_capability,
+            )
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+        ) -> list[tuple[int, int, int, int]]:
+            m, k = inputs[0].shape
+            n = inputs[1].shape[1]
+            return list(
+                dict.fromkeys(
+                    astuple(config)
+                    for config in (
+                        default_tactic(m, n, k),
+                        *autotune_tactics(m, n, k),
+                    )
+                )
+            )
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic=-1,
+            do_preparation: bool = False,
+            **kwargs,
+        ) -> torch.Tensor:
+            a, b, *_ = inputs
+            if tactic == -1:
+                tactic = default_tactic(a.shape[0], b.shape[1], a.shape[1])
+            else:
+                try:
+                    tactic = SplitKTactic(*tactic)
+                except TypeError as error:
+                    raise ValueError(
+                        "CuTeDSL split-K tactics must be "
+                        "(mma_m, mma_n, split_k, ab_stages)."
+                    ) from error
+            return run_splitk_dense(
+                a,
+                b,
+                inputs[2],
+                inputs[4],
+                bool(inputs[3]),
+                tactic,
+            )
+
+    return CuteDSLSplitKBf16Runner()
+
+
 def bf16_gemm_sm100(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1452,6 +1578,13 @@ def bf16_gemm_sm100(
         runners.append(_tgv_gemm_runner(a.dtype, use_sm_100f))
     if "tinygemm" in runner_names:
         runners.append(_tinygemm_bf16_gemm_runner())
+    if "cute-dsl" in runner_names:
+        compute_capability = torch.cuda.get_device_capability(a.device)
+        runners.append(
+            _cute_dsl_splitk_bf16_gemm_runner(
+                compute_capability[0] * 10 + compute_capability[1],
+            )
+        )
     assert runners, "No suitable runners found"
 
     inputs = [a, b, bias, pdl, out, workspace_buffer]

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -388,7 +388,7 @@ def _tgv_gemm_requirement(
 
 
 @supported_compute_capability([100, 103])
-def _cute_dsl_splitk_mm_bf16_requirement(
+def _cute_dsl_mm_bf16_requirement(
     a: torch.Tensor,
     b: torch.Tensor,
     out: Optional[torch.Tensor] = None,
@@ -400,19 +400,19 @@ def _cute_dsl_splitk_mm_bf16_requirement(
     ] = "cudnn",
 ):
     if out_dtype != torch.bfloat16:
-        raise ValueError("The CuTeDSL split-K backend requires bfloat16 output.")
+        raise ValueError("The CuTeDSL low-M backend requires bfloat16 output.")
     if out is not None and out.dtype != torch.bfloat16:
-        raise ValueError("The CuTeDSL split-K backend requires a bfloat16 out tensor.")
-    if not _match_sm_version(a.device, ["100", "103"]):
+        raise ValueError("The CuTeDSL low-M backend requires a bfloat16 out tensor.")
+    if not is_sm100a_supported(a.device):
         raise ValueError(
-            "The CuTeDSL split-K backend requires SM100/SM103 with CUDA 12.8+."
+            "The CuTeDSL low-M backend requires SM100/SM103 with CUDA 12.8+."
         )
     if a.ndim != 2 or b.ndim != 2:
-        raise ValueError("The CuTeDSL split-K backend requires 2D inputs.")
+        raise ValueError("The CuTeDSL low-M backend requires 2D inputs.")
     if not a.is_contiguous():
-        raise ValueError("The CuTeDSL split-K backend requires row-major A.")
+        raise ValueError("The CuTeDSL low-M backend requires row-major A.")
     if not b.T.is_contiguous():
-        raise ValueError("The CuTeDSL split-K backend requires column-major B.")
+        raise ValueError("The CuTeDSL low-M backend requires column-major B.")
     if b.shape[0] != a.shape[1]:
         raise ValueError(
             f"Incompatible shapes: A is {tuple(a.shape)}, B is {tuple(b.shape)}."
@@ -420,7 +420,7 @@ def _cute_dsl_splitk_mm_bf16_requirement(
     if b.device != a.device:
         raise ValueError("A and B must be on the same CUDA device.")
     if out is not None and not out.is_contiguous():
-        raise ValueError("The CuTeDSL split-K backend requires row-major output.")
+        raise ValueError("The CuTeDSL low-M backend requires row-major output.")
     if bias is not None and (
         bias.device != a.device
         or bias.shape != (b.shape[1],)
@@ -433,7 +433,7 @@ def _cute_dsl_splitk_mm_bf16_requirement(
     from flashinfer.cute_dsl.utils import is_cute_dsl_available
 
     if not is_cute_dsl_available():
-        raise LibraryError("The CuTeDSL split-K backend requires nvidia-cutlass-dsl.")
+        raise LibraryError("The CuTeDSL low-M backend requires nvidia-cutlass-dsl.")
 
     from .kernels.dense_bf16_gemm_sm100_splitk import default_tactic
 
@@ -588,7 +588,7 @@ def _heuristic_func_mm_bf16(
         "cublaslt": _cublaslt_mm_bf16_requirement,
         "tinygemm": _tinygemm_mm_bf16_requirement,
         "cutile": _cutile_mm_bf16_requirement,
-        "cute-dsl": _cute_dsl_splitk_mm_bf16_requirement,
+        "cute-dsl": _cute_dsl_mm_bf16_requirement,
     },
     common_check=_check_mm_bf16_problem_size,
     heuristic_func=_heuristic_func_mm_bf16,
@@ -737,6 +737,8 @@ def mm_bf16(
         backends = _heuristic_func_mm_bf16(
             ["tinygemm"], a, b, bias, pdl, out, out_dtype, backend
         )
+    elif backend == "cute-dsl":
+        backends = ["cute-dsl"]
     else:
         backends = [backend]
 
@@ -1499,11 +1501,12 @@ def _cute_dsl_splitk_bf16_gemm_runner(
 
     class CuteDSLSplitKBf16Runner(TunableRunner):
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+            a, _, bias, pdl, out, *_ = inputs
             return (
-                str(inputs[0].dtype),
-                str(inputs[4].dtype),
-                inputs[2] is not None,
-                bool(inputs[3]),
+                str(a.dtype),
+                str(out.dtype),
+                bias is not None,
+                bool(pdl),
                 compute_capability,
             )
 
@@ -1512,8 +1515,9 @@ def _cute_dsl_splitk_bf16_gemm_runner(
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
         ) -> list[tuple[int, int, int, int]]:
-            m, k = inputs[0].shape
-            n = inputs[1].shape[1]
+            a, b, *_ = inputs
+            m, k = a.shape
+            n = b.shape[1]
             try:
                 default = default_tactic(m, n, k)
             except ValueError:
@@ -1535,7 +1539,7 @@ def _cute_dsl_splitk_bf16_gemm_runner(
             do_preparation: bool = False,
             **kwargs,
         ) -> torch.Tensor:
-            a, b, *_ = inputs
+            a, b, bias, pdl, out, *_ = inputs
             if tactic == -1:
                 tactic = default_tactic(a.shape[0], b.shape[1], a.shape[1])
             else:
@@ -1546,14 +1550,7 @@ def _cute_dsl_splitk_bf16_gemm_runner(
                         "CuTeDSL split-K tactics must be "
                         "(mma_m, mma_n, split_k, ab_stages)."
                     ) from error
-            return run_splitk_dense(
-                a,
-                b,
-                inputs[2],
-                inputs[4],
-                bool(inputs[3]),
-                tactic,
-            )
+            return run_splitk_dense(a, b, bias, out, bool(pdl), tactic)
 
     return CuteDSLSplitKBf16Runner()
 
@@ -1571,10 +1568,11 @@ def _cute_dsl_direct_bf16_gemm_runner(
 
     class CuteDSLDirectBf16Runner(TunableRunner):
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+            a, _, _, pdl, out, *_ = inputs
             return (
-                str(inputs[0].dtype),
-                str(inputs[4].dtype),
-                bool(inputs[3]),
+                str(a.dtype),
+                str(out.dtype),
+                bool(pdl),
                 compute_capability,
             )
 
@@ -1583,10 +1581,11 @@ def _cute_dsl_direct_bf16_gemm_runner(
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
         ) -> list[tuple[int, int, int]]:
-            if inputs[2] is not None:
+            a, b, bias, *_ = inputs
+            if bias is not None:
                 return []
-            m, k = inputs[0].shape
-            n = inputs[1].shape[1]
+            m, k = a.shape
+            n = b.shape[1]
             return [astuple(config) for config in autotune_tactics(m, n, k)]
 
         def forward(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -401,6 +401,10 @@ def _cute_dsl_splitk_mm_bf16_requirement(
 ):
     if out_dtype != torch.bfloat16:
         raise ValueError("The CuTeDSL split-K backend requires bfloat16 output.")
+    if not is_sm100a_supported(a.device):
+        raise ValueError(
+            "The CuTeDSL split-K backend requires SM100/SM103 with CUDA 12.8+."
+        )
     if a.ndim != 2 or b.ndim != 2:
         raise ValueError("The CuTeDSL split-K backend requires 2D inputs.")
     if not a.is_contiguous():
@@ -617,18 +621,21 @@ def mm_bf16(
         Weight tensor, shape (k, n), bf16 in column-major layout.
 
     bias: Optional[torch.Tensor]
-        Optional bias tensor, shape (n,). Enabled for TGV and TinyGEMM backends. Defaults to ``None``.
+        Optional bias tensor, shape (n,). Enabled for TGV, TinyGEMM, and
+        CuTeDSL backends. Defaults to ``None``.
 
     pdl: bool
-        Whether to use Programmatic Dependent Launch. Enabled for TGV and TinyGEMM backends. Defaults to ``False``.
+        Whether to use Programmatic Dependent Launch. Enabled for TGV,
+        TinyGEMM, and CuTeDSL backends. Defaults to ``False``.
 
     out: Optional[torch.Tensor]
         Out tensor, shape (m, n), bf16, fp16, or fp32. FP16 and FP32 output are enabled
-        for CUTLASS and cuDNN backends; TinyGEMM requires bf16 output.
+        for CUTLASS and cuDNN backends; TinyGEMM and CuTeDSL require bf16 output.
 
     out_dtype: torch.dtype
         Output dtype, bf16, fp16, or fp32. Enabled for CUTLASS, cuDNN, and cuBLASLt backends.
-        Defaults to ``torch.bfloat16``.
+        TinyGEMM and CuTeDSL require ``torch.bfloat16``. Defaults to
+        ``torch.bfloat16``.
 
     backend: Literal["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "cute-dsl", "auto"]
         The backend to use for the operation. Defaults to ``"cudnn"``.
@@ -1502,11 +1509,15 @@ def _cute_dsl_splitk_bf16_gemm_runner(
         ) -> list[tuple[int, int, int, int]]:
             m, k = inputs[0].shape
             n = inputs[1].shape[1]
+            try:
+                default = default_tactic(m, n, k)
+            except ValueError:
+                return []
             return list(
                 dict.fromkeys(
                     astuple(config)
                     for config in (
-                        default_tactic(m, n, k),
+                        default,
                         *autotune_tactics(m, n, k),
                     )
                 )

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -401,7 +401,9 @@ def _cute_dsl_splitk_mm_bf16_requirement(
 ):
     if out_dtype != torch.bfloat16:
         raise ValueError("The CuTeDSL split-K backend requires bfloat16 output.")
-    if not is_sm100a_supported(a.device):
+    if out is not None and out.dtype != torch.bfloat16:
+        raise ValueError("The CuTeDSL split-K backend requires a bfloat16 out tensor.")
+    if not _match_sm_version(a.device, ["100", "103"]):
         raise ValueError(
             "The CuTeDSL split-K backend requires SM100/SM103 with CUDA 12.8+."
         )
@@ -647,8 +649,11 @@ def mm_bf16(
         ``"cutile"`` uses the cuTile (cuda.tile Python) backend. Pure-Python
             persistent-scheduled GEMM with per-shape exhaustive autotune; ignores
             ``bias`` / ``pdl``. Requires SM >= 90.
-        ``"cute-dsl"`` uses the standalone Blackwell low-M split-K kernel. It is
-        never auto-selected; serving frameworks must select it explicitly.
+        ``"cute-dsl"`` uses standalone Blackwell low-M direct and split-K
+        kernels for M <= 32. It is never auto-selected; serving frameworks
+        must select it explicitly. Without autotuning, a measured shape
+        heuristic chooses between the algorithms. With autotuning, both tactic
+        spaces are profiled when bias is disabled; bias uses split-K only.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
 
     Returns
@@ -1553,6 +1558,62 @@ def _cute_dsl_splitk_bf16_gemm_runner(
     return CuteDSLSplitKBf16Runner()
 
 
+@functools.cache
+def _cute_dsl_direct_bf16_gemm_runner(
+    compute_capability: int,
+):
+    from .kernels.dense_bf16_gemm_direct import (
+        DirectTactic,
+        autotune_tactics,
+        default_tactic,
+        run_direct_dense,
+    )
+
+    class CuteDSLDirectBf16Runner(TunableRunner):
+        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+            return (
+                str(inputs[0].dtype),
+                str(inputs[4].dtype),
+                bool(inputs[3]),
+                compute_capability,
+            )
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+        ) -> list[tuple[int, int, int]]:
+            if inputs[2] is not None:
+                return []
+            m, k = inputs[0].shape
+            n = inputs[1].shape[1]
+            return [astuple(config) for config in autotune_tactics(m, n, k)]
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic=-1,
+            do_preparation: bool = False,
+            **kwargs,
+        ) -> torch.Tensor:
+            a, b, bias, pdl, out, *_ = inputs
+            if bias is not None:
+                raise ValueError("CuTeDSL direct GEMM does not support bias.")
+            if tactic == -1:
+                tactic = default_tactic(a.shape[0], b.shape[1], a.shape[1])
+            else:
+                try:
+                    tactic = DirectTactic(*tactic)
+                except TypeError as error:
+                    raise ValueError(
+                        "CuTeDSL direct tactics must be "
+                        "(block_size, outputs_per_block, rows_per_block)."
+                    ) from error
+            return run_direct_dense(a, b, out, bool(pdl), tactic)
+
+    return CuteDSLDirectBf16Runner()
+
+
 def bf16_gemm_sm100(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1591,11 +1652,24 @@ def bf16_gemm_sm100(
         runners.append(_tinygemm_bf16_gemm_runner())
     if "cute-dsl" in runner_names:
         compute_capability = torch.cuda.get_device_capability(a.device)
-        runners.append(
-            _cute_dsl_splitk_bf16_gemm_runner(
-                compute_capability[0] * 10 + compute_capability[1],
+        compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
+        splitk_runner = _cute_dsl_splitk_bf16_gemm_runner(compute_capability_number)
+        if bias is None:
+            from .kernels.dense_bf16_gemm_direct import (
+                prefer_direct_bf16_gemm_sm100,
             )
-        )
+
+            direct_runner = _cute_dsl_direct_bf16_gemm_runner(compute_capability_number)
+            prefer_direct = prefer_direct_bf16_gemm_sm100(
+                a.shape[0], b.shape[1], a.shape[1]
+            )
+            runners.extend(
+                (direct_runner, splitk_runner)
+                if prefer_direct
+                else (splitk_runner, direct_runner)
+            )
+        else:
+            runners.append(splitk_runner)
     assert runners, "No suitable runners found"
 
     inputs = [a, b, bias, pdl, out, workspace_buffer]

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_direct.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_direct.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+"""Register-prefetch BF16 GEMM for low-M, long-K decode shapes.
+
+The kernel keeps a complete output dot product inside one CTA and reuses each
+prefetched B value across several public-M rows.  It is intentionally a
+separate autotuner runner from the Blackwell tensor-core split-K kernel: the
+two algorithms have different useful shape regions and tactic spaces.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+
+import cuda.bindings.driver as _cuda
+import cutlass
+import cutlass.cute as cute
+import torch as _torch
+from cutlass import const_expr
+from cutlass.cute import experimental as cute_ext
+from cutlass.cute.runtime import from_dlpack
+
+
+_VECTOR_WIDTH = 8
+_SUPPORTED_BLOCK_SIZES = (32, 64, 96, 128, 192, 256, 384)
+_SUPPORTED_OUTPUTS_PER_BLOCK = (1, 2, 4)
+_MAX_M = 32
+_COMPILE_OPTIONS = "--ptxas-options -maxrregcount=64"
+
+
+@dataclasses.dataclass(frozen=True)
+class DirectTactic:
+    """One direct-kernel specialization."""
+
+    block_size: int
+    outputs_per_block: int
+    rows_per_block: int
+
+
+def _default_rows_per_block(m: int) -> int:
+    if m <= 8:
+        return m
+    return next(rows for rows in (8, 4, 2, 1) if m % rows == 0)
+
+
+def validate_tactic(tactic: DirectTactic, m: int, n: int, k: int) -> None:
+    """Reject a direct tactic that cannot serve ``(m, n, k)``."""
+    if tactic.block_size not in _SUPPORTED_BLOCK_SIZES:
+        raise ValueError(f"unsupported block_size={tactic.block_size}")
+    if tactic.outputs_per_block not in _SUPPORTED_OUTPUTS_PER_BLOCK:
+        raise ValueError(f"unsupported outputs_per_block={tactic.outputs_per_block}")
+    if not 1 <= m <= _MAX_M:
+        raise ValueError(f"direct GEMM requires 1 <= M <= {_MAX_M}, got {m}")
+    if not 1 <= tactic.rows_per_block <= m or m % tactic.rows_per_block:
+        raise ValueError(f"rows_per_block={tactic.rows_per_block} must divide M={m}")
+    if n <= 0 or n % tactic.outputs_per_block:
+        raise ValueError(
+            f"N={n} must be divisible by outputs_per_block={tactic.outputs_per_block}"
+        )
+    k_tile = tactic.block_size * _VECTOR_WIDTH
+    if k <= 0 or k % k_tile:
+        raise ValueError(f"K={k} must be divisible by {k_tile}")
+
+
+def default_tactic(m: int, n: int, k: int) -> DirectTactic:
+    """Choose the measured register-prefetch fallback tactic."""
+    block_size = next(
+        (
+            block
+            for block in (256, 192, 128, 96, 64, 32)
+            if k % (block * _VECTOR_WIDTH) == 0
+        ),
+        None,
+    )
+    if block_size is None:
+        raise ValueError("direct GEMM requires a supported 16-byte K tiling")
+    outputs_per_block = next(outputs for outputs in (2, 1) if n % outputs == 0)
+    tactic = DirectTactic(
+        block_size,
+        outputs_per_block,
+        _default_rows_per_block(m),
+    )
+    validate_tactic(tactic, m, n, k)
+    return tactic
+
+
+def autotune_tactics(m: int, n: int, k: int) -> list[DirectTactic]:
+    """Enumerate the compact tactic space used by FlashInfer autotuning.
+
+    Block sizes cover every configuration exercised in the H100/B200 sweep;
+    output grouping spans the measured 1/2/4-column choices.  Row tiling stays
+    at the occupancy-oriented default to keep JIT cost bounded.
+    """
+    try:
+        default = default_tactic(m, n, k)
+    except ValueError:
+        return []
+    tactics = [default]
+    for block_size in _SUPPORTED_BLOCK_SIZES:
+        for outputs_per_block in _SUPPORTED_OUTPUTS_PER_BLOCK:
+            tactic = DirectTactic(
+                block_size,
+                outputs_per_block,
+                default.rows_per_block,
+            )
+            try:
+                validate_tactic(tactic, m, n, k)
+            except ValueError:
+                continue
+            tactics.append(tactic)
+    return list(dict.fromkeys(tactics))
+
+
+def prefer_direct_bf16_gemm_sm100(m: int, n: int, k: int) -> bool:
+    """Return the conservative B200 no-autotune crossover heuristic.
+
+    The three bands are a compact fit to a warm/cold sweep over M=1..16,24,32,
+    18 N values, and 11 K values.  This is deliberately not a blanket rule for
+    K=8192: direct wins only where public M and N leave the tensor-core path
+    with too little independent output work.
+    """
+    return k == 8192 and (
+        (m == 1 and n <= 4608) or (m <= 4 and n <= 512) or (m <= 8 and n <= 256)
+    )
+
+
+class DirectDenseGemmKernel:
+    """K-specialized direct GEMM with whole-mainloop vector prefetch."""
+
+    def __init__(
+        self,
+        *,
+        element_type,
+        num_rows: int,
+        k_extent: int,
+        tactic: DirectTactic,
+        use_pdl: bool,
+    ) -> None:
+        validate_tactic(tactic, num_rows, tactic.outputs_per_block, k_extent)
+        self.element_type = element_type
+        self.num_rows = num_rows
+        self.rows_per_block = tactic.rows_per_block
+        self.k_extent = k_extent
+        self.block_size = tactic.block_size
+        self.outputs_per_block = tactic.outputs_per_block
+        self.vector_width = _VECTOR_WIDTH
+        self.use_pdl = use_pdl
+        self.num_warps = tactic.block_size // cute.arch.WARP_SIZE
+        self.num_k_tiles = k_extent // (tactic.block_size * _VECTOR_WIDTH)
+
+    @cute.jit
+    def __call__(
+        self,
+        gA: cute.Tensor,
+        gB: cute.Tensor,
+        gC: cute.Tensor,
+        stream: _cuda.CUstream,
+    ) -> None:
+        n = cute.size(gB, mode=[0])
+        copy_a = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            self.element_type,
+            num_bits_per_copy=self.vector_width * self.element_type.width,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.ALWAYS,
+        )
+        copy_b = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            self.element_type,
+            num_bits_per_copy=self.vector_width * self.element_type.width,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.STREAMING,
+        )
+        self.kernel(gA, gB, gC, copy_a, copy_b).launch(
+            grid=[
+                cute.ceil_div(n, self.outputs_per_block),
+                self.num_rows // self.rows_per_block,
+                1,
+            ],
+            block=[self.block_size, 1, 1],
+            smem=self.rows_per_block * self.outputs_per_block * self.num_warps * 4,
+            stream=stream,
+            use_pdl=self.use_pdl,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        gA: cute.Tensor,
+        gB: cute.Tensor,
+        gC: cute.Tensor,
+        copy_a: cute.CopyAtom,
+        copy_b: cute.CopyAtom,
+    ) -> None:
+        tidx, _, _ = cute.arch.thread_idx()
+        block_idx, block_m, _ = cute.arch.block_idx()
+        warp_idx = cute.arch.warp_idx()
+
+        num_rows: cutlass.Constexpr = self.rows_per_block
+        outputs_per_block: cutlass.Constexpr = self.outputs_per_block
+        vector_width: cutlass.Constexpr = self.vector_width
+        block_size: cutlass.Constexpr = self.block_size
+        num_warps: cutlass.Constexpr = self.num_warps
+        num_k_tiles: cutlass.Constexpr = self.num_k_tiles
+
+        acc = cute.make_rmem_tensor(
+            cute.make_layout(
+                (num_rows, outputs_per_block), stride=(outputs_per_block, 1)
+            ),
+            cutlass.Float32,
+        )
+        acc.fill(0.0)
+
+        if const_expr(self.use_pdl):
+            cute.arch.griddepcontrol_wait()
+
+        n_base = block_idx * outputs_per_block
+        m_base = block_m * num_rows
+        gA_vec = cute.logical_divide(gA, (None, vector_width))
+        gB_vec = cute.logical_divide(gB, (None, vector_width))
+        tA_all = cute.logical_divide(gA_vec, (None, (None, block_size)))
+        tB_all = cute.logical_divide(gB_vec, (None, (None, block_size)))
+        tA = tA_all[None, (None, (tidx, None))]
+
+        b_regs = cute.make_rmem_tensor(
+            cute.make_layout(
+                (outputs_per_block, num_k_tiles, vector_width),
+                stride=(num_k_tiles * vector_width, vector_width, 1),
+            ),
+            self.element_type,
+        )
+        for ni in cutlass.range_constexpr(outputs_per_block):
+            tB = tB_all[n_base + ni, (None, (tidx, None))]
+            for k_tile in cutlass.range_constexpr(num_k_tiles):
+                cute.copy(copy_b, tB[None, k_tile], b_regs[ni, k_tile, None])
+
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_k_tiles, vector_width), stride=(vector_width, 1)),
+            self.element_type,
+        )
+        for mi in cutlass.range_constexpr(num_rows):
+            for k_tile in cutlass.range_constexpr(num_k_tiles):
+                cute.copy(
+                    copy_a,
+                    tA[m_base + mi, None, k_tile],
+                    a_regs[k_tile, None],
+                )
+            for k_tile in cutlass.range_constexpr(num_k_tiles):
+                for vi in cutlass.range_constexpr(vector_width):
+                    a_value = a_regs[k_tile, vi].to(cutlass.Float32)
+                    for ni in cutlass.range_constexpr(outputs_per_block):
+                        acc[mi, ni] = acc[mi, ni] + a_value * b_regs[ni, k_tile, vi].to(
+                            cutlass.Float32
+                        )
+
+        for mi in cutlass.range_constexpr(num_rows):
+            for ni in cutlass.range_constexpr(outputs_per_block):
+                acc[mi, ni] = cute.arch.warp_reduction_sum(acc[mi, ni])
+
+        smem_layout = cute.make_layout(
+            (num_rows, outputs_per_block, num_warps),
+            stride=(outputs_per_block * num_warps, num_warps, 1),
+        )
+        smem = cutlass.utils.SmemAllocator()
+        partials = smem.allocate_tensor(cutlass.Float32, smem_layout, byte_alignment=16)
+        with cute.arch.elect_one():
+            for mi in cutlass.range_constexpr(num_rows):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    partials[mi, ni, warp_idx] = acc[mi, ni]
+
+        cute.arch.sync_threads()
+        if tidx == 0:
+            for mi in cutlass.range_constexpr(num_rows):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    total = cutlass.Float32(0.0)
+                    for warp in cutlass.range_constexpr(num_warps):
+                        total = total + partials[mi, ni, warp]
+                    gC[m_base + mi, n_base + ni] = total.to(self.element_type)
+
+        if const_expr(self.use_pdl):
+            cute.arch.griddepcontrol_launch_dependents()
+
+
+def _from_dlpack_static(tensor: _torch.Tensor):
+    # K is specialized and the row stride must retain its 16-byte divisibility
+    # for the verifier to accept vectorized G2R copies.
+    return from_dlpack(tensor, assumed_align=32)
+
+
+def _make_compile_repr_tensors(dtype, m: int, n: int, k: int):
+    return tuple(
+        _from_dlpack_static(tensor)
+        for tensor in (
+            _torch.empty((m, k), dtype=dtype, device="cuda"),
+            _torch.empty((n, k), dtype=dtype, device="cuda"),
+            _torch.empty((m, n), dtype=dtype, device="cuda"),
+        )
+    )
+
+
+@functools.cache
+def _get_compiled_direct_kernel(
+    dtype,
+    m: int,
+    n: int,
+    k: int,
+    tactic: DirectTactic,
+    use_pdl: bool,
+):
+    if dtype != _torch.bfloat16:
+        raise ValueError(f"direct GEMM supports BF16; got {dtype}")
+    kernel = DirectDenseGemmKernel(
+        element_type=cutlass.BFloat16,
+        num_rows=m,
+        k_extent=k,
+        tactic=tactic,
+        use_pdl=use_pdl,
+    )
+    tensors = _make_compile_repr_tensors(dtype, m, n, k)
+    stream = _cuda.CUstream(_torch.cuda.current_stream().cuda_stream)
+    return cute_ext.compile(kernel, *tensors, stream, options=_COMPILE_OPTIONS)
+
+
+def _validate_runtime_tensors(a, b, out, tactic: DirectTactic):
+    if any(not isinstance(tensor, _torch.Tensor) for tensor in (a, b, out)):
+        raise ValueError("a, b, and out must be torch tensors")
+    if a.ndim != 2 or b.ndim != 2 or out.ndim != 2:
+        raise ValueError("direct GEMM accepts only 2D tensors")
+    if a.device.type != "cuda" or b.device != a.device or out.device != a.device:
+        raise ValueError("a, b, and out must be on the same CUDA device")
+    if a.dtype != _torch.bfloat16 or b.dtype != a.dtype or out.dtype != a.dtype:
+        raise ValueError("a, b, and out must share BF16 dtype")
+    if not a.is_contiguous() or not b.T.is_contiguous() or not out.is_contiguous():
+        raise ValueError("direct GEMM requires row-major A/out and column-major B")
+    if any(tensor.data_ptr() % 32 for tensor in (a, b, out)):
+        raise ValueError("a, b, and out must be 32-byte aligned")
+
+    m, k = a.shape
+    if b.shape[0] != k:
+        raise ValueError(
+            f"incompatible shapes: a is {tuple(a.shape)}, b is {tuple(b.shape)}"
+        )
+    n = b.shape[1]
+    if out.shape != (m, n):
+        raise ValueError(f"out must have shape {(m, n)}, got {tuple(out.shape)}")
+    validate_tactic(tactic, m, n, k)
+    return m, n, k
+
+
+def run_direct_dense(a, b, out, pdl: bool, tactic: DirectTactic):
+    """Run direct ``A[M,K] @ B[K,N]`` with the ``mm_bf16`` layouts."""
+    m, n, k = _validate_runtime_tensors(a, b, out, tactic)
+    compiled = _get_compiled_direct_kernel(a.dtype, m, n, k, tactic, pdl)
+    tensors = tuple(_from_dlpack_static(tensor) for tensor in (a, b.T, out))
+    stream = _cuda.CUstream(_torch.cuda.current_stream(a.device).cuda_stream)
+    compiled(*tensors, stream)
+    return out
+
+
+__all__ = [
+    "DirectTactic",
+    "autotune_tactics",
+    "default_tactic",
+    "prefer_direct_bf16_gemm_sm100",
+    "run_direct_dense",
+]

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
@@ -134,6 +134,17 @@ def validate_tactic(
     smem_capacity: int = _SMEM_CAPACITY_BYTES,
 ) -> None:
     """Reject a tactic that cannot serve ``(m, n, k)``."""
+    if tactic.mma_m not in _SUPPORTED_MMA_M:
+        raise ValueError(f"unsupported mma_m={tactic.mma_m}")
+    if tactic.mma_n not in _SUPPORTED_MMA_N:
+        raise ValueError(f"unsupported mma_n={tactic.mma_n}")
+    if tactic.split_k not in _SUPPORTED_SPLIT_K:
+        raise ValueError(f"unsupported split_k={tactic.split_k}")
+    if not _MIN_AB_STAGES <= tactic.ab_stages <= _MAX_AB_STAGES:
+        raise ValueError(
+            f"ab_stages must be in [{_MIN_AB_STAGES}, {_MAX_AB_STAGES}], "
+            f"got {tactic.ab_stages}"
+        )
     if not 1 <= m <= _MAX_M:
         raise ValueError(f"this low-M policy requires 1 <= M <= {_MAX_M}, got {m}")
     if n <= 0:
@@ -176,7 +187,10 @@ def autotune_tactics(
                     for ab_stages in (
                         range(_MIN_AB_STAGES, min(max_stages, 6) + 1)
                         if k <= 4 * _CTA_K
-                        else range(max(5, max_stages - 2), max_stages + 1)
+                        else range(
+                            min(max(5, max_stages - 2), max_stages),
+                            max_stages + 1,
+                        )
                     )
                 )
     return tactics
@@ -743,6 +757,9 @@ class SplitKDenseGemmKernel:
 
         # Peers publish FP32 partials; only rank 0 reduces and stores.
         if cutlass.const_expr(self.split_k > 1):
+            assert cute.size(rmem_layout) == self.mailbox_elements // (
+                (self.split_k - 1) * self.epilog_threads
+            )
             values_per_thread = cutlass.const_expr(cute.size(rmem_layout))
             values_per_peer = cutlass.const_expr(
                 self.epilog_threads * values_per_thread

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
@@ -1,0 +1,1025 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Blackwell low-M BF16/FP16 GEMM with an in-kernel cluster split-K reduction.
+
+Each cluster rank accumulates an exact K slice in FP32. Peers publish partials
+to rank 0 through DSMEM; rank 0 reduces, casts, and stores once. The public
+``A[M, K] @ B[K, N]`` problem is swapped internally, so tile dimensions below
+use kernel coordinates: kernel-M carries public N and kernel-N carries public M.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import cuda.bindings.driver as _cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass import Int32
+from cutlass._mlir.dialects import llvm
+from cutlass.cute import experimental as cute_ext
+from cutlass.cute.nvgpu import tcgen05
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+
+#: Per-CTA SMEM capacity reported by CuTeDSL on SM100/SM103.
+_SMEM_CAPACITY_BYTES = 227 * 1024
+
+#: K extent of one CTA tile.
+_CTA_K = 128
+
+#: Kernel-M tiles; 64 increases CTA count for low-M decode shapes.
+_SUPPORTED_MMA_M = (64, 128)
+
+#: Kernel-N carries public M, which is limited to 32.
+_SUPPORTED_MMA_N = (8, 16, 32)
+
+#: Physical cluster-K sizes; split 1 compiles out the DSMEM path.
+_SUPPORTED_SPLIT_K = (1, 2, 3, 4)
+
+#: Largest public M this low-M policy serves.
+_MAX_M = 32
+
+#: Bytes per FP32 partial exchanged through DSMEM.
+_FP32_BYTES = 4
+
+#: DSMEM mailbox base alignment, in bytes.
+_MAILBOX_ALIGN_BYTES = 128
+
+#: Size and alignment of one mbarrier, in bytes.
+_MBARRIER_BYTES = 8
+
+#: Size and alignment of the TMEM base pointer slot.
+_TMEM_POINTER_BYTES = 4
+
+#: Bytes per BF16/FP16 element.
+_AB_ELEMENT_BYTES = 2
+
+#: Alignment of the A/B shared-memory buffers.
+_AB_BUFFER_ALIGN_BYTES = 1024
+
+#: A/B pipeline stage bounds.
+_MIN_AB_STAGES = 2
+_MAX_AB_STAGES = 12
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SplitKTactic:
+    """One specialization; mma_m carries public N and mma_n carries public M."""
+
+    mma_m: int
+    mma_n: int
+    split_k: int
+    ab_stages: int
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def _smem_bytes(
+    tactic: SplitKTactic,
+    ab_stages: int,
+) -> int:
+    """Mirror the device allocator's shared-memory layout."""
+    cursor = (
+        _align_up(
+            tactic.mma_m * _CTA_K * _AB_ELEMENT_BYTES * ab_stages,
+            _AB_BUFFER_ALIGN_BYTES,
+        )
+        + tactic.mma_n * _CTA_K * _AB_ELEMENT_BYTES * ab_stages
+    )
+
+    cursor = _align_up(cursor, _MBARRIER_BYTES)
+    cursor += 2 * ab_stages * _MBARRIER_BYTES
+    cursor += 3 * _MBARRIER_BYTES
+    cursor = _align_up(cursor, _TMEM_POINTER_BYTES)
+    cursor += _TMEM_POINTER_BYTES
+
+    if tactic.split_k == 1:
+        return cursor
+
+    return (
+        _align_up(
+            _align_up(cursor, _MAILBOX_ALIGN_BYTES)
+            + (tactic.split_k - 1) * tactic.mma_m * tactic.mma_n * _FP32_BYTES,
+            _MBARRIER_BYTES,
+        )
+        + _MBARRIER_BYTES
+    )
+
+
+def _max_ab_stages_for(
+    tactic: SplitKTactic,
+    smem_capacity: int,
+) -> int:
+    return next(
+        (
+            stages
+            for stages in range(_MAX_AB_STAGES, -1, -1)
+            if _smem_bytes(tactic, stages) <= smem_capacity
+        ),
+        0,
+    )
+
+
+def validate_tactic(
+    tactic: SplitKTactic,
+    m: int,
+    n: int,
+    k: int,
+    *,
+    smem_capacity: int = _SMEM_CAPACITY_BYTES,
+) -> None:
+    """Reject a tactic that cannot serve ``(m, n, k)``."""
+    if not 1 <= m <= _MAX_M:
+        raise ValueError(f"this low-M policy requires 1 <= M <= {_MAX_M}, got {m}")
+    if n <= 0:
+        raise ValueError(f"N must be positive, got {n}")
+    if k <= 0 or k % _CTA_K or (k // _CTA_K) % tactic.split_k:
+        raise ValueError(
+            f"K={k} with CTA_K={_CTA_K} does not divide evenly across "
+            f"split_k={tactic.split_k}"
+        )
+    smem_bytes = _smem_bytes(tactic, tactic.ab_stages)
+    if smem_bytes > smem_capacity:
+        raise ValueError(
+            f"tactic {tactic} needs {smem_bytes} B of shared memory but only "
+            f"{smem_capacity} B are available; max ab_stages is "
+            f"{_max_ab_stages_for(tactic, smem_capacity)}"
+        )
+
+
+def autotune_tactics(
+    m: int,
+    n: int,
+    k: int,
+    *,
+    smem_capacity: int = _SMEM_CAPACITY_BYTES,
+) -> list[SplitKTactic]:
+    """Return valid tactics in the shape-specific stage window."""
+    tactics: list[SplitKTactic] = []
+    for mma_m in _SUPPORTED_MMA_M:
+        for mma_n in _SUPPORTED_MMA_N:
+            for split_k in _SUPPORTED_SPLIT_K:
+                base = SplitKTactic(mma_m, mma_n, split_k, _MIN_AB_STAGES)
+                try:
+                    validate_tactic(base, m, n, k, smem_capacity=smem_capacity)
+                except ValueError:
+                    continue
+                max_stages = _max_ab_stages_for(base, smem_capacity)
+                # Short K favors shallow pipelines; long K stays near the cap.
+                tactics.extend(
+                    dataclasses.replace(base, ab_stages=ab_stages)
+                    for ab_stages in (
+                        range(_MIN_AB_STAGES, min(max_stages, 6) + 1)
+                        if k <= 4 * _CTA_K
+                        else range(max(5, max_stages - 2), max_stages + 1)
+                    )
+                )
+    return tactics
+
+
+def default_tactic(m: int, n: int, k: int) -> SplitKTactic:
+    """Choose the default occupancy-oriented tactic."""
+    if n <= 512:
+        mma_m = 64
+        mma_n = 16 if n == 512 and m > 24 else 8
+        requested_split = 4
+    else:
+        mma_n = 8 if m <= 8 else 16 if m <= 16 else 32
+        if n <= 3072:
+            mma_m = 128 if m <= 16 else 64
+            requested_split = 4 if m <= 16 else 2
+        elif n < 8192:
+            mma_m = 64
+            requested_split = 2
+        else:
+            mma_m = 128 if k <= 1024 and m <= 24 else 64
+            requested_split = 1
+
+    if k <= 4 * _CTA_K:
+        requested_split = 1
+    split_k = next(
+        split_k
+        for split_k in reversed(_SUPPORTED_SPLIT_K)
+        if split_k <= requested_split and (k // _CTA_K) % split_k == 0
+    )
+    tactic = SplitKTactic(mma_m, mma_n, split_k, _MIN_AB_STAGES)
+    max_stages = _max_ab_stages_for(tactic, _SMEM_CAPACITY_BYTES)
+    tactic = dataclasses.replace(
+        tactic,
+        ab_stages=(
+            _MIN_AB_STAGES
+            if k <= 2 * _CTA_K and m > 8
+            else min(max_stages, 6)
+            if k <= 4 * _CTA_K
+            else max_stages
+        ),
+    )
+    validate_tactic(tactic, m, n, k)
+    return tactic
+
+
+__all__ = [
+    "SplitKTactic",
+    "autotune_tactics",
+    "default_tactic",
+    "run_splitk_dense",
+]
+
+
+@dsl_user_op
+def _map_shared_rank(
+    smem_ptr: "cute.Pointer",
+    peer_cta_rank_in_cluster: "Int32",
+    *,
+    loc=None,
+    ip=None,
+) -> "Int32":
+    """Map an SMEM pointer into a peer CTA's address space."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                smem_ptr.toint(loc=loc, ip=ip).ir_value(),
+                peer_cta_rank_in_cluster.ir_value(),
+            ],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _store_shared_remote_v4(
+    value0,
+    value1,
+    value2,
+    value3,
+    smem_ptr: "cute.Pointer",
+    mbar_ptr: "cute.Pointer",
+    peer_cta_rank_in_cluster: "Int32",
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    """Publish four FP32 partials into a peer's SMEM, crediting 16 bytes."""
+    llvm.inline_asm(
+        None,
+        [
+            _map_shared_rank(
+                smem_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+            ).ir_value(),
+            value0.bitcast(Int32).ir_value(loc=loc, ip=ip),
+            value1.bitcast(Int32).ir_value(loc=loc, ip=ip),
+            value2.bitcast(Int32).ir_value(loc=loc, ip=ip),
+            value3.bitcast(Int32).ir_value(loc=loc, ip=ip),
+            _map_shared_rank(
+                mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+            ).ir_value(),
+        ],
+        "st.async.shared::cluster.mbarrier::complete_tx::bytes.v4.b32 "
+        "[$0], {$1, $2, $3, $4}, [$5];",
+        "r,r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+#: Rank that gathers partials and stores the output.
+OWNER_RANK = 0
+
+
+class SplitKDenseGemmKernel:
+    """Standalone BF16/FP16 GEMM with a cluster-local split-K reduction."""
+
+    def __init__(
+        self,
+        *,
+        tactic: SplitKTactic,
+        use_pdl: bool,
+        has_bias: bool,
+    ) -> None:
+        self.acc_dtype = cutlass.Float32
+        self.cta_m = tactic.mma_m
+        self.cta_n = tactic.mma_n
+        self.cta_k = _CTA_K
+        self.num_ab_stage = tactic.ab_stages
+        self.split_k = tactic.split_k
+        self.use_pdl = use_pdl
+        self.has_bias = has_bias
+
+        self.threads_per_cta = 256
+        self.epilog_threads = 128
+        self.mma_tiler_mn = (tactic.mma_m, tactic.mma_n)
+        self.cta_group = tcgen05.CtaGroup.ONE
+        self.tma_op = cute_ext.OperationTypeEnum.SM90_TMA_LOAD
+        self.cluster_shape = (1, tactic.split_k, 1)
+
+        values_per_thread = (tactic.mma_m * tactic.mma_n) // self.epilog_threads
+        if values_per_thread % 4:
+            raise ValueError(
+                f"CTA tile ({tactic.mma_m}, {tactic.mma_n}) gives "
+                f"{values_per_thread} "
+                "values per epilogue thread; remote stores require a multiple of 4"
+            )
+        self.mailbox_elements = (
+            (tactic.split_k - 1) * self.epilog_threads * values_per_thread
+        )
+        self.expected_transaction_bytes = self.mailbox_elements * _FP32_BYTES
+
+    @cute.experimental.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        bias: cute.Tensor,
+        stream: _cuda.CUstream,
+    ):
+        # Grid-y packs output-N tile and cluster rank.
+        self.kernel(a, b, c, bias).launch(
+            grid=(
+                cute.ceil_div(c.layout.shape[0], self.cta_m),
+                cute.ceil_div(c.layout.shape[1], self.cta_n) * self.split_k,
+                c.layout.shape[2],
+            ),
+            block=(self.threads_per_cta, 1, 1),
+            cluster=self.cluster_shape,
+            smem=cute.Int64(utils.get_smem_capacity_in_bytes("sm_100")),
+            stream=stream,
+            use_pdl=self.use_pdl,
+        )
+
+    @cute.experimental.kernel
+    def kernel(
+        self,
+        mA: cute.Tensor,  # (Gemm_M, Gemm_K, Gemm_L), K-major
+        mB: cute.Tensor,  # (Gemm_N, Gemm_K, Gemm_L), K-major
+        mC: cute.Tensor,  # (Gemm_M, Gemm_N, Gemm_L), M-major
+        mBias: cute.Tensor,  # Broadcast bias; dead when has_bias=False
+    ):
+        """Allocate storage and dispatch the specialized warps."""
+        stages = self.num_ab_stage
+
+        ab_dtype = mA.element_type
+        tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            ab_dtype,
+            ab_dtype,
+            utils.LayoutEnum.from_tensor(mA).mma_major_mode(),
+            utils.LayoutEnum.from_tensor(mB).mma_major_mode(),
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler_mn,
+        )
+
+        mnk_tiler = (self.mma_tiler_mn[0], self.mma_tiler_mn[1], self.cta_k)
+        block_idx = cute.arch.block_idx()
+        bidx = block_idx[0]
+        split_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        n_idx = block_idx[1] // self.split_k
+        l_idx = block_idx[2]
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        sA = cute_ext.allocate(
+            ab_dtype,
+            cute.AddressSpace.smem,
+            sm100_utils.make_smem_layout_a(tiled_mma, mnk_tiler, ab_dtype, stages),
+            alignment=_AB_BUFFER_ALIGN_BYTES,
+        )
+        sB = cute_ext.allocate(
+            ab_dtype,
+            cute.AddressSpace.smem,
+            sm100_utils.make_smem_layout_b(tiled_mma, mnk_tiler, ab_dtype, stages),
+            alignment=_AB_BUFFER_ALIGN_BYTES,
+        )
+
+        acc_layout = cute_ext.make_tmem_layout_acc(
+            tiled_mma, self.mma_tiler_mn, acc_stage=1
+        )
+        c_tiler_mn = (self.cta_m, self.cta_n)
+
+        bar_full = cute_ext.allocate(
+            cutlass.Int64,
+            cute.AddressSpace.smem,
+            cute.make_layout(stages),
+            alignment=_MBARRIER_BYTES,
+        ).iterator
+        bar_empty = cute_ext.allocate(
+            cutlass.Int64,
+            cute.AddressSpace.smem,
+            cute.make_layout(stages),
+            alignment=_MBARRIER_BYTES,
+        ).iterator
+        bar_tma_epilog = cute_ext.allocate(
+            cutlass.Int64,
+            cute.AddressSpace.smem,
+            cute.make_layout(1),
+            alignment=_MBARRIER_BYTES,
+        ).iterator
+        bar_mma_epilog = cute_ext.allocate(
+            cutlass.Int64,
+            cute.AddressSpace.smem,
+            cute.make_layout(1),
+            alignment=_MBARRIER_BYTES,
+        ).iterator
+        bar_tmem_alloc = cute_ext.allocate(
+            cutlass.Int64,
+            cute.AddressSpace.smem,
+            cute.make_layout(1),
+            alignment=_MBARRIER_BYTES,
+        ).iterator
+        tmem_base_ptr = cute_ext.allocate(
+            cutlass.Int32,
+            cute.AddressSpace.smem,
+            cute.make_layout(1),
+            alignment=_TMEM_POINTER_BYTES,
+        ).iterator
+
+        if cutlass.const_expr(self.split_k > 1):
+            mailbox = cute_ext.allocate(
+                cutlass.Float32,
+                cute.AddressSpace.smem,
+                cute.make_layout(self.mailbox_elements),
+                alignment=_MAILBOX_ALIGN_BYTES,
+            )
+            bar_reduce = cute_ext.allocate(
+                cutlass.Int64,
+                cute.AddressSpace.smem,
+                cute.make_layout(1),
+                alignment=_MBARRIER_BYTES,
+            ).iterator
+        else:
+            # Dummy operands for the compile-time-elided reduction.
+            mailbox = sA
+            bar_reduce = bar_mma_epilog
+
+        if warp_idx == 0:
+            with cute.arch.elect_one():
+                for i in range(stages):
+                    cute.arch.mbarrier_init(bar_full + i, 2)
+                    cute.arch.mbarrier_init(bar_empty + i, 1)
+                cute.arch.mbarrier_init(bar_tma_epilog, 32)
+                cute.arch.mbarrier_init(bar_mma_epilog, 1)
+                cute.arch.mbarrier_init(bar_tmem_alloc, 160)
+
+                if cutlass.const_expr(self.split_k > 1):
+                    # Owner arrival plus peer transaction-byte credits.
+                    cute.arch.mbarrier_init(bar_reduce, 1)
+
+        cute.arch.mbarrier_init_fence()
+        if cutlass.const_expr(self.split_k > 1):
+            # Publish peer barriers before cross-CTA stores.
+            cute.arch.cluster_arrive_relaxed()
+        else:
+            cute.arch.barrier()
+
+        # Host validation guarantees an equal, tail-free K partition.
+        k_tile_count = cute.size(mA, mode=[1]) // self.cta_k // self.split_k
+        k_tile_start = split_rank * k_tile_count
+
+        if cutlass.const_expr(self.split_k > 1):
+            cute.arch.cluster_wait()
+
+        # Warp 3 is idle; warps 4-7 run the epilogue.
+        if warp_idx == 0:
+            self.dma_warp(
+                bar_full,
+                bar_empty,
+                bar_tma_epilog,
+                cute.local_tile(mA, (self.cta_m, self.cta_k), (bidx, None, l_idx)),
+                sA,
+                cute_ext.get_cta_v_map_ab(mA, mnk_tiler, tiled_mma, "A"),
+                k_tile_start,
+                k_tile_count,
+                True,
+            )
+        elif warp_idx == 1:
+            self.dma_warp(
+                bar_full,
+                bar_empty,
+                bar_tma_epilog,
+                cute.local_tile(mB, (self.cta_n, self.cta_k), (n_idx, None, l_idx)),
+                sB,
+                cute_ext.get_cta_v_map_ab(mB, mnk_tiler, tiled_mma, "B"),
+                k_tile_start,
+                k_tile_count,
+                False,
+            )
+        elif warp_idx == 2:
+            self.mma_warp(
+                bar_full,
+                bar_empty,
+                bar_mma_epilog,
+                bar_tmem_alloc,
+                tiled_mma,
+                sA,
+                sB,
+                tmem_base_ptr,
+                acc_layout,
+                self.cta_k // cute.size(tiled_mma.shape_mnk, mode=[2]),
+                k_tile_count,
+            )
+        elif warp_idx >= 4:
+            self.epilog_warp(
+                bar_tma_epilog,
+                bar_mma_epilog,
+                bar_tmem_alloc,
+                tmem_base_ptr,
+                acc_layout,
+                cute.local_tile(mC, c_tiler_mn, (bidx, n_idx, l_idx)),
+                cute.local_tile(mBias, c_tiler_mn, (bidx, n_idx, l_idx)),
+                cute.arch.thread_idx()[0] - 128,
+                mC.element_type,
+                utils.LayoutEnum.from_tensor(mC),
+                mailbox,
+                bar_reduce,
+                split_rank,
+            )
+
+    @cute.experimental.jit
+    def dma_warp(
+        self,
+        bar_full,
+        bar_empty,
+        bar_tma_epilog,
+        g_tile: cute.Tensor,
+        s_tile: cute.Tensor,
+        cta_v_map: cute.Layout,
+        k_tile_start: cutlass.Int32,
+        k_tile_count: cutlass.Int32,
+        is_a: cutlass.Constexpr,
+    ):
+        stages = self.num_ab_stage
+        if cutlass.const_expr(not is_a and self.use_pdl):
+            cute.arch.griddepcontrol_wait()
+
+        empty_phase = cutlass.Int32(1)
+        for k_tile in cutlass.range(k_tile_count, unroll=1):
+            stage = k_tile % stages
+            cute.arch.mbarrier_wait(bar_empty + stage, empty_phase)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(
+                    bar_full + stage,
+                    cute.size_in_bytes(
+                        s_tile.element_type,
+                        cute.slice_(s_tile.layout, (None, None, None, 0)),
+                    ),
+                )
+            cute_ext.tma_load(
+                g_tile[None, None, k_tile_start + k_tile],
+                s_tile[None, None, None, stage],
+                (bar_full + stage).value,
+                cta_v_map=cta_v_map,
+                tma_operation_type=self.tma_op,
+                update_expect_tx=False,
+            )
+            if stage == stages - 1:
+                empty_phase = empty_phase ^ 1
+
+        if cutlass.const_expr(is_a and self.use_pdl):
+            cute.arch.griddepcontrol_launch_dependents()
+        if cutlass.const_expr(not is_a and self.has_bias):
+            cute.arch.mbarrier_arrive(bar_tma_epilog)
+        self._drain_producer(bar_empty, empty_phase, k_tile_count)
+
+    @cute.experimental.jit
+    def _drain_producer(
+        self,
+        bar_empty,
+        empty_phase: cutlass.Int32,
+        k_tile_count: cutlass.Int32,
+    ):
+        stages = self.num_ab_stage
+        for tail in cutlass.range(stages, unroll=1):
+            stage = (tail + k_tile_count) % stages
+            cute.arch.mbarrier_wait(bar_empty + stage, empty_phase)
+            if stage == stages - 1:
+                empty_phase = empty_phase ^ 1
+
+    @cute.experimental.jit
+    def mma_warp(
+        self,
+        bar_full,
+        bar_empty,
+        bar_mma_epilog,
+        bar_tmem_alloc,
+        tiled_mma: cute.TiledMma,
+        sA: cute.Tensor,
+        sB: cute.Tensor,
+        tmem_base_ptr,
+        acc_layout: cutlass.Constexpr,
+        mma_inst_tile_k: cutlass.Constexpr,
+        k_tile_count: cutlass.Int32,
+    ):
+        num_tmem_cols = 256
+        cute.arch.alloc_tmem(num_tmem_cols, tmem_base_ptr, is_two_cta=False)
+        cute.arch.mbarrier_arrive(bar_tmem_alloc)
+        cute.arch.relinquish_tmem_alloc_permit(is_two_cta=False)
+
+        tmem_ptr = cute.arch.retrieve_tmem_ptr(self.acc_dtype, 16, tmem_base_ptr)
+        accumulator = cute.make_tensor(tmem_ptr, acc_layout)[None, None, None, 0]
+        mma_atom = cute.make_mma_atom(tiled_mma.op)
+        full_phase = cutlass.Int32(0)
+        for k_tile in cutlass.range(k_tile_count, unroll=1):
+            stage = k_tile % self.num_ab_stage
+            cute.arch.mbarrier_wait(bar_full + stage, full_phase)
+            for k_block in range(mma_inst_tile_k):
+                if k_block == 0:
+                    mma_atom.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                else:
+                    mma_atom.set(tcgen05.Field.ACCUMULATE, True)
+                cute_ext.dot(
+                    mma_atom,
+                    cute.append_ones(sA[None, None, k_block, stage], up_to_rank=3),
+                    cute.append_ones(sB[None, None, k_block, stage], up_to_rank=3),
+                    accumulator,
+                )
+            with cute.arch.elect_one():
+                tcgen05.commit(bar_empty + stage, None, self.cta_group)
+            if stage == self.num_ab_stage - 1:
+                full_phase = full_phase ^ 1
+
+        with cute.arch.elect_one():
+            tcgen05.commit(bar_mma_epilog, None, self.cta_group)
+        cute.arch.mbarrier_arrive(bar_tmem_alloc)
+        cute.arch.mbarrier_wait(bar_tmem_alloc, 1)
+        cute.arch.dealloc_tmem(tmem_ptr, num_tmem_cols, is_two_cta=False)
+
+    @cute.experimental.jit
+    def epilog_warp(
+        self,
+        bar_tma_epilog,
+        bar_mma_epilog,
+        bar_tmem_alloc,
+        tmem_base_ptr,
+        acc_layout: cutlass.Constexpr,
+        gD_tile: cute.Tensor,
+        gBias_tile: cute.Tensor,
+        epi_tid: cutlass.Int32,
+        c_dtype: cutlass.Constexpr,
+        d_layout: cutlass.Constexpr,
+        mailbox,
+        bar_reduce,
+        split_rank: cutlass.Int32,
+    ):
+        # Wait until MMA publishes the TMEM base pointer.
+        cute.arch.mbarrier_arrive(bar_tmem_alloc)
+        cute.arch.mbarrier_wait(bar_tmem_alloc, 0)
+
+        acc_view = cute.make_tensor(
+            cute.arch.retrieve_tmem_ptr(self.acc_dtype, 16, tmem_base_ptr),
+            acc_layout,
+        )[((None, None), 0, 0, 0)]
+
+        epi_tile = (self.cta_m, self.cta_n)
+        tiled_copy_t2r = cute.nvgpu.tcgen05.make_tmem_copy(
+            sm100_utils.get_tmem_load_op(
+                (self.cta_m, self.cta_n, self.cta_k),
+                d_layout,
+                c_dtype,
+                self.acc_dtype,
+                epi_tile,
+                False,
+            ),
+            acc_view,
+        )
+        gD_epi = cute.flat_divide(gD_tile, epi_tile)
+
+        # Match each epilogue thread's TMEM partition in RMEM.
+        rmem_layout = cute_ext.make_t2r_rmem_layout(tiled_copy_t2r, gD_epi, epi_tid)
+        rAcc = cute_ext.allocate(
+            self.acc_dtype,
+            cute.AddressSpace.rmem,
+            rmem_layout,
+            alignment=32,
+        )
+        rD = cute_ext.allocate(
+            c_dtype,
+            cute.AddressSpace.rmem,
+            rmem_layout,
+            alignment=32,
+        )
+        thr_t2r = tiled_copy_t2r.get_slice(epi_tid)
+
+        if cutlass.const_expr(self.has_bias):
+            bias_dtype = gBias_tile.element_type
+            rBias = cute_ext.allocate(
+                bias_dtype,
+                cute.AddressSpace.rmem,
+                rmem_layout,
+                alignment=32,
+            )
+            rBiasAcc = cute_ext.allocate(
+                self.acc_dtype,
+                cute.AddressSpace.rmem,
+                rmem_layout,
+                alignment=32,
+            )
+            if split_rank == OWNER_RANK:
+                cute.arch.mbarrier_wait(bar_tma_epilog, 0)
+                cute_ext.partition_and_copy(
+                    cute.make_tiled_copy_D(
+                        cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), bias_dtype),
+                        tiled_copy_t2r,
+                    ).get_slice(epi_tid),
+                    cute.flat_divide(gBias_tile, epi_tile)[None, None, 0, 0],
+                    rBias,
+                )
+                rBiasAcc.store(rBias.load().to(self.acc_dtype))
+
+        cute.arch.mbarrier_wait(bar_mma_epilog, 0)
+        cute_ext.partition_and_copy(thr_t2r, acc_view, rAcc)
+        # Make tcgen05.ld visible before TMEM release and RMEM use.
+        cute.arch.fence_view_async_tmem_load()
+        cute.arch.mbarrier_arrive(bar_tmem_alloc)
+
+        # Peers publish FP32 partials; only rank 0 reduces and stores.
+        if cutlass.const_expr(self.split_k > 1):
+            values_per_thread = cutlass.const_expr(cute.size(rmem_layout))
+            values_per_peer = cutlass.const_expr(
+                self.epilog_threads * values_per_thread
+            )
+            if split_rank != OWNER_RANK:
+                for value_idx in cutlass.range_constexpr(0, values_per_thread, 4):
+                    _store_shared_remote_v4(
+                        rAcc[value_idx],
+                        rAcc[value_idx + 1],
+                        rAcc[value_idx + 2],
+                        rAcc[value_idx + 3],
+                        mailbox.iterator
+                        + (split_rank - Int32(1)) * values_per_peer
+                        + epi_tid * values_per_thread
+                        + value_idx,
+                        bar_reduce,
+                        Int32(OWNER_RANK),
+                    )
+            else:
+                if epi_tid == 0:
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        bar_reduce, self.expected_transaction_bytes
+                    )
+                cute.arch.mbarrier_wait(bar_reduce, 0)
+                for peer in cutlass.range_constexpr(self.split_k - 1):
+                    for value_idx in cutlass.range_constexpr(values_per_thread):
+                        rAcc[value_idx] = (
+                            rAcc[value_idx]
+                            + mailbox[
+                                peer * values_per_peer
+                                + epi_tid * values_per_thread
+                                + value_idx
+                            ]
+                        )
+
+        if split_rank == OWNER_RANK:
+            if cutlass.const_expr(self.has_bias):
+                rAcc.store(rAcc.load() + rBiasAcc.load())
+
+            rD.store(rAcc.load().to(c_dtype))
+            # Preserve TMEM coordinates; the copy predicates output tails.
+            cute_ext.partition_and_copy(thr_t2r, rD, gD_epi[None, None, 0, 0])
+
+        # The reduction mbarrier covers remote stores; no cluster barrier needed.
+
+
+import torch as _torch
+
+_SUPPORTED_TORCH_DTYPES = (_torch.bfloat16, _torch.float16)
+
+
+@cute.experimental.jit
+def _bmm_no_bias(
+    gemm_op: cutlass.Constexpr,
+    a: cute.Tensor,
+    b: cute.Tensor,
+    c: cute.Tensor,
+    stream: _cuda.CUstream,
+):
+    c = cute.make_tensor(c.iterator, cute.select(c.layout, mode=[1, 2, 0]))
+    gemm_op(
+        cute.make_tensor(a.iterator, cute.select(a.layout, mode=[1, 2, 0])),
+        cute.make_tensor(b.iterator, cute.select(b.layout, mode=[2, 1, 0])),
+        c,
+        cute.make_tensor(c.iterator, cute.select(c.layout, mode=[0, 1, 2])),
+        stream,
+    )
+
+
+@cute.experimental.jit
+def _bmm_bias(
+    gemm_op: cutlass.Constexpr,
+    a: cute.Tensor,
+    b: cute.Tensor,
+    c: cute.Tensor,
+    bias: cute.Tensor,
+    stream: _cuda.CUstream,
+):
+    gemm_op(
+        cute.make_tensor(a.iterator, cute.select(a.layout, mode=[1, 2, 0])),
+        cute.make_tensor(b.iterator, cute.select(b.layout, mode=[2, 1, 0])),
+        cute.make_tensor(c.iterator, cute.select(c.layout, mode=[1, 2, 0])),
+        cute.make_tensor(bias.iterator, cute.select(bias.layout, mode=[1, 2, 0])),
+        stream,
+    )
+
+
+def _from_dlpack_dynamic(tensor, leading_dim: int, assumed_align: int = 32):
+    return from_dlpack(tensor, assumed_align=assumed_align).mark_layout_dynamic(
+        leading_dim=leading_dim
+    )
+
+
+def _detect_leading_dim(tensor: _torch.Tensor) -> int:
+    # Ignore synthetic batch stride, including 1x1.
+    for dim, stride in enumerate(tensor.stride()[1:], start=1):
+        if stride == 1:
+            return dim
+    raise ValueError("tensor has no stride-1 dimension")
+
+
+def _make_layout_tensor(
+    shape: tuple[int, ...], dtype: _torch.dtype, leading_dim: int
+) -> _torch.Tensor:
+    permutation = [dim for dim in range(len(shape)) if dim != leading_dim] + [
+        leading_dim
+    ]
+    return _torch.empty(
+        tuple(shape[dim] for dim in permutation), dtype=dtype, device="cuda"
+    ).permute([permutation.index(dim) for dim in range(len(shape))])
+
+
+def _make_compile_repr_tensors(
+    dtype: _torch.dtype,
+    has_bias: bool,
+    a_leading: int,
+    b_leading: int,
+    c_leading: int,
+):
+    m, n, k, batch = 64, 8, _CTA_K, 1
+    tensors = tuple(
+        _from_dlpack_dynamic(
+            _make_layout_tensor(shape, dtype, leading_dim), leading_dim
+        )
+        for shape, leading_dim in zip(
+            ((batch, n, k), (batch, k, m), (batch, n, m)),
+            (a_leading, b_leading, c_leading),
+            strict=True,
+        )
+    )
+    if not has_bias:
+        return (*tensors, None)
+    return (
+        *tensors,
+        _from_dlpack_dynamic(
+            _torch.empty((n,), dtype=dtype, device="cuda").as_strided(
+                size=(batch, n, m), stride=(0, 1, 0)
+            ),
+            1,
+            2,
+        ),
+    )
+
+
+def _to_cute_swap(a, b, out, bias):
+    a_swap = b.unsqueeze(0).transpose(-2, -1)
+    b_swap = a.unsqueeze(0).transpose(-2, -1)
+    c_swap = out.unsqueeze(0).transpose(-2, -1)
+    leading_dims = tuple(
+        _detect_leading_dim(tensor) for tensor in (a_swap, b_swap, c_swap)
+    )
+    cute_tensors = tuple(
+        _from_dlpack_dynamic(tensor, leading_dim)
+        for tensor, leading_dim in zip(
+            (a_swap, b_swap, c_swap), leading_dims, strict=True
+        )
+    )
+    if bias is None:
+        return (*cute_tensors, None, leading_dims)
+    return (
+        *cute_tensors,
+        _from_dlpack_dynamic(
+            bias.as_strided(
+                size=(1, c_swap.shape[1], c_swap.shape[2]), stride=(0, 1, 0)
+            ),
+            1,
+            2,
+        ),
+        leading_dims,
+    )
+
+
+# Tactic hashes all compile-time tile, split, and stage fields.
+_SPLITK_COMPILE_CACHE: dict = {}
+
+
+def _get_compiled_splitk_kernel(
+    dtype,
+    tactic: SplitKTactic,
+    use_pdl: bool,
+    has_bias: bool,
+    leading_dims: tuple[int, int, int],
+):
+    key = (
+        dtype,
+        tactic,
+        use_pdl,
+        has_bias,
+        *leading_dims,
+    )
+    cached = _SPLITK_COMPILE_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    if dtype not in _SUPPORTED_TORCH_DTYPES:
+        raise ValueError(
+            f"split-K dense GEMM supports {_SUPPORTED_TORCH_DTYPES}; got {dtype}"
+        )
+
+    kernel = SplitKDenseGemmKernel(
+        tactic=tactic,
+        use_pdl=use_pdl,
+        has_bias=has_bias,
+    )
+    compile_tensors = _make_compile_repr_tensors(dtype, has_bias, *leading_dims)
+    stream = _cuda.CUstream(_torch.cuda.current_stream().cuda_stream)
+    if has_bias:
+        compiled = cute_ext.compile(_bmm_bias, kernel, *compile_tensors, stream)
+    else:
+        compiled = cute_ext.compile(_bmm_no_bias, kernel, *compile_tensors[:3], stream)
+    _SPLITK_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def _validate_runtime_tensors(a, b, bias, out) -> tuple[int, int, int]:
+    tensors = (a, b, out) + ((bias,) if bias is not None else ())
+    if any(not isinstance(tensor, _torch.Tensor) for tensor in tensors):
+        raise ValueError("a, b, out, and bias must be torch tensors")
+    if a.ndim != 2 or b.ndim != 2 or out.ndim != 2:
+        raise ValueError("split-K dense GEMM accepts only 2D tensors")
+    if a.device.type != "cuda" or any(tensor.device != a.device for tensor in tensors):
+        raise ValueError("all tensors must be on the same CUDA device")
+    if a.dtype not in _SUPPORTED_TORCH_DTYPES or any(
+        tensor.dtype != a.dtype for tensor in tensors
+    ):
+        raise ValueError("a, b, out, and bias must share BF16 or FP16 dtype")
+    if any(
+        not (tensor.is_contiguous() or tensor.t().is_contiguous())
+        for tensor in (a, b, out)
+    ):
+        raise ValueError(
+            "a, b, and out must be dense row-major or column-major matrices"
+        )
+    if any(tensor.data_ptr() % 32 for tensor in (a, b, out)):
+        raise ValueError("a, b, and out must be 32-byte aligned")
+
+    m, k = a.shape
+    if b.shape[0] != k:
+        raise ValueError(
+            f"incompatible shapes: a is {tuple(a.shape)}, b is {tuple(b.shape)}"
+        )
+    n = b.shape[1]
+    if out.shape != (m, n):
+        raise ValueError(f"out must have shape {(m, n)}, got {tuple(out.shape)}")
+    if bias is not None and (
+        bias.ndim != 1 or bias.shape[0] != n or not bias.is_contiguous()
+    ):
+        raise ValueError(
+            f"bias must be contiguous with shape {(n,)}, "
+            f"got shape {tuple(bias.shape)} and stride {bias.stride()}"
+        )
+
+    return m, n, k
+
+
+def run_splitk_dense(
+    a,
+    b,
+    bias,
+    out,
+    pdl: bool,
+    tactic: SplitKTactic,
+):
+    """Run ``A[M,K] @ B[K,N]`` with the ``mm_bf16`` layouts."""
+    validate_tactic(tactic, *_validate_runtime_tensors(a, b, bias, out))
+    has_bias = bias is not None
+    cute_tensors = _to_cute_swap(a, b, out, bias)
+    compiled = _get_compiled_splitk_kernel(
+        dtype=a.dtype,
+        tactic=tactic,
+        use_pdl=pdl,
+        has_bias=has_bias,
+        leading_dims=cute_tensors[4],
+    )
+    stream = _cuda.CUstream(_torch.cuda.current_stream(a.device).cuda_stream)
+    if has_bias:
+        compiled(*cute_tensors[:4], stream)
+    else:
+        compiled(*cute_tensors[:3], stream)
+    return out

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
@@ -11,6 +11,7 @@ use kernel coordinates: kernel-M carries public N and kernel-N carries public M.
 from __future__ import annotations
 
 import dataclasses
+import functools
 import cuda.bindings.driver as _cuda
 import cutlass
 import cutlass.cute as cute
@@ -25,7 +26,7 @@ from cutlass.cutlass_dsl import T, dsl_user_op
 
 
 #: Per-CTA SMEM capacity reported by CuTeDSL on SM100/SM103.
-_SMEM_CAPACITY_BYTES = 227 * 1024
+_SMEM_CAPACITY_BYTES = utils.get_smem_capacity_in_bytes("sm_100")
 
 #: K extent of one CTA tile.
 _CTA_K = 128
@@ -60,12 +61,13 @@ _AB_ELEMENT_BYTES = 2
 #: Alignment of the A/B shared-memory buffers.
 _AB_BUFFER_ALIGN_BYTES = 1024
 
-#: A/B pipeline stage bounds.
-_MIN_AB_STAGES = 2
+#: A/B pipeline stage bounds. One stage is useful only for a single K tile.
+_MIN_AB_STAGES = 1
+_DEFAULT_MIN_AB_STAGES = 2
 _MAX_AB_STAGES = 12
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class SplitKTactic:
     """One specialization; mma_m carries public N and mma_n carries public M."""
 
@@ -175,7 +177,8 @@ def autotune_tactics(
     for mma_m in _SUPPORTED_MMA_M:
         for mma_n in _SUPPORTED_MMA_N:
             for split_k in _SUPPORTED_SPLIT_K:
-                base = SplitKTactic(mma_m, mma_n, split_k, _MIN_AB_STAGES)
+                min_stages = _MIN_AB_STAGES if k == _CTA_K else _DEFAULT_MIN_AB_STAGES
+                base = SplitKTactic(mma_m, mma_n, split_k, min_stages)
                 try:
                     validate_tactic(base, m, n, k, smem_capacity=smem_capacity)
                 except ValueError:
@@ -185,7 +188,7 @@ def autotune_tactics(
                 tactics.extend(
                     dataclasses.replace(base, ab_stages=ab_stages)
                     for ab_stages in (
-                        range(_MIN_AB_STAGES, min(max_stages, 6) + 1)
+                        range(min_stages, min(max_stages, 6) + 1)
                         if k <= 4 * _CTA_K
                         else range(
                             min(max(5, max_stages - 2), max_stages),
@@ -227,6 +230,8 @@ def default_tactic(m: int, n: int, k: int) -> SplitKTactic:
         tactic,
         ab_stages=(
             _MIN_AB_STAGES
+            if k == _CTA_K
+            else _DEFAULT_MIN_AB_STAGES
             if k <= 2 * _CTA_K and m > 8
             else min(max_stages, 6)
             if k <= 4 * _CTA_K
@@ -884,10 +889,10 @@ def _make_compile_repr_tensors(
         _from_dlpack_dynamic(
             _make_layout_tensor(shape, dtype, leading_dim), leading_dim
         )
-        for shape, leading_dim in zip(
-            ((batch, n, k), (batch, k, m), (batch, n, m)),
-            (a_leading, b_leading, c_leading),
-            strict=True,
+        for shape, leading_dim in (
+            ((batch, n, k), a_leading),
+            ((batch, k, m), b_leading),
+            ((batch, n, m), c_leading),
         )
     )
     if not has_bias:
@@ -932,10 +937,7 @@ def _to_cute_swap(a, b, out, bias):
     )
 
 
-# Tactic hashes all compile-time tile, split, and stage fields.
-_SPLITK_COMPILE_CACHE: dict = {}
-
-
+@functools.cache
 def _get_compiled_splitk_kernel(
     dtype,
     tactic: SplitKTactic,
@@ -943,17 +945,6 @@ def _get_compiled_splitk_kernel(
     has_bias: bool,
     leading_dims: tuple[int, int, int],
 ):
-    key = (
-        dtype,
-        tactic,
-        use_pdl,
-        has_bias,
-        *leading_dims,
-    )
-    cached = _SPLITK_COMPILE_CACHE.get(key)
-    if cached is not None:
-        return cached
-
     if dtype not in _SUPPORTED_TORCH_DTYPES:
         raise ValueError(
             f"split-K dense GEMM supports {_SUPPORTED_TORCH_DTYPES}; got {dtype}"
@@ -970,7 +961,6 @@ def _get_compiled_splitk_kernel(
         compiled = cute_ext.compile(_bmm_bias, kernel, *compile_tensors, stream)
     else:
         compiled = cute_ext.compile(_bmm_no_bias, kernel, *compile_tensors[:3], stream)
-    _SPLITK_COMPILE_CACHE[key] = compiled
     return compiled
 
 

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -53,16 +53,16 @@ def test_mm_bf16(
 
     if backend == "cute-dsl":
         if not is_sm100a_supported(torch.device("cuda")):
-            pytest.skip("CuTeDSL split-K backend requires SM100/SM103 with CUDA 12.8+.")
+            pytest.skip("CuTeDSL low-M backend requires SM100/SM103 with CUDA 12.8+.")
 
         from flashinfer.cute_dsl.utils import is_cute_dsl_available
 
         if not is_cute_dsl_available():
             pytest.skip("nvidia-cutlass-dsl is not available.")
         if m > 32:
-            pytest.skip("CuTeDSL split-K backend requires M <= 32.")
+            pytest.skip("CuTeDSL low-M backend requires M <= 32.")
         if res_dtype != torch.bfloat16:
-            pytest.skip("CuTeDSL split-K backend requires BF16 output.")
+            pytest.skip("CuTeDSL low-M backend requires BF16 output.")
 
     if backend == "auto" and (enable_bias or pdl):
         pytest.skip("mm_bf16 with auto backend does not support bias or pdl arguments.")
@@ -244,34 +244,6 @@ def test_mm_bf16_cute_dsl_one_stage_splitk(enable_bias: bool):
     reference = F.linear(a, b, bias)
     cos_sim = F.cosine_similarity(reference.reshape(-1), out.reshape(-1), dim=0)
     assert cos_sim > 0.99
-
-
-def test_cute_dsl_low_m_tactic_policies():
-    from flashinfer.gemm.kernels.dense_bf16_gemm_direct import (
-        DirectTactic,
-        autotune_tactics as direct_autotune_tactics,
-        prefer_direct_bf16_gemm_sm100,
-    )
-    from flashinfer.gemm.kernels.dense_bf16_gemm_sm100_splitk import (
-        autotune_tactics as splitk_autotune_tactics,
-        default_tactic as splitk_default_tactic,
-    )
-
-    assert prefer_direct_bf16_gemm_sm100(1, 4608, 8192)
-    assert prefer_direct_bf16_gemm_sm100(4, 512, 8192)
-    assert prefer_direct_bf16_gemm_sm100(8, 256, 8192)
-    assert not prefer_direct_bf16_gemm_sm100(2, 4608, 8192)
-    assert not prefer_direct_bf16_gemm_sm100(8, 512, 8192)
-    assert not prefer_direct_bf16_gemm_sm100(1, 4608, 4096)
-
-    assert DirectTactic(256, 2, 8) in direct_autotune_tactics(8, 256, 8192)
-    assert splitk_default_tactic(1, 1024, 128).ab_stages == 1
-    assert (
-        min(tactic.ab_stages for tactic in splitk_autotune_tactics(1, 1024, 128)) == 1
-    )
-    assert (
-        min(tactic.ab_stages for tactic in splitk_autotune_tactics(1, 1024, 256)) == 2
-    )
 
 
 if __name__ == "__main__":

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -15,7 +15,8 @@ from flashinfer.utils import get_compute_capability
 @pytest.mark.parametrize("enable_bias", [True, False])
 @pytest.mark.parametrize("pdl", [True, False])
 @pytest.mark.parametrize(
-    "backend", ["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "auto"]
+    "backend",
+    ["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "cute-dsl", "auto"],
 )
 @pytest.mark.parametrize("auto_tuning", [False, True])
 def test_mm_bf16(
@@ -49,6 +50,16 @@ def test_mm_bf16(
             pytest.skip(
                 "cuda-tile / tileiras compiler not available in this environment."
             )
+
+    if backend == "cute-dsl":
+        from flashinfer.cute_dsl.utils import is_cute_dsl_available
+
+        if not is_cute_dsl_available():
+            pytest.skip("nvidia-cutlass-dsl is not available.")
+        if m > 32:
+            pytest.skip("CuTeDSL split-K backend requires M <= 32.")
+        if res_dtype != torch.bfloat16:
+            pytest.skip("CuTeDSL split-K backend requires BF16 output.")
 
     if backend == "auto" and (enable_bias or pdl):
         pytest.skip("mm_bf16 with auto backend does not support bias or pdl arguments.")

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from flashinfer import autotune, mm_bf16
 from flashinfer.gemm.gemm_base import CUDNN_AVAILABLE
 from flashinfer.gemm import is_cuda_tile_available
-from flashinfer.utils import get_compute_capability
+from flashinfer.utils import get_compute_capability, is_sm100a_supported
 
 
 @pytest.mark.parametrize("m", [1, 8, 16, 32, 64])
@@ -52,6 +52,9 @@ def test_mm_bf16(
             )
 
     if backend == "cute-dsl":
+        if not is_sm100a_supported(torch.device("cuda")):
+            pytest.skip("CuTeDSL split-K backend requires SM100/SM103 with CUDA 12.8+.")
+
         from flashinfer.cute_dsl.utils import is_cute_dsl_available
 
         if not is_cute_dsl_available():

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -218,7 +218,9 @@ def test_mm_bf16_cute_dsl_direct_fallback(pdl: bool):
     a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
     b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
     out = mm_bf16(a, b.T, pdl=pdl, backend="cute-dsl")
-    torch.testing.assert_close(out, a @ b.T, rtol=2e-2, atol=5e-1)
+    reference = a @ b.T
+    cos_sim = F.cosine_similarity(reference.reshape(-1), out.reshape(-1), dim=0)
+    assert cos_sim > 0.99
 
 
 @pytest.mark.parametrize("enable_bias", [False, True])
@@ -240,7 +242,8 @@ def test_mm_bf16_cute_dsl_one_stage_splitk(enable_bias: bool):
     )
     out = mm_bf16(a, b.T, bias=bias, pdl=True, backend="cute-dsl")
     reference = F.linear(a, b, bias)
-    torch.testing.assert_close(out, reference, rtol=2e-2, atol=5e-1)
+    cos_sim = F.cosine_similarity(reference.reshape(-1), out.reshape(-1), dim=0)
+    assert cos_sim > 0.99
 
 
 def test_cute_dsl_low_m_tactic_policies():

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -203,5 +203,73 @@ def test_cublaslt_bf16_runner_zero_algos():
         runner._get_algos = original_get_algos
 
 
+@pytest.mark.parametrize("pdl", [False, True])
+def test_mm_bf16_cute_dsl_direct_fallback(pdl: bool):
+    """The no-autotune fallback uses direct in its measured crossover band."""
+    if get_compute_capability(torch.device("cuda")) not in ((10, 0), (10, 3)):
+        pytest.skip("CuTeDSL low-M backend requires SM100/SM103.")
+
+    from flashinfer.cute_dsl.utils import is_cute_dsl_available
+
+    if not is_cute_dsl_available():
+        pytest.skip("nvidia-cutlass-dsl is not available.")
+
+    m, n, k = 1, 256, 8192
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    out = mm_bf16(a, b.T, pdl=pdl, backend="cute-dsl")
+    torch.testing.assert_close(out, a @ b.T, rtol=2e-2, atol=5e-1)
+
+
+@pytest.mark.parametrize("enable_bias", [False, True])
+def test_mm_bf16_cute_dsl_one_stage_splitk(enable_bias: bool):
+    """K=128 exercises the shallow one-stage tensor-core pipeline."""
+    if get_compute_capability(torch.device("cuda")) not in ((10, 0), (10, 3)):
+        pytest.skip("CuTeDSL low-M backend requires SM100/SM103.")
+
+    from flashinfer.cute_dsl.utils import is_cute_dsl_available
+
+    if not is_cute_dsl_available():
+        pytest.skip("nvidia-cutlass-dsl is not available.")
+
+    m, n, k = 1, 1024, 128
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    bias = (
+        torch.randn((n,), device="cuda", dtype=torch.bfloat16) if enable_bias else None
+    )
+    out = mm_bf16(a, b.T, bias=bias, pdl=True, backend="cute-dsl")
+    reference = F.linear(a, b, bias)
+    torch.testing.assert_close(out, reference, rtol=2e-2, atol=5e-1)
+
+
+def test_cute_dsl_low_m_tactic_policies():
+    from flashinfer.gemm.kernels.dense_bf16_gemm_direct import (
+        DirectTactic,
+        autotune_tactics as direct_autotune_tactics,
+        prefer_direct_bf16_gemm_sm100,
+    )
+    from flashinfer.gemm.kernels.dense_bf16_gemm_sm100_splitk import (
+        autotune_tactics as splitk_autotune_tactics,
+        default_tactic as splitk_default_tactic,
+    )
+
+    assert prefer_direct_bf16_gemm_sm100(1, 4608, 8192)
+    assert prefer_direct_bf16_gemm_sm100(4, 512, 8192)
+    assert prefer_direct_bf16_gemm_sm100(8, 256, 8192)
+    assert not prefer_direct_bf16_gemm_sm100(2, 4608, 8192)
+    assert not prefer_direct_bf16_gemm_sm100(8, 512, 8192)
+    assert not prefer_direct_bf16_gemm_sm100(1, 4608, 4096)
+
+    assert DirectTactic(256, 2, 8) in direct_autotune_tactics(8, 256, 8192)
+    assert splitk_default_tactic(1, 1024, 128).ab_stages == 1
+    assert (
+        min(tactic.ab_stages for tactic in splitk_autotune_tactics(1, 1024, 128)) == 1
+    )
+    assert (
+        min(tactic.ab_stages for tactic in splitk_autotune_tactics(1, 1024, 256)) == 2
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add blackwell cutedsl BF16 split K dense gemm for small BS

## 🔍 Related Issues

<!-- Link any related issues here -->

## Performance

###  N=256, K=8192

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 5.149 | 3.519 | 1.463x |
| 2 | 5.252 | 3.519 | 1.492x |
| 4 | 5.441 | 3.521 | 1.545x |
| 6 | 5.498 | 3.523 | 1.561x |
| 8 | 5.484 | 3.523 | 1.557x |
| 16 | 5.555 | 3.651 | 1.522x |
| 24 | 5.426 | 3.668 | 1.479x |
| 32 | 5.584 | 3.713 | 1.504x |

### N=512, K=8192

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 5.504 | 3.575 | 1.540x |
| 2 | 5.541 | 3.585 | 1.546x |
| 4 | 5.595 | 3.586 | 1.560x |
| 6 | 5.596 | 3.647 | 1.534x |
| 8 | 5.616 | 3.649 | 1.539x |
| 16 | 5.984 | 3.774 | 1.586x |
| 24 | 5.960 | 4.038 | 1.476x |
| 32 | 5.877 | 4.216 | 1.394x |



### N=2560, K=8192

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 10.266 | 8.162 | 1.258x |
| 2 | 10.667 | 8.256 | 1.292x |
| 4 | 10.455 | 8.274 | 1.264x |
| 6 | 10.348 | 8.287 | 1.249x |
| 8 | 10.397 | 8.317 | 1.250x |
| 16 | 10.655 | 9.014 | 1.182x |
| 24 | 12.919 | 9.532 | 1.355x |
| 32 | 11.016 | 9.568 | 1.151x |

### N=4608, K=8192

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 16.246 | 13.620 | 1.193x |
| 2 | 15.740 | 13.646 | 1.153x |
| 4 | 15.786 | 13.668 | 1.155x |
| 6 | 15.681 | 13.728 | 1.142x |
| 8 | 15.695 | 13.755 | 1.141x |
| 16 | 16.028 | 13.946 | 1.149x |
| 24 | 16.747 | 14.503 | 1.155x |
| 32 | 16.356 | 14.670 | 1.115x |

### N=8192, K=128

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 1.602 | 1.536 | 1.043x |
| 2 | 1.601 | 1.537 | 1.042x |
| 4 | 1.601 | 1.583 | 1.011x |
| 6 | 1.597 | 1.545 | 1.034x |
| 8 | 1.610 | 1.600 | 1.006x |
| 16 | 1.773 | 1.727 | 1.027x |
| 24 | 2.103 | 1.923 | 1.094x |
| 32 | 2.119 | 2.045 | 1.036x |

### N=8192, K=256

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 2.543 | 1.763 | 1.442x |
| 2 | 2.558 | 1.798 | 1.423x |
| 4 | 2.564 | 1.834 | 1.398x |
| 6 | 2.575 | 1.799 | 1.431x |
| 8 | 2.605 | 1.856 | 1.404x |
| 16 | 2.678 | 2.103 | 1.273x |
| 24 | 2.792 | 2.286 | 1.221x |
| 32 | 2.825 | 2.425 | 1.165x |

### N=8192, K=1024

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 4.824 | 3.815 | 1.264x |
| 2 | 4.796 | 4.009 | 1.196x |
| 4 | 4.785 | 4.041 | 1.184x |
| 6 | 4.788 | 4.022 | 1.190x |
| 8 | 4.794 | 4.039 | 1.187x |
| 16 | 4.851 | 4.138 | 1.172x |
| 24 | 4.949 | 4.502 | 1.099x |
| 32 | 5.075 | 4.523 | 1.122x |

### N=8192, K=2048

| M | cuBLAS us | New kernel us | vs cuBLAS |
|---:|---:|---:|---:|
| 1 | 7.263 | 6.589 | 1.102x |
| 2 | 7.614 | 6.559 | 1.161x |
| 4 | 7.424 | 6.540 | 1.135x |
| 6 | 7.311 | 6.598 | 1.108x |
| 8 | 7.324 | 6.604 | 1.109x |
| 16 | 7.486 | 6.632 | 1.129x |
| 24 | 7.515 | 6.833 | 1.100x |
| 32 | 7.829 | 6.883 | 1.137x |

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added an optional CuTeDSL split-K backend for BF16 matrix multiplication on supported NVIDIA hardware.
* Added selectable split-K tactics for compatible low-M workloads, including optional bias support.
* Backend selection is explicit and does not affect automatic backend selection.

## Performance

* Improves supported BF16 GEMM execution through split-K processing and tunable execution strategies.

## Tests

* Expanded BF16 GEMM coverage with environment-aware checks for hardware, CUDA, output type, and workload constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->