### PR TITLE
[MoE] Add direct owner output to CuTeDSL NVFP4 finalize

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -364,6 +364,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         enable_pdl: bool = True,
         use_a_per_token_scale: bool = False,
         use_fused_finalize: bool = True,
+        direct_output: bool = False,
+        output_rows_per_owner: int = 1,
+        output_physical_rows_per_owner: int = 1,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel.
 
@@ -387,6 +390,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.enable_pdl = enable_pdl
         self.use_a_per_token_scale = use_a_per_token_scale
         self.use_fused_finalize = use_fused_finalize
+        self.direct_output = direct_output
+        self.output_rows_per_owner = output_rows_per_owner
+        self.output_physical_rows_per_owner = output_physical_rows_per_owner
         self.acc_dtype = cutlass.Float32
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = cluster_shape_mn
@@ -1967,7 +1973,16 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                     gather_tok = token_idx * is_valid_row
                     token_scale = token_final_scales[(gather_tok, topk_idx)]
                     output_idx = token_idx
-                    if cutlass.const_expr(not self.use_fused_finalize):
+                    if cutlass.const_expr(self.direct_output):
+                        output_owner = safe_idx // self.output_rows_per_owner
+                        output_local_row = (
+                            safe_idx - output_owner * self.output_rows_per_owner
+                        )
+                        output_idx = (
+                            output_owner * self.output_physical_rows_per_owner
+                            + output_local_row
+                        )
+                    elif cutlass.const_expr(not self.use_fused_finalize):
                         token_scale = self.final_scale_dtype(1.0)
                         output_idx = safe_idx
                     if cutlass.const_expr(self.use_a_per_token_scale):
@@ -2160,7 +2175,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                     scatter_out_offset = cute.domain_offset(
                         (reduce_token_idx, coord_n, 0), out
                     )
-                    if cutlass.const_expr(not self.use_fused_finalize):
+                    if cutlass.const_expr(
+                        self.direct_output or not self.use_fused_finalize
+                    ):
                         blk_copy(
                             scatter_out_offset,
                             sC[reduce_row, None, 0],
@@ -2807,7 +2824,17 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             ),
         )
         output_rows = num_tokens
