### PR TITLE
fix(test): mock the DEEPGEMM_RUBIN pin in test_get_subdir_file_list

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -226,7 +226,15 @@ def get_checksums(subdirs):
             FLASHINFER_CUBINS_REPOSITORY, safe_urljoin(subdir, "checksums.txt")
         )
         checksum_path = FLASHINFER_CUBIN_DIR / safe_urljoin(subdir, "checksums.txt")
-        download_file(uri, checksum_path)
+        if not download_file(uri, checksum_path) and not checksum_path.is_file():
+            # Without this the next open() fails with a bare FileNotFoundError on
+            # the local cache path, which hides the real cause: the artifact pin
+            # is unreachable (typo'd/unpublished pin, or network/mirror failure).
+            raise RuntimeError(
+                f"Failed to fetch the checksum manifest for artifact pin '{subdir}' "
+                f"from {uri}. Check that the pin exists in "
+                f"{FLASHINFER_CUBINS_REPOSITORY} and is reachable."
+            )
         with open(checksum_path, "r") as f:
             for line in f:
                 sha256, filename = line.strip().split()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -4,6 +4,7 @@ from flashinfer.artifacts import (
     get_subdir_file_list,
 )
 
+import pytest
 import responses
 
 from flashinfer.jit.cubin_loader import safe_urljoin
@@ -297,6 +298,50 @@ def test_get_available_cubin_files_non_200_response():
         source, retries=1, delay=0, timeout=5
     )
     assert available_cubin_files == ()
