### PR TITLE
feat(cake_kda): share recurrent decode kernels across SM100 family

### DIFF
--- a/benchmarks/bench_recurrent_kda_decode_export.py
+++ b/benchmarks/bench_recurrent_kda_decode_export.py
@@ -33,6 +33,7 @@ import statistics
 import subprocess
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Optional
 
 import torch
 import torch.nn.functional as F
@@ -47,11 +48,11 @@ EVOLUTION_PEER_SHA = "cea7f46ffc190cabf82c95a39cd0d2aa6c888c17"
 DATA_SEED = 42
 PRECOMPUTED_SEQUENCE_COUNTS = (8, 16, 32, 64, 128)
 T3_LOWER_BOUND_SEQUENCE_COUNTS = (1, 2, 4, 8, 16)
+SUPPORTED_FLASH_KDA_DECODE_ARCHS = {(10, 0): "sm100a", (10, 3): "sm103a"}
 
-# Keep the measured public-export routes in one place. T1 uses a direct
-# register-state body with split16 at N8 and split8 at N16+; the exported split
-# sweep selects split4 for T2 and split2 for T4. T3 has one exact lower-bound
-# split4 specialization.
+# Keep the measured public-export routes in one place. T3 has one exact
+# lower-bound split4 specialization. The final 30-shape matrix has
+# architecture-local T1 routes and one measured SM103a T4/N8 route override.
 EXPECTED_VARIANTS_BY_T = {
     2: "d128_t2_precomputed_split4",
     3: "d128_t3_lower_bound_split4",
@@ -59,12 +60,21 @@ EXPECTED_VARIANTS_BY_T = {
     5: "d128_t5_precomputed_gram_split1",
     6: "d128_t6_precomputed_gram_split1",
 }
-EXPECTED_T1_VARIANTS_BY_N = {
-    8: "d128_t1_precomputed_direct_split16",
-    16: "d128_t1_precomputed_direct_split8",
-    32: "d128_t1_precomputed_direct_split8",
-    64: "d128_t1_precomputed_direct_split8",
-    128: "d128_t1_precomputed_direct_split8",
+EXPECTED_T1_VARIANTS_BY_ARCH_AND_N = {
+    "sm100a": {
+        8: "d128_t1_precomputed_direct_split16",
+        16: "d128_t1_precomputed_direct_split8",
+        32: "d128_t1_precomputed_direct_split8",
+        64: "d128_t1_precomputed_direct_split8",
+        128: "d128_t1_precomputed_direct_split8",
+    },
+    "sm103a": {
+        num_sequences: "d128_t1_precomputed_direct_split16"
+        for num_sequences in PRECOMPUTED_SEQUENCE_COUNTS
+    },
+}
+EXPECTED_SM103A_VARIANTS_BY_T_AND_N = {
+    (4, 8): "d128_t4_precomputed_split1",
 }
 
 
@@ -99,6 +109,24 @@ def _case_specs_for_tokens(num_tokens: int) -> tuple[dict, ...]:
 CASES = tuple(
     spec for num_tokens in range(1, 7) for spec in _case_specs_for_tokens(num_tokens)
 )
+
+
+def _hardware_metadata(device: torch.device) -> dict:
+    compute_capability = torch.cuda.get_device_capability(device)
+    properties = torch.cuda.get_device_properties(device)
+    device_index = (
+        device.index if device.index is not None else torch.cuda.current_device()
+    )
+    return {
+        "device_name": properties.name,
+        "device_index": device_index,
+        "compute_capability": list(compute_capability),
+        "cuda_arch": SUPPORTED_FLASH_KDA_DECODE_ARCHS[compute_capability],
+        "multiprocessor_count": properties.multi_processor_count,
+        "total_memory_bytes": properties.total_memory,
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
+    }
 
 
 def _make_case(spec: dict, device: torch.device) -> dict:
@@ -270,12 +298,25 @@ def _parse_expected_variant_overrides(values: list[str]) -> dict[int, str]:
 def _expected_variant_for_spec(
     spec: dict,
     expected_variant_overrides: dict[int, str],
+    cuda_arch: Optional[str] = None,
 ) -> str:
     num_tokens = spec["T"]
     if num_tokens in expected_variant_overrides:
         return expected_variant_overrides[num_tokens]
+    if cuda_arch is None:
+        compute_capability = torch.cuda.get_device_capability()
+        cuda_arch = SUPPORTED_FLASH_KDA_DECODE_ARCHS[compute_capability]
     if num_tokens == 1:
-        return EXPECTED_T1_VARIANTS_BY_N[spec["N"]]
+        return EXPECTED_T1_VARIANTS_BY_ARCH_AND_N[cuda_arch][spec["N"]]
+    if (
+        cuda_arch == "sm103a"
+        and (
+            num_tokens,
+            spec["N"],
+        )
+        in EXPECTED_SM103A_VARIANTS_BY_T_AND_N
+    ):
+        return EXPECTED_SM103A_VARIANTS_BY_T_AND_N[(num_tokens, spec["N"])]
     return EXPECTED_VARIANTS_BY_T[num_tokens]
 
 
@@ -441,8 +482,19 @@ def main() -> None:
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
     device = torch.device("cuda")
-    if torch.cuda.get_device_capability(device) != (10, 0):
-        raise RuntimeError("this benchmark requires exact B200 / sm_100a")
+    compute_capability = torch.cuda.get_device_capability(device)
+    if compute_capability not in SUPPORTED_FLASH_KDA_DECODE_ARCHS:
+        raise RuntimeError(
+            "this benchmark requires exact CC 10.0 (SM100a; B200/GB200) "
+            "or CC 10.3 (SM103a; B300/GB300), got "
+            f"CC {compute_capability[0]}.{compute_capability[1]}"
+        )
+    hardware = _hardware_metadata(device)
+    print(
+        "Hardware: "
+        f"{hardware['device_name']} CC {hardware['compute_capability'][0]}."
+        f"{hardware['compute_capability'][1]} ({hardware['cuda_arch']})"
+    )
 
     rows = []
     cases_per_t = {
@@ -454,8 +506,11 @@ def main() -> None:
         case_ordinal_by_t[spec["T"]] += 1
         kwargs = _make_case(spec, device)
         selected_variant = None
-        expected_variant = _expected_variant_for_spec(spec, expected_variants)
+        expected_variant = None
         if args.mode == "frozen":
+            expected_variant = _expected_variant_for_spec(
+                spec, expected_variants, hardware["cuda_arch"]
+            )
             selected_variant = _assert_frozen_route(spec, kwargs, expected_variant)
         call_kwargs = dict(kwargs)
         if args.mode == "frozen":
@@ -527,6 +582,7 @@ def main() -> None:
             raise RuntimeError(f"invalid timing for {spec['name']}: {median_ms}")
         row = {
             **spec,
+            "hardware": hardware,
             "mode": args.mode,
             "data_seed": DATA_SEED,
             "case_ordinal_within_t": case_ordinal_by_t[spec["T"]],

--- a/benchmarks/bench_recurrent_kda_decode_split_sweep.py
+++ b/benchmarks/bench_recurrent_kda_decode_split_sweep.py
@@ -14,10 +14,11 @@
 
 """Sweep frozen recurrent-KDA decode value splits through the public API.
 
-This B200-only harness forces every split1/2/4/8 specialization for the
-D128, H16, HV32 precomputed-gate T=1/2/4/5/6 contracts. T=1 uses the standard
-decode ABI; the other token counts use packed speculative decode. For every
-coordinate, it:
+This exact-SM100a/SM103a harness forces every split1/2/4/8 specialization for
+the D128, H16, HV32 precomputed-gate T=1/2/4/5/6 contracts. It additionally
+sweeps both direct-state T=1 schedules (split8 and split16), while retaining
+the four T=1 WY schedules. T=1 uses the standard decode ABI; the other token
+counts use packed speculative decode. For every coordinate, it:
 
 1. computes a reference with the explicit public ``backend="cute-dsl"`` path;
 2. checks the output and the complete mutated state from every forced frozen
@@ -57,6 +58,7 @@ NUM_VALUE_HEADS = 32
 TOKEN_COUNTS = (1, 2, 4, 5, 6)
 SEQUENCE_COUNTS = (1, 2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128)
 VALUE_SPLITS = (1, 2, 4, 8)
+SUPPORTED_FLASH_KDA_DECODE_ARCHS = {(10, 0): "sm100a", (10, 3): "sm103a"}
 VARIANT_PREFIXES = {
     1: "d128_t1_precomputed_split",
     2: "d128_t2_precomputed_split",
@@ -68,8 +70,28 @@ VARIANT_PREFIXES = {
 recurrent_module = importlib.import_module("flashinfer.kda_kernels.recurrent_kda")
 
 
-def _variant_name(num_tokens: int, value_split: int) -> str:
-    return f"{VARIANT_PREFIXES[num_tokens]}{value_split}"
+def _variant_specs_for_tokens(num_tokens: int) -> tuple[dict, ...]:
+    """Return every frozen schedule that should be swept for one token count."""
+
+    schedule_kind = "coefficient_gram" if num_tokens in (5, 6) else "wy"
+    specs = [
+        {
+            "schedule_kind": schedule_kind,
+            "value_split": value_split,
+            "variant": f"{VARIANT_PREFIXES[num_tokens]}{value_split}",
+        }
+        for value_split in VALUE_SPLITS
+    ]
+    if num_tokens == 1:
+        specs.extend(
+            {
+                "schedule_kind": "direct_state",
+                "value_split": value_split,
+                "variant": f"d128_t1_precomputed_direct_split{value_split}",
+            }
+            for value_split in (8, 16)
+        )
+    return tuple(specs)
 
 
 def _make_case(num_tokens: int, num_sequences: int, device: torch.device) -> dict:
@@ -469,9 +491,19 @@ def main() -> None:
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
     device = torch.device("cuda")
-    if torch.cuda.get_device_capability(device) != (10, 0):
-        raise RuntimeError("this benchmark requires exact B200 / sm_100a")
+    compute_capability = torch.cuda.get_device_capability(device)
+    if compute_capability not in SUPPORTED_FLASH_KDA_DECODE_ARCHS:
+        raise RuntimeError(
+            "this benchmark requires exact CC 10.0 (SM100a; B200/GB200) "
+            "or CC 10.3 (SM103a; B300/GB300), got "
+            f"CC {compute_capability[0]}.{compute_capability[1]}"
+        )
     device_properties = torch.cuda.get_device_properties(device)
+    cuda_arch = SUPPORTED_FLASH_KDA_DECODE_ARCHS[compute_capability]
+    print(
+        f"Hardware: {device_properties.name} CC {compute_capability[0]}."
+        f"{compute_capability[1]} ({cuda_arch})"
+    )
 
     rows = []
     best_by_t_n = []
@@ -493,8 +525,9 @@ def main() -> None:
             )
 
             case_rows = []
-            for value_split in VALUE_SPLITS:
-                variant = _variant_name(num_tokens, value_split)
+            for variant_spec in _variant_specs_for_tokens(num_tokens):
+                value_split = variant_spec["value_split"]
+                variant = variant_spec["variant"]
                 correctness = _check_correctness(
                     case,
                     initial_state=initial_state,
@@ -520,6 +553,7 @@ def main() -> None:
                     "HV": case["HV"],
                     "api_mode": case["api_mode"],
                     "gate_mode": case["gate_mode"],
+                    "schedule_kind": variant_spec["schedule_kind"],
                     "value_split": value_split,
                     "variant": variant,
                     "correctness": correctness,
@@ -550,6 +584,7 @@ def main() -> None:
                 "HV": NUM_VALUE_HEADS,
                 "api_mode": case["api_mode"],
                 "gate_mode": case["gate_mode"],
+                "best_schedule_kind": best_row["schedule_kind"],
                 "best_value_split": best_row["value_split"],
                 "best_variant": best_row["variant"],
                 "cute_dsl_median_ms": best_row["cute_dsl"]["median_ms"],
@@ -568,8 +603,12 @@ def main() -> None:
         "source_root": str(args.expected_source_root.resolve()),
         "flashinfer_version": flashinfer.__version__,
         "device": device_properties.name,
-        "compute_capability": list(torch.cuda.get_device_capability(device)),
+        "compute_capability": list(compute_capability),
+        "cuda_arch": cuda_arch,
         "sm_count": device_properties.multi_processor_count,
+        "total_memory_bytes": device_properties.total_memory,
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
         "timing_backend": "CUPTI",
         "cupti_python_version": cupti_python_version,
         "matrix": {
@@ -579,6 +618,10 @@ def main() -> None:
             "H": NUM_HEADS,
             "HV": NUM_VALUE_HEADS,
             "value_splits": list(VALUE_SPLITS),
+            "variants_by_t": {
+                str(num_tokens): list(_variant_specs_for_tokens(num_tokens))
+                for num_tokens in TOKEN_COUNTS
+            },
             "gate_mode": "precomputed",
             "t1_api_mode": "standard_decode",
             "other_api_mode": "packed_spec_decode",

--- a/csrc/kda/flashkda_decode_binding_common.cuh
+++ b/csrc/kda/flashkda_decode_binding_common.cuh
@@ -62,17 +62,38 @@ inline void CheckCuda(cudaError_t status, const char* operation) {
   TVM_FFI_ICHECK(status == cudaSuccess) << operation << " failed: " << cudaGetErrorString(status);
 }
 
-inline void CheckExactSm100a(int32_t device_id) {
+#ifndef FLASHINFER_FLASH_KDA_DECODE_TARGET_KIND
+#error "FLASHINFER_FLASH_KDA_DECODE_TARGET_KIND must be defined by the JIT/AOT spec"
+#endif
+
+constexpr int kFlashKDADecodeTargetKind = FLASHINFER_FLASH_KDA_DECODE_TARGET_KIND;
+constexpr int kFlashKDADecodeFamilyTarget = 100;
+constexpr int kFlashKDADecodeExactSM100aTarget = 1000;
+constexpr int kFlashKDADecodeExactSM103aTarget = 1003;
+static_assert(kFlashKDADecodeTargetKind == kFlashKDADecodeFamilyTarget ||
+                  kFlashKDADecodeTargetKind == kFlashKDADecodeExactSM100aTarget ||
+                  kFlashKDADecodeTargetKind == kFlashKDADecodeExactSM103aTarget,
+              "FlashKDA decode target must be SM100f, exact SM100a, or exact SM103a");
+
+inline void CheckFlashKDADecodeTarget(int32_t device_id) {
   int major = 0;
   int minor = 0;
   CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id),
             "cudaDeviceGetAttribute(major)");
   CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
             "cudaDeviceGetAttribute(minor)");
-  TVM_FFI_ICHECK(major == 10 && minor == 0)
-      << "frozen FlashKDA decode kernels require exact compute capability 10.0 "
-         "(sm_100a), got "
-      << major << "." << minor;
+  if (kFlashKDADecodeTargetKind == kFlashKDADecodeFamilyTarget) {
+    TVM_FFI_ICHECK(major == 10 && (minor == 0 || minor == 3))
+        << "this frozen FlashKDA decode module was compiled for the SM100 family "
+           "(compute capability 10.0 or 10.3), got "
+        << major << "." << minor;
+    return;
+  }
+
+  const int expected_minor = kFlashKDADecodeTargetKind == kFlashKDADecodeExactSM100aTarget ? 0 : 3;
+  TVM_FFI_ICHECK(major == 10 && minor == expected_minor)
+      << "this frozen FlashKDA decode module was compiled for exact compute capability 10."
+      << expected_minor << ", got " << major << "." << minor;
 }
 
 inline void CheckCudaTensor(const TensorView& tensor, const char* name, int32_t device_id) {
@@ -186,7 +207,7 @@ LaunchContext CheckInputs(const TensorView& q, const TensorView& k, const Tensor
   TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
   const int32_t device_id = q.device().device_id;
   ffi::CUDADeviceGuard device_guard(device_id);
-  CheckExactSm100a(device_id);
+  CheckFlashKDADecodeTarget(device_id);
 
   for (const auto& named :
        {std::pair<const TensorView*, const char*>(&q, "q"),

--- a/docs/api/kda_decode.rst
+++ b/docs/api/kda_decode.rst
@@ -10,9 +10,9 @@ The public ``recurrent_kda`` API supports standard decode with one token per
 sequence (``T=1``) and packed speculative decode with two or more tokens per
 sequence (``T>=2``).
 
-Pass ``backend="cake"`` to select the exported Cake backend. On exact SM100a
-devices, its D128 ``T=1..6`` family with in-kernel QK normalization exports 23
-frozen CUDA modules:
+Pass ``backend="cake"`` to select the exported Cake backend. On SM100-family
+SM100a (B200/GB200) and SM103a (B300/GB300) devices, its D128 ``T=1..6``
+family with in-kernel QK normalization exports 23 frozen CUDA bodies:
 
 * ``T=3`` with raw gates, ``use_gate_in_kernel=True``, a negative
   ``lower_bound``, float32 ``A_log`` and ``dt_bias``, ``H=HV=16``, and
@@ -26,13 +26,36 @@ frozen CUDA modules:
   explicit ``T=1`` ``cu_seqlens`` metadata is outside the Cake contract.
 
 Let ``W=N*HV`` be the active sequence/value-head work and ``S`` the device SM
-count. The Cake dispatcher selects the direct split-16 schedule for T1 when
-``W<=2S`` and the direct split-8 schedule otherwise. It selects split 4 for
-T2, split 4 for the exact T3 lower-bound contract, and split 2 for T4. The
-T5/T6 coefficient-Gram schedules reproduce Cake's CTA-wave policy: split 8
-for ``W<=3S/8``, split 2 for ``3S/8<W<=S/2``, split 4 for
-``S/2<W<=3S/4``, split 2 for ``3S/4<W<=3S/2``, and split 1 above that
-range.
+count. SM100a retains the B200-measured policy: direct split 16 for T1 when
+``W<=2S`` and direct split 8 otherwise; split 4 for T2; split 2 for T4; and
+the T5/T6 CTA-wave policy of split 8 for ``W<=3S/8``, split 2 for
+``3S/8<W<=S/2``, split 4 for ``S/2<W<=3S/4``, split 2 for
+``3S/4<W<=3S/2``, and split 1 above that range.
+
+SM103a uses its separately measured GB300 policy. T1 selects direct split 16
+through a conservative ``W<=32S`` extrapolation guard (measured through
+``W/S=26.95``), and direct split 8 beyond it. T2 selects split 8 through
+``W<=S/2`` and split 4 above it. T4 selects split 8 through ``W<=S/2``, split
+4 through ``W<=S``, split 2 through ``W<=3S/2``, split 1 through ``W<=2S``,
+and split 2 above it. T5 keeps the SM100a CTA-wave policy except for a measured
+split-1 island at ``3S/4<W<=S``. T6 selects split 8 through ``W<=3S/8``, split
+2 through ``W<=S/2``, and split 1 above it. T3 uses its sole exact lower-bound
+split-4 specialization on both architectures.
+
+With CUDA 12.9 or newer, JIT and AOT compile all 23 checked-in bodies once for
+the ``sm_100f`` family target. The family module URI and cubin artifact can run
+on both CC 10.0 and CC 10.3; build workspaces may still materialize separate
+cache directories for their local architecture context. Runtime split
+selection remains device-specific. A cold-L2 CUPTI A/B against exact-target
+cubins measured no aggregate change on B200 (``1.0000x`` exact/family) and
+``0.9987x`` on GB300. The GB300 direct-T1 path was the repeatable exception
+(``0.9790x``), so its two public direct variants retain exact ``sm_103a``
+cubins while every other GB300 route uses ``sm_100f``.
+
+CUDA 12.8 cannot compile ``sm_100f``. On B200 it therefore retains exact
+``sm_100a`` modules for all 23 bodies. SM103a requires CUDA 12.9 or newer.
+Every binding validates its family or exact-device contract before launch, and
+the frozen generated body bytes are identical across all physical targets.
 
 Once ``backend="cake"`` is selected, every supported call launches exactly one
 exported Cake kernel. An unsupported architecture, shape, gate mode, layout,

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -67,6 +67,7 @@ from .jit.flash_kda import (
     gen_flash_kda_m128_module,
 )
 from .jit.flash_kda_decode import (
+    FLASH_KDA_DECODE_DIRECT_VARIANTS,
     FLASH_KDA_DECODE_VARIANTS,
     gen_flash_kda_decode_module,
 )
@@ -508,12 +509,18 @@ def gen_all_modules(
     has_sm80 = sm_capabilities.get("sm80", False)
     has_sm90 = sm_capabilities.get("sm90", False)
     has_sm100 = sm_capabilities.get("sm100", False)
-    has_sm100a_exact = sm_capabilities.get("sm100a_exact", False)
     has_flash_kda_prefill_sm100a = sm_capabilities.get(
         "flash_kda_prefill_sm100a", False
     )
     has_flash_kda_prefill_sm100f = sm_capabilities.get(
         "flash_kda_prefill_sm100f", False
+    )
+    has_flash_kda_decode_sm100a_legacy = sm_capabilities.get(
+        "flash_kda_decode_sm100a_legacy", False
+    )
+    has_flash_kda_decode_sm100f = sm_capabilities.get("flash_kda_decode_sm100f", False)
+    has_flash_kda_decode_sm103a_direct = sm_capabilities.get(
+        "flash_kda_decode_sm103a_direct", False
     )
     has_sm100f = sm_capabilities.get("sm100f", False)
     has_sm103 = sm_capabilities.get("sm103", False)
@@ -554,11 +561,26 @@ def gen_all_modules(
                     gen_flash_kda_m128_module(flash_kda_target),
                 ]
             )
-    if has_sm100a_exact:
-        # The decode export is validated and packaged for exact SM100a.
+
+    # CUDA 12.8 predates the SM100-family target, so B200 keeps one exact
+    # SM100a module for every frozen body. CUDA 12.9+ builds the 23-body
+    # family portfolio once for both CC 10.0 and CC 10.3. GB300 additionally
+    # retains only the two exact-SM103a direct-T1 modules whose family-target
+    # latency regressed in the measured A/B.
+    if has_flash_kda_decode_sm100a_legacy:
         jit_specs.extend(
-            gen_flash_kda_decode_module(variant)
+            gen_flash_kda_decode_module(variant, "sm100a")
             for variant in FLASH_KDA_DECODE_VARIANTS
+        )
+    if has_flash_kda_decode_sm100f:
+        jit_specs.extend(
+            gen_flash_kda_decode_module(variant, "sm100f")
+            for variant in FLASH_KDA_DECODE_VARIANTS
+        )
+    if has_flash_kda_decode_sm103a_direct:
+        jit_specs.extend(
+            gen_flash_kda_decode_module(variant, "sm103a")
+            for variant in FLASH_KDA_DECODE_DIRECT_VARIANTS
         )
 
     if add_act:
@@ -1009,6 +1031,13 @@ def detect_sm_capabilities():
         (10, "3a"),
         (10, "3f"),
     }
+    flash_kda_decode_family_arches = {
+        (10, "0a"),
+        (10, "0f"),
+        (10, "3a"),
+        (10, "3f"),
+    }
+    flash_kda_decode_sm103_arches = {(10, "3a"), (10, "3f")}
     return {
         "sm80": has_any_sm8x and cuda_version >= Version("11.0"),
         "sm90": has_sm("compute_90", "12.3"),
@@ -1026,7 +1055,21 @@ def detect_sm_capabilities():
             and cuda_version >= Version("12.9")
         ),
         "sm100f": has_sm("compute_100", "12.9"),
+        "flash_kda_decode_sm100a_legacy": (
+            (10, "0a") in compilation_context.TARGET_CUDA_ARCHS
+            and Version("12.8") <= cuda_version < Version("12.9")
+        ),
+        "flash_kda_decode_sm100f": bool(
+            flash_kda_decode_family_arches & compilation_context.TARGET_CUDA_ARCHS
+        )
+        and cuda_version >= Version("12.9"),
+        "flash_kda_decode_sm103a_direct": bool(
+            flash_kda_decode_sm103_arches & compilation_context.TARGET_CUDA_ARCHS
+        )
+        and cuda_version >= Version("12.9"),
         "sm103": has_sm("compute_103", "12.9"),
+        "sm103a_exact": (10, "3a") in compilation_context.TARGET_CUDA_ARCHS
+        and cuda_version >= Version("12.9"),
         "sm107": has_sm("compute_107", "12.9"),
         "sm110": has_sm("compute_110", "13.0"),
         "sm120": has_sm("compute_120", "12.8"),

--- a/flashinfer/jit/flash_kda_decode.py
+++ b/flashinfer/jit/flash_kda_decode.py
@@ -19,7 +19,14 @@ from pathlib import Path
 from typing import Literal, NamedTuple
 
 from . import env as jit_env
-from .core import JitSpec, gen_jit_spec, logger, sm100a_nvcc_flags
+from .core import (
+    JitSpec,
+    gen_jit_spec,
+    logger,
+    sm100a_nvcc_flags,
+    sm100f_nvcc_flags,
+    sm103a_nvcc_flags,
+)
 from .utils import write_if_different
 
 FlashKDADecodeVariant = Literal[
@@ -47,7 +54,23 @@ FlashKDADecodeVariant = Literal[
     "d128_t6_precomputed_gram_split4",
     "d128_t6_precomputed_gram_split8",
 ]
+FlashKDADecodeTarget = Literal["sm100a", "sm100f", "sm103a"]
 
+_FLASH_KDA_DECODE_NVCC_FLAGS = {
+    "sm100a": sm100a_nvcc_flags,
+    "sm100f": sm100f_nvcc_flags,
+    "sm103a": sm103a_nvcc_flags,
+}
+
+# The binding uses one numeric target kind to enforce the same execution
+# boundary for JIT and AOT modules. 100 is the CC 10.0/10.3 family target;
+# 1000 and 1003 are exact CC targets used by the CUDA-12.8 compatibility path
+# and the two GB300 direct-T1 performance specializations, respectively.
+_FLASH_KDA_DECODE_TARGET_KIND = {
+    "sm100f": 100,
+    "sm100a": 1000,
+    "sm103a": 1003,
+}
 FLASH_KDA_DECODE_VARIANTS: tuple[FlashKDADecodeVariant, ...] = (
     "d128_t1_precomputed_split1",
     "d128_t1_precomputed_split2",
@@ -72,6 +95,11 @@ FLASH_KDA_DECODE_VARIANTS: tuple[FlashKDADecodeVariant, ...] = (
     "d128_t6_precomputed_gram_split2",
     "d128_t6_precomputed_gram_split4",
     "d128_t6_precomputed_gram_split8",
+)
+
+FLASH_KDA_DECODE_DIRECT_VARIANTS: tuple[FlashKDADecodeVariant, ...] = (
+    "d128_t1_precomputed_direct_split16",
+    "d128_t1_precomputed_direct_split8",
 )
 
 
@@ -173,12 +201,21 @@ def _get_include_dir() -> Path:
     )
 
 
-def get_flash_kda_decode_uri(variant: FlashKDADecodeVariant) -> str:
-    """Return the stable JIT/AOT cache key for one physical decode schedule."""
+def get_flash_kda_decode_uri(
+    variant: FlashKDADecodeVariant, target: FlashKDADecodeTarget
+) -> str:
+    """Return the physical-target JIT/AOT key for one decode schedule."""
 
     if variant not in FLASH_KDA_DECODE_VARIANTS:
         raise ValueError(f"unsupported FlashKDA decode variant: {variant}")
-    return f"flash_kda_decode_{variant}_sm100a"
+    if target not in _FLASH_KDA_DECODE_NVCC_FLAGS:
+        raise ValueError(f"unsupported FlashKDA decode target: {target}")
+    if target == "sm103a" and variant not in FLASH_KDA_DECODE_DIRECT_VARIANTS:
+        raise ValueError(
+            "exact SM103a FlashKDA decode modules are only retained for "
+            f"direct T=1 variants, got {variant}"
+        )
+    return f"flash_kda_decode_{variant}_{target}"
 
 
 def _get_binding_cu(
@@ -221,8 +258,16 @@ def _get_binding_cu(
 
 
 @functools.cache
-def gen_flash_kda_decode_module(variant: FlashKDADecodeVariant) -> JitSpec:
-    """Generate one exact-sm_100a frozen FlashKDA decode module."""
+def gen_flash_kda_decode_module(
+    variant: FlashKDADecodeVariant, target: FlashKDADecodeTarget
+) -> JitSpec:
+    """Generate one family or exact-target frozen decode module.
+
+    ``sm100f`` is the normal CUDA-12.9+ target for both CC 10.0 and CC 10.3.
+    ``sm100a`` preserves CUDA-12.8 B200 support, while ``sm103a`` is limited to
+    the two direct T=1 bodies whose family-target code showed a measurable
+    GB300 latency regression.
+    """
 
     csrc_dir = _get_csrc_dir()
     body = csrc_dir / f"flashkda_decode_{variant}.cu"
@@ -235,42 +280,55 @@ def gen_flash_kda_decode_module(variant: FlashKDADecodeVariant) -> JitSpec:
         )
 
     metadata = FLASH_KDA_DECODE_VARIANT_METADATA[variant]
-    uri = get_flash_kda_decode_uri(variant)
+    uri = get_flash_kda_decode_uri(variant, target)
     binding = jit_env.FLASHINFER_GEN_SRC_DIR / uri / "flashkda_decode_binding.cu"
     write_if_different(binding, _get_binding_cu(variant, metadata))
 
     spec = gen_jit_spec(
         name=uri,
         sources=[binding],
-        extra_cuda_cflags=[*sm100a_nvcc_flags, "--maxrregcount=128"],
+        extra_cuda_cflags=[
+            *_FLASH_KDA_DECODE_NVCC_FLAGS[target],
+            (
+                "-DFLASHINFER_FLASH_KDA_DECODE_TARGET_KIND="
+                f"{_FLASH_KDA_DECODE_TARGET_KIND[target]}"
+            ),
+            "--maxrregcount=128",
+        ],
         extra_include_paths=[
             csrc_dir,
             csrc_dir.parent,
             _get_include_dir(),
         ],
     )
-    logger.info(f"Generated FlashKDA decode {variant} JIT spec: {spec.name}")
+    logger.info(f"Generated FlashKDA decode {variant} {target} JIT spec: {spec.name}")
     return spec
 
 
 @functools.cache
-def load_flash_kda_decode_module(variant: FlashKDADecodeVariant):
-    """Build or load one physical FlashKDA decode module."""
+def load_flash_kda_decode_module(
+    variant: FlashKDADecodeVariant, target: FlashKDADecodeTarget
+):
+    """Build or load one physical-target decode module."""
 
-    module = gen_flash_kda_decode_module(variant).build_and_load()
-    logger.info(f"Loaded FlashKDA decode {variant} module")
+    module = gen_flash_kda_decode_module(variant, target).build_and_load()
+    logger.info(f"Loaded FlashKDA decode {variant} {target} module")
     return module
 
 
-def get_flash_kda_decode_module(variant: FlashKDADecodeVariant):
+def get_flash_kda_decode_module(
+    variant: FlashKDADecodeVariant, target: FlashKDADecodeTarget
+):
     """Return the loaded module used by the recurrent-KDA dispatcher."""
 
-    return load_flash_kda_decode_module(variant)
+    return load_flash_kda_decode_module(variant, target)
 
 
 __all__ = [
+    "FLASH_KDA_DECODE_DIRECT_VARIANTS",
     "FLASH_KDA_DECODE_VARIANT_METADATA",
     "FLASH_KDA_DECODE_VARIANTS",
+    "FlashKDADecodeTarget",
     "FlashKDADecodeVariant",
     "FlashKDADecodeVariantMetadata",
     "gen_flash_kda_decode_module",

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -49,10 +49,22 @@ from cutlass.utils import SmemAllocator
 import tvm_ffi  # noqa: F401 -- TVM FFI required for zero-overhead kernel dispatch
 
 from ..jit.flash_kda_decode import (
+    FLASH_KDA_DECODE_DIRECT_VARIANTS,
+    FlashKDADecodeTarget,
     FlashKDADecodeVariant,
     get_flash_kda_decode_module,
 )
+from ..jit.cpp_ext import is_cuda_version_at_least
 from ..utils import get_compute_capability
+
+FlashKDADecodeDeviceArch = Literal["sm100a", "sm103a"]
+
+_FLASH_KDA_DECODE_ARCH_BY_COMPUTE_CAPABILITY: dict[
+    tuple[int, int], FlashKDADecodeDeviceArch
+] = {
+    (10, 0): "sm100a",
+    (10, 3): "sm103a",
+}
 
 # ==============================================================================
 # CONSTANTS
@@ -1155,10 +1167,10 @@ def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
     return lhs_begin < rhs_end and rhs_begin < lhs_end
 
 
-def _select_flash_kda_decode_value_split(
+def _select_flash_kda_decode_value_split_current(
     num_tokens: int, work: int, sm_count: int
 ) -> int:
-    """Select the measured public-export route across frozen value-row splits."""
+    """Apply the B200-measured public-export split policy."""
 
     if num_tokens == 1:
         return 16 if work <= 2 * sm_count else 8
@@ -1178,6 +1190,63 @@ def _select_flash_kda_decode_value_split(
             return 2
         return 1
     raise ValueError(f"unsupported precomputed token count: {num_tokens}")
+
+
+def _select_flash_kda_decode_value_split_sm103a(
+    num_tokens: int, work: int, sm_count: int
+) -> int:
+    """Apply the GB300-measured public-export split policy."""
+
+    if num_tokens == 1:
+        # Direct split16 won every measured point through W/S=26.95. Keep the
+        # next natural wave boundary as a conservative extrapolation guard.
+        return 16 if work <= 32 * sm_count else 8
+    if num_tokens == 2:
+        return 8 if 2 * work <= sm_count else 4
+    if num_tokens == 4:
+        if 2 * work <= sm_count:
+            return 8
+        if work <= sm_count:
+            return 4
+        if 2 * work <= 3 * sm_count:
+            return 2
+        if work <= 2 * sm_count:
+            return 1
+        return 2
+    if num_tokens == 5:
+        if 4 * work > 3 * sm_count and work <= sm_count:
+            return 1
+        return _select_flash_kda_decode_value_split_current(num_tokens, work, sm_count)
+    if num_tokens == 6:
+        if 8 * work <= 3 * sm_count:
+            return 8
+        if 2 * work <= sm_count:
+            return 2
+        return 1
+    raise ValueError(f"unsupported precomputed token count: {num_tokens}")
+
+
+_FLASH_KDA_DECODE_VALUE_SPLIT_SELECTOR_BY_ARCH: dict[
+    FlashKDADecodeDeviceArch, Callable[[int, int, int], int]
+] = {
+    "sm100a": _select_flash_kda_decode_value_split_current,
+    "sm103a": _select_flash_kda_decode_value_split_sm103a,
+}
+
+
+def _select_flash_kda_decode_value_split(
+    num_tokens: int,
+    work: int,
+    sm_count: int,
+    arch: FlashKDADecodeDeviceArch = "sm100a",
+) -> int:
+    """Select a frozen value-row split using the target architecture policy."""
+
+    try:
+        selector = _FLASH_KDA_DECODE_VALUE_SPLIT_SELECTOR_BY_ARCH[arch]
+    except KeyError as error:
+        raise ValueError(f"unsupported FlashKDA decode architecture: {arch}") from error
+    return selector(num_tokens, work, sm_count)
 
 
 def _select_flash_kda_decode_variant(
@@ -1203,7 +1272,7 @@ def _select_flash_kda_decode_variant(
     initial_state_source: Optional[torch.Tensor],
     beta_is_logit: bool,
 ) -> Optional[FlashKDADecodeVariant]:
-    """Select a frozen B200 decode schedule for the strict Cake contract.
+    """Select a frozen SM100-family schedule for the strict Cake contract.
 
     The exported family covers D128/T=1..6. T=3 preserves its measured
     lower-bound contract; T=1/2/4/5/6 use precomputed gates, with T1 routed to
@@ -1234,10 +1303,15 @@ def _select_flash_kda_decode_variant(
         and A_log is None
         and dt_bias is None
     )
+    if not q.is_cuda:
+        return None
+    arch = _FLASH_KDA_DECODE_ARCH_BY_COMPUTE_CAPABILITY.get(
+        get_compute_capability(q.device)
+    )
+    if arch is None:
+        return None
     if (
-        not q.is_cuda
-        or get_compute_capability(q.device) != (10, 0)
-        or not (is_t3_lower_bound or is_precomputed)
+        not (is_t3_lower_bound or is_precomputed)
         or cu_seqlens is None
         or ssm_state_indices is None
         or initial_state_source is not None
@@ -1365,7 +1439,7 @@ def _select_flash_kda_decode_variant(
 
     work = num_sequences * num_value_heads
     sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
-    value_split = _select_flash_kda_decode_value_split(num_tokens, work, sm_count)
+    value_split = _select_flash_kda_decode_value_split(num_tokens, work, sm_count, arch)
     if num_tokens == 1:
         return cast(
             FlashKDADecodeVariant,
@@ -1404,7 +1478,31 @@ def _run_flash_kda_decode(
 ) -> None:
     """Launch one frozen decode specialization on the current CUDA stream."""
 
-    module = get_flash_kda_decode_module(variant)
+    compute_capability = get_compute_capability(q.device)
+    if compute_capability not in _FLASH_KDA_DECODE_ARCH_BY_COMPUTE_CAPABILITY:
+        raise RuntimeError(
+            "frozen recurrent-KDA decode requires exact compute capability "
+            "10.0 (SM100a) or 10.3 (SM103a); got "
+            f"{compute_capability[0]}.{compute_capability[1]}"
+        )
+    if compute_capability == (10, 0):
+        if is_cuda_version_at_least("12.9"):
+            target: FlashKDADecodeTarget = "sm100f"
+        elif is_cuda_version_at_least("12.8"):
+            target = "sm100a"
+        else:
+            raise RuntimeError(
+                "frozen recurrent-KDA decode on compute capability 10.0 "
+                "requires CUDA 12.8 or newer"
+            )
+    else:
+        if not is_cuda_version_at_least("12.9"):
+            raise RuntimeError(
+                "frozen recurrent-KDA decode on compute capability 10.3 "
+                "requires CUDA 12.9 or newer"
+            )
+        target = "sm103a" if variant in FLASH_KDA_DECODE_DIRECT_VARIANTS else "sm100f"
+    module = get_flash_kda_decode_module(variant, target)
     module.run(
         q,
         k,

--- a/tests/jit/test_flash_kda_decode_jit.py
+++ b/tests/jit/test_flash_kda_decode_jit.py
@@ -14,6 +14,7 @@
 
 import hashlib
 import re
+from types import SimpleNamespace
 
 import pytest
 from packaging.version import Version
@@ -124,6 +125,42 @@ _FROZEN_BODY_BEGIN = "// BEGIN FROZEN GENERATED BODY\n"
 _FROZEN_BODY_END = "// END FROZEN GENERATED BODY\n"
 _VOLATILE_TEMP = re.compile(r"\b_(bval|bits|addr)_([0-9]{6,})\b")
 
+_PHYSICAL_TARGET_CASES = [
+    *(
+        (
+            variant,
+            "sm100a",
+            (10, "0a"),
+            "-gencode=arch=compute_100a,code=sm_100a",
+            1000,
+        )
+        for variant in FROZEN_GENERATED_BODY_SHA256
+    ),
+    *(
+        (
+            variant,
+            "sm100f",
+            (10, "0f"),
+            "-gencode=arch=compute_100f,code=sm_100f",
+            100,
+        )
+        for variant in FROZEN_GENERATED_BODY_SHA256
+    ),
+    *(
+        (
+            variant,
+            "sm103a",
+            (10, "3a"),
+            "-gencode=arch=compute_103a,code=sm_103a",
+            1003,
+        )
+        for variant in (
+            "d128_t1_precomputed_direct_split16",
+            "d128_t1_precomputed_direct_split8",
+        )
+    ),
+]
+
 
 def _normalize_generated_body(source):
     source = source.replace("\r\n", "\n").replace("\r", "\n")
@@ -140,17 +177,23 @@ def _normalize_generated_body(source):
 
 
 @pytest.mark.parametrize(
-    ("variant", "body_hashes"),
-    FROZEN_GENERATED_BODY_SHA256.items(),
+    ("variant", "target", "target_arch", "expected_flag", "target_kind"),
+    _PHYSICAL_TARGET_CASES,
 )
 def test_flash_kda_decode_jit_spec_and_frozen_body(
-    monkeypatch, tmp_path, variant, body_hashes
+    monkeypatch,
+    tmp_path,
+    variant,
+    target,
+    target_arch,
+    expected_flag,
+    target_kind,
 ):
-    raw_sha256, normalized_sha256 = body_hashes
+    raw_sha256, normalized_sha256 = FROZEN_GENERATED_BODY_SHA256[variant]
     monkeypatch.setattr(
         jit_core.current_compilation_context,
         "TARGET_CUDA_ARCHS",
-        {(10, "0a")},
+        {target_arch},
     )
     monkeypatch.setattr(
         flash_kda_decode.jit_env,
@@ -159,21 +202,27 @@ def test_flash_kda_decode_jit_spec_and_frozen_body(
     )
     flash_kda_decode.gen_flash_kda_decode_module.cache_clear()
 
-    uri = flash_kda_decode.get_flash_kda_decode_uri(variant)
-    spec = flash_kda_decode.gen_flash_kda_decode_module(variant)
+    uri = flash_kda_decode.get_flash_kda_decode_uri(variant, target)
+    spec = flash_kda_decode.gen_flash_kda_decode_module(variant, target)
 
-    assert uri == f"flash_kda_decode_{variant}_sm100a"
+    assert uri == f"flash_kda_decode_{variant}_{target}"
     assert spec.name == uri
     assert len(spec.sources) == 1
     assert spec.sources[0] == tmp_path / uri / "flashkda_decode_binding.cu"
     assert spec.sources[0].is_file()
-    assert "-gencode=arch=compute_100a,code=sm_100a" in spec.extra_cuda_cflags
+    assert expected_flag in spec.extra_cuda_cflags
+    target_defines = [
+        flag
+        for flag in spec.extra_cuda_cflags
+        if flag.startswith("-DFLASHINFER_FLASH_KDA_DECODE_TARGET_KIND=")
+    ]
+    assert target_defines == [
+        f"-DFLASHINFER_FLASH_KDA_DECODE_TARGET_KIND={target_kind}"
+    ]
     assert "-use_fast_math" in spec.extra_cuda_cflags
     assert "--maxrregcount=128" in spec.extra_cuda_cflags
-    assert not any(
-        "compute_103" in flag or "compute_120" in flag
-        for flag in spec.extra_cuda_cflags
-    )
+    assert sum("-gencode=arch=compute_" in flag for flag in spec.extra_cuda_cflags) == 1
+    assert not any("compute_120" in flag for flag in spec.extra_cuda_cflags)
 
     frozen_source = flash_kda_decode._get_csrc_dir() / f"flashkda_decode_{variant}.cu"
     frozen_text = frozen_source.read_text()
@@ -236,6 +285,7 @@ def test_flash_kda_decode_jit_spec_and_frozen_body(
         "#define FLASHKDA_DECODE_DIRECT_IMPL 1" in binding_text
     ) is metadata.direct_impl
     assert '#include "flashkda_decode_binding.cuh"' in binding_text
+    flash_kda_decode.gen_flash_kda_decode_module.cache_clear()
 
 
 def test_flash_kda_decode_binding_contract():
@@ -249,7 +299,13 @@ def test_flash_kda_decode_binding_contract():
     assert "#include FLASHKDA_DECODE_BODY_FILE" in binding
     assert "#ifdef FLASHKDA_DECODE_DIRECT_IMPL" in binding
     assert '#include "flashkda_decode_binding_direct_impl.cuh"' in binding
-    assert "CheckExactSm100a" in common
+    assert "#ifndef FLASHINFER_FLASH_KDA_DECODE_TARGET_KIND" in common
+    assert "kFlashKDADecodeTargetKind == kFlashKDADecodeFamilyTarget" in common
+    assert "kFlashKDADecodeTargetKind == kFlashKDADecodeExactSM100aTarget" in common
+    assert "kFlashKDADecodeTargetKind == kFlashKDADecodeExactSM103aTarget" in common
+    assert "major == 10 && (minor == 0 || minor == 3)" in common
+    assert "major == 10 && minor == expected_minor" in common
+    assert "CheckFlashKDADecodeTarget(device_id)" in common
     assert "struct VariantTraits" in common
     assert "static_assert(Tokens >= 1)" in common
     assert "ValueSplit == 16" in common
@@ -331,16 +387,18 @@ def test_flash_kda_decode_variant_validation_and_getter(monkeypatch):
         "d128_t6_precomputed_gram_split4": 192,
         "d128_t6_precomputed_gram_split8": 192,
     }
-    assert {
+    direct_variants = {
         variant
         for variant, metadata in (
             flash_kda_decode.FLASH_KDA_DECODE_VARIANT_METADATA.items()
         )
         if metadata.direct_impl
-    } == {
+    }
+    assert direct_variants == {
         "d128_t1_precomputed_direct_split16",
         "d128_t1_precomputed_direct_split8",
     }
+    assert set(flash_kda_decode.FLASH_KDA_DECODE_DIRECT_VARIANTS) == direct_variants
     for removed_variant in (
         "d128_t4_precomputed",
         "d128_t5_precomputed",
@@ -348,31 +406,81 @@ def test_flash_kda_decode_variant_validation_and_getter(monkeypatch):
         "d128_t5_precomputed_gram_split3",
     ):
         with pytest.raises(ValueError, match="unsupported FlashKDA decode variant"):
-            flash_kda_decode.get_flash_kda_decode_uri(removed_variant)
-
+            flash_kda_decode.get_flash_kda_decode_uri(removed_variant, "sm100f")
+    with pytest.raises(ValueError, match="unsupported FlashKDA decode target"):
+        flash_kda_decode.get_flash_kda_decode_uri(expected_variants[0], "sm120a")
+    with pytest.raises(ValueError, match="only retained for direct T=1"):
+        flash_kda_decode.get_flash_kda_decode_uri(expected_variants[0], "sm103a")
     sentinel = object()
     monkeypatch.setattr(
         flash_kda_decode,
         "load_flash_kda_decode_module",
-        lambda variant: (sentinel, variant),
+        lambda variant, target: (sentinel, variant, target),
     )
     for variant in expected_variants:
-        assert flash_kda_decode.get_flash_kda_decode_module(variant) == (
+        assert flash_kda_decode.get_flash_kda_decode_module(variant, "sm100f") == (
             sentinel,
             variant,
+            "sm100f",
         )
 
 
+def test_flash_kda_decode_physical_targets_have_deliberate_cache_keys(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        jit_core.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(10, "0a"), (10, "3a")},
+    )
+    monkeypatch.setattr(
+        flash_kda_decode.jit_env,
+        "FLASHINFER_GEN_SRC_DIR",
+        tmp_path,
+    )
+    flash_kda_decode.gen_flash_kda_decode_module.cache_clear()
+
+    variant = flash_kda_decode.FLASH_KDA_DECODE_DIRECT_VARIANTS[0]
+    family = flash_kda_decode.gen_flash_kda_decode_module(variant, "sm100f")
+    cached_family = flash_kda_decode.gen_flash_kda_decode_module(variant, "sm100f")
+    legacy = flash_kda_decode.gen_flash_kda_decode_module(variant, "sm100a")
+    gb300_direct = flash_kda_decode.gen_flash_kda_decode_module(variant, "sm103a")
+
+    assert family is cached_family
+    assert len({family.name, legacy.name, gb300_direct.name}) == 3
+    assert family.name == f"flash_kda_decode_{variant}_sm100f"
+    assert legacy.name == f"flash_kda_decode_{variant}_sm100a"
+    assert gb300_direct.name == f"flash_kda_decode_{variant}_sm103a"
+    flash_kda_decode.gen_flash_kda_decode_module.cache_clear()
+
+
 @pytest.mark.parametrize(
-    ("target_archs", "expected_exact"),
+    (
+        "target_archs",
+        "cuda_version",
+        "expected_legacy",
+        "expected_family",
+        "expected_sm103_direct",
+    ),
     [
-        ({(10, "0a")}, True),
-        ({(10, "0f")}, False),
-        ({(10, "3a")}, False),
-        ({(12, "0f")}, False),
+        ({(10, "0a")}, "12.8", True, False, False),
+        ({(10, "0a")}, "12.9", False, True, False),
+        ({(10, "0f")}, "13.0", False, True, False),
+        ({(10, "3a")}, "12.8", False, False, False),
+        ({(10, "3a")}, "12.9", False, True, True),
+        ({(10, "3f")}, "13.0", False, True, True),
+        ({(10, "0a"), (10, "3a")}, "13.0", False, True, True),
+        ({(12, "0f")}, "13.0", False, False, False),
     ],
 )
-def test_aot_detects_only_exact_sm100a(monkeypatch, target_archs, expected_exact):
+def test_aot_detects_flash_kda_decode_physical_targets(
+    monkeypatch,
+    target_archs,
+    cuda_version,
+    expected_legacy,
+    expected_family,
+    expected_sm103_direct,
+):
     from flashinfer import aot
 
     class FakeCompilationContext:
@@ -386,5 +494,95 @@ def test_aot_detects_only_exact_sm100a(monkeypatch, target_archs, expected_exact
             ]
 
     monkeypatch.setattr(aot, "CompilationContext", FakeCompilationContext)
-    monkeypatch.setattr(aot, "get_cuda_version", lambda: Version("13.0"))
-    assert aot.detect_sm_capabilities()["sm100a_exact"] is expected_exact
+    monkeypatch.setattr(aot, "get_cuda_version", lambda: Version(cuda_version))
+    capabilities = aot.detect_sm_capabilities()
+    assert capabilities["flash_kda_decode_sm100a_legacy"] is expected_legacy
+    assert capabilities["flash_kda_decode_sm100f"] is expected_family
+    assert capabilities["flash_kda_decode_sm103a_direct"] is expected_sm103_direct
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected_targets"),
+    [
+        (
+            {"flash_kda_decode_sm100a_legacy": True},
+            [
+                (variant, "sm100a")
+                for variant in flash_kda_decode.FLASH_KDA_DECODE_VARIANTS
+            ],
+        ),
+        (
+            {"flash_kda_decode_sm100f": True},
+            [
+                (variant, "sm100f")
+                for variant in flash_kda_decode.FLASH_KDA_DECODE_VARIANTS
+            ],
+        ),
+        (
+            {
+                "flash_kda_decode_sm100f": True,
+                "flash_kda_decode_sm103a_direct": True,
+            },
+            [
+                *[
+                    (variant, "sm100f")
+                    for variant in flash_kda_decode.FLASH_KDA_DECODE_VARIANTS
+                ],
+                *[
+                    (variant, "sm103a")
+                    for variant in flash_kda_decode.FLASH_KDA_DECODE_DIRECT_VARIANTS
+                ],
+            ],
+        ),
+    ],
+)
+def test_aot_registers_flash_kda_decode_physical_portfolio(
+    monkeypatch, capabilities, expected_targets
+):
+    from flashinfer import aot
+
+    calls = []
+
+    def fake_flash_kda_decode(variant, target):
+        calls.append((variant, target))
+        return SimpleNamespace(name=f"flash_kda_decode_{variant}_{target}")
+
+    monkeypatch.setattr(
+        aot,
+        "gen_flash_kda_decode_module",
+        fake_flash_kda_decode,
+    )
+    monkeypatch.setattr(
+        aot, "gen_spdlog_module", lambda: SimpleNamespace(name="spdlog")
+    )
+    monkeypatch.setattr(aot, "gen_attention", lambda *args: ())
+    monkeypatch.setattr(
+        aot, "gen_cudnn_fmha_module", lambda: SimpleNamespace(name="cudnn")
+    )
+
+    specs = aot.gen_all_modules(
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        capabilities,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+
+    assert calls == expected_targets
+    assert [spec.name for spec in specs] == [
+        "spdlog",
+        *(
+            f"flash_kda_decode_{variant}_{target}"
+            for variant, target in expected_targets
+        ),
+        "cudnn",
+    ]

--- a/tests/kda/test_recurrent_kda_decode_export.py
+++ b/tests/kda/test_recurrent_kda_decode_export.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn.functional as F
+from packaging.version import Version
 
 from flashinfer.kda_decode import recurrent_kda
 
@@ -42,12 +43,15 @@ _PRECOMPUTED_VARIANT_PREFIXES = {
 
 
 @pytest.fixture
-def b200():
+def flash_kda_device():
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")
     device = torch.device("cuda")
-    if torch.cuda.get_device_capability(device) != (10, 0):
-        pytest.skip("frozen FlashKDA decode tests require exact B200 / sm_100a")
+    if torch.cuda.get_device_capability(device) not in ((10, 0), (10, 3)):
+        pytest.skip(
+            "frozen FlashKDA decode tests require exact CC 10.0 "
+            "(SM100a; B200/GB200) or CC 10.3 (SM103a; B300/GB300)"
+        )
     return device
 
 
@@ -338,8 +342,60 @@ def test_cake_value_split_boundaries(num_tokens, work, sm_count, expected_split)
     )
 
 
-def test_exact_cpu_contract_selects_frozen_variant(monkeypatch):
-    _patch_cpu_selector_environment(monkeypatch)
+@pytest.mark.parametrize(
+    ("num_tokens", "work", "sm_count", "expected_split"),
+    [
+        (1, 5120, 160, 16),
+        (1, 5121, 160, 8),
+        (2, 80, 160, 8),
+        (2, 81, 160, 4),
+        (4, 80, 160, 8),
+        (4, 81, 160, 4),
+        (4, 160, 160, 4),
+        (4, 161, 160, 2),
+        (5, 256, 160, 1),
+        (6, 60, 160, 8),
+        (6, 61, 160, 2),
+        (6, 80, 160, 2),
+        (6, 81, 160, 1),
+    ],
+)
+def test_sm103a_cake_value_split_boundaries(num_tokens, work, sm_count, expected_split):
+    assert (
+        recurrent_module._select_flash_kda_decode_value_split(
+            num_tokens, work, sm_count, "sm103a"
+        )
+        == expected_split
+    )
+
+
+def test_sm103a_split_policy_has_an_independent_retuning_hook(monkeypatch):
+    sentinel_calls = []
+
+    def sm103a_selector(num_tokens, work, sm_count):
+        sentinel_calls.append((num_tokens, work, sm_count))
+        return 8
+
+    monkeypatch.setitem(
+        recurrent_module._FLASH_KDA_DECODE_VALUE_SPLIT_SELECTOR_BY_ARCH,
+        "sm103a",
+        sm103a_selector,
+    )
+
+    assert (
+        recurrent_module._select_flash_kda_decode_value_split(5, 256, 160, "sm103a")
+        == 8
+    )
+    assert sentinel_calls == [(5, 256, 160)]
+    assert (
+        recurrent_module._select_flash_kda_decode_value_split(5, 256, 160, "sm100a")
+        == 1
+    )
+
+
+@pytest.mark.parametrize("cc", [(10, 0), (10, 3)])
+def test_exact_cpu_contract_selects_frozen_variant(monkeypatch, cc):
+    _patch_cpu_selector_environment(monkeypatch, cc=cc)
     assert recurrent_module._select_flash_kda_decode_variant(
         **_fake_selector_kwargs()
     ) == (_VARIANT_PREFIX + "1")
@@ -360,6 +416,40 @@ def test_precomputed_token_family_uses_tuned_export_dispatch(
     monkeypatch, num_tokens, num_sequences, expected_variant
 ):
     _patch_cpu_selector_environment(monkeypatch)
+    assert (
+        recurrent_module._select_flash_kda_decode_variant(
+            **_fake_precomputed_selector_kwargs(
+                num_tokens,
+                num_sequences=num_sequences,
+            )
+        )
+        == expected_variant
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "num_sequences", "expected_variant"),
+    [
+        (1, 16, _PRECOMPUTED_VARIANT_PREFIXES[1] + "16"),
+        (2, 2, _PRECOMPUTED_VARIANT_PREFIXES[2] + "8"),
+        (2, 3, _PRECOMPUTED_VARIANT_PREFIXES[2] + "4"),
+        (4, 2, _PRECOMPUTED_VARIANT_PREFIXES[4] + "8"),
+        (4, 3, _PRECOMPUTED_VARIANT_PREFIXES[4] + "4"),
+        (4, 7, _PRECOMPUTED_VARIANT_PREFIXES[4] + "2"),
+        (4, 8, _PRECOMPUTED_VARIANT_PREFIXES[4] + "1"),
+        (4, 16, _PRECOMPUTED_VARIANT_PREFIXES[4] + "2"),
+        (5, 3, _PRECOMPUTED_VARIANT_PREFIXES[5] + "4"),
+        (5, 4, _PRECOMPUTED_VARIANT_PREFIXES[5] + "1"),
+        (5, 5, _PRECOMPUTED_VARIANT_PREFIXES[5] + "2"),
+        (6, 1, _PRECOMPUTED_VARIANT_PREFIXES[6] + "8"),
+        (6, 2, _PRECOMPUTED_VARIANT_PREFIXES[6] + "2"),
+        (6, 3, _PRECOMPUTED_VARIANT_PREFIXES[6] + "1"),
+    ],
+)
+def test_sm103a_precomputed_token_family_uses_gb300_dispatch(
+    monkeypatch, num_tokens, num_sequences, expected_variant
+):
+    _patch_cpu_selector_environment(monkeypatch, sm_count=152, cc=(10, 3))
     assert (
         recurrent_module._select_flash_kda_decode_variant(
             **_fake_precomputed_selector_kwargs(
@@ -598,8 +688,9 @@ def test_tensor_layout_and_alias_mismatches_are_rejected_by_cake_selector_cpu(
     assert recurrent_module._select_flash_kda_decode_variant(**kwargs) is None
 
 
-def test_non_sm100a_is_rejected_by_cake_selector_cpu(monkeypatch):
-    _patch_cpu_selector_environment(monkeypatch, cc=(10, 3))
+@pytest.mark.parametrize("cc", [(10, 1), (12, 0)])
+def test_unsupported_arch_is_rejected_by_cake_selector_cpu(monkeypatch, cc):
+    _patch_cpu_selector_environment(monkeypatch, cc=cc)
     assert (
         recurrent_module._select_flash_kda_decode_variant(**_fake_selector_kwargs())
         is None
@@ -614,15 +705,40 @@ class _RecorderModule:
         self.calls.append(args)
 
 
-def test_frozen_runner_forwards_ffi_abi_and_current_stream_cpu(monkeypatch):
+@pytest.mark.parametrize(
+    ("cc", "cuda_version", "variant", "expected_target"),
+    [
+        ((10, 0), "12.8", _VARIANT_PREFIX + "4", "sm100a"),
+        (
+            (10, 0),
+            "12.8",
+            "d128_t1_precomputed_direct_split16",
+            "sm100a",
+        ),
+        ((10, 0), "12.9", _VARIANT_PREFIX + "4", "sm100f"),
+        ((10, 0), "13.0", "d128_t1_precomputed_direct_split16", "sm100f"),
+        ((10, 3), "12.9", _VARIANT_PREFIX + "4", "sm100f"),
+        ((10, 3), "12.9", "d128_t1_precomputed_direct_split16", "sm103a"),
+        ((10, 3), "13.0", "d128_t1_precomputed_direct_split8", "sm103a"),
+    ],
+)
+def test_frozen_runner_selects_physical_target_and_forwards_ffi_abi_cpu(
+    monkeypatch, cc, cuda_version, variant, expected_target
+):
     module = _RecorderModule()
     loaded = []
 
-    def get_module(variant):
-        loaded.append(variant)
+    def get_module(variant, target):
+        loaded.append((variant, target))
         return module
 
     monkeypatch.setattr(recurrent_module, "get_flash_kda_decode_module", get_module)
+    monkeypatch.setattr(recurrent_module, "get_compute_capability", lambda device: cc)
+    monkeypatch.setattr(
+        recurrent_module,
+        "is_cuda_version_at_least",
+        lambda version: Version(cuda_version) >= Version(version),
+    )
     monkeypatch.setattr(
         torch.cuda,
         "current_stream",
@@ -630,7 +746,6 @@ def test_frozen_runner_forwards_ffi_abi_and_current_stream_cpu(monkeypatch):
     )
     tensors = _fake_selector_kwargs()
     dummy_f32 = _fake_tensor((1,), torch.float32, 0x300000000000)
-    variant = _VARIANT_PREFIX + "4"
     recurrent_module._run_flash_kda_decode(
         variant,
         q=tensors["q"],
@@ -649,7 +764,7 @@ def test_frozen_runner_forwards_ffi_abi_and_current_stream_cpu(monkeypatch):
         lower_bound=0.0,
     )
 
-    assert loaded == [variant]
+    assert loaded == [(variant, expected_target)]
     (args,) = module.calls
     assert len(args) == 15
     assert args[:5] == (
@@ -672,12 +787,80 @@ def test_frozen_runner_forwards_ffi_abi_and_current_stream_cpu(monkeypatch):
     assert args[14] == 0xCAFE
 
 
+def test_frozen_runner_rejects_sm103a_before_cuda_12_9_cpu(monkeypatch):
+    monkeypatch.setattr(
+        recurrent_module, "get_compute_capability", lambda device: (10, 3)
+    )
+    monkeypatch.setattr(
+        recurrent_module, "is_cuda_version_at_least", lambda version: False
+    )
+    tensors = _fake_selector_kwargs()
+    dummy_f32 = _fake_tensor((1,), torch.float32, 0x300000000000)
+
+    with pytest.raises(RuntimeError, match="requires CUDA 12.9 or newer"):
+        recurrent_module._run_flash_kda_decode(
+            _VARIANT_PREFIX + "4",
+            q=tensors["q"],
+            k=tensors["k"],
+            v=tensors["v"],
+            g=tensors["g"],
+            beta=tensors["beta"],
+            state=tensors["state"],
+            out=tensors["out"],
+            cu_seqlens=tensors["cu_seqlens"],
+            ssm_state_indices=tensors["ssm_state_indices"],
+            num_accepted_tokens=tensors["num_accepted_tokens"],
+            scale=tensors["scale"],
+            A_log=dummy_f32,
+            dt_bias=dummy_f32,
+            lower_bound=0.0,
+        )
+
+
+def test_frozen_runner_rejects_sm100a_before_cuda_12_8_cpu(monkeypatch):
+    monkeypatch.setattr(
+        recurrent_module, "get_compute_capability", lambda device: (10, 0)
+    )
+    monkeypatch.setattr(
+        recurrent_module,
+        "is_cuda_version_at_least",
+        lambda version: Version("12.7") >= Version(version),
+    )
+    tensors = _fake_selector_kwargs()
+    dummy_f32 = _fake_tensor((1,), torch.float32, 0x300000000000)
+
+    with pytest.raises(RuntimeError, match="requires CUDA 12.8 or newer"):
+        recurrent_module._run_flash_kda_decode(
+            _VARIANT_PREFIX + "4",
+            q=tensors["q"],
+            k=tensors["k"],
+            v=tensors["v"],
+            g=tensors["g"],
+            beta=tensors["beta"],
+            state=tensors["state"],
+            out=tensors["out"],
+            cu_seqlens=tensors["cu_seqlens"],
+            ssm_state_indices=tensors["ssm_state_indices"],
+            num_accepted_tokens=tensors["num_accepted_tokens"],
+            scale=tensors["scale"],
+            A_log=dummy_f32,
+            dt_bias=dummy_f32,
+            lower_bound=0.0,
+        )
+
+
 def test_t3_frozen_runner_forwards_real_gate_parameters_cpu(monkeypatch):
     module = _RecorderModule()
     monkeypatch.setattr(
         recurrent_module,
         "get_flash_kda_decode_module",
-        lambda variant: module,
+        lambda variant, target: module,
+    )
+    monkeypatch.setattr(
+        recurrent_module, "get_compute_capability", lambda device: (10, 0)
+    )
+    monkeypatch.setattr(
+        recurrent_module, "is_cuda_version_at_least", lambda version: True
     )
     monkeypatch.setattr(
         torch.cuda,
@@ -1024,13 +1207,13 @@ def _clone_state_with_layout(state):
 
 @pytest.mark.parametrize("split", [8, 2, 4, 1])
 def test_public_recurrent_kda_forced_t5_splits_match_upstream_cute(
-    b200, monkeypatch, split
+    flash_kda_device, monkeypatch, split
 ):
     num_value_heads = 32
     num_sequences = 8
     variant = _VARIANT_PREFIX + str(split)
     case = _make_case(
-        b200,
+        flash_kda_device,
         num_sequences=num_sequences,
         num_heads=16,
         num_value_heads=num_value_heads,
@@ -1081,7 +1264,7 @@ def test_public_recurrent_kda_forced_t5_splits_match_upstream_cute(
     [(1, 8), (1, 16), (2, 8), (4, 8), (5, 8), (6, 8)],
 )
 def test_public_recurrent_kda_precomputed_matrix_matches_cute_dsl(
-    b200, monkeypatch, num_tokens, num_sequences
+    flash_kda_device, monkeypatch, num_tokens, num_sequences
 ):
     accepted_tokens = (
         None
@@ -1098,7 +1281,7 @@ def test_public_recurrent_kda_precomputed_matrix_matches_cute_dsl(
         ]
     )
     case = _make_case(
-        b200,
+        flash_kda_device,
         num_sequences=num_sequences,
         num_heads=16,
         num_value_heads=32,
@@ -1151,10 +1334,14 @@ def test_public_recurrent_kda_precomputed_matrix_matches_cute_dsl(
         backend="cake",
     )
 
-    expected_split = (
-        (16 if num_sequences == 8 else 8)
-        if num_tokens == 1
-        else {2: 4, 4: 2, 5: 1, 6: 1}[num_tokens]
+    arch = recurrent_module._FLASH_KDA_DECODE_ARCH_BY_COMPUTE_CAPABILITY[
+        torch.cuda.get_device_capability(flash_kda_device)
+    ]
+    expected_split = recurrent_module._select_flash_kda_decode_value_split(
+        num_tokens,
+        num_sequences * 32,
+        torch.cuda.get_device_properties(flash_kda_device).multi_processor_count,
+        arch,
     )
     expected_variant = _PRECOMPUTED_VARIANT_PREFIXES[num_tokens] + str(expected_split)
     assert frozen_calls == [expected_variant]
@@ -1217,10 +1404,10 @@ def test_public_recurrent_kda_precomputed_matrix_matches_cute_dsl(
 
 
 def test_cake_backend_rejects_unexported_precomputed_t3_without_entering_cute_dsl(
-    b200, monkeypatch
+    flash_kda_device, monkeypatch
 ):
     case = _make_case(
-        b200,
+        flash_kda_device,
         num_sequences=4,
         num_heads=16,
         num_value_heads=32,
@@ -1254,11 +1441,11 @@ def test_cake_backend_rejects_unexported_precomputed_t3_without_entering_cute_ds
 
 
 def test_cake_backend_rejects_explicit_t1_cu_seqlens_without_launching(
-    b200, monkeypatch
+    flash_kda_device, monkeypatch
 ):
     num_sequences = 2
     case = _make_case(
-        b200,
+        flash_kda_device,
         num_sequences=num_sequences,
         num_heads=16,
         num_value_heads=32,
@@ -1268,9 +1455,11 @@ def test_cake_backend_rejects_explicit_t1_cu_seqlens_without_launching(
     for name in ("q", "k", "v", "g", "beta", "output"):
         tensor = case[name]
         case[name] = tensor.reshape(1, num_sequences, *tensor.shape[2:])
-    case["cu_seqlens"] = torch.arange(num_sequences + 1, dtype=torch.int32, device=b200)
+    case["cu_seqlens"] = torch.arange(
+        num_sequences + 1, dtype=torch.int32, device=flash_kda_device
+    )
     case["ssm_state_indices"] = torch.arange(
-        num_sequences, dtype=torch.int32, device=b200
+        num_sequences, dtype=torch.int32, device=flash_kda_device
     )
 
     def unexpected_launch(*args, **kwargs):
@@ -1298,35 +1487,46 @@ def test_cake_backend_rejects_explicit_t1_cu_seqlens_without_launching(
         recurrent_kda(**_call_kwargs(case), backend="cake")
 
 
-def test_internal_direct_t1_nonidentity_metadata_is_memory_safe(b200):
-    generator = torch.Generator(device=b200).manual_seed(2271)
+def test_internal_direct_t1_nonidentity_metadata_is_memory_safe(flash_kda_device):
+    generator = torch.Generator(device=flash_kda_device).manual_seed(2271)
     num_sequences = 2
     num_heads = 16
     num_value_heads = 32
     shape_q = (1, num_sequences, num_heads, _D)
     shape_v = (1, num_sequences, num_value_heads, _D)
-    q = torch.randn(shape_q, dtype=torch.bfloat16, device=b200, generator=generator)
+    q = torch.randn(
+        shape_q, dtype=torch.bfloat16, device=flash_kda_device, generator=generator
+    )
     k = torch.randn_like(q)
-    v = torch.randn(shape_v, dtype=torch.bfloat16, device=b200, generator=generator)
+    v = torch.randn(
+        shape_v, dtype=torch.bfloat16, device=flash_kda_device, generator=generator
+    )
     g = F.logsigmoid(
-        torch.randn(shape_v, dtype=torch.float32, device=b200, generator=generator)
+        torch.randn(
+            shape_v,
+            dtype=torch.float32,
+            device=flash_kda_device,
+            generator=generator,
+        )
     ).to(torch.bfloat16)
     beta = torch.rand(
         (1, num_sequences, num_value_heads),
         dtype=torch.bfloat16,
-        device=b200,
+        device=flash_kda_device,
         generator=generator,
     )
     state = torch.randn(
         (num_sequences, num_value_heads, _D, _D),
         dtype=torch.bfloat16,
-        device=b200,
+        device=flash_kda_device,
         generator=generator,
     )
     state_before = state.clone()
     output_sentinel = 17.0
-    out = torch.full(shape_v, output_sentinel, dtype=torch.bfloat16, device=b200)
-    dummy_f32 = torch.zeros(1, dtype=torch.float32, device=b200)
+    out = torch.full(
+        shape_v, output_sentinel, dtype=torch.bfloat16, device=flash_kda_device
+    )
+    dummy_f32 = torch.zeros(1, dtype=torch.float32, device=flash_kda_device)
 
     recurrent_module._run_flash_kda_decode(
         "d128_t1_precomputed_direct_split16",
@@ -1337,15 +1537,19 @@ def test_internal_direct_t1_nonidentity_metadata_is_memory_safe(b200):
         beta=beta,
         state=state,
         out=out,
-        cu_seqlens=torch.tensor([0, 2, 2], dtype=torch.int32, device=b200),
-        ssm_state_indices=torch.arange(num_sequences, dtype=torch.int32, device=b200),
-        num_accepted_tokens=torch.ones(num_sequences, dtype=torch.int32, device=b200),
+        cu_seqlens=torch.tensor([0, 2, 2], dtype=torch.int32, device=flash_kda_device),
+        ssm_state_indices=torch.arange(
+            num_sequences, dtype=torch.int32, device=flash_kda_device
+        ),
+        num_accepted_tokens=torch.ones(
+            num_sequences, dtype=torch.int32, device=flash_kda_device
+        ),
         scale=_D**-0.5,
         A_log=dummy_f32,
         dt_bias=dummy_f32,
         lower_bound=0.0,
     )
-    torch.cuda.synchronize(b200)
+    torch.cuda.synchronize(flash_kda_device)
 
     torch.testing.assert_close(
         out[:, 1],
@@ -1358,7 +1562,7 @@ def test_internal_direct_t1_nonidentity_metadata_is_memory_safe(b200):
 
 @pytest.mark.parametrize("num_sequences", _T3_SEQUENCE_COUNTS)
 def test_public_recurrent_kda_t3_lower_bound_measured_routes_match_cute_dsl(
-    b200, monkeypatch, num_sequences
+    flash_kda_device, monkeypatch, num_sequences
 ):
     frozen_calls = []
     run_frozen = recurrent_module._run_flash_kda_decode
@@ -1371,7 +1575,7 @@ def test_public_recurrent_kda_t3_lower_bound_measured_routes_match_cute_dsl(
 
     def check_case(*, accepted_token, padded_last_sequence):
         case = _make_t3_lower_bound_case(
-            b200,
+            flash_kda_device,
             num_sequences=num_sequences,
             accepted_token=accepted_token,
             padded_last_sequence=padded_last_sequence,
@@ -1461,10 +1665,12 @@ def test_public_recurrent_kda_t3_lower_bound_measured_routes_match_cute_dsl(
     )
 
 
-def test_public_route_supports_padded_slots_nat_and_outer_strides(b200, monkeypatch):
+def test_public_route_supports_padded_slots_nat_and_outer_strides(
+    flash_kda_device, monkeypatch
+):
     accepted_tokens = [0, 1, _T, _T + 7, _T - 1]
     case = _make_case(
-        b200,
+        flash_kda_device,
         num_sequences=len(accepted_tokens),
         num_heads=16,
         num_value_heads=32,
@@ -1503,10 +1709,14 @@ def test_public_route_supports_padded_slots_nat_and_outer_strides(b200, monkeypa
         backend="cake",
     )
 
+    arch = recurrent_module._FLASH_KDA_DECODE_ARCH_BY_COMPUTE_CAPABILITY[
+        torch.cuda.get_device_capability(flash_kda_device)
+    ]
     expected_split = recurrent_module._select_flash_kda_decode_value_split(
         _T,
         len(accepted_tokens) * 32,
-        torch.cuda.get_device_properties(b200).multi_processor_count,
+        torch.cuda.get_device_properties(flash_kda_device).multi_processor_count,
+        arch,
     )
     assert frozen_calls == [_VARIANT_PREFIX + str(expected_split)]
     assert actual_state_result is actual_state
@@ -1526,9 +1736,9 @@ def test_public_route_supports_padded_slots_nat_and_outer_strides(b200, monkeypa
     )
 
 
-def test_frozen_decode_cuda_graph_on_non_default_stream(b200, monkeypatch):
+def test_frozen_decode_cuda_graph_on_non_default_stream(flash_kda_device, monkeypatch):
     case = _make_case(
-        b200,
+        flash_kda_device,
         num_sequences=5,
         num_heads=16,
         num_value_heads=32,
@@ -1549,7 +1759,7 @@ def test_frozen_decode_cuda_graph_on_non_default_stream(b200, monkeypatch):
         frozen_calls.append(
             (
                 variant,
-                int(torch.cuda.current_stream(b200).cuda_stream),
+                int(torch.cuda.current_stream(flash_kda_device).cuda_stream),
             )
         )
         return run_frozen(variant, **kwargs)
@@ -1558,8 +1768,8 @@ def test_frozen_decode_cuda_graph_on_non_default_stream(b200, monkeypatch):
     graph_state = initial.clone()
     graph_output = torch.empty_like(case["output"])
     graph_kwargs = _call_kwargs(case, state=graph_state, output=graph_output)
-    capture_stream = torch.cuda.Stream(device=b200)
-    capture_stream.wait_stream(torch.cuda.current_stream(b200))
+    capture_stream = torch.cuda.Stream(device=flash_kda_device)
+    capture_stream.wait_stream(torch.cuda.current_stream(flash_kda_device))
     with torch.cuda.stream(capture_stream):
         recurrent_kda(**graph_kwargs, backend="cake")
         graph_state.copy_(initial)


### PR DESCRIPTION
> [!IMPORTANT]
> Follow-up to merged #4279. This PR is a single incremental SM100-family
> target-consolidation commit based directly on upstream `main@4433996e`.

## Description

Compile the frozen recurrent-KDA decode portfolio as `sm_100f` on CUDA 12.9+
and share it between CC 10.0 (B200/GB200) and CC 10.3 (B300/GB300). The public
`backend="cake"` contract and all device split selectors remain unchanged.

Two physical-target exceptions are deliberate:

- CUDA 12.8 B200 retains the exact `sm_100a` portfolio because `sm_100f` is
  unavailable in that toolkit.
- GB300 retains exact `sm_103a` modules for the two direct-T1 variants. A
  repeated target-only A/B found a systematic approximately 2.1% regression
  when those variants were compiled as `sm_100f`.

All 23 frozen generated CUDA bodies are byte-identical to #4279. CUDA 12.9+
B200 registers 23 family modules. CUDA 12.9+ GB300 registers the family
portfolio plus two exact direct-T1 modules; T2-T6 use the family modules.

## Validation

Publication commit: `e2552d7b0671b6694564053d22f67a7f82ef023f` (tree
`d3312b2fbd8b52544f0a1ba6c9f1b8b318ca9aad`), based directly on upstream
`main@4433996e`. Its tree is byte-identical to ready commit `0c8212ad` and to
the candidate validated on both GPUs.

| Gate | B200 | GB300 |
|---|---:|---:|
| Public decode GPU tests | 151/151 passed | 151/151 passed |
| Targeted CPU tests at publication commit | 194 passed, 20 skipped | same commit |
| Pre-commit at publication commit | passed | same commit |

Strict CUPTI, cold-L2, balanced-process A/B below compares the final family /
hybrid build with the exact-target implementation. Speedup is
`exact / family-or-hybrid`.

| GPU | T1 | T2 | T3 | T4 | T5 | T6 | 30-shape geomean |
|---|---:|---:|---:|---:|---:|---:|---:|
| B200 | 1.0043x | 1.0031x | 1.0029x | 0.9954x | 1.0003x | 1.0006x | **1.0011x** |
| GB300 | 1.0015x | 0.9988x | 1.0138x | 1.0035x | 0.9998x | 0.9985x | **1.0027x** |

GB300 T1 in this final table is exact `sm103a` on both sides; the row verifies
that retaining the performance exception does not perturb public dispatch.
The existing #4279/upstream and CAKE-internal baseline measurements remain the
algorithm-level performance comparison; this A/B isolates physical-target
consolidation.

Follow-up to merged #4279. Related to #4254.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Flash-KDA decode support for SM103a and SM100-family targets, including direct single-token variants.
  - Added architecture-aware JIT and AOT module generation, loading, caching, and dispatch.
  - Added support for architecture-specific scheduling and value-split policies.

- **Bug Fixes**
  - Improved validation for GPU architecture and CUDA version compatibility.
  - Unsupported target and variant combinations are now rejected earlier.

- **Documentation**
  - Updated recurrent KDA guidance with supported architectures, compilation requirements, scheduling policies, and performance details.

- **Tests**
  - Expanded coverage for target selection, routing, compatibility checks, and numerical correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->