### PR TITLE
fix(docker): stop pip from swapping the +cuXXX torch in CI image

### DIFF
--- a/docker/Dockerfile.cu132
+++ b/docker/Dockerfile.cu132
@@ -26,10 +26,9 @@ ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/c
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
-# use nightly/cu132 temporarily and change to cu132 when torch releases stable version
 COPY requirements.txt /install/requirements.txt
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
-RUN bash /install/install_python_packages.sh nightly/cu132
+RUN bash /install/install_python_packages.sh cu132
 
 # Install tilelang and cuda-tile
 RUN pip install tilelang cuda-tile

--- a/docker/Dockerfile.cu132.dev
+++ b/docker/Dockerfile.cu132.dev
@@ -45,10 +45,9 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-# use nightly/cu132 temporarily and change to cu132 when torch releases stable version
 COPY requirements.txt /install/requirements.txt
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
-RUN bash /install/install_python_packages.sh nightly/cu132 && pip3 install pre-commit
+RUN bash /install/install_python_packages.sh cu132 && pip3 install pre-commit
 
 # Install tilelang and cuda-tile
 RUN pip install tilelang cuda-tile

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -23,19 +23,46 @@ pip3 install --upgrade "setuptools>=77" "pip>=24"
 
 # Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
 CUDA_VERSION=${1:-cu128}
+CUDA_MAJOR="${CUDA_VERSION:2:2}"  # cu129 -> 12, cu130 -> 13
 
 # Install torch with specific CUDA version first, followed by others in requirements.txt, and then others.
 # This is to ensure that the torch version is compatible with the CUDA version.
 pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
+
+# Pin the +cuXXX torch: it is unpinned in requirements.txt, so a dependency
+# conflict lets pip swap it for the PyPI build of a different CUDA major.
+# Pin the dist version: the PyPI wheel installs as "2.13.0", not "2.13.0+cu130".
+python3 -c 'import importlib.metadata as m; print("torch==" + m.version("torch"))' \
+  > /install/torch-constraint.txt
+export PIP_CONSTRAINT=/install/torch-constraint.txt
+
+# Keep cuda-python on this image's CUDA major: before requirements.txt (floored
+# >=12.0, else pip takes CUDA-13 and drags torch along) and after (nvshmem4py
+# pins <=12.9).
+if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
+  CUDA_PYTHON="cuda-python==13.0"
+else
+  CUDA_PYTHON="cuda-python==12.*"
+fi
+
+pip3 install --upgrade "$CUDA_PYTHON"
 pip3 install -r /install/requirements.txt
 pip3 install responses pytest scipy build cuda-python nvshmem4py-cu12
+pip3 install --upgrade "$CUDA_PYTHON"
 
 # Install cudnn package based on CUDA version
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
-  pip3 install --upgrade cuda-python==13.0
   pip3 install --upgrade nvidia-cudnn-cu13
   pip3 install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
 else
-  pip3 install --upgrade cuda-python==12.*
   pip3 install --upgrade nvidia-cudnn-cu12
 fi
+
+# Fail the build if torch or cuda-python drifted off this image's CUDA major.
+python3 -c "
+import importlib.metadata as m, sys, torch
+for name, ver in (('torch', torch.version.cuda or ''), ('cuda-python', m.version('cuda-python'))):
+    if ver.split('.')[0] != '${CUDA_MAJOR}':
+        sys.exit(f'ERROR: {name} targets CUDA {ver}, but this image is CUDA ${CUDA_MAJOR}')
+print('CUDA ${CUDA_MAJOR} check passed:', torch.__version__)
+"

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -36,18 +36,21 @@ python3 -c 'import importlib.metadata as m; print("torch==" + m.version("torch")
   > /install/torch-constraint.txt
 export PIP_CONSTRAINT=/install/torch-constraint.txt
 
-# Keep cuda-python on this image's CUDA major: before requirements.txt (floored
-# >=12.0, else pip takes CUDA-13 and drags torch along) and after (nvshmem4py
-# pins <=12.9).
+# Pick the CUDA-major-matched packages: nvshmem4py-cuXX pins cuda-python to its
+# own major, so mixing them leaves a broken dependency graph. cuda-python is
+# installed before requirements.txt (floored >=12.0, else pip takes CUDA-13 and
+# drags torch along) and again after, since nvshmem4py can pull it back down.
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
   CUDA_PYTHON="cuda-python==13.0"
