### PR TITLE
perf(topk): skip output index sort for tie-break selection

### DIFF
--- a/benchmarks/bench_topk.py
+++ b/benchmarks/bench_topk.py
@@ -24,8 +24,6 @@ from flashinfer.topk import TopKTieBreak
 from flashinfer.testing.utils import bench_gpu_time
 from flashinfer.utils import get_compute_capability
 
-BENCH_ENABLE_CUPTI = True
-
 
 def set_topk_algo(algo: str):
     """Set environment variable to force specific topk algorithm."""
@@ -69,10 +67,10 @@ def torch_deterministic_algorithms(enabled: bool):
 def bench_median_ms(fn) -> float:
     measurements = bench_gpu_time(
         fn,
-        enable_cupti=BENCH_ENABLE_CUPTI,
+        enable_cupti=True,
         dry_run_iters=10,
         repeat_iters=100,
-        use_cuda_graph=True,
+        use_cuda_graph=False,
     )
     return float(np.median(measurements))
 
@@ -939,8 +937,6 @@ def parse_dtype(dtype_str: str) -> torch.dtype:
 
 @torch.inference_mode()
 def main():
-    global BENCH_ENABLE_CUPTI
-
     parser = argparse.ArgumentParser(description="Benchmark Top-K operations")
     parser.add_argument(
         "--compare-sglang",
@@ -977,11 +973,6 @@ def main():
             "FlashInfer(tie-small/tie-large) columns with slowdown against "
             "the non-deterministic baseline"
         ),
-    )
-    parser.add_argument(
-        "--disable-cupti",
-        action="store_true",
-        help="Use CUDA-event timing instead of CUPTI activity profiling",
     )
     parser.add_argument(
         "--compare-torch-deterministic",
@@ -1043,7 +1034,6 @@ def main():
         help="Query length per request for the varlen prefill (causal) regime (default: 128)",
     )
     args = parser.parse_args()
-    BENCH_ENABLE_CUPTI = not args.disable_cupti
 
     if args.varlen_k <= 0:
         parser.error("--varlen-k must be a positive integer")

--- a/benchmarks/bench_topk.py
+++ b/benchmarks/bench_topk.py
@@ -24,6 +24,8 @@ from flashinfer.topk import TopKTieBreak
 from flashinfer.testing.utils import bench_gpu_time
 from flashinfer.utils import get_compute_capability
 
+BENCH_ENABLE_CUPTI = True
+
 
 def set_topk_algo(algo: str):
     """Set environment variable to force specific topk algorithm."""
