### PR TITLE
test(msa_ops): fix stale split-K heuristic expectation on high-SM GPUs

### DIFF
--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -443,7 +443,10 @@ def test_proxy_split_k_heuristic():
     """The kv-block split factor is 1 once the base grid fills the SMs and grows
     as the base grid shrinks (low-batch decode), capped by max_k_tiles."""
     _skip_if_unsupported()
-    from flashinfer.msa_ops.proxy_score import _proxy_split_k_fp4
+    from flashinfer.msa_ops.proxy_score import (
+        _proxy_split_k_fp4,
+        _split_k_makespan_argmin,
+    )
 
     dev = torch.device("cuda")
     sm = torch.cuda.get_device_properties(dev).multi_processor_count
@@ -452,8 +455,10 @@ def test_proxy_split_k_heuristic():
     # Trivial / degenerate -> no split.
     assert _proxy_split_k_fp4(8, 1, dev) == 1
     assert _proxy_split_k_fp4(0, 512, dev) == 1
-    # Small base grid -> split enough to reach ~2 CTAs/SM, capped by max_k_tiles.
-    assert _proxy_split_k_fp4(8, 512, dev) == -(-2 * sm // 8)
+    # Small base grid -> split toward ~2 CTAs/SM, capped by max_k_tiles. Assert
+    # against the makespan model itself (wave/tile quantization make it diverge
+    # from a closed form); keeps this independent of the runtime SM count.
+    assert _proxy_split_k_fp4(8, 512, dev) == _split_k_makespan_argmin(8, 512, 2 * sm)
     assert _proxy_split_k_fp4(4, 8, dev) == 8  # clamped to max_k_tiles
 
 


### PR DESCRIPTION
Fixes #4276.

`test_proxy_split_k_heuristic` hard-coded the fp4 split factor as `ceil(2*sm/8)`, but `_proxy_split_k_fp4` delegates to the `_split_k_makespan_argmin` model, which caps at one CTA wave and breaks ties to the smaller split. The closed form ignores wave and KV-tile quantization, so it diverges from the implementation on most SM counts — e.g. it asserts 43 vs the correct 40 on a 170-SM RTX 5090 (sm120), where CI caught it.

**Change:** assert against `_split_k_makespan_argmin(8, 512, 2*sm)` instead of a closed form. `get_device_sm_count == multi_processor_count`, so this mirrors exactly what `_proxy_split_k_fp4` computes and stays correct regardless of the runtime SM count, while still exercising the real code path (residency target + degenerate-case guards). The other assertions in the test are unchanged.

**Not a kernel change** — test-only fix; the heuristic behavior is correct.

AI-assisted: root-caused and fixed with Claude Code.