### PR TITLE
feat(sm120): add native MXFP4 W4A4 fused MoE

### DIFF
--- a/benchmarks/bench_b12x_mxfp4_moe.py
+++ b/benchmarks/bench_b12x_mxfp4_moe.py
@@ -127,6 +127,15 @@ def main():
     parser.add_argument("--seed", type=int, default=20260730)
     args = parser.parse_args()
 
+    if (
+        any(num_tokens <= 0 for num_tokens in args.tokens)
+        or args.hidden_size <= 0
+        or args.intermediate_size <= 0
+        or args.num_experts <= 0
+        or args.top_k <= 0
+    ):
+        parser.error("tokens, dimensions, num-experts, and top-k must be positive")
+
     major, minor = torch.cuda.get_device_capability()
     if (major, minor) not in ((12, 0), (12, 1)):
         raise RuntimeError(f"b12x MXFP4 MoE requires SM120/SM121, got SM{major}{minor}")

--- a/benchmarks/bench_b12x_mxfp4_moe.py
+++ b/benchmarks/bench_b12x_mxfp4_moe.py
@@ -1,0 +1,239 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Report-only SM120/SM121 W4A4 fused-MoE benchmark.
+
+The default shape follows a DeepSeek-style expert:
+H=7168, I=2048, E=256, top-k=8, with token counts from decode to prefill.
+MXFP4 and NVFP4 use the same packed E2M1 weight bytes, BF16 inputs, routing
+IDs, and routing weights. Scale tensors use their native UE8M0/block-32 and
+E4M3/block-16 layouts. This avoids a large temporary BF16 weight allocation
+while keeping the performance comparison data-identical.
+
+Usage:
+    python benchmarks/bench_b12x_mxfp4_moe.py
+    python benchmarks/bench_b12x_mxfp4_moe.py --tokens 1 8 32
+"""
+
+import argparse
+
+import numpy as np
+import torch
+
+from flashinfer import B12xMoEWrapper
+from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
+    select_sm120_moe_backend,
+)
+from flashinfer.testing.utils import bench_gpu_time
+
+
+def _make_mma_scale_factors(
+    num_experts: int,
+    rows: int,
+    columns: int,
+    quant_mode: str,
+) -> torch.Tensor:
+    """Create native MMA-layout scale factors with decoded scale value 1."""
+    sf_vec_size = 32 if quant_mode == "mxfp4" else 16
+    m_tiles = (rows + 127) // 128
+    k_tiles = ((columns + sf_vec_size - 1) // sf_vec_size + 3) // 4
+    if quant_mode == "mxfp4":
+        storage = torch.full(
+            (num_experts, m_tiles, k_tiles, 32, 4, 4),
+            127,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+    else:
+        storage = torch.full(
+            (num_experts, m_tiles, k_tiles, 32, 4, 4),
+            1.0,
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+    return storage.permute(3, 4, 1, 5, 2, 0)
+
+
+def _make_weights(
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+):
+    generator = torch.Generator(device="cuda").manual_seed(2027)
+    w1 = torch.randint(
+        0,
+        256,
+        (num_experts, 2 * intermediate_size, hidden_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (num_experts, hidden_size, intermediate_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    )
+    alpha = torch.ones(num_experts, dtype=torch.float32, device="cuda")
+    return w1, w2, alpha
+
+
+def _tflops(
+    num_tokens: int,
+    top_k: int,
+    hidden_size: int,
+    intermediate_size: int,
+    latency_ms: float,
+) -> float:
+    # Gated FC1 has gate+up projections (2 GEMMs); FC2 adds one GEMM.
+    operations = 6 * num_tokens * top_k * hidden_size * intermediate_size
+    return operations * 1e-9 / latency_ms
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tokens",
+        nargs="+",
+        type=int,
+        default=[1, 8, 32, 128, 512, 2048],
+    )
+    parser.add_argument("--hidden-size", type=int, default=7168)
+    parser.add_argument("--intermediate-size", type=int, default=2048)
+    parser.add_argument("--num-experts", type=int, default=256)
+    parser.add_argument("--top-k", type=int, default=8)
+    parser.add_argument("--warmup-ms", type=int, default=20)
+    parser.add_argument("--repeat-ms", type=int, default=200)
+    parser.add_argument(
+        "--quant-modes",
+        nargs="+",
+        choices=["nvfp4", "mxfp4"],
+        default=["nvfp4", "mxfp4"],
+    )
+    parser.add_argument("--seed", type=int, default=20260730)
+    args = parser.parse_args()
+
+    major, minor = torch.cuda.get_device_capability()
+    if (major, minor) not in ((12, 0), (12, 1)):
+        raise RuntimeError(f"b12x MXFP4 MoE requires SM120/SM121, got SM{major}{minor}")
+    if args.hidden_size % 128 or args.intermediate_size % 128:
+        raise ValueError("hidden and intermediate sizes must be multiples of 128")
+
+    torch.manual_seed(args.seed)
+    w1, w2, alpha = _make_weights(
+        args.num_experts,
+        args.hidden_size,
+        args.intermediate_size,
+    )
+    scales = {
+        quant_mode: (
+            _make_mma_scale_factors(
+                args.num_experts,
+                2 * args.intermediate_size,
+                args.hidden_size,
+                quant_mode,
+            ),
+            _make_mma_scale_factors(
+                args.num_experts,
+                args.hidden_size,
+                args.intermediate_size,
+                quant_mode,
+            ),
+        )
+        for quant_mode in args.quant_modes
+    }
+    print(
+        "quant_mode,tokens,backend,latency_ms,tflops",
+        flush=True,
+    )
+    for num_tokens in args.tokens:
+        x = (
+            torch.randn(
+                num_tokens,
+                args.hidden_size,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            / 100
+        )
+        token_ids = (
+            torch.arange(num_tokens, device="cuda", dtype=torch.int32)[:, None]
+            * args.top_k
+            + torch.arange(args.top_k, device="cuda", dtype=torch.int32)[None, :]
+        ) % args.num_experts
+        token_weights = torch.full(
+            (num_tokens, args.top_k),
+            1.0 / args.top_k,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        for quant_mode in args.quant_modes:
+            w1_sf, w2_sf = scales[quant_mode]
+            moe = B12xMoEWrapper(
+                num_experts=args.num_experts,
+                top_k=args.top_k,
+                hidden_size=args.hidden_size,
+                intermediate_size=args.intermediate_size,
+                use_cuda_graph=True,
+                max_num_tokens=num_tokens,
+                quant_mode=quant_mode,
+            )
+
+            def run():
+                return moe.run(
+                    x=x,
+                    w1_weight=w1,
+                    w1_weight_sf=w1_sf,
+                    w1_alpha=alpha,
+                    fc2_input_scale=(alpha[:1] if quant_mode == "nvfp4" else None),
+                    w2_weight=w2,
+                    w2_weight_sf=w2_sf,
+                    w2_alpha=alpha,
+                    token_selected_experts=token_ids,
+                    token_final_scales=token_weights,
+                )
+
+            run()
+            measurements = bench_gpu_time(
+                run,
+                dry_run_time_ms=args.warmup_ms,
+                repeat_time_ms=args.repeat_ms,
+                use_cuda_graph=True,
+                cold_l2_cache=False,
+            )
+            latency_ms = float(np.median(measurements))
+            backend = select_sm120_moe_backend(
+                num_tokens=num_tokens,
+                num_topk=args.top_k,
+                quant_mode=quant_mode,
+            )
+            achieved_tflops = _tflops(
+                num_tokens,
+                args.top_k,
+                args.hidden_size,
+                args.intermediate_size,
+                latency_ms,
+            )
+            print(
+                f"{quant_mode},{num_tokens},{backend},"
+                f"{latency_ms:.6f},{achieved_tflops:.2f}",
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_b12x_mxfp4_moe.py
+++ b/benchmarks/bench_b12x_mxfp4_moe.py
@@ -22,6 +22,13 @@ IDs, and routing weights. Scale tensors use their native UE8M0/block-32 and
 E4M3/block-16 layouts. This avoids a large temporary BF16 weight allocation
 while keeping the performance comparison data-identical.
 
+This script measures one rank and does not simulate expert-parallel dispatch.
+For EP comparisons, pass the number of experts resident on that rank and choose
+--tokens/--top-k so that tokens * top_k matches the routed pairs
+actually processed by that rank. Under balanced routing this is approximately
+the model top-k divided by the EP size, but it can be fractional or imbalanced;
+the default --top-k 8 is a single-rank workload and is not EP-aware.
+
 Usage:
     python benchmarks/bench_b12x_mxfp4_moe.py
     python benchmarks/bench_b12x_mxfp4_moe.py --tokens 1 8 32

--- a/flashinfer/cute_dsl/fp4_common.py
+++ b/flashinfer/cute_dsl/fp4_common.py
@@ -2675,10 +2675,57 @@ def quantize_block_fp4_fast(
 
 
 @cute.jit
+def quantize_and_pack_32(
+    values: cute.Tensor, inv_scale: Float32
+) -> Tuple[Uint64, Uint64]:
+    """Scale and pack one OCP MXFP4 block (32 E2M1 values)."""
+    q = cute.make_rmem_tensor((32,), Float32)
+    for i in cutlass.range_constexpr(32):
+        q[i] = values[i] * inv_scale
+
+    p0 = cvt_e2m1x8_f32(q[0], q[1], q[2], q[3], q[4], q[5], q[6], q[7])
+    p1 = cvt_e2m1x8_f32(q[8], q[9], q[10], q[11], q[12], q[13], q[14], q[15])
+    p2 = cvt_e2m1x8_f32(q[16], q[17], q[18], q[19], q[20], q[21], q[22], q[23])
+    p3 = cvt_e2m1x8_f32(q[24], q[25], q[26], q[27], q[28], q[29], q[30], q[31])
+    return (
+        (Uint64(p1) << Uint64(32)) | Uint64(p0),
+        (Uint64(p3) << Uint64(32)) | Uint64(p2),
+    )
+
+
+@cute.jit
+def quantize_block_mxfp4(
+    values: cute.Tensor, max_abs: Float32
+) -> Tuple[Uint64, Uint64, Uint8]:
+    """Quantize 32 floats using an OCP MXFP4 UE8M0 block scale.
+
+    E2M1's largest finite magnitude is 6, so UE8M0 encodes the power-of-two
+    ceiling of ``max_abs / 6``.  The returned pair contains 16 packed bytes.
+    """
+    scale_u32 = cvt_f32_to_ue8m0(max_abs * rcp_approx_ftz(Float32(FLOAT4_E2M1_MAX)))
+    scale_byte = Uint8(scale_u32 & Uint32(0xFF))
+    packed_lo = Uint64(0)
+    packed_hi = Uint64(0)
+    if scale_u32 != Uint32(0):
+        inv_scale = ue8m0_to_output_scale(scale_u32)
+        packed_lo, packed_hi = quantize_and_pack_32(values, inv_scale)
+    return packed_lo, packed_hi, scale_byte
+
+
+@cute.jit
 def max_abs_16(values: cute.Tensor) -> Float32:
     """Compute the maximum absolute value of 16 float32 values."""
     result = fabs_f32(values[0])
     for i in cutlass.range_constexpr(1, 16):
+        result = fmax_f32(result, fabs_f32(values[i]))
+    return result
+
+
+@cute.jit
+def max_abs_32(values: cute.Tensor) -> Float32:
+    """Compute the maximum absolute value of 32 float32 values."""
+    result = fabs_f32(values[0])
+    for i in cutlass.range_constexpr(1, 32):
         result = fmax_f32(result, fabs_f32(values[i]))
     return result
 

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -116,14 +116,14 @@ def b12x_fused_moe(
         Per-expert global scale for FC2.
     fc2_input_scale : Optional[torch.Tensor]
         Global scale for FC2 input quantization.  Required for
-        ``quant_mode="nvfp4"``; accepted but ignored for
-        ``quant_mode="w4a16"``.
+        ``quant_mode="nvfp4"``; ignored for ``"mxfp4"`` and
+        ``"w4a16"``.
     input_global_scale : Optional[torch.Tensor]
         Global scale for FC1 input quantization, scalar or
         ``[num_experts]``.  Lets ``w1_alpha`` carry the exact fp32 weight
         scale; folded into the output multiplier internally.  Defaults to
         ``w1_alpha``, which then serves both roles.  Ignored for
-        ``quant_mode="w4a16"``.
+        ``quant_mode="mxfp4"`` and ``quant_mode="w4a16"``.
     num_local_experts : Optional[int]
         Local experts for expert parallelism.  Defaults to ``num_experts``.
     output : Optional[torch.Tensor]
@@ -144,8 +144,9 @@ def b12x_fused_moe(
         Backward-compatible alias for ``quant_mode``.  ``"fp4"`` selects
         ``quant_mode="nvfp4"``; ``"bf16"`` selects ``quant_mode="w4a16"``.
     quant_mode : Optional[str]
-        Quantization mode, ``"nvfp4"`` / ``"w4a4"`` or ``"w4a16"``.  When set,
-        selects the backend and internal workspace family.
+        Quantization mode, ``"nvfp4"`` / ``"w4a4"``, ``"mxfp4"``, or
+        ``"w4a16"``. When set, selects the backend and internal workspace
+        family.
     source_format : str
         Source weight format for ``quant_mode="w4a16"`` — ``"modelopt"`` or
         ``"compressed_tensors"``.  Defaults to ``"modelopt"``.
@@ -251,8 +252,8 @@ class B12xMoEWrapper:
             "relu2". Default: "silu". swiglu_alpha/beta/limit apply to swigluoai.
         activation_precision: Backward-compatible alias for quant_mode.
             "fp4" selects quant_mode="nvfp4"; "bf16" selects quant_mode="w4a16".
-        quant_mode: Quantization mode, "nvfp4"/"w4a4" or "w4a16". When set,
-            this selects the backend and internal workspace family.
+        quant_mode: Quantization mode, "nvfp4"/"w4a4", "mxfp4", or "w4a16".
+            When set, this selects the backend and internal workspace family.
         source_format: Source weight format for quant_mode="w4a16".
             Supports "modelopt" and "compressed_tensors". Default: "modelopt".
 
@@ -322,7 +323,8 @@ class B12xMoEWrapper:
             Backward-compatible alias for ``quant_mode``.  ``"fp4"`` selects
             ``quant_mode="nvfp4"``; ``"bf16"`` selects ``quant_mode="w4a16"``.
         quant_mode : Optional[str]
-            Quantization mode, ``"nvfp4"`` / ``"w4a4"`` or ``"w4a16"``.
+            Quantization mode, ``"nvfp4"`` / ``"w4a4"``, ``"mxfp4"``, or
+            ``"w4a16"``.
         source_format : str
             Source weight format for ``quant_mode="w4a16"`` —
             ``"modelopt"`` (default) or ``"compressed_tensors"``.
@@ -427,6 +429,7 @@ class B12xMoEWrapper:
                 num_tokens=self.max_num_tokens,
                 num_topk=self.top_k,
                 activation_precision=self.activation_precision,
+                quant_mode=self.quant_mode,
             )
             == "dynamic"
             and self.num_local_experts == self.num_experts
@@ -574,6 +577,7 @@ class B12xMoEWrapper:
                     num_tokens=num_tokens,
                     num_topk=self.top_k,
                     activation_precision=self.activation_precision,
+                    quant_mode=self.quant_mode,
                 )
                 == "dynamic"
             ):
@@ -597,7 +601,7 @@ class B12xMoEWrapper:
                 self._folded_w1_alpha_key = fold_key
             w1_alpha = self._folded_w1_alpha
 
-        if self.quant_mode == "nvfp4":
+        if self.quant_mode != "w4a16":
             # Cache weight views; invalidate if weight pointers change.
             weight_key = (
                 self.quant_mode,
@@ -631,6 +635,7 @@ class B12xMoEWrapper:
                         self.hidden_size,
                         w1_weight.size(0),
                         is_gated,
+                        self.quant_mode,
                     )
                     self._padded_weight_key = padded_weight_key
                 (
@@ -653,6 +658,7 @@ class B12xMoEWrapper:
                     n=n_eff,
                     k=self.hidden_size,
                     activation_precision=self.activation_precision,
+                    quant_mode=self.quant_mode,
                 )
                 self._weight_key = weight_key
         else:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/_moe_dynamic/generic.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/_moe_dynamic/generic.py
@@ -1,5 +1,5 @@
 """