+  NVSHMEM4PY="nvshmem4py-cu13"
 else
   CUDA_PYTHON="cuda-python==12.*"
+  NVSHMEM4PY="nvshmem4py-cu12"
 fi
 
 pip3 install --upgrade "$CUDA_PYTHON"
 pip3 install -r /install/requirements.txt
-pip3 install responses pytest scipy build cuda-python nvshmem4py-cu12
+pip3 install responses pytest scipy build "$NVSHMEM4PY"
 pip3 install --upgrade "$CUDA_PYTHON"
 
 # Install cudnn package based on CUDA version

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -23,7 +23,8 @@ pip3 install --upgrade "setuptools>=77" "pip>=24"
 
 # Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
 CUDA_VERSION=${1:-cu128}
-CUDA_MAJOR="${CUDA_VERSION:2:2}"  # cu129 -> 12, cu130 -> 13
+CUDA_TAG="${CUDA_VERSION##*/}"    # cu129 -> cu129, nightly/cu132 -> cu132
+CUDA_MAJOR="${CUDA_TAG:2:2}"      # cu129 -> 12, cu132 -> 13
 
 # Install torch with specific CUDA version first, followed by others in requirements.txt, and then others.
 # This is to ensure that the torch version is compatible with the CUDA version.
@@ -32,9 +33,11 @@ pip3 install --force-reinstall torch --index-url https://download.pytorch.org/wh
 # Pin the +cuXXX torch: it is unpinned in requirements.txt, so a dependency
 # conflict lets pip swap it for the PyPI build of a different CUDA major.
 # Pin the dist version: the PyPI wheel installs as "2.13.0", not "2.13.0+cu130".
+# mktemp, not /install: the .dev images run this as a non-root USER.
+TORCH_CONSTRAINT="$(mktemp)"
 python3 -c 'import importlib.metadata as m; print("torch==" + m.version("torch"))' \
-  > /install/torch-constraint.txt
-export PIP_CONSTRAINT=/install/torch-constraint.txt
+  > "$TORCH_CONSTRAINT"
+export PIP_CONSTRAINT="$TORCH_CONSTRAINT"
 
 # Pick the CUDA-major-matched packages: nvshmem4py-cuXX pins cuda-python to its
 # own major, so mixing them leaves a broken dependency graph. cuda-python is


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The latest cu12 CI image `flashinfer-ci-cu129:20260728-e63fc61` shipped with `torch 2.13.0+cu130` inside a CUDA 12.9 container.
  
On a clean build, `cuda-python>=12.0` (requirements.txt) resolves to 13.3.x, whose `cuda-bindings~=13.3.1` conflicts with the `+cu129` torch's `cuda-toolkit==12.9.1`. pip backtracks on `torch` (also unpinned in requirements.txt) and swaps in the PyPI CUDA-13 wheel. The later `cuda-python==12.*` restores cuda-python but not torch.

FlashInfer's JIT modules link `libcublasLt.so.12`, but `torch.cuda.current_blas_handle()` now returns a cuBLAS-**13** handle, which cuBLASLt 12 rejects with `CUBLAS_STATUS_NOT_INITIALIZED`, which was observed in the CI of #4201

**The Fix**
1. Pin `cuda-python` to the image's CUDA major **before** `requirements.txt` (keeping the existing pin after it, since `nvshmem4py-cu12` pins `cuda-python<=12.9`).                                                                  
2. `PIP_CONSTRAINT` the installed `+cuXXX` torch for the rest of the build, so a re-resolution fails loudly instead of silently switching CUDA major.                                                                           
3. Assert at end of build that torch and cuda-python match the image's CUDA major.      

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability for CUDA-enabled Python environments.
  * Ensured PyTorch and CUDA Python packages match the image’s CUDA major version.
  * Added support for compatible CUDA 12 and CUDA 13 packages.
  * Added validation to detect incompatible CUDA package installations.
  * Preserved required CUDA-specific cuDNN and CUTLASS components.

* **Chores**
  * Updated CUDA 13.2 images to use the stable package channel for more predictable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->