### PR TITLE
feat(cake_kda): share recurrent prefill kernels across SM100 family

### DIFF
--- a/benchmarks/bench_recurrent_kda_prefill.py
+++ b/benchmarks/bench_recurrent_kda_prefill.py
@@ -50,6 +50,7 @@ from flashinfer.utils import get_compute_capability
 FLASH_KDA_PEER_COMMIT = "d2ff19a6a0c82f39f796f637ebd1c36090b1268f"
 FLASH_KDA_CUTLASS_COMMIT = "5c149f52a436782210263fb2f19b354443a61c6a"
 DEFAULT_STATE_ROTATIONS = 512
+SUPPORTED_FLASH_KDA_ARCHS = {(10, 0): "sm100a", (10, 3): "sm103a"}
 
 
 @dataclass(frozen=True)
@@ -95,6 +96,24 @@ def _require_cupti() -> None:
     cupti_version = version("cupti-python")
     if int(cupti_version.split(".", 1)[0]) < 13:
         raise RuntimeError(f"cupti-python >= 13 is required, found {cupti_version}")
+
+
+def _hardware_metadata(device: torch.device) -> dict:
+    compute_capability = get_compute_capability(device)
+    properties = torch.cuda.get_device_properties(device)
+    device_index = (
+        device.index if device.index is not None else torch.cuda.current_device()
+    )
+    return {
+        "device_name": properties.name,
+        "device_index": device_index,
+        "compute_capability": list(compute_capability),
+        "cuda_arch": SUPPORTED_FLASH_KDA_ARCHS[compute_capability],
+        "multiprocessor_count": properties.multi_processor_count,
+        "total_memory_bytes": properties.total_memory,
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
+    }
 
 
 def _sha256(path: Path) -> str:
@@ -490,9 +509,23 @@ def main() -> None:
         )
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
-    if get_compute_capability(torch.device("cuda")) != (10, 0):
-        raise RuntimeError("frozen recurrent-KDA prefill requires B200 (cc 10.0)")
+    device = torch.device("cuda")
+    compute_capability = get_compute_capability(device)
+    if compute_capability not in SUPPORTED_FLASH_KDA_ARCHS:
+        raise RuntimeError(
+            "frozen recurrent-KDA prefill requires exact CC 10.0 "
+            "(SM100a; B200/GB200) or CC 10.3 (SM103a; B300/GB300), "
+            f"got CC {compute_capability[0]}."
+            f"{compute_capability[1]}"
+        )
     _require_cupti()
+    hardware = _hardware_metadata(device)
+    print(
+        "Hardware: "
+        f"{hardware['device_name']} cc "
+        f"{hardware['compute_capability'][0]}."
+        f"{hardware['compute_capability'][1]} ({hardware['cuda_arch']})"
+    )
 
     flash_kda = None
     peer_provenance = None
@@ -518,7 +551,7 @@ def main() -> None:
             state_rotations=args.state_rotations,
             flash_kda=flash_kda,
         )
-        result = dict(prepared.metadata)
+        result = {**prepared.metadata, "hardware": hardware}
         if prepared.peer_raw_run is None:
             prepared.reset_state_pools()
             prepared.candidate_run()