-MoEDynamicKernel — queue-driven routed NVFP4 MoE kernel for SM120/SM121.
+MoEDynamicKernel — queue-driven routed W4A4 MoE kernel for SM120/SM121.
 
 Ported from the b12x kernel library to FlashInfer.
 
@@ -84,6 +84,7 @@ from flashinfer.cute_dsl.fp4_common import (
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
+    quantize_block_mxfp4,
     get_ptr_as_int64,
     st_global_f32,
     st_global_i32,
@@ -287,7 +288,7 @@ class MoEDynamicKernel:
         self.swiglu_beta = float(swiglu_beta)
         self.swiglu_limit = float(swiglu_limit) if swiglu_limit is not None else None
         self.share_input_across_experts = share_input_across_experts
-        tile_k = sf_vec_size * 8
+        tile_k = 128 if sf_vec_size == 32 else sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         # Scale factors come in 128-row atoms, so for sub-128 MMA tiles the
         # TMA atoms and smem are built at max(128, tile) and the kernel
@@ -356,11 +357,18 @@ class MoEDynamicKernel:
 
         self._hidden_size = hidden_size
 
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        if self.sf_vec_size == 32:
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_layout = cute.make_layout(self.atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
@@ -983,7 +991,7 @@ class MoEDynamicKernel:
         scatter_base = scatter_output.iterator.toint()
         row_counts = launch_params.row_counts
         num_experts = Int32(row_counts.shape[0])
-        sf_blocks_per_row = cols // Int32(16)
+        sf_blocks_per_row = cols // Int32(self.sf_vec_size)
         output_bytes_per_row = cols // Int32(2)
         cols_u32 = cols // Int32(2)
         scatter_output_u32 = cute.recast_tensor(scatter_output, cutlass.Uint32)
@@ -991,7 +999,8 @@ class MoEDynamicKernel:
         num_topk = total_pairs // num_tokens
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
-        num_k_tiles = (cols + Int32(63)) // Int32(64)
+        sf_k_tile = Int32(self.sf_vec_size * 4)
+        num_k_tiles = (cols + sf_k_tile - Int32(1)) // sf_k_tile
         route_gate_tile_cnt = launch_params.gate_tile_cnt
         task_slice_chunk = Int32(_TASK_SLICE_CHUNK)
         materialized_num_groups = (
@@ -1176,10 +1185,14 @@ class MoEDynamicKernel:
 
                             sf_idx = lane_id
                             while sf_idx < sf_blocks_per_row:
-                                block_start = sf_idx * Int32(16)
-                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_start = sf_idx * Int32(self.sf_vec_size)
+                                values = cute.make_rmem_tensor(
+                                    (self.sf_vec_size,), cutlass.Float32
+                                )
                                 block_max = cutlass.Float32(0.0)
-                                for elem_idx in cutlass.range_constexpr(16):
+                                for elem_idx in cutlass.range_constexpr(
+                                    self.sf_vec_size
+                                ):
                                     value = cutlass.Float32(
                                         a_input[
                                             token_idx, block_start + Int32(elem_idx)
@@ -1187,16 +1200,22 @@ class MoEDynamicKernel:
                                     )
                                     values[elem_idx] = value
                                     block_max = fmax_f32(block_max, fabs_f32(value))
-                                packed64 = Uint64(0)
                                 scale_byte = Uint8(0)
-                                if self.fast_math:
-                                    packed64, scale_byte = quantize_block_fp4_fast(
-                                        values, block_max, gs_value
+                                if cutlass.const_expr(self.sf_vec_size == 32):
+                                    packed_lo, packed_hi, scale_byte = (
+                                        quantize_block_mxfp4(values, block_max)
                                     )
                                 else:
-                                    packed64, scale_byte = quantize_block_fp4(
-                                        values, block_max, gs_value
-                                    )
+                                    packed_lo = Uint64(0)
+                                    packed_hi = Uint64(0)
+                                    if self.fast_math:
+                                        packed_lo, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed_lo, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
 
                                 k_tile_idx = sf_idx // Int32(4)
                                 scale_k_base = k_tile_idx * Int32(32 * 4 * 4) + (
@@ -1205,13 +1224,21 @@ class MoEDynamicKernel:
                                 for cache_slot in cutlass.range_constexpr(8):
                                     output_offset = route_output_base[
                                         cache_slot
-                                    ] + sf_idx * Int32(8)
+                                    ] + sf_idx * Int32(self.sf_vec_size // 2)
                                     st_global_u64(
                                         get_ptr_as_int64(
                                             packed_a_storage, output_offset
                                         ),
-                                        packed64,
+                                        packed_lo,
                                     )
+                                    if cutlass.const_expr(self.sf_vec_size == 32):
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage,
+                                                output_offset + Int32(8),
+                                            ),
+                                            packed_hi,
+                                        )
                                     scale_storage[
                                         route_scale_base[cache_slot] + scale_k_base
                                     ] = scale_byte
@@ -1219,10 +1246,14 @@ class MoEDynamicKernel:
                         else:
                             sf_idx = lane_id
                             while sf_idx < sf_blocks_per_row:
-                                block_start = sf_idx * Int32(16)
-                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_start = sf_idx * Int32(self.sf_vec_size)
+                                values = cute.make_rmem_tensor(
+                                    (self.sf_vec_size,), cutlass.Float32
+                                )
                                 block_max = cutlass.Float32(0.0)
-                                for elem_idx in cutlass.range_constexpr(16):
+                                for elem_idx in cutlass.range_constexpr(
+                                    self.sf_vec_size
+                                ):
                                     value = cutlass.Float32(
                                         a_input[
                                             token_idx, block_start + Int32(elem_idx)
@@ -1230,16 +1261,22 @@ class MoEDynamicKernel:
                                     )
                                     values[elem_idx] = value
                                     block_max = fmax_f32(block_max, fabs_f32(value))
-                                packed64 = Uint64(0)
                                 scale_byte = Uint8(0)
-                                if self.fast_math:
-                                    packed64, scale_byte = quantize_block_fp4_fast(
-                                        values, block_max, gs_value
+                                if cutlass.const_expr(self.sf_vec_size == 32):
+                                    packed_lo, packed_hi, scale_byte = (
+                                        quantize_block_mxfp4(values, block_max)
                                     )
                                 else:
-                                    packed64, scale_byte = quantize_block_fp4(
-                                        values, block_max, gs_value
-                                    )
+                                    packed_lo = Uint64(0)
+                                    packed_hi = Uint64(0)
+                                    if self.fast_math:
+                                        packed_lo, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed_lo, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
 
                                 topk_slot = Int32(0)
                                 while topk_slot < num_topk:
@@ -1249,14 +1286,22 @@ class MoEDynamicKernel:
                                     )
                                     output_offset = (
                                         phys_row * output_bytes_per_row
-                                        + sf_idx * Int32(8)
+                                        + sf_idx * Int32(self.sf_vec_size // 2)
                                     )
                                     st_global_u64(
                                         get_ptr_as_int64(
                                             packed_a_storage, output_offset
                                         ),
-                                        packed64,
+                                        packed_lo,
                                     )
+                                    if cutlass.const_expr(self.sf_vec_size == 32):
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage,
+                                                output_offset + Int32(8),
+                                            ),
+                                            packed_hi,
+                                        )
                                     # Scale storage is tiled in 128-row SF
                                     # atoms, not MMA tiles.
                                     k_tile_idx = sf_idx // Int32(4)
@@ -1324,10 +1369,14 @@ class MoEDynamicKernel:
                                     gs_value = cutlass.Float32(1.0) / gs_value
                             sf_idx = lane_id
                             while sf_idx < sf_blocks_per_row:
-                                block_start = sf_idx * Int32(16)
-                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_start = sf_idx * Int32(self.sf_vec_size)
+                                values = cute.make_rmem_tensor(
+                                    (self.sf_vec_size,), cutlass.Float32
+                                )
                                 block_max = cutlass.Float32(0.0)
-                                for elem_idx in cutlass.range_constexpr(16):
+                                for elem_idx in cutlass.range_constexpr(
+                                    self.sf_vec_size
+                                ):
                                     value = cutlass.Float32(
                                         a_input[
                                             token_idx, block_start + Int32(elem_idx)
@@ -1335,25 +1384,41 @@ class MoEDynamicKernel:
                                     )
                                     values[elem_idx] = value
                                     block_max = fmax_f32(block_max, fabs_f32(value))
-                                packed64 = Uint64(0)
                                 scale_byte = Uint8(0)
-                                if self.fast_math:
-                                    packed64, scale_byte = quantize_block_fp4_fast(
-                                        values, block_max, gs_value
+                                if cutlass.const_expr(self.sf_vec_size == 32):
+                                    packed_lo, packed_hi, scale_byte = (
+                                        quantize_block_mxfp4(values, block_max)
                                     )
                                 else:
-                                    packed64, scale_byte = quantize_block_fp4(
-                                        values, block_max, gs_value
-                                    )
+                                    packed_lo = Uint64(0)
+                                    packed_hi = Uint64(0)
+                                    if self.fast_math:
+                                        packed_lo, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed_lo, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
 
                                 output_offset = (
                                     phys_tile * Int32(self.tile_shape_mnk[0])
                                     + row % Int32(self.tile_shape_mnk[0])
-                                ) * output_bytes_per_row + sf_idx * Int32(8)
+                                ) * output_bytes_per_row + sf_idx * Int32(
+                                    self.sf_vec_size // 2
+                                )
                                 st_global_u64(
                                     get_ptr_as_int64(packed_a_storage, output_offset),
-                                    packed64,
+                                    packed_lo,
                                 )
+                                if cutlass.const_expr(self.sf_vec_size == 32):
+                                    st_global_u64(
+                                        get_ptr_as_int64(
+                                            packed_a_storage,
+                                            output_offset + Int32(8),
+                                        ),
+                                        packed_hi,
+                                    )
 
                                 # Scale storage is tiled in 128-row SF atoms,
                                 # not MMA tiles.
@@ -2082,7 +2147,9 @@ class MoEDynamicKernel:
                     # Activation + quant into sA
                     sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                     packed_cols = Int32(self.tile_shape_mnk[2] // 2)
-                    sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
+                    sf_blocks_per_row = Int32(
+                        self.tile_shape_mnk[2] // self.sf_vec_size
+                    )
                     gs_value = global_scale[task_expert_idx].to(cutlass.Float32)
                     if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
                         0.0
@@ -2156,11 +2223,13 @@ class MoEDynamicKernel:
                             local_row = quant_idx // sf_blocks_per_row
                             row = rows_offset + local_row
                             sf_block = quant_idx - local_row * sf_blocks_per_row
-                            block_start = sf_block * Int32(16)
+                            block_start = sf_block * Int32(self.sf_vec_size)
 
-                            values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                            values = cute.make_rmem_tensor(
+                                (self.sf_vec_size,), cutlass.Float32
+                            )
                             block_max = cutlass.Float32(0.0)
-                            for elem_idx in cutlass.range_constexpr(16):
+                            for elem_idx in cutlass.range_constexpr(self.sf_vec_size):
                                 value = cutlass.Float32(
                                     sC[
                                         local_row,
@@ -2171,27 +2240,42 @@ class MoEDynamicKernel:
                                 values[elem_idx] = value
                                 block_max = fmax_f32(block_max, fabs_f32(value))
 
-                            packed64 = Uint64(0)
                             scale_byte = Uint8(0)
-                            if self.fast_math:
-                                packed64, scale_byte = quantize_block_fp4_fast(
-                                    values, block_max, gs_value
+                            if cutlass.const_expr(self.sf_vec_size == 32):
+                                packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
+                                    values, block_max
                                 )
                             else:
-                                packed64, scale_byte = quantize_block_fp4(
-                                    values, block_max, gs_value
-                                )
-                            packed_base = sf_block << Int32(3)
+                                packed_lo = Uint64(0)
+                                packed_hi = Uint64(0)
+                                if self.fast_math:
+                                    packed_lo, scale_byte = quantize_block_fp4_fast(
+                                        values, block_max, gs_value
+                                    )
+                                else:
+                                    packed_lo, scale_byte = quantize_block_fp4(
+                                        values, block_max, gs_value
+                                    )
+                            packed_base = sf_block * Int32(self.sf_vec_size // 2)
                             dst_pcol = row & Int32(63)
                             xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
                             row_high = row >> Int32(6)
-                            for byte_idx in cutlass.range_constexpr(8):
+                            for byte_idx in cutlass.range_constexpr(
+                                self.sf_vec_size // 2
+                            ):
                                 src_pcol = packed_base + Int32(byte_idx)
                                 dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
                                 dst_flat = dst_row * packed_cols + dst_pcol
-                                byte_val = Uint8(
-                                    (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                                )
+                                if cutlass.const_expr(byte_idx < 8):
+                                    byte_val = Uint8(
+                                        (packed_lo >> Uint64(byte_idx * 8))
+                                        & Uint64(0xFF)
+                                    )
+                                else:
+                                    byte_val = Uint8(
+                                        (packed_hi >> Uint64((byte_idx - 8) * 8))
+                                        & Uint64(0xFF)
+                                    )
                                 sA_u8[dst_flat] = byte_val
 
                             outer_m_idx = row % Int32(32)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -59,6 +59,7 @@ from .moe_w4a16_prepare import (
 # Constants
 # ---------------------------------------------------------------------------
 _NVFP4_BLOCK_SIZE = 16
+_MXFP4_BLOCK_SIZE = 32
 _LEVEL_TILE_M = 128
 _LEVEL_TILE_N = 128
 # Must equal the kernel's task materialization granularity or the task
@@ -198,6 +199,7 @@ def _normalize_quant_mode(
         "fp4": "nvfp4",
         "nvfp4": "nvfp4",
         "w4a4": "nvfp4",
+        "mxfp4": "mxfp4",
         "bf16": "w4a16",
         "w4a16": "w4a16",
     }
@@ -205,8 +207,17 @@ def _normalize_quant_mode(
         return aliases[normalized]
     except KeyError as exc:
         raise ValueError(
-            f"quant_mode must be 'nvfp4'/'w4a4' or 'w4a16' (got {quant_mode!r})."
+            "quant_mode must be 'nvfp4'/'w4a4', 'mxfp4', or 'w4a16' "
+            f"(got {quant_mode!r})."
         ) from exc
+
+
+def _sf_params_for_quant_mode(quant_mode: str):
+    """Return (vector size, CuTe scale dtype) for a W4A4 mode."""
+    mode = _normalize_quant_mode(quant_mode)
+    if mode == "mxfp4":
+        return _MXFP4_BLOCK_SIZE, cutlass.Float8E8M0FNU
+    return _NVFP4_BLOCK_SIZE, cutlass.Float8E4M3FN
 
 
 def _activation_precision_from_quant_mode(quant_mode: str) -> str:
@@ -215,7 +226,7 @@ def _activation_precision_from_quant_mode(quant_mode: str) -> str:
 
 def _normalize_source_format_for_quant_mode(source_format: str, quant_mode: str) -> str:
     normalized = _normalize_source_format(source_format)
-    if quant_mode == "nvfp4" and normalized == "compressed_tensors":
+    if quant_mode != "w4a16" and normalized == "compressed_tensors":
         raise ValueError(
             "source_format='compressed_tensors' requires quant_mode='w4a16'."
         )
@@ -339,6 +350,7 @@ class Sm120StaticMoEWorkspace:
     num_topk: int
     device: torch.device
     activation_precision: str
+    quant_mode: str
 
     # Buffers
     row_counts: torch.Tensor  # [state_E] int32
@@ -385,6 +397,7 @@ def allocate_sm120_static_workspace(
     num_topk: int,
     device: torch.device,
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> Sm120StaticMoEWorkspace:
     """Allocate workspace buffers for the SM120 static MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -394,8 +407,10 @@ def allocate_sm120_static_workspace(
             "use allocate_sm120_moe_workspace(..., quant_mode='w4a16') for W4A16."
         )
 
+    quant_mode = _normalize_quant_mode(quant_mode, activation_precision)
+    sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     rows_pad_k = _align_up(max_rows, 128)
-    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
     _check_memref_limit("static packed_input", state_E * max_rows * (k // 2))
     _check_memref_limit("static packed_input_scale", state_E * rows_pad_k * cols_pad_k)
     packed_input = torch.empty(
@@ -411,6 +426,7 @@ def allocate_sm120_static_workspace(
         num_topk=num_topk,
         device=device,
         activation_precision=activation_precision,
+        quant_mode=quant_mode,
         row_counts=torch.zeros(state_E, dtype=torch.int32, device=device),
         token_map=torch.zeros(state_E, max_rows, dtype=torch.int32, device=device),
         token_weights=torch.zeros(
@@ -431,7 +447,6 @@ def allocate_sm120_static_workspace(
     )
 
     # Finalize views
-    sf_dtype = cutlass.Float8E4M3FN
     workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0).view(
         torch.float4_e2m1fn_x2
     )
@@ -514,6 +529,7 @@ def _get_weight_views(
     n: int,
     k: int,
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> _WeightViews:
     """Create permuted weight views for the static kernel.
 
@@ -521,6 +537,8 @@ def _get_weight_views(
     via a single TMA descriptor.
     """
     activation_precision = _normalize_activation_precision(activation_precision)
+    quant_mode = _normalize_quant_mode(quant_mode, activation_precision)
+    sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     tile_n = _level_tile_n(activation_precision)
     # The kernel splits w13 into gate/up halves by tile index. This only works
     # when the boundary between halves lands on a tile-aligned column.
@@ -532,6 +550,7 @@ def _get_weight_views(
 
     key = (
         activation_precision,
+        quant_mode,
         w1_fp4.data_ptr(),
         w1_blockscale.data_ptr(),
         w1_alphas.data_ptr(),
@@ -545,10 +564,18 @@ def _get_weight_views(
         w1_rows = w1_fp4.shape[1]  # 2*n for gated, n for non-gated
         cached = (
             convert_sf_from_mma_layout(
-                w1_blockscale, m=w1_rows, k=k, num_groups=w1_fp4.shape[0]
+                w1_blockscale,
+                m=w1_rows,
+                k=k,
+                num_groups=w1_fp4.shape[0],
+                sf_vec_size=sf_vec_size,
             ).contiguous(),
             convert_sf_from_mma_layout(
-                w2_blockscale, m=k, k=n, num_groups=w2_fp4.shape[0]
+                w2_blockscale,
+                m=k,
+                k=n,
+                num_groups=w2_fp4.shape[0],
+                sf_vec_size=sf_vec_size,
             ).contiguous(),
             w1_alphas.contiguous().to(torch.float32),
             w2_alphas.contiguous().to(torch.float32),
@@ -567,7 +594,6 @@ def _get_weight_views(
     w13_sf_contiguous, down_sf_contiguous, w1_alpha, w2_alpha = cached
 
     # Permute [E, w1_rows, k//2] -> [w1_rows, k//2, E] (view, no copy).
-    sf_dtype = cutlass.Float8E4M3FN
     w13 = w1_fp4.permute(1, 2, 0)
     down = w2_fp4.permute(1, 2, 0)
     return _WeightViews(
@@ -618,6 +644,8 @@ def _kernel_source_files() -> Tuple[str, ...]:
     from flashinfer.cute_dsl import utils as cute_dsl_utils
     from flashinfer.gemm.kernels import dense_blockscaled_gemm_sm120_b12x
 
+    from ._moe_dynamic import gated as moe_dynamic_gated
+    from ._moe_dynamic import generic as moe_dynamic_generic
     from . import (
         moe_activation,
         moe_dynamic_kernel,
@@ -631,6 +659,8 @@ def _kernel_source_files() -> Tuple[str, ...]:
         moe_static_kernel.__file__,
         moe_micro_kernel.__file__,
         moe_dynamic_kernel.__file__,
+        moe_dynamic_gated.__file__,
+        moe_dynamic_generic.__file__,
         cute_dsl_utils.__file__,
         fp4_common.__file__,
         dense_blockscaled_gemm_sm120_b12x.__file__,
@@ -658,6 +688,7 @@ def _disk_kernel_name(prefix: str, cache_key: Tuple) -> str:
 def _static_kernel_cache_key(
     *,
     activation_precision: str,
+    quant_mode: str,
     state_E: int,
     weight_E: int,
     m: int,
@@ -683,6 +714,7 @@ def _static_kernel_cache_key(
     return (
         "static",
         activation_precision,
+        quant_mode,
         state_E,
         weight_E,
         m,
@@ -704,6 +736,7 @@ def _static_kernel_cache_key(
 
 def _micro_kernel_cache_key(
     *,
+    quant_mode: str,
     state_E: int,
     weight_E: int,
     m: int,
@@ -727,6 +760,7 @@ def _micro_kernel_cache_key(
     """The micro kernel's cache key (see :func:`_static_kernel_cache_key`)."""
     return (
         "micro",
+        quant_mode,
         state_E,
         weight_E,
         m,
@@ -752,6 +786,7 @@ def _micro_kernel_cache_key(
 def _dynamic_kernel_cache_key(
     *,
     activation_precision: str,
+    quant_mode: str,
     E: int,
     k: int,
     n: int,
@@ -776,6 +811,7 @@ def _dynamic_kernel_cache_key(
     return (
         "dynamic",
         activation_precision,
+        quant_mode,
         E,
         k,
         n,
@@ -814,6 +850,7 @@ def _get_static_kernel(
     swiglu_beta: float = 1.0,
     swiglu_limit: float | None = None,
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ):
     """Compile (or retrieve cached) the SM120 static MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -821,7 +858,8 @@ def _get_static_kernel(
         raise ValueError(
             "internal routing error: quant_mode='w4a16' reached the NVFP4 static compiler"
         )
-    sf_vec_size = 16
+    quant_mode = _normalize_quant_mode(quant_mode, activation_precision)
+    sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     sm_count = get_num_sm(torch.device("cuda"))
     mac = (
         mac_override
@@ -837,6 +875,7 @@ def _get_static_kernel(
 
     cache_key = _static_kernel_cache_key(
         activation_precision=activation_precision,
+        quant_mode=quant_mode,
         state_E=state_E,
         weight_E=weight_E,
         m=m,
@@ -860,7 +899,6 @@ def _get_static_kernel(
 
     ab_dtype = cutlass.Float4E2M1FN
     weight_dtype = cutlass.Float4E2M1FN
-    sf_dtype = cutlass.Float8E4M3FN
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
@@ -881,7 +919,7 @@ def _get_static_kernel(
     w1_rows = (2 if is_gated else 1) * n  # 2*n for gated, n for non-gated
 
     rows_pad_k = _align_up(max_rows, 128)
-    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
 
     # Build fake tensors for compilation
     a_input_fake = cute.runtime.make_fake_compact_tensor(
@@ -1068,9 +1106,10 @@ def _get_micro_kernel(
     swiglu_alpha: float = 1.702,
     swiglu_beta: float = 1.0,
     swiglu_limit: float | None = None,
+    quant_mode: str = "nvfp4",
 ):
     """Compile (or retrieve cached) the SM120 micro MoE kernel."""
-    sf_vec_size = 16
+    sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     sm_count = get_num_sm(torch.device("cuda"))
     mac = (
         mac_override
@@ -1083,6 +1122,7 @@ def _get_micro_kernel(
     mma_tiler_mn = _select_moe_mma_tiler_mn(routed_rows, n)
 
     cache_key = _micro_kernel_cache_key(
+        quant_mode=quant_mode,
         state_E=state_E,
         weight_E=weight_E,
         m=m,
@@ -1108,7 +1148,6 @@ def _get_micro_kernel(
         return cached
 
     ab_dtype = cutlass.Float4E2M1FN
-    sf_dtype = cutlass.Float8E4M3FN
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
@@ -1131,7 +1170,7 @@ def _get_micro_kernel(
     w1_rows = (2 if is_gated else 1) * n
 
     rows_pad_k = _align_up(max_rows, 128)
-    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
 
     # Build fake tensors for compilation (identical to static kernel)
     a_input_fake = cute.runtime.make_fake_compact_tensor(
@@ -1418,6 +1457,7 @@ def launch_sm120_static_moe(
     swiglu_beta: float = 1.0,
     swiglu_limit: float | None = None,
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> torch.Tensor:
     """Launch the SM120 static, micro, or direct micro MoE kernel.
 
@@ -1429,6 +1469,7 @@ def launch_sm120_static_moe(
     """
     _check_memref_limit("scatter_output", scatter_output.numel())
     activation_precision = _normalize_activation_precision(activation_precision)
+    quant_mode = _normalize_quant_mode(quant_mode, activation_precision)
     if activation_precision == "bf16":
         raise ValueError(
             "internal routing error: quant_mode='w4a16' reached the NVFP4 static launcher"
@@ -1645,6 +1686,7 @@ def launch_sm120_static_moe(
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
+            quant_mode=quant_mode,
         )
     else:
         compiled, mac = _get_static_kernel(
@@ -1664,6 +1706,7 @@ def launch_sm120_static_moe(
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
         launch_ids = flat_ids
 
@@ -1745,6 +1788,7 @@ class Sm120DynamicMoEWorkspace:
     num_topk: int
     device: torch.device
     activation_precision: str
+    quant_mode: str
 
     # Core buffers
     row_counts: torch.Tensor
@@ -1814,6 +1858,7 @@ def allocate_sm120_dynamic_workspace(
     device: torch.device,
     activation_precision: str = "fp4",
     activation: str = "silu",
+    quant_mode: str = "nvfp4",
 ) -> Sm120DynamicMoEWorkspace:
     """Allocate workspace buffers for the SM120 dynamic MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -1822,6 +1867,8 @@ def allocate_sm120_dynamic_workspace(
             "allocate_sm120_dynamic_workspace only supports quant_mode='nvfp4'; "
             "use allocate_sm120_moe_workspace(..., quant_mode='w4a16') for W4A16."
         )
+    quant_mode = _normalize_quant_mode(quant_mode, activation_precision)
+    sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     tile_m = _select_dynamic_tile_m(routed_rows, state_E, activation)
     physical_tiles, _, max_tasks = _dynamic_task_geometry(
         state_E,
@@ -1834,7 +1881,7 @@ def allocate_sm120_dynamic_workspace(
     # The kernel addresses activation scales in 128-row SF atoms regardless of
     # tile_m, so the scale plane must cover the last partial atom.
     scale_rows = _align_up(rows_padded, 128)
-    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
     _check_memref_limit("dynamic packed_input", rows_padded * (k // 2))
     _check_memref_limit("dynamic packed_input_scale", scale_rows * cols_pad_k)
     packed_input = torch.empty(1, rows_padded, k // 2, dtype=torch.uint8, device=device)
@@ -1848,6 +1895,7 @@ def allocate_sm120_dynamic_workspace(
         num_topk=num_topk,
         device=device,
         activation_precision=activation_precision,
+        quant_mode=quant_mode,
         routed_rows_capacity=routed_rows,
         physical_tiles_capacity=physical_tiles,
         task_capacity=max_tasks,
@@ -1871,7 +1919,6 @@ def allocate_sm120_dynamic_workspace(
     )
 
     # Finalize views
-    sf_dtype = cutlass.Float8E4M3FN
     workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0).view(
         torch.float4_e2m1fn_x2
     )
@@ -1894,7 +1941,14 @@ def allocate_sm120_dynamic_workspace(
 class _DynamicMoELaunch:
     """Thin JIT wrapper that makes num_tokens and max_rows runtime Int32."""
 
-    def __init__(self, kernel, k, num_topk, activation_precision: str = "fp4"):
+    def __init__(
+        self,
+        kernel,
+        k,
+        num_topk,
+        activation_precision: str = "fp4",
+        sf_vec_size: int = _NVFP4_BLOCK_SIZE,
+    ):
         activation_precision = _normalize_activation_precision(activation_precision)
         if activation_precision == "bf16":
             raise ValueError(
@@ -1904,7 +1958,7 @@ class _DynamicMoELaunch:
         self._k = k
         self._packed_storage_cols = k // 2
         self._num_topk = num_topk
-        self._cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+        self._cols_pad_k = _align_up(k // sf_vec_size, 4)
 
     @cute.jit
     def __call__(
@@ -2045,6 +2099,7 @@ def _get_dynamic_kernel(
     activation_precision: str = "fp4",
     share_input_across_experts: bool = False,
     tile_m: int = _LEVEL_TILE_M,
+    quant_mode: str = "nvfp4",
 ):
     """Compile (or retrieve cached) the SM120 dynamic MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -2060,7 +2115,8 @@ def _get_dynamic_kernel(
         and activation_precision == "fp4"
         and num_topk <= _MAX_SHARED_INPUT_TOPK
     )
-    sf_vec_size = 16
+    quant_mode = _normalize_quant_mode(quant_mode, activation_precision)
+    sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     sm_count = get_num_sm(torch.device("cuda"))
     base_mac = min(get_max_active_clusters(1), sm_count)
     tuned_mac = _lookup_mac_ladder(_DYNAMIC_MAC_LADDER, m * num_topk)
@@ -2071,6 +2127,7 @@ def _get_dynamic_kernel(
 
     cache_key = _dynamic_kernel_cache_key(
         activation_precision=activation_precision,
+        quant_mode=quant_mode,
         E=E,
         k=k,
         n=n,
@@ -2095,7 +2152,6 @@ def _get_dynamic_kernel(
 
     scratch_dtype = cutlass.Float4E2M1FN
     weight_dtype = cutlass.Float4E2M1FN
-    sf_dtype = cutlass.Float8E4M3FN
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
@@ -2118,6 +2174,7 @@ def _get_dynamic_kernel(
         k=k,
         num_topk=num_topk,
         activation_precision=activation_precision,
+        sf_vec_size=sf_vec_size,
     )
 
     topk_ids_cutlass_dtype = (
@@ -2286,6 +2343,7 @@ def launch_sm120_dynamic_moe(
     swiglu_beta: float = 1.0,
     swiglu_limit: float | None = None,
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> torch.Tensor:
     """Launch the SM120 dynamic MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -2294,6 +2352,7 @@ def launch_sm120_dynamic_moe(
             "internal routing error: quant_mode='w4a16' reached the NVFP4 dynamic launcher"
         )
     _check_memref_limit("scatter_output", scatter_output.numel())
+    quant_mode = _normalize_quant_mode(quant_mode, activation_precision)
     flat_ids = topk_ids.view(-1).to(torch.int32)
     flat_weights = topk_weights.view(-1).to(torch.float32)
     input_gs_is_shared = input_gs.numel() == 1
@@ -2319,6 +2378,7 @@ def launch_sm120_dynamic_moe(
         activation_precision=activation_precision,
         share_input_across_experts=input_gs_is_shared,
         tile_m=workspace.tile_m,
+        quant_mode=quant_mode,
     )
 
     # Dynamic kernel: runtime-shaped args are DataPointer (pass data_ptr()),
@@ -2834,6 +2894,7 @@ def allocate_sm120_moe_workspace(
             ),
             num_topk=int(num_topk),
             activation_precision=activation_precision,
+            quant_mode=mode,
         )
     if backend == "dynamic":
         return allocate_sm120_dynamic_workspace(
@@ -2846,6 +2907,7 @@ def allocate_sm120_moe_workspace(
             device=device,
             activation_precision=activation_precision,
             activation=activation,
+            quant_mode=mode,
         )
     if backend == "static":
         return allocate_sm120_static_workspace(
@@ -2857,6 +2919,7 @@ def allocate_sm120_moe_workspace(
             num_topk=num_topk,
             device=device,
             activation_precision=activation_precision,
+            quant_mode=mode,
         )
     raise ValueError(f"unsupported SM120 MoE backend {backend!r}")
 
@@ -2960,11 +3023,14 @@ def _pad_intermediate_to_tile(
     h,
     num_experts,
     is_gated,
+    quant_mode="nvfp4",
 ):
-    """Zero-pad NVFP4 weights + scale factors so the intermediate size is a
+    """Zero-pad W4A4 weights + scale factors so the intermediate size is a
     multiple of ``tile`` (gate/up tile-split requirement); padded channels are
     zero, so the result is numerically identical.
     """
+    quant_mode = _normalize_quant_mode(quant_mode)
+    sf_vec_size, _ = _sf_params_for_quant_mode(quant_mode)
     n_pad = ((n + tile - 1) // tile) * tile
     if n_pad == n:
         return w1_weight, w1_weight_sf, w2_weight, w2_weight_sf, fc2_input_scale, n
@@ -2976,6 +3042,7 @@ def _pad_intermediate_to_tile(
         h,
         E,
         bool(is_gated),
+        quant_mode,
         w1_weight.data_ptr(),
         w1_weight_sf.data_ptr(),
         w2_weight.data_ptr(),
@@ -2987,18 +3054,44 @@ def _pad_intermediate_to_tile(
         return cached
 
     def mma_to_logical(sf, m, k):
-        sw = convert_sf_from_mma_layout(sf, m=m, k=k, num_groups=E)
+        sw = convert_sf_from_mma_layout(
+            sf,
+            m=m,
+            k=k,
+            num_groups=E,
+            sf_vec_size=sf_vec_size,
+        )
         m_pad = ((m + 127) // 128) * 128
         sw = sw.reshape(E, m_pad, -1)
-        cb = (k + SF_VEC_SIZE - 1) // SF_VEC_SIZE
+        cb = (k + sf_vec_size - 1) // sf_vec_size
+        if quant_mode == "mxfp4":
+            cols_padded = ((cb + 3) // 4) * 4
+            return torch.stack(
+                [
+                    sw[e]
+                    .reshape(m_pad // 128, cols_padded // 4, 32, 4, 4)
+                    .permute(0, 3, 2, 1, 4)
+                    .contiguous()
+                    .reshape(m_pad, cols_padded)[:m, :cb]
+                    for e in range(E)
+                ],
+                0,
+            )
         return torch.stack(
             [unswizzle_block_scale(sw[e], rows=m, cols_blocks=cb) for e in range(E)], 0
         )
 
     def logical_to_mma(log, m, k):
         sw = torch.stack([swizzle_block_scale(log[e]) for e in range(E)], 0)
-        sw2d = sw.reshape(E * sw.shape[1], sw.shape[2]).to(torch.float8_e4m3fn)
-        return convert_sf_to_mma_layout(sw2d, m=m, k=k, num_groups=E)
+        scale_dtype = torch.uint8 if quant_mode == "mxfp4" else torch.float8_e4m3fn
+        sw2d = sw.reshape(E * sw.shape[1], sw.shape[2]).to(scale_dtype)
+        return convert_sf_to_mma_layout(
+            sw2d,
+            m=m,
+            k=k,
+            num_groups=E,
+            sf_vec_size=sf_vec_size,
+        )
 
     def pad_dim(t, dim, old, new):
         if new == old:
@@ -3026,8 +3119,8 @@ def _pad_intermediate_to_tile(
     # w2 reduces over the intermediate dim: pad its packed columns + SF columns.
     w2p = pad_dim(w2_weight, 2, n // 2, n_pad // 2)
     log2 = mma_to_logical(w2_weight_sf, m=h, k=n)
-    cb_n = (n + SF_VEC_SIZE - 1) // SF_VEC_SIZE
-    cb_np = (n_pad + SF_VEC_SIZE - 1) // SF_VEC_SIZE
+    cb_n = (n + sf_vec_size - 1) // sf_vec_size
+    cb_np = (n_pad + sf_vec_size - 1) // sf_vec_size
     w2_sf_p = logical_to_mma(pad_dim(log2, 2, cb_n, cb_np), m=h, k=n_pad)
 
     if fc2_input_scale_src is not None and fc2_input_scale_src.numel() == n:
@@ -3097,8 +3190,10 @@ def launch_sm120_moe(
     # w1_weight.size(1) is 2*n for gated or n for non-gated
     intermediate_size = w1_weight.size(1) // 2 if is_gated else w1_weight.size(1)
     n = intermediate_size
+    if quant_mode == "mxfp4" and k % 128 != 0:
+        raise ValueError(f"MXFP4 b12x hidden_size ({k}) must be a multiple of 128.")
 
-    # NVFP4 kernels need padded intermediate size.
+    # W4A4 kernels need a tile-aligned gate/up split.
     if quant_mode != "w4a16" and n % _LEVEL_TILE_N != 0 and _weight_views is None:
         (
             w1_weight,
@@ -3118,6 +3213,7 @@ def launch_sm120_moe(
             k,
             w1_weight.size(0),
             is_gated,
+            quant_mode,
         )
 
     routed_rows = num_tokens * top_k
@@ -3145,9 +3241,15 @@ def launch_sm120_moe(
         )
 
     if fc2_input_scale is None:
-        raise ValueError("fc2_input_scale is required when quant_mode='nvfp4'.")
-    down_input_scale = fc2_input_scale
-    if input_global_scale is not None:
+        if quant_mode == "nvfp4":
+            raise ValueError("fc2_input_scale is required when quant_mode='nvfp4'.")
+        # MXFP4 has no tensor-wide FC2 input scale. Reuse an existing
+        # per-expert tensor because the shared kernel signature still carries
+        # the argument; the MXFP4 quantizer ignores it.
+        down_input_scale = w2_alpha
+    else:
+        down_input_scale = fc2_input_scale
+    if quant_mode == "nvfp4" and input_global_scale is not None:
         input_gs = input_global_scale
         if _weight_views is None:
             # Alpha must carry input_gs back or the output magnitude is wrong.
@@ -3171,6 +3273,7 @@ def launch_sm120_moe(
             n=n,
             k=k,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
     )
 
@@ -3187,6 +3290,12 @@ def launch_sm120_moe(
             raise ValueError(
                 "pre-allocated workspace activation_precision does not match "
                 f"requested activation_precision={activation_precision!r}."
+            )
+        workspace_quant_mode = getattr(workspace, "quant_mode", quant_mode)
+        if workspace_quant_mode != quant_mode:
+            raise ValueError(
+                "pre-allocated workspace quant_mode does not match "
+                f"requested quant_mode={quant_mode!r}."
             )
         if isinstance(workspace, Sm120DynamicMoEWorkspace):
             if num_local_experts != num_experts:
@@ -3205,6 +3314,7 @@ def launch_sm120_moe(
             num_tokens=num_tokens,
             num_topk=top_k,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
         # The dynamic kernel indexes row_counts/expert_write_rows directly with
         # topk_ids but those buffers are sized with num_local_experts. Unless
@@ -3248,6 +3358,7 @@ def launch_sm120_moe(
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
     else:
         return launch_sm120_static_moe(
@@ -3271,4 +3382,5 @@ def launch_sm120_moe(
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -461,7 +461,11 @@ def allocate_sm120_static_workspace(
 
     # Direct micro reads weights by global expert id, so its planes are only
     # useful without EP remapping.
-    if state_E == weight_E and _direct_micro_candidate(k, n, num_topk, weight_E):
+    if (
+        quant_mode == "nvfp4"
+        and state_E == weight_E
+        and _direct_micro_candidate(k, n, num_topk, weight_E)
+    ):
         dm_rows = min(max_rows, _MICRO_MAX_TOKENS * num_topk)
         # The epoch-based barriers restore their slots after each launch, so
         # the zeroed allocation is the only reset needed (graph-replay safe).
@@ -1506,7 +1510,7 @@ def launch_sm120_static_moe(
     # Direct micro takes its band before the MMA micro decision. It reads
     # weights by global expert id, so EP shapes keep the compact path.
     use_direct_micro = (
-        activation_precision == "fp4"
+        quant_mode == "nvfp4"
         and workspace.state_E == num_experts
         and workspace.dm_barrier_count is not None
         and workspace.dm_barrier_count.numel() >= routed_rows + num_tokens * 16
@@ -1517,6 +1521,10 @@ def launch_sm120_static_moe(
     )
     if _FORCED_BACKEND is not None:
         if _FORCED_BACKEND == "direct_micro":
+            if quant_mode != "nvfp4":
+                raise ValueError(
+                    "forced direct_micro backend only supports quant_mode=nvfp4"
+                )
             if workspace.dm_barrier_count is None or not (
                 MoEDirectMicroKernel.is_supported(num_tokens, k, n, top_k, num_experts)
             ):

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -1109,6 +1109,7 @@ def _get_micro_kernel(
     quant_mode: str = "nvfp4",
 ):
     """Compile (or retrieve cached) the SM120 micro MoE kernel."""
+    quant_mode = _normalize_quant_mode(quant_mode)
     sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     sm_count = get_num_sm(torch.device("cuda"))
     mac = (
@@ -3064,6 +3065,7 @@ def _pad_intermediate_to_tile(
         m_pad = ((m + 127) // 128) * 128
         sw = sw.reshape(E, m_pad, -1)
         cb = (k + sf_vec_size - 1) // sf_vec_size
+        # MXFP4 logical scales remain raw UE8M0 bytes.
         if quant_mode == "mxfp4":
             cols_padded = ((cb + 3) // 4) * 4
             return torch.stack(
@@ -3077,6 +3079,7 @@ def _pad_intermediate_to_tile(
                 ],
                 0,
             )
+        # NVFP4 logical scales are decoded float32 magnitudes.
         return torch.stack(
             [unswizzle_block_scale(sw[e], rows=m, cols_blocks=cb) for e in range(E)], 0
         )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -1,5 +1,5 @@
 """
-MoEMicroKernel — micro-scheduled routed NVFP4 MoE kernel for SM120/SM121 (Blackwell).
+MoEMicroKernel — micro-scheduled routed W4A4 MoE kernel for SM120/SM121.
 
 Ported from the b12x kernel library to FlashInfer.
 
@@ -114,6 +114,7 @@ from flashinfer.cute_dsl.fp4_common import (
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
+    quantize_block_mxfp4,
     get_ptr_as_int64,
     st_global_f32,
     st_global_i32,
@@ -394,7 +395,7 @@ class MoEMicroKernel:
         self.share_input_across_experts = share_input_across_experts
         self.share_expert_scales = share_expert_scales
         self.single_token = single_token
-        tile_k = sf_vec_size * 8
+        tile_k = 128 if sf_vec_size == 32 else sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
         self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
@@ -526,11 +527,18 @@ class MoEMicroKernel:
 
         self._hidden_size = hidden_size
 
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        if self.sf_vec_size == 32:
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_layout = cute.make_layout((2, 2, 1))
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
@@ -544,8 +552,9 @@ class MoEMicroKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
+        atom_shape = (2, 2, 1)
+        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * atom_shape[1])
         self.num_k_blocks = self.tile_shape_mnk[2] // 64
 
         sfa_smem = sm120_make_smem_layout_sfa(
@@ -1002,7 +1011,7 @@ class MoEMicroKernel:
         num_tokens = Int32(a_input.shape[0])
         cols = Int32(a_input.shape[1])
         num_experts = Int32(row_counts.shape[0])
-        sf_blocks_per_row = cols // Int32(16)
+        sf_blocks_per_row = cols // Int32(self.sf_vec_size)
         output_bytes_per_row = cols // Int32(2)
         max_rows = Int32(token_map.shape[1])
         total_pairs = Int32(topk_ids.shape[0])
@@ -1010,7 +1019,8 @@ class MoEMicroKernel:
         expert_scale_stride = Int32(scale_storage.shape[0]) // num_experts
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
-        num_k_tiles = (cols + Int32(63)) // Int32(64)
+        sf_k_tile = Int32(self.sf_vec_size * 4)
+        num_k_tiles = (cols + sf_k_tile - Int32(1)) // sf_k_tile
 
         # Phase 0: cooperative init — set row_counts and zero scatter_output.
         # The Triton compact pre-pass has already populated
@@ -1079,7 +1089,7 @@ class MoEMicroKernel:
                 expert_id = _ld_shared_i32(ctrl_base_addr + Int32(8))
 
             # Distribute quantization across all CTA threads. Each FP4 block
-            # covers 16 elements and can be packed independently.
+            # covers one scale-vector and can be packed independently.
             should_quantize = Int32(1)
             packed_local_expert_id = local_expert_id
             packed_row = row
@@ -1116,34 +1126,47 @@ class MoEMicroKernel:
                         gs_value = cutlass.Float32(1.0) / gs_value
                 sf_idx = Int32(tidx)
                 while sf_idx < sf_blocks_per_row:
-                    block_start = sf_idx * Int32(16)
-                    values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                    block_start = sf_idx * Int32(self.sf_vec_size)
+                    values = cute.make_rmem_tensor((self.sf_vec_size,), cutlass.Float32)
                     block_max = cutlass.Float32(0.0)
-                    for elem_idx in cutlass.range_constexpr(16):
+                    for elem_idx in cutlass.range_constexpr(self.sf_vec_size):
                         value = cutlass.Float32(
                             a_input[token_idx, block_start + Int32(elem_idx)]
                         )
                         values[elem_idx] = value
                         block_max = fmax_f32(block_max, fabs_f32(value))
-                    packed64 = Uint64(0)
                     scale_byte = Uint8(0)
-                    if self.fast_math:
-                        packed64, scale_byte = quantize_block_fp4_fast(
-                            values, block_max, gs_value
+                    if cutlass.const_expr(self.sf_vec_size == 32):
+                        packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
+                            values, block_max
                         )
                     else:
-                        packed64, scale_byte = quantize_block_fp4(
-                            values, block_max, gs_value
-                        )
+                        packed_lo = Uint64(0)
+                        packed_hi = Uint64(0)
+                        if self.fast_math:
+                            packed_lo, scale_byte = quantize_block_fp4_fast(
+                                values, block_max, gs_value
+                            )
+                        else:
+                            packed_lo, scale_byte = quantize_block_fp4(
+                                values, block_max, gs_value
+                            )
 
                     output_offset = (
                         packed_local_expert_id * max_rows * output_bytes_per_row
                         + packed_row * output_bytes_per_row
-                        + sf_idx * Int32(8)
+                        + sf_idx * Int32(self.sf_vec_size // 2)
                     )
                     st_global_u64(
-                        get_ptr_as_int64(packed_a_storage, output_offset), packed64
+                        get_ptr_as_int64(packed_a_storage, output_offset), packed_lo
                     )
+                    if cutlass.const_expr(self.sf_vec_size == 32):
+                        st_global_u64(
+                            get_ptr_as_int64(
+                                packed_a_storage, output_offset + Int32(8)
+                            ),
+                            packed_hi,
+                        )
 
                     m_tile_idx = packed_row // Int32(32 * 4)
                     k_tile_idx = sf_idx // Int32(4)
@@ -1839,7 +1862,7 @@ class MoEMicroKernel:
                 # Activation + quant into sA
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
-                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
+                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // self.sf_vec_size)
                 scale_idx = (
                     Int32(0)
                     if cutlass.const_expr(self.share_expert_scales)
@@ -1916,38 +1939,52 @@ class MoEMicroKernel:
                         local_row = quant_idx // sf_blocks_per_row
                         row = sa_row_base + rows_offset + local_row
                         sf_block = quant_idx - local_row * sf_blocks_per_row
-                        block_start = sf_block * Int32(16)
+                        block_start = sf_block * Int32(self.sf_vec_size)
 
-                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                        values = cute.make_rmem_tensor(
+                            (self.sf_vec_size,), cutlass.Float32
+                        )
                         block_max = cutlass.Float32(0.0)
-                        for elem_idx in cutlass.range_constexpr(16):
+                        for elem_idx in cutlass.range_constexpr(self.sf_vec_size):
                             value = cutlass.Float32(
                                 sC[local_row, block_start + elem_idx, silu_epi_buffer]
                             )
                             values[elem_idx] = value
                             block_max = fmax_f32(block_max, fabs_f32(value))
 
-                        packed64 = Uint64(0)
                         scale_byte = Uint8(0)
-                        if self.fast_math:
-                            packed64, scale_byte = quantize_block_fp4_fast(
-                                values, block_max, gs_value
+                        if cutlass.const_expr(self.sf_vec_size == 32):
+                            packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
+                                values, block_max
                             )
                         else:
-                            packed64, scale_byte = quantize_block_fp4(
-                                values, block_max, gs_value
-                            )
-                        packed_base = sf_block << Int32(3)
+                            packed_lo = Uint64(0)
+                            packed_hi = Uint64(0)
+                            if self.fast_math:
+                                packed_lo, scale_byte = quantize_block_fp4_fast(
+                                    values, block_max, gs_value
+                                )
+                            else:
+                                packed_lo, scale_byte = quantize_block_fp4(
+                                    values, block_max, gs_value
+                                )
+                        packed_base = sf_block * Int32(self.sf_vec_size // 2)
                         dst_pcol = row & Int32(63)
                         xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
                         row_high = row >> Int32(6)
-                        for byte_idx in cutlass.range_constexpr(8):
+                        for byte_idx in cutlass.range_constexpr(self.sf_vec_size // 2):
                             src_pcol = packed_base + Int32(byte_idx)
                             dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
                             dst_flat = dst_row * packed_cols + dst_pcol
-                            byte_val = Uint8(
-                                (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                            )
+                            if cutlass.const_expr(byte_idx < 8):
+                                byte_val = Uint8(
+                                    (packed_lo >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                            else:
+                                byte_val = Uint8(
+                                    (packed_hi >> Uint64((byte_idx - 8) * 8))
+                                    & Uint64(0xFF)
+                                )
                             sA_u8[dst_flat] = byte_val
 
                         outer_m_idx = row % Int32(32)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -539,7 +539,8 @@ class MoEMicroKernel:
                 self.acc_dtype,
                 self.sf_dtype,
             )
-        atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -552,7 +553,6 @@ class MoEMicroKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        atom_shape = (2, 2, 1)
         self.num_m_tiles = self.tile_shape_mnk[0] // (16 * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (8 * atom_shape[1])
         self.num_k_blocks = self.tile_shape_mnk[2] // 64

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -1,5 +1,5 @@
 """
-MoEStaticKernel — static-scheduled routed NVFP4 MoE kernel for SM120/SM121 (Blackwell).
+MoEStaticKernel — static-scheduled routed W4A4 MoE kernel for SM120/SM121.
 
 Ported from the b12x kernel library to FlashInfer.
 
@@ -112,6 +112,7 @@ from flashinfer.cute_dsl.fp4_common import (
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
+    quantize_block_mxfp4,
     get_ptr_as_int64,
     ld_shared_i32_relaxed,
     st_global_f32,
@@ -365,7 +366,10 @@ class MoEStaticKernel:
         self.swiglu_alpha = float(swiglu_alpha)
         self.swiglu_beta = float(swiglu_beta)
         self.swiglu_limit = float(swiglu_limit) if swiglu_limit is not None else None
-        tile_k = sf_vec_size * 8
+        # The fused epilogue feeds one 128-wide FC1 slice directly to FC2.
+        # MXFP4 therefore keeps K=128 (four block-32 scales) instead of using
+        # the dense GEMM default of 32*8=256.
+        tile_k = 128 if sf_vec_size == 32 else sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
         self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
@@ -497,11 +501,18 @@ class MoEStaticKernel:
 
         self._hidden_size = hidden_size
 
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        if self.sf_vec_size == 32:
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_layout = cute.make_layout((2, 2, 1))
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
@@ -515,8 +526,9 @@ class MoEStaticKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
+        atom_shape = (2, 2, 1)
+        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * atom_shape[1])
         self.num_k_blocks = self.tile_shape_mnk[2] // 64
 
         sfa_smem = sm120_make_smem_layout_sfa(
@@ -973,7 +985,7 @@ class MoEStaticKernel:
         num_tokens = Int32(a_input.shape[0])
         cols = Int32(a_input.shape[1])
         num_experts = Int32(row_counts.shape[0])
-        sf_blocks_per_row = cols // Int32(16)
+        sf_blocks_per_row = cols // Int32(self.sf_vec_size)
         output_bytes_per_row = cols // Int32(2)
         max_rows = Int32(token_map.shape[1])
         total_pairs = Int32(topk_ids.shape[0])
@@ -982,7 +994,8 @@ class MoEStaticKernel:
         num_global_experts = Int32(global_to_local_expert.shape[0])
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
-        num_k_tiles = (cols + Int32(63)) // Int32(64)
+        sf_k_tile = Int32(self.sf_vec_size * 4)
+        num_k_tiles = (cols + sf_k_tile - Int32(1)) // sf_k_tile
 
         # Phase 0: cooperative init — zero row_counts and scatter_output
         i = flat_tid
@@ -1067,34 +1080,45 @@ class MoEStaticKernel:
                     gs_value = cutlass.Float32(1.0) / gs_value
             sf_idx = Int32(tidx)
             while sf_idx < sf_blocks_per_row:
-                block_start = sf_idx * Int32(16)
-                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                block_start = sf_idx * Int32(self.sf_vec_size)
+                values = cute.make_rmem_tensor((self.sf_vec_size,), cutlass.Float32)
                 block_max = cutlass.Float32(0.0)
-                for elem_idx in cutlass.range_constexpr(16):
+                for elem_idx in cutlass.range_constexpr(self.sf_vec_size):
                     value = cutlass.Float32(
                         a_input[token_idx, block_start + Int32(elem_idx)]
                     )
                     values[elem_idx] = value
                     block_max = fmax_f32(block_max, fabs_f32(value))
-                packed64 = Uint64(0)
                 scale_byte = Uint8(0)
-                if self.fast_math:
-                    packed64, scale_byte = quantize_block_fp4_fast(
-                        values, block_max, gs_value
+                if cutlass.const_expr(self.sf_vec_size == 32):
+                    packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
+                        values, block_max
                     )
                 else:
-                    packed64, scale_byte = quantize_block_fp4(
-                        values, block_max, gs_value
-                    )
+                    packed_lo = Uint64(0)
+                    packed_hi = Uint64(0)
+                    if self.fast_math:
+                        packed_lo, scale_byte = quantize_block_fp4_fast(
+                            values, block_max, gs_value
+                        )
+                    else:
+                        packed_lo, scale_byte = quantize_block_fp4(
+                            values, block_max, gs_value
+                        )
 
                 output_offset = (
                     local_expert_id * max_rows * output_bytes_per_row
                     + row * output_bytes_per_row
-                    + sf_idx * Int32(8)
+                    + sf_idx * Int32(self.sf_vec_size // 2)
                 )
                 st_global_u64(
-                    get_ptr_as_int64(packed_a_storage, output_offset), packed64
+                    get_ptr_as_int64(packed_a_storage, output_offset), packed_lo
                 )
+                if cutlass.const_expr(self.sf_vec_size == 32):
+                    st_global_u64(
+                        get_ptr_as_int64(packed_a_storage, output_offset + Int32(8)),
+                        packed_hi,
+                    )
 
                 m_tile_idx = row // Int32(32 * 4)
                 k_tile_idx = sf_idx // Int32(4)
@@ -1762,7 +1786,7 @@ class MoEStaticKernel:
                 # Activation + quant into sA
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
-                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
+                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // self.sf_vec_size)
                 gs_value = global_scale[weight_expert_idx].to(cutlass.Float32)
                 if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
                     0.0
@@ -1834,38 +1858,52 @@ class MoEStaticKernel:
                         local_row = quant_idx // sf_blocks_per_row
                         row = sa_row_base + rows_offset + local_row
                         sf_block = quant_idx - local_row * sf_blocks_per_row
-                        block_start = sf_block * Int32(16)
+                        block_start = sf_block * Int32(self.sf_vec_size)
 
-                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                        values = cute.make_rmem_tensor(
+                            (self.sf_vec_size,), cutlass.Float32
+                        )
                         block_max = cutlass.Float32(0.0)
-                        for elem_idx in cutlass.range_constexpr(16):
+                        for elem_idx in cutlass.range_constexpr(self.sf_vec_size):
                             value = cutlass.Float32(
                                 sC[local_row, block_start + elem_idx, silu_epi_buffer]
                             )
                             values[elem_idx] = value
                             block_max = fmax_f32(block_max, fabs_f32(value))
 
-                        packed64 = Uint64(0)
                         scale_byte = Uint8(0)
-                        if self.fast_math:
-                            packed64, scale_byte = quantize_block_fp4_fast(
-                                values, block_max, gs_value
+                        if cutlass.const_expr(self.sf_vec_size == 32):
+                            packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
+                                values, block_max
                             )
                         else:
-                            packed64, scale_byte = quantize_block_fp4(
-                                values, block_max, gs_value
-                            )
-                        packed_base = sf_block << Int32(3)
+                            packed_lo = Uint64(0)
+                            packed_hi = Uint64(0)
+                            if self.fast_math:
+                                packed_lo, scale_byte = quantize_block_fp4_fast(
+                                    values, block_max, gs_value
+                                )
+                            else:
+                                packed_lo, scale_byte = quantize_block_fp4(
+                                    values, block_max, gs_value
+                                )
+                        packed_base = sf_block * Int32(self.sf_vec_size // 2)
                         dst_pcol = row & Int32(63)
                         xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
                         row_high = row >> Int32(6)
-                        for byte_idx in cutlass.range_constexpr(8):
+                        for byte_idx in cutlass.range_constexpr(self.sf_vec_size // 2):
                             src_pcol = packed_base + Int32(byte_idx)
                             dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
                             dst_flat = dst_row * packed_cols + dst_pcol
-                            byte_val = Uint8(
-                                (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                            )
+                            if cutlass.const_expr(byte_idx < 8):
+                                byte_val = Uint8(
+                                    (packed_lo >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                            else:
+                                byte_val = Uint8(
+                                    (packed_hi >> Uint64((byte_idx - 8) * 8))
+                                    & Uint64(0xFF)
+                                )
                             sA_u8[dst_flat] = byte_val
 
                         outer_m_idx = row % Int32(32)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -513,7 +513,8 @@ class MoEStaticKernel:
                 self.acc_dtype,
                 self.sf_dtype,
             )
-        atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -526,7 +527,6 @@ class MoEStaticKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        atom_shape = (2, 2, 1)
         self.num_m_tiles = self.tile_shape_mnk[0] // (16 * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (8 * atom_shape[1])
         self.num_k_blocks = self.tile_shape_mnk[2] // 64
@@ -1071,7 +1071,7 @@ class MoEStaticKernel:
             row = _ld_shared_i32(ctrl_base_addr + Int32(4))
 
             # Distribute quantization across ALL CTA threads, not just leader.
-            # Each FP4 block (16 elements) is independent — perfect parallelism.
+            # Each scale vector can be quantized and packed independently.
             gs_value = input_global_scale[expert_id].to(cutlass.Float32)
             if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(0.0):
                 if self.fast_math:

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -40,8 +40,10 @@ from flashinfer.cute_dsl import is_cute_dsl_available
 from .utils import (
     check_accuracy,
     compute_reference_moe_fp4,
+    compute_reference_moe_mxfp4_w4a4,
     compute_reference_moe_relu2,
     create_b12x_moe_tensors as create_moe_tensors,
+    create_b12x_mxfp4_moe_tensors,
     create_relu2_moe_tensors,
     quant_dequant_fp4_reference,
 )
@@ -715,6 +717,165 @@ def test_preallocated_dynamic_workspace_rejects_remapped_experts():
 @cuda_13_required
 class TestB12xFunctional:
     """Tests for the functional API: b12x_fused_moe."""
+
+    def test_mxfp4_static_functional_accuracy(self):
+        """Native block-32 MXFP4 must cover the normal static dispatch path."""
+        from flashinfer import b12x_fused_moe
+
+        # One expert forces more than one physical M tile and guards the
+        # block-32 scale-factor tile stride as well as the common static path.
+        num_tokens = 256
+        hidden_size = intermediate_size = 256
+        num_experts, top_k = 1, 1
+        tensors = create_b12x_mxfp4_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        actual = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            quant_mode="mxfp4",
+        )
+        expected = compute_reference_moe_mxfp4_w4a4(
+            tensors["x_bf16"],
+            tensors["w1_weight_bf16"],
+            tensors["w2_weight_bf16"],
+            tensors["token_selected_experts"],
+            tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            intermediate_size=intermediate_size,
+        )
+
+        passed, percent_within, atol = check_accuracy(actual, expected)
+        assert passed, (
+            f"MXFP4 static: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    def test_mxfp4_intermediate_padding_accuracy(self):
+        """MXFP4 weight scales must remain valid across gate/up tile padding."""
+        from flashinfer import b12x_fused_moe
+
+        num_tokens = 32
+        hidden_size, intermediate_size = 256, 192
+        num_experts, top_k = 4, 2
+        tensors = create_b12x_mxfp4_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=2028,
+        )
+        actual = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=None,
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            quant_mode="mxfp4",
+        )
+        expected = compute_reference_moe_mxfp4_w4a4(
+            tensors["x_bf16"],
+            tensors["w1_weight_bf16"],
+            tensors["w2_weight_bf16"],
+            tensors["token_selected_experts"],
+            tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            intermediate_size=intermediate_size,
+        )
+        passed, percent_within, atol = check_accuracy(actual, expected)
+        assert passed, (
+            f"MXFP4 padded: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    @pytest.mark.parametrize(
+        ("num_tokens", "expected_backend"),
+        [(4, "static"), (321, "dynamic")],
+    )
+    def test_mxfp4_micro_and_dynamic_accuracy(
+        self, num_tokens: int, expected_backend: str
+    ):
+        """MXFP4 must cover the micro subpath and queue-driven dynamic path."""
+        from flashinfer import b12x_fused_moe
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
+            select_sm120_moe_backend,
+        )
+
+        hidden_size = intermediate_size = 256
+        num_experts, top_k = 8, 2
+        assert (
+            select_sm120_moe_backend(
+                num_tokens=num_tokens, num_topk=top_k, quant_mode="mxfp4"
+            )
+            == expected_backend
+        )
+        tensors = create_b12x_mxfp4_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=43 + num_tokens,
+        )
+
+        actual = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            quant_mode="mxfp4",
+        )
+        expected = compute_reference_moe_mxfp4_w4a4(
+            tensors["x_bf16"],
+            tensors["w1_weight_bf16"],
+            tensors["w2_weight_bf16"],
+            tensors["token_selected_experts"],
+            tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            intermediate_size=intermediate_size,
+        )
+        passed, percent_within, atol = check_accuracy(actual, expected)
+        assert passed, (
+            f"MXFP4 {expected_backend}: {percent_within * 100:.2f}% within "
+            f"tolerance (atol={atol:.4f})"
+        )
 
     @pytest.mark.parametrize(
         "hidden_size,intermediate_size", [(256, 512), (1024, 2048)]
@@ -1452,6 +1613,68 @@ class TestB12xFunctional:
 @cuda_13_required
 class TestB12xWrapper:
     """Tests for the wrapper API: B12xMoEWrapper."""
+
+    def test_mxfp4_wrapper_cuda_graph_accuracy(self):
+        """MXFP4 dynamic workspace must be capture-safe and replay accurately."""
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens = 321
+        hidden_size = intermediate_size = 256
+        num_experts, top_k = 8, 2
+        tensors = create_b12x_mxfp4_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=2027,
+        )
+        moe = B12xMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=True,
+            max_num_tokens=num_tokens,
+            quant_mode="mxfp4",
+        )
+        kwargs = {
+            "x": tensors["x_bf16"],
+            "w1_weight": tensors["w1_weight"],
+            "w1_weight_sf": tensors["w1_weight_sf"],
+            "w1_alpha": tensors["w1_alpha"],
+            "fc2_input_scale": None,
+            "w2_weight": tensors["w2_weight"],
+            "w2_weight_sf": tensors["w2_weight_sf"],
+            "w2_alpha": tensors["w2_alpha"],
+            "token_selected_experts": tensors["token_selected_experts"],
+            "token_final_scales": tensors["token_final_scales"],
+        }
+
+        moe.run(**kwargs)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = moe.run(**kwargs)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        expected = compute_reference_moe_mxfp4_w4a4(
+            tensors["x_bf16"],
+            tensors["w1_weight_bf16"],
+            tensors["w2_weight_bf16"],
+            tensors["token_selected_experts"],
+            tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            intermediate_size=intermediate_size,
+        )
+        passed, percent_within, atol = check_accuracy(actual, expected)
+        assert passed, (
+            f"MXFP4 CUDA Graph: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
 
     @pytest.mark.parametrize(
         "activation", ["silu", "gelu_tanh", "swigluoai_uninterleave"]

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -816,26 +816,50 @@ class TestB12xFunctional:
         )
 
     @pytest.mark.parametrize(
-        ("num_tokens", "expected_backend"),
-        [(4, "static"), (321, "dynamic")],
+        ("num_tokens", "num_experts", "expected_backend", "expected_tile_m"),
+        [
+            (4, 8, "static", None),
+            (321, 64, "dynamic", 16),
+            (321, 32, "dynamic", 32),
+            (321, 8, "dynamic", 64),
+            (321, 4, "dynamic", 128),
+        ],
     )
     def test_mxfp4_micro_and_dynamic_accuracy(
-        self, num_tokens: int, expected_backend: str
+        self,
+        num_tokens: int,
+        num_experts: int,
+        expected_backend: str,
+        expected_tile_m: int | None,
+        monkeypatch,
     ):
-        """MXFP4 must cover the micro subpath and queue-driven dynamic path."""
+        """MXFP4 covers MMA micro and every dynamic tile-M variant."""
         from flashinfer import b12x_fused_moe
-        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
-            select_sm120_moe_backend,
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+        def reject_direct_micro(*args, **kwargs):
+            raise AssertionError("MXFP4 must not enter the NVFP4 direct-micro path")
+
+        monkeypatch.setattr(
+            moe_dispatch, "_get_direct_micro_kernel", reject_direct_micro
         )
+        select_sm120_moe_backend = moe_dispatch.select_sm120_moe_backend
 
         hidden_size = intermediate_size = 256
-        num_experts, top_k = 8, 2
+        top_k = 2
         assert (
             select_sm120_moe_backend(
                 num_tokens=num_tokens, num_topk=top_k, quant_mode="mxfp4"
             )
             == expected_backend
         )
+        if expected_tile_m is not None:
+            assert (
+                moe_dispatch._select_dynamic_tile_m(
+                    num_tokens * top_k, num_experts
+                )
+                == expected_tile_m
+            )
         tensors = create_b12x_mxfp4_moe_tensors(
             num_tokens=num_tokens,
             hidden_size=hidden_size,

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -855,9 +855,7 @@ class TestB12xFunctional:
         )
         if expected_tile_m is not None:
             assert (
-                moe_dispatch._select_dynamic_tile_m(
-                    num_tokens * top_k, num_experts
-                )
+                moe_dispatch._select_dynamic_tile_m(num_tokens * top_k, num_experts)
                 == expected_tile_m
             )
         tensors = create_b12x_mxfp4_moe_tensors(

--- a/tests/moe/test_b12x_moe_kernel_cache.py
+++ b/tests/moe/test_b12x_moe_kernel_cache.py
@@ -60,6 +60,7 @@ NON_CODEGEN_PARAMS = {"mac_override", "tile_m"}
 
 STATIC_BASELINE = {
     "activation_precision": "fp4",
+    "quant_mode": "nvfp4",
     "state_E": 32,
     "weight_E": 32,
     "m": 64,
@@ -79,6 +80,7 @@ STATIC_BASELINE = {
 }
 STATIC_PERTURBED = {
     "activation_precision": "w4a16",
+    "quant_mode": "mxfp4",
     "state_E": 16,
     "weight_E": 16,
     "m": 128,
@@ -112,6 +114,7 @@ MICRO_PERTURBED.update(
 
 DYNAMIC_BASELINE = {
     "activation_precision": "fp4",
+    "quant_mode": "nvfp4",
     "E": 32,
     "k": 2048,
     "n": 1024,
@@ -129,6 +132,7 @@ DYNAMIC_BASELINE = {
 }
 DYNAMIC_PERTURBED = {
     "activation_precision": "w4a16",
+    "quant_mode": "mxfp4",
     "E": 16,
     "k": 4096,
     "n": 2048,

--- a/tests/moe/utils.py
+++ b/tests/moe/utils.py
@@ -825,6 +825,143 @@ def create_relu2_moe_tensors(
     }
 
 
+def _mxfp4_quant_dequant_linear(tensor: torch.Tensor) -> torch.Tensor:
+    """Snap a 2-D tensor to OCP MXFP4 using linear block-32 UE8M0 scales."""
+    from flashinfer.quantization import SfLayout, mxfp4_dequantize, mxfp4_quantize
+
+    packed, scales = mxfp4_quantize(
+        tensor.to(torch.bfloat16),
+        backend="cuda",
+        sfLayout=SfLayout.layout_linear,
+    )
+    return mxfp4_dequantize(packed, scales, sfLayout=SfLayout.layout_linear).to(
+        tensor.device
+    )
+
+
+def create_b12x_mxfp4_moe_tensors(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    num_local_experts: int,
+    top_k: int,
+    device: str = "cuda",
+    seed: int = 42,
+):
+    """Create native MXFP4-weight tensors for the SM12x W4A4 b12x path."""
+    from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+    from flashinfer.quantization import mxfp4_dequantize, mxfp4_quantize
+
+    if hidden_size % 128 != 0 or intermediate_size % 32 != 0:
+        raise ValueError(
+            "b12x MXFP4 test hidden size must be a multiple of 128 and "
+            "intermediate size a multiple of 32"
+        )
+
+    torch.manual_seed(seed)
+    x_bf16 = (
+        torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device=device) / 10
+    )
+    router_logits = torch.randn(num_tokens, num_experts, device=device)
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, top_k, dim=-1)
+    routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+
+    w1_bf16 = (
+        torch.randn(
+            num_local_experts,
+            2 * intermediate_size,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 10
+    )
+    w2_bf16 = (
+        torch.randn(
+            num_local_experts,
+            hidden_size,
+            intermediate_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 10
+    )
+
+    def quantize_experts(weight: torch.Tensor):
+        experts, rows, columns = weight.shape
+        packed_experts = []
+        scale_experts = []
+        reference_experts = []
+        for expert in range(experts):
+            packed, scales = mxfp4_quantize(weight[expert], backend="cuda")
+            packed_experts.append(packed)
+            scale_experts.append(scales)
+            reference_experts.append(mxfp4_dequantize(packed, scales))
+        packed = torch.stack(packed_experts)
+        reference = torch.stack(reference_experts).to(device)
+        scales = torch.cat(scale_experts)
+        scales = convert_sf_to_mma_layout(
+            scales,
+            m=rows,
+            k=columns,
+            num_groups=experts,
+            sf_vec_size=32,
+        )
+        return packed, scales, reference
+
+    w1_weight, w1_weight_sf, w1_reference = quantize_experts(w1_bf16)
+    w2_weight, w2_weight_sf, w2_reference = quantize_experts(w2_bf16)
+    ones = torch.ones(num_local_experts, device=device, dtype=torch.float32)
+
+    return {
+        "x_bf16": x_bf16,
+        "token_selected_experts": selected_experts.to(torch.int32),
+        "token_final_scales": routing_weights.float(),
+        "w1_weight": w1_weight,
+        "w1_weight_sf": w1_weight_sf,
+        "w1_weight_bf16": w1_reference,
+        "w1_alpha": ones,
+        "fc2_input_scale": torch.ones(1, device=device, dtype=torch.float32),
+        "w2_weight": w2_weight,
+        "w2_weight_sf": w2_weight_sf,
+        "w2_weight_bf16": w2_reference,
+        "w2_alpha": ones.clone(),
+    }
+
+
+def compute_reference_moe_mxfp4_w4a4(
+    hidden_states: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    token_selected_experts: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    *,
+    num_experts: int,
+    top_k: int,
+    intermediate_size: int,
+) -> torch.Tensor:
+    """Strict W4A4 reference with MXFP4 snapping before FC1 and FC2."""
+    x = _mxfp4_quant_dequant_linear(hidden_states).float()
+    output = torch.zeros_like(x, dtype=torch.float32)
+
+    for expert in range(num_experts):
+        token_indices, slots = torch.where(token_selected_experts == expert)
+        if token_indices.numel() == 0:
+            continue
+        fc1 = x[token_indices] @ gemm1_weights[expert].float().T
+        up = fc1[:, :intermediate_size]
+        gate = fc1[:, intermediate_size:]
+        intermediate = _mxfp4_quant_dequant_linear(F.silu(gate) * up).float()
+        expert_out = intermediate @ gemm2_weights[expert].float().T
+        weighted = (
+            token_final_scales[token_indices, slots].float().unsqueeze(1) * expert_out
+        )
+        output.index_add_(0, token_indices, weighted)
+    return output
+
+
 def check_accuracy(
     actual: torch.Tensor, expected: torch.Tensor, percent_threshold: float = 0.97
 ):


### PR DESCRIPTION
## 📌 Description

Adds native MXFP4 × MXFP4 W4A4 support to the SM120/SM121 CuTe-DSL fused MoE path.

- Adds public `quant_mode="mxfp4"` support to `b12x_fused_moe` and `B12xMoEWrapper`.
- Uses E2M1 data with block-32 UE8M0 scales and `MmaMXF4Op`.
- Supports the existing micro, static, and dynamic fused schedules, including CUDA Graph reuse and non-128 intermediate padding.
- Keeps NVFP4 and W4A16 behavior unchanged. MXFP4 self-scales each block and therefore ignores tensor-wide `input_global_scale` and `fc2_input_scale`.

The fused boundary remains the same as NVFP4: route/pack, input quantization, FC1, gated activation, intermediate quantization, FC2, and weighted scatter remain in the fused MoE kernel.

### Accuracy

RTX PRO 6000 Blackwell Server Edition (SM120), CUDA 13.0. Both formats use the same BF16 inputs, source weights, routing IDs, and routing weights. NVFP4 uses standard global-scale calibration; MXFP4 uses native block-32 scaling.

| Metric | NVFP4 | MXFP4 |
|---|---:|---:|
| Input quant relative L2 | 0.0949 | 0.1170 |
| W1 quant relative L2 | 0.0950 | 0.1165 |
| W2 quant relative L2 | 0.0950 | 0.1166 |
| End-to-end MoE relative L2 vs BF16 | 0.2306 | 0.2923 |
| Kernel relative L2 vs strict quantized reference | 0.0405 | 0.0401 |
| Kernel cosine vs strict quantized reference | 0.99918 | 0.99920 |

Accuracy shape: tokens=321, hidden=256, intermediate=256, experts=8, top-k=2, seed=20260730.

### Performance

Standalone MoE benchmark: H=7168, I=2048, E=256, top-k=8. `T` is input tokens per invocation and routed pairs equal `T × 8`. T=1/8/32 is decode-oriented; larger T measures large-batch decode/prefill throughput. Both modes use identical inputs, packed E2M1 weights, and routing.

- Timed: `route/pack + input quant + FC1 + activation + intermediate quant + FC2 + weighted scatter`
- Excluded: `router logits + top-k selection + weight/workspace preparation + JIT compilation`
- Method: CUDA Graph, warm L2, median of three interleaved rounds

There is no standalone sorting kernel; route/pack is fused into the W4A4 MoE path.

| Input tokens (T) | Routed pairs (T × 8) | NVFP4 ms | MXFP4 ms | MXFP4 speedup |
|---:|---:|---:|---:|---:|
| 1 | 8 | 0.2090 | 0.2022 | 1.033x |
| 8 | 64 | 1.1175 | 1.0557 | 1.059x |
| 32 | 256 | 4.8876 | 4.6947 | 1.041x |
| 128 | 1,024 | 4.6867 | 4.4768 | 1.047x |
| 512 | 4,096 | 4.7641 | 4.5523 | 1.047x |
| 2048 | 16,384 | 5.6317 | 5.5596 | 1.013x |

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files`.

## 🧪 Tests

- [x] Tests have been added or updated.
- [x] All relevant tests are passing.

Validation:

- `pre-commit run --all-files`: passed
- `pytest -q tests/moe/test_b12x_fused_moe.py -x`: 148 passed
- MXFP4 static, micro, dynamic, non-aligned padding, and CUDA Graph tests: passed

## Reviewer Notes

The MoE K tile remains 128 for MXFP4 to preserve the fused FC1-epilogue/FC2-K-tile coupling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added MXFP4 quantization support for W4A4 fused MoE workloads on compatible GPUs.
  * Extended MXFP4 support across static, dynamic, and micro execution paths.
  * Added a configurable benchmark with TFLOPS measurements and CSV output.
* **Improvements**
  * Improved quantization-mode handling, scale processing, workspace selection, and backend dispatch.
* **Tests**
  * Added functional, accuracy, intermediate-padding, backend-selection, and CUDA graph coverage for MXFP4 MoE execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->