-        if cutlass.const_expr(not self.use_fused_finalize):
+        if cutlass.const_expr(self.direct_output):
+            logical_rows = num_tokens * top_k
+            owners = (
+                logical_rows + self.output_rows_per_owner - 1
+            ) // self.output_rows_per_owner
+            output_rows = (
+                (owners - 1) * self.output_physical_rows_per_owner
+                + logical_rows
+                - (owners - 1) * self.output_rows_per_owner
+            )
+        elif cutlass.const_expr(not self.use_fused_finalize):
             output_rows = num_tokens * top_k
         c = cute.make_tensor(
             c_ptr, layout=cute.make_ordered_layout((output_rows, n, 1), order=(1, 0, 2))

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -190,6 +190,9 @@ def _get_compiled_finalize_kernel(
     enable_pdl: bool = True,
     use_a_per_token_scale: bool = False,
     use_fused_finalize: bool = True,
+    direct_output: bool = False,
+    output_rows_per_owner: int = 1,
+    output_physical_rows_per_owner: int = 1,
 ):
     """Get or compile the grouped GEMM with finalize fusion kernel.
 
@@ -212,6 +215,9 @@ def _get_compiled_finalize_kernel(
         enable_pdl,
         use_a_per_token_scale,
         use_fused_finalize,
+        direct_output,
+        output_rows_per_owner,
+        output_physical_rows_per_owner,
     )
 
     if cache_key not in _finalize_kernel_cache:
@@ -224,6 +230,9 @@ def _get_compiled_finalize_kernel(
             enable_pdl=enable_pdl,
             use_a_per_token_scale=use_a_per_token_scale,
             use_fused_finalize=use_fused_finalize,
+            direct_output=direct_output,
+            output_rows_per_owner=output_rows_per_owner,
+            output_physical_rows_per_owner=output_physical_rows_per_owner,
         )
 
         # Compile with runtime parameters - they can vary across calls
@@ -289,6 +298,9 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4(
     sm_count: Optional[int] = None,
     enable_pdl: bool = True,
     use_fused_finalize: bool = True,
+    direct_output: bool = False,
+    output_rows_per_owner: int = 1,
+    output_physical_rows_per_owner: int = 1,
 ) -> torch.Tensor:
     """Blockscaled contiguous grouped GEMM for MoE GEMM2 workloads.
 
@@ -438,10 +450,23 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4(
             f"mma_tiler_mn={mma_tiler_mn}, cluster_shape_mn={cluster_shape_mn}, shape=({permuted_m}, {n}, {k}, {num_experts})"
         )
 
+    if direct_output and not use_fused_finalize:
+        raise ValueError("Direct output requires fused routing-weight finalization")
+    if direct_output and (
+        output_rows_per_owner <= 0
+        or output_physical_rows_per_owner < output_rows_per_owner
+    ):
+        raise ValueError(
+            "Direct output requires a positive logical owner extent and a "
+            "physical owner stride at least as large as that extent"
+        )
+
     output_rows = seq_len if use_fused_finalize else seq_len * topk
 
     # Atomic fused finalize requires zero-initialized output.
     if out is None:
+        if direct_output:
+            raise ValueError("Direct output requires a pre-allocated output buffer")
         allocator = torch.zeros if use_fused_finalize else torch.empty
         out = allocator(
             (output_rows, n),
@@ -452,6 +477,23 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4(
         raise ValueError(
             f"out must have shape ({output_rows}, {n}), got {tuple(out.shape)}"
         )
+    if direct_output:
+        last_expanded_row = seq_len * topk - 1
+        required_rows = 0
+        if last_expanded_row >= 0:
+            last_owner = last_expanded_row // output_rows_per_owner
+            last_owner_row = last_expanded_row % output_rows_per_owner
+            required_rows = (
+                last_owner * output_physical_rows_per_owner + last_owner_row + 1
+            )
+        available_elements = (
+            out.untyped_storage().nbytes() // out.element_size() - out.storage_offset()
+        )
+        if required_rows * n > available_elements:
+            raise ValueError(
+                "Direct output backing storage is smaller than its physical "
+                "owner-row extent"
+            )
 
     # Get SM count
     if sm_count is None:
@@ -549,6 +591,9 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4(
         enable_pdl=enable_pdl,
         use_fused_finalize=use_fused_finalize,
         use_a_per_token_scale=use_a_per_token_scale,
+        direct_output=direct_output,
+        output_rows_per_owner=output_rows_per_owner,
+        output_physical_rows_per_owner=output_physical_rows_per_owner,
     )
 
     # Execute kernel with runtime parameters

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -173,6 +173,9 @@ def _moe_core_impl(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    direct_output: bool = False,
+    output_rows_per_owner: int = 1,
+    output_physical_rows_per_owner: int = 1,
 ) -> torch.Tensor:
     """Core MoE implementation shared by functional and wrapper APIs.
 
@@ -222,6 +225,10 @@ def _moe_core_impl(
         swiglu_alpha: SwiGLU sigmoid multiplier.
         swiglu_beta: SwiGLU up-projection bias.
         swiglu_limit: SwiGLU clamp limit.
+        direct_output: Store weighted expanded token/top-k rows in the
+            caller-provided output instead of reducing them into token rows.
+        output_rows_per_owner: Logical expanded rows reserved for each owner.
+        output_physical_rows_per_owner: Physical row stride between owners.
 
     Returns:
         Output tensor [num_tokens, hidden_size].
@@ -231,6 +238,14 @@ def _moe_core_impl(
     num_tokens = token_selected_experts.size(0)
     hidden_size = w2_weight.size(1)
     use_per_token_activation = per_token_scale is not None
+
+    if direct_output:
+        if not use_fused_finalize:
+            raise ValueError("Direct output requires fused routing-weight finalization")
+        if moe_output is None:
+            raise ValueError("Direct output requires a pre-allocated output buffer")
+        if moe_output.stride() != (hidden_size, 1):
+            raise ValueError("Direct output requires a contiguous row-major view")
 
     if moe_output is None:
         moe_output = torch.empty(
@@ -245,7 +260,7 @@ def _moe_core_impl(
         )
 
     # Fused finalize overlaps output zeroing with GEMM1.
-    if use_async_memset and use_fused_finalize:
+    if use_async_memset and use_fused_finalize and not direct_output:
         if aux_stream is None or main_event is None or memset_event is None:
             resources = _get_cuda_graph_resources()
             aux_stream = aux_stream or resources["aux_stream"]
@@ -272,7 +287,7 @@ def _moe_core_impl(
         **moe_sort_kwargs,
     )
 
-    if use_async_memset and use_fused_finalize:
+    if use_async_memset and use_fused_finalize and not direct_output:
         main_event.record()
         moe_output.record_stream(aux_stream)
 
@@ -336,7 +351,9 @@ def _moe_core_impl(
 
     # Atomic finalize requires a zeroed token output. Deterministic finalize
     # writes each route to a unique expanded row.
-    if use_fused_finalize:
+    if direct_output:
+        gemm2_output = moe_output
+    elif use_fused_finalize:
         if use_async_memset:
             with torch.cuda.stream(aux_stream):
                 main_event.wait()
@@ -371,6 +388,9 @@ def _moe_core_impl(
         cluster_shape_mn=gemm2_cluster_shape_mn,
         enable_pdl=enable_pdl,
         use_fused_finalize=use_fused_finalize,
+        direct_output=direct_output,
+        output_rows_per_owner=output_rows_per_owner,
+        output_physical_rows_per_owner=output_physical_rows_per_owner,
     )
 
     # Step 4: Deterministic routing-weight reduction
@@ -806,6 +826,9 @@ def _cute_dsl_fused_moe_nvfp4_impl(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    direct_output: bool = False,
+    output_rows_per_owner: int = 1,
+    output_physical_rows_per_owner: int = 1,
 ) -> torch.Tensor:
     """Internal implementation called by auto-tuner for functional API."""
     return _moe_core_impl(
@@ -840,6 +863,9 @@ def _cute_dsl_fused_moe_nvfp4_impl(
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
         swiglu_limit=swiglu_limit,
+        direct_output=direct_output,
+        output_rows_per_owner=output_rows_per_owner,
+        output_physical_rows_per_owner=output_physical_rows_per_owner,
     )
 
 
@@ -872,6 +898,9 @@ def cute_dsl_fused_moe_nvfp4(
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
     *,
     per_token_scale: Optional[torch.Tensor] = None,
+    direct_output: bool = False,
+    output_rows_per_owner: int = 1,
+    output_physical_rows_per_owner: int = 1,
 ) -> torch.Tensor:
     r"""Run a fused MoE forward pass using the CuTe-DSL NVFP4 kernels.
 
@@ -937,6 +966,13 @@ def cute_dsl_fused_moe_nvfp4(
     per_token_scale : Optional[torch.Tensor]
         Per-token input row scale for GEMM1. Passing this enables the
         per-token activation path.
+    direct_output : bool
+        Store weighted expanded token/top-k rows in ``moe_output`` without
+        reducing them into token rows.
+    output_rows_per_owner : int
+        Logical expanded rows reserved for each output owner.
+    output_physical_rows_per_owner : int
+        Physical row stride between output owners.
 
     Returns
     -------
@@ -952,6 +988,17 @@ def cute_dsl_fused_moe_nvfp4(
     num_tokens = token_selected_experts.size(0)
     hidden_size = w2_weight.size(1)
 
+    if direct_output:
+        if moe_output is None:
+            raise ValueError("Direct output requires a pre-allocated output buffer")
+        if (
+            output_rows_per_owner <= 0
+            or output_physical_rows_per_owner < output_rows_per_owner
+        ):
+            raise ValueError(
+                "Direct output requires a positive logical owner extent and a "
+                "physical owner stride at least as large as that extent"
+            )
     if moe_output is None:
         moe_output = torch.empty(
             (num_tokens, hidden_size),
@@ -975,6 +1022,9 @@ def cute_dsl_fused_moe_nvfp4(
         swiglu_beta=swiglu_beta,
         swiglu_limit=swiglu_limit,
         use_per_token_activation=use_per_token_activation,
+        direct_output=direct_output,
+        output_rows_per_owner=output_rows_per_owner,
+        output_physical_rows_per_owner=output_physical_rows_per_owner,
     )
 
     inputs = [

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -265,6 +265,10 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         output_dtype: Output data type (default: torch.bfloat16).
         use_per_token_activation: Whether inputs include per-token row scales
             for GEMM1.
+        direct_output: Whether GEMM2 stores weighted expanded rows without
+            reducing them into token rows.
+        output_rows_per_owner: Logical expanded rows reserved for each owner.
+        output_physical_rows_per_owner: Physical row stride between owners.
     """
 
     def __init__(
@@ -282,8 +286,19 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         swiglu_beta: float = DEFAULT_SWIGLU_BETA,
         swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
         use_per_token_activation: bool = False,
+        direct_output: bool = False,
+        output_rows_per_owner: int = 1,
+        output_physical_rows_per_owner: int = 1,
     ):
         activation_type, gated = normalize_cute_dsl_moe_activation_type(activation_type)
+        if direct_output and (
+            output_rows_per_owner <= 0
+            or output_physical_rows_per_owner < output_rows_per_owner
+        ):
+            raise ValueError(
+                "Direct output requires a positive logical owner extent and a "
+                "physical owner stride at least as large as that extent"
+            )
         self.forward_impl = forward_impl
         self.num_experts = num_experts
         self.top_k = top_k
@@ -298,6 +313,9 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         self.swiglu_beta = swiglu_beta
         self.swiglu_limit = swiglu_limit
         self.use_per_token_activation = use_per_token_activation
+        self.direct_output = direct_output
+        self.output_rows_per_owner = output_rows_per_owner
+        self.output_physical_rows_per_owner = output_physical_rows_per_owner
 
         # Helper that builds a deterministic balanced approx-max-load
         # assignment for token_selected_experts during autotune profiling.
@@ -310,6 +328,32 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
 
         # Instance-level so dummy expert IDs span all local experts
         # (randint(0, num_experts)) for realistic profiling.
+        def output_initializer(shapes, dtype, device):
+            if not self.direct_output:
+                return torch.empty(shapes, dtype=dtype, device=device)
+            num_tokens, hidden_size = shapes
+            logical_rows = num_tokens * self.top_k
+            last_expanded_row = logical_rows - 1
+            required_rows = 0
+            if last_expanded_row >= 0:
+                last_owner = last_expanded_row // self.output_rows_per_owner
+                last_owner_row = last_expanded_row % self.output_rows_per_owner
+                required_rows = (
+                    last_owner * self.output_physical_rows_per_owner
+                    + last_owner_row
+                    + 1
+                )
+            storage = torch.empty(
+                (required_rows, hidden_size),
+                dtype=dtype,
+                device=device,
+            )
+            return torch.as_strided(
+                storage,
+                size=shapes,
+                stride=(hidden_size, 1),
+            )
+
         self.tuning_config = TuningConfig(
             dynamic_tensor_specs=(
                 DynamicTensorSpec(
@@ -375,9 +419,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                             if use_per_token_activation
                             else []
                         ),
-                        lambda shapes, dtype, device: torch.empty(
-                            shapes, dtype=dtype, device=device
-                        ),
+                        output_initializer,
                     ],
                 ),
             ),
@@ -403,6 +445,9 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                 self.swiglu_beta,
                 self.swiglu_limit,
                 self.use_per_token_activation,
+                self.direct_output,
+                self.output_rows_per_owner,
+                self.output_physical_rows_per_owner,
             )
         )
 
@@ -412,6 +457,9 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
             self.swiglu_alpha,
             self.swiglu_beta,
             self.swiglu_limit,
+            self.direct_output,
+            self.output_rows_per_owner,
+            self.output_physical_rows_per_owner,
         )
 
     def get_valid_tactics(  # type: ignore[override]
@@ -600,6 +648,13 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         else:
             per_token_scale = None
             moe_output = optional_inputs[0] if optional_inputs else None
+
+        kwargs.setdefault("direct_output", self.direct_output)
+        kwargs.setdefault("output_rows_per_owner", self.output_rows_per_owner)
+        kwargs.setdefault(
+            "output_physical_rows_per_owner",
+            self.output_physical_rows_per_owner,
+        )
 
         # Call the implementation with tactic parameters
         return self.forward_impl(

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1128,6 +1128,128 @@ class TestCuteDslFusedMoeFunctional:
         assert result.shape == (num_tokens, hidden_size)
         assert not torch.isnan(result).any()
 
+    def test_direct_owner_output(self):
+        """Direct output preserves expanded rows and physical owner gaps."""
+        from flashinfer import cute_dsl_fused_moe_nvfp4
+        from flashinfer.fused_moe.cute_dsl.tuner import (
+            CuteDslFusedMoENvfp4Runner,
+        )
+
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+        num_owners = 2
+        output_rows_per_owner = num_tokens * top_k // num_owners
+        output_physical_rows_per_owner = output_rows_per_owner + 32
+
+        runner = CuteDslFusedMoENvfp4Runner(
+            forward_impl=lambda **_: None,
+            num_experts=num_experts,
+            top_k=top_k,
+            num_local_experts=num_experts,
+            direct_output=True,
+            output_rows_per_owner=output_rows_per_owner,
+            output_physical_rows_per_owner=output_physical_rows_per_owner,
+        )
+        tensor_initializers = runner.tuning_config.dynamic_tensor_specs[
+            0
+        ].tensor_initializers
+        assert tensor_initializers is not None
+        output_initializer = tensor_initializers[-1]
+        tuning_output = output_initializer(
+            (num_tokens, hidden_size),
+            torch.bfloat16,
+            torch.device("cuda"),
+        )
+        required_tuning_rows = output_physical_rows_per_owner + output_rows_per_owner
+        assert tuning_output.shape == (num_tokens, hidden_size)
+        assert (
+            tuning_output.untyped_storage().nbytes()
+            == required_tuning_rows * hidden_size * tuning_output.element_size()
+        )
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+        kwargs = {
+            "x": tensors["x"],
+            "x_sf": tensors["x_sf"],
+            "token_selected_experts": tensors["token_selected_experts"],
+            "token_final_scales": tensors["token_final_scales"],
+            "w1_weight": tensors["w1_weight"],
+            "w1_weight_sf": tensors["w1_weight_sf"],
+            "w1_alpha": tensors["w1_alpha"],
+            "fc2_input_scale": tensors["fc2_input_scale"],
+            "w2_weight": tensors["w2_weight"],
+            "w2_weight_sf": tensors["w2_weight_sf"],
+            "w2_alpha": tensors["w2_alpha"],
+            "num_experts": num_experts,
+            "top_k": top_k,
+            "num_local_experts": num_experts,
+        }
+
+        reduced_output = cute_dsl_fused_moe_nvfp4(**kwargs)
+        physical_output = torch.full(
+            (num_owners * output_physical_rows_per_owner, hidden_size),
+            torch.nan,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        logical_output = torch.as_strided(
+            physical_output,
+            size=(num_tokens, hidden_size),
+            stride=(hidden_size, 1),
+        )
+        cute_dsl_fused_moe_nvfp4(
+            **kwargs,
+            moe_output=logical_output,
+            direct_output=True,
+            output_rows_per_owner=output_rows_per_owner,
+            output_physical_rows_per_owner=output_physical_rows_per_owner,
+        )
+
+        expanded_rows = torch.arange(num_tokens * top_k, device="cuda")
+        owners = expanded_rows // output_rows_per_owner
+        owner_rows = expanded_rows % output_rows_per_owner
+        physical_rows = owners * output_physical_rows_per_owner + owner_rows
+        direct_output = (
+            physical_output[physical_rows]
+            .view(num_tokens, top_k, hidden_size)
+            .float()
+            .sum(dim=1)
+            .to(torch.bfloat16)
+        )
+
+        passed, percent_within, atol = check_accuracy(
+            direct_output,
+            reduced_output,
+        )
+        assert passed, (
+            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
+        for owner in range(num_owners):
+            gap_start = owner * output_physical_rows_per_owner + output_rows_per_owner
+            gap_end = (owner + 1) * output_physical_rows_per_owner
+            assert torch.isnan(physical_output[gap_start:gap_end]).all()
+
+        with pytest.raises(ValueError, match="pre-allocated"):
+            cute_dsl_fused_moe_nvfp4(
+                **kwargs,
+                direct_output=True,
+            )
+        with pytest.raises(ValueError, match="backing storage"):
+            cute_dsl_fused_moe_nvfp4(
+                **kwargs,
+                moe_output=torch.empty_like(reduced_output),
+                direct_output=True,
+                output_rows_per_owner=output_rows_per_owner,
+                output_physical_rows_per_owner=output_physical_rows_per_owner,
+            )
+
     def test_swiglu_oai_accuracy(self):
         """Accuracy test for the OAI SwiGLU epilogue variant."""
         from flashinfer import cute_dsl_fused_moe_nvfp4


### PR DESCRIPTION
## 📌 Description

Add an opt-in direct-output mode to the CuTeDSL NVFP4 fused MoE finalize path. Instead of atomically reducing expanded token/top-k contributions into token rows, GEMM2 applies the routing weights and writes each expanded row once into a caller-provided owner-sharded output mapping.

The caller supplies the logical rows reserved per owner and the physical row stride between owners. The wrapper validates the row-major view and backing-storage extent, the compiled-kernel and autotuning cache identities include the new layout, and every tuning trial uses a private physically-strided scratch allocation. The default finalize behavior is unchanged.

This is needed by vLLM SharedEP, where each owner's output allocation is mapped at a stable peer-visible address and W2 can write directly into canonical owner/token/top-k slots. The owner then performs a local top-k reduction. Related draft: https://github.com/vllm-project/vllm/pull/50392.

Performance on four GB200 GPUs, EP4, H=6144, I=2048, 64 local experts/rank, top-k=8, balanced routes, 20 warmups, 100 captured iterations/trial, five trials:

| Tokens/rank | Existing owner-pull output | Direct owner output | Saving |
| ---: | ---: | ---: | ---: |
| 1 | 57.443 us | 55.303 us | 2.141 us (3.73%) |
| 4 | 67.922 us | 65.721 us | 2.201 us (3.24%) |
| 16 | 107.438 us | 105.230 us | 2.209 us (2.06%) |
| 32 | 154.044 us | 151.178 us | 2.866 us (1.86%) |

At the request level on GLM-5.2 with EP4, batch one/rank, exactly 128 input and 128 output tokens, three warmups and five trials, direct output reduced median TPOT from 14.740 to 14.305 ms/token (0.435 ms/token, 2.95%) and median elapsed time from 2424.229 to 2361.013 ms (63.216 ms, 2.61%). The same 128 greedy tokens were produced on every rank and trial.

## 🔍 Related Issues

- vLLM SharedEP draft: https://github.com/vllm-project/vllm/pull/50392
- CUDA VMM dependency: https://github.com/vllm-project/vllm/pull/50009

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the applicable hooks on all five changed files and fixed the reported issues.

> If you are unsure about how to set up `pre-commit`, see the [pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] The direct-owner test passes on GB200: 1 passed, 380 deselected in 6.37 s after the one-time build.
- [x] Independent-reference maximum absolute error is 0.25; eager repeat, CUDA-graph replay, and graph-versus-eager checks are exact for T=1/4/16/32.

## Reviewer Notes

Please focus on the expanded-row to physical-owner-row address calculation and on the autotuner contract. Direct output must remain fail-closed: it requires a pre-allocated row-major view, a positive logical owner extent, a physical owner stride no smaller than that extent, and sufficient backing storage.

AI assistance was used for implementation, testing, benchmarking, and PR preparation. The submitting human should understand and be able to defend the layout and autotuning changes.