+
+
+def test_get_checksums_unreachable_pin_raises(monkeypatch, tmp_path):
+    """An artifact pin whose checksums.txt cannot be fetched must fail loudly.
+
+    Guards the diagnosis path exercised by #4280: a pin added to `cubin_dirs`
+    without a published (or, in tests, mocked) manifest used to surface as a bare
+    FileNotFoundError on a local cache path, which reads like a corrupt cache
+    rather than an unreachable pin. `download_file` is stubbed rather than mocked
+    over HTTP so the test does not pay its 4 retries of exponential backoff.
+    """
+    from flashinfer import artifacts
+
+    monkeypatch.setattr(artifacts, "FLASHINFER_CUBIN_DIR", tmp_path / "cubins")
+    monkeypatch.setattr(artifacts, "download_file", lambda *args, **kwargs: False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        artifacts.get_checksums([artifact_paths.DEEPGEMM_RUBIN])
+    # The pin must be named -- that is the whole point of the error.
+    assert artifact_paths.DEEPGEMM_RUBIN in str(excinfo.value)
+
+
+def test_get_checksums_falls_back_to_cached_manifest(monkeypatch, tmp_path):
+    """A failed refresh must not invalidate an already-cached manifest.
+
+    Offline / FLASHINFER_NO_DOWNLOAD setups rely on the on-disk copy.
+    """
+    from flashinfer import artifacts
+
+    cubin_dir = tmp_path / "cubins"
+    monkeypatch.setattr(artifacts, "FLASHINFER_CUBIN_DIR", cubin_dir)
+    monkeypatch.setattr(artifacts, "download_file", lambda *args, **kwargs: False)
+
+    cached = cubin_dir / safe_urljoin(artifact_paths.DEEPGEMM_RUBIN, "checksums.txt")
+    cached.parent.mkdir(parents=True)
+    cached.write_text("abc123 kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin\n")
+
+    checksums = artifacts.get_checksums([artifact_paths.DEEPGEMM_RUBIN])
+    assert checksums == {
+        safe_urljoin(
+            artifact_paths.DEEPGEMM_RUBIN,
+            "kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin",
+        ): "abc123"
+    }
 
 
 @responses.activate

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -239,6 +239,12 @@ def _mock_file_index_responses():
     responses.add(
         responses.GET, gemm_rubin_source, body=success_gemm_response, status=200
     )
+    deepgemm_rubin_source = safe_urljoin(
+        test_cubin_repository, artifact_paths.DEEPGEMM_RUBIN
+    )
+    responses.add(
+        responses.GET, deepgemm_rubin_source, body=success_deepgemm_response, status=200
+    )
 
 
 @responses.activate
@@ -349,6 +355,13 @@ e8f9a0b1c2d3 kernel.fp8_m_grouped_gemm.02acb2ba71fd.cubin
 f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
 """
 
+    checksums_deepgemm_rubin = """3333333333333333333333333333333333333333333333333333333333333333 kernel_map.json
+1111aaaabbbbcccc kernel.fp8_m_grouped_gemm.007404769193.cubin
+2222aaaabbbbcccc kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin
+3333aaaabbbbcccc kernel.fp8_m_grouped_gemm.02acb2ba71fd.cubin
+4444aaaabbbbcccc kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
+"""
+
     # Add mock responses for checksums.txt files
     fmha_checksums_url = safe_urljoin(
         test_cubin_repository,
@@ -389,6 +402,17 @@ f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
     )
     responses.add(
         responses.GET, deepgemm_checksums_url, body=checksums_deepgemm, status=200
+    )
+
+    deepgemm_rubin_checksums_url = safe_urljoin(
+        test_cubin_repository,
+        safe_urljoin(artifact_paths.DEEPGEMM_RUBIN, "checksums.txt"),
+    )
+    responses.add(
+        responses.GET,
+        deepgemm_rubin_checksums_url,
+        body=checksums_deepgemm_rubin,
+        status=200,
     )
 
     # Mock DSL_FMHA checksums + directory index for the host cpu_arch.
@@ -479,6 +503,11 @@ f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
             "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
             artifact_paths.TRTLLM_GEN_GEMM,
             artifact_paths.TRTLLM_GEN_GEMM_RUBIN,
+        ),
+        (
+            "kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin",
+            artifact_paths.DEEPGEMM,
+            artifact_paths.DEEPGEMM_RUBIN,
         ),
     ):
         plain_path = safe_urljoin(plain_dir, shared_name)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`tests/test_artifacts.py::test_get_subdir_file_list` has been failing on `main` since #4280:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/tmp/pytest-of-root/pytest-0/test_get_subdir_file_list0/cubins/7ec7ac40b9fd48172651b77ff2ebe20d79decc39/deep-gemm/checksums.txt'
```

**Root cause.** #4280 added `ArtifactPath.DEEPGEMM_RUBIN` and appended it to the `cubin_dirs`
list walked by `get_subdir_file_list()`. The same PR registered `responses` mocks for the two
*other* new Rubin pins (`TRTLLM_GEN_BMM_RUBIN`, `TRTLLM_GEN_GEMM_RUBIN`) but not for the
deep-gemm one. Under `@responses.activate` an unregistered URL raises `ConnectionError`, so
`download_file()` exhausts its 4 retries and returns `False`; `get_checksums()` ignores that
return value and `open()`s a `checksums.txt` that was never written.

**The artifact itself is fine** — I fetched both deep-gemm manifests from artifactory (HTTP 200)
and the live SHA256 of `7ec7ac40…/deep-gemm/checksums.txt` matches the pin in
`CheckSumHash.DEEPGEMM_RUBIN` (`09e961d4…`). Only the unit test's mock registry was stale, so no
production download path is affected.

**Changes:**

- `tests/test_artifacts.py`: register the `DEEPGEMM_RUBIN` directory index and `checksums.txt`,
  mirroring the BMM/GEMM Rubin pattern (same index body, distinct per-pin hashes).
- `tests/test_artifacts.py`: extend the existing per-pin-hash-collision assertion to a shared
  deep-gemm kernel name, so deep-gemm gets the same regression coverage the trtllm-gen pins have.
- `flashinfer/artifacts.py`: `get_checksums()` now raises a `RuntimeError` naming the pin and the
  URL when the manifest download fails, instead of falling through to a bare `FileNotFoundError`
  on a local cache path. That failure mode is what made this read as a cache bug rather than
  "a pin was added without a mock".

## 🔍 Related Issues

Regression from #4280. Observed on unrelated PR CI, e.g.
https://github.com/flashinfer-ai/flashinfer/actions/runs/30607427968/job/91082694368

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.) — verification in progress on a dev box; draft until `tests/test_artifacts.py` is confirmed green.

## Reviewer Notes

CPU-only change; no kernel or GPU behavior is touched. The `get_checksums()` error-path change is
the only non-test edit — it converts a silent-download-failure into a diagnosable error and does
not alter the success path.

AI-assisted (Claude Code): diagnosis and patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum validation when artifact manifests are unavailable.
  * Errors now clearly identify the affected artifact and repository instead of producing a less informative file-not-found error.
  * Added fallback to cached checksum manifests when refreshing from a repository fails.
  * Prevented checksum collisions for shared kernel filenames across different DeepGEMM paths, including the Rubin variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->