### PR TITLE
feat(sm120): support DeepSeek-V4 top-k 192

### DIFF
--- a/csrc/sparse_mla_sm120_decode_dsv4.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv4.cu
@@ -133,7 +133,7 @@ static bool launch_decode_dsv4_impl(const bf16* Q, const uint8_t* KV_cache, cons
 
 // Public surface — explicit instantiation switch over the PR-body bench grid.
 // DSV4 only, page_block_size=64 only. NUM_HEADS ∈ {8, 16, 32, 64, 128},
-// TOPK ∈ {128, 512, 1024}.
+// TOPK ∈ {128, 192, 512, 1024}.
 bool launch_sparse_mla_decode_dsv4(ModelType mt, int num_heads, int topk, int page_block_size,
                                    int num_tokens, int num_splits, const bf16* Q,
                                    const uint8_t* KV_cache, const int32_t* indices, bf16* mid_out,
@@ -154,18 +154,23 @@ bool launch_sparse_mla_decode_dsv4(ModelType mt, int num_heads, int topk, int pa
         stride_kv_block, stream);                                                           \
   }
   DSV4_DISPATCH(8, 128)
+  DSV4_DISPATCH(8, 192)
   DSV4_DISPATCH(8, 512)
   DSV4_DISPATCH(8, 1024)
   DSV4_DISPATCH(16, 128)
+  DSV4_DISPATCH(16, 192)
   DSV4_DISPATCH(16, 512)
   DSV4_DISPATCH(16, 1024)
   DSV4_DISPATCH(32, 128)
+  DSV4_DISPATCH(32, 192)
   DSV4_DISPATCH(32, 512)
   DSV4_DISPATCH(32, 1024)
   DSV4_DISPATCH(64, 128)
+  DSV4_DISPATCH(64, 192)
   DSV4_DISPATCH(64, 512)
   DSV4_DISPATCH(64, 1024)
   DSV4_DISPATCH(128, 128)
+  DSV4_DISPATCH(128, 192)
   DSV4_DISPATCH(128, 512)
   DSV4_DISPATCH(128, 1024)
 #undef DSV4_DISPATCH

--- a/csrc/sparse_mla_sm120_prefill.cu
+++ b/csrc/sparse_mla_sm120_prefill.cu
@@ -293,6 +293,8 @@ inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const u
   // amortises FP8's higher Tensor-Core throughput.
   if (topk == 128)
     DISPATCH_BY_NH_CM(BF16, 128);
+  else if (topk == 192)
+    DISPATCH_BY_NH_CM(BF16, 192);
   else if (topk == 512)
     DISPATCH_BY_NH_CM(FP8, 512);
   else if (topk == 1024)

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -79,18 +79,23 @@ _DECODE_MAX_TOKENS = 64
 _DECODE_DSV4_DISPATCH = frozenset(
     {
         (8, 128),
+        (8, 192),
         (8, 512),
         (8, 1024),
         (16, 128),
+        (16, 192),
         (16, 512),
         (16, 1024),
         (32, 128),
+        (32, 192),
         (32, 512),
         (32, 1024),
         (64, 128),
+        (64, 192),
         (64, 512),
         (64, 1024),
         (128, 128),
+        (128, 192),
         (128, 512),
         (128, 1024),
     }
@@ -1228,8 +1233,8 @@ def sparse_mla_sm120_decode_dsv4(
     kv_cache : torch.Tensor
         Paged FP8 cache, shape ``[num_blocks, page_bytes]`` uint8.
     indices : torch.Tensor
-        ``[T, topk]`` int32. ``topk`` must be one of {128, 512, 1024}; ``-1``
-        marks invalid slots.
+        ``[T, topk]`` int32. ``topk`` must be one of {128, 192, 512, 1024};
+        ``-1`` marks invalid slots.
     mid_out : torch.Tensor
         Scratch, ``[T, num_heads, num_splits, d_v]`` bf16. ``num_splits =
         ceil(topk / 64) + ceil(extra_topk / 64)``.

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
@@ -56,7 +56,7 @@
 //   MT:              ModelType (DSV3_2 / DSV4)
 //   CM:              ComputeMode (FP8 / BF16) for the QK MMA; XV is always FP8
 //   NUM_HEADS:       8, 16, 64, 128 (NUM_HEADS < HPB=16 zero-pads + gates)
-//   TOPK:            128, 512, 1024, 2048
+//   TOPK:            128, 192, 512, 1024, 2048
 //   PAGE_BLOCK_SIZE: 64 (DSV3_2 and DSV4 both use the 64-token page layout)
 // ============================================================================
 

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -292,11 +292,16 @@ def _make_decode_scratch(
 
 _DSV4_DECODE_CONFIGS = [
     (8, 128),
+    (8, 192),
     (8, 512),
     (8, 1024),
     (16, 128),
+    (16, 192),
+    (32, 192),
     (32, 512),
+    (64, 192),
     (64, 1024),
+    (128, 192),
     (128, 1024),
 ]
 
@@ -368,12 +373,14 @@ def test_sparse_mla_sm120_decode_dsv4(
     torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
 
 
-def test_sparse_mla_sm120_decode_dsv4_topk_length_truncation() -> None:
+@pytest.mark.parametrize("topk,topk_len", [(192, 133), (512, 128)])
+def test_sparse_mla_sm120_decode_dsv4_topk_length_truncation(
+    topk: int, topk_len: int
+) -> None:
     """DSv4 decode honors topk_length."""
     torch.manual_seed(0)
     device = torch.device("cuda")
-    num_heads, topk, num_tokens = 32, 512, 16
-    topk_len = 128
+    num_heads, num_tokens = 32, 16
     d_qk, d_v = 512, 512
     page_block_size = 64
     num_blocks = 64
@@ -890,8 +897,12 @@ def test_sparse_mla_sm120_prefill_glm_nsa_arbitrary_fp32(num_heads: int) -> None
 
 _DSV4_PREFILL_CONFIGS = [
     (16, 128),
+    (16, 192),
+    (32, 192),
     (32, 512),
+    (64, 192),
     (64, 1024),
+    (128, 192),
     (128, 1024),
 ]
 
@@ -954,6 +965,57 @@ def test_sparse_mla_sm120_prefill_dsv4(
         sm_scale,
         d_v=d_v,
         attn_sink=attn_sink,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+def test_sparse_mla_sm120_prefill_dsv4_topk_length_truncation() -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    num_heads, topk, topk_len, num_tokens = 32, 192, 133, 128
+    d_qk, d_v = 512, 512
+    page_block_size = 64
+    num_blocks = 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_dsv4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4(kv_packed)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    topk_length = torch.full((num_tokens,), topk_len, dtype=torch.int32, device=device)
+
+    sm_scale = d_qk**-0.5
+    ref_indices = indices.clone()
+    ref_indices[:, topk_len:] = -1
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, ref_indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        topk_length=topk_length,
     )
 
     torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)


### PR DESCRIPTION
## 📌 Description

A downstream `DeepSeek-V4-Flash-0731` integration produces 133 valid sparse-MLA entries per query: 128 sliding-window entries plus a DSpark block of 5. The last dimension is padded to 192 because the kernel tiles indices in 64-entry units. The SM120 DeepSeek-V4 decode dispatch supports top-k 128, 512, and 1024, and single-cache prefill additionally supports 2048; neither currently supports 192.

This 192 shape reaches the single-cache prefill path because the DSpark draft metadata in that integration is created with compression disabled. Dual-cache prefill remains limited to top-k 128 and is outside this change.

This change:

- adds top-k 192 DeepSeek-V4 decode instantiations for 8, 16, 32, 64, and 128 query heads;
- adds the top-k 192 prefill dispatch, routed through BF16 QK like the existing top-k 128 case;
- adds 192 to the Python decode dispatch set and updates the Python API docstring; and
- covers decode and prefill with a padded top-k of 192 and an active length of 133 while retaining the existing 512/128 truncation case.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I used `uvx pre-commit`.
- [ ] I installed the hooks with `pre-commit install`. Not used; hooks were run directly with `uvx`.
- [x] Focused pre-commit checks pass for all five changed paths: `csrc/sparse_mla_sm120_decode_dsv4.cu`, `csrc/sparse_mla_sm120_prefill.cu`, `flashinfer/mla/_sparse_mla_sm120.py`, `include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh`, and `tests/attention/test_sparse_mla_sm120.py`.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] The complete repository test suite was not run.
- `uv run --no-project python -m pytest -q tests/attention/test_sparse_mla_sm120.py -k 'dsv4 and (192 or topk_length_truncation)'` on SM120: 52 passed, 133 deselected.
- A `DeepSeek-V4-Flash-0731` TP2 DSpark server completed target and draft CUDA graph capture with this dispatch enabled.

AI was used to assist with implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `topk=192` in DSV4 sparse MLA decode and prefill operations across supported head counts.
  * Expanded supported top-k configuration options and benchmark coverage.

* **Tests**
  * Added coverage for varying top-k values and top-k lengths, including truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->