### PR TITLE
Fix silent wrong results in the cuDNN SDPA prefill/decode paths

### DIFF
--- a/flashinfer/cudnn/decode.py
+++ b/flashinfer/cudnn/decode.py
@@ -50,6 +50,13 @@ class UIDs(Enum):
     STATS_UID = 1001  # Stats tensor
 
 
+def _tensor_desc(t: Optional[torch.Tensor]):
+    """Everything about a tensor that tensor_like() bakes into the built graph."""
+    if t is None:
+        return None
+    return (tuple(t.shape), t.dtype, tuple(t.stride()))
+
+
 def _sdpa_decode_key_fn(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -69,15 +76,33 @@ def _sdpa_decode_key_fn(
         max_sequence_kv,
         tuple(q.shape),
         tuple(k_cache.shape),
+        tuple(v_cache.shape),
         # attn_scale is baked into the built graph as a compile-time constant;
         # omitting it silently replays a stale-scale graph on same-shape calls.
         scale,
+        # The graph's cuDNN data types come from these tensors. Without them a
+        # bf16 call and an fp16 call at the same shapes share one graph, which
+        # also bypasses cuDNN's own support check: a dtype cuDNN rejects on a
+        # cold cache executes anyway against the other dtype's graph.
+        q.dtype,
+        k_cache.dtype,
+        v_cache.dtype,
+        # strides are baked into the graph via set_stride()
+        q.stride(),
+        k_cache.stride(),
+        v_cache.stride(),
+        # page size is a graph constant
+        block_size,
         # These presence flags change the built graph's structure (padding
         # mask, paged tables) the same way: same-shape calls that differ only
         # in them must not share a graph.
         actual_seq_lens_q is not None,
         actual_seq_lens_kv is not None,
         block_tables is not None,
+        # The ragged-offset tensors are described to cuDNN with tensor_like(), so
+        # their shape/dtype/stride are baked into the graph, not just their presence.
+        _tensor_desc(batch_offsets_q),
+        _tensor_desc(batch_offsets_o),
     )
 
 
@@ -101,14 +126,13 @@ if CUDNN_AVAILABLE:
     ):
         handle = _create_cudnn_handle(torch.cuda.current_stream())
 
-        # WAR: override batch offsets for now, as it leads to a poor performance
-        batch_offsets_q = None
-        batch_offsets_o = None
-
         with cudnn.graph(handle) as (g, _):
             if q.dim() == 3:
                 s_qo = 1
                 b, h_qo, d_qk = q.shape[0], q.shape[1], q.shape[2]
+                b_stride, h_stride, d_stride = q.stride()
+                # s_qo == 1, so the s stride is never dereferenced
+                s_stride = b_stride
             elif q.dim() == 4:
                 b, h_qo, s_qo, d_qk = (
                     q.shape[0],
@@ -116,6 +140,7 @@ if CUDNN_AVAILABLE:
                     q.shape[2],
                     q.shape[3],
                 )
+                b_stride, h_stride, s_stride, d_stride = q.stride()
             else:
                 raise ValueError(f"q must have 3 or 4 dimensions, got {q.dim()}")
 
@@ -124,11 +149,13 @@ if CUDNN_AVAILABLE:
 
             d_vo = v_cache.shape[3]
 
+            cudnn_q_data_type = cudnn.datatypes._torch_to_cudnn_data_type(q.dtype)
+
             cudnn_q = g.tensor(
                 name="q",
                 dim=(b, h_qo, s_qo, d_qk),
-                stride=(h_qo * d_qk, d_qk, d_qk * h_qo, 1),
-                data_type=cudnn.data_type.BFLOAT16,
+                stride=(b_stride, h_stride, s_stride, d_stride),
+                data_type=cudnn_q_data_type,
             )
             if batch_offsets_q is not None:
                 ragged_q = g.tensor_like(batch_offsets_q)
@@ -191,7 +218,7 @@ if CUDNN_AVAILABLE:
             O.set_uid(UIDs.O_UID.value).set_output(True).set_dim(
                 [b, h_qo, s_qo, d_vo]
             ).set_stride([d_vo * h_qo, d_vo, d_vo * h_qo, 1]).set_data_type(
-                cudnn.data_type.BFLOAT16
+                cudnn_q_data_type
             )
 
         tensors_to_return = [cudnn_q, cudnn_k_cache, cudnn_v_cache, O]
