### PR TITLE
feat(gemm): port SM12x MXFP8 dense GEMM from b12x

### DIFF
--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -632,6 +632,9 @@ def sm120_make_smem_layout_sfa(
     k_basic_block_shape = (sf_vec_size, mma_nsf)
     k_basic_block_stride = (0, 1)
 
+    # Sub-64-row M tiles are consumed only by the b12x dense GEMM path,
+    # whose SF fragment layouts handle them; other callers (MoE, MSA) keep
+    # 64-row-multiple tiles.
     assert tile_shape_mnk[0] % (blk_mn // 8) == 0, (
         "tile_shape_mnk[0] must be divisible by 16"
     )

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -632,8 +632,8 @@ def sm120_make_smem_layout_sfa(
     k_basic_block_shape = (sf_vec_size, mma_nsf)
     k_basic_block_stride = (0, 1)
 
-    assert tile_shape_mnk[0] % (blk_mn // 2) == 0, (
-        "tile_shape_mnk[0] must be divisible by 64"
+    assert tile_shape_mnk[0] % (blk_mn // 8) == 0, (
+        "tile_shape_mnk[0] must be divisible by 16"
     )
 
     # Scale-factor tiles are quantized in 128-row blocks, so narrower MMA

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -632,9 +632,8 @@ def sm120_make_smem_layout_sfa(
     k_basic_block_shape = (sf_vec_size, mma_nsf)
     k_basic_block_stride = (0, 1)
 
-    # Sub-64-row M tiles are consumed only by the b12x dense GEMM path,
-    # whose SF fragment layouts handle them; other callers (MoE, MSA) keep
-    # 64-row-multiple tiles.
+    # Sub-64-row M tiles appear only in the b12x dense GEMM path, whose SF
+    # fragment layouts handle them.
     assert tile_shape_mnk[0] % (blk_mn // 8) == 0, (
         "tile_shape_mnk[0] must be divisible by 16"
     )

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6846,7 +6846,7 @@ def _b12x_gemm_mxfp8_runner(
                 swap_ab=swap_ab,
             )
 
-            # swap_ab is device-internal (applied in the kernel ctor); public C
+            # swap_ab is applied inside the kernel, so the public C tensor
             # stays row-major (m, n).
             compiled_gemm, _ = _compile_block_scaled_gemm(
                 _B12X_MM_MXFP8_KERNEL_CACHE,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4885,7 +4885,12 @@ def _b12x_mxfp8_dsl_supported() -> bool:
         dsl_version = importlib.metadata.version("nvidia-cutlass-dsl")
     except importlib.metadata.PackageNotFoundError:
         return False
-    return tuple(int(x) for x in dsl_version.split(".")[:2]) >= (4, 6)
+    from packaging import version as pkg_version
+
+    try:
+        return pkg_version.Version(dsl_version).release[:2] >= (4, 6)
+    except pkg_version.InvalidVersion:
+        return False
 
 
 @supported_compute_capability([120, 121])
@@ -5418,7 +5423,8 @@ def _heuristic_func_mm_mxfp8(
 ) -> List[str]:
     # Prefer b12x where eligible, other setups keep the pre-existing order.
     if "b12x" in suitable_backends:
-        return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
+        order = ["b12x", "cutlass"] + (["cudnn"] if CUDNN_AVAILABLE else [])
+        return [c for c in order if c in suitable_backends]
     # don't select trtllm since it requires weight shuffling
     if "cutlass" in suitable_backends:
         return ["cutlass"]

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+import importlib.metadata
 import logging
 import warnings
 from collections import defaultdict
@@ -4870,6 +4871,13 @@ def _cudnn_mm_mxfp8_requirement(
     return _cudnn_available_or_raise_for_backend(backend)
 
 
+# Minimum contraction dim for the b12x MXFP8 backend: six BK128 tiles, one
+# more than the deepest smem pipeline (5 stages). The kernel races when the
+# mainloop runs no more K iterations than it has stages while the grid
+# exceeds one work tile per SM; see can_implement in the kernel file.
+_B12X_MXFP8_MIN_K = 768
+
+
 @supported_compute_capability([120, 121])
 def _b12x_gemm_mxfp8_requirement(
     a: torch.Tensor,
@@ -4895,17 +4903,24 @@ def _b12x_gemm_mxfp8_requirement(
             "b12x mm_mxfp8 requires 1D 128x4-swizzled block scales. "
             "Use mxfp8_quantize(..., is_sf_swizzled_layout=True)."
         )
-    if a.shape[1] % 128 != 0 or a.shape[1] < 640:
+    if a.shape[1] % 128 != 0 or a.shape[1] < _B12X_MXFP8_MIN_K:
         if backend != "b12x":
             return False
         raise ValueError(
             "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
-            f"128 and at least 640. Got K={a.shape[1]}."
+            f"128 and at least {_B12X_MXFP8_MIN_K}. Got K={a.shape[1]}."
         )
-    _check_cute_dsl_availability()
-    import cutlass.cute as cute
-
-    if not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
+    # Probe the installed distribution instead of importing cutlass.cute here:
+    # the DSL import takes seconds and this runs during auto-mode backend
+    # selection. MmaMXF8Op ships with cutlass-dsl 4.6.0.
+    try:
+        dsl_version = importlib.metadata.version("nvidia-cutlass-dsl")
+    except importlib.metadata.PackageNotFoundError:
+        dsl_version = None
+    if dsl_version is None or tuple(int(x) for x in dsl_version.split(".")[:2]) < (
+        4,
+        6,
+    ):
         if backend != "b12x":
             return False
         raise ValueError(
@@ -5401,14 +5416,12 @@ def _heuristic_func_mm_mxfp8(
     use_8x4_sf_layout: bool = True,
     backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "auto"] = "auto",
 ) -> List[str]:
-    # SM12x: prefer b12x (fastest at decode M, at parity elsewhere); the
-    # requirement function already gates on CUDA 13, cutlass-dsl >= 4.6, and
-    # the swizzled-scale layout, so unsuitable setups fall through to cutlass.
-    major, _ = get_compute_capability(a.device)
-    if major == 12:
-        preferred = [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
-        if preferred:
-            return preferred
+    # Prefer b12x when suitable (SM12x only, fastest at decode M and at
+    # parity elsewhere). Its requirement gates on CUDA 13, cutlass-dsl >=
+    # 4.6, and the scale layout, so unsuitable setups keep the pre-existing
+    # selection.
+    if "b12x" in suitable_backends:
+        return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
     # don't select trtllm since it requires weight shuffling
     if "cutlass" in suitable_backends:
         return ["cutlass"]
@@ -5484,7 +5497,8 @@ def mm_mxfp8(
         backend when its requirements are met.
         - The ``"b12x"`` backend (SM120/SM121) is a warp-level MMA kernel with
           small-M decode tiles. It requires CUDA 13+, nvidia-cutlass-dsl >=
-          4.6.0, 1D swizzled 128x4 scales, and K divisible by 128.
+          4.6.0, 1D swizzled 128x4 scales, and K divisible by 128 and at
+          least 768.
         - The ``"cute-dsl"`` backend currently requires swizzled 1D scales
           (``mxfp8_quantize(..., is_sf_swizzled_layout=True)``).
         - The ``"trtllm"`` requires b to be quantized with 128x4 swizzle layout and shuffled.
@@ -6708,8 +6722,9 @@ def _b12x_gemm_mxfp8_runner(
                     if tac not in valid_tactics:
                         valid_tactics.append(tac)
 
-            # Balanced tiles plus the MXFP8 M-narrow decode tiles; keep the grid
-            # small so the tuner's bucket representative stays meaningful.
+            # Balanced tiles plus the MXFP8 M-narrow decode tiles. Keep the
+            # grid small so the tuner's bucket representative stays
+            # meaningful.
             for mma_tiler_mn in [
                 (16, 128),
                 (32, 128),

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5416,7 +5416,7 @@ def _heuristic_func_mm_mxfp8(
     use_8x4_sf_layout: bool = True,
     backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "auto"] = "auto",
 ) -> List[str]:
-    # Prefer b12x where eligible, other setups keep the pre-existing order.
+    # Prefer b12x where eligible.
     if "b12x" in suitable_backends:
         order = ["b12x", "cutlass"] + (["cudnn"] if CUDNN_AVAILABLE else [])
         return [c for c in order if c in suitable_backends]
@@ -6490,7 +6490,7 @@ def _b12x_gemm_fp4_runner(
             valid_tactics = []
 
             def _add(mma_tiler_mn, swap_ab):
-                # can_implement is M-independent (takes no `m`)
+                # can_implement takes no m, so validity is M-independent.
                 if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
                     ab_dtype,
                     sf_dtype,
@@ -6692,7 +6692,7 @@ def _b12x_gemm_mxfp8_runner(
             valid_tactics = []
 
             def _add(mma_tiler_mn, swap_ab):
-                # can_implement is M-independent (takes no `m`)
+                # can_implement takes no m, so validity is M-independent.
                 if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
                     ab_dtype,
                     sf_dtype,
@@ -6714,8 +6714,8 @@ def _b12x_gemm_mxfp8_runner(
                     if tac not in valid_tactics:
                         valid_tactics.append(tac)
 
-            # A small tactic grid keeps the tuner's bucket representative
-            # meaningful.
+            # A few tiles for the tuner to profile (a larger grid overfits the
+            # bucket representative and makes picks noisier).
             for mma_tiler_mn in [
                 (16, 128),
                 (32, 128),

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4878,6 +4878,18 @@ def _cudnn_mm_mxfp8_requirement(
 _B12X_MXFP8_MIN_K = 768
 
 
+@functools.cache
+def _b12x_mxfp8_dsl_supported() -> bool:
+    # Probe distribution metadata rather than import cutlass.cute, which
+    # takes seconds. Cached because the lookup hits the filesystem and this
+    # runs on every call.
+    try:
+        dsl_version = importlib.metadata.version("nvidia-cutlass-dsl")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    return tuple(int(x) for x in dsl_version.split(".")[:2]) >= (4, 6)
+
+
 @supported_compute_capability([120, 121])
 def _b12x_gemm_mxfp8_requirement(
     a: torch.Tensor,
@@ -4910,17 +4922,7 @@ def _b12x_gemm_mxfp8_requirement(
             "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
             f"128 and at least {_B12X_MXFP8_MIN_K}. Got K={a.shape[1]}."
         )
-    # Probe the installed distribution instead of importing cutlass.cute here:
-    # the DSL import takes seconds and this runs during auto-mode backend
-    # selection. MmaMXF8Op ships with cutlass-dsl 4.6.0.
-    try:
-        dsl_version = importlib.metadata.version("nvidia-cutlass-dsl")
-    except importlib.metadata.PackageNotFoundError:
-        dsl_version = None
-    if dsl_version is None or tuple(int(x) for x in dsl_version.split(".")[:2]) < (
-        4,
-        6,
-    ):
+    if not _b12x_mxfp8_dsl_supported():
         if backend != "b12x":
             return False
         raise ValueError(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4871,10 +4871,8 @@ def _cudnn_mm_mxfp8_requirement(
     return _cudnn_available_or_raise_for_backend(backend)
 
 
-# Minimum contraction dim for the b12x MXFP8 backend: six BK128 tiles, one
-# more than the deepest smem pipeline (5 stages). The kernel races when the
-# mainloop runs no more K iterations than it has stages while the grid
-# exceeds one work tile per SM; see can_implement in the kernel file.
+# Six BK128 tiles, one more than the deepest smem pipeline (5 stages).
+# Shorter mainloops can race the pipeline, see the kernel's can_implement.
 _B12X_MXFP8_MIN_K = 768
 
 
@@ -5418,10 +5416,7 @@ def _heuristic_func_mm_mxfp8(
     use_8x4_sf_layout: bool = True,
     backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "auto"] = "auto",
 ) -> List[str]:
-    # Prefer b12x when suitable (SM12x only, fastest at decode M and at
-    # parity elsewhere). Its requirement gates on CUDA 13, cutlass-dsl >=
-    # 4.6, and the scale layout, so unsuitable setups keep the pre-existing
-    # selection.
+    # Prefer b12x where eligible, other setups keep the pre-existing order.
     if "b12x" in suitable_backends:
         return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
     # don't select trtllm since it requires weight shuffling
@@ -6078,13 +6073,11 @@ def _b12x_short_mainloop_race_window(
 ) -> bool:
     """True when a b12x launch with this tile can hit the pipeline race.
 
-    The SM120 b12x kernel corrupts output when the mainloop runs no more K
-    iterations than the smem pipeline has stages AND the grid has more work
-    tiles than SMs, so a persistent CTA revisits work tiles. Iterations equal
-    to the stage count still race (measured 2/20 at k=640 on the 5-stage
-    (64, 128) tile), so safety requires strictly more. Stage counts mirror
-    the caps in the kernel's ``_compute_stages`` (the raw stage count can be
-    lower for large tiles, so this is conservative).
+    The kernel corrupts output when the mainloop runs no more K iterations
+    than the smem pipeline has stages and the grid has more work tiles than
+    SMs. Iterations equal to the stage count still race, so safety requires
+    strictly more. Stage counts mirror the caps in the kernel's
+    ``_compute_stages`` and are conservative for large tiles.
     """
     stage_cap = 5 if mma_tiler_mn[0] in (16, 64) and mma_tiler_mn[1] == 128 else 4
     k_iters = -(-k // 128)
@@ -6131,10 +6124,9 @@ def _b12x_gemm_fp4_requirement(
             "b12x FP4 GEMM requires the contraction dim K to be a multiple of 32 "
             f"(TMA 16-byte alignment). Got K={real_k}."
         )
-    # Short-mainloop race containment (see _b12x_short_mainloop_race_window).
-    # (128, 128) has the fewest work tiles and the lowest stage cap of any
-    # reachable tactic, so a shape is rejected only when even that fallback
-    # tile would race. The runner routes allowed shapes to non-racing tiles.
+    # Reject a shape only when even (128, 128) would race: it has the fewest
+    # work tiles and the lowest stage cap of any reachable tactic. The runner
+    # steers allowed shapes to non-racing tiles.
     if _b12x_short_mainloop_race_window(
         (128, 128), a.shape[0], b.shape[1], real_k, get_device_sm_count(a.device)
     ):
@@ -6591,10 +6583,9 @@ def _b12x_gemm_fp4_runner(
                 tile, swap = plan.mma_tiler_mn, plan.swap_ab
                 sm_count = get_device_sm_count(a.device)
                 if _b12x_short_mainloop_race_window(tile, m, n, real_k, sm_count):
-                    # (128, 128) is the safe fallback the requirement
-                    # check guarantees. An unsafe plan tile reaches this
-                    # point only via skip_check=True, which must not corrupt
-                    # silently.
+                    # The requirement check guarantees (128, 128) is safe.
+                    # Only skip_check=True reaches here with an unsafe tile,
+                    # and it must not corrupt silently.
                     tile, swap = (128, 128), False
                     if _b12x_short_mainloop_race_window(tile, m, n, real_k, sm_count):
                         raise RuntimeError(
@@ -6730,12 +6721,7 @@ def _b12x_gemm_mxfp8_runner(
         )
 
     class B12xMxfp8GemmRunner(TunableRunner):
-        """TunableRunner for b12x block-scaled MXFP8 dense GEMM on SM12x.
-
-        Tactics are tuples:
-            (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch, kernel_type, use_tma_store)
-        where kernel_type is always "sm120" and use_tma_store is always None.
-        """
+        """TunableRunner for b12x block-scaled MXFP8 dense GEMM on SM12x."""
 
         def get_valid_tactics(
             self,
@@ -6777,8 +6763,7 @@ def _b12x_gemm_mxfp8_runner(
                     if tac not in valid_tactics:
                         valid_tactics.append(tac)
 
-            # Balanced tiles plus the MXFP8 M-narrow decode tiles. Keep the
-            # grid small so the tuner's bucket representative stays
+            # A small tactic grid keeps the tuner's bucket representative
             # meaningful.
             for mma_tiler_mn in [
                 (16, 128),

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4895,12 +4895,12 @@ def _b12x_gemm_mxfp8_requirement(
             "b12x mm_mxfp8 requires 1D 128x4-swizzled block scales. "
             "Use mxfp8_quantize(..., is_sf_swizzled_layout=True)."
         )
-    if a.shape[1] % 128 != 0:
+    if a.shape[1] % 128 != 0 or a.shape[1] < 256:
         if backend != "b12x":
             return False
         raise ValueError(
             "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
-            f"128 (one full BK128 tile). Got K={a.shape[1]}."
+            f"128 and at least 256 (two BK128 tiles). Got K={a.shape[1]}."
         )
     _check_cute_dsl_availability()
     import cutlass.cute as cute

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import functools
-import importlib.metadata
 import logging
 import warnings
 from collections import defaultdict
@@ -57,7 +56,12 @@ from ..fused_moe.utils import (
 from .gemm_mm_fp4_cute_dsl import (
     _compile_block_scaled_gemm,
     _mm_fp4_cache_key,
+    _prepare_alpha_for_launch,
     precompile_mm_fp4_tactics,
+)
+from .gemm_mm_mxfp8_cute_dsl import (
+    _b12x_gemm_mxfp8_requirement,
+    _b12x_gemm_mxfp8_runner,
 )
 from .kernels.utils import (
     _SM100_CLUSTER_SHAPE_MN_CANDIDATES,
@@ -4871,65 +4875,6 @@ def _cudnn_mm_mxfp8_requirement(
     return _cudnn_available_or_raise_for_backend(backend)
 
 
-@functools.cache
-def _b12x_mxfp8_dsl_supported() -> bool:
-    # Probe distribution metadata rather than import cutlass.cute, which
-    # takes seconds. Cached because the lookup hits the filesystem and this
-    # runs on every call.
-    try:
-        dsl_version = importlib.metadata.version("nvidia-cutlass-dsl")
-    except importlib.metadata.PackageNotFoundError:
-        return False
-    from packaging import version as pkg_version
-
-    try:
-        return pkg_version.Version(dsl_version).release[:2] >= (4, 6)
-    except pkg_version.InvalidVersion:
-        return False
-
-
-@supported_compute_capability([120, 121])
-def _b12x_gemm_mxfp8_requirement(
-    a: torch.Tensor,
-    b: torch.Tensor,
-    a_descale: torch.Tensor,
-    b_descale: torch.Tensor,
-    out: Optional[torch.Tensor] = None,
-    out_dtype: torch.dtype = torch.bfloat16,
-    use_8x4_sf_layout: bool = True,
-    backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "b12x", "auto"] = "auto",
-):
-    if get_cuda_version().major < 13:
-        if backend != "b12x":
-            return False
-        raise ValueError(
-            "b12x mm_mxfp8 requires CUDA 13 or later. "
-            f"Current CUDA version: {get_cuda_version()}."
-        )
-    if use_8x4_sf_layout or a_descale.ndim != 1 or b_descale.ndim != 1:
-        if backend != "b12x":
-            return False
-        raise ValueError(
-            "b12x mm_mxfp8 requires 1D 128x4-swizzled block scales. "
-            "Use mxfp8_quantize(..., is_sf_swizzled_layout=True)."
-        )
-    if a.shape[1] % 128 != 0:
-        if backend != "b12x":
-            return False
-        raise ValueError(
-            "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
-            f"128 (one full BK128 tile). Got K={a.shape[1]}."
-        )
-    if not _b12x_mxfp8_dsl_supported():
-        if backend != "b12x":
-            return False
-        raise ValueError(
-            "b12x mm_mxfp8 requires nvidia-cutlass-dsl >= 4.6.0 "
-            "(cute.nvgpu.warp.MmaMXF8Op)."
-        )
-    return True
-
-
 # Shared helpers for CuTe DSL block-scaled GEMM runners (mxfp8 & mxfp4/nvfp4)
 _SM100_DEFAULT_MMA_TILER_MN = (128, 128)
 _SM100_DEFAULT_CLUSTER_SHAPE_MN = (1, 1)
@@ -5015,26 +4960,6 @@ def _get_sm100_block_scaled_tactics(
                         (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch)
                     )
     return valid_tactics
-
-
-_CUTE_DSL_ALPHA_ONE_CACHE: dict = {}
-
-
-def _prepare_alpha_for_launch(alpha_tensor, device):
-    """Prepare alpha as a 1-dim float32 device tensor with shape [1].
-
-    When *alpha_tensor* is ``None``, returns a cached ``tensor([1.0])``
-    on *device* (allocated once, reused forever).
-    """
-    if alpha_tensor is None:
-        cached = _CUTE_DSL_ALPHA_ONE_CACHE.get(device)
-        if cached is None:
-            cached = torch.tensor([1.0], dtype=torch.float32, device=device)
-            _CUTE_DSL_ALPHA_ONE_CACHE[device] = cached
-        return cached
-    if alpha_tensor.dim() == 0:
-        return alpha_tensor.unsqueeze(0)
-    return alpha_tensor.reshape(1)
 
 
 _CUTE_DSL_MM_MXFP8_KERNEL_CACHE: dict[tuple, tuple] = {}
@@ -6628,209 +6553,6 @@ def _b12x_gemm_fp4_runner(
             return out
 
     return B12xFp4GemmRunner()
-
-
-# Module-level kernel cache for b12x MXFP8 GEMM.
-_B12X_MM_MXFP8_KERNEL_CACHE: dict[tuple, tuple] = {}
-
-
-def _b12x_gemm_mxfp8_runner(
-    sm_major: int,
-    sm_minor: int,
-    enable_pdl: bool,
-    out_dtype: torch.dtype,
-):
-    """Create a b12x MXFP8 GEMM runner for SM12x.
-
-    Same warp-level MMA kernel as the b12x FP4 backend, driven with MXFP8
-    operands (m16n8k32 atom, UE8M0 scales, BK128) and the MXFP8 tile regimes.
-    """
-    import cutlass
-
-    from .kernels.dense_blockscaled_gemm_sm120_b12x import (
-        Sm120B12xBlockScaledDenseGemmKernel,
-        _select_default_dense_gemm_plan,
-    )
-
-    from ..cute_dsl.utils import torch_to_cutlass_dtype
-
-    if out_dtype not in (torch.bfloat16, torch.float16):
-        raise ValueError(
-            f"b12x backend does not support output dtype {out_dtype}. "
-            f"Supported: torch.bfloat16, torch.float16."
-        )
-    c_cutlass_dtype = torch_to_cutlass_dtype(out_dtype)
-
-    def _default_dense_plan(m, n, real_k, device):
-        return _select_default_dense_gemm_plan(
-            m,
-            n,
-            real_k,
-            get_device_sm_count(device),
-            is_mxfp8=True,
-            expected_m=m,
-        )
-
-    class B12xMxfp8GemmRunner(TunableRunner):
-        """TunableRunner for b12x block-scaled MXFP8 dense GEMM on SM12x."""
-
-        def get_valid_tactics(
-            self,
-            inputs: List[torch.Tensor],
-            profile: OptimizationProfile,
-        ) -> list:
-            (a, b, a_descale, b_descale, _, out, _) = inputs
-            m = a.shape[0]
-            real_k = a.shape[1]
-            n = b.shape[1]
-
-            sf_vec_size = 32
-            ab_dtype = cutlass.Float8E4M3FN
-            sf_dtype = cutlass.Float8E8M0FNU
-            batch_size = 1
-
-            valid_tactics = []
-
-            def _add(mma_tiler_mn, swap_ab):
-                # can_implement takes no m, so validity is M-independent.
-                if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
-                    ab_dtype,
-                    sf_dtype,
-                    sf_vec_size,
-                    c_cutlass_dtype,
-                    mma_tiler_mn,
-                    (1, 1),
-                    n,
-                    real_k,
-                    batch_size,
-                    "k",
-                    "k",
-                    "n",
-                    swap_ab=swap_ab,
-                ):
-                    return
-                for use_prefetch in (False, True):
-                    tac = (mma_tiler_mn, (1, 1), swap_ab, use_prefetch, "sm120", None)
-                    if tac not in valid_tactics:
-                        valid_tactics.append(tac)
-
-            # A few tiles for the tuner to profile (a larger grid overfits the
-            # bucket representative and makes picks noisier).
-            for mma_tiler_mn in [
-                (16, 128),
-                (32, 128),
-                (64, 64),
-                (64, 128),
-                (128, 128),
-            ]:
-                _add(mma_tiler_mn, swap_ab=False)
-
-            # Also include the default-path tile so the tuner can't pick worse
-            # than static.
-            plan = _default_dense_plan(m, n, real_k, a.device)
-            _add(plan.mma_tiler_mn, swap_ab=plan.swap_ab)
-            return valid_tactics
-
-        def forward(
-            self,
-            inputs: List[torch.Tensor],
-            tactic=None,
-            do_preparation: bool = False,
-            **kwargs,
-        ):
-            (a, b, a_descale, b_descale, _, out, _) = inputs
-            m = a.shape[0]
-            real_k = a.shape[1]
-            n = b.shape[1]
-
-            sf_vec_size = 32
-            sf_dtype = cutlass.Float8E8M0FNU
-            batch_size = 1
-
-            if tactic is None or tactic == -1:
-                plan = _default_dense_plan(m, n, real_k, a.device)
-                tactic = (
-                    plan.mma_tiler_mn,
-                    (1, 1),
-                    plan.swap_ab,
-                    False,
-                    "sm120",
-                    None,
-                )
-
-            (
-                mma_tiler_mn,
-                cluster_shape_mn,
-                swap_ab,
-                use_prefetch,
-                kernel_type,
-                use_tma_store,
-            ) = tactic
-
-            kernel_a, kernel_b = a, b.T
-            kernel_a_sf, kernel_b_sf = a_descale, b_descale
-
-            sf_m = (m + 127) // 128
-            sf_n = (n + 127) // 128
-            sf_k = (real_k // sf_vec_size + 3) // 4
-
-            cache_key = (
-                sf_vec_size,
-                mma_tiler_mn,
-                cluster_shape_mn,
-                swap_ab,
-                use_prefetch,
-                kernel_type,
-                use_tma_store,
-                enable_pdl,
-                out_dtype,
-            )
-
-            make_kernel = lambda: Sm120B12xBlockScaledDenseGemmKernel(
-                sf_vec_size,
-                mma_tiler_mn,
-                cluster_shape_mn,
-                mma_k=32,
-                tile_k=128,
-                use_prefetch=use_prefetch,
-                enable_pdl=enable_pdl,
-                swap_ab=swap_ab,
-            )
-
-            # swap_ab is applied inside the kernel, so the public C tensor
-            # stays row-major (m, n).
-            compiled_gemm, _ = _compile_block_scaled_gemm(
-                _B12X_MM_MXFP8_KERNEL_CACHE,
-                cache_key,
-                make_kernel,
-                ab_cutlass_dtype=cutlass.Float8E4M3FN,
-                sf_dtype=sf_dtype,
-                c_cutlass_dtype=c_cutlass_dtype,
-                ab_assumed_align=32,
-                cluster_shape_mn=cluster_shape_mn,
-                swap_ab=False,
-                sf_m=sf_m,
-                sf_n=sf_n,
-                sf_k=sf_k,
-                batch_size=batch_size,
-            )
-
-            alpha_for_launch = _prepare_alpha_for_launch(None, a.device)
-
-            compiled_gemm(
-                kernel_a,
-                kernel_b,
-                out,
-                sf_m,
-                sf_n,
-                sf_k,
-                kernel_a_sf.data_ptr(),
-                kernel_b_sf.data_ptr(),
-                alpha_for_launch,
-            )
-            return out
-
-    return B12xMxfp8GemmRunner()
 
 
 def _heuristic_func_mm_fp4(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6071,10 +6071,31 @@ def _cute_dsl_gemm_fp4_requirement(
     return True
 
 
+def _b12x_short_mainloop_race_window(
+    mma_tiler_mn: Tuple[int, int], m: int, n: int, k: int, sm_count: int
+) -> bool:
+    """True when a b12x launch with this tile can hit the pipeline race.
+
+    The SM120 b12x kernel corrupts output when the mainloop runs no more K
+    iterations than the smem pipeline has stages AND the grid has more work
+    tiles than SMs, so a persistent CTA revisits work tiles. Iterations equal
+    to the stage count still race (measured 2/20 at k=640 on the 5-stage
+    (64, 128) tile), so safety requires strictly more. Stage counts mirror
+    the caps in the kernel's ``_compute_stages`` (the raw stage count can be
+    lower for large tiles, so this is conservative).
+    """
+    stage_cap = 5 if mma_tiler_mn[0] in (16, 64) and mma_tiler_mn[1] == 128 else 4
+    k_iters = -(-k // 128)
+    if k_iters > stage_cap:
+        return False
+    work_tiles = -(-m // mma_tiler_mn[0]) * -(-n // mma_tiler_mn[1])
+    return work_tiles > sm_count
+
+
 @supported_compute_capability([120, 121])
 def _b12x_gemm_fp4_requirement(
     a: torch.Tensor,
-    b: torch.Tensor,  # unused
+    b: torch.Tensor,
     a_descale: torch.Tensor,  # unused
     b_descale: torch.Tensor,  # unused
     alpha: Optional[torch.Tensor] = None,  # unused
@@ -6107,6 +6128,20 @@ def _b12x_gemm_fp4_requirement(
         raise ValueError(
             "b12x FP4 GEMM requires the contraction dim K to be a multiple of 32 "
             f"(TMA 16-byte alignment). Got K={real_k}."
+        )
+    # Short-mainloop race containment (see _b12x_short_mainloop_race_window).
+    # (128, 128) has the fewest work tiles and the lowest stage cap of any
+    # reachable tactic, so a shape is rejected only when even that fallback
+    # tile would race. The runner routes allowed shapes to non-racing tiles.
+    if _b12x_short_mainloop_race_window(
+        (128, 128), a.shape[0], b.shape[1], real_k, get_device_sm_count(a.device)
+    ):
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x FP4 GEMM does not support short-K launches beyond one work "
+            "tile per SM (a known kernel race; use the cutlass backend). Got "
+            f"K={real_k}, M={a.shape[0]}, N={b.shape[1]}."
         )
     _check_cute_dsl_availability()
     return True
@@ -6493,6 +6528,10 @@ def _b12x_gemm_fp4_runner(
             valid_tactics = []
 
             def _add(mma_tiler_mn, swap_ab):
+                if _b12x_short_mainloop_race_window(
+                    mma_tiler_mn, m, n, real_k, get_device_sm_count(a.device)
+                ):
+                    return
                 # can_implement is M-independent (takes no `m`)
                 if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
                     ab_dtype,
@@ -6547,10 +6586,24 @@ def _b12x_gemm_fp4_runner(
                 # Default path: the m-aware plan picks the tile (and swap_ab for
                 # narrow-N) for this shape; expected_m=m since m is the actual size.
                 plan = _default_dense_plan(m, n, real_k, a.device)
+                tile, swap = plan.mma_tiler_mn, plan.swap_ab
+                sm_count = get_device_sm_count(a.device)
+                if _b12x_short_mainloop_race_window(tile, m, n, real_k, sm_count):
+                    # (128, 128) is the safe fallback the requirement
+                    # check guarantees. An unsafe plan tile reaches this
+                    # point only via skip_check=True, which must not corrupt
+                    # silently.
+                    tile, swap = (128, 128), False
+                    if _b12x_short_mainloop_race_window(tile, m, n, real_k, sm_count):
+                        raise RuntimeError(
+                            "b12x FP4 GEMM cannot run short-K launches beyond "
+                            "one work tile per SM (known kernel race). Got "
+                            f"K={real_k}, M={m}, N={n}."
+                        )
                 tactic = (
-                    plan.mma_tiler_mn,
+                    tile,
                     (1, 1),
-                    plan.swap_ab,
+                    swap,
                     False,
                     "sm120",
                     None,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4871,11 +4871,6 @@ def _cudnn_mm_mxfp8_requirement(
     return _cudnn_available_or_raise_for_backend(backend)
 
 
-# Six BK128 tiles, one more than the deepest smem pipeline (5 stages).
-# Shorter mainloops can race the pipeline, see the kernel's can_implement.
-_B12X_MXFP8_MIN_K = 768
-
-
 @functools.cache
 def _b12x_mxfp8_dsl_supported() -> bool:
     # Probe distribution metadata rather than import cutlass.cute, which
@@ -4918,12 +4913,12 @@ def _b12x_gemm_mxfp8_requirement(
             "b12x mm_mxfp8 requires 1D 128x4-swizzled block scales. "
             "Use mxfp8_quantize(..., is_sf_swizzled_layout=True)."
         )
-    if a.shape[1] % 128 != 0 or a.shape[1] < _B12X_MXFP8_MIN_K:
+    if a.shape[1] % 128 != 0:
         if backend != "b12x":
             return False
         raise ValueError(
             "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
-            f"128 and at least {_B12X_MXFP8_MIN_K}. Got K={a.shape[1]}."
+            f"128 (one full BK128 tile). Got K={a.shape[1]}."
         )
     if not _b12x_mxfp8_dsl_supported():
         if backend != "b12x":
@@ -5500,8 +5495,7 @@ def mm_mxfp8(
         backend when its requirements are met.
         - The ``"b12x"`` backend (SM120/SM121) is a warp-level MMA kernel with
           small-M decode tiles. It requires CUDA 13+, nvidia-cutlass-dsl >=
-          4.6.0, 1D swizzled 128x4 scales, and K divisible by 128 and at
-          least 768.
+          4.6.0, 1D swizzled 128x4 scales, and K divisible by 128.
         - The ``"cute-dsl"`` backend currently requires swizzled 1D scales
           (``mxfp8_quantize(..., is_sf_swizzled_layout=True)``).
         - The ``"trtllm"`` requires b to be quantized with 128x4 swizzle layout and shuffled.
@@ -6074,25 +6068,6 @@ def _cute_dsl_gemm_fp4_requirement(
     return True
 
 
-def _b12x_short_mainloop_race_window(
-    mma_tiler_mn: Tuple[int, int], m: int, n: int, k: int, sm_count: int
-) -> bool:
-    """True when a b12x launch with this tile can hit the pipeline race.
-
-    The kernel corrupts output when the mainloop runs no more K iterations
-    than the smem pipeline has stages and the grid has more work tiles than
-    SMs. Iterations equal to the stage count still race, so safety requires
-    strictly more. Stage counts mirror the caps in the kernel's
-    ``_compute_stages`` and are conservative for large tiles.
-    """
-    stage_cap = 5 if mma_tiler_mn[0] in (16, 64) and mma_tiler_mn[1] == 128 else 4
-    k_iters = -(-k // 128)
-    if k_iters > stage_cap:
-        return False
-    work_tiles = -(-m // mma_tiler_mn[0]) * -(-n // mma_tiler_mn[1])
-    return work_tiles > sm_count
-
-
 @supported_compute_capability([120, 121])
 def _b12x_gemm_fp4_requirement(
     a: torch.Tensor,
@@ -6129,19 +6104,6 @@ def _b12x_gemm_fp4_requirement(
         raise ValueError(
             "b12x FP4 GEMM requires the contraction dim K to be a multiple of 32 "
             f"(TMA 16-byte alignment). Got K={real_k}."
-        )
-    # Reject a shape only when even (128, 128) would race: it has the fewest
-    # work tiles and the lowest stage cap of any reachable tactic. The runner
-    # steers allowed shapes to non-racing tiles.
-    if _b12x_short_mainloop_race_window(
-        (128, 128), a.shape[0], b.shape[1], real_k, get_device_sm_count(a.device)
-    ):
-        if backend != "b12x":
-            return False
-        raise ValueError(
-            "b12x FP4 GEMM does not support short-K launches beyond one work "
-            "tile per SM (a known kernel race; use the cutlass backend). Got "
-            f"K={real_k}, M={a.shape[0]}, N={b.shape[1]}."
         )
     _check_cute_dsl_availability()
     return True
@@ -6528,10 +6490,6 @@ def _b12x_gemm_fp4_runner(
             valid_tactics = []
 
             def _add(mma_tiler_mn, swap_ab):
-                if _b12x_short_mainloop_race_window(
-                    mma_tiler_mn, m, n, real_k, get_device_sm_count(a.device)
-                ):
-                    return
                 # can_implement is M-independent (takes no `m`)
                 if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
                     ab_dtype,
@@ -6586,23 +6544,10 @@ def _b12x_gemm_fp4_runner(
                 # Default path: the m-aware plan picks the tile (and swap_ab for
                 # narrow-N) for this shape; expected_m=m since m is the actual size.
                 plan = _default_dense_plan(m, n, real_k, a.device)
-                tile, swap = plan.mma_tiler_mn, plan.swap_ab
-                sm_count = get_device_sm_count(a.device)
-                if _b12x_short_mainloop_race_window(tile, m, n, real_k, sm_count):
-                    # The requirement check guarantees (128, 128) is safe.
-                    # Only skip_check=True reaches here with an unsafe tile,
-                    # and it must not corrupt silently.
-                    tile, swap = (128, 128), False
-                    if _b12x_short_mainloop_race_window(tile, m, n, real_k, sm_count):
-                        raise RuntimeError(
-                            "b12x FP4 GEMM cannot run short-K launches beyond "
-                            "one work tile per SM (known kernel race). Got "
-                            f"K={real_k}, M={m}, N={n}."
-                        )
                 tactic = (
-                    tile,
+                    plan.mma_tiler_mn,
                     (1, 1),
-                    swap,
+                    plan.swap_ab,
                     False,
                     "sm120",
                     None,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4870,6 +4870,51 @@ def _cudnn_mm_mxfp8_requirement(
     return _cudnn_available_or_raise_for_backend(backend)
 
 
+@supported_compute_capability([120, 121])
+def _b12x_gemm_mxfp8_requirement(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_descale: torch.Tensor,
+    b_descale: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    use_8x4_sf_layout: bool = True,
+    backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "b12x", "auto"] = "auto",
+):
+    if get_cuda_version().major < 13:
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires CUDA 13 or later. "
+            f"Current CUDA version: {get_cuda_version()}."
+        )
+    if use_8x4_sf_layout or a_descale.ndim != 1 or b_descale.ndim != 1:
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires 1D 128x4-swizzled block scales. "
+            "Use mxfp8_quantize(..., is_sf_swizzled_layout=True)."
+        )
+    if a.shape[1] % 128 != 0:
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
+            f"128 (one full BK128 tile). Got K={a.shape[1]}."
+        )
+    _check_cute_dsl_availability()
+    import cutlass.cute as cute
+
+    if not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires nvidia-cutlass-dsl >= 4.6.0 "
+            "(cute.nvgpu.warp.MmaMXF8Op)."
+        )
+    return True
+
+
 # Shared helpers for CuTe DSL block-scaled GEMM runners (mxfp8 & mxfp4/nvfp4)
 _SM100_DEFAULT_MMA_TILER_MN = (128, 128)
 _SM100_DEFAULT_CLUSTER_SHAPE_MN = (1, 1)
@@ -5356,6 +5401,14 @@ def _heuristic_func_mm_mxfp8(
     use_8x4_sf_layout: bool = True,
     backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "auto"] = "auto",
 ) -> List[str]:
+    # SM12x: prefer b12x (fastest at decode M, at parity elsewhere); the
+    # requirement function already gates on CUDA 13, cutlass-dsl >= 4.6, and
+    # the swizzled-scale layout, so unsuitable setups fall through to cutlass.
+    major, _ = get_compute_capability(a.device)
+    if major == 12:
+        preferred = [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
+        if preferred:
+            return preferred
     # don't select trtllm since it requires weight shuffling
     if "cutlass" in suitable_backends:
         return ["cutlass"]
@@ -5372,6 +5425,7 @@ def _heuristic_func_mm_mxfp8(
         "trtllm": _trtllm_gemm_mxfp8_requirement,
         "cute-dsl": _cute_dsl_gemm_mxfp8_requirement,
         "cudnn": _cudnn_mm_mxfp8_requirement,
+        "b12x": _b12x_gemm_mxfp8_requirement,
     },
     common_check=_check_mm_mxfp8_problem_size,
     heuristic_func=_heuristic_func_mm_mxfp8,  # result stored in mm_mxfp8.suitable_auto_backends
@@ -5385,7 +5439,7 @@ def mm_mxfp8(
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
     use_8x4_sf_layout: bool = False,
-    backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "auto"] = "auto",
+    backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "b12x", "auto"] = "auto",
 ) -> torch.Tensor:
     r"""MM MXFP8 (block size 32)
 
@@ -5423,10 +5477,14 @@ def mm_mxfp8(
     use_8x4_sf_layout: bool
         Whether the scale tensors for a are in 8x4 layout (vs 128x4).
 
-    backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "auto"]
+    backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "b12x", "auto"]
         The backend to use for the operation. Defaults to ``"auto"``.
         ``"auto"`` selects the CUTLASS backend when available and otherwise
-        falls back to the cuDNN backend.
+        falls back to the cuDNN backend. On SM120/SM121 it prefers the b12x
+        backend when its requirements are met.
+        - The ``"b12x"`` backend (SM120/SM121) is a warp-level MMA kernel with
+          small-M decode tiles. It requires CUDA 13+, nvidia-cutlass-dsl >=
+          4.6.0, 1D swizzled 128x4 scales, and K divisible by 128.
         - The ``"cute-dsl"`` backend currently requires swizzled 1D scales
           (``mxfp8_quantize(..., is_sf_swizzled_layout=True)``).
         - The ``"trtllm"`` requires b to be quantized with 128x4 swizzle layout and shuffled.
@@ -5507,6 +5565,7 @@ def mm_mxfp8(
         ),
         "cute-dsl": lambda: _cute_dsl_gemm_mxfp8_runner(major, minor, True, out_dtype),
         "cudnn": lambda: _cudnn_mm_mxfp8_runner(),
+        "b12x": lambda: _b12x_gemm_mxfp8_runner(major, minor, True, out_dtype),
     }
 
     runners: List[TunableRunner] = [
@@ -6558,6 +6617,214 @@ def _b12x_gemm_fp4_runner(
             return out
 
     return B12xFp4GemmRunner()
+
+
+# Module-level kernel cache for b12x MXFP8 GEMM.
+_B12X_MM_MXFP8_KERNEL_CACHE: dict[tuple, tuple] = {}
+
+
+def _b12x_gemm_mxfp8_runner(
+    sm_major: int,
+    sm_minor: int,
+    enable_pdl: bool,
+    out_dtype: torch.dtype,
+):
+    """Create a b12x MXFP8 GEMM runner for SM12x.
+
+    Same warp-level MMA kernel as the b12x FP4 backend, driven with MXFP8
+    operands (m16n8k32 atom, UE8M0 scales, BK128) and the MXFP8 tile regimes.
+    """
+    import cutlass
+
+    from .kernels.dense_blockscaled_gemm_sm120_b12x import (
+        Sm120B12xBlockScaledDenseGemmKernel,
+        _select_default_dense_gemm_plan,
+    )
+
+    from ..cute_dsl.utils import torch_to_cutlass_dtype
+
+    if out_dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(
+            f"b12x backend does not support output dtype {out_dtype}. "
+            f"Supported: torch.bfloat16, torch.float16."
+        )
+    c_cutlass_dtype = torch_to_cutlass_dtype(out_dtype)
+
+    def _default_dense_plan(m, n, real_k, device):
+        return _select_default_dense_gemm_plan(
+            m,
+            n,
+            real_k,
+            get_device_sm_count(device),
+            is_mxfp8=True,
+            expected_m=m,
+        )
+
+    class B12xMxfp8GemmRunner(TunableRunner):
+        """TunableRunner for b12x block-scaled MXFP8 dense GEMM on SM12x.
+
+        Tactics are tuples:
+            (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch, kernel_type, use_tma_store)
+        where kernel_type is always "sm120" and use_tma_store is always None.
+        """
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+        ) -> list:
+            (a, b, a_descale, b_descale, _, out, _) = inputs
+            m = a.shape[0]
+            real_k = a.shape[1]
+            n = b.shape[1]
+
+            sf_vec_size = 32
+            ab_dtype = cutlass.Float8E4M3FN
+            sf_dtype = cutlass.Float8E8M0FNU
+            batch_size = 1
+
+            valid_tactics = []
+
+            def _add(mma_tiler_mn, swap_ab):
+                # can_implement is M-independent (takes no `m`)
+                if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
+                    ab_dtype,
+                    sf_dtype,
+                    sf_vec_size,
+                    c_cutlass_dtype,
+                    mma_tiler_mn,
+                    (1, 1),
+                    n,
+                    real_k,
+                    batch_size,
+                    "k",
+                    "k",
+                    "n",
+                    swap_ab=swap_ab,
+                ):
+                    return
+                for use_prefetch in (False, True):
+                    tac = (mma_tiler_mn, (1, 1), swap_ab, use_prefetch, "sm120", None)
+                    if tac not in valid_tactics:
+                        valid_tactics.append(tac)
+
+            # Balanced tiles plus the MXFP8 M-narrow decode tiles; keep the grid
+            # small so the tuner's bucket representative stays meaningful.
+            for mma_tiler_mn in [
+                (16, 128),
+                (32, 128),
+                (64, 64),
+                (64, 128),
+                (128, 128),
+            ]:
+                _add(mma_tiler_mn, swap_ab=False)
+
+            # Also include the default-path tile so the tuner can't pick worse
+            # than static.
+            plan = _default_dense_plan(m, n, real_k, a.device)
+            _add(plan.mma_tiler_mn, swap_ab=plan.swap_ab)
+            return valid_tactics
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic=None,
+            do_preparation: bool = False,
+            **kwargs,
+        ):
+            (a, b, a_descale, b_descale, _, out, _) = inputs
+            m = a.shape[0]
+            real_k = a.shape[1]
+            n = b.shape[1]
+
+            sf_vec_size = 32
+            sf_dtype = cutlass.Float8E8M0FNU
+            batch_size = 1
+
+            if tactic is None or tactic == -1:
+                plan = _default_dense_plan(m, n, real_k, a.device)
+                tactic = (
+                    plan.mma_tiler_mn,
+                    (1, 1),
+                    plan.swap_ab,
+                    False,
+                    "sm120",
+                    None,
+                )
+
+            (
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+                kernel_type,
+                use_tma_store,
+            ) = tactic
+
+            kernel_a, kernel_b = a, b.T
+            kernel_a_sf, kernel_b_sf = a_descale, b_descale
+
+            sf_m = (m + 127) // 128
+            sf_n = (n + 127) // 128
+            sf_k = (real_k // sf_vec_size + 3) // 4
+
+            cache_key = (
+                sf_vec_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+                kernel_type,
+                use_tma_store,
+                enable_pdl,
+                out_dtype,
+            )
+
+            make_kernel = lambda: Sm120B12xBlockScaledDenseGemmKernel(
+                sf_vec_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                mma_k=32,
+                tile_k=128,
+                use_prefetch=use_prefetch,
+                enable_pdl=enable_pdl,
+                swap_ab=swap_ab,
+            )
+
+            # swap_ab is device-internal (applied in the kernel ctor); public C
+            # stays row-major (m, n).
+            compiled_gemm, _ = _compile_block_scaled_gemm(
+                _B12X_MM_MXFP8_KERNEL_CACHE,
+                cache_key,
+                make_kernel,
+                ab_cutlass_dtype=cutlass.Float8E4M3FN,
+                sf_dtype=sf_dtype,
+                c_cutlass_dtype=c_cutlass_dtype,
+                ab_assumed_align=32,
+                cluster_shape_mn=cluster_shape_mn,
+                swap_ab=False,
+                sf_m=sf_m,
+                sf_n=sf_n,
+                sf_k=sf_k,
+                batch_size=batch_size,
+            )
+
+            alpha_for_launch = _prepare_alpha_for_launch(None, a.device)
+
+            compiled_gemm(
+                kernel_a,
+                kernel_b,
+                out,
+                sf_m,
+                sf_n,
+                sf_k,
+                kernel_a_sf.data_ptr(),
+                kernel_b_sf.data_ptr(),
+                alpha_for_launch,
+            )
+            return out
+
+    return B12xMxfp8GemmRunner()
 
 
 def _heuristic_func_mm_fp4(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5405,7 +5405,8 @@ def mm_mxfp8(
 
     out: Optional[torch.Tensor]
         Out tensor, shape (m, n), bf16 or fp16. If provided, the result is written
-        into it (supported by the CUTLASS and cuDNN backends). Defaults to ``None``.
+        into it (supported by the CUTLASS, cuDNN, and b12x backends). Defaults to
+        ``None``.
 
     out_dtype: torch.dtype
         Output dtype, bf16 or fp16. Defaults to ``torch.bfloat16``.

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4895,12 +4895,12 @@ def _b12x_gemm_mxfp8_requirement(
             "b12x mm_mxfp8 requires 1D 128x4-swizzled block scales. "
             "Use mxfp8_quantize(..., is_sf_swizzled_layout=True)."
         )
-    if a.shape[1] % 128 != 0 or a.shape[1] < 256:
+    if a.shape[1] % 128 != 0 or a.shape[1] < 640:
         if backend != "b12x":
             return False
         raise ValueError(
             "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
-            f"128 and at least 256 (two BK128 tiles). Got K={a.shape[1]}."
+            f"128 and at least 640. Got K={a.shape[1]}."
         )
     _check_cute_dsl_availability()
     import cutlass.cute as cute

--- a/flashinfer/gemm/gemm_mm_fp4_cute_dsl.py
+++ b/flashinfer/gemm/gemm_mm_fp4_cute_dsl.py
@@ -228,6 +228,26 @@ def _make_blockscaled_gemm_compile_fn(
     return compile_kernel
 
 
+_CUTE_DSL_ALPHA_ONE_CACHE: dict = {}
+
+
+def _prepare_alpha_for_launch(alpha_tensor, device):
+    """Prepare alpha as a 1-dim float32 device tensor with shape [1].
+
+    When *alpha_tensor* is ``None``, returns a cached ``tensor([1.0])``
+    on *device* (allocated once, reused forever).
+    """
+    if alpha_tensor is None:
+        cached = _CUTE_DSL_ALPHA_ONE_CACHE.get(device)
+        if cached is None:
+            cached = torch.tensor([1.0], dtype=torch.float32, device=device)
+            _CUTE_DSL_ALPHA_ONE_CACHE[device] = cached
+        return cached
+    if alpha_tensor.dim() == 0:
+        return alpha_tensor.unsqueeze(0)
+    return alpha_tensor.reshape(1)
+
+
 def _mm_fp4_precompile_worker(payload):
     """Compile one mm_fp4 tactic in a spawned subprocess and persist it to
     the on-disk CuTe-DSL kernel cache.

--- a/flashinfer/gemm/gemm_mm_mxfp8_cute_dsl.py
+++ b/flashinfer/gemm/gemm_mm_mxfp8_cute_dsl.py
@@ -41,7 +41,7 @@ def _b12x_mxfp8_dsl_supported() -> bool:
     from packaging import version as pkg_version
 
     try:
-        return pkg_version.Version(dsl_version).release[:2] >= (4, 6)
+        return pkg_version.Version(dsl_version) >= pkg_version.Version("4.6.0")
     except pkg_version.InvalidVersion:
         return False
 

--- a/flashinfer/gemm/gemm_mm_mxfp8_cute_dsl.py
+++ b/flashinfer/gemm/gemm_mm_mxfp8_cute_dsl.py
@@ -1,0 +1,291 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+import importlib.metadata
+from typing import List, Literal, Optional
+
+import torch
+
+from ..autotuner import OptimizationProfile, TunableRunner
+from ..jit.cpp_ext import get_cuda_version
+from ..utils import get_device_sm_count, supported_compute_capability
+from .gemm_mm_fp4_cute_dsl import (
+    _compile_block_scaled_gemm,
+    _prepare_alpha_for_launch,
+)
+
+
+@functools.cache
+def _b12x_mxfp8_dsl_supported() -> bool:
+    # Probe distribution metadata rather than import cutlass.cute, which
+    # takes seconds. Cached because the lookup hits the filesystem and this
+    # runs on every call.
+    try:
+        dsl_version = importlib.metadata.version("nvidia-cutlass-dsl")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    from packaging import version as pkg_version
+
+    try:
+        return pkg_version.Version(dsl_version).release[:2] >= (4, 6)
+    except pkg_version.InvalidVersion:
+        return False
+
+
+@supported_compute_capability([120, 121])
+def _b12x_gemm_mxfp8_requirement(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_descale: torch.Tensor,
+    b_descale: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    use_8x4_sf_layout: bool = True,
+    backend: Literal["cutlass", "cute-dsl", "trtllm", "cudnn", "b12x", "auto"] = "auto",
+):
+    if get_cuda_version().major < 13:
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires CUDA 13 or later. "
+            f"Current CUDA version: {get_cuda_version()}."
+        )
+    if use_8x4_sf_layout or a_descale.ndim != 1 or b_descale.ndim != 1:
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires 1D 128x4-swizzled block scales. "
+            "Use mxfp8_quantize(..., is_sf_swizzled_layout=True)."
+        )
+    if a.shape[1] % 128 != 0:
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires the contraction dim K to be a multiple of "
+            f"128 (one full BK128 tile). Got K={a.shape[1]}."
+        )
+    if not _b12x_mxfp8_dsl_supported():
+        if backend != "b12x":
+            return False
+        raise ValueError(
+            "b12x mm_mxfp8 requires nvidia-cutlass-dsl >= 4.6.0 "
+            "(cute.nvgpu.warp.MmaMXF8Op)."
+        )
+    return True
+
+
+# Module-level kernel cache for b12x MXFP8 GEMM.
+_B12X_MM_MXFP8_KERNEL_CACHE: dict[tuple, tuple] = {}
+
+
+def _b12x_gemm_mxfp8_runner(
+    sm_major: int,
+    sm_minor: int,
+    enable_pdl: bool,
+    out_dtype: torch.dtype,
+):
+    """Create a b12x MXFP8 GEMM runner for SM12x.
+
+    Same warp-level MMA kernel as the b12x FP4 backend, driven with MXFP8
+    operands (m16n8k32 atom, UE8M0 scales, BK128) and the MXFP8 tile regimes.
+    """
+    import cutlass
+
+    from .kernels.dense_blockscaled_gemm_sm120_b12x import (
+        Sm120B12xBlockScaledDenseGemmKernel,
+        _select_default_dense_gemm_plan,
+    )
+
+    from ..cute_dsl.utils import torch_to_cutlass_dtype
+
+    if out_dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(
+            f"b12x backend does not support output dtype {out_dtype}. "
+            f"Supported: torch.bfloat16, torch.float16."
+        )
+    c_cutlass_dtype = torch_to_cutlass_dtype(out_dtype)
+
+    def _default_dense_plan(m, n, real_k, device):
+        return _select_default_dense_gemm_plan(
+            m,
+            n,
+            real_k,
+            get_device_sm_count(device),
+            is_mxfp8=True,
+            expected_m=m,
+        )
+
+    class B12xMxfp8GemmRunner(TunableRunner):
+        """TunableRunner for b12x block-scaled MXFP8 dense GEMM on SM12x."""
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+        ) -> list:
+            (a, b, a_descale, b_descale, _, out, _) = inputs
+            m = a.shape[0]
+            real_k = a.shape[1]
+            n = b.shape[1]
+
+            sf_vec_size = 32
+            ab_dtype = cutlass.Float8E4M3FN
+            sf_dtype = cutlass.Float8E8M0FNU
+            batch_size = 1
+
+            valid_tactics = []
+
+            def _add(mma_tiler_mn, swap_ab):
+                # can_implement takes no m, so validity is M-independent.
+                if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
+                    ab_dtype,
+                    sf_dtype,
+                    sf_vec_size,
+                    c_cutlass_dtype,
+                    mma_tiler_mn,
+                    (1, 1),
+                    n,
+                    real_k,
+                    batch_size,
+                    "k",
+                    "k",
+                    "n",
+                    swap_ab=swap_ab,
+                ):
+                    return
+                for use_prefetch in (False, True):
+                    tac = (mma_tiler_mn, (1, 1), swap_ab, use_prefetch, "sm120", None)
+                    if tac not in valid_tactics:
+                        valid_tactics.append(tac)
+
+            # A few tiles for the tuner to profile (a larger grid overfits the
+            # bucket representative and makes picks noisier).
+            for mma_tiler_mn in [
+                (16, 128),
+                (32, 128),
+                (64, 64),
+                (64, 128),
+                (128, 128),
+            ]:
+                _add(mma_tiler_mn, swap_ab=False)
+
+            # Also include the default-path tile so the tuner can't pick worse
+            # than static.
+            plan = _default_dense_plan(m, n, real_k, a.device)
+            _add(plan.mma_tiler_mn, swap_ab=plan.swap_ab)
+            return valid_tactics
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic=None,
+            do_preparation: bool = False,
+            **kwargs,
+        ):
+            (a, b, a_descale, b_descale, _, out, _) = inputs
+            m = a.shape[0]
+            real_k = a.shape[1]
+            n = b.shape[1]
+
+            sf_vec_size = 32
+            sf_dtype = cutlass.Float8E8M0FNU
+            batch_size = 1
+
+            if tactic is None or tactic == -1:
+                plan = _default_dense_plan(m, n, real_k, a.device)
+                tactic = (
+                    plan.mma_tiler_mn,
+                    (1, 1),
+                    plan.swap_ab,
+                    False,
+                    "sm120",
+                    None,
+                )
+
+            (
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+                kernel_type,
+                use_tma_store,
+            ) = tactic
+
+            kernel_a, kernel_b = a, b.T
+            kernel_a_sf, kernel_b_sf = a_descale, b_descale
+
+            sf_m = (m + 127) // 128
+            sf_n = (n + 127) // 128
+            sf_k = (real_k // sf_vec_size + 3) // 4
+
+            cache_key = (
+                sf_vec_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+                kernel_type,
+                use_tma_store,
+                enable_pdl,
+                out_dtype,
+            )
+
+            make_kernel = lambda: Sm120B12xBlockScaledDenseGemmKernel(
+                sf_vec_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                mma_k=32,
+                tile_k=128,
+                use_prefetch=use_prefetch,
+                enable_pdl=enable_pdl,
+                swap_ab=swap_ab,
+            )
+
+            # swap_ab is applied inside the kernel, so the public C tensor
+            # stays row-major (m, n).
+            compiled_gemm, _ = _compile_block_scaled_gemm(
+                _B12X_MM_MXFP8_KERNEL_CACHE,
+                cache_key,
+                make_kernel,
+                ab_cutlass_dtype=cutlass.Float8E4M3FN,
+                sf_dtype=sf_dtype,
+                c_cutlass_dtype=c_cutlass_dtype,
+                ab_assumed_align=32,
+                cluster_shape_mn=cluster_shape_mn,
+                swap_ab=False,
+                sf_m=sf_m,
+                sf_n=sf_n,
+                sf_k=sf_k,
+                batch_size=batch_size,
+            )
+
+            alpha_for_launch = _prepare_alpha_for_launch(None, a.device)
+
+            compiled_gemm(
+                kernel_a,
+                kernel_b,
+                out,
+                sf_m,
+                sf_n,
+                sf_k,
+                kernel_a_sf.data_ptr(),
+                kernel_b_sf.data_ptr(),
+                alpha_for_launch,
+            )
+            return out
+
+    return B12xMxfp8GemmRunner()

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -2443,7 +2443,12 @@ class DenseGemmKernel:
             return False
         if is_mxfp8:
             # MXFP8 runs the full BK128 tile; no ragged-K predication ported.
-            if k % 128 != 0:
+            # Single-K-tile shapes (k == 128) are rejected: the kernel has a
+            # pre-existing synchronization race when the mainloop runs exactly
+            # one K iteration with m >= 1024 (present upstream and in the FP4
+            # path too); keep those shapes on the CUTLASS backend until the
+            # race is fixed.
+            if k % 128 != 0 or k < 256:
                 return False
         elif k % 32 != 0:
             # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -2443,12 +2443,12 @@ class DenseGemmKernel:
             return False
         if is_mxfp8:
             # MXFP8 runs the full BK128 tile; no ragged-K predication ported.
-            # Single-K-tile shapes (k == 128) are rejected: the kernel has a
-            # pre-existing synchronization race when the mainloop runs exactly
-            # one K iteration with m >= 1024 (present upstream and in the FP4
-            # path too); keep those shapes on the CUTLASS backend until the
-            # race is fixed.
-            if k % 128 != 0 or k < 256:
+            # Short-K shapes are rejected: the kernel has a pre-existing
+            # synchronization race whenever the mainloop runs fewer K
+            # iterations than the smem pipeline has stages (up to 5, so
+            # k >= 5 * 128); it is present upstream and in the FP4 path too.
+            # Keep shorter K on the CUTLASS backend until the race is fixed.
+            if k % 128 != 0 or k < 640:
                 return False
         elif k % 32 != 0:
             # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -185,10 +185,13 @@ class DenseGemmKernel:
         - Supported combinations:
             * NVF4: A/B: Float4E2M1FN, SF: Float8E4M3FN, sf_vec_size: 16
             * MXF4: A/B: Float4E2M1FN, SF: Float8E8M0FNU, sf_vec_size: 32
+            * MXFP8: A/B: Float8E4M3FN, SF: Float8E8M0FNU, sf_vec_size: 32,
+              mma_k 32, tile_k 128 (needs cutlass-dsl >= 4.6.0 for MmaMXF8Op)
         - Tile shape constraints:
             * tile_m must be divisible by 128
             * tile_n must be divisible by 128
             * tile_k must be divisible by 64 (sf_vec_size=16) or 128 (sf_vec_size=32)
+            * MXFP8 additionally allows the decode tiles (16|32, 64|128)
     """
 
     def __init__(
@@ -282,20 +285,26 @@ class DenseGemmKernel:
         self.mma_register_requirement = 232
 
     def _setup_attributes(self):
-        # FP4-only target (NVF4 sf_vec_size=16 / MXF4 sf_vec_size=32). The MXFP8
-        # warp-MMA path was dropped: FlashInfer only drives this kernel for FP4,
-        # and cute.nvgpu.warp.MmaMXF8Op is absent in the public cutlass-dsl build.
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        if self.is_mxfp8:
+            # m16n8k32 .kind::mxf8 atom; only cutlass-dsl >= 4.6.0 exposes it,
+            # callers gate on hasattr(cute.nvgpu.warp, "MmaMXF8Op").
+            mma_op = cute.nvgpu.warp.MmaMXF8Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_shape = self.atom_shape
         atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.mma_tile_shape_mnk,
             self.sf_vec_size,
-            False,  # is_mxfp8: FP4-only
+            self.is_mxfp8,
         )
         self.tiled_mma = cute.make_tiled_mma(
             mma_op,
@@ -397,6 +406,7 @@ class DenseGemmKernel:
         self.b_dtype = b.element_type
         self.c_dtype = c.element_type
         self.sf_dtype = sfa.element_type
+        self.is_mxfp8 = self.a_dtype == cutlass.Float8E4M3FN
 
         self.a_layout = utils.LayoutEnum.from_tensor(a)
         self.b_layout = utils.LayoutEnum.from_tensor(b)
@@ -569,9 +579,16 @@ class DenseGemmKernel:
         assert cute.rank(sfa_tensor) >= 2
 
         atom_shape_mnk = tiled_mma.shape_mnk
-        atom_sfa_layout = cute.make_layout(
-            shape=((2, 2, 8), 64), stride=((8, 0, 1), 16)
-        )
+        # Atom TV layouts per instruction K (cutlass-dsl 4.6.0
+        # blackwell_helpers.thrfrg_SFA): m16n8k64 FP4 vs m16n8k32 MXFP8.
+        if cute.size(atom_shape_mnk[2]) == 32:
+            atom_sfa_layout = cute.make_layout(
+                shape=((2, 2, 8), (32, 1)), stride=((8, 0, 1), (16, 0))
+            )
+        else:
+            atom_sfa_layout = cute.make_layout(
+                shape=((2, 2, 8), 64), stride=((8, 0, 1), 16)
+            )
         permutation_mnk = tiled_mma.permutation_mnk
         thr_layout_vmnk = tiled_mma.thr_layout_vmnk
 
@@ -604,7 +621,12 @@ class DenseGemmKernel:
         assert cute.rank(sfb_tensor) >= 2
 
         atom_shape_mnk = tiled_mma.shape_mnk
-        atom_sfb_layout = cute.make_layout(shape=((4, 8), 64), stride=((0, 1), 8))
+        if cute.size(atom_shape_mnk[2]) == 32:
+            atom_sfb_layout = cute.make_layout(
+                shape=((4, 8), (32, 1)), stride=((0, 1), (8, 0))
+            )
+        else:
+            atom_sfb_layout = cute.make_layout(shape=((4, 8), 64), stride=((0, 1), 8))
         permutation_mnk = tiled_mma.permutation_mnk
         thr_layout_vmnk = tiled_mma.thr_layout_vmnk
 
@@ -2375,20 +2397,28 @@ class DenseGemmKernel:
             return False
         if load_path not in _DENSE_LOAD_PATHS:
             return False
-        # FP4-only target (NVF4/MXF4). The MXFP8 warp-MMA path was dropped.
-        if ab_dtype != cutlass.Float4E2M1FN:
+        if ab_dtype not in (cutlass.Float4E2M1FN, cutlass.Float8E4M3FN):
+            return False
+        is_mxfp8 = ab_dtype == cutlass.Float8E4M3FN
+        if is_mxfp8 and not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
+            # cutlass-dsl < 4.6.0 does not expose the MXFP8 warp-MMA atom.
             return False
         if swap_ab:
             if l != 1:
                 return False
-            if sf_vec_size != 16:
+            if (ab_dtype, sf_vec_size) not in (
+                (cutlass.Float4E2M1FN, 16),
+                (cutlass.Float8E4M3FN, 32),
+            ):
                 return False
         if load_path == "cpasync" and (sf_vec_size != 16 or l != 1):
             return False
-        # FP4 experiments allow narrow N tiles. The scale-factor smem paths
-        # still allocate full 128-element SF blocks, but the live MMA tile may
-        # consume only 16/32 columns.
-        if (
+        # Narrow M/N tiles are allowed. The scale-factor smem paths still
+        # allocate full 128-element SF blocks, but the live MMA tile may
+        # consume only 16/32 rows or columns.
+        if is_mxfp8 and mma_tiler_mn in ((16, 64), (16, 128), (32, 64), (32, 128)):
+            pass
+        elif (
             mma_tiler_mn[0] % 64 != 0
             or mma_tiler_mn[1] % 16 != 0
             or mma_tiler_mn[1] > 128
@@ -2402,15 +2432,23 @@ class DenseGemmKernel:
             return False
         if sf_vec_size == 32 and sf_dtype != cutlass.Float8E8M0FNU:
             return False
+        # MXFP8 pairs only with UE8M0 scales at vector size 32.
+        if is_mxfp8 and sf_vec_size != 32:
+            return False
         # Public output is 16-bit; split-K internally uses FP32 partial output.
         if c_dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float32):
             return False
         # A must be K-major, B must be K-major
         if a_major != "k" or b_major != "k":
             return False
-        # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not tile_k: the
-        # mainloop predicates the partial tile, so ragged K works. Mirror gemm_base.py.
-        if k % 32 != 0:
+        if is_mxfp8:
+            # MXFP8 runs the full BK128 tile; no ragged-K predication ported.
+            if k % 128 != 0:
+                return False
+        elif k % 32 != 0:
+            # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not
+            # tile_k: the mainloop predicates the partial tile, so ragged K
+            # works. Mirror gemm_base.py.
             return False
         return True
 
@@ -2500,12 +2538,41 @@ def _select_default_mma_tiler_mn(
     n: int,
     sm_count: int,
     *,
+    is_mxfp8: bool = False,
     expected_m: Optional[int] = None,
     k: Optional[int] = None,
 ) -> Tuple[int, int]:
-    # FP4-only tile selector. The MXFP8 regimes (16x64/16x128/32x128 decode
-    # tiles, narrow-N 64x64) were dropped along with the MXFP8 warp-MMA path.
     coarse_tile = (128, 128)
+    if is_mxfp8 and n > 1536:
+        # DeepGEMM-style regime hint: when a caller declares expected_m, pick
+        # the per-regime optimal tile and key the compile on it, one kernel per
+        # (N,K,expected_m) reused for every live M in that regime. Regime
+        # boundaries follow the upstream b12x probe sweeps; upstream's
+        # exact-shape pins for its own serving shapes are dropped here, the
+        # autotuner covers exact shapes instead.
+        if expected_m is not None:
+            if expected_m == 1:
+                return (16, 64)
+            if expected_m <= 8:
+                return (16, 128)
+            if expected_m <= 128:
+                return (32, 128)
+            return (64, 128)
+        if m == 1:
+            return (16, 64)
+        if m <= 8:
+            return (16, 128)
+        # 64x128 is the best M-independent wide-N tile; 128x128 launches too
+        # few CTAs at small/medium M and loses at every M.
+        return (64, 128)
+    if is_mxfp8:
+        # Narrow-N MXFP8: (64,64) maximizes CTAs and is M-independent; declared
+        # prefill regimes take (64,128), exact M=1 the decode winner (16,64).
+        if expected_m == 1 or (expected_m is None and m == 1):
+            return (16, 64)
+        if expected_m is not None and expected_m > 128:
+            return (64, 128)
+        return (64, 64)
     plan_m = expected_m if expected_m is not None else m
     if plan_m == 1 and k is not None:
         # Flushed M=1 FP4 probe (benchmarks/probe_dense_fp4_tile_load_sweep.py)
@@ -2553,19 +2620,23 @@ def _select_default_dense_gemm_plan(
     k: int,
     sm_count: int,
     *,
+    is_mxfp8: bool = False,
     expected_m: Optional[int] = None,
 ) -> _DenseGemmPlan:
     tile = _select_default_mma_tiler_mn(
         m,
         n,
         sm_count,
+        is_mxfp8=is_mxfp8,
         expected_m=expected_m,
         k=k,
     )
+    # MXFP8 never auto-swaps: its narrow tiles are M-narrow (16/32 rows), not
+    # N-narrow like the FP4 (64,32) tile.
     return _DenseGemmPlan(
         mma_tiler_mn=tile,
         load_path="tma",
-        swap_ab=(tile[1] < 64),
+        swap_ab=(not is_mxfp8 and tile[1] < 64),
     )
 
 

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -287,8 +287,6 @@ class DenseGemmKernel:
 
     def _setup_attributes(self):
         if self.is_mxfp8:
-            # The m16n8k32 .kind::mxf8 atom exists only in cutlass-dsl 4.6.0
-            # and later. Callers gate on hasattr before compiling.
             mma_op = cute.nvgpu.warp.MmaMXF8Op(
                 self.a_dtype,
                 self.acc_dtype,
@@ -1874,8 +1872,9 @@ class DenseGemmKernel:
                         work_tile = tile_sched.get_current_work()
 
             if cutlass.const_expr(not self.swap_ab):
-                # Retire the outstanding store group before PDL may launch
-                # dependent grids below.
+                # Drain outstanding TMA stores: writes are visible to PDL
+                # dependent grids only if they complete before
+                # griddepcontrol_launch_dependents.
                 if warp_idx == 0:
                     tma_store_pipeline.producer_tail()
 
@@ -2410,8 +2409,8 @@ class DenseGemmKernel:
             # cutlass-dsl < 4.6.0 does not expose the MXFP8 warp-MMA atom.
             return False
         if swap_ab:
-            # The MXFP8 path never swaps A and B, its narrow tiles are
-            # M-narrow. Reject rather than accept an unvalidated layout.
+            # MXFP8 never uses the swap (its narrow tiles are M-narrow), so
+            # only the FP4 layout is validated.
             if l != 1:
                 return False
             if (ab_dtype, sf_vec_size) != (cutlass.Float4E2M1FN, 16):
@@ -2421,8 +2420,6 @@ class DenseGemmKernel:
         # SF smem still allocates full 128-element blocks even when the live
         # MMA tile uses only 16 or 32 rows or columns.
         if is_mxfp8:
-            # Outside the small-M whitelist, both tile dims must be
-            # multiples of 64.
             if mma_tiler_mn not in ((16, 64), (16, 128), (32, 64), (32, 128)) and (
                 mma_tiler_mn[0] % 64 != 0
                 or mma_tiler_mn[1] % 64 != 0
@@ -2443,7 +2440,6 @@ class DenseGemmKernel:
             return False
         if sf_vec_size == 32 and sf_dtype != cutlass.Float8E8M0FNU:
             return False
-        # MXFP8 pairs only with UE8M0 scales at vector size 32.
         if is_mxfp8 and sf_vec_size != 32:
             return False
         # Public output is 16-bit; split-K internally uses FP32 partial output.
@@ -2459,7 +2455,7 @@ class DenseGemmKernel:
         elif k % 32 != 0:
             # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not
             # tile_k: the mainloop predicates the partial tile, so ragged K
-            # works. Keep in sync with gemm_base.py.
+            # works.
             return False
         return True
 

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -188,10 +188,11 @@ class DenseGemmKernel:
             * MXFP8: A/B: Float8E4M3FN, SF: Float8E8M0FNU, sf_vec_size: 32,
               mma_k 32, tile_k 128 (needs cutlass-dsl >= 4.6.0 for MmaMXF8Op)
         - Tile shape constraints:
-            * tile_m must be divisible by 128
-            * tile_n must be divisible by 128
+            * FP4: tile_m divisible by 64, tile_n divisible by 16 and <= 128
+              (tile_n < 64 requires swap_ab)
+            * MXFP8: tile_m and tile_n divisible by 64 with tile_n <= 128,
+              plus the small-M tiles (16|32, 64|128)
             * tile_k must be divisible by 64 (sf_vec_size=16) or 128 (sf_vec_size=32)
-            * MXFP8 additionally allows the decode tiles (16|32, 64|128)
     """
 
     def __init__(

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -1264,6 +1264,15 @@ class DenseGemmKernel:
             )
             tCrSFB_copy_view_full = thr_copy_ldmatrix_SFB.retile(tCrSFB_full)
 
+            tma_store_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_mma_warps * self.num_threads_per_warp,
+            )
+            tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.epi_stage,
+                producer_group=tma_store_producer_group,
+            )
+
             while work_tile.is_valid_tile:
                 tile_coord_mnl = work_tile.tile_idx
                 gC_mnl_slice = gC_mnl[(None, None, *tile_coord_mnl)]
@@ -1628,19 +1637,6 @@ class DenseGemmKernel:
                     epi_tile_n = self.epi_tile[1]
                     mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
                     mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
-                    has_multi_epi_store = cutlass.const_expr(
-                        not (
-                            self.epi_stage == 1 and epi_rest_m == 1 and epi_rest_n == 1
-                        )
-                    )
-                    tma_store_producer_group = pipeline.CooperativeGroup(
-                        pipeline.Agent.Thread,
-                        self.num_mma_warps * self.num_threads_per_warp,
-                    )
-                    tma_store_pipeline = pipeline.PipelineTmaStore.create(
-                        num_stages=self.epi_stage,
-                        producer_group=tma_store_producer_group,
-                    )
 
                     for epi_m in cutlass.range_constexpr(epi_rest_m):
                         for epi_n in cutlass.range_constexpr(epi_rest_n):
@@ -1803,8 +1799,12 @@ class DenseGemmKernel:
                                 epi_buffer = (epi_m * epi_rest_n + epi_n) % cute.size(
                                     tRS_sD, mode=[3]
                                 )
-                                if has_multi_epi_store:
-                                    self.epilog_sync_barrier.arrive_and_wait()
+                                # The TMA store issued from this sC buffer,
+                                # possibly by the previous work tile, may
+                                # still be reading it.
+                                if warp_idx == 0:
+                                    tma_store_pipeline.producer_acquire()
+                                self.epilog_sync_barrier.arrive_and_wait()
                                 cute.copy(
                                     tiled_copy_r2s,
                                     tRS_rD_out,
@@ -1858,9 +1858,10 @@ class DenseGemmKernel:
                                             bSG_sD[(None, epi_buffer)],
                                             bSG_gD[(None, gmem_coord)],
                                         )
-                                        if has_multi_epi_store:
-                                            tma_store_pipeline.producer_commit()
-                                            tma_store_pipeline.producer_acquire()
+                                        # The matching wait sits just before
+                                        # the next sC write, so it overlaps
+                                        # the next work tile's mainloop.
+                                        tma_store_pipeline.producer_commit()
 
                     # Advance to the next work tile
                     if cutlass.const_expr(self.single_work_tile_per_cta):
@@ -1871,10 +1872,12 @@ class DenseGemmKernel:
                     else:
                         tile_sched.advance_to_next_work()
                         work_tile = tile_sched.get_current_work()
-                    if has_multi_epi_store and cutlass.const_expr(
-                        self.split_k_slices == 1
-                    ):
-                        tma_store_pipeline.producer_tail()
+
+            if cutlass.const_expr(not self.swap_ab):
+                # Retire the outstanding store group before PDL may launch
+                # dependent grids below.
+                if warp_idx == 0:
+                    tma_store_pipeline.producer_tail()
 
         elif warp_idx == self.tma_load_warp_id:
             cute.arch.setmaxregister_decrease(self.load_register_requirement)

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -2453,10 +2453,8 @@ class DenseGemmKernel:
         if a_major != "k" or b_major != "k":
             return False
         if is_mxfp8:
-            # MXFP8 has no ragged-K predication, and the mainloop can race
-            # the smem pipeline when it runs no more K iterations than there
-            # are stages (up to 5, hence the six-tile floor).
-            if k % 128 != 0 or k < 768:
+            # MXFP8 has no ragged-K predication, so K must be whole BK128 tiles.
+            if k % 128 != 0:
                 return False
         elif k % 32 != 0:
             # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -579,8 +579,9 @@ class DenseGemmKernel:
         assert cute.rank(sfa_tensor) >= 2
 
         atom_shape_mnk = tiled_mma.shape_mnk
-        # Atom TV layouts per instruction K (cutlass-dsl 4.6.0
-        # blackwell_helpers.thrfrg_SFA): m16n8k64 FP4 vs m16n8k32 MXFP8.
+        # The scale-factor layout must match the MMA instruction's K width:
+        # 32 for the MXFP8 atom, 64 for the FP4 atom. Both layouts come from
+        # blackwell_helpers.thrfrg_SFA in cutlass-dsl 4.6.0.
         if cute.size(atom_shape_mnk[2]) == 32:
             atom_sfa_layout = cute.make_layout(
                 shape=((2, 2, 8), (32, 1)), stride=((8, 0, 1), (16, 0))
@@ -621,6 +622,7 @@ class DenseGemmKernel:
         assert cute.rank(sfb_tensor) >= 2
 
         atom_shape_mnk = tiled_mma.shape_mnk
+        # Same K-width split as _thrfrg_SFA, from blackwell_helpers.thrfrg_SFB.
         if cute.size(atom_shape_mnk[2]) == 32:
             atom_sfb_layout = cute.make_layout(
                 shape=((4, 8), (32, 1)), stride=((0, 1), (8, 0))
@@ -2415,8 +2417,8 @@ class DenseGemmKernel:
         # SF smem still allocates full 128-element blocks even when the live
         # MMA tile uses only 16 or 32 rows or columns.
         if is_mxfp8:
-            # Decode whitelist, else both dims must be multiples of 64
-            # (upstream's MXFP8 gate; stricter than the FP4 branch).
+            # Outside the small-M whitelist, both tile dims must be
+            # multiples of 64.
             if mma_tiler_mn not in ((16, 64), (16, 128), (32, 64), (32, 128)) and (
                 mma_tiler_mn[0] % 64 != 0
                 or mma_tiler_mn[1] % 64 != 0

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -286,8 +286,8 @@ class DenseGemmKernel:
 
     def _setup_attributes(self):
         if self.is_mxfp8:
-            # m16n8k32 .kind::mxf8 atom; only cutlass-dsl >= 4.6.0 exposes it,
-            # callers gate on hasattr(cute.nvgpu.warp, "MmaMXF8Op").
+            # The m16n8k32 .kind::mxf8 atom exists only in cutlass-dsl 4.6.0
+            # and later. Callers gate on hasattr before compiling.
             mma_op = cute.nvgpu.warp.MmaMXF8Op(
                 self.a_dtype,
                 self.acc_dtype,
@@ -2404,20 +2404,27 @@ class DenseGemmKernel:
             # cutlass-dsl < 4.6.0 does not expose the MXFP8 warp-MMA atom.
             return False
         if swap_ab:
+            # Upstream also allows swap_ab for MXFP8. This port never swaps
+            # for MXFP8 (its narrow tiles are M-narrow), so the path stays
+            # unported and is rejected rather than accepted unvalidated.
             if l != 1:
                 return False
-            if (ab_dtype, sf_vec_size) not in (
-                (cutlass.Float4E2M1FN, 16),
-                (cutlass.Float8E4M3FN, 32),
-            ):
+            if (ab_dtype, sf_vec_size) != (cutlass.Float4E2M1FN, 16):
                 return False
         if load_path == "cpasync" and (sf_vec_size != 16 or l != 1):
             return False
         # Narrow M/N tiles are allowed. The scale-factor smem paths still
         # allocate full 128-element SF blocks, but the live MMA tile may
         # consume only 16/32 rows or columns.
-        if is_mxfp8 and mma_tiler_mn in ((16, 64), (16, 128), (32, 64), (32, 128)):
-            pass
+        if is_mxfp8:
+            # Decode whitelist, else both dims must be multiples of 64
+            # (upstream's MXFP8 gate; stricter than the FP4 branch).
+            if mma_tiler_mn not in ((16, 64), (16, 128), (32, 64), (32, 128)) and (
+                mma_tiler_mn[0] % 64 != 0
+                or mma_tiler_mn[1] % 64 != 0
+                or mma_tiler_mn[1] > 128
+            ):
+                return False
         elif (
             mma_tiler_mn[0] % 64 != 0
             or mma_tiler_mn[1] % 16 != 0
@@ -2442,13 +2449,14 @@ class DenseGemmKernel:
         if a_major != "k" or b_major != "k":
             return False
         if is_mxfp8:
-            # MXFP8 runs the full BK128 tile; no ragged-K predication ported.
-            # Short-K shapes are rejected: the kernel has a pre-existing
-            # synchronization race whenever the mainloop runs fewer K
-            # iterations than the smem pipeline has stages (up to 5, so
-            # k >= 5 * 128); it is present upstream and in the FP4 path too.
-            # Keep shorter K on the CUTLASS backend until the race is fixed.
-            if k % 128 != 0 or k < 640:
+            # MXFP8 runs the full BK128 tile, no ragged-K predication was
+            # ported. Short K is rejected: the kernel has a pre-existing
+            # synchronization race whenever the mainloop runs no more K
+            # iterations than the smem pipeline has stages (up to 5, hence
+            # the six-tile floor). The race exists upstream and in the FP4
+            # path too. Shorter K stays on the CUTLASS backend until it is
+            # fixed.
+            if k % 128 != 0 or k < 768:
                 return False
         elif k % 32 != 0:
             # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not
@@ -2550,10 +2558,10 @@ def _select_default_mma_tiler_mn(
     coarse_tile = (128, 128)
     if is_mxfp8 and n > 1536:
         # DeepGEMM-style regime hint: when a caller declares expected_m, pick
-        # the per-regime optimal tile and key the compile on it, one kernel per
-        # (N,K,expected_m) reused for every live M in that regime. Regime
-        # boundaries follow the upstream b12x probe sweeps; upstream's
-        # exact-shape pins for its own serving shapes are dropped here, the
+        # the per-regime optimal tile and key the compile on it, one kernel
+        # per (N, K, expected_m) reused for every live M in that regime.
+        # Regime boundaries follow the upstream b12x probe sweeps. Upstream's
+        # exact-shape pins for its own serving shapes are dropped, the
         # autotuner covers exact shapes instead.
         if expected_m is not None:
             if expected_m == 1:
@@ -2567,12 +2575,13 @@ def _select_default_mma_tiler_mn(
             return (16, 64)
         if m <= 8:
             return (16, 128)
-        # 64x128 is the best M-independent wide-N tile; 128x128 launches too
-        # few CTAs at small/medium M and loses at every M.
+        # 64x128 is the best M-independent wide-N tile. 128x128 launches
+        # too few CTAs at small and medium M and loses at every M.
         return (64, 128)
     if is_mxfp8:
-        # Narrow-N MXFP8: (64,64) maximizes CTAs and is M-independent; declared
-        # prefill regimes take (64,128), exact M=1 the decode winner (16,64).
+        # Narrow-N MXFP8: (64, 64) maximizes CTAs and is M-independent.
+        # Declared prefill regimes take (64, 128), exact M=1 the decode
+        # winner (16, 64).
         if expected_m == 1 or (expected_m is None and m == 1):
             return (16, 64)
         if expected_m is not None and expected_m > 128:

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -2404,18 +2404,16 @@ class DenseGemmKernel:
             # cutlass-dsl < 4.6.0 does not expose the MXFP8 warp-MMA atom.
             return False
         if swap_ab:
-            # Upstream also allows swap_ab for MXFP8. This port never swaps
-            # for MXFP8 (its narrow tiles are M-narrow), so the path stays
-            # unported and is rejected rather than accepted unvalidated.
+            # The MXFP8 path never swaps A and B, its narrow tiles are
+            # M-narrow. Reject rather than accept an unvalidated layout.
             if l != 1:
                 return False
             if (ab_dtype, sf_vec_size) != (cutlass.Float4E2M1FN, 16):
                 return False
         if load_path == "cpasync" and (sf_vec_size != 16 or l != 1):
             return False
-        # Narrow M/N tiles are allowed. The scale-factor smem paths still
-        # allocate full 128-element SF blocks, but the live MMA tile may
-        # consume only 16/32 rows or columns.
+        # SF smem still allocates full 128-element blocks even when the live
+        # MMA tile uses only 16 or 32 rows or columns.
         if is_mxfp8:
             # Decode whitelist, else both dims must be multiples of 64
             # (upstream's MXFP8 gate; stricter than the FP4 branch).
@@ -2449,19 +2447,15 @@ class DenseGemmKernel:
         if a_major != "k" or b_major != "k":
             return False
         if is_mxfp8:
-            # MXFP8 runs the full BK128 tile, no ragged-K predication was
-            # ported. Short K is rejected: the kernel has a pre-existing
-            # synchronization race whenever the mainloop runs no more K
-            # iterations than the smem pipeline has stages (up to 5, hence
-            # the six-tile floor). The race exists upstream and in the FP4
-            # path too. Shorter K stays on the CUTLASS backend until it is
-            # fixed.
+            # MXFP8 has no ragged-K predication, and the mainloop can race
+            # the smem pipeline when it runs no more K iterations than there
+            # are stages (up to 5, hence the six-tile floor).
             if k % 128 != 0 or k < 768:
                 return False
         elif k % 32 != 0:
             # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not
             # tile_k: the mainloop predicates the partial tile, so ragged K
-            # works. Mirror gemm_base.py.
+            # works. Keep in sync with gemm_base.py.
             return False
         return True
 
@@ -2557,12 +2551,8 @@ def _select_default_mma_tiler_mn(
 ) -> Tuple[int, int]:
     coarse_tile = (128, 128)
     if is_mxfp8 and n > 1536:
-        # DeepGEMM-style regime hint: when a caller declares expected_m, pick
-        # the per-regime optimal tile and key the compile on it, one kernel
-        # per (N, K, expected_m) reused for every live M in that regime.
-        # Regime boundaries follow the upstream b12x probe sweeps. Upstream's
-        # exact-shape pins for its own serving shapes are dropped, the
-        # autotuner covers exact shapes instead.
+        # expected_m keys the compile: one kernel per (N, K, expected_m)
+        # serves every live M in its regime.
         if expected_m is not None:
             if expected_m == 1:
                 return (16, 64)
@@ -2575,13 +2565,11 @@ def _select_default_mma_tiler_mn(
             return (16, 64)
         if m <= 8:
             return (16, 128)
-        # 64x128 is the best M-independent wide-N tile. 128x128 launches
-        # too few CTAs at small and medium M and loses at every M.
+        # 64x128 keeps the CTA count up at small and medium M, where 128x128
+        # underfills the grid.
         return (64, 128)
     if is_mxfp8:
-        # Narrow-N MXFP8: (64, 64) maximizes CTAs and is M-independent.
-        # Declared prefill regimes take (64, 128), exact M=1 the decode
-        # winner (16, 64).
+        # (64, 64) maximizes CTAs and is M-independent.
         if expected_m == 1 or (expected_m is None and m == 1):
             return (16, 64)
         if expected_m is not None and expected_m > 128:

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -10,12 +10,10 @@ from flashinfer import (
 )
 from flashinfer.utils import (
     get_compute_capability,
-    get_device_sm_count,
     is_sm12x_supported,
     version_at_least,
     LibraryError,
 )
-from flashinfer.gemm import gemm_base
 from flashinfer.gemm.gemm_base import CUDNN_FP4_MXFP4_SM120_CUDNN_VERSION_ERROR
 
 
@@ -50,10 +48,6 @@ def _test_mm_fp4(
             pytest.skip("b12x backend only supports NVFP4 (sf_vec_size=16).")
         if torch.version.cuda and int(torch.version.cuda.split(".")[0]) < 13:
             pytest.skip("b12x backend requires CUDA 13+.")
-        if gemm_base._b12x_short_mainloop_race_window(
-            (128, 128), m, n, k, get_device_sm_count(torch.device("cuda"))
-        ):
-            pytest.skip("b12x rejects short-K launches beyond one work tile per SM")
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
     if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:
@@ -215,62 +209,37 @@ def _nvfp4_operands(m, n, k):
     return a, b, a_fp4, a_s, b_fp4, b_s, 1.0 / (g_in * g_w)
 
 
-def _skip_unless_short_k_guarded(m, n, k):
+def test_mm_fp4_b12x_short_k_multi_wave():
+    # One K tile and more work tiles than SMs stress the epilogue smem
+    # handoff between a persistent CTA's work tiles, a regime the
+    # parametrized shapes never reach. Repeats, since a bad handoff shows
+    # up as a timing-dependent mismatch.
     device = torch.device("cuda")
     if not (
         is_sm12x_supported(device) and version_at_least(torch.version.cuda, "13.0")
     ):
         pytest.skip("b12x backend requires SM120/SM121 + CUDA 13+.")
-    if not gemm_base._b12x_short_mainloop_race_window(
-        (128, 128), m, n, k, get_device_sm_count(device)
-    ):
-        pytest.skip("shape has a race-free tile on this device")
-
-
-def test_mm_fp4_b12x_short_k_large_launch_raises():
     m, n, k = 1024, 4096, 128
-    _skip_unless_short_k_guarded(m, n, k)
-    _, _, a_fp4, a_s, b_fp4, b_s, alpha = _nvfp4_operands(m, n, k)
-    res = torch.empty([m, n], device="cuda", dtype=torch.bfloat16)
-    with pytest.raises(ValueError, match="short-K"):
-        mm_fp4(
+    for _ in range(3):
+        a, b, a_fp4, a_s, b_fp4, b_s, alpha = _nvfp4_operands(m, n, k)
+        res = mm_fp4(
             a_fp4,
             b_fp4.T,
             a_s,
             b_s.T,
             alpha,
             torch.bfloat16,
-            res,
+            None,
             block_size=16,
             use_8x4_sf_layout=False,
             backend="b12x",
             use_nvfp4=True,
-            skip_check=False,
         )
-
-
-def test_mm_fp4_b12x_short_k_auto_falls_back():
-    m, n, k = 1024, 4096, 128
-    _skip_unless_short_k_guarded(m, n, k)
-    a, b, a_fp4, a_s, b_fp4, b_s, alpha = _nvfp4_operands(m, n, k)
-    res = mm_fp4(
-        a_fp4,
-        b_fp4.T,
-        a_s,
-        b_s.T,
-        alpha,
-        torch.bfloat16,
-        None,
-        block_size=16,
-        use_8x4_sf_layout=False,
-        backend="auto",
-        use_nvfp4=True,
-    )
-    reference = torch.mm(a, b.T)
-    cos_sim = F.cosine_similarity(
-        reference.reshape(-1).float(), res.reshape(-1).float(), dim=0
-    ).item()
-    assert cos_sim > 0.97
+        reference = torch.mm(a, b.T)
+        cos_sim = F.cosine_similarity(
+            reference.reshape(-1).float(), res.reshape(-1).float(), dim=0
+        ).item()
+        assert cos_sim > 0.97
 
 
 def test_mm_fp4_cute_dsl_misaligned_n_raises():

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -10,10 +10,12 @@ from flashinfer import (
 )
 from flashinfer.utils import (
     get_compute_capability,
+    get_device_sm_count,
     is_sm12x_supported,
     version_at_least,
     LibraryError,
 )
+from flashinfer.gemm import gemm_base
 from flashinfer.gemm.gemm_base import CUDNN_FP4_MXFP4_SM120_CUDNN_VERSION_ERROR
 
 
@@ -48,6 +50,10 @@ def _test_mm_fp4(
             pytest.skip("b12x backend only supports NVFP4 (sf_vec_size=16).")
         if torch.version.cuda and int(torch.version.cuda.split(".")[0]) < 13:
             pytest.skip("b12x backend requires CUDA 13+.")
+        if gemm_base._b12x_short_mainloop_race_window(
+            (128, 128), m, n, k, get_device_sm_count(torch.device("cuda"))
+        ):
+            pytest.skip("b12x rejects short-K launches beyond one work tile per SM")
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
     if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:
@@ -176,6 +182,26 @@ def test_mm_fp4_b12x_misaligned_k_raises():
     ):
         pytest.skip("b12x backend requires SM120/SM121 + CUDA 13+.")
     m, n, k = 64, 512, 112  # k % 32 == 16
+    _, _, a_fp4, a_s, b_fp4, b_s, alpha = _nvfp4_operands(m, n, k)
+    res = torch.empty([m, n], device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="multiple of 32"):
+        mm_fp4(
+            a_fp4,
+            b_fp4.T,
+            a_s,
+            b_s.T,
+            alpha,
+            torch.bfloat16,
+            res,
+            block_size=16,
+            use_8x4_sf_layout=False,
+            backend="b12x",
+            use_nvfp4=True,
+            skip_check=False,
+        )
+
+
+def _nvfp4_operands(m, n, k):
     a = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
     b = torch.randn([n, k], device="cuda", dtype=torch.bfloat16)
     g_in = (448 * 6) / a.float().abs().nan_to_num().max()
@@ -186,14 +212,33 @@ def test_mm_fp4_b12x_misaligned_k_raises():
     b_fp4, b_s = nvfp4_quantize(
         b, g_w, sfLayout=SfLayout.layout_128x4, do_shuffle=False
     )
+    return a, b, a_fp4, a_s, b_fp4, b_s, 1.0 / (g_in * g_w)
+
+
+def _skip_unless_short_k_guarded(m, n, k):
+    device = torch.device("cuda")
+    if not (
+        is_sm12x_supported(device) and version_at_least(torch.version.cuda, "13.0")
+    ):
+        pytest.skip("b12x backend requires SM120/SM121 + CUDA 13+.")
+    if not gemm_base._b12x_short_mainloop_race_window(
+        (128, 128), m, n, k, get_device_sm_count(device)
+    ):
+        pytest.skip("shape has a race-free tile on this device")
+
+
+def test_mm_fp4_b12x_short_k_large_launch_raises():
+    m, n, k = 1024, 4096, 128
+    _skip_unless_short_k_guarded(m, n, k)
+    _, _, a_fp4, a_s, b_fp4, b_s, alpha = _nvfp4_operands(m, n, k)
     res = torch.empty([m, n], device="cuda", dtype=torch.bfloat16)
-    with pytest.raises(ValueError, match="multiple of 32"):
+    with pytest.raises(ValueError, match="short-K"):
         mm_fp4(
             a_fp4,
             b_fp4.T,
             a_s,
             b_s.T,
-            1.0 / (g_in * g_w),
+            alpha,
             torch.bfloat16,
             res,
             block_size=16,
@@ -202,6 +247,30 @@ def test_mm_fp4_b12x_misaligned_k_raises():
             use_nvfp4=True,
             skip_check=False,
         )
+
+
+def test_mm_fp4_b12x_short_k_auto_falls_back():
+    m, n, k = 1024, 4096, 128
+    _skip_unless_short_k_guarded(m, n, k)
+    a, b, a_fp4, a_s, b_fp4, b_s, alpha = _nvfp4_operands(m, n, k)
+    res = mm_fp4(
+        a_fp4,
+        b_fp4.T,
+        a_s,
+        b_s.T,
+        alpha,
+        torch.bfloat16,
+        None,
+        block_size=16,
+        use_8x4_sf_layout=False,
+        backend="auto",
+        use_nvfp4=True,
+    )
+    reference = torch.mm(a, b.T)
+    cos_sim = F.cosine_similarity(
+        reference.reshape(-1).float(), res.reshape(-1).float(), dim=0
+    ).item()
+    assert cos_sim > 0.97
 
 
 def test_mm_fp4_cute_dsl_misaligned_n_raises():

--- a/tests/gemm/test_mm_mxfp8.py
+++ b/tests/gemm/test_mm_mxfp8.py
@@ -51,6 +51,11 @@ def _skip_if_unsupported(backend: str = "cutlass"):
             "Skipping test because mm_mxfp8 backend is not supported on compute "
             f"capability {compute_capability_number}."
         )
+    if backend == "b12x":
+        import cutlass.cute as cute
+
+        if not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
+            pytest.skip("b12x mm_mxfp8 requires nvidia-cutlass-dsl >= 4.6.0")
 
 
 def _run_mm_mxfp8(
@@ -149,7 +154,7 @@ def _prepare_mxfp8_tensors(
 @pytest.mark.parametrize("k", [128, 256, 512, 1024, 2048, 2560, 3200])
 @pytest.mark.parametrize("input_dtype", [torch.bfloat16])
 @pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("backend", ["cutlass", "cute-dsl", "trtllm"])
+@pytest.mark.parametrize("backend", ["cutlass", "cute-dsl", "trtllm", "b12x"])
 @pytest.mark.parametrize("auto_tuning", [True, False])
 def test_mm_mxfp8(m, n, k, input_dtype, out_dtype, backend, auto_tuning):
     _run_mm_mxfp8(
@@ -170,7 +175,7 @@ def test_mm_mxfp8(m, n, k, input_dtype, out_dtype, backend, auto_tuning):
 @pytest.mark.parametrize("k", [4096, 8192])
 @pytest.mark.parametrize("input_dtype", [torch.bfloat16])
 @pytest.mark.parametrize("out_dtype", [torch.bfloat16])
-@pytest.mark.parametrize("backend", ["cutlass", "cute-dsl", "trtllm", "auto"])
+@pytest.mark.parametrize("backend", ["cutlass", "cute-dsl", "trtllm", "b12x", "auto"])
 def test_mm_mxfp8_large_dimensions(m, n, k, input_dtype, out_dtype, backend):
     _run_mm_mxfp8(
         m,
@@ -205,6 +210,44 @@ def test_mm_mxfp8_small_m(m, n, k):
         torch.bfloat16,
         torch.bfloat16,
         "cutlass",
+        auto_tuning=False,
+        provide_out=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "m,k",
+    [
+        (1, 768),
+        (16, 1536),
+        (32, 2048),
+    ],
+)
+def test_mm_mxfp8_b12x_low_m(m, k):
+    if k % 128 != 0:
+        pytest.skip("b12x requires K % 128 == 0")
+    _run_mm_mxfp8(
+        m,
+        256,
+        k,
+        torch.bfloat16,
+        torch.bfloat16,
+        "b12x",
+        auto_tuning=False,
+        provide_out=True,
+    )
+
+
+@pytest.mark.parametrize("m", [1, 2, 4, 8, 16, 64])
+@pytest.mark.parametrize("n,k", [(6144, 4096), (2688, 4096)])
+def test_mm_mxfp8_b12x_decode_m(m, n, k):
+    _run_mm_mxfp8(
+        m,
+        n,
+        k,
+        torch.bfloat16,
+        torch.bfloat16,
+        "b12x",
         auto_tuning=False,
         provide_out=True,
     )

--- a/tests/gemm/test_mm_mxfp8.py
+++ b/tests/gemm/test_mm_mxfp8.py
@@ -80,8 +80,8 @@ def _run_mm_mxfp8(
             pytest.skip("trtllm does not support non-multiple of 256")
         if out_dtype != torch.bfloat16:
             pytest.skip("trtllm does not support non-bfloat16 output")
-    if backend == "b12x" and (k % 128 != 0 or k < gemm_base._B12X_MXFP8_MIN_K):
-        pytest.skip("b12x requires K % 128 == 0 above the short-K race floor")
+    if backend == "b12x" and k % 128 != 0:
+        pytest.skip("b12x requires K % 128 == 0")
     if backend == "cutlass" and use_8x4_sf_layout_for_a:
         pytest.skip("cutlass doesn't support 8x4 swizzle layout")
 
@@ -240,6 +240,26 @@ def test_mm_mxfp8_b12x_low_m(m, k):
         auto_tuning=False,
         provide_out=True,
     )
+
+
+@pytest.mark.parametrize("m,n,k", [(2048, 1024, 128), (2048, 1024, 256)])
+def test_mm_mxfp8_b12x_short_k_multi_wave(m, n, k):
+    # One K tile and more work tiles than SMs stress the epilogue smem
+    # handoff between a persistent CTA's work tiles. m=2048 keeps the
+    # launch multi-wave on the largest SM120 parts and misses the
+    # autotuner cache the parametrized suite fills. Repeats, since a bad
+    # handoff shows up as a timing-dependent mismatch.
+    for _ in range(3):
+        _run_mm_mxfp8(
+            m,
+            n,
+            k,
+            torch.bfloat16,
+            torch.bfloat16,
+            "b12x",
+            auto_tuning=False,
+            provide_out=True,
+        )
 
 
 @pytest.mark.parametrize("m", [1, 2, 4, 8, 16, 64])

--- a/tests/gemm/test_mm_mxfp8.py
+++ b/tests/gemm/test_mm_mxfp8.py
@@ -76,8 +76,8 @@ def _run_mm_mxfp8(
             pytest.skip("trtllm does not support non-multiple of 256")
         if out_dtype != torch.bfloat16:
             pytest.skip("trtllm does not support non-bfloat16 output")
-    if backend == "b12x" and (k % 128 != 0 or k < 256):
-        pytest.skip("b12x requires K % 128 == 0 and K >= 256")
+    if backend == "b12x" and (k % 128 != 0 or k < 640):
+        pytest.skip("b12x requires K % 128 == 0 and K >= 640")
     if backend == "cutlass" and use_8x4_sf_layout_for_a:
         pytest.skip("cutlass doesn't support 8x4 swizzle layout")
 

--- a/tests/gemm/test_mm_mxfp8.py
+++ b/tests/gemm/test_mm_mxfp8.py
@@ -11,6 +11,7 @@ from flashinfer import (
 )
 from flashinfer.fp8_quantization import mxfp8_quantize
 from flashinfer.gemm import gemm_base
+from flashinfer.gemm.gemm_mm_mxfp8_cute_dsl import _b12x_mxfp8_dsl_supported
 from flashinfer.utils import get_compute_capability
 
 
@@ -54,11 +55,8 @@ def _skip_if_unsupported(backend: str = "cutlass"):
     if backend == "b12x":
         if torch.version.cuda is None or int(torch.version.cuda.split(".")[0]) < 13:
             pytest.skip("b12x mm_mxfp8 requires CUDA 13+")
-        try:
-            import cutlass.cute as cute
-        except ImportError:
-            pytest.skip("nvidia-cutlass-dsl not installed")
-        if not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
+        # Not a hasattr(MmaMXF8Op) probe: the op exists on versions the gate rejects.
+        if not _b12x_mxfp8_dsl_supported():
             pytest.skip("b12x mm_mxfp8 requires nvidia-cutlass-dsl >= 4.6.0")
 
 

--- a/tests/gemm/test_mm_mxfp8.py
+++ b/tests/gemm/test_mm_mxfp8.py
@@ -76,6 +76,8 @@ def _run_mm_mxfp8(
             pytest.skip("trtllm does not support non-multiple of 256")
         if out_dtype != torch.bfloat16:
             pytest.skip("trtllm does not support non-bfloat16 output")
+    if backend == "b12x" and (k % 128 != 0 or k < 256):
+        pytest.skip("b12x requires K % 128 == 0 and K >= 256")
     if backend == "cutlass" and use_8x4_sf_layout_for_a:
         pytest.skip("cutlass doesn't support 8x4 swizzle layout")
 
@@ -224,8 +226,6 @@ def test_mm_mxfp8_small_m(m, n, k):
     ],
 )
 def test_mm_mxfp8_b12x_low_m(m, k):
-    if k % 128 != 0:
-        pytest.skip("b12x requires K % 128 == 0")
     _run_mm_mxfp8(
         m,
         256,

--- a/tests/gemm/test_mm_mxfp8.py
+++ b/tests/gemm/test_mm_mxfp8.py
@@ -52,8 +52,12 @@ def _skip_if_unsupported(backend: str = "cutlass"):
             f"capability {compute_capability_number}."
         )
     if backend == "b12x":
-        import cutlass.cute as cute
-
+        if torch.version.cuda is None or int(torch.version.cuda.split(".")[0]) < 13:
+            pytest.skip("b12x mm_mxfp8 requires CUDA 13+")
+        try:
+            import cutlass.cute as cute
+        except ImportError:
+            pytest.skip("nvidia-cutlass-dsl not installed")
         if not hasattr(cute.nvgpu.warp, "MmaMXF8Op"):
             pytest.skip("b12x mm_mxfp8 requires nvidia-cutlass-dsl >= 4.6.0")
 
@@ -76,8 +80,8 @@ def _run_mm_mxfp8(
             pytest.skip("trtllm does not support non-multiple of 256")
         if out_dtype != torch.bfloat16:
             pytest.skip("trtllm does not support non-bfloat16 output")
-    if backend == "b12x" and (k % 128 != 0 or k < 640):
-        pytest.skip("b12x requires K % 128 == 0 and K >= 640")
+    if backend == "b12x" and (k % 128 != 0 or k < gemm_base._B12X_MXFP8_MIN_K):
+        pytest.skip("b12x requires K % 128 == 0 above the short-K race floor")
     if backend == "cutlass" and use_8x4_sf_layout_for_a:
         pytest.skip("cutlass doesn't support 8x4 swizzle layout")
 


### PR DESCRIPTION
## 📌 Description

Adds a `b12x` backend to `mm_mxfp8` for SM120/SM121, ported from [b12x](https://github.com/local-inference-lab/sparkinfer). It outperforms the existing CUTLASS backend at small and large token counts on the target shapes (numbers below) and serves the MXFP8 W8A8 projections of Nemotron-family checkpoints.

Changes:

- Extend the SM120 warp-level block-scaled GEMM kernel, also used by `mm_fp4(backend="b12x")`, with an MXFP8 operand path and small-M tile shapes.
- Register `b12x` as a new `mm_mxfp8` backend and prefer it in `auto` mode on SM120/SM121.
- Fix an epilogue race in the shared kernel: the next work tile could overwrite the output tile's smem while its TMA store was still in flight, corrupting short-K multi-wave launches.

Public API and behavior changes:

- `mm_mxfp8` accepts `backend="b12x"`. On SM120/SM121, `auto` now selects it when eligible (CUDA 13+, nvidia-cutlass-dsl >= 4.6.0 installed, K a multiple of 128).
- `mm_fp4(backend="b12x")` no longer corrupts output on short-K launches that span more than one wave.

## 📊 Performance

Speedup over the CUTLASS backend on the linear-projection shapes of the target checkpoints:

| m | DGX Spark GB10 | RTX 5080 | RTX Pro 6000 SE |
|---|---|---|---|
| 1-8 | 1.43-2.18x | 2.07-2.67x | 1.83-3.25x |
| 16-32 | 0.98-1.68x | 1.13-2.45x | 1.04-2.55x |
| 64-128 | 0.94-1.00x | 1.00-1.46x | 0.81-1.24x |
| 512-2048 | 1.11-1.48x | 1.18-1.51x | 1.12-1.45x |

## 🔍 Related Issues

#4223 (item 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added b12x backend support for MXFP8 matrix multiplication on SM120/SM121 GPUs.
  * Added automatic planning, compilation, caching, and execution for supported MXFP8 workloads.
  * Expanded support for smaller dense GEMM tile sizes.

* **Bug Fixes**
  * Improved shared-memory synchronization during kernel execution.
  * Added validation for supported scale layouts, tile shapes, and K dimensions.

* **Tests**
  * Added coverage for low-M, short-K, decode-M, and multi-wave MXFP8 and FP4 workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->