### PR TITLE
Upgrade CuTe DSL FMHA cubins

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -153,8 +153,13 @@ class ArtifactPath:
     # (and KernelMap.KERNEL_MAP_HASH_RUBIN for the Rubin variant below).
     DEEPGEMM: str = "a72d85b019dc125b9f711300cb989430f762f5a6/deep-gemm/"
     DEEPGEMM_RUBIN: str = "7ec7ac40b9fd48172651b77ff2ebe20d79decc39/deep-gemm/"
-    DSL_FMHA: str = "801e770219613fbf088bc074c414732b26cc550d/fmha/cute-dsl/"
-    DSL_FMHA_ARCHS: tuple[str, ...] = ("sm_100a", "sm_103a", "sm_110a")
+    DSL_FMHA: str = "5b34f84266cbc2135066ce96885b664992535670/fmha/cute-dsl/"
+    DSL_FMHA_ARCHS: tuple[str, ...] = (
+        "sm_100a",
+        "sm_103a",
+        "sm_107a",
+        "sm_110a",
+    )
 
 
 class CheckSumHash:
@@ -187,14 +192,16 @@ class CheckSumHash:
     # NOT hashes of individual kernel .so files.
     DSL_FMHA_CHECKSUMS: dict[str, dict[str, str]] = {
         "x86_64": {
-            "sm_100a": "778738c3aa89872248fcfddd134b57ae516021471df992d4ba9b058ead546d56",
-            "sm_103a": "f57abef4c65968c99e93faa051d9b98cf789c82c805bd3a177fb3f2a426dac4f",
-            "sm_110a": "f2450d136221d7c355876140af860999fd5f5cdd16ffa4b06ff8b799c2106c29",
+            "sm_100a": "832c303bb9b386af590d3efc294681859829b91991975fd2e188a5d7dc30c461",
+            "sm_103a": "57322c10ddbbe9072c7ded41e2856fdf9d4276fbd79ac4bc825af0cd78844da6",
+            "sm_107a": "8480678539adf622f8395e875923471bce683be7158694556bd6c536eadeaa45",
+            "sm_110a": "4f6f0f3a868f0e9171c8ab217e6d2a87fde46b02a9417d8f55f1a779c53fa9fb",
         },
         "aarch64": {
-            "sm_100a": "10af42097962a92cbc8942a65dedf87259fdb8684d26c4f8326dbfbe4e8ff566",
-            "sm_103a": "2418ee60ced8eec216af5a44682151173c1ed63d5296c92c185bc3bef92f91cd",
-            "sm_110a": "6807c536800fba3c9ff516f4cc0a7b12bd5570dd94ab04704c9bc7daf9d1e821",
+            "sm_100a": "064cfcac21886c3e16b5007ca769f1b93111db7a63864db1e026a53e61fe20fe",
+            "sm_103a": "1631a884738d706f5bc39bf4032bcd54b25ba0a0d734c26f388dce4ae32093c9",
+            "sm_107a": "0348ef0b74dffa67c0c9662d3f567b26dccf46c356009f315860f31a9550e207",
+            "sm_110a": "8f16f510d159797432bda92d55d0d82d65d3e19080f9af1b751dec4146cdcbe6",
         },
     }
     map_checksums: dict[str, str] = {

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -119,23 +119,32 @@ def _dtype_to_str(dtype: torch.dtype) -> str:
 
 
 def _get_variant_name(
-    in_dtype: torch.dtype,
+    qk_dtype: torch.dtype,
+    pv_dtype: torch.dtype,
     out_dtype: torch.dtype,
     head_dim: int,
     is_causal: bool,
     is_persistent: bool = True,
     varlen: bool = False,
     with_lse: bool = False,
+    enable_tvm_ffi: bool = False,
     enable_skip_softmax: bool = False,
     enable_sink: bool = False,
     use_pdl: bool = False,
-    enable_tvm_ffi: bool = False,
 ) -> str:
     """Generate the variant name matching compile_cute_dsl_fmha.py naming convention."""
-    in_str = _dtype_to_str(in_dtype)
+    qk_str = _dtype_to_str(qk_dtype)
+    pv_str = _dtype_to_str(pv_dtype)
     out_str = _dtype_to_str(out_dtype)
-    # Only include out_dtype in name when it differs from in_dtype (mixed precision)
-    dtype_str = f"{in_str}_{out_str}" if in_dtype != out_dtype else in_str
+    # Include all three dtypes for partially quantized kernels.  Preserve the
+    # compact legacy names when QK and PV use the same dtype.
+    dtype_str = (
+        f"{qk_str}_{pv_str}_{out_str}"
+        if qk_dtype != pv_dtype
+        else f"{qk_str}_{out_str}"
+        if qk_dtype != out_dtype
+        else qk_str
+    )
     causal_str = "causal" if is_causal else "nocausal"
     persist_str = "persistent" if is_persistent else "nonpersistent"
     varlen_str = "_varlen" if varlen else ""
@@ -229,7 +238,8 @@ def _load_from_local(variant_name: str, local_dir: str, enable_tvm_ffi: bool = F
 @functools.cache
 def get_cute_dsl_fmha_kernel(
     gpu_arch: str,
-    in_dtype: torch.dtype,
+    qk_dtype: torch.dtype,
+    pv_dtype: torch.dtype,
     out_dtype: torch.dtype,
     head_dim: int,
     is_causal: bool,
@@ -251,10 +261,14 @@ def get_cute_dsl_fmha_kernel(
     gpu_arch : str
         GPU architecture string (e.g. 'sm_100a'), used both for selecting the
         correct artifact and as part of the cache key.
-    in_dtype : torch.dtype
-        Input data type (torch.float16, torch.bfloat16, or torch.float8_e4m3fn).
+    qk_dtype : torch.dtype
+        Query/key data type (torch.float16, torch.bfloat16, or
+        torch.float8_e4m3fn).
+    pv_dtype : torch.dtype
+        Value data type (torch.float16, torch.bfloat16, or
+        torch.float8_e4m3fn).
     out_dtype : torch.dtype
-        Output data type. Same as in_dtype for non-mixed precision.
+        Output data type. Same as qk_dtype for non-mixed precision.
     head_dim : int
         Head dimension (e.g., 64, 128, 192). Note: 192 only supports FP8.
     is_causal : bool
@@ -275,17 +289,18 @@ def get_cute_dsl_fmha_kernel(
         The compiled kernel function.
     """
     variant_name = _get_variant_name(
-        in_dtype,
+        qk_dtype,
+        pv_dtype,
         out_dtype,
         head_dim,
         is_causal,
         is_persistent,
-        varlen,
-        with_lse,
-        enable_skip_softmax,
-        enable_sink,
-        use_pdl,
-        enable_tvm_ffi,
+        varlen=varlen,
+        with_lse=with_lse,
+        enable_tvm_ffi=enable_tvm_ffi,
+        enable_skip_softmax=enable_skip_softmax,
+        enable_sink=enable_sink,
+        use_pdl=use_pdl,
     )
 
     # Check for local .so directory (development mode)
@@ -407,8 +422,6 @@ def cute_dsl_fmha_ragged_prefill(
                 f"cute-dsl FMHA requires q.dtype == k.dtype, got {q.dtype} and {k.dtype}"
             )
         try:
-            if k.dtype != v.dtype:
-                raise RuntimeError("Separate dtype_qk / dtype_vo requires JIT")
             if window_left != -1 or window_right != -1:
                 # The exported artifact matrix has no window axis: every
                 # prebuilt variant is traced with window_size_left=None (and
@@ -419,6 +432,7 @@ def cute_dsl_fmha_ragged_prefill(
             kernel_fn = get_cute_dsl_fmha_kernel(
                 gpu_arch,
                 q.dtype,
+                v.dtype,
                 o.dtype,
                 D,
                 is_causal,
@@ -534,9 +548,10 @@ def cute_dsl_fmha_ragged_prefill(
         )
     else:
         # CuTe native ABI: convert to cute tensors and pass with explicit stream.
-        is_fp8_in = q.dtype == torch.float8_e4m3fn
+        is_fp8_qk = q.dtype == torch.float8_e4m3fn
+        is_fp8_pv = v.dtype == torch.float8_e4m3fn
         is_fp8_out = o.dtype == torch.float8_e4m3fn
-        if is_fp8_in:
+        if is_fp8_qk:
             q_cute = from_dlpack(
                 q_5d.view(torch.int8), assumed_align=16
             ).mark_layout_dynamic(leading_dim=4)
@@ -545,10 +560,6 @@ def cute_dsl_fmha_ragged_prefill(
                 k_5d.view(torch.int8), assumed_align=16
             ).mark_layout_dynamic(leading_dim=4)
             k_cute.element_type = cutlass.Float8E4M3FN
-            v_cute = from_dlpack(
-                v_5d.view(torch.int8), assumed_align=16
-            ).mark_layout_dynamic(leading_dim=4)
-            v_cute.element_type = cutlass.Float8E4M3FN
         else:
             q_cute = from_dlpack(q_5d, assumed_align=16).mark_layout_dynamic(
                 leading_dim=4
@@ -556,6 +567,12 @@ def cute_dsl_fmha_ragged_prefill(
             k_cute = from_dlpack(k_5d, assumed_align=16).mark_layout_dynamic(
                 leading_dim=4
             )
+        if is_fp8_pv:
+            v_cute = from_dlpack(
+                v_5d.view(torch.int8), assumed_align=16
+            ).mark_layout_dynamic(leading_dim=4)
+            v_cute.element_type = cutlass.Float8E4M3FN
+        else:
             v_cute = from_dlpack(v_5d, assumed_align=16).mark_layout_dynamic(
                 leading_dim=4
             )

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -497,10 +497,7 @@ def cute_dsl_fmha_ragged_prefill(
 
     # Skip-softmax threshold (convert scale_factor to log2 domain)
     skip_threshold_log2 = None
-    if (
-        skip_softmax_threshold_scale_factor is not None
-        and skip_softmax_threshold_scale_factor > 0
-    ):
+    if use_skip_softmax:
         threshold = skip_softmax_threshold_scale_factor / max_s_k
         skip_threshold_log2 = Float32(math.log2(threshold))
 

--- a/flashinfer/attention/cute_dsl/fmha_blockscaled.py
+++ b/flashinfer/attention/cute_dsl/fmha_blockscaled.py
@@ -45,7 +45,7 @@ from flashinfer.cute_dsl.attention.fmha.compile import (
 logger = logging.getLogger("flashinfer.attention.cute_dsl.fmha_blockscaled")
 
 
-def _reshape_sf_for_kernel(
+def _reshape_swizzled_sf(
     sf: torch.Tensor,
     batch_size: int,
     num_heads: int,
@@ -91,11 +91,7 @@ def _get_variant_name(
     sink_str = "_sink" if enable_sink else ""
     pdl_str = "_pdl" if use_pdl else ""
     ffi_str = "_tvmffi" if enable_tvm_ffi else ""
-    return (
-        f"cute_dsl_fmha_blockscaled_{qk_mode}_{pv_str}_{out_str}_h{head_dim}_"
-        f"{causal_str}_{persist_str}{varlen_str}{lse_str}{skip_str}{sink_str}"
-        f"{pdl_str}{ffi_str}"
-    )
+    return f"cute_dsl_fmha_blockscaled_{qk_mode}_{pv_str}_{out_str}_h{head_dim}_{causal_str}_{persist_str}{varlen_str}{lse_str}{skip_str}{sink_str}{pdl_str}{ffi_str}"
 
 
 @functools.cache
@@ -135,17 +131,16 @@ def get_cute_dsl_fmha_blockscaled_kernel(
         use_pdl=use_pdl,
     )
 
+    # Check for local .so directory (development mode)
     local_dir = os.environ.get("FLASHINFER_DSL_FMHA_LOCAL_DIR")
     if local_dir:
         logger.info(
-            "Loading block-scaled DSL FMHA kernel from local dir: "
-            f"{local_dir} (tvm_ffi={enable_tvm_ffi})"
+            f"Loading block-scaled DSL FMHA kernel from local dir: {local_dir} (tvm_ffi={enable_tvm_ffi})"
         )
         return _load_from_local(variant_name, local_dir, enable_tvm_ffi=enable_tvm_ffi)
 
     logger.info(
-        "Loading block-scaled DSL FMHA kernel variant: "
-        f"{variant_name} (tvm_ffi={enable_tvm_ffi})"
+        f"Loading block-scaled DSL FMHA kernel variant: {variant_name} (tvm_ffi={enable_tvm_ffi})"
     )
     return _load_from_artifact(variant_name, gpu_arch, enable_tvm_ffi=enable_tvm_ffi)
 
@@ -185,12 +180,15 @@ def cute_dsl_fmha_blockscaled_prefill(
         raise ValueError(
             f"qk_mode must be one of {tuple(_BLOCKSCALED_MODES)}, got {qk_mode!r}"
         )
-    batch_size, s_q, H_q, _ = q.shape
+    batch_size, s_q, H_q, D = q.shape
     _, s_k, H_k, _ = k.shape
-    D = D_v = v.shape[-1]
+    D_v = v.shape[-1]
+    num_store_bits = q.element_size() * 8
+    num_dtype_bits = _BLOCKSCALED_MODES[qk_mode][0].width
+    D *= num_store_bits // num_dtype_bits
     h_r = H_q // H_k
 
-    use_skip = (
+    use_skip_softmax = (
         skip_softmax_threshold_scale_factor is not None
         and skip_softmax_threshold_scale_factor > 0
     )
@@ -211,7 +209,7 @@ def cute_dsl_fmha_blockscaled_prefill(
             is_persistent=False,
             enable_tvm_ffi=True,
             with_lse=lse is not None,
-            enable_skip_softmax=use_skip,
+            enable_skip_softmax=use_skip_softmax,
             use_pdl=enable_pdl,
         )
     except (RuntimeError, FileNotFoundError) as e:
@@ -227,7 +225,7 @@ def cute_dsl_fmha_blockscaled_prefill(
             D,
             is_causal,
             lse is not None,
-            use_skip,
+            use_skip_softmax,
             enable_pdl,
             q.device,
             has_window_left=window_left != -1,
@@ -248,7 +246,7 @@ def cute_dsl_fmha_blockscaled_prefill(
     problem_size = (batch_size, s_q, s_q, s_k, H_q, H_k, D, D_v)
 
     skip_threshold_log2 = None
-    if use_skip:
+    if use_skip_softmax:
         skip_threshold_log2 = Float32(
             math.log2(skip_softmax_threshold_scale_factor / s_k)
         )
@@ -261,8 +259,8 @@ def cute_dsl_fmha_blockscaled_prefill(
     q_5d = q.reshape(batch_size, s_q, H_k, h_r, q.shape[-1])
     k_5d = k.reshape(batch_size, s_k, H_k, 1, k.shape[-1])
     sf_vec_size = _BLOCKSCALED_MODES[qk_mode][2]
-    q_sf_6d = _reshape_sf_for_kernel(q_sf, batch_size, H_q, s_q, D, sf_vec_size)
-    k_sf_6d = _reshape_sf_for_kernel(k_sf, batch_size, H_k, s_k, D, sf_vec_size)
+    q_sf_6d = _reshape_swizzled_sf(q_sf, batch_size, H_q, s_q, D, sf_vec_size)
+    k_sf_6d = _reshape_swizzled_sf(k_sf, batch_size, H_k, s_k, D, sf_vec_size)
     v_5d = v.reshape(batch_size, s_k, H_k, 1, D_v)
     assert o.data_ptr() % 32 == 0, "o must be 32-byte aligned (256-bit stores)"
     o_5d = o.reshape(batch_size, s_q, H_k, h_r, D_v)

--- a/flashinfer/attention/cute_dsl/fmha_blockscaled.py
+++ b/flashinfer/attention/cute_dsl/fmha_blockscaled.py
@@ -12,28 +12,142 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Block-scaled CuTe DSL FMHA entry (JIT)
-======================================
+Block-scaled CuTe DSL FMHA entry
+================================
 
 PyTorch-friendly wrapper for the trtllm block-scaled (MXFP8 / NVFP4) FMHA kernel.
-Unlike :mod:`flashinfer.attention.cute_dsl.fmha`, there is no published cubin for the
-block-scaled kernel, so this path is always JIT-compiled: the kernel handle comes from
-``flashinfer.cute_dsl.attention.fmha.compile.compile_cute_dsl_fmha_blockscaled_kernel``
-and this module only does the tensor marshalling. Pre-quantized Q/K + scale-factor tensors
-are produced by ``flashinfer.cute_dsl.attention.fmha.quantize.quantize_blockscaled_qk``.
+Published cubins are preferred, with JIT compilation as a fallback for variants that
+are not in the artifact matrix. Pre-quantized Q/K + scale-factor tensors are produced
+by ``flashinfer.cute_dsl.attention.fmha.quantize.quantize_blockscaled_qk``.
 """
 
+import functools
+import logging
 import math
+import os
 from typing import Optional
 
 from cutlass.cute.typing import Float32, Int32
 
 import torch
 
+from flashinfer.attention.cute_dsl.fmha import (
+    _dtype_to_str,
+    _get_gpu_arch,
+    _load_from_artifact,
+    _load_from_local,
+)
 from flashinfer.cute_dsl.attention.fmha.compile import (
     _BLOCKSCALED_MODES,
     compile_cute_dsl_fmha_blockscaled_kernel,
 )
+
+logger = logging.getLogger("flashinfer.attention.cute_dsl.fmha_blockscaled")
+
+
+def _reshape_sf_for_kernel(
+    sf: torch.Tensor,
+    batch_size: int,
+    num_heads: int,
+    seq_len: int,
+    head_dim: int,
+    sf_vec_size: int,
+) -> torch.Tensor:
+    """Expose a flat 128x4-swizzled SF buffer through the kernel's 6D ABI."""
+    seq_tiles = (seq_len + 127) // 128
+    sf_k_tiles = (head_dim // sf_vec_size + 3) // 4
+    expected_numel = batch_size * num_heads * seq_tiles * sf_k_tiles * 32 * 4 * 4
+    if sf.numel() != expected_numel:
+        raise ValueError(
+            f"scale-factor tensor has {sf.numel()} elements, expected "
+            f"{expected_numel} for shape (B={batch_size}, S={seq_len}, "
+            f"H={num_heads}, D={head_dim}) and sf_vec_size={sf_vec_size}"
+        )
+    return sf.reshape(batch_size * num_heads, seq_tiles, sf_k_tiles, 32, 4, 4)
+
+
+def _get_variant_name(
+    qk_mode: str,
+    pv_dtype: torch.dtype,
+    out_dtype: torch.dtype,
+    head_dim: int,
+    is_causal: bool,
+    is_persistent: bool,
+    varlen: bool = False,
+    with_lse: bool = False,
+    enable_tvm_ffi: bool = False,
+    enable_skip_softmax: bool = False,
+    enable_sink: bool = False,
+    use_pdl: bool = False,
+) -> str:
+    """Generate the block-scaled variant name used by the artifact compiler."""
+    pv_str = _dtype_to_str(pv_dtype)
+    out_str = _dtype_to_str(out_dtype)
+    causal_str = "causal" if is_causal else "nocausal"
+    persist_str = "persistent" if is_persistent else "nonpersistent"
+    varlen_str = "_varlen" if varlen else ""
+    lse_str = "_lse" if with_lse else ""
+    skip_str = "_skipsm" if enable_skip_softmax else ""
+    sink_str = "_sink" if enable_sink else ""
+    pdl_str = "_pdl" if use_pdl else ""
+    ffi_str = "_tvmffi" if enable_tvm_ffi else ""
+    return (
+        f"cute_dsl_fmha_blockscaled_{qk_mode}_{pv_str}_{out_str}_h{head_dim}_"
+        f"{causal_str}_{persist_str}{varlen_str}{lse_str}{skip_str}{sink_str}"
+        f"{pdl_str}{ffi_str}"
+    )
+
+
+@functools.cache
+def get_cute_dsl_fmha_blockscaled_kernel(
+    gpu_arch: str,
+    qk_mode: str,
+    pv_dtype: torch.dtype,
+    out_dtype: torch.dtype,
+    head_dim: int,
+    is_causal: bool,
+    is_persistent: bool = False,
+    enable_tvm_ffi: bool = False,
+    varlen: bool = False,
+    with_lse: bool = False,
+    enable_skip_softmax: bool = False,
+    enable_sink: bool = False,
+    use_pdl: bool = False,
+):
+    """Load a compiled block-scaled FMHA kernel from local or remote artifacts."""
+    if qk_mode not in _BLOCKSCALED_MODES:
+        raise ValueError(
+            f"qk_mode must be one of {tuple(_BLOCKSCALED_MODES)}, got {qk_mode!r}"
+        )
+
+    variant_name = _get_variant_name(
+        qk_mode,
+        pv_dtype,
+        out_dtype,
+        head_dim,
+        is_causal,
+        is_persistent,
+        varlen=varlen,
+        with_lse=with_lse,
+        enable_tvm_ffi=enable_tvm_ffi,
+        enable_skip_softmax=enable_skip_softmax,
+        enable_sink=enable_sink,
+        use_pdl=use_pdl,
+    )
+
+    local_dir = os.environ.get("FLASHINFER_DSL_FMHA_LOCAL_DIR")
+    if local_dir:
+        logger.info(
+            "Loading block-scaled DSL FMHA kernel from local dir: "
+            f"{local_dir} (tvm_ffi={enable_tvm_ffi})"
+        )
+        return _load_from_local(variant_name, local_dir, enable_tvm_ffi=enable_tvm_ffi)
+
+    logger.info(
+        "Loading block-scaled DSL FMHA kernel variant: "
+        f"{variant_name} (tvm_ffi={enable_tvm_ffi})"
+    )
+    return _load_from_artifact(variant_name, gpu_arch, enable_tvm_ffi=enable_tvm_ffi)
 
 
 def cute_dsl_fmha_blockscaled_prefill(
@@ -57,7 +171,7 @@ def cute_dsl_fmha_blockscaled_prefill(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     enable_pdl: bool = False,
 ) -> None:
-    """Batched (non-varlen) block-scaled prefill via the JIT-compiled trtllm kernel.
+    """Batched (non-varlen) block-scaled prefill via the trtllm kernel.
 
     Inputs are batched:
     - q (b, s_q, H_q, D), q_sf (quantized block-scaled format)
@@ -80,18 +194,45 @@ def cute_dsl_fmha_blockscaled_prefill(
         skip_softmax_threshold_scale_factor is not None
         and skip_softmax_threshold_scale_factor > 0
     )
-    kernel_fn = compile_cute_dsl_fmha_blockscaled_kernel(
-        qk_mode,
-        o.dtype,
-        H_q,
-        H_k,
-        D,
-        is_causal,
-        lse is not None,
-        use_skip,
-        enable_pdl,
-        q.device,
-    )
+    try:
+        if window_left != -1 or window_right != -1:
+            # The artifact name has no window axis, so only its traced
+            # no-window/causal-right-bound signatures are safe to load.
+            raise RuntimeError(
+                "windowed block-scaled DSL FMHA variants are not exported"
+            )
+        kernel_fn = get_cute_dsl_fmha_blockscaled_kernel(
+            _get_gpu_arch(q.device),
+            qk_mode,
+            v.dtype,
+            o.dtype,
+            D,
+            is_causal,
+            is_persistent=False,
+            enable_tvm_ffi=True,
+            with_lse=lse is not None,
+            enable_skip_softmax=use_skip,
+            use_pdl=enable_pdl,
+        )
+    except (RuntimeError, FileNotFoundError) as e:
+        logger.info(
+            f"Block-scaled DSL FMHA cubin unavailable ({e}); JIT-compiling the kernel."
+        )
+        kernel_fn = compile_cute_dsl_fmha_blockscaled_kernel(
+            qk_mode,
+            v.dtype,
+            o.dtype,
+            H_q,
+            H_k,
+            D,
+            is_causal,
+            lse is not None,
+            use_skip,
+            enable_pdl,
+            q.device,
+            has_window_left=window_left != -1,
+            has_window_right=is_causal or window_right != -1,
+        )
 
     if sm_scale is None:
         sm_scale = 1.0 / math.sqrt(D)
@@ -119,6 +260,9 @@ def cute_dsl_fmha_blockscaled_prefill(
 
     q_5d = q.reshape(batch_size, s_q, H_k, h_r, q.shape[-1])
     k_5d = k.reshape(batch_size, s_k, H_k, 1, k.shape[-1])
+    sf_vec_size = _BLOCKSCALED_MODES[qk_mode][2]
+    q_sf_6d = _reshape_sf_for_kernel(q_sf, batch_size, H_q, s_q, D, sf_vec_size)
+    k_sf_6d = _reshape_sf_for_kernel(k_sf, batch_size, H_k, s_k, D, sf_vec_size)
     v_5d = v.reshape(batch_size, s_k, H_k, 1, D_v)
     assert o.data_ptr() % 32 == 0, "o must be 32-byte aligned (256-bit stores)"
     o_5d = o.reshape(batch_size, s_q, H_k, h_r, D_v)
@@ -127,8 +271,8 @@ def cute_dsl_fmha_blockscaled_prefill(
     kernel_fn(
         q_5d,
         k_5d,
-        q_sf.reshape(-1),
-        k_sf.reshape(-1),
+        q_sf_6d,
+        k_sf_6d,
         v_5d,
         o_5d,
         problem_size,

--- a/flashinfer/cute_dsl/attention/fmha/compile.py
+++ b/flashinfer/cute_dsl/attention/fmha/compile.py
@@ -212,6 +212,7 @@ def compile_cute_dsl_fmha_kernel(
 @functools.cache
 def compile_cute_dsl_fmha_blockscaled_kernel(
     qk_mode: str,
+    pv_dtype: torch.dtype,
     out_dtype: torch.dtype,
     num_qo_heads: int,
     num_kv_heads: int,
@@ -221,12 +222,17 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
     enable_skip_softmax: bool,
     use_pdl: bool,
     device: torch.device,
+    has_window_left: bool = False,
+    has_window_right=None,
 ):
     """Compile (and cache) the trtllm block-scaled FMHA kernel (batched, non-varlen)."""
     from .fmha_blockscaled import BlackwellFusedMultiHeadBlockScaledAttentionForward
 
+    if has_window_right is None:
+        has_window_right = is_causal
     enable_ex2_emulation = _ex2_emulation_enabled(device)
     qk, sf_dt, sf_vec = _BLOCKSCALED_MODES[qk_mode]
+    pv = _CUTLASS_DTYPE[pv_dtype]
     out = _CUTLASS_DTYPE[out_dtype]
     d = dv = head_dim
 
@@ -236,7 +242,7 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
         mma_tiler=(128, 128),
         head_dim=d,
         is_persistent=False,
-        mask_type=_mask_type(is_causal),
+        mask_type=_mask_type(has_window_left or has_window_right),
         enable_ex2_emulation=enable_ex2_emulation,
         enable_skip_correction=True,
         qk_sf_vec_size=sf_vec,
@@ -264,7 +270,7 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
         assumed_align=16,
     )
     v_fake = make_fake_compact_tensor(
-        cutlass.Float8E4M3FN,
+        pv,
         (sym_b, sym_s_k, sym_hk, 1, sym_dv),
         stride_order=(4, 3, 2, 1, 0),
         assumed_align=16,
@@ -275,11 +281,21 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
         stride_order=(4, 3, 2, 1, 0),
         assumed_align=32,
     )
-    # SF: the kernel reconstructs the blocked layout from q.shape via
-    # tile_atom_to_shape_SF and only reads the SF pointer, so a flat 1D tensor
-    # (the fused quantizer's SF, flattened) is sufficient.
-    q_sf_fake = make_fake_compact_tensor(sf_dt, (cute.sym_int(),), assumed_align=16)
-    k_sf_fake = make_fake_compact_tensor(sf_dt, (cute.sym_int(),), assumed_align=16)
+    # The fused quantizer produces the same contiguous 128x4-swizzled storage.
+    # Expose it through the compiler's 6D ABI: (L, M/128, SF_K/4, 32, 4, 4).
+    sym_sf_k_tiles = cute.sym_int()
+    q_sf_fake = make_fake_compact_tensor(
+        sf_dt,
+        (cute.sym_int(), cute.sym_int(), sym_sf_k_tiles, 32, 4, 4),
+        stride_order=(5, 4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
+    k_sf_fake = make_fake_compact_tensor(
+        sf_dt,
+        (cute.sym_int(), cute.sym_int(), sym_sf_k_tiles, 32, 4, 4),
+        stride_order=(5, 4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
     lse_fake = (
         make_fake_compact_tensor(
             cutlass.Float32,
@@ -294,7 +310,8 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
     problem_size = (1, 1, 1, 1, num_qo_heads, num_kv_heads, d, dv)
     scale_softmax = 1.0 / math.sqrt(d)
     skip_threshold_log2 = Float32(0.0) if enable_skip_softmax else None
-    ws_right = Int32(0) if is_causal else None
+    ws_left = Int32(0) if has_window_left else None
+    ws_right = Int32(0) if has_window_right else None
     stream_fake = make_fake_stream(use_tvm_ffi_env_stream=True)
 
     return cute.compile(
@@ -315,7 +332,7 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
         1.0,
         None,  # scale_v_channels
         skip_threshold_log2,
-        None,
+        ws_left,
         ws_right,
         None,
         None,

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -277,7 +277,8 @@ def _blockscaled_dequant(x_bshd, qk_mode):
 
 @pytest.mark.parametrize("qk_mode", ["mxfp8", "nvfp4"])
 @pytest.mark.parametrize("causal", [False, True])
-def test_blockscaled_quantize_and_prefill(qk_mode, causal):
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_blockscaled_quantize_and_prefill(qk_mode, causal, out_dtype):
     """End-to-end block-scaled path: fused quantizer -> SF -> FMHA kernel."""
     from flashinfer.cute_dsl.attention.fmha.quantize import quantize_blockscaled_qk
     from flashinfer.attention.cute_dsl.fmha_blockscaled import (
@@ -296,7 +297,7 @@ def test_blockscaled_quantize_and_prefill(qk_mode, causal):
     )
     v_store = v.to(torch.float8_e4m3fn)
     v_deq = v_store.float()
-    o = torch.empty(b, s, H, D, device=DEVICE, dtype=torch.bfloat16)
+    o = torch.empty(b, s, H, D, device=DEVICE, dtype=out_dtype)
     cute_dsl_fmha_blockscaled_prefill(
         q_store,
         k_store,
@@ -321,4 +322,6 @@ def test_blockscaled_quantize_and_prefill(qk_mode, causal):
         s_logits = s_logits.masked_fill((col > row).view(1, 1, s, s), float("-inf"))
     p = torch.softmax(s_logits, dim=-1)
     o_ref = torch.einsum("bhqk,bkhd->bqhd", p, v_deq)
-    torch.testing.assert_close(o.float(), o_ref, atol=0.1, rtol=1e-2)
+    atol = 0.25 if out_dtype == torch.float8_e4m3fn else 0.1
+    rtol = 0.1 if out_dtype == torch.float8_e4m3fn else 1e-2
+    torch.testing.assert_close(o.float(), o_ref, atol=atol, rtol=rtol)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Our internal cubin artifact has published a new set of CuTe DSL FMHA cubins:

New cubins supported by this PR:

- mixed QK/PV dtype cubins
- blocksclaed cubins
- Rubin cubins

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GPU architecture `sm_107a`.
  * Enabled separate data type configuration for query/key and value tensors, including mixed FP8 attention configurations.
  * Added support for loading precompiled attention kernels with JIT compilation fallback.

* **Improvements**
  * Enhanced sliding-window and block-scaled attention support.
  * Improved quantization-scale handling and skip-softmax configuration.
  * Expanded support for different output data types, including bfloat16 and float8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->