### PR TITLE
test(msa_ops): fix stale split-K heuristic expectation on high-SM GPUs

### DIFF
--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -443,7 +443,10 @@ def test_proxy_split_k_heuristic():
     """The kv-block split factor is 1 once the base grid fills the SMs and grows
     as the base grid shrinks (low-batch decode), capped by max_k_tiles."""
     _skip_if_unsupported()
-    from flashinfer.msa_ops.proxy_score import _proxy_split_k_fp4
+    from flashinfer.msa_ops.proxy_score import (
+        _proxy_split_k_fp4,
+        _split_k_makespan_argmin,
+    )
 
     dev = torch.device("cuda")
     sm = torch.cuda.get_device_properties(dev).multi_processor_count
@@ -452,8 +455,10 @@ def test_proxy_split_k_heuristic():
     # Trivial / degenerate -> no split.
     assert _proxy_split_k_fp4(8, 1, dev) == 1
     assert _proxy_split_k_fp4(0, 512, dev) == 1
-    # Small base grid -> split enough to reach ~2 CTAs/SM, capped by max_k_tiles.
-    assert _proxy_split_k_fp4(8, 512, dev) == -(-2 * sm // 8)
+    # Small base grid -> split toward ~2 CTAs/SM, capped by max_k_tiles. Assert
+    # against the makespan model itself (wave/tile quantization make it diverge
+    # from a closed form); keeps this independent of the runtime SM count.
+    assert _proxy_split_k_fp4(8, 512, dev) == _split_k_makespan_argmin(8, 512, 2 * sm)
     assert _proxy_split_k_fp4(4, 8, dev) == 8  # clamped to max_k_tiles
 
 


### PR DESCRIPTION
## 📌 Description

Fixes #4276 on `main`. Same one-line test fix as #4273, which targets `release-v0.6.16` — `main` and `release-v0.6.16` are byte-identical for both `tests/msa_ops/test_proxy_fp4.py` and `flashinfer/msa_ops/proxy_score.py`, so the bug is present on `main` too and #4273 alone does not cover it.

`test_proxy_split_k_heuristic` hard-coded the fp4 split factor as `ceil(2*sm/8)`, but `_proxy_split_k_fp4` delegates to the `_split_k_makespan_argmin` model, which caps at one CTA wave and breaks ties to the smaller split. The closed form ignores wave quantization and KV-tile rounding, so it diverges from the implementation on most SM counts:

| SMs | model | `ceil(2*sm/8)` | |
|---|---|---|---|
| 82 | 20 | 21 | mismatch |
| 108 (H100) | 27 | 27 | ok |
| 132 (B200) | 32 | 33 | mismatch |
| 144 | 35 | 36 | mismatch |
| 170 (RTX 5090 / sm120) | 40 | 43 | mismatch |
| 192 | 47 | 48 | mismatch |

sm120 CI is just where it first surfaced. This is a test-only bug — the kernel and the heuristic are correct.

Assert against `_split_k_makespan_argmin(8, 512, 2 * sm)` instead of a closed form. `get_device_sm_count == multi_processor_count`, so this mirrors exactly what `_proxy_split_k_fp4` computes and stays correct regardless of the runtime SM count, while still exercising the real code path (residency target + degenerate-case guards).

## 🔍 Related Issues

Fixes #4276. Release-branch counterpart: #4273.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Diff is byte-identical to #4273. Not runnable on my local L40S (sm89 — `_skip_if_unsupported()` skips); relies on CI's sm120 runner, which is where the original failure was caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated split-factor validation to use the makespan model for more accurate small-grid heuristic coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->