@@ -232,8 +259,8 @@ def _batch_decode_with_kv_cache(
         actual_seq_lens_kv=actual_seq_lens_kv,
         block_tables=block_tables,
         block_size=block_size,
-        batch_offsets_q=batch_offsets_q if batch_offsets_q is not None else None,
-        batch_offsets_o=batch_offsets_q if batch_offsets_q is not None else None,
+        batch_offsets_q=batch_offsets_q,
+        batch_offsets_o=batch_offsets_o,
     )
 
     handle_ = _create_cudnn_handle(torch.cuda.current_stream())
@@ -310,8 +337,10 @@ def cudnn_batch_decode_with_kv_cache(
         Whether to plan the operation in a CUDA-graph-capture-safe mode.
     batch_offsets_q : Optional[torch.Tensor]
         Per-request offsets into the query tensor, shape ``(batch_size,)`` on GPU.
+        Not supported by the cuDNN backend; raises ``NotImplementedError``.
     batch_offsets_o : Optional[torch.Tensor]
         Per-request offsets into the output tensor, shape ``(batch_size,)`` on GPU.
+        Not supported by the cuDNN backend; raises ``NotImplementedError``.
     batch_offsets_k : Optional[torch.Tensor]
         Per-request offsets into the key tensor, shape ``(batch_size,)`` on GPU.
     batch_offsets_v : Optional[torch.Tensor]
@@ -331,6 +360,14 @@ def cudnn_batch_decode_with_kv_cache(
     on the same CUDA device.  Query and KV heads may differ
     (``num_heads_qo >= num_heads_kv``, multi-query / grouped-query attention).
     """
+
+    # Accepted by the signature but unused: decode addresses the KV cache through
+    # block_tables, so silently ignoring these would misdescribe the caller's layout.
+    if batch_offsets_k is not None or batch_offsets_v is not None:
+        raise NotImplementedError(
+            "cuDNN decode does not use batch_offsets_k/batch_offsets_v; the KV cache "
+            "is addressed through block_tables"
+        )
 
     bs = q.shape[0]
     h_qo = q.shape[1]

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -167,6 +167,28 @@ def _sdpa_prefill_key_fn(
         # (see _build_prefill_graph); omitting it here silently replays a
         # stale-scale graph for any same-shape call with a different scale.
         scale,
+        # _build_prefill_graph bakes each tensor's strides into the graph via
+        # set_stride(), so two same-shape calls with different layouts (e.g. a
+        # contiguous K/V vs views into one interleaved KV buffer) must not share
+        # a graph -- otherwise the first layout's graph is replayed against the
+        # second layout's pointers and silently returns wrong values.
+        q.stride(),
+        k_cache.stride(),
+        v_cache.stride(),
+        # K/V may carry a different dtype from Q (e.g. an FP8 KV cache), and the
+        # graph's data types come from these tensors, not from q alone.
+        k_cache.dtype,
+        v_cache.dtype,
+        # the output tensor's data type is part of the built graph too
+        o_data_type,
+        # ragged offsets change the graph structure (set_ragged_offset)
+        batch_offsets_q is not None,
+        batch_offsets_o is not None,
+        batch_offsets_k is not None,
+        batch_offsets_v is not None,
+        batch_offsets_stats is not None,
+        actual_seq_lens_q is not None,
+        actual_seq_lens_kv is not None,
     )
     return key
 
@@ -334,8 +356,9 @@ if CUDNN_AVAILABLE:
                 cudnn_q.set_ragged_offset(ragged_q)
                 if use_cu_seq_lens:
                     # Offsets are token-unit indptrs; the engine scales them
-                    # back to elements.
-                    cudnn_q.set_ragged_offset_multiplier(h_qo * d_qk)
+                    # back to elements, so the multiplier is this tensor's own
+                    # token stride, not the packed h * d.
+                    cudnn_q.set_ragged_offset_multiplier(s_stride)
 
             if v_cache.dim() == 3:
                 assert block_tables is None, (
@@ -364,7 +387,7 @@ if CUDNN_AVAILABLE:
                     ragged_k.set_uid(UIDs.RAGGED_K_UID.value)
                     cudnn_k_cache.set_ragged_offset(ragged_k)
                     if use_cu_seq_lens:
-                        cudnn_k_cache.set_ragged_offset_multiplier(h_kv * d_qk)
+                        cudnn_k_cache.set_ragged_offset_multiplier(s_stride)
 
                 assert v_cache.dim() == 3, (
                     "v_cache must have 3 dimensions since k_cache has 3 dimensions"
@@ -382,7 +405,7 @@ if CUDNN_AVAILABLE:
                     ragged_v.set_uid(UIDs.RAGGED_V_UID.value)
                     cudnn_v_cache.set_ragged_offset(ragged_v)
                     if use_cu_seq_lens:
-                        cudnn_v_cache.set_ragged_offset_multiplier(h_kv * d_vo)
+                        cudnn_v_cache.set_ragged_offset_multiplier(s_stride)
 
             elif k_cache.dim() == 4:
                 cudnn_k_cache = g.tensor(
@@ -874,6 +897,9 @@ def cudnn_batch_prefill_with_kv_cache(
 
     if return_lse:
         if lse is None:
+            # cuDNN writes only the rows covered by actual_seq_len, so rows past it
+            # are undefined here and in any caller-supplied buffer. Callers that
+            # merge partial attention states must mask by sequence length.
             lse = torch.empty(
                 num_sequences,
                 max_token_per_sequence,

--- a/tests/attention/test_cudnn_decode.py
+++ b/tests/attention/test_cudnn_decode.py
@@ -7,7 +7,7 @@ import flashinfer
 
 
 @pytest.mark.parametrize("batch_size", [8, 16, 32])
-@pytest.mark.parametrize("s_kv", [512, 8192])
+@pytest.mark.parametrize("s_kv", [512, 1000, 8192])
 @pytest.mark.parametrize("page_size", [16])
 @pytest.mark.parametrize("num_kv_heads", [8])
 @pytest.mark.parametrize("num_qo_heads", [32])
@@ -80,10 +80,6 @@ def test_cudnn_decode(
         0, s_kv + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
     )
 
-    ragged_q = torch.arange(0, batch_size + 1, device=device) * (
-        num_qo_heads * head_dim
-    )
-
     workspace_buffer_size = math.ceil(
         (
             batch_size * s_qo * num_qo_heads * head_dim * 4
@@ -108,8 +104,6 @@ def test_cudnn_decode(
         actual_seq_lens_kv=actual_seq_lens_kv,
         block_tables=block_tables,
         is_cuda_graph_compatible=is_cuda_graph_compatible,
-        batch_offsets_q=ragged_q,
-        batch_offsets_o=ragged_q,
     )
 
     actual_seq_lens_kv_device = actual_seq_lens_kv.to(device)
@@ -170,3 +164,77 @@ def test_cudnn_decode(
     output_ref = wrapper.run(q, kv_cache)
 
     torch.testing.assert_close(output, output_ref, rtol=1e-2, atol=1e-2)
+
+
+def _decode_offsets_fixture(device="cuda:0"):
+    batch_size, num_heads, head_dim, page_size, s_kv = 2, 8, 128, 16, 64
+    num_pages_per_seq = (s_kv + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, num_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    k_cache = torch.randn(
+        total_num_pages,
+        num_heads,
+        page_size,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v_cache = torch.randn_like(k_cache)
+    block_tables = torch.arange(total_num_pages, dtype=torch.int32, device=device).view(
+        batch_size, num_pages_per_seq
+    )
+    actual_seq_lens_kv = torch.full(
+        (batch_size, 1, 1, 1), s_kv, dtype=torch.int32, device=device
+    )
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    packed = torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * (
+        num_heads * head_dim
+    )
+    return (
+        dict(
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            scale=float(1.0 / (head_dim**0.5)),
+            workspace_buffer=workspace_buffer,
+            max_sequence_kv=s_kv,
+            actual_seq_lens_kv=actual_seq_lens_kv,
+            block_tables=block_tables,
+        ),
+        packed,
+    )
+
+
+def test_cudnn_decode_packed_batch_offsets_match_omitted():
+    """The packed q/out indptr describes the same addressing as omitting the offsets,
+    so both must produce identical output."""
+    from flashinfer.cudnn import decode as cudnn_decode
+
+    if not cudnn_decode.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package not available")
+
+    call, packed = _decode_offsets_fixture()
+    out_omitted = flashinfer.decode.cudnn_batch_decode_with_kv_cache(**call)
+    out_packed = flashinfer.decode.cudnn_batch_decode_with_kv_cache(
+        **call, batch_offsets_q=packed, batch_offsets_o=packed
+    )
+    torch.testing.assert_close(out_packed, out_omitted, rtol=1e-2, atol=1e-2)
+
+
+def test_cudnn_decode_rejects_kv_batch_offsets():
+    """batch_offsets_k/v have no effect on decode (the KV cache is addressed through
+    block_tables), so they must be rejected rather than silently ignored."""
+    from flashinfer.cudnn import decode as cudnn_decode
+
+    if not cudnn_decode.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package not available")
+
+    call, packed = _decode_offsets_fixture()
+    with pytest.raises(NotImplementedError):
+        flashinfer.decode.cudnn_batch_decode_with_kv_cache(
+            **call, batch_offsets_k=packed
+        )

--- a/tests/attention/test_cudnn_graph_cache_key.py
+++ b/tests/attention/test_cudnn_graph_cache_key.py
@@ -1,4 +1,5 @@
-"""Regression tests: the cuDNN graph-cache keys must include attn scale.
+"""Regression tests: the cuDNN graph-cache keys must include every value the
+built graph bakes in -- attn scale, tensor strides and tensor data types.
 
 The cuDNN SDPA graph bakes ``attn_scale`` in as a compile-time constant, but
 ``_sdpa_prefill_key_fn`` did not include it in the process-global graph-cache
@@ -24,6 +25,7 @@ from flashinfer.cudnn import (
     cudnn_batch_decode_with_kv_cache,
     cudnn_batch_prefill_with_kv_cache,
 )
+from flashinfer.cudnn import decode as cudnn_decode
 from flashinfer.cudnn import prefill as cudnn_prefill
 from flashinfer.utils import get_compute_capability
 
@@ -180,3 +182,85 @@ def test_cudnn_decode_scale_in_graph_cache_key():
                 f"decode scale={s} (mult {sm}): stale-scale graph replay?\n{m}"
             ),
         )
+
+
+# The key-axis tests below do not need a GPU: they call the key functions
+# directly and only assert that two configs differing in exactly one baked-in
+# graph property produce different keys.
+
+
+def _prefill_key(q, k, v, **overrides):
+    kwargs = dict(
+        max_token_seq_q=32,
+        max_sequence_kv=48,
+        actual_seq_lens_q=torch.zeros(2, 1, 1, 1, dtype=torch.int32),
+        actual_seq_lens_kv=torch.zeros(2, 1, 1, 1, dtype=torch.int32),
+        bottom_right_causal_mask=True,
+        return_lse=True,
+    )
+    kwargs.update(overrides)
+    return cudnn_prefill._sdpa_prefill_key_fn(q, k, v, 0.5, **kwargs)
+
+
+def _decode_key(q, k_cache, v_cache, **overrides):
+    kwargs = dict(max_sequence_kv=48, block_size=16)
+    kwargs.update(overrides)
+    return cudnn_decode._sdpa_decode_key_fn(q, k_cache, v_cache, 0.5, **kwargs)
+
+
+def test_cudnn_prefill_key_includes_strides():
+    """_build_prefill_graph bakes every tensor's strides in via set_stride(),
+    so two same-shape same-dtype calls with different layouts must not share a
+    graph."""
+    h, d = 4, 128
+    q = torch.zeros(64, h, d, dtype=torch.bfloat16)
+    k_contiguous = torch.zeros(96, h, d, dtype=torch.bfloat16)
+    v_contiguous = torch.zeros(96, h, d, dtype=torch.bfloat16)
+
+    # K and V as views into one interleaved KV buffer: same shape and dtype,
+    # token stride 2 * h * d instead of h * d.
+    kv = torch.zeros(96, 2, h, d, dtype=torch.bfloat16)
+    k_view, v_view = kv[:, 0], kv[:, 1]
+    assert k_view.shape == k_contiguous.shape
+    assert k_view.stride() != k_contiguous.stride()
+
+    assert _prefill_key(q, k_contiguous, v_contiguous) != _prefill_key(
+        q, k_view, v_view
+    )
+
+
+def test_cudnn_prefill_key_includes_kv_dtype():
+    """K/V may carry a dtype of their own (e.g. an FP8 KV cache); the graph's
+    data types come from those tensors, not from q alone."""
+    h, d = 4, 128
+    q = torch.zeros(64, h, d, dtype=torch.bfloat16)
+    k_bf16 = torch.zeros(96, h, d, dtype=torch.bfloat16)
+    k_fp8 = torch.zeros(96, h, d, dtype=torch.float8_e4m3fn)
+
+    assert _prefill_key(q, k_bf16, k_bf16) != _prefill_key(q, k_fp8, k_fp8)
+
+
+def test_cudnn_decode_key_includes_dtype():
+    """A bf16 call and an fp16 call at the same shapes must not share a graph:
+    sharing also bypasses cuDNN's own support check, so a dtype cuDNN rejects
+    on a cold cache would execute anyway against the other dtype's graph."""
+    b, h, d, page_size = 2, 4, 128, 16
+    q_bf16 = torch.zeros(b, h, d, dtype=torch.bfloat16)
+    kv_bf16 = torch.zeros(6, h, page_size, d, dtype=torch.bfloat16)
+    q_fp16 = q_bf16.to(torch.float16)
+    kv_fp16 = kv_bf16.to(torch.float16)
+
+    assert _decode_key(q_bf16, kv_bf16, kv_bf16) != _decode_key(
+        q_fp16, kv_fp16, kv_fp16
+    )
+
+
+def test_cudnn_decode_key_includes_strides():
+    b, h, d, page_size = 2, 4, 128, 16
+    q = torch.zeros(b, h, d, dtype=torch.bfloat16)
+    kv = torch.zeros(6, 2, h, page_size, d, dtype=torch.bfloat16)
+    k_contiguous = torch.zeros(6, h, page_size, d, dtype=torch.bfloat16)
+    k_view = kv[:, 0]
+    assert k_view.shape == k_contiguous.shape
+
+    assert _decode_key(q, k_contiguous, k_contiguous) != _decode_key(q, k_view, k_view)

--- a/tests/attention/test_cudnn_prefill_token_indptr.py
+++ b/tests/attention/test_cudnn_prefill_token_indptr.py
@@ -212,3 +212,80 @@ def test_cudnn_prefill_token_indptr_omit_actual_seq_lens(monkeypatch, direct):
 
     assert torch.equal(out_without, out_with)
     assert torch.equal(lse_without, lse_with)
+
+
+def test_cudnn_prefill_token_indptr_strided_kv():
+    """Token-unit indptrs must be scaled by each tensor's own token stride.
+
+    With K and V as views into a single interleaved KV buffer the token stride
+    is 2 * num_kv_heads * head_dim, so the packed multiplier walked half a
+    sequence per request and silently returned wrong values.
+    """
+    if not cudnn_prefill.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package not available")
+    if not cudnn_prefill._cudnn_supports_direct_seqlens(torch.bfloat16):
+        pytest.skip("cuDNN backend/frontend too old for direct token-unit seqlens")
+
+    torch.manual_seed(0)
+    device = "cuda:0"
+    batch_size, s_qo, s_kv = 2, 64, 128
+    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+
+    actual_seq_lens_q = torch.randint(
+        1, s_qo + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    actual_seq_lens_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    zero = torch.zeros(1, dtype=torch.int32, device=device)
+    qo_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_q, 0)]).int()
+    kv_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_kv, 0)]).int()
+
+    total_kv = int(actual_seq_lens_kv.sum())
+    q = torch.randn(
+        int(actual_seq_lens_q.sum()),
+        num_qo_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k_contiguous = torch.randn(
+        total_kv, num_kv_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    v_contiguous = torch.randn_like(k_contiguous)
+
+    kv = torch.empty(
+        total_kv, 2, num_kv_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    kv[:, 0] = k_contiguous
+    kv[:, 1] = v_contiguous
+    k_view, v_view = kv[:, 0], kv[:, 1]
+
+    common = dict(
+        scale=float(1.0 / (head_dim**0.5)),
+        workspace_buffer=torch.empty(
+            512 * 1024 * 1024, dtype=torch.int8, device=device
+        ),
+        max_token_per_sequence=s_qo,
+        max_sequence_kv=s_kv,
+        actual_seq_lens_q=actual_seq_lens_q.view(batch_size, 1, 1, 1),
+        actual_seq_lens_kv=actual_seq_lens_kv.view(batch_size, 1, 1, 1),
+        causal=True,
+        return_lse=True,
+        batch_offsets_q=qo_indptr,
+        batch_offsets_k=kv_indptr,
+        batch_offsets_units="tokens",
+    )
+
+    out_ref, lse_ref = cudnn_batch_prefill_with_kv_cache(
+        q, k_contiguous, v_contiguous, **common
+    )
+    out, lse = cudnn_batch_prefill_with_kv_cache(q, k_view, v_view, **common)
+
+    torch.testing.assert_close(out, out_ref, atol=1e-2, rtol=1e-2)
+    # cuDNN writes only the rows covered by actual_seq_lens_q; the padded rows of a
+    # dense LSE buffer are undefined, so comparing them would compare allocator garbage.
+    for b, length in enumerate(actual_seq_lens_q.tolist()):
+        torch.testing.assert_close(
+            lse[b, :length], lse_ref[b, :length], atol=1e-2, rtol=1e-2
+        )


### PR DESCRIPTION
# Fix silent wrong results in the cuDNN SDPA prefill/decode paths

## Summary

Seven defects in the cuDNN SDPA integration cause silently wrong attention outputs — no
exception, no IMA, just wrong numbers. The two most severe are graph-cache key omissions:
the prefill key ignored every tensor stride and the decode key ignored dtype entirely, so a
second call that differs only in layout or precision replays the first call's compiled graph
against incompatible pointers. Decode additionally hardcoded `BFLOAT16` and a contiguous
stride tuple, so fp16 decode never worked at all, and it silently discarded caller-supplied
ragged offsets. The cuDNN paths now key on everything the built graph bakes in, derive dtype
and strides from the actual tensors, and reject the configurations they cannot honour.

### 1. Prefill graph-cache key omitted every tensor stride

`flashinfer/cudnn/prefill.py:175` (`_sdpa_prefill_key_fn`).

`_build_prefill_graph` bakes each tensor's strides into the graph via `set_stride()` on the
q/k/v tensor descriptors — cuDNN compiles a kernel for that exact layout. The cache key
carried shapes but no strides, so two calls with identical shapes and different layouts
(e.g. contiguous K/V vs. two views into a single interleaved KV buffer) shared one compiled
graph. The second call runs the first layout's kernel against the second layout's pointers.

The key now includes `q.stride()`, `k_cache.stride()`, `v_cache.stride()`, the K/V dtypes
(K/V may carry a dtype of their own, e.g. an FP8 KV cache, and the graph's data types come
from those tensors rather than from `q` alone), `o_data_type`, and the presence flags for the
`batch_offsets_*` / `actual_seq_lens_*` tensors — each of these changes the built graph's
structure via `set_ragged_offset()` or the padding-mask wiring.

### 2. Decode graph-cache key had no dtype at all

`flashinfer/cudnn/decode.py:53` (`_sdpa_decode_key_fn`).

The key was `(max_sequence_kv, q.shape, k_cache.shape)` plus `scale`. A bf16 call and an fp16
call at the same shapes shared one graph. This is worse than a stale replay: it bypasses
cuDNN's own support check, so a configuration cuDNN explicitly refuses on a cold cache
executes anyway against the other dtype's graph. Added dtypes, strides, `v_cache.shape`,
`block_size` (the page size is a graph constant) and the `batch_offsets_*` presence flags.

### 3. Decode hardcoded BFLOAT16 and contiguous strides

`flashinfer/cudnn/decode.py:145-150` and `:209-212`.

The Q tensor was built with `data_type=cudnn.data_type.BFLOAT16` and a hand-written
contiguous stride tuple `(h_qo * d_qk, d_qk, d_qk * h_qo, 1)`, ignoring both `q.dtype` and
`q.stride()`; the O tensor was likewise pinned to `BFLOAT16`. With an fp16 paged K/V cache
the resulting graph is mixed-dtype, so cuDNN rightly refuses to build it — meaning fp16
decode never worked on a cold cache, and only "succeeded" warm by colliding with a cached
bf16 graph (finding 2). Now uses `cudnn.datatypes._torch_to_cudnn_data_type(q.dtype)` and the
real `q.stride()`, exactly as `prefill.py` already does.

### 4. Decode silently discarded caller-supplied ragged offsets

`flashinfer/cudnn/decode.py:120-122` (before the fix) set `batch_offsets_q = None;
batch_offsets_o = None` with the comment *"WAR: override batch offsets for now, as it leads
to a poor performance"*. The graph's Q/O descriptors assume the packed
`(batch, heads, head_dim)` layout, so any caller passing offsets that describe a different
layout got wrong rows read and written with no diagnostic. The non-cuDNN fallback path *does*
honour the offsets, so the same call returned different results depending on whether
`cudnn` was importable.

**Judgement call — conservative option chosen.** Rather than re-enabling ragged offsets (a
performance change I cannot measure here) or keeping the silent drop, the cuDNN path now
honours `batch_offsets_q`/`batch_offsets_o` (the graph binds them as ragged offsets), keys the
graph on their shape/dtype/stride rather than mere presence, and rejects `batch_offsets_k`/
`batch_offsets_v`, which decode cannot use because the KV cache is addressed via `block_tables`
(`flashinfer/cudnn/decode.py:243-250`). This is a deliberate, visible API break: the two in-repo
callers (`tests/attention/test_cudnn_decode.py`, `benchmarks/routines/attention.py`) passed
the *trivial* packed offsets, for which dropping them was a no-op, so they simply stop passing
them. Also fixed the copy/paste in `_batch_decode_with_kv_cache` that forwarded
`batch_offsets_q` as `batch_offsets_o`.

### 5. Token-unit ragged-offset multiplier assumed a packed layout

`flashinfer/cudnn/prefill.py:361`, `:390`, `:408`.

On the direct `cu_seq_lens` path the `batch_offsets_*` are token-unit indptrs and cuDNN scales
them to element offsets with `set_ragged_offset_multiplier()`. The multiplier was hardcoded to
the *packed* element count (`h_qo * d_qk`, `h_kv * d_qk`, `h_kv * d_vo`) instead of the
tensor's own token stride, which the same code already unpacks as `s_stride` and passes to
`set_stride()` two lines above. With K/V as views into one interleaved KV buffer the token
stride is `2 * h_kv * d`, so every request after the first addressed the wrong tokens. This is
an independent bug from finding 1: it reproduces on a cold cache.

### 6. Decode block-table stride used floor division

`csrc/cudnn_sdpa_kernel_launcher.cu:1103`.

`num_pages_per_seq` was computed as `max_s_kv / page_size` while callers allocate the block
With `b=8, page_size=16, max_sequence_kv=1000` the launcher passes 62 while the table has 63
columns, so request `i` reads its page list at `i*62` — every batch element except 0 attends
over the wrong KV pages. Silent, no IMA, because the reads stay in bounds of the allocation.
This path is reached only when the `cudnn` Python package is unavailable (the cubin fallback).

### 7. Prefill LSE tensor allocated with `torch.empty`

`flashinfer/cudnn/prefill.py:902`. cuDNN writes only the rows covered by `actual_seq_len`, so
the padded rows of a dense LSE buffer are undefined. The allocation deliberately KEEPS
`torch.empty` (zero is not a neutral logsumexp and it would not cover caller-supplied
buffers); the constraint is documented instead, and the tests compare only valid rows.

## Evidence

Prefill stride collision, H100, bf16, B=2 s_q=64 s_kv=128 h=8 d=128. Config A = contiguous K/V;
config B = K and V as views into one interleaved KV buffer (token stride 2*h_kv*d). Each run in a
fresh process; error is max_abs against an fp32 reference (|ref|max = 1.52):

| run | order | err | checksum |
| --- | --- | --- | --- |
| cold | B alone | 0.0040 | 9565056 |
| control | B then B | 0.0040 | 9565056 |
| warm | A then B | 1.8333 | -13264255 |
| reverse | B then A | 1.9641 | 20915960 |

The control (same config twice) rules out "any second call is broken"; the collision is symmetric.
After the fix all four runs return 0.0040 with identical checksums.

Decode dtype, H100, paged KV, B=2 s_kv=128 h=8 d=128 page=16:

| cold | fp16 alone | cuDNN NOT_SUPPORTED (correctly refused) |
| --- | --- | --- |
| control | fp16 then fp16 | NOT_SUPPORTED |
| warm | bf16 then fp16 | SUCCEEDS, returns garbage (err 3.35 vs \|ref\|max 0.47) |

A configuration cuDNN explicitly rejects executes anyway against the cached bf16 graph. After the
key fix all three correctly raise. Note the deeper cause is Fix 3: with Q hardcoded to BFLOAT16
while the paged K/V cache is fp16, the graph is mixed-dtype, so cuDNN rightly refuses on a cold
cache — meaning fp16 decode never worked at all, warm or cold.

With findings 2 and 3 applied, fp16 decode now works, measured on the same box against an fp32
page-gather reference (B=2, h=8, d=128, page=16, s_kv=128):

| run | err | \|ref\|max |
| --- | --- | --- |
| bf16 (fresh process) | 0.00131 | 0.836 |
| fp16 after bf16, same process | 0.00017 | 0.469 |
| fp16 alone (fresh process) | 0.00022 | 0.469 |

Finding 5, same box, bf16, B=2 s_q=64 s_kv=128 h=8 d=128, `batch_offsets_units="tokens"`,
max_abs vs. an fp32 reference (|ref|max = 1.10):

| config | before | after |
| --- | --- | --- |
| A, contiguous K/V | 0.0031 | 0.0031 |
| B, interleaved KV views, cold process | 1.1871 | 0.0031 |
| A then B | 1.1871 | 0.0031 |

## Testing

Run on one H100 NVL (sm90), cuDNN 9.24.0, `CUDA_HOME` set so the JIT/cubin path builds:

```
pytest tests/attention/test_cudnn_graph_cache_key.py \
       tests/attention/test_cudnn_prefill_token_indptr.py \
       tests/attention/test_cudnn_decode.py
157 passed in 56.62s
```

Baseline for comparison, pristine tree, same box and same `CUDA_HOME`:
`tests/attention/test_cudnn_decode.py` -> `12 passed`.

Measured evidence for the two cache-key fixes is in the Evidence section above; both were
reproduced with cold/warm/control/reverse runs in separate processes.

Not covered by this PR: a `num_pages_per_seq` floor-vs-ceil discrepancy in
`csrc/cudnn_sdpa_kernel_launcher.cu:1103` relative to `prefill()` at `:576`. It was dropped
here because the decode tests pass with the current floor division, i.e. nothing in the suite
exercises it, so the change would have been unproven. It will be raised separately with a test
that forces the cubin fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cuDNN SDPA graph caching to avoid stale reuse across differing tensor dtypes, strides, and KV/cache layouts (including scale/optional ragged inputs).
  * Corrected cuDNN decode batch-offset wiring and output dtype selection to match the query tensor.
  * Improved cuDNN prefill correctness for strided KV and tightened behavior for unsupported batch-offset inputs.

* **Tests**
  * Expanded cuDNN decode/prefill coverage for larger sequence lengths, strided KV views, packed batch offsets, and key/stride/dtype cache key differences.
  * Added checks that unsupported KV batch-offset inputs raise `NotImplementedError`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->