--- a/csrc/kda/flashkda_bf16_fused_m128_binding.cu
+++ b/csrc/kda/flashkda_bf16_fused_m128_binding.cu
@@ -47,7 +47,7 @@ void RunM128(TensorView q, TensorView k, TensorView v, TensorView g, TensorView 
   TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
   const int32_t device_id = q.device().device_id;
   ffi::CUDADeviceGuard device_guard(device_id);
-  CheckExactSm100a(device_id);
+  CheckFlashKDATarget(device_id);
 
   const int64_t num_seqs =
       CheckCommonInputs(q, k, v, g, beta, beta_tma, A_log, dt_bias, cu_seqlens, seq_order,
@@ -69,6 +69,7 @@ void RunM128(TensorView q, TensorView k, TensorView v, TensorView g, TensorView 
   const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
   const TmaPointers tma = EncodeTmaPointers<128>(q, k, v, g, beta_tma, out, descriptor_storage,
                                                  prepare_descriptors, stream);
+  PackBetaForTmaIfNeeded(beta, beta_tma, num_heads, stream);
 
   kernel_flashkda_bf16_fused_m128<<<grid, block, kSmemBytes, stream>>>(
       reinterpret_cast<__nv_bfloat16*>(q.data_ptr()), tma.q,

--- a/csrc/kda/flashkda_bf16_fused_m64_binding.cu
+++ b/csrc/kda/flashkda_bf16_fused_m64_binding.cu
@@ -50,7 +50,7 @@ void RunM64(TensorView q, TensorView k, TensorView v, TensorView g, TensorView b
   TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
   const int32_t device_id = q.device().device_id;
   ffi::CUDADeviceGuard device_guard(device_id);
-  CheckExactSm100a(device_id);
+  CheckFlashKDATarget(device_id);
 
   const int64_t num_seqs =
       CheckCommonInputs(q, k, v, g, beta, beta_tma, A_log, dt_bias, cu_seqlens, seq_order,

--- a/csrc/kda/flashkda_binding_common.cuh
+++ b/csrc/kda/flashkda_binding_common.cuh
@@ -40,6 +40,24 @@ constexpr size_t kTensorMapCount = 6;
 constexpr size_t kTensorMapAlignment = 64;
 static_assert(sizeof(CUtensorMap) == 128);
 constexpr size_t kDescriptorStorageBytes = kTensorMapCount * sizeof(CUtensorMap);
+constexpr int64_t kBetaTmaMinHeads = 8;
+
+static __global__ void PackBetaForTmaKernel(const __nv_bfloat16* beta, __nv_bfloat16* beta_tma,
+                                            int64_t token_count, int64_t padded_token_count,
+                                            int32_t num_heads) {
+  const int64_t linear_index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t padded_elements = padded_token_count * kBetaTmaMinHeads;
+  if (linear_index >= padded_elements) {
+    return;
+  }
+  const int64_t token_index = linear_index / kBetaTmaMinHeads;
+  const int32_t head_index = static_cast<int32_t>(linear_index % kBetaTmaMinHeads);
+  __nv_bfloat16 value = __float2bfloat16(0.0f);
+  if (token_index < token_count && head_index < num_heads) {
+    value = beta[token_index * num_heads + head_index];
+  }
+  beta_tma[linear_index] = value;
+}
 
 inline void CheckCuda(cudaError_t status, const char* operation) {
   TVM_FFI_ICHECK(status == cudaSuccess) << operation << " failed: " << cudaGetErrorString(status);
@@ -95,20 +113,38 @@ inline void CheckNoPartialOverlapOrExactAlias(const TensorView& lhs, const char*
   const bool exact_alias = lhs_range.begin == rhs_range.begin && lhs_range.end == rhs_range.end;
   TVM_FFI_ICHECK(!overlaps || exact_alias)
       << lhs_name << " and " << rhs_name
-      << " must either be disjoint or exactly alias the same state storage";
+      << " must either be disjoint or exactly alias the same storage";
 }
 
-inline void CheckExactSm100a(int32_t device_id) {
+#if defined(FLASHINFER_FLASH_KDA_TARGET_MINOR) == defined(FLASHINFER_FLASH_KDA_TARGET_FAMILY)
+#error "exactly one FlashKDA target must be defined by the JIT/AOT spec"
+#endif
+
+#if defined(FLASHINFER_FLASH_KDA_TARGET_MINOR)
+constexpr int kFlashKDATargetMinor = FLASHINFER_FLASH_KDA_TARGET_MINOR;
+static_assert(kFlashKDATargetMinor == 0, "legacy FlashKDA target must be exact SM100a");
+#else
+constexpr int kFlashKDATargetFamily = FLASHINFER_FLASH_KDA_TARGET_FAMILY;
+static_assert(kFlashKDATargetFamily == 100, "FlashKDA family target must be SM100f");
+#endif
+
+inline void CheckFlashKDATarget(int32_t device_id) {
   int major = 0;
   int minor = 0;
   CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id),
             "cudaDeviceGetAttribute(major)");
   CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
             "cudaDeviceGetAttribute(minor)");
-  TVM_FFI_ICHECK(major == 10 && minor == 0)
-      << "FlashKDA frozen kernels require exact compute capability 10.0 "
-         "(sm_100a), got "
+#if defined(FLASHINFER_FLASH_KDA_TARGET_MINOR)
+  TVM_FFI_ICHECK(major == 10 && minor == kFlashKDATargetMinor)
+      << "this FlashKDA module was compiled for exact compute capability 10."
+      << kFlashKDATargetMinor << ", got " << major << "." << minor;
+#else
+  TVM_FFI_ICHECK(major == 10 && (minor == 0 || minor == 3))
+      << "this FlashKDA sm_100f module supports compute capability 10.0 or "
+         "10.3, got "
       << major << "." << minor;
+#endif
 }
 
 inline int64_t CheckCommonInputs(const TensorView& q, const TensorView& k, const TensorView& v,
@@ -198,6 +234,20 @@ inline int64_t CheckCommonInputs(const TensorView& q, const TensorView& k, const
                  beta_tma.numel() / beta_tma_heads >= std::max<int64_t>(token_count, 32))
       << "beta_tma must have at least [max(tokens, 32), max(H, 8)] "
          "storage";
+  CheckNoPartialOverlapOrExactAlias(beta, "beta", beta_tma, "beta_tma");
+  if (num_heads < kBetaTmaMinHeads) {
+    CheckNoOverlap(beta_tma, "beta_tma", q, "q");
+    CheckNoOverlap(beta_tma, "beta_tma", k, "k");
+    CheckNoOverlap(beta_tma, "beta_tma", v, "v");
+    CheckNoOverlap(beta_tma, "beta_tma", g, "g");
+    CheckNoOverlap(beta_tma, "beta_tma", A_log, "A_log");
+    CheckNoOverlap(beta_tma, "beta_tma", dt_bias, "dt_bias");
+    CheckNoOverlap(beta_tma, "beta_tma", cu_seqlens, "cu_seqlens");
+    CheckNoOverlap(beta_tma, "beta_tma", seq_order, "seq_order");
+    if (use_initial_state != 0) {
+      CheckNoOverlap(beta_tma, "beta_tma", initial_state, "initial_state");
+    }
+  }
   TVM_FFI_ICHECK(A_log.numel() == num_heads) << "A_log must contain H elements";
   TVM_FFI_ICHECK(dt_bias.numel() == num_heads * kHeadDim)
       << "dt_bias must contain H * 128 elements";
@@ -260,6 +310,28 @@ inline int64_t CheckCommonInputs(const TensorView& q, const TensorView& k, const
     }
   }
   return num_seqs;
+}
+
+inline void PackBetaForTmaIfNeeded(const TensorView& beta, const TensorView& beta_tma,
+                                   int64_t num_heads, cudaStream_t stream) {
+  // Full chunks TMA-load an eight-head beta box.  Only H<8 requires a
+  // materialized row-padded source; H>=8 aliases beta whenever a full chunk
+  // exists, while shorter inputs stay entirely on the direct-load tail path.
+  if (num_heads >= kBetaTmaMinHeads) {
+    return;
+  }
+  const int64_t token_count = beta.numel() / num_heads;
+  const int64_t padded_token_count = beta_tma.numel() / kBetaTmaMinHeads;
+  const int64_t padded_elements = padded_token_count * kBetaTmaMinHeads;
+  constexpr int32_t kThreads = 256;
+  const int64_t blocks_i64 = (padded_elements + kThreads - 1) / kThreads;
+  TVM_FFI_ICHECK(blocks_i64 > 0 && blocks_i64 <= std::numeric_limits<uint32_t>::max())
+      << "beta TMA pack grid.x is out of range: " << blocks_i64;
+  PackBetaForTmaKernel<<<static_cast<uint32_t>(blocks_i64), kThreads, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(beta.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta_tma.data_ptr()), token_count, padded_token_count,
+      static_cast<int32_t>(num_heads));
+  CheckCuda(cudaGetLastError(), "PackBetaForTmaKernel launch");
 }
 
 inline CUtensorMap EncodeQkTma(const TensorView& tensor, const char* name) {

--- a/docs/api/kda_prefill.rst
+++ b/docs/api/kda_prefill.rst
@@ -5,7 +5,7 @@ flashinfer.kda_prefill
 
 Optimized recurrent Kimi Delta Attention (KDA) prefill support. The
 :func:`flashinfer.kda.recurrent_kda` facade dispatches a strict ordinary
-multi-token prefill subset to frozen FlashKDA-compatible SM100a kernels.
+multi-token prefill subset to frozen FlashKDA-compatible SM100-family kernels.
 
 .. currentmodule:: flashinfer.kda_prefill
 
@@ -14,13 +14,14 @@ multi-token prefill subset to frozen FlashKDA-compatible SM100a kernels.
 
     RecurrentKDAPrefillWorkspace
 
-Optimized B200 prefill subset
------------------------------
+Optimized SM100-family prefill subset
+-------------------------------------
 
 ``flashinfer.kda.recurrent_kda`` uses the frozen prefill backend only when
 every condition below holds:
 
-* the device has compute capability 10.0;
+* the device has compute capability 10.0 (SM100a; B200/GB200) or 10.3
+  (SM103a; B300/GB300);
 * input is ordinary multi-token prefill: fixed ``T > 1``, or packed input
   whose total token count is greater than its number of sequences;
 * Q, K, V, and G are contiguous BF16 ``[B,T,H,128]`` tensors with one shared
@@ -34,6 +35,14 @@ every condition below holds:
 
 Calls outside that subset retain the existing CuTe-DSL path. In particular,
 T=1 decode and speculative decode are not rerouted.
+
+With CUDA 12.9 or newer, JIT and AOT use one ``sm_100f`` URI, JIT
+specification, and cubin target per M64/M128 variant for both CC 10.0 and CC
+10.3. FlashInfer can still place a built copy in a compilation-context-specific
+workspace; the shared logical target does not promise one physical cache path
+across device contexts. The binding accepts only the two validated family
+members. CUDA 12.8 predates ``sm_100f``, so B200 retains one exact ``sm_100a``
+module per variant. CC 10.3 requires CUDA 12.9 or newer.
 
 Fixed input omits ``cu_seqlens``. Packed input has ``B=1`` and accepts a
 contiguous CUDA int32 or int64 ``cu_seqlens``. The frozen binding consumes

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -62,6 +62,7 @@ from .jit.fp4_quantization import (
 from .jit.fp4_kv_dequantization import gen_fp4_kv_dequantization_module
 from .jit.fp4_kv_quantization import gen_fp4_kv_quantization_module
 from .jit.flash_kda import (
+    FlashKDATarget,
     gen_flash_kda_m64_module,
     gen_flash_kda_m128_module,
 )
@@ -508,6 +509,12 @@ def gen_all_modules(
     has_sm90 = sm_capabilities.get("sm90", False)
     has_sm100 = sm_capabilities.get("sm100", False)
     has_sm100a_exact = sm_capabilities.get("sm100a_exact", False)
+    has_flash_kda_prefill_sm100a = sm_capabilities.get(
+        "flash_kda_prefill_sm100a", False
+    )
+    has_flash_kda_prefill_sm100f = sm_capabilities.get(
+        "flash_kda_prefill_sm100f", False
+    )
     has_sm100f = sm_capabilities.get("sm100f", False)
     has_sm103 = sm_capabilities.get("sm103", False)
     has_sm107 = sm_capabilities.get("sm107", False)
@@ -532,19 +539,23 @@ def gen_all_modules(
     )
     if has_sm120 or has_sm121:
         jit_specs.append(gen_nvfp4_attention_sm120_module())
+    # CUDA 12.8 predates the sm_100f target and therefore retains one exact
+    # B200 cubin per variant. CUDA 12.9+ registers only one family cubin per
+    # variant even when both CC 10.0 and CC 10.3 are requested.
+    flash_kda_targets: tuple[tuple[FlashKDATarget, bool], ...] = (
+        ("sm100a", has_flash_kda_prefill_sm100a),
+        ("sm100f", has_flash_kda_prefill_sm100f),
+    )
+    for flash_kda_target, enabled in flash_kda_targets:
+        if enabled:
+            jit_specs.extend(
+                [
+                    gen_flash_kda_m64_module(flash_kda_target),
+                    gen_flash_kda_m128_module(flash_kda_target),
+                ]
+            )
     if has_sm100a_exact:
-        # Frozen FlashKDA prefill sources use the SM100a-only tcgen05/TMEM
-        # surface.
-        # Do not package them for SM100f, SM103, or later architectures until
-        # those exact cubins have been independently validated.
-        jit_specs.extend(
-            [
-                gen_flash_kda_m64_module(),
-                gen_flash_kda_m128_module(),
-            ]
-        )
-        # The decode export is likewise validated and packaged for exact
-        # SM100a independently of the prefill modules above.
+        # The decode export is validated and packaged for exact SM100a.
         jit_specs.extend(
             gen_flash_kda_decode_module(variant)
             for variant in FLASH_KDA_DECODE_VARIANTS
@@ -991,12 +1002,29 @@ def detect_sm_capabilities():
     # `sm80` is true if any 8.x arch (sm_80/sm_86/sm_89) is in the build —
     # all support cp.async, which the SSU MTP-simple kernel requires.
     has_any_sm8x = any(major == 8 for major, _ in compilation_context.TARGET_CUDA_ARCHS)
+    cuda_version = get_cuda_version()
+    flash_kda_prefill_family_arches = {
+        (10, "0a"),
+        (10, "0f"),
+        (10, "3a"),
+        (10, "3f"),
+    }
     return {
-        "sm80": has_any_sm8x and get_cuda_version() >= Version("11.0"),
+        "sm80": has_any_sm8x and cuda_version >= Version("11.0"),
         "sm90": has_sm("compute_90", "12.3"),
         "sm100": has_sm("compute_100", "12.8"),
         "sm100a_exact": (10, "0a") in compilation_context.TARGET_CUDA_ARCHS
-        and get_cuda_version() >= Version("12.8"),
+        and cuda_version >= Version("12.8"),
+        "flash_kda_prefill_sm100a": (
+            (10, "0a") in compilation_context.TARGET_CUDA_ARCHS
+            and Version("12.8") <= cuda_version < Version("12.9")
+        ),
+        "flash_kda_prefill_sm100f": (
+            bool(
+                flash_kda_prefill_family_arches & compilation_context.TARGET_CUDA_ARCHS
+            )
+            and cuda_version >= Version("12.9")
+        ),
         "sm100f": has_sm("compute_100", "12.9"),
         "sm103": has_sm("compute_103", "12.9"),
         "sm107": has_sm("compute_107", "12.9"),

--- a/flashinfer/jit/flash_kda.py
+++ b/flashinfer/jit/flash_kda.py
@@ -19,9 +19,25 @@ from pathlib import Path
 from typing import Literal
 
 from . import env as jit_env
-from .core import JitSpec, gen_jit_spec, logger, sm100a_nvcc_flags
+from .core import (
+    JitSpec,
+    gen_jit_spec,
+    logger,
+    sm100a_nvcc_flags,
+    sm100f_nvcc_flags,
+)
 
 FlashKDAVariant = Literal["m64", "m128"]
+FlashKDATarget = Literal["sm100a", "sm100f"]
+
+_FLASH_KDA_NVCC_FLAGS = {
+    "sm100a": sm100a_nvcc_flags,
+    "sm100f": sm100f_nvcc_flags,
+}
+_FLASH_KDA_TARGET_DEFINE = {
+    "sm100a": "-DFLASHINFER_FLASH_KDA_TARGET_MINOR=0",
+    "sm100f": "-DFLASHINFER_FLASH_KDA_TARGET_FAMILY=100",
+}
 
 
 def _get_flash_kda_csrc_dir() -> Path:
@@ -57,27 +73,30 @@ def _get_flash_kda_include_dir() -> Path:
     )
 
 
-def get_flash_kda_uri(variant: FlashKDAVariant) -> str:
-    """Return the stable JIT/AOT cache key for one physical schedule."""
+def get_flash_kda_uri(variant: FlashKDAVariant, target: FlashKDATarget) -> str:
+    """Return the target-specific JIT/AOT key for one schedule."""
 
     if variant not in ("m64", "m128"):
         raise ValueError(f"unsupported FlashKDA variant: {variant}")
-    return f"flash_kda_bf16_fused_{variant}_sm100a"
+    if target not in _FLASH_KDA_NVCC_FLAGS:
+        raise ValueError(f"unsupported FlashKDA target: {target}")
+    return f"flash_kda_bf16_fused_{variant}_{target}"
 
 
 @functools.cache
-def gen_flash_kda_module(variant: FlashKDAVariant) -> JitSpec:
-    """Generate one exact-sm_100a FlashKDA JIT module.
+def gen_flash_kda_module(variant: FlashKDAVariant, target: FlashKDATarget) -> JitSpec:
+    """Generate one legacy exact-SM100a or SM100-family JIT module.
 
     Each physical schedule is compiled in its own translation unit because the
     checked-in frozen sources intentionally retain generated helper names and
     macros. ``gen_jit_spec`` supplies FlashInfer's standard ``-use_fast_math``
-    flag; the explicit architecture flags below emit only an sm_100a cubin.
+    flag. CUDA 12.8 uses the exact ``sm_100a`` target on B200. CUDA 12.9 and
+    newer use one ``sm_100f`` target validated on both CC 10.0 and CC 10.3.
     """
 
     csrc_dir = _get_flash_kda_csrc_dir()
     include_dir = _get_flash_kda_include_dir()
-    uri = get_flash_kda_uri(variant)
+    uri = get_flash_kda_uri(variant, target)
     binding = csrc_dir / f"flashkda_bf16_fused_{variant}_binding.cu"
     if not binding.exists():
         raise FileNotFoundError(f"FlashKDA binding source not found: {binding}")
@@ -85,57 +104,61 @@ def gen_flash_kda_module(variant: FlashKDAVariant) -> JitSpec:
     spec = gen_jit_spec(
         name=uri,
         sources=[binding],
-        extra_cuda_cflags=sm100a_nvcc_flags,
+        extra_cuda_cflags=[
+            *_FLASH_KDA_NVCC_FLAGS[target],
+            _FLASH_KDA_TARGET_DEFINE[target],
+        ],
         extra_include_paths=[
             csrc_dir,
             csrc_dir.parent,
             include_dir,
         ],
     )
-    logger.info(f"Generated FlashKDA {variant} JIT spec: {spec.name}")
+    logger.info(f"Generated FlashKDA {variant} {target} JIT spec: {spec.name}")
     return spec
 
 
-def gen_flash_kda_m64_module() -> JitSpec:
+def gen_flash_kda_m64_module(target: FlashKDATarget) -> JitSpec:
     """Generate the fixed N=1, H=64 two-CTA M64 module."""
 
-    return gen_flash_kda_module("m64")
+    return gen_flash_kda_module("m64", target)
 
 
-def gen_flash_kda_m128_module() -> JitSpec:
+def gen_flash_kda_m128_module(target: FlashKDATarget) -> JitSpec:
     """Generate the general packed/fixed M128 module."""
 
-    return gen_flash_kda_module("m128")
+    return gen_flash_kda_module("m128", target)
 
 
 @functools.cache
-def load_flash_kda_module(variant: FlashKDAVariant):
-    """Build or load one physical FlashKDA module."""
+def load_flash_kda_module(variant: FlashKDAVariant, target: FlashKDATarget):
+    """Build or load one physical, target-specific FlashKDA module."""
 
-    module = gen_flash_kda_module(variant).build_and_load()
-    logger.info(f"Loaded FlashKDA {variant} module")
+    module = gen_flash_kda_module(variant, target).build_and_load()
+    logger.info(f"Loaded FlashKDA {variant} {target} module")
     return module
 
 
-def load_flash_kda_m64_module():
+def load_flash_kda_m64_module(target: FlashKDATarget):
     """Load the fixed N=1, H=64 two-CTA M64 module."""
 
-    return load_flash_kda_module("m64")
+    return load_flash_kda_module("m64", target)
 
 
-def load_flash_kda_m128_module():
+def load_flash_kda_m128_module(target: FlashKDATarget):
     """Load the general packed/fixed M128 module."""
 
-    return load_flash_kda_module("m128")
+    return load_flash_kda_module("m128", target)
 
 
-def get_flash_kda_prefill_module(variant: FlashKDAVariant):
+def get_flash_kda_prefill_module(variant: FlashKDAVariant, target: FlashKDATarget):
     """Return the loaded module used by the recurrent-KDA prefill dispatcher."""
 
-    return load_flash_kda_module(variant)
+    return load_flash_kda_module(variant, target)
 
 
 __all__ = [
+    "FlashKDATarget",
     "FlashKDAVariant",
     "gen_flash_kda_m64_module",
     "gen_flash_kda_m128_module",

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -65,10 +65,10 @@ def recurrent_kda(
     This is the public API layer for the CuTe DSL implementation in
     ``flashinfer.kda_kernels.recurrent_kda``. It supports single-token decode,
     fused speculative decode, GQA, optional cu_seqlens packing, and the same
-    gate modes as the backend implementation. On NVIDIA B200, the exact
-    FlashKDA-compatible subset of ordinary multi-token prefill is dispatched to
-    frozen SM100a kernels. All existing decode and speculative-decode calls
-    retain the CuTe DSL backend.
+    gate modes as the backend implementation. On SM100a (B200/GB200) and
+    SM103a (B300/GB300), the FlashKDA-compatible subset of ordinary multi-token
+    prefill is dispatched to the corresponding frozen SM100-family kernel. All
+    existing decode and speculative-decode calls retain the CuTe DSL backend.
 
     Args:
         q (torch.Tensor):
@@ -157,11 +157,11 @@ def recurrent_kda(
             timed launches. Fixed-layout prefill and decode calls must leave it
             as ``None``.
         prefill_workspace (Optional[RecurrentKDAPrefillWorkspace]):
-            Caller-owned workspace for the frozen B200 prefill backend. It is
-            optional for eager execution and required for CUDA graph capture.
-            Warm it eagerly with the exact tensors on the capture stream before
-            capture. Use one workspace per captured ``recurrent_kda``
-            invocation.
+            Caller-owned workspace for the frozen SM100-family prefill backend.
+            It is optional for eager execution and required for CUDA graph
+            capture. Warm it eagerly with the exact tensors on the capture
+            stream before capture. Use one workspace per captured
+            ``recurrent_kda`` invocation.
 
     Returns:
         Tuple of ``(output, final_state)`` where ``final_state`` is ``None``
@@ -220,12 +220,12 @@ def recurrent_kda(
     if prefill_workspace is not None:
         raise ValueError(
             "prefill_workspace is only supported by eligible ordinary "
-            "prefill on the frozen B200 FlashKDA backend"
+            "prefill on the frozen SM100-family FlashKDA backend"
         )
     if seq_order is not None:
         raise ValueError(
             "seq_order is only supported by eligible packed ordinary prefill "
-            "on the frozen B200 FlashKDA backend"
+            "on the frozen SM100-family FlashKDA backend"
         )
     if _kda_decode._run_recurrent_kda is None:
         raise NotImplementedError("recurrent KDA backend is unavailable")

--- a/flashinfer/kda_prefill.py
+++ b/flashinfer/kda_prefill.py
@@ -20,7 +20,7 @@ Kimi Delta Attention Prefill - Backend Layer
 
 This file provides workspace management, validation, and frozen-kernel launch
 support for recurrent KDA prefill.  The stable public dispatcher remains in
-``flashinfer.kda_decode``.
+``flashinfer.kda``.
 """
 
 import math
@@ -32,11 +32,11 @@ import torch
 from .utils import get_compute_capability
 
 if TYPE_CHECKING:
-    from .jit.flash_kda import FlashKDAVariant
+    from .jit.flash_kda import FlashKDATarget, FlashKDAVariant
 
 _FLASH_KDA_HEAD_DIM = 128
 _FLASH_KDA_BETA_TMA_MIN_HEADS = 8
-_FLASH_KDA_B200_COMPUTE_CAPABILITY = (10, 0)
+_FLASH_KDA_SUPPORTED_COMPUTE_CAPABILITIES = {(10, 0), (10, 3)}
 _FLASH_KDA_DESCRIPTOR_STORAGE_BYTES = 6 * 128
 _flash_kda_tensor_cache: dict[tuple, torch.Tensor] = {}
 _flash_kda_tensor_cache_lock = threading.Lock()
@@ -166,7 +166,8 @@ def _flash_kda_prefill_is_eligible(
         return False
     if (
         not q.is_cuda
-        or get_compute_capability(q.device) != _FLASH_KDA_B200_COMPUTE_CAPABILITY
+        or get_compute_capability(q.device)
+        not in _FLASH_KDA_SUPPORTED_COMPUTE_CAPABILITIES
     ):
         return False
     if not _is_contiguous_cuda_tensor(q, dtype=torch.bfloat16, device=q.device):
@@ -395,10 +396,10 @@ def _beta_tma_source(
             "this stream before capture"
         ),
     ).view(shape)
-    # The descriptor may fetch a full (32 token, 8 head) box at the tail.
-    # Clear reused padding so every legal OOB-adjacent fetch has defined data.
-    padded.zero_()
-    padded[:total_tokens, :num_heads].copy_(beta_flat)
+    # The frozen binding refreshes head-padded storage from ``beta`` immediately
+    # before launching the frozen kernel. Keeping pack + main-kernel submission
+    # in one FFI call avoids two Python-dispatched activities and their host gap,
+    # while retaining stable storage for the TMA descriptor and CUDA graphs.
     return padded
 
 
@@ -518,10 +519,41 @@ def _validate_prefill_seq_order(
     return seq_order
 
 
-def _get_flash_kda_prefill_module(variant: "FlashKDAVariant"):
+def _is_cuda_version_at_least(version: str) -> bool:
+    # Keep JIT imports lazy so importing the public KDA facade does not
+    # initialize the extension toolchain.
+    from .jit.cpp_ext import is_cuda_version_at_least
+
+    return is_cuda_version_at_least(version)
+
+
+def _select_flash_kda_prefill_target(device: torch.device) -> "FlashKDATarget":
+    compute_capability = get_compute_capability(device)
+    if compute_capability not in _FLASH_KDA_SUPPORTED_COMPUTE_CAPABILITIES:
+        raise RuntimeError(
+            "frozen recurrent-KDA prefill requires compute capability 10.0 "
+            "(SM100a; B200/GB200) or 10.3 (SM103a; B300/GB300); got "
+            f"{compute_capability[0]}.{compute_capability[1]}"
+        )
+    if _is_cuda_version_at_least("12.9"):
+        return "sm100f"
+    if compute_capability == (10, 0) and _is_cuda_version_at_least("12.8"):
+        return "sm100a"
+    if compute_capability == (10, 3):
+        raise RuntimeError(
+            "frozen recurrent-KDA prefill on compute capability 10.3 requires "
+            "CUDA 12.9 or newer for the sm_100f family target"
+        )
+    raise RuntimeError(
+        "frozen recurrent-KDA prefill on compute capability 10.0 requires "
+        "CUDA 12.8 or newer"
+    )
+
+
+def _get_flash_kda_prefill_module(variant: "FlashKDAVariant", target: "FlashKDATarget"):
     from .jit.flash_kda import get_flash_kda_prefill_module
 
-    return get_flash_kda_prefill_module(variant)
+    return get_flash_kda_prefill_module(variant, target)
 
 
 def _run_flash_kda_prefill(
@@ -634,6 +666,7 @@ def _run_flash_kda_prefill(
         num_sequences=num_sequences,
         num_heads=num_heads,
     )
+    target = _select_flash_kda_prefill_target(q.device)
     stream_ptr = int(torch.cuda.current_stream(q.device).cuda_stream)
     explicit_workspace = prefill_workspace is not None
     workspace: _RecurrentKDAPrefillWorkspaceBase
@@ -681,7 +714,7 @@ def _run_flash_kda_prefill(
         else:
             prepare_descriptors = int(warmed_signature != signature)
         descriptor_storage = workspace._descriptor_storages[variant]
-        module = _get_flash_kda_prefill_module(variant)
+        module = _get_flash_kda_prefill_module(variant, target)
         try:
             module.run(
                 q,

--- a/tests/jit/test_flash_kda_jit.py
+++ b/tests/jit/test_flash_kda_jit.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import hashlib
+from types import SimpleNamespace
 
 import pytest
 from packaging.version import Version
@@ -36,28 +37,71 @@ from flashinfer.jit import flash_kda
         ),
     ],
 )
-def test_flash_kda_uri_and_jit_spec(monkeypatch, variant, smem_bytes, generated_sha256):
+@pytest.mark.parametrize(
+    (
+        "target",
+        "target_arch",
+        "expected_flag",
+        "expected_define",
+        "forbidden_compute",
+    ),
+    [
+        (
+            "sm100a",
+            (10, "0a"),
+            "-gencode=arch=compute_100a,code=sm_100a",
+            "-DFLASHINFER_FLASH_KDA_TARGET_MINOR=0",
+            ("compute_100f", "compute_103a"),
+        ),
+        (
+            "sm100f",
+            (10, "0f"),
+            "-gencode=arch=compute_100f,code=sm_100f",
+            "-DFLASHINFER_FLASH_KDA_TARGET_FAMILY=100",
+            ("compute_100a", "compute_103a"),
+        ),
+    ],
+)
+def test_flash_kda_uri_and_jit_spec(
+    monkeypatch,
+    variant,
+    smem_bytes,
+    generated_sha256,
+    target,
+    target_arch,
+    expected_flag,
+    expected_define,
+    forbidden_compute,
+):
     monkeypatch.setattr(
         jit_core.current_compilation_context,
         "TARGET_CUDA_ARCHS",
-        {(10, "0a")},
+        {target_arch},
     )
     flash_kda.gen_flash_kda_module.cache_clear()
 
-    uri = flash_kda.get_flash_kda_uri(variant)
-    spec = flash_kda.gen_flash_kda_module(variant)
+    uri = flash_kda.get_flash_kda_uri(variant, target)
+    spec = flash_kda.gen_flash_kda_module(variant, target)
 
-    assert uri == f"flash_kda_bf16_fused_{variant}_sm100a"
+    assert uri == f"flash_kda_bf16_fused_{variant}_{target}"
     assert spec.name == uri
     assert len(spec.sources) == 1
     assert spec.sources[0].name == f"flashkda_bf16_fused_{variant}_binding.cu"
     assert spec.sources[0].is_file()
-    assert "-gencode=arch=compute_100a,code=sm_100a" in spec.extra_cuda_cflags
+    assert expected_flag in spec.extra_cuda_cflags
+    target_defines = [
+        flag
+        for flag in spec.extra_cuda_cflags
+        if flag.startswith("-DFLASHINFER_FLASH_KDA_TARGET_")
+    ]
+    assert target_defines == [expected_define]
     assert "-use_fast_math" in spec.extra_cuda_cflags
     assert not any(
-        "compute_103" in flag or "compute_120" in flag
+        compute in flag
+        for compute in forbidden_compute
         for flag in spec.extra_cuda_cflags
     )
+    assert not any("compute_120" in flag for flag in spec.extra_cuda_cflags)
     frozen_source = spec.sources[0].parent / f"flashkda_bf16_fused_{variant}.cu"
     frozen_text = frozen_source.read_text()
     assert f"Provenance: generated Loom schedule 'flashkda_bf16_fused_{variant}'" in (
@@ -121,6 +165,7 @@ def test_flash_kda_uri_and_jit_spec(monkeypatch, variant, smem_bytes, generated_
     binding_text = spec.sources[0].read_text()
     assert "#define uint64_t flashkda_generated_uint64_t" in binding_text
     assert "TensorView descriptor_storage, int64_t prepare_descriptors" in binding_text
+    assert "CheckFlashKDATarget(device_id)" in binding_text
 
 
 def test_flash_kda_descriptor_workspace_contract():
@@ -137,34 +182,85 @@ def test_flash_kda_descriptor_workspace_contract():
     assert "PublishTensorMaps<<<1, 128, 0, stream>>>" in common_text
     assert "prepare_descriptors must be 0 during CUDA graph capture" in common_text
     assert "cudaMemcpyAsync(TMA descriptors)" not in common_text
+    assert "defined(FLASHINFER_FLASH_KDA_TARGET_MINOR)" in common_text
+    assert "defined(FLASHINFER_FLASH_KDA_TARGET_FAMILY)" in common_text
+    assert "kFlashKDATargetMinor == 0" in common_text
+    assert "kFlashKDATargetFamily == 100" in common_text
+    assert "major == 10 && minor == kFlashKDATargetMinor" in common_text
+    assert "major == 10 && (minor == 0 || minor == 3)" in common_text
+    assert "CheckFlashKDATarget" in common_text
+    assert "PackBetaForTmaKernel" in common_text
+    assert (
+        'CheckNoPartialOverlapOrExactAlias(beta, "beta", beta_tma, "beta_tma")'
+        in common_text
+    )
+
+    m128_binding = (
+        flash_kda._get_flash_kda_csrc_dir() / "flashkda_bf16_fused_m128_binding.cu"
+    ).read_text()
+    assert "PackBetaForTmaIfNeeded(beta, beta_tma, num_heads, stream);" in (
+        m128_binding
+    )
 
 
 def test_flash_kda_variant_validation_and_public_getter(monkeypatch):
     with pytest.raises(ValueError, match="unsupported FlashKDA variant"):
-        flash_kda.get_flash_kda_uri("m32")
+        flash_kda.get_flash_kda_uri("m32", "sm100f")
+    with pytest.raises(ValueError, match="unsupported FlashKDA target"):
+        flash_kda.get_flash_kda_uri("m128", "sm120a")
 
     sentinel = object()
     monkeypatch.setattr(
         flash_kda,
         "load_flash_kda_module",
-        lambda variant: (sentinel, variant),
+        lambda variant, target: (sentinel, variant, target),
     )
-    assert flash_kda.get_flash_kda_prefill_module("m128") == (
+    assert flash_kda.get_flash_kda_prefill_module("m128", "sm100f") == (
         sentinel,
         "m128",
+        "sm100f",
     )
+
+
+def test_flash_kda_legacy_and_family_targets_have_independent_cache_keys(monkeypatch):
+    monkeypatch.setattr(
+        jit_core.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(10, "0a"), (10, "3a")},
+    )
+    flash_kda.gen_flash_kda_module.cache_clear()
+
+    sm100a = flash_kda.gen_flash_kda_module("m128", "sm100a")
+    sm100f = flash_kda.gen_flash_kda_module("m128", "sm100f")
+    sm100f_cached = flash_kda.gen_flash_kda_module("m128", "sm100f")
+
+    assert sm100a is not sm100f
+    assert sm100a.name == "flash_kda_bf16_fused_m128_sm100a"
+    assert sm100f.name == "flash_kda_bf16_fused_m128_sm100f"
+    assert sm100f is sm100f_cached
 
 
 @pytest.mark.parametrize(
-    ("target_archs", "expected_exact"),
+    (
+        "target_archs",
+        "cuda_version",
+        "expected_legacy",
+        "expected_family",
+    ),
     [
-        ({(10, "0a")}, True),
-        ({(10, "0f")}, False),
-        ({(10, "3a")}, False),
-        ({(12, "0f")}, False),
+        ({(10, "0a")}, "12.8", True, False),
+        ({(10, "0a")}, "12.9", False, True),
+        ({(10, "0f")}, "12.9", False, True),
+        ({(10, "3a")}, "12.8", False, False),
+        ({(10, "3a")}, "12.9", False, True),
+        ({(10, "3f")}, "13.0", False, True),
+        ({(10, "0a"), (10, "3a")}, "13.0", False, True),
+        ({(12, "0f")}, "13.0", False, False),
     ],
 )
-def test_aot_detects_only_exact_sm100a(monkeypatch, target_archs, expected_exact):
+def test_aot_detects_flash_kda_target_matrix(
+    monkeypatch, target_archs, cuda_version, expected_legacy, expected_family
+):
     from flashinfer import aot
 
     class FakeCompilationContext:
@@ -178,7 +274,73 @@ def test_aot_detects_only_exact_sm100a(monkeypatch, target_archs, expected_exact
             ]
 
     monkeypatch.setattr(aot, "CompilationContext", FakeCompilationContext)
-    monkeypatch.setattr(aot, "get_cuda_version", lambda: Version("13.0"))
+    monkeypatch.setattr(aot, "get_cuda_version", lambda: Version(cuda_version))
 
     capabilities = aot.detect_sm_capabilities()
-    assert capabilities["sm100a_exact"] is expected_exact
+    assert capabilities["flash_kda_prefill_sm100a"] is expected_legacy
+    assert capabilities["flash_kda_prefill_sm100f"] is expected_family
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected_target"),
+    [
+        ({"flash_kda_prefill_sm100a": True}, "sm100a"),
+        ({"flash_kda_prefill_sm100f": True}, "sm100f"),
+    ],
+)
+def test_aot_registers_two_flash_kda_modules(
+    monkeypatch, capabilities, expected_target
+):
+    from flashinfer import aot
+
+    calls = []
+
+    def fake_flash_kda(variant, target):
+        calls.append((variant, target))
+        return SimpleNamespace(name=f"flash_kda_{variant}_{target}")
+
+    monkeypatch.setattr(
+        aot,
+        "gen_flash_kda_m64_module",
+        lambda target: fake_flash_kda("m64", target),
+    )
+    monkeypatch.setattr(
+        aot,
+        "gen_flash_kda_m128_module",
+        lambda target: fake_flash_kda("m128", target),
+    )
+    monkeypatch.setattr(
+        aot, "gen_spdlog_module", lambda: SimpleNamespace(name="spdlog")
+    )
+    monkeypatch.setattr(aot, "gen_attention", lambda *args: ())
+    monkeypatch.setattr(
+        aot, "gen_cudnn_fmha_module", lambda: SimpleNamespace(name="cudnn")
+    )
+
+    specs = aot.gen_all_modules(
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        capabilities,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+
+    assert calls == [
+        ("m64", expected_target),
+        ("m128", expected_target),
+    ]
+    assert [spec.name for spec in specs] == [
+        "spdlog",
+        f"flash_kda_m64_{expected_target}",
+        f"flash_kda_m128_{expected_target}",
+        "cudnn",
+    ]

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -18,6 +18,7 @@ import math
 import pytest
 import torch
 import torch.nn.functional as F
+from packaging.version import Version
 
 import flashinfer
 from flashinfer.kda import recurrent_kda
@@ -156,10 +157,51 @@ def cuda_device():
 
 
 @pytest.fixture
-def b200(cuda_device):
-    if get_compute_capability(cuda_device) != (10, 0):
-        pytest.skip("frozen recurrent KDA prefill requires B200 (cc 10.0)")
+def flash_kda_device(cuda_device):
+    if get_compute_capability(cuda_device) not in ((10, 0), (10, 3)):
+        pytest.skip(
+            "frozen recurrent KDA prefill requires CC 10.0 "
+            "(SM100a; B200/GB200) or CC 10.3 (SM103a; B300/GB300)"
+        )
     return cuda_device
+
+
+@pytest.mark.parametrize(
+    ("compute_capability", "cuda_version", "expected_target", "error_match"),
+    [
+        ((10, 0), "12.8", "sm100a", None),
+        ((10, 0), "12.9", "sm100f", None),
+        ((10, 3), "12.8", None, "10.3 requires CUDA 12.9"),
+        ((10, 3), "12.9", "sm100f", None),
+        ((12, 0), "13.0", None, "requires compute capability 10.0"),
+        ((10, 0), "12.7", None, "10.0 requires CUDA 12.8"),
+    ],
+)
+def test_flash_kda_target_resolution(
+    monkeypatch,
+    compute_capability,
+    cuda_version,
+    expected_target,
+    error_match,
+):
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "get_compute_capability",
+        lambda device: compute_capability,
+    )
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_is_cuda_version_at_least",
+        lambda required: Version(cuda_version) >= Version(required),
+    )
+    device = torch.device("cuda")
+    if error_match is not None:
+        with pytest.raises(RuntimeError, match=error_match):
+            kda_prefill_api._select_flash_kda_prefill_target(device)
+    else:
+        assert (
+            kda_prefill_api._select_flash_kda_prefill_target(device) == expected_target
+        )
 
 
 class _RecorderModule:
@@ -190,7 +232,7 @@ def test_decode_and_spec_stay_on_existing_backend(monkeypatch):
     monkeypatch.setattr(
         kda_prefill_api,
         "_get_flash_kda_prefill_module",
-        lambda variant: pytest.fail(f"unexpected frozen route {variant}"),
+        lambda variant, arch: pytest.fail(f"unexpected frozen route {variant}/{arch}"),
     )
     q = torch.empty((2, 1, 4, 128), dtype=torch.bfloat16)
     result = recurrent_kda(q, q, q, q, torch.empty((2, 1, 4)))
@@ -216,7 +258,7 @@ def test_multi_token_gqa_stays_on_existing_backend(cuda_device, monkeypatch):
     monkeypatch.setattr(
         kda_prefill_api,
         "_get_flash_kda_prefill_module",
-        lambda variant: pytest.fail(f"unexpected frozen route {variant}"),
+        lambda variant, arch: pytest.fail(f"unexpected frozen route {variant}/{arch}"),
     )
     q = torch.randn((1, 2, 2, 128), dtype=torch.bfloat16, device=cuda_device)
     v = torch.randn((1, 2, 4, 128), dtype=torch.bfloat16, device=cuda_device)
@@ -240,20 +282,33 @@ def test_multi_token_gqa_stays_on_existing_backend(cuda_device, monkeypatch):
     ("packed", "num_heads", "expected_variant"),
     [(False, 64, "m64"), (True, 64, "m128"), (True, 2, "m128")],
 )
+@pytest.mark.parametrize(
+    ("compute_capability", "expected_target"),
+    [((10, 0), "sm100f"), ((10, 3), "sm100f")],
+)
 def test_frozen_route_and_ffi_abi(
     cuda_device,
     monkeypatch,
     packed,
     num_heads,
     expected_variant,
+    compute_capability,
+    expected_target,
 ):
     monkeypatch.setattr(
-        kda_prefill_api, "get_compute_capability", lambda device: (10, 0)
+        kda_prefill_api,
+        "get_compute_capability",
+        lambda device: compute_capability,
+    )
+    monkeypatch.setattr(
+        kda_prefill_api, "_is_cuda_version_at_least", lambda version: True
     )
     monkeypatch.setattr(kda_prefill_api, "_flash_kda_stream_workspaces", {})
     modules = {}
+    routes = []
 
-    def get_module(variant):
+    def get_module(variant, target):
+        routes.append((variant, target))
         modules.setdefault(variant, _RecorderModule())
         return modules[variant]
 
@@ -277,6 +332,7 @@ def test_frozen_route_and_ffi_abi(
     assert actual.data_ptr() == output.data_ptr()
     assert state is None
     assert set(modules) == {expected_variant}
+    assert routes == [(expected_variant, expected_target)]
     (args,) = modules[expected_variant].calls
     assert len(args) == 21
     assert args[0].data_ptr() == inputs["q"].data_ptr()
@@ -297,12 +353,8 @@ def test_frozen_route_and_ffi_abi(
     assert math.isclose(args[18], 128**-0.5)
     assert args[19] == -5.0
     assert args[20] == int(torch.cuda.current_stream(cuda_device).cuda_stream)
-    if args[5].data_ptr() != inputs["beta"].data_ptr():
-        total_tokens = inputs["q"].numel() // (num_heads * 128)
-        torch.testing.assert_close(
-            args[5][:total_tokens, :num_heads],
-            inputs["beta"].reshape(-1, num_heads),
-        )
+    if num_heads < 8:
+        assert args[5].data_ptr() != inputs["beta"].data_ptr()
 
 
 def test_frozen_route_passes_nondefault_stream(cuda_device, monkeypatch):
@@ -311,7 +363,9 @@ def test_frozen_route_passes_nondefault_stream(cuda_device, monkeypatch):
     )
     module = _RecorderModule()
     monkeypatch.setattr(
-        kda_prefill_api, "_get_flash_kda_prefill_module", lambda variant: module
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        lambda variant, arch: module,
     )
     inputs = _make_inputs(seq_lens=[2], num_heads=2, packed=False)
     stream = torch.cuda.Stream(device=cuda_device)
@@ -331,7 +385,9 @@ def test_frozen_route_rejects_output_overlap(cuda_device, monkeypatch):
     )
     module = _RecorderModule()
     monkeypatch.setattr(
-        kda_prefill_api, "_get_flash_kda_prefill_module", lambda variant: module
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        lambda variant, arch: module,
     )
     inputs = _make_inputs(seq_lens=[2], num_heads=2, packed=False)
     with pytest.raises(ValueError, match="output must not overlap q"):
@@ -348,7 +404,9 @@ def test_initial_state_is_updated_in_place(cuda_device, monkeypatch):
     )
     module = _RecorderModule(final_value=0.25)
     monkeypatch.setattr(
-        kda_prefill_api, "_get_flash_kda_prefill_module", lambda variant: module
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        lambda variant, arch: module,
     )
     inputs = _make_inputs(seq_lens=[2], num_heads=2, packed=False, initial_state=True)
     original_state = inputs["initial_state"]
@@ -379,7 +437,9 @@ def test_stream_workspace_does_not_allocate_state_scratch_for_inplace_update(
     monkeypatch.setattr(kda_prefill_api, "_flash_kda_stream_workspaces", {})
     module = _RecorderModule(final_value=0.0)
     monkeypatch.setattr(
-        kda_prefill_api, "_get_flash_kda_prefill_module", lambda variant: module
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        lambda variant, arch: module,
     )
     cases = [
         _make_inputs(
@@ -424,7 +484,7 @@ def test_packed_seq_order_validation(cuda_device, monkeypatch, dtype, size_delta
     monkeypatch.setattr(
         kda_prefill_api,
         "_get_flash_kda_prefill_module",
-        lambda variant: _RecorderModule(),
+        lambda variant, arch: _RecorderModule(),
     )
     inputs = _make_inputs(seq_lens=[1, 2], num_heads=2, packed=True)
     seq_order = torch.arange(2 + size_delta, dtype=dtype, device="cuda")
@@ -480,7 +540,9 @@ def test_explicit_workspace_descriptor_prepare_and_reuse(cuda_device, monkeypatc
     )
     module = _RecorderModule()
     monkeypatch.setattr(
-        kda_prefill_api, "_get_flash_kda_prefill_module", lambda variant: module
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        lambda variant, arch: module,
     )
     inputs = _make_inputs(seq_lens=[2], num_heads=2, packed=False)
     output = torch.empty_like(inputs["q"])
@@ -516,7 +578,9 @@ def test_captured_workspace_rejects_eager_reuse_and_capture_mismatch(
     )
     module = _RecorderModule()
     monkeypatch.setattr(
-        kda_prefill_api, "_get_flash_kda_prefill_module", lambda variant: module
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        lambda variant, arch: module,
     )
     inputs = _make_inputs(seq_lens=[2], num_heads=2, packed=False)
     output = torch.empty_like(inputs["q"])
@@ -565,7 +629,9 @@ def test_workspace_rejects_a_different_stream(cuda_device, monkeypatch):
     )
     module = _RecorderModule()
     monkeypatch.setattr(
-        kda_prefill_api, "_get_flash_kda_prefill_module", lambda variant: module
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        lambda variant, arch: module,
     )
     inputs = _make_inputs(seq_lens=[2], num_heads=2, packed=False)
     output = torch.empty_like(inputs["q"])
@@ -598,7 +664,7 @@ def test_flash_kda_jit_getter_is_importable():
 
 @pytest.mark.parametrize("packed", [False, True])
 @pytest.mark.parametrize("non_default_stream", [False, True])
-def test_frozen_prefill_matches_reference(b200, packed, non_default_stream):
+def test_frozen_prefill_matches_reference(flash_kda_device, packed, non_default_stream):
     inputs = _make_inputs(
         seq_lens=[3, 5] if packed else [4, 4],
         num_heads=2,
@@ -613,11 +679,15 @@ def test_frozen_prefill_matches_reference(b200, packed, non_default_stream):
     expected_output, expected_state = _reference(reference_inputs)
     output = torch.empty_like(inputs["q"])
     state_identity = inputs["initial_state"]
-    seq_order = torch.tensor([1, 0], dtype=torch.int32, device=b200) if packed else None
+    seq_order = (
+        torch.tensor([1, 0], dtype=torch.int32, device=flash_kda_device)
+        if packed
+        else None
+    )
 
     if non_default_stream:
-        stream = torch.cuda.Stream(device=b200)
-        stream.wait_stream(torch.cuda.current_stream(b200))
+        stream = torch.cuda.Stream(device=flash_kda_device)
+        stream.wait_stream(torch.cuda.current_stream(flash_kda_device))
         with torch.cuda.stream(stream):
             actual_output, actual_state = recurrent_kda(
                 **_strict_prefill_kwargs(inputs),
@@ -650,7 +720,7 @@ def test_frozen_prefill_matches_reference(b200, packed, non_default_stream):
     )
 
 
-def test_frozen_prefill_without_initial_or_final_state(b200):
+def test_frozen_prefill_without_initial_or_final_state(flash_kda_device):
     inputs = _make_inputs(seq_lens=[3], num_heads=2, packed=False, initial_state=False)
     expected_output, _ = _reference(inputs)
     output = torch.empty_like(inputs["q"])
@@ -669,7 +739,44 @@ def test_frozen_prefill_without_initial_or_final_state(b200):
     )
 
 
-def test_frozen_prefill_m64_matches_reference(b200):
+def test_frozen_prefill_h6_full_tma_chunk_matches_reference(flash_kda_device):
+    inputs = _make_inputs(
+        seq_lens=[32],
+        num_heads=6,
+        packed=True,
+        initial_state=True,
+        seed=2032,
+    )
+    reference_inputs = {
+        **inputs,
+        "initial_state": inputs["initial_state"].clone(),
+    }
+    expected_output, expected_state = _reference(reference_inputs)
+    output = torch.empty_like(inputs["q"])
+
+    actual_output, actual_state = recurrent_kda(
+        **_strict_prefill_kwargs(inputs),
+        output=output,
+        output_final_state=True,
+    )
+
+    assert actual_output.data_ptr() == output.data_ptr()
+    assert actual_state is inputs["initial_state"]
+    torch.testing.assert_close(
+        actual_output.float(),
+        expected_output.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    torch.testing.assert_close(
+        actual_state.float(),
+        expected_state.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
+def test_frozen_prefill_m64_matches_reference(flash_kda_device):
     inputs = _make_inputs(
         seq_lens=[2],
         num_heads=64,
@@ -712,7 +819,7 @@ def test_frozen_prefill_m64_matches_reference(b200):
     [(False, 64, True), (True, 2, False)],
 )
 def test_frozen_prefill_cuda_graph_capture_and_replay(
-    b200,
+    flash_kda_device,
     packed,
     num_heads,
     has_initial_state,
@@ -736,10 +843,14 @@ def test_frozen_prefill_cuda_graph_capture_and_replay(
         }
     )
     output = torch.empty_like(inputs["q"])
-    seq_order = torch.tensor([1, 0], dtype=torch.int32, device=b200) if packed else None
-    workspace = RecurrentKDAPrefillWorkspace(b200)
-    capture_stream = torch.cuda.Stream(device=b200)
-    capture_stream.wait_stream(torch.cuda.current_stream(b200))
+    seq_order = (
+        torch.tensor([1, 0], dtype=torch.int32, device=flash_kda_device)
+        if packed
+        else None
+    )
+    workspace = RecurrentKDAPrefillWorkspace(flash_kda_device)
+    capture_stream = torch.cuda.Stream(device=flash_kda_device)
+    capture_stream.wait_stream(torch.cuda.current_stream(flash_kda_device))
 
     call_kwargs = {
         **_strict_prefill_kwargs(inputs),
@@ -787,9 +898,70 @@ def test_frozen_prefill_cuda_graph_capture_and_replay(
     )
 
 
-def test_frozen_prefill_cuda_graph_workspaces_are_isolated(b200):
-    capture_stream = torch.cuda.Stream(device=b200)
-    launch_stream = torch.cuda.Stream(device=b200)
+def test_frozen_prefill_h6_full_chunk_graph_refreshes_beta(flash_kda_device):
+    inputs = _make_inputs(
+        seq_lens=[32],
+        num_heads=6,
+        packed=False,
+        initial_state=True,
+        seed=2033,
+    )
+    initial_state_seed = inputs["initial_state"].clone()
+    output = torch.empty_like(inputs["q"])
+    workspace = RecurrentKDAPrefillWorkspace(flash_kda_device)
+    capture_stream = torch.cuda.Stream(device=flash_kda_device)
+    capture_stream.wait_stream(torch.cuda.current_stream(flash_kda_device))
+    call_kwargs = {
+        **_strict_prefill_kwargs(inputs),
+        "output": output,
+        "output_final_state": True,
+        "prefill_workspace": workspace,
+    }
+
+    with torch.cuda.stream(capture_stream):
+        recurrent_kda(**call_kwargs)
+        inputs["initial_state"].copy_(initial_state_seed)
+    capture_stream.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        captured_output, captured_state = recurrent_kda(**call_kwargs)
+
+    with torch.cuda.stream(capture_stream):
+        inputs["beta"].fill_(2.0)
+        inputs["initial_state"].copy_(initial_state_seed)
+        output.fill_(float("nan"))
+    capture_stream.synchronize()
+    expected_output, expected_state = _reference(
+        {
+            **inputs,
+            "initial_state": initial_state_seed,
+        }
+    )
+    torch.cuda.synchronize()
+
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured_output.data_ptr() == output.data_ptr()
+    assert captured_state is inputs["initial_state"]
+    torch.testing.assert_close(
+        captured_output.float(),
+        expected_output.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    torch.testing.assert_close(
+        captured_state.float(),
+        expected_state.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
+def test_frozen_prefill_cuda_graph_workspaces_are_isolated(flash_kda_device):
+    capture_stream = torch.cuda.Stream(device=flash_kda_device)
+    launch_stream = torch.cuda.Stream(device=flash_kda_device)
     bundles = []
 
     for seed in (2030, 2031):
@@ -808,14 +980,14 @@ def test_frozen_prefill_cuda_graph_workspaces_are_isolated(b200):
             }
         )
         output = torch.empty_like(inputs["q"])
-        workspace = RecurrentKDAPrefillWorkspace(b200)
+        workspace = RecurrentKDAPrefillWorkspace(flash_kda_device)
         call_kwargs = {
             **_strict_prefill_kwargs(inputs),
             "output": output,
             "output_final_state": True,
             "prefill_workspace": workspace,
         }
-        capture_stream.wait_stream(torch.cuda.current_stream(b200))
+        capture_stream.wait_stream(torch.cuda.current_stream(flash_kda_device))
         with torch.cuda.stream(capture_stream):
             recurrent_kda(**call_kwargs)
             inputs["initial_state"].copy_(state_seed)


### PR DESCRIPTION
> [!IMPORTANT]
> Follow-up to merged #4262. This PR contains only SM100-family packaging,
> routing, validation, and GB300 enablement; it does not add another frozen
> prefill kernel body.

## Description

Compile the existing frozen recurrent-KDA prefill M64 and M128 kernels once as
`sm_100f` on CUDA 12.9 and newer, and use those modules on both CC 10.0
(B200/GB200) and CC 10.3 (B300/GB300). CUDA 12.8 B200 keeps the exact
`sm_100a` compatibility modules because that toolkit predates `sm_100f`.

The M64 and M128 generated CUDA bodies remain byte-identical to #4262. JIT and
AOT use target-bearing module identities, and the binding accepts the family
module only on CC 10.0 or CC 10.3.

## Validation

Publication commit: `8d3bbb27e26795609638f8002d345917c6d802c5` (tree
`c859b6d5241b5994cc9ccf4ceb5faacce15f4057`), based directly on upstream
`main@4433996e` after #4279 merged. The incremental prefill implementation is
identical to the candidate validated on both GPUs: the ten non-AOT files are
blob-identical, and their stable patch-id is unchanged. The only replay
resolution was mechanical in `flashinfer/aot.py`: it preserves the merged
#4279 decode registration while applying the same prefill family registration.

| Gate | B200 | GB300 |
|---|---:|---:|
| Public prefill GPU tests | 39/39 passed | 39/39 passed |
| Targeted CPU tests at publication commit | 26 passed, 30 skipped | same commit |
| Pre-commit at publication commit | passed | same commit |

Strict CUPTI, cold-L2, balanced-process A/B below compares the family target
with the same frozen bodies compiled for the exact device target. Speedup is
`exact / sm100f`; values near 1 mean target consolidation is performance
neutral.

| GPU / run | Historical six | H6 four | All ten |
|---|---:|---:|---:|
| B200 | 0.9994x | 0.9992x | 0.9993x |
| GB300 primary ABBA | 0.9996x | 0.9905x | 0.9959x |
| GB300 reverse-BAAB confirmation | 0.9999x | 0.9957x | 0.9982x |

The only stable tiny-shape difference is `h6_packed_n8_t128`: `sm100f`
25.664 us versus exact `sm103a` 25.360 us (0.9882x, 0.304 us absolute).
Keeping an extra exact M128 target for this one coordinate would reintroduce a
third target and shape-specific routing, so this PR retains the simpler shared
family module.

The existing six-shape comparison with pinned official FlashKDA remains the
performance baseline documented by this PR; the new A/B isolates only the
physical target change.

Related to #4254.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recurrent KDA prefill support for SM100a and SM103a GPUs.
  * Added automatic selection of compatible kernels based on GPU architecture and CUDA version.
  * Added support for smaller head counts through automatic beta-data padding.
  * Improved hardware information included in benchmark results.

* **Bug Fixes**
  * Improved device and input validation, shared-memory checks, and launch error reporting.

* **Documentation**
  * Updated KDA prefill documentation with supported architectures and CUDA requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->