### PR TITLE
fix(moe_ep): preserve singleton expert TMA modes

### DIFF
--- a/flashinfer/moe_ep/kernel_src/sm100/cutedsl_megamoe/shim/nvfp4.py
+++ b/flashinfer/moe_ep/kernel_src/sm100/cutedsl_megamoe/shim/nvfp4.py
@@ -774,7 +774,11 @@ class MegaMoENvfp4Frontend:
 
     @staticmethod
     def _to_cute(
-        tensor: torch.Tensor, assumed_align: int = 16, *, static_layout: bool = False
+        tensor: torch.Tensor,
+        assumed_align: int = 16,
+        *,
+        static_layout: bool = False,
+        dynamic_compact_shape_modes: tuple[int, ...] = (),
     ):
         import cutlass.torch as cutlass_torch
 
@@ -782,7 +786,13 @@ class MegaMoENvfp4Frontend:
         if static_layout:
             return cute_tensor
         leading_dim = cutlass_torch.get_leading_dim(tensor)
-        return cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+        for mode in dynamic_compact_shape_modes:
+            cute_tensor = cute_tensor.mark_compact_shape_dynamic(
+                mode=mode,
+                stride_order=tensor.dim_order(),
+            )
+        return cute_tensor
 
     def _build_mega_runtime_kwargs(
         self,
@@ -806,15 +816,22 @@ class MegaMoENvfp4Frontend:
             rank_idx=c.rank,
             num_max_ranks=c.world_size,
         )
+        dynamic_weight_modes = (0,) if c.num_experts_per_rank == 1 else ()
 
         return dict(
             activation=self._to_cute(inputs.activation),
             activation_sf=self._to_cute(inputs.activation_sf),
             topk_idx=self._to_cute(inputs.topk_idx),
             topk_weights=self._to_cute(inputs.topk_weights),
-            fc1_weight=self._to_cute(inputs.fc1_weight),
+            fc1_weight=self._to_cute(
+                inputs.fc1_weight,
+                dynamic_compact_shape_modes=dynamic_weight_modes,
+            ),
             fc1_weight_sf=self._to_cute(inputs.fc1_weight_sf),
-            fc2_weight=self._to_cute(inputs.fc2_weight),
+            fc2_weight=self._to_cute(
+                inputs.fc2_weight,
+                dynamic_compact_shape_modes=dynamic_weight_modes,
+            ),
             fc2_weight_sf=self._to_cute(inputs.fc2_weight_sf),
             fc1_alpha=self._to_cute(inputs.fc1_alpha, assumed_align=4),
             fc2_alpha=self._to_cute(inputs.fc2_alpha, assumed_align=4),

--- a/flashinfer/moe_ep/kernel_src/sm100/cutedsl_megamoe/src/moe_nvfp4_swapab/kernel_fc12.py
+++ b/flashinfer/moe_ep/kernel_src/sm100/cutedsl_megamoe/src/moe_nvfp4_swapab/kernel_fc12.py
@@ -772,6 +772,12 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
     ) -> None:
         """Launch the fused fc1+fc2 swap-AB SwiGLU NVFP4 kernel."""
 
+        # Keep the real runtime extent for singleton-expert TMA descriptors.
+        # A static extent of one is canonicalized out of the TMA basis before
+        # the descriptor is derefined to the kernel ABI.
+        fc1_weight_experts_runtime = fc1_weight.shape[0]
+        fc2_weight_experts_runtime = fc2_weight.shape[0]
+
         # Bind data-tensor shapes to codegen-time expert dims when requested.
         # Strides, token rows, and SF tensors stay runtime-dynamic because they
         # encode host padding/swizzle choices.
@@ -836,13 +842,21 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         # A_gemm (fc1 weights): (experts, hidden, intermediate_gateup)
         # -> (M=intermediate_gateup, K=hidden, L=experts).
         experts, hidden_b, intermediate_gateup = fc1_weight.shape