@@ -67,7 +69,7 @@ def torch_deterministic_algorithms(enabled: bool):
 def bench_median_ms(fn) -> float:
     measurements = bench_gpu_time(
         fn,
-        enable_cupti=True,
+        enable_cupti=BENCH_ENABLE_CUPTI,
         dry_run_iters=10,
         repeat_iters=100,
         use_cuda_graph=True,
@@ -174,7 +176,7 @@ def bench_top_k_from_scores(
     result["torch_us"] = torch_ms * 1e3
     result["speedup_vs_torch"] = torch_ms / fi_ms
     if compare_tie_break:
-        # Align tie-break slowdowns with the DetSlowdown baseline when present.
+        # Use the same non-deterministic baseline as DetSlowdown when present.
         baseline_ms = (
             fi_nondeterministic_ms if fi_nondeterministic_ms is not None else fi_ms
         )
@@ -183,7 +185,7 @@ def bench_top_k_from_scores(
                 lambda tie_break: flashinfer.top_k(
                     scores,
                     k,
-                    deterministic=True,
+                    deterministic=deterministic,
                     tie_break=tie_break,
                 ),
                 baseline_ms,
@@ -431,9 +433,6 @@ def bench_page_table_transform(
         .expand(batch_size, -1)
         .contiguous()
     )
-    use_cuda_graph = True
-    enable_cupti = True
-
     set_topk_algo("default")
     fi_ms, fi_nondeterministic_ms = bench_flashinfer_modes(
         lambda deterministic_mode: flashinfer.top_k_page_table_transform(
@@ -462,16 +461,11 @@ def bench_page_table_transform(
 
     # FlashInfer clusters
     set_topk_algo("clusters")
-    measurements = bench_gpu_time(
+    fast_topk_ms = bench_median_ms(
         lambda: flashinfer.top_k_page_table_transform(
             scores, src_page_table, lengths, k
-        ),
-        enable_cupti=enable_cupti,
-        dry_run_iters=10,
-        repeat_iters=100,
-        use_cuda_graph=use_cuda_graph,
+        )
     )
-    fast_topk_ms = np.median(measurements)
     result["fast_topk_us"] = fast_topk_ms * 1e3
     result["speedup_vs_flashinfer"] = fi_ms / fast_topk_ms
     set_topk_algo("auto")
@@ -488,7 +482,7 @@ def bench_page_table_transform(
         result["speedup_vs_sglang"] = sg_ms / fi_ms
 
     if compare_tie_break:
-        # Align tie-break slowdowns with the DetSlowdown baseline when present.
+        # Use the same non-deterministic baseline as DetSlowdown when present.
         baseline_ms = (
             fi_nondeterministic_ms if fi_nondeterministic_ms is not None else fi_ms
         )
@@ -499,7 +493,7 @@ def bench_page_table_transform(
                     src_page_table,
                     lengths,
                     k,
-                    deterministic=True,
+                    deterministic=deterministic,
                     tie_break=tie_break,
                 ),
                 baseline_ms,
@@ -525,9 +519,6 @@ def bench_ragged_transform(
     offsets = torch.arange(
         0, batch_size * seq_len, seq_len, device="cuda", dtype=torch.int32
     )
-    use_cuda_graph = True
-    enable_cupti = True
-
     set_topk_algo("default")
     fi_ms, fi_nondeterministic_ms = bench_flashinfer_modes(
         lambda deterministic_mode: flashinfer.top_k_ragged_transform(
@@ -556,14 +547,9 @@ def bench_ragged_transform(
 
     # FlashInfer clusters
     set_topk_algo("clusters")
-    measurements = bench_gpu_time(
+    fast_topk_ms = bench_median_ms(
         lambda: flashinfer.top_k_ragged_transform(scores, offsets, lengths, k),
-        enable_cupti=enable_cupti,
-        dry_run_iters=10,
-        repeat_iters=100,
-        use_cuda_graph=use_cuda_graph,
     )
-    fast_topk_ms = np.median(measurements)
     result["fast_topk_us"] = fast_topk_ms * 1e3
     result["speedup_vs_flashinfer"] = fi_ms / fast_topk_ms
     set_topk_algo("auto")
@@ -588,7 +574,7 @@ def bench_ragged_transform(
                     offsets,
                     lengths,
                     k,
-                    deterministic=True,
+                    deterministic=deterministic,
                     tie_break=tie_break,
                 ),
                 baseline_ms,
@@ -915,13 +901,13 @@ def bench_varlen_transform(
     set_topk_algo("auto")
 
     if compare_tie_break:
-        # Align tie-break slowdowns with the DetSlowdown baseline when present.
+        # Use the same non-deterministic baseline as DetSlowdown when present.
         baseline_ms = (
             fi_nondeterministic_ms if fi_nondeterministic_ms is not None else fi_ms
         )
         result.update(
             bench_tie_break_variants(
-                lambda tie_break: run(True, tie_break),
+                lambda tie_break: run(deterministic, tie_break),
                 baseline_ms,
             )
         )
@@ -953,6 +939,8 @@ def parse_dtype(dtype_str: str) -> torch.dtype:
 
 @torch.inference_mode()
 def main():
+    global BENCH_ENABLE_CUPTI
+
     parser = argparse.ArgumentParser(description="Benchmark Top-K operations")
     parser.add_argument(
         "--compare-sglang",
@@ -985,9 +973,15 @@ def main():
         "--tie-break",
         action="store_true",
         help=(
-            "Also benchmark deterministic tie-break variants and report "
-            "FlashInfer(tie-small/tie-large) columns with slowdown aligned to DetSlowdown baseline"
+            "Also benchmark tie-break variants and report "
+            "FlashInfer(tie-small/tie-large) columns with slowdown against "
+            "the non-deterministic baseline"
         ),
+    )
+    parser.add_argument(
+        "--disable-cupti",
+        action="store_true",
+        help="Use CUDA-event timing instead of CUPTI activity profiling",
     )
     parser.add_argument(
         "--compare-torch-deterministic",
@@ -1049,6 +1043,7 @@ def main():
         help="Query length per request for the varlen prefill (causal) regime (default: 128)",
     )
     args = parser.parse_args()
+    BENCH_ENABLE_CUPTI = not args.disable_cupti
 
     if args.varlen_k <= 0:
         parser.error("--varlen-k must be a positive integer")
@@ -1056,12 +1051,6 @@ def main():
         parser.error("--varlen-q-len must be a positive integer")
 
     dtype = parse_dtype(args.dtype)
-
-    if args.tie_break and not args.deterministic:
-        print(
-            "NOTE: --tie-break requires deterministic kernels; enabling --deterministic."
-        )
-        args.deterministic = True
 
     if args.compare_sglang and not HAS_SGL_KERNEL:
         print("WARNING: sgl_kernel not found, skipping SGLang comparison")
@@ -1167,8 +1156,8 @@ def main():
             )
         if args.tie_break:
             print(
-                "NOTE: tie-break columns benchmark deterministic tie-small/tie-large; "
-                "slowdowns align with the same baseline as DetSlowdown"
+                f"NOTE: tie-break columns use deterministic={args.deterministic}; "
+                "slowdowns use the non-deterministic baseline"
             )
         print(
             "NOTE: default top-k sweep includes two extra large-batch/long-vocab "
@@ -1293,8 +1282,8 @@ def main():
             )
         if args.tie_break:
             print(
-                "NOTE: tie-break columns benchmark deterministic tie-small/tie-large; "
-                "slowdowns align with the same baseline as DetSlowdown"
+                f"NOTE: tie-break columns use deterministic={args.deterministic}; "
+                "slowdowns use the non-deterministic baseline"
             )
         print("=" * 100)
 
@@ -1418,8 +1407,8 @@ def main():
             )
         if args.tie_break:
             print(
-                "NOTE: tie-break columns benchmark deterministic tie-small/tie-large; "
-                "slowdowns align with the same baseline as DetSlowdown"
+                f"NOTE: tie-break columns use deterministic={args.deterministic}; "
+                "slowdowns use the non-deterministic baseline"
             )
         print("=" * 100)
 
@@ -1523,8 +1512,8 @@ def main():
             )
         if args.tie_break:
             print(
-                "NOTE: tie-break columns benchmark deterministic tie-small/tie-large; "
-                "slowdowns align with the same baseline as DetSlowdown"
+                f"NOTE: tie-break columns use deterministic={args.deterministic}; "
+                "slowdowns use the non-deterministic baseline"
             )
         print("=" * 100)
 
@@ -1663,8 +1652,8 @@ def main():
                 )
             if args.tie_break:
                 print(
-                    "NOTE: tie-break columns benchmark deterministic tie-small/tie-large; "
-                    "slowdowns align with the same baseline as DetSlowdown"
+                    f"NOTE: tie-break columns use deterministic={args.deterministic}; "
+                    "slowdowns use the non-deterministic baseline"
                 )
             print(
                 "NOTE: Clusters column omitted under deterministic/tie-break "

--- a/csrc/topk.cu
+++ b/csrc/topk.cu
@@ -57,9 +57,6 @@ void radix_topk(TensorView input, TensorView output_indices, TensorView output_v
   cudaError_t status;
   auto dtype = input.dtype();
   sampling::TopKTieBreak tie_break_mode = ParseTopKTieBreak(tie_break);
-  if (tie_break_mode != sampling::TopKTieBreak::None) {
-    deterministic = true;
-  }
   // Get row_states_buffer if provided (for multi-CTA path)
   sampling::RadixRowState* row_states_ptr = nullptr;
   if (maybe_row_states_buffer.has_value()) {
@@ -114,9 +111,6 @@ void radix_topk_page_table_transform(TensorView input, TensorView output_page_ta
   cudaError_t status;
   auto dtype = input.dtype();
   sampling::TopKTieBreak tie_break_mode = ParseTopKTieBreak(tie_break);
-  if (tie_break_mode != sampling::TopKTieBreak::None) {
-    deterministic = true;
-  }
 
   sampling::RadixRowState* row_states_ptr = nullptr;
   if (maybe_row_states_buffer.has_value()) {
@@ -184,9 +178,6 @@ void radix_topk_ragged_transform(TensorView input, TensorView output_indices, Te
   cudaError_t status;
   auto dtype = input.dtype();
   sampling::TopKTieBreak tie_break_mode = ParseTopKTieBreak(tie_break);
-  if (tie_break_mode != sampling::TopKTieBreak::None) {
-    deterministic = true;
-  }
 
   sampling::RadixRowState* row_states_ptr = nullptr;
   if (maybe_row_states_buffer.has_value()) {

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -499,8 +499,8 @@ def topk_clusters_ragged_transform(logits, seq_lens, offsets, top_k, pdl=False):
     return indices
 
 
-def can_use_clusters_topk(device, deterministic, dsa_graph_safe):
-    if dsa_graph_safe:
+def can_use_clusters_topk(device, deterministic, tie_break, dsa_graph_safe):
+    if dsa_graph_safe or tie_break != TopKTieBreak.NONE:
         return False
     algo = os.environ.get("FLASHINFER_TOPK_ALGO")
     cap = get_compute_capability(device)
@@ -550,6 +550,9 @@ def top_k(
         - ``2``: prefer larger indices
 
         Default is ``0``.
+        Tie-breaking controls which boundary elements are selected; it does not
+        imply deterministic output ordering. Set ``deterministic=True`` when
+        repeatable output ordering is also required.
     dsa_graph_safe : bool, optional
         If True, force FilteredTopK path and graph-safe vectorization (VEC_SIZE=1).
         Default is False.
@@ -602,11 +605,7 @@ def top_k(
     batch_size = input.size(0)
     device = input.device
 
-    # tie_break modes 1/2 imply deterministic mode.
-    if tie_break != TopKTieBreak.NONE:
-        deterministic = True
-
-    if can_use_clusters_topk(input.device, deterministic, dsa_graph_safe):
+    if can_use_clusters_topk(input.device, deterministic, tie_break, dsa_graph_safe):
         indices, output_values = topk_clusters_exact(
             input, k, output_values=True, out_dtype=torch.int64
         )
@@ -717,6 +716,9 @@ def top_k_page_table_transform(
         - ``2``: prefer larger indices
 
         Default is ``0``.
+        Tie-breaking controls which boundary elements are selected; it does not
+        imply deterministic output ordering. Set ``deterministic=True`` when
+        repeatable output ordering is also required.
     dsa_graph_safe : bool, optional
         If True, force FilteredTopK path and graph-safe vectorization (VEC_SIZE=1).
         Default is False.
@@ -760,12 +762,13 @@ def top_k_page_table_transform(
     device = input.device
     num_rows = input.size(0)
 
-    # tie_break modes 1/2 imply deterministic mode.
-    if tie_break != TopKTieBreak.NONE:
-        deterministic = True
-
     if (
-        can_use_clusters_topk(input.device, deterministic, dsa_graph_safe)
+        can_use_clusters_topk(
+            input.device,
+            deterministic,
+            tie_break,
+            dsa_graph_safe,
+        )
         and row_to_batch is None
         and row_starts is None
         and page_table_row_starts is None
@@ -844,6 +847,9 @@ def top_k_ragged_transform(
         - ``2``: prefer larger indices
 
         Default is ``0``.
+        Tie-breaking controls which boundary elements are selected; it does not
+        imply deterministic output ordering. Set ``deterministic=True`` when
+        repeatable output ordering is also required.
     dsa_graph_safe : bool, optional
         If True, force FilteredTopK path and graph-safe vectorization (VEC_SIZE=1).
         Default is False.
@@ -885,12 +891,13 @@ def top_k_ragged_transform(
     device = input.device
     num_rows = input.size(0)
 
-    # tie_break modes 1/2 imply deterministic mode.
-    if tie_break != TopKTieBreak.NONE:
-        deterministic = True
-
     if (
-        can_use_clusters_topk(input.device, deterministic, dsa_graph_safe)
+        can_use_clusters_topk(
+            input.device,
+            deterministic,
+            tie_break,
+            dsa_graph_safe,
+        )
         and row_starts is None
     ):
         return topk_clusters_ragged_transform(input, lengths, offsets, k)

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -2955,10 +2955,10 @@ struct SortTopKByIndexBlockRadixSort<false, BLOCK_THREADS, ITEMS_PER_THREAD, DTy
   using Type = cub::BlockRadixSort<uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD>;
 };
 
-template <bool SORT_OUTPUT_BY_INDEX, FilteredTopKMode MODE, uint32_t BLOCK_THREADS,
+template <bool SORT_LOCAL_INDICES, FilteredTopKMode MODE, uint32_t BLOCK_THREADS,
           uint32_t ITEMS_PER_THREAD, typename DType, typename IdType>
 __global__ void __launch_bounds__(BLOCK_THREADS)
-    FinalizeTopKByIndexKernel(IdType* output_indices, DType* output_values, const IdType* aux_input,
+    FinalizeTopKIndicesKernel(IdType* output_indices, DType* output_values, const IdType* aux_input,
                               int64_t aux_stride, const IdType* page_table_row_starts,
                               const IdType* row_to_batch, uint32_t top_k, uint32_t max_len) {
   constexpr bool WITH_VALUES = (MODE == FilteredTopKMode::Plain);
@@ -2990,7 +2990,7 @@ __global__ void __launch_bounds__(BLOCK_THREADS)
     }
   }
 
-  if constexpr (SORT_OUTPUT_BY_INDEX) {
+  if constexpr (SORT_LOCAL_INDICES) {
     int end_bit = 32 - __clz(max_len);
     if constexpr (MODE == FilteredTopKMode::Plain) {
       BlockRadixSortT(temp_storage).Sort(keys, values, 0, end_bit);
@@ -3029,8 +3029,8 @@ __global__ void __launch_bounds__(BLOCK_THREADS)
   }
 }
 
-template <bool SORT_OUTPUT_BY_INDEX, FilteredTopKMode MODE, typename DType, typename IdType>
-cudaError_t LaunchFinalizeTopKByIndex(IdType* output_indices, DType* output_values,
+template <bool SORT_LOCAL_INDICES, FilteredTopKMode MODE, typename DType, typename IdType>
+cudaError_t LaunchFinalizeTopKIndices(IdType* output_indices, DType* output_values,
                                       const IdType* aux_input, int64_t aux_stride,
                                       const IdType* page_table_row_starts,
                                       const IdType* row_to_batch, uint32_t num_rows,
@@ -3052,30 +3052,30 @@ cudaError_t LaunchFinalizeTopKByIndex(IdType* output_indices, DType* output_valu
   dim3 grid(num_rows);
   void* args[] = {&output_indices,        &output_values, &aux_input, &aux_stride,
                   &page_table_row_starts, &row_to_batch,  &top_k_val, &max_len};
-  auto launch_sort = [&](auto kernel, uint32_t threads) -> cudaError_t {
+  auto launch_finalize = [&](auto kernel, uint32_t threads) -> cudaError_t {
     dim3 block(threads);
     return cudaLaunchKernel((void*)kernel, grid, block, args, 0, stream);
   };
 
   cudaError_t status;
   if (top_k_val <= 128) {
-    status = launch_sort(
-        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 32, 4, DType, IdType>, 32);
+    status = launch_finalize(
+        FinalizeTopKIndicesKernel<SORT_LOCAL_INDICES, MODE, 32, 4, DType, IdType>, 32);
   } else if (top_k_val <= 256) {
-    status = launch_sort(
-        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 32, 8, DType, IdType>, 32);
+    status = launch_finalize(
+        FinalizeTopKIndicesKernel<SORT_LOCAL_INDICES, MODE, 32, 8, DType, IdType>, 32);
   } else if (top_k_val <= 512) {
-    status = launch_sort(
-        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 64, 8, DType, IdType>, 64);
+    status = launch_finalize(
+        FinalizeTopKIndicesKernel<SORT_LOCAL_INDICES, MODE, 64, 8, DType, IdType>, 64);
   } else if (top_k_val <= 576) {
-    status = launch_sort(
-        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 64, 9, DType, IdType>, 64);
+    status = launch_finalize(
+        FinalizeTopKIndicesKernel<SORT_LOCAL_INDICES, MODE, 64, 9, DType, IdType>, 64);
   } else if (top_k_val <= 1024) {
-    status = launch_sort(
-        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 128, 8, DType, IdType>, 128);
+    status = launch_finalize(
+        FinalizeTopKIndicesKernel<SORT_LOCAL_INDICES, MODE, 128, 8, DType, IdType>, 128);
   } else {
-    status = launch_sort(
-        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 256, 8, DType, IdType>, 256);
+    status = launch_finalize(
+        FinalizeTopKIndicesKernel<SORT_LOCAL_INDICES, MODE, 256, 8, DType, IdType>, 256);
   }
   return status;
 }
@@ -3391,12 +3391,12 @@ cudaError_t TopKPageTableTransformDispatch(
         dsa_graph_safe)));
     if (deterministic) {
       FLASHINFER_CUDA_CALL(
-          (LaunchFinalizeTopKByIndex<true, FilteredTopKMode::PageTable, uint8_t, IdType>(
+          (LaunchFinalizeTopKIndices<true, FilteredTopKMode::PageTable, uint8_t, IdType>(
               output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride,
               page_table_row_starts, row_to_batch, num_rows, top_k_val, max_len, stream)));
     } else if (tie_break != TopKTieBreak::None) {
       FLASHINFER_CUDA_CALL(
-          (LaunchFinalizeTopKByIndex<false, FilteredTopKMode::PageTable, uint8_t, IdType>(
+          (LaunchFinalizeTopKIndices<false, FilteredTopKMode::PageTable, uint8_t, IdType>(
               output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride,
               page_table_row_starts, row_to_batch, num_rows, top_k_val, max_len, stream)));
     }
@@ -3426,12 +3426,12 @@ cudaError_t TopKRaggedTransformDispatch(DType* input, IdType* output_indices, co
         deterministic, tie_break, stream, dsa_graph_safe)));
     if (deterministic) {
       FLASHINFER_CUDA_CALL(
-          (LaunchFinalizeTopKByIndex<true, FilteredTopKMode::Ragged, uint8_t, IdType>(
+          (LaunchFinalizeTopKIndices<true, FilteredTopKMode::Ragged, uint8_t, IdType>(
               output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, nullptr, nullptr,
               num_rows, top_k_val, max_len, stream)));
     } else if (tie_break != TopKTieBreak::None) {
       FLASHINFER_CUDA_CALL(
-          (LaunchFinalizeTopKByIndex<false, FilteredTopKMode::Ragged, uint8_t, IdType>(
+          (LaunchFinalizeTopKIndices<false, FilteredTopKMode::Ragged, uint8_t, IdType>(
               output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, nullptr, nullptr,
               num_rows, top_k_val, max_len, stream)));
     }
@@ -3458,7 +3458,7 @@ cudaError_t TopKDispatch(DType* input, IdType* output_indices, DType* output_val
                                                       num_rows, top_k_val, max_len, deterministic,
                                                       tie_break, stream, dsa_graph_safe)));
     if (deterministic) {
-      FLASHINFER_CUDA_CALL((LaunchFinalizeTopKByIndex<true, FilteredTopKMode::Plain, DType, IdType>(
+      FLASHINFER_CUDA_CALL((LaunchFinalizeTopKIndices<true, FilteredTopKMode::Plain, DType, IdType>(
           output_indices, output_values, nullptr, 0, nullptr, nullptr, num_rows, top_k_val, max_len,
           stream)));
     }

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -2417,7 +2417,7 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
           dst_values[i] = DType(0);
         }
       } else if constexpr (DETERMINISTIC) {
-        // In deterministic mode the page-table/ragged transform happens in SortTopKByIndexKernel
+        // Defer the page-table/ragged transform to the lightweight finalizer.
         dst[i] = (i < length) ? static_cast<IdType>(i) : static_cast<IdType>(-1);
       } else if constexpr (MODE == FilteredTopKMode::PageTable) {
         dst[i] = (i < length) ? src_page_entry[page_table_row_start + i] : static_cast<IdType>(-1);
@@ -2909,7 +2909,7 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
     if constexpr (MODE == FilteredTopKMode::Plain) {
       dst[base] = static_cast<IdType>(idx);
       dst_values[base] = score[idx];
-    } else if constexpr (DETERMINISTIC) {  // transform in SortTopKByIndexKernel
+    } else if constexpr (DETERMINISTIC) {
       dst[base] = static_cast<IdType>(idx);
     } else if constexpr (MODE == FilteredTopKMode::PageTable) {
       dst[base] = src_page_entry[page_table_row_start + idx];
@@ -2955,12 +2955,12 @@ struct SortTopKByIndexBlockRadixSort<false, BLOCK_THREADS, ITEMS_PER_THREAD, DTy
   using Type = cub::BlockRadixSort<uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD>;
 };
 
-template <FilteredTopKMode MODE, uint32_t BLOCK_THREADS, uint32_t ITEMS_PER_THREAD, typename DType,
-          typename IdType>
+template <bool SORT_OUTPUT_BY_INDEX, FilteredTopKMode MODE, uint32_t BLOCK_THREADS,
+          uint32_t ITEMS_PER_THREAD, typename DType, typename IdType>
 __global__ void __launch_bounds__(BLOCK_THREADS)
-    SortTopKByIndexKernel(IdType* output_indices, DType* output_values, const IdType* aux_input,
-                          int64_t aux_stride, const IdType* page_table_row_starts,
-                          const IdType* row_to_batch, uint32_t top_k, uint32_t max_len) {
+    FinalizeTopKByIndexKernel(IdType* output_indices, DType* output_values, const IdType* aux_input,
+                              int64_t aux_stride, const IdType* page_table_row_starts,
+                              const IdType* row_to_batch, uint32_t top_k, uint32_t max_len) {
   constexpr bool WITH_VALUES = (MODE == FilteredTopKMode::Plain);
   using BlockRadixSortT = typename SortTopKByIndexBlockRadixSort<WITH_VALUES, BLOCK_THREADS,
                                                                  ITEMS_PER_THREAD, DType>::Type;
@@ -2990,11 +2990,13 @@ __global__ void __launch_bounds__(BLOCK_THREADS)
     }
   }
 
-  int end_bit = 32 - __clz(max_len);
-  if constexpr (MODE == FilteredTopKMode::Plain) {
-    BlockRadixSortT(temp_storage).Sort(keys, values, 0, end_bit);
-  } else {
-    BlockRadixSortT(temp_storage).Sort(keys, 0, end_bit);
+  if constexpr (SORT_OUTPUT_BY_INDEX) {
+    int end_bit = 32 - __clz(max_len);
+    if constexpr (MODE == FilteredTopKMode::Plain) {
+      BlockRadixSortT(temp_storage).Sort(keys, values, 0, end_bit);
+    } else {
+      BlockRadixSortT(temp_storage).Sort(keys, 0, end_bit);
+    }
   }
 
   const IdType* src_page_entry = nullptr;
@@ -3027,12 +3029,13 @@ __global__ void __launch_bounds__(BLOCK_THREADS)
   }
 }
 
-template <FilteredTopKMode MODE, typename DType, typename IdType>
-cudaError_t LaunchSortTopKByIndex(IdType* output_indices, DType* output_values,
-                                  const IdType* aux_input, int64_t aux_stride,
-                                  const IdType* page_table_row_starts, const IdType* row_to_batch,
-                                  uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
-                                  cudaStream_t stream = 0) {
+template <bool SORT_OUTPUT_BY_INDEX, FilteredTopKMode MODE, typename DType, typename IdType>
+cudaError_t LaunchFinalizeTopKByIndex(IdType* output_indices, DType* output_values,
+                                      const IdType* aux_input, int64_t aux_stride,
+                                      const IdType* page_table_row_starts,
+                                      const IdType* row_to_batch, uint32_t num_rows,
+                                      uint32_t top_k_val, uint32_t max_len,
+                                      cudaStream_t stream = 0) {
   // Block-local sort variants cover at most 256 * 8 = 2048 elements.
   if (top_k_val > 2048) {
     return cudaErrorInvalidValue;
@@ -3056,17 +3059,23 @@ cudaError_t LaunchSortTopKByIndex(IdType* output_indices, DType* output_values,
 
   cudaError_t status;
   if (top_k_val <= 128) {
-    status = launch_sort(SortTopKByIndexKernel<MODE, 32, 4, DType, IdType>, 32);
+    status = launch_sort(
+        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 32, 4, DType, IdType>, 32);
   } else if (top_k_val <= 256) {
-    status = launch_sort(SortTopKByIndexKernel<MODE, 32, 8, DType, IdType>, 32);
+    status = launch_sort(
+        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 32, 8, DType, IdType>, 32);
   } else if (top_k_val <= 512) {
-    status = launch_sort(SortTopKByIndexKernel<MODE, 64, 8, DType, IdType>, 64);
+    status = launch_sort(
+        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 64, 8, DType, IdType>, 64);
   } else if (top_k_val <= 576) {
-    status = launch_sort(SortTopKByIndexKernel<MODE, 64, 9, DType, IdType>, 64);
+    status = launch_sort(
+        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 64, 9, DType, IdType>, 64);
   } else if (top_k_val <= 1024) {
-    status = launch_sort(SortTopKByIndexKernel<MODE, 128, 8, DType, IdType>, 128);
+    status = launch_sort(
+        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 128, 8, DType, IdType>, 128);
   } else {
-    status = launch_sort(SortTopKByIndexKernel<MODE, 256, 8, DType, IdType>, 256);
+    status = launch_sort(
+        FinalizeTopKByIndexKernel<SORT_OUTPUT_BY_INDEX, MODE, 256, 8, DType, IdType>, 256);
   }
   return status;
 }
@@ -3169,6 +3178,7 @@ cudaError_t LaunchFilteredTopKUnified(DType* input, IdType* output, DType* aux_o
                                       cudaStream_t stream = 0, bool dsa_graph_safe = false) {
   constexpr size_t smem_size = FILTERED_TOPK_SMEM_DYNAMIC;
   constexpr int MAX_VEC = 16 / sizeof(DType);
+  const bool deterministic_selection = deterministic || tie_break != TopKTieBreak::None;
 
   dim3 grid(num_rows);
   dim3 block(FILTERED_TOPK_BLOCK_THREADS);
@@ -3189,20 +3199,18 @@ cudaError_t LaunchFilteredTopKUnified(DType* input, IdType* output, DType* aux_o
     FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, grid, block, args, smem_size, stream)); \
   } while (0)
 
-#define DISPATCH_VEC_SIZE(VS)                                  \
-  if (vec_size == VS) {                                        \
-    if (!deterministic) {                                      \
-      LAUNCH_FILTERED_KERNEL(VS, false, TopKTieBreak::None);   \
-    } else {                                                   \
-      if (tie_break == TopKTieBreak::Small) {                  \
-        LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::Small); \
-      } else if (tie_break == TopKTieBreak::Large) {           \
-        LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::Large); \
-      } else {                                                 \
-        LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::None);  \
-      }                                                        \
-    }                                                          \
-    return cudaSuccess;                                        \
+#define DISPATCH_VEC_SIZE(VS)                                \
+  if (vec_size == VS) {                                      \
+    if (!deterministic_selection) {                          \
+      LAUNCH_FILTERED_KERNEL(VS, false, TopKTieBreak::None); \
+    } else if (tie_break == TopKTieBreak::Small) {           \
+      LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::Small); \
+    } else if (tie_break == TopKTieBreak::Large) {           \
+      LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::Large); \
+    } else {                                                 \
+      LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::None);  \
+    }                                                        \
+    return cudaSuccess;                                      \
   }
 
   DISPATCH_VEC_SIZE(1)
@@ -3372,9 +3380,6 @@ cudaError_t TopKPageTableTransformDispatch(
     page_table_row_starts = row_starts;
   }
   const bool require_filtered = dsa_graph_safe || tie_break != TopKTieBreak::None;
-  if (tie_break != TopKTieBreak::None) {
-    deterministic = true;
-  }
   if (require_filtered && (top_k_val > FILTERED_TOPK_MAX_K || !CanImplementFilteredTopK())) {
     return cudaErrorNotSupported;
   }
@@ -3385,9 +3390,15 @@ cudaError_t TopKPageTableTransformDispatch(
         page_table_row_starts, num_rows, top_k_val, max_len, deterministic, tie_break, stream,
         dsa_graph_safe)));
     if (deterministic) {
-      FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::PageTable, uint8_t, IdType>(
-          output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride,
-          page_table_row_starts, row_to_batch, num_rows, top_k_val, max_len, stream)));
+      FLASHINFER_CUDA_CALL(
+          (LaunchFinalizeTopKByIndex<true, FilteredTopKMode::PageTable, uint8_t, IdType>(
+              output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride,
+              page_table_row_starts, row_to_batch, num_rows, top_k_val, max_len, stream)));
+    } else if (tie_break != TopKTieBreak::None) {
+      FLASHINFER_CUDA_CALL(
+          (LaunchFinalizeTopKByIndex<false, FilteredTopKMode::PageTable, uint8_t, IdType>(
+              output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride,
+              page_table_row_starts, row_to_batch, num_rows, top_k_val, max_len, stream)));
     }
     return cudaSuccess;
   }
@@ -3405,9 +3416,6 @@ cudaError_t TopKRaggedTransformDispatch(DType* input, IdType* output_indices, co
                                         TopKTieBreak tie_break = TopKTieBreak::None,
                                         cudaStream_t stream = 0, bool dsa_graph_safe = false) {
   const bool require_filtered = dsa_graph_safe || tie_break != TopKTieBreak::None;
-  if (tie_break != TopKTieBreak::None) {
-    deterministic = true;
-  }
   if (require_filtered && (top_k_val > FILTERED_TOPK_MAX_K || !CanImplementFilteredTopK())) {
     return cudaErrorNotSupported;
   }
@@ -3417,9 +3425,15 @@ cudaError_t TopKRaggedTransformDispatch(DType* input, IdType* output_indices, co
         input, output_indices, offsets, lengths, row_starts, num_rows, top_k_val, max_len,
         deterministic, tie_break, stream, dsa_graph_safe)));
     if (deterministic) {
-      FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::Ragged, uint8_t, IdType>(
-          output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, nullptr, nullptr, num_rows,
-          top_k_val, max_len, stream)));
+      FLASHINFER_CUDA_CALL(
+          (LaunchFinalizeTopKByIndex<true, FilteredTopKMode::Ragged, uint8_t, IdType>(
+              output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, nullptr, nullptr,
+              num_rows, top_k_val, max_len, stream)));
+    } else if (tie_break != TopKTieBreak::None) {
+      FLASHINFER_CUDA_CALL(
+          (LaunchFinalizeTopKByIndex<false, FilteredTopKMode::Ragged, uint8_t, IdType>(
+              output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, nullptr, nullptr,
+              num_rows, top_k_val, max_len, stream)));
     }
     return cudaSuccess;
   }
@@ -3435,9 +3449,6 @@ cudaError_t TopKDispatch(DType* input, IdType* output_indices, DType* output_val
                          bool deterministic = false, TopKTieBreak tie_break = TopKTieBreak::None,
                          cudaStream_t stream = 0, bool dsa_graph_safe = false) {
   const bool require_filtered = dsa_graph_safe || tie_break != TopKTieBreak::None;
-  if (tie_break != TopKTieBreak::None) {
-    deterministic = true;
-  }
   if (require_filtered && (top_k_val > FILTERED_TOPK_MAX_K || !CanImplementFilteredTopK())) {
     return cudaErrorNotSupported;
   }
@@ -3447,7 +3458,7 @@ cudaError_t TopKDispatch(DType* input, IdType* output_indices, DType* output_val
                                                       num_rows, top_k_val, max_len, deterministic,
                                                       tie_break, stream, dsa_graph_safe)));
     if (deterministic) {
-      FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::Plain, DType, IdType>(
+      FLASHINFER_CUDA_CALL((LaunchFinalizeTopKByIndex<true, FilteredTopKMode::Plain, DType, IdType>(
           output_indices, output_values, nullptr, 0, nullptr, nullptr, num_rows, top_k_val, max_len,
           stream)));
     }

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -2073,11 +2073,13 @@ def test_top_k_deterministic_sorted_repeatable_valid_selection_under_ties(
 @pytest.mark.parametrize(
     ("algo", "batch_size", "vocab_size", "k"),
     [
+        ("clusters", 2, 128 * 1024, 2048),
         ("filtered", 2, 128 * 1024, 2048),
         ("filtered", 1, 1024 * 1024, 1024),
         ("filtered", 74, 16 * 1024, 512),
     ],
     ids=[
+        "clusters_override_b2_l128k_k2048",
         "filtered_b2_l128k_k2048",
         "filtered_b1_l1m_k1024",
         "filtered_b74_l16k_k512",
@@ -2085,7 +2087,7 @@ def test_top_k_deterministic_sorted_repeatable_valid_selection_under_ties(
 )
 def test_top_k_tie_break_modes(algo, batch_size, vocab_size, k, set_topk_algo):
     """tie_break=1|2 should select row-global smallest/largest pivot indices."""
-    if algo == "filtered" and not can_implement_filtered_topk():
+    if not can_implement_filtered_topk():
         pytest.skip("Filtered top-k not supported on this device")
 
     set_topk_algo(algo)
@@ -2122,23 +2124,25 @@ def test_top_k_tie_break_modes(algo, batch_size, vocab_size, k, set_topk_algo):
 
 
 @pytest.mark.parametrize(
-    ("algo", "num_rows", "max_len", "k"),
+    ("algo", "num_rows", "max_len", "k", "dtype"),
     [
-        ("filtered", 2, 128 * 1024, 2048),
-        ("filtered", 1, 1024 * 1024, 1024),
-        ("filtered", 74, 16 * 1024, 512),
+        ("clusters", 2, 128 * 1024, 2048, torch.bfloat16),
+        ("filtered", 2, 128 * 1024, 2048, torch.bfloat16),
+        ("filtered", 1, 1024 * 1024, 1024, torch.float32),
+        ("filtered", 74, 16 * 1024, 512, torch.float32),
     ],
     ids=[
+        "clusters_override_rows2_l128k_k2048",
         "filtered_rows2_l128k_k2048",
         "filtered_rows1_l1m_k1024",
         "filtered_rows74_l16k_k512",
     ],
 )
 def test_top_k_tie_break_modes_transform_apis(
-    algo, num_rows, max_len, k, set_topk_algo
+    algo, num_rows, max_len, k, dtype, set_topk_algo
 ):
     """Transform APIs should honor tie_break selection before remapping outputs."""
-    if algo == "filtered" and not can_implement_filtered_topk():
+    if not can_implement_filtered_topk():
         pytest.skip("Filtered top-k not supported on this device")
 
     set_topk_algo(algo)
@@ -2147,20 +2151,19 @@ def test_top_k_tie_break_modes_transform_apis(
     generator = torch.Generator(device=device)
     generator.manual_seed(0)
     scores = (
-        torch.randn(
-            (num_rows, 1), device=device, dtype=torch.float32, generator=generator
-        )
+        torch.randn((num_rows, 1), device=device, dtype=dtype, generator=generator)
         .expand(num_rows, max_len)
         .contiguous()
     )
     lengths = torch.full((num_rows,), max_len, device=device, dtype=torch.int32)
-    src_page_table = (
-        torch.arange(max_len, device=device, dtype=torch.int32)
-        .unsqueeze(0)
-        .expand(num_rows, -1)
-        .contiguous()
+    row_bases = (torch.arange(num_rows, device=device, dtype=torch.int32) + 1) * (
+        max_len + 17
     )
-    offsets = torch.zeros((num_rows,), device=device, dtype=torch.int32)
+    src_page_table = (
+        row_bases.unsqueeze(1)
+        + torch.arange(max_len, device=device, dtype=torch.int32).unsqueeze(0)
+    ).contiguous()
+    offsets = row_bases
 
     page_small = flashinfer.top_k_page_table_transform(
         scores, src_page_table, lengths, k, tie_break=1
@@ -2175,21 +2178,122 @@ def test_top_k_tie_break_modes_transform_apis(
         scores, offsets, lengths, k, tie_break=2
     )
 
-    expected_small = (
+    local_small = (
         torch.arange(k, device=device, dtype=torch.int32)
         .unsqueeze(0)
         .expand(num_rows, -1)
     )
-    expected_large = (
+    local_large = (
         torch.arange(max_len - k, max_len, device=device, dtype=torch.int32)
         .unsqueeze(0)
         .expand(num_rows, -1)
     )
+    expected_small = row_bases.unsqueeze(1) + local_small
+    expected_large = row_bases.unsqueeze(1) + local_large
 
-    assert torch.equal(page_small, expected_small)
-    assert torch.equal(page_large, expected_large)
-    assert torch.equal(ragged_small, expected_small)
-    assert torch.equal(ragged_large, expected_large)
+    _assert_unordered_indices_match(page_small, expected_small)
+    _assert_unordered_indices_match(page_large, expected_large)
+    _assert_unordered_indices_match(ragged_small, expected_small)
+    _assert_unordered_indices_match(ragged_large, expected_large)
+
+
+@pytest.mark.parametrize(
+    "tie_break",
+    [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
+)
+def test_top_k_tie_break_explicit_deterministic_order(tie_break, set_topk_algo):
+    """Explicit deterministic mode should retain canonical tie-break output order."""
+    if not can_implement_filtered_topk():
+        pytest.skip("Filtered top-k not supported on this device")
+
+    set_topk_algo("filtered")
+    device = "cuda"
+    num_rows = 2
+    max_len = 8192
+    k = 512
+    scores = torch.ones((num_rows, max_len), device=device, dtype=torch.float32)
+
+    values_a, indices_a = flashinfer.top_k(
+        scores, k, deterministic=True, tie_break=tie_break
+    )
+    values_b, indices_b = flashinfer.top_k(
+        scores, k, deterministic=True, tie_break=tie_break
+    )
+
+    start = 0 if tie_break == flashinfer.TopKTieBreak.SMALL else max_len - k
+    expected_indices = (
+        torch.arange(start, start + k, device=device, dtype=torch.int64)
+        .unsqueeze(0)
+        .expand(num_rows, -1)
+    )
+    torch.testing.assert_close(values_a, torch.ones_like(values_a))
+    assert torch.equal(values_a, values_b)
+    assert torch.equal(indices_a, expected_indices)
+    assert torch.equal(indices_a, indices_b)
+
+
+@pytest.mark.parametrize(
+    "tie_break",
+    [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
+)
+def test_top_k_tie_break_explicit_deterministic_transform_order(
+    tie_break, set_topk_algo
+):
+    """Deterministic transform APIs should sort local indices before remapping."""
+    if not can_implement_filtered_topk():
+        pytest.skip("Filtered top-k not supported on this device")
+
+    set_topk_algo("filtered")
+    device = "cuda"
+    num_rows = 2
+    max_len = 8192
+    length = 4096
+    k = 512
+    scores = torch.ones((num_rows, max_len), device=device, dtype=torch.float32)
+    lengths = torch.full((num_rows,), length, device=device, dtype=torch.int32)
+    row_starts = torch.tensor([7, 13], device=device, dtype=torch.int32)
+    page_table_row_starts = torch.tensor([23, 31], device=device, dtype=torch.int32)
+    row_to_batch = torch.tensor([1, 0], device=device, dtype=torch.int32)
+    src_page_table = torch.arange(max_len, device=device, dtype=torch.int32).unsqueeze(
+        0
+    ) * 3 + torch.tensor([[100_000], [200_000]], device=device, dtype=torch.int32)
+    offsets = torch.tensor([300_000, 400_000], device=device, dtype=torch.int32)
+
+    page_output = flashinfer.top_k_page_table_transform(
+        scores,
+        src_page_table,
+        lengths,
+        k,
+        row_to_batch=row_to_batch,
+        deterministic=True,
+        tie_break=tie_break,
+        row_starts=row_starts,
+        page_table_row_starts=page_table_row_starts,
+    )
+    ragged_output = flashinfer.top_k_ragged_transform(
+        scores,
+        offsets,
+        lengths,
+        k,
+        deterministic=True,
+        tie_break=tie_break,
+        row_starts=row_starts,
+    )
+
+    start = 0 if tie_break == flashinfer.TopKTieBreak.SMALL else length - k
+    local_indices = (
+        torch.arange(start, start + k, device=device, dtype=torch.int32)
+        .unsqueeze(0)
+        .expand(num_rows, -1)
+    )
+    expected_page = torch.gather(
+        src_page_table[row_to_batch],
+        1,
+        page_table_row_starts.unsqueeze(1) + local_indices,
+    )
+    expected_ragged = offsets.unsqueeze(1) + local_indices
+    assert torch.equal(page_output, expected_page)
+    assert torch.equal(ragged_output, expected_ragged)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -2201,17 +2201,29 @@ def test_top_k_tie_break_modes_transform_apis(
     "tie_break",
     [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
 )
-def test_top_k_tie_break_explicit_deterministic_order(tie_break, set_topk_algo):
+@pytest.mark.parametrize(
+    ("algo", "batch_size", "vocab_size", "k"),
+    [
+        ("filtered", 2, 128 * 1024, 2048),
+        ("filtered", 1, 1024 * 1024, 1024),
+        ("filtered", 74, 16 * 1024, 512),
+    ],
+    ids=[
+        "filtered_b2_l128k_k2048",
+        "filtered_b1_l1m_k1024",
+        "filtered_b74_l16k_k512",
+    ],
+)
+def test_top_k_tie_break_explicit_deterministic_order(
+    tie_break, algo, batch_size, vocab_size, k, set_topk_algo
+):
     """Explicit deterministic mode should retain canonical tie-break output order."""
     if not can_implement_filtered_topk():
         pytest.skip("Filtered top-k not supported on this device")
 
-    set_topk_algo("filtered")
+    set_topk_algo(algo)
     device = "cuda"
-    num_rows = 2
-    max_len = 8192
-    k = 512
-    scores = torch.ones((num_rows, max_len), device=device, dtype=torch.float32)
+    scores = torch.ones((batch_size, vocab_size), device=device, dtype=torch.float32)
 
     values_a, indices_a = flashinfer.top_k(
         scores, k, deterministic=True, tie_break=tie_break
@@ -2220,11 +2232,11 @@ def test_top_k_tie_break_explicit_deterministic_order(tie_break, set_topk_algo):
         scores, k, deterministic=True, tie_break=tie_break
     )
 
-    start = 0 if tie_break == flashinfer.TopKTieBreak.SMALL else max_len - k
+    start = 0 if tie_break == flashinfer.TopKTieBreak.SMALL else vocab_size - k
     expected_indices = (
         torch.arange(start, start + k, device=device, dtype=torch.int64)
         .unsqueeze(0)
-        .expand(num_rows, -1)
+        .expand(batch_size, -1)
     )
     torch.testing.assert_close(values_a, torch.ones_like(values_a))
     assert torch.equal(values_a, values_b)
@@ -2236,28 +2248,40 @@ def test_top_k_tie_break_explicit_deterministic_order(tie_break, set_topk_algo):
     "tie_break",
     [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
 )
+@pytest.mark.parametrize(
+    ("algo", "num_rows", "max_len", "k"),
+    [
+        ("filtered", 2, 128 * 1024, 2048),
+        ("filtered", 1, 1024 * 1024, 1024),
+        ("filtered", 74, 16 * 1024, 512),
+    ],
+    ids=[
+        "filtered_rows2_l128k_k2048",
+        "filtered_rows1_l1m_k1024",
+        "filtered_rows74_l16k_k512",
+    ],
+)
 def test_top_k_tie_break_explicit_deterministic_transform_order(
-    tie_break, set_topk_algo
+    tie_break, algo, num_rows, max_len, k, set_topk_algo
 ):
     """Deterministic transform APIs should sort local indices before remapping."""
     if not can_implement_filtered_topk():
         pytest.skip("Filtered top-k not supported on this device")
 
-    set_topk_algo("filtered")
+    set_topk_algo(algo)
     device = "cuda"
-    num_rows = 2
-    max_len = 8192
-    length = 4096
-    k = 512
     scores = torch.ones((num_rows, max_len), device=device, dtype=torch.float32)
+    row_ids = torch.arange(num_rows, device=device, dtype=torch.int32)
+    row_starts = 7 + 13 * row_ids
+    page_table_row_starts = 23 + 17 * row_ids
+    length = max_len - (23 + 17 * (num_rows - 1))
     lengths = torch.full((num_rows,), length, device=device, dtype=torch.int32)
-    row_starts = torch.tensor([7, 13], device=device, dtype=torch.int32)
-    page_table_row_starts = torch.tensor([23, 31], device=device, dtype=torch.int32)
-    row_to_batch = torch.tensor([1, 0], device=device, dtype=torch.int32)
-    src_page_table = torch.arange(max_len, device=device, dtype=torch.int32).unsqueeze(
-        0
-    ) * 3 + torch.tensor([[100_000], [200_000]], device=device, dtype=torch.int32)
-    offsets = torch.tensor([300_000, 400_000], device=device, dtype=torch.int32)
+    row_to_batch = torch.arange(num_rows - 1, -1, -1, device=device, dtype=torch.int32)
+    src_page_table = (
+        torch.arange(max_len, device=device, dtype=torch.int32).unsqueeze(0)
+        + 100_000 * (row_ids + 1).unsqueeze(1)
+    ).contiguous()
+    offsets = 300_000 + 100_000 * row_ids
 
     page_output = flashinfer.top_k_page_table_transform(
         scores,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

@humansand

Follow-up to #3095.

`tie_break` determines which equal-valued elements are selected at the top-k boundary. Today, requesting a tie-break also promotes the public `deterministic` flag, which runs the index-ordering finalizer even though the default API output is unsorted.

This PR separates deterministic selection from deterministic output ordering:

- tie-break modes still use deterministic filtered selection so `SMALL`/`LARGE` choose the intended boundary indices;
- the shared `FinalizeTopKIndicesKernel` always finalizes/remaps indices, with `SORT_LOCAL_INDICES` as the compile-time switch for its optional local-index radix sort;
- explicit `deterministic=True` retains the existing CUB index sort and repeatable output order;
- tie-break with `deterministic=False` skips the finalizer entirely for plain Top-K, while page-table/ragged transforms run only the required remapping work;
- `can_use_clusters_topk` now receives `tie_break` and rejects tie-break modes at the same early-exit boundary as `dsa_graph_safe`;
- API documentation, exact-set/remapping tests, and the Top-K benchmark driver reflect that tie-breaking controls selection, not output order.

`sorted=True` remains unchanged and still requests descending value order.

#### `sorted` and `deterministic` use different sort keys

These options are independent and should not be conflated:

| Option | Contract | Sort key/order |
|---|---|---|
| `sorted=True` | Return the selected top-k elements in score order, matching `torch.topk(..., sorted=True)` | value descending, carrying the corresponding index |
| `deterministic=True` | Make selection and output ordering repeatable for a fixed input and system | on the filtered path, local/original index ascending, carrying the corresponding value |

The deterministic filtered-path index sort is a canonicalization step; it does **not** imply descending score order. If both options are enabled, FlashInfer first establishes deterministic index order and then applies a stable descending value sort. Equal values therefore retain the deterministic prior order. For page-table and ragged transforms, local indices are canonicalized before remapping, so the returned mapped IDs are not necessarily numerically sorted.

`tie_break` is separate from both: it controls which equal-valued elements are selected at the top-k boundary, not the final output order.

### Performance

Both sides used the same final benchmark driver and ran on the same physical GPU (`CUDA_VISIBLE_DEVICES=2`) in the `flashinfer-pr4048-cu132` devbox from the `hell` queue. Speedup is `BEFORE / AFTER`.

| Environment | Value |
|---|---|
| GPU | NVIDIA B200 (`sm100`) |
| CUDA toolkit | 13.2.1 |
| PyTorch | 2.13.0+cu132 |
| Driver | 580.126.09 |
| CUPTI Python/native | 13.2.0 / 13.2.75 |
| FlashInfer source version | 0.6.17 |
| BEFORE | `upstream/main` at `668a1ba1ca86432c79f6adad37ecfce8d06ec083` |
| AFTER | `89c649679af75792b2cad1020c91b41bf2262adc` |
| Timing | CUPTI activity timing, no CUDA graph replay, cold L2, 10 dry runs, 100 measured iterations, median |

The shared timer supports CUPTI with and without CUDA graphs. A control sweep with CUPTI + CUDA graphs + cold-L2 reproduced the same illegal-memory-access failure on both upstream `main` and this branch at the first 128K page-table row, so it is not specific to this PR's kernel changes. The final benchmark follows existing FlashInfer CUPTI microbenchmarks by using `enable_cupti=True` with `use_cuda_graph=False`; no benchmark-specific environment, global, or CLI escape hatch remains.

Commands:

```bash
export CUDA_VISIBLE_DEVICES=2

python benchmarks/bench_topk.py \
  --op dsa_topk \
  --dtype bf16 \
  --dsa-input-pattern dsa_relu \
  --dsa-case all \
  --dsa-topk 2048 \
  --tie-break

python benchmarks/bench_topk.py \
  --op varlen \
  --dtype bf16 \
  --length-dist causal \
  --varlen-k 2048 \
  --varlen-q-len 128 \
  --tie-break
```

Summary (geometric mean across cases):

| Suite | Tie-break | Geomean speedup | Case range |
|---|---:|---:|---:|
| DSA Top-K | small | **1.141x** | 1.123x–1.182x |
| DSA Top-K | large | **1.135x** | 1.071x–1.170x |
| Varlen page-table | small | **1.080x** | 1.034x–1.145x |
| Varlen page-table | large | **1.078x** | 1.035x–1.139x |
| Varlen ragged | small | **1.121x** | 1.061x–1.186x |
| Varlen ragged | large | **1.119x** | 1.061x–1.195x |

DSA Top-K results (latency in µs):

| Case | Small BEFORE | Small AFTER | Speedup | Large BEFORE | Large AFTER | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| `decode_b1_q1_l128k` | 83.17 | 74.08 | **1.123x** | 84.54 | 72.24 | **1.170x** |
| `decode_b8_q1_l64k` | 80.69 | 68.29 | **1.182x** | 79.04 | 67.86 | **1.165x** |
| `decode_b32_q1_l128k` | 90.56 | 80.51 | **1.125x** | 85.92 | 80.19 | **1.071x** |
| `prefill_b1_q128_l128k` | 91.41 | 80.51 | **1.135x** | 91.33 | 80.43 | **1.136x** |

Variable-length transform results (latency in µs):

| Transform | Rows | Max length | Small BEFORE | Small AFTER | Speedup | Large BEFORE | Large AFTER | Speedup |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| page-table | 512 | 16,384 | 49.06 | 42.85 | **1.145x** | 49.09 | 43.10 | **1.139x** |
| ragged | 512 | 16,384 | 47.87 | 40.35 | **1.186x** | 48.10 | 40.26 | **1.195x** |
| page-table | 512 | 65,536 | 86.38 | 79.07 | **1.092x** | 87.66 | 80.67 | **1.087x** |
| ragged | 512 | 65,536 | 84.80 | 75.50 | **1.123x** | 85.39 | 76.99 | **1.109x** |
| page-table | 512 | 131,072 | 99.63 | 92.54 | **1.077x** | 99.92 | 92.80 | **1.077x** |
| ragged | 512 | 131,072 | 98.61 | 89.41 | **1.103x** | 98.75 | 89.68 | **1.101x** |
| page-table | 2,048 | 16,384 | 172.29 | 157.33 | **1.095x** | 173.63 | 158.94 | **1.092x** |
| ragged | 2,048 | 16,384 | 170.30 | 144.35 | **1.180x** | 171.66 | 145.87 | **1.177x** |
| page-table | 2,048 | 65,536 | 442.69 | 424.46 | **1.043x** | 444.54 | 426.35 | **1.043x** |
| ragged | 2,048 | 65,536 | 437.07 | 405.06 | **1.079x** | 438.82 | 406.80 | **1.079x** |
| page-table | 2,048 | 131,072 | 565.89 | 547.06 | **1.034x** | 568.35 | 548.93 | **1.035x** |
| ragged | 2,048 | 131,072 | 558.54 | 526.56 | **1.061x** | 561.33 | 529.02 | **1.061x** |

<details>
<summary>Raw BEFORE output: DSA Top-K</summary>

```text
====================================================================================================
dsa_topk: DeepSeek DSA-like indexer top-k workload (dtype=BF16, deterministic=False, dsa_pattern=dsa_relu, k=2048, tie_break=True)
NOTE: tie-break columns use deterministic=False; slowdowns use the non-deterministic baseline
====================================================================================================
                    case     rows    seq_len      k |   FlashInfer FlashInfer(det) DetSlowdown FlashInfer(tie-small)  TieSmallSlowdown FlashInfer(tie-large)  TieLargeSlowdown   torch.topk    Speedup
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      decode_b1_q1_l128k        1     131072   2048 |      40.90us            n/a         n/a               83.17us             2.03x               84.54us             2.07x      75.44us      1.84x
       decode_b8_q1_l64k        8      65536   2048 |      40.75us            n/a         n/a               80.69us             1.98x               79.04us             1.94x      82.86us      2.03x
     decode_b32_q1_l128k       32     131072   2048 |      45.66us            n/a         n/a               90.56us             1.98x               85.92us             1.88x     112.77us      2.47x
   prefill_b1_q128_l128k      128     131072   2048 |      82.61us            n/a         n/a               91.41us             1.11x               91.33us             1.11x     197.28us      2.39x
```

</details>

<details>
<summary>Raw AFTER output: DSA Top-K</summary>

```text
====================================================================================================
dsa_topk: DeepSeek DSA-like indexer top-k workload (dtype=BF16, deterministic=False, dsa_pattern=dsa_relu, k=2048, tie_break=True)
NOTE: tie-break columns use deterministic=False; slowdowns use the non-deterministic baseline
====================================================================================================
                    case     rows    seq_len      k |   FlashInfer FlashInfer(det) DetSlowdown FlashInfer(tie-small)  TieSmallSlowdown FlashInfer(tie-large)  TieLargeSlowdown   torch.topk    Speedup
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      decode_b1_q1_l128k        1     131072   2048 |      41.02us            n/a         n/a               74.08us             1.81x               72.24us             1.76x      73.60us      1.79x
       decode_b8_q1_l64k        8      65536   2048 |      40.69us            n/a         n/a               68.29us             1.68x               67.86us             1.67x      82.58us      2.03x
     decode_b32_q1_l128k       32     131072   2048 |      45.89us            n/a         n/a               80.51us             1.75x               80.19us             1.75x     112.69us      2.46x
   prefill_b1_q128_l128k      128     131072   2048 |      82.59us            n/a         n/a               80.51us             0.97x               80.43us             0.97x     198.18us      2.40x
```

</details>

<details>
<summary>Raw BEFORE output: variable-length transforms</summary>

```text
====================================================================================================
varlen: Variable-length segment top-k transforms (production-realistic) (dtype=BF16, length_dist=causal, k=2048, deterministic=False, tie_break=True)
NOTE: lengths model per-row valid windows; decode = independent context lengths, prefill(causal) = monotonic growth within a request (q_len=128)
NOTE: torch(mask) masks invalid positions once (outside timing) then torch.topk, isolating selection cost vs the length-aware kernel
NOTE: tie-break columns use deterministic=False; slowdowns use the non-deterministic baseline
NOTE: Clusters column omitted under deterministic/tie-break (clusters requires the non-deterministic path)
====================================================================================================
  regime       dist   transform     rows   reqs   max_len      k |  len_min  len_mean  len_max  triv% |   FlashInfer FlashInfer(det) DetSlowdown FlashInfer(tie-small)  TieSmallSlowdown FlashInfer(tie-large)  TieLargeSlowdown   torch(mask)   Speedup
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 prefill     causal  page_table      512      4     16384   2048 |      375    7109.2    12411  25.0% |      30.34us            n/a         n/a               49.06us             1.62x               49.09us             1.62x      153.26us     5.05x
 prefill     causal      ragged      512      4     16384   2048 |      375    7109.2    12411  25.0% |      27.33us            n/a         n/a               47.87us             1.75x               48.10us             1.76x      152.34us     5.57x
 prefill     causal  page_table      512      4     65536   2048 |     2039   22253.8    37156   2.0% |      65.44us            n/a         n/a               86.38us             1.32x               87.66us             1.34x      308.99us     4.72x
 prefill     causal      ragged      512      4     65536   2048 |     2039   22253.8    37156   2.0% |      60.43us            n/a         n/a               84.80us             1.40x               85.39us             1.41x      309.34us     5.12x
 prefill     causal  page_table      512      4    131072   2048 |      524   33177.8   101452  25.0% |     152.19us            n/a         n/a               99.63us             0.65x               99.92us             0.66x      592.27us     3.89x
 prefill     causal      ragged      512      4    131072   2048 |      524   33177.8   101452  25.0% |     144.70us            n/a         n/a               98.61us             0.68x               98.75us             0.68x      591.23us     4.09x
 prefill     causal  page_table     2048     16     16384   2048 |      416    7917.1    15346  12.5% |     122.30us            n/a         n/a              172.29us             1.41x              173.63us             1.42x      366.67us     3.00x
 prefill     causal      ragged     2048     16     16384   2048 |      416    7917.1    15346  12.5% |     111.49us            n/a         n/a              170.30us             1.53x              171.66us             1.54x      367.58us     3.30x
 prefill     causal  page_table     2048     16     65536   2048 |     7804   36260.2    63720   0.0% |     318.27us            n/a         n/a              442.69us             1.39x              444.54us             1.40x     1114.34us     3.50x
 prefill     causal      ragged     2048     16     65536   2048 |     7804   36260.2    63720   0.0% |     298.85us            n/a         n/a              437.07us             1.46x              438.82us             1.47x     1114.48us     3.73x
 prefill     causal  page_table     2048     16    131072   2048 |     7095   60508.9   124975   0.0% |     870.77us            n/a         n/a              565.89us             0.65x              568.35us             0.65x     2000.19us     2.30x
 prefill     causal      ragged     2048     16    131072   2048 |     7095   60508.9   124975   0.0% |     849.74us            n/a         n/a              558.54us             0.66x              561.33us             0.66x     2001.38us     2.36x
```

</details>

<details>
<summary>Raw AFTER output: variable-length transforms</summary>

```text
====================================================================================================
varlen: Variable-length segment top-k transforms (production-realistic) (dtype=BF16, length_dist=causal, k=2048, deterministic=False, tie_break=True)
NOTE: lengths model per-row valid windows; decode = independent context lengths, prefill(causal) = monotonic growth within a request (q_len=128)
NOTE: torch(mask) masks invalid positions once (outside timing) then torch.topk, isolating selection cost vs the length-aware kernel
NOTE: tie-break columns use deterministic=False; slowdowns use the non-deterministic baseline
NOTE: Clusters column omitted under deterministic/tie-break (clusters requires the non-deterministic path)
====================================================================================================
  regime       dist   transform     rows   reqs   max_len      k |  len_min  len_mean  len_max  triv% |   FlashInfer FlashInfer(det) DetSlowdown FlashInfer(tie-small)  TieSmallSlowdown FlashInfer(tie-large)  TieLargeSlowdown   torch(mask)   Speedup
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 prefill     causal  page_table      512      4     16384   2048 |      375    7109.2    12411  25.0% |      30.30us            n/a         n/a               42.85us             1.41x               43.10us             1.42x      153.52us     5.07x
 prefill     causal      ragged      512      4     16384   2048 |      375    7109.2    12411  25.0% |      27.39us            n/a         n/a               40.35us             1.47x               40.26us             1.47x      152.86us     5.58x
 prefill     causal  page_table      512      4     65536   2048 |     2039   22253.8    37156   2.0% |      65.34us            n/a         n/a               79.07us             1.21x               80.67us             1.23x      309.01us     4.73x
 prefill     causal      ragged      512      4     65536   2048 |     2039   22253.8    37156   2.0% |      60.45us            n/a         n/a               75.50us             1.25x               76.99us             1.27x      310.05us     5.13x
 prefill     causal  page_table      512      4    131072   2048 |      524   33177.8   101452  25.0% |     152.22us            n/a         n/a               92.54us             0.61x               92.80us             0.61x      591.52us     3.89x
 prefill     causal      ragged      512      4    131072   2048 |      524   33177.8   101452  25.0% |     144.75us            n/a         n/a               89.41us             0.62x               89.68us             0.62x      591.46us     4.09x
 prefill     causal  page_table     2048     16     16384   2048 |      416    7917.1    15346  12.5% |     122.27us            n/a         n/a              157.33us             1.29x              158.94us             1.30x      366.85us     3.00x
 prefill     causal      ragged     2048     16     16384   2048 |      416    7917.1    15346  12.5% |     111.52us            n/a         n/a              144.35us             1.29x              145.87us             1.31x      366.70us     3.29x
 prefill     causal  page_table     2048     16     65536   2048 |     7804   36260.2    63720   0.0% |     318.19us            n/a         n/a              424.46us             1.33x              426.35us             1.34x     1113.92us     3.50x
 prefill     causal      ragged     2048     16     65536   2048 |     7804   36260.2    63720   0.0% |     298.83us            n/a         n/a              405.06us             1.36x              406.80us             1.36x     1114.29us     3.73x
 prefill     causal  page_table     2048     16    131072   2048 |     7095   60508.9   124975   0.0% |     870.80us            n/a         n/a              547.06us             0.63x              548.93us             0.63x     1999.70us     2.30x
 prefill     causal      ragged     2048     16    131072   2048 |     7095   60508.9   124975   0.0% |     849.66us            n/a         n/a              526.56us             0.62x              529.02us             0.62x     2000.72us     2.35x
```

</details>

## 🔍 Related Issues

- Follow-up to #3095.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

```text
python -m pytest -q tests/utils/test_topk.py
1396 passed, 2 warnings in 75.78s

pre-commit run --all-files
all hooks passed
```

Coverage includes:

- unordered exact-set checks for `SMALL`/`LARGE` tie-break output;
- an explicit clusters override that verifies tie-break modes take the filtered path;
- page-table/ragged transforms with non-identity remapping;
- explicit `deterministic=True` ordering for plain and transform APIs;
- BF16 long-context filtered Top-K at 128K sequence length and `k=2048`.

## Reviewer Notes

The intended contract is:

- `tie_break` controls deterministic boundary selection only;
- `deterministic=True` additionally requests repeatable output ordering;
- `sorted=True` continues to request descending value order.

The key implementation detail is keeping `DETERMINISTIC` for filtered selection. The shared `FinalizeTopKIndicesKernel` always performs final mapping/writeback; `SORT_LOCAL_INDICES` independently controls its pre-writeback CUB sort. Transformed tie-break outputs retain the remap path with sorting disabled, while plain tie-break output skips the finalizer entirely.

The benchmark driver keeps CUPTI enabled and disables CUDA graph replay, matching other FlashInfer CUPTI microbenchmarks. This avoids adding a benchmark-global variable, environment setting, or CLI fallback solely for this workload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Updates**
  * Tie-breaking and deterministic ordering are now controlled independently.
  * Selecting a tie-break option no longer automatically enables deterministic execution.
  * Deterministic mode provides consistent index ordering; tie-breaking alone does not guarantee output order.
  * Clustered execution avoids unsupported tie-break and graph-safe combinations.
  * Page-table and ragged Top-K transformations preserve correct ordering and index mappings.

* **Benchmarking**
  * Top-K benchmarks now provide more consistent timing comparisons against the nondeterministic baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
