### PR TITLE
fix(moe): prepare MXFP8 MXFP4 profiler inputs

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4730,8 +4730,9 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
     quant_6_size = num_experts_per_node * sizeof(float);
   } else if (is_native_wfp4afp8_family) {
     quant_1_size = sizeof(float);
-    quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+    quant_2_size =
+        getOffsetWeightSF(num_experts_per_node, fc1_out_size, hidden_size, mScalingType) *
+        sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
     quant_3_size = num_experts_per_node * sizeof(float);
     quant_4_size = sizeof(float);
     quant_5_size = getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
@@ -5034,12 +5035,30 @@ void GemmProfilerBackend::prepareQuantParams(int num_tokens, char* workspace_ptr
   } else if (mDType == nvinfer1::DataType::kFP8 &&
              (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64)) {
     TLLM_CHECK(quant_1 && quant_2 && quant_3 && quant_4 && quant_5 && quant_6);
-    mQuantParams = QuantParams::FP8MXFP4(
-        static_cast<float const*>(quant_1),
-        static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_2),
-        static_cast<float const*>(quant_3), static_cast<float const*>(quant_4),
-        static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_5),
-        static_cast<float const*>(quant_6));
+    if (mUseMxfp8ActScaling) {
+#ifdef USING_OSS_CUTLASS_MOE_GEMM
+      // Normalize the profiler's fabricated weight block scale factors to UE8M0 unity so tactic
+      // timing is not driven by random exponents from the workspace.
+      TLLM_CUDA_CHECK(cudaMemsetAsync(const_cast<void*>(quant_2), 0x7F,
+                                      workspaces.at("quant_2").first, stream));
+      TLLM_CUDA_CHECK(cudaMemsetAsync(const_cast<void*>(quant_5), 0x7F,
+                                      workspaces.at("quant_5").first, stream));
+      mQuantParams = QuantParams::MXFP8MXFP4(
+          static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_2),
+          static_cast<float const*>(quant_3),
+          static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_5),
+          static_cast<float const*>(quant_6));
+#else
+      TLLM_CHECK_WITH_INFO(false, "MXFP8 x MXFP4 profiling requires OSS Cutlass MoE GEMM");
+#endif
+    } else {
+      mQuantParams = QuantParams::FP8MXFP4(
+          static_cast<float const*>(quant_1),
+          static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_2),
+          static_cast<float const*>(quant_3), static_cast<float const*>(quant_4),
+          static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_5),
+          static_cast<float const*>(quant_6));
+    }
   } else if ((mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
              (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64)) {
     // nvllm still uses int64 because torch doesn't have fp4 yet.

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -1078,6 +1078,7 @@ struct GemmProfilerBackend {
     mNeedWeights = need_weights;
     mParallelismConfig = parallelism_config;
     mEnableAlltoall = enable_alltoall;
+    mUseMxfp8ActScaling = use_mxfp8_act_scaling;
     mSm90Wfp4Afp8Mode = sm90_wfp4afp8_mode;
     mSM = common::getSMVersion();
 
@@ -1144,6 +1145,7 @@ struct GemmProfilerBackend {
   bool mUseLora{};
   bool mMinLatencyMode{};
   bool mNeedWeights{};
+  bool mUseMxfp8ActScaling{};
   Sm90Wfp4Afp8ScaleMode mSm90Wfp4Afp8Mode = Sm90Wfp4Afp8ScaleMode::kDisabled;
 
   TmaWarpSpecializedGroupedGemmInput::FpXBlockScalingType mScalingType{};

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -1498,6 +1498,7 @@ def dequant_mxfp8_batches(
 @pytest.mark.parametrize(
     ("alpha", "beta", "limit"), [(None, None, None), (0.5, 0.0, 7.0), (1.702, 1.0, 7.0)]
 )
+@pytest.mark.parametrize("use_autotune", [False, True])
 @pytest.mark.skipif(
     torch.cuda.get_device_capability()[0] not in [10, 11, 12],
     reason="MXFP8xMXFP4 is only supported on SM100, SM110 and SM120/SM121",
@@ -1512,6 +1513,7 @@ def test_moe_mxfp8_mxfp4(
     alpha,
     beta,
     limit,
+    use_autotune,
 ):
     """
     Test MoE with MXFP8 activations and MXFP4 weights.
@@ -1562,21 +1564,22 @@ def test_moe_mxfp8_mxfp4(
         beta_t = None
 
     # Call cutlass_fused_moe with MXFP8 activations and MXFP4 weights
-    _ = fused_moe.cutlass_fused_moe(
-        mxfp8_x,
-        selected_experts.to(torch.int),
-        routing_weights,
-        mxfp4_w1.contiguous().view(torch.long),
-        mxfp4_w2.contiguous().view(torch.long),
-        otype,
-        swiglu_alpha=alpha_t,
-        swiglu_limit=limit_t,
-        swiglu_beta=beta_t,
-        quant_scales=quant_scales,
-        input_sf=mxfp8_x_sf,
-        use_mxfp8_act_scaling=True,
-        output=flash_output,
-    )
+    with autotune(True) if use_autotune else nullcontext():
+        _ = fused_moe.cutlass_fused_moe(
+            mxfp8_x,
+            selected_experts.to(torch.int),
+            routing_weights,
+            mxfp4_w1.contiguous().view(torch.long),
+            mxfp4_w2.contiguous().view(torch.long),
+            otype,
+            swiglu_alpha=alpha_t,
+            swiglu_limit=limit_t,
+            swiglu_beta=beta_t,
+            quant_scales=quant_scales,
+            input_sf=mxfp8_x_sf,
+            use_mxfp8_act_scaling=True,
+            output=flash_output,
+        )
 
     dq_mxfp8_x = (
         mxfp8_dequantize_host(


### PR DESCRIPTION
## 📌 Description

`GemmProfilerBackend::init()` receives `use_mxfp8_act_scaling` but does not retain it, so `prepareQuantParams()` always constructs `QuantParams::FP8MXFP4` on the FP8-activation/MXFP4-weight path. That leaves the `mxfp8_mxfp4` weight block-scale pointers null, so the MXFPX scale-factor descriptor setup is skipped during profiling.

VictoriaLogs captured the affected DeepSeek-V4-Flash-0731 TP2 startup reaching fused-MoE profiling and then exiting after this error surfaced:

```text
[AutoTuner]: Tuning trtllm::fused_moe::gemm1
...
torch.AcceleratorError: CUDA error: an illegal instruction was encountered
...
[2026-07-31 15:42:01] Received sigquit from a child process. It usually means the child failed.
```

This change:

- stores `use_mxfp8_act_scaling` in the profiler;
- sizes the fc1 weight scale-factor workspace for the doubled gated-activation output;
- initializes the profiler's fc1/fc2 weight block scale-factor workspaces to UE8M0 unity on the MXFP8-activation path;
- constructs `QuantParams::MXFP8MXFP4` for MXFP8-activation/MXFP4-weight profiling; and
- runs the existing numerical test with autotuning disabled and enabled.

When `use_mxfp8_act_scaling` is false, the existing `QuantParams::FP8MXFP4` branch remains in use. The shared fc1 scale-factor workspace sizing is corrected for the gated output in both branches. PR #4066 skips profiling and selects fallback tactics for MXFP8×MXFP4 on SM120/SM121; this change repairs the profiler inputs and retains tactic profiling. Both changes update the same regression test.

If this change is accepted, PR #4066's SM120/SM121 fallback-tactic override should be removed, or #4066 closed. That override keeps SM120/SM121 on fallback tactics for this mode, which makes this profiler fix inert there.

## 🔍 Related Issues

Fixes #4049.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I used `uvx pre-commit`.
- [ ] I installed the hooks with `pre-commit install`. Not used; hooks were run directly with `uvx`.
- [x] Focused pre-commit checks pass for all three changed paths: `csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh`, `csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h`, and `tests/moe/test_trtllm_cutlass_fused_moe.py`.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] The complete repository test suite was not run.
- `uv run --no-project python -m pytest -q tests/moe/test_trtllm_cutlass_fused_moe.py -k mxfp8_mxfp4` on SM120: 12 passed, 6 skipped, 132 deselected.
- With this change applied, a `DeepSeek-V4-Flash-0731` TP2 startup completed all 10 gemm1 and 10 gemm2 profiler candidates on both ranks, completed FlashInfer autotuning, captured the target and draft CUDA graphs, and reached ready state with zero restarts.

Test limitations: the autotuned numerical test exercises this path and checks numerical parity, but it does not directly inspect the fabricated workspace contents. The non-MXFP8 activation branch touched by the shared fc1 scale-factor sizing has no focused autotune regression case in this validation.

## Reviewer Notes

The table below compares heuristic fallback tactics with profiler-selected tactics. It is not a direct patched-versus-unpatched throughput comparison; the patch is what allows the profiled-tactic side to start successfully. Both sides used the same SGLang revision, model, TP2 configuration, FP8 KV cache, DSpark width 5, hardware, and workload. The control skipped `trtllm::fused_moe::gemm1` and `gemm2`; the candidate profiled them.

Methodology: each decode cell is one unreplicated 30-second run at C1, C2, C4, C8, C16, and C32. The coding row is the median of five sequential requests with a 2,000-token cap. The prefill rows are the median client-observed throughput from standalone cold-prefill runs at exact 8K, 64K, and 128K prompts with 7, 2, and 1 samples, respectively. All rows are single comparison runs with no variance estimate, and no effect size is claimed from any row.

| Cell | Fallback tactics | Profiled tactics |
|---|---:|---:|
| C1 decode (tok/s) | 187.7 | 240.5 |
| C2 decode (tok/s) | 241.4 | 349.5 |
| C4 decode (tok/s) | 347.1 | 515.2 |
| C8 decode (tok/s) | 456.5 | 662.9 |
| C16 decode (tok/s) | 683.8 | 992.8 |
| C32 decode (tok/s) | 1030.7 | 1413.6 |
| Coding median (tok/s) | 218.1 | 264.8 |
| 8K prefill (tok/s) | 7444 | 7638 |
| 64K prefill (tok/s) | 8557 | 8351 |
| 128K prefill (tok/s) | 7922 | 7744 |

The pinned 1,319-row GSM8K gate was not counted as passing because each run had one response finish at the 1,024-token cap. Two profiled-tactic runs scored 1,241 and 1,239 correct; the fallback-tactic control scored 1,240 correct. No quality difference is claimed from these runs.

AI was used to assist with implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profiling for fused mixture-of-experts workloads using MXFP8 activations and MXFP4 weights.
  * Corrected workspace sizing and scaling behavior for quantized weight formats.
  * Added validation for unsupported scaling configurations.

* **Tests**
  * Expanded coverage to verify both autotuned and default execution paths for quantized MoE workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->