### PR TITLE
fix(gdn): use block-end decay for SM100 state updates

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -4387,8 +4387,6 @@ class GatedDeltaNetChunkedKernel:
         tCsO = thr_o_r2s.partition_D(sO)
 
         sub_tile_size = 32
-        max_coord = tTR_tCcShared[cute.size(tTR_tCcShared) - 1]
-
         sV_vt_view = utils.gemm.sm100.transform_partitioned_tensor_layout(sV)
         tCsV = thr_v_s2r.partition_S(sV_vt_view)
 
@@ -4409,7 +4407,10 @@ class GatedDeltaNetChunkedKernel:
         # the per-row gate work until the previous state has been published
         # and decayed, keeping its register fragment in one contiguous region.
         gate_handle = load_gate_consumer.wait_and_advance()
-        cumprod_total = sCumprod[max_coord[1], 0, gate_handle.index]
+        # valid_len = max(0, min(self.b_t, seqlen_b - chunk_iter * self.b_t))
+        # gamma_end = 1.0 if valid_len == 0 else sCumprod[valid_len - 1, 0, gate_handle.index]
+        # OOB alpha is padded with 1 before the prefix scan, so the last physical slot equals gamma_end.
+        cumprod_total = sCumprod[self.b_t - 1, 0, gate_handle.index]
 
         kv_prev_handle = kv_acc_consumer.current_handle()
         if valid_state:

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -171,6 +171,67 @@ def _test_prefill_kernel(
     torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
 
 
+@torch.inference_mode()
+def test_prefill_block_end_decay(qkv_factory, seed=0):
+    _skip_if_unsupported()
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    seq_lens = [64, 111, 192]
+    total_seqlen = sum(seq_lens)
+    num_heads = 1
+    head_size = 128
+    dtype = torch.float16
+    device = torch.device("cuda")
+
+    with device:
+        q, k, v = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype
+        )
+        k = torch.nn.functional.normalize(k, p=2.0, dim=-1)
+        alpha = 0.99 + 0.01 * torch.rand(total_seqlen, num_heads)
+        beta = 0.99 + 0.01 * torch.rand(total_seqlen, num_heads)
+        cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int64)
+
+    our_o = torch.empty_like(q)
+    our_state = torch.empty(
+        (len(seq_lens), num_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        1.0,
+        None,
+        True,
+        cu_seqlens,
+        True,
+        output=our_o,
+        output_state=our_state,
+        use_cp=False,
+    )
+
+    ref_o, ref_state = blockwise_delta_rule(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        block_size=64,
+        state_dtype=torch.float32,
+    )
+    torch.testing.assert_close(our_o, ref_o.to(dtype), atol=2e-3, rtol=1e-3)
+    torch.testing.assert_close(
+        our_state.transpose(-1, -2), ref_state, atol=1e-3, rtol=1e-4
+    )
+
+
 @pytest.mark.parametrize("beta", [False, True])
 @pytest.mark.parametrize("alpha", [False, True])
 @pytest.mark.parametrize("scale", [1.0, "auto"])


### PR DESCRIPTION
## Summary

- restore the block-end cumulative decay when updating the recurrent SM100 GDN state
- remove the thread-local coordinate materialization used to select that scalar
- add a shared regression test covering full, partial, and recurrent blocks on all supported GDN architectures

## Root cause

PR #4133 replaced the fixed block-end lookup with an index derived from the last coordinate in each thread's partitioned accumulator fragment:

```python
max_coord = tTR_tCcShared[cute.size(tTR_tCcShared) - 1]
cumprod_total = sCumprod[max_coord[1], 0, gate_handle.index]
```


That max_coord coordinate is thread-dependent. Its second coordinate is:

```
tid % 4 == 0: coord[1] = 57
tid % 4 == 1: coord[1] = 59
tid % 4 == 2: coord[1] = 61
tid % 4 == 3: coord[1] = 63
```

Representative output:

```
tid=0   coord=(24, 57)
tid=1   coord=(24, 59)
tid=2   coord=(24, 61)
tid=3   coord=(24, 63)
...
tid=124 coord=(127, 57)
tid=125 coord=(127, 59)
tid=126 coord=(127, 61)
tid=127 coord=(127, 63)
```

The fix directly loads the block-end scalar:

```python
cumprod_total = sCumprod[self.b_t - 1, 0, gate_handle.index]
```

This remains correct for a partial block. The gate loader predicates out-of-bounds elements after initializing them to the multiplicative identity `1.0`. Their log2 contribution is therefore zero, so the inclusive prefix product remains constant after the final valid token and slot `BT - 1` contains the product over exactly the valid block.

## Reproduction

The regression test uses FP16, sequence lengths `[64, 111, 192]`, one head, normalized K, and alpha/beta sampled from `[0.99, 1.0)`. These lengths cover one full block, a non-multiple tail with recurrent carry, and three aligned blocks.

| Revision | Output max error | Output mismatches | State max error | State mismatches |
|---|---:|---:|---:|---:|
| Before #4133 (`6258e522`) | `5.80e-4` | `0 / 46976` | `2.28e-4` | `0 / 49152` |
| After #4133 (`f057e15b`) | `1.59e-2` | `1660 / 46976` | `1.01e-2` | `6361 / 49152` |
| This fix | `5.80e-4` | `0 / 46976` | `2.28e-4` | `0 / 49152` |

## Validation

```bash
PYTHONPATH=. python -m pytest -q \
  tests/gdn/test_prefill_delta_rule.py::test_prefill_block_end_decay
```

Result: `1 passed` on SM100 with CUDA 13. The test now collects on SM90, SM100, and SM12x so architecture CI covers the shared contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gated delta network prefill behavior for partial chunks and block-boundary sequence lengths.
  * Ensured cumulative decay uses neutral padding values when processing incomplete chunks.

* **Tests**
  * Added GPU coverage comparing prefill results and final states against the blockwise reference implementation, including decay factors near one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->