+        # Static shape refinement above rewrites the expert mode to a Python
+        # int. Re-inject its runtime extent for E=1 so TMA keeps the L basis.
+        fc1_weight_tma_experts = experts
+        if cutlass.const_expr(
+            self.static_expert_shape is not None
+            and self.static_expert_shape[0] == 1
+        ):
+            fc1_weight_tma_experts = fc1_weight_experts_runtime
         fc1_weight_gemm = cute.make_tensor(
             fc1_weight.iterator,
             cute.make_layout(
                 (
                     cutlass.Int32(intermediate_gateup),
                     cutlass.Int32(hidden_b),
-                    cutlass.Int32(experts),
+                    cutlass.Int32(fc1_weight_tma_experts),
                 ),
                 stride=(
                     fc1_weight.stride[2],
@@ -921,13 +935,19 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         # A_gemm (fc2 weights): (experts, intermediate_downproj, hidden)
         # -> (M=hidden, K=intermediate_downproj, L=experts).
         experts2, intermediate_downproj_b2, hidden_b2 = fc2_weight.shape
+        fc2_weight_tma_experts = experts2
+        if cutlass.const_expr(
+            self.static_expert_shape is not None
+            and self.static_expert_shape[0] == 1
+        ):
+            fc2_weight_tma_experts = fc2_weight_experts_runtime
         fc2_weight_gemm = cute.make_tensor(
             fc2_weight.iterator,
             cute.make_layout(
                 (
                     cutlass.Int32(hidden_b2),
                     cutlass.Int32(intermediate_downproj_b2),
-                    cutlass.Int32(experts2),
+                    cutlass.Int32(fc2_weight_tma_experts),
                 ),
                 stride=(
                     fc2_weight.stride[2],

--- a/tests/moe_ep/test_nvfp4_cutedsl_kernel_vs_reference.py
+++ b/tests/moe_ep/test_nvfp4_cutedsl_kernel_vs_reference.py
@@ -39,13 +39,11 @@ def _require_cuda():
         pytest.skip("needs CUDA")
 
 
-def _single_rank_problem(hidden=2048, intermediate=1024):
+def _single_rank_problem(hidden=2048, intermediate=1024, *, num_experts=4, topk=4):
     import torch
 
     num_tokens = 32
     max_tokens = 64
-    num_experts = 4
-    topk = 4
     num_local_experts = num_experts
     gate_up_clamp = 10.0
 
@@ -336,16 +334,19 @@ def test_nvfp4_preprocess_fp4_weights_match_plain_quant():
 
 @pytest.mark.arch_blackwell
 @pytest.mark.parametrize(
-    "hidden,intermediate",
+    "hidden,intermediate,num_experts,topk",
     [
-        (2048, 1024),
+        pytest.param(2048, 1024, 4, 4, id="regular-e4"),
         # 128-misaligned (hidden % 128 == 64): exercises the ceil-div K-tail
         # and predicated epilogue paths the %64 validation relaxation opened
         # up (gpt-oss-120b geometry class).
-        (2880, 2880),
+        pytest.param(2880, 2880, 4, 4, id="tail-e4"),
+        pytest.param(2048, 1024, 1, 1, id="singleton-e1"),
     ],
 )
-def test_nvfp4_kernel_matches_torch_reference(monkeypatch, hidden, intermediate):
+def test_nvfp4_kernel_matches_torch_reference(
+    monkeypatch, hidden, intermediate, num_experts, topk
+):
     """Single-rank ``nvfp4_mega_moe`` output matches the pure-torch oracle."""
     _require_cuda()
 
@@ -373,7 +374,12 @@ def test_nvfp4_kernel_matches_torch_reference(monkeypatch, hidden, intermediate)
     # monkeypatch (not os.environ): restored after the test, so it cannot
     # silently downgrade later nvshmem-path tests in the same process.
     monkeypatch.setenv("MEGA_NO_DIST", "1")
-    problem = _single_rank_problem(hidden=hidden, intermediate=intermediate)
+    problem = _single_rank_problem(
+        hidden=hidden,
+        intermediate=intermediate,
+        num_experts=num_experts,
+        topk=topk,
+    )
     rank = 0
     world_size = 1
     num_tokens = problem["num_tokens"]


### PR DESCRIPTION
## Summary

- Keep the runtime expert extent visible in singleton-expert FC1 and FC2 weight TMA descriptors.
- Mark only the compact expert mode of singleton weight tensors dynamic while retaining static hidden, intermediate, scheduler, workspace, and epilogue specialization.
- Add an `E_local=1`, `topk=1` NVFP4 MegaMoE regression to the existing independent torch-oracle test.

## Root cause

NVFP4 MegaMoE always supplies `static_expert_shape`. When the local expert count is one, static shape refinement rewrites the weight expert mode to a Python `1`. CuTeDSL 4.6.0 canonicalizes that singleton TMA batch basis before the descriptor is derefined to the kernel ABI, causing a segmentation fault during the first kernel compilation/launch.

The frontend now keeps the singleton weight expert mode runtime-dynamic, and the kernel saves that runtime extent before static refinement and reuses it for the FC1 and FC2 weight TMA descriptors. Multi-expert launches follow the existing path unchanged.

## Validation

Tested on NVIDIA B200 with CUDA 13 and `nvidia-cutlass-dsl==4.6.0`.

Before the fix:

- `E_local=4`, `topk=4`: passes the torch oracle.
- `E_local=1`, `topk=1`: reproducibly segfaults at the first kernel compile/launch after preprocessing, staging, and oracle computation complete.

After the fix:

```text
tests/moe_ep/test_nvfp4_cutedsl_kernel_vs_reference.py
4 passed

regular-e4:   rel_l2=0.002695
tail-e4:      rel_l2=0.002707
singleton-e1: rel_l2=0, max_abs=0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mixture-of-Experts kernel handling for configurations with a single expert.
  * Preserved correct runtime tensor dimensions during specialized processing.
  * Expanded validation across standard, tail-aligned, and singleton-expert configurations to ensure results match the reference implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->