### PR TITLE
fix: make the FP16_QK_REDUCTION path compile and decode QK logits correctly

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1397,7 +1397,7 @@ __device__ __forceinline__ void logits_transform(
 
 #ifdef FP16_QK_REDUCTION_SUPPORTED
         if constexpr (std::is_same<DTypeQKAccum, __half>::value) {
-          logits = std::bit_cast<float>(fp16_ieee_to_fp32_value(s_frag[mma_q][mma_kv][reg_id]));
+          logits = fp16_ieee_to_fp32_value(std::bit_cast<uint16_t>(s_frag[mma_q][mma_kv][reg_id]));
         } else if constexpr (!std::is_same<DTypeQKAccum, __half>::value) {
           logits = s_frag[mma_q][mma_kv][reg_id];
         }

--- a/include/flashinfer/attention/variant_helper.cuh
+++ b/include/flashinfer/attention/variant_helper.cuh
@@ -83,7 +83,7 @@ struct AttentionVariantBase {
   REGISTER_M_D_UPDATE(params, kv_tile_idx, qo_head_idx, m, d, scale, { return; })
 
   REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, {
-    float d_rcp = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
+    float d_rcp = (m != static_cast<T_M>(-math::inf)) ? math::ptx_rcp(d) : 0.f;
     float v_scale_val = get_v_scale(params);
     return output * d_rcp * v_scale_val;
   })


### PR DESCRIPTION
Fixes #4297

### Problem

The `FP16_QK_REDUCTION` path (`DTypeQKAccum = __half`) has two independent
latent defects, the first hiding the second.

**1. It does not compile.** `variant_helper.cuh:86` in
`AttentionVariantBase::OutputTransform` compares `m` (type `T_M&`, i.e. `__half`
here) against `-math::inf` (a `float`). That is ambiguous — `__half` converts to
`float`, `float` converts to `__half`, and CUDA supplies `operator!=` for
`__half`/`__half2`/`__nv_bfloat16`/`__nv_bfloat162` — so nvcc rejects it with
"no operator `!=` matches these operands".

Note `math::inf` is the **finite** sentinel `5e4`, not an infinity, so widening
`m` to `float` would compile but silently break masked rows: the `__half` mask
fill value is `fp16_ieee_from_fp32_value(-math::inf)` = `0xFA1A` = `-49984.0f`,
which compares unequal to `-50000.0f`, so a fully-masked row would be treated as
live and take `math::ptx_rcp(d)` with `d == 0`.

**2. It decodes QK logits with a value cast.**
`include/flashinfer/attention/prefill.cuh:1400` passed a `__half` straight to
`fp16_ieee_to_fp32_value(uint16_t)` (`include/flashinfer/fp16.h:48`), which
expects the IEEE half **bit pattern**. No bit-cast was applied to the argument,
so `__half`'s implicit `operator unsigned short()` ran instead — a saturating
round-toward-zero **value** conversion (`__half2ushort_rz`).

Result: negative logits (including the `-inf` mask sentinel) saturate to
`0x0000` and decode to `+0.0f`; positive logits truncate to an integer that is
then read as a half bit pattern, yielding a subnormal. Among 63,490 non-NaN half
patterns, 63,489 decode incorrectly; only `+0.0` matches bit-for-bit.

It was silent because the symmetric write-back at `:1415` is correct, so the
fragment stayed well-formed. Masked positions gained uniform softmax weight,
collapsing rows to `lse == log2(kv_len)` and `output == mean(V)`.

The line was introduced verbatim by #962 (`3a695603`), whose goal was to make
this path *compile*; with `__half`'s implicit `operator unsigned short()`
available it compiled cleanly, so the value cast went unnoticed.

### Change

Two commits, one per defect. 2 files changed, +2/-2.

**1. `variant_helper.cuh` — compare in the accumulator type:**

```diff
-    float d_rcp = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
+    float d_rcp = (m != static_cast<T_M>(-math::inf)) ? math::ptx_rcp(d) : 0.f;
```

This resolves the ambiguity via the unambiguous
`operator!=(const __half&, const __half&)`. It is also the only variant that
stays correct given the finite sentinel: `static_cast<__half>` rounds to nearest
even exactly as `fp16_ieee_from_fp32_value` does, so it reproduces the `0xFA1A`
fill value and the comparison selects the masked branch. For `T_M = float` the
cast is the identity, so **fp32 behaviour is bit-for-bit unchanged**.

**2. `prefill.cuh` — bit-cast the fragment instead of value-converting it:**

```diff
-          logits = std::bit_cast<float>(fp16_ieee_to_fp32_value(s_frag[mma_q][mma_kv][reg_id]));
+          logits = fp16_ieee_to_fp32_value(std::bit_cast<uint16_t>(s_frag[mma_q][mma_kv][reg_id]));
```

`std::bit_cast` matches the existing idiom in this same file (`:1415`, `:333`);
`<bit>` is already pulled in by `fp16.h` under the same `#ifdef`. The outer
`std::bit_cast<float>` is dropped because it was a no-op —
`fp16_ieee_to_fp32_value` already returns `float`.

This also makes the line portable to builds that define
`__CUDA_NO_HALF_CONVERSIONS__` — as some PyTorch extension configurations do —
where `__half`'s `operator unsigned short()` is gated out and the old expression
is a **hard compile error** rather than a silent miscomputation. Both directions
were checked with nvcc (sm_80, C++20): the old line fails to compile with the
macro defined and compiles-but-miscomputes without it; the new line compiles and
is correct in both configurations.

### Testing

Verified statically, on the host, and on hardware.

**Host-side proof of the decode bug (deterministic, exhaustive).** Comparing the
correct bit-cast decode against the value-cast decode the old line performed:
**Among 63,490 non-NaN half patterns, 63,489 decode incorrectly; only `+0.0`
matches bit-for-bit.** All 31,745 negative patterns collapse to `+0.0`. Program
and full output in the linked issue.

**GPU confirmation — H200 (sm90).** Built upstream `main` with only these two
commits applied, using
`-DFP16_QK_REDUCTION_SUPPORTED -I<boost ccmath shim> -std=c++20`. The path
compiles and runs. All cases below are one build / one process; fp32 controls use
the same translation unit with `use_fp16_qk_reduction=False`, so they exercise the
`static_cast<T_M>` identity case and the `else if constexpr` branch. Reference is
fp64.

| case (raw QK dot) | fp16 lse | fp64 ref lse | out max-err |
|---|---|---|---|
| `-512 / -256` | -27.656 | -27.644 | 1.202e-04 |
| `+512 / -256` (sign mix) | 70.312 | 70.289 | 1.202e-04 |
| `+51200` (all positive) | 6537.249 | 6534.892 | 1.150e-04 |
| fully masked | finite sentinel | — | out **exactly 0** |

- The `-512/-256` case is the one that exposed the decode bug: before the fix it
  returned `lse = log2(64) = 6.00` exactly with `output = mean(V)`, the signature
  of `s_frag` arriving all-zero. It now tracks the fp64 reference to within fp16
  accumulation error.
- The positive and sign-mixed cases confirm the bug was never negatives-only.
- **No regression:** the four fp32 controls reproduce the fp64 reference with
  `|dlse| = 0.000`.
- **fp16 and fp32 now agree bit-for-bit on output** (`|do|max = 0.000e+00`) for
  all three live cases on identical inputs; lse differs only by fp16
  accumulation error.

Note on the fully-masked case: `math::inf` is the finite sentinel `5e4`, so on
`main` a fully-masked row reports a large negative lse rather than `-inf`. I
assert the in-scope property — output exactly `0` — and left that sentinel
behaviour alone.

**Out of scope, for transparency.** A case whose legitimate raw QK dot is
`-51200` still disagrees with the reference, because `-51200` is more negative
than the `-50000` mask sentinel and the kernel cannot distinguish the two. That
is a separate pre-existing issue. This is tracked separately in #4267 and is not
addressed by this PR. It fails
*identically* with `use_fp16_qk_reduction` on and off (`lse=-49978.047` vs
`-49993.891`, ref `-6522.892`), which is what shows it is unrelated to these
changes.

**No CI coverage exists for this path.** `FP16_QK_REDUCTION_SUPPORTED` is
referenced only inside `prefill.cuh`; nothing in the build or workflows defines
it, and the `static_assert` at `:1405` blocks the fp16-accum instantiation
without it. So existing CI never instantiates `FP16_QK_REDUCTION`. Note that the
generic `OutputTransform` in `variant_helper.cuh` is still compiled by existing
jobs, for `T_M = float`, where `static_cast<T_M>` is the identity — so that half
of the change is exercised today and cannot regress silently. What existing jobs
cannot verify is the FP16-specific behaviour: the `__half` comparison and the
`s_frag` bit-cast. I'm glad to add a test if you can point me at where a build with
the define should live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected FP16 attention score conversion for more accurate calculations.
  * Improved handling of negative-infinity values in output transformations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
