### PR TITLE
fix(test): stub CuTe DSL arch guard in autotune replay contract test

### DIFF
--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -468,6 +468,13 @@ class TestAutotuneReplayMemsetContract:
             fused_moe.AutoTuner, "get", staticmethod(lambda: StubTuner())
         )
 
+        # `_require_cute_dsl_arch_for` in `cute_dsl_fused_moe_nvfp4`
+        # reads `torch.cuda.get_device_capability(x.device)`,
+        # which rejects a CPU device.
+        monkeypatch.setattr(
+            fused_moe, "_require_cute_dsl_arch_for", lambda *args, **kwargs: None
+        )
+
         tensors = {
             "x": torch.empty((2, 8), dtype=torch.uint8),
             "x_sf": torch.empty((2, 1), dtype=torch.uint8),


### PR DESCRIPTION
## 📌 Description

Fixes `tests/moe/test_cute_dsl_fused_moe.py::TestAutotuneReplayMemsetContract::test_selected_tactic_disables_async_memset_while_tuning[*-functional]`, which is currently failing on `main`:

```
FAILED ...test_selected_tactic_disables_async_memset_while_tuning[False-functional] - ValueError: Expected a cuda device, but got: cpu
FAILED ...test_selected_tactic_disables_async_memset_while_tuning[True-functional]  - ValueError: Expected a cuda device, but got: cpu
```

## 🔍 Related Issues

None. 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the autotune replay stream contract test to run with CPU tensors without requiring CUDA-device validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->