### PR TITLE
fix(test): repair main CI regressions from #4280 (artifacts Rubin pins + CuTe-DSL MoE device guard)

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -226,7 +226,15 @@ def get_checksums(subdirs):
             FLASHINFER_CUBINS_REPOSITORY, safe_urljoin(subdir, "checksums.txt")
         )
         checksum_path = FLASHINFER_CUBIN_DIR / safe_urljoin(subdir, "checksums.txt")
-        download_file(uri, checksum_path)
+        if not download_file(uri, checksum_path) and not checksum_path.is_file():
+            # Without this the next open() fails with a bare FileNotFoundError on
+            # the local cache path, which hides the real cause: the artifact pin
+            # is unreachable (typo'd/unpublished pin, or network/mirror failure).
+            raise RuntimeError(
+                f"Failed to fetch the checksum manifest for artifact pin '{subdir}' "
+                f"from {uri}. Check that the pin exists in "
+                f"{FLASHINFER_CUBINS_REPOSITORY} and is reachable."
+            )
         with open(checksum_path, "r") as f:
             for line in f:
                 sha256, filename = line.strip().split()

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -468,19 +468,22 @@ class TestAutotuneReplayMemsetContract:
             fused_moe.AutoTuner, "get", staticmethod(lambda: StubTuner())
         )
 
-        tensors = {
-            "x": torch.empty((2, 8), dtype=torch.uint8),
-            "x_sf": torch.empty((2, 1), dtype=torch.uint8),
-            "token_selected_experts": torch.zeros((2, 1), dtype=torch.int32),
-            "token_final_scales": torch.ones((2, 1), dtype=torch.float32),
-            "w1_weight": torch.empty((1, 32, 8), dtype=torch.uint8),
-            "w1_weight_sf": torch.empty((1, 32, 1), dtype=torch.uint8),
-            "w1_alpha": torch.ones(1, dtype=torch.float32),
-            "fc2_input_scale": torch.ones(1, dtype=torch.float32),
-            "w2_weight": torch.empty((1, 16, 8), dtype=torch.uint8),
-            "w2_weight_sf": torch.empty((1, 16, 1), dtype=torch.uint8),
-            "w2_alpha": torch.ones(1, dtype=torch.float32),
-        }
+        # Inputs must live on CUDA: the functional API validates the device
+        # arch (require_cute_dsl_arch -> torch.cuda.get_device_capability).
+        with torch.device("cuda"):
+            tensors = {
+                "x": torch.empty((2, 8), dtype=torch.uint8),
+                "x_sf": torch.empty((2, 1), dtype=torch.uint8),
+                "token_selected_experts": torch.zeros((2, 1), dtype=torch.int32),
+                "token_final_scales": torch.ones((2, 1), dtype=torch.float32),
+                "w1_weight": torch.empty((1, 32, 8), dtype=torch.uint8),
+                "w1_weight_sf": torch.empty((1, 32, 1), dtype=torch.uint8),
+                "w1_alpha": torch.ones(1, dtype=torch.float32),
+                "fc2_input_scale": torch.ones(1, dtype=torch.float32),
+                "w2_weight": torch.empty((1, 16, 8), dtype=torch.uint8),
+                "w2_weight_sf": torch.empty((1, 16, 1), dtype=torch.uint8),
+                "w2_alpha": torch.ones(1, dtype=torch.float32),
+            }
 
         if api == "functional":
             monkeypatch.setattr(

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -446,6 +446,13 @@ class TestAutotuneReplayMemsetContract:
     ):
         from flashinfer.fused_moe.cute_dsl import fused_moe
 
+        # CPU-only contract test (see class header): stub out the functional
+        # API's arch guard, which otherwise calls torch.cuda.get_device_capability()
+        # on the CPU input tensors and raises "Expected a cuda device, but got: cpu".
+        monkeypatch.setattr(
+            fused_moe, "_require_cute_dsl_arch_for", lambda *a, **k: None
+        )
+
         calls = []
 
         class RecordingRunner:
@@ -468,22 +475,19 @@ class TestAutotuneReplayMemsetContract:
             fused_moe.AutoTuner, "get", staticmethod(lambda: StubTuner())
         )
 
-        # Inputs must live on CUDA: the functional API validates the device
-        # arch (require_cute_dsl_arch -> torch.cuda.get_device_capability).
-        with torch.device("cuda"):
-            tensors = {
-                "x": torch.empty((2, 8), dtype=torch.uint8),
-                "x_sf": torch.empty((2, 1), dtype=torch.uint8),
-                "token_selected_experts": torch.zeros((2, 1), dtype=torch.int32),
-                "token_final_scales": torch.ones((2, 1), dtype=torch.float32),
-                "w1_weight": torch.empty((1, 32, 8), dtype=torch.uint8),
-                "w1_weight_sf": torch.empty((1, 32, 1), dtype=torch.uint8),
-                "w1_alpha": torch.ones(1, dtype=torch.float32),
-                "fc2_input_scale": torch.ones(1, dtype=torch.float32),
-                "w2_weight": torch.empty((1, 16, 8), dtype=torch.uint8),
-                "w2_weight_sf": torch.empty((1, 16, 1), dtype=torch.uint8),
-                "w2_alpha": torch.ones(1, dtype=torch.float32),
-            }
+        tensors = {
+            "x": torch.empty((2, 8), dtype=torch.uint8),
+            "x_sf": torch.empty((2, 1), dtype=torch.uint8),
+            "token_selected_experts": torch.zeros((2, 1), dtype=torch.int32),
+            "token_final_scales": torch.ones((2, 1), dtype=torch.float32),
+            "w1_weight": torch.empty((1, 32, 8), dtype=torch.uint8),
+            "w1_weight_sf": torch.empty((1, 32, 1), dtype=torch.uint8),
+            "w1_alpha": torch.ones(1, dtype=torch.float32),
+            "fc2_input_scale": torch.ones(1, dtype=torch.float32),
+            "w2_weight": torch.empty((1, 16, 8), dtype=torch.uint8),
+            "w2_weight_sf": torch.empty((1, 16, 1), dtype=torch.uint8),
+            "w2_alpha": torch.ones(1, dtype=torch.float32),
+        }
 
         if api == "functional":
             monkeypatch.setattr(

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -4,6 +4,7 @@ from flashinfer.artifacts import (
     get_subdir_file_list,
 )
 
+import pytest
 import responses
 
 from flashinfer.jit.cubin_loader import safe_urljoin
@@ -297,6 +298,50 @@ def test_get_available_cubin_files_non_200_response():
         source, retries=1, delay=0, timeout=5
     )
     assert available_cubin_files == ()
+
+
+def test_get_checksums_unreachable_pin_raises(monkeypatch, tmp_path):
+    """An artifact pin whose checksums.txt cannot be fetched must fail loudly.
+
+    Guards the diagnosis path exercised by #4280: a pin added to `cubin_dirs`
+    without a published (or, in tests, mocked) manifest used to surface as a bare
+    FileNotFoundError on a local cache path, which reads like a corrupt cache
+    rather than an unreachable pin. `download_file` is stubbed rather than mocked
+    over HTTP so the test does not pay its 4 retries of exponential backoff.
+    """
+    from flashinfer import artifacts
+
+    monkeypatch.setattr(artifacts, "FLASHINFER_CUBIN_DIR", tmp_path / "cubins")
+    monkeypatch.setattr(artifacts, "download_file", lambda *args, **kwargs: False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        artifacts.get_checksums([artifact_paths.DEEPGEMM_RUBIN])
+    # The pin must be named -- that is the whole point of the error.
+    assert artifact_paths.DEEPGEMM_RUBIN in str(excinfo.value)
+
+
+def test_get_checksums_falls_back_to_cached_manifest(monkeypatch, tmp_path):
+    """A failed refresh must not invalidate an already-cached manifest.
+
+    Offline / FLASHINFER_NO_DOWNLOAD setups rely on the on-disk copy.
+    """
+    from flashinfer import artifacts
+
+    cubin_dir = tmp_path / "cubins"
+    monkeypatch.setattr(artifacts, "FLASHINFER_CUBIN_DIR", cubin_dir)
+    monkeypatch.setattr(artifacts, "download_file", lambda *args, **kwargs: False)
+
+    cached = cubin_dir / safe_urljoin(artifact_paths.DEEPGEMM_RUBIN, "checksums.txt")
+    cached.parent.mkdir(parents=True)
+    cached.write_text("abc123 kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin\n")
+
+    checksums = artifacts.get_checksums([artifact_paths.DEEPGEMM_RUBIN])
+    assert checksums == {
+        safe_urljoin(
+            artifact_paths.DEEPGEMM_RUBIN,
+            "kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin",
+        ): "abc123"
+    }
 
 
 @responses.activate

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -239,6 +239,12 @@ def _mock_file_index_responses():
     responses.add(
         responses.GET, gemm_rubin_source, body=success_gemm_response, status=200
     )
+    deepgemm_rubin_source = safe_urljoin(
+        test_cubin_repository, artifact_paths.DEEPGEMM_RUBIN
+    )
+    responses.add(
+        responses.GET, deepgemm_rubin_source, body=success_deepgemm_response, status=200
+    )
 
 
 @responses.activate
@@ -349,6 +355,13 @@ e8f9a0b1c2d3 kernel.fp8_m_grouped_gemm.02acb2ba71fd.cubin
 f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
 """
 
+    checksums_deepgemm_rubin = """3333333333333333333333333333333333333333333333333333333333333333 kernel_map.json
+1111aaaabbbbcccc kernel.fp8_m_grouped_gemm.007404769193.cubin
+2222aaaabbbbcccc kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin
+3333aaaabbbbcccc kernel.fp8_m_grouped_gemm.02acb2ba71fd.cubin
+4444aaaabbbbcccc kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
+"""
+
     # Add mock responses for checksums.txt files
     fmha_checksums_url = safe_urljoin(
         test_cubin_repository,
@@ -389,6 +402,17 @@ f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
     )
     responses.add(
         responses.GET, deepgemm_checksums_url, body=checksums_deepgemm, status=200
+    )
+
+    deepgemm_rubin_checksums_url = safe_urljoin(
+        test_cubin_repository,
+        safe_urljoin(artifact_paths.DEEPGEMM_RUBIN, "checksums.txt"),
+    )
+    responses.add(
+        responses.GET,
+        deepgemm_rubin_checksums_url,
+        body=checksums_deepgemm_rubin,
+        status=200,
     )
 
     # Mock DSL_FMHA checksums + directory index for the host cpu_arch.
@@ -479,6 +503,11 @@ f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
             "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
             artifact_paths.TRTLLM_GEN_GEMM,
             artifact_paths.TRTLLM_GEN_GEMM_RUBIN,
+        ),
+        (
+            "kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin",
+            artifact_paths.DEEPGEMM,
+            artifact_paths.DEEPGEMM_RUBIN,
         ),
     ):
         plain_path = safe_urljoin(plain_dir, shared_name)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

`main` is currently red on multiple test files, all stemming from #4280. This PR bundles the fixes so CI can go green in a single run — the gate requires one passing run, and none of these fixes pass in isolation (each file still fails on the others), so they cannot land separately.

**Supersedes #4292** . Current PR includes the commit from #4292 and adds the remaining MoE fix on top to pass the CI

## 🔍 Related Issues

<!-- Link any related issues here -->

- #4280
- #4292

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when checksum manifests cannot be downloaded and are unavailable locally, including details about the affected artifact.
  * Preserved the use of cached checksum manifests when refresh attempts fail, preventing unnecessary errors when valid local data is available.
  * Improved reliability when validating artifacts across multiple hardware and